### PR TITLE
chore: remove lint check from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npm run lint


### PR DESCRIPTION
# Pull Request

## Description

This PR removes the lint action in pre-commit hook whilst retaining the conventional commit check

## Related Issues

Closes #180 

## Changes Made

The file pertaining to the lint command has been removed from `.husky` folder

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

A sample of how the pre-commit hook runs locally with the recent changes has been attached below:

```
// Valid and acceptable commit message
➜  maidr-ts git:(chore/remove-lint-precommit) ✗ git commit -m "chore: remove lint check from pre-commit hook"
[chore/remove-lint-precommit 46cc450] chore: remove lint check from pre-commit hook
 1 file changed, 1 deletion(-)
 delete mode 100755 .husky/pre-commit

// When commit message does not follow conventional commit format
➜  maidr-ts git:(chore/remove-lint-precommit) ✗ git commit -m "fix precommit"
.husky/commit-msg: line 1: unexpected EOF while looking for matching `"'
husky - commit-msg script failed (code 2)
➜  maidr-ts git:(chore/remove-lint-precommit) ✗ 
```