### PR TITLE
feat: add realtime/streaming data support via setData API (Phase 1)

### DIFF
--- a/examples/d3-bindbar.html
+++ b/examples/d3-bindbar.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Bar Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Bar Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Sample data
+      const data = [
+        { day: 'Mon', count: 45 },
+        { day: 'Tue', count: 72 },
+        { day: 'Wed', count: 89 },
+        { day: 'Thu', count: 64 },
+        { day: 'Fri', count: 53 },
+        { day: 'Sat', count: 95 },
+        { day: 'Sun', count: 38 },
+      ];
+
+      // Chart dimensions
+      const margin = { top: 40, right: 20, bottom: 50, left: 60 };
+      const width = 600 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      // Create SVG
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-bar-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      // Scales
+      const x = d3.scaleBand()
+        .domain(data.map(d => d.day))
+        .range([0, width])
+        .padding(0.2);
+
+      const y = d3.scaleLinear()
+        .domain([0, d3.max(data, d => d.count)])
+        .nice()
+        .range([height, 0]);
+
+      // Bars
+      svg.selectAll('rect.bar')
+        .data(data)
+        .join('rect')
+        .attr('class', 'bar')
+        .attr('x', d => x(d.day))
+        .attr('y', d => y(d.count))
+        .attr('width', x.bandwidth())
+        .attr('height', d => height - y(d.count))
+        .attr('fill', '#4682b4');
+
+      // Axes
+      svg.append('g')
+        .attr('transform', `translate(0,${height})`)
+        .call(d3.axisBottom(x));
+
+      svg.append('g')
+        .call(d3.axisLeft(y));
+
+      // Title
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '16px')
+        .text('Daily Activity Count');
+
+      // Axis labels
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 40)
+        .attr('text-anchor', 'middle')
+        .text('Day of Week');
+
+      svg.append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('x', -height / 2)
+        .attr('y', -45)
+        .attr('text-anchor', 'middle')
+        .text('Count');
+
+      // === MAIDR Integration ===
+      // Use the D3 binder to generate MAIDR data from the D3 chart
+      const svgElement = document.getElementById('d3-bar-chart');
+      const result = maidrD3.bindD3Bar(svgElement, {
+        selector: 'rect.bar',
+        title: 'Daily Activity Count',
+        axes: { x: 'Day of Week', y: 'Count' },
+        x: 'day',
+        y: 'count',
+      });
+
+      // Apply MAIDR data to the SVG element
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindcandlestick.html
+++ b/examples/d3-bindcandlestick.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Candlestick Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Candlestick Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Sample OHLC data
+      const data = [
+        { date: 'Jan 1', open: 100, high: 115, low: 95, close: 110, volume: 50000 },
+        { date: 'Jan 2', open: 110, high: 120, low: 105, close: 108, volume: 45000 },
+        { date: 'Jan 3', open: 108, high: 125, low: 100, close: 122, volume: 60000 },
+        { date: 'Jan 4', open: 122, high: 130, low: 118, close: 119, volume: 40000 },
+        { date: 'Jan 5', open: 119, high: 128, low: 112, close: 125, volume: 55000 },
+        { date: 'Jan 6', open: 125, high: 135, low: 120, close: 130, volume: 70000 },
+        { date: 'Jan 7', open: 130, high: 132, low: 115, close: 118, volume: 48000 },
+      ];
+
+      const margin = { top: 40, right: 20, bottom: 50, left: 60 };
+      const width = 600 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-candlestick-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      const x = d3.scaleBand().domain(data.map(d => d.date)).range([0, width]).padding(0.3);
+      const y = d3.scaleLinear().domain([d3.min(data, d => d.low) - 5, d3.max(data, d => d.high) + 5]).range([height, 0]);
+
+      // Draw candles
+      const candles = svg.selectAll('g.candle')
+        .data(data)
+        .join('g')
+        .attr('class', 'candle');
+
+      // Wick (high-low line)
+      candles.append('line')
+        .attr('x1', d => x(d.date) + x.bandwidth() / 2)
+        .attr('x2', d => x(d.date) + x.bandwidth() / 2)
+        .attr('y1', d => y(d.high))
+        .attr('y2', d => y(d.low))
+        .attr('stroke', 'black');
+
+      // Body (open-close rect)
+      candles.append('rect')
+        .attr('x', d => x(d.date))
+        .attr('y', d => y(Math.max(d.open, d.close)))
+        .attr('width', x.bandwidth())
+        .attr('height', d => Math.abs(y(d.open) - y(d.close)))
+        .attr('fill', d => d.close >= d.open ? '#4caf50' : '#f44336');
+
+      svg.append('g').attr('transform', `translate(0,${height})`).call(d3.axisBottom(x));
+      svg.append('g').call(d3.axisLeft(y));
+      svg.append('text').attr('x', width / 2).attr('y', -10).attr('text-anchor', 'middle').style('font-size', '16px').text('Stock Price');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-candlestick-chart');
+      const result = maidrD3.bindD3Candlestick(svgElement, {
+        selector: 'g.candle',
+        title: 'Stock Price',
+        axes: { x: 'Date', y: 'Price ($)' },
+        value: 'date',
+        open: 'open',
+        high: 'high',
+        low: 'low',
+        close: 'close',
+        volume: 'volume',
+      });
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindheatmap.html
+++ b/examples/d3-bindheatmap.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Heatmap Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Heatmap</h1>
+    <p>Click on the chart and use arrow keys to navigate cells.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Sample data: task scores by model
+      const models = ['GPT-4', 'Claude', 'Gemini', 'LLaMA'];
+      const tasks = ['Math', 'Code', 'Writing', 'Reasoning'];
+      const values = [
+        { model: 'GPT-4',   task: 'Math', score: 92 },
+        { model: 'GPT-4',   task: 'Code', score: 88 },
+        { model: 'GPT-4',   task: 'Writing', score: 85 },
+        { model: 'GPT-4',   task: 'Reasoning', score: 90 },
+        { model: 'Claude',  task: 'Math', score: 89 },
+        { model: 'Claude',  task: 'Code', score: 91 },
+        { model: 'Claude',  task: 'Writing', score: 93 },
+        { model: 'Claude',  task: 'Reasoning', score: 88 },
+        { model: 'Gemini',  task: 'Math', score: 86 },
+        { model: 'Gemini',  task: 'Code', score: 84 },
+        { model: 'Gemini',  task: 'Writing', score: 82 },
+        { model: 'Gemini',  task: 'Reasoning', score: 85 },
+        { model: 'LLaMA',   task: 'Math', score: 78 },
+        { model: 'LLaMA',   task: 'Code', score: 80 },
+        { model: 'LLaMA',   task: 'Writing', score: 75 },
+        { model: 'LLaMA',   task: 'Reasoning', score: 77 },
+      ];
+
+      // Chart dimensions
+      const margin = { top: 40, right: 20, bottom: 60, left: 80 };
+      const width = 500 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      // Create SVG
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-heatmap-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      // Scales
+      const x = d3.scaleBand().domain(tasks).range([0, width]).padding(0.05);
+      const y = d3.scaleBand().domain(models).range([0, height]).padding(0.05);
+      const color = d3.scaleSequential(d3.interpolateYlOrRd).domain([70, 95]);
+
+      // Cells
+      svg.selectAll('rect.cell')
+        .data(values)
+        .join('rect')
+        .attr('class', 'cell')
+        .attr('x', d => x(d.task))
+        .attr('y', d => y(d.model))
+        .attr('width', x.bandwidth())
+        .attr('height', y.bandwidth())
+        .attr('fill', d => color(d.score))
+        .attr('stroke', '#fff');
+
+      // Cell labels
+      svg.selectAll('text.label')
+        .data(values)
+        .join('text')
+        .attr('class', 'label')
+        .attr('x', d => x(d.task) + x.bandwidth() / 2)
+        .attr('y', d => y(d.model) + y.bandwidth() / 2)
+        .attr('text-anchor', 'middle')
+        .attr('dominant-baseline', 'middle')
+        .style('font-size', '12px')
+        .text(d => d.score);
+
+      // Axes
+      svg.append('g')
+        .attr('transform', `translate(0,${height})`)
+        .call(d3.axisBottom(x));
+
+      svg.append('g')
+        .call(d3.axisLeft(y));
+
+      // Title
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '16px')
+        .text('Model Scores by Task');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-heatmap-chart');
+      const result = maidrD3.bindD3Heatmap(svgElement, {
+        selector: 'rect.cell',
+        title: 'Model Scores by Task',
+        axes: { x: 'Task', y: 'Model', fill: 'Score' },
+        x: 'task',
+        y: 'model',
+        value: 'score',
+      });
+
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindhistogram.html
+++ b/examples/d3-bindhistogram.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Histogram Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Histogram</h1>
+    <p>Click on the chart and use arrow keys to navigate between bins.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Generate sample data (normal distribution)
+      const randomNormal = d3.randomNormal(50, 15);
+      const rawData = Array.from({ length: 500 }, randomNormal);
+
+      // Chart dimensions
+      const margin = { top: 40, right: 20, bottom: 50, left: 60 };
+      const width = 600 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      // Create SVG
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-histogram-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      // Scales
+      const x = d3.scaleLinear()
+        .domain([0, 100])
+        .range([0, width]);
+
+      // Create bins
+      const bins = d3.bin()
+        .domain(x.domain())
+        .thresholds(x.ticks(20))(rawData);
+
+      const y = d3.scaleLinear()
+        .domain([0, d3.max(bins, d => d.length)])
+        .nice()
+        .range([height, 0]);
+
+      // Bars
+      svg.selectAll('rect.bar')
+        .data(bins)
+        .join('rect')
+        .attr('class', 'bar')
+        .attr('x', d => x(d.x0) + 1)
+        .attr('y', d => y(d.length))
+        .attr('width', d => Math.max(0, x(d.x1) - x(d.x0) - 1))
+        .attr('height', d => height - y(d.length))
+        .attr('fill', '#69b3a2');
+
+      // Axes
+      svg.append('g')
+        .attr('transform', `translate(0,${height})`)
+        .call(d3.axisBottom(x));
+
+      svg.append('g')
+        .call(d3.axisLeft(y));
+
+      // Title
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '16px')
+        .text('Value Distribution');
+
+      // Axis labels
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 40)
+        .attr('text-anchor', 'middle')
+        .text('Value');
+
+      svg.append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('x', -height / 2)
+        .attr('y', -45)
+        .attr('text-anchor', 'middle')
+        .text('Frequency');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-histogram-chart');
+      const result = maidrD3.bindD3Histogram(svgElement, {
+        selector: 'rect.bar',
+        title: 'Value Distribution',
+        axes: { x: 'Value', y: 'Frequency' },
+        // D3 bins have x0, x1 properties and are arrays (length = count)
+        x: (d) => `${Math.round(d.x0)}-${Math.round(d.x1)}`,
+        y: (d) => d.length,
+        xMin: 'x0',
+        xMax: 'x1',
+        yMin: () => 0,
+        yMax: (d) => d.length,
+      });
+
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindline.html
+++ b/examples/d3-bindline.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Line Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Line Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate along the line.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Sample data: monthly temperatures for two cities
+      const cityA = [
+        { month: 'Jan', temp: 32, city: 'New York' },
+        { month: 'Feb', temp: 35, city: 'New York' },
+        { month: 'Mar', temp: 45, city: 'New York' },
+        { month: 'Apr', temp: 55, city: 'New York' },
+        { month: 'May', temp: 65, city: 'New York' },
+        { month: 'Jun', temp: 75, city: 'New York' },
+        { month: 'Jul', temp: 80, city: 'New York' },
+        { month: 'Aug', temp: 78, city: 'New York' },
+        { month: 'Sep', temp: 70, city: 'New York' },
+        { month: 'Oct', temp: 58, city: 'New York' },
+        { month: 'Nov', temp: 45, city: 'New York' },
+        { month: 'Dec', temp: 35, city: 'New York' },
+      ];
+
+      const cityB = [
+        { month: 'Jan', temp: 55, city: 'San Francisco' },
+        { month: 'Feb', temp: 58, city: 'San Francisco' },
+        { month: 'Mar', temp: 58, city: 'San Francisco' },
+        { month: 'Apr', temp: 60, city: 'San Francisco' },
+        { month: 'May', temp: 62, city: 'San Francisco' },
+        { month: 'Jun', temp: 64, city: 'San Francisco' },
+        { month: 'Jul', temp: 65, city: 'San Francisco' },
+        { month: 'Aug', temp: 66, city: 'San Francisco' },
+        { month: 'Sep', temp: 68, city: 'San Francisco' },
+        { month: 'Oct', temp: 65, city: 'San Francisco' },
+        { month: 'Nov', temp: 58, city: 'San Francisco' },
+        { month: 'Dec', temp: 54, city: 'San Francisco' },
+      ];
+
+      const allData = [cityA, cityB];
+      const colors = ['#2196F3', '#FF9800'];
+
+      // Chart dimensions
+      const margin = { top: 40, right: 120, bottom: 50, left: 60 };
+      const width = 700 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+      const months = cityA.map(d => d.month);
+
+      // Create SVG
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-line-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      // Scales
+      const x = d3.scalePoint()
+        .domain(months)
+        .range([0, width]);
+
+      const y = d3.scaleLinear()
+        .domain([25, 85])
+        .range([height, 0]);
+
+      // Line generator
+      const line = d3.line()
+        .x(d => x(d.month))
+        .y(d => y(d.temp));
+
+      // Draw lines
+      svg.selectAll('path.line')
+        .data(allData)
+        .join('path')
+        .attr('class', 'line')
+        .attr('d', d => line(d))
+        .attr('fill', 'none')
+        .attr('stroke', (d, i) => colors[i])
+        .attr('stroke-width', 2);
+
+      // Axes
+      svg.append('g')
+        .attr('transform', `translate(0,${height})`)
+        .call(d3.axisBottom(x));
+
+      svg.append('g')
+        .call(d3.axisLeft(y));
+
+      // Title
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '16px')
+        .text('Monthly Temperature by City');
+
+      // Axis labels
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 40)
+        .attr('text-anchor', 'middle')
+        .text('Month');
+
+      svg.append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('x', -height / 2)
+        .attr('y', -45)
+        .attr('text-anchor', 'middle')
+        .text('Temperature (°F)');
+
+      // Legend
+      const legend = svg.append('g')
+        .attr('transform', `translate(${width + 10}, 0)`);
+
+      ['New York', 'San Francisco'].forEach((city, i) => {
+        const g = legend.append('g')
+          .attr('transform', `translate(0, ${i * 25})`);
+        g.append('rect').attr('width', 15).attr('height', 15).attr('fill', colors[i]);
+        g.append('text').attr('x', 20).attr('y', 12).text(city).style('font-size', '12px');
+      });
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-line-chart');
+      const result = maidrD3.bindD3Line(svgElement, {
+        selector: 'path.line',
+        title: 'Monthly Temperature by City',
+        axes: { x: 'Month', y: 'Temperature (°F)' },
+        x: 'month',
+        y: 'temp',
+        fill: 'city',
+      });
+
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindscatter.html
+++ b/examples/d3-bindscatter.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Scatter Plot Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Scatter Plot</h1>
+    <p>Click on the chart and use arrow keys to navigate between data points.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Sample data: height vs weight
+      const data = [
+        { height: 160, weight: 55 },
+        { height: 165, weight: 62 },
+        { height: 170, weight: 68 },
+        { height: 172, weight: 70 },
+        { height: 175, weight: 75 },
+        { height: 178, weight: 72 },
+        { height: 180, weight: 80 },
+        { height: 182, weight: 78 },
+        { height: 185, weight: 85 },
+        { height: 168, weight: 60 },
+        { height: 173, weight: 65 },
+        { height: 177, weight: 77 },
+        { height: 163, weight: 58 },
+        { height: 188, weight: 90 },
+        { height: 171, weight: 67 },
+      ];
+
+      // Chart dimensions
+      const margin = { top: 40, right: 20, bottom: 50, left: 60 };
+      const width = 600 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      // Create SVG
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-scatter-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      // Scales
+      const x = d3.scaleLinear()
+        .domain([155, 195])
+        .range([0, width]);
+
+      const y = d3.scaleLinear()
+        .domain([50, 95])
+        .range([height, 0]);
+
+      // Points
+      svg.selectAll('circle.dot')
+        .data(data)
+        .join('circle')
+        .attr('class', 'dot')
+        .attr('cx', d => x(d.height))
+        .attr('cy', d => y(d.weight))
+        .attr('r', 5)
+        .attr('fill', '#e74c3c')
+        .attr('opacity', 0.7);
+
+      // Axes
+      svg.append('g')
+        .attr('transform', `translate(0,${height})`)
+        .call(d3.axisBottom(x));
+
+      svg.append('g')
+        .call(d3.axisLeft(y));
+
+      // Title
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '16px')
+        .text('Height vs Weight');
+
+      // Axis labels
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 40)
+        .attr('text-anchor', 'middle')
+        .text('Height (cm)');
+
+      svg.append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('x', -height / 2)
+        .attr('y', -45)
+        .attr('text-anchor', 'middle')
+        .text('Weight (kg)');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-scatter-chart');
+      const result = maidrD3.bindD3Scatter(svgElement, {
+        selector: 'circle.dot',
+        title: 'Height vs Weight',
+        axes: { x: 'Height (cm)', y: 'Weight (kg)' },
+        x: 'height',
+        y: 'weight',
+      });
+
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindsegmented.html
+++ b/examples/d3-bindsegmented.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Stacked Bar Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Stacked Bar Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Sample data: sales by quarter and region
+      const data = [
+        { quarter: 'Q1', region: 'North', sales: 120 },
+        { quarter: 'Q1', region: 'South', sales: 80 },
+        { quarter: 'Q1', region: 'East', sales: 95 },
+        { quarter: 'Q2', region: 'North', sales: 150 },
+        { quarter: 'Q2', region: 'South', sales: 110 },
+        { quarter: 'Q2', region: 'East', sales: 130 },
+        { quarter: 'Q3', region: 'North', sales: 180 },
+        { quarter: 'Q3', region: 'South', sales: 90 },
+        { quarter: 'Q3', region: 'East', sales: 140 },
+        { quarter: 'Q4', region: 'North', sales: 200 },
+        { quarter: 'Q4', region: 'South', sales: 130 },
+        { quarter: 'Q4', region: 'East', sales: 160 },
+      ];
+
+      const margin = { top: 40, right: 120, bottom: 50, left: 60 };
+      const width = 600 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-stacked-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      const quarters = [...new Set(data.map(d => d.quarter))];
+      const regions = [...new Set(data.map(d => d.region))];
+
+      // Create stacked data
+      const stackedData = d3.stack()
+        .keys(regions)
+        .value((d, key) => d[key] || 0)(
+        quarters.map(q => {
+          const row = { quarter: q };
+          data.filter(d => d.quarter === q).forEach(d => row[d.region] = d.sales);
+          return row;
+        })
+      );
+
+      const x = d3.scaleBand().domain(quarters).range([0, width]).padding(0.2);
+      const y = d3.scaleLinear().domain([0, d3.max(stackedData, d => d3.max(d, d => d[1]))]).nice().range([height, 0]);
+      const color = d3.scaleOrdinal().domain(regions).range(d3.schemeCategory10);
+
+      // Draw stacked bars
+      svg.selectAll('g.layer')
+        .data(stackedData)
+        .join('g')
+        .attr('class', 'layer')
+        .attr('fill', d => color(d.key))
+        .selectAll('rect.bar')
+        .data(d => d.map(point => ({ ...point, fill: d.key, quarter: quarters[point.index] })))
+        .join('rect')
+        .attr('class', 'bar')
+        .attr('x', d => x(d.quarter))
+        .attr('y', d => y(d[1]))
+        .attr('height', d => y(d[0]) - y(d[1]))
+        .attr('width', x.bandwidth());
+
+      svg.append('g').attr('transform', `translate(0,${height})`).call(d3.axisBottom(x));
+      svg.append('g').call(d3.axisLeft(y));
+
+      svg.append('text').attr('x', width / 2).attr('y', -10).attr('text-anchor', 'middle').style('font-size', '16px').text('Sales by Quarter and Region');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-stacked-chart');
+      const result = maidrD3.bindD3Segmented(svgElement, {
+        selector: 'rect.bar',
+        type: 'stacked_bar',
+        title: 'Sales by Quarter and Region',
+        axes: { x: 'Quarter', y: 'Sales' },
+        x: 'quarter',
+        y: (d) => d[1] - d[0],
+        fill: 'fill',
+      });
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindsmooth.html
+++ b/examples/d3-bindsmooth.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Smooth/Regression Line Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Smooth/Regression Line</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Generate sample data with a smooth regression line
+      const rawData = [];
+      for (let i = 0; i <= 20; i++) {
+        rawData.push({ x: i, y: 2 * i + 5 + (Math.random() - 0.5) * 10 });
+      }
+
+      // Simple linear regression for smooth line
+      const n = rawData.length;
+      const sumX = rawData.reduce((s, d) => s + d.x, 0);
+      const sumY = rawData.reduce((s, d) => s + d.y, 0);
+      const sumXY = rawData.reduce((s, d) => s + d.x * d.y, 0);
+      const sumX2 = rawData.reduce((s, d) => s + d.x * d.x, 0);
+      const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+      const intercept = (sumY - slope * sumX) / n;
+
+      const margin = { top: 40, right: 20, bottom: 50, left: 60 };
+      const width = 600 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-smooth-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      const x = d3.scaleLinear().domain([0, 20]).range([0, width]);
+      const y = d3.scaleLinear().domain([0, 55]).range([height, 0]);
+
+      // Scatter points
+      svg.selectAll('circle.data-point')
+        .data(rawData)
+        .join('circle')
+        .attr('class', 'data-point')
+        .attr('cx', d => x(d.x))
+        .attr('cy', d => y(d.y))
+        .attr('r', 4)
+        .attr('fill', '#2196f3');
+
+      // Smooth regression line points
+      const smoothPoints = [];
+      for (let i = 0; i <= 20; i += 0.5) {
+        const yPred = slope * i + intercept;
+        smoothPoints.push({ x: i, y: yPred, svg_x: x(i), svg_y: y(yPred) });
+      }
+
+      const line = d3.line().x(d => x(d.x)).y(d => y(d.y));
+      svg.append('g')
+        .attr('class', 'smooth-group')
+        .append('path')
+        .datum(smoothPoints)
+        .attr('class', 'smooth')
+        .attr('d', line)
+        .attr('fill', 'none')
+        .attr('stroke', '#f44336')
+        .attr('stroke-width', 2);
+
+      // Add regression points
+      svg.select('g.smooth-group')
+        .selectAll('circle.smooth-point')
+        .data(smoothPoints)
+        .join('circle')
+        .attr('class', 'smooth-point')
+        .attr('cx', d => x(d.x))
+        .attr('cy', d => y(d.y))
+        .attr('r', 2)
+        .attr('fill', '#f44336')
+        .attr('opacity', 0.5);
+
+      svg.append('g').attr('transform', `translate(0,${height})`).call(d3.axisBottom(x));
+      svg.append('g').call(d3.axisLeft(y));
+      svg.append('text').attr('x', width / 2).attr('y', -10).attr('text-anchor', 'middle').style('font-size', '16px').text('Linear Regression');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-smooth-chart');
+      const result = maidrD3.bindD3Smooth(svgElement, {
+        selector: 'path.smooth',
+        pointSelector: 'circle.smooth-point',
+        title: 'Linear Regression',
+        axes: { x: 'X', y: 'Predicted Y' },
+        x: 'x',
+        y: 'y',
+        svgX: 'svg_x',
+        svgY: 'svg_y',
+      });
+      svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+    </script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maidr",
-  "version": "3.50.0",
+  "version": "3.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maidr",
-      "version": "3.50.0",
+      "version": "3.51.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
       "types": "./dist/react.d.mts",
       "import": "./dist/react.mjs",
       "default": "./dist/react.mjs"
