### PR TITLE
feat(candlestick): support visual highlight per segment

### DIFF
--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -1,4 +1,4 @@
-import type { CandlestickPoint, CandlestickTrend, MaidrLayer } from '@type/grammar';
+import type { CandlestickPoint, CandlestickSelector, CandlestickTrend, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, TextState } from '@type/state';
@@ -32,7 +32,7 @@ export class Candlestick extends AbstractTrace<number> {
   private readonly min: number;
   private readonly max: number;
 
-  protected readonly highlightValues: SVGElement[][] | null;
+  protected readonly highlightValues: (SVGElement[] | SVGElement)[][] | null;
 
   // Service dependency for navigation logic
   protected readonly navigationService: NavigationService;
@@ -79,8 +79,7 @@ export class Candlestick extends AbstractTrace<number> {
       this.row = 0; // Points to 'open' segment index in sections array
     }
 
-    const selectors = typeof layer.selectors === 'string' ? layer.selectors : '';
-    this.highlightValues = this.mapToSvgElements(selectors);
+    this.highlightValues = this.mapToSvgElements(layer.selectors as string | string[] | CandlestickSelector | undefined);
   }
 
   /**
@@ -391,31 +390,139 @@ export class Candlestick extends AbstractTrace<number> {
     };
   }
 
-  protected mapToSvgElements(selector: string): SVGElement[][] | null {
-    if (!selector) {
+  protected mapToSvgElements(
+    selectors: string | string[] | CandlestickSelector | undefined,
+  ): (SVGElement[] | SVGElement)[][] | null {
+    if (!selectors) {
       return null;
     }
 
-    const allElements = Svg.selectAllElements(selector);
+    // Legacy: a single selector for all elements
+    if (typeof selectors === 'string' || Array.isArray(selectors)) {
+      const selectorString = Array.isArray(selectors) ? (selectors[0] || '') : selectors;
+      const allElements = Svg.selectAllElements(selectorString);
 
-    // Create a 2D array structure that matches the dynamic value-sorted navigation:
-    // - Rows represent value-sorted positions (0=lowest, 3=highest)
-    // - Cols represent candlestick points
-    // This ensures highlightValues[dynamicRow][col] works correctly
-    const segmentElements: SVGElement[][] = [];
+      const segmentElements: (SVGElement[] | SVGElement)[][] = [];
+      for (let pos = 0; pos < this.sections.length; pos++) {
+        segmentElements[pos] = [];
+        for (let pointIndex = 0; pointIndex < this.candles.length; pointIndex++) {
+          const elementIndex = pointIndex < allElements.length ? pointIndex : 0;
+          segmentElements[pos][pointIndex] = allElements[elementIndex];
+        }
+      }
+      return segmentElements;
+    }
 
-    for (
-      let sortedPosition = 0;
-      sortedPosition < this.sections.length;
-      sortedPosition++
-    ) {
-      segmentElements[sortedPosition] = [];
+    // Structured selectors
+    const cs = selectors as CandlestickSelector;
+    const N = this.candles.length;
 
-      for (let pointIndex = 0; pointIndex < this.candles.length; pointIndex++) {
-        // For each candlestick point, assign the corresponding SVG element
-        // All segments of a candlestick typically share the same SVG element
-        const elementIndex = pointIndex < allElements.length ? pointIndex : 0;
-        segmentElements[sortedPosition][pointIndex] = allElements[elementIndex];
+    const collect = (sel?: string | string[]): SVGElement[] => {
+      if (!sel)
+        return [];
+      const arr = Array.isArray(sel) ? sel : [sel];
+      const out: SVGElement[] = [];
+      for (const s of arr) out.push(...Svg.selectAllElements(s));
+      return out;
+    };
+
+    const bodies = collect(cs.body);
+    let highs = collect(cs.wickHigh);
+    let lows = collect(cs.wickLow);
+    // Fallback to a single combined wick if provided
+    if (highs.length === 0 || lows.length === 0) {
+      const combined = collect(cs.wick);
+      if (combined.length > 0) {
+        if (highs.length === 0)
+          highs = combined;
+        if (lows.length === 0)
+          lows = combined;
+      }
+    }
+    const opens = collect(cs.open);
+    const closes = collect(cs.close);
+    // Volatility will be composed from [wickHigh, body, wickLow]; no direct selectors used
+
+    const at = (arr: SVGElement[], i: number): SVGElement | null => (i < arr.length ? arr[i] : null);
+
+    const derivedOpen: SVGElement[] = Array.from({ length: N });
+    const derivedClose: SVGElement[] = Array.from({ length: N });
+    const derivedVolatility: SVGElement[] = Array.from({ length: N });
+
+    for (let i = 0; i < N; i++) {
+      // Open (explicit otherwise derive from body using data)
+      let openEl = at(opens, i);
+      if (!openEl) {
+        const body = at(bodies, i);
+        if (body) {
+          const { open, close } = this.candles[i];
+          const edge: 'top' | 'bottom' = close > open ? 'bottom' : close < open ? 'top' : 'bottom';
+          openEl = Svg.createLineElement(body, edge);
+        } else {
+          openEl = Svg.createEmptyElement();
+        }
+      }
+      derivedOpen[i] = openEl;
+
+      // Close (explicit otherwise derive from body using data)
+      let closeEl = at(closes, i);
+      if (!closeEl) {
+        const body = at(bodies, i);
+        if (body) {
+          const { open, close } = this.candles[i];
+          const edge: 'top' | 'bottom' = close > open ? 'top' : close < open ? 'bottom' : 'top';
+          closeEl = Svg.createLineElement(body, edge);
+        } else {
+          closeEl = Svg.createEmptyElement();
+        }
+      }
+      derivedClose[i] = closeEl;
+
+      // Volatility: composed later as [high, body, low]; no single element here
+      derivedVolatility[i] = Svg.createEmptyElement();
+    }
+
+    // Build 2D array in value-sorted navigation order per point
+    const segmentElements: (SVGElement[] | SVGElement)[][] = Array.from({ length: this.sections.length }, () => Array.from({ length: N }));
+
+    for (let pointIndex = 0; pointIndex < N; pointIndex++) {
+      const navOrder = this.sortedSegmentsByPoint[pointIndex]; // ['volatility', ...sorted OHLC]
+      for (let pos = 0; pos < navOrder.length; pos++) {
+        const seg = navOrder[pos];
+        let el: SVGElement | SVGElement[];
+        switch (seg) {
+          case 'volatility':
+            {
+              const parts: SVGElement[] = [];
+              const body = at(bodies, pointIndex);
+              const hi = at(highs, pointIndex) ?? body;
+              const lo = at(lows, pointIndex) ?? body;
+              if (hi)
+                parts.push(hi);
+              if (body)
+                parts.push(body);
+              if (lo)
+                parts.push(lo);
+              const unique = Array.from(new Set(parts));
+              el = unique.length > 0 ? unique : [Svg.createEmptyElement()];
+            }
+            break;
+          case 'open':
+            el = derivedOpen[pointIndex];
+            break;
+          case 'close':
+            el = derivedClose[pointIndex];
+            break;
+          case 'high':
+            el = at(highs, pointIndex) ?? at(bodies, pointIndex) ?? Svg.createEmptyElement();
+            break;
+          case 'low':
+            el = at(lows, pointIndex) ?? at(bodies, pointIndex) ?? Svg.createEmptyElement();
+            break;
+          default:
+            el = Svg.createEmptyElement();
+        }
+        segmentElements[pos][pointIndex] = el;
       }
     }
 

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -93,11 +93,20 @@ export enum Orientation {
   HORIZONTAL = 'horz',
 }
 
+export interface CandlestickSelector {
+  body: string | string[];
+  wickHigh?: string | string[];
+  wickLow?: string | string[];
+  wick?: string | string[]; // single combined wick (high-to-low) line
+  open?: string | string[];
+  close?: string | string[];
+}
+
 export interface MaidrLayer {
   id: string;
   type: TraceType;
   title?: string;
-  selectors?: string | string[] | BoxSelector[];
+  selectors?: string | string[] | BoxSelector[] | CandlestickSelector;
   orientation?: Orientation;
   axes?: {
     x?: string;


### PR DESCRIPTION
# Pull Request

## Description

This functionality enables granular highlighting of individual components within candlestick plots, similar to how box plots work in MAIDR. Instead of highlighting the entire candlestick patch, users can now navigate and highlight specific OHLC (Open, High, Low, Close) values and volatility.

Component-Based Highlighting:

Body: The main rectangle representing the open-close range
High Wick: Line extending upward from the body to the high value
Low Wick: Line extending downward from the body to the low value
Open/Close: Derived horizontal lines at the appropriate edges of the body
Volatility: Combined highlight of high wick + body + low wick

```
   interface CandlestickSelector {
     body: string | string[];           // Mandatory
     wickHigh: string | string[];       // Optional  
     wickLow: string | string[];        // Optional
     wick?: string | string[];          // Optional fallback for combined wicks
     open?: string | string[];          // Optional explicit selectors
     close?: string | string[];         // Optional explicit selectors
   }
```

Open/Close Lines: Automatically created from body elements when not explicitly provided []
Trend-Aware Positioning:
1. Bullish candles: open=bottom edge, close=top edge
2. Bearish candles: open=top edge, close=bottom edge
3. Neutral candles: open=bottom edge, close=top edge
4. Wick Fallbacks: Uses combined wick selector (case when high+low wick is single line (like legacy plots)) or body when separate high/low wicks aren't available individually


## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
