### PR TITLE
fix: address audio panning issue for line plots

### DIFF
--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -130,8 +130,8 @@ export class LineTrace extends AbstractTrace {
         raw: this.lineValues[this.row][this.col],
       },
       panning: {
-        x: this.row,
-        y: this.col,
+        x: this.col,
+        y: this.row,
         rows: this.lineValues.length,
         cols: this.lineValues[this.row].length,
       },
@@ -302,12 +302,12 @@ export class LineTrace extends AbstractTrace {
           {
             freq: {
               min: this.min[r],
-              max: this.max[c],
+              max: this.max[r],
               raw: currentY,
             },
             panning: {
-              x: this.row,
-              y: this.col,
+              x: this.col,
+              y: this.row,
               rows: this.lineValues.length,
               cols: this.lineValues[this.row].length,
             },

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -199,11 +199,12 @@ export class AudioService implements Observer<PlotState>, Disposable {
       if (state.warning) {
         this.playWarningTone();
       } else {
+        // Use the panning from state.audio which contains the boundary position
         this.playEmptyTone({
-          x: 0,
-          y: 0,
-          rows: 0,
-          cols: 0,
+          x: state.audio.x,
+          y: state.audio.y,
+          rows: state.audio.rows,
+          cols: state.audio.cols,
         });
       }
       return;


### PR DESCRIPTION
# Pull Request

## Description

Stereo audio panning broken - all audio plays on the left speaker instead of panning left-to-right based on data position.

Two separate bugs introduced in commit 6c6ef670 (Refactor and cleanup #480):

1. Line plot panning swap: The refactor accidentally swapped X/Y panning coordinates in line.ts. For a single-line plot, panning.x was set to this.row (always 0) instead of this.col, causing audio to always position at -1 (left).

2. Boundary audio ignored position: AudioService.update() called playEmptyTone() with hardcoded {x: 0, y: 0, rows: 0, cols: 0} instead of using the actual boundary position from state.audio, causing boundary tones to always play on the left.


## Changes Made

src/model/line.ts: Fixed audio getter and findIntersections() to use correct panning coordinates (x: 
this.col, y: this.row)

src/service/audio.ts: Fixed update() to pass state.audio panning to playEmptyTone() for spatially-aware
boundary feedback


## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
