### PR TITLE
refactor: update plot grammar to align with visualization properties

### DIFF
--- a/src/plot/grammar.ts
+++ b/src/plot/grammar.ts
@@ -7,23 +7,43 @@ export interface Maidr {
   axes?: {
     x?: string;
     y?: string;
+    z?: string;
   };
-  data: BarData | LineData;
+  data: BarData | LineData | HistData | BoxData;
 }
 
 export type BarData =
   | {
-      x: number[] | string[];
-      y: number[];
-    }
+    x: string[];
+    y: number[];
+  }
   | {
-      x: number[];
-      y: number[] | string[];
-    };
+    x: number[];
+    y: string[];
+  };
 
 export type LineData = [
   {
-    x: number;
-    y: number;
+    x: Date[] | number[];
+    y: number[];
+  }
+];
+
+
+export type HistData = [
+  {
+    x: number[];
+    y: number[];
   },
 ];
+
+
+export type BoxData =
+  | {
+    x: string[];
+    y: number[];
+  }
+  | {
+    x: number[];
+    y: string[];
+  };


### PR DESCRIPTION
This pull request includes a refactoring of the plot grammar to align with each of the visualization properties. The changes ensure that the axes x, y, and z are properly defined and that the data structures for BarData, LineData, HistData, and BoxData are updated to match the required formats.

We can add more grammar as we add more plots later.

Fixes #7