### PR TITLE
feat: support custom dom ordering

### DIFF
--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -105,13 +105,26 @@ export class Heatmap extends AbstractTrace<number> {
         svgElements.push(row);
       }
     } else if (domElements[0] instanceof SVGRectElement) {
-      for (let r = 0; r < numRows; r++) {
-        const row = new Array<SVGElement>();
-        for (let c = 0; c < numCols; c++) {
-          const flatIndex = c * numRows + r;
-          row.push(domElements[flatIndex]);
+      // If layer.domMapping?.order === 'row', use row-major mapping for rects.
+      // Otherwise, preserve current default: column-major mapping.
+      if (this.layer.domMapping?.order === 'row') {
+        for (let r = 0; r < numRows; r++) {
+          const row = new Array<SVGElement>();
+          for (let c = 0; c < numCols; c++) {
+            const flatIndex = r * numCols + c;
+            row.push(domElements[flatIndex]);
+          }
+          svgElements.push(row);
         }
-        svgElements.push(row);
+      } else {
+        for (let r = 0; r < numRows; r++) {
+          const row = new Array<SVGElement>();
+          for (let c = 0; c < numCols; c++) {
+            const flatIndex = c * numRows + r;
+            row.push(domElements[flatIndex]);
+          }
+          svgElements.push(row);
+        }
       }
     }
 

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -247,8 +247,9 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
         svgElements.push(new Array<SVGElement>());
       }
 
+      const isForward = this.layer.domMapping?.groupDirection === 'forward';
       for (let c = 0, domIndex = 0; c < this.barValues[0].length; c++) {
-        if (this.layer.domOrder === 'forward') {
+        if (isForward) {
           for (let r = 0; r < this.barValues.length; r++) {
             if (domIndex >= domElements.length) {
               return new Array<Array<SVGElement>>();

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -108,7 +108,24 @@ export interface MaidrLayer {
   title?: string;
   selectors?: string | string[] | BoxSelector[] | CandlestickSelector;
   orientation?: Orientation;
-  domOrder?: 'forward' | 'reverse';
+  /**
+   * Optional DOM mapping hints. When provided, individual traces can opt-in
+   * to use these hints to map DOM elements to the internal row-major data grid
+   * without changing default behavior when omitted.
+   */
+  domMapping?: {
+    /**
+     * Specify DOM flattening order for grid-like traces.
+     * 'row' => row-major, 'column' => column-major.
+     */
+    order?: 'row' | 'column';
+    /**
+     * For segmented/dodged bars, control the per-column group/level iteration.
+     * 'forward' => iterate groups top-to-bottom (as previously domOrder='forward').
+     * 'reverse' => iterate bottom-to-top (default).
+     */
+    groupDirection?: 'forward' | 'reverse';
+  };
   axes?: {
     x?: string;
     y?: string;


### PR DESCRIPTION
# Pull Request

## Description

Introduces an explicit, optional domMapping contract on layers to control DOM→data alignment.

Heatmap: supports row-major mapping for rect-based heatmaps via domMapping.order='row' (default remains unchanged).

Segmented (stacked/dodged): supports forward column-level ordering via domMapping.groupDirection='forward' (default is reverse).

Removes legacy domOrder from the schema in favor of domMapping for a single, consistent configuration surface.

## Extensibility

One explicit, optional configuration surface (domMapping) instead of plot-specific ad-hoc flags.

Targeted, minimal change:

Heatmap: only rect-based mapping gated by domMapping.order='row'; paths unaffected.
Segmented: single knob to control per-column level iteration direction.

Backward-compat stance:
Defaults preserve existing behavior unless domMapping is provided.
domOrder was removed by request to avoid dual configuration paths.

Extensibility

The domMapping object is designed to grow without breaking callers:
Today: order (heatmap rects) and groupDirection (segmented/dodged).
Future: can add rowDirection, colDirection, or plot-agnostic mapping hints without changing existing defaults.

Other plots can adopt the same domMapping contract:
Histogram bins (rects): could use order similarly.
Box/candlestick: could opt-in to mapping hints where appropriate (most already use structured selectors).
Line/scatter: can use a consistent “point mapping” strategy later (e.g., x-asc, y-desc) keyed off domMapping if needed.


## Changes Made

src/type/grammar.ts

Removed: domOrder from MaidrLayer.
Added: domMapping?: { order?: 'row' | 'column'; groupDirection?: 'forward' | 'reverse' }.

src/model/heatmap.ts
For SVGPathElement: no change (existing row-major with Y reversal).
For SVGRectElement:
If layer.domMapping?.order === 'row': use row-major mapping.
Else: preserve existing column-major mapping.

src/model/segmented.ts

Replaced use of legacy domOrder with layer.domMapping?.groupDirection.
If groupDirection === 'forward': iterate groups/levels top→bottom per column (same behavior as prior domOrder='forward').
Else (default): iterate bottom→top (current default behavior).
Applies to both stacked and dodged bar plots since they share SegmentedTrace.

How to use (payload snippets)

Heatmap (rects) row-major:

"domMapping": { "order": "row" }

Segmented/dodged forward grouping:

"domMapping": { "groupDirection": "forward" }

Omit domMapping to retain existing behavior.

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

