### PR TITLE
refactor: remodel help modal

### DIFF
--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -5,41 +5,49 @@ import { Scope } from '@type/event';
 import { Platform } from '@util/platform';
 
 const TRACE_HELP_MENU = [
-  { description: 'Navigate Data Points', key: 'arrow keys' },
+  // Navigation Group - Always start the description with "Move"
+  { description: 'Move across data points', key: 'arrow keys' },
   { description: 'Move to Next Layer', key: 'page up' },
   { description: 'Move to Previous Layer', key: 'page down' },
-  { description: 'Go to Left/Right/Top/Bottom Extreme Point', key: `${Platform.ctrl} + arrow keys` },
-  { description: 'Replay Current Point', key: 'space' },
+  { description: 'Move to Left/Right/Top/Bottom Extreme Point', key: `${Platform.ctrl} + arrow keys` },
+  { description: 'Play Current Point', key: 'space' },
 
+  // Mode Group - Always start the description with "Toggle"
   { description: 'Toggle Braille Mode', key: 'b' },
   { description: 'Toggle Text Mode', key: 't' },
   { description: 'Toggle Sonification Mode', key: 's' },
   { description: 'Toggle Review Mode', key: 'r' },
 
-  { description: 'Autoplay Outward', key: `${Platform.ctrl} + shift + arrow keys` },
+  // Autoplay Group - Always start the description with "Start" or "Stop" and include "Autoplay" in the description
+  { description: 'Start Autoplay Outward', key: `${Platform.ctrl} + shift + arrow keys` },
   { description: 'Stop Autoplay', key: `${Platform.ctrl}` },
   { description: 'Speed Up Autoplay', key: '. (period)' },
   { description: 'Speed Down Autoplay', key: ', (comma)' },
   { description: 'Reset Autoplay Speed', key: '/ (slash)' },
 
+  // Announcement Group - Always start the description with "Announce"
   { description: 'Announce Plot Title', key: 'l t' },
   { description: 'Announce X Label', key: 'l x' },
   { description: 'Announce Y Label', key: 'l y' },
   { description: 'Announce Fill (Z) Label', key: 'l f' },
 
+  // General Group - All other items should be added here
   { description: 'Open Settings', key: `${Platform.ctrl} + ,` },
   { description: 'Open Chat', key: `shift + /` },
   { description: 'Open Help', key: `${Platform.ctrl} + /` },
 ];
 
 const SUBPLOT_HELP_MENU = [
+  // Navigation Group - Always start the description with "Move"
   { description: 'Move around Subplot', key: 'arrow keys' },
   { description: 'Activate Current Subplot', key: `${Platform.enter}` },
 
+  // Announcement Group - Always start the description with "Announce"
   { description: 'Announce Plot Title', key: 'l t' },
   { description: 'Announce Subtitle', key: 'l s' },
   { description: 'Announce Caption', key: 'l c' },
 
+  // General Group - All other items should be added here
   { description: 'Open Settings', key: `${Platform.ctrl} + ,` },
 ];
 

