### PR TITLE
fix(html): remove maidr-data attribute from boxplot svgs

### DIFF
--- a/examples/boxplot-horizontal.html
+++ b/examples/boxplot-horizontal.html
@@ -19,9 +19,7 @@
             viewBox="0 0 478 344"
             version="1.1"
             id="boxplot_horizontal"
-            tabindex="0"
-            maidr-data='{"id":"boxplot_horizontal","subplots":[[{"layers":[{"type":"box","orientation":"horz","selector":"#geom_boxplot\\\\.gTree\\\\.177\\\\.1","axes":{"x":"Life Expectancy","y":"Continent"},"data":[{"fill":"Africa","lowerOutliers":[23.599],"min":30,"q1":42.361,"q2":47.792,"q3":54.416,"max":72.301,"upperOutliers":[72.737,72.801,73.042,73.615,73.923,73.952,74.772,75.744,76.442]},{"fill":"Americas","lowerOutliers":[37.579],"min":40.414,"q1":58.373,"q2":67.048,"q3":71.717,"max":80.653,"upperOutliers":[]},{"fill":"Asia","lowerOutliers":[],"min":28.801,"q1":51.3955,"q2":61.7915,"q3":69.5105,"max":82.603,"upperOutliers":[]},{"fill":"Europe","lowerOutliers":[43.585,48.079,52.098,53.82,54.336,55.23,57.005,57.996,58.45,59.164,59.28,59.507,59.6,59.82],"min":61.036,"q1":69.56,"q2":72.241,"q3":75.456,"max":81.757,"upperOutliers":[]},{"fill":"Oceania","lowerOutliers":[],"min":69.12,"q1":71.17,"q2":73.665,"q3":77.555,"max":81.235,"upperOutliers":[]}]}]}]]}'
-          >
+            tabindex="0"          >
             <metadata xmlns:gridsvg="http://www.stat.auckland.ac.nz/~paul/R/gridSVG/">
               <gridsvg:generator name="gridSVG" version="1.7-4" time="2023-03-03 15:24:45" />
               <gridsvg:argument name="name" value="boxplot_user_study.svg" />

--- a/examples/boxplot-vertical.html
+++ b/examples/boxplot-vertical.html
@@ -19,9 +19,7 @@
             viewBox="0 0 478 344"
             version="1.1"
             id="boxplot_vertical"
-            tabindex="0"
-            maidr-data='{"id":"boxplot_vertical","subplots":[[{"layers":[{"type":"box","orientation":"vert","selector":"#geom_boxplot\\\\.gTree\\\\.78\\\\.1","axes":{"x":"class","y":"hwy"},"data":[{"fill":"2seater","lowerOutliers":[],"min":23,"q1":24,"q2":0,"q3":25,"max":26,"upperOutliers":[]},{"fill":"compact","lowerOutliers":[],"min":23,"q1":26,"q2":27,"q3":29,"max":33,"upperOutliers":[35,35,37,44]},{"fill":"midsize","lowerOutliers":[],"min":23,"q1":26,"q2":27,"q3":29,"max":32,"upperOutliers":[]},{"fill":"minivan","lowerOutliers":[17],"min":21,"q1":22,"q2":23,"q3":29,"max":32,"upperOutliers":[]},{"fill":"pickup","lowerOutliers":[12,12,12],"min":15,"q1":16,"q2":17,"q3":18,"max":20,"upperOutliers":[22]},{"fill":"subcompact","lowerOutliers":[],"min":20,"q1":24.5,"q2":26,"q3":30.5,"max":36,"upperOutliers":[41,44]},{"fill":"suv","lowerOutliers":[12,12],"min":14,"q1":17,"q2":17.5,"q3":19,"max":22,"upperOutliers":[23,24,25,25,26,27]}]}]}]]}'
-          >
+            tabindex="0"          >
             <metadata xmlns:gridsvg="http://www.stat.auckland.ac.nz/~paul/R/gridSVG/">
               <gridsvg:generator name="gridSVG" version="1.7-4" time="2023-02-22 19:47:59" />
               <gridsvg:argument name="name" value="boxplot.svg" />


### PR DESCRIPTION
# Pull Request

## Description

This PR removes the `maidr-data` attribute from the <svg> tags in boxplot HTML files.  
The plots now rely on `window.maidr` for structured selectors, ensuring consistency for arrow-key highlighting and sound.

## Changes Made

- Removed the `maidr-data` attribute from <svg id="boxplot_horizontal"> in boxplot-horizontal.html
- Removed the `maidr-data` attribute from <svg id="boxplot_vertical"> in boxplot-vertical.html
- Verified that the existing window.maidr block handles structured selectors without requiring additional scripts

## Screenshots (if applicable)

![Recording 2025-09-22 at 17 07 49](https://github.com/user-attachments/assets/91866bbb-d9e6-45d7-bf87-ebc5207153bb)
![Recording 2025-09-22 at 17 59 13](https://github.com/user-attachments/assets/0b2de6f3-302c-4646-9527-60c2e43f42cc)

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [ X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

No new functionality added; this is a cleanup/refactor for consistency.
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
