### PR TITLE
fix: support per-stat highlighting for Plotly single-path box plots (#535)

### DIFF
--- a/examples/boxplot-plotly-horizontal.html
+++ b/examples/boxplot-plotly-horizontal.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>Plotly-style Horizontal Box Plot Example</title>
+  <script>
+    var maidr = {
+  "id": "plotly-boxplot-horizontal",
+  "subplots": [
+    [
+      {
+        "id": "subplot-1",
+        "layers": [
+          {
+            "id": "layer-1",
+            "type": "box",
+            "title": "Plotly-style Horizontal Box Plot: Groups and Values",
+            "axes": {
+              "x": "Values",
+              "y": "Group",
+              "format": {
+                "x": { "type": "fixed", "decimals": 1 }
+              }
+            },
+            "data": [
+              {
+                "lowerOutliers": [
+                  -20,
+                  -10
+                ],
+                "min": 8.75,
+                "q1": 61.31,
+                "q2": 78.91,
+                "q3": 100.73,
+                "max": 156.81,
+                "upperOutliers": [
+                  200,
+                  210
+                ],
+                "fill": "Group 3"
+              },
+              {
+                "lowerOutliers": [
+                  10,
+                  20
+                ],
+                "min": 32.23,
+                "q1": 73.98,
+                "q2": 89.67,
+                "q3": 102.79,
+                "max": 133.52,
+                "upperOutliers": [
+                  154.55,
+                  180,
+                  190
+                ],
+                "fill": "Group 2"
+              },
+              {
+                "lowerOutliers": [
+                  40,
+                  50
+                ],
+                "min": 77.27,
+                "q1": 93.90,
+                "q2": 99.79,
+                "q3": 106.53,
+                "max": 124.85,
+                "upperOutliers": [
+                  150,
+                  160
+                ],
+                "fill": "Group 1"
+              }
+            ],
+            "selectors": [
+              {
+                "lowerOutliers": [
+                  "#plotly-hbox-outliers-1 > :nth-child(-n+2 of circle)"
+                ],
+                "min": "#plotly-hbox-1 > path",
+                "max": "#plotly-hbox-1 > path",
+                "q2": "#plotly-hbox-1 > path",
+                "iq": "#plotly-hbox-1 > path",
+                "upperOutliers": [
+                  "#plotly-hbox-outliers-1 > :nth-child(n+3 of circle)"
+                ]
+              },
+              {
+                "lowerOutliers": [
+                  "#plotly-hbox-outliers-2 > :nth-child(-n+2 of circle)"
+                ],
+                "min": "#plotly-hbox-2 > path",
+                "max": "#plotly-hbox-2 > path",
+                "q2": "#plotly-hbox-2 > path",
+                "iq": "#plotly-hbox-2 > path",
+                "upperOutliers": [
+                  "#plotly-hbox-outliers-2 > :nth-child(n+3 of circle)"
+                ]
+              },
+              {
+                "lowerOutliers": [
+                  "#plotly-hbox-outliers-3 > :nth-child(-n+2 of circle)"
+                ],
+                "min": "#plotly-hbox-3 > path",
+                "max": "#plotly-hbox-3 > path",
+                "q2": "#plotly-hbox-3 > path",
+                "iq": "#plotly-hbox-3 > path",
+                "upperOutliers": [
+                  "#plotly-hbox-outliers-3 > :nth-child(n+3 of circle)"
+                ]
+              }
+            ],
+            "orientation": "horz"
+          }
+        ]
+      }
+    ]
+  ]
+}
+  </script>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../src/ui/css/styles.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        This SVG simulates Plotly's rendering approach for HORIZONTAL box plots.
+        Each box plot is drawn as a single <path> element containing whiskers,
+        IQ box, and median line. Outliers are rendered as separate circle elements.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="460.8pt" height="345.6pt"
+        viewBox="0 0 460.8 345.6" version="1.1" id="plotly-boxplot-horizontal">
+        <defs>
+          <style type="text/css">
+            * { stroke-linejoin: round; stroke-linecap: butt; }
+          </style>
+        </defs>
+        <g id="figure_1">
+          <!-- Background -->
+          <g id="maidr-bg">
+            <path d="M 0 345.6 L 460.8 345.6 L 460.8 0 L 0 0 z" style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <!-- Plot area background -->
+            <g id="maidr-plot-bg">
+              <path d="M 57.6 307.584 L 414.72 307.584 L 414.72 41.472 L 57.6 41.472 z" style="fill: #ffffff" />
+            </g>
+
+            <!-- Horizontal Box 1 (Group 3, bottom): single path
+                 Data: min=8.75, q1=61.31, q2=78.91, q3=100.73, max=156.81
+                 X range: x=57.6 (value=-50) to x=414.72 (value=250)
+                 Scale: (414.72 - 57.6) / 300 = 1.19040 per unit
+                 min=8.75   -> x = 57.6 + (8.75+50)*1.19040 = 127.536
+                 q1=61.31   -> x = 57.6 + (61.31+50)*1.19040 = 190.112
+                 q2=78.91   -> x = 57.6 + (78.91+50)*1.19040 = 211.067
+                 q3=100.73  -> x = 57.6 + (100.73+50)*1.19040 = 237.020
+                 max=156.81 -> x = 57.6 + (156.81+50)*1.19040 = 303.756
+                 Box center y = 263.232, box half-height = 13.3056
+            -->
+            <g id="plotly-hbox-1">
+              <path d="
+                M 127.536 263.232 L 190.112 263.232
+                M 190.112 249.926 L 190.112 276.538 L 237.020 276.538 L 237.020 249.926 L 190.112 249.926
+                M 211.067 249.926 L 211.067 276.538
+                M 237.020 263.232 L 303.756 263.232
+                M 127.536 256.579 L 127.536 269.885
+                M 303.756 256.579 L 303.756 269.885
+              " style="fill: rgba(210,180,140,0.5); stroke: #d62728; stroke-width: 1.5" />
+            </g>
+            <!-- Outliers for HBox 1: lower=[-20,-10], upper=[200,210]
+                 value=-20  -> x = 57.6 + (-20+50)*1.19040 = 93.312
+                 value=-10  -> x = 57.6 + (-10+50)*1.19040 = 105.216
+                 value=200  -> x = 57.6 + (200+50)*1.19040 = 355.200
+                 value=210  -> x = 57.6 + (210+50)*1.19040 = 367.104
+            -->
+            <g id="plotly-hbox-outliers-1">
+              <circle cx="93.312" cy="263.232" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+              <circle cx="105.216" cy="263.232" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+              <circle cx="355.200" cy="263.232" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+              <circle cx="367.104" cy="263.232" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+            </g>
+
+            <!-- Horizontal Box 2 (Group 2, middle): single path
+                 Data: min=32.23, q1=73.98, q2=89.67, q3=102.79, max=133.52
+                 min=32.23  -> x = 57.6 + (32.23+50)*1.19040 = 155.496
+                 q1=73.98   -> x = 57.6 + (73.98+50)*1.19040 = 205.186
+                 q2=89.67   -> x = 57.6 + (89.67+50)*1.19040 = 223.861
+                 q3=102.79  -> x = 57.6 + (102.79+50)*1.19040 = 239.472
+                 max=133.52 -> x = 57.6 + (133.52+50)*1.19040 = 276.048
+                 Box center y = 174.528, box half-height = 13.3056
+            -->
+            <g id="plotly-hbox-2">
+              <path d="
+                M 155.496 174.528 L 205.186 174.528
+                M 205.186 161.222 L 205.186 187.834 L 239.472 187.834 L 239.472 161.222 L 205.186 161.222
+                M 223.861 161.222 L 223.861 187.834
+                M 239.472 174.528 L 276.048 174.528
+                M 155.496 167.875 L 155.496 181.181
+                M 276.048 167.875 L 276.048 181.181
+              " style="fill: rgba(144,238,144,0.5); stroke: #2ca02c; stroke-width: 1.5" />
+            </g>
+            <!-- Outliers for HBox 2: lower=[10,20], upper=[154.55,180,190]
+                 value=10    -> x = 57.6 + (10+50)*1.19040 = 129.024
+                 value=20    -> x = 57.6 + (20+50)*1.19040 = 140.928
+                 value=154.55-> x = 57.6 + (154.55+50)*1.19040 = 301.070
+                 value=180   -> x = 57.6 + (180+50)*1.19040 = 331.392
+                 value=190   -> x = 57.6 + (190+50)*1.19040 = 343.296
+            -->
+            <g id="plotly-hbox-outliers-2">
+              <circle cx="129.024" cy="174.528" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="140.928" cy="174.528" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="301.070" cy="174.528" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="331.392" cy="174.528" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="343.296" cy="174.528" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+            </g>
+
+            <!-- Horizontal Box 3 (Group 1, top): single path
+                 Data: min=77.27, q1=93.90, q2=99.79, q3=106.53, max=124.85
+                 min=77.27  -> x = 57.6 + (77.27+50)*1.19040 = 209.103
+                 q1=93.90   -> x = 57.6 + (93.90+50)*1.19040 = 228.899
+                 q2=99.79   -> x = 57.6 + (99.79+50)*1.19040 = 235.909
+                 q3=106.53  -> x = 57.6 + (106.53+50)*1.19040 = 243.933
+                 max=124.85 -> x = 57.6 + (124.85+50)*1.19040 = 265.734
+                 Box center y = 85.824, box half-height = 13.3056
+            -->
+            <g id="plotly-hbox-3">
+              <path d="
+                M 209.103 85.824 L 228.899 85.824
+                M 228.899 72.518 L 228.899 99.130 L 243.933 99.130 L 243.933 72.518 L 228.899 72.518
+                M 235.909 72.518 L 235.909 99.130
+                M 243.933 85.824 L 265.734 85.824
+                M 209.103 79.171 L 209.103 92.477
+                M 265.734 79.171 L 265.734 92.477
+              " style="fill: rgba(173,216,230,0.5); stroke: #1f77b4; stroke-width: 1.5" />
+            </g>
+            <!-- Outliers for HBox 3: lower=[40,50], upper=[150,160]
+                 value=40  -> x = 57.6 + (40+50)*1.19040 = 164.736
+                 value=50  -> x = 57.6 + (50+50)*1.19040 = 176.640
+                 value=150 -> x = 57.6 + (150+50)*1.19040 = 295.680
+                 value=160 -> x = 57.6 + (160+50)*1.19040 = 307.584
+            -->
+            <g id="plotly-hbox-outliers-3">
+              <circle cx="164.736" cy="85.824" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+              <circle cx="176.640" cy="85.824" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+              <circle cx="295.680" cy="85.824" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+              <circle cx="307.584" cy="85.824" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+            </g>
+
+            <!-- Axes -->
+            <g id="matplotlib.axis_1">
+              <text x="236.16" y="335.860" text-anchor="middle" font-size="10">Values</text>
+            </g>
+            <g id="matplotlib.axis_2">
+              <g id="text_group_1">
+                <text x="47" y="266.232" text-anchor="end" font-size="10">Group 1</text>
+              </g>
+              <g id="text_group_2">
+                <text x="47" y="177.528" text-anchor="end" font-size="10">Group 2</text>
+              </g>
+              <g id="text_group_3">
+                <text x="47" y="88.824" text-anchor="end" font-size="10">Group 3</text>
+              </g>
+              <text x="15" y="174.528" text-anchor="middle" font-size="10" transform="rotate(-90, 15, 174.528)">Group</text>
+            </g>
+            <text x="236.16" y="30" text-anchor="middle" font-size="12" font-weight="bold">Plotly-style Horizontal Box Plot</text>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/examples/boxplot-plotly-vertical.html
+++ b/examples/boxplot-plotly-vertical.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>Plotly-style Vertical Box Plot Example</title>
+  <script>
+    var maidr = {
+  "id": "plotly-boxplot-vertical",
+  "subplots": [
+    [
+      {
+        "id": "subplot-1",
+        "layers": [
+          {
+            "id": "layer-1",
+            "type": "box",
+            "title": "Plotly-style Vertical Box Plot: Groups and Values",
+            "axes": {
+              "x": "Group",
+              "y": "Values",
+              "format": {
+                "y": { "type": "fixed", "decimals": 2 }
+              }
+            },
+            "data": [
+              {
+                "lowerOutliers": [],
+                "min": 20,
+                "q1": 40,
+                "q2": 55,
+                "q3": 70,
+                "max": 90,
+                "upperOutliers": [],
+                "fill": "Group A"
+              },
+              {
+                "lowerOutliers": [],
+                "min": 30,
+                "q1": 50,
+                "q2": 65,
+                "q3": 80,
+                "max": 95,
+                "upperOutliers": [],
+                "fill": "Group B"
+              },
+              {
+                "lowerOutliers": [],
+                "min": 10,
+                "q1": 35,
+                "q2": 50,
+                "q3": 75,
+                "max": 100,
+                "upperOutliers": [],
+                "fill": "Group C"
+              }
+            ],
+            "selectors": [
+              {
+                "lowerOutliers": [],
+                "min": "#plotly-box-1 > path",
+                "max": "#plotly-box-1 > path",
+                "q2": "#plotly-box-1 > path",
+                "iq": "#plotly-box-1 > path",
+                "upperOutliers": []
+              },
+              {
+                "lowerOutliers": [],
+                "min": "#plotly-box-2 > path",
+                "max": "#plotly-box-2 > path",
+                "q2": "#plotly-box-2 > path",
+                "iq": "#plotly-box-2 > path",
+                "upperOutliers": []
+              },
+              {
+                "lowerOutliers": [],
+                "min": "#plotly-box-3 > path",
+                "max": "#plotly-box-3 > path",
+                "q2": "#plotly-box-3 > path",
+                "iq": "#plotly-box-3 > path",
+                "upperOutliers": []
+              }
+            ],
+            "orientation": "vert"
+          }
+        ]
+      }
+    ]
+  ]
+}
+  </script>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../src/ui/css/styles.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        This SVG simulates Plotly's rendering approach where each box plot is drawn
+        as a single <path> element containing whiskers, IQ box, and median line.
+        This is in contrast to Matplotlib which renders each part as separate elements.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="460.8pt" height="345.6pt"
+        viewBox="0 0 460.8 345.6" version="1.1" id="plotly-boxplot-vertical">
+        <defs>
+          <style type="text/css">
+            * { stroke-linejoin: round; stroke-linecap: butt; }
+          </style>
+        </defs>
+        <g id="figure_1">
+          <!-- Background -->
+          <g id="maidr-bg">
+            <path d="M 0 345.6 L 460.8 345.6 L 460.8 0 L 0 0 z" style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <!-- Plot area background -->
+            <g id="maidr-plot-bg">
+              <path d="M 57.6 307.584 L 414.72 307.584 L 414.72 41.472 L 57.6 41.472 z" style="fill: #ffffff" />
+            </g>
+
+            <!-- Box 1 (Group A): single path for entire box
+                 Data: min=20, q1=40, q2=55, q3=70, max=90
+                 Y range in SVG: y=307.584 (value=0) to y=41.472 (value=100)
+                 Scale: (307.584 - 41.472) / 100 = 2.66112 per unit
+                 min=20 -> y = 307.584 - 20*2.66112 = 254.3616
+                 q1=40 -> y = 307.584 - 40*2.66112 = 201.1392
+                 q2=55 -> y = 307.584 - 55*2.66112 = 161.2224
+                 q3=70 -> y = 307.584 - 70*2.66112 = 121.3056
+                 max=90 -> y = 307.584 - 90*2.66112 = 67.6832
+                 Box center x = 117.12, box half-width = 17.856
+            -->
+            <g id="plotly-box-1">
+              <path d="
+                M 117.12 254.362 L 117.12 201.139
+                M 99.264 201.139 L 134.976 201.139 L 134.976 121.306 L 99.264 121.306 L 99.264 201.139
+                M 99.264 161.222 L 134.976 161.222
+                M 117.12 121.306 L 117.12 67.683
+                M 108.192 254.362 L 126.048 254.362
+                M 108.192 67.683 L 126.048 67.683
+              " style="fill: rgba(173,216,230,0.5); stroke: #1f77b4; stroke-width: 1.5" />
+            </g>
+
+            <!-- Box 2 (Group B): single path for entire box
+                 Data: min=30, q1=50, q2=65, q3=80, max=95
+                 min=30 -> y = 307.584 - 30*2.66112 = 227.7504
+                 q1=50 -> y = 307.584 - 50*2.66112 = 174.528
+                 q2=65 -> y = 307.584 - 65*2.66112 = 134.611
+                 q3=80 -> y = 307.584 - 80*2.66112 = 94.694
+                 max=95 -> y = 307.584 - 95*2.66112 = 54.777
+                 Box center x = 236.16, box half-width = 17.856
+            -->
+            <g id="plotly-box-2">
+              <path d="
+                M 236.16 227.750 L 236.16 174.528
+                M 218.304 174.528 L 254.016 174.528 L 254.016 94.694 L 218.304 94.694 L 218.304 174.528
+                M 218.304 134.611 L 254.016 134.611
+                M 236.16 94.694 L 236.16 54.777
+                M 227.232 227.750 L 245.088 227.750
+                M 227.232 54.777 L 245.088 54.777
+              " style="fill: rgba(144,238,144,0.5); stroke: #2ca02c; stroke-width: 1.5" />
+            </g>
+
+            <!-- Box 3 (Group C): single path for entire box
+                 Data: min=10, q1=35, q2=50, q3=75, max=100
+                 min=10 -> y = 307.584 - 10*2.66112 = 280.973
+                 q1=35 -> y = 307.584 - 35*2.66112 = 214.445
+                 q2=50 -> y = 307.584 - 50*2.66112 = 174.528
+                 q3=75 -> y = 307.584 - 75*2.66112 = 108.0
+                 max=100 -> y = 307.584 - 100*2.66112 = 41.472
+                 Box center x = 355.2, box half-width = 17.856
+            -->
+            <g id="plotly-box-3">
+              <path d="
+                M 355.2 280.973 L 355.2 214.445
+                M 337.344 214.445 L 373.056 214.445 L 373.056 108.0 L 337.344 108.0 L 337.344 214.445
+                M 337.344 174.528 L 373.056 174.528
+                M 355.2 108.0 L 355.2 41.472
+                M 346.272 280.973 L 364.128 280.973
+                M 346.272 41.472 L 364.128 41.472
+              " style="fill: rgba(210,180,140,0.5); stroke: #d62728; stroke-width: 1.5" />
+            </g>
+
+            <!-- Axes -->
+            <g id="matplotlib.axis_1">
+              <g id="text_group_a">
+                <text x="117.12" y="322" text-anchor="middle" font-size="10">Group A</text>
+              </g>
+              <g id="text_group_b">
+                <text x="236.16" y="322" text-anchor="middle" font-size="10">Group B</text>
+              </g>
+              <g id="text_group_c">
+                <text x="355.2" y="322" text-anchor="middle" font-size="10">Group C</text>
+              </g>
+              <text x="236.16" y="340" text-anchor="middle" font-size="10">Group</text>
+            </g>
+            <g id="matplotlib.axis_2">
+              <text x="30" y="174.528" text-anchor="middle" font-size="10" transform="rotate(-90, 30, 174.528)">Values</text>
+            </g>
+            <text x="236.16" y="30" text-anchor="middle" font-size="12" font-weight="bold">Plotly-style Vertical Box Plot</text>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/examples/boxplot-plotly-vertical.html
+++ b/examples/boxplot-plotly-vertical.html
@@ -25,60 +25,92 @@
             },
             "data": [
               {
-                "lowerOutliers": [],
+                "lowerOutliers": [
+                  5,
+                  10
+                ],
                 "min": 20,
                 "q1": 40,
                 "q2": 55,
                 "q3": 70,
                 "max": 90,
-                "upperOutliers": [],
+                "upperOutliers": [
+                  95,
+                  98
+                ],
                 "fill": "Group A"
               },
               {
-                "lowerOutliers": [],
+                "lowerOutliers": [
+                  15,
+                  20
+                ],
                 "min": 30,
                 "q1": 50,
                 "q2": 65,
                 "q3": 80,
                 "max": 95,
-                "upperOutliers": [],
+                "upperOutliers": [
+                  100,
+                  108,
+                  115
+                ],
                 "fill": "Group B"
               },
               {
-                "lowerOutliers": [],
+                "lowerOutliers": [
+                  -10,
+                  -5,
+                  0
+                ],
                 "min": 10,
                 "q1": 35,
                 "q2": 50,
                 "q3": 75,
                 "max": 100,
-                "upperOutliers": [],
+                "upperOutliers": [
+                  110,
+                  120
+                ],
                 "fill": "Group C"
               }
             ],
             "selectors": [
               {
-                "lowerOutliers": [],
+                "lowerOutliers": [
+                  "#plotly-outliers-1 > :nth-child(-n+2 of circle)"
+                ],
                 "min": "#plotly-box-1 > path",
                 "max": "#plotly-box-1 > path",
                 "q2": "#plotly-box-1 > path",
                 "iq": "#plotly-box-1 > path",
-                "upperOutliers": []
+                "upperOutliers": [
+                  "#plotly-outliers-1 > :nth-child(n+3 of circle)"
+                ]
               },
               {
-                "lowerOutliers": [],
+                "lowerOutliers": [
+                  "#plotly-outliers-2 > :nth-child(-n+2 of circle)"
+                ],
                 "min": "#plotly-box-2 > path",
                 "max": "#plotly-box-2 > path",
                 "q2": "#plotly-box-2 > path",
                 "iq": "#plotly-box-2 > path",
-                "upperOutliers": []
+                "upperOutliers": [
+                  "#plotly-outliers-2 > :nth-child(n+3 of circle)"
+                ]
               },
               {
-                "lowerOutliers": [],
+                "lowerOutliers": [
+                  "#plotly-outliers-3 > :nth-child(-n+3 of circle)"
+                ],
                 "min": "#plotly-box-3 > path",
                 "max": "#plotly-box-3 > path",
                 "q2": "#plotly-box-3 > path",
                 "iq": "#plotly-box-3 > path",
-                "upperOutliers": []
+                "upperOutliers": [
+                  "#plotly-outliers-3 > :nth-child(n+4 of circle)"
+                ]
               }
             ],
             "orientation": "vert"
