### PR TITLE
fix: add values to layer announcement

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -73,7 +73,7 @@ export class Controller implements Disposable {
     this.helpService = new HelpService(this.context, this.displayService);
     this.chatService = new ChatService(this.displayService, maidr);
 
-    this.textViewModel = new TextViewModel(store, this.textService, this.notificationService, this.autoplayService);
+    this.textViewModel = new TextViewModel(store, this.textService, this.notificationService, this.autoplayService, this.context);
     this.brailleViewModel = new BrailleViewModel(store, this.brailleService);
     this.reviewViewModel = new ReviewViewModel(store, this.reviewService);
     this.displayViewModel = new DisplayViewModel(store, this.displayService);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -73,7 +73,7 @@ export class Controller implements Disposable {
     this.helpService = new HelpService(this.context, this.displayService);
     this.chatService = new ChatService(this.displayService, maidr);
 
-    this.textViewModel = new TextViewModel(store, this.textService, this.notificationService, this.autoplayService, this.context);
+    this.textViewModel = new TextViewModel(store, this.textService, this.notificationService, this.autoplayService);
     this.brailleViewModel = new BrailleViewModel(store, this.brailleService);
     this.reviewViewModel = new ReviewViewModel(store, this.reviewService);
     this.displayViewModel = new DisplayViewModel(store, this.displayService);

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -217,7 +217,7 @@ export class LineTrace extends AbstractTrace<number> {
       const [row, col] = target;
       return (
         row >= 0 && row < this.values.length
-        && col >= 0 && col < this.values[this.row].length
+        && col >= 0 && col < this.values[row].length // Fixed: use target row instead of current row
       );
     }
 

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -45,7 +45,7 @@ export class TextService implements Observer<PlotState>, Disposable {
     } else if (state.type === 'figure') {
       return this.formatFigureText(state.index, state.size, state.traceTypes);
     } else if (state.type === 'subplot') {
-      return this.formatSubplotText(state.index, state.size, state.trace.traceType);
+      return this.formatSubplotText(state.index, state.size, state.trace.traceType, state.trace);
     } else if (this.mode === TextMode.VERBOSE) {
       return this.formatVerboseTraceText(state.text);
     } else {
@@ -60,8 +60,10 @@ export class TextService implements Observer<PlotState>, Disposable {
     return `Subplot ${index} of ${size}: ${details}. Press 'ENTER' to select this subplot.`;
   }
 
-  private formatSubplotText(index: number, size: number, traceType: string): string {
-    return `Layer ${index} of ${size}: ${traceType} plot`;
+  private formatSubplotText(index: number, size: number, traceType: string, traceState?: any): string {
+    // Use plotType if available, otherwise fall back to traceType
+    const type = traceState?.plotType || traceType;
+    return `Layer ${index} of ${size}: ${type} plot`;
   }
 
   private formatVerboseTraceText(state: TextState): string {

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -84,7 +84,8 @@ export class TextService implements Observer<PlotState>, Disposable {
     } else if (this.currentSubplotIndex === null) {
       // First time setting the subplot index
       this.currentSubplotIndex = newSubplotIndex;
-      return false;
+      // If this is not the first layer (index 0), treat it as a layer switch
+      return newSubplotIndex !== 0;
     }
 
     return false;

--- a/src/state/viewModel/textViewModel.ts
+++ b/src/state/viewModel/textViewModel.ts
@@ -1,8 +1,9 @@
+import type { Context } from '@model/context';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { AutoplayService } from '@service/autoplay';
 import type { NotificationService } from '@service/notification';
 import type { TextService } from '@service/text';
-import type { PlotState } from '@type/state';
+import type { PlotState, SubplotState, TraceState } from '@type/state';
 import type { AppStore } from '../store';
 import { createSlice } from '@reduxjs/toolkit';
 import { AbstractViewModel } from './viewModel';
@@ -49,16 +50,21 @@ const { update, announceText, toggle, notify, clearMessage, reset } = textSlice.
 
 export class TextViewModel extends AbstractViewModel<TextState> {
   private readonly textService: TextService;
+  private readonly context: Context;
   private isLayerSwitching: boolean = false;
+  private layerSwitchPoint: { x: any; y: any } | null = null;
+  private hasProcessedInitialUpdate: boolean = false;
 
   public constructor(
     store: AppStore,
     text: TextService,
     notification: NotificationService,
     autoplay: AutoplayService,
+    context: Context,
   ) {
     super(store);
     this.textService = text;
+    this.context = context;
     this.registerListeners(notification, autoplay);
   }
 
@@ -70,14 +76,83 @@ export class TextViewModel extends AbstractViewModel<TextState> {
   private registerListeners(notification: NotificationService, autoplay: AutoplayService): void {
     this.disposables.push(this.textService.onChange((e) => {
       this.update(e.value);
+
+      // Check if this is a navigation update and we're in layer switching mode
+      if (this.isLayerSwitching) {
+        // Skip the first trace state update after layer switch (it's the same point)
+        if (!this.hasProcessedInitialUpdate) {
+          this.hasProcessedInitialUpdate = true;
+          return;
+        }
+
+        // Get the current state from the context to extract actual coordinate values
+        const currentState = this.context.state;
+
+        if (currentState && !currentState.empty
+          && ((currentState.type === 'trace' && !currentState.empty)
+            || (currentState.type === 'subplot' && !currentState.empty && !currentState.trace.empty))) {
+          // Handle both SubplotState and TraceState
+          let traceText;
+          if (currentState.type === 'subplot' && !currentState.empty && !currentState.trace.empty) {
+            traceText = currentState.trace.text;
+          } else if (currentState.type === 'trace' && !currentState.empty) {
+            traceText = (currentState as any).text;
+          }
+
+          if (traceText) {
+            const currentPoint = {
+              x: traceText.main?.value,
+              y: traceText.cross?.value,
+            };
+
+            // Check if the current point is different from the layer switch point
+            if (this.layerSwitchPoint
+              && (currentPoint.x !== this.layerSwitchPoint.x || currentPoint.y !== this.layerSwitchPoint.y)) {
+              // User has navigated to a different point - clear the layer switching flag
+              this.isLayerSwitching = false;
+              this.layerSwitchPoint = null;
+              this.hasProcessedInitialUpdate = false;
+              this.store.dispatch(clearMessage());
+            }
+          }
+        }
+      }
     }));
 
     this.disposables.push(notification.onChange((e) => {
-      this.isLayerSwitching = true;
-      this.notify(e.value);
-      setTimeout(() => {
-        this.isLayerSwitching = false;
-      }, 100);
+      // Check if this is a layer switch notification (contains "Layer X of Y")
+      if (e.value.includes('Layer') && e.value.includes('of') && e.value.includes('plot')) {
+        // Set layer switching flag and reset initial update flag
+        this.isLayerSwitching = true;
+        this.hasProcessedInitialUpdate = false;
+
+        // Get the current state from the text service to extract coordinates
+        const currentState = this.getCurrentSubplotState();
+        if (currentState && !currentState.empty && !currentState.trace.empty) {
+          // Store the current point for navigation detection
+          this.layerSwitchPoint = {
+            x: currentState.trace.text?.main?.value,
+            y: currentState.trace.text?.cross?.value,
+          };
+
+          const coordinates = this.getCoordinateText(currentState.trace);
+          if (coordinates) {
+            const enhancedMessage = `${e.value} at ${coordinates}`;
+            this.notify(enhancedMessage);
+          } else {
+            this.notify(e.value);
+          }
+        } else {
+          this.notify(e.value);
+        }
+
+        // Don't clear the layer switching flag with a timeout
+        // It will be cleared when the user navigates to a different point
+        // This allows the layer switch announcement to persist
+      } else {
+        // Not a layer switch, just pass through the notification
+        this.notify(e.value);
+      }
     }));
 
     this.disposables.push(autoplay.onChange((e) => {
@@ -93,6 +168,57 @@ export class TextViewModel extends AbstractViewModel<TextState> {
     }));
   }
 
+  private getCurrentSubplotState(): SubplotState | null {
+    try {
+      const currentState = this.context.state;
+      if (currentState.type === 'subplot') {
+        return currentState;
+      }
+      return null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  private getCoordinateText(traceState: TraceState): string | null {
+    if (traceState.empty || !traceState.text) {
+      return null;
+    }
+
+    const { text } = traceState;
+    const parts: string[] = [];
+
+    // Add X coordinate
+    if (text.main && text.main.value !== undefined) {
+      const xValue = Array.isArray(text.main.value)
+        ? text.main.value.join(', ')
+        : String(text.main.value);
+      parts.push(`${text.main.label} is ${xValue}`);
+    }
+
+    // Add Y coordinate
+    if (text.cross && text.cross.value !== undefined) {
+      const yValue = Array.isArray(text.cross.value)
+        ? text.cross.value.join(', ')
+        : String(text.cross.value);
+      parts.push(`${text.cross.label} is ${yValue}`);
+    }
+
+    // Add fill/type information (for line plots this includes group/type like "MAV=3")
+    if (text.fill && text.fill.value !== undefined) {
+      parts.push(`${text.fill.label} is ${text.fill.value}`);
+    }
+
+    return parts.length > 0 ? parts.join(', ') : null;
+  }
+
+  public clearLayerSwitchingFlag(): void {
+    if (this.isLayerSwitching) {
+      this.isLayerSwitching = false;
+      this.store.dispatch(clearMessage());
+    }
+  }
+
   public get state(): TextState {
     return this.store.getState().text;
   }
@@ -105,9 +231,13 @@ export class TextViewModel extends AbstractViewModel<TextState> {
   public update(text: string | PlotState): void {
     const formattedText = this.textService.format(text);
     this.store.dispatch(update(formattedText));
+
+    // Only clear the message for normal navigation (not layer switches)
     if (!this.isLayerSwitching) {
       this.store.dispatch(clearMessage());
     }
+    // If we are in layer switching mode, don't clear the message
+    // This allows the enhanced layer switch announcement to persist
   }
 
   public notify(message: string): void {


### PR DESCRIPTION
# Pull Request

## Description

1. Fixed Multi-Layer Navigation Bug

Issue: Navigation between bar and line layers in multi-layer plots did not preserve point highlighting correctly for certain moving average lines
Fix: Corrected the isMovable method in LineTrace class to use target row bounds instead of current row bounds

2. Enhanced Layer Switch Announcements

Feature: Layer switch announcements now include coordinate information and plot type details
Implementation:
Detects layer switch notifications (containing "Layer X of Y")
Appends coordinate information in natural language format
Persists enhanced announcements until user navigates to a different point

3. Multi-Line Plot Detection

Feature: Automatically detects and announces multi-line plots as "multiline" instead of generic "line"
Implementation: Added plotType field to TraceState that distinguishes between single-line and multi-line plots


## Changes Made

src/model/line.ts: Fixed navigation bug, enhanced intersection detection, added plotType
src/service/text.ts: Enhanced subplot text formatting with plotType support
src/state/viewModel/textViewModel.ts: Implemented layer switch detection and enhanced announcements

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

