### PR TITLE
fix: integrate prompt level into chat flow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -88,27 +89,20 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     title: `[CodeQL] ${alert.rule.id}: ${alert.rule.description.substring(0, 100)}`,
-                    body: |
-                      ### CodeQL Security Finding
-
-                      **Severity:** ${alert.rule.severity}
-                      **Rule:** ${alert.rule.id}
-                      **State:** ${alert.state}
-
-                      **Location:**
-                      ${alert.most_recent_instance.location.path}:${alert.most_recent_instance.location.start_line}
-
-                      **Description:**
-                      ${alert.rule.description}
-
-                      **Recommendation:**
-                      ${alert.rule.tags.includes('security') ? 'Security vulnerability - please address immediately.' : 'Please review this finding.'}
-
-                      **View in Code Scanning:**
-                      ${alert.html_url}
-
-                      ---
-                      *Automatically created by CodeQL analysis (Workflow Run: ${context.runId})*
+                    body: '### CodeQL Security Finding\n\n' +
+                      '**Severity:** ' + alert.rule.severity + '\n' +
+                      '**Rule:** ' + alert.rule.id + '\n' +
+                      '**State:** ' + alert.state + '\n\n' +
+                      '**Location:**\n' +
+                      alert.most_recent_instance.location.path + ':' + alert.most_recent_instance.location.start_line + '\n\n' +
+                      '**Description:**\n' +
+                      alert.rule.description + '\n\n' +
+                      '**Recommendation:**\n' +
+                      (alert.rule.tags.includes('security') ? 'Security vulnerability - please address immediately.' : 'Please review this finding.') + '\n\n' +
+                      '**View in Code Scanning:**\n' +
+                      alert.html_url + '\n\n' +
+                      '---\n' +
+                      '*Automatically created by CodeQL analysis (Workflow Run: ' + context.runId + ')*',
                     labels: [
                       'security',
                       'codeql',

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-      issues: write
 
     steps:
       - name: Checkout repository
@@ -89,20 +88,27 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     title: `[CodeQL] ${alert.rule.id}: ${alert.rule.description.substring(0, 100)}`,
-                    body: '### CodeQL Security Finding\n\n' +
-                      '**Severity:** ' + alert.rule.severity + '\n' +
-                      '**Rule:** ' + alert.rule.id + '\n' +
-                      '**State:** ' + alert.state + '\n\n' +
-                      '**Location:**\n' +
-                      alert.most_recent_instance.location.path + ':' + alert.most_recent_instance.location.start_line + '\n\n' +
-                      '**Description:**\n' +
-                      alert.rule.description + '\n\n' +
-                      '**Recommendation:**\n' +
-                      (alert.rule.tags.includes('security') ? 'Security vulnerability - please address immediately.' : 'Please review this finding.') + '\n\n' +
-                      '**View in Code Scanning:**\n' +
-                      alert.html_url + '\n\n' +
-                      '---\n' +
-                      '*Automatically created by CodeQL analysis (Workflow Run: ' + context.runId + ')*',
+                    body: |
+                      ### CodeQL Security Finding
+
+                      **Severity:** ${alert.rule.severity}
+                      **Rule:** ${alert.rule.id}
+                      **State:** ${alert.state}
+
+                      **Location:**
+                      ${alert.most_recent_instance.location.path}:${alert.most_recent_instance.location.start_line}
+
+                      **Description:**
+                      ${alert.rule.description}
+
+                      **Recommendation:**
+                      ${alert.rule.tags.includes('security') ? 'Security vulnerability - please address immediately.' : 'Please review this finding.'}
+
+                      **View in Code Scanning:**
+                      ${alert.html_url}
+
+                      ---
+                      *Automatically created by CodeQL analysis (Workflow Run: ${context.runId})*
                     labels: [
                       'security',
                       'codeql',

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -73,6 +73,22 @@ abstract class AbstractLlmModel<T> implements LlmModel {
     this.codeQueryParam = 'I8Aa2PlPspjQ8Hks0QzGyszP8_i2-XJ3bq7Xh8-ykEe4AzFuYn_QWA%3D%3D';
   }
 
+  protected validateExpertise(expertise: string): 'basic' | 'intermediate' | 'advanced' {
+    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
+    type ExpertiseLevel = typeof validExpertiseLevels[number];
+
+    const isValidExpertise = (value: string): value is ExpertiseLevel => {
+      return validExpertiseLevels.includes(value as any);
+    };
+
+    if (!isValidExpertise(expertise)) {
+      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
+      return 'basic';
+    }
+
+    return expertise;
+  }
+
   public async getLlmResponse(request: LlmRequest): Promise<LlmResponse> {
     try {
       const image = await Svg.toBase64(this.svg);
@@ -140,7 +156,7 @@ abstract class AbstractLlmModel<T> implements LlmModel {
     image: string,
     currentText: string,
     message: string,
-    expertise: string,
+    expertise: 'basic' | 'intermediate' | 'advanced',
   ): string;
 
   protected abstract formatResponse(response: T): LlmResponse;
@@ -168,26 +184,14 @@ class Gpt extends AbstractLlmModel<GptResponse> {
     image: string,
     currentPositionText: string,
     message: string,
-    expertise: string,
+    expertise: 'basic' | 'intermediate' | 'advanced',
   ): string {
-    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
-    type ExpertiseLevel = typeof validExpertiseLevels[number];
-
-    const isValidExpertise = (value: string): value is ExpertiseLevel => {
-      return validExpertiseLevels.includes(value as any);
-    };
-
-    const validatedExpertise: ExpertiseLevel = isValidExpertise(expertise) ? expertise : 'basic';
-    if (!isValidExpertise(expertise)) {
-      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
-    }
-
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: validatedExpertise,
+      expertiseLevel: this.validateExpertise(expertise),
     };
 
     return JSON.stringify({
@@ -259,26 +263,14 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
     image: string,
     currentPositionText: string,
     message: string,
-    expertise: string,
+    expertise: 'basic' | 'intermediate' | 'advanced',
   ): string {
-    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
-    type ExpertiseLevel = typeof validExpertiseLevels[number];
-
-    const isValidExpertise = (value: string): value is ExpertiseLevel => {
-      return validExpertiseLevels.includes(value as any);
-    };
-
-    const validatedExpertise: ExpertiseLevel = isValidExpertise(expertise) ? expertise : 'basic';
-    if (!isValidExpertise(expertise)) {
-      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
-    }
-
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: validatedExpertise,
+      expertiseLevel: this.validateExpertise(expertise),
     };
 
     return JSON.stringify({
@@ -352,26 +344,14 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
     image: string,
     currentPositionText: string,
     message: string,
-    expertise: string,
+    expertise: 'basic' | 'intermediate' | 'advanced',
   ): string {
-    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
-    type ExpertiseLevel = typeof validExpertiseLevels[number];
-
-    const isValidExpertise = (value: string): value is ExpertiseLevel => {
-      return validExpertiseLevels.includes(value as any);
-    };
-
-    const validatedExpertise: ExpertiseLevel = isValidExpertise(expertise) ? expertise : 'basic';
-    if (!isValidExpertise(expertise)) {
-      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
-    }
-
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: validatedExpertise,
+      expertiseLevel: this.validateExpertise(expertise),
     };
 
     return JSON.stringify({

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -82,6 +82,7 @@ abstract class AbstractLlmModel<T> implements LlmModel {
         image,
         '',
         request.message,
+        request.expertise,
       );
 
       const url = request.clientToken
@@ -139,6 +140,7 @@ abstract class AbstractLlmModel<T> implements LlmModel {
     image: string,
     currentText: string,
     message: string,
+    expertise: string,
   ): string;
 
   protected abstract formatResponse(response: T): LlmResponse;
@@ -166,12 +168,14 @@ class Gpt extends AbstractLlmModel<GptResponse> {
     image: string,
     currentPositionText: string,
     message: string,
+    expertise: string,
   ): string {
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
+      expertiseLevel: expertise as 'basic' | 'intermediate' | 'advanced',
     };
 
     return JSON.stringify({
@@ -180,7 +184,7 @@ class Gpt extends AbstractLlmModel<GptResponse> {
       messages: [
         {
           role: 'system',
-          content: formatSystemPrompt(customInstruction),
+          content: formatSystemPrompt(customInstruction, context.expertiseLevel),
         },
         {
           role: 'user',
@@ -243,12 +247,14 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
     image: string,
     currentPositionText: string,
     message: string,
+    expertise: string,
   ): string {
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
+      expertiseLevel: expertise as 'basic' | 'intermediate' | 'advanced',
     };
 
     return JSON.stringify({
@@ -268,7 +274,7 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
             },
             {
               type: 'text',
-              text: `${formatSystemPrompt(customInstruction)}\n\n${formatUserPrompt(context)}`,
+              text: `${formatSystemPrompt(customInstruction, context.expertiseLevel)}\n\n${formatUserPrompt(context)}`,
             },
           ],
         },
@@ -322,12 +328,14 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
     image: string,
     currentPositionText: string,
     message: string,
+    expertise: string,
   ): string {
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
+      expertiseLevel: expertise as 'basic' | 'intermediate' | 'advanced',
     };
 
     return JSON.stringify({
@@ -338,7 +346,7 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
           role: 'user',
           parts: [
             {
-              text: formatSystemPrompt(customInstruction),
+              text: formatSystemPrompt(customInstruction, context.expertiseLevel),
             },
           ],
         },

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -78,7 +78,7 @@ abstract class AbstractLlmModel<T> implements LlmModel {
     type ExpertiseLevel = typeof validExpertiseLevels[number];
 
     const isValidExpertise = (value: string): value is ExpertiseLevel => {
-      return validExpertiseLevels.includes(value as any);
+      return validExpertiseLevels.includes(value as ExpertiseLevel);
     };
 
     if (!isValidExpertise(expertise)) {

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -170,12 +170,24 @@ class Gpt extends AbstractLlmModel<GptResponse> {
     message: string,
     expertise: string,
   ): string {
+    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
+    type ExpertiseLevel = typeof validExpertiseLevels[number];
+
+    const isValidExpertise = (value: string): value is ExpertiseLevel => {
+      return validExpertiseLevels.includes(value as any);
+    };
+
+    const validatedExpertise: ExpertiseLevel = isValidExpertise(expertise) ? expertise : 'basic';
+    if (!isValidExpertise(expertise)) {
+      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
+    }
+
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: expertise as 'basic' | 'intermediate' | 'advanced',
+      expertiseLevel: validatedExpertise,
     };
 
     return JSON.stringify({
@@ -249,12 +261,24 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
     message: string,
     expertise: string,
   ): string {
+    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
+    type ExpertiseLevel = typeof validExpertiseLevels[number];
+
+    const isValidExpertise = (value: string): value is ExpertiseLevel => {
+      return validExpertiseLevels.includes(value as any);
+    };
+
+    const validatedExpertise: ExpertiseLevel = isValidExpertise(expertise) ? expertise : 'basic';
+    if (!isValidExpertise(expertise)) {
+      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
+    }
+
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: expertise as 'basic' | 'intermediate' | 'advanced',
+      expertiseLevel: validatedExpertise,
     };
 
     return JSON.stringify({
@@ -330,12 +354,24 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
     message: string,
     expertise: string,
   ): string {
+    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
+    type ExpertiseLevel = typeof validExpertiseLevels[number];
+
+    const isValidExpertise = (value: string): value is ExpertiseLevel => {
+      return validExpertiseLevels.includes(value as any);
+    };
+
+    const validatedExpertise: ExpertiseLevel = isValidExpertise(expertise) ? expertise : 'basic';
+    if (!isValidExpertise(expertise)) {
+      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
+    }
+
     const context: PromptContext = {
       customInstruction,
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: expertise as 'basic' | 'intermediate' | 'advanced',
+      expertiseLevel: validatedExpertise,
     };
 
     return JSON.stringify({

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -73,21 +73,6 @@ abstract class AbstractLlmModel<T> implements LlmModel {
     this.codeQueryParam = 'I8Aa2PlPspjQ8Hks0QzGyszP8_i2-XJ3bq7Xh8-ykEe4AzFuYn_QWA%3D%3D';
   }
 
-  protected validateExpertise(expertise: string): 'basic' | 'intermediate' | 'advanced' {
-    const validExpertiseLevels = ['basic', 'intermediate', 'advanced'] as const;
-    type ExpertiseLevel = typeof validExpertiseLevels[number];
-
-    const isValidExpertise = (value: string): value is ExpertiseLevel => {
-      return validExpertiseLevels.includes(value as ExpertiseLevel);
-    };
-
-    if (!isValidExpertise(expertise)) {
-      return 'basic';
-    }
-
-    return expertise;
-  }
-
   public async getLlmResponse(request: LlmRequest): Promise<LlmResponse> {
     try {
       const image = await Svg.toBase64(this.svg);
@@ -190,7 +175,7 @@ class Gpt extends AbstractLlmModel<GptResponse> {
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: this.validateExpertise(expertise),
+      expertiseLevel: expertise,
     };
 
     return JSON.stringify({
@@ -269,7 +254,7 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: this.validateExpertise(expertise),
+      expertiseLevel: expertise,
     };
 
     return JSON.stringify({
@@ -350,7 +335,7 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
       maidrJson,
       currentPositionText,
       message,
-      expertiseLevel: this.validateExpertise(expertise),
+      expertiseLevel: expertise,
     };
 
     return JSON.stringify({

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -82,7 +82,6 @@ abstract class AbstractLlmModel<T> implements LlmModel {
     };
 
     if (!isValidExpertise(expertise)) {
-      console.warn(`Invalid expertise level: ${expertise}, defaulting to basic`);
       return 'basic';
     }
 

--- a/src/service/prompts.ts
+++ b/src/service/prompts.ts
@@ -50,7 +50,7 @@ const SYSTEM_PROMPTS: Record<PromptContext['expertiseLevel'], string> = {
 };
 
 function getSystemPromptForExpertiseLevel(expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {
-  return SYSTEM_PROMPTS[expertiseLevel] || BASIC_SYSTEM_PROMPT;
+  return SYSTEM_PROMPTS[expertiseLevel];
 }
 
 export function formatSystemPrompt(customInstruction: string, expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {

--- a/src/service/prompts.ts
+++ b/src/service/prompts.ts
@@ -2,13 +2,29 @@
  * Prompt templates and constants for LLM interactions
  */
 
-export const SYSTEM_PROMPT = `You are an expert accessibility assistant specializing in describing statistical visualizations to blind users. Your role is to:
+const BASIC_SYSTEM_PROMPT = `You are an accessibility assistant specializing in describing statistical visualizations to blind users. Your role is to:
+1. Provide simple, straightforward descriptions of charts and graphs
+2. Focus on basic patterns and key points
+3. Use simple, everyday language with minimal statistical terms
+4. Structure your responses in a clear, step-by-step manner
+5. Point out obvious trends and notable values
+6. Provide basic context and simple interpretations`;
+
+const INTERMEDIATE_SYSTEM_PROMPT = `You are an expert accessibility assistant specializing in describing statistical visualizations to blind users. Your role is to:
 1. Provide clear, concise, and accurate descriptions of charts and graphs
 2. Focus on the most important patterns and insights
 3. Use accessible language that assumes basic statistical knowledge
 4. Structure your responses in a logical, easy-to-follow manner
 5. Highlight key trends, outliers, and relationships in the data
 6. Provide context and interpretation when relevant`;
+
+const ADVANCED_SYSTEM_PROMPT = `You are a highly specialized accessibility assistant for statistical visualizations, designed for blind users with strong statistical background. Your role is to:
+1. Provide detailed, technical descriptions of charts and graphs
+2. Focus on complex patterns, statistical significance, and nuanced insights
+3. Use precise statistical terminology and advanced concepts
+4. Structure your responses with technical depth while maintaining clarity
+5. Analyze trends, outliers, relationships, and statistical properties
+6. Provide comprehensive context and sophisticated interpretations`;
 
 export const USER_PROMPT_TEMPLATE = `I need your help understanding this statistical visualization. Here's what I have:
 
@@ -24,10 +40,23 @@ export interface PromptContext {
   maidrJson: string;
   currentPositionText: string;
   message: string;
+  expertiseLevel: 'basic' | 'intermediate' | 'advanced';
 }
 
-export function formatSystemPrompt(customInstruction: string): string {
-  return `${SYSTEM_PROMPT}\n\n${customInstruction}`;
+function getSystemPromptForExpertiseLevel(expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {
+  switch (expertiseLevel) {
+    case 'basic':
+      return BASIC_SYSTEM_PROMPT;
+    case 'intermediate':
+      return INTERMEDIATE_SYSTEM_PROMPT;
+    case 'advanced':
+      return ADVANCED_SYSTEM_PROMPT;
+  }
+}
+
+export function formatSystemPrompt(customInstruction: string, expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {
+  const basePrompt = getSystemPromptForExpertiseLevel(expertiseLevel);
+  return `${basePrompt}\n\n${customInstruction}`;
 }
 
 export function formatUserPrompt(context: PromptContext): string {

--- a/src/service/prompts.ts
+++ b/src/service/prompts.ts
@@ -49,12 +49,12 @@ const SYSTEM_PROMPTS: Record<PromptContext['expertiseLevel'], string> = {
   advanced: ADVANCED_SYSTEM_PROMPT,
 };
 
-function getSystemPromptForExpertiseLevel(expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {
+function selectPromptByLevel(expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {
   return SYSTEM_PROMPTS[expertiseLevel];
 }
 
 export function formatSystemPrompt(customInstruction: string, expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {
-  const basePrompt = getSystemPromptForExpertiseLevel(expertiseLevel);
+  const basePrompt = selectPromptByLevel(expertiseLevel);
   return `${basePrompt}\n\n${customInstruction}`;
 }
 

--- a/src/service/prompts.ts
+++ b/src/service/prompts.ts
@@ -43,17 +43,14 @@ export interface PromptContext {
   expertiseLevel: 'basic' | 'intermediate' | 'advanced';
 }
 
+const SYSTEM_PROMPTS: Record<PromptContext['expertiseLevel'], string> = {
+  basic: BASIC_SYSTEM_PROMPT,
+  intermediate: INTERMEDIATE_SYSTEM_PROMPT,
+  advanced: ADVANCED_SYSTEM_PROMPT,
+};
+
 function getSystemPromptForExpertiseLevel(expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {
-  switch (expertiseLevel) {
-    case 'basic':
-      return BASIC_SYSTEM_PROMPT;
-    case 'intermediate':
-      return INTERMEDIATE_SYSTEM_PROMPT;
-    case 'advanced':
-      return ADVANCED_SYSTEM_PROMPT;
-    default:
-      return BASIC_SYSTEM_PROMPT;
-  }
+  return SYSTEM_PROMPTS[expertiseLevel] || BASIC_SYSTEM_PROMPT;
 }
 
 export function formatSystemPrompt(customInstruction: string, expertiseLevel: 'basic' | 'intermediate' | 'advanced'): string {

--- a/src/service/prompts.ts
+++ b/src/service/prompts.ts
@@ -51,6 +51,8 @@ function getSystemPromptForExpertiseLevel(expertiseLevel: 'basic' | 'intermediat
       return INTERMEDIATE_SYSTEM_PROMPT;
     case 'advanced':
       return ADVANCED_SYSTEM_PROMPT;
+    default:
+      return BASIC_SYSTEM_PROMPT;
   }
 }
 

--- a/src/type/llm.ts
+++ b/src/type/llm.ts
@@ -14,7 +14,7 @@ export type LlmVersion = GptVersion | ClaudeVersion | GeminiVersion;
 export interface LlmRequest {
   message: string;
   customInstruction: string;
-  expertise: string;
+  expertise: 'basic' | 'intermediate' | 'advanced';
   apiKey?: string;
   email?: string;
   clientToken?: string;

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -1,3 +1,6 @@
+import type {
+  SelectChangeEvent,
+} from '@mui/material';
 import type { Llm, LlmVersion } from '@type/llm';
 import type { AriaMode, GeneralSettings, LlmModelSettings, LlmSettings } from '@type/settings';
 import { Check as CheckIcon } from '@mui/icons-material';
@@ -21,7 +24,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useViewModel } from '@state/hook/useViewModel';
-import React, { useEffect, useId, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 
 type GptVersion = 'gpt-4o' | 'gpt-4o-mini' | 'gpt-4.1' | 'o1-mini' | 'o3' | 'o4-mini';
 type ClaudeVersion = 'claude-3-5-haiku-latest' | 'claude-3-5-sonnet-latest' | 'claude-3-7-sonnet-latest';
@@ -250,6 +253,15 @@ const Settings: React.FC = () => {
     viewModel.saveAndClose({ general: generalSettings, llm: llmSettings });
   };
 
+  const handleSelectClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  const handleSelectChange = useCallback((e: SelectChangeEvent<'basic' | 'intermediate' | 'advanced'>) => {
+    e.stopPropagation();
+    handleLlmChange('expertiseLevel', e.target.value);
+  }, [handleLlmChange]);
+
   return (
     <Dialog
       id={id}
@@ -432,12 +444,8 @@ const Settings: React.FC = () => {
                 <FormControl fullWidth size="small">
                   <Select
                     value={llmSettings.expertiseLevel}
-                    onChange={(e) => {
-                      // Prevent event bubbling to parent Dialog to avoid unintended dialog closure
-                      e.stopPropagation();
-                      handleLlmChange('expertiseLevel', e.target.value);
-                    }}
-                    onClick={e => e.stopPropagation()} // Prevent click events from bubbling to parent Dialog
+                    onChange={handleSelectChange}
+                    onClick={handleSelectClick}
                     MenuProps={{
                       disablePortal: true,
                       PaperProps: {

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -432,7 +432,19 @@ const Settings: React.FC = () => {
                 <FormControl fullWidth size="small">
                   <Select
                     value={llmSettings.expertiseLevel}
-                    onChange={e => handleLlmChange('expertiseLevel', e.target.value)}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      handleLlmChange('expertiseLevel', e.target.value);
+                    }}
+                    onClick={e => e.stopPropagation()}
+                    MenuProps={{
+                      disablePortal: true,
+                      PaperProps: {
+                        sx: {
+                          maxHeight: 200,
+                        },
+                      },
+                    }}
                   >
                     <MenuItem value="basic">Basic</MenuItem>
                     <MenuItem value="intermediate">Intermediate</MenuItem>

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -214,7 +214,7 @@ const Settings: React.FC = () => {
     }));
   };
 
-  const handleLlmChange = (key: keyof LlmSettings, value: string): void => {
+  const handleLlmChange = (key: keyof LlmSettings, value: string | 'basic' | 'intermediate' | 'advanced'): void => {
     setLlmSettings(prev => ({
       ...prev,
       [key]: value,

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -433,10 +433,11 @@ const Settings: React.FC = () => {
                   <Select
                     value={llmSettings.expertiseLevel}
                     onChange={(e) => {
+                      // Prevent event bubbling to parent Dialog to avoid unintended dialog closure
                       e.stopPropagation();
                       handleLlmChange('expertiseLevel', e.target.value);
                     }}
-                    onClick={e => e.stopPropagation()}
+                    onClick={e => e.stopPropagation()} // Prevent click events from bubbling to parent Dialog
                     MenuProps={{
                       disablePortal: true,
                       PaperProps: {


### PR DESCRIPTION
# Pull Request

## Description

This PR aims to integrate the prompt expertise level into the basic prompting set

## Related Issues

closes #296 

## Changes Made

Following is a gist of changes made:
1. Prevented the unexpected closing of settings modal when the expertise level dropdown is clicked.
2. Implemented the expertise level feature by creating three distinct system prompts (basic, intermediate, and advanced) that adjust the language complexity and statistical depth of the AI's responses. 
3. The changes were integrated into the chat service by modifying the prompt formatting functions to accept the expertise level parameter and passing it through the LLM request chain.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
