### PR TITLE
fix: integrate min and max frequency into settings flow

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -62,8 +62,8 @@ export class Controller implements Disposable {
 
     const storageService = new LocalStorageService();
     this.audioService = new AudioService(this.notificationService, this.context.state);
-    this.settingsService = new SettingsService(storageService, this.displayService, this.audioService);
-    this.audioService.updateSettings(this.settingsService);
+    this.settingsService = new SettingsService(storageService, this.displayService);
+    this.audioService.settings = this.settingsService;
 
     this.brailleService = new BrailleService(this.context, this.notificationService, this.displayService);
     this.textService = new TextService(this.notificationService);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -63,7 +63,7 @@ export class Controller implements Disposable {
     const storageService = new LocalStorageService();
     this.audioService = new AudioService(this.notificationService, this.context.state);
     this.settingsService = new SettingsService(storageService, this.displayService, this.audioService);
-    this.audioService.initializeSettings(this.settingsService);
+    this.audioService.updateSettings(this.settingsService);
 
     this.brailleService = new BrailleService(this.context, this.notificationService, this.displayService);
     this.textService = new TextService(this.notificationService);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -60,9 +60,10 @@ export class Controller implements Disposable {
     this.displayService = new DisplayService(this.context, plot, reactContainer);
     this.notificationService = new NotificationService();
 
+    const storageService = new LocalStorageService();
     this.audioService = new AudioService(this.notificationService, this.context.state);
-
-    this.settingsService = new SettingsService(new LocalStorageService(), this.displayService, this.audioService);
+    this.settingsService = new SettingsService(storageService, this.displayService, this.audioService);
+    this.audioService.initializeSettings(this.settingsService);
 
     this.brailleService = new BrailleService(this.context, this.notificationService, this.displayService);
     this.textService = new TextService(this.notificationService);

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -34,11 +34,6 @@ implements Observer<SubplotState | TraceState>, Disposable {
   private readonly notification: NotificationService;
   private readonly audioPalette: AudioPaletteService;
   public settings: SettingsService | null = null;
-  private cachedFrequencyRange: { min: number; max: number } = {
-    min: AudioService.DEFAULT_MIN_FREQUENCY,
-    max: AudioService.DEFAULT_MAX_FREQUENCY,
-  };
-
   private cachedVolume: number = AudioService.DEFAULT_VOLUME;
 
   private isCombinedAudio: boolean;
@@ -73,7 +68,10 @@ implements Observer<SubplotState | TraceState>, Disposable {
 
   private getFrequencyRange(): { min: number; max: number } {
     if (!this.settings) {
-      return this.cachedFrequencyRange;
+      return {
+        min: AudioService.DEFAULT_MIN_FREQUENCY,
+        max: AudioService.DEFAULT_MAX_FREQUENCY,
+      };
     }
     const settings = this.settings.loadSettings();
     return {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -28,9 +28,16 @@ enum AudioMode {
 
 export class AudioService
 implements Observer<SubplotState | TraceState>, Disposable {
+  private static readonly DEFAULT_MIN_FREQUENCY = 200;
+  private static readonly DEFAULT_MAX_FREQUENCY = 1000;
+
   private readonly notification: NotificationService;
   private readonly audioPalette: AudioPaletteService;
   private settings: SettingsService | null = null;
+  private cachedFrequencyRange: { min: number; max: number } = {
+    min: AudioService.DEFAULT_MIN_FREQUENCY,
+    max: AudioService.DEFAULT_MAX_FREQUENCY,
+  };
 
   private isCombinedAudio: boolean;
   private mode: AudioMode;
@@ -56,19 +63,23 @@ implements Observer<SubplotState | TraceState>, Disposable {
     this.compressor = this.initCompressor();
   }
 
-  public initializeSettings(settings: SettingsService): void {
-    this.settings = settings;
-  }
-
-  private getFrequencyRange(): { min: number; max: number } {
+  private updateCachedFrequencyRange(): void {
     if (!this.settings) {
-      return { min: 200, max: 1000 };
+      this.cachedFrequencyRange = {
+        min: AudioService.DEFAULT_MIN_FREQUENCY,
+        max: AudioService.DEFAULT_MAX_FREQUENCY,
+      };
+      return;
     }
     const settings = this.settings.loadSettings();
-    return {
+    this.cachedFrequencyRange = {
       min: settings.general.minFrequency,
       max: settings.general.maxFrequency,
     };
+  }
+
+  private getFrequencyRange(): { min: number; max: number } {
+    return this.cachedFrequencyRange;
   }
 
   public dispose(): void {
@@ -704,5 +715,6 @@ implements Observer<SubplotState | TraceState>, Disposable {
 
   public updateSettings(settings: SettingsService): void {
     this.settings = settings;
+    this.updateCachedFrequencyRange();
   }
 }

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -18,7 +18,6 @@ const WAITING_FREQUENCY = 440;
 const COMPLETE_FREQUENCY = 880;
 
 const DEFAULT_DURATION = 0.3;
-const DEFAULT_VOLUME = 0.5;
 
 enum AudioMode {
   OFF = 'off',
@@ -30,21 +29,23 @@ export class AudioService
 implements Observer<SubplotState | TraceState>, Disposable {
   private static readonly DEFAULT_MIN_FREQUENCY = 200;
   private static readonly DEFAULT_MAX_FREQUENCY = 1000;
+  private static readonly DEFAULT_VOLUME = 0.5;
 
   private readonly notification: NotificationService;
   private readonly audioPalette: AudioPaletteService;
-  private settings: SettingsService | null = null;
+  public settings: SettingsService | null = null;
   private cachedFrequencyRange: { min: number; max: number } = {
     min: AudioService.DEFAULT_MIN_FREQUENCY,
     max: AudioService.DEFAULT_MAX_FREQUENCY,
   };
+
+  private cachedVolume: number = AudioService.DEFAULT_VOLUME;
 
   private isCombinedAudio: boolean;
   private mode: AudioMode;
 
   private readonly activeAudioIds: Map<AudioId, OscillatorNode[]>;
 
-  private volume: number;
   private readonly audioContext: AudioContext;
   private readonly compressor: DynamicsCompressorNode;
 
@@ -58,28 +59,27 @@ implements Observer<SubplotState | TraceState>, Disposable {
 
     this.activeAudioIds = new Map();
 
-    this.volume = DEFAULT_VOLUME;
     this.audioContext = new AudioContext();
     this.compressor = this.initCompressor();
   }
 
-  private updateCachedFrequencyRange(): void {
+  private getVolume(): number {
     if (!this.settings) {
-      this.cachedFrequencyRange = {
-        min: AudioService.DEFAULT_MIN_FREQUENCY,
-        max: AudioService.DEFAULT_MAX_FREQUENCY,
-      };
-      return;
+      return this.cachedVolume;
     }
     const settings = this.settings.loadSettings();
-    this.cachedFrequencyRange = {
-      min: settings.general.minFrequency,
-      max: settings.general.maxFrequency,
-    };
+    return Math.min(Math.max(settings.general.volume / 100, 0), 1);
   }
 
   private getFrequencyRange(): { min: number; max: number } {
-    return this.cachedFrequencyRange;
+    if (!this.settings) {
+      return this.cachedFrequencyRange;
+    }
+    const settings = this.settings.loadSettings();
+    return {
+      min: settings.general.minFrequency,
+      max: settings.general.maxFrequency,
+    };
   }
 
   public dispose(): void {
@@ -292,12 +292,13 @@ implements Observer<SubplotState | TraceState>, Disposable {
   ): GainNode[] {
     const gainNodes: GainNode[] = [];
     const startTime = this.audioContext.currentTime;
+    const currentVolume = this.getVolume();
 
     for (let i = 0; i < oscillators.length; i++) {
       const gainNode = this.audioContext.createGain();
 
       // Apply timbre modulation envelope or use default
-      let oscillatorVolume = volume;
+      let oscillatorVolume = currentVolume;
 
       if (i === 0) {
         // Primary oscillator - use fundamental amplitude if specified
@@ -335,7 +336,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
     paletteEntry?: AudioPaletteEntry,
   ): AudioId {
     const duration = DEFAULT_DURATION;
-    const volume = this.volume;
+    const volume = this.getVolume();
 
     // Use default sine wave if no palette entry provided (for backwards compatibility)
     if (!paletteEntry) {
@@ -472,6 +473,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
     const startTime = ctx.currentTime;
     const duration = DEFAULT_DURATION;
     const freqRange = this.getFrequencyRange();
+    const currentVolume = this.getVolume();
 
     // Use default sine wave if no palette entry provided
     const waveType = paletteEntry?.waveType || 'sine';
@@ -507,7 +509,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
     const envelope = this.createAdsrEnvelope(
       gainNode,
       paletteEntry,
-      this.volume,
+      currentVolume,
       startTime,
       duration,
     );
@@ -554,13 +556,14 @@ implements Observer<SubplotState | TraceState>, Disposable {
     const ctx = this.audioContext;
     const now = ctx.currentTime;
     const duration = 0.2;
+    const currentVolume = this.getVolume();
 
     const frequencies = [500, 1000, 1500, 2100, 2700];
     const gains = [1, 0.6, 0.4, 0.2, 0.1];
 
     const masterGain = ctx.createGain();
-    masterGain.gain.setValueAtTime(0.3, now);
-    masterGain.gain.exponentialRampToValueAtTime(0.01, now + duration);
+    masterGain.gain.setValueAtTime(0.3 * currentVolume, now);
+    masterGain.gain.exponentialRampToValueAtTime(0.01 * currentVolume, now + duration);
     masterGain.connect(this.compressor);
 
     const fromPanning = { min: 0, max: size };
@@ -591,8 +594,8 @@ implements Observer<SubplotState | TraceState>, Disposable {
       osc.frequency.value = frequencies[i];
       osc.type = 'sine';
 
-      gain.gain.setValueAtTime(gains[i] * this.volume, now);
-      gain.gain.exponentialRampToValueAtTime(0.001, now + duration);
+      gain.gain.setValueAtTime(gains[i] * currentVolume, now);
+      gain.gain.exponentialRampToValueAtTime(0.001 * currentVolume, now + duration);
 
       stereoPannerNode.pan.value = panning;
 
@@ -703,18 +706,5 @@ implements Observer<SubplotState | TraceState>, Disposable {
       });
     });
     this.activeAudioIds.clear();
-  }
-
-  /**
-   * Sets the volume of the audio element.
-   * @param volumePercent - The volume as a percentage (0 to 100), which is normalized to a [0,1] range.
-   */
-  public setVolume(volumePercent: number): void {
-    this.volume = Math.min(Math.max(volumePercent / 100, 0), 1);
-  }
-
-  public updateSettings(settings: SettingsService): void {
-    this.settings = settings;
-    this.updateCachedFrequencyRange();
   }
 }

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -1,4 +1,3 @@
-import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { StorageService } from '@service/storage';
 import type { Settings } from '@type/settings';
@@ -9,19 +8,13 @@ const SETTINGS_KEY = 'maidr-settings';
 export class SettingsService {
   private readonly storage: StorageService;
   private readonly display: DisplayService;
-  private readonly audio: AudioService;
 
   private readonly defaultSettings: Settings;
   private currentSettings: Settings;
 
-  private updateVolume(volume: number): void {
-    this.audio.setVolume(volume);
-  }
-
-  public constructor(storage: StorageService, display: DisplayService, audio: AudioService) {
+  public constructor(storage: StorageService, display: DisplayService) {
     this.storage = storage;
     this.display = display;
-    this.audio = audio;
 
     this.defaultSettings = {
       general: {
@@ -61,7 +54,6 @@ export class SettingsService {
 
     const saved = this.storage.load<Settings>(SETTINGS_KEY);
     this.currentSettings = saved ?? this.defaultSettings;
-    this.updateVolume(this.currentSettings.general.volume);
   }
 
   public loadSettings(): Settings {
@@ -71,13 +63,11 @@ export class SettingsService {
   public saveSettings(newSettings: Settings): void {
     this.currentSettings = newSettings;
     this.storage.save(SETTINGS_KEY, this.currentSettings);
-    this.updateVolume(newSettings.general.volume);
   }
 
   public resetSettings(): Settings {
     this.currentSettings = this.defaultSettings;
     this.storage.remove(SETTINGS_KEY);
-    this.updateVolume(this.defaultSettings.general.volume);
     return this.currentSettings;
   }
 


### PR DESCRIPTION
# Pull Request

## Description

This PR aims to allow for persistent configuration of min and max frequencies from settings modal.

## Related Issues

Closes #309 

## Changes Made

Following is a gist of changes made:

1. Removed hardcoded frequency constants and implemented dynamic frequency range based on user settings
2. Added proper dependency injection between `AudioService` and `SettingsService`
3. Centralized frequency range logic with a `getFrequencyRange()` and proper null handling
4. Ensured frequency settings are properly persisted in localStorage and take effect immediately for new audio generation

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