+    },
+    "./d3": {
+      "types": "./dist/d3.d.mts",
+      "import": "./dist/d3.mjs",
+      "default": "./dist/d3.js"
     }
   },
   "main": "dist/maidr.js",
@@ -20,9 +25,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "vite build && vite build --config vite.react.config.ts",
+    "build": "vite build && vite build --config vite.react.config.ts && vite build --config vite.d3.config.ts",
     "build:script": "vite build",
     "build:react": "vite build --config vite.react.config.ts",
+    "build:d3": "vite build --config vite.d3.config.ts",
     "prepublishOnly": "npm run build",
     "prepare": "husky",
     "commitlint": "commitlint --from=HEAD~1 --to=HEAD",

--- a/src/d3/bindBar.ts
+++ b/src/d3/bindBar.ts
@@ -1,0 +1,96 @@
+/**
+ * D3 binder for bar charts.
+ *
+ * Extracts data from D3.js-rendered bar chart SVG elements and generates
+ * the MAIDR JSON schema for accessible bar chart interaction.
+ */
+
+import type { BarPoint, Maidr, MaidrLayer } from '../type/grammar';
+import type { D3BarConfig, D3BinderResult } from './types';
+import { Orientation, TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js bar chart to MAIDR, generating the accessible data representation.
+ *
+ * Extracts data from D3-bound SVG elements (`<rect>`, `<path>`, etc.) and
+ * produces a complete {@link Maidr} data structure for sonification, text
+ * descriptions, braille output, and keyboard navigation.
+ *
+ * @param svg - The SVG element (or container) containing the D3 bar chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * // D3 bar chart with data bound to <rect> elements
+ * const result = bindD3Bar(svgElement, {
+ *   selector: 'rect.bar',
+ *   title: 'Sales by Quarter',
+ *   axes: { x: 'Quarter', y: 'Revenue' },
+ *   x: 'quarter',     // property name on the bound datum
+ *   y: 'revenue',     // property name on the bound datum
+ * });
+ *
+ * // Use with maidr-data attribute
+ * svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+ *
+ * // Or use with React
+ * <Maidr data={result.maidr}><svg>...</svg></Maidr>
+ * ```
+ */
+export function bindD3Bar(svg: Element, config: D3BarConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    x: xAccessor = 'x',
+    y: yAccessor = 'y',
+    orientation = Orientation.VERTICAL,
+  } = config;
+
+  const elements = queryD3Elements(svg, selector);
+
+  const data: BarPoint[] = elements.map(({ datum, index }) => {
+    if (!datum) {
+      throw new Error(
+        `No D3 data bound to element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${selector}" elements.`,
+      );
+    }
+    return {
+      x: resolveAccessor<string | number>(datum, xAccessor, index),
+      y: resolveAccessor<number | string>(datum, yAccessor, index),
+    };
+  });
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.BAR,
+    title,
+    selectors: scopeSelector(svg, selector),
+    orientation,
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{ layers: [layer] }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindBar.ts
+++ b/src/d3/bindBar.ts
@@ -63,8 +63,8 @@ export function bindD3Bar(svg: Element, config: D3BarConfig): D3BinderResult {
       );
     }
     return {
-      x: resolveAccessor<string | number>(datum, xAccessor, index),
-      y: resolveAccessor<number | string>(datum, yAccessor, index),
+      x: resolveAccessor<string | number>(datum, xAccessor, index) as string | number,
+      y: resolveAccessor<number | string>(datum, yAccessor, index) as number | string,
     };
   });
 

