### PR TITLE
fix: remove redundant tooltip styles

### DIFF
--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -168,31 +168,6 @@
   padding-left: 1.5rem;
 }
 
-/* Tooltip styles */
-[data-tooltip] {
-  position: relative;
-  cursor: help;
-}
-
-[data-tooltip]:hover::after {
-  content: attr(data-tooltip);
-  position: fixed;
-  bottom: auto;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 8px 12px;
-  background-color: rgba(0, 0, 0, 0.8);
-  color: white;
-  border-radius: 4px;
-  font-size: 14px;
-  white-space: pre-wrap;
-  z-index: 9999;
-  pointer-events: none;
-  max-width: 300px;
-  text-align: center;
-}
-
 .invis_button {
   background-color: transparent;
   border: none;


### PR DESCRIPTION
# Pull Request

## Description

This PR removes tooltip related styles that had been duplicated

## Changes Made

`styles.css` has been refactored to include only one copy of tooltip styles.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.