### PR TITLE
chore: upgrade actions to use v4 instead of v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 

--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Ensures commit history is pulled
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 


### PR DESCRIPTION
# Pull Request

## Description

This PR changes `actions/v2` references to `actions/v4`.

## Related Issues

Closes #339 

## Changes Made

All references to `actions/<purpose>@v2` have been updated to `actions/<purpose>@v4`

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