--- a/src/d3/bindBar.ts
+++ b/src/d3/bindBar.ts
@@ -8,7 +8,7 @@
 import type { BarPoint, Maidr, MaidrLayer } from '../type/grammar';
 import type { D3BarConfig, D3BinderResult } from './types';
 import { Orientation, TraceType } from '../type/grammar';
-import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+import { buildAxes, generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
 
 /**
  * Binds a D3.js bar chart to MAIDR, generating the accessible data representation.
@@ -75,12 +75,7 @@ export function bindD3Bar(svg: Element, config: D3BarConfig): D3BinderResult {
     title,
     selectors: scopeSelector(svg, selector),
     orientation,
-    axes: axes
-      ? {
-          ...axes,
-          ...(format ? { format } : {}),
-        }
-      : undefined,
+    axes: buildAxes(axes, format),
     data,
   };
 

--- a/src/d3/bindBox.ts
+++ b/src/d3/bindBox.ts
@@ -8,7 +8,7 @@
 import type { BoxPoint, Maidr, MaidrLayer } from '../type/grammar';
 import type { D3BinderResult, D3BoxConfig } from './types';
 import { Orientation, TraceType } from '../type/grammar';
-import { generateId, getD3Datum, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+import { buildAxes, generateId, getD3Datum, queryD3Elements, resolveAccessor, scopeSelector } from './util';
 
 /**
  * Binds a D3.js box plot to MAIDR, generating the accessible data representation.
@@ -102,12 +102,7 @@ export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
     title,
     selectors: scopeSelector(svg, selector),
     orientation,
-    axes: axes
-      ? {
-          ...axes,
-          ...(format ? { format } : {}),
-        }
-      : undefined,
+    axes: buildAxes(axes, format),
     data,
   };
 

--- a/src/d3/bindBox.ts
+++ b/src/d3/bindBox.ts
@@ -1,0 +1,134 @@
+/**
+ * D3 binder for box plots.
+ *
+ * Extracts data from D3.js-rendered box plot SVG elements and generates
+ * the MAIDR JSON schema for accessible box plot interaction.
+ */
+
+import type { BoxPoint, Maidr, MaidrLayer } from '../type/grammar';
+import type { D3BinderResult, D3BoxConfig } from './types';
+import { Orientation, TraceType } from '../type/grammar';
+import { generateId, getD3Datum, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js box plot to MAIDR, generating the accessible data representation.
+ *
+ * Box plots in D3 are typically constructed from multiple SVG elements per box
+ * (a rect for the IQR, lines for whiskers, a line for the median, and circles
+ * for outliers). This binder extracts statistical summary data from D3-bound
+ * data on the box group elements.
+ *
+ * @param svg - The SVG element containing the D3 box plot.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Box(svgElement, {
+ *   selector: 'g.box',
+ *   title: 'Distribution by Category',
+ *   axes: { x: 'Category', y: 'Value' },
+ *   fill: 'category',
+ *   min: 'whiskerLow',
+ *   q1: 'q1',
+ *   q2: 'median',
+ *   q3: 'q3',
+ *   max: 'whiskerHigh',
+ *   lowerOutliers: 'lowOutliers',
+ *   upperOutliers: 'highOutliers',
+ * });
+ * ```
+ */
+export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    fill: fillAccessor = 'fill',
+    min: minAccessor = 'min',
+    q1: q1Accessor = 'q1',
+    q2: q2Accessor = 'q2',
+    q3: q3Accessor = 'q3',
+    max: maxAccessor = 'max',
+    lowerOutliers: lowerOutliersAccessor = 'lowerOutliers',
+    upperOutliers: upperOutliersAccessor = 'upperOutliers',
+    orientation = Orientation.VERTICAL,
+  } = config;
+
+  const boxGroups = queryD3Elements(svg, selector);
+
+  const data: BoxPoint[] = boxGroups.map(({ element, datum, index }) => {
+    // Try to get data from the group element's D3 binding first
+    let effectiveDatum = datum;
+
+    // If no data on the group, try to find it on child elements
+    if (!effectiveDatum) {
+      const firstChild = element.querySelector('rect, line, path');
+      if (firstChild) {
+        effectiveDatum = getD3Datum(firstChild);
+      }
+    }
+
+    if (!effectiveDatum) {
+      throw new Error(
+        `No D3 data bound to box group element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${selector}" elements.`,
+      );
+    }
+
+    let lowerOutliers: number[];
+    try {
+      lowerOutliers = resolveAccessor<number[]>(effectiveDatum, lowerOutliersAccessor, index);
+    } catch {
+      lowerOutliers = [];
+    }
+
+    let upperOutliers: number[];
+    try {
+      upperOutliers = resolveAccessor<number[]>(effectiveDatum, upperOutliersAccessor, index);
+    } catch {
+      upperOutliers = [];
+    }
+
+    return {
+      fill: resolveAccessor<string>(effectiveDatum, fillAccessor, index),
+      lowerOutliers: lowerOutliers ?? [],
+      min: resolveAccessor<number>(effectiveDatum, minAccessor, index),
+      q1: resolveAccessor<number>(effectiveDatum, q1Accessor, index),
+      q2: resolveAccessor<number>(effectiveDatum, q2Accessor, index),
+      q3: resolveAccessor<number>(effectiveDatum, q3Accessor, index),
+      max: resolveAccessor<number>(effectiveDatum, maxAccessor, index),
+      upperOutliers: upperOutliers ?? [],
+    };
+  });
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.BOX,
+    title,
+    selectors: scopeSelector(svg, selector),
+    orientation,
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{ layers: [layer] }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindBox.ts
+++ b/src/d3/bindBox.ts
@@ -80,29 +80,18 @@ export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
       );
     }
 
-    let lowerOutliers: number[];
-    try {
-      lowerOutliers = resolveAccessor<number[]>(effectiveDatum, lowerOutliersAccessor, index);
-    } catch {
-      lowerOutliers = [];
-    }
-
-    let upperOutliers: number[];
-    try {
-      upperOutliers = resolveAccessor<number[]>(effectiveDatum, upperOutliersAccessor, index);
-    } catch {
-      upperOutliers = [];
-    }
+    const lowerOutliers = resolveAccessor<number[]>(effectiveDatum, lowerOutliersAccessor, index);
+    const upperOutliers = resolveAccessor<number[]>(effectiveDatum, upperOutliersAccessor, index);
 
     return {
-      fill: resolveAccessor<string>(effectiveDatum, fillAccessor, index),
-      lowerOutliers: lowerOutliers ?? [],
-      min: resolveAccessor<number>(effectiveDatum, minAccessor, index),
-      q1: resolveAccessor<number>(effectiveDatum, q1Accessor, index),
-      q2: resolveAccessor<number>(effectiveDatum, q2Accessor, index),
-      q3: resolveAccessor<number>(effectiveDatum, q3Accessor, index),
-      max: resolveAccessor<number>(effectiveDatum, maxAccessor, index),
-      upperOutliers: upperOutliers ?? [],
+      fill: resolveAccessor<string>(effectiveDatum, fillAccessor, index) ?? `Group ${index + 1}`,
+      lowerOutliers: Array.isArray(lowerOutliers) ? lowerOutliers : [],
+      min: resolveAccessor<number>(effectiveDatum, minAccessor, index) as number,
+      q1: resolveAccessor<number>(effectiveDatum, q1Accessor, index) as number,
+      q2: resolveAccessor<number>(effectiveDatum, q2Accessor, index) as number,
+      q3: resolveAccessor<number>(effectiveDatum, q3Accessor, index) as number,
+      max: resolveAccessor<number>(effectiveDatum, maxAccessor, index) as number,
+      upperOutliers: Array.isArray(upperOutliers) ? upperOutliers : [],
     };
   });
 

