### PR TITLE
fix: address boundary spatial audio bug

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -224,17 +224,17 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
 
   public get state(): TraceState {
     if (this.isOutOfBounds) {
-      // Safety check: ensure we don't access undefined values
-      const { row: safeRow, col: safeCol } = this.getSafeIndices();
       const values = this.values;
+      const currentRow = this.row;
+      const currentCol = this.col;
 
       return {
         empty: true,
         type: 'trace',
         traceType: this.type,
         audio: {
-          size: values[safeRow]?.length || 0,
-          index: safeCol,
+          size: values[currentRow]?.length || 0,
+          index: currentCol,
         },
       };
     }
@@ -259,17 +259,17 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
 
   protected highlight(): HighlightState {
     if (this.highlightValues === null || this.isInitialEntry) {
-      // Safety check: ensure we don't access undefined values
-      const { row: safeRow, col: safeCol } = this.getSafeIndices();
       const values = this.values;
+      const currentRow = this.row;
+      const currentCol = this.col;
 
       return {
         empty: true,
         type: 'trace',
         traceType: this.type,
         audio: {
-          size: values[safeRow]?.length || 0,
-          index: safeCol,
+          size: values[currentRow]?.length || 0,
+          index: currentCol,
         },
       };
     }

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -101,28 +101,24 @@ implements Observer<ObservableStates>, Observer<Settings>, Disposable {
     this.updateMode(state);
     // TODO: Clean up previous audio state once syncing with Autoplay interval.
 
-    // Handle empty states (boundary conditions)
-    if (state.empty) {
-      this.playBoundaryAudio();
-      return;
-    }
-
     // Handle FigureState - no audio for normal subplot navigation
     if (state.type === 'figure') {
       return;
     }
 
     // Extract trace state from subplot state if needed
-    const traceState: TraceState = state.type === 'subplot' ? state.trace : state;
+    let traceState: TraceState;
+    if (state.type === 'subplot') {
+      if (state.empty) {
+        // Empty subplot state - no trace to play audio for
+        return;
+      }
+      traceState = state.trace;
+    } else {
+      traceState = state;
+    }
 
     this.handleTraceState(traceState);
-  }
-
-  private playBoundaryAudio(): void {
-    // Stop any existing audio first to prevent overlap
-    this.stopAll();
-    // Use default size and index for boundary audio
-    this.playEmptyTone(1, 0);
   }
 
   private handleTraceState(traceState: TraceState): void {


### PR DESCRIPTION
# Pull Request

## Description

Boundary audio (played when navigating beyond chart limits) was incorrectly hardcoded to always play on the left side, regardless of whether the user hit the left or right boundary.

RCA

1. Audio service used hardcoded playBoundaryAudio() with fixed values size=1, index=0
2. Abstract trace used safe fallback indices instead of current position for audio state
3. Spatial calculation always resulted in panning = -1 (left side)

Fix

Removed hardcoded boundary audio - now routes all states through handleTraceState()
Fixed audio state generation - uses current position (this.row, this.col) instead of fallback indices

## Changes Made

src/model/abstract.ts - Fixed audio state generation for boundary conditions
src/service/audio.ts - Removed hardcoded boundary audio, unified audio handling

## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
