### PR TITLE
fix: address inconsistent x-values during inter-layer navigation

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -1,6 +1,7 @@
 import type { Disposable } from '@type/disposable';
 import type { MaidrLayer, TraceType } from '@type/grammar';
 import type { Movable, MovableDirection } from '@type/movable';
+import type { XValue } from '@type/navigation';
 import type { Observable, Observer } from '@type/observable';
 import type { AudioState, AutoplayState, BrailleState, HighlightState, TextState, TraceState } from '@type/state';
 import type { Trace } from './plot';
@@ -181,7 +182,7 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
   protected readonly fill: string;
 
   // Service for navigation business logic
-  private readonly navigationService: NavigationService;
+  protected readonly navigationService: NavigationService;
 
   protected constructor(layer: MaidrLayer) {
     super();
@@ -305,7 +306,7 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
    * Base implementation for getting current X value
    * Subclasses can override if they have different data structures
    */
-  public getCurrentXValue(): any {
+  public getCurrentXValue(): XValue | null {
     // Handle traces with points array (BarTrace, LineTrace)
     if (this.hasPointsArray()) {
       const points = this.getPointsArray();
@@ -318,7 +319,7 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
     if (this.hasValuesArray()) {
       const values = this.values;
       if (this.isValidValuesArray(values)) {
-        return this.navigationService.extractXValueFromValues(values, this.row, this.col);
+        return this.navigationService.extractXValueFromValues(values as any, this.row, this.col);
       }
     }
 
@@ -329,7 +330,7 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
    * Base implementation for moving to X value
    * Subclasses can override if they have different data structures
    */
-  public moveToXValue(xValue: any): boolean {
+  public moveToXValue(xValue: XValue): boolean {
     // Handle traces with points array (BarTrace, LineTrace)
     if (this.hasPointsArray()) {
       const points = this.getPointsArray();
@@ -342,7 +343,7 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
     if (this.hasValuesArray()) {
       const values = this.values;
       if (this.isValidValuesArray(values)) {
-        return this.navigationService.moveToXValueInValues(values, xValue, this.moveToIndex.bind(this));
+        return this.navigationService.moveToXValueInValues(values as any, xValue, this.moveToIndex.bind(this));
       }
     }
 

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -1,5 +1,6 @@
 import type { CandlestickPoint, CandlestickTrend, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
+import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, TextState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
@@ -32,7 +33,7 @@ export class Candlestick extends AbstractTrace<number> {
   protected readonly highlightValues: SVGElement[][] | null;
 
   // Service dependency for navigation logic
-  private readonly navigationService: NavigationService;
+  protected readonly navigationService: NavigationService;
 
   constructor(layer: MaidrLayer) {
     super(layer);
@@ -436,7 +437,7 @@ export class Candlestick extends AbstractTrace<number> {
    * Get the current X value from the candlestick trace
    * @returns The current X value or null if not available
    */
-  public getCurrentXValue(): any {
+  public getCurrentXValue(): XValue | null {
     if (this.currentPointIndex >= 0 && this.currentPointIndex < this.candles.length) {
       return this.candles[this.currentPointIndex].value;
     }
@@ -448,7 +449,7 @@ export class Candlestick extends AbstractTrace<number> {
    * @param xValue The X value to move to
    * @returns true if the position was found and set, false otherwise
    */
-  public moveToXValue(xValue: any): boolean {
+  public moveToXValue(xValue: XValue): boolean {
     const targetIndex = this.candles.findIndex(candle => candle.value === xValue);
     if (targetIndex !== -1) {
       this.currentPointIndex = targetIndex;

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -431,4 +431,33 @@ export class Candlestick extends AbstractTrace<number> {
   public getCurrentTrend(): CandlestickTrend {
     return this.candles[this.currentPointIndex].trend;
   }
+
+  /**
+   * Get the current X value from the candlestick trace
+   * @returns The current X value or null if not available
+   */
+  public getCurrentXValue(): any {
+    if (this.currentPointIndex >= 0 && this.currentPointIndex < this.candles.length) {
+      return this.candles[this.currentPointIndex].value;
+    }
+    return null;
+  }
+
+  /**
+   * Move the candlestick to the position that matches the given X value
+   * @param xValue The X value to move to
+   * @returns true if the position was found and set, false otherwise
+   */
+  public moveToXValue(xValue: any): boolean {
+    const targetIndex = this.candles.findIndex(candle => candle.value === xValue);
+    if (targetIndex !== -1) {
+      this.currentPointIndex = targetIndex;
+      this.currentSegmentType = 'open'; // Default to open segment
+      this.updateVisualPointPosition();
+      this.updateVisualSegmentPosition();
+      this.notifyStateUpdate();
+      return true;
+    }
+    return false;
+  }
 }

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -89,10 +89,27 @@ export class Context implements Disposable {
   public stepTrace(direction: MovableDirection): void {
     if (this.plotContext.size() > 1) {
       this.plotContext.pop(); // Remove current Trace.
+
       const activeSubplot = this.active as Subplot;
+
+      // Get current trace position before switching
+      const currentTrace = activeSubplot.activeTrace;
+
+      // Get current X value using standard interface
+      const currentXValue = currentTrace.getCurrentXValue();
+
       activeSubplot.moveOnce(direction);
       this.active.notifyStateUpdate();
-      this.plotContext.push(activeSubplot.activeTrace);
+
+      const newTrace = activeSubplot.activeTrace;
+
+      // Add the new trace back to the context
+      this.plotContext.push(newTrace);
+
+      // Preserve X value using standard interface
+      if (currentXValue !== null) {
+        newTrace.moveToXValue(currentXValue);
+      }
     }
   }
 

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -99,7 +99,6 @@ export class Context implements Disposable {
       const currentXValue = currentTrace.getCurrentXValue();
 
       activeSubplot.moveOnce(direction);
-      this.active.notifyStateUpdate();
 
       const newTrace = activeSubplot.activeTrace;
 
@@ -110,6 +109,9 @@ export class Context implements Disposable {
       if (currentXValue !== null) {
         newTrace.moveToXValue(currentXValue);
       }
+
+      // Notify state update after context is complete
+      this.active.notifyStateUpdate();
     }
   }
 

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -199,4 +199,17 @@ export class Subplot extends AbstractObservableElement<Trace, SubplotState> {
   }
 }
 
-export interface Trace extends Movable, Observable<TraceState>, Disposable { }
+export interface Trace extends Movable, Observable<TraceState>, Disposable {
+  /**
+   * Get the current X value from the trace
+   * @returns The current X value or null if not available
+   */
+  getCurrentXValue: () => any;
+
+  /**
+   * Move the trace to the position that matches the given X value
+   * @param xValue The X value to move to
+   * @returns true if the position was found and set, false otherwise
+   */
+  moveToXValue: (xValue: any) => boolean;
+}

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -24,9 +24,9 @@ export class NavigationService implements Disposable {
     orientation: Orientation,
     sections: readonly T[],
   ): {
-    pointIndex: number;
-    segmentType: T;
-  } {
+      pointIndex: number;
+      segmentType: T;
+    } {
     if (orientation === Orientation.HORIZONTAL) {
       return {
         pointIndex: row,
@@ -52,9 +52,9 @@ export class NavigationService implements Disposable {
     segmentPosition: number,
     orientation: Orientation,
   ): {
-    row: number;
-    col: number;
-  } {
+      row: number;
+      col: number;
+    } {
     if (orientation === Orientation.HORIZONTAL) {
       return {
         row: pointIndex,
@@ -171,8 +171,8 @@ export class NavigationService implements Disposable {
    * Validate position in values array
    */
   private isValidPosition(values: any[][], row: number, col: number): boolean {
-    return row >= 0 && row < values.length &&
-      col >= 0 && col < values[row].length;
+    return row >= 0 && row < values.length
+      && col >= 0 && col < values[row].length;
   }
 
   public dispose(): void {

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -7,7 +7,7 @@ import { Orientation } from '@type/grammar';
  *
  * This service encapsulates the business logic for translating between
  * UI coordinates (row, col) and model coordinates (pointIndex, segmentType)
- * based on data orientation.
+ * based on data orientation, as well as X-value navigation across trace types.
  */
 export class NavigationService implements Disposable {
   /**
@@ -24,9 +24,9 @@ export class NavigationService implements Disposable {
     orientation: Orientation,
     sections: readonly T[],
   ): {
-      pointIndex: number;
-      segmentType: T;
-    } {
+    pointIndex: number;
+    segmentType: T;
+  } {
     if (orientation === Orientation.HORIZONTAL) {
       return {
         pointIndex: row,
@@ -52,9 +52,9 @@ export class NavigationService implements Disposable {
     segmentPosition: number,
     orientation: Orientation,
   ): {
-      row: number;
-      col: number;
-    } {
+    row: number;
+    col: number;
+  } {
     if (orientation === Orientation.HORIZONTAL) {
       return {
         row: pointIndex,
@@ -66,6 +66,113 @@ export class NavigationService implements Disposable {
         col: pointIndex,
       };
     }
+  }
+
+  /**
+   * Extract X value from points array based on current position
+   */
+  public extractXValueFromPoints(points: any[], row: number, col: number): any {
+    // Single-row traces (like BarTrace)
+    if (points.length === 1 && points[0]) {
+      const point = points[0][col];
+      return this.extractXFromPoint(point);
+    }
+
+    // Multi-row traces (like LineTrace)
+    if (points[row] && points[row][col]) {
+      const point = points[row][col];
+      return this.extractXFromPoint(point);
+    }
+
+    return null;
+  }
+
+  /**
+   * Extract X value from values array based on current position
+   */
+  public extractXValueFromValues(values: any[][], row: number, col: number): any {
+    if (this.isValidPosition(values, row, col)) {
+      const value = values[row][col];
+      return this.extractXFromValue(value);
+    }
+    return null;
+  }
+
+  /**
+   * Move to X value in points array
+   */
+  public moveToXValueInPoints(points: any[], xValue: any, moveToIndex: (row: number, col: number) => void): boolean {
+    // Single-row traces (like BarTrace)
+    if (points.length === 1 && points[0]) {
+      const targetIndex = this.findPointIndexByX(points[0], xValue);
+      if (targetIndex !== -1) {
+        moveToIndex(0, targetIndex);
+        return true;
+      }
+    }
+
+    // Multi-row traces (like LineTrace)
+    for (let row = 0; row < points.length; row++) {
+      const colIndex = this.findPointIndexByX(points[row], xValue);
+      if (colIndex !== -1) {
+        moveToIndex(row, colIndex);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Move to X value in values array
+   */
+  public moveToXValueInValues(values: any[][], xValue: any, moveToIndex: (row: number, col: number) => void): boolean {
+    for (let row = 0; row < values.length; row++) {
+      for (let col = 0; col < values[row].length; col++) {
+        const value = values[row][col];
+        const valueToCompare = this.extractXFromValue(value);
+        if (valueToCompare === xValue) {
+          moveToIndex(row, col);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Extract X value from a point object
+   */
+  private extractXFromPoint(point: any): any {
+    if (point && typeof point === 'object' && 'x' in point) {
+      return point.x;
+    }
+    return null;
+  }
+
+  /**
+   * Extract X value from a generic value
+   */
+  private extractXFromValue(value: any): any {
+    if (value !== null && typeof value === 'object' && 'x' in value) {
+      return value.x;
+    }
+    return value;
+  }
+
+  /**
+   * Find point index by X value
+   */
+  private findPointIndexByX(points: any[], xValue: any): number {
+    return points.findIndex(point => this.extractXFromPoint(point) === xValue);
+  }
+
+  /**
+   * Validate position in values array
+   */
+  private isValidPosition(values: any[][], row: number, col: number): boolean {
+    return row >= 0 && row < values.length &&
+      col >= 0 && col < values[row].length;
   }
 
   public dispose(): void {


### PR DESCRIPTION
# Pull Request

## Description

Problem
1. Navigation between different trace layers (candlestick, bar, line) was not preserving X values, causing inconsistent user experience when switching between plot types.

Solution
1. Implemented a generic X-value navigation system that maintains consistent X positioning across all trace types.


## Changes Made

1. New Interface in AbstractTrace
Added getCurrentXValue() and moveToXValue() methods
Provides base implementation for all trace types
Eliminates code duplication across trace classes

2. Context Layer Coordination
Context.stepTrace() now extracts current X value before switching
Preserves X position when navigating between trace layers
Maintains MVCC compliance by keeping coordination separate from business logic

3. Trace Class Refactoring
BarTrace & LineTrace: Removed duplicated X-value methods (use base implementation)
Candlestick: Kept custom implementation (different data structure)
All traces now support consistent X-value navigation


## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

