### PR TITLE
fix: move describe point to default scope

### DIFF
--- a/src/core/manager/keymap.ts
+++ b/src/core/manager/keymap.ts
@@ -16,6 +16,8 @@ export enum DefaultKey {
   TOGGLE_BRAILLE = 'b',
   TOGGLE_TEXT = 't',
   TOGGLE_AUDIO = 's',
+
+  DESCRIBE_POINT = 'space',
 }
 
 export enum LabelKey {
@@ -24,7 +26,6 @@ export enum LabelKey {
   // Description
   DESCRIBE_X = 'x',
   DESCRIBE_Y = 'y',
-  DESCRIBE_POINT = 'space',
 }
 
 const scopedKeymap = {


### PR DESCRIPTION
# Pull Request

## Description
This PR contains a minor change which consists of defining `DESCRIBE_POINT` to default scope from label scope
## Related Issues
closes #46 
## Changes Made
The `DESCRIBE_POINT` is now defined in default scope enum instead of label scope enum. Consequently, the key binding is available to the user only in default scope and not available in label scope.

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
