### PR TITLE
feat: provide audio feedback when moved out of bounds

### DIFF
--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -105,8 +105,8 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
       return;
     }
 
-    // TODO: Play empty sound.
     if (state.empty) {
+      this.playEmpty();
       return;
     }
 
@@ -114,7 +114,7 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     if (Array.isArray(audio.value)) {
       const values = audio.value as number[];
       if (values.length === 0) {
-        this.playZero();
+        this.playEmpty();
         return;
       }
 
@@ -132,12 +132,7 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
 
       playNext();
     } else {
-      const value = audio.value as number;
-      if (value === 0) {
-        this.playZero();
-      } else {
-        this.playTone(audio.min, audio.max, value, audio.size, audio.index);
-      }
+      this.playTone(audio.min, audio.max, audio.value as number, audio.size, audio.index);
     }
   }
 
@@ -230,7 +225,7 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     return audioId;
   }
 
-  private playZero(): AudioId {
+  private playEmpty(): AudioId {
     const frequency = NULL_FREQUENCY;
     const panning = 0;
     const wave = 'triangle';


### PR DESCRIPTION
# Pull Request

## Description

Currently, when an action results in an out-of-bounds state, there is no audio feedback provided to the user. To improve accessibility and user experience, a specific sound should be played when the moved state is invalid or empty.

## Related Issues

Closes [#218](https://github.com/xability/maidr-ts/issues/218)

## Changes Made
- Triggered a special "empty" tone when the current state is detected as empty.
- Retained existing tone for valid states.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.