--- a/src/d3/bindCandlestick.ts
+++ b/src/d3/bindCandlestick.ts
@@ -1,0 +1,118 @@
+/**
+ * D3 binder for candlestick (OHLC) charts.
+ *
+ * Extracts data from D3.js-rendered candlestick chart SVG elements and generates
+ * the MAIDR JSON schema for accessible candlestick chart interaction.
+ */
+
+import type { CandlestickPoint, CandlestickTrend, Maidr, MaidrLayer } from '../type/grammar';
+import type { D3BinderResult, D3CandlestickConfig } from './types';
+import { TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js candlestick chart to MAIDR, generating the accessible data representation.
+ *
+ * Candlestick charts display OHLC (Open, High, Low, Close) financial data.
+ * Each candle is typically rendered as a group with a rect (body) and lines (wicks).
+ *
+ * @param svg - The SVG element containing the D3 candlestick chart.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Candlestick(svgElement, {
+ *   selector: 'g.candle',
+ *   title: 'Stock Price',
+ *   axes: { x: 'Date', y: 'Price ($)' },
+ *   value: 'date',
+ *   open: 'open',
+ *   high: 'high',
+ *   low: 'low',
+ *   close: 'close',
+ *   volume: 'volume',
+ * });
+ * ```
+ */
+export function bindD3Candlestick(svg: Element, config: D3CandlestickConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    value: valueAccessor = 'value',
+    open: openAccessor = 'open',
+    high: highAccessor = 'high',
+    low: lowAccessor = 'low',
+    close: closeAccessor = 'close',
+    volume: volumeAccessor = 'volume',
+  } = config;
+
+  const elements = queryD3Elements(svg, selector);
+
+  const data: CandlestickPoint[] = elements.map(({ datum, index }) => {
+    if (!datum) {
+      throw new Error(
+        `No D3 data bound to element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${selector}" elements.`,
+      );
+    }
+
+    const open = resolveAccessor<number>(datum, openAccessor, index) as number;
+    const close = resolveAccessor<number>(datum, closeAccessor, index) as number;
+    const high = resolveAccessor<number>(datum, highAccessor, index) as number;
+    const low = resolveAccessor<number>(datum, lowAccessor, index) as number;
+    const volume = resolveAccessor<number>(datum, volumeAccessor, index) ?? 0;
+
+    let trend: CandlestickTrend;
+    if (close > open)
+      trend = 'Bull';
+    else if (close < open)
+      trend = 'Bear';
+    else
+      trend = 'Neutral';
+
+    const range = high - low;
+    const volatility = range > 0 ? Math.round((range / low) * 10000) / 100 : 0;
+
+    return {
+      value: String(resolveAccessor<string>(datum, valueAccessor, index)),
+      open,
+      high,
+      low,
+      close,
+      volume: volume as number,
+      trend,
+      volatility,
+    };
+  });
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.CANDLESTICK,
+    title,
+    selectors: scopeSelector(svg, selector),
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{ layers: [layer] }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindCandlestick.ts
+++ b/src/d3/bindCandlestick.ts
@@ -8,7 +8,7 @@
 import type { CandlestickPoint, CandlestickTrend, Maidr, MaidrLayer } from '../type/grammar';
 import type { D3BinderResult, D3CandlestickConfig } from './types';
 import { TraceType } from '../type/grammar';
-import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+import { buildAxes, generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
 
 /**
  * Binds a D3.js candlestick chart to MAIDR, generating the accessible data representation.
@@ -97,12 +97,7 @@ export function bindD3Candlestick(svg: Element, config: D3CandlestickConfig): D3
     type: TraceType.CANDLESTICK,
     title,
     selectors: scopeSelector(svg, selector),
-    axes: axes
-      ? {
-          ...axes,
-          ...(format ? { format } : {}),
-        }
-      : undefined,
+    axes: buildAxes(axes, format),
     data,
   };
 

--- a/src/d3/bindHeatmap.ts
+++ b/src/d3/bindHeatmap.ts
@@ -1,0 +1,129 @@
+/**
+ * D3 binder for heatmaps.
+ *
+ * Extracts data from D3.js-rendered heatmap SVG elements and generates
+ * the MAIDR JSON schema for accessible heatmap interaction.
+ */
+
+import type { HeatmapData, Maidr, MaidrLayer } from '../type/grammar';
+import type { D3BinderResult, D3HeatmapConfig } from './types';
+import { TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js heatmap to MAIDR, generating the accessible data representation.
+ *
+ * Extracts cell data from D3-bound SVG elements (`<rect>`) organized in a grid
+ * and produces a complete {@link Maidr} data structure. The cells are grouped
+ * by their x and y category values to form the 2D points grid.
+ *
+ * @param svg - The SVG element containing the D3 heatmap.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Heatmap(svgElement, {
+ *   selector: 'rect.cell',
+ *   title: 'Correlation Matrix',
+ *   axes: { x: 'Variable', y: 'Variable', fill: 'Correlation' },
+ *   x: 'xVar',
+ *   y: 'yVar',
+ *   value: 'correlation',
+ * });
+ * ```
+ */
+export function bindD3Heatmap(svg: Element, config: D3HeatmapConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    x: xAccessor = 'x',
+    y: yAccessor = 'y',
+    value: valueAccessor = 'value',
+  } = config;
+
+  const elements = queryD3Elements(svg, selector);
+
+  // Extract raw cell data
+  const cells: { x: string; y: string; value: number }[] = elements.map(({ datum, index }) => {
+    if (!datum) {
+      throw new Error(
+        `No D3 data bound to element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${selector}" elements.`,
+      );
+    }
+    return {
+      x: String(resolveAccessor<string>(datum, xAccessor, index)),
+      y: String(resolveAccessor<string>(datum, yAccessor, index)),
+      value: resolveAccessor<number>(datum, valueAccessor, index),
+    };
+  });
+
+  // Build unique sorted x and y labels (preserving order of appearance)
+  const xLabels: string[] = [];
+  const yLabels: string[] = [];
+  const seenX = new Set<string>();
+  const seenY = new Set<string>();
+
+  for (const cell of cells) {
+    if (!seenX.has(cell.x)) {
+      seenX.add(cell.x);
+      xLabels.push(cell.x);
+    }
+    if (!seenY.has(cell.y)) {
+      seenY.add(cell.y);
+      yLabels.push(cell.y);
+    }
+  }
+
+  // Build the 2D points grid (y rows x columns)
+  const points: number[][] = [];
+  const cellMap = new Map<string, number>();
+  for (const cell of cells) {
+    cellMap.set(`${cell.y}::${cell.x}`, cell.value);
+  }
+
+  for (const yLabel of yLabels) {
+    const row: number[] = [];
+    for (const xLabel of xLabels) {
+      row.push(cellMap.get(`${yLabel}::${xLabel}`) ?? 0);
+    }
+    points.push(row);
+  }
+
+  const data: HeatmapData = {
+    x: xLabels,
+    y: yLabels,
+    points,
+  };
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.HEATMAP,
+    title,
+    selectors: scopeSelector(svg, selector),
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{ layers: [layer] }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindHeatmap.ts
+++ b/src/d3/bindHeatmap.ts
@@ -8,7 +8,7 @@
 import type { HeatmapData, Maidr, MaidrLayer } from '../type/grammar';
 import type { D3BinderResult, D3HeatmapConfig } from './types';
 import { TraceType } from '../type/grammar';
