### PR TITLE
fix: announce new chat responses

### DIFF
--- a/src/ui/pages/Chat.tsx
+++ b/src/ui/pages/Chat.tsx
@@ -31,6 +31,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
         justifyContent: message.isUser ? 'flex-end' : 'flex-start',
         mb: 2,
       }}
+      {...(!message.isUser ? { 'aria-live': 'assertive' } : {})}
     >
       <Box
         sx={{

--- a/src/ui/pages/Chat.tsx
+++ b/src/ui/pages/Chat.tsx
@@ -23,7 +23,6 @@ interface MessageBubbleProps {
 
 const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
   const theme = useTheme();
-
   return (
     <Box
       sx={{
@@ -31,6 +30,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
         justifyContent: message.isUser ? 'flex-end' : 'flex-start',
         mb: 2,
       }}
+      /* Use 'aria-live' so screen readers announce AI updates */
       {...(!message.isUser ? { 'aria-live': 'assertive' } : {})}
     >
       <Box


### PR DESCRIPTION
# Pull Request

## Description

New chat responses are automatically announced by screen readers by adding aria-live attribute.

## Related Issues

Closes [#245](https://github.com/xability/maidr/issues/245)

## Changes Made

Added aria-live="assertive" to all messages in the chat interface to enable screen readers to announce them automatically.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.