### PR TITLE
fix: improve tooltip text formatting and appearance

### DIFF
--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -233,7 +233,7 @@
 
   /* Fallback display: Ensures max-height fallback works if -webkit-box is not supported. */
   /* ::after is inline by default; max-height needs block or inline-block. */
-  display: block;
+  display: block; /* Fallback for browsers that do not support -webkit-box. Ensures proper block-level behavior. */
 
   /* WebKit-specific line clamping */
   display: -webkit-box; /* Required for -webkit-line-clamp. Overrides 'display: block;' in supporting browsers. */

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -182,14 +182,22 @@
   left: 50%;
   transform: translate(-50%, -50%);
   padding: 8px 12px;
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: #000000;
   color: white;
   border-radius: 4px;
   font-size: 14px;
-  white-space: pre-wrap;
+  width: 300px;
+  max-width: 300px;
+  min-width: 200px;
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
   z-index: 9999;
   pointer-events: none;
-  max-width: 300px;
   text-align: center;
 }
 
@@ -274,6 +282,7 @@ button.close {
   background-color: transparent;
   border: 0;
   -webkit-appearance: none;
+  appearance: none;
 }
 
 .close {
@@ -515,14 +524,22 @@ textarea {
   left: 50%;
   transform: translate(-50%, -50%);
   padding: 8px 12px;
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: #000000;
   color: white;
   border-radius: 4px;
   font-size: 14px;
-  white-space: pre-wrap;
+  width: 300px;
+  max-width: 300px;
+  min-width: 200px;
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
   z-index: 9999;
   pointer-events: none;
-  max-width: 300px;
   text-align: center;
 }
 

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -228,6 +228,7 @@
   max-width: var(--tooltip-max-width);
   min-width: var(--tooltip-min-width);
   white-space: normal;
+  box-sizing: border-box; /* Ensures padding and borders are included in width/height calculations */
   overflow: hidden; /* Crucial for all truncation methods */
   text-overflow: ellipsis; /* Primarily for single-line or when line-clamp works */
   position: relative; /* Required for positioning the ::before pseudo-element */

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -246,7 +246,9 @@
   /* Fallback for browsers that do not support line-clamp (either version) */
   /* Relies on the element being block-level (achieved by 'display: block;' or 'display: -webkit-box;') */
   /* and 'overflow: hidden;' */
-  max-height: calc(var(--tooltip-line-clamp) * var(--tooltip-line-height)); /* Dynamically reflects the actual line height */
+  max-height: calc(
+    var(--tooltip-line-clamp) * var(--tooltip-line-height)
+  ); /* Dynamically reflects the actual line height */
 
   z-index: var(--tooltip-z-index);
   pointer-events: none;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -223,6 +223,8 @@
   border-radius: var(--tooltip-border-radius);
   font-size: var(--tooltip-font-size);
   width: var(--tooltip-width);
+  max-width: var(--tooltip-max-width);
+  min-width: var(--tooltip-min-width);
   white-space: normal;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -232,8 +234,6 @@
   -webkit-box-orient: vertical;
   /* Fallback for browsers that do not support line-clamp */
   max-height: calc(var(--tooltip-line-clamp) * 1.2em); /* Approximate line height */
-  overflow: hidden;
-  white-space: normal;
   z-index: var(--tooltip-z-index);
   pointer-events: none;
   text-align: center;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -219,7 +219,7 @@
   color: var(--tooltip-text-color);
   border-radius: var(--tooltip-border-radius);
   font-size: var(--tooltip-font-size);
-  width: 300px;
+  width: var(--tooltip-width);
   max-width: 300px;
   min-width: 200px;
   white-space: normal;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -13,6 +13,8 @@
   --tooltip-padding: var(--padding-sm-px) var(--padding-md-px); /* 8px 12px */
   --tooltip-font-size: 14px;
   --tooltip-width: 300px; 
+  --tooltip-max-width: 300px; 
+  --tooltip-min-width: 200px; 
   --tooltip-border-radius: var(--border-radius-sm-px); /* 4px */
   --tooltip-z-index: 9999;
   --tooltip-line-clamp: 2;
@@ -558,9 +560,9 @@ textarea {
   color: var(--tooltip-text-color);
   border-radius: var(--tooltip-border-radius);
   font-size: var(--tooltip-font-size);
-  width: 300px;
-  max-width: 300px;
-  min-width: 200px;
+  width: var(--tooltip-width);
+  max-width: var(--tooltip-max-width);
+  min-width: var(--tooltip-min-width);
   white-space: normal;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -14,6 +14,9 @@
   --tooltip-font-size: 14px;
   --tooltip-width: 300px;
   --tooltip-min-width: 200px;
+  --tooltip-max-width: 400px;
+  --tooltip-line-height: 1.2;
+  --tooltip-max-height: 3.6em;
   --tooltip-border-radius: var(--border-radius-sm-px); /* 4px */
   --tooltip-z-index: 9999;
   --tooltip-line-clamp: 2;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -230,6 +230,7 @@
   white-space: normal;
   overflow: hidden; /* Crucial for all truncation methods */
   text-overflow: ellipsis; /* Primarily for single-line or when line-clamp works */
+  position: relative; /* Required for positioning the ::before pseudo-element */
 
   /* Fallback display: Ensures max-height fallback works if -webkit-box is not supported. */
   /* ::after is inline by default; max-height needs block or inline-block. */

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -12,9 +12,9 @@
   --tooltip-text-color: #ffffff;
   --tooltip-padding: var(--padding-sm-px) var(--padding-md-px); /* 8px 12px */
   --tooltip-font-size: 14px;
-  --tooltip-width: 300px; 
-  --tooltip-max-width: 300px; 
-  --tooltip-min-width: 200px; 
+  --tooltip-width: 300px;
+  --tooltip-max-width: 300px;
+  --tooltip-min-width: 200px;
   --tooltip-border-radius: var(--border-radius-sm-px); /* 4px */
   --tooltip-z-index: 9999;
   --tooltip-line-clamp: 2;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -204,15 +204,12 @@
   padding-left: 1.5rem;
 }
 
-/* Tooltip styles */ /* Moved from later in the file to consolidate */
 [data-tooltip] {
-  /* Moved from later in the file */
   position: relative;
   cursor: help;
 }
 
 [data-tooltip]:hover::after {
-  /* This is the existing block from lines 220-239, now part of the consolidated tooltip styles */
   content: attr(data-tooltip);
   position: fixed;
   bottom: auto;
@@ -230,24 +227,24 @@
   white-space: normal;
   overflow: hidden; /* Crucial for all truncation methods */
   text-overflow: ellipsis; /* Primarily for single-line or when line-clamp works */
-  
+
   /* Fallback display: Ensures max-height fallback works if -webkit-box is not supported. */
   /* ::after is inline by default; max-height needs block or inline-block. */
-  display: block; 
-  
+  display: block;
+
   /* WebKit-specific line clamping */
   display: -webkit-box; /* Required for -webkit-line-clamp. Overrides 'display: block;' in supporting browsers. */
   -webkit-line-clamp: var(--tooltip-line-clamp); /* Supported in WebKit-based browsers */
   -webkit-box-orient: vertical;
-  
+
   /* Standard line clamping */
   line-clamp: var(--tooltip-line-clamp); /* Not widely supported yet. Works with block/inline-block. */
-  
+
   /* Fallback for browsers that do not support line-clamp (either version) */
   /* Relies on the element being block-level (achieved by 'display: block;' or 'display: -webkit-box;') */
   /* and 'overflow: hidden;' */
   max-height: calc(var(--tooltip-line-clamp) * 1.2em); /* Approximate line height (assumes line-height ~1.2) */
-  
+
   z-index: var(--tooltip-z-index);
   pointer-events: none;
   text-align: center;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -12,6 +12,7 @@
   --tooltip-text-color: #ffffff;
   --tooltip-padding: var(--padding-sm-px) var(--padding-md-px); /* 8px 12px */
   --tooltip-font-size: 14px;
+  --tooltip-width: 300px; 
   --tooltip-border-radius: var(--border-radius-sm-px); /* 4px */
   --tooltip-z-index: 9999;
   --tooltip-line-clamp: 2;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -223,7 +223,7 @@
   color: var(--tooltip-text-color);
   border-radius: var(--tooltip-border-radius);
   font-size: var(--tooltip-font-size);
-  line-height: 1.2; /* Explicit line-height to match max-height calculation */
+  line-height: var(--tooltip-line-height); /* Explicit line-height to match max-height calculation */
   width: var(--tooltip-width);
   max-width: var(--tooltip-max-width);
   min-width: var(--tooltip-min-width);

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -227,9 +227,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: var(--tooltip-line-clamp);
-  line-clamp: var(--tooltip-line-clamp);
+  -webkit-line-clamp: var(--tooltip-line-clamp); /* Supported in WebKit-based browsers */
+  line-clamp: var(--tooltip-line-clamp); /* Not widely supported yet */
   -webkit-box-orient: vertical;
+  /* Fallback for browsers that do not support line-clamp */
+  max-height: calc(var(--tooltip-line-clamp) * 1.2em); /* Approximate line height */
+  overflow: hidden;
+  white-space: normal;
   z-index: var(--tooltip-z-index);
   pointer-events: none;
   text-align: center;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -224,7 +224,6 @@
   border-radius: var(--tooltip-border-radius);
   font-size: var(--tooltip-font-size);
   line-height: var(--tooltip-line-height); /* Explicit line-height to match max-height calculation */
-  width: var(--tooltip-width);
   max-width: var(--tooltip-max-width);
   min-width: var(--tooltip-min-width);
   white-space: normal;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -228,14 +228,26 @@
   max-width: var(--tooltip-max-width);
   min-width: var(--tooltip-min-width);
   white-space: normal;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
+  overflow: hidden; /* Crucial for all truncation methods */
+  text-overflow: ellipsis; /* Primarily for single-line or when line-clamp works */
+  
+  /* Fallback display: Ensures max-height fallback works if -webkit-box is not supported. */
+  /* ::after is inline by default; max-height needs block or inline-block. */
+  display: block; 
+  
+  /* WebKit-specific line clamping */
+  display: -webkit-box; /* Required for -webkit-line-clamp. Overrides 'display: block;' in supporting browsers. */
   -webkit-line-clamp: var(--tooltip-line-clamp); /* Supported in WebKit-based browsers */
-  line-clamp: var(--tooltip-line-clamp); /* Not widely supported yet */
   -webkit-box-orient: vertical;
-  /* Fallback for browsers that do not support line-clamp */
-  max-height: calc(var(--tooltip-line-clamp) * 1.2em); /* Approximate line height */
+  
+  /* Standard line clamping */
+  line-clamp: var(--tooltip-line-clamp); /* Not widely supported yet. Works with block/inline-block. */
+  
+  /* Fallback for browsers that do not support line-clamp (either version) */
+  /* Relies on the element being block-level (achieved by 'display: block;' or 'display: -webkit-box;') */
+  /* and 'overflow: hidden;' */
+  max-height: calc(var(--tooltip-line-clamp) * 1.2em); /* Approximate line height (assumes line-height ~1.2) */
+  
   z-index: var(--tooltip-z-index);
   pointer-events: none;
   text-align: center;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -204,13 +204,15 @@
   padding-left: 1.5rem;
 }
 
-/* Tooltip styles */
+/* Tooltip styles */ /* Moved from later in the file to consolidate */
 [data-tooltip] {
+  /* Moved from later in the file */
   position: relative;
   cursor: help;
 }
 
 [data-tooltip]:hover::after {
+  /* This is the existing block from lines 220-239, now part of the consolidated tooltip styles */
   content: attr(data-tooltip);
   position: fixed;
   bottom: auto;
@@ -544,39 +546,6 @@ textarea {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-}
-
-/* Tooltip styles */
-[data-tooltip] {
-  position: relative;
-  cursor: help;
-}
-
-[data-tooltip]:hover::after {
-  content: attr(data-tooltip);
-  position: fixed;
-  bottom: auto;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: var(--tooltip-padding);
-  background-color: var(--tooltip-bg-color);
-  color: var(--tooltip-text-color);
-  border-radius: var(--tooltip-border-radius);
-  font-size: var(--tooltip-font-size);
-  width: var(--tooltip-width);
-  max-width: var(--tooltip-max-width);
-  min-width: var(--tooltip-min-width);
-  white-space: normal;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: var(--tooltip-line-clamp);
-  line-clamp: var(--tooltip-line-clamp);
-  -webkit-box-orient: vertical;
-  z-index: var(--tooltip-z-index);
-  pointer-events: none;
-  text-align: center;
 }
 
 /* Settings component styles */

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -13,7 +13,6 @@
   --tooltip-padding: var(--padding-sm-px) var(--padding-md-px); /* 8px 12px */
   --tooltip-font-size: 14px;
   --tooltip-width: 300px;
-  --tooltip-max-width: 300px;
   --tooltip-min-width: 200px;
   --tooltip-border-radius: var(--border-radius-sm-px); /* 4px */
   --tooltip-z-index: 9999;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -1,4 +1,37 @@
 /* Base styles */
+:root {
+  /* Common Values */
+  --border-radius-sm-px: 4px;
+  --border-radius-std-rem: 0.25rem; /* Standard for form controls etc. (4px if 1rem=16px) */
+
+  --padding-sm-px: 8px;
+  --padding-md-px: 12px;
+
+  /* Tooltip Specific */
+  --tooltip-bg-color: #000000;
+  --tooltip-text-color: #ffffff;
+  --tooltip-padding: var(--padding-sm-px) var(--padding-md-px); /* 8px 12px */
+  --tooltip-font-size: 14px;
+  --tooltip-border-radius: var(--border-radius-sm-px); /* 4px */
+  --tooltip-z-index: 9999;
+  --tooltip-line-clamp: 2;
+
+  /* Form Control Specific */
+  --form-control-padding: 0.375rem 0.75rem;
+  --form-control-font-size: 1rem;
+  --form-control-line-height: 1.5;
+  --form-control-text-color: #495057;
+  --form-control-bg-color: #ffffff;
+  --form-control-border-color: #ced4da;
+  --form-control-border-radius: var(--border-radius-std-rem); /* 0.25rem */
+  --form-control-transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+  /* Settings Custom Instruction Specific */
+  --settings-textarea-padding: var(--padding-sm-px); /* 8px */
+  --settings-textarea-border-color: #ccc;
+  --settings-textarea-border-radius: var(--border-radius-sm-px); /* 4px */
+}
+
 *,
 ::after,
 ::before {
@@ -181,11 +214,11 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  padding: 8px 12px;
-  background-color: #000000;
-  color: white;
-  border-radius: 4px;
-  font-size: 14px;
+  padding: var(--tooltip-padding);
+  background-color: var(--tooltip-bg-color);
+  color: var(--tooltip-text-color);
+  border-radius: var(--tooltip-border-radius);
+  font-size: var(--tooltip-font-size);
   width: 300px;
   max-width: 300px;
   min-width: 200px;
@@ -193,10 +226,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
+  -webkit-line-clamp: var(--tooltip-line-clamp);
+  line-clamp: var(--tooltip-line-clamp);
   -webkit-box-orient: vertical;
-  z-index: 9999;
+  z-index: var(--tooltip-z-index);
   pointer-events: none;
   text-align: center;
 }
@@ -428,17 +461,15 @@ label {
 .form-control {
   display: block;
   width: 100%;
-  padding: 0.375rem 0.75rem;
-  font-size: 1rem;
-  line-height: 1.5;
-  color: #495057;
-  background-color: #fff;
+  padding: var(--form-control-padding);
+  font-size: var(--form-control-font-size);
+  line-height: var(--form-control-line-height);
+  color: var(--form-control-text-color);
+  background-color: var(--form-control-bg-color);
   background-clip: padding-box;
-  border: 1px solid #ced4da;
-  border-radius: 0.25rem;
-  transition:
-    border-color 0.15s ease-in-out,
-    box-shadow 0.15s ease-in-out;
+  border: 1px solid var(--form-control-border-color);
+  border-radius: var(--form-control-border-radius);
+  transition: var(--form-control-transition);
 }
 button,
 input,
@@ -523,11 +554,11 @@ textarea {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  padding: 8px 12px;
-  background-color: #000000;
-  color: white;
-  border-radius: 4px;
-  font-size: 14px;
+  padding: var(--tooltip-padding);
+  background-color: var(--tooltip-bg-color);
+  color: var(--tooltip-text-color);
+  border-radius: var(--tooltip-border-radius);
+  font-size: var(--tooltip-font-size);
   width: 300px;
   max-width: 300px;
   min-width: 200px;
@@ -535,10 +566,10 @@ textarea {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
+  -webkit-line-clamp: var(--tooltip-line-clamp);
+  line-clamp: var(--tooltip-line-clamp);
   -webkit-box-orient: vertical;
-  z-index: 9999;
+  z-index: var(--tooltip-z-index);
   pointer-events: none;
   text-align: center;
 }

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -220,6 +220,7 @@
   color: var(--tooltip-text-color);
   border-radius: var(--tooltip-border-radius);
   font-size: var(--tooltip-font-size);
+  line-height: 1.2; /* Explicit line-height to match max-height calculation */
   width: var(--tooltip-width);
   max-width: var(--tooltip-max-width);
   min-width: var(--tooltip-min-width);

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -246,7 +246,7 @@
   /* Fallback for browsers that do not support line-clamp (either version) */
   /* Relies on the element being block-level (achieved by 'display: block;' or 'display: -webkit-box;') */
   /* and 'overflow: hidden;' */
-  max-height: calc(var(--tooltip-line-clamp) * 1.2em); /* Approximate line height (assumes line-height ~1.2) */
+  max-height: calc(var(--tooltip-line-clamp) * var(--tooltip-line-height)); /* Dynamically reflects the actual line height */
 
   z-index: var(--tooltip-z-index);
   pointer-events: none;

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -220,8 +220,6 @@
   border-radius: var(--tooltip-border-radius);
   font-size: var(--tooltip-font-size);
   width: var(--tooltip-width);
-  max-width: 300px;
-  min-width: 200px;
   white-space: normal;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
# Pull Request

## Description

This PR updates tooltip styling to appear 1) with a black background behhind white text, and 2) condensed in two lines, improving tooltip readability. 

## Related Issues

N/A 

## Changes Made

- Tooltip background is now solid black (#000000) with white text for improved contrast and readability.
- Tooltip box is limited to approximately two lines using multi-line ellipsis (`-webkit-line-clamp: 2;`, `line-clamp: 2;` ) and a fixed width.
- Added the standard `line-clamp` property for compatibility with more browsers.
- Added the `standard appearance: none;` property alongside `-webkit-appearance: none;` for better cross-browser support.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.