### PR TITLE
feat: support distinct audio for group plots

### DIFF
--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -55,7 +55,7 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace<
       min: Math.min(...this.min),
       max: Math.max(...this.max),
       size,
-      index,
+      col: index,
       value,
     };
   }

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -90,7 +90,7 @@ export class BoxTrace extends AbstractTrace<number[] | number> {
       min: this.min,
       max: this.max,
       size,
-      index,
+      col: index,
       value,
     };
   }

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -61,7 +61,7 @@ export class Candlestick extends AbstractTrace<number> {
       min: this.min,
       max: this.max,
       size: this.candles.length,
-      index,
+      col: index,
       value,
     };
   }

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -45,7 +45,7 @@ export class Heatmap extends AbstractTrace<number> {
       min: this.min,
       max: this.max,
       size: this.heatmapValues.length,
-      index: this.col,
+      col: this.col,
       value: this.heatmapValues[this.row][this.col],
     };
   }

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -45,7 +45,8 @@ export class LineTrace extends AbstractTrace<number> {
       min: this.min[this.row],
       max: this.max[this.row],
       size: this.points[this.row].length,
-      index: this.col,
+      col: this.col,
+      row: this.row,
       value: this.points[this.row][this.col].y,
     };
   }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -109,7 +109,7 @@ export class ScatterTrace extends AbstractTrace<number> {
         min: this.minY,
         max: this.maxY,
         size: current.y.length,
-        index: this.col,
+        col: this.col,
         value: current.y,
       };
     } else {
@@ -118,7 +118,7 @@ export class ScatterTrace extends AbstractTrace<number> {
         min: this.minX,
         max: this.maxX,
         size: current.x.length,
-        index: this.row,
+        col: this.row,
         value: current.x,
       };
     }

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -1,5 +1,5 @@
 import type { MaidrLayer, SegmentedPoint } from '@type/grammar';
-import type { HighlightState, TextState } from '@type/state';
+import type { AudioState, HighlightState, TextState } from '@type/state';
 import { Orientation } from '@type/grammar';
 import { Svg } from '@util/svg';
 import { AbstractBarPlot } from './bar';
@@ -51,6 +51,13 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
         label: LEVEL,
         value: this.points[this.row][this.col].fill ?? UNDEFINED,
       },
+    };
+  }
+
+  protected audio(): AudioState {
+    return {
+      ...super.audio(),
+      row: this.row,
     };
   }
 

--- a/src/model/smooth.ts
+++ b/src/model/smooth.ts
@@ -22,7 +22,7 @@ export class SmoothTrace extends LineTrace {
       min: this.min[this.row],
       max: this.max[this.row],
       size: rowYValues.length,
-      index: col,
+      col,
       value: [prev, curr, next],
       isContinuous: true,
     };

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -62,13 +62,15 @@ export interface AudioState {
   max: number;
   size: number;
   value: number | number[];
-  index: number;
+  col: number;
+  row?: number;
   /**
    * Indicates whether the audio is continuous.
    * If true, the audio plays without interruption.
    * If false or undefined, the audio may have discrete segments.
    */
   isContinuous?: boolean;
+
 }
 
 export type BrailleState =


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new audio command to play legends for data groups in multi-line charts and stacked bar plots.

## Related Issues

Closes [#149](https://github.com/xability/maidr/issues/149)

## Changes Made

- Used OscillatorType waveforms to generate distinct frequencies for each group.
- Modified plot transformers to support group-level audio metadata.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.