### PR TITLE
feat: fix label scope freeze wherever data is not available

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -49,9 +49,9 @@ export class DescribeXCommand extends DescribeCommand {
   public execute(): void {
     const state = this.context.state;
     if (state.type === 'trace' && !state.empty) {
-      const message = `X label is ${state.xAxis}`;
-      this.textViewModel.update(message);
+      this.textViewModel.update(`X label is ${state.xAxis}`);
     } else {
+      this.textViewModel.update('X label is not available');
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -76,9 +76,9 @@ export class DescribeYCommand extends DescribeCommand {
   public execute(): void {
     const state = this.context.state;
     if (state.type === 'trace' && !state.empty) {
-      const message = `Y label is ${state.yAxis}`;
-      this.textViewModel.update(message);
+      this.textViewModel.update(`Y label is ${state.yAxis}`);
     } else {
+      this.textViewModel.update('Y label is not available');
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -102,10 +102,10 @@ export class DescribeFillCommand extends DescribeCommand {
    */
   public execute(): void {
     const state = this.context.state;
-    if (state.type === 'trace' && !state.empty) {
-      const message = `Fill is ${state.fill}`;
-      this.textViewModel.update(message);
+    if (state.type === 'trace' && !state.empty && state.fill !== 'unavailable') {
+      this.textViewModel.update(`Fill is ${state.fill}`);
     } else {
+      this.textViewModel.update('Fill is not available');
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -131,13 +131,15 @@ export class DescribeTitleCommand extends DescribeCommand {
     const state = this.context.state;
     if (!state.empty) {
       if (state.type === 'figure') {
-        const message = `Figure title is ${state.title}`;
-        this.textViewModel.update(message);
-      } else if (state.type === 'trace') {
-        const message = `Subplot title is ${state.title}`;
-        this.textViewModel.update(message);
+        this.textViewModel.update(`Figure title is ${state.title}`);
+      } else if (state.type === 'trace' && state.title !== 'unavailable') {
+        this.textViewModel.update(`Subplot title is ${state.title}`);
+      } else {
+        this.textViewModel.update('Title is not available');
+        this.context.toggleScope(Scope.TRACE);
       }
     } else {
+      this.textViewModel.update('Title is not available');
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -161,10 +163,10 @@ export class DescribeSubtitleCommand extends DescribeCommand {
    */
   public execute(): void {
     const state = this.context.state;
-    if (state.type === 'figure' && !state.empty) {
-      const message = `Subtitle is ${state.subtitle}`;
-      this.textViewModel.update(message);
+    if (state.type === 'figure' && !state.empty && state.subtitle !== 'unavailable') {
+      this.textViewModel.update(`Subtitle is ${state.subtitle}`);
     } else {
+      this.textViewModel.update('Subtitle is not available');
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -188,10 +190,10 @@ export class DescribeCaptionCommand extends DescribeCommand {
    */
   public execute(): void {
     const state = this.context.state;
-    if (state.type === 'figure' && !state.empty) {
-      const message = `Caption is ${state.caption}`;
-      this.textViewModel.update(message);
+    if (state.type === 'figure' && !state.empty && state.caption !== 'unavailable') {
+      this.textViewModel.update(`Caption is ${state.caption}`);
     } else {
+      this.textViewModel.update('Caption is not available');
       this.context.toggleScope(Scope.TRACE);
     }
   }

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -12,15 +12,18 @@ import { Scope } from '@type/event';
 abstract class DescribeCommand implements Command {
   protected readonly context: Context;
   protected readonly textViewModel: TextViewModel;
+  protected readonly audioService: AudioService;
 
   /**
    * Creates an instance of DescribeCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {AudioService} audioService - The audio service.
    */
-  protected constructor(context: Context, textViewModel: TextViewModel) {
+  protected constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
     this.context = context;
     this.textViewModel = textViewModel;
+    this.audioService = audioService;
   }
 
   /**
@@ -38,9 +41,10 @@ export class DescribeXCommand extends DescribeCommand {
    * Creates an instance of DescribeXCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {AudioService} audioService - The audio service.
    */
-  public constructor(context: Context, textViewModel: TextViewModel) {
-    super(context, textViewModel);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
+    super(context, textViewModel, audioService);
   }
 
   /**
@@ -52,6 +56,7 @@ export class DescribeXCommand extends DescribeCommand {
       this.textViewModel.update(`X label is ${state.xAxis}`);
     } else {
       this.textViewModel.update('X label is not available');
+      this.audioService.playWarningToneIfEnabled();
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -65,9 +70,10 @@ export class DescribeYCommand extends DescribeCommand {
    * Creates an instance of DescribeYCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {AudioService} audioService - The audio service.
    */
-  public constructor(context: Context, textViewModel: TextViewModel) {
-    super(context, textViewModel);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
+    super(context, textViewModel, audioService);
   }
 
   /**
@@ -79,6 +85,7 @@ export class DescribeYCommand extends DescribeCommand {
       this.textViewModel.update(`Y label is ${state.yAxis}`);
     } else {
       this.textViewModel.update('Y label is not available');
+      this.audioService.playWarningToneIfEnabled();
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -92,9 +99,10 @@ export class DescribeFillCommand extends DescribeCommand {
    * Creates an instance of DescribeFillCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {AudioService} audioService - The audio service.
    */
-  public constructor(context: Context, textViewModel: TextViewModel) {
-    super(context, textViewModel);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
+    super(context, textViewModel, audioService);
   }
 
   /**
@@ -106,6 +114,7 @@ export class DescribeFillCommand extends DescribeCommand {
       this.textViewModel.update(`Fill is ${state.fill}`);
     } else {
       this.textViewModel.update('Fill is not available');
+      this.audioService.playWarningToneIfEnabled();
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -119,9 +128,10 @@ export class DescribeTitleCommand extends DescribeCommand {
    * Creates an instance of DescribeTitleCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {AudioService} audioService - The audio service.
    */
-  public constructor(context: Context, textViewModel: TextViewModel) {
-    super(context, textViewModel);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
+    super(context, textViewModel, audioService);
   }
 
   /**
@@ -136,10 +146,12 @@ export class DescribeTitleCommand extends DescribeCommand {
         this.textViewModel.update(`Subplot title is ${state.title}`);
       } else {
         this.textViewModel.update('Title is not available');
+        this.audioService.playWarningToneIfEnabled();
         this.context.toggleScope(Scope.TRACE);
       }
     } else {
       this.textViewModel.update('Title is not available');
+      this.audioService.playWarningToneIfEnabled();
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -153,9 +165,10 @@ export class DescribeSubtitleCommand extends DescribeCommand {
    * Creates an instance of DescribeSubtitleCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {AudioService} audioService - The audio service.
    */
-  public constructor(context: Context, textViewModel: TextViewModel) {
-    super(context, textViewModel);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
+    super(context, textViewModel, audioService);
   }
 
   /**
@@ -167,6 +180,7 @@ export class DescribeSubtitleCommand extends DescribeCommand {
       this.textViewModel.update(`Subtitle is ${state.subtitle}`);
     } else {
       this.textViewModel.update('Subtitle is not available');
+      this.audioService.playWarningToneIfEnabled();
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -180,9 +194,10 @@ export class DescribeCaptionCommand extends DescribeCommand {
    * Creates an instance of DescribeCaptionCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {AudioService} audioService - The audio service.
    */
-  public constructor(context: Context, textViewModel: TextViewModel) {
-    super(context, textViewModel);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
+    super(context, textViewModel, audioService);
   }
 
   /**
@@ -194,6 +209,7 @@ export class DescribeCaptionCommand extends DescribeCommand {
       this.textViewModel.update(`Caption is ${state.caption}`);
     } else {
       this.textViewModel.update('Caption is not available');
+      this.audioService.playWarningToneIfEnabled();
       this.context.toggleScope(Scope.TRACE);
     }
   }
@@ -222,7 +238,7 @@ export class DescribePointCommand extends DescribeCommand {
     brailleViewModel: BrailleViewModel,
     textViewModel: TextViewModel,
   ) {
-    super(context, textViewModel);
+    super(context, textViewModel, audioService);
     this.audio = audioService;
     this.highlight = highlightService;
     this.brailleViewModel = brailleViewModel;

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -4,6 +4,7 @@ import type { HighlightService } from '@service/highlight';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
 import type { Command } from './command';
+import { Scope } from '@type/event';
 
 /**
  * Abstract base class for describe commands.
@@ -50,6 +51,8 @@ export class DescribeXCommand extends DescribeCommand {
     if (state.type === 'trace' && !state.empty) {
       const message = `X label is ${state.xAxis}`;
       this.textViewModel.update(message);
+    } else {
+      this.context.toggleScope(Scope.TRACE);
     }
   }
 }
@@ -75,6 +78,8 @@ export class DescribeYCommand extends DescribeCommand {
     if (state.type === 'trace' && !state.empty) {
       const message = `Y label is ${state.yAxis}`;
       this.textViewModel.update(message);
+    } else {
+      this.context.toggleScope(Scope.TRACE);
     }
   }
 }
@@ -100,6 +105,8 @@ export class DescribeFillCommand extends DescribeCommand {
     if (state.type === 'trace' && !state.empty) {
       const message = `Fill is ${state.fill}`;
       this.textViewModel.update(message);
+    } else {
+      this.context.toggleScope(Scope.TRACE);
     }
   }
 }
@@ -122,16 +129,16 @@ export class DescribeTitleCommand extends DescribeCommand {
    */
   public execute(): void {
     const state = this.context.state;
-    if (state.empty) {
-      return;
-    }
-
-    if (state.type === 'figure') {
-      const message = `Figure title is ${state.title}`;
-      this.textViewModel.update(message);
-    } else if (state.type === 'trace') {
-      const message = `Subplot title is ${state.title}`;
-      this.textViewModel.update(message);
+    if (!state.empty) {
+      if (state.type === 'figure') {
+        const message = `Figure title is ${state.title}`;
+        this.textViewModel.update(message);
+      } else if (state.type === 'trace') {
+        const message = `Subplot title is ${state.title}`;
+        this.textViewModel.update(message);
+      }
+    } else {
+      this.context.toggleScope(Scope.TRACE);
     }
   }
 }
@@ -157,6 +164,8 @@ export class DescribeSubtitleCommand extends DescribeCommand {
     if (state.type === 'figure' && !state.empty) {
       const message = `Subtitle is ${state.subtitle}`;
       this.textViewModel.update(message);
+    } else {
+      this.context.toggleScope(Scope.TRACE);
     }
   }
 }
@@ -182,6 +191,8 @@ export class DescribeCaptionCommand extends DescribeCommand {
     if (state.type === 'figure' && !state.empty) {
       const message = `Caption is ${state.caption}`;
       this.textViewModel.update(message);
+    } else {
+      this.context.toggleScope(Scope.TRACE);
     }
   }
 }

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -222,11 +222,11 @@ export class CommandFactory {
       case 'COMMAND_PALETTE_CLOSE':
         return new CommandPaletteCloseCommand(this.commandPaletteViewModel);
       case 'DESCRIBE_X':
-        return new DescribeXCommand(this.context, this.textViewModel);
+        return new DescribeXCommand(this.context, this.textViewModel, this.audioService);
       case 'DESCRIBE_Y':
-        return new DescribeYCommand(this.context, this.textViewModel);
+        return new DescribeYCommand(this.context, this.textViewModel, this.audioService);
       case 'DESCRIBE_FILL':
-        return new DescribeFillCommand(this.context, this.textViewModel);
+        return new DescribeFillCommand(this.context, this.textViewModel, this.audioService);
       case 'DESCRIBE_POINT':
         return new DescribePointCommand(
           this.context,
@@ -236,11 +236,11 @@ export class CommandFactory {
           this.textViewModel,
         );
       case 'DESCRIBE_TITLE':
-        return new DescribeTitleCommand(this.context, this.textViewModel);
+        return new DescribeTitleCommand(this.context, this.textViewModel, this.audioService);
       case 'DESCRIBE_SUBTITLE':
-        return new DescribeSubtitleCommand(this.context, this.textViewModel);
+        return new DescribeSubtitleCommand(this.context, this.textViewModel, this.audioService);
       case 'DESCRIBE_CAPTION':
-        return new DescribeCaptionCommand(this.context, this.textViewModel);
+        return new DescribeCaptionCommand(this.context, this.textViewModel, this.audioService);
 
       case 'ACTIVATE_FIGURE_LABEL_SCOPE':
       case 'DEACTIVATE_FIGURE_LABEL_SCOPE':

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -523,6 +523,13 @@ export class AudioService implements Observer<PlotState>, Disposable {
     // setTimeout(() => this.audioContext.close(), (WARNING_SPACE + WARNING_DURATION + 0.1) * 1000);
   }
 
+  public playWarningToneIfEnabled(): void {
+    if (this.mode === AudioMode.OFF) {
+      return;
+    }
+    this.playWarningTone();
+  }
+
   private playZeroTone(panning: Panning): AudioId {
     const xPos = this.clamp(this.interpolate(panning.x, { min: 0, max: panning.cols - 1 }, { min: -1, max: 1 }), -1, 1);
     const yPos = this.clamp(this.interpolate(panning.y, { min: 0, max: panning.rows - 1 }, { min: -1, max: 1 }), -1, 1);


### PR DESCRIPTION
# Pull Request

## Description

When in TRACE_LABEL scope (activated by pressing l), if a label is unavailable (e.g., no caption exists), the scope remains active and arrow key navigation stops working. Users must press ESC to exit, even though no label was displayed.

## Related Issues

Closes #511 

## Changes Made

Root Cause: Describe commands in TRACE_LABEL scope silently did nothing when data was unavailable, leaving users stuck in label scope without any way to navigate except pressing ESC.

Modified all label describe commands in src/command/describe.ts to auto-exit to TRACE scope when data is unavailable:

  - DescribeXCommand
  - DescribeYCommand
  - DescribeFillCommand
  - DescribeTitleCommand
  - DescribeSubtitleCommand
  - DescribeCaptionCommand

Each command now exits to TRACE scope only when its condition fails (data unavailable), preserving existing behavior when data exists.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
