### PR TITLE
fix(braille): restrict the effect of selectionchange event

### DIFF
--- a/src/core/manager/braille.ts
+++ b/src/core/manager/braille.ts
@@ -30,16 +30,16 @@ export default class BrailleManager implements Observer {
     this.brailleDiv = brailleDiv;
     this.brailleInput = brailleInput;
 
-    this.selectionChangeHandler = e => {
-      e.preventDefault();
+    this.selectionChangeHandler = (event: Event) => {
+      event.preventDefault();
       moveToIndex(this.brailleInput?.selectionStart || 0);
     };
-
-    this.setBraille(state);
     this.brailleInput.addEventListener(
       EventType.SELECTION_CHANGE,
       this.selectionChangeHandler
     );
+
+    this.setBraille(state);
   }
 
   private setBraille(state: PlotState): void {

--- a/src/plot/bar.ts
+++ b/src/plot/bar.ts
@@ -40,11 +40,7 @@ export class BarPlot extends AbstractPlot {
     this.brailleValues = this.toBraille(this.values);
   }
 
-  public empty(): boolean {
-    return this.index < 0 || this.index >= this.values.length;
-  }
-
-  public audio(): AudioState {
+  protected audio(): AudioState {
     return {
       min: this.min,
       max: this.max,
@@ -54,14 +50,14 @@ export class BarPlot extends AbstractPlot {
     };
   }
 
-  public braille(): BrailleState {
+  protected braille(): BrailleState {
     return {
       values: this.brailleValues,
       index: this.index,
     };
   }
 
-  public text(): TextState {
+  protected text(): TextState {
     if (this.orientation === Orientation.VERTICAL) {
       return {
         mainLabel: this.xAxis,
@@ -99,6 +95,11 @@ export class BarPlot extends AbstractPlot {
     if (this.index < this.values.length) {
       this.index += 1;
     }
+  }
+
+  protected isWithinRange(index?: number): boolean {
+    const idx = index ?? this.index;
+    return idx >= 0 && idx < this.values.length;
   }
 
   protected toIndex(index: number): void {

--- a/src/plot/line.ts
+++ b/src/plot/line.ts
@@ -16,11 +16,6 @@ export class LinePlot extends AbstractPlot {
     return {index: 0, max: 0, min: 0, size: 0, value: 0};
   }
 
-  public empty(): boolean {
-    // TODO: Modify boundary conditions according to grammar of lineplot
-    return this.index < 0 || this.index >= this.values.length;
-  }
-
   braille(): BrailleState {
     return {values: [], index: 0};
   }
@@ -38,4 +33,9 @@ export class LinePlot extends AbstractPlot {
   protected up(): void {}
 
   protected toIndex(index: number): void {}
+
+  protected isWithinRange(index?: number): boolean {
+    // TODO: Modify boundary conditions according to grammar of lineplot
+    return this.index < 0 || this.index >= this.values.length;
+  }
 }

--- a/src/plot/plot.ts
+++ b/src/plot/plot.ts
@@ -78,7 +78,7 @@ export abstract class AbstractPlot implements Plot {
 
   public get state(): PlotState {
     return {
-      empty: this.empty(),
+      empty: !this.isWithinRange(),
       audio: this.audio(),
       braille: this.braille(),
       text: this.text(),
@@ -105,11 +105,13 @@ export abstract class AbstractPlot implements Plot {
   }
 
   public moveToIndex(index: number): void {
-    this.toIndex(index);
-    this.notifyObservers();
+    if (this.isWithinRange(index)) {
+      this.toIndex(index);
+      this.notifyObservers();
+    }
   }
 
-  protected abstract empty(): boolean;
+  protected abstract isWithinRange(index?: number): boolean;
   protected abstract audio(): AudioState;
   protected abstract braille(): BrailleState;
   protected abstract text(): TextState;


### PR DESCRIPTION
# Pull Request
Selectionchange event of braille fires whenever there is a change in focus, even for focus. Because of this the plot starts at the end of the plot and throws out of bound errors. This PR restricts the movement of the point with the plot no matter how the event is fired.

## Description
<!-- Provide a brief description of the changes made in this pull request. -->

## Related Issues
<!-- Specify any related issues or tickets that this pull request addresses. -->

## Changes Made
<!-- Describe the specific changes made in this pull request. -->

## Screenshots (if applicable)
<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
