### PR TITLE
feat: fix terse mode label announcements

### DIFF
--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -6,6 +6,7 @@ import type { HighContrastService } from '@service/highContrast';
 import type { HighlightService } from '@service/highlight';
 import type { RotorNavigationService } from '@service/rotor';
 import type { SettingsService } from '@service/settings';
+import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { ChatViewModel } from '@state/viewModel/chatViewModel';
 import type { CommandPaletteViewModel } from '@state/viewModel/commandPaletteViewModel';
@@ -47,6 +48,8 @@ export interface CommandContext {
   /** Rotor navigation service for alternative navigation. */
   rotorNavigationService: RotorNavigationService;
   settingsService: SettingsService;
+  /** Text service for mode-aware text formatting. */
+  textService: TextService;
 
   /** Braille view model for braille display. */
   brailleViewModel: BrailleViewModel;

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -1,6 +1,7 @@
 import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
 import type { HighlightService } from '@service/highlight';
+import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
 import type { Command } from './command';
@@ -13,17 +14,20 @@ abstract class DescribeCommand implements Command {
   protected readonly context: Context;
   protected readonly textViewModel: TextViewModel;
   protected readonly audioService: AudioService;
+  protected readonly textService: TextService;
 
   /**
    * Creates an instance of DescribeCommand.
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
    * @param {AudioService} audioService - The audio service.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
-  protected constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
+  protected constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService, textService: TextService) {
     this.context = context;
     this.textViewModel = textViewModel;
     this.audioService = audioService;
+    this.textService = textService;
   }
 
   /**
@@ -31,6 +35,18 @@ abstract class DescribeCommand implements Command {
    * @param {Event} [event] - Optional event that triggered the command.
    */
   public abstract execute(event?: Event): void;
+
+  /**
+   * Restores the scope to the correct parent after a label describe command.
+   * Returns to SUBPLOT when at figure level (came from FIGURE_LABEL),
+   * TRACE otherwise (came from TRACE_LABEL).
+   */
+  protected restoreScope(): void {
+    const returnScope = this.context.state.type === 'figure'
+      ? Scope.SUBPLOT
+      : Scope.TRACE;
+    this.context.toggleScope(returnScope);
+  }
 }
 
 /**
@@ -42,9 +58,10 @@ export class DescribeXCommand extends DescribeCommand {
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
    * @param {AudioService} audioService - The audio service.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
-  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
-    super(context, textViewModel, audioService);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService, textService: TextService) {
+    super(context, textViewModel, audioService, textService);
   }
 
   /**
@@ -53,12 +70,18 @@ export class DescribeXCommand extends DescribeCommand {
   public execute(): void {
     const state = this.context.state;
     if (state.type === 'trace' && !state.empty) {
-      this.textViewModel.update(`X label is ${state.xAxis}`);
+      const text = this.textService.isTerse()
+        ? state.xAxis
+        : `X label is ${state.xAxis}`;
+      this.textViewModel.update(text);
     } else {
-      this.textViewModel.update('X label is not available');
+      const text = this.textService.isTerse()
+        ? 'unavailable'
+        : 'X label is not available';
+      this.textViewModel.update(text);
       this.audioService.playWarningToneIfEnabled();
     }
-    this.context.toggleScope(Scope.TRACE);
+    this.restoreScope();
   }
 }
 
@@ -71,9 +94,10 @@ export class DescribeYCommand extends DescribeCommand {
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
    * @param {AudioService} audioService - The audio service.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
-  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
-    super(context, textViewModel, audioService);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService, textService: TextService) {
+    super(context, textViewModel, audioService, textService);
   }
 
   /**
@@ -82,12 +106,18 @@ export class DescribeYCommand extends DescribeCommand {
   public execute(): void {
     const state = this.context.state;
     if (state.type === 'trace' && !state.empty) {
-      this.textViewModel.update(`Y label is ${state.yAxis}`);
+      const text = this.textService.isTerse()
+        ? state.yAxis
+        : `Y label is ${state.yAxis}`;
+      this.textViewModel.update(text);
     } else {
-      this.textViewModel.update('Y label is not available');
+      const text = this.textService.isTerse()
+        ? 'unavailable'
+        : 'Y label is not available';
+      this.textViewModel.update(text);
       this.audioService.playWarningToneIfEnabled();
     }
-    this.context.toggleScope(Scope.TRACE);
+    this.restoreScope();
   }
 }
 
@@ -100,9 +130,10 @@ export class DescribeFillCommand extends DescribeCommand {
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
    * @param {AudioService} audioService - The audio service.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
-  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
-    super(context, textViewModel, audioService);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService, textService: TextService) {
+    super(context, textViewModel, audioService, textService);
   }
 
   /**
@@ -111,12 +142,18 @@ export class DescribeFillCommand extends DescribeCommand {
   public execute(): void {
     const state = this.context.state;
     if (state.type === 'trace' && !state.empty && state.fill !== 'unavailable') {
-      this.textViewModel.update(`Fill is ${state.fill}`);
+      const text = this.textService.isTerse()
+        ? state.fill
+        : `Fill is ${state.fill}`;
+      this.textViewModel.update(text);
     } else {
-      this.textViewModel.update('Fill is not available');
+      const text = this.textService.isTerse()
+        ? 'unavailable'
+        : 'Fill is not available';
+      this.textViewModel.update(text);
       this.audioService.playWarningToneIfEnabled();
     }
-    this.context.toggleScope(Scope.TRACE);
+    this.restoreScope();
   }
 }
 
@@ -129,30 +166,85 @@ export class DescribeTitleCommand extends DescribeCommand {
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
    * @param {AudioService} audioService - The audio service.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
-  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
-    super(context, textViewModel, audioService);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService, textService: TextService) {
+    super(context, textViewModel, audioService, textService);
   }
 
   /**
    * Executes the command to display the title based on state type.
+   *
+   * - Single-panel plots: announces the figure title as "Title is ...".
+   * - Multi-panel at figure level: announces "Figure title is ...".
+   * - Multi-panel at trace level: announces "Subplot title is ...".
    */
   public execute(): void {
     const state = this.context.state;
-    if (!state.empty) {
-      if (state.type === 'figure') {
-        this.textViewModel.update(`Figure title is ${state.title}`);
-      } else if (state.type === 'trace' && state.title !== 'unavailable') {
-        this.textViewModel.update(`Subplot title is ${state.title}`);
-      } else {
-        this.textViewModel.update('Title is not available');
-        this.audioService.playWarningToneIfEnabled();
-      }
-    } else {
-      this.textViewModel.update('Title is not available');
-      this.audioService.playWarningToneIfEnabled();
+
+    if (state.empty) {
+      this.announceUnavailable();
+      this.restoreScope();
+      return;
     }
-    this.context.toggleScope(Scope.TRACE);
+
+    if (state.type === 'figure') {
+      this.announce(state.title, 'Figure title');
+      this.restoreScope();
+      return;
+    }
+
+    if (state.type === 'trace') {
+      this.announceTraceTitle(state.title);
+      this.restoreScope();
+      return;
+    }
+
+    // Fallback for unexpected state types (e.g. 'subplot').
+    this.announceUnavailable();
+    this.restoreScope();
+  }
+
+  /**
+   * Announces a title value with the given label prefix.
+   */
+  private announce(title: string, label: string): void {
+    const text = this.textService.isTerse()
+      ? title
+      : `${label} is ${title}`;
+    this.textViewModel.update(text);
+  }
+
+  /**
+   * Announces the appropriate title when in trace context:
+   * subplot title for multi-panel, figure title for single-panel.
+   */
+  private announceTraceTitle(traceTitle: string): void {
+    // Multi-panel: show the subplot-level title if available.
+    if (this.context.isMultiPanel && traceTitle !== 'unavailable') {
+      this.announce(traceTitle, 'Subplot title');
+      return;
+    }
+
+    // Single-panel (or multi-panel without subplot title): show figure title.
+    const figureTitle = this.context.figureTitle;
+    if (figureTitle !== 'unavailable') {
+      this.announce(figureTitle, 'Title');
+      return;
+    }
+
+    this.announceUnavailable();
+  }
+
+  /**
+   * Announces that the title is not available and plays a warning tone.
+   */
+  private announceUnavailable(): void {
+    const text = this.textService.isTerse()
+      ? 'unavailable'
+      : 'Title is not available';
+    this.textViewModel.update(text);
+    this.audioService.playWarningToneIfEnabled();
   }
 }
 
@@ -165,23 +257,32 @@ export class DescribeSubtitleCommand extends DescribeCommand {
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
    * @param {AudioService} audioService - The audio service.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
-  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
-    super(context, textViewModel, audioService);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService, textService: TextService) {
+    super(context, textViewModel, audioService, textService);
   }
 
   /**
    * Executes the command to display the subtitle.
+   * Accesses subtitle from the figure level via Context, since subtitle
+   * is a figure-level property not available on trace state.
    */
   public execute(): void {
-    const state = this.context.state;
-    if (state.type === 'figure' && !state.empty && state.subtitle !== 'unavailable') {
-      this.textViewModel.update(`Subtitle is ${state.subtitle}`);
+    const subtitle = this.context.figureSubtitle;
+    if (subtitle !== 'unavailable') {
+      const text = this.textService.isTerse()
+        ? subtitle
+        : `Subtitle is ${subtitle}`;
+      this.textViewModel.update(text);
     } else {
-      this.textViewModel.update('Subtitle is not available');
+      const text = this.textService.isTerse()
+        ? 'unavailable'
+        : 'Subtitle is not available';
+      this.textViewModel.update(text);
       this.audioService.playWarningToneIfEnabled();
     }
-    this.context.toggleScope(Scope.TRACE);
+    this.restoreScope();
   }
 }
 
@@ -194,23 +295,32 @@ export class DescribeCaptionCommand extends DescribeCommand {
    * @param {Context} context - The application context.
    * @param {TextViewModel} textViewModel - The text view model.
    * @param {AudioService} audioService - The audio service.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
-  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService) {
-    super(context, textViewModel, audioService);
+  public constructor(context: Context, textViewModel: TextViewModel, audioService: AudioService, textService: TextService) {
+    super(context, textViewModel, audioService, textService);
   }
 
   /**
    * Executes the command to display the caption.
+   * Accesses caption from the figure level via Context, since caption
+   * is a figure-level property not available on trace state.
    */
   public execute(): void {
-    const state = this.context.state;
-    if (state.type === 'figure' && !state.empty && state.caption !== 'unavailable') {
-      this.textViewModel.update(`Caption is ${state.caption}`);
+    const caption = this.context.figureCaption;
+    if (caption !== 'unavailable') {
+      const text = this.textService.isTerse()
+        ? caption
+        : `Caption is ${caption}`;
+      this.textViewModel.update(text);
     } else {
-      this.textViewModel.update('Caption is not available');
+      const text = this.textService.isTerse()
+        ? 'unavailable'
+        : 'Caption is not available';
+      this.textViewModel.update(text);
       this.audioService.playWarningToneIfEnabled();
     }
-    this.context.toggleScope(Scope.TRACE);
+    this.restoreScope();
   }
 }
 
@@ -229,6 +339,7 @@ export class DescribePointCommand extends DescribeCommand {
    * @param {HighlightService} highlightService - The highlight service.
    * @param {BrailleViewModel} brailleViewModel - The braille view model.
    * @param {TextViewModel} textViewModel - The text view model.
+   * @param {TextService} textService - The text service for mode-aware formatting.
    */
   public constructor(
     context: Context,
@@ -236,8 +347,9 @@ export class DescribePointCommand extends DescribeCommand {
     highlightService: HighlightService,
     brailleViewModel: BrailleViewModel,
     textViewModel: TextViewModel,
+    textService: TextService,
   ) {
-    super(context, textViewModel, audioService);
+    super(context, textViewModel, audioService, textService);
     this.audio = audioService;
     this.highlight = highlightService;
     this.brailleViewModel = brailleViewModel;

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -4,6 +4,7 @@ import type { AutoplayService } from '@service/autoplay';
 import type { HighContrastService } from '@service/highContrast';
 import type { HighlightService } from '@service/highlight';
 import type { RotorNavigationService } from '@service/rotor';
+import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { ChatViewModel } from '@state/viewModel/chatViewModel';
 import type { CommandPaletteViewModel } from '@state/viewModel/commandPaletteViewModel';
@@ -92,6 +93,7 @@ export class CommandFactory {
   private readonly highContrastService: HighContrastService;
   private readonly highlightService: HighlightService;
   private readonly rotorService: RotorNavigationService;
+  private readonly textService: TextService;
 
   private readonly brailleViewModel: BrailleViewModel;
   private readonly chatViewModel: ChatViewModel;
@@ -115,6 +117,7 @@ export class CommandFactory {
     this.highContrastService = commandContext.highContrastService;
     this.highlightService = commandContext.highlightService;
     this.rotorService = commandContext.rotorNavigationService;
+    this.textService = commandContext.textService;
 
     this.brailleViewModel = commandContext.brailleViewModel;
     this.chatViewModel = commandContext.chatViewModel;
@@ -222,11 +225,11 @@ export class CommandFactory {
       case 'COMMAND_PALETTE_CLOSE':
         return new CommandPaletteCloseCommand(this.commandPaletteViewModel);
       case 'DESCRIBE_X':
-        return new DescribeXCommand(this.context, this.textViewModel, this.audioService);
+        return new DescribeXCommand(this.context, this.textViewModel, this.audioService, this.textService);
       case 'DESCRIBE_Y':
-        return new DescribeYCommand(this.context, this.textViewModel, this.audioService);
+        return new DescribeYCommand(this.context, this.textViewModel, this.audioService, this.textService);
       case 'DESCRIBE_FILL':
-        return new DescribeFillCommand(this.context, this.textViewModel, this.audioService);
+        return new DescribeFillCommand(this.context, this.textViewModel, this.audioService, this.textService);
       case 'DESCRIBE_POINT':
         return new DescribePointCommand(
           this.context,
@@ -234,13 +237,14 @@ export class CommandFactory {
           this.highlightService,
           this.brailleViewModel,
           this.textViewModel,
+          this.textService,
         );
       case 'DESCRIBE_TITLE':
-        return new DescribeTitleCommand(this.context, this.textViewModel, this.audioService);
+        return new DescribeTitleCommand(this.context, this.textViewModel, this.audioService, this.textService);
       case 'DESCRIBE_SUBTITLE':
-        return new DescribeSubtitleCommand(this.context, this.textViewModel, this.audioService);
+        return new DescribeSubtitleCommand(this.context, this.textViewModel, this.audioService, this.textService);
       case 'DESCRIBE_CAPTION':
-        return new DescribeCaptionCommand(this.context, this.textViewModel, this.audioService);
+        return new DescribeCaptionCommand(this.context, this.textViewModel, this.audioService, this.textService);
 
       case 'ACTIVATE_FIGURE_LABEL_SCOPE':
       case 'DEACTIVATE_FIGURE_LABEL_SCOPE':

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -33,6 +33,7 @@ import { ReviewViewModel } from '@state/viewModel/reviewViewModel';
 import { RotorNavigationViewModel } from '@state/viewModel/rotorNavigationViewModel';
 import { SettingsViewModel } from '@state/viewModel/settingsViewModel';
 import { TextViewModel } from '@state/viewModel/textViewModel';
+import { resolveSubplotLayout } from '@util/subplotLayout';
 
 /**
  * Main controller class that orchestrates all services, view models, and interactions for the MAIDR application.
@@ -81,6 +82,7 @@ export class Controller implements Disposable {
    */
   public constructor(maidr: Maidr, plot: HTMLElement) {
     this.figure = new Figure(maidr);
+    this.figure.applyLayout(resolveSubplotLayout(this.figure.subplots));
     this.context = new Context(this.figure);
 
     this.notificationService = new NotificationService();
@@ -174,6 +176,7 @@ export class Controller implements Disposable {
       highlightService: this.highlightService,
       rotorNavigationService: this.rotorNavigationService,
       settingsService: this.settingsService,
+      textService: this.textService,
 
       brailleViewModel: this.brailleViewModel,
       chatViewModel: this.chatViewModel,
@@ -196,6 +199,7 @@ export class Controller implements Disposable {
         highlightService: this.highlightService,
         rotorNavigationService: this.rotorNavigationService,
         settingsService: this.settingsService,
+        textService: this.textService,
 
         brailleViewModel: this.brailleViewModel,
         chatViewModel: this.chatViewModel,
@@ -222,6 +226,7 @@ export class Controller implements Disposable {
         highlightService: this.highlightService,
         rotorNavigationService: this.rotorNavigationService,
         settingsService: this.settingsService,
+        textService: this.textService,
 
         brailleViewModel: this.brailleViewModel,
         chatViewModel: this.chatViewModel,

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -87,8 +87,48 @@ export class Context implements Disposable {
     return this.isRotorActive;
   }
 
+  /**
+   * Returns whether this figure has multiple subplots (facets/multi-panel).
+   */
+  public get isMultiPanel(): boolean {
+    const figureState = this.figure.state;
+    return !figureState.empty && figureState.size > 1;
+  }
+
+  /**
+   * Returns the figure-level title (the top-level plot title).
+   */
+  public get figureTitle(): string {
+    const figureState = this.figure.state;
+    if (!figureState.empty) {
+      return figureState.title;
+    }
+    return 'unavailable';
+  }
+
+  /**
+   * Returns the figure-level subtitle.
+   */
+  public get figureSubtitle(): string {
+    const figureState = this.figure.state;
+    if (!figureState.empty) {
+      return figureState.subtitle;
+    }
+    return 'unavailable';
+  }
+
+  /**
+   * Returns the figure-level caption.
+   */
+  public get figureCaption(): string {
+    const figureState = this.figure.state;
+    if (!figureState.empty) {
+      return figureState.caption;
+    }
+    return 'unavailable';
+  }
+
   public toggleScope(scope: Scope): void {
-    // Clear the scope context and set the new scope
     this.scopeContext.clear();
     this.scopeContext.push(scope);
 

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -185,7 +185,11 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
 
     // Use the visual order map to determine the correct display index.
     // This is data-ordering-agnostic: always shows top-left as "Subplot 1".
-    const currentIndex = this.visualOrderMap.get(`${this.row},${this.col}`) ?? 1;
+    const key = `${this.row},${this.col}`;
+    const currentIndex = this.visualOrderMap.get(key);
+    if (currentIndex === undefined) {
+      console.warn(`[Figure] Visual order map missing key "${key}". Was applyLayout() called?`);
+    }
 
     const activeSubplot = this.activeSubplot;
 
@@ -196,7 +200,7 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
       subtitle: this.subtitle,
       caption: this.caption,
       size: this.size,
-      index: currentIndex,
+      index: currentIndex ?? 1,
       subplot: activeSubplot.getStateWithFigurePosition(this.row, this.col),
       traceTypes: activeSubplot.traceTypes,
       highlight: this.highlight,

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -4,6 +4,7 @@ import type { Maidr, MaidrSubplot } from '@type/grammar';
 import type { Movable, MovableDirection } from '@type/movable';
 import type { Observable } from '@type/observable';
 import type { FigureState, HighlightState, SubplotState, TraceState } from '@type/state';
+import type { SubplotLayout } from '@util/subplotLayout';
 import type { Dimension } from './abstract';
 import { TraceType } from '@type/grammar';
 import { Constant } from '@util/constant';
@@ -28,7 +29,7 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
   }
 
   public readonly id: string;
-  protected readonly movable: Movable;
+  protected movable: Movable;
 
   private readonly title: string;
   private readonly subtitle: string;
@@ -38,7 +39,29 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
   private readonly size: number;
 
   /**
-   * Creates a new Figure instance from MAIDR data
+   * Maps each data (row, col) to its 1-based visual position (top-left = 1).
+   * Populated by {@link applyLayout}; defaults to data-array order.
+   */
+  private visualOrderMap: Map<string, number>;
+
+  /**
+   * Whether pressing Up arrow should decrease the data row index
+   * (true when data row 0 is visually at the top).
+   * Set by {@link applyLayout}; defaults to `false`.
+   */
+  private invertVertical: boolean;
+
+  /**
+   * Total number of axes groups in the SVG.
+   * Set by {@link applyLayout}; used by the highlight getter.
+   */
+  private totalAxesCount: number;
+
+  /**
+   * Creates a new Figure instance from MAIDR data.
+   *
+   * After construction, call {@link applyLayout} with the result of
+   * `resolveSubplotLayout()` to set visual ordering and axes references.
    * @param maidr - The MAIDR data containing figure information and subplots
    */
   public constructor(maidr: Maidr) {
@@ -56,7 +79,71 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
     );
     this.size = this.subplots.reduce((sum, row) => sum + row.length, 0);
 
-    this.movable = new MovableGrid<Subplot>(this.subplots, { row: this.subplots.length - 1 });
+    // Defaults until applyLayout() is called.
+    this.visualOrderMap = new Map<string, number>();
+    this.invertVertical = false;
+    this.totalAxesCount = 0;
+    this.movable = new MovableGrid<Subplot>(this.subplots);
+  }
+
+  /**
+   * Applies pre-computed visual layout data to this figure and its subplots.
+   *
+   * Must be called once after construction (and before the figure is used)
+   * with the result of `resolveSubplotLayout()`.
+   *
+   * @param layout - The pre-computed layout from the utility function.
+   */
+  public applyLayout(layout: SubplotLayout): void {
+    this.visualOrderMap = layout.visualOrderMap;
+    this.invertVertical = layout.invertVertical;
+    this.totalAxesCount = layout.totalAxesCount;
+
+    // Propagate axes element references to each subplot.
+    for (let r = 0; r < this.subplots.length; r++) {
+      for (let c = 0; c < this.subplots[r].length; c++) {
+        const axesEl = layout.axesElements.get(`${r},${c}`) ?? null;
+        this.subplots[r][c].setAxesElement(axesEl);
+      }
+    }
+
+    // Re-create movable starting at the visually top-left subplot.
+    this.movable = new MovableGrid<Subplot>(this.subplots, { row: layout.topLeftRow });
+  }
+
+  /**
+   * Overrides navigation to conditionally invert vertical direction.
+   * When data row 0 is at the visual top, we invert UPWARD/DOWNWARD so that
+   * pressing Up arrow moves toward lower row indices (visual top).
+   */
+  public override moveOnce(direction: MovableDirection): boolean {
+    return super.moveOnce(this.adjustDirection(direction));
+  }
+
+  /**
+   * Overrides extreme navigation with the same directional adjustment.
+   */
+  public override moveToExtreme(direction: MovableDirection): boolean {
+    return super.moveToExtreme(this.adjustDirection(direction));
+  }
+
+  /**
+   * Adjusts the navigation direction based on the data-to-visual mapping.
+   * Inverts UPWARD/DOWNWARD when the data array is ordered top-to-bottom
+   * (since MovableGrid maps UPWARD to row+1, but we need it to go to a lower row).
+   */
+  private adjustDirection(direction: MovableDirection): MovableDirection {
+    if (!this.invertVertical) {
+      return direction;
+    }
+    switch (direction) {
+      case 'UPWARD':
+        return 'DOWNWARD';
+      case 'DOWNWARD':
+        return 'UPWARD';
+      default:
+        return direction;
+    }
   }
 
   /**
@@ -96,10 +183,9 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
       };
     }
 
-    const currentIndex
-      = this.col
-        + 1
-        + this.subplots.slice(0, this.row).reduce((sum, r) => sum + r.length, 0);
+    // Use the visual order map to determine the correct display index.
+    // This is data-ordering-agnostic: always shows top-left as "Subplot 1".
+    const currentIndex = this.visualOrderMap.get(`${this.row},${this.col}`) ?? 1;
 
     const activeSubplot = this.activeSubplot;
 
@@ -118,9 +204,7 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
   }
 
   protected get highlight(): HighlightState {
-    const totalSubplots = document.querySelectorAll('g[id^="axes_"]').length;
-
-    if (totalSubplots <= 1) {
+    if (this.totalAxesCount <= 1) {
       return {
         empty: true,
         type: 'trace',
@@ -133,38 +217,12 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
       };
     }
 
-    try {
-      const numCols = this.subplots[0]?.length || 1;
-      const subplotIndex = this.row * numCols + this.col + 1;
-      const subplotSelector = `g[id="axes_${subplotIndex}"]`;
-      const subplotElement = document.querySelector(
-        subplotSelector,
-      ) as SVGElement;
-
-      if (subplotElement) {
-        return {
-          empty: false,
-          elements: subplotElement,
-        };
-      }
-
-      const allSubplots = document.querySelectorAll('g[id^="axes_"]');
-      if (allSubplots.length > 0 && subplotIndex - 1 < allSubplots.length) {
-        return {
-          empty: false,
-          elements: allSubplots[subplotIndex - 1] as SVGElement,
-        };
-      }
-    } catch (error) {
+    // Use the pre-resolved axes element (set by applyLayout).
+    const axesElement = this.activeSubplot.axesElement;
+    if (axesElement) {
       return {
-        empty: true,
-        type: 'trace',
-        audio: {
-          y: this.row,
-          x: this.col,
-          rows: this.subplots.length,
-          cols: this.subplots[this.row].length,
-        },
+        empty: false,
+        elements: axesElement,
       };
     }
 
@@ -214,6 +272,13 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
   private readonly size: number;
   private readonly highlightValue: SVGElement | null;
   private readonly isViolinPlot: boolean;
+  private readonly layerSelector: string | null;
+
+  /**
+   * The pre-resolved parent `<g id="axes_*">` SVG element for this subplot.
+   * Set by {@link Figure.applyLayout} after construction; `null` until then.
+   */
+  private _axesElement: SVGElement | null = null;
 
   /**
    * Creates a new Subplot instance from MAIDR subplot data
@@ -224,6 +289,14 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
 
     const layers = subplot.layers;
     this.size = layers.length;
+
+    // Store the first layer's selector string for DOM-based axes lookup.
+    const firstLayerSelectors = layers[0]?.selectors;
+    this.layerSelector = typeof firstLayerSelectors === 'string'
+      ? firstLayerSelectors
+      : Array.isArray(firstLayerSelectors) && typeof firstLayerSelectors[0] === 'string'
+        ? firstLayerSelectors[0]
+        : null;
 
     // Structural detection for violin plots is done once at subplot level:
     // BOX + SMOOTH in the same subplot => violin plot.
@@ -350,6 +423,43 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
     _figureCol: number,
   ): SubplotState {
     return this.state;
+  }
+
+  /**
+   * Returns the subplot's own SVG highlight element (resolved from `subplot.selector`).
+   * Used by the layout utility to locate the parent axes group.
+   * @returns The SVG element, or `null` if the subplot has no selector.
+   */
+  public getHighlightElement(): SVGElement | null {
+    return this.highlightValue;
+  }
+
+  /**
+   * Returns the CSS selector string from the first layer of this subplot.
+   * Used as a fallback by the layout utility when `getHighlightElement()` is `null`.
+   * @returns The selector string, or `null` if unavailable.
+   */
+  public getLayerSelector(): string | null {
+    return this.layerSelector;
+  }
+
+  /**
+   * Returns the pre-resolved parent `<g id="axes_*">` element for this subplot.
+   * This is set externally via {@link setAxesElement} during layout resolution
+   * and does not perform any DOM queries.
+   * @returns The axes SVGElement, or `null` if not resolved.
+   */
+  public get axesElement(): SVGElement | null {
+    return this._axesElement;
+  }
+
+  /**
+   * Sets the pre-resolved axes element for this subplot.
+   * Called by {@link Figure.applyLayout} during initialization.
+   * @param element - The axes SVGElement to store.
+   */
+  public setAxesElement(element: SVGElement | null): void {
+    this._axesElement = element;
   }
 
   private mapToSvgElement(selector?: string): SVGElement | null {

--- a/src/service/commandExecutor.ts
+++ b/src/service/commandExecutor.ts
@@ -38,7 +38,6 @@ export class CommandExecutor {
     // Check if command is valid for current scope
     const scopeKeymap = SCOPED_KEYMAP[this.currentScope];
     if (!scopeKeymap || !(commandKey in scopeKeymap)) {
-      console.warn(`Command ${commandKey} is not available in scope ${this.currentScope}`);
       return;
     }
 

--- a/src/util/subplotLayout.ts
+++ b/src/util/subplotLayout.ts
@@ -1,0 +1,235 @@
+import type { Subplot } from '@model/plot';
+
+/**
+ * Pre-computed visual layout information for a multi-panel figure.
+ *
+ * Because the ordering of subplots in the MAIDR JSON data array does not always
+ * match the visual (top-to-bottom, left-to-right) ordering in the SVG, we must
+ * inspect the DOM at initialization time to determine the true visual positions.
+ *
+ * This data is computed once by {@link resolveSubplotLayout} (called from the
+ * Controller) and then passed into the Figure, keeping the Model layer free of
+ * direct DOM access.
+ */
+export interface SubplotLayout {
+  /**
+   * Maps each data position `"row,col"` to its 1-based visual display index
+   * (top-left = 1, reading order).
+   */
+  visualOrderMap: Map<string, number>;
+
+  /**
+   * The data-array row index that corresponds to the visually top-left subplot.
+   */
+  topLeftRow: number;
+
+  /**
+   * Whether pressing the Up arrow should decrease the data row index.
+   *
+   * This is `true` when data row 0 is already at the visual top (lower Y),
+   * because {@link MovableGrid} maps UPWARD to row + 1 by default.
+   */
+  invertVertical: boolean;
+
+  /**
+   * Total number of `<g id="axes_*">` groups found in the SVG.
+   * Used by Figure.highlight to decide whether to show subplot outlines.
+   */
+  totalAxesCount: number;
+
+  /**
+   * Pre-resolved SVG axes elements keyed by `"row,col"`.
+   * Each subplot's axes `<g>` is looked up once and stored here so that
+   * the Figure.highlight getter needs no runtime DOM access.
+   */
+  axesElements: Map<string, SVGElement | null>;
+}
+
+/**
+ * Position entry used internally during visual-order computation.
+ */
+interface AxesPosition {
+  row: number;
+  col: number;
+  x: number;
+  y: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Inspects the DOM to resolve the visual layout of all subplots in a figure.
+ *
+ * This is the **only** place where subplot-related DOM queries happen.
+ * The result is a plain data object that can be passed into the Figure model
+ * without violating MVVC layer boundaries.
+ *
+ * @param subplots - The 2D subplot array from the Figure (already constructed).
+ * @returns A {@link SubplotLayout} containing pre-computed visual ordering,
+ *          starting position, inversion flag, and axes element references.
+ */
+export function resolveSubplotLayout(subplots: Subplot[][]): SubplotLayout {
+  const axesElements = collectAxesElements(subplots);
+  const positions = collectAxesPositions(subplots, axesElements);
+  const totalAxesCount = document.querySelectorAll('g[id^="axes_"]').length;
+
+  if (positions.length === 0) {
+    return buildFallbackLayout(subplots, totalAxesCount, axesElements);
+  }
+
+  const sorted = sortByVisualPosition(positions);
+  const visualOrderMap = buildOrderMap(sorted);
+  const topLeftRow = sorted[0].row;
+  const invertVertical = detectInversion(positions, subplots.length);
+
+  return { visualOrderMap, topLeftRow, invertVertical, totalAxesCount, axesElements };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — each function has a single, well-defined purpose.
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds the parent `<g id="axes_*">` SVG element for a given subplot.
+ *
+ * Tries two strategies:
+ * 1. Walk up from the subplot's own selector element (`subplot.selector`).
+ * 2. Walk up from the first layer's selector string (for facet-style plots
+ *    where the subplot itself has no selector).
+ *
+ * @param highlightElement - The subplot's own SVG highlight element (may be null).
+ * @param layerSelector    - CSS selector string from the first layer (may be null).
+ * @returns The matching `<g>` element, or `null` if not found.
+ */
+function findAxesElement(
+  highlightElement: SVGElement | null,
+  layerSelector: string | null,
+): SVGElement | null {
+  if (highlightElement) {
+    const axes = highlightElement.closest('g[id^="axes_"]') as SVGElement | null;
+    if (axes)
+      return axes;
+  }
+
+  if (layerSelector) {
+    const el = document.querySelector(layerSelector) as SVGElement | null;
+    if (el) {
+      const axes = el.closest('g[id^="axes_"]') as SVGElement | null;
+      if (axes)
+        return axes;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the axes element for every subplot and returns them in a map
+ * keyed by `"row,col"`.
+ */
+function collectAxesElements(subplots: Subplot[][]): Map<string, SVGElement | null> {
+  const map = new Map<string, SVGElement | null>();
+
+  for (let r = 0; r < subplots.length; r++) {
+    for (let c = 0; c < subplots[r].length; c++) {
+      const subplot = subplots[r][c];
+      const axesEl = findAxesElement(
+        subplot.getHighlightElement(),
+        subplot.getLayerSelector(),
+      );
+      map.set(`${r},${c}`, axesEl);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Reads bounding-box positions for every subplot that has a resolved axes element.
+ */
+function collectAxesPositions(
+  subplots: Subplot[][],
+  axesElements: Map<string, SVGElement | null>,
+): AxesPosition[] {
+  const positions: AxesPosition[] = [];
+
+  for (let r = 0; r < subplots.length; r++) {
+    for (let c = 0; c < subplots[r].length; c++) {
+      const axesEl = axesElements.get(`${r},${c}`);
+      if (axesEl) {
+        const bbox = axesEl.getBoundingClientRect();
+        positions.push({ row: r, col: c, y: bbox.top, x: bbox.left });
+      }
+    }
+  }
+
+  return positions;
+}
+
+/**
+ * Sorts position entries in visual reading order: top-to-bottom (ascending Y),
+ * then left-to-right (ascending X).
+ */
+function sortByVisualPosition(entries: AxesPosition[]): AxesPosition[] {
+  return [...entries].sort((a, b) => a.y - b.y || a.x - b.x);
+}
+
+/**
+ * Creates a 1-based visual index map from a sorted array of positions.
+ */
+function buildOrderMap(sorted: AxesPosition[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (let i = 0; i < sorted.length; i++) {
+    map.set(`${sorted[i].row},${sorted[i].col}`, i + 1);
+  }
+  return map;
+}
+
+/**
+ * Determines whether vertical navigation directions should be inverted.
+ *
+ * If data row 0 has a *lower* screen Y than data row 1 (i.e. row 0 is
+ * visually above row 1), then the data is ordered top-to-bottom. Because
+ * {@link MovableGrid} maps `UPWARD` to `row + 1`, we must invert so that
+ * pressing Up actually moves toward lower row indices (visually upward).
+ */
+function detectInversion(entries: AxesPosition[], numRows: number): boolean {
+  if (numRows <= 1)
+    return false;
+
+  const row0 = entries.find(e => e.row === 0);
+  const row1 = entries.find(e => e.row === 1);
+
+  if (row0 && row1) {
+    return row0.y < row1.y;
+  }
+  return false;
+}
+
+/**
+ * Returns a default layout when no DOM elements are found (fallback).
+ * Uses data-array order directly: index 1 = (0,0), no inversion.
+ */
+function buildFallbackLayout(
+  subplots: Subplot[][],
+  totalAxesCount: number,
+  axesElements: Map<string, SVGElement | null>,
+): SubplotLayout {
+  const visualOrderMap = new Map<string, number>();
+  let idx = 1;
+  for (let r = 0; r < subplots.length; r++) {
+    for (let c = 0; c < subplots[r].length; c++) {
+      visualOrderMap.set(`${r},${c}`, idx++);
+    }
+  }
+
+  return {
+    visualOrderMap,
+    topLeftRow: 0,
+    invertVertical: false,
+    totalAxesCount,
+    axesElements,
+  };
+}


### PR DESCRIPTION
# Pull Request

## Description

1. Fix subplot highlight mismatch in multi-panel plots where the wrong subplot received the visual border highlight due to a formula-based axes lookup that assumed data array order equals SVG visual order
2. Fix multi-panel navigation starting from the bottom-right instead of the top-left by detecting the visually top-left subplot via DOM position inspection at initialization
3. Fix arrow key direction in facet plots where pressing Down moved visually upward because MovableGrid maps UPWARD to row+1, conflicting with top-to-bottom data ordering
4. Fix "Subplot N of M" displaying incorrect indices by replacing the formula-based index with a pre-computed visual order map
5. Add terse/verbose mode support to all label describe commands (X, Y, fill, title, subtitle, caption) using TextService.isTerse()
6. Fix subtitle and caption describe commands being inaccessible from trace level by reading from figure-level Context getters instead of state type checks
7. Fix scope restoration after label commands in multi-panel plots where all commands hardcoded Scope.TRACE, breaking navigation when returning from figure-level label scope
8. Fix spacebar re-announcement for screen readers by detecting duplicate text and forcing a DOM change cycle via invisible separator
9. Move all subplot DOM queries from Model layer to a utility function called by Controller, restoring MVVC
compliance

## Changes Made

**src/util/subplotLayout.ts:** Utility for resolving subplot visual layout from DOM                             
**src/model/plot.ts:** Refactor Figure/Subplot to remove DOM access, add applyLayout() and axes element storage              
**src/controller.ts:** Call layout utility after Figure construction, add textService to CommandContext                      
**src/command/describe.ts:** Add terse mode, fix scope restoration, flatten DescribeTitleCommand, fix subtitle/caption data source 
**src/command/factory.ts:** Pass textService to all describe command constructors                                  
**src/command/command.ts:** Add textService to CommandContext interface                           
**src/model/context.ts:** Add isMultiPanel, figureTitle, figureSubtitle, figureCaption getters                                  
**src/state/viewModel/textViewModel.ts:** Force re-announcement when text unchanged                              
**src/service/commandExecutor.ts:** Remove debug console.warn

## Checklist


- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.
