### PR TITLE
feat: support for both maidr-data & maidr payload within svg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,19 @@ if (document.readyState === 'loading') {
   main();
 }
 
+function parseAndInit(
+  plot: HTMLElement,
+  json: string,
+  source: 'maidr' | 'maidr-data',
+): void {
+  try {
+    const maidr = JSON.parse(json) as Maidr;
+    initMaidr(maidr, plot);
+  } catch (error) {
+    console.error(`Error parsing ${source} attribute:`, error);
+  }
+}
+
 function main(): void {
   const plotsWithMaidr = document.querySelectorAll<HTMLElement>(
     Constant.MAIDR_JSON_SELECTOR,
@@ -26,12 +39,7 @@ function main(): void {
         return;
       }
 
-      try {
-        const maidr = JSON.parse(maidrAttr);
-        initMaidr(maidr, plot);
-      } catch (error) {
-        console.error('Error parsing maidr attribute:', error);
-      }
+      parseAndInit(plot, maidrAttr, 'maidr');
     });
 
     return;
@@ -44,12 +52,7 @@ function main(): void {
       return;
     }
 
-    try {
-      const maidr = JSON.parse(maidrData);
-      initMaidr(maidr, plot);
-    } catch (error) {
-      console.error('Error parsing maidr-data attribute:', error);
-    }
+    parseAndInit(plot, maidrData, 'maidr-data');
   });
 
   // Fall back to window.maidr if no attribute found.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,29 @@ if (document.readyState === 'loading') {
 }
 
 function main(): void {
+  const plotsWithMaidr = document.querySelectorAll<HTMLElement>(
+    Constant.MAIDR_JSON_SELECTOR,
+  );
+
+  if (plotsWithMaidr.length > 0) {
+    plotsWithMaidr.forEach((plot) => {
+      const maidrAttr = plot.getAttribute(Constant.MAIDR);
+
+      if (!maidrAttr) {
+        return;
+      }
+
+      try {
+        const maidr = JSON.parse(maidrAttr);
+        initMaidr(maidr, plot);
+      } catch (error) {
+        console.error('Error parsing maidr attribute:', error);
+      }
+    });
+
+    return;
+  }
+
   const plots = document.querySelectorAll<HTMLElement>(`[${Constant.MAIDR_DATA}]`);
   plots.forEach((plot) => {
     const maidrData = plot.getAttribute(Constant.MAIDR_DATA);
@@ -25,7 +48,7 @@ function main(): void {
       const maidr = JSON.parse(maidrData);
       initMaidr(maidr, plot);
     } catch (error) {
-      console.error('Error parsing maidr attribute:', error);
+      console.error('Error parsing maidr-data attribute:', error);
     }
   });
 
@@ -43,6 +66,7 @@ function main(): void {
 
   const plot = document.getElementById(maidr.id);
   if (!plot) {
+    console.error('Plot not found for maidr:', maidr.id);
     return;
   }
   initMaidr(maidr, plot);

--- a/src/util/constant.ts
+++ b/src/util/constant.ts
@@ -43,6 +43,9 @@ export abstract class Constant {
 
   // MAIDR Terms
   static readonly MAIDR_SUBPLOT = 'subplot';
+  static readonly MAIDR = 'maidr';
+  // CSS selector for elements whose `maidr` attribute contains JSON (starts with '{')
+  static readonly MAIDR_JSON_SELECTOR = '[maidr^="{"]';
   // Attribute values.
   static readonly AFTER_END = 'afterend';
   static readonly APPLICATION = 'application';


### PR DESCRIPTION
# Pull Request

## Description

Adds simple, backward-compatible support for initializing from a JSON maidr attribute on the root SVG (variable-based workflow unchanged), prioritizes it over maidr-data

## Changes Made

src/index.ts

Prioritize initialization from [maidr] (JSON) before [maidr-data], then fallback to window.maidr.
Use a centralized selector to only match maidr attributes that start with { (JSON).
Parse only when the attribute looks like JSON to avoid UUID values on nested elements.

src/util/constant.ts

Added MAIDR_JSON_SELECTOR = '[maidr^="{"]' for query selection.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

