### PR TITLE
fix: address anouncements for single line plots

### DIFF
--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -375,7 +375,7 @@ export class LineTrace extends AbstractTrace<number> {
     // Add the plotType field for non-empty states
     const stateWithPlotType = {
       ...baseState,
-      plotType: this.points.length > 1 ? 'multiline' : 'line',
+      plotType: this.points.length > 1 ? 'multiline' : 'single line',
     };
 
     // Check for intersection at current (x, y)


### PR DESCRIPTION
# Pull Request

## Description

Change announcements to explicitly callout single line plots


## Changes Made

changed type to single line if it contains just a line


## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