-import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+import { buildAxes, generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
 
 /**
  * Binds a D3.js heatmap to MAIDR, generating the accessible data representation.
@@ -133,12 +133,7 @@ export function bindD3Heatmap(svg: Element, config: D3HeatmapConfig): D3BinderRe
     type: TraceType.HEATMAP,
     title,
     selectors: scopeSelector(svg, selector),
-    axes: axes
-      ? {
-          ...axes,
-          ...(format ? { format } : {}),
-        }
-      : undefined,
+    axes: buildAxes(axes, format),
     data,
   };
 

--- a/src/d3/bindHistogram.ts
+++ b/src/d3/bindHistogram.ts
@@ -8,7 +8,7 @@
 import type { HistogramPoint, Maidr, MaidrLayer } from '../type/grammar';
 import type { D3BinderResult, D3HistogramConfig } from './types';
 import { TraceType } from '../type/grammar';
-import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+import { buildAxes, generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
 
 /**
  * Binds a D3.js histogram to MAIDR, generating the accessible data representation.
@@ -97,12 +97,7 @@ export function bindD3Histogram(svg: Element, config: D3HistogramConfig): D3Bind
     type: TraceType.HISTOGRAM,
     title,
     selectors: scopeSelector(svg, selector),
-    axes: axes
-      ? {
-          ...axes,
-          ...(format ? { format } : {}),
-        }
-      : undefined,
+    axes: buildAxes(axes, format),
     data,
   };
 

--- a/src/d3/bindHistogram.ts
+++ b/src/d3/bindHistogram.ts
@@ -66,14 +66,20 @@ export function bindD3Histogram(svg: Element, config: D3HistogramConfig): D3Bind
 
     // For D3 bin data, the datum is typically an array with x0/x1 properties.
     // The "y" value is usually the array length (count of items in the bin).
-    const xValue = resolveAccessor<string | number>(datum, xAccessor, index);
-    const yValue = resolveAccessor<number | string>(datum, yAccessor, index);
-    const xMin = resolveAccessor<number>(datum, xMinAccessor, index);
-    const xMax = resolveAccessor<number>(datum, xMaxAccessor, index);
-    const yMin = resolveAccessor<number>(datum, yMinAccessor, index);
+    const xValue = resolveAccessor<string | number>(datum, xAccessor, index) as string | number;
+    const yValue = resolveAccessor<number | string>(datum, yAccessor, index) as number | string;
+    const xMin = resolveAccessor<number>(datum, xMinAccessor, index) as number;
+    const xMax = resolveAccessor<number>(datum, xMaxAccessor, index) as number;
+    const yMin = resolveAccessor<number>(datum, yMinAccessor, index) as number;
     const yMax = yMaxAccessor
-      ? resolveAccessor<number>(datum, yMaxAccessor, index)
+      ? resolveAccessor<number>(datum, yMaxAccessor, index) as number
       : Number(yValue);
+
+    if (Number.isNaN(xMin) || Number.isNaN(xMax)) {
+      console.warn(
+        `[maidr/d3] Histogram bin at index ${index} has NaN boundaries (xMin=${xMin}, xMax=${xMax}).`,
+      );
+    }
 
     return {
       x: xValue,

--- a/src/d3/bindHistogram.ts
+++ b/src/d3/bindHistogram.ts
@@ -1,0 +1,112 @@
+/**
+ * D3 binder for histograms.
+ *
+ * Extracts data from D3.js-rendered histogram SVG elements and generates
+ * the MAIDR JSON schema for accessible histogram interaction.
+ */
+
+import type { HistogramPoint, Maidr, MaidrLayer } from '../type/grammar';
+import type { D3BinderResult, D3HistogramConfig } from './types';
+import { TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js histogram to MAIDR, generating the accessible data representation.
+ *
+ * D3 histograms are typically created with `d3.bin()` (or `d3.histogram()` in v5),
+ * which produces arrays with `x0` and `x1` properties for bin boundaries. This
+ * binder extracts bin data from D3-bound rect elements.
+ *
+ * @param svg - The SVG element containing the D3 histogram.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * // D3 histogram using d3.bin()
+ * const result = bindD3Histogram(svgElement, {
+ *   selector: 'rect.bar',
+ *   title: 'Age Distribution',
+ *   axes: { x: 'Age', y: 'Count' },
+ *   x: (d) => `${d.x0}-${d.x1}`,
+ *   y: (d) => d.length,
+ *   xMin: 'x0',
+ *   xMax: 'x1',
+ *   yMin: () => 0,
+ *   yMax: (d) => d.length,
+ * });
+ * ```
+ */
+export function bindD3Histogram(svg: Element, config: D3HistogramConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    x: xAccessor = 'x',
+    y: yAccessor = 'y',
+    xMin: xMinAccessor = 'x0',
+    xMax: xMaxAccessor = 'x1',
+    yMin: yMinAccessor = (_d: unknown, _i: number) => 0,
+    yMax: yMaxAccessor,
+  } = config;
+
+  const elements = queryD3Elements(svg, selector);
+
+  const data: HistogramPoint[] = elements.map(({ datum, index }) => {
+    if (!datum) {
+      throw new Error(
+        `No D3 data bound to element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${selector}" elements.`,
+      );
+    }
+
+    // For D3 bin data, the datum is typically an array with x0/x1 properties.
+    // The "y" value is usually the array length (count of items in the bin).
+    const xValue = resolveAccessor<string | number>(datum, xAccessor, index);
+    const yValue = resolveAccessor<number | string>(datum, yAccessor, index);
+    const xMin = resolveAccessor<number>(datum, xMinAccessor, index);
+    const xMax = resolveAccessor<number>(datum, xMaxAccessor, index);
+    const yMin = resolveAccessor<number>(datum, yMinAccessor, index);
+    const yMax = yMaxAccessor
+      ? resolveAccessor<number>(datum, yMaxAccessor, index)
+      : Number(yValue);
+
+    return {
+      x: xValue,
+      y: yValue,
+      xMin,
+      xMax,
+      yMin,
+      yMax,
+    };
+  });
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.HISTOGRAM,
+    title,
+    selectors: scopeSelector(svg, selector),
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{ layers: [layer] }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindLine.ts
+++ b/src/d3/bindLine.ts
@@ -1,0 +1,164 @@
+/**
+ * D3 binder for line charts.
+ *
+ * Extracts data from D3.js-rendered line chart SVG elements and generates
+ * the MAIDR JSON schema for accessible line chart interaction.
+ */
+
+import type { LinePoint, Maidr, MaidrLayer } from '../type/grammar';
+import type { D3BinderResult, D3LineConfig } from './types';
+import { TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js line chart to MAIDR, generating the accessible data representation.
+ *
+ * Supports both single-line and multi-line charts. Data can be extracted from:
+ * 1. D3-bound data on point elements (circles, etc.) via `pointSelector`.
+ * 2. D3-bound data on the path elements themselves (array of points per path).
+ *
+ * @param svg - The SVG element containing the D3 line chart.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * // Multi-line chart with paths and point circles
+ * const result = bindD3Line(svgElement, {
+ *   selector: 'path.line',
+ *   pointSelector: 'circle.data-point',
+ *   title: 'Temperature Over Time',
+ *   axes: { x: 'Month', y: 'Temperature (F)' },
+ *   x: 'month',
+ *   y: 'temp',
+ *   fill: 'city',
+ * });
+ * ```
+ */
+export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    pointSelector,
+    x: xAccessor = 'x',
+    y: yAccessor = 'y',
+    fill: fillAccessor = 'fill',
+  } = config;
+
+  const lineElements = queryD3Elements(svg, selector);
+  const data: LinePoint[][] = [];
+  const selectors: string[] = [];
+
+  if (pointSelector) {
+    // Extract data from individual point elements grouped by line
+    // Each line path has associated point elements
+    for (const { element } of lineElements) {
+      const parent = element.parentElement ?? svg;
+      const points = queryD3Elements(parent, pointSelector);
+
+      const lineData: LinePoint[] = points.map(({ datum, index }) => {
+        if (!datum) {
+          throw new Error(
+            `No D3 data bound to point element at index ${index}. `
+            + `Ensure D3's .data() join has been applied to the "${pointSelector}" elements.`,
+          );
+        }
+        const point: LinePoint = {
+          x: resolveAccessor<number | string>(datum, xAccessor, index),
+          y: resolveAccessor<number>(datum, yAccessor, index),
+        };
+        try {
+          const fill = resolveAccessor<string>(datum, fillAccessor, index);
+          if (fill !== undefined) {
+            point.fill = fill;
+          }
+        } catch {
+          // fill accessor not available, skip
+        }
+        return point;
+      });
+
+      if (lineData.length > 0) {
+        data.push(lineData);
+        selectors.push(scopeSelector(svg, `${pointSelector}`));
+      }
+    }
+  } else {
+    // Extract data from the path element's bound data directly
+    // D3 line charts typically bind an array of points to each path
+    for (const { datum } of lineElements) {
+      if (!datum) {
+        throw new Error(
+          `No D3 data bound to line path element. `
+          + `Ensure D3's .data() join has been applied to the "${selector}" elements, `
+          + `or provide a pointSelector.`,
+        );
+      }
+
+      const pointArray = Array.isArray(datum) ? datum : [datum];
+      const lineData: LinePoint[] = pointArray.map((d: unknown, index: number) => {
+        const point: LinePoint = {
+          x: resolveAccessor<number | string>(d, xAccessor, index),
+          y: resolveAccessor<number>(d, yAccessor, index),
+        };
+        try {
+          const fill = resolveAccessor<string>(d, fillAccessor, index);
+          if (fill !== undefined) {
+            point.fill = fill;
+          }
+        } catch {
+          // fill accessor not available, skip
+        }
+        return point;
+      });
+
+      if (lineData.length > 0) {
+        data.push(lineData);
+      }
+    }
+
+    selectors.push(scopeSelector(svg, selector));
+  }
+
+  // Extract legend labels from fill values
+  const legend: string[] = [];
+  for (const lineData of data) {
+    const fill = lineData[0]?.fill;
+    if (fill) {
+      legend.push(fill);
+    }
+  }
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.LINE,
+    title,
+    selectors: selectors.length === 1 ? selectors[0] : selectors,
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{
+      ...(legend.length > 0 ? { legend } : {}),
+      layers: [layer],
+    }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindLine.ts
+++ b/src/d3/bindLine.ts
@@ -11,6 +11,39 @@ import { TraceType } from '../type/grammar';
 import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
 
 /**
+ * Extracts a single line's point data from a set of D3-bound point elements.
+ */
+function extractLinePoints(
+  points: { datum: unknown; index: number }[],
+  xAccessor: D3LineConfig['x'],
+  yAccessor: D3LineConfig['y'],
+  fillAccessor: D3LineConfig['fill'],
+  pointSelector: string,
+): LinePoint[] {
+  const xAcc = xAccessor ?? 'x';
+  const yAcc = yAccessor ?? 'y';
+  const fillAcc = fillAccessor ?? 'fill';
+
+  return points.map(({ datum, index }) => {
+    if (!datum) {
+      throw new Error(
+        `No D3 data bound to point element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${pointSelector}" elements.`,
+      );
+    }
+    const point: LinePoint = {
+      x: resolveAccessor<number | string>(datum, xAcc, index) as number | string,
+      y: resolveAccessor<number>(datum, yAcc, index) as number,
+    };
+    const fill = resolveAccessor<string>(datum, fillAcc, index);
+    if (fill !== undefined) {
+      point.fill = fill;
+    }
+    return point;
+  });
+}
+
+/**
  * Binds a D3.js line chart to MAIDR, generating the accessible data representation.
  *
  * Supports both single-line and multi-line charts. Data can be extracted from:
@@ -55,37 +88,46 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
   const selectors: string[] = [];
 
   if (pointSelector) {
-    // Extract data from individual point elements grouped by line
-    // Each line path has associated point elements
+    // Extract data from individual point elements grouped by line.
+    // Each line path's direct parent <g> should contain its associated
+    // points. We scope queries to each parent to avoid matching points
+    // from other lines that share a higher-level ancestor.
+    let usedScopedExtraction = false;
+
     for (const { element } of lineElements) {
-      const parent = element.parentElement ?? svg;
-      const points = queryD3Elements(parent, pointSelector);
-
-      const lineData: LinePoint[] = points.map(({ datum, index }) => {
-        if (!datum) {
-          throw new Error(
-            `No D3 data bound to point element at index ${index}. `
-            + `Ensure D3's .data() join has been applied to the "${pointSelector}" elements.`,
-          );
+      const parent = element.parentElement;
+      // Only scope to parent if it is a distinct <g> wrapper for this line
+      // (not the SVG root itself, which would match all points).
+      if (parent && parent !== svg && parent.tagName.toLowerCase() === 'g') {
+        const points = queryD3Elements(parent, pointSelector);
+        const lineData = extractLinePoints(points, xAccessor, yAccessor, fillAccessor, pointSelector);
+        if (lineData.length > 0) {
+          data.push(lineData);
+          selectors.push(scopeSelector(svg, pointSelector));
+          usedScopedExtraction = true;
         }
-        const point: LinePoint = {
-          x: resolveAccessor<number | string>(datum, xAccessor, index),
-          y: resolveAccessor<number>(datum, yAccessor, index),
-        };
-        try {
-          const fill = resolveAccessor<string>(datum, fillAccessor, index);
-          if (fill !== undefined) {
-            point.fill = fill;
-          }
-        } catch {
-          // fill accessor not available, skip
-        }
-        return point;
-      });
+      }
+    }
 
-      if (lineData.length > 0) {
-        data.push(lineData);
-        selectors.push(scopeSelector(svg, `${pointSelector}`));
+    // Fallback: if lines are not wrapped in individual <g> elements,
+    // query all points from the SVG and partition evenly by line count.
+    if (!usedScopedExtraction && lineElements.length > 0) {
+      const allPoints = queryD3Elements(svg, pointSelector);
+      const pointsPerLine = Math.floor(allPoints.length / lineElements.length);
+      for (let i = 0; i < lineElements.length; i++) {
+        const start = i * pointsPerLine;
+        const end = i === lineElements.length - 1 ? allPoints.length : start + pointsPerLine;
+        const lineData = extractLinePoints(
+          allPoints.slice(start, end),
+          xAccessor,
+          yAccessor,
+          fillAccessor,
+          pointSelector,
+        );
+        if (lineData.length > 0) {
+          data.push(lineData);
+          selectors.push(scopeSelector(svg, pointSelector));
+        }
       }
     }
   } else {
@@ -103,16 +145,12 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
       const pointArray = Array.isArray(datum) ? datum : [datum];
       const lineData: LinePoint[] = pointArray.map((d: unknown, index: number) => {
         const point: LinePoint = {
-          x: resolveAccessor<number | string>(d, xAccessor, index),
-          y: resolveAccessor<number>(d, yAccessor, index),
+          x: resolveAccessor<number | string>(d, xAccessor, index) as number | string,
+          y: resolveAccessor<number>(d, yAccessor, index) as number,
         };
-        try {
-          const fill = resolveAccessor<string>(d, fillAccessor, index);
-          if (fill !== undefined) {
-            point.fill = fill;
-          }
-        } catch {
-          // fill accessor not available, skip
+        const fill = resolveAccessor<string>(d, fillAccessor, index);
+        if (fill !== undefined) {
+          point.fill = fill;
         }
         return point;
       });

--- a/src/d3/bindScatter.ts
+++ b/src/d3/bindScatter.ts
@@ -54,8 +54,8 @@ export function bindD3Scatter(svg: Element, config: D3ScatterConfig): D3BinderRe
       );
     }
     return {
-      x: resolveAccessor<number>(datum, xAccessor, index),
-      y: resolveAccessor<number>(datum, yAccessor, index),
+      x: resolveAccessor<number>(datum, xAccessor, index) as number,
+      y: resolveAccessor<number>(datum, yAccessor, index) as number,
     };
   });
 

--- a/src/d3/bindScatter.ts
+++ b/src/d3/bindScatter.ts
@@ -8,7 +8,7 @@
 import type { Maidr, MaidrLayer, ScatterPoint } from '../type/grammar';
 import type { D3BinderResult, D3ScatterConfig } from './types';
 import { TraceType } from '../type/grammar';
-import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+import { buildAxes, generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
 
 /**
  * Binds a D3.js scatter plot to MAIDR, generating the accessible data representation.
@@ -64,13 +64,8 @@ export function bindD3Scatter(svg: Element, config: D3ScatterConfig): D3BinderRe
     id: layerId,
     type: TraceType.SCATTER,
     title,
-    selectors: [scopeSelector(svg, selector)],
-    axes: axes
-      ? {
-          ...axes,
-          ...(format ? { format } : {}),
-        }
-      : undefined,
+    selectors: scopeSelector(svg, selector),
+    axes: buildAxes(axes, format),
     data,
   };
 

--- a/src/d3/bindScatter.ts
+++ b/src/d3/bindScatter.ts
@@ -1,0 +1,86 @@
+/**
+ * D3 binder for scatter plots.
+ *
+ * Extracts data from D3.js-rendered scatter plot SVG elements and generates
+ * the MAIDR JSON schema for accessible scatter plot interaction.
+ */
+
+import type { Maidr, MaidrLayer, ScatterPoint } from '../type/grammar';
+import type { D3BinderResult, D3ScatterConfig } from './types';
+import { TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js scatter plot to MAIDR, generating the accessible data representation.
+ *
+ * Extracts x/y data from D3-bound SVG point elements (`<circle>`, `<use>`, etc.)
+ * and produces a complete {@link Maidr} data structure.
+ *
+ * @param svg - The SVG element containing the D3 scatter plot.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Scatter(svgElement, {
+ *   selector: 'circle.dot',
+ *   title: 'Height vs Weight',
+ *   axes: { x: 'Height (cm)', y: 'Weight (kg)' },
+ *   x: 'height',
+ *   y: 'weight',
+ * });
+ * ```
+ */
+export function bindD3Scatter(svg: Element, config: D3ScatterConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    x: xAccessor = 'x',
+    y: yAccessor = 'y',
+  } = config;
+
+  const elements = queryD3Elements(svg, selector);
+
+  const data: ScatterPoint[] = elements.map(({ datum, index }) => {
+    if (!datum) {
+      throw new Error(
+        `No D3 data bound to element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${selector}" elements.`,
+      );
+    }
+    return {
+      x: resolveAccessor<number>(datum, xAccessor, index),
+      y: resolveAccessor<number>(datum, yAccessor, index),
+    };
+  });
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.SCATTER,
+    title,
+    selectors: [scopeSelector(svg, selector)],
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{ layers: [layer] }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindSegmented.ts
+++ b/src/d3/bindSegmented.ts
@@ -1,0 +1,113 @@
+/**
+ * D3 binder for segmented (stacked, dodged, normalized) bar charts.
+ *
+ * Extracts data from D3.js-rendered grouped bar chart SVG elements and generates
+ * the MAIDR JSON schema for accessible interaction with stacked, dodged, and
+ * normalized bar charts.
+ */
+
+import type { Maidr, MaidrLayer, SegmentedPoint } from '../type/grammar';
+import type { D3BinderResult, D3SegmentedConfig } from './types';
+import { Orientation, TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js segmented bar chart (stacked, dodged, or normalized) to MAIDR.
+ *
+ * Segmented bar charts show multiple groups/categories per x-axis position.
+ * Data is organized as a 2D array where each inner array represents one
+ * group/fill level across all x-axis positions.
+ *
+ * @param svg - The SVG element containing the D3 segmented bar chart.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Segmented(svgElement, {
+ *   selector: 'rect.bar',
+ *   type: TraceType.STACKED,
+ *   title: 'Sales by Region and Quarter',
+ *   axes: { x: 'Quarter', y: 'Sales' },
+ *   x: 'quarter',
+ *   y: 'sales',
+ *   fill: 'region',
+ * });
+ * ```
+ */
+export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    type = TraceType.STACKED,
+    x: xAccessor = 'x',
+    y: yAccessor = 'y',
+    fill: fillAccessor = 'fill',
+    orientation = Orientation.VERTICAL,
+  } = config;
+
+  const elements = queryD3Elements(svg, selector);
+
+  // Extract raw flat data
+  const rawData: SegmentedPoint[] = elements.map(({ datum, index }) => {
+    if (!datum) {
+      throw new Error(
+        `No D3 data bound to element at index ${index}. `
+        + `Ensure D3's .data() join has been applied to the "${selector}" elements.`,
+      );
+    }
+    return {
+      x: resolveAccessor<string | number>(datum, xAccessor, index) as string | number,
+      y: resolveAccessor<number | string>(datum, yAccessor, index) as number | string,
+      fill: resolveAccessor<string>(datum, fillAccessor, index) as string,
+    };
+  });
+
+  // Group by fill value to create 2D array (each group is one fill level)
+  const fillGroups = new Map<string, SegmentedPoint[]>();
+  const fillOrder: string[] = [];
+  for (const point of rawData) {
+    const fillKey = String(point.fill);
+    if (!fillGroups.has(fillKey)) {
+      fillGroups.set(fillKey, []);
+      fillOrder.push(fillKey);
+    }
+    fillGroups.get(fillKey)!.push(point);
+  }
+
+  const data: SegmentedPoint[][] = fillOrder.map(fill => fillGroups.get(fill)!);
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type,
+    title,
+    selectors: scopeSelector(svg, selector),
+    orientation,
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{
+      ...(fillOrder.length > 0 ? { legend: fillOrder } : {}),
+      layers: [layer],
+    }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/bindSmooth.ts
+++ b/src/d3/bindSmooth.ts
@@ -1,0 +1,161 @@
+/**
+ * D3 binder for smooth/regression line charts.
+ *
+ * Extracts data from D3.js-rendered smooth curve SVG elements and generates
+ * the MAIDR JSON schema for accessible smooth plot interaction.
+ */
+
+import type { Maidr, MaidrLayer, SmoothPoint } from '../type/grammar';
+import type { D3BinderResult, D3SmoothConfig } from './types';
+import { TraceType } from '../type/grammar';
+import { generateId, queryD3Elements, resolveAccessor, scopeSelector } from './util';
+
+/**
+ * Binds a D3.js smooth/regression line to MAIDR, generating the accessible data representation.
+ *
+ * Smooth traces are typically regression lines or kernel density curves. Each point
+ * has both data coordinates (x, y) and SVG pixel coordinates (svg_x, svg_y).
+ *
+ * @param svg - The SVG element containing the D3 smooth line.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Smooth(svgElement, {
+ *   selector: 'circle.smooth-point',
+ *   title: 'Regression Line',
+ *   axes: { x: 'X', y: 'Predicted Y' },
+ *   x: 'x',
+ *   y: 'yPred',
+ *   svgX: (d) => d.screenX,
+ *   svgY: (d) => d.screenY,
+ * });
+ * ```
+ */
+export function bindD3Smooth(svg: Element, config: D3SmoothConfig): D3BinderResult {
+  const {
+    id = generateId(),
+    title,
+    subtitle,
+    caption,
+    axes,
+    format,
+    selector,
+    pointSelector,
+    x: xAccessor = 'x',
+    y: yAccessor = 'y',
+    svgX: svgXAccessor = 'svg_x',
+    svgY: svgYAccessor = 'svg_y',
+    fill: fillAccessor = 'fill',
+  } = config;
+
+  const lineElements = queryD3Elements(svg, selector);
+  const data: SmoothPoint[][] = [];
+  const selectors: string[] = [];
+
+  if (pointSelector) {
+    // Extract from individual point elements grouped by line
+    for (const { element } of lineElements) {
+      const parent = element.parentElement;
+      const container = (parent && parent !== svg && parent.tagName.toLowerCase() === 'g')
+        ? parent
+        : svg;
+      const points = queryD3Elements(container, pointSelector);
+
+      const lineData: SmoothPoint[] = points.map(({ datum, element: el, index }) => {
+        if (!datum) {
+          throw new Error(
+            `No D3 data bound to point element at index ${index}. `
+            + `Ensure D3's .data() join has been applied to the "${pointSelector}" elements.`,
+          );
+        }
+
+        // Try data accessors first, fall back to SVG element attributes
+        const svgX = resolveAccessor<number>(datum, svgXAccessor, index)
+          ?? Number(el.getAttribute('cx') ?? el.getAttribute('x') ?? 0);
+        const svgY = resolveAccessor<number>(datum, svgYAccessor, index)
+          ?? Number(el.getAttribute('cy') ?? el.getAttribute('y') ?? 0);
+
+        return {
+          x: resolveAccessor<number>(datum, xAccessor, index) as number,
+          y: resolveAccessor<number>(datum, yAccessor, index) as number,
+          svg_x: svgX,
+          svg_y: svgY,
+        };
+      });
+
+      if (lineData.length > 0) {
+        data.push(lineData);
+        selectors.push(scopeSelector(svg, pointSelector));
+      }
+    }
+  } else {
+    // Extract from path's bound data (array of points per path)
+    for (const { datum } of lineElements) {
+      if (!datum) {
+        throw new Error(
+          `No D3 data bound to smooth path element. `
+          + `Ensure D3's .data() join has been applied to the "${selector}" elements, `
+          + `or provide a pointSelector.`,
+        );
+      }
+
+      const pointArray = Array.isArray(datum) ? datum : [datum];
+      const lineData: SmoothPoint[] = pointArray.map((d: unknown, index: number) => ({
+        x: resolveAccessor<number>(d, xAccessor, index) as number,
+        y: resolveAccessor<number>(d, yAccessor, index) as number,
+        svg_x: resolveAccessor<number>(d, svgXAccessor, index) ?? 0,
+        svg_y: resolveAccessor<number>(d, svgYAccessor, index) ?? 0,
+      }));
+
+      if (lineData.length > 0) {
+        data.push(lineData);
+      }
+    }
+    selectors.push(scopeSelector(svg, selector));
+  }
+
+  // Extract legend labels
+  const legend: string[] = [];
+  if (fillAccessor && pointSelector) {
+    for (const _lineData of data) {
+      // Attempt to extract fill from the first point's raw datum
+      const firstPointElements = queryD3Elements(svg, pointSelector);
+      if (firstPointElements.length > 0 && firstPointElements[0].datum) {
+        const fill = resolveAccessor<string>(firstPointElements[0].datum, fillAccessor, 0);
+        if (fill !== undefined) {
+          legend.push(fill);
+        }
+      }
+    }
+  }
+
+  const layerId = generateId();
+  const layer: MaidrLayer = {
+    id: layerId,
+    type: TraceType.SMOOTH,
+    title,
+    selectors: selectors.length === 1 ? selectors[0] : selectors,
+    axes: axes
+      ? {
+          ...axes,
+          ...(format ? { format } : {}),
+        }
+      : undefined,
+    data,
+  };
+
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{
+      ...(legend.length > 0 ? { legend } : {}),
+      layers: [layer],
+    }]],
+  };
+
+  return { maidr, layer };
+}