@@ -99,6 +131,7 @@
       <!--
         This SVG simulates Plotly's rendering approach where each box plot is drawn
         as a single <path> element containing whiskers, IQ box, and median line.
+        Outliers are rendered as separate circle elements (as Plotly does).
         This is in contrast to Matplotlib which renders each part as separate elements.
       -->
       <svg xmlns="http://www.w3.org/2000/svg" width="460.8pt" height="345.6pt"
@@ -123,11 +156,11 @@
                  Data: min=20, q1=40, q2=55, q3=70, max=90
                  Y range in SVG: y=307.584 (value=0) to y=41.472 (value=100)
                  Scale: (307.584 - 41.472) / 100 = 2.66112 per unit
-                 min=20 -> y = 307.584 - 20*2.66112 = 254.3616
-                 q1=40 -> y = 307.584 - 40*2.66112 = 201.1392
-                 q2=55 -> y = 307.584 - 55*2.66112 = 161.2224
-                 q3=70 -> y = 307.584 - 70*2.66112 = 121.3056
-                 max=90 -> y = 307.584 - 90*2.66112 = 67.6832
+                 min=20 -> y = 307.584 - 20*2.66112 = 254.362
+                 q1=40 -> y = 307.584 - 40*2.66112 = 201.139
+                 q2=55 -> y = 307.584 - 55*2.66112 = 161.222
+                 q3=70 -> y = 307.584 - 70*2.66112 = 121.306
+                 max=90 -> y = 307.584 - 90*2.66112 = 67.683
                  Box center x = 117.12, box half-width = 17.856
             -->
             <g id="plotly-box-1">
