### PR TITLE
fix: stop traversal at left and right extremes of barplot

### DIFF
--- a/src/core/manager/audio.ts
+++ b/src/core/manager/audio.ts
@@ -57,6 +57,11 @@ export default class AudioManager implements Observer {
       return;
     }
 
+    if (state.audio.left_extreme || state.audio.right_extreme) {
+      this.playUniqueSound(300, 0.3);
+      return;
+    }
+
     // TODO: Play empty sound.
     if (state.empty) {
       return;
@@ -156,5 +161,28 @@ export default class AudioManager implements Observer {
 
   public updateVolume(volume: number): void {
     this.volume = volume;
+  }
+
+  public playUniqueSound(frequency: number, duration: number): void {
+    const ctx = this.audioContext;
+    const now = ctx.currentTime;
+
+    // Create an oscillator
+    const oscillator = ctx.createOscillator();
+    oscillator.type = 'sine'; // Set Oscilscope type
+    oscillator.frequency.setValueAtTime(frequency, now); // Set the frequency
+
+    // Create a gain node for volume control
+    const gainNode = ctx.createGain();
+    gainNode.gain.setValueAtTime(this.volume, now);
+    gainNode.gain.exponentialRampToValueAtTime(0.01, now + duration);
+
+    // Connect the oscillator to the gain node and the gain node to the destination
+    oscillator.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    // Start and stop the oscillator
+    oscillator.start(now);
+    oscillator.stop(now + duration);
   }
 }

--- a/src/plot/bar.ts
+++ b/src/plot/bar.ts
@@ -5,6 +5,8 @@ import {BarData, Maidr} from './grammar';
 export class BarPlot extends AbstractPlot {
   private readonly x: number[] | string[];
   private readonly y: number[] | string[];
+  protected left_extreme = false;
+  protected right_extreme = false;
 
   private readonly min: number;
   private readonly max: number;
@@ -47,6 +49,8 @@ export class BarPlot extends AbstractPlot {
       size: this.values.length,
       index: this.index,
       value: this.values[this.index],
+      left_extreme: this.left_extreme,
+      right_extreme: this.right_extreme,
     };
   }
 
@@ -87,13 +91,23 @@ export class BarPlot extends AbstractPlot {
 
   protected left(): void {
     if (this.index > 0) {
+      if (this.right_extreme) {
+        this.right_extreme = false;
+      }
       this.index -= 1;
+    } else {
+      this.left_extreme = true;
     }
   }
 
   protected right(): void {
     if (this.index < this.values.length - 1) {
+      if (this.left_extreme) {
+        this.left_extreme = false;
+      }
       this.index += 1;
+    } else {
+      this.right_extreme = true;
     }
   }
 

--- a/src/plot/state.ts
+++ b/src/plot/state.ts
@@ -13,6 +13,8 @@ export type AudioState = {
   index: number;
   count?: number;
   volume?: number;
+  left_extreme?: boolean;
+  right_extreme?: boolean;
 };
 
 export type BrailleState = {


### PR DESCRIPTION
# Pull Request

## Description
This PR resolves the scenario where plot traversal exceeds beyond the left and right extremes

## Related Issues
closes #28 

## Changes Made
The boundary conditions are now checked at 0 and n-1 instead of -1 and n respectively for left and right extremes. Changes have been contained to purely to the move functions and `isWithinRange`.

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
