### PR TITLE
fix: show the keyboard shortcuts properly on toggle

### DIFF
--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -58,8 +58,6 @@ export class HelpService {
   }
 
   public getMenuItems(): HelpMenuItem[] {
-    console.error(this.context.scope);
-    console.error(this.scopedMenuItems[this.context.scope]);
     return this.scopedMenuItems[this.context.scope] ?? [];
   }
 

--- a/src/state/viewModel/helpViewModel.ts
+++ b/src/state/viewModel/helpViewModel.ts
@@ -38,10 +38,8 @@ export class HelpViewModel extends AbstractViewModel<HelpMenuState> {
   }
 
   public toggle(): void {
-    const currentState = this.state.enabled;
-    const enabled = this.helpService.toggle(currentState);
     const items = this.helpService.getMenuItems();
-
+    const enabled = this.helpService.toggle(this.state.enabled);
     this.store.dispatch(setHelpState({ enabled, items }));
   }
 


### PR DESCRIPTION
Currently, the help menu doesn't show the keyboard shortcuts when toggled. It just shows an empty modal. This PR fixes that issue.