### PR TITLE
fix: retain the same aria label for llm toggles

### DIFF
--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -62,7 +62,7 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
             checked={modelSettings.enabled}
             onChange={e => onToggle(modelKey, e.target.checked)}
             slotProps={{
-              input: { 'aria-label': `${!modelSettings.enabled ? 'Enable' : 'Disable'} ${modelSettings.name}` },
+              input: { 'aria-label': `Enable ${modelSettings.name}` },
             }}
           />
         </Grid>


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes made in this pull request. -->
Retained the same aria label during LLM toggles, instead of changing the name based on the state.

## Related Issues
<!-- Specify any related issues or tickets that this pull request addresses. -->
Closes #198 

## Changes Made

<!-- Describe the specific changes made in this pull request. -->
Removed the model enabled state to toggle the aria label, and kept a single label for the LLM toggles.

## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
