### PR TITLE
fix: assign application role to svg upon activation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maidr",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maidr",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -37,7 +37,6 @@ export class DisplayService implements Disposable {
     this.onChangeEmitter = new Emitter<FocusChangedEvent>();
     this.onChange = this.onChangeEmitter.event;
 
-    // Add click handler to remove tooltip when plot is activated
     this.plot.addEventListener('click', () => {
       const figureElement = this.plot.closest(Constant.FIGURE);
       const articleElement = this.plot.closest(Constant.ARTICLE);
@@ -47,10 +46,12 @@ export class DisplayService implements Disposable {
         articleElement.removeAttribute(Constant.TITLE);
     });
 
-    this.addInstruction();
+    this.removeInstruction();
   }
 
   public dispose(): void {
+    this.addInstruction();
+
     this.onChangeEmitter.dispose();
 
     this.reactRoot?.unmount();
@@ -64,19 +65,16 @@ export class DisplayService implements Disposable {
     this.plot.setAttribute(Constant.ROLE, Constant.IMAGE);
     this.plot.tabIndex = 0;
 
-    // Set title on both figure and article elements
     const figureElement = this.plot.closest(Constant.FIGURE);
     const articleElement = this.plot.closest(Constant.ARTICLE);
 
     if (figureElement) {
       figureElement.setAttribute(Constant.TITLE, maidrInstruction);
-      // Add mouse events to handle tooltip visibility
       figureElement.addEventListener('mouseenter', this.handleMouseEnter);
       figureElement.addEventListener('mouseleave', this.handleMouseLeave);
     }
     if (articleElement) {
       articleElement.setAttribute(Constant.TITLE, maidrInstruction);
-      // Add mouse events to handle tooltip visibility
       articleElement.addEventListener('mouseenter', this.handleMouseEnter);
       articleElement.addEventListener('mouseleave', this.handleMouseLeave);
     }
@@ -97,19 +95,16 @@ export class DisplayService implements Disposable {
     this.plot.setAttribute(Constant.ROLE, Constant.APPLICATION);
     this.plot.tabIndex = -1;
 
-    // Remove title and event listeners from both figure and article elements
     const figureElement = this.plot.closest(Constant.FIGURE);
     const articleElement = this.plot.closest(Constant.ARTICLE);
 
     if (figureElement) {
       figureElement.removeAttribute(Constant.TITLE);
-      // Remove event listeners
       figureElement.removeEventListener('mouseenter', this.handleMouseEnter);
       figureElement.removeEventListener('mouseleave', this.handleMouseLeave);
     }
     if (articleElement) {
       articleElement.removeAttribute(Constant.TITLE);
-      // Remove event listeners
       articleElement.removeEventListener('mouseenter', this.handleMouseEnter);
       articleElement.removeEventListener('mouseleave', this.handleMouseLeave);
     }
@@ -120,12 +115,10 @@ export class DisplayService implements Disposable {
       this.focusStack.push(focus);
     }
     this.context.toggleScope(focus);
-    this.addInstruction();
     this.updateFocus(this.focusStack.peek()!);
   }
 
   private updateFocus(newScope: Focus): void {
-    this.addInstruction();
     if (newScope === 'TRACE' || newScope === 'SUBPLOT') {
       this.plot.focus();
     }


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses a bug related to assigning the `application` role to plot SVG.

## Related Issues

Closes #276 

## Changes Made

Following changes have been made:
1. The `addInstruction()` call was made by multiple methods thus leading to any attempt to set the role as `application` futile.
2. Now the constructor calls `removeInstruction()` first and `addInstruction()` is invoked in `dispose()` - this clarifies any ambiguous, redundant calls to `addInstructions()`.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

The migration to `react-tooltip` can be covered in another PR.