### PR TITLE
feat: add instruction message tooltip on plot hover 

### DIFF
--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -34,12 +34,10 @@ export class DisplayService implements Disposable {
     this.onChangeEmitter = new Emitter<FocusChangedEvent>();
     this.onChange = this.onChangeEmitter.event;
 
-    this.removeInstruction();
+    this.addInstruction();
   }
 
   public dispose(): void {
-    this.addInstruction();
-
     this.onChangeEmitter.dispose();
 
     this.reactRoot?.unmount();

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -98,14 +98,14 @@ export class DisplayService implements Disposable {
     if (figureElement) {
       figureElement.removeAttribute(Constant.TITLE);
       // Remove event listeners
-      figureElement.removeEventListener('mouseenter', () => {});
-      figureElement.removeEventListener('mouseleave', () => {});
+      figureElement.removeEventListener('mouseenter', this.handleMouseEnter);
+      figureElement.removeEventListener('mouseleave', this.handleMouseLeave);
     }
     if (articleElement) {
       articleElement.removeAttribute(Constant.TITLE);
       // Remove event listeners
-      articleElement.removeEventListener('mouseenter', () => {});
-      articleElement.removeEventListener('mouseleave', () => {});
+      articleElement.removeEventListener('mouseenter', this.handleMouseEnter);
+      articleElement.removeEventListener('mouseleave', this.handleMouseLeave);
     }
   }
 

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -34,6 +34,16 @@ export class DisplayService implements Disposable {
     this.onChangeEmitter = new Emitter<FocusChangedEvent>();
     this.onChange = this.onChangeEmitter.event;
 
+    // Add click handler to remove tooltip when plot is activated
+    this.plot.addEventListener('click', () => {
+      const figureElement = this.plot.closest(Constant.FIGURE);
+      const articleElement = this.plot.closest(Constant.ARTICLE);
+      if (figureElement)
+        figureElement.removeAttribute(Constant.TITLE);
+      if (articleElement)
+        articleElement.removeAttribute(Constant.TITLE);
+    });
+
     this.addInstruction();
   }
 
@@ -47,16 +57,56 @@ export class DisplayService implements Disposable {
   public addInstruction(): void {
     const maidrInstruction = this.context.getInstruction(true);
     this.plot.setAttribute(Constant.ARIA_LABEL, maidrInstruction);
-    this.plot.setAttribute(Constant.TITLE, maidrInstruction);
     this.plot.setAttribute(Constant.ROLE, Constant.IMAGE);
     this.plot.tabIndex = 0;
+
+    // Set title on both figure and article elements
+    const figureElement = this.plot.closest(Constant.FIGURE);
+    const articleElement = this.plot.closest(Constant.ARTICLE);
+
+    if (figureElement) {
+      figureElement.setAttribute(Constant.TITLE, maidrInstruction);
+      // Add mouse events to handle tooltip visibility
+      figureElement.addEventListener('mouseenter', () => {
+        figureElement.setAttribute(Constant.TITLE, maidrInstruction);
+      });
+      figureElement.addEventListener('mouseleave', () => {
+        figureElement.removeAttribute(Constant.TITLE);
+      });
+    }
+    if (articleElement) {
+      articleElement.setAttribute(Constant.TITLE, maidrInstruction);
+      // Add mouse events to handle tooltip visibility
+      articleElement.addEventListener('mouseenter', () => {
+        articleElement.setAttribute(Constant.TITLE, maidrInstruction);
+      });
+      articleElement.addEventListener('mouseleave', () => {
+        articleElement.removeAttribute(Constant.TITLE);
+      });
+    }
   }
 
   private removeInstruction(): void {
     this.plot.removeAttribute(Constant.ARIA_LABEL);
-    this.plot.removeAttribute(Constant.TITLE);
     this.plot.setAttribute(Constant.ROLE, Constant.APPLICATION);
     this.plot.tabIndex = -1;
+
+    // Remove title and event listeners from both figure and article elements
+    const figureElement = this.plot.closest(Constant.FIGURE);
+    const articleElement = this.plot.closest(Constant.ARTICLE);
+
+    if (figureElement) {
+      figureElement.removeAttribute(Constant.TITLE);
+      // Remove event listeners
+      figureElement.removeEventListener('mouseenter', () => {});
+      figureElement.removeEventListener('mouseleave', () => {});
+    }
+    if (articleElement) {
+      articleElement.removeAttribute(Constant.TITLE);
+      // Remove event listeners
+      articleElement.removeEventListener('mouseenter', () => {});
+      articleElement.removeEventListener('mouseleave', () => {});
+    }
   }
 
   public toggleFocus(focus: Focus): void {
@@ -64,10 +114,12 @@ export class DisplayService implements Disposable {
       this.focusStack.push(focus);
     }
     this.context.toggleScope(focus);
+    this.addInstruction();
     this.updateFocus(this.focusStack.peek()!);
   }
 
   private updateFocus(newScope: Focus): void {
+    this.addInstruction();
     if (newScope === 'TRACE' || newScope === 'SUBPLOT') {
       this.plot.focus();
     }

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -338,3 +338,28 @@ textarea {
   flex-direction: column;
   align-items: flex-end;
 }
+
+/* Tooltip styles */
+[title] {
+  position: relative;
+  cursor: help;
+}
+
+[title]:hover::after {
+  content: attr(title);
+  position: fixed;
+  bottom: auto;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 8px 12px;
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  border-radius: 4px;
+  font-size: 14px;
+  white-space: pre-wrap;
+  z-index: 9999;
+  pointer-events: none;
+  max-width: 300px;
+  text-align: center;
+}

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -340,13 +340,13 @@ textarea {
 }
 
 /* Tooltip styles */
-[title] {
+[data-tooltip] {
   position: relative;
   cursor: help;
 }
 
-[title]:hover::after {
-  content: attr(title);
+[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
   position: fixed;
   bottom: auto;
   top: 50%;


### PR DESCRIPTION
# Pull Request

## Description

- Added tooltip functionality to display plot instructions on hover
- Tooltip shows same content as aria-label for consistency between sighted and screen reader users
- Tooltip disappears when plot is activated (clicked)
- Tooltip updates when plot context changes (figure → subplot → trace)

## Related Issues

Addresses issue #227.
 
## Changes Made

- Set the title attribute on figure/article elements to show tooltip
- Added CSS styling for tooltip appearance (dark background, white text)
- Added mouse event handlers for tooltip visibility
- Removed tooltip on plot activation

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.