### PR TITLE
fix: removed unnecessary sonification models from stacked bar plot

### DIFF
--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -75,7 +75,8 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
   }
 
   protected hasMultiPoints(): boolean {
-    return true;
+    // Stacked bar plots should not use combined/separate audio modes
+    return false;
   }
 
   protected mapToSvgElements(selector?: string): SVGElement[][] {


### PR DESCRIPTION
# Pull Request

## Description

Fix stacked bar plot sonification to only show relevant audio modes. Removes unnecessary "separate" and "combine" sonification options that are only meaningful for scatter plots, simplifying the user interface and preventing confusion.

## Related Issues

Fixes #373.

## Changes Made

- Core Model Update: Added `hasMultiPoints` override in `SegmentedTrace` class that returns `false`

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Scatter plot sonification models were also tested and continue to work as expected with the three modes (combined, separate, and off). 