### PR TITLE
feat: support distinct audio legend for group levels

### DIFF
--- a/src/audio/audio-transitions.ts
+++ b/src/audio/audio-transitions.ts
@@ -4,50 +4,127 @@
  */
 
 /**
- * Applies a fade-in to an audio parameter
+ * Applies a fade-in to an audio parameter using an exponential curve for smoother transitions
+ *
  * @param param - The audio parameter to fade in (e.g., gainNode.gain)
- * @param startValue - The starting value (usually 0)
+ * @param startValue - The starting value (usually near-zero)
  * @param endValue - The target value to fade to
  * @param startTime - When to start the fade (in seconds)
  * @param duration - How long the fade should last (in seconds)
  */
 export function fadeIn(
   param: AudioParam,
-  startValue: number = 0,
+  startValue: number = 0.001, // Small non-zero value for exponential curve
   endValue: number = 1,
   startTime: number,
   duration: number = 0.015,
 ): void {
-  param.setValueAtTime(startValue, startTime);
-  param.linearRampToValueAtTime(endValue, startTime + duration);
+  // Web Audio API requires non-zero value for exponentialRampToValueAtTime
+  const safeStartValue = Math.max(0.001, startValue);
+
+  // Cancel any scheduled parameter changes
+  try {
+    param.cancelScheduledValues(startTime);
+  } catch {
+    // Ignore errors if no values were scheduled
+  }
+
+  // Set the initial value
+  param.setValueAtTime(safeStartValue, startTime);
+
+  // Use exponential ramping for more natural volume fades
+  param.exponentialRampToValueAtTime(endValue, startTime + duration);
 }
 
 /**
- * Applies a fade-out to an audio parameter
+ * Applies a fade-out to an audio parameter with an exponential curve for smoother transitions
+ *
  * @param param - The audio parameter to fade out (e.g., gainNode.gain)
  * @param startValue - The starting value (usually the current value)
- * @param endValue - The target value to fade to (usually 0)
+ * @param endValue - The target value to fade to (near-zero)
  * @param startTime - When to start the fade (in seconds)
  * @param duration - How long the fade should last (in seconds)
  */
 export function fadeOut(
   param: AudioParam,
   startValue: number = 1,
-  endValue: number = 0,
+  endValue: number = 0.001, // Small non-zero value for exponential curve
   startTime: number,
   duration: number = 0.015,
 ): void {
-  param.setValueAtTime(startValue, startTime);
-  param.linearRampToValueAtTime(endValue, startTime + duration);
+  // Web Audio API requires non-zero value for exponentialRampToValueAtTime
+  const safeStartValue = Math.max(0.001, startValue);
+  const safeEndValue = Math.max(0.001, endValue);
+
+  // Cancel any scheduled parameter changes
+  try {
+    param.cancelScheduledValues(startTime);
+  } catch {
+    // Ignore errors if no values were scheduled
+  }
+
+  // Set the initial value
+  param.setValueAtTime(safeStartValue, startTime);
+
+  // Use exponential ramping for more natural volume fades
+  param.exponentialRampToValueAtTime(safeEndValue, startTime + duration);
+
+  // Zero the parameter just after the exponential ramp is complete
+  if (endValue === 0) {
+    param.setValueAtTime(0, startTime + duration + 0.001);
+  }
 }
 
 /**
- * Creates an envelope for an oscillator to prevent clicks and pops
+ * Creates a crisp envelope for individual data points with minimal smoothing
+ * to preserve the clarity and character of the original waveform
+ *
  * @param gainNode - The gain node to apply the envelope to
  * @param startTime - When to start the envelope (in seconds)
  * @param duration - Total duration of the sound (in seconds)
  * @param attackTime - How long the attack phase should last (in seconds)
  * @param releaseTime - How long the release phase should last (in seconds)
+ * @param sustainLevel - The level to maintain during the sustain phase (default 1)
+ */
+export function createCrispEnvelope(
+  gainNode: GainNode,
+  startTime: number,
+  duration: number,
+  attackTime: number = 0.005, // Shorter attack time for crisp onset
+  releaseTime: number = 0.005, // Shorter release time for crisp ending
+  sustainLevel: number = 1,
+): void {
+  // Ensure the envelope fits within the duration
+  const maxAttackRelease = duration * 0.3; // Less time spent on attack/release
+  const actualAttack = Math.min(attackTime, maxAttackRelease / 2);
+  const actualRelease = Math.min(releaseTime, maxAttackRelease / 2);
+
+  // Calculate the sustain start and end times
+  const sustainStart = startTime + actualAttack;
+  const sustainEnd = startTime + duration - actualRelease;
+
+  // Quick ramp up with minimal smoothing
+  gainNode.gain.setValueAtTime(0, startTime);
+  gainNode.gain.linearRampToValueAtTime(sustainLevel, sustainStart);
+
+  // Strong sustain for clarity
+  gainNode.gain.setValueAtTime(sustainLevel, sustainStart);
+  gainNode.gain.setValueAtTime(sustainLevel, sustainEnd);
+
+  // Quick ramp down
+  gainNode.gain.linearRampToValueAtTime(0, startTime + duration);
+}
+
+/**
+ * Creates an advanced envelope for an oscillator to prevent clicks and pops
+ * with smoother attack and release curves
+ *
+ * @param gainNode - The gain node to apply the envelope to
+ * @param startTime - When to start the envelope (in seconds)
+ * @param duration - Total duration of the sound (in seconds)
+ * @param attackTime - How long the attack phase should last (in seconds)
+ * @param releaseTime - How long the release phase should last (in seconds)
+ * @param sustainLevel - The level to maintain during the sustain phase (default 1)
  */
 export function createEnvelope(
   gainNode: GainNode,
@@ -55,18 +132,86 @@ export function createEnvelope(
   duration: number,
   attackTime: number = 0.015,
   releaseTime: number = 0.015,
+  sustainLevel: number = 1,
 ): void {
   // Ensure the envelope fits within the duration
-  const maxAttackRelease = duration * 0.8;
+  const maxAttackRelease = duration * 0.9;
   const actualAttack = Math.min(attackTime, maxAttackRelease / 2);
   const actualRelease = Math.min(releaseTime, maxAttackRelease / 2);
 
-  // Calculate the release start time
-  const releaseStart = startTime + duration - actualRelease;
+  // Calculate the sustain start and end times
+  const sustainStart = startTime + actualAttack;
+  const sustainEnd = startTime + duration - actualRelease;
 
-  // Apply attack (fade in)
-  fadeIn(gainNode.gain, 0, 1, startTime, actualAttack);
+  // Ensure gain is set to 0 at the start (prevents clicks)
+  gainNode.gain.setValueAtTime(0, startTime);
 
-  // Apply release (fade out)
-  fadeOut(gainNode.gain, 1, 0, releaseStart, actualRelease);
+  // Apply attack (fade in) - use exponential for smoother sound
+  fadeIn(gainNode.gain, 0.001, sustainLevel, startTime, actualAttack);
+
+  // Hold at sustain level
+  if (sustainEnd > sustainStart) {
+    gainNode.gain.setValueAtTime(sustainLevel, sustainStart);
+    gainNode.gain.setValueAtTime(sustainLevel, sustainEnd);
+  }
+
+  // Apply release (fade out) - use exponential for smoother sound
+  fadeOut(gainNode.gain, sustainLevel, 0.001, sustainEnd, actualRelease);
+
+  // Ensure gain is set to 0 at the end (prevents lingering sounds)
+  gainNode.gain.setValueAtTime(0, startTime + duration + 0.001);
+}
+
+/**
+ * Creates a smooth DC offset filter to eliminate pops and clicks
+ * caused by oscillators starting and stopping
+ *
+ * @param audioContext - The Web Audio API context
+ * @returns A configured DC offset filter node
+ */
+export function createDCFilter(audioContext: AudioContext): BiquadFilterNode {
+  // Create a high-pass filter to remove DC offset
+  const dcFilter = audioContext.createBiquadFilter();
+  dcFilter.type = 'highpass';
+  dcFilter.frequency.value = 20; // 20Hz removes inaudible low frequencies
+  dcFilter.Q.value = 0.707; // Butterworth response for flat passband
+
+  return dcFilter;
+}
+
+/**
+ * Creates a click suppression filter chain
+ *
+ * @param audioContext - The Web Audio API context
+ * @param preserveHighs - Whether to preserve high frequencies (for individual points)
+ * @returns An object containing the input and output nodes of the filter chain
+ */
+export function createClickSuppressor(
+  audioContext: AudioContext,
+  preserveHighs: boolean = false,
+): { input: AudioNode; output: AudioNode } {
+  // Create a DC offset filter to block ultra-low frequencies
+  const dcFilter = createDCFilter(audioContext);
+
+  // For individual data points, we want minimal filtering to preserve clarity
+  if (preserveHighs) {
+    return {
+      input: dcFilter,
+      output: dcFilter,
+    };
+  }
+
+  // For autoplay, add additional filtering to smooth transitions
+  const smoothingFilter = audioContext.createBiquadFilter();
+  smoothingFilter.type = 'lowpass';
+  smoothingFilter.frequency.value = 18000; // Just below human hearing range
+  smoothingFilter.Q.value = 0.5;
+
+  // Connect filters in series
+  dcFilter.connect(smoothingFilter);
+
+  return {
+    input: dcFilter,
+    output: smoothingFilter,
+  };
 }

--- a/src/audio/audio-transitions.ts
+++ b/src/audio/audio-transitions.ts
@@ -1,0 +1,72 @@
+/**
+ * Utility functions for creating smooth audio transitions
+ * to prevent clicks and pops in Web Audio API
+ */
+
+/**
+ * Applies a fade-in to an audio parameter
+ * @param param - The audio parameter to fade in (e.g., gainNode.gain)
+ * @param startValue - The starting value (usually 0)
+ * @param endValue - The target value to fade to
+ * @param startTime - When to start the fade (in seconds)
+ * @param duration - How long the fade should last (in seconds)
+ */
+export function fadeIn(
+  param: AudioParam,
+  startValue: number = 0,
+  endValue: number = 1,
+  startTime: number,
+  duration: number = 0.015,
+): void {
+  param.setValueAtTime(startValue, startTime);
+  param.linearRampToValueAtTime(endValue, startTime + duration);
+}
+
+/**
+ * Applies a fade-out to an audio parameter
+ * @param param - The audio parameter to fade out (e.g., gainNode.gain)
+ * @param startValue - The starting value (usually the current value)
+ * @param endValue - The target value to fade to (usually 0)
+ * @param startTime - When to start the fade (in seconds)
+ * @param duration - How long the fade should last (in seconds)
+ */
+export function fadeOut(
+  param: AudioParam,
+  startValue: number = 1,
+  endValue: number = 0,
+  startTime: number,
+  duration: number = 0.015,
+): void {
+  param.setValueAtTime(startValue, startTime);
+  param.linearRampToValueAtTime(endValue, startTime + duration);
+}
+
+/**
+ * Creates an envelope for an oscillator to prevent clicks and pops
+ * @param gainNode - The gain node to apply the envelope to
+ * @param startTime - When to start the envelope (in seconds)
+ * @param duration - Total duration of the sound (in seconds)
+ * @param attackTime - How long the attack phase should last (in seconds)
+ * @param releaseTime - How long the release phase should last (in seconds)
+ */
+export function createEnvelope(
+  gainNode: GainNode,
+  startTime: number,
+  duration: number,
+  attackTime: number = 0.015,
+  releaseTime: number = 0.015,
+): void {
+  // Ensure the envelope fits within the duration
+  const maxAttackRelease = duration * 0.8;
+  const actualAttack = Math.min(attackTime, maxAttackRelease / 2);
+  const actualRelease = Math.min(releaseTime, maxAttackRelease / 2);
+
+  // Calculate the release start time
+  const releaseStart = startTime + duration - actualRelease;
+
+  // Apply attack (fade in)
+  fadeIn(gainNode.gain, 0, 1, startTime, actualAttack);
+
+  // Apply release (fade out)
+  fadeOut(gainNode.gain, 1, 0, releaseStart, actualRelease);
+}

--- a/src/command/audio-legend.ts
+++ b/src/command/audio-legend.ts
@@ -1,0 +1,46 @@
+import type { AudioService } from '@service/audio';
+import type { Command } from './command';
+import type { Plot } from '@type/plot';
+
+/**
+ * Command to play an audio legend demonstrating the different sounds for each data group
+ * Used in multi-line plots and stacked bar plots to help users distinguish between groups
+ */
+export class PlayAudioLegendCommand implements Command {
+    private readonly audio: AudioService;
+    private readonly plot: Plot;
+
+    /**
+     * Creates a new PlayAudioLegendCommand
+     *
+     * @param audio - The audio service to use for playing the legend
+     * @param plot - The plot to get data series/group count from
+     */
+    public constructor(audio: AudioService, plot: Plot) {
+        this.audio = audio;
+        this.plot = plot;
+    }
+
+    /**
+     * Executes the command to play an audio legend
+     * Determines the number of groups in the plot and plays a distinct sound for each
+     */
+    public execute(): void {
+        const state = this.plot.state;
+
+        // If the plot is empty, there's nothing to play
+        if (state.empty) {
+            return;
+        }
+
+        // For multi-line plots, the number of groups is the length of the values array
+        // For stacked bar plots, we use the same approach
+        const groupCount = state.empty ? 0 :
+            (Array.isArray(state.audio.value) ?
+                state.audio.value.length :
+                (state.audio.groupIndex !== undefined ? state.audio.groupIndex + 1 : 1));
+
+        // Play the audio legend with the determined number of groups
+        this.audio.playAudioLegend(Math.max(1, groupCount));
+    }
+}

--- a/src/command/audio-legend.ts
+++ b/src/command/audio-legend.ts
@@ -1,46 +1,47 @@
 import type { AudioService } from '@service/audio';
-import type { Command } from './command';
 import type { Plot } from '@type/plot';
+import type { Command } from './command';
 
 /**
  * Command to play an audio legend demonstrating the different sounds for each data group
  * Used in multi-line plots and stacked bar plots to help users distinguish between groups
  */
 export class PlayAudioLegendCommand implements Command {
-    private readonly audio: AudioService;
-    private readonly plot: Plot;
+  private readonly audio: AudioService;
+  private readonly plot: Plot;
 
-    /**
-     * Creates a new PlayAudioLegendCommand
-     *
-     * @param audio - The audio service to use for playing the legend
-     * @param plot - The plot to get data series/group count from
-     */
-    public constructor(audio: AudioService, plot: Plot) {
-        this.audio = audio;
-        this.plot = plot;
+  /**
+   * Creates a new PlayAudioLegendCommand
+   *
+   * @param audio - The audio service to use for playing the legend
+   * @param plot - The plot to get data series/group count from
+   */
+  public constructor(audio: AudioService, plot: Plot) {
+    this.audio = audio;
+    this.plot = plot;
+  }
+
+  /**
+   * Executes the command to play an audio legend
+   * Determines the number of groups in the plot and plays a distinct sound for each
+   */
+  public execute(): void {
+    const state = this.plot.state;
+
+    // If the plot is empty, there's nothing to play
+    if (state.empty) {
+      return;
     }
 
-    /**
-     * Executes the command to play an audio legend
-     * Determines the number of groups in the plot and plays a distinct sound for each
-     */
-    public execute(): void {
-        const state = this.plot.state;
+    // For multi-line plots, the number of groups is the length of the values array
+    // For stacked bar plots, we use the same approach
+    const groupCount = state.empty
+      ? 0
+      : (Array.isArray(state.audio.value)
+          ? state.audio.value.length
+          : (state.audio.groupIndex !== undefined ? state.audio.groupIndex + 1 : 1));
 
-        // If the plot is empty, there's nothing to play
-        if (state.empty) {
-            return;
-        }
-
-        // For multi-line plots, the number of groups is the length of the values array
-        // For stacked bar plots, we use the same approach
-        const groupCount = state.empty ? 0 :
-            (Array.isArray(state.audio.value) ?
-                state.audio.value.length :
-                (state.audio.groupIndex !== undefined ? state.audio.groupIndex + 1 : 1));
-
-        // Play the audio legend with the determined number of groups
-        this.audio.playAudioLegend(Math.max(1, groupCount));
-    }
+    // Play the audio legend with the determined number of groups
+    this.audio.playAudioLegend(Math.max(1, groupCount));
+  }
 }

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -7,9 +7,16 @@ import type { TextService } from '@service/text';
 import type { Plot } from '@type/plot';
 
 export interface Command {
-  execute: (event?: Event) => void;
+  execute(event?: KeyboardEvent): void;
 }
 
+export class EmptyCommand implements Command {
+  public execute(): void { }
+}
+
+/**
+ * The context for commands, containing all the services that commands might need
+ */
 export interface CommandContext {
   plot: Plot;
 

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -7,7 +7,7 @@ import type { TextService } from '@service/text';
 import type { Plot } from '@type/plot';
 
 export interface Command {
-  execute(event?: KeyboardEvent): void;
+  execute: (event?: KeyboardEvent) => void;
 }
 
 export class EmptyCommand implements Command {

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -48,6 +48,7 @@ import {
   ToggleSettingsCommand,
   ToggleTextCommand,
 } from './toggle';
+import { PlayAudioLegendCommand } from './audio-legend';
 
 export class CommandFactory {
   private readonly plot: Plot;
@@ -145,6 +146,9 @@ export class CommandFactory {
         return new SpeedDownAutoplayCommand(this.autoplay);
       case 'RESET_AUTOPLAY_SPEED':
         return new ResetAutoplaySpeedCommand(this.autoplay);
+
+      case 'PLAY_AUDIO_LEGEND':
+        return new PlayAudioLegendCommand(this.audio, this.plot); // New command for audio legend
 
       default:
         throw new Error(`Invalid command name: ${command}`);

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -8,6 +8,7 @@ import type { Keys } from '@type/keys';
 import type { Plot } from '@type/plot';
 import type { Command, CommandContext } from './command';
 import { Scope } from '@type/keys';
+import { PlayAudioLegendCommand } from './audio-legend';
 import {
   AutoplayBackwardCommand,
   AutoplayDownwardCommand,
@@ -48,7 +49,6 @@ import {
   ToggleSettingsCommand,
   ToggleTextCommand,
 } from './toggle';
-import { PlayAudioLegendCommand } from './audio-legend';
 
 export class CommandFactory {
   private readonly plot: Plot;

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -30,6 +30,7 @@ export class LinePlot extends AbstractPlot<number> {
       size: this.points[this.row].length,
       index: this.col,
       value: this.points[this.row][this.col].y,
+      groupIndex: this.row, // Include the row/group index for audio differentiation
     };
   }
 

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -248,6 +248,7 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractPlot<n
       size,
       index,
       value,
+      groupIndex: isVertical ? this.row : this.col, // Include the group index for audio differentiation
     };
   }
 

--- a/src/redux/slice/settingsSlice.ts
+++ b/src/redux/slice/settingsSlice.ts
@@ -13,6 +13,7 @@ interface GeneralSettings {
   maxFrequency: number;
   autoplayDuration: number;
   audioTransitionTime: number;
+  sineWaveSmoothing: boolean; // Enable by default for better audio experience
   ariaMode: 'assertive' | 'polite';
 }
 
@@ -28,6 +29,7 @@ const defaultGeneralSettings: GeneralSettings = {
   maxFrequency: 1000,
   autoplayDuration: 1000,
   audioTransitionTime: 15,
+  sineWaveSmoothing: true, // Enable by default for better audio experience
   ariaMode: 'assertive',
 };
 

--- a/src/redux/slice/settingsSlice.ts
+++ b/src/redux/slice/settingsSlice.ts
@@ -2,21 +2,38 @@ import type { ThunkContext } from '@redux/store';
 import type { Settings } from '@type/settings';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
+/**
+ * Interface defining general settings configuration
+ */
+interface GeneralSettings {
+  volume: number;
+  highlightColor: string;
+  brailleDisplaySize: number;
+  minFrequency: number;
+  maxFrequency: number;
+  autoplayDuration: number;
+  audioTransitionTime: number;
+  ariaMode: 'assertive' | 'polite';
+}
+
 interface SettingsState extends Settings {
   enabled: boolean;
 }
 
+const defaultGeneralSettings: GeneralSettings = {
+  volume: 50,
+  highlightColor: '#1976d2',
+  brailleDisplaySize: 100,
+  minFrequency: 200,
+  maxFrequency: 1000,
+  autoplayDuration: 1000,
+  audioTransitionTime: 15,
+  ariaMode: 'assertive',
+};
+
 const initialState: SettingsState = {
   enabled: false,
-  general: {
-    volume: 50,
-    highlightColor: '#03c809',
-    brailleDisplaySize: 32,
-    minFrequency: 200,
-    maxFrequency: 1000,
-    autoplayDuration: 4000,
-    ariaMode: 'assertive',
-  },
+  general: defaultGeneralSettings,
   llm: {
     expertiseLevel: 'basic',
     customInstruction: '',

--- a/src/redux/slice/settingsSlice.ts
+++ b/src/redux/slice/settingsSlice.ts
@@ -13,7 +13,6 @@ interface GeneralSettings {
   maxFrequency: number;
   autoplayDuration: number;
   audioTransitionTime: number;
-  sineWaveSmoothing: boolean; // Enable by default for better audio experience
   ariaMode: 'assertive' | 'polite';
 }
 
@@ -29,7 +28,6 @@ const defaultGeneralSettings: GeneralSettings = {
   maxFrequency: 1000,
   autoplayDuration: 1000,
   audioTransitionTime: 15,
-  sineWaveSmoothing: true, // Enable by default for better audio experience
   ariaMode: 'assertive',
 };
 

--- a/src/service/autoplay.ts
+++ b/src/service/autoplay.ts
@@ -1,5 +1,6 @@
 import type { Movable, MovableDirection } from '@type/movable';
 import type { PlotState } from '@type/state';
+import type { AudioService } from './audio';
 import type { NotificationService } from './notification';
 import type { TextService } from './text';
 
@@ -10,10 +11,15 @@ const MAX_SPEED = 500;
 const TOTAL_DURATION = 4000;
 const DEFAULT_INTERVAL = 20;
 
+/**
+ * Service to handle autoplay functionality
+ * Controls the automated traversal through data points
+ */
 export class AutoplayService {
   private readonly notification: NotificationService;
   private readonly text: TextService;
   private readonly movable: Movable;
+  private readonly audioService?: AudioService;
 
   private playId: NodeJS.Timeout | null;
   private currentDirection: MovableDirection | null;
@@ -27,10 +33,24 @@ export class AutoplayService {
   private readonly totalDuration: number;
   private readonly interval: number;
 
-  public constructor(notification: NotificationService, text: TextService, movable: Movable) {
+  /**
+   * Creates a new AutoplayService
+   *
+   * @param notification - Service to display notifications
+   * @param text - Service to handle text output
+   * @param movable - Interface for moving through data points
+   * @param audioService - Optional audio service to notify of autoplay state changes
+   */
+  public constructor(
+    notification: NotificationService,
+    text: TextService,
+    movable: Movable,
+    audioService?: AudioService,
+  ) {
     this.notification = notification;
     this.text = text;
     this.movable = movable;
+    this.audioService = audioService;
 
     this.playId = null;
     this.currentDirection = null;
@@ -49,12 +69,23 @@ export class AutoplayService {
     this.stop();
   }
 
+  /**
+   * Starts autoplay in the specified direction
+   *
+   * @param direction - The direction to move in during autoplay
+   * @param state - Current plot state (optional)
+   */
   public start(direction: MovableDirection, state?: PlotState): void {
     this.stop();
     this.text.mute();
 
     this.autoplayRate = this.getAutoplayRate(direction, state);
     this.currentDirection = direction;
+
+    // Notify audio service that autoplay is starting
+    if (this.audioService) {
+      this.audioService.setAutoplayState(true);
+    }
 
     this.playId = setInterval(() => {
       if (this.movable.isMovable(direction)) {
@@ -65,6 +96,9 @@ export class AutoplayService {
     }, this.autoplayRate);
   }
 
+  /**
+   * Stops the current autoplay session
+   */
   public stop(): void {
     if (this.playId) {
       clearInterval(this.playId);
@@ -73,6 +107,11 @@ export class AutoplayService {
     this.playId = null;
     this.currentDirection = null;
     this.text.unmute();
+
+    // Notify audio service that autoplay has stopped
+    if (this.audioService) {
+      this.audioService.setAutoplayState(false);
+    }
   }
 
   private restart(): void {

--- a/src/service/controller.ts
+++ b/src/service/controller.ts
@@ -37,7 +37,7 @@ export class ControllerService {
     this.notification = new NotificationService(this.display);
     this.settings = new SettingsService(this.display);
 
-    this.audio = new AudioService(this.notification, this.plot.hasMultiPoints);
+    this.audio = new AudioService(this.notification, this.plot.hasMultiPoints, this.settings);
     this.braille = new BrailleService(
       this.notification,
       this.display,

--- a/src/service/controller.ts
+++ b/src/service/controller.ts
@@ -50,6 +50,7 @@ export class ControllerService {
       this.notification,
       this.text,
       this.plot,
+      this.audio, // Pass audio service to autoplay service
     );
     this.help = new HelpService(this.display);
     this.chat = new ChatService(this.display, maidr);

--- a/src/service/controller.ts
+++ b/src/service/controller.ts
@@ -13,6 +13,10 @@ import { NotificationService } from './notification';
 import { ReviewService } from './review';
 import { TextService } from './text';
 
+/**
+ * Service that coordinates all other services
+ * Acts as the main controller for the application
+ */
 export class ControllerService {
   private readonly plot: Plot;
 
@@ -30,6 +34,12 @@ export class ControllerService {
   public readonly chat: ChatService;
   private readonly keybinding: KeybindingService;
 
+  /**
+   * Creates a new controller service
+   *
+   * @param display - The display service
+   * @param maidr - The Maidr configuration
+   */
   public constructor(display: DisplayService, maidr: Maidr) {
     this.plot = PlotFactory.create(maidr);
 
@@ -46,11 +56,12 @@ export class ControllerService {
     this.text = new TextService(this.notification, this.display.textDiv);
     this.review = new ReviewService(this.notification, this.display, this.text);
 
+    // Pass audio service to autoplay service
     this.autoplay = new AutoplayService(
       this.notification,
       this.text,
       this.plot,
-      this.audio, // Pass audio service to autoplay service
+      this.audio,
     );
     this.help = new HelpService(this.display);
     this.chat = new ChatService(this.display, maidr);
@@ -71,6 +82,9 @@ export class ControllerService {
     this.plot.addObserver(this.text);
   }
 
+  /**
+   * Destroys all services and cleans up resources
+   */
   public destroy(): void {
     this.plot.removeObserver(this.text);
     this.plot.removeObserver(this.braille);

--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -19,6 +19,7 @@ export class HelpService {
       { description: 'Toggle Text Mode', key: 't' },
       { description: 'Toggle Sonification Mode', key: 's' },
       { description: 'Toggle Review Mode', key: 'r' },
+      { description: 'Play Audio Legend', key: 'a' }, // New menu item for Audio Legend
 
       { description: 'Autoplay Outward', key: 'command + shift + arrow key' },
       { description: 'Stop Autoplay', key: 'command' },

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -40,6 +40,7 @@ enum DefaultKey {
   TOGGLE_TEXT = 't',
   TOGGLE_AUDIO = 's',
   TOGGLE_REVIEW = 'r',
+  PLAY_AUDIO_LEGEND = 'a', // New keyboard shortcut for audio legend
 
   // Misc
   TOGGLE_SCATTER_NAVIGATION = 'n',

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -25,6 +25,7 @@ export class SettingsService {
         autoplayDuration: 4000,
         audioTransitionTime: 15,
         ariaMode: 'assertive',
+        sineWaveSmoothing: false,
       },
       llm: {
         expertiseLevel: 'basic',
@@ -62,12 +63,8 @@ export class SettingsService {
   public saveSettings(newSettings: Settings): void {
     // Apply the settings to relevant services
     if (this.audioService) {
-      this.audioService.updateVolume(newSettings.general.volume / 100);
-
-      // Apply audio transition time if available
-      if (newSettings.general.audioTransitionTime) {
-        this.audioService.updateTransitionTime(newSettings.general.audioTransitionTime);
-      }
+      // Apply all audio-related settings at once for better coordination
+      this.audioService.updateSettings(newSettings.general);
     }
 
     this.currentSettings = newSettings;

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -25,7 +25,6 @@ export class SettingsService {
         autoplayDuration: 4000,
         audioTransitionTime: 15,
         ariaMode: 'assertive',
-        sineWaveSmoothing: false,
       },
       llm: {
         expertiseLevel: 'basic',

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -1,3 +1,4 @@
+import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { Settings } from '@type/settings';
 import { Scope } from '@type/keys';
@@ -5,12 +6,14 @@ import hotkeys from 'hotkeys-js';
 
 export class SettingsService {
   private readonly display: DisplayService;
+  private readonly audioService?: AudioService;
 
   private readonly defaultSettings: Settings;
   private currentSettings: Settings;
 
-  public constructor(display: DisplayService) {
+  public constructor(display: DisplayService, audioService?: AudioService) {
     this.display = display;
+    this.audioService = audioService;
 
     this.defaultSettings = {
       general: {
@@ -20,6 +23,7 @@ export class SettingsService {
         minFrequency: 200,
         maxFrequency: 1000,
         autoplayDuration: 4000,
+        audioTransitionTime: 15,
         ariaMode: 'assertive',
       },
       llm: {
@@ -51,7 +55,21 @@ export class SettingsService {
     return this.currentSettings;
   }
 
+  /**
+   * Saves updated settings to local storage
+   * @param newSettings - The settings to save
+   */
   public saveSettings(newSettings: Settings): void {
+    // Apply the settings to relevant services
+    if (this.audioService) {
+      this.audioService.updateVolume(newSettings.general.volume / 100);
+
+      // Apply audio transition time if available
+      if (newSettings.general.audioTransitionTime) {
+        this.audioService.updateTransitionTime(newSettings.general.audioTransitionTime);
+      }
+    }
+
     this.currentSettings = newSettings;
   }
 

--- a/src/type/keys.ts
+++ b/src/type/keys.ts
@@ -9,4 +9,52 @@ export enum Scope {
   SETTINGS = 'SETTINGS',
 }
 
-export type Keys = keyof Keymap[Scope];
+export enum CommandCategory {
+  AUTOPLAY = 'AUTOPLAY',
+  NAVIGATION = 'NAVIGATION',
+  DESCRIPTION = 'DESCRIPTION',
+  MODE = 'MODE',
+  SCOPE = 'SCOPE',
+  MISC = 'MISC',
+  EMPTY = 'EMPTY',
+}
+
+/**
+ * Keys is a union of all possible command names
+ * Each key has a corresponding handler in CommandFactory
+ */
+export type Keys =
+  | 'ACTIVATE_DEFAULT_SCOPE'
+  | 'ACTIVATE_LABEL_SCOPE'
+  | 'AUTOPLAY_BACKWARD'
+  | 'AUTOPLAY_DOWNWARD'
+  | 'AUTOPLAY_FORWARD'
+  | 'AUTOPLAY_UPWARD'
+  | 'DESCRIBE_CAPTION'
+  | 'DESCRIBE_FILL'
+  | 'DESCRIBE_POINT'
+  | 'DESCRIBE_SUBTITLE'
+  | 'DESCRIBE_TITLE'
+  | 'DESCRIBE_X'
+  | 'DESCRIBE_Y'
+  | 'MOVE_DOWN'
+  | 'MOVE_LEFT'
+  | 'MOVE_RIGHT'
+  | 'MOVE_TO_BOTTOM_EXTREME'
+  | 'MOVE_TO_LEFT_EXTREME'
+  | 'MOVE_TO_RIGHT_EXTREME'
+  | 'MOVE_TO_TOP_EXTREME'
+  | 'MOVE_UP'
+  | 'PLAY_AUDIO_LEGEND'  // Added new command for audio legend
+  | 'RESET_AUTOPLAY_SPEED'
+  | 'SPEED_DOWN_AUTOPLAY'
+  | 'SPEED_UP_AUTOPLAY'
+  | 'STOP_AUTOPLAY'
+  | 'TOGGLE_AUDIO'
+  | 'TOGGLE_BRAILLE'
+  | 'TOGGLE_CHAT'
+  | 'TOGGLE_HELP'
+  | 'TOGGLE_REVIEW'
+  | 'TOGGLE_SCATTER_NAVIGATION'
+  | 'TOGGLE_SETTINGS'
+  | 'TOGGLE_TEXT';

--- a/src/type/keys.ts
+++ b/src/type/keys.ts
@@ -1,5 +1,3 @@
-import type { Keymap } from '@service/keybinding';
-
 export enum Scope {
   CHAT = 'CHAT',
   DEFAULT = 'DEFAULT',
@@ -45,7 +43,7 @@ export type Keys =
   | 'MOVE_TO_RIGHT_EXTREME'
   | 'MOVE_TO_TOP_EXTREME'
   | 'MOVE_UP'
-  | 'PLAY_AUDIO_LEGEND'  // Added new command for audio legend
+  | 'PLAY_AUDIO_LEGEND' // Added new command for audio legend
   | 'RESET_AUTOPLAY_SPEED'
   | 'SPEED_DOWN_AUTOPLAY'
   | 'SPEED_UP_AUTOPLAY'

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -25,7 +25,6 @@ export interface GeneralSettings {
   maxFrequency: number;
   autoplayDuration: number;
   audioTransitionTime: number;
-  sineWaveSmoothing: boolean;
   ariaMode: AriaMode;
 }
 

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -25,6 +25,7 @@ export interface GeneralSettings {
   maxFrequency: number;
   autoplayDuration: number;
   audioTransitionTime: number;
+  sineWaveSmoothing: boolean;
   ariaMode: AriaMode;
 }
 

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -24,6 +24,7 @@ export interface GeneralSettings {
   minFrequency: number;
   maxFrequency: number;
   autoplayDuration: number;
+  audioTransitionTime: number;
   ariaMode: AriaMode;
 }
 

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -21,6 +21,7 @@ export interface AudioState {
   size: number;
   value: number | number[];
   index: number;
+  groupIndex?: number; // Added to identify which data group/series a point belongs to
 }
 
 export type BrailleState =

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -281,24 +281,6 @@ const Settings: React.FC = () => {
             />
           </Grid2>
 
-          {/* Sine Wave Extra Smoothing Option */}
-          <Grid2 size={12}>
-            <SettingRow
-              label="Sine Wave Extra Smoothing"
-              input={(
-                <FormControlLabel
-                  control={(
-                    <Switch
-                      checked={generalSettings.sineWaveSmoothing || false}
-                      onChange={e => handleGeneralChange('sineWaveSmoothing', e.target.checked)}
-                    />
-                  )}
-                  label="Apply additional smoothing for sine waves"
-                />
-              )}
-            />
-          </Grid2>
-
           {/* Aria Mode Radio */}
           <Grid2 size={12}>
             <SettingRow

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -97,7 +97,7 @@ const Settings: React.FC = () => {
     setLlmSettings(llm);
   }, [general, llm]);
 
-  const handleGeneralChange = (key: keyof GeneralSettings, value: string | number): void => {
+  const handleGeneralChange = (key: keyof GeneralSettings, value: string | number | boolean): void => {
     setGeneralSettings(prev => ({
       ...prev,
       [key]: value,
@@ -273,9 +273,27 @@ const Settings: React.FC = () => {
                   value={generalSettings.audioTransitionTime || 15}
                   onChange={e => handleGeneralChange('audioTransitionTime', Number(e.target.value))}
                   InputProps={{
-                    inputProps: { min: 5, max: 50 },
+                    inputProps: { min: 5, max: 100 },
                   }}
-                  helperText="Lower values: faster transitions. Higher values: smoother sound with less popping"
+                  helperText="Higher values give smoother sound transitions (5-100ms)"
+                />
+              )}
+            />
+          </Grid2>
+
+          {/* Sine Wave Extra Smoothing Option */}
+          <Grid2 size={12}>
+            <SettingRow
+              label="Sine Wave Extra Smoothing"
+              input={(
+                <FormControlLabel
+                  control={(
+                    <Switch
+                      checked={generalSettings.sineWaveSmoothing || false}
+                      onChange={e => handleGeneralChange('sineWaveSmoothing', e.target.checked)}
+                    />
+                  )}
+                  label="Apply additional smoothing for sine waves"
                 />
               )}
             />

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -261,6 +261,26 @@ const Settings: React.FC = () => {
             />
           </Grid2>
 
+          {/* Audio Transition Time */}
+          <Grid2 size={12}>
+            <SettingRow
+              label="Audio Transition Time (ms)"
+              input={(
+                <TextField
+                  fullWidth
+                  type="number"
+                  size="small"
+                  value={generalSettings.audioTransitionTime || 15}
+                  onChange={e => handleGeneralChange('audioTransitionTime', Number(e.target.value))}
+                  InputProps={{
+                    inputProps: { min: 5, max: 50 },
+                  }}
+                  helperText="Lower values: faster transitions. Higher values: smoother sound with less popping"
+                />
+              )}
+            />
+          </Grid2>
+
           {/* Aria Mode Radio */}
           <Grid2 size={12}>
             <SettingRow


### PR DESCRIPTION
Introduce a new command to play audio legends for data groups in multi-line and stacked bar plots. Refactor the command interface to accommodate this feature and enhance audio differentiation by including group indices in relevant models.

Fixes #149 and #115