### PR TITLE
fix: adapt highlight color for heatmap cell based on cell color

### DIFF
--- a/src/util/constant.ts
+++ b/src/util/constant.ts
@@ -59,4 +59,10 @@ export abstract class Constant {
   static readonly VISIBLE = 'visible';
   static readonly X = 'x';
   static readonly Y = 'y';
+
+  // Highlight values
+  static readonly HIGHLIGHT_BASE_COLOR = { r: 255, g: 255, b: 255 };
+  static readonly HIGHLIGHT_CONSTRAT = 2.0;
+  static readonly HIGHLIGHT_COLOR_RATIO = 0.6;
+  static readonly HIGHLIGHT_MAX_COLOR = 255;
 }

--- a/src/util/constant.ts
+++ b/src/util/constant.ts
@@ -62,7 +62,7 @@ export abstract class Constant {
 
   // Highlight values
   static readonly HIGHLIGHT_BASE_COLOR = { r: 255, g: 255, b: 255 };
-  static readonly HIGHLIGHT_CONSTRAT = 2.0;
+  static readonly HIGHLIGHT_CONTRAST_RATIO = 2.0;
   static readonly HIGHLIGHT_COLOR_RATIO = 0.6;
   static readonly HIGHLIGHT_MAX_COLOR = 255;
 }

--- a/src/util/constant.ts
+++ b/src/util/constant.ts
@@ -62,7 +62,7 @@ export abstract class Constant {
 
   // Highlight values
   static readonly HIGHLIGHT_BASE_COLOR = { r: 255, g: 255, b: 255 };
-  static readonly HIGHLIGHT_CONTRAST_RATIO = 2.0;
+  static readonly HIGHLIGHT_CONTRAST_RATIO = 3.0;
   static readonly HIGHLIGHT_COLOR_RATIO = 0.6;
   static readonly HIGHLIGHT_MAX_COLOR = 255;
 }

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -169,10 +169,10 @@ export abstract class Svg {
     }
 
     const contrastWithWhite = Color.getContrastRatio(originalRgb, Constant.HIGHLIGHT_BASE_COLOR);
-    const isDark = contrastWithWhite < Constant.HIGHLIGHT_CONTRAST_RATIO;
+    const isLight = contrastWithWhite < Constant.HIGHLIGHT_CONTRAST_RATIO;
 
     // For dark colors, just use the fallback color
