### PR TITLE
fix: integrate volume toggle with audioservice

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -59,9 +59,11 @@ export class Controller implements Disposable {
 
     this.displayService = new DisplayService(this.context, plot, reactContainer);
     this.notificationService = new NotificationService();
-    this.settingsService = new SettingsService(new LocalStorageService(), this.displayService);
 
     this.audioService = new AudioService(this.notificationService, this.context.state);
+
+    this.settingsService = new SettingsService(new LocalStorageService(), this.displayService, this.audioService);
+
     this.brailleService = new BrailleService(this.context, this.notificationService, this.displayService);
     this.textService = new TextService(this.notificationService);
     this.reviewService = new ReviewService(this.notificationService, this.displayService, this.textService);

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -556,6 +556,10 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     this.activeAudioIds.clear();
   }
 
+  /**
+   * Sets the volume of the audio element.
+   * @param volumePercent - The volume as a percentage (0 to 100), which is normalized to a [0,1] range.
+   */
   public setVolume(volumePercent: number): void {
     this.volume = Math.min(Math.max(volumePercent / 100, 0), 1);
   }

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -36,7 +36,7 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
 
   private readonly activeAudioIds: Map<AudioId, OscillatorNode[]>;
 
-  private readonly volume: number;
+  private volume: number;
   private readonly audioContext: AudioContext;
   private readonly compressor: DynamicsCompressorNode;
 
@@ -554,5 +554,9 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
       });
     });
     this.activeAudioIds.clear();
+  }
+
+  public setVolume(volumePercent: number): void {
+    this.volume = Math.min(Math.max(volumePercent / 100, 0), 1);
   }
 }

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -1,3 +1,4 @@
+import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { StorageService } from '@service/storage';
 import type { Settings } from '@type/settings';
@@ -8,13 +9,15 @@ const SETTINGS_KEY = 'maidr-settings';
 export class SettingsService {
   private readonly storage: StorageService;
   private readonly display: DisplayService;
+  private readonly audio: AudioService;
 
   private readonly defaultSettings: Settings;
   private currentSettings: Settings;
 
-  public constructor(storage: StorageService, display: DisplayService) {
+  public constructor(storage: StorageService, display: DisplayService, audio: AudioService) {
     this.storage = storage;
     this.display = display;
+    this.audio = audio;
 
     this.defaultSettings = {
       general: {
@@ -54,6 +57,7 @@ export class SettingsService {
 
     const saved = this.storage.load<Settings>(SETTINGS_KEY);
     this.currentSettings = saved ?? this.defaultSettings;
+    this.audio.setVolume(this.currentSettings.general.volume);
   }
 
   public loadSettings(): Settings {
@@ -63,11 +67,13 @@ export class SettingsService {
   public saveSettings(newSettings: Settings): void {
     this.currentSettings = newSettings;
     this.storage.save(SETTINGS_KEY, this.currentSettings);
+    this.audio.setVolume(newSettings.general.volume);
   }
 
   public resetSettings(): Settings {
     this.currentSettings = this.defaultSettings;
     this.storage.remove(SETTINGS_KEY);
+    this.audio.setVolume(this.defaultSettings.general.volume);
     return this.currentSettings;
   }
 

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -14,6 +14,10 @@ export class SettingsService {
   private readonly defaultSettings: Settings;
   private currentSettings: Settings;
 
+  private updateVolume(volume: number): void {
+    this.audio.setVolume(volume);
+  }
+
   public constructor(storage: StorageService, display: DisplayService, audio: AudioService) {
     this.storage = storage;
     this.display = display;
@@ -57,7 +61,7 @@ export class SettingsService {
 
     const saved = this.storage.load<Settings>(SETTINGS_KEY);
     this.currentSettings = saved ?? this.defaultSettings;
-    this.audio.setVolume(this.currentSettings.general.volume);
+    this.updateVolume(this.currentSettings.general.volume);
   }
 
   public loadSettings(): Settings {
@@ -67,13 +71,13 @@ export class SettingsService {
   public saveSettings(newSettings: Settings): void {
     this.currentSettings = newSettings;
     this.storage.save(SETTINGS_KEY, this.currentSettings);
-    this.audio.setVolume(newSettings.general.volume);
+    this.updateVolume(newSettings.general.volume);
   }
 
   public resetSettings(): Settings {
     this.currentSettings = this.defaultSettings;
     this.storage.remove(SETTINGS_KEY);
-    this.audio.setVolume(this.defaultSettings.general.volume);
+    this.updateVolume(this.defaultSettings.general.volume);
     return this.currentSettings;
   }
 


### PR DESCRIPTION
# Pull Request

## Description

This PR aims to integrate the volume toggle on settings modal with the `AudioService`

## Related Issues

closes #298 

## Changes Made

Following is a gist of changes made:
- Modified the volume property in `AudioService` to be mutable and added a method to update it based on user settings.
- Connected the volume setting to the AudioService by properly injecting the `AudioService` into the `SettingsService` and ensuring the volume changes are properly propagated.
- Fixed the resulting the dependency injection in the `Controller` class to ensure the `AudioService` is properly initialized before being passed to the `SettingsService`, which resolved the initialization errors.

## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
