### PR TITLE
feat: add remaining features of label scope

### DIFF
--- a/src/core/command/describe.ts
+++ b/src/core/command/describe.ts
@@ -38,6 +38,37 @@ export class DescribeYCommand extends DescribeCommand {
   }
 }
 
+export class DescribeTitleCommand extends DescribeCommand {
+  constructor(plot: Plot, text: TextManager) {
+    super(plot, text);
+  }
+
+  public execute(): void {
+    const message = `Title is ${this.plot.title}`;
+    this.text.update(message);
+  }
+}
+
+export class DescribeSubtitleCommand extends DescribeCommand {
+  constructor(plot: Plot, text: TextManager) {
+    super(plot, text);
+  }
+
+  public execute(): void {
+    const message = `Subtitle is ${this.plot.subtitle}`;
+    this.text.update(message);
+  }
+}
+export class DescribeCaptionCommand extends DescribeCommand {
+  constructor(plot: Plot, text: TextManager) {
+    super(plot, text);
+  }
+
+  public execute(): void {
+    const message = `Caption is ${this.plot.caption}`;
+    this.text.update(message);
+  }
+}
 export class DescribePointCommand extends DescribeCommand {
   private readonly audio: AudioManager;
   private readonly braille: BrailleManager;

--- a/src/core/command/factory.ts
+++ b/src/core/command/factory.ts
@@ -2,9 +2,12 @@ import AudioManager from '../manager/audio';
 import BrailleManager from '../manager/braille';
 import {Command, CommandContext} from './command';
 import {
+  DescribeCaptionCommand,
   DescribePointCommand,
   DescribeXCommand,
   DescribeYCommand,
+  DescribeSubtitleCommand,
+  DescribeTitleCommand,
 } from './describe';
 import {
   MoveDownCommand,
@@ -64,6 +67,12 @@ export class CommandFactory {
           this.braille,
           this.text
         );
+      case 'DESCRIBE_TITLE':
+        return new DescribeTitleCommand(this.plot, this.text);
+      case 'DESCRIBE_SUBTITLE':
+        return new DescribeSubtitleCommand(this.plot, this.text);
+      case 'DESCRIBE_CAPTION':
+        return new DescribeCaptionCommand(this.plot, this.text);
 
       case 'ACTIVATE_LABEL_SCOPE':
         return new SwitchScopeCommand('LABEL');

--- a/src/core/manager/keymap.ts
+++ b/src/core/manager/keymap.ts
@@ -26,6 +26,9 @@ export enum LabelKey {
   // Description
   DESCRIBE_X = 'x',
   DESCRIBE_Y = 'y',
+  DESCRIBE_TITLE = 't',
+  DESCRIBE_SUBTITLE = 's',
+  DESCRIBE_CAPTION = 'c',
 }
 
 const scopedKeymap = {

--- a/src/model/grammar.ts
+++ b/src/model/grammar.ts
@@ -3,6 +3,8 @@ export interface Maidr {
   type: string;
   selector?: string;
   title?: string;
+  subtitle?: string;
+  caption?: string;
   orientation?: string;
   axes?: {
     x?: string;

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -3,6 +3,8 @@ import {Maidr} from './grammar';
 import {Observer, Subject} from '../core/observer';
 
 const DEFAULT_TILE = 'MAIDR Plot';
+const DEFAULT_SUBTITLE = 'unavailable';
+const DEFAULT_CAPTION = 'unavailable';
 const DEFAULT_X_AXIS = 'X';
 const DEFAULT_Y_AXIS = 'Y';
 
@@ -23,6 +25,8 @@ export interface Plot extends Subject {
   title: string;
   xAxis: string;
   yAxis: string;
+  subtitle: string;
+  caption: string;
 
   get state(): PlotState;
 
@@ -40,6 +44,9 @@ export abstract class AbstractPlot implements Plot {
   public readonly type: string;
   public readonly title: string;
 
+  public readonly subtitle: string;
+  public readonly caption: string;
+
   public readonly xAxis: string;
   public readonly yAxis: string;
 
@@ -51,6 +58,9 @@ export abstract class AbstractPlot implements Plot {
     this.id = maidr.id;
     this.type = maidr.type;
     this.title = maidr.title ?? DEFAULT_TILE;
+
+    this.subtitle = maidr.subtitle ?? DEFAULT_SUBTITLE;
+    this.caption = maidr.caption ?? DEFAULT_CAPTION;
 
     this.xAxis = maidr.axes?.x ?? DEFAULT_X_AXIS;
     this.yAxis = maidr.axes?.y ?? DEFAULT_Y_AXIS;


### PR DESCRIPTION
# Pull Request

## Description
This PR integrates the leftover features of `label` scope.

## Related Issues
closes #48 
## Changes Made
Summary of changes made for title are as follows:
1. Created a `DescribeTitleCommand` class that extends from `DescribeCommand`.
2. Defined title in label scope enum and created relevant initiation in `factory`.
3. Title was already defined in maidr grammar and plot so no further changes were needed.

Summary of current changes for subtitle and caption are as follows:
1. Introduced subtitle and caption as optional string parameters in maidr grammar.
4. Defined subtitle and caption in Plot class.
5. Defined their values in label scope enum and created relevant conditional initiations in `factory`.
6. Extended their relevant classes from `DescribeCommand`.
7. Implemented a conditional text assignment for both as they are optional parameters.
## Screenshots (if applicable)
<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes
Fill is yet to be implemented.
