### PR TITLE
feat: pick up aria live config in chat from global store

### DIFF
--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -5,6 +5,7 @@ import rehypeMathjax from 'rehype-mathjax/svg';
 import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
+import { useViewModelState } from '@state/hook/useViewModel';
 
 interface TypingEffectProps {
   text: string;
@@ -15,6 +16,7 @@ export const TypingEffect: React.FC<TypingEffectProps> = ({ text, isUser }) => {
   const [displayedText, setDisplayedText] = useState('');
   const [isTyping, setIsTyping] = useState(true);
   const messageRef = useRef<HTMLDivElement>(null);
+  const settings = useViewModelState('settings');
 
   useEffect(() => {
     if (isUser) {
@@ -48,14 +50,8 @@ export const TypingEffect: React.FC<TypingEffectProps> = ({ text, isUser }) => {
 
   return (
     <Box>
-      <div
-        ref={messageRef}
-        className={`chat-message-content ${isUser ? 'user' : ''}`}
-        role="text"
-        aria-busy="false"
-        aria-live="off"
-        aria-atomic="true"
-      >
+      {/* Visual typing effect for users */}
+      <div className={`chat-message-content ${isUser ? 'user' : ''}`}>
         <ReactMarkdown
           rehypePlugins={[
             rehypeMathjax,
@@ -106,6 +102,14 @@ export const TypingEffect: React.FC<TypingEffectProps> = ({ text, isUser }) => {
         >
           {displayedText}
         </ReactMarkdown>
+      </div>
+      {/* Visually hidden live region for screen readers */}
+      <div
+        style={{ position: 'absolute', left: '-9999px', height: '1px', width: '1px', overflow: 'hidden' }}
+        aria-live={settings.general.ariaMode}
+        aria-atomic="true"
+      >
+        {isTyping ? '' : text}
       </div>
       {isTyping && (
         <span

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@mui/material';
+import { useViewModelState } from '@state/hook/useViewModel';
 import React, { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeMathjax from 'rehype-mathjax/svg';
 import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
-import { useViewModelState } from '@state/hook/useViewModel';
 
 interface TypingEffectProps {
   text: string;

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -105,7 +105,7 @@ export const TypingEffect: React.FC<TypingEffectProps> = ({ text, isUser }) => {
       </div>
       {/* Visually hidden live region for screen readers */}
       <div
-        style={{ position: 'absolute', left: '-9999px', height: '1px', width: '1px', overflow: 'hidden' }}
+        className="sr-only"
         aria-live={settings.general.ariaMode}
         aria-atomic="true"
       >

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -226,16 +226,16 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
                       >
                         {isValidating
                           ? (
-                              <CircularProgress size={20} />
-                            )
+                            <CircularProgress size={20} />
+                          )
                           : isValid === true
                             ? (
-                                <CheckIcon color="success" />
-                              )
+                              <CheckIcon color="success" />
+                            )
                             : isValid === false
                               ? (
-                                  <ErrorIcon color="error" />
-                                )
+                                <ErrorIcon color="error" />
+                              )
                               : null}
                       </div>
                     </InputAdornment>

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -226,16 +226,16 @@ const LlmModelSettingRow: React.FC<LlmModelSettingRowProps> = ({
                       >
                         {isValidating
                           ? (
-                            <CircularProgress size={20} />
-                          )
+                              <CircularProgress size={20} />
+                            )
                           : isValid === true
                             ? (
-                              <CheckIcon color="success" />
-                            )
+                                <CheckIcon color="success" />
+                              )
                             : isValid === false
                               ? (
-                                <ErrorIcon color="error" />
-                              )
+                                  <ErrorIcon color="error" />
+                                )
                               : null}
                       </div>
                     </InputAdornment>


### PR DESCRIPTION
# Pull Request

## Description

I have made changes to TypingEffects.tsx to pickup aria-live configuration from global state. Have made changes only to chat component and tested with screen reader. If this looks good, I am planning to replicate this fix to other relevant components also.

## Related Issues

Closes #334 

## Changes Made

1. Changes made to TypingEffects.tsx to get global setting state. Also, made changes to ensure screen reader starts announcing text only after its full typed (avoid repeated announcements).


## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

Please review and let me know if it's working as intended in chat component.