### PR TITLE
feat: improvise prompts and refactor chat service

### DIFF
--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -1,9 +1,11 @@
 import type { DisplayService } from '@service/display';
 import type { Maidr } from '@type/grammar';
 import type { Llm, LlmRequest, LlmResponse } from '@type/llm';
+import type { PromptContext } from './prompts';
 import { Scope } from '@type/event';
 import { Api } from '@util/api';
 import { Svg } from '@util/svg';
+import { formatSystemPrompt, formatUserPrompt } from './prompts';
 
 export class ChatService {
   private readonly display: DisplayService;
@@ -152,26 +154,27 @@ class Gpt extends AbstractLlmModel<GptResponse> {
     currentPositionText: string,
     message: string,
   ): string {
+    const context: PromptContext = {
+      customInstruction,
+      maidrJson,
+      currentPositionText,
+      message,
+    };
+
     return JSON.stringify({
       model: 'gpt-4o-2024-11-20',
       max_tokens: 1000,
       messages: [
         {
           role: 'system',
-          content:
-            'You are a helpful assistant describing the chart to a blind person.',
+          content: formatSystemPrompt(customInstruction),
         },
         {
           role: 'user',
           content: [
             {
               type: 'text',
-              text:
-                `Describe this chart to a blind person who has a basic understanding of statistical charts.
-                \n${customInstruction}\n
-                Here is a chart in image format and raw data in json format: \n${maidrJson}\n
-                Also currently this point is selected: ${currentPositionText}\n.
-                My question is: ${message}`,
+              text: formatUserPrompt(context),
             },
             {
               type: 'image_url',
@@ -220,6 +223,13 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
     currentPositionText: string,
     message: string,
   ): string {
+    const context: PromptContext = {
+      customInstruction,
+      maidrJson,
+      currentPositionText,
+      message,
+    };
+
     return JSON.stringify({
       anthropic_version: 'vertex-2023-10-16',
       max_tokens: 256,
@@ -237,12 +247,7 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
             },
             {
               type: 'text',
-              text:
-                `You are a helpful assistant describing the chart to a blind person.\n${customInstruction}\n.
-                Here is the raw data in json format: ${maidrJson}\n\n\n
-                Here is the current position in the chart; no response necessarily needed,
-                use this info only if its relevant to future questions: ${currentPositionText}.
-                My question is: ${message}`,
+              text: `${formatSystemPrompt(customInstruction)}\n\n${formatUserPrompt(context)}`,
             },
           ],
         },
@@ -285,6 +290,13 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
     currentPositionText: string,
     message: string,
   ): string {
+    const context: PromptContext = {
+      customInstruction,
+      maidrJson,
+      currentPositionText,
+      message,
+    };
+
     return JSON.stringify({
       generationConfig: {},
       safetySettings: [],
@@ -293,7 +305,7 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
           role: 'user',
           parts: [
             {
-              text: 'You are a helpful assistant describing the chart to a blind person.',
+              text: formatSystemPrompt(customInstruction),
             },
           ],
         },
@@ -301,27 +313,13 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
           role: 'user',
           parts: [
             {
-              text:
-                `You are a helpful assistant describing the chart to a blind person.\n${customInstruction}\n\n
-                Describe this chart to a blind person who has a basic understanding of statistical charts.
-                Here is a chart in image format and raw data in json format: ${maidrJson}`,
+              text: formatUserPrompt(context),
             },
             {
               inlineData: {
                 data: image.split(',')[1],
                 mimeType: 'image/svg+xml',
               },
-            },
-          ],
-        },
-        {
-          role: 'user',
-          parts: [
-            {
-              text:
-                `Here is the current position in the chart; no response necessarily needed,
-                use this info only if it's relevant to future questions: ${currentPositionText}\n.
-                My question is: ${message}`,
             },
           ],
         },

--- a/src/service/prompts.ts
+++ b/src/service/prompts.ts
@@ -1,0 +1,38 @@
+/**
+ * Prompt templates and constants for LLM interactions
+ */
+
+export const SYSTEM_PROMPT = `You are an expert accessibility assistant specializing in describing statistical visualizations to blind users. Your role is to:
+1. Provide clear, concise, and accurate descriptions of charts and graphs
+2. Focus on the most important patterns and insights
+3. Use accessible language that assumes basic statistical knowledge
+4. Structure your responses in a logical, easy-to-follow manner
+5. Highlight key trends, outliers, and relationships in the data
+6. Provide context and interpretation when relevant`;
+
+export const USER_PROMPT_TEMPLATE = `I need your help understanding this statistical visualization. Here's what I have:
+
+1. Raw data in JSON format: \n{maidrJson}\n
+2. Current selected point: {currentPositionText}
+
+Please help me understand: {message}
+
+Focus on providing a clear, structured response that helps me understand the key insights from this visualization.`;
+
+export interface PromptContext {
+  customInstruction: string;
+  maidrJson: string;
+  currentPositionText: string;
+  message: string;
+}
+
+export function formatSystemPrompt(customInstruction: string): string {
+  return `${SYSTEM_PROMPT}\n\n${customInstruction}`;
+}
+
+export function formatUserPrompt(context: PromptContext): string {
+  return USER_PROMPT_TEMPLATE
+    .replace('{maidrJson}', context.maidrJson)
+    .replace('{currentPositionText}', context.currentPositionText)
+    .replace('{message}', context.message);
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR aims to improvise on the current prompts used for various LLM agents integration and refactor the chat service.

## Related Issues

Closes #254 
## Changes Made

Following changes have been made on the chat service:
1. The basic prompts have now been changed to include more detail on what the concerned LLM agent is supposed to assume of itself and the expectations of the interaction.
2. A new file called `prompt.ts` has been created to reduce code duplication across the various LLM agent service classes.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

I have verified the changes with GPT using the API key.
