### PR TITLE
fix(candlestick): use distinctive bear tone

### DIFF
--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -2,7 +2,6 @@ import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { AudioState, BrailleState, TextState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
-import { AudioPaletteIndex } from '@service/audioPalette';
 import { Orientation } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -316,15 +315,10 @@ export class Candlestick extends AbstractTrace<number> {
    * @returns Object containing groupIndex if applicable, empty object otherwise
    */
   protected getAudioGroupIndex(): { groupIndex?: number } {
-    const trend = this.candles[this.currentPointIndex].trend;
-
-    // Bull trend uses basic sine, Bear trend uses soft sawtooth
-    // This provides distinct audio signatures for different market conditions
-    return {
-      groupIndex: trend === 'Bull'
-        ? AudioPaletteIndex.SINE_BASIC
-        : AudioPaletteIndex.SAWTOOTH_SOFT,
-    };
+    // For candlesticks, groupIndex is determined by trend analysis
+    // This logic is handled by the AudioPaletteService to maintain
+    // proper architectural separation of concerns
+    return {};
   }
 
   protected audio(): AudioState {
@@ -336,6 +330,7 @@ export class Candlestick extends AbstractTrace<number> {
       size: this.candles.length,
       index: this.currentPointIndex,
       value,
+      trend: this.candles[this.currentPointIndex].trend,
       ...this.getAudioGroupIndex(),
     };
   }
@@ -401,5 +396,15 @@ export class Candlestick extends AbstractTrace<number> {
       section: this.currentSegmentType,
       fill: { label: TREND, value: point.trend },
     };
+  }
+
+  /**
+   * Gets the current candlestick trend for audio palette selection.
+   * This provides raw data that services can use for business logic.
+   *
+   * @returns The trend of the current candlestick point
+   */
+  public getCurrentTrend(): 'Bull' | 'Bear' | 'Neutral' {
+    return this.candles[this.currentPointIndex].trend;
   }
 }

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -1,4 +1,4 @@
-import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
+import type { CandlestickPoint, CandlestickTrend, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { AudioState, BrailleState, TextState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
@@ -404,7 +404,7 @@ export class Candlestick extends AbstractTrace<number> {
    *
    * @returns The trend of the current candlestick point
    */
-  public getCurrentTrend(): 'Bull' | 'Bear' | 'Neutral' {
+  public getCurrentTrend(): CandlestickTrend {
     return this.candles[this.currentPointIndex].trend;
   }
 }

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -2,6 +2,7 @@ import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { AudioState, BrailleState, TextState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
+import { AudioPaletteIndex } from '@service/audioPalette';
 import { Orientation } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -317,10 +318,12 @@ export class Candlestick extends AbstractTrace<number> {
   protected getAudioGroupIndex(): { groupIndex?: number } {
     const trend = this.candles[this.currentPointIndex].trend;
 
-    // Bull trend uses basic sine (index 0), Bear trend uses harmonic sine (index 5)
+    // Bull trend uses basic sine, Bear trend uses harmonic sine
     // This provides distinct audio signatures for different market conditions
     return {
-      groupIndex: trend === 'Bull' ? 0 : 5,
+      groupIndex: trend === 'Bull'
+        ? AudioPaletteIndex.SINE_BASIC
+        : AudioPaletteIndex.SINE_HARMONIC,
     };
   }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -307,12 +307,25 @@ export class Candlestick extends AbstractTrace<number> {
     return this.candleValues;
   }
 
+  /**
+   * Determines the audio group index based on candlestick trend.
+   * This method encapsulates the business logic for mapping market trends
+   * to appropriate audio palette entries.
+   *
+   * @returns Object containing groupIndex if applicable, empty object otherwise
+   */
+  protected getAudioGroupIndex(): { groupIndex?: number } {
+    const trend = this.candles[this.currentPointIndex].trend;
+
+    // Bull trend uses basic sine (index 0), Bear trend uses harmonic sine (index 5)
+    // This provides distinct audio signatures for different market conditions
+    return {
+      groupIndex: trend === 'Bull' ? 0 : 5,
+    };
+  }
+
   protected audio(): AudioState {
     const value = this.candles[this.currentPointIndex][this.currentSegmentType];
-
-    // set mood: 5 (fancy sine) for Bear, 0 (default sine) for Bull. From AudioPalette.
-    const groupIndex
-      = this.candles[this.currentPointIndex].trend === 'Bull' ? 0 : 5;
 
     return {
       min: this.min,
@@ -320,7 +333,7 @@ export class Candlestick extends AbstractTrace<number> {
       size: this.candles.length,
       index: this.currentPointIndex,
       value,
-      groupIndex,
+      ...this.getAudioGroupIndex(),
     };
   }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -312,7 +312,7 @@ export class Candlestick extends AbstractTrace<number> {
 
     // set mood: 5 (fancy sine) for Bear, 0 (default sine) for Bull. From AudioPalette.
     const groupIndex
-      = this.candles[this.currentPointIndex].trend === 'Bull' ? 0 : 10;
+      = this.candles[this.currentPointIndex].trend === 'Bull' ? 0 : 5;
 
     return {
       min: this.min,

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -307,20 +307,6 @@ export class Candlestick extends AbstractTrace<number> {
     return this.candleValues;
   }
 
-  /**
-   * Determines the audio group index based on candlestick trend.
-   * This method encapsulates the business logic for mapping market trends
-   * to appropriate audio palette entries.
-   *
-   * @returns Object containing groupIndex if applicable, empty object otherwise
-   */
-  protected getAudioGroupIndex(): { groupIndex?: number } {
-    // For candlesticks, groupIndex is determined by trend analysis
-    // This logic is handled by the AudioPaletteService to maintain
-    // proper architectural separation of concerns
-    return {};
-  }
-
   protected audio(): AudioState {
     const value = this.candles[this.currentPointIndex][this.currentSegmentType];
 
@@ -331,7 +317,6 @@ export class Candlestick extends AbstractTrace<number> {
       index: this.currentPointIndex,
       value,
       trend: this.candles[this.currentPointIndex].trend,
-      ...this.getAudioGroupIndex(),
     };
   }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -312,7 +312,7 @@ export class Candlestick extends AbstractTrace<number> {
 
     // set mood: 5 (fancy sine) for Bear, 0 (default sine) for Bull. From AudioPalette.
     const groupIndex
-      = this.candles[this.currentPointIndex].trend === 'Bull' ? 0 : 5;
+      = this.candles[this.currentPointIndex].trend === 'Bull' ? 0 : 10;
 
     return {
       min: this.min,

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -68,7 +68,8 @@ export class Candlestick extends AbstractTrace<number> {
       this.row = 0; // Points to 'open' segment index in sections array
     }
 
-    const selectors = typeof layer.selectors === 'string' ? layer.selectors : '';
+    const selectors
+      = typeof layer.selectors === 'string' ? layer.selectors : '';
     this.highlightValues = this.mapToSvgElements(selectors);
   }
 
@@ -309,9 +310,9 @@ export class Candlestick extends AbstractTrace<number> {
   protected audio(): AudioState {
     const value = this.candles[this.currentPointIndex][this.currentSegmentType];
 
-    // set mood: 9 (fancy sine) for Bear, 0 (default sine) for Bull. From AudioPalette.
+    // set mood: 5 (fancy sine) for Bear, 0 (default sine) for Bull. From AudioPalette.
     const groupIndex
-      = this.candles[this.currentPointIndex].trend === 'Bull' ? 0 : 9;
+      = this.candles[this.currentPointIndex].trend === 'Bull' ? 0 : 5;
 
     return {
       min: this.min,
@@ -348,7 +349,11 @@ export class Candlestick extends AbstractTrace<number> {
     // This ensures highlightValues[dynamicRow][col] works correctly
     const segmentElements: SVGElement[][] = [];
 
-    for (let sortedPosition = 0; sortedPosition < this.sections.length; sortedPosition++) {
+    for (
+      let sortedPosition = 0;
+      sortedPosition < this.sections.length;
+      sortedPosition++
+    ) {
       segmentElements[sortedPosition] = [];
 
       for (let pointIndex = 0; pointIndex < this.candles.length; pointIndex++) {

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -68,8 +68,7 @@ export class Candlestick extends AbstractTrace<number> {
       this.row = 0; // Points to 'open' segment index in sections array
     }
 
-    const selectors
-      = typeof layer.selectors === 'string' ? layer.selectors : '';
+    const selectors = typeof layer.selectors === 'string' ? layer.selectors : '';
     this.highlightValues = this.mapToSvgElements(selectors);
   }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -318,12 +318,12 @@ export class Candlestick extends AbstractTrace<number> {
   protected getAudioGroupIndex(): { groupIndex?: number } {
     const trend = this.candles[this.currentPointIndex].trend;
 
-    // Bull trend uses basic sine, Bear trend uses harmonic sine
+    // Bull trend uses basic sine, Bear trend uses soft sawtooth
     // This provides distinct audio signatures for different market conditions
     return {
       groupIndex: trend === 'Bull'
         ? AudioPaletteIndex.SINE_BASIC
-        : AudioPaletteIndex.SINE_HARMONIC,
+        : AudioPaletteIndex.SAWTOOTH_SOFT,
     };
   }
 

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -155,7 +155,7 @@ export class ScatterTrace extends AbstractTrace<number> {
       audio: {
         index: 0,
         size: 0,
-        groupIndex: undefined,
+        groupIndex: 0,
       },
     };
   }
@@ -194,7 +194,7 @@ export class ScatterTrace extends AbstractTrace<number> {
         audio: {
           index: 0,
           size: 0,
-          groupIndex: undefined,
+          groupIndex: 0,
         },
       };
     }
@@ -210,7 +210,7 @@ export class ScatterTrace extends AbstractTrace<number> {
         audio: {
           index: 0,
           size: 0,
-          groupIndex: undefined,
+          groupIndex: 0,
         },
       };
     }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -155,6 +155,7 @@ export class ScatterTrace extends AbstractTrace<number> {
       audio: {
         index: 0,
         size: 0,
+        groupIndex: undefined,
       },
     };
   }
@@ -193,6 +194,7 @@ export class ScatterTrace extends AbstractTrace<number> {
         audio: {
           index: 0,
           size: 0,
+          groupIndex: undefined,
         },
       };
     }
@@ -208,6 +210,7 @@ export class ScatterTrace extends AbstractTrace<number> {
         audio: {
           index: 0,
           size: 0,
+          groupIndex: undefined,
         },
       };
     }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -152,6 +152,10 @@ export class ScatterTrace extends AbstractTrace<number> {
       empty: true,
       type: 'trace',
       traceType: this.type,
+      audio: {
+        index: 0,
+        size: 0,
+      },
     };
   }
 
@@ -186,6 +190,10 @@ export class ScatterTrace extends AbstractTrace<number> {
         empty: true,
         type: 'trace',
         traceType: this.type,
+        audio: {
+          index: 0,
+          size: 0,
+        },
       };
     }
 
@@ -197,6 +205,10 @@ export class ScatterTrace extends AbstractTrace<number> {
         empty: true,
         type: 'trace',
         traceType: this.type,
+        audio: {
+          index: 0,
+          size: 0,
+        },
       };
     }
 

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -60,6 +60,10 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
         empty: true,
         type: 'trace',
         traceType: this.type,
+        audio: {
+          index: 0,
+          size: 0,
+        },
       };
     }
 

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -63,6 +63,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
         audio: {
           index: 0,
           size: 0,
+          groupIndex: 0,
         },
       };
     }

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -355,7 +355,16 @@ implements Observer<SubplotState | TraceState>, Observer<Settings>, Disposable {
 
     // Use default sine wave if no palette entry provided (for backwards compatibility)
     if (!paletteEntry) {
-      paletteEntry = { index: 0, waveType: 'sine' };
+      paletteEntry = {
+        index: 0,
+        waveType: 'sine',
+        timbreModulation: {
+          attack: 0.01,
+          decay: 0.1,
+          sustain: 0.8,
+          release: 0.2,
+        },
+      };
     }
 
     const oscillators: OscillatorNode[] = this.createOscillators(

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -105,7 +105,12 @@ implements Observer<SubplotState | TraceState>, Observer<Settings>, Disposable {
     }
 
     const audio = state.audio;
-    const groupIndex = audio.groupIndex;
+    let groupIndex = audio.groupIndex;
+
+    // Handle candlestick trend-based audio selection
+    if (audio.trend && groupIndex === undefined) {
+      groupIndex = this.audioPalette.getCandlestickGroupIndex(audio.trend);
+    }
 
     // Determine if we need to use multiclass audio based on whether groupIndex is defined
     // If groupIndex is defined (including 0), we have multiple groups and should use palette entries

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -355,7 +355,7 @@ implements Observer<SubplotState | TraceState>, Observer<Settings>, Disposable {
 
     // Use default sine wave if no palette entry provided (for backwards compatibility)
     if (!paletteEntry) {
-      paletteEntry = { waveType: 'sine' };
+      paletteEntry = { index: 0, waveType: 'sine' };
     }
 
     const oscillators: OscillatorNode[] = this.createOscillators(
@@ -640,18 +640,18 @@ implements Observer<SubplotState | TraceState>, Observer<Settings>, Disposable {
 
   private playZeroTone(): AudioId {
     // Always use original triangle wave for zero values, regardless of groups
-    return this.playOscillator(NULL_FREQUENCY, 0, { waveType: 'triangle' });
+    return this.playOscillator(NULL_FREQUENCY, 0, { index: -1, waveType: 'triangle' });
   }
 
   public playWaitingTone(): AudioId {
     return setInterval(
-      () => this.playOscillator(WAITING_FREQUENCY, 0, { waveType: 'sine' }),
+      () => this.playOscillator(WAITING_FREQUENCY, 0, { index: -1, waveType: 'sine' }),
       1000,
     );
   }
 
   public playCompleteTone(): AudioId {
-    return this.playOscillator(COMPLETE_FREQUENCY, 0, { waveType: 'sine' });
+    return this.playOscillator(COMPLETE_FREQUENCY, 0, { index: -1, waveType: 'sine' });
   }
 
   private interpolate(value: number, from: Range, to: Range): number {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -19,6 +19,7 @@ const WAITING_FREQUENCY = 440;
 const COMPLETE_FREQUENCY = 880;
 
 const DEFAULT_DURATION = 0.3;
+const DEFAULT_PALETTE_INDEX = -1;
 
 enum AudioMode {
   OFF = 'off',
@@ -640,18 +641,18 @@ implements Observer<SubplotState | TraceState>, Observer<Settings>, Disposable {
 
   private playZeroTone(): AudioId {
     // Always use original triangle wave for zero values, regardless of groups
-    return this.playOscillator(NULL_FREQUENCY, 0, { index: -1, waveType: 'triangle' });
+    return this.playOscillator(NULL_FREQUENCY, 0, { index: DEFAULT_PALETTE_INDEX, waveType: 'triangle' });
   }
 
   public playWaitingTone(): AudioId {
     return setInterval(
-      () => this.playOscillator(WAITING_FREQUENCY, 0, { index: -1, waveType: 'sine' }),
+      () => this.playOscillator(WAITING_FREQUENCY, 0, { index: DEFAULT_PALETTE_INDEX, waveType: 'sine' }),
       1000,
     );
   }
 
   public playCompleteTone(): AudioId {
-    return this.playOscillator(COMPLETE_FREQUENCY, 0, { index: -1, waveType: 'sine' });
+    return this.playOscillator(COMPLETE_FREQUENCY, 0, { index: DEFAULT_PALETTE_INDEX, waveType: 'sine' });
   }
 
   private interpolate(value: number, from: Range, to: Range): number {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -353,18 +353,9 @@ implements Observer<SubplotState | TraceState>, Observer<Settings>, Disposable {
     const duration = DEFAULT_DURATION;
     const volume = this.getVolume();
 
-    // Use default sine wave if no palette entry provided (for backwards compatibility)
+    // Use base palette entry (index 0) if no palette entry provided (for backwards compatibility)
     if (!paletteEntry) {
-      paletteEntry = {
-        index: 0,
-        waveType: 'sine',
-        timbreModulation: {
-          attack: 0.01,
-          decay: 0.1,
-          sustain: 0.8,
-          release: 0.2,
-        },
-      };
+      paletteEntry = this.audioPalette.getPaletteEntry(0);
     }
 
     const oscillators: OscillatorNode[] = this.createOscillators(

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -5,7 +5,7 @@ import type { PlotState, SubplotState, TraceState } from '@type/state';
 import type { AudioPaletteEntry } from './audioPalette';
 import type { NotificationService } from './notification';
 import type { SettingsService } from './settings';
-import { AudioPaletteService } from './audioPalette';
+import { AudioPaletteIndex, AudioPaletteService } from './audioPalette';
 
 interface Range {
   min: number;
@@ -19,7 +19,7 @@ const WAITING_FREQUENCY = 440;
 const COMPLETE_FREQUENCY = 880;
 
 const DEFAULT_DURATION = 0.3;
-const DEFAULT_PALETTE_INDEX = -1;
+const DEFAULT_PALETTE_INDEX = AudioPaletteIndex.SINE_BASIC;
 
 enum AudioMode {
   OFF = 'off',

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -29,6 +29,7 @@ export const AudioPaletteIndex = {
 } as const;
 
 export interface AudioPaletteEntry {
+  index: number;
   waveType: WaveType;
   harmonicMix?: {
     fundamental: number;
@@ -59,6 +60,7 @@ export class AudioPaletteService implements Disposable {
     // Base palette with fundamental wave types
     this.basePalette = [
       {
+        index: AudioPaletteIndex.SINE_BASIC,
         waveType: 'sine',
         timbreModulation: {
           attack: 0.01,
@@ -68,6 +70,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
+        index: AudioPaletteIndex.SQUARE_BASIC,
         waveType: 'square',
         timbreModulation: {
           attack: 0.005,
@@ -77,6 +80,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
+        index: AudioPaletteIndex.SAWTOOTH_BASIC,
         waveType: 'sawtooth',
         timbreModulation: {
           attack: 0.02,
@@ -86,6 +90,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
+        index: AudioPaletteIndex.TRIANGLE_BASIC,
         waveType: 'triangle',
         timbreModulation: {
           attack: 0.015,
@@ -95,7 +100,8 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sawtooth', // AudioPaletteIndex.SAWTOOTH_DARK - duller and darker than basic sawtooth
+        index: AudioPaletteIndex.SAWTOOTH_DARK,
+        waveType: 'sawtooth',
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -112,7 +118,8 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sine', // AudioPaletteIndex.SINE_HARMONIC
+        index: AudioPaletteIndex.SINE_HARMONIC,
+        waveType: 'sine',
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -128,7 +135,8 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'triangle', // AudioPaletteIndex.TRIANGLE_HARMONIC
+        index: AudioPaletteIndex.TRIANGLE_HARMONIC,
+        waveType: 'triangle',
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -144,7 +152,8 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'square', // AudioPaletteIndex.SQUARE_HARMONIC
+        index: AudioPaletteIndex.SQUARE_HARMONIC,
+        waveType: 'square',
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -160,7 +169,8 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'triangle', // AudioPaletteIndex.TRIANGLE_MELLOW
+        index: AudioPaletteIndex.TRIANGLE_MELLOW,
+        waveType: 'triangle',
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -176,7 +186,8 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sine', // AudioPaletteIndex.SINE_SUBTLE
+        index: AudioPaletteIndex.SINE_SUBTLE,
+        waveType: 'sine',
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -192,7 +203,8 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sawtooth', // AudioPaletteIndex.SAWTOOTH_SOFT
+        index: AudioPaletteIndex.SAWTOOTH_SOFT,
+        waveType: 'sawtooth',
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -209,8 +221,13 @@ export class AudioPaletteService implements Disposable {
       },
     ];
 
+    // Validate that array indices match the index properties
+    this.validateBasePalette();
+
     this.extendedPalette = new Map();
     this.generateExtendedPalette();
+
+    this.validateBasePalette();
   }
 
   public dispose(): void {
@@ -276,6 +293,7 @@ export class AudioPaletteService implements Disposable {
     const extendedDefinitions: AudioPaletteEntry[] = [
       // Harmonic variations of sine wave
       {
+        index: this.basePalette.length + 0,
         waveType: 'sine',
         harmonicMix: {
           fundamental: 1.0,
@@ -293,6 +311,7 @@ export class AudioPaletteService implements Disposable {
       },
       // Harmonic variations of square wave
       {
+        index: this.basePalette.length + 1,
         waveType: 'square',
         harmonicMix: {
           fundamental: 1.0,
@@ -310,6 +329,7 @@ export class AudioPaletteService implements Disposable {
       },
       // Complex harmonic mix with sawtooth
       {
+        index: this.basePalette.length + 2,
         waveType: 'sawtooth',
         harmonicMix: {
           fundamental: 1.0,
@@ -328,6 +348,7 @@ export class AudioPaletteService implements Disposable {
       },
       // Triangle with unique modulation
       {
+        index: this.basePalette.length + 3,
         waveType: 'triangle',
         harmonicMix: {
           fundamental: 1.0,
@@ -374,6 +395,7 @@ export class AudioPaletteService implements Disposable {
     );
 
     return {
+      index: groupIndex,
       waveType: baseEntry.waveType,
       harmonicMix: {
         fundamental: 1.0,
@@ -424,5 +446,20 @@ export class AudioPaletteService implements Disposable {
       ),
       release: Math.max(0.1, Math.min(0.5, base.release * factor)),
     };
+  }
+
+  /**
+   * Validates that the base palette entries have correct indices
+   * to prevent silent mismatches when reordering
+   */
+  private validateBasePalette(): void {
+    this.basePalette.forEach((entry, arrayIndex) => {
+      if (entry.index !== arrayIndex) {
+        throw new Error(
+          `AudioPalette validation error: Entry at array position ${arrayIndex} has index ${entry.index}. `
+          + `Array position must match the index property to prevent audio palette mismatches.`,
+        );
+      }
+    });
   }
 }

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -414,7 +414,7 @@ export class AudioPaletteService implements Disposable {
     // Generate harmonics based on variation
     const numHarmonics
       = AudioPaletteService.MIN_HARMONICS
-      + (variation % AudioPaletteService.HARMONIC_VARIATION);
+        + (variation % AudioPaletteService.HARMONIC_VARIATION);
 
     for (let i = 0; i < numHarmonics; i++) {
       const frequency = 1.0 + (i + 1) * (0.5 + ((variation * 0.3) % 1.0));

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -89,7 +89,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sine',
+        waveType: 'sine', // 5
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -105,7 +105,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'triangle',
+        waveType: 'triangle', // 6
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -121,7 +121,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'square',
+        waveType: 'square', // 7
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -137,7 +137,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'triangle',
+        waveType: 'triangle', // 8
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -153,7 +153,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sine',
+        waveType: 'sine', // 9
         harmonicMix: {
           fundamental: 1,
           harmonics: [

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -1,4 +1,5 @@
 import type { Disposable } from '@type/disposable';
+import type { CandlestickTrend } from '@type/grammar';
 
 /**
  * Audio palette types for distinguishing groups in multiclass plots
@@ -252,7 +253,7 @@ export class AudioPaletteService implements Disposable {
    * @param trend The candlestick trend (Bull, Bear, or Neutral)
    * @returns The palette index for the specified trend
    */
-  public getCandlestickGroupIndex(trend: 'Bull' | 'Bear' | 'Neutral'): number {
+  public getCandlestickGroupIndex(trend: CandlestickTrend): number {
     switch (trend) {
       case 'Bull':
         return AudioPaletteIndex.SINE_BASIC; // Basic sine for positive market trends

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -261,6 +261,9 @@ export class AudioPaletteService implements Disposable {
         return AudioPaletteIndex.SAWTOOTH_SOFT; // Soft sawtooth for negative market trends
       case 'Neutral':
         return AudioPaletteIndex.TRIANGLE_BASIC; // Triangle for neutral market trends
+      default:
+        // Defensive fallback for unexpected trend values
+        return AudioPaletteIndex.SINE_BASIC;
     }
   }
 

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -5,6 +5,28 @@ import type { Disposable } from '@type/disposable';
  */
 export type WaveType = 'sine' | 'square' | 'sawtooth' | 'triangle';
 
+/**
+ * Predefined palette indices for base audio signatures.
+ * These constants provide semantic meaning to palette positions
+ * and make the code more maintainable than magic numbers.
+ */
+export const AudioPaletteIndex = {
+  // Basic wave types (0-3)
+  SINE_BASIC: 0,
+  SQUARE_BASIC: 1,
+  SAWTOOTH_BASIC: 2,
+  TRIANGLE_BASIC: 3,
+
+  // Harmonic variations (4+)
+  SAWTOOTH_DARK: 4,
+  SINE_HARMONIC: 5,
+  TRIANGLE_HARMONIC: 6,
+  SQUARE_HARMONIC: 7,
+  TRIANGLE_MELLOW: 8,
+  SINE_SUBTLE: 9,
+  SAWTOOTH_SOFT: 10,
+} as const;
+
 export interface AudioPaletteEntry {
   waveType: WaveType;
   harmonicMix?: {
@@ -72,7 +94,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sawtooth', // duller and darker than 'sine' or 'square'
+        waveType: 'sawtooth', // AudioPaletteIndex.SAWTOOTH_DARK - duller and darker than basic sawtooth
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -89,7 +111,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sine', // 5
+        waveType: 'sine', // AudioPaletteIndex.SINE_HARMONIC
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -105,7 +127,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'triangle', // 6
+        waveType: 'triangle', // AudioPaletteIndex.TRIANGLE_HARMONIC
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -121,7 +143,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'square', // 7
+        waveType: 'square', // AudioPaletteIndex.SQUARE_HARMONIC
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -137,7 +159,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'triangle', // 8
+        waveType: 'triangle', // AudioPaletteIndex.TRIANGLE_MELLOW
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -153,7 +175,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sine', // 9
+        waveType: 'sine', // AudioPaletteIndex.SINE_SUBTLE
         harmonicMix: {
           fundamental: 1,
           harmonics: [
@@ -169,7 +191,7 @@ export class AudioPaletteService implements Disposable {
         },
       },
       {
-        waveType: 'sawtooth', // 10
+        waveType: 'sawtooth', // AudioPaletteIndex.SAWTOOTH_SOFT
         harmonicMix: {
           fundamental: 1,
           harmonics: [

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -291,7 +291,7 @@ export class AudioPaletteService implements Disposable {
     const extendedDefinitions: AudioPaletteEntry[] = [
       // Harmonic variations of sine wave
       {
-        index: this.basePalette.length + 0,
+        index: this.basePalette.length,
         waveType: 'sine',
         harmonicMix: {
           fundamental: 1.0,
@@ -414,7 +414,7 @@ export class AudioPaletteService implements Disposable {
     // Generate harmonics based on variation
     const numHarmonics
       = AudioPaletteService.MIN_HARMONICS
-        + (variation % AudioPaletteService.HARMONIC_VARIATION);
+      + (variation % AudioPaletteService.HARMONIC_VARIATION);
 
     for (let i = 0; i < numHarmonics; i++) {
       const frequency = 1.0 + (i + 1) * (0.5 + ((variation * 0.3) % 1.0));

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -56,27 +56,6 @@ export class AudioPaletteService implements Disposable {
   private readonly basePalette: AudioPaletteEntry[];
   private readonly extendedPalette: Map<number, AudioPaletteEntry>;
 
-  /**
-   * Helper method to create a base palette entry with guaranteed index consistency.
-   * Use this when adding new entries to ensure index property matches array position.
-   *
-   * @param index - The index from AudioPaletteIndex constants
-   * @param waveType - The wave type for this entry
-   * @param additionalProps - Additional properties (harmonicMix, timbreModulation, etc.)
-   * @returns AudioPaletteEntry with guaranteed index consistency
-   */
-  private static createBasePaletteEntry(
-    index: number,
-    waveType: WaveType,
-    additionalProps: Partial<Omit<AudioPaletteEntry, 'index' | 'waveType'>> = {},
-  ): AudioPaletteEntry {
-    return {
-      index,
-      waveType,
-      ...additionalProps,
-    };
-  }
-
   public constructor() {
     // IMPORTANT: Base palette index consistency requirement
     // When modifying this basePalette array:

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -168,6 +168,22 @@ export class AudioPaletteService implements Disposable {
           release: 0.15,
         },
       },
+      {
+        waveType: 'sawtooth', // 10
+        harmonicMix: {
+          fundamental: 1,
+          harmonics: [
+            { frequency: 2, amplitude: 0.05 },
+            { frequency: 6, amplitude: 0.02 },
+          ],
+        },
+        timbreModulation: {
+          attack: 0.005,
+          decay: 0.4,
+          sustain: 0.2,
+          release: 0.6,
+        },
+      },
     ];
 
     this.extendedPalette = new Map();

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -245,6 +245,25 @@ export class AudioPaletteService implements Disposable {
   }
 
   /**
+   * Determines the appropriate audio palette index for candlestick trends.
+   * This encapsulates the business logic for mapping market conditions
+   * to distinct audio signatures.
+   *
+   * @param trend The candlestick trend (Bull, Bear, or Neutral)
+   * @returns The palette index for the specified trend
+   */
+  public getCandlestickGroupIndex(trend: 'Bull' | 'Bear' | 'Neutral'): number {
+    switch (trend) {
+      case 'Bull':
+        return AudioPaletteIndex.SINE_BASIC; // Basic sine for positive market trends
+      case 'Bear':
+        return AudioPaletteIndex.SAWTOOTH_SOFT; // Soft sawtooth for negative market trends
+      case 'Neutral':
+        return AudioPaletteIndex.TRIANGLE_BASIC; // Triangle for neutral market trends
+    }
+  }
+
+  /**
    * Generates extended palette entries by creating unique combinations
    * of harmonic mixes and timbre modulations
    */

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -459,11 +459,8 @@ export class AudioPaletteService implements Disposable {
   }
 
   /**
-   * Validates that the base palette entries have correct indices
-   * to prevent silent mismatches when reordering
-   */
-  /**
-   * Validates that all base palette entries have index properties that match their array positions.
+   * Validates that all base palette entries have correct indices to prevent silent mismatches
+   * when reordering. Ensures that each entry's index property matches its array position.
    * This method should be called in the constructor and whenever the basePalette is modified.
    *
    * @throws Error if any entry's index doesn't match its array position

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -226,8 +226,6 @@ export class AudioPaletteService implements Disposable {
 
     this.extendedPalette = new Map();
     this.generateExtendedPalette();
-
-    this.validateBasePalette();
   }
 
   public dispose(): void {

--- a/src/service/audioPalette.ts
+++ b/src/service/audioPalette.ts
@@ -56,7 +56,40 @@ export class AudioPaletteService implements Disposable {
   private readonly basePalette: AudioPaletteEntry[];
   private readonly extendedPalette: Map<number, AudioPaletteEntry>;
 
+  /**
+   * Helper method to create a base palette entry with guaranteed index consistency.
+   * Use this when adding new entries to ensure index property matches array position.
+   *
+   * @param index - The index from AudioPaletteIndex constants
+   * @param waveType - The wave type for this entry
+   * @param additionalProps - Additional properties (harmonicMix, timbreModulation, etc.)
+   * @returns AudioPaletteEntry with guaranteed index consistency
+   */
+  private static createBasePaletteEntry(
+    index: number,
+    waveType: WaveType,
+    additionalProps: Partial<Omit<AudioPaletteEntry, 'index' | 'waveType'>> = {},
+  ): AudioPaletteEntry {
+    return {
+      index,
+      waveType,
+      ...additionalProps,
+    };
+  }
+
   public constructor() {
+    // IMPORTANT: Base palette index consistency requirement
+    // When modifying this basePalette array:
+    // 1. Each entry's `index` property MUST match its array position (0-based)
+    // 2. Use AudioPaletteIndex constants for semantic clarity
+    // 3. Update AudioPaletteIndex constants if adding/removing entries
+    // 4. The validateBasePalette() method will enforce this at runtime
+    //
+    // Example: basePalette[0] must have index: AudioPaletteIndex.SINE_BASIC (0)
+    //          basePalette[1] must have index: AudioPaletteIndex.SQUARE_BASIC (1)
+    //
+    // This consistency is critical for proper audio palette group mapping.
+
     // Base palette with fundamental wave types
     this.basePalette = [
       {
@@ -449,6 +482,12 @@ export class AudioPaletteService implements Disposable {
   /**
    * Validates that the base palette entries have correct indices
    * to prevent silent mismatches when reordering
+   */
+  /**
+   * Validates that all base palette entries have index properties that match their array positions.
+   * This method should be called in the constructor and whenever the basePalette is modified.
+   *
+   * @throws Error if any entry's index doesn't match its array position
    */
   private validateBasePalette(): void {
     this.basePalette.forEach((entry, arrayIndex) => {

--- a/src/state/viewModel/chatViewModel.ts
+++ b/src/state/viewModel/chatViewModel.ts
@@ -138,7 +138,7 @@ export class ChatViewModel extends AbstractViewModel<ChatState> {
         const response = await this.chatService.sendMessage(model, {
           message: newMessage,
           customInstruction: llmSettings.customInstruction,
-          expertise: llmSettings.customExpertise ?? llmSettings.expertiseLevel,
+          expertise: llmSettings.expertiseLevel,
           apiKey: config.apiKey,
         });
 

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -1,3 +1,9 @@
+/**
+ * Represents the trend direction for candlestick data points.
+ * Used across the application for audio palette selection and data representation.
+ */
+export type CandlestickTrend = 'Bull' | 'Bear' | 'Neutral';
+
 export interface Maidr {
   id: string;
   title?: string;
@@ -43,7 +49,7 @@ export interface CandlestickPoint {
   low: number;
   close: number;
   volume: number;
-  trend: 'Bull' | 'Bear' | 'Neutral';
+  trend: CandlestickTrend;
 }
 
 export interface HeatmapData {

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -63,6 +63,7 @@ export type TraceState
 export interface AudioEmptyState {
   index: number;
   size: number;
+  groupIndex?: number;
 }
 
 export interface AudioState {

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -81,6 +81,12 @@ export interface AudioState {
    * If undefined, defaults to 0 (single group).
    */
   groupIndex?: number;
+  /**
+   * Candlestick trend information for audio palette selection.
+   * Used by AudioService to determine appropriate audio characteristics.
+   * Only applicable for candlestick traces.
+   */
+  trend?: 'Bull' | 'Bear' | 'Neutral';
 }
 
 export type BrailleState

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -1,4 +1,4 @@
-import type { BoxPoint, TraceType } from '@type/grammar';
+import type { BoxPoint, CandlestickTrend, TraceType } from '@type/grammar';
 import type { MovableDirection } from './movable';
 
 export type PlotState = FigureState | SubplotState | TraceState;
@@ -88,7 +88,7 @@ export interface AudioState {
    * Used by AudioService to determine appropriate audio characteristics.
    * Only applicable for candlestick traces.
    */
-  trend?: 'Bull' | 'Bear' | 'Neutral';
+  trend?: CandlestickTrend;
 }
 
 export type BrailleState


### PR DESCRIPTION
- **feat: better bear tone**
- **chore: better tone round 3**
- **feat: enhance audio palette with predefined indices for better maintainability**
- **fix: adjust group index for Bear trend in Candlestick class**
- **feat: add method to determine audio group index based on candlestick trend**
- **feat: update audio group index to use AudioPaletteIndex constants for better clarity**
- **fix: update audio group index for Bear trend to use soft sawtooth for distinct audio signatures**
- **feat: implement trend-based audio group index selection for candlestick trends**
