### PR TITLE
feat: support Plotly SVG scatter point highlighting (#533)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maidr",
-  "version": "3.50.0",
+  "version": "3.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maidr",
-      "version": "3.50.0",
+      "version": "3.51.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -468,39 +468,106 @@ export class ScatterTrace extends AbstractTrace {
 
   /**
    * Extracts the SVG position of an element by trying multiple attribute sources.
-   * Supports x/y attributes (matplotlib), cx/cy attributes (circle elements),
-   * and transform translate (Plotly).
+   * Supports: x/y attributes (matplotlib <use>, <rect>), cx/cy attributes (D3 <circle>),
+   * transform translate/matrix (Plotly <path>/<g>), and getBoundingClientRect fallback.
    * @param element - The SVG element to extract position from
    * @returns The x and y coordinates, or null if position cannot be determined
    */
   private getElementPosition(element: SVGElement): { x: number; y: number } | null {
-    // Try x/y attributes (matplotlib-style elements like <use>)
+    // Try x/y attributes (matplotlib-style <use>, <rect>, <image>, <text> elements)
     const x = Number.parseFloat(element.getAttribute('x') || '');
     const y = Number.parseFloat(element.getAttribute('y') || '');
     if (!Number.isNaN(x) && !Number.isNaN(y)) {
       return { x, y };
     }
 
-    // Try cx/cy attributes (SVG circle/ellipse elements)
+    // Try cx/cy attributes (D3/Bokeh <circle>, <ellipse> elements)
     const cx = Number.parseFloat(element.getAttribute('cx') || '');
     const cy = Number.parseFloat(element.getAttribute('cy') || '');
     if (!Number.isNaN(cx) && !Number.isNaN(cy)) {
       return { x: cx, y: cy };
     }
 
-    // Try transform attribute (Plotly-style elements with translate)
+    // Try transform attribute (Plotly-style <path>/<g> elements)
+    const pos = this.getPositionFromTransform(element);
+    if (pos) {
+      return pos;
+    }
+
+    // Fallback: use bounding box center for any remaining SVG element types
+    // (e.g. <path> with absolute coordinates in d attribute, or <polygon>)
+    return this.getPositionFromBoundingBox(element);
+  }
+
+  /**
+   * Extracts position from an SVG transform attribute.
+   * Handles translate(x,y), translate(x), and matrix(a,b,c,d,e,f) forms.
+   * @param element - The SVG element to extract transform position from
+   * @returns The x and y coordinates, or null if no valid transform found
+   */
+  private getPositionFromTransform(element: SVGElement): { x: number; y: number } | null {
     const transform = element.getAttribute('transform');
-    if (transform) {
-      const match = transform.match(/translate\(\s*([-\d.e+]+)\s*[,\s]\s*([-\d.e+]+)\s*\)/);
-      if (match) {
-        const tx = Number.parseFloat(match[1]);
-        const ty = Number.parseFloat(match[2]);
-        if (!Number.isNaN(tx) && !Number.isNaN(ty)) {
-          return { x: tx, y: ty };
-        }
+    if (!transform) {
+      return null;
+    }
+
+    // Try translate(x, y) or translate(x y)
+    const translateMatch = transform.match(
+      /translate\(\s*([-\d.e+]+)[,\s]+([-\d.e+]+)\s*\)/,
+    );
+    if (translateMatch) {
+      const tx = Number.parseFloat(translateMatch[1]);
+      const ty = Number.parseFloat(translateMatch[2]);
+      if (!Number.isNaN(tx) && !Number.isNaN(ty)) {
+        return { x: tx, y: ty };
       }
     }
 
+    // Try translate(x) — single argument, y defaults to 0
+    const translateSingleMatch = transform.match(
+      /translate\(\s*([-\d.e+]+)\s*\)/,
+    );
+    if (translateSingleMatch) {
+      const tx = Number.parseFloat(translateSingleMatch[1]);
+      if (!Number.isNaN(tx)) {
+        return { x: tx, y: 0 };
+      }
+    }
+
+    // Try matrix(a, b, c, d, e, f) — e and f are the translation components
+    const matrixMatch = transform.match(
+      /matrix\(\s*[-\d.e+]+[,\s]+[-\d.e+]+[,\s]+[-\d.e+]+[,\s]+[-\d.e+]+[,\s]+([-\d.e+]+)[,\s]+([-\d.e+]+)\s*\)/,
+    );
+    if (matrixMatch) {
+      const tx = Number.parseFloat(matrixMatch[1]);
+      const ty = Number.parseFloat(matrixMatch[2]);
+      if (!Number.isNaN(tx) && !Number.isNaN(ty)) {
+        return { x: tx, y: ty };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Extracts position from an element's bounding box as a last resort.
+   * Works for any visible SVG element (<path>, <polygon>, <g>, etc.).
+   * Uses viewport coordinates rounded to avoid floating-point grouping issues.
+   * @param element - The SVG element to extract bounding box position from
+   * @returns The center coordinates, or null if bounding box is unavailable
+   */
+  private getPositionFromBoundingBox(element: SVGElement): { x: number; y: number } | null {
+    try {
+      const rect = element.getBoundingClientRect();
+      if (rect.width > 0 || rect.height > 0) {
+        return {
+          x: Math.round(rect.x + rect.width / 2),
+          y: Math.round(rect.y + rect.height / 2),
+        };
+      }
+    } catch {
+      // getBoundingClientRect may fail for elements not in the DOM
+    }
     return null;
   }
 

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -552,21 +552,22 @@ export class ScatterTrace extends AbstractTrace {
   /**
    * Extracts position from an element's bounding box as a last resort.
    * Works for any visible SVG element (<path>, <polygon>, <g>, etc.).
-   * Uses viewport coordinates rounded to avoid floating-point grouping issues.
+   * Uses getBBox() which returns coordinates in SVG user space, consistent
+   * with x/y and cx/cy attribute extraction methods above.
    * @param element - The SVG element to extract bounding box position from
-   * @returns The center coordinates, or null if bounding box is unavailable
+   * @returns The center coordinates in SVG user space, or null if unavailable
    */
   private getPositionFromBoundingBox(element: SVGElement): { x: number; y: number } | null {
     try {
-      const rect = element.getBoundingClientRect();
-      if (rect.width > 0 || rect.height > 0) {
+      const bbox = (element as SVGGraphicsElement).getBBox();
+      if (bbox.width > 0 || bbox.height > 0) {
         return {
-          x: Math.round(rect.x + rect.width / 2),
-          y: Math.round(rect.y + rect.height / 2),
+          x: bbox.x + bbox.width / 2,
+          y: bbox.y + bbox.height / 2,
         };
       }
     } catch {
-      // getBoundingClientRect may fail for elements not in the DOM
+      // getBBox may fail for elements not in the DOM or without geometric data
     }
     return null;
   }


### PR DESCRIPTION
Enhance scatter trace position extraction to support SVG elements that
use transform translate or cx/cy attributes instead of x/y attributes.
This fixes highlighting for Plotly scatter plots where markers use
transform="translate(x, y)" for positioning.

https://claude.ai/code/session_01G8aSXXDCkdRL7ym57XQueM