### PR TITLE
feat: add visual highlighting; currently bar, hist, and heatmap

### DIFF
--- a/examples/heatmap.html
+++ b/examples/heatmap.html
@@ -4323,6 +4323,7 @@
           y: 'Month',
           fill: 'Passenger Count',
         },
+        selector: 'g#QuadMesh_1 > path',
         data: {
           x: [1949, 1950, 1951, 1952, 1953, 1954, 1955, 1956, 1957, 1958, 1959, 1960],
           y: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -1,5 +1,6 @@
 import type { HeatmapData, Maidr } from './grammar';
 import type { AudioState, TextState } from './state';
+import { Constant } from '../util/constant';
 import { AbstractPlot } from './plot';
 
 export class Heatmap extends AbstractPlot<number> {
@@ -8,6 +9,15 @@ export class Heatmap extends AbstractPlot<number> {
 
   private readonly min: number;
   private readonly max: number;
+
+  private squareIndex: number;
+  private rectStrokeWidth: number;
+  private rectHeight: number;
+  private rectWidth: number;
+  private hasRect: boolean;
+  private x_coord: number[];
+  private y_coord: number[];
+  protected elements: NodeListOf<Element> | undefined;
 
   public constructor(maidr: Maidr) {
     super(maidr);
@@ -22,6 +32,41 @@ export class Heatmap extends AbstractPlot<number> {
 
     this.row = this.values.length - 1;
     this.brailleValues = this.toBraille(this.values);
+
+    // rect stuff
+    if (maidr.selector) {
+      this.elements = document.querySelectorAll(maidr.selector);
+      this.hasRect = true;
+    } else {
+      this.hasRect = false;
+    }
+    if (this.hasRect) {
+      this.squareIndex = 0;
+      this.rectStrokeWidth = 4; // px
+      const recData = this.SetHeatmapRectData();
+      this.x_coord = recData[0];
+      this.y_coord = recData[1];
+      this.rectHeight = Math.abs(
+        Number(this.y_coord[1]) - Number(this.y_coord[0]),
+      );
+      this.rectWidth = Math.abs(
+        Number(this.x_coord[1]) - Number(this.x_coord[0]),
+      );
+    } else {
+      this.squareIndex = 0;
+      this.rectStrokeWidth = 4;
+      this.rectHeight = 0;
+      this.rectWidth = 0;
+      this.x_coord = [];
+      this.y_coord = [];
+    }
+  }
+
+  public notifyStateUpdate(): void {
+    super.notifyStateUpdate();
+    if (this.hasRect && !this.isOutOfBounds) {
+      this.UpdateRectDisplay();
+    }
   }
 
   protected audio(): AudioState {
@@ -69,5 +114,166 @@ export class Heatmap extends AbstractPlot<number> {
     }
 
     return braille;
+  }
+
+  /**
+   * Returns an array of heatmap data containing unique x and y coordinates.
+   * If 'data' exists in singleMaidr, it returns the norms from the data.
+   * Otherwise, it calculates the norms from the unique x and y coordinates.
+   */
+  SetHeatmapRectData(): number[][] {
+    if (!this.elements || !this.elements.length) {
+      return [[], []];
+    }
+
+    const xCoords: number[] = [];
+    const yCoords: number[] = [];
+
+    this.elements.forEach((element) => {
+      if (!element)
+        return;
+
+      if (element instanceof SVGPathElement) {
+        const coords = this.ExtractPathCoordinates(element);
+        if (coords) {
+          xCoords.push(coords.x);
+          yCoords.push(coords.y);
+        }
+      } else {
+        const x = element.getAttribute('x');
+        const y = element.getAttribute('y');
+        if (x !== null && y !== null) {
+          xCoords.push(Number.parseFloat(x));
+          yCoords.push(Number.parseFloat(y));
+        }
+      }
+    });
+
+    // return sorted unique values
+    const sortedCoords = this.SortAndScaleCoordinates(xCoords, yCoords);
+    return [[...new Set(sortedCoords[0])], [...new Set(sortedCoords[1])]];
+  }
+
+  /**
+   * Extracts x and y coordinates from an SVG path element.
+   */
+  private ExtractPathCoordinates(
+    element: SVGPathElement,
+  ): { x: number; y: number } | null {
+    const pathData = element.getAttribute('d');
+    if (!pathData)
+      return null;
+
+    const regex = /[ML]\s*-?\d+(?:\.\d*)?\s+-?\d+\.?\d*/;
+    const match = regex.exec(pathData);
+    if (!match)
+      return null;
+
+    return {
+      x: Number.parseFloat(match[1]),
+      y: Number.parseFloat(match[3]),
+    };
+  }
+
+  /**
+   * Sorts and applies scaling transformations to x and y coordinates.
+   */
+  private SortAndScaleCoordinates(
+    xCoords: number[],
+    yCoords: number[],
+  ): number[][] {
+    xCoords.sort((a, b) => a - b);
+    yCoords.sort((a, b) => a - b);
+
+    const [scaleX, scaleY] = this.GetSVGScaler();
+    if (scaleX === -1)
+      xCoords.reverse();
+    if (scaleY === -1)
+      yCoords.reverse();
+
+    return [xCoords, yCoords];
+  }
+
+  /**
+   * Returns an array containing the X and Y scales of the first SVG element found in the elements array.
+   * @returns A tuple `[scaleX, scaleY]` representing the scale of the SVG element.
+   */
+  GetSVGScaler(): [number, number] {
+    let scaleX = 1;
+    let scaleY = 1;
+
+    // Check if the element is inside an SVG that can be scaled
+    const firstElement = this.elements ? this.elements[0] : null;
+    if (!firstElement)
+      return [scaleX, scaleY];
+
+    if (!this.IsInsideSVG(firstElement))
+      return [scaleX, scaleY];
+
+    // Traverse up the DOM tree to check for scale transformations
+    let element: Node | null = firstElement;
+    while (
+      element
+      && element instanceof HTMLElement
+      && element.tagName.toLowerCase() !== 'body'
+    ) {
+      const transform = element.getAttribute('transform');
+      if (transform) {
+        const match = transform.match(
+          /scale\((-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)\)/,
+        );
+        if (match) {
+          scaleX *= Number.parseFloat(match[1]) || 1;
+          scaleY *= Number.parseFloat(match[3]) || 1;
+        }
+      }
+      element = element.parentNode;
+    }
+
+    return [scaleX, scaleY];
+  }
+
+  /**
+   * Checks if the given element is inside an SVG that supports scaling.
+   */
+  private IsInsideSVG(element: Node): boolean {
+    while (element && element instanceof HTMLElement) {
+      if (element.tagName.toLowerCase() === 'svg')
+        return true;
+      if (element.tagName.toLowerCase() === 'body')
+        break;
+      element = element.parentNode as Node;
+    }
+    return false;
+  }
+
+  /**
+   * Updates the rectangle display.
+   */
+  UpdateRectDisplay(): void {
+    const existingRect = document.getElementById('highlight_rect');
+    if (existingRect)
+      existingRect.remove(); // Destroy and recreate
+
+    const svgns = 'http://www.w3.org/2000/svg';
+    const rect = document.createElementNS(svgns, 'rect');
+    rect.setAttribute('id', 'highlight_rect');
+    rect.setAttribute('x', String(this.x_coord[this.col]));
+    rect.setAttribute(
+      'y',
+      String(this.y_coord[this.y_coord.length - 1 - this.row]),
+    );
+    rect.setAttribute('width', String(this.rectWidth));
+    rect.setAttribute('height', String(this.rectHeight));
+    rect.setAttribute('stroke', Constant.defaultElementColor);
+    rect.setAttribute('stroke-width', String(this.rectStrokeWidth));
+    rect.setAttribute('fill', 'none');
+
+    const parentElement = this.elements
+      ? this.elements[this.squareIndex]?.parentNode
+      : null;
+    if (parentElement) {
+      parentElement.appendChild(rect);
+    }
   }
 }

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -7,6 +7,7 @@ import type {
   PlotState,
   TextState,
 } from './state';
+import { Constant } from '../util/constant';
 import { MovableDirection } from './interface';
 
 const DEFAULT_TITLE = 'MAIDR Plot';
@@ -146,7 +147,6 @@ export abstract class AbstractPlot<T> implements Plot {
     const movement = {
       UPWARD: () => {
         this.row += 1;
-        this.row = this.values.length - 1;
         if (this.col < 0)
           this.col = 0;
         if (this.col > this.values[this.row]?.length - 1)
@@ -290,7 +290,6 @@ export abstract class AbstractBarPlot<
   // visual highlighting vars
   protected activeElement: HTMLElement | undefined;
   protected activeElementColor: string | undefined;
-  protected readonly defaultElementColor: string = '#BADA55';
   protected barElements: NodeListOf<HTMLElement> | undefined;
 
   protected constructor(maidr: Maidr, points: T[][]) {
@@ -459,7 +458,7 @@ export abstract class AbstractBarPlot<
       && (rgb[0] > 86 || rgb[0] < 169)
     ) {
       // Too gray and too close to center gray, use default
-      newColor = this.defaultElementColor;
+      newColor = Constant.defaultElementColor;
     }
 
     return newColor;
@@ -574,5 +573,3 @@ export abstract class AbstractBarPlot<
     }
   }
 }
-
-// bookmark: just added all the above code, copied over from js, now it's time to run and debug

--- a/src/util/constant.ts
+++ b/src/util/constant.ts
@@ -54,4 +54,7 @@ export abstract class Constant {
   static readonly TRUE = 'true';
   static readonly X = 'x';
   static readonly Y = 'y';
+
+  // temp area for help settings. todo: move once we create a help menu
+  static readonly defaultElementColor: string = '#BADA55';
 }


### PR DESCRIPTION
# Pull Request

## Description

Added color inverse for bar type plots, and rectangle indicator for heatmap

## Related Issues

Partially fixes #90 

## Changes Made

 - Added functions for color inverse of bar charts
 - Added svg coordinate vars and svg rect creation functions, to heatmap
## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

These changes require 2D movement, which was modified in my last PR. Recommend doing that one first to avoid extra work. 
