### PR TITLE
fix: implement observer on settings for audio and autoplay services

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -69,7 +69,7 @@ export class Controller implements Disposable {
     this.textService = new TextService(this.notificationService);
     this.reviewService = new ReviewService(this.notificationService, this.displayService, this.textService);
 
-    this.autoplayService = new AutoplayService(this.context, this.notificationService);
+    this.autoplayService = new AutoplayService(this.context, this.notificationService, this.settingsService);
     this.highlightService = new HighlightService();
     this.helpService = new HelpService(this.context, this.displayService);
     this.chatService = new ChatService(this.displayService, maidr);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -61,9 +61,8 @@ export class Controller implements Disposable {
     this.notificationService = new NotificationService();
 
     const storageService = new LocalStorageService();
-    this.audioService = new AudioService(this.notificationService, this.context.state);
     this.settingsService = new SettingsService(storageService, this.displayService);
-    this.audioService.settings = this.settingsService;
+    this.audioService = new AudioService(this.notificationService, this.context.state, this.settingsService);
 
     this.brailleService = new BrailleService(this.context, this.notificationService, this.displayService);
     this.textService = new TextService(this.notificationService);

--- a/src/service/autoplay.ts
+++ b/src/service/autoplay.ts
@@ -71,6 +71,10 @@ export class AutoplayService implements Disposable, Observer<Settings> {
   }
 
   public update(settings: Settings): void {
+    this.updateSettings(settings);
+  }
+
+  private updateSettings(settings: Settings): void {
     this.currentDuration = settings.general.autoplayDuration;
     if (this.currentDirection) {
       this.restart();

--- a/src/service/autoplay.ts
+++ b/src/service/autoplay.ts
@@ -4,13 +4,13 @@ import type { Event } from '@type/event';
 import type { MovableDirection } from '@type/movable';
 import type { TraceState } from '@type/state';
 import type { NotificationService } from './notification';
+import type { SettingsService } from './settings';
 import { Emitter } from '@type/event';
 
 const DEFAULT_SPEED = 250;
 const MIN_SPEED = 50;
 const MAX_SPEED = 500;
 
-const TOTAL_DURATION = 4000;
 const DEFAULT_INTERVAL = 20;
 
 interface AutoplayChangeEvent {
@@ -22,6 +22,7 @@ type AutoplayId = ReturnType<typeof setInterval>;
 export class AutoplayService implements Disposable {
   private readonly context: Context;
   private readonly notification: NotificationService;
+  private readonly settings: SettingsService;
 
   private autoplayId: AutoplayId | null;
   private currentDirection: MovableDirection | null;
@@ -32,15 +33,15 @@ export class AutoplayService implements Disposable {
   private readonly maxSpeed: number;
 
   private autoplayRate: number;
-  private readonly totalDuration: number;
   private readonly interval: number;
 
   private readonly onChangeEmitter: Emitter<AutoplayChangeEvent>;
   public readonly onChange: Event<AutoplayChangeEvent>;
 
-  public constructor(context: Context, notification: NotificationService) {
+  public constructor(context: Context, notification: NotificationService, settings: SettingsService) {
     this.notification = notification;
     this.context = context;
+    this.settings = settings;
 
     this.autoplayId = null;
     this.currentDirection = null;
@@ -51,7 +52,6 @@ export class AutoplayService implements Disposable {
     this.maxSpeed = MAX_SPEED;
 
     this.autoplayRate = this.defaultSpeed;
-    this.totalDuration = TOTAL_DURATION;
     this.interval = DEFAULT_INTERVAL;
 
     this.onChangeEmitter = new Emitter<AutoplayChangeEvent>();
@@ -136,8 +136,9 @@ export class AutoplayService implements Disposable {
     }
 
     if (state && !state.empty) {
+      const currentDuration = this.settings.loadSettings().general.autoplayDuration;
       const calculatedRate = Math.ceil(
-        this.totalDuration / state.autoplay[direction],
+        currentDuration / state.autoplay[direction],
       );
       this.defaultSpeed = calculatedRate;
       this.minSpeed = Math.min(this.minSpeed, calculatedRate);


### PR DESCRIPTION
# Pull Request

## Description

This PR includes changes for integrating autoplay duration into user flow.

## Related Issues

Closes #312 

## Changes Made

Following is a gist of changes made:
1. `SettingsService` is now injected into `AutoplayService`.
2. `AutoplayService` utilizes the value of `Autoplay Duration` from the current copy of settings object whenever the user initiates an autoplay run.
3. `Autoplay Duration` aims to control the speed at which the datapoints are autoplayed in the user selected direction.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
