### PR TITLE
feat: made boundary audio spatial

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -191,6 +191,10 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
         empty: true,
         type: 'trace',
         traceType: this.type,
+        audio: {
+          size: this.values[this.row].length,
+          index: this.col,
+        },
       };
     }
 
@@ -217,6 +221,10 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
         empty: true,
         type: 'trace',
         traceType: this.type,
+        audio: {
+          size: this.values[this.row].length,
+          index: this.col,
+        },
       };
     }
 

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -430,6 +430,14 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     this.activeAudioIds.set(audioId, [oscillator]);
   }
 
+  /**
+   * Plays a spatialized tone indicating an "empty" or out-of-bounds state.
+   *
+   * Panning Calculation:
+   * The `index` is interpolated within the range `[0, size]` to a stereo pan range `[-1, 1]`.
+   * This allows the tone to be played with directional spatial cues, helping users infer
+   * where the empty state occurs within the overall layout.
+   */
   private playEmptyTone(size: number, index: number): AudioId {
     const ctx = this.audioContext;
     const now = ctx.currentTime;

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -113,7 +113,7 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     }
 
     if (state.empty) {
-      this.playEmptyTone();
+      this.playEmptyTone(state.audio.size, state.audio.index);
       return;
     }
 
@@ -430,7 +430,7 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     this.activeAudioIds.set(audioId, [oscillator]);
   }
 
-  private playEmptyTone(): AudioId {
+  private playEmptyTone(size: number, index: number): AudioId {
     const ctx = this.audioContext;
     const now = ctx.currentTime;
     const duration = 0.2;
@@ -443,10 +443,30 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
     masterGain.gain.exponentialRampToValueAtTime(0.01, now + duration);
     masterGain.connect(this.compressor);
 
+    const fromPanning = { min: 0, max: size };
+    const toPanning = { min: -1, max: 1 };
+    const panning = this.clamp(this.interpolate(index, fromPanning, toPanning), -1, 1);
+
     const oscillators: OscillatorNode[] = [];
     for (let i = 0; i < frequencies.length; i++) {
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
+      const stereoPannerNode = this.audioContext.createStereoPanner();
+      const pannerNode = new PannerNode(this.audioContext, {
+        distanceModel: 'linear',
+        positionX: 0.0,
+        positionY: 0.0,
+        positionZ: 0.0,
+        orientationX: 0.0,
+        orientationY: 0.0,
+        orientationZ: -1.0,
+        refDistance: 1,
+        maxDistance: 1e4,
+        rolloffFactor: 10,
+        coneInnerAngle: 40,
+        coneOuterAngle: 50,
+        coneOuterGain: 0.4,
+      });
 
       osc.frequency.value = frequencies[i];
       osc.type = 'sine';
@@ -454,8 +474,12 @@ export class AudioService implements Observer<SubplotState | TraceState>, Dispos
       gain.gain.setValueAtTime(gains[i] * this.volume, now);
       gain.gain.exponentialRampToValueAtTime(0.001, now + duration);
 
+      stereoPannerNode.pan.value = panning;
+
       osc.connect(gain);
-      gain.connect(masterGain);
+      gain.connect(stereoPannerNode);
+      stereoPannerNode.connect(pannerNode);
+      pannerNode.connect(masterGain);
 
       osc.start(now);
       osc.stop(now + duration);

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -1,6 +1,5 @@
 import type { BoxPoint, TraceType } from '@type/grammar';
 import type { MovableDirection } from './movable';
-import * as querystring from "node:querystring";
 
 export type PlotState = FigureState | SubplotState | TraceState;
 

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -1,5 +1,6 @@
 import type { BoxPoint, TraceType } from '@type/grammar';
 import type { MovableDirection } from './movable';
+import * as querystring from "node:querystring";
 
 export type PlotState = FigureState | SubplotState | TraceState;
 
@@ -37,6 +38,7 @@ interface TraceEmptyState {
   empty: true;
   type: 'trace';
   traceType: TraceType;
+  audio: AudioEmptyState;
 }
 
 export type TraceState =
@@ -56,6 +58,11 @@ export type TraceState =
     autoplay: AutoplayState;
     highlight: HighlightState;
   };
+
+export interface AudioEmptyState {
+  index: number;
+  size: number;
+}
 
 export interface AudioState {
   min: number;


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces the audio feedback for out-of-bounds conditions by implementing spatial audio effects.

## Related Issues

Closes [#234](https://github.com/xability/maidr/issues/234)

## Changes Made

- Enabled spatial audio in playEmptyTone using PannerNode
- Modified the notifyOutOfBounds method to utilize the updated playEmptyTone for spatial audio playback.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.