### PR TITLE
fix: address nav bug after plot title/ axis diplay

### DIFF
--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -62,11 +62,10 @@ export class Context implements Disposable {
   }
 
   public toggleScope(scope: Scope): void {
-    // Clear the scope context and set the new scope
-    this.scopeContext.clear();
-    this.scopeContext.push(scope);
-
-    hotkeys.setScope(scope);
+    if (!this.scopeContext.removeLast(scope)) {
+      this.scopeContext.push(scope);
+    }
+    hotkeys.setScope(this.scope);
   }
 
   public get scope(): Scope {

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -70,12 +70,9 @@ export class DisplayService implements Disposable {
       this.focusStack.push(focus);
     }
 
-    const newScope = this.focusStack.peek()!;
+    this.context.toggleScope(focus);
 
-    // FIXED: Pass the new scope from focus stack, not the input focus
-    this.context.toggleScope(newScope);
-
-    this.updateFocus(newScope);
+    this.updateFocus(this.focusStack.peek()!);
   }
 
   private updateFocus(newScope: Focus): void {


### PR DESCRIPTION
# Pull Request

## Description

Problem: Navigation stops working after using label commands (lx, ly, lt) due to scope management changes introduced in PR #418.

Root Cause: The DisplayService.toggleFocus() method was modified to pass focus stack scope instead of input focus to context.toggleScope(), causing scope synchronization issues between context and hotkeys.

Impact: Users cannot navigate plots after accessing axis labels, breaking core functionality.

## Changes Made

Solution: Revert toggleFocus() to use input focus directly and restore toggleScope() to use removeLast/push semantics with hotkeys.setScope(this.scope).

Files Modified:

src/service/display.ts - Revert toggleFocus logic
src/model/context.ts - Restore toggleScope behavior

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