@@ -140,10 +173,22 @@
                 M 108.192 67.683 L 126.048 67.683
               " style="fill: rgba(173,216,230,0.5); stroke: #1f77b4; stroke-width: 1.5" />
             </g>
+            <!-- Outliers for Box 1: lower=[5,10], upper=[95,98]
+                 value=5  -> y = 307.584 - 5*2.66112 = 294.278
+                 value=10 -> y = 307.584 - 10*2.66112 = 280.973
+                 value=95 -> y = 307.584 - 95*2.66112 = 54.778
+                 value=98 -> y = 307.584 - 98*2.66112 = 46.795
+            -->
+            <g id="plotly-outliers-1">
+              <circle cx="117.12" cy="294.278" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+              <circle cx="117.12" cy="280.973" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+              <circle cx="117.12" cy="54.778" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+              <circle cx="117.12" cy="46.795" r="3" style="fill: #1f77b4; fill-opacity: 0.5; stroke: #1f77b4; stroke-opacity: 0.5" />
+            </g>
 
             <!-- Box 2 (Group B): single path for entire box
                  Data: min=30, q1=50, q2=65, q3=80, max=95
-                 min=30 -> y = 307.584 - 30*2.66112 = 227.7504
+                 min=30 -> y = 307.584 - 30*2.66112 = 227.750
                  q1=50 -> y = 307.584 - 50*2.66112 = 174.528
                  q2=65 -> y = 307.584 - 65*2.66112 = 134.611
                  q3=80 -> y = 307.584 - 80*2.66112 = 94.694