--- a/src/d3/index.ts
+++ b/src/d3/index.ts
@@ -1,0 +1,103 @@
+/**
+ * MAIDR D3.js Binder
+ *
+ * Provides functions to extract data from D3.js-rendered SVG charts and convert
+ * them to the MAIDR JSON schema for accessible, non-visual chart interaction.
+ *
+ * D3.js is the most widely used low-level SVG-based data visualization library
+ * on the web. This binder bridges D3 charts to MAIDR's accessibility features
+ * including audio sonification, text descriptions, braille output, and keyboard
+ * navigation.
+ *
+ * ## Supported Chart Types
+ *
+ * - **Bar charts** via {@link bindD3Bar}
+ * - **Line charts** (single and multi-line) via {@link bindD3Line}
+ * - **Scatter plots** via {@link bindD3Scatter}
+ * - **Heatmaps** via {@link bindD3Heatmap}
+ * - **Box plots** via {@link bindD3Box}
+ * - **Histograms** via {@link bindD3Histogram}
+ *
+ * ## How It Works
+ *
+ * D3.js binds data to DOM elements via the `__data__` property during `.data()`
+ * joins. The binder functions query the SVG for chart elements using CSS selectors
+ * and extract the bound data to generate the MAIDR schema.
+ *
+ * ## Usage
+ *
+ * ### With Script Tag (vanilla JS)
+ * ```html
+ * <script src="maidr/dist/d3.js"></script>
+ * <script>
+ *   // After D3 renders the chart:
+ *   const result = maidrD3.bindD3Bar(svgElement, {
+ *     selector: 'rect.bar',
+ *     title: 'My Chart',
+ *     axes: { x: 'Category', y: 'Value' },
+ *   });
+ *   svgElement.setAttribute('maidr-data', JSON.stringify(result.maidr));
+ * </script>
+ * ```
+ *
+ * ### With ES Modules
+ * ```ts
+ * import { bindD3Bar } from 'maidr/d3';
+ *
+ * const result = bindD3Bar(svgElement, {
+ *   selector: 'rect.bar',
+ *   title: 'My Chart',
+ *   axes: { x: 'Category', y: 'Value' },
+ * });
+ * ```
+ *
+ * ### With React
+ * ```tsx
+ * import { Maidr } from 'maidr/react';
+ * import { bindD3Bar } from 'maidr/d3';
+ *
+ * function AccessibleBarChart() {
+ *   const svgRef = useRef(null);
+ *   const [maidrData, setMaidrData] = useState(null);
+ *
+ *   useEffect(() => {
+ *     // After D3 renders into svgRef.current:
+ *     const result = bindD3Bar(svgRef.current, { ... });
+ *     setMaidrData(result.maidr);
+ *   }, []);
+ *
+ *   return maidrData ? (
+ *     <Maidr data={maidrData}>
+ *       <svg ref={svgRef}>...</svg>
+ *     </Maidr>
+ *   ) : <svg ref={svgRef} />;
+ * }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Re-export commonly needed MAIDR types for convenience
+export type { Maidr as MaidrData, MaidrLayer, MaidrSubplot } from '../type/grammar';
+export { Orientation, TraceType } from '../type/grammar';
+// Binder functions
+export { bindD3Bar } from './bindBar';
+export { bindD3Box } from './bindBox';
+export { bindD3Heatmap } from './bindHeatmap';
+export { bindD3Histogram } from './bindHistogram';
+
+export { bindD3Line } from './bindLine';
+
+export { bindD3Scatter } from './bindScatter';
+// Types
+export type {
+  D3BarConfig,
+  D3BinderConfig,
+  D3BinderResult,
+  D3BoxConfig,
+  D3HeatmapConfig,
+  D3HistogramConfig,
+  D3LineConfig,
+  D3ScatterConfig,
+  DataAccessor,
+} from './types';

--- a/src/d3/index.ts
+++ b/src/d3/index.ts
@@ -17,6 +17,9 @@
  * - **Heatmaps** via {@link bindD3Heatmap}
  * - **Box plots** via {@link bindD3Box}
  * - **Histograms** via {@link bindD3Histogram}
+ * - **Stacked / Dodged / Normalized bar charts** via {@link bindD3Segmented}
+ * - **Candlestick (OHLC) charts** via {@link bindD3Candlestick}
+ * - **Smooth / Regression lines** via {@link bindD3Smooth}
  *
  * ## How It Works
  *
@@ -80,24 +83,30 @@
 // Re-export commonly needed MAIDR types for convenience
 export type { Maidr as MaidrData, MaidrLayer, MaidrSubplot } from '../type/grammar';
 export { Orientation, TraceType } from '../type/grammar';
+
 // Binder functions
 export { bindD3Bar } from './bindBar';
 export { bindD3Box } from './bindBox';
+export { bindD3Candlestick } from './bindCandlestick';
 export { bindD3Heatmap } from './bindHeatmap';
 export { bindD3Histogram } from './bindHistogram';
-
 export { bindD3Line } from './bindLine';
-
 export { bindD3Scatter } from './bindScatter';
+export { bindD3Segmented } from './bindSegmented';
+export { bindD3Smooth } from './bindSmooth';
+
 // Types
 export type {
   D3BarConfig,
   D3BinderConfig,
   D3BinderResult,
   D3BoxConfig,
+  D3CandlestickConfig,
   D3HeatmapConfig,
   D3HistogramConfig,
   D3LineConfig,
   D3ScatterConfig,
+  D3SegmentedConfig,
+  D3SmoothConfig,
   DataAccessor,
 } from './types';

--- a/src/d3/types.ts
+++ b/src/d3/types.ts
@@ -1,0 +1,190 @@
+/**
+ * Configuration types for the MAIDR D3.js binder.
+ *
+ * These types define the configuration options for extracting data from
+ * D3.js-rendered SVG charts and converting them to the MAIDR JSON schema.
+ */
+
+import type {
+  BarPoint,
+  BoxPoint,
+  FormatConfig,
+  HeatmapData,
+  HistogramPoint,
+  LinePoint,
+  Maidr,
+  MaidrLayer,
+  Orientation,
+  ScatterPoint,
+} from '../type/grammar';
+
+/**
+ * Common configuration shared across all D3 chart binders.
+ */
+export interface D3BinderConfig {
+  /** Unique identifier for the chart. Used as the MAIDR `id`. */
+  id?: string;
+  /** Chart title displayed in text descriptions. */
+  title?: string;
+  /** Chart subtitle. */
+  subtitle?: string;
+  /** Chart caption. */
+  caption?: string;
+  /** Axis labels. */
+  axes?: {
+    x?: string;
+    y?: string;
+    fill?: string;
+  };
+  /** Optional formatting configuration for axis values. */
+  format?: FormatConfig;
+}
+
+/**
+ * Data accessor function or property name for extracting a value from a D3 datum.
+ * If a string is provided, it's used as a property key on the datum object.
+ * If a function is provided, it receives the datum and its index, returning the value.
+ */
+export type DataAccessor<T> = string | ((datum: unknown, index: number) => T);
+
+/**
+ * Configuration for binding a D3 bar chart.
+ */
+export interface D3BarConfig extends D3BinderConfig {
+  /** CSS selector for the bar elements (e.g., `'rect.bar'`, `'rect'`, `'path'`). */
+  selector: string;
+  /** Accessor for the x-axis (category) value. @default 'x' */
+  x?: DataAccessor<string | number>;
+  /** Accessor for the y-axis (numeric) value. @default 'y' */
+  y?: DataAccessor<number | string>;
+  /** Chart orientation. @default Orientation.VERTICAL */
+  orientation?: Orientation;
+}
+
+/**
+ * Configuration for binding a D3 line chart.
+ */
+export interface D3LineConfig extends D3BinderConfig {
+  /**
+   * CSS selector for the line path elements (e.g., `'path.line'`, `'.line'`).
+   * Each matched element represents one line/series.
+   */
+  selector: string;
+  /**
+   * CSS selector for the data point elements per line (e.g., `'circle'`).
+   * If not provided, data is extracted from the line path `__data__` binding.
+   */
+  pointSelector?: string;
+  /** Accessor for the x-axis value of each point. @default 'x' */
+  x?: DataAccessor<number | string>;
+  /** Accessor for the y-axis value of each point. @default 'y' */
+  y?: DataAccessor<number>;
+  /** Accessor for the series/fill label. @default 'fill' */
+  fill?: DataAccessor<string>;
+}
+
+/**
+ * Configuration for binding a D3 scatter plot.
+ */
+export interface D3ScatterConfig extends D3BinderConfig {
+  /** CSS selector for the point elements (e.g., `'circle'`, `'circle.dot'`). */
+  selector: string;
+  /** Accessor for the x-axis value. @default 'x' */
+  x?: DataAccessor<number>;
+  /** Accessor for the y-axis value. @default 'y' */
+  y?: DataAccessor<number>;
+}
+
+/**
+ * Configuration for binding a D3 heatmap.
+ */
+export interface D3HeatmapConfig extends D3BinderConfig {
+  /** CSS selector for the cell elements (e.g., `'rect.cell'`, `'rect'`). */
+  selector: string;
+  /** Accessor for the x-axis category value. @default 'x' */
+  x?: DataAccessor<string>;
+  /** Accessor for the y-axis category value. @default 'y' */
+  y?: DataAccessor<string>;
+  /** Accessor for the cell value. @default 'value' */
+  value?: DataAccessor<number>;
+}
+
+/**
+ * Configuration for binding a D3 box plot.
+ */
+export interface D3BoxConfig extends D3BinderConfig {
+  /**
+   * CSS selector for the box group elements. Each matched element should
+   * represent one box (e.g., `'g.box'`).
+   */
+  selector: string;
+  /** Selector for the IQR box rectangle within each box group. @default 'rect' */
+  boxSelector?: string;
+  /** Selector for the median line within each box group. @default 'line.median' */
+  medianSelector?: string;
+  /** Selector for the whisker lines within each box group. */
+  whiskerSelector?: string;
+  /** Selector for outlier points within each box group. @default 'circle' */
+  outlierSelector?: string;
+  /** Accessor for the group/fill label. @default 'fill' */
+  fill?: DataAccessor<string>;
+  /** Accessor for the min value. @default 'min' */
+  min?: DataAccessor<number>;
+  /** Accessor for q1 value. @default 'q1' */
+  q1?: DataAccessor<number>;
+  /** Accessor for median (q2) value. @default 'q2' */
+  q2?: DataAccessor<number>;
+  /** Accessor for q3 value. @default 'q3' */
+  q3?: DataAccessor<number>;
+  /** Accessor for the max value. @default 'max' */
+  max?: DataAccessor<number>;
+  /** Accessor for lower outlier values. @default 'lowerOutliers' */
+  lowerOutliers?: DataAccessor<number[]>;
+  /** Accessor for upper outlier values. @default 'upperOutliers' */
+  upperOutliers?: DataAccessor<number[]>;
+  /** Chart orientation. @default Orientation.VERTICAL */
+  orientation?: Orientation;
+}
+
+/**
+ * Configuration for binding a D3 histogram.
+ */
+export interface D3HistogramConfig extends D3BinderConfig {
+  /** CSS selector for the histogram bar elements (e.g., `'rect.bar'`, `'rect'`). */
+  selector: string;
+  /** Accessor for the x-axis (bin label) value. @default 'x' */
+  x?: DataAccessor<string | number>;
+  /** Accessor for the y-axis (count/frequency) value. @default 'y' */
+  y?: DataAccessor<number | string>;
+  /** Accessor for bin min x value. @default 'x0' */
+  xMin?: DataAccessor<number>;
+  /** Accessor for bin max x value. @default 'x1' */
+  xMax?: DataAccessor<number>;
+  /** Accessor for bin min y value (typically 0). @default 0 */
+  yMin?: DataAccessor<number>;
+  /** Accessor for bin max y value. Defaults to the y accessor. */
+  yMax?: DataAccessor<number>;
+}
+
+/**
+ * Result of a D3 binder function.
+ * Contains the complete MAIDR data structure and the generated layer
+ * for further customization if needed.
+ */
+export interface D3BinderResult {
+  /** Complete MAIDR JSON data ready to use with the `<Maidr>` component or `maidr-data` attribute. */
+  maidr: Maidr;
+  /** The generated layer for direct inspection or modification. */
+  layer: MaidrLayer;
+}
+
+/**
+ * Union of all supported data point types extracted by the D3 binder.
+ */
+export type D3ExtractedData
+  = | BarPoint[]
+    | BoxPoint[]
+    | HeatmapData
+    | HistogramPoint[]
+    | LinePoint[][]
+    | ScatterPoint[];

