### PR TITLE
feat: resolve layer switching regression

### DIFF
--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -283,23 +283,14 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
   /**
    * Override moveOnce to avoid "initial entry" no-op behavior for layer navigation.
    *
-   * For violin subplots, the MovableGrid is only used to step between layers
-   * (traces), not between data points. We don't want the first MOVE_UP/DOWN
-   * to be eaten by handleInitialEntry; instead, the first PageUp/PageDown
-   * should actually switch layers.
-   *
-   * For non-violin plots, we delegate directly to the base implementation to
-   * preserve existing behavior.
+   * For multi-layer subplots, the MovableGrid is used to step between layers
+   * (traces). We don't want the first PageUp/PageDown to be eaten by
+   * handleInitialEntry; instead, it should actually switch layers.
    */
   public override moveOnce(direction: MovableDirection): boolean {
-    // Only customize behavior for violin subplots
-    if (!this.isViolinPlot) {
-      return super.moveOnce(direction);
-    }
-
-    // For violin subplots, clear initial-entry state on first move so the
+    // For multi-layer subplots, clear initial-entry state on first move so the
     // first PageUp/PageDown actually switches layers.
-    if (this.isInitialEntry) {
+    if (this.size > 1 && this.isInitialEntry) {
       this.isInitialEntry = false;
     }
     return super.moveOnce(direction);

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -198,7 +198,7 @@ export class AudioService implements Observer<PlotState>, Disposable {
     if (state.empty) {
       if (state.warning) {
         this.playWarningTone();
-      } else {
+      } else if (state.type === 'trace' && state.audio) {
         // Use the panning from state.audio which contains the boundary position
         this.playEmptyTone({
           x: state.audio.x,
@@ -206,6 +206,9 @@ export class AudioService implements Observer<PlotState>, Disposable {
           rows: state.audio.rows,
           cols: state.audio.cols,
         });
+      } else {
+        // Subplot/Figure empty state - no spatial audio info available
+        this.playEmptyTone({ x: 0, y: 0, rows: 1, cols: 1 });
       }
       return;
     }

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -44,16 +44,17 @@ export class NavigationService implements Disposable {
     }
 
     // Allow trace-specific switch handling (e.g., preserve Y)
+    let handled = false;
     if (typeof newTrace.onSwitchFrom === 'function') {
-      const handled = newTrace.onSwitchFrom(currentTrace);
-      if (handled) {
-        this.notifyLayerSwitch(subplot, newTrace);
-        return newTrace;
-      }
+      handled = newTrace.onSwitchFrom(currentTrace);
     }
 
-    // Default: preserve X value when changing layers
-    newTrace.moveToXValue(currentXValue);
+    // Default: preserve X value when changing layers (only if not handled)
+    if (!handled) {
+      newTrace.moveToXValue(currentXValue);
+    }
+
+    // Notify after positioning is complete
     this.notifyLayerSwitch(subplot, newTrace);
     return newTrace;
   }


### PR DESCRIPTION
# Pull Request

## Description

PR #515 introduced layerId to TraceState, causing layer switching to break due to:
1. Notification fired before positioning completed
2. isInitialEntry flag only cleared for violin plots, not all multi-layer subplots
  

## Changes Made

- navigation.ts: Reorder operations - complete positioning before calling notifyLayerSwitch()
- plot.ts: Clear isInitialEntry for all multi-layer subplots (size > 1), not just violin
- audio.ts: Handle empty states for Subplot/Figure that lack audio property (prevents undefined access)

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
