### PR TITLE
fix: remove JAWS/NVDA special char announcement for spacebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ playwright-report/
 
 # Site
 _site/
+test-react-app/

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -250,14 +250,11 @@ export class Controller implements Disposable {
    * Announces the initial instruction to screen readers using a live region.
    */
   public announceInitialInstruction(): void {
-    // Prime the live region with an invisible separator to force a DOM-change event
-    // U+2063: INVISIBLE SEPARATOR (not trimmed by String.trim())
-    this.notificationService.notify('\u2063');
-    setTimeout(() => {
-      this.notificationService.notify(
-        this.displayService.getInstruction(false),
-      );
-    }, 50);
+    const instruction = this.displayService.getInstruction(false);
+    // Use textViewModel.update() so the revision counter is bumped,
+    // which forces the View to re-mount the role="alert" element and
+    // triggers a screen-reader announcement.
+    this.textViewModel.update(instruction);
   }
 
   /**

--- a/src/state/viewModel/textViewModel.ts
+++ b/src/state/viewModel/textViewModel.ts
@@ -14,6 +14,9 @@ interface TextState {
   enabled: boolean;
   announce: boolean;
   value: string;
+  /** Monotonic counter that increments on every update (including same-text updates).
+   *  Used by the View to detect re-announcement requests without invisible characters. */
+  revision: number;
   message: string | null;
 }
 
@@ -21,6 +24,7 @@ const initialState: TextState = {
   enabled: true,
   announce: true,
   value: '',
+  revision: 0,
   message: null,
 };
 
@@ -30,6 +34,7 @@ const textSlice = createSlice({
   reducers: {
     update(state, action: PayloadAction<string>): void {
       state.value = action.payload;
+      state.revision += 1;
     },
     announceText(state, action: PayloadAction<boolean>): void {
       state.announce = action.payload;
@@ -132,27 +137,16 @@ export class TextViewModel extends AbstractViewModel<TextState> {
 
   /**
    * Updates the displayed text with formatted content.
-   * When the new text is identical to the current value, forces a re-announcement
-   * by first clearing with an invisible separator then re-setting after a short delay.
-   * This ensures screen readers detect a DOM change and re-announce the text.
+   * Each dispatch increments a revision counter in the Redux state, so the View
+   * always receives a new state — even when the text is identical. This allows
+   * the View to force a screen-reader re-announcement by re-mounting the alert
+   * element with a new React key, without relying on invisible Unicode characters.
    * @param text - The text or plot state to display
    */
   public update(text: string | PlotState): void {
     const formattedText = this.textService.format(text);
-    const currentValue = this.store.getState().text.value;
-
-    if (formattedText === currentValue) {
-      // Force re-announcement: prime with invisible separator, then re-set after delay
-      // U+2063: INVISIBLE SEPARATOR (same pattern as Controller.announceInitialInstruction)
-      this.store.dispatch(update('\u2063'));
-      this.store.dispatch(clearMessage());
-      setTimeout(() => {
-        this.store.dispatch(update(formattedText));
-      }, 100);
-    } else {
-      this.store.dispatch(update(formattedText));
-      this.store.dispatch(clearMessage());
-    }
+    this.store.dispatch(update(formattedText));
+    this.store.dispatch(clearMessage());
   }
 
   /**

--- a/src/state/viewModel/textViewModel.ts
+++ b/src/state/viewModel/textViewModel.ts
@@ -14,8 +14,10 @@ interface TextState {
   enabled: boolean;
   announce: boolean;
   value: string;
-  /** Monotonic counter that increments on every update (including same-text updates).
-   *  Used by the View to detect re-announcement requests without invisible characters. */
+  /**
+   * Monotonic counter that increments on every update (including same-text updates).
+   *  Used by the View to detect re-announcement requests without invisible characters.
+   */
   revision: number;
   message: string | null;
 }

--- a/src/ui/component/Text.tsx
+++ b/src/ui/component/Text.tsx
@@ -2,8 +2,24 @@ import { useViewModelState } from '@state/hook/useViewModel';
 import { Constant } from '@util/constant';
 import React from 'react';
 
+/**
+ * Visually-hidden style that keeps an element in the accessibility tree
+ * but invisible on screen (standard "sr-only" / "clip" pattern).
+ */
+const visuallyHidden: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
 const Text: React.FC = () => {
-  const { enabled, announce, value, message } = useViewModelState('text');
+  const { enabled, announce, value, revision, message } = useViewModelState('text');
   const { rotor_value } = useViewModelState('rotor');
   const settings = useViewModelState('settings');
   const navText = (enabled && value) || '';
@@ -18,16 +34,25 @@ const Text: React.FC = () => {
 
   return (
     <div>
-      <div
-        id={Constant.TEXT_CONTAINER}
-        {...(current && { role: 'alert' })}
-      >
+      <div id={Constant.TEXT_CONTAINER}>
         {visual && visual.trim().length > 0 && (
           <p>
             {visual}
           </p>
         )}
       </div>
+
+      {/* Screen-reader announcement region.
+          Using `key={revision}` forces React to unmount and re-mount this element
+          on every text update (including identical text). Inserting a fresh
+          role="alert" element into the DOM is the most reliable way to trigger
+          screen-reader announcements across NVDA, JAWS, and VoiceOver — without
+          resorting to invisible Unicode characters. */}
+      {current && (
+        <div key={revision} role="alert" style={visuallyHidden}>
+          {current}
+        </div>
+      )}
 
       <div
         id={Constant.ROTOR_AREA}


### PR DESCRIPTION

# Pull Request

## Description

Screen readers (NVDA/JAWS) were spelling out the invisible Unicode character U+2063 (INVISIBLE SEPARATOR) that was used to force re-announcements of identical text in aria-live regions. When a user pressed spacebar to re-read the current data point, the screen reader would announce "invisible separator" instead of silently triggering a re-announcement.

Fix

Replaced the invisible character hack with a revision counter + React key-based re-mount pattern:

1. Added a revision counter to the Redux TextState that increments on every update dispatch — including when the text
is identical
2. In Text.tsx, the role="alert" element uses key={revision}, so React unmounts and re-mounts it on every update.
Inserting a fresh role="alert" element into the DOM is the most reliable way to trigger screen reader re-announcements
(recommended by W3C, MDN, and Adobe's react-aria)
3. Separated the visual text display (<p>) from the SR announcement (role="alert" with visually-hidden styling) so
neither duplicates nor flashes. This eliminates the setTimeout timing dependency and all invisible Unicode characters.

## Changes Made

src/state/viewModel/textViewModel.ts — Added revision counter to state; simplified update() method (removed U+2063 and setTimeout)
src/ui/component/Text.tsx — Separated visual and SR elements; added key={revision} on visually-hidden role="alert" div for reliable re-mount
src/controller.ts — Simplified announceInitialInstruction() to use textViewModel.update() instead of notificationService.notify('\u2063')

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