--- a/src/d3/types.ts
+++ b/src/d3/types.ts
@@ -8,6 +8,7 @@
 import type {
   BarPoint,
   BoxPoint,
+  CandlestickPoint,
   FormatConfig,
   HeatmapData,
   HistogramPoint,
@@ -16,6 +17,9 @@ import type {
   MaidrLayer,
   Orientation,
   ScatterPoint,
+  SegmentedPoint,
+  SmoothPoint,
+  TraceType,
 } from '../type/grammar';
 
 /**
@@ -167,6 +171,64 @@ export interface D3HistogramConfig extends D3BinderConfig {
 }
 
 /**
+ * Configuration for binding a D3 segmented bar chart (stacked, dodged, or normalized).
+ */
+export interface D3SegmentedConfig extends D3BinderConfig {
+  /** CSS selector for the bar elements (e.g., `'rect.bar'`, `'rect'`). */
+  selector: string;
+  /** The segmented bar chart type. @default TraceType.STACKED */
+  type?: TraceType.STACKED | TraceType.DODGED | TraceType.NORMALIZED;
+  /** Accessor for the x-axis (category) value. @default 'x' */
+  x?: DataAccessor<string | number>;
+  /** Accessor for the y-axis (numeric) value. @default 'y' */
+  y?: DataAccessor<number | string>;
+  /** Accessor for the fill/group label. @default 'fill' */
+  fill?: DataAccessor<string>;
+  /** Chart orientation. @default Orientation.VERTICAL */
+  orientation?: Orientation;
+}
+
+/**
+ * Configuration for binding a D3 candlestick (OHLC) chart.
+ */
+export interface D3CandlestickConfig extends D3BinderConfig {
+  /** CSS selector for the candlestick group elements (e.g., `'g.candle'`). */
+  selector: string;
+  /** Accessor for the x-axis label (e.g., date). @default 'value' */
+  value?: DataAccessor<string>;
+  /** Accessor for the open price. @default 'open' */
+  open?: DataAccessor<number>;
+  /** Accessor for the high price. @default 'high' */
+  high?: DataAccessor<number>;
+  /** Accessor for the low price. @default 'low' */
+  low?: DataAccessor<number>;
+  /** Accessor for the close price. @default 'close' */
+  close?: DataAccessor<number>;
+  /** Accessor for the volume. @default 'volume' */
+  volume?: DataAccessor<number>;
+}
+
+/**
+ * Configuration for binding a D3 smooth/regression line chart.
+ */
+export interface D3SmoothConfig extends D3BinderConfig {
+  /** CSS selector for the smooth line path elements (e.g., `'path.smooth'`). */
+  selector: string;
+  /** CSS selector for individual point elements along the smooth line. */
+  pointSelector?: string;
+  /** Accessor for the x-axis data value. @default 'x' */
+  x?: DataAccessor<number>;
+  /** Accessor for the y-axis data value. @default 'y' */
+  y?: DataAccessor<number>;
+  /** Accessor for the SVG x pixel coordinate. @default 'svg_x' */
+  svgX?: DataAccessor<number>;
+  /** Accessor for the SVG y pixel coordinate. @default 'svg_y' */
+  svgY?: DataAccessor<number>;
+  /** Accessor for the series/fill label. @default 'fill' */
+  fill?: DataAccessor<string>;
+}
+
+/**
  * Result of a D3 binder function.
  * Contains the complete MAIDR data structure and the generated layer
  * for further customization if needed.
@@ -182,9 +244,12 @@ export interface D3BinderResult {
  * Union of all supported data point types extracted by the D3 binder.
  */
 export type D3ExtractedData
-  = | BarPoint[]
+  = BarPoint[]
     | BoxPoint[]
+    | CandlestickPoint[]
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]
-    | ScatterPoint[];
+    | ScatterPoint[]
+    | SegmentedPoint[][]
+    | SmoothPoint[][];

