### PR TITLE
fix(display): reset focus on teardown to prevent missing braille view

### DIFF
--- a/src/state/viewModel/displayViewModel.ts
+++ b/src/state/viewModel/displayViewModel.ts
@@ -36,12 +36,12 @@ const displaySlice = createSlice({
     updateFocus(state, action: PayloadAction<Focus>): void {
       state.focus = action.payload;
     },
-    reset(): DisplayState {
-      return initialState;
+    clearFocus(state): void {
+      state.focus = null;
     },
   },
 });
-const { hideTooltip, showTooltip, updateFocus, reset } = displaySlice.actions;
+const { hideTooltip, showTooltip, updateFocus, clearFocus } = displaySlice.actions;
 
 export class DisplayViewModel extends AbstractViewModel<DisplayState> {
   private readonly displayService: DisplayService;
@@ -56,7 +56,8 @@ export class DisplayViewModel extends AbstractViewModel<DisplayState> {
   }
 
   public dispose(): void {
-    this.store.dispatch(reset());
+    // Clear only focus to avoid wiping other display UI state
+    this.store.dispatch(clearFocus());
     this.store.dispatch(showTooltip(this.displayService.getInstruction()));
     super.dispose();
   }

--- a/src/state/viewModel/displayViewModel.ts
+++ b/src/state/viewModel/displayViewModel.ts
@@ -36,9 +36,12 @@ const displaySlice = createSlice({
     updateFocus(state, action: PayloadAction<Focus>): void {
       state.focus = action.payload;
     },
+    reset(): DisplayState {
+      return initialState;
+    },
   },
 });
-const { hideTooltip, showTooltip, updateFocus } = displaySlice.actions;
+const { hideTooltip, showTooltip, updateFocus, reset } = displaySlice.actions;
 
 export class DisplayViewModel extends AbstractViewModel<DisplayState> {
   private readonly displayService: DisplayService;
@@ -53,6 +56,7 @@ export class DisplayViewModel extends AbstractViewModel<DisplayState> {
   }
 
   public dispose(): void {
+    this.store.dispatch(reset());
     this.store.dispatch(showTooltip(this.displayService.getInstruction()));
     super.dispose();
   }


### PR DESCRIPTION

# Pull Request

## Description

1. In Braille mode, moving focus out throws: “Error while loading view model for braille”.
2. Symptoms came from React still rendering <Braille /> while its view model was no longer available.


Root cause

The Controller owns ViewModelRegistry. On focus-out, the Controller is disposed and clears the registry.
The React tree stays mounted and App still has display.focus === 'BRAILLE', so Braille.tsx calls useViewModel('braille'), which throws because the registry is empty.
The focus in/out handlers are deferred (setTimeout(0)), creating a small race window.

Fix

Added a reset() action to the display slice and dispatched it in DisplayViewModel.dispose().
This sets display.focus to null during teardown, so React stops rendering <Braille /> before/while the registry is being cleared.
We still show the instruction tooltip after resetting focus to keep UX guidance intact.


## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
