### PR TITLE
fix: address visual highlighting on multi lineplot

### DIFF
--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -209,7 +209,6 @@ export class LineTrace extends AbstractTrace<number> {
         }
       }
       if (coordinates.length !== this.lineValues[r].length) {
-        // console.warn(`Mismatch: SVG has ${coordinates.length} points, data has ${this.lineValues[r].length} points for line ${r}. Slicing/padding data.`);
         if (coordinates.length < this.lineValues[r].length) {
           while (coordinates.length < this.lineValues[r].length) {
             coordinates.push({ x: Number.NaN, y: Number.NaN });

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -7,7 +7,7 @@ import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
 
 const TYPE = 'Type';
-const SVG_PATH_LINE_POINT_REGEX = /[ML]\s*(-?\d+(\.\d+)?)\s+(-?\d+(\.\d+)?)/g;
+const SVG_PATH_LINE_POINT_REGEX = /[ML]\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g;
 
 export class LineTrace extends AbstractTrace<number> {
   private readonly points: LinePoint[][];
@@ -182,19 +182,22 @@ export class LineTrace extends AbstractTrace<number> {
       return null;
     }
 
-    const svgElements = new Array<Array<SVGElement>>();
+    const svgElements: SVGElement[][] = [];
+    let allFailed = true;
     for (let r = 0; r < selectors.length; r++) {
       const lineElement = Svg.selectElement(selectors[r], false);
       if (!lineElement) {
-        return null;
+        svgElements.push([]);
+        continue;
       }
 
-      const coordinates = new Array<LinePoint>();
+      const coordinates: LinePoint[] = [];
       if (lineElement instanceof SVGPathElement) {
         const pathD = lineElement.getAttribute(Constant.D) || Constant.EMPTY;
-        let match = SVG_PATH_LINE_POINT_REGEX.exec(pathD);
+        SVG_PATH_LINE_POINT_REGEX.lastIndex = 0;
+        let match: RegExpExecArray | null = SVG_PATH_LINE_POINT_REGEX.exec(pathD);
         while (match !== null) {
-          coordinates.push({ x: Number.parseFloat(match[1]), y: Number.parseFloat(match[3]) });
+          coordinates.push({ x: Number.parseFloat(match[1]), y: Number.parseFloat(match[2]) });
           match = SVG_PATH_LINE_POINT_REGEX.exec(pathD);
         }
       } else if (lineElement instanceof SVGPolylineElement) {
@@ -206,19 +209,38 @@ export class LineTrace extends AbstractTrace<number> {
         }
       }
       if (coordinates.length !== this.lineValues[r].length) {
-        return null;
+        // console.warn(`Mismatch: SVG has ${coordinates.length} points, data has ${this.lineValues[r].length} points for line ${r}. Slicing/padding data.`);
+        if (coordinates.length < this.lineValues[r].length) {
+          while (coordinates.length < this.lineValues[r].length) {
+            coordinates.push({ x: Number.NaN, y: Number.NaN });
+          }
+        } else if (coordinates.length > this.lineValues[r].length) {
+          coordinates.length = this.lineValues[r].length;
+        }
       }
 
-      const linePointElements = new Array<SVGElement>();
+      const linePointElements: SVGElement[] = [];
+      let lineFailed = false;
       for (const coordinate of coordinates) {
         if (Number.isNaN(coordinate.x) || Number.isNaN(coordinate.y)) {
-          return null;
+          lineFailed = true;
+          break;
         }
         linePointElements.push(Svg.createCircleElement(coordinate.x, coordinate.y, lineElement));
+      }
+      if (lineFailed) {
+        svgElements.push([]);
+        continue;
+      }
+      if (linePointElements.length > 0) {
+        allFailed = false;
       }
       svgElements.push(linePointElements);
     }
 
+    if (allFailed) {
+      return null;
+    }
     return svgElements;
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR includes a fix for making visual highlighting work on multi-lineplot

## Changes Made

Following are the changes made in this PR:
1. Refactored `LineTrace.mapToSvgElements` to handle mismatches between the number of data points and SVG path points for multi-line plots. The method now slices or pads the data to match the SVG, ensuring robust highlighting even when counts differ.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

1. Tested on standard lineplot and the changes made in this PR do not have any collateral effects on it.
2. The validation for multi-lineplot were done using `examples/multi-lineplot.html`.
3. I would like to retroactively test with the example in `pymaidr.ai` once the changes have been released.
4. We can close #315 manually once we have verified all aspects of visual highlighting are working fine.
