### PR TITLE
docs: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "fix: "
+labels: bug
+assignees: ''
+---
+
+# Bug Report
+
+## Description
+<!-- Please provide a clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1. Step 1
+2. Step 2
+3. Step 3
+
+## Actual Behavior
+<!-- Please describe what actually happened. -->
+
+## Expected Behavior
+<!-- Please describe what you expected to happen. -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain the problem. -->
+<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
+<!-- https://gifcap.dev -->
+
+## Environment
+- Operating System: [e.g. Windows 10]
+- Browser: [e.g. Chrome, Firefox]
+- Version: [e.g. 1.0.0]
+
+## Additional Information
+<!-- Add any other relevant information about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+# Feature Request
+
+## Description
+
+Please provide a clear and concise description of the feature you would like to request.
+
+## Motivation
+
+Explain why this feature is important and how it would benefit the project.
+
+## Proposed Solution
+
+Outline your proposed solution or any ideas you have for implementing this feature.
+
+## Additional Context
+
+Add any additional context or screenshots about the feature request here.
+
+## Checklist
+
+- [ ] I have searched for similar feature requests and confirmed that this is a new request.
+- [ ] I have provided a clear and concise description of the feature.
+- [ ] I have explained the motivation behind this feature request.
+- [ ] I have outlined a proposed solution or ideas for implementing this feature.
+- [ ] I have provided any additional context or screenshots if applicable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+
+# Pull Request
+
+## Description
+<!-- Provide a brief description of the changes made in this pull request. -->
+
+## Related Issues
+<!-- Specify any related issues or tickets that this pull request addresses. -->
+
+## Changes Made
+<!-- Describe the specific changes made in this pull request. -->
+
+## Screenshots (if applicable)
+<!-- Include any relevant screenshots or images to help visualize the changes. -->
+<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
+<!-- https://gifcap.dev -->
+
+## Checklist
+<!-- Please select all applicable options. -->
+<!-- To select your options, please put an 'x' in the all boxes that apply. -->
+
+- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
+- [ ] I have performed a self-review of my own code and ensured it follows the project's coding standards.
+- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] I have updated the documentation, if applicable.
+- [ ] I have added appropriate unit tests, if applicable.
+
+## Additional Notes
+<!-- Add any additional notes or comments here. -->
+<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->


### PR DESCRIPTION
This pull request adds GitHub issue and PR templates to the repository. The templates include a bug report template and a feature request template. The bug report template allows users to provide a clear and concise description of a bug, steps to reproduce, actual behavior, expected behavior, screenshots, and additional information. The feature request template allows users to suggest new ideas for the project, provide a description of the feature, explain the motivation behind the request, propose a solution, and provide additional context. The pull request also includes a pull request template that provides a brief description of the changes made, related issues, specific changes, screenshots (if applicable), and a checklist for contributors to follow. This will help contributors create issues and pull requests with the necessary information. 

Fixes #5