### PR TITLE
feat: support Plotly heatmap cell highlighting via SVG overlays

### DIFF
--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -349,11 +349,11 @@ export class Heatmap extends AbstractTrace {
     numCols: number,
   ): SVGElement[][] | null {
     const imageElement = this.findHeatmapImage(selector);
-    if (!imageElement) {
+    if (!(imageElement instanceof SVGGraphicsElement)) {
       return null;
     }
 
-    const bbox = (imageElement as SVGGraphicsElement).getBBox();
+    const bbox = imageElement.getBBox();
     if (bbox.width === 0 || bbox.height === 0) {
       return null;
     }
@@ -424,7 +424,13 @@ export class Heatmap extends AbstractTrace {
     }
 
     // Try Plotly-specific DOM structure: .heatmaplayer > .hm > image
-    const plotlyImage = document.querySelector('.heatmaplayer image');
+    // Scope search to the closest SVG ancestor of the selector match to avoid
+    // matching heatmap images from other plots on the same page.
+    const scopeRoot = elements.length > 0
+      ? elements[0].closest('svg')
+      : null;
+    const searchRoot = scopeRoot ?? document;
+    const plotlyImage = searchRoot.querySelector('.heatmaplayer image');
     if (plotlyImage instanceof SVGElement) {
       return plotlyImage;
     }

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -15,7 +15,7 @@ export abstract class Svg {
   /**
    * SVG namespace URI for creating SVG elements.
    */
-  private static SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+  static readonly SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 
   /**
    * Converts an SVG element to a Base64-encoded JPEG data URL.


### PR DESCRIPTION
When Plotly renders heatmaps as a single rasterized <image> element
instead of individual SVG cells, the existing highlight system cannot
find per-cell elements to highlight. This adds a fallback that detects
the rasterized image, computes cell positions from its bounding box,
and creates transparent SVG rect overlays for each cell. The existing
HighlightService then highlights these overlays normally.

Closes #534

https://claude.ai/code/session_017AzuGoX7XAPLw5mmDd7n3L