### PR TITLE
feat: fix smooth plot naming conventions

### DIFF
--- a/src/model/smooth.ts
+++ b/src/model/smooth.ts
@@ -1,10 +1,21 @@
 import type { MaidrLayer } from '@type/grammar';
-import type { AudioState } from '@type/state';
+import type { AudioState, TraceState } from '@type/state';
 import { LineTrace } from './line';
 
 export class SmoothTrace extends LineTrace {
   public constructor(layer: MaidrLayer) {
     super(layer);
+  }
+
+  public get state(): TraceState {
+    const baseState = super.state;
+    if (baseState.empty)
+      return baseState;
+
+    return {
+      ...baseState,
+      plotType: 'smooth',
+    };
   }
 
   protected get audio(): AudioState {

--- a/src/model/smooth.ts
+++ b/src/model/smooth.ts
@@ -7,6 +7,12 @@ export class SmoothTrace extends LineTrace {
     super(layer);
   }
 
+  /**
+   * Get the state for this smooth trace.
+   * Overrides the parent state to set plotType to 'smooth' for proper identification
+   * in instruction text and layer announcements.
+   * @returns The trace state with plotType set to 'smooth'
+   */
   public get state(): TraceState {
     const baseState = super.state;
     if (baseState.empty)


### PR DESCRIPTION
# Pull Request

## Description

Change the naming of smooth plots from single_line to smooth in instruction text


## Changes Made

Override state in smooth.ts to emit smooth as plot type

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.