-    if (!isDark) {
+    if (!isLight) {
       return fallbackColor;
     }
 

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -169,7 +169,7 @@ export abstract class Svg {
     }
 
     const contrastWithWhite = Color.getContrastRatio(originalRgb, Constant.HIGHLIGHT_BASE_COLOR);
-    const isDark = contrastWithWhite < Constant.HIGHLIGHT_CONSTRAT;
+    const isDark = contrastWithWhite < Constant.HIGHLIGHT_CONTRAST_RATIO;
 
     // For dark colors, just use the fallback color
     if (!isDark) {

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -168,12 +168,11 @@ export abstract class Svg {
       return fallbackColor;
     }
 
-    const white = { r: 255, g: 255, b: 255 };
-    const contrastWithWhite = Color.getContrastRatio(originalRgb, white);
-    const isLight = contrastWithWhite < 2.0;
+    const contrastWithWhite = Color.getContrastRatio(originalRgb, Constant.HIGHLIGHT_BASE_COLOR);
+    const isDark = contrastWithWhite < Constant.HIGHLIGHT_CONSTRAT;
 
     // For dark colors, just use the fallback color
-    if (!isLight) {
+    if (!isDark) {
       return fallbackColor;
     }
 
@@ -182,17 +181,17 @@ export abstract class Svg {
     // Check if the color is grayscale (R=G=B)
     if (originalRgb.r === originalRgb.g && originalRgb.g === originalRgb.b) {
       // For grayscale, modify all channels uniformly
-      modifiedRgb.r = Math.min(255, Math.floor(originalRgb.r * 0.6));
-      modifiedRgb.g = Math.min(255, Math.floor(originalRgb.g * 0.6));
-      modifiedRgb.b = Math.min(255, Math.floor(originalRgb.b * 0.6));
+      modifiedRgb.r = Math.min(Constant.HIGHLIGHT_MAX_COLOR, Math.floor(originalRgb.r * Constant.HIGHLIGHT_COLOR_RATIO));
+      modifiedRgb.g = Math.min(Constant.HIGHLIGHT_MAX_COLOR, Math.floor(originalRgb.g * Constant.HIGHLIGHT_COLOR_RATIO));
+      modifiedRgb.b = Math.min(Constant.HIGHLIGHT_MAX_COLOR, Math.floor(originalRgb.b * Constant.HIGHLIGHT_COLOR_RATIO));
     } else {
       // For non-grayscale colors, modify only the dominant channel
       if (originalRgb.r >= originalRgb.g && originalRgb.r >= originalRgb.b) {
-        modifiedRgb.r = Math.min(255, Math.floor(originalRgb.r * 0.6));
+        modifiedRgb.r = Math.min(Constant.HIGHLIGHT_MAX_COLOR, Math.floor(originalRgb.r * Constant.HIGHLIGHT_COLOR_RATIO));
       } else if (originalRgb.g >= originalRgb.r && originalRgb.g >= originalRgb.b) {
-        modifiedRgb.g = Math.min(255, Math.floor(originalRgb.g * 0.6));
+        modifiedRgb.g = Math.min(Constant.HIGHLIGHT_MAX_COLOR, Math.floor(originalRgb.g * Constant.HIGHLIGHT_COLOR_RATIO));
       } else {
-        modifiedRgb.b = Math.min(255, Math.floor(originalRgb.b * 0.6));
+        modifiedRgb.b = Math.min(Constant.HIGHLIGHT_MAX_COLOR, Math.floor(originalRgb.b * Constant.HIGHLIGHT_COLOR_RATIO));
       }
     }
 

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -168,12 +168,24 @@ export abstract class Svg {
       return fallbackColor;
     }
 
-    const invertedRgb = Color.invert(originalRgb);
-    const contrastRatio = Color.getContrastRatio(originalRgb, invertedRgb);
-    if (contrastRatio >= 4.5) {
-      return Color.rgbToString(invertedRgb);
+    const white = { r: 255, g: 255, b: 255 };
+    const contrastWithWhite = Color.getContrastRatio(originalRgb, white);
+    const isLight = contrastWithWhite < 3.0;
+
+    // For dark colors, just use the fallback color
+    if (!isLight) {
+      return fallbackColor;
     }
 
-    return fallbackColor;
+    const modifiedRgb = { ...originalRgb };
+    if (originalRgb.r >= originalRgb.g && originalRgb.r >= originalRgb.b) {
+      modifiedRgb.r = Math.min(255, Math.floor(originalRgb.r * 0.6));
+    } else if (originalRgb.g >= originalRgb.r && originalRgb.g >= originalRgb.b) {
+      modifiedRgb.g = Math.min(255, Math.floor(originalRgb.g * 0.6));
+    } else {
+      modifiedRgb.b = Math.min(255, Math.floor(originalRgb.b * 0.6));
+    }
+
+    return Color.rgbToString(modifiedRgb);
   }
 }

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -170,7 +170,7 @@ export abstract class Svg {
 
     const white = { r: 255, g: 255, b: 255 };
     const contrastWithWhite = Color.getContrastRatio(originalRgb, white);
-    const isLight = contrastWithWhite < 3.0;
+    const isLight = contrastWithWhite < 2.0;
 
     // For dark colors, just use the fallback color
     if (!isLight) {
@@ -178,12 +178,22 @@ export abstract class Svg {
     }
 
     const modifiedRgb = { ...originalRgb };
-    if (originalRgb.r >= originalRgb.g && originalRgb.r >= originalRgb.b) {
+
+    // Check if the color is grayscale (R=G=B)
+    if (originalRgb.r === originalRgb.g && originalRgb.g === originalRgb.b) {
+      // For grayscale, modify all channels uniformly
       modifiedRgb.r = Math.min(255, Math.floor(originalRgb.r * 0.6));
-    } else if (originalRgb.g >= originalRgb.r && originalRgb.g >= originalRgb.b) {
       modifiedRgb.g = Math.min(255, Math.floor(originalRgb.g * 0.6));
-    } else {
       modifiedRgb.b = Math.min(255, Math.floor(originalRgb.b * 0.6));
+    } else {
+      // For non-grayscale colors, modify only the dominant channel
+      if (originalRgb.r >= originalRgb.g && originalRgb.r >= originalRgb.b) {
+        modifiedRgb.r = Math.min(255, Math.floor(originalRgb.r * 0.6));
+      } else if (originalRgb.g >= originalRgb.r && originalRgb.g >= originalRgb.b) {
+        modifiedRgb.g = Math.min(255, Math.floor(originalRgb.g * 0.6));
+      } else {
+        modifiedRgb.b = Math.min(255, Math.floor(originalRgb.b * 0.6));
+      }
     }
 
     return Color.rgbToString(modifiedRgb);


### PR DESCRIPTION
# Pull Request

## Description

This PR consists changes related to adjusting highlight color of a heatmap cell based on its current color

## Related Issues

closes #316 

## Changes Made

Following is a list of changes made:
1. The color contrast ratio is calculated in `getHighlightColor` method against `white`
2. If the color contrast ratio is below a certain threshold to prove that its a `dark` color, the color constant for highlight is used.
3. If the color contrast ratio is above the threshold, the dominant color is multiplied by a factor of `0.6` to adjust the color.
4. This approach has helped in making sure text of the highlighted cell is visible even when the highlight color changes.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
