### PR TITLE
feat: go to specific value in bar & candlestick plots

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -119,13 +119,6 @@ export class Controller implements Disposable {
     this.notificationService.notify(this.displayService.getInstruction(false));
   }
 
-  public updateAriaLabelToCoordinateText(): void {
-    // Clear any stale notification messages
-    this.textViewModel.clearMessage();
-    // Update ARIA label to coordinate text
-    this.displayService.removeInstruction();
-  }
-
   public dispose(): void {
     this.keybinding.unregister();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ function initMaidr(maidr: Maidr, plot: HTMLElement): void {
         controller.dispose();
         controller = null;
       }
+
       const maidrClone = JSON.parse(JSON.stringify(maidr));
       controller = new Controller(maidrClone, plot);
       controller.announceInitialInstruction();

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -379,10 +379,10 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
   protected navigableReferences: NavigableReference[] = [];
 
   /**
-   * Build navigation references for this trace
-   * Subclasses must implement this to populate navigableReferences
+   * Build navigation references for this trace.
+   * Only implemented by plots that support extrema navigation.
    */
-  protected abstract buildNavigableReferences(): void;
+  protected buildNavigableReferences?(): void;
 
   /**
    * Get all available X values for navigation using the pre-computed references

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -1,4 +1,5 @@
 import type { Disposable } from '@type/disposable';
+import type { ExtremaTarget } from '@type/extrema';
 import type { MaidrLayer, TraceType } from '@type/grammar';
 import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
@@ -314,6 +315,37 @@ export abstract class AbstractTrace<T> extends AbstractObservableElement<T, Trac
   protected abstract text(): TextState;
 
   protected abstract get highlightValues(): (SVGElement[] | SVGElement)[][] | null;
+
+  /**
+   * Get available extrema targets for the current navigation context
+   * @returns Array of extrema targets that can be navigated to
+   * Default implementation returns empty array (no extrema support)
+   */
+  public getExtremaTargets(): ExtremaTarget[] {
+    return []; // Default: no extrema support
+  }
+
+  /**
+   * Base implementation for navigateToExtrema
+   * Subclasses must override to provide actual implementation
+   * @param _target The extrema target to navigate to
+   */
+  public navigateToExtrema(_target: ExtremaTarget): void {
+    throw new Error('Extrema navigation not supported by this plot type');
+  }
+
+  /**
+   * Check if this plot supports extrema navigation
+   * @returns True if extrema navigation is supported
+   */
+  public supportsExtremaNavigation(): boolean {
+    return this.supportsExtrema;
+  }
+
+  /**
+   * Abstract property that subclasses must implement to indicate extrema support
+   */
+  protected abstract readonly supportsExtrema: boolean;
 
   /**
    * Base implementation for getting current X value

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -7,6 +7,8 @@ import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
 
 export class BoxTrace extends AbstractTrace<number[] | number> {
+  protected readonly supportsExtrema = false;
+
   private readonly points: BoxPoint[];
   private readonly boxValues: (number[] | number)[][];
   protected readonly highlightValues: (SVGElement[] | SVGElement)[][] | null;

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -1,7 +1,7 @@
 import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
 import type { AudioState, BrailleState, TextState } from '@type/state';
 import { BoxplotSection } from '@type/boxplotSection';
-import { Orientation, TraceType } from '@type/grammar';
+import { Orientation } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
@@ -64,8 +64,6 @@ export class BoxTrace extends AbstractTrace<number[] | number> {
     this.highlightValues = this.mapToSvgElements(
       layer.selectors as BoxSelector[],
     );
-
-    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -73,27 +71,6 @@ export class BoxTrace extends AbstractTrace<number[] | number> {
     this.sections.length = 0;
 
     super.dispose();
-  }
-
-  /**
-   * Build navigation references for this box trace
-   */
-  protected buildNavigableReferences(): void {
-    this.navigableReferences = this.points.map((point, index) => ({
-      id: `box-${index}`,
-      value: point.fill, // Category is the X value
-      type: 'category',
-      position: { row: index, col: 0 },
-      context: {
-        plotType: TraceType.BOX,
-        orientation: this.orientation,
-      },
-      accessibility: {
-        description: `Box plot category: ${point.fill}`,
-        shortLabel: point.fill,
-        valueType: 'categorical',
-      },
-    }));
   }
 
   public moveToIndex(row: number, col: number): void {

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -1,7 +1,7 @@
 import type { BoxPoint, BoxSelector, MaidrLayer } from '@type/grammar';
 import type { AudioState, BrailleState, TextState } from '@type/state';
 import { BoxplotSection } from '@type/boxplotSection';
-import { Orientation } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
@@ -64,6 +64,8 @@ export class BoxTrace extends AbstractTrace<number[] | number> {
     this.highlightValues = this.mapToSvgElements(
       layer.selectors as BoxSelector[],
     );
+
+    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -71,6 +73,27 @@ export class BoxTrace extends AbstractTrace<number[] | number> {
     this.sections.length = 0;
 
     super.dispose();
+  }
+
+  /**
+   * Build navigation references for this box trace
+   */
+  protected buildNavigableReferences(): void {
+    this.navigableReferences = this.points.map((point, index) => ({
+      id: `box-${index}`,
+      value: point.fill, // Category is the X value
+      type: 'category',
+      position: { row: index, col: 0 },
+      context: {
+        plotType: TraceType.BOX,
+        orientation: this.orientation,
+      },
+      accessibility: {
+        description: `Box plot category: ${point.fill}`,
+        shortLabel: point.fill,
+        valueType: 'categorical',
+      },
+    }));
   }
 
   public moveToIndex(row: number, col: number): void {

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -1,4 +1,4 @@
-import type { ExtremaTarget } from '@service/goToExtrema';
+import type { ExtremaTarget } from '@type/extrema';
 import type { CandlestickPoint, CandlestickSelector, CandlestickTrend, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
@@ -19,6 +19,8 @@ type CandlestickSegmentType = 'open' | 'high' | 'low' | 'close';
 type CandlestickNavSegmentType = 'volatility' | CandlestickSegmentType;
 
 export class Candlestick extends AbstractTrace<number> {
+  protected readonly supportsExtrema = true;
+
   private readonly candles: CandlestickPoint[];
   private readonly candleValues: number[][];
 
@@ -628,6 +630,7 @@ export class Candlestick extends AbstractTrace<number> {
         pointIndex: maxVolatilityIndex,
         segment: 'volatility',
         type: 'max',
+        navigationType: 'point',
       });
 
       targets.push({
@@ -636,6 +639,7 @@ export class Candlestick extends AbstractTrace<number> {
         pointIndex: minVolatilityIndex,
         segment: 'volatility',
         type: 'min',
+        navigationType: 'point',
       });
     } else {
       // For OHLC segments, find min and max
@@ -649,6 +653,7 @@ export class Candlestick extends AbstractTrace<number> {
         pointIndex: maxIndex,
         segment: currentSegment,
         type: 'max',
+        navigationType: 'point',
       });
 
       targets.push({
@@ -657,6 +662,7 @@ export class Candlestick extends AbstractTrace<number> {
         pointIndex: minIndex,
         segment: currentSegment,
         type: 'min',
+        navigationType: 'point',
       });
     }
 

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -5,6 +5,8 @@ import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
 
 export class Heatmap extends AbstractTrace<number> {
+  protected readonly supportsExtrema = false;
+
   private readonly heatmapValues: number[][];
   protected readonly highlightValues: SVGElement[][] | null;
 

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -1,5 +1,6 @@
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
 import type { AudioState, BrailleState, TextState } from '@type/state';
+import { TraceType } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
@@ -29,6 +30,8 @@ export class Heatmap extends AbstractTrace<number> {
     this.max = max;
 
     this.highlightValues = this.mapToSvgElements(layer.selectors as string);
+
+    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -72,6 +75,31 @@ export class Heatmap extends AbstractTrace<number> {
       cross: { label: this.yAxis, value: this.y[this.row] },
       fill: { label: this.fill, value: String(this.heatmapValues[this.row][this.col]) },
     };
+  }
+
+  /**
+   * Build navigation references for this heatmap
+   */
+  protected buildNavigableReferences(): void {
+    this.navigableReferences = [];
+
+    // X-axis values (columns)
+    for (let col = 0; col < this.x.length; col++) {
+      this.navigableReferences.push({
+        id: `heatmap-x-${col}`,
+        value: this.x[col], // Column label
+        type: 'category',
+        position: { row: 0, col },
+        context: {
+          plotType: TraceType.HEATMAP,
+        },
+        accessibility: {
+          description: `Heatmap column: ${this.x[col]}`,
+          shortLabel: this.x[col],
+          valueType: 'categorical',
+        },
+      });
+    }
   }
 
   private mapToSvgElements(selector?: string): SVGElement[][] | null {

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -1,6 +1,5 @@
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
 import type { AudioState, BrailleState, TextState } from '@type/state';
-import { TraceType } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
@@ -30,8 +29,6 @@ export class Heatmap extends AbstractTrace<number> {
     this.max = max;
 
     this.highlightValues = this.mapToSvgElements(layer.selectors as string);
-
-    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -75,31 +72,6 @@ export class Heatmap extends AbstractTrace<number> {
       cross: { label: this.yAxis, value: this.y[this.row] },
       fill: { label: this.fill, value: String(this.heatmapValues[this.row][this.col]) },
     };
-  }
-
-  /**
-   * Build navigation references for this heatmap
-   */
-  protected buildNavigableReferences(): void {
-    this.navigableReferences = [];
-
-    // X-axis values (columns)
-    for (let col = 0; col < this.x.length; col++) {
-      this.navigableReferences.push({
-        id: `heatmap-x-${col}`,
-        value: this.x[col], // Column label
-        type: 'category',
-        position: { row: 0, col },
-        context: {
-          plotType: TraceType.HEATMAP,
-        },
-        accessibility: {
-          description: `Heatmap column: ${this.x[col]}`,
-          shortLabel: this.x[col],
-          valueType: 'categorical',
-        },
-      });
-    }
   }
 
   private mapToSvgElements(selector?: string): SVGElement[][] | null {

--- a/src/model/histogram.ts
+++ b/src/model/histogram.ts
@@ -4,8 +4,10 @@ import { Orientation } from '@type/grammar';
 import { AbstractBarPlot } from './bar';
 
 export class Histogram extends AbstractBarPlot<HistogramPoint> {
+  protected readonly supportsExtrema = false;
   public constructor(layer: MaidrLayer) {
     super(layer, [layer.data as HistogramPoint[]]);
+    this.buildNavigableReferences();
   }
 
   protected text(): TextState {
@@ -19,5 +21,36 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
       ...super.text(),
       range: { min, max },
     };
+  }
+
+  /**
+   * Build navigation references for this histogram
+   */
+  protected buildNavigableReferences(): void {
+    this.navigableReferences = [];
+
+    for (let row = 0; row < this.points.length; row++) {
+      for (let col = 0; col < this.points[row].length; col++) {
+        const point = this.points[row][col];
+        const xValue = this.orientation === Orientation.VERTICAL ? point.x : point.y;
+
+        this.navigableReferences.push({
+          id: `histogram-${row}-${col}`,
+          value: xValue,
+          type: typeof xValue === 'number' ? 'bin' : 'category',
+          position: { row, col },
+          context: {
+            plotType: 'histogram',
+            orientation: this.orientation,
+            groupIndex: row,
+          },
+          accessibility: {
+            description: `Histogram bin: ${point.xMin} to ${point.xMax}`,
+            shortLabel: String(xValue),
+            valueType: typeof xValue === 'number' ? 'numeric' : 'categorical',
+          },
+        });
+      }
+    }
   }
 }

--- a/src/model/histogram.ts
+++ b/src/model/histogram.ts
@@ -7,7 +7,6 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
   protected readonly supportsExtrema = false;
   public constructor(layer: MaidrLayer) {
     super(layer, [layer.data as HistogramPoint[]]);
-    this.buildNavigableReferences();
   }
 
   protected text(): TextState {
@@ -21,36 +20,5 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
       ...super.text(),
       range: { min, max },
     };
-  }
-
-  /**
-   * Build navigation references for this histogram
-   */
-  protected buildNavigableReferences(): void {
-    this.navigableReferences = [];
-
-    for (let row = 0; row < this.points.length; row++) {
-      for (let col = 0; col < this.points[row].length; col++) {
-        const point = this.points[row][col];
-        const xValue = this.orientation === Orientation.VERTICAL ? point.x : point.y;
-
-        this.navigableReferences.push({
-          id: `histogram-${row}-${col}`,
-          value: xValue,
-          type: typeof xValue === 'number' ? 'bin' : 'category',
-          position: { row, col },
-          context: {
-            plotType: 'histogram',
-            orientation: this.orientation,
-            groupIndex: row,
-          },
-          accessibility: {
-            description: `Histogram bin: ${point.xMin} to ${point.xMax}`,
-            shortLabel: String(xValue),
-            valueType: typeof xValue === 'number' ? 'numeric' : 'categorical',
-          },
-        });
-      }
-    }
   }
 }

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -1,7 +1,6 @@
 import type { LinePoint, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { AudioState, BrailleState, TextState, TraceState } from '@type/state';
-import { TraceType } from '@type/grammar';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -33,8 +32,6 @@ export class LineTrace extends AbstractTrace<number> {
     this.max = this.lineValues.map(row => MathUtil.safeMax(row));
 
     this.highlightValues = this.mapToSvgElements(layer.selectors as string[]);
-
-    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -391,35 +388,6 @@ export class LineTrace extends AbstractTrace<number> {
       return { ...stateWithPlotType, intersections };
     }
     return stateWithPlotType;
-  }
-
-  /**
-   * Build navigation references for this line trace
-   */
-  protected buildNavigableReferences(): void {
-    this.navigableReferences = [];
-
-    for (let row = 0; row < this.points.length; row++) {
-      for (let col = 0; col < this.points[row].length; col++) {
-        const point = this.points[row][col];
-
-        this.navigableReferences.push({
-          id: `line-${row}-${col}`,
-          value: point.x,
-          type: typeof point.x === 'number' ? 'coordinate' : 'category',
-          position: { row, col },
-          context: {
-            plotType: TraceType.LINE,
-            groupIndex: row,
-          },
-          accessibility: {
-            description: `Line point at ${point.x}`,
-            shortLabel: String(point.x),
-            valueType: typeof point.x === 'number' ? 'numeric' : 'categorical',
-          },
-        });
-      }
-    }
   }
 
   public moveToIndex(row: number, col: number): void {

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -10,6 +10,8 @@ const TYPE = 'Group';
 const SVG_PATH_LINE_POINT_REGEX = /[ML]\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g;
 
 export class LineTrace extends AbstractTrace<number> {
+  protected readonly supportsExtrema = false;
+
   protected readonly points: LinePoint[][];
   protected readonly lineValues: number[][];
   protected readonly highlightValues: SVGElement[][] | null;

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -1,6 +1,7 @@
 import type { LinePoint, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { AudioState, BrailleState, TextState, TraceState } from '@type/state';
+import { TraceType } from '@type/grammar';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -32,6 +33,8 @@ export class LineTrace extends AbstractTrace<number> {
     this.max = this.lineValues.map(row => MathUtil.safeMax(row));
 
     this.highlightValues = this.mapToSvgElements(layer.selectors as string[]);
+
+    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -389,4 +392,49 @@ export class LineTrace extends AbstractTrace<number> {
     }
     return stateWithPlotType;
   }
+
+  /**
+   * Build navigation references for this line trace
+   */
+  protected buildNavigableReferences(): void {
+    this.navigableReferences = [];
+
+    for (let row = 0; row < this.points.length; row++) {
+      for (let col = 0; col < this.points[row].length; col++) {
+        const point = this.points[row][col];
+
+        this.navigableReferences.push({
+          id: `line-${row}-${col}`,
+          value: point.x,
+          type: typeof point.x === 'number' ? 'coordinate' : 'category',
+          position: { row, col },
+          context: {
+            plotType: TraceType.LINE,
+            groupIndex: row,
+          },
+          accessibility: {
+            description: `Line point at ${point.x}`,
+            shortLabel: String(point.x),
+            valueType: typeof point.x === 'number' ? 'numeric' : 'categorical',
+          },
+        });
+      }
+    }
+  }
+
+  public moveToIndex(row: number, col: number): void {
+    if (row < 0 || row >= this.points.length || col < 0 || col >= this.points[row].length) {
+      this.notifyOutOfBounds();
+      return;
+    }
+
+    this.row = row;
+    this.col = col;
+    this.notifyStateUpdate();
+  }
+
+  /**
+   * Get the current point based on row and column
+   * @returns The current point or null if invalid
+   */
 }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -21,6 +21,8 @@ interface ScatterYPoint {
 }
 
 export class ScatterTrace extends AbstractTrace<number> {
+  protected readonly supportsExtrema = false;
+
   private mode: NavMode;
 
   private readonly xPoints: ScatterXPoint[];

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1,6 +1,7 @@
 import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { AudioState, AutoplayState, BrailleState, HighlightState, TextState } from '@type/state';
+import { TraceType } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
@@ -76,6 +77,8 @@ export class ScatterTrace extends AbstractTrace<number> {
     this.maxY = MathUtil.safeMax(this.yValues);
 
     [this.highlightXValues, this.highlightYValues] = this.mapToSvgElements(layer.selectors as string);
+
+    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -411,6 +414,26 @@ export class ScatterTrace extends AbstractTrace<number> {
           return true;
       }
     }
+  }
+
+  /**
+   * Build navigation references for this scatter trace
+   */
+  protected buildNavigableReferences(): void {
+    this.navigableReferences = this.xValues.map((xValue, index) => ({
+      id: `scatter-${index}`,
+      value: xValue, // X coordinate
+      type: 'coordinate',
+      position: { row: 0, col: index },
+      context: {
+        plotType: TraceType.SCATTER,
+      },
+      accessibility: {
+        description: `Scatter point at X: ${xValue}`,
+        shortLabel: String(xValue),
+        valueType: 'numeric',
+      },
+    }));
   }
 
   private mapToSvgElements(selector?: string): [SVGElement[][], SVGElement[][]] | [null, null] {

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1,7 +1,6 @@
 import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { AudioState, AutoplayState, BrailleState, HighlightState, TextState } from '@type/state';
-import { TraceType } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
@@ -77,8 +76,6 @@ export class ScatterTrace extends AbstractTrace<number> {
     this.maxY = MathUtil.safeMax(this.yValues);
 
     [this.highlightXValues, this.highlightYValues] = this.mapToSvgElements(layer.selectors as string);
-
-    this.buildNavigableReferences();
   }
 
   public dispose(): void {
@@ -414,26 +411,6 @@ export class ScatterTrace extends AbstractTrace<number> {
           return true;
       }
     }
-  }
-
-  /**
-   * Build navigation references for this scatter trace
-   */
-  protected buildNavigableReferences(): void {
-    this.navigableReferences = this.xValues.map((xValue, index) => ({
-      id: `scatter-${index}`,
-      value: xValue, // X coordinate
-      type: 'coordinate',
-      position: { row: 0, col: index },
-      context: {
-        plotType: TraceType.SCATTER,
-      },
-      accessibility: {
-        description: `Scatter point at X: ${xValue}`,
-        shortLabel: String(xValue),
-        valueType: 'numeric',
-      },
-    }));
   }
 
   private mapToSvgElements(selector?: string): [SVGElement[][], SVGElement[][]] | [null, null] {

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -1,3 +1,4 @@
+import type { ExtremaTarget } from '@type/extrema';
 import type { MaidrLayer, SegmentedPoint } from '@type/grammar';
 import type { HighlightState, TextState } from '@type/state';
 import { Orientation } from '@type/grammar';
@@ -42,6 +43,143 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     const { min: summaryMin, max: summaryMax } = MathUtil.minMax(summaryValues);
     this.min.push(summaryMin);
     this.max.push(summaryMax);
+  }
+
+  /**
+   * Get extrema targets for the current segmented bar plot trace
+   * Returns min and max values within the current group the user is navigating
+   * @returns Array of extrema targets for navigation
+   */
+  public override getExtremaTargets(): ExtremaTarget[] {
+    const targets: ExtremaTarget[] = [];
+    const currentGroup = this.row;
+
+    if (currentGroup < 0 || currentGroup >= this.barValues.length) {
+      return targets;
+    }
+
+    // Use pre-computed min/max values instead of recalculating
+    const groupMin = this.min[currentGroup];
+    const groupMax = this.max[currentGroup];
+    const groupValues = this.barValues[currentGroup];
+
+    if (!groupValues || groupValues.length === 0) {
+      return targets;
+    }
+
+    // Find indices of min/max values
+    const maxIndex = groupValues.indexOf(groupMax);
+    const minIndex = groupValues.indexOf(groupMin);
+
+    // Get group label and category labels
+    const groupLabel = this.getGroupLabel(currentGroup);
+    const maxCategoryLabel = this.getCategoryLabel(maxIndex);
+    const minCategoryLabel = this.getCategoryLabel(minIndex);
+
+    // Add max target
+    targets.push({
+      label: `Max ${groupLabel} at ${maxCategoryLabel}`,
+      value: groupMax,
+      pointIndex: maxIndex,
+      segment: groupLabel,
+      type: 'max',
+      groupIndex: currentGroup,
+      categoryIndex: maxIndex,
+      navigationType: 'group',
+    });
+
+    // Add min target
+    targets.push({
+      label: `Min ${groupLabel} at ${minCategoryLabel}`,
+      value: groupMin,
+      pointIndex: minIndex,
+      segment: groupLabel,
+      type: 'min',
+      groupIndex: currentGroup,
+      categoryIndex: minIndex,
+      navigationType: 'group',
+    });
+
+    return targets;
+  }
+
+  /**
+   * Navigate to a specific extrema target
+   * @param target The extrema target to navigate to
+   */
+  public override navigateToExtrema(target: ExtremaTarget): void {
+    // For group-based navigation, stay in same group but move to different category
+    if (target.groupIndex !== undefined && target.categoryIndex !== undefined) {
+      this.row = target.groupIndex;
+      this.col = target.categoryIndex;
+    } else {
+      // Fallback to point-based navigation
+      this.col = target.pointIndex;
+    }
+
+    // Update visual positioning and notify observers
+    this.updateVisualPointPosition();
+    this.notifyStateUpdate();
+  }
+
+  /**
+   * Get a human-readable label for the current group
+   * @param groupIndex The index of the group
+   * @returns A label for the group
+   */
+  private getGroupLabel(groupIndex: number): string {
+    if (this.points[groupIndex] && this.points[groupIndex].length > 0) {
+      const firstPoint = this.points[groupIndex][0];
+
+      // Check if this is the summary level
+      if (groupIndex === this.barValues.length - 1) {
+        return 'Total';
+      }
+
+      // For dodged/stacked plots, use the fill value as group identifier
+      if (firstPoint.fill) {
+        return `${this.getFillAxisLabel()}: '${firstPoint.fill}'`;
+      }
+    }
+
+    return `Group ${groupIndex}`;
+  }
+
+  /**
+   * Get a human-readable label for a specific category
+   * @param categoryIndex The index of the category
+   * @returns A label for the category
+   */
+  private getCategoryLabel(categoryIndex: number): string {
+    if (this.points[0] && this.points[0][categoryIndex]) {
+      const point = this.points[0][categoryIndex];
+      if (this.orientation === Orientation.VERTICAL) {
+        return `${point.x}`;
+      } else {
+        return `${point.y}`;
+      }
+    }
+    return `Category ${categoryIndex}`;
+  }
+
+  /**
+   * Get the label for the fill axis (e.g., "Drive", "Survival Status")
+   * @returns The fill axis label
+   */
+  private getFillAxisLabel(): string {
+    // Try to get from the layer axes, fallback to generic label
+    return 'Category';
+  }
+
+  /**
+   * Update the visual position of the current point
+   * This method should be called when navigation changes
+   */
+  private updateVisualPointPosition(): void {
+    // Ensure we're within bounds
+    const { row: safeRow, col: safeCol } = this.getSafeIndices();
+    this.row = safeRow;
+    this.col = safeCol;
   }
 
   protected text(): TextState {

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -163,7 +163,6 @@ export class DisplayService implements Disposable {
 
     this.context.toggleScope(focus);
     this.updateFocus(focus);
-
   }
 
   private updateFocus(newScope: Focus): void {

--- a/src/service/goToExtrema.ts
+++ b/src/service/goToExtrema.ts
@@ -43,6 +43,6 @@ export class GoToExtremaService {
    * Called when the modal is closed to restore plot navigation
    */
   public returnToTraceScope(): void {
-    this.display.toggleFocus(Scope.GO_TO_EXTREMA);
+    this.display.setFocus(Scope.TRACE);
   }
 }

--- a/src/service/goToExtrema.ts
+++ b/src/service/goToExtrema.ts
@@ -1,16 +1,8 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
 import type { TraceState } from '@type/state';
+import { AbstractTrace } from '@model/abstract';
 import { Scope } from '@type/event';
-import { TraceType } from '@type/grammar';
-
-export interface ExtremaTarget {
-  label: string;
-  value: number;
-  pointIndex: number;
-  segment: string;
-  type: 'max' | 'min';
-}
 
 export class GoToExtremaService {
   private readonly context: Context;
@@ -26,18 +18,24 @@ export class GoToExtremaService {
       return;
     }
 
-    if (state.traceType !== TraceType.CANDLESTICK) {
-      return;
-    }
-
-    // Get the active trace (should be a candlestick)
+    // Get the active trace
     const activeTrace = this.context.active;
 
-    if (activeTrace && 'getExtremaTargets' in activeTrace) {
+    // Check if the trace supports extrema navigation using the abstract class method
+    if (activeTrace && this.isExtremaNavigable(activeTrace)) {
       // Change scope to GO_TO_EXTREMA - this will activate the GO_TO_EXTREMA_KEYMAP
       // and deactivate the TRACE_KEYMAP, so arrow keys will work in the modal
       this.display.toggleFocus(Scope.GO_TO_EXTREMA);
     }
+  }
+
+  /**
+   * Check if a trace supports extrema navigation
+   * @param trace The trace to check
+   * @returns True if the trace supports extrema navigation
+   */
+  private isExtremaNavigable(trace: any): trace is AbstractTrace<number> {
+    return trace instanceof AbstractTrace && trace.supportsExtremaNavigation();
   }
 
   /**

--- a/src/service/goToSpecificValue.ts
+++ b/src/service/goToSpecificValue.ts
@@ -1,0 +1,35 @@
+import type { Context } from '@model/context';
+import type { DisplayService } from '@service/display';
+import type { TraceState } from '@type/state';
+import { AbstractTrace } from '@model/abstract';
+import { Scope } from '@type/event';
+
+export class GoToSpecificValueService {
+  private readonly context: Context;
+  private readonly display: DisplayService;
+
+  public constructor(context: Context, display: DisplayService) {
+    this.context = context;
+    this.display = display;
+  }
+
+  public toggle(state: TraceState): void {
+    if (state.empty) {
+      return;
+    }
+
+    const activeTrace = this.context.active;
+
+    if (activeTrace && this.isSpecificValueNavigable(activeTrace)) {
+      this.display.toggleFocus(Scope.GO_TO_SPECIFIC_VALUE);
+    }
+  }
+
+  private isSpecificValueNavigable(trace: any): trace is AbstractTrace<number> {
+    return trace instanceof AbstractTrace && 'getAvailableXValues' in trace && 'moveToXValue' in trace;
+  }
+
+  public returnToTraceScope(): void {
+    this.display.setFocus(Scope.TRACE);
+  }
+}

--- a/src/service/highlight.ts
+++ b/src/service/highlight.ts
@@ -71,7 +71,11 @@ export class HighlightService implements Observer<HighlightStateUnion>, Disposab
   }
 
   private handleTraceState(state: TraceState): void {
-    if (state.empty || state.highlight.empty) {
+    if (state.empty) {
+      return;
+    }
+
+    if (state.highlight.empty) {
       return;
     }
 

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -104,6 +104,19 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     this.goToExtremaService.returnToTraceScope();
   }
 
+  /**
+   * Gets the X-axis label from the current context state
+   * This provides a meaningful label for the specific value input field
+   */
+  public getXAxisLabel(): string {
+    const contextState = this.context.state;
+    if (contextState.type === 'trace' && !contextState.empty && contextState.xAxis) {
+      return contextState.xAxis;
+    }
+    // Fallback to generic label if no specific X-axis label is available
+    return 'X value';
+  }
+
   public get activeContext(): Context {
     return this.context;
   }
@@ -143,7 +156,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       try {
         activeTrace.navigateToExtrema(target);
       } catch (error) {
-        console.error('Error calling navigateToExtrema:', error);
+        console.error('❌ Error calling navigateToExtrema:', error);
       }
     }
 

--- a/src/state/viewModel/goToSpecificValueViewModel.ts
+++ b/src/state/viewModel/goToSpecificValueViewModel.ts
@@ -1,0 +1,131 @@
+import type { Context } from '@model/context';
+import type { GoToSpecificValueService } from '@service/goToSpecificValue';
+import type { XValue } from '@type/navigation';
+import type { AppStore } from '../store';
+import { AbstractViewModel } from './viewModel';
+
+export class GoToSpecificValueViewModel extends AbstractViewModel<null> {
+  private readonly context: Context;
+  private readonly goToSpecificValueService: GoToSpecificValueService;
+
+  public constructor(store: AppStore, context: Context, goToSpecificValueService: GoToSpecificValueService) {
+    super(store);
+    this.context = context;
+    this.goToSpecificValueService = goToSpecificValueService;
+  }
+
+  public dispose(): void {
+    super.dispose();
+  }
+
+  public get state(): null {
+    return null; // This ViewModel doesn't maintain state, just delegates to service
+  }
+
+  public show(): void {
+    const currentState = this.context.state;
+    if (currentState.type === 'trace') {
+      this.goToSpecificValueService.toggle(currentState);
+    }
+  }
+
+  public hide(): void {
+    this.goToSpecificValueService.returnToTraceScope();
+  }
+
+  public getAvailableXValues(): XValue[] {
+    const currentState = this.context.state;
+    if (currentState.type !== 'trace' || currentState.empty) {
+      return [];
+    }
+
+    const activeTrace = this.context.active;
+
+    if (!activeTrace || !('getAvailableXValues' in activeTrace)) {
+      return [];
+    }
+
+    const trace = activeTrace as { getAvailableXValues: () => XValue[] };
+    return trace.getAvailableXValues();
+  }
+
+  /**
+   * Get X values with group information for stacked/dodged plots
+   * This provides more context than just the basic X values
+   */
+  public getXValuesWithGroups(): Array<{ value: XValue; group?: string; description: string }> {
+    const currentState = this.context.state;
+    if (currentState.type !== 'trace' || currentState.empty) {
+      return [];
+    }
+
+    const activeTrace = this.context.active;
+
+    if (!activeTrace) {
+      return [];
+    }
+
+    // First try to use the method with group information if available (for SegmentedTrace)
+    if ('getXValuesWithGroups' in activeTrace) {
+      const trace = activeTrace as { getXValuesWithGroups: () => Array<{ value: any; group: string; description: string }> };
+      const valuesWithGroups = trace.getXValuesWithGroups();
+      return valuesWithGroups;
+    }
+
+    // Fallback to navigable references if available
+    if ('getNavigableReferences' in activeTrace) {
+      const trace = activeTrace as { getNavigableReferences: () => any[] };
+      const references = trace.getNavigableReferences();
+
+      const result = references.map((ref) => {
+        // For stacked bars, use the fill value as the group identifier
+        let groupLabel: string | undefined;
+        if (ref.context?.groupIndex !== undefined) {
+          // Try to get the actual fill value from the reference
+          if (ref.accessibility?.description) {
+            // Extract fill value from description like "Segmented bar at X in Drive: 'r'"
+            const match = ref.accessibility.description.match(/in (.+)$/);
+            if (match) {
+              groupLabel = match[1];
+            } else {
+              // Fallback to the description itself
+              groupLabel = ref.accessibility.description;
+            }
+          } else {
+            // Fallback to generic group label
+            groupLabel = `Group ${ref.context.groupIndex + 1}`;
+          }
+        }
+
+        const enhanced = {
+          value: ref.value,
+          group: groupLabel,
+          description: String(ref.value), // Just show the value, not the full description
+        };
+
+        return enhanced;
+      });
+
+      return result;
+    }
+
+    // Final fallback to basic X values
+    return this.getAvailableXValues().map(value => ({
+      value,
+      description: String(value), // Just show the value, not a description
+    }));
+  }
+
+  public navigateToXValue(value: XValue): void {
+    const activeTrace = this.context.active;
+    if (!activeTrace || !('moveToXValue' in activeTrace)) {
+      return;
+    }
+    const trace = activeTrace as { moveToXValue: (value: XValue) => boolean };
+    trace.moveToXValue(value);
+  }
+
+  public get activeContext(): Context {
+    return this.context;
+  }
+}

--- a/src/state/viewModel/registry.ts
+++ b/src/state/viewModel/registry.ts
@@ -1,6 +1,7 @@
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { DisplayViewModel } from '@state/viewModel/displayViewModel';
 import type { GoToExtremaViewModel } from '@state/viewModel/goToExtremaViewModel';
+import type { GoToSpecificValueViewModel } from '@state/viewModel/goToSpecificValueViewModel';
 import type { ReviewViewModel } from '@state/viewModel/reviewViewModel';
 import type { Disposable } from '@type/disposable';
 import type { ChatViewModel } from './chatViewModel';
@@ -13,6 +14,7 @@ export interface ViewModelMap {
   chat: ChatViewModel;
   display: DisplayViewModel;
   goToExtrema: GoToExtremaViewModel;
+  goToSpecificValue: GoToSpecificValueViewModel;
   help: HelpViewModel;
   review: ReviewViewModel;
   settings: SettingsViewModel;

--- a/src/state/viewModel/textViewModel.ts
+++ b/src/state/viewModel/textViewModel.ts
@@ -106,6 +106,10 @@ export class TextViewModel extends AbstractViewModel<TextState> {
     this.store.dispatch(notify(message));
   }
 
+  public clearMessage(): void {
+    this.store.dispatch(clearMessage());
+  }
+
   private setAriaAnnouncement(enabled: boolean): void {
     this.store.dispatch(announceText(enabled));
   }

--- a/src/type/event.ts
+++ b/src/type/event.ts
@@ -29,6 +29,7 @@ export enum Scope {
   TRACE_LABEL = 'TRACE_LABEL',
   REVIEW = 'REVIEW',
   SETTINGS = 'SETTINGS',
+  GO_TO_SPECIFIC_VALUE = 'GO_TO_SPECIFIC_VALUE',
 }
 
 export type Focus = Exclude<Scope, Scope.FIGURE_LABEL | Scope.TRACE_LABEL>;

--- a/src/type/extrema.ts
+++ b/src/type/extrema.ts
@@ -1,0 +1,46 @@
+/**
+ * Interface for plots that support extrema navigation
+ * Any plot implementing this interface can be used with the go-to extrema feature
+ */
+export interface ExtremaNavigable {
+  /**
+   * Get available extrema targets for the current navigation context
+   * @returns Array of extrema targets that can be navigated to
+   */
+  getExtremaTargets: () => ExtremaTarget[];
+
+  /**
+   * Navigate to a specific extrema target
+   * @param target The extrema target to navigate to
+   */
+  navigateToExtrema: (target: ExtremaTarget) => void;
+}
+
+/**
+ * Represents a single extrema target that can be navigated to
+ */
+export interface ExtremaTarget {
+  /** Human-readable label for the extrema (e.g., "Max Open", "Min Volatility") */
+  label: string;
+
+  /** The actual numeric value of the extrema */
+  value: number;
+
+  /** Index of the point to navigate to */
+  pointIndex: number;
+
+  /** Identifier for the segment/group this extrema belongs to */
+  segment: string;
+
+  /** Type of extrema - maximum or minimum */
+  type: 'max' | 'min';
+
+  /** Index of the group this extrema belongs to (for group-based plots) */
+  groupIndex?: number;
+
+  /** Index of the category within the group (for group-based plots) */
+  categoryIndex?: number;
+
+  /** Type of navigation this extrema requires */
+  navigationType: 'point' | 'group';
+}

--- a/src/type/navigation.ts
+++ b/src/type/navigation.ts
@@ -40,3 +40,33 @@ export function isXValue(value: unknown): value is XValue {
 export function isPointWithX(point: unknown): point is PointWithX {
   return point !== null && typeof point === 'object' && 'x' in point;
 }
+
+export interface NavigableReference {
+  // Essential identification
+  id: string;
+  value: XValue; // The actual navigable value
+
+  // Navigation type based on data structure
+  type: 'coordinate' | 'category' | 'group' | 'bin' | 'timestamp';
+
+  // Position within the plot's data structure
+  position: {
+    row: number; // Row index in data array
+    col: number; // Column index in data array
+    subIndex?: number; // For nested data (e.g., outliers in box plots)
+  };
+
+  // Plot context
+  context: {
+    plotType: string; // From grammar.ts TraceType enum
+    orientation?: string; // VERTICAL or HORIZONTAL (optional for plots without orientation)
+    groupIndex?: number; // For grouped plots (stacked/dodged)
+  };
+
+  // Accessibility
+  accessibility: {
+    description: string; // Human-readable description
+    shortLabel: string; // Short label for UI
+    valueType: 'numeric' | 'categorical' | 'temporal';
+  };
+}

--- a/src/ui/components/GoToExtrema.tsx
+++ b/src/ui/components/GoToExtrema.tsx
@@ -1,15 +1,35 @@
 import type { ExtremaTarget } from '@type/extrema';
-import { Close } from '@mui/icons-material';
-import { Box, IconButton, Typography } from '@mui/material';
+import type { XValue } from '@type/navigation';
+import { Close, KeyboardArrowDown } from '@mui/icons-material';
+import { Box, IconButton, List, ListItem, ListItemText, TextField, Typography } from '@mui/material';
 import { useViewModel, useViewModelState } from '@state/hook/useViewModel';
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export const GoToExtrema: React.FC = () => {
   const goToExtremaViewModel = useViewModel('goToExtrema');
+  const goToSpecificValueViewModel = useViewModel('goToSpecificValue');
   const state = useViewModelState('goToExtrema');
   const selectedItemRef = useRef<HTMLDivElement>(null);
   const listContainerRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+
+  // Go to Specific Value state
+  const [inputValue, setInputValue] = useState('');
+  const [filteredOptions, setFilteredOptions] = useState<Array<{ value: XValue; group?: string; description: string }>>([]);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+
+  const availableXValues = useMemo(() => {
+    const values = goToSpecificValueViewModel?.getXValuesWithGroups() || [];
+    return values;
+  }, [goToSpecificValueViewModel]);
+
+  // Get the X-axis label for the input field
+  const xAxisLabel = useMemo(() => {
+    return goToExtremaViewModel?.getXAxisLabel() || 'X value';
+  }, [goToExtremaViewModel]);
 
   useEffect(() => {
     if (modalRef.current) {
@@ -40,6 +60,91 @@ export const GoToExtrema: React.FC = () => {
     }
   }, [state.selectedIndex]);
 
+  // Filter options when input changes
+  useEffect(() => {
+    if (inputValue.trim() === '') {
+      setFilteredOptions(availableXValues);
+    } else {
+      const filtered = availableXValues.filter(option =>
+        String(option.value).toLowerCase().includes(inputValue.toLowerCase())
+        || (option.group && option.group.toLowerCase().includes(inputValue.toLowerCase()))
+        || option.description.toLowerCase().includes(inputValue.toLowerCase()),
+      );
+      setFilteredOptions(filtered);
+    }
+  }, [inputValue, availableXValues]);
+
+  // Announce filtered results for accessibility
+  useEffect(() => {
+    if (isDropdownOpen && filteredOptions.length > 0) {
+      const hasGroups = filteredOptions.some(option => option.group);
+      let announcement = `${filteredOptions.length} option${filteredOptions.length === 1 ? '' : 's'} available`;
+
+      if (hasGroups) {
+        const uniqueGroups = new Set(filteredOptions.map(option => option.group).filter(Boolean));
+        if (uniqueGroups.size > 0) {
+          announcement += ` across ${uniqueGroups.size} group${uniqueGroups.size === 1 ? '' : 's'}`;
+        }
+      }
+
+      // Use a timeout to ensure the announcement happens after the dropdown is rendered
+      setTimeout(() => {
+        const liveRegion = document.getElementById('filtered-results-announcement');
+        if (liveRegion) {
+          liveRegion.textContent = announcement;
+        }
+      }, 100);
+    }
+  }, [filteredOptions.length, isDropdownOpen]);
+
+  // Handle clicks outside the dropdown to close it
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+        setSelectedIndex(-1);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  // Focus the input when dropdown opens for better accessibility
+  useEffect(() => {
+    if (isDropdownOpen && inputRef.current) {
+      const input = inputRef.current.querySelector('input');
+      if (input) {
+        // Small delay to ensure the dropdown is fully rendered
+        setTimeout(() => {
+          input.focus();
+        }, 100);
+      }
+    }
+  }, [isDropdownOpen]);
+
+  // Ensure selected option is visible in dropdown
+  const scrollSelectedIntoView = useCallback((index: number) => {
+    if (listboxRef.current && index >= 0) {
+      const selectedOption = listboxRef.current.querySelector(`#option-${index}`);
+      if (selectedOption) {
+        selectedOption.scrollIntoView({
+          block: 'nearest',
+          behavior: 'smooth',
+        });
+      }
+    }
+  }, []);
+
+  // Scroll selected option into view when selection changes
+  useEffect(() => {
+    if (selectedIndex >= 0) {
+      scrollSelectedIntoView(selectedIndex);
+    }
+  }, [selectedIndex, scrollSelectedIntoView]);
+
   const handleTargetSelect = (target: ExtremaTarget): void => {
     const activeTrace = goToExtremaViewModel.activeContext?.active;
     if (activeTrace && goToExtremaViewModel.isExtremaNavigable(activeTrace)) {
@@ -48,28 +153,63 @@ export const GoToExtrema: React.FC = () => {
     goToExtremaViewModel.hide();
   };
 
+  const handleSpecificValueSelect = (value: XValue): void => {
+    if (goToSpecificValueViewModel) {
+      goToSpecificValueViewModel.navigateToXValue(value);
+      goToExtremaViewModel.hide();
+    }
+  };
+
   const handleClose = (): void => {
     goToExtremaViewModel.hide();
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent): void => {
-    // Prevent focus from escaping the modal
-    if (event.key === 'Tab') {
-      const focusableElements = modalRef.current?.querySelectorAll(
-        'button, [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusableElements && focusableElements.length > 0) {
-        const firstElement = focusableElements[0] as HTMLElement;
-        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
-
-        if (event.shiftKey && document.activeElement === firstElement) {
-          event.preventDefault();
-          lastElement.focus();
-        } else if (!event.shiftKey && document.activeElement === lastElement) {
-          event.preventDefault();
-          firstElement.focus();
-        }
+  const handleInputKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Enter' && selectedIndex >= 0) {
+      event.preventDefault();
+      const chosen = String(filteredOptions[selectedIndex].value);
+      setInputValue(chosen);
+      setIsDropdownOpen(false);
+      setSelectedIndex(-1);
+      handleSpecificValueSelect(chosen);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setIsDropdownOpen(false);
+      setSelectedIndex(-1);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      let newIndex: number;
+      if (selectedIndex === -1) {
+        // First arrow down - select first option
+        newIndex = 0;
+      } else {
+        newIndex = Math.min(selectedIndex + 1, filteredOptions.length - 1);
       }
+      setSelectedIndex(newIndex);
+      // Focus the selected option after state update
+      setTimeout(() => {
+        const optionElement = listboxRef.current?.querySelector(`#option-${newIndex}`);
+        if (optionElement) {
+          (optionElement as HTMLElement).focus();
+        }
+      }, 0);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      let newIndex: number;
+      if (selectedIndex === -1) {
+        // First arrow up - select last option
+        newIndex = filteredOptions.length - 1;
+      } else {
+        newIndex = Math.max(selectedIndex - 1, 0);
+      }
+      setSelectedIndex(newIndex);
+      // Focus the selected option after state update
+      setTimeout(() => {
+        const optionElement = listboxRef.current?.querySelector(`#option-${newIndex}`);
+        if (optionElement) {
+          (optionElement as HTMLElement).focus();
+        }
+      }, 0);
     }
   };
 
@@ -83,7 +223,26 @@ export const GoToExtrema: React.FC = () => {
           aria-labelledby="go-to-extrema-title"
           aria-describedby="go-to-extrema-description"
           tabIndex={0}
-          onKeyDown={handleKeyDown}
+          onKeyDown={(event) => {
+            // Handle Tab navigation within the modal
+            if (event.key === 'Tab') {
+              const focusableElements = modalRef.current?.querySelectorAll(
+                'button, [tabindex]:not([tabindex="-1"]), input, [role="option"]',
+              );
+              if (focusableElements && focusableElements.length > 0) {
+                const firstElement = focusableElements[0] as HTMLElement;
+                const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+                if (event.shiftKey && document.activeElement === firstElement) {
+                  event.preventDefault();
+                  lastElement.focus();
+                } else if (!event.shiftKey && document.activeElement === lastElement) {
+                  event.preventDefault();
+                  firstElement.focus();
+                }
+              }
+            }
+          }}
           sx={{
             position: 'fixed',
             top: '50%',
@@ -96,9 +255,16 @@ export const GoToExtrema: React.FC = () => {
             p: 3,
             boxShadow: 3,
             zIndex: 1000,
-            minWidth: 300,
-            maxHeight: '80vh',
+            // Responsive sizing that works well in iframes
+            minWidth: { xs: '90vw', sm: '400px', md: '500px' },
+            maxWidth: { xs: '95vw', sm: '80vw', md: '60vw' },
+            width: 'fit-content',
+            maxHeight: { xs: '90vh', sm: '85vh' },
+            height: 'fit-content',
             outline: 'none',
+            overflow: 'visible', // Allow dropdown to extend beyond modal
+            // Ensure modal works well in iframes
+            contain: 'layout style',
           }}
         >
           <Box
@@ -140,6 +306,7 @@ export const GoToExtrema: React.FC = () => {
               borderColor: 'divider',
               borderRadius: 1,
               p: 1,
+              mb: 2,
             }}
           >
             {state.targets.map((target: ExtremaTarget, index: number) => (
@@ -154,28 +321,205 @@ export const GoToExtrema: React.FC = () => {
                 tabIndex={0}
                 sx={{
                   'p': 1.5,
-                  'border': 1,
-                  'borderColor': state.selectedIndex === index ? 'primary.main' : 'divider',
-                  'borderRadius': 1,
-                  'mb': 1,
                   'cursor': 'pointer',
-                  'bgcolor': state.selectedIndex === index ? 'action.selected' : 'background.paper',
-                  'transition': 'all 0.2s ease',
+                  'borderRadius': 1,
+                  'mb': 0.5,
+                  'border': state.selectedIndex === index ? 2 : 1,
+                  'borderColor': state.selectedIndex === index ? 'primary.main' : 'divider',
+                  'bgcolor': state.selectedIndex === index ? 'action.selected' : 'transparent',
                   '&:hover': {
-                    bgcolor: state.selectedIndex === index ? 'action.selected' : 'action.hover',
+                    bgcolor: 'action.hover',
+                  },
+                  '&:focus': {
+                    outline: 'none',
+                    borderColor: 'primary.main',
+                    bgcolor: 'action.selected',
                   },
                 }}
               >
-                <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.5 }}>
+                <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
                   {target.label}
                 </Typography>
-                <Typography variant="caption" color="text.secondary">
+                <Typography variant="body2" color="text.secondary">
                   Value:
                   {' '}
                   {target.value.toFixed(2)}
                 </Typography>
               </Box>
             ))}
+          </Box>
+
+          {/* Go to Specific Value Section */}
+          <Box sx={{ borderTop: 1, borderColor: 'divider', mt: 2, pt: 2, overflow: 'visible', position: 'relative' }}>
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+              Go to Specific
+              {' '}
+              {xAxisLabel}
+            </Typography>
+
+            {availableXValues.length > 0
+              ? (
+                  <Box sx={{ position: 'relative' }}>
+                    <TextField
+                      ref={inputRef}
+                      label={xAxisLabel}
+                      placeholder={`Type to search ${xAxisLabel.toLowerCase()} values`}
+                      fullWidth
+                      variant="outlined"
+                      size="small"
+                      value={inputValue}
+                      onChange={(e) => {
+                        const newValue = e.target.value;
+                        setInputValue(newValue);
+                        setIsDropdownOpen(true);
+                        setSelectedIndex(-1);
+                      }}
+                      onFocus={() => {
+                        setIsDropdownOpen(true);
+                        setSelectedIndex(-1);
+                      }}
+                      onKeyDown={handleInputKeyDown}
+                      slotProps={{
+                        input: {
+                          'aria-autocomplete': 'list',
+                          'aria-haspopup': 'listbox',
+                          'aria-controls': 'x-value-listbox',
+                          'aria-expanded': isDropdownOpen,
+                          'aria-activedescendant': selectedIndex >= 0 ? `option-${selectedIndex}` : undefined,
+                          'role': 'combobox',
+                          'aria-label': 'Search and select X value',
+                          'endAdornment': (
+                            <IconButton
+                              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                              aria-label={isDropdownOpen ? 'Close dropdown' : 'Open dropdown'}
+                              size="small"
+                            >
+                              <KeyboardArrowDown />
+                            </IconButton>
+                          ),
+                        },
+                      }}
+                    />
+
+                    {/* Accessibility announcement for filtered results */}
+                    <div
+                      id="filtered-results-announcement"
+                      aria-live="polite"
+                      aria-atomic="true"
+                      style={{ position: 'absolute', left: '-10000px', width: '1px', height: '1px', overflow: 'hidden' }}
+                    />
+
+                    {isDropdownOpen && filteredOptions.length > 0 && (
+                      <List
+                        ref={listboxRef}
+                        id="x-value-listbox"
+                        role="listbox"
+                        aria-label="Available X values"
+                        sx={{
+                          position: 'absolute',
+                          bottom: '100%', // Position above the input
+                          left: 0,
+                          right: 0,
+                          bgcolor: 'background.paper',
+                          border: 1,
+                          borderColor: 'divider',
+                          borderRadius: 1,
+                          maxHeight: 200,
+                          overflowY: 'auto',
+                          zIndex: 9999,
+                          boxShadow: 2,
+                          marginBottom: 1,
+                        }}
+                      >
+                        {filteredOptions.map((option, index) => (
+                          <ListItem
+                            key={index}
+                            disablePadding
+                            id={`option-${index}`}
+                            role="option"
+                            aria-selected={index === selectedIndex}
+                            aria-posinset={index + 1}
+                            aria-setsize={filteredOptions.length}
+                            tabIndex={0}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                const chosen = String(option.value);
+                                setInputValue(chosen);
+                                setIsDropdownOpen(false);
+                                setSelectedIndex(-1);
+                                handleSpecificValueSelect(option.value);
+                              } else if (e.key === 'Escape') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                setIsDropdownOpen(false);
+                                setSelectedIndex(-1);
+                              } else if (e.key === 'ArrowDown') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                const newIndex = Math.min(index + 1, filteredOptions.length - 1);
+                                setSelectedIndex(newIndex);
+                                setTimeout(() => {
+                                  const nextOption = listboxRef.current?.querySelector(`#option-${newIndex}`);
+                                  if (nextOption) {
+                                    (nextOption as HTMLElement).focus();
+                                  }
+                                }, 0);
+                              } else if (e.key === 'ArrowUp') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                const newIndex = Math.max(index - 1, 0);
+                                setSelectedIndex(newIndex);
+                                setTimeout(() => {
+                                  const prevOption = listboxRef.current?.querySelector(`#option-${newIndex}`);
+                                  if (prevOption) {
+                                    (prevOption as HTMLElement).focus();
+                                  }
+                                }, 0);
+                              }
+                            }}
+                          >
+                            <ListItemText
+                              primary={(
+                                <span style={{ display: 'flex', alignItems: 'center' }}>
+                                  <Typography variant="body2" component="span">
+                                    {option.value}
+                                  </Typography>
+                                  {option.group && (
+                                    <Typography variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                                      (
+                                      {option.group}
+                                      )
+                                    </Typography>
+                                  )}
+                                </span>
+                              )}
+                              onClick={() => {
+                                const chosen = String(option.value);
+                                setInputValue(chosen);
+                                setIsDropdownOpen(false);
+                                setSelectedIndex(-1);
+                                handleSpecificValueSelect(option.value);
+                              }}
+                              sx={{
+                                'cursor': 'pointer',
+                                '&:hover': {
+                                  bgcolor: 'action.hover',
+                                },
+                              }}
+                            />
+                          </ListItem>
+                        ))}
+                      </List>
+                    )}
+                  </Box>
+                )
+              : (
+                  <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 1 }}>
+                    No specific values available for this plot type.
+                  </Typography>
+                )}
           </Box>
         </Box>
       )

--- a/src/ui/components/GoToExtrema.tsx
+++ b/src/ui/components/GoToExtrema.tsx
@@ -1,4 +1,4 @@
-import type { ExtremaTarget } from '@service/goToExtrema';
+import type { ExtremaTarget } from '@type/extrema';
 import { Close } from '@mui/icons-material';
 import { Box, IconButton, Typography } from '@mui/material';
 import { useViewModel, useViewModelState } from '@state/hook/useViewModel';
@@ -42,8 +42,8 @@ export const GoToExtrema: React.FC = () => {
 
   const handleTargetSelect = (target: ExtremaTarget): void => {
     const activeTrace = goToExtremaViewModel.activeContext?.active;
-    if (activeTrace && 'navigateToExtrema' in activeTrace) {
-      (activeTrace as any).navigateToExtrema(target);
+    if (activeTrace && goToExtremaViewModel.isExtremaNavigable(activeTrace)) {
+      activeTrace.navigateToExtrema(target);
     }
     goToExtremaViewModel.hide();
   };
@@ -124,7 +124,7 @@ export const GoToExtrema: React.FC = () => {
 
           <Box id="go-to-extrema-description" sx={{ mb: 2 }}>
             <Typography variant="body2" color="text.secondary" sx={{ m: 0 }}>
-              Navigate to statistical extremes within the current candlestick
+              {state.description || 'Navigate to statistical extremes'}
             </Typography>
           </Box>
 


### PR DESCRIPTION
# Pull Request

## Description

Core Functionality

Integrated "Go to Specific Value" into existing "Go to Extrema" modal - Users can now search for specific X values directly within the extrema navigation interface
Dynamic X-axis labeling - Input field label changes to match the actual X-axis name from the plot (e.g., "Enter Day value" instead of generic "Enter X value")
Intelligent filtering and search - Real-time search with accessibility announcements for result counts


## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.
