### PR TITLE
fix: adress audio service error in safari

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,17 @@ function initMaidr(maidr: Maidr, plot: HTMLElement): void {
     }, 0);
   };
 
+  const onVisibilityChange = (): void => {
+    if (document.visibilityState === 'visible') {
+      if (controller) {
+        controller.dispose();
+        controller = null;
+      }
+      const maidrClone = JSON.parse(JSON.stringify(maidr));
+      controller = new Controller(maidrClone, plot);
+    }
+  };
+
   const figureElement = document.createElement(Constant.FIGURE);
   figureElement.id = `${Constant.MAIDR_FIGURE}-${maidr.id}`;
   plot.parentNode!.replaceChild(figureElement, plot);
@@ -99,6 +110,8 @@ function initMaidr(maidr: Maidr, plot: HTMLElement): void {
   plot.addEventListener(DomEventType.FOCUS_IN, onFocusIn);
   plot.addEventListener(DomEventType.CLICK, onFocusIn);
   maidrContainer.addEventListener(DomEventType.FOCUS_OUT, onFocusOut);
+
+  document.addEventListener(DomEventType.VISIBILITY_CHANGE, onVisibilityChange);
 
   const reactRoot = createRoot(reactContainer, { identifierPrefix: maidr.id });
   reactRoot.render(MaidrApp(plot));

--- a/src/type/event.ts
+++ b/src/type/event.ts
@@ -10,6 +10,7 @@ export enum DomEventType {
   MOUSE_LEAVE = 'mouseleave',
   MOUSE_MOVE = 'mousemove',
   SELECTION_CHANGE = 'selectionchange',
+  VISIBILITY_CHANGE = 'visibilitychange',
 }
 
 export type Status


### PR DESCRIPTION
# Pull Request

## Description

After context/tab switch in safari, the audio service is disposed and hence breaking navigation, highlighting and all other services. So, the controller is restart after tab/ context switch to ensure consistent behavior across platforms.


## Changes Made

1. Added onVisibilityChange listener to detect switches and restart controller

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.