@@ -159,6 +204,20 @@
                 M 227.232 227.750 L 245.088 227.750
                 M 227.232 54.777 L 245.088 54.777
               " style="fill: rgba(144,238,144,0.5); stroke: #2ca02c; stroke-width: 1.5" />
+            </g>
+            <!-- Outliers for Box 2: lower=[15,20], upper=[100,108,115]
+                 value=15  -> y = 307.584 - 15*2.66112 = 267.667
+                 value=20  -> y = 307.584 - 20*2.66112 = 254.362
+                 value=100 -> y = 307.584 - 100*2.66112 = 41.472
+                 value=108 -> y = 307.584 - 108*2.66112 = 20.184 (approx, below chart)
+                 value=115 -> y = 307.584 - 115*2.66112 = 1.561 (approx, below chart)
+            -->
+            <g id="plotly-outliers-2">
+              <circle cx="236.16" cy="267.667" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="236.16" cy="254.362" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="236.16" cy="41.472" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="236.16" cy="20.184" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
+              <circle cx="236.16" cy="1.561" r="3" style="fill: #2ca02c; fill-opacity: 0.5; stroke: #2ca02c; stroke-opacity: 0.5" />
             </g>
 
             <!-- Box 3 (Group C): single path for entire box
@@ -179,6 +238,20 @@
                 M 346.272 280.973 L 364.128 280.973
                 M 346.272 41.472 L 364.128 41.472
               " style="fill: rgba(210,180,140,0.5); stroke: #d62728; stroke-width: 1.5" />
