### PR TITLE
feat: add email input and verify with the maidr server

### DIFF
--- a/src/state/viewModel/settingsViewModel.ts
+++ b/src/state/viewModel/settingsViewModel.ts
@@ -62,7 +62,7 @@ const settingsSlice = createSlice({
     },
     setVerification: (
       state,
-      action: PayloadAction<{ verifiedEmail: string; clientToken: string }>
+      action: PayloadAction<{ verifiedEmail: string; clientToken: string }>,
     ) => {
       state.verifiedEmail = action.payload.verifiedEmail;
       state.clientToken = action.payload.clientToken;

--- a/src/state/viewModel/settingsViewModel.ts
+++ b/src/state/viewModel/settingsViewModel.ts
@@ -7,6 +7,8 @@ import { AbstractViewModel } from './viewModel';
 
 interface SettingsState extends Settings {
   enabled: boolean;
+  verifiedEmail?: string;
+  clientToken?: string;
 }
 
 const initialState: SettingsState = {
@@ -41,6 +43,8 @@ const initialState: SettingsState = {
       },
     },
   },
+  verifiedEmail: localStorage.getItem('verifiedEmail') || undefined,
+  clientToken: localStorage.getItem('clientToken') || undefined,
 };
 
 const settingsSlice = createSlice({
@@ -56,9 +60,20 @@ const settingsSlice = createSlice({
     reset: (): SettingsState => {
       return initialState;
     },
+    setVerification: (
+      state,
+      action: PayloadAction<{ verifiedEmail: string; clientToken: string }>
+    ) => {
+      state.verifiedEmail = action.payload.verifiedEmail;
+      state.clientToken = action.payload.clientToken;
+    },
+    clearVerification: (state) => {
+      state.verifiedEmail = undefined;
+      state.clientToken = undefined;
+    },
   },
 });
-const { update, toggle, reset } = settingsSlice.actions;
+const { update, toggle, reset, setVerification, clearVerification } = settingsSlice.actions;
 
 export class SettingsViewModel extends AbstractViewModel<SettingsState> {
   private readonly settingsService: SettingsService;
@@ -96,6 +111,14 @@ export class SettingsViewModel extends AbstractViewModel<SettingsState> {
     this.settingsService.resetSettings();
     const settings = this.settingsService.loadSettings();
     this.store.dispatch(update(settings));
+  }
+
+  public setVerification(verifiedEmail: string, clientToken: string): void {
+    this.store.dispatch(setVerification({ verifiedEmail, clientToken }));
+  }
+
+  public clearVerification(): void {
+    this.store.dispatch(clearVerification());
   }
 }
 

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -25,6 +25,8 @@ export interface GeneralSettings {
   maxFrequency: number;
   autoplayDuration: number;
   ariaMode: AriaMode;
+  verifiedEmail?: string;
+  clientToken?: string;
 }
 
 export interface Settings {

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -369,20 +369,29 @@ const Settings: React.FC = () => {
           </Grid2>
 
           {/* LLM Model Toggles */}
-          {(Object.keys(llmSettings.models) as Llm[]).map((modelKey) => {
-            const model = llmSettings.models[modelKey];
-
-            return (
-              <Grid2 size={12} key={modelKey}>
-                <LlmModelSettingRow
-                  modelKey={modelKey}
-                  modelSettings={model}
-                  onToggle={(key, enabled) => handleLlmModelChange(key, 'enabled', enabled)}
-                  onChangeKey={(key, value) => handleLlmModelChange(key, 'apiKey', value)}
-                />
-              </Grid2>
-            );
-          })}
+          {!isVerified
+            ? (
+                (Object.keys(llmSettings.models) as Llm[]).map((modelKey) => {
+                  const model = llmSettings.models[modelKey];
+                  return (
+                    <Grid2 size={12} key={modelKey}>
+                      <LlmModelSettingRow
+                        modelKey={modelKey}
+                        modelSettings={model}
+                        onToggle={(key, enabled) => handleLlmModelChange(key, 'enabled', enabled)}
+                        onChangeKey={(key, value) => handleLlmModelChange(key, 'apiKey', value)}
+                      />
+                    </Grid2>
+                  );
+                })
+              )
+            : (
+                <Grid2 size={12}>
+                  <Typography variant="body2" sx={{ ml: 4, color: 'success.main' }}>
+                    ✓ Using verified server connection for LLM communication
+                  </Typography>
+                </Grid2>
+              )}
 
           {/* Expertise Level */}
           <Grid2 size={12}>


### PR DESCRIPTION
# Pull Request

## Description

Adding email input verification for `maidr-ts`.

## Related Issues

Addresses feature request #173. 

## Changes Made

1. Created an input field with a "verify email "button above the LLM toggle in the settings.
2. The default LLM API input should disappear after the user verifies the email.
3. If the user verification fails, an alert should show an error message.
4. Once the verification succeeds, the client token is saved in the local storage and used for further communication.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