--- a/src/d3/util.ts
+++ b/src/d3/util.ts
@@ -31,18 +31,19 @@ export function getD3Datum(element: Element): unknown {
  * @param datum - The data object bound to a D3 element.
  * @param accessor - Property key or function to extract the value.
  * @param index - The index of the element in its selection.
- * @returns The extracted value.
+ * @returns The extracted value, or `undefined` if the property does not exist.
  */
 export function resolveAccessor<T>(
   datum: unknown,
   accessor: DataAccessor<T>,
   index: number,
-): T {
+): T | undefined {
   if (typeof accessor === 'function') {
     return accessor(datum, index);
   }
   // String accessor: use as property key
-  return (datum as Record<string, T>)[accessor];
+  const record = datum as Record<string, unknown>;
+  return record[accessor] as T | undefined;
 }
 
 /**
@@ -145,36 +146,4 @@ export function scopeSelector(container: Element, selector: string): string {
  */
 export function generateId(): string {
   return `d3-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-/**
- * Extracts data from D3-bound elements using the provided accessors.
- * Falls back to DOM attribute extraction if `__data__` is not available.
- */
-export function extractBarDataFromDOM(
-  elements: Element[],
-  orientation: 'vert' | 'horz',
-): { x: string | number; y: number }[] {
-  return elements.map((el) => {
-    const datum = getD3Datum(el);
-    if (datum && typeof datum === 'object') {
-      return datum as { x: string | number; y: number };
-    }
-
-    // Fallback: try to infer from SVG attributes (rect elements)
-    const tag = el.tagName.toLowerCase();
-    if (tag === 'rect') {
-      const x = Number(el.getAttribute('x') ?? 0);
-      const y = Number(el.getAttribute('y') ?? 0);
-      const width = Number(el.getAttribute('width') ?? 0);
-      const height = Number(el.getAttribute('height') ?? 0);
-
-      if (orientation === 'vert') {
-        return { x: x + width / 2, y: height };
-      }
-      return { x: width, y: y + height / 2 };
-    }
-
-    return { x: 0, y: 0 };
-  });
 }

--- a/src/d3/util.ts
+++ b/src/d3/util.ts
@@ -1,0 +1,180 @@
+/**
+ * Utility functions for the D3 binder.
+ * Handles extracting data from D3.js-bound DOM elements.
+ */
+
+import type { DataAccessor } from './types';
+
+/**
+ * Interface for DOM elements with D3's `__data__` property.
+ * D3.js binds data to elements via this property during `.data()` joins.
+ */
+interface D3BoundElement extends Element {
+  __data__?: unknown;
+}
+
+/**
+ * Extracts the D3-bound datum from a DOM element.
+ * D3.js stores bound data on the `__data__` property of DOM elements
+ * after a `.data()` join.
+ *
+ * @param element - The DOM element to extract data from.
+ * @returns The bound datum, or `undefined` if no data is bound.
+ */
+export function getD3Datum(element: Element): unknown {
+  return (element as D3BoundElement).__data__;
+}
+
+/**
+ * Resolves a {@link DataAccessor} to extract a value from a datum.
+ *
+ * @param datum - The data object bound to a D3 element.
+ * @param accessor - Property key or function to extract the value.
+ * @param index - The index of the element in its selection.
+ * @returns The extracted value.
+ */
+export function resolveAccessor<T>(
+  datum: unknown,
+  accessor: DataAccessor<T>,
+  index: number,
+): T {
+  if (typeof accessor === 'function') {
+    return accessor(datum, index);
+  }
+  // String accessor: use as property key
+  return (datum as Record<string, T>)[accessor];
+}
+
+/**
+ * Queries all matching elements within a container and returns them with
+ * their D3-bound data.
+ *
+ * @param container - The root element (typically an SVG) to query within.
+ * @param selector - CSS selector for the target elements.
+ * @returns Array of `{ element, datum, index }` tuples.
+ */
+export function queryD3Elements(
+  container: Element,
+  selector: string,
+): { element: Element; datum: unknown; index: number }[] {
+  const elements = Array.from(container.querySelectorAll(selector));
+  return elements.map((element, index) => ({
+    element,
+    datum: getD3Datum(element),
+    index,
+  }));
+}
+
+/**
+ * Generates a unique CSS selector for a D3 element within its container.
+ * This creates a selector that MAIDR can use to highlight individual elements.
+ *
+ * Strategy:
+ * 1. Use existing `id` attribute if present.
+ * 2. Use combination of tag name, classes, and `nth-of-type` for uniqueness.
+ *
+ * @param element - The SVG element to generate a selector for.
+ * @param container - The root container element.
+ * @returns A CSS selector string targeting the element.
+ */
+export function generateSelector(
+  element: Element,
+  container: Element,
+): string {
+  if (element.id) {
+    return `#${CSS.escape(element.id)}`;
+  }
+
+  // Build a selector based on the element's parent chain relative to container
+  const parts: string[] = [];
+  let current: Element | null = element;
+
+  while (current && current !== container) {
+    let part = current.tagName.toLowerCase();
+
+    if (current.id) {
+      parts.unshift(`#${CSS.escape(current.id)} > ${part}`);
+      break;
+    }
+
+    // Add classes if present
+    const classes = Array.from(current.classList)
+      .map(c => `.${CSS.escape(c)}`)
+      .join('');
+    if (classes) {
+      part += classes;
+    }
+
+    // Add nth-of-type for disambiguation
+    const parent = current.parentElement;
+    if (parent) {
+      const siblings = Array.from(parent.children).filter(
+        s => s.tagName === current!.tagName,
+      );
+      if (siblings.length > 1) {
+        const idx = siblings.indexOf(current) + 1;
+        part += `:nth-of-type(${idx})`;
+      }
+    }
+
+    parts.unshift(part);
+    current = current.parentElement;
+  }
+
+  return parts.join(' > ');
+}
+
+/**
+ * Generates a single CSS selector that matches all elements in the given
+ * selector string within the container. This is used for the MAIDR layer
+ * `selectors` field.
+ *
+ * @param container - The root SVG container.
+ * @param selector - The user-provided CSS selector.
+ * @returns The selector string, scoped if the container has an ID.
+ */
+export function scopeSelector(container: Element, selector: string): string {
+  if (container.id) {
+    return `#${CSS.escape(container.id)} ${selector}`;
+  }
+  return selector;
+}
+
+/**
+ * Generates a unique ID string for use in MAIDR data structures.
+ */
+export function generateId(): string {
+  return `d3-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Extracts data from D3-bound elements using the provided accessors.
+ * Falls back to DOM attribute extraction if `__data__` is not available.
+ */
+export function extractBarDataFromDOM(
+  elements: Element[],
+  orientation: 'vert' | 'horz',
+): { x: string | number; y: number }[] {
+  return elements.map((el) => {
+    const datum = getD3Datum(el);
+    if (datum && typeof datum === 'object') {
+      return datum as { x: string | number; y: number };
+    }
+
+    // Fallback: try to infer from SVG attributes (rect elements)
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'rect') {
+      const x = Number(el.getAttribute('x') ?? 0);
+      const y = Number(el.getAttribute('y') ?? 0);
+      const width = Number(el.getAttribute('width') ?? 0);
+      const height = Number(el.getAttribute('height') ?? 0);
+
+      if (orientation === 'vert') {
+        return { x: x + width / 2, y: height };
+      }
+      return { x: width, y: y + height / 2 };
+    }
+
+    return { x: 0, y: 0 };
+  });
+}

--- a/src/react-entry.ts
+++ b/src/react-entry.ts
@@ -3,7 +3,8 @@
  *
  * Provides the `<Maidr>` component for adding accessible, non-visual access to
  * statistical visualizations in React applications. Supports audio sonification,
- * text descriptions, braille output, and keyboard navigation.
+ * text descriptions, braille output, keyboard navigation, and realtime data
+ * updates via the `MaidrRef` imperative handle.
  *
  * @remarks
  * Requires React 18 or 19 as a peer dependency.
@@ -39,7 +40,7 @@
  *
  * @packageDocumentation
  */
-export { Maidr, type MaidrProps } from './maidr-component';
+export { Maidr, type MaidrProps, type MaidrRef } from './maidr-component';
 
 /**
  * Re-exported types for constructing the MAIDR data prop.

--- a/vite.d3.config.ts
+++ b/vite.d3.config.ts
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig({
+  plugins: [
+    dts({
+      tsconfigPath: './tsconfig.build.json',
+      rollupTypes: true,
+      insertTypesEntry: false,
+    }),
+  ],
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'src/d3/index.ts'),
+      name: 'maidrD3',
+      formats: ['es', 'umd'],
+      fileName: format => format === 'es' ? 'd3.mjs' : 'd3.js',
+    },
+    sourcemap: true,
+    outDir: 'dist',
+    emptyOutDir: false,
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+          return;
+        }
+        warn(warning);
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@command': path.resolve(__dirname, 'src/command'),
+      '@model': path.resolve(__dirname, 'src/model'),
+      '@state': path.resolve(__dirname, 'src/state'),
+      '@service': path.resolve(__dirname, 'src/service'),
+      '@type': path.resolve(__dirname, 'src/type'),
+      '@ui': path.resolve(__dirname, 'src/ui'),
+      '@util': path.resolve(__dirname, 'src/util'),
+    },
+  },
+});


### PR DESCRIPTION
Implements Phase 1 of issue #536 by adding a `setData` API that allows
chart data to be replaced at runtime without unmounting the component.

Changes:
- Convert `<Maidr>` component to `forwardRef` and expose `MaidrRef`
  handle with `setData()` method via `useImperativeHandle`
- Support prop-driven data updates: changing the `data` prop while the
  chart is focused transparently rebuilds the Controller
- Add `useMaidrController` effect to detect data changes and recreate
  the Controller while preserving the Redux store
- Expose `window.maidrPlots` global registry for script-tag consumers
  to call `setData()` by plot ID
- Export `MaidrRef` type from `maidr/react` public API

https://claude.ai/code/session_011ooVhoME1PLoimCg71q9rW