+            </g>
+            <!-- Outliers for Box 3: lower=[-10,-5,0], upper=[110,120]
+                 value=-10 -> y = 307.584 - (-10)*2.66112 = 334.195
+                 value=-5  -> y = 307.584 - (-5)*2.66112 = 320.890
+                 value=0   -> y = 307.584 - 0*2.66112 = 307.584
+                 value=110 -> y = 307.584 - 110*2.66112 = 14.861
+                 value=120 -> y = 307.584 - 120*2.66112 = -12.750 (below chart)
+            -->
+            <g id="plotly-outliers-3">
+              <circle cx="355.2" cy="334.195" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+              <circle cx="355.2" cy="320.890" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+              <circle cx="355.2" cy="307.584" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+              <circle cx="355.2" cy="14.861" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
+              <circle cx="355.2" cy="-12.750" r="3" style="fill: #d62728; fill-opacity: 0.5; stroke: #d62728; stroke-opacity: 0.5" />
             </g>
 
             <!-- Axes -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maidr",
-  "version": "3.50.0",
+  "version": "3.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maidr",
-      "version": "3.50.0",
+      "version": "3.51.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -337,34 +337,63 @@ export class BoxTrace extends AbstractTrace {
         return clone;
       });
 
-      const min = this.cloneElementOrEmpty(original.min);
-      const max = this.cloneElementOrEmpty(original.max);
-      const q2 = this.cloneElementOrEmpty(original.q2);
+      let sections: (SVGElement[] | SVGElement)[];
 
