### PR TITLE
feat: support outlier visual highlight in boxplots

### DIFF
--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -181,7 +181,9 @@ export abstract class Svg {
         const unit = match[2] || '';
         clone.setAttribute(Constant.STROKE_WIDTH, `${value + this.STROKE_WIDTH_HIGHLIGHT_INCREASE}${unit}`);
       } else {
-        clone.setAttribute(Constant.STROKE_WIDTH, `${Number.parseFloat(strokeWidth) + this.STROKE_WIDTH_HIGHLIGHT_INCREASE}`);
+        const parsed = Number.parseFloat(strokeWidth);
+        const value = Number.isNaN(parsed) ? this.STROKE_WIDTH_HIGHLIGHT_INCREASE : parsed + this.STROKE_WIDTH_HIGHLIGHT_INCREASE;
+        clone.setAttribute(Constant.STROKE_WIDTH, `${value}`);
       }
     }
 

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -174,7 +174,16 @@ export abstract class Svg {
 
     if (isLineElement) {
       const strokeWidth = window.getComputedStyle(clone).getPropertyValue(Constant.STROKE_WIDTH);
-      clone.setAttribute(Constant.STROKE_WIDTH, `${Number.parseFloat(strokeWidth) + 2}`);
+      // Preserve units when increasing stroke width
+      const match = strokeWidth.match(/^([0-9.]+)([a-z%]*)$/i);
+      if (match) {
+        const value = parseFloat(match[1]);
+        const unit = match[2] || '';
+        clone.setAttribute(Constant.STROKE_WIDTH, `${value + 2}${unit}`);
+      } else {
+        // Fallback: just add 2, no unit
+        clone.setAttribute(Constant.STROKE_WIDTH, `${Number.parseFloat(strokeWidth) + 2}`);
+      }
     }
 
     element.insertAdjacentElement(Constant.AFTER_END, clone);

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -145,7 +145,7 @@ export abstract class Svg {
   private static getAdjustedOpacity(value: string | null, minThreshold: number): string {
     const parsed = value ? Number.parseFloat(value) : Number.NaN;
     if (!Number.isNaN(parsed) && parsed > minThreshold) {
-      return value!;
+      return parsed.toString();
     }
     return '1';
   }

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -141,6 +141,7 @@ export abstract class Svg {
 
   private static readonly MIN_VISIBLE_FILL_OPACITY = 0.01;
   private static readonly MIN_VISIBLE_STROKE_OPACITY = 0.01;
+  private static readonly STROKE_WIDTH_HIGHLIGHT_INCREASE = 2;
 
   private static getAdjustedOpacity(value: string | null, minThreshold: number): string {
     const parsed = value ? Number.parseFloat(value) : Number.NaN;
@@ -174,15 +175,13 @@ export abstract class Svg {
 
     if (isLineElement) {
       const strokeWidth = window.getComputedStyle(clone).getPropertyValue(Constant.STROKE_WIDTH);
-      // Preserve units when increasing stroke width
       const match = strokeWidth.match(/^([0-9.]+)([a-z%]*)$/i);
       if (match) {
         const value = Number.parseFloat(match[1]);
         const unit = match[2] || '';
-        clone.setAttribute(Constant.STROKE_WIDTH, `${value + 2}${unit}`);
+        clone.setAttribute(Constant.STROKE_WIDTH, `${value + this.STROKE_WIDTH_HIGHLIGHT_INCREASE}${unit}`);
       } else {
-        // Fallback: just add 2, no unit
-        clone.setAttribute(Constant.STROKE_WIDTH, `${Number.parseFloat(strokeWidth) + 2}`);
+        clone.setAttribute(Constant.STROKE_WIDTH, `${Number.parseFloat(strokeWidth) + this.STROKE_WIDTH_HIGHLIGHT_INCREASE}`);
       }
     }
 

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -177,7 +177,7 @@ export abstract class Svg {
       // Preserve units when increasing stroke width
       const match = strokeWidth.match(/^([0-9.]+)([a-z%]*)$/i);
       if (match) {
-        const value = parseFloat(match[1]);
+        const value = Number.parseFloat(match[1]);
         const unit = match[2] || '';
         clone.setAttribute(Constant.STROKE_WIDTH, `${value + 2}${unit}`);
       } else {

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -144,7 +144,7 @@ export abstract class Svg {
 
   private static getAdjustedOpacity(value: string | null, minThreshold: number): string {
     const parsed = value ? Number.parseFloat(value) : Number.NaN;
-    if (!Number.isNaN(parsed) && parsed > minThreshold && parsed !== 1) {
+    if (!Number.isNaN(parsed) && parsed > minThreshold) {
       return value!;
     }
     return '1';

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -182,7 +182,9 @@ export abstract class Svg {
         clone.setAttribute(Constant.STROKE_WIDTH, `${value + this.STROKE_WIDTH_HIGHLIGHT_INCREASE}${unit}`);
       } else {
         const parsed = Number.parseFloat(strokeWidth);
-        const value = Number.isNaN(parsed) ? this.STROKE_WIDTH_HIGHLIGHT_INCREASE : parsed + this.STROKE_WIDTH_HIGHLIGHT_INCREASE;
+        const value = Number.isNaN(parsed)
+          ? this.STROKE_WIDTH_HIGHLIGHT_INCREASE
+          : parsed + this.STROKE_WIDTH_HIGHLIGHT_INCREASE;
         clone.setAttribute(Constant.STROKE_WIDTH, `${value}`);
       }
     }

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -140,7 +140,7 @@ export abstract class Svg {
   }
 
   private static readonly MIN_VISIBLE_FILL_OPACITY = 0.01;
-  private static readonly MIN_VISIBLE_STROKE_OPACITY = 0.0;
+  private static readonly MIN_VISIBLE_STROKE_OPACITY = 0.01;
 
   private static getAdjustedOpacity(value: string | null, minThreshold: number): string {
     const parsed = value ? Number.parseFloat(value) : Number.NaN;


### PR DESCRIPTION
# Pull Request

## Description

This PR adds opacity preservation functionality to the createHighlightElement method in the SVG utils. The enhancement ensures that when MAIDR creates highlight elements for accessibility features, the original fill-opacity and stroke-opacity values are preserved, maintaining visual fidelity and improving the user experience for elements with transparency.

## Changes Made

src/util/svg.ts - Enhanced createHighlightElement method

## Screenshots (if applicable)

![Recording 2025-10-07 at 11 22 49](https://github.com/user-attachments/assets/edf71bcc-ebde-4447-ad64-02c913f941d7)

## Checklist

- [ x ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ x ] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have updated the documentation, if applicable.
- [ x ] I have added appropriate unit tests, if applicable.

