### PR TITLE
fix: address multi-panel plot navigation

### DIFF
--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -148,7 +148,7 @@ export class Context implements Disposable {
       this.plotContext.pop(); // Remove current Trace.
       this.plotContext.pop(); // Remove current Subplot.
       this.active.notifyStateUpdate();
-      this.toggleScope(Scope.TRACE);
+      this.toggleScope(Scope.SUBPLOT);
     }
   }
 

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -2,7 +2,7 @@ import type { ExtremaTarget } from '@type/extrema';
 import type { LinePoint, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, TextState, TraceState } from '@type/state';
+import type { AudioState, BrailleState, HighlightState, TextState, TraceState } from '@type/state';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -501,13 +501,15 @@ export class LineTrace extends AbstractTrace<number> {
    * @returns true if the position was found and set, false otherwise
    */
   public moveToXValue(xValue: XValue): boolean {
-    const targetIndex = this.points[this.row].findIndex(point => point.x === xValue);
-    if (targetIndex !== -1) {
-      this.col = targetIndex;
-      this.updateVisualPointPosition();
-      this.notifyStateUpdate();
-      return true;
+    // Handle initial entry properly
+    if (this.isInitialEntry) {
+      this.handleInitialEntry();
     }
-    return false;
+
+    return super.moveToXValue(xValue);
+  }
+
+  protected highlight(): HighlightState {
+    return super.highlight();
   }
 }

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -2,7 +2,7 @@ import type { ExtremaTarget } from '@type/extrema';
 import type { LinePoint, MaidrLayer } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, HighlightState, TextState, TraceState } from '@type/state';
+import type { AudioState, BrailleState, TextState, TraceState } from '@type/state';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -505,11 +505,6 @@ export class LineTrace extends AbstractTrace<number> {
     if (this.isInitialEntry) {
       this.handleInitialEntry();
     }
-
     return super.moveToXValue(xValue);
-  }
-
-  protected highlight(): HighlightState {
-    return super.highlight();
   }
 }

--- a/src/model/smooth.ts
+++ b/src/model/smooth.ts
@@ -7,6 +7,27 @@ export class SmoothTrace extends LineTrace {
     super(layer);
   }
 
+  public moveToXValue(xValue: number): boolean {
+    if (this.isInitialEntry) {
+      this.handleInitialEntry();
+    }
+
+    const points = this.points;
+    if (!points || !points.length)
+      return false;
+
+    const success = this.navigationService.moveToXValueInPoints(
+      points,
+      xValue,
+      this.moveToIndex.bind(this),
+    );
+
+    if (success) {
+      this.notifyStateUpdate();
+    }
+    return success;
+  }
+
   protected audio(): AudioState {
     const rowYValues = this.lineValues[this.row];
     const col = this.col;


### PR DESCRIPTION

## Description

Fixed plot hopping in multi-panel plots to ensure subplot keymap is active when exiting subplots and re-entering other.

Standardized the initialization process during layer switches to ensure all plot types (bar, line, scatter, etc.) maintain their visual feedback and interactive features when users navigate between layers.


## Changes Made

1. Modified line.ts & smooth.ts to process initial entry the right way
2. In context.ts subplot scope toggled when exiting a subplot within figure scope


## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.