-      // Only create line elements if iq selector exists and element was found
-      // If iq is empty/missing, create empty line elements instead
-      // Check if IQR direction should be reversed (for Base R vertical boxplots)
-      const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
-      const [q1, q3] = original.iq
-        ? (isVertical
-            ? isIqrReversed
-              ? [
-                  Svg.createLineElement(original.iq, 'top'), // Q1 (25%) = top edge (reversed)
-                  Svg.createLineElement(original.iq, 'bottom'), // Q3 (75%) = bottom edge (reversed)
-                ]
-              : [
-                  Svg.createLineElement(original.iq, 'bottom'), // Q1 (25%) = bottom edge (default)
-                  Svg.createLineElement(original.iq, 'top'), // Q3 (75%) = top edge (default)
-                ]
-            : [
-                Svg.createLineElement(original.iq, 'left'), // Q1 (25%) = left boundary
-                Svg.createLineElement(original.iq, 'right'), // Q3 (75%) = right boundary
-              ])
-        : [
-            Svg.createEmptyElement('line'), // Empty line element for Q1
-            Svg.createEmptyElement('line'), // Empty line element for Q3
+      if (this.isSinglePathBox(original)) {
+        // Plotly-style single-path box: create data-driven overlay elements
+        const referenceElement = original.iq ?? original.min ?? original.max ?? original.q2;
+        if (referenceElement) {
+          // Use original (unreversed) data to match selector order
+          const point = (this.layer.data as BoxPoint[])[boxIdx];
+          sections = this.createDataDrivenOverlays(
+            referenceElement,
+            point,
+            isVertical,
+            lowerOutliers,
+            upperOutliers,
+          );
+        } else {
+          sections = [
+            lowerOutliers,
+            Svg.createEmptyElement('line'),
+            Svg.createEmptyElement('line'),
+            Svg.createEmptyElement('line'),
+            Svg.createEmptyElement('line'),
+            Svg.createEmptyElement('line'),
+            upperOutliers,
           ];
-      const sections = [lowerOutliers, min, q1, q2, q3, max, upperOutliers];
+        }
+      } else {
+        // Standard multi-element box (e.g., matplotlib): clone individual elements
+        const min = this.cloneElementOrEmpty(original.min);
+        const max = this.cloneElementOrEmpty(original.max);
+        const q2 = this.cloneElementOrEmpty(original.q2);
+
+        // Only create line elements if iq selector exists and element was found
+        // If iq is empty/missing, create empty line elements instead
+        // Check if IQR direction should be reversed (for Base R vertical boxplots)
+        const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
+        const [q1, q3] = original.iq
+          ? (isVertical
+              ? isIqrReversed
+                ? [
+                    Svg.createLineElement(original.iq, 'top'), // Q1 (25%) = top edge (reversed)
+                    Svg.createLineElement(original.iq, 'bottom'), // Q3 (75%) = bottom edge (reversed)
+                  ]
+                : [
+                    Svg.createLineElement(original.iq, 'bottom'), // Q1 (25%) = bottom edge (default)
+                    Svg.createLineElement(original.iq, 'top'), // Q3 (75%) = top edge (default)
+                  ]
+              : [
+                  Svg.createLineElement(original.iq, 'left'), // Q1 (25%) = left boundary
+                  Svg.createLineElement(original.iq, 'right'), // Q3 (75%) = right boundary
+                ])
+          : [
+              Svg.createEmptyElement('line'), // Empty line element for Q1
+              Svg.createEmptyElement('line'), // Empty line element for Q3
+            ];
+        sections = [lowerOutliers, min, q1, q2, q3, max, upperOutliers];
+      }
 
       if (isVertical) {
         sections.forEach((section, sectionIdx) => {
@@ -391,6 +420,100 @@ export class BoxTrace extends AbstractTrace {
     clone.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
     original.insertAdjacentElement(Constant.AFTER_END, clone);
     return clone;
+  }
+
+  /**
+   * Detects whether all non-outlier selectors resolve to the same SVG element.
+   * This occurs with Plotly box plots where the entire box is rendered as a single <path>.
+   * @param original - The collected original SVG elements for a box
+   * @param original.min - The min whisker SVG element or null
+   * @param original.max - The max whisker SVG element or null
+   * @param original.iq - The interquartile range SVG element or null
+   * @param original.q2 - The median SVG element or null
+   * @returns True if this is a single-path box plot (Plotly-style)
+   */
+  private isSinglePathBox(original: {
+    min: SVGElement | null;
+    max: SVGElement | null;
+    iq: SVGElement | null;
+    q2: SVGElement | null;
+  }): boolean {
+    const elements = [original.min, original.max, original.iq, original.q2].filter(
+      (el): el is SVGElement => el !== null,
+    );
+    if (elements.length <= 1) {
+      return false;
+    }
+    return elements.every(el => el === elements[0]);
+  }
+
+  /**
+   * Creates synthetic SVG line overlays positioned using data values for single-path box plots.
+   * Maps data coordinates to SVG coordinates using the reference element's bounding box.
+   * @param referenceElement - The single path element encompassing the entire box
+   * @param point - The box plot data point with statistical values
+   * @param isVertical - Whether this is a vertical box plot
+   * @param lowerOutliers - Pre-cloned lower outlier elements
+   * @param upperOutliers - Pre-cloned upper outlier elements
+   * @returns Array of sections [lowerOutliers, min, q1, q2, q3, max, upperOutliers]
+   */
+  private createDataDrivenOverlays(
+    referenceElement: SVGElement,
+    point: BoxPoint,
+    isVertical: boolean,
+    lowerOutliers: SVGElement[],
+    upperOutliers: SVGElement[],
+  ): (SVGElement[] | SVGElement)[] {
+    const svg = referenceElement as SVGGraphicsElement;
+    const bbox = svg.getBBox();
+
+    const dataMin = point.min;
+    const dataMax = point.max;
+    const dataRange = dataMax - dataMin;
+
+    if (dataRange === 0) {
+      return [
+        lowerOutliers,
+        Svg.createEmptyElement('line'),
+        Svg.createEmptyElement('line'),
+        Svg.createEmptyElement('line'),
+        Svg.createEmptyElement('line'),
+        Svg.createEmptyElement('line'),
+        upperOutliers,
+      ];
+    }
+
+    const createLineAtValue = (value: number): SVGElement => {
+      if (isVertical) {
+        const y = bbox.y + ((dataMax - value) / dataRange) * bbox.height;
+        return Svg.createPositionedLineElement(
+          bbox.x,
+          y,
+          bbox.x + bbox.width,
+          y,
+          referenceElement,
+        );
+      } else {
+        const x = bbox.x + ((value - dataMin) / dataRange) * bbox.width;
+        return Svg.createPositionedLineElement(
+          x,
+          bbox.y,
+          x,
+          bbox.y + bbox.height,
+          referenceElement,
+        );
+      }
+    };
+
+    return [
+      lowerOutliers,
+      createLineAtValue(point.min),
+      createLineAtValue(point.q1),
+      createLineAtValue(point.q2),
+      createLineAtValue(point.q3),
+      createLineAtValue(point.max),
+      upperOutliers,
+    ];
   }
 
   /**

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -171,23 +171,12 @@ export abstract class Svg {
         break;
     }
 
-    const style = window.getComputedStyle(box);
-    const line = document.createElementNS(this.SVG_NAMESPACE, Constant.LINE) as SVGElement;
-    line.setAttribute(Constant.X1, String(x1));
-    line.setAttribute(Constant.Y1, String(y1));
-    line.setAttribute(Constant.X2, String(x2));
-    line.setAttribute(Constant.Y2, String(y2));
-    line.setAttribute(Constant.STROKE, style.stroke);
-    line.setAttribute(Constant.STROKE_WIDTH, style.strokeWidth || '2');
-    line.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
-
-    box.insertAdjacentElement(Constant.AFTER_END, line);
-    return line;
+    return this.createPositionedLineElement(x1, y1, x2, y2, box);
   }
 
   /**
    * Creates a hidden line element at specified coordinates, styled to match a reference element.
-   * Used for data-driven overlay elements in single-path box plots (e.g., Plotly).
+   * Used by createLineElement for bounding box edges and by BoxTrace for data-driven overlays.
    * @param x1 - Start x-coordinate
    * @param y1 - Start y-coordinate
    * @param x2 - End x-coordinate

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -186,6 +186,37 @@ export abstract class Svg {
   }
 
   /**
+   * Creates a hidden line element at specified coordinates, styled to match a reference element.
+   * Used for data-driven overlay elements in single-path box plots (e.g., Plotly).
+   * @param x1 - Start x-coordinate
+   * @param y1 - Start y-coordinate
+   * @param x2 - End x-coordinate
+   * @param y2 - End y-coordinate
+   * @param referenceElement - Element to inherit stroke styling from
+   * @returns The newly created line element
+   */
+  public static createPositionedLineElement(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    referenceElement: SVGElement,
+  ): SVGElement {
+    const style = window.getComputedStyle(referenceElement);
+    const line = document.createElementNS(this.SVG_NAMESPACE, Constant.LINE) as SVGElement;
+    line.setAttribute(Constant.X1, String(x1));
+    line.setAttribute(Constant.Y1, String(y1));
+    line.setAttribute(Constant.X2, String(x2));
+    line.setAttribute(Constant.Y2, String(y2));
+    line.setAttribute(Constant.STROKE, style.stroke || '#000000');
+    line.setAttribute(Constant.STROKE_WIDTH, style.strokeWidth || '2');
+    line.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
+
+    referenceElement.insertAdjacentElement(Constant.AFTER_END, line);
+    return line;
+  }
+
+  /**
    * Minimum opacity value for fill to be considered visible.
    */
   private static readonly MIN_VISIBLE_FILL_OPACITY = 0.01;


### PR DESCRIPTION
Plotly renders each box plot as a single <path> element containing
whiskers, IQ box, and median line, whereas MAIDR expects separate SVG
elements for each statistical component. This caused within-box stat
navigation and per-stat visual highlighting to fail for Plotly box plots.

Add detection for single-path box plots (where all BoxSelector fields
resolve to the same DOM element) and create synthetic SVG line overlays
at data-driven positions using bounding box coordinate mapping. The
existing multi-element code path (matplotlib, etc.) is preserved and
only activates when 2+ non-null selectors resolve to different elements.

Changes:
- Add isSinglePathBox() detection method to BoxTrace
- Add createDataDrivenOverlays() for data-to-SVG coordinate mapping
- Add Svg.createPositionedLineElement() utility for positioned overlays
- Add Plotly-style vertical box plot example

https://claude.ai/code/session_012wiRFDsjMCepsrpfVaPJza