### PR TITLE
feat: exit l scope when axis/figure metadata is present

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -57,8 +57,8 @@ export class DescribeXCommand extends DescribeCommand {
     } else {
       this.textViewModel.update('X label is not available');
       this.audioService.playWarningToneIfEnabled();
-      this.context.toggleScope(Scope.TRACE);
     }
+    this.context.toggleScope(Scope.TRACE);
   }
 }
 
@@ -86,8 +86,8 @@ export class DescribeYCommand extends DescribeCommand {
     } else {
       this.textViewModel.update('Y label is not available');
       this.audioService.playWarningToneIfEnabled();
-      this.context.toggleScope(Scope.TRACE);
     }
+    this.context.toggleScope(Scope.TRACE);
   }
 }
 
@@ -115,8 +115,8 @@ export class DescribeFillCommand extends DescribeCommand {
     } else {
       this.textViewModel.update('Fill is not available');
       this.audioService.playWarningToneIfEnabled();
-      this.context.toggleScope(Scope.TRACE);
     }
+    this.context.toggleScope(Scope.TRACE);
   }
 }
 
@@ -147,13 +147,12 @@ export class DescribeTitleCommand extends DescribeCommand {
       } else {
         this.textViewModel.update('Title is not available');
         this.audioService.playWarningToneIfEnabled();
-        this.context.toggleScope(Scope.TRACE);
       }
     } else {
       this.textViewModel.update('Title is not available');
       this.audioService.playWarningToneIfEnabled();
-      this.context.toggleScope(Scope.TRACE);
     }
+    this.context.toggleScope(Scope.TRACE);
   }
 }
 
@@ -181,8 +180,8 @@ export class DescribeSubtitleCommand extends DescribeCommand {
     } else {
       this.textViewModel.update('Subtitle is not available');
       this.audioService.playWarningToneIfEnabled();
-      this.context.toggleScope(Scope.TRACE);
     }
+    this.context.toggleScope(Scope.TRACE);
   }
 }
 
@@ -210,8 +209,8 @@ export class DescribeCaptionCommand extends DescribeCommand {
     } else {
       this.textViewModel.update('Caption is not available');
       this.audioService.playWarningToneIfEnabled();
-      this.context.toggleScope(Scope.TRACE);
     }
+    this.context.toggleScope(Scope.TRACE);
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Exit label scope when user is in l x / l y / l t scope and axis data is present.

## Changes Made

1. Added toggle scope both in happy path / exit conditions

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
