### PR TITLE
build: modify filename of vite bundle post build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'maidr',
       formats: ['es', 'umd'],
-      fileName: format => `maidr.${format}.js`,
+      fileName: () => `maidr.js`,
     },
     sourcemap: true,
     outDir: 'dist',


### PR DESCRIPTION
# Pull Request

## Description

This PR aims to set the right name for the vite bundle file.

## Related Issues

closes #261 

## Changes Made

The vite config file now saves the files as `maidr.js` instead of using the format name in the vite bundle filename.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
