### PR TITLE
feat: add audio cue while waiting for llm response

### DIFF
--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -13,6 +13,8 @@ type AudioId = ReturnType<typeof setTimeout>;
 const MIN_FREQUENCY = 200;
 const MAX_FREQUENCY = 1000;
 const NULL_FREQUENCY = 100;
+const WAITING_FREQUENCY = 440;
+const COMPLETE_FREQUENCY = 880;
 
 const DEFAULT_DURATION = 0.3;
 const DEFAULT_VOLUME = 0.5;
@@ -161,7 +163,7 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
 
   private playOscillator(
     frequency: number,
-    panning: number,
+    panning: number = 0,
     wave: OscillatorType = 'sine',
   ): AudioId {
     const duration = DEFAULT_DURATION;
@@ -277,15 +279,15 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
   }
 
   private playZeroTone(): AudioId {
-    const frequency = NULL_FREQUENCY;
-    const panning = 0;
-    const wave = 'triangle';
-
-    return this.playOscillator(frequency, panning, wave);
+    return this.playOscillator(NULL_FREQUENCY, 0, 'triangle');
   }
 
   public playWaitingTone(): AudioId {
-    return setTimeout(() => {});
+    return setInterval(() => this.playOscillator(WAITING_FREQUENCY), 1000);
+  }
+
+  public playCompleteTone(): AudioId {
+    return this.playOscillator(COMPLETE_FREQUENCY);
   }
 
   private interpolate(value: number, from: Range, to: Range): number {
@@ -329,6 +331,11 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     const audioIds = Array.isArray(audioId) ? audioId : [audioId];
     audioIds.forEach((audioId) => {
       const activeNode = this.activeAudioIds.get(audioId);
+      if (!activeNode) {
+        clearInterval(audioId);
+        return;
+      }
+
       const activeNodes = Array.isArray(activeNode) ? activeNode : [activeNode];
       activeNodes.forEach((node) => {
         node?.disconnect();

--- a/src/state/viewModel/chatViewModel.ts
+++ b/src/state/viewModel/chatViewModel.ts
@@ -154,6 +154,7 @@ export class ChatViewModel extends AbstractViewModel<ChatState> {
             data: response.data!,
             timestamp,
           }));
+          this.audioService.playCompleteTone();
         }
       } catch (error) {
         this.audioService.stop(audioId);


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a short beep audio cue to notify the user when the LLM response is being processed.

## Related Issues

Closes [#199](https://github.com/xability/maidr/issues/199)

## Changes Made

Updated AudioService to play a waiting tone during LLM response processing and a completion tone once the response is received.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.