### PR TITLE
fix: support multi-line axis label & titles

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -173,7 +173,7 @@ export abstract class AbstractObservableElement<Element, State> implements Movab
 export abstract class AbstractTrace<T> extends AbstractObservableElement<T, TraceState> implements Trace {
   protected readonly id: string;
   protected readonly type: TraceType;
-  private readonly title: string;
+  protected readonly title: string;
 
   protected readonly xAxis: string;
   protected readonly yAxis: string;

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -1,6 +1,6 @@
 import type { CandlestickPoint, CandlestickTrend, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
-import type { AudioState, BrailleState, TextState } from '@type/state';
+import type { AudioState, BrailleState, TextState, TraceState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Orientation } from '@type/grammar';
@@ -44,11 +44,11 @@ export class Candlestick extends AbstractTrace<number> {
     this.candles = data.map(candle => ({
       ...candle,
       trend:
-        candle.close > candle.open
-          ? 'Bull'
-          : candle.close < candle.open
-            ? 'Bear'
-            : 'Neutral',
+                candle.close > candle.open
+                  ? 'Bull'
+                  : candle.close < candle.open
+                    ? 'Bear'
+                    : 'Neutral',
     }));
 
     this.orientation = layer.orientation ?? Orientation.VERTICAL;
@@ -86,7 +86,7 @@ export class Candlestick extends AbstractTrace<number> {
     return this.candles.map((candle) => {
       // Create array of [segmentType, value] pairs
       const segmentPairs: [CandlestickSegmentType, number][]
-        = this.sections.map(segmentType => [segmentType, candle[segmentType]]);
+                = this.sections.map(segmentType => [segmentType, candle[segmentType]]);
 
       // Sort by value and return just the segment types
       return segmentPairs.sort((a, b) => a[1] - b[1]).map(pair => pair[0]);
@@ -179,9 +179,9 @@ export class Candlestick extends AbstractTrace<number> {
           this.currentSegmentType,
         );
         const newSegmentPosition
-          = direction === 'UPWARD'
-            ? currentSegmentPosition + 1
-            : currentSegmentPosition - 1;
+                    = direction === 'UPWARD'
+                      ? currentSegmentPosition + 1
+                      : currentSegmentPosition - 1;
 
         if (
           newSegmentPosition >= 0
@@ -203,9 +203,9 @@ export class Candlestick extends AbstractTrace<number> {
       case 'BACKWARD': {
         // Horizontal movement: navigate between candlesticks while preserving segment type
         const newPointIndex
-          = direction === 'FORWARD'
-            ? this.currentPointIndex + 1
-            : this.currentPointIndex - 1;
+                    = direction === 'FORWARD'
+                      ? this.currentPointIndex + 1
+                      : this.currentPointIndex - 1;
 
         if (newPointIndex >= 0 && newPointIndex < this.candles.length) {
           this.currentPointIndex = newPointIndex;
@@ -231,7 +231,7 @@ export class Candlestick extends AbstractTrace<number> {
       case 'UPWARD': {
         // Move to the highest value segment in current candlestick
         const currentSorted
-          = this.sortedSegmentsByPoint[this.currentPointIndex];
+                    = this.sortedSegmentsByPoint[this.currentPointIndex];
         this.currentSegmentType = currentSorted[currentSorted.length - 1];
         this.updateVisualSegmentPosition();
         break;
@@ -239,7 +239,7 @@ export class Candlestick extends AbstractTrace<number> {
       case 'DOWNWARD': {
         // Move to the lowest value segment in current candlestick
         const currentSortedDown
-          = this.sortedSegmentsByPoint[this.currentPointIndex];
+                    = this.sortedSegmentsByPoint[this.currentPointIndex];
         this.currentSegmentType = currentSortedDown[0];
         this.updateVisualSegmentPosition();
         break;
@@ -310,9 +310,9 @@ export class Candlestick extends AbstractTrace<number> {
           this.currentSegmentType,
         );
         const newSegmentPosition
-          = target === 'UPWARD'
-            ? currentSegmentPosition + 1
-            : currentSegmentPosition - 1;
+                    = target === 'UPWARD'
+                      ? currentSegmentPosition + 1
+                      : currentSegmentPosition - 1;
         return (
           newSegmentPosition >= 0 && newSegmentPosition < this.sections.length
         );
@@ -322,9 +322,9 @@ export class Candlestick extends AbstractTrace<number> {
       case 'BACKWARD': {
         // Horizontal movement: check if we can move between candlesticks
         const newPointIndex
-          = target === 'FORWARD'
-            ? this.currentPointIndex + 1
-            : this.currentPointIndex - 1;
+                    = target === 'FORWARD'
+                      ? this.currentPointIndex + 1
+                      : this.currentPointIndex - 1;
         return newPointIndex >= 0 && newPointIndex < this.candles.length;
       }
     }
@@ -409,12 +409,12 @@ export class Candlestick extends AbstractTrace<number> {
     return {
       main: {
         label:
-          this.orientation === Orientation.HORIZONTAL ? this.yAxis : this.xAxis,
+                    this.orientation === Orientation.HORIZONTAL ? this.yAxis : this.xAxis,
         value: point.value,
       },
       cross: {
         label:
-          this.orientation === Orientation.HORIZONTAL ? this.xAxis : this.yAxis,
+                    this.orientation === Orientation.HORIZONTAL ? this.xAxis : this.yAxis,
         value: crossValue,
       },
       section: this.currentSegmentType,
@@ -430,5 +430,24 @@ export class Candlestick extends AbstractTrace<number> {
    */
   public getCurrentTrend(): CandlestickTrend {
     return this.candles[this.currentPointIndex].trend;
+  }
+
+  /**
+   * Override the state getter to provide dynamic axis labels for candlestick plots
+   * - xAxis: Shows the X-axis label (e.g., "Date") for l x command
+   * - yAxis: Shows the current segment type (open, high, low, close) for l y command
+   */
+  public override get state(): TraceState {
+    const parentState = super.state;
+
+    if (parentState.empty) {
+      return parentState;
+    }
+
+    return {
+      ...parentState,
+      xAxis: this.xAxis, // Use original X-axis label (e.g., "Date")
+      yAxis: this.currentSegmentType, // Current segment type (open, high, low, close)
+    };
   }
 }

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -1,6 +1,6 @@
 import type { CandlestickPoint, CandlestickTrend, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
-import type { AudioState, BrailleState, TextState, TraceState } from '@type/state';
+import type { AudioState, BrailleState, TextState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Orientation } from '@type/grammar';
@@ -430,24 +430,5 @@ export class Candlestick extends AbstractTrace<number> {
    */
   public getCurrentTrend(): CandlestickTrend {
     return this.candles[this.currentPointIndex].trend;
-  }
-
-  /**
-   * Override the state getter to provide dynamic axis labels for candlestick plots
-   * - xAxis: Shows the X-axis label (e.g., "Date") for l x command
-   * - yAxis: Shows the current segment type (open, high, low, close) for l y command
-   */
-  public override get state(): TraceState {
-    const parentState = super.state;
-
-    if (parentState.empty) {
-      return parentState;
-    }
-
-    return {
-      ...parentState,
-      xAxis: this.xAxis, // Use original X-axis label (e.g., "Date")
-      yAxis: this.currentSegmentType, // Current segment type (open, high, low, close)
-    };
   }
 }

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -1,6 +1,6 @@
-import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { LineDataItem, LinePoint, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
-import type { AudioState, BrailleState, TextState } from '@type/state';
+import type { AudioState, BrailleState, TextState, TraceState } from '@type/state';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -17,10 +17,32 @@ export class LineTrace extends AbstractTrace<number> {
   protected readonly min: number[];
   protected readonly max: number[];
 
+  // Support for dynamic axis labels and titles per line
+  private readonly lineDataItems?: LineDataItem[];
+  private readonly isEnhancedFormat: boolean;
+
   public constructor(layer: MaidrLayer) {
     super(layer);
 
-    this.points = layer.data as LinePoint[][];
+    // Check if data is in the new enhanced format
+    const data = layer.data;
+    if (Array.isArray(data) && data.length > 0 && 'points' in data[0]) {
+      // New enhanced format: LineDataItem[]
+      this.isEnhancedFormat = true;
+      this.lineDataItems = data as LineDataItem[];
+
+      // Convert to the expected LinePoint[][] format for compatibility
+      this.points = this.lineDataItems.map(item =>
+        item.points.map(point => ({
+          ...point,
+        })),
+      );
+    } else {
+      // Legacy format: LinePoint[][]
+      this.isEnhancedFormat = false;
+      this.lineDataItems = undefined;
+      this.points = data as LinePoint[][];
+    }
 
     this.lineValues = this.points.map(row => row.map(point => Number(point.y)));
     this.min = this.lineValues.map(row => MathUtil.safeMin(row));
@@ -40,6 +62,26 @@ export class LineTrace extends AbstractTrace<number> {
 
   protected get values(): number[][] {
     return this.lineValues;
+  }
+
+  public get state(): TraceState {
+    const baseState = super.state;
+
+    if (baseState.empty) {
+      return baseState;
+    }
+
+    // Use dynamic title and axis labels for enhanced format
+    const dynamicTitle = this.getDynamicTitle();
+    const dynamicXAxis = this.getDynamicXAxisLabel();
+    const dynamicYAxis = this.getDynamicYAxisLabel();
+
+    return {
+      ...baseState,
+      title: dynamicTitle || baseState.title,
+      xAxis: dynamicXAxis,
+      yAxis: dynamicYAxis,
+    };
   }
 
   protected audio(): AudioState {
@@ -72,8 +114,8 @@ export class LineTrace extends AbstractTrace<number> {
       : {};
 
     return {
-      main: { label: this.xAxis, value: this.points[this.row][this.col].x },
-      cross: { label: this.yAxis, value: this.points[this.row][this.col].y },
+      main: { label: this.getDynamicXAxisLabel(), value: this.points[this.row][this.col].x },
+      cross: { label: this.getDynamicYAxisLabel(), value: this.points[this.row][this.col].y },
       ...fillData,
     };
   }
@@ -284,5 +326,57 @@ export class LineTrace extends AbstractTrace<number> {
       return null;
     }
     return svgElements;
+  }
+
+  /**
+   * Gets the dynamic X-axis label for the current line
+   * @returns The X-axis label for the current line, or the top-level label if not available
+   */
+  public getDynamicXAxisLabel(): string {
+    if (this.isEnhancedFormat && this.lineDataItems && this.row < this.lineDataItems.length) {
+      const lineItem = this.lineDataItems[this.row];
+      return lineItem.axes?.x || this.xAxis;
+    }
+    return this.xAxis;
+  }
+
+  /**
+   * Gets the dynamic Y-axis label for the current line
+   * @returns The Y-axis label for the current line, or the top-level label if not available
+   */
+  public getDynamicYAxisLabel(): string {
+    if (this.isEnhancedFormat && this.lineDataItems && this.row < this.lineDataItems.length) {
+      const lineItem = this.lineDataItems[this.row];
+      return lineItem.axes?.y || this.yAxis;
+    }
+    return this.yAxis;
+  }
+
+  /**
+   * Gets the dynamic title for the current line
+   * @returns The title for the current line, or the top-level title if not available
+   */
+  public getDynamicTitle(): string | undefined {
+    if (this.isEnhancedFormat && this.lineDataItems && this.row < this.lineDataItems.length) {
+      const lineItem = this.lineDataItems[this.row];
+      return lineItem.title || this.title;
+    }
+    return this.title;
+  }
+
+  /**
+   * Gets the current line index
+   * @returns The current line index
+   */
+  public getCurrentLineIndex(): number {
+    return this.row;
+  }
+
+  /**
+   * Gets the total number of lines
+   * @returns The total number of lines
+   */
+  public getTotalLines(): number {
+    return this.points.length;
   }
 }

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -71,6 +71,15 @@ export interface LinePoint {
   fill?: string;
 }
 
+export interface LineDataItem {
+  title?: string;
+  axes?: {
+    x?: string;
+    y?: string;
+  };
+  points: LinePoint[];
+}
+
 export interface ScatterPoint {
   x: number;
   y: number;
@@ -110,6 +119,7 @@ export interface MaidrLayer {
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]
+    | LineDataItem[]
     | ScatterPoint[]
     | SegmentedPoint[][];
 }


### PR DESCRIPTION
# Pull Request

## Description

1. Added support for enhanced line plot data format with individual line titles and axis labels
2. Implemented dynamic axis label and title resolution that falls back to top-level values when line-specific ones are unavailable
3. Enhanced LineTrace class to handle both legacy LinePoint[][] and new LineDataItem[] formats while maintaining full backward compatibility
4. Updated state management to expose dynamic labels and titles during navigation, enabling context-aware labeling for each line in multi-line plots


## Changes Made

1. src/type/grammar.ts
    Added LineDataItem interface to support enhanced line data structure with individual line titles and axes
    Updated MaidrLayer.data union type to include LineDataItem[] format alongside existing LinePoint[][]
2. src/model/abstract.ts
    Changed title property from private readonly to protected readonly.
3. src/model/line.ts
    Added enhanced format detection in constructor to support old and new data formats
    Added lineDataItems and isEnhancedFormat private properties for internal state management
     Implemented data conversion logic to transform LineDataItem[] to LinePoint[][] for compatibility
     Added getDynamicXAxisLabel(), getDynamicYAxisLabel(), and getDynamicTitle() methods for dynamic label resolution

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
