### PR TITLE
chore: suppress non-fatal build warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,7 @@ export default defineConfig({
     emptyOutDir: true,
     rollupOptions: {
       onwarn(warning, warn) {
-        if (warning.message.includes('Module level directives cause errors when bundled')
-          || warning.message.includes('Error when using sourcemap for reporting an error')) {
+        if (warning.code === 'MODULE_LEVEL_DIRECTIVE' || warning.code === 'SOURCEMAP_ERROR') {
           return;
         }
         warn(warning);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,15 @@ export default defineConfig({
     sourcemap: true,
     outDir: 'dist',
     emptyOutDir: true,
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.message.includes('Module level directives cause errors when bundled')
+          || warning.message.includes('Error when using sourcemap for reporting an error')) {
+          return;
+        }
+        warn(warning);
+      },
+    },
   },
   define: {
     'process.env': {},


### PR DESCRIPTION
# Pull Request

## Description

This PR aims to suppress the non-fatal build warnings seen during `npm run build`.

## Related Issues

Closes #319 

## Changes Made

The `rollUpOptions` parameter handles the suppression of targetted warnings.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