--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -9,6 +9,7 @@ const TRACE_HELP_MENU = [
   { description: 'Move to Next Layer', key: 'page up' },
   { description: 'Move to Previous Layer', key: 'page down' },
   { description: 'Go to Left/Right/Top/Bottom Extreme Point', key: `${Platform.ctrl} + arrow keys` },
+  { description: 'Replay Current Point', key: 'space' },
 
   { description: 'Toggle Braille Mode', key: 'b' },
   { description: 'Toggle Text Mode', key: 't' },
@@ -20,7 +21,6 @@ const TRACE_HELP_MENU = [
   { description: 'Speed Up Autoplay', key: '. (period)' },
   { description: 'Speed Down Autoplay', key: ', (comma)' },
   { description: 'Reset Autoplay Speed', key: '/ (slash)' },
-  { description: 'Replay Current Point', key: 'space' },
 
   { description: 'Announce Plot Title', key: 'l t' },
   { description: 'Announce X Label', key: 'l x' },
@@ -28,7 +28,8 @@ const TRACE_HELP_MENU = [
   { description: 'Announce Fill (Z) Label', key: 'l f' },
 
   { description: 'Open Settings', key: `${Platform.ctrl} + ,` },
-  { description: 'Open Chat', key: `?` },
+  { description: 'Open Chat', key: `shift + /` },
+  { description: 'Open Help', key: `${Platform.ctrl} + /` },
 ];
 
 const SUBPLOT_HELP_MENU = [

--- a/src/ui/components/help/HelpGroup.tsx
+++ b/src/ui/components/help/HelpGroup.tsx
@@ -1,0 +1,88 @@
+import type { HelpMenuItem } from '@type/help';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import { Collapse, Divider, Grid, IconButton, Typography } from '@mui/material';
+import React, { useId, useMemo } from 'react';
+import { HelpRow } from './HelpRow';
+
+interface HelpGroupProps {
+  title: string;
+  items: HelpMenuItem[];
+  isExpanded: boolean;
+  onToggle: () => void;
+  searchQuery: string;
+}
+
+export const HelpGroup: React.FC<HelpGroupProps> = ({ title, items, isExpanded, onToggle, searchQuery }) => {
+  const contentId = useId();
+  const buttonId = useId();
+
+  // Filter items based on search query
+  const filteredItems = useMemo(() => {
+    if (!searchQuery)
+      return items;
+    const query = searchQuery.toLowerCase();
+    return items.filter(item =>
+      item.description.toLowerCase().includes(query)
+      || item.key.toLowerCase().includes(query),
+    );
+  }, [items, searchQuery]);
+
+  // Don't render group if no items match the search
+  if (searchQuery && filteredItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <Grid container spacing={1} className="help-group">
+      <Grid size={12} className="help-group-header">
+        <IconButton
+          id={buttonId}
+          onClick={onToggle}
+          sx={{ p: 0, mr: 1 }}
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${title} section`}
+        >
+          {isExpanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
+        </IconButton>
+        <Typography
+          variant="subtitle1"
+          component="span"
+          className="help-group-title"
+          fontWeight="bold"
+          onClick={onToggle}
+        >
+          {title}
+        </Typography>
+      </Grid>
+      <Grid size={12}>
+        <Collapse in={isExpanded}>
+          <div
+            id={contentId}
+            role="region"
+            aria-label={`${title} shortcuts`}
+          >
+            <Grid container spacing={1}>
+              {filteredItems.map((item, index) => (
+                <React.Fragment key={index}>
+                  <Grid size={12} className="help-row">
+                    <HelpRow
+                      label={item.description}
+                      shortcut={item.key}
+                    />
+                  </Grid>
+                  {index !== filteredItems.length - 1 && (
+                    <Grid size={12}>
+                      <Divider />
+                    </Grid>
+                  )}
+                </React.Fragment>
+              ))}
+            </Grid>
+          </div>
+        </Collapse>
+      </Grid>
+    </Grid>
+  );
+};

--- a/src/ui/components/help/HelpGroup.tsx
+++ b/src/ui/components/help/HelpGroup.tsx
@@ -64,15 +64,15 @@ export const HelpGroup: React.FC<HelpGroupProps> = ({ title, items, isExpanded, 
             aria-label={`${title} shortcuts`}
           >
             <Grid container spacing={1}>
-              {filteredItems.map((item, index) => (
-                <React.Fragment key={index}>
+              {filteredItems.map(item => (
+                <React.Fragment key={`${item.key}-${item.description}`}>
                   <Grid size={12} className="help-row">
                     <HelpRow
                       label={item.description}
                       shortcut={item.key}
                     />
                   </Grid>
-                  {index !== filteredItems.length - 1 && (
+                  {filteredItems.indexOf(item) !== filteredItems.length - 1 && (
                     <Grid size={12}>
                       <Divider />
                     </Grid>

--- a/src/ui/components/help/HelpGroup.tsx
+++ b/src/ui/components/help/HelpGroup.tsx
@@ -48,10 +48,26 @@ export const HelpGroup: React.FC<HelpGroupProps> = ({ title, items, isExpanded, 
         </IconButton>
         <Typography
           variant="subtitle1"
-          component="span"
+          component="button"
           className="help-group-title"
           fontWeight="bold"
           onClick={onToggle}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onToggle();
+            }
+          }}
+          sx={{
+            'border': 'none',
+            'background': 'none',
+            'padding': 0,
+            'cursor': 'pointer',
+            '&:focus-visible': {
+              outline: '2px solid',
+              outlineOffset: '2px',
+            },
+          }}
         >
           {title}
         </Typography>

--- a/src/ui/components/help/HelpGroup.tsx
+++ b/src/ui/components/help/HelpGroup.tsx
@@ -64,7 +64,7 @@ export const HelpGroup: React.FC<HelpGroupProps> = ({ title, items, isExpanded, 
             aria-label={`${title} shortcuts`}
           >
             <Grid container spacing={1}>
-              {filteredItems.map(item => (
+              {filteredItems.map((item, index) => (
                 <React.Fragment key={`${item.key}-${item.description}`}>
                   <Grid size={12} className="help-row">
                     <HelpRow
@@ -72,7 +72,7 @@ export const HelpGroup: React.FC<HelpGroupProps> = ({ title, items, isExpanded, 
                       shortcut={item.key}
                     />
                   </Grid>
-                  {filteredItems.indexOf(item) !== filteredItems.length - 1 && (
+                  {index !== filteredItems.length - 1 && (
                     <Grid size={12}>
                       <Divider />
                     </Grid>

--- a/src/ui/components/help/HelpRow.tsx
+++ b/src/ui/components/help/HelpRow.tsx
@@ -1,0 +1,27 @@
+import { Grid, Typography } from '@mui/material';
+import React from 'react';
+
+interface HelpRowProps {
+  label: string;
+  shortcut: string;
+}
+
+export const HelpRow: React.FC<HelpRowProps> = ({ label, shortcut }) => (
+  <Grid
+    container
+    spacing={1}
+    alignItems="center"
+    sx={{ py: 1 }}
+  >
+    <Grid size={{ xs: 12, sm: 6, md: 7 }}>
+      <Typography variant="body2">
+        {label}
+      </Typography>
+    </Grid>
+    <Grid size={{ xs: 12, sm: 6, md: 5 }}>
+      <Typography variant="body2" fontWeight={300}>
+        {shortcut}
+      </Typography>
+    </Grid>
+  </Grid>
+);

--- a/src/ui/components/help/HelpSearch.tsx
+++ b/src/ui/components/help/HelpSearch.tsx
@@ -31,9 +31,6 @@ export const HelpSearch: React.FC<HelpSearchProps> = ({ value, onChange }) => (
     />
     <div
       id="search-description"
-      style={{
-
-      }}
     >
       Enter characters to search for keyboard shortcuts.
     </div>

--- a/src/ui/components/help/HelpSearch.tsx
+++ b/src/ui/components/help/HelpSearch.tsx
@@ -1,0 +1,31 @@
+import SearchIcon from '@mui/icons-material/Search';
+import { InputAdornment, TextField } from '@mui/material';
+import React from 'react';
+
+interface HelpSearchProps {
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const HelpSearch: React.FC<HelpSearchProps> = ({ value, onChange }) => (
+  <TextField
+    fullWidth
+    variant="outlined"
+    placeholder="Type a few letters to search..."
+    value={value}
+    onChange={onChange}
+    className="help-search"
+    slotProps={{
+      input: {
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon aria-hidden="true" />
+          </InputAdornment>
+        ),
+      },
+    }}
+    aria-label="Search keyboard shortcuts"
+    aria-describedby="search-description"
+    role="searchbox"
+  />
+);

--- a/src/ui/components/help/HelpSearch.tsx
+++ b/src/ui/components/help/HelpSearch.tsx
@@ -8,24 +8,29 @@ interface HelpSearchProps {
 }
 
 export const HelpSearch: React.FC<HelpSearchProps> = ({ value, onChange }) => (
-  <TextField
-    fullWidth
-    variant="outlined"
-    placeholder="Type a few letters to search..."
-    value={value}
-    onChange={onChange}
-    className="help-search"
-    slotProps={{
-      input: {
-        startAdornment: (
-          <InputAdornment position="start">
-            <SearchIcon aria-hidden="true" />
-          </InputAdornment>
-        ),
-      },
-    }}
-    aria-label="Search keyboard shortcuts"
-    aria-describedby="search-description"
-    role="searchbox"
-  />
+  <>
+    <TextField
+      fullWidth
+      variant="outlined"
+      placeholder="Type a few letters to search..."
+      value={value}
+      onChange={onChange}
+      className="help-search"
+      slotProps={{
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon aria-hidden="true" />
+            </InputAdornment>
+          ),
+        },
+      }}
+      aria-label="Search keyboard shortcuts"
+      aria-describedby="search-description"
+      role="searchbox"
+    />
+    <div className="search-description">
+      Enter characters to search for keyboard shortcuts.
+    </div>
+  </>
 );

--- a/src/ui/components/help/HelpSearch.tsx
+++ b/src/ui/components/help/HelpSearch.tsx
@@ -29,7 +29,12 @@ export const HelpSearch: React.FC<HelpSearchProps> = ({ value, onChange }) => (
       aria-describedby="search-description"
       role="searchbox"
     />
-    <div id="search-description">
+    <div
+      id="search-description"
+      style={{
+
+      }}
+    >
       Enter characters to search for keyboard shortcuts.
     </div>
   </>

--- a/src/ui/components/help/HelpSearch.tsx
+++ b/src/ui/components/help/HelpSearch.tsx
@@ -29,7 +29,7 @@ export const HelpSearch: React.FC<HelpSearchProps> = ({ value, onChange }) => (
       aria-describedby="search-description"
       role="searchbox"
     />
-    <div className="search-description">
+    <div id="search-description">
       Enter characters to search for keyboard shortcuts.
     </div>
   </>

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -639,7 +639,15 @@ textarea {
 }
 
 #search-description {
-  display: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Responsive adjustments */

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -608,7 +608,7 @@ textarea {
   margin-bottom: 1rem;
 }
 
-.help-group {
+.help-group-list {
   margin-top: 0.2rem;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
@@ -638,7 +638,7 @@ textarea {
   color: var(--text-secondary);
 }
 
-.search-description {
+#search-description {
   display: none;
 }
 
@@ -646,9 +646,5 @@ textarea {
 @media (max-width: 600px) {
   .help-row {
     flex-direction: column;
-  }
-
-  .help-row-shortcut {
-    margin-top: 0.25rem;
   }
 }

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -598,3 +598,61 @@ textarea {
 .settings-row-input {
   width: 100%;
 }
+
+/* Help Dialog Styles */
+.help-dialog {
+  z-index: 9998;
+}
+
+.help-search {
+  margin-bottom: 1rem;
+}
+
+.help-group {
+  margin-top: 0.2rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.help-group-header {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-weight: bold;
+  padding: 0.5rem 0;
+}
+
+.help-group-title {
+  font-weight: bold;
+  margin-left: 0.5rem;
+}
+
+.help-row {
+  padding: 0.5rem 0;
+  margin-left: 0.5rem;
+}
+
+.help-row-label {
+  font-weight: bold;
+}
+
+.help-row-shortcut {
+  font-weight: 300;
+}
+
+.help-no-results {
+  text-align: center;
+  padding: 2rem 0;
+  color: var(--text-secondary);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .help-row {
+    flex-direction: column;
+  }
+
+  .help-row-shortcut {
+    margin-top: 0.25rem;
+  }
+}

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -632,18 +632,14 @@ textarea {
   margin-left: 0.5rem;
 }
 
-.help-row-label {
-  font-weight: bold;
-}
-
-.help-row-shortcut {
-  font-weight: 300;
-}
-
 .help-no-results {
   text-align: center;
   padding: 2rem 0;
   color: var(--text-secondary);
+}
+
+.search-description {
+  display: none;
 }
 
 /* Responsive adjustments */

--- a/src/ui/pages/Help.tsx
+++ b/src/ui/pages/Help.tsx
@@ -61,11 +61,12 @@ const Help: React.FC = () => {
     setSearchQuery(event.target.value);
     // Auto-expand groups that have matching items
     if (event.target.value) {
+      const lowercasedQuery = event.target.value.toLowerCase();
       const matchingGroups = HELP_GROUPS.filter((groupTitle) => {
         const groupItems = getGroupItems(groupTitle);
         return groupItems.some(item =>
-          item.description.toLowerCase().includes(event.target.value.toLowerCase())
-          || item.key.toLowerCase().includes(event.target.value.toLowerCase()),
+          item.description.toLowerCase().includes(lowercasedQuery)
+          || item.key.toLowerCase().includes(lowercasedQuery),
         );
       });
       if (matchingGroups.length > 0) {

--- a/src/ui/pages/Help.tsx
+++ b/src/ui/pages/Help.tsx
@@ -14,6 +14,13 @@ import { HelpSearch } from '@ui/components/help/HelpSearch';
 import { HELP_GROUP_FILTERS, HELP_GROUPS } from '@ui/react_constants';
 import React, { useId, useMemo, useState } from 'react';
 
+function filterHelpItems(items: HelpMenuItem[], filterFn: ((item: HelpMenuItem) => boolean) | ((item: HelpMenuItem, otherGroups: HelpMenuItem[][]) => boolean), otherGroups?: HelpMenuItem[][]): HelpMenuItem[] {
+  if (otherGroups) {
+    return items.filter(item => (filterFn as (item: HelpMenuItem, otherGroups: HelpMenuItem[][]) => boolean)(item, otherGroups));
+  }
+  return items.filter(item => (filterFn as (item: HelpMenuItem) => boolean)(item));
+}
+
 const Help: React.FC = () => {
   const id = useId();
   const titleId = useId();
@@ -23,22 +30,23 @@ const Help: React.FC = () => {
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Memoize grouped items
   const navigationItems = useMemo(() =>
-    items.filter(item => HELP_GROUP_FILTERS.Navigation(item)), [items]);
+    filterHelpItems(items, HELP_GROUP_FILTERS.Navigation), [items]);
 
   const modeItems = useMemo(() =>
-    items.filter(item => HELP_GROUP_FILTERS.Modes(item)), [items]);
+    filterHelpItems(items, HELP_GROUP_FILTERS.Modes), [items]);
 
   const autoplayItems = useMemo(() =>
-    items.filter(item => HELP_GROUP_FILTERS['Autoplay Controls'](item)), [items]);
+    filterHelpItems(items, HELP_GROUP_FILTERS['Autoplay Controls']), [items]);
 
   const labelItems = useMemo(() =>
-    items.filter(item => HELP_GROUP_FILTERS['Label Announcements'](item)), [items]);
+    filterHelpItems(items, HELP_GROUP_FILTERS['Label Announcements']), [items]);
 
   const generalItems = useMemo(() =>
-    items.filter(item =>
-      HELP_GROUP_FILTERS['General Controls'](item, [navigationItems, modeItems, autoplayItems, labelItems]),
+    filterHelpItems(
+      items,
+      HELP_GROUP_FILTERS['General Controls'],
+      [navigationItems, modeItems, autoplayItems, labelItems],
     ), [items, navigationItems, modeItems, autoplayItems, labelItems]);
 
   const getGroupItems = useMemo(() => (groupTitle: string): HelpMenuItem[] => {

--- a/src/ui/pages/Help.tsx
+++ b/src/ui/pages/Help.tsx
@@ -23,16 +23,25 @@ const Help: React.FC = () => {
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Group items by purpose
-  const navigationItems = items.filter(item => HELP_GROUP_FILTERS.Navigation(item));
-  const modeItems = items.filter(item => HELP_GROUP_FILTERS.Modes(item));
-  const autoplayItems = items.filter(item => HELP_GROUP_FILTERS['Autoplay Controls'](item));
-  const labelItems = items.filter(item => HELP_GROUP_FILTERS['Label Announcements'](item));
-  const generalItems = items.filter(item =>
-    HELP_GROUP_FILTERS['General Controls'](item, [navigationItems, modeItems, autoplayItems, labelItems]),
-  );
+  // Memoize grouped items
+  const navigationItems = useMemo(() =>
+    items.filter(item => HELP_GROUP_FILTERS.Navigation(item)), [items]);
 
-  const getGroupItems = (groupTitle: string): HelpMenuItem[] => {
+  const modeItems = useMemo(() =>
+    items.filter(item => HELP_GROUP_FILTERS.Modes(item)), [items]);
+
+  const autoplayItems = useMemo(() =>
+    items.filter(item => HELP_GROUP_FILTERS['Autoplay Controls'](item)), [items]);
+
+  const labelItems = useMemo(() =>
+    items.filter(item => HELP_GROUP_FILTERS['Label Announcements'](item)), [items]);
+
+  const generalItems = useMemo(() =>
+    items.filter(item =>
+      HELP_GROUP_FILTERS['General Controls'](item, [navigationItems, modeItems, autoplayItems, labelItems]),
+    ), [items, navigationItems, modeItems, autoplayItems, labelItems]);
+
+  const getGroupItems = useMemo(() => (groupTitle: string): HelpMenuItem[] => {
     switch (groupTitle) {
       case 'Navigation':
         return navigationItems;
@@ -47,7 +56,7 @@ const Help: React.FC = () => {
       default:
         return [];
     }
-  };
+  }, [navigationItems, modeItems, autoplayItems, labelItems, generalItems]);
 
   const handleClose = (): void => {
     viewModel.toggle();

--- a/src/ui/pages/Help.tsx
+++ b/src/ui/pages/Help.tsx
@@ -1,85 +1,156 @@
+import type { HelpMenuItem } from '@type/help';
 import {
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   Grid,
   Typography,
 } from '@mui/material';
 import { useViewModel } from '@state/hook/useViewModel';
-import React, { useId } from 'react';
-
-interface HelpRowProps {
-  label: string;
-  shortcut: string;
-}
-
-const HelpRow: React.FC<HelpRowProps> = ({ label, shortcut }) => (
-  <Grid
-    container
-    spacing={1}
-    alignItems="center"
-    sx={{ py: 1 }}
-  >
-    <Grid size={{ xs: 12, sm: 6, md: 7 }}>
-      <Typography variant="body2">
-        {label}
-      </Typography>
-    </Grid>
-    <Grid size={{ xs: 12, sm: 6, md: 5 }}>
-      <Typography variant="body2" fontWeight={300}>
-        {shortcut}
-      </Typography>
-    </Grid>
-  </Grid>
-);
+import { HelpGroup } from '@ui/components/help/HelpGroup';
+import { HelpSearch } from '@ui/components/help/HelpSearch';
+import { HELP_GROUP_FILTERS, HELP_GROUPS } from '@ui/react_constants';
+import React, { useId, useMemo, useState } from 'react';
 
 const Help: React.FC = () => {
   const id = useId();
+  const titleId = useId();
+  const descriptionId = useId();
   const viewModel = useViewModel('help');
   const { items } = viewModel.state;
+  const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Group items by purpose
+  const navigationItems = items.filter(item => HELP_GROUP_FILTERS.Navigation(item));
+  const modeItems = items.filter(item => HELP_GROUP_FILTERS.Modes(item));
+  const autoplayItems = items.filter(item => HELP_GROUP_FILTERS['Autoplay Controls'](item));
+  const labelItems = items.filter(item => HELP_GROUP_FILTERS['Label Announcements'](item));
+  const generalItems = items.filter(item =>
+    HELP_GROUP_FILTERS['General Controls'](item, [navigationItems, modeItems, autoplayItems, labelItems]),
+  );
+
+  const getGroupItems = (groupTitle: string): HelpMenuItem[] => {
+    switch (groupTitle) {
+      case 'Navigation':
+        return navigationItems;
+      case 'Modes':
+        return modeItems;
+      case 'Autoplay Controls':
+        return autoplayItems;
+      case 'Label Announcements':
+        return labelItems;
+      case 'General Controls':
+        return generalItems;
+      default:
+        return [];
+    }
+  };
 
   const handleClose = (): void => {
     viewModel.toggle();
   };
 
+  const handleGroupToggle = (groupTitle: string): void => {
+    setExpandedGroup(expandedGroup === groupTitle ? null : groupTitle);
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    setSearchQuery(event.target.value);
+    // Auto-expand groups that have matching items
+    if (event.target.value) {
+      const matchingGroups = HELP_GROUPS.filter((groupTitle) => {
+        const groupItems = getGroupItems(groupTitle);
+        return groupItems.some(item =>
+          item.description.toLowerCase().includes(event.target.value.toLowerCase())
+          || item.key.toLowerCase().includes(event.target.value.toLowerCase()),
+        );
+      });
+      if (matchingGroups.length > 0) {
+        setExpandedGroup(matchingGroups[0]);
+      }
+    } else {
+      setExpandedGroup(null);
+    }
+  };
+
+  // Check if any groups have matching items
+  const hasMatchingItems = useMemo(() => {
+    if (!searchQuery)
+      return true;
+    return HELP_GROUPS.some((groupTitle) => {
+      const groupItems = getGroupItems(groupTitle);
+      return groupItems.some(item =>
+        item.description.toLowerCase().includes(searchQuery.toLowerCase())
+        || item.key.toLowerCase().includes(searchQuery.toLowerCase()),
+      );
+    });
+  }, [searchQuery, navigationItems, modeItems, autoplayItems, labelItems, generalItems]);
+
   return (
     <Dialog
       id={id}
       role="dialog"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
       open={true}
       onClose={handleClose}
       maxWidth="sm"
       fullWidth
       disablePortal
+      className="help-dialog"
     >
       {/* Header */}
       <Grid container component={DialogTitle}>
         <Grid size="grow">
-          <Typography variant="h6" fontWeight="bold">
+          <Typography id={titleId} variant="h6" fontWeight="bold">
             Keyboard Shortcuts
           </Typography>
         </Grid>
       </Grid>
 
       <DialogContent>
-        <Grid container spacing={1}>
-          {items.map((item, index) => (
-            <React.Fragment key={index}>
-              <Grid size={12} key={index}>
-                <HelpRow
-                  label={item.description}
-                  shortcut={item.key}
-                />
-              </Grid>
-              {index !== items.length - 1 && (
-                <Grid size={12}>
-                  <Divider />
-                </Grid>
-              )}
-            </React.Fragment>
+        <Typography id={descriptionId} variant="body2" sx={{ mb: 2 }}>
+          Click on a section to view its shortcuts. Alternatively, use the search bar to find specific shortcuts.
+        </Typography>
+
+        <HelpSearch value={searchQuery} onChange={handleSearchChange} />
+
+        {!hasMatchingItems && searchQuery && (
+          <Typography
+            variant="body1"
+            color="text.secondary"
+            align="center"
+            className="help-no-results"
+            role="status"
+            aria-live="polite"
+          >
+            No results found for "
+            {searchQuery}
+            "
+          </Typography>
+        )}
+
+        <Grid
+          container
+          spacing={2}
+          id="help-groups"
+          role="region"
+          aria-label="Keyboard shortcuts groups"
+          className="help-group"
+        >
+          {HELP_GROUPS.map(groupTitle => (
+            <Grid key={groupTitle} size={12} className="help-group">
+              <HelpGroup
+                title={groupTitle}
+                items={getGroupItems(groupTitle)}
+                isExpanded={expandedGroup === groupTitle}
+                onToggle={() => handleGroupToggle(groupTitle)}
+                searchQuery={searchQuery}
+              />
+            </Grid>
           ))}
         </Grid>
       </DialogContent>
@@ -94,7 +165,12 @@ const Help: React.FC = () => {
           sx={{ px: 2, py: 1 }}
         >
           <Grid size="auto">
-            <Button variant="contained" color="primary" onClick={handleClose}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleClose}
+              aria-label="Close keyboard shortcuts dialog"
+            >
               Close
             </Button>
           </Grid>

--- a/src/ui/pages/Help.tsx
+++ b/src/ui/pages/Help.tsx
@@ -139,7 +139,7 @@ const Help: React.FC = () => {
           id="help-groups"
           role="region"
           aria-label="Keyboard shortcuts groups"
-          className="help-group"
+          className="help-group-list"
         >
           {HELP_GROUPS.map(groupTitle => (
             <Grid key={groupTitle} size={12} className="help-group">

--- a/src/ui/react_constants.ts
+++ b/src/ui/react_constants.ts
@@ -24,6 +24,10 @@ export const HELP_GROUP_FILTERS = {
   'Label Announcements': (item: { description: string }) =>
     item.description.toLowerCase().includes('announce'),
 
-  'General Controls': (item: { description: string }, otherGroups: any[]) =>
-    !otherGroups.some(group => group.includes(item)),
+  'General Controls': (item: { description: string; key: string }, otherGroups: any[]) =>
+    !otherGroups.some(group =>
+      group.some((otherItem: { description: string; key: string }) =>
+        otherItem.description === item.description && otherItem.key === item.key,
+      ),
+    ),
 };

--- a/src/ui/react_constants.ts
+++ b/src/ui/react_constants.ts
@@ -1,3 +1,8 @@
+interface HelpMenuItem {
+  description: string;
+  key: string;
+}
+
 export const HELP_GROUPS = [
   'Navigation',
   'Modes',
@@ -7,7 +12,7 @@ export const HELP_GROUPS = [
 ] as const;
 
 export const HELP_GROUP_FILTERS = {
-  'Navigation': (item: { description: string }) => {
+  'Navigation': (item: HelpMenuItem) => {
     const normalizedDesc = item.description.toLowerCase();
     return normalizedDesc.includes('navigate')
       || normalizedDesc.includes('move')
@@ -15,26 +20,26 @@ export const HELP_GROUP_FILTERS = {
       || normalizedDesc.includes('replay');
   },
 
-  'Modes': (item: { description: string }) => {
+  'Modes': (item: HelpMenuItem) => {
     const normalizedDesc = item.description.toLowerCase();
     return normalizedDesc.includes('toggle')
       && !normalizedDesc.includes('autoplay');
   },
 
-  'Autoplay Controls': (item: { description: string }) => {
+  'Autoplay Controls': (item: HelpMenuItem) => {
     const normalizedDesc = item.description.toLowerCase();
     return normalizedDesc.includes('autoplay')
       || normalizedDesc.includes('speed');
   },
 
-  'Label Announcements': (item: { description: string }) => {
+  'Label Announcements': (item: HelpMenuItem) => {
     const normalizedDesc = item.description.toLowerCase();
     return normalizedDesc.includes('announce');
   },
 
-  'General Controls': (item: { description: string; key: string }, otherGroups: any[]) =>
+  'General Controls': (item: HelpMenuItem, otherGroups: HelpMenuItem[][]) =>
     !otherGroups.some(group =>
-      group.some((otherItem: { description: string; key: string }) =>
+      group.some((otherItem: HelpMenuItem) =>
         otherItem.description === item.description && otherItem.key === item.key,
       ),
     ),

--- a/src/ui/react_constants.ts
+++ b/src/ui/react_constants.ts
@@ -7,22 +7,30 @@ export const HELP_GROUPS = [
 ] as const;
 
 export const HELP_GROUP_FILTERS = {
-  'Navigation': (item: { description: string }) =>
-    item.description.toLowerCase().includes('navigate')
-    || item.description.toLowerCase().includes('move')
-    || item.description.toLowerCase().includes('go to')
-    || item.description.toLowerCase().includes('replay'),
+  'Navigation': (item: { description: string }) => {
+    const normalizedDesc = item.description.toLowerCase();
+    return normalizedDesc.includes('navigate')
+      || normalizedDesc.includes('move')
+      || normalizedDesc.includes('go to')
+      || normalizedDesc.includes('replay');
+  },
 
-  'Modes': (item: { description: string }) =>
-    item.description.toLowerCase().includes('toggle')
-    && !item.description.toLowerCase().includes('autoplay'),
+  'Modes': (item: { description: string }) => {
+    const normalizedDesc = item.description.toLowerCase();
+    return normalizedDesc.includes('toggle')
+      && !normalizedDesc.includes('autoplay');
+  },
 
-  'Autoplay Controls': (item: { description: string }) =>
-    item.description.toLowerCase().includes('autoplay')
-    || item.description.toLowerCase().includes('speed'),
+  'Autoplay Controls': (item: { description: string }) => {
+    const normalizedDesc = item.description.toLowerCase();
+    return normalizedDesc.includes('autoplay')
+      || normalizedDesc.includes('speed');
+  },
 
-  'Label Announcements': (item: { description: string }) =>
-    item.description.toLowerCase().includes('announce'),
+  'Label Announcements': (item: { description: string }) => {
+    const normalizedDesc = item.description.toLowerCase();
+    return normalizedDesc.includes('announce');
+  },
 
   'General Controls': (item: { description: string; key: string }, otherGroups: any[]) =>
     !otherGroups.some(group =>

--- a/src/ui/react_constants.ts
+++ b/src/ui/react_constants.ts
@@ -1,0 +1,29 @@
+export const HELP_GROUPS = [
+  'Navigation',
+  'Modes',
+  'Autoplay Controls',
+  'Label Announcements',
+  'General Controls',
+] as const;
+
+export const HELP_GROUP_FILTERS = {
+  'Navigation': (item: { description: string }) =>
+    item.description.toLowerCase().includes('navigate')
+    || item.description.toLowerCase().includes('move')
+    || item.description.toLowerCase().includes('go to')
+    || item.description.toLowerCase().includes('replay'),
+
+  'Modes': (item: { description: string }) =>
+    item.description.toLowerCase().includes('toggle')
+    && !item.description.toLowerCase().includes('autoplay'),
+
+  'Autoplay Controls': (item: { description: string }) =>
+    item.description.toLowerCase().includes('autoplay')
+    || item.description.toLowerCase().includes('speed'),
+
+  'Label Announcements': (item: { description: string }) =>
+    item.description.toLowerCase().includes('announce'),
+
+  'General Controls': (item: { description: string }, otherGroups: any[]) =>
+    !otherGroups.some(group => group.includes(item)),
+};


### PR DESCRIPTION
# Pull Request

## Description

This PR includes certain reorganizations of help modal

## Related Issues

Closes #321 

## Changes Made

Following is a list of changes made:
1. Split the monolithic `Help.tsx` into smaller, reusable components `HelpRow, HelpGroup, HelpSearch` and moved them to a dedicated help directory under components.
2. Added dedicated CSS classes in `styles.css` for better styling control, including proper spacing, margins, and responsive design for the help menu components.
3. Implemented a search bar with real-time filtering, auto-expanding matching groups, and a "No results" message when no matches are found.
4. Added proper ARIA labels, roles, and descriptions throughout the components.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

Some considerations:
1. The initial plan was to add a `X` icon at the right end of the search bar to allow users to clear the search. However, the click event seems to propagate through the DOM and end up closing help modal and deactivating maidr. This needs to be investigated a bit and can be added later on.
2. The remaining keybaord shortcuts can be added once the changes seem feasible.