### PR TITLE
fix: remove warning suppression in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,15 +12,6 @@ export default defineConfig({
     sourcemap: true,
     outDir: 'dist',
     emptyOutDir: true,
-    rollupOptions: {
-      onwarn(warning, warn) {
-        if (warning.message.includes('Module level directives cause errors when bundled')
-          || warning.message.includes('Error when using sourcemap for reporting an error')) {
-          return;
-        }
-        warn(warning);
-      },
-    },
   },
   define: {
     'process.env': {},


### PR DESCRIPTION
# Pull Request

## Description

This PR removes the warning suppressor added to vite config.