### PR TITLE
fix: organize tooltip styling

### DIFF
--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -176,13 +176,12 @@
 
 [data-tooltip]:hover::after {
   content: attr(data-tooltip);
-  position: fixed;
-  bottom: auto;
-  top: 50%;
+  position: absolute;
+  bottom: 100%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   padding: 8px 12px;
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: rgba(0, 0, 0, 0.9);
   color: white;
   border-radius: 4px;
   font-size: 14px;
@@ -191,6 +190,21 @@
   pointer-events: none;
   max-width: 300px;
   text-align: center;
+  margin-bottom: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+[data-tooltip]:hover::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% - 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 4px;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.9) transparent transparent transparent;
+  z-index: 9999;
+  pointer-events: none;
 }
 
 .invis_button {
@@ -499,31 +513,6 @@ textarea {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-}
-
-/* Tooltip styles */
-[data-tooltip] {
-  position: relative;
-  cursor: help;
-}
-
-[data-tooltip]:hover::after {
-  content: attr(data-tooltip);
-  position: fixed;
-  bottom: auto;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 8px 12px;
-  background-color: rgba(0, 0, 0, 0.8);
-  color: white;
-  border-radius: 4px;
-  font-size: 14px;
-  white-space: pre-wrap;
-  z-index: 9999;
-  pointer-events: none;
-  max-width: 300px;
-  text-align: center;
 }
 
 /* Settings component styles */

--- a/src/ui/css/styles.css
+++ b/src/ui/css/styles.css
@@ -172,6 +172,7 @@
 [data-tooltip] {
   position: relative;
   cursor: help;
+  z-index: 9999;
 }
 
 [data-tooltip]:hover::after {
@@ -186,7 +187,6 @@
   border-radius: 4px;
   font-size: 14px;
   white-space: pre-wrap;
-  z-index: 9999;
   pointer-events: none;
   max-width: 300px;
   text-align: center;


### PR DESCRIPTION
# Pull Request

## Description

This PR removes duplicate styles for tooltip and organizes the intended styling

## Related Issues

Re-integrates the tooltip styling removed in 3.12.0

## Changes Made

A single copy of tooltip styling is available with common CSS props integrated to the remaining definition.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.