### PR TITLE
fix: address scatter plot navigation

### DIFF
--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -437,31 +437,27 @@ export class ScatterTrace extends AbstractTrace {
 
     if (this.mode === NavMode.COL) {
       switch (target) {
-        case 'FORWARD': {
-          const forwardResult = this.col < this.xPoints.length - 1;
-          return forwardResult;
-        }
-        case 'BACKWARD': {
-          const backwardResult = this.col > 0;
-          return backwardResult;
-        }
+        case 'FORWARD':
+          return this.col < this.xPoints.length - 1;
+        case 'BACKWARD':
+          return this.col > 0;
         case 'UPWARD':
         case 'DOWNWARD':
           return true;
+        default:
+          return false;
       }
     } else {
       switch (target) {
-        case 'UPWARD': {
-          const upwardResult = this.row < this.yPoints.length - 1;
-          return upwardResult;
-        }
-        case 'DOWNWARD': {
-          const downwardResult = this.row > 0;
-          return downwardResult;
-        }
+        case 'UPWARD':
+          return this.row < this.yPoints.length - 1;
+        case 'DOWNWARD':
+          return this.row > 0;
         case 'FORWARD':
         case 'BACKWARD':
           return true;
+        default:
+          return false;
       }
     }
   }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -23,7 +23,7 @@ interface ScatterYPoint {
   y: number;
 }
 enum NavMode {
-  COL = 'column',
+  COL = 'col',
   ROW = 'row',
 }
 
@@ -122,7 +122,7 @@ export class ScatterTrace extends AbstractTrace {
    * @returns SVG elements for X-based or Y-based highlighting depending on mode
    */
   protected get highlightValues(): SVGElement[][] | null {
-    return this.movable.mode === 'col'
+    return this.mode === NavMode.COL
       ? this.highlightXValues
       : this.highlightYValues;
   }
@@ -184,7 +184,7 @@ export class ScatterTrace extends AbstractTrace {
   }
 
   protected get audio(): AudioState {
-    if (this.movable.mode === 'col') {
+    if (this.mode === NavMode.COL) {
       const current = this.xPoints[this.col];
       return {
         freq: {
@@ -218,7 +218,7 @@ export class ScatterTrace extends AbstractTrace {
   }
 
   protected get text(): TextState {
-    if (this.movable.mode === 'col') {
+    if (this.mode === NavMode.COL) {
       const current = this.xPoints[this.col];
       return {
         main: { label: this.xAxis, value: current.x },
@@ -245,7 +245,7 @@ export class ScatterTrace extends AbstractTrace {
       return this.outOfBoundsState as HighlightState;
     }
 
-    const elements = this.movable.mode === 'col'
+    const elements = this.mode === NavMode.COL
       ? this.col < this.highlightValues.length ? this.highlightValues![this.col] : null
       : this.row < this.highlightValues.length ? this.highlightValues![this.row] : null;
     if (!elements) {
@@ -271,7 +271,6 @@ export class ScatterTrace extends AbstractTrace {
     this.row = 0;
     this.col = 0;
     this.mode = NavMode.COL;
-    this.movable.mode = 'col';
   }
 
   /**
@@ -293,7 +292,6 @@ export class ScatterTrace extends AbstractTrace {
       }
 
       this.mode = NavMode.ROW;
-      this.movable.mode = 'row';
     } else {
       // Switch from ROW to COL mode
       const currentYPoint = this.yPoints[this.row];
@@ -309,7 +307,6 @@ export class ScatterTrace extends AbstractTrace {
       }
 
       this.mode = NavMode.COL;
-      this.movable.mode = 'col';
       this.row = 0; // Set to 0 for COL mode since values[0] = xValues
     }
   }
@@ -601,7 +598,6 @@ export class ScatterTrace extends AbstractTrace {
   public moveToPoint(x: number, y: number): void {
     // set to vertical mode
     this.mode = NavMode.COL;
-    this.movable.mode = 'col';
 
     const nearest = this.findNearestPoint(x, y);
     if (nearest) {

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -271,6 +271,7 @@ export class ScatterTrace extends AbstractTrace {
     this.row = 0;
     this.col = 0;
     this.mode = NavMode.COL;
+    this.movable.mode = 'col';
   }
 
   /**
@@ -292,6 +293,7 @@ export class ScatterTrace extends AbstractTrace {
       }
 
       this.mode = NavMode.ROW;
+      this.movable.mode = 'row';
     } else {
       // Switch from ROW to COL mode
       const currentYPoint = this.yPoints[this.row];
@@ -307,6 +309,7 @@ export class ScatterTrace extends AbstractTrace {
       }
 
       this.mode = NavMode.COL;
+      this.movable.mode = 'col';
       this.row = 0; // Set to 0 for COL mode since values[0] = xValues
     }
   }
@@ -598,6 +601,7 @@ export class ScatterTrace extends AbstractTrace {
   public moveToPoint(x: number, y: number): void {
     // set to vertical mode
     this.mode = NavMode.COL;
+    this.movable.mode = 'col';
 
     const nearest = this.findNearestPoint(x, y);
     if (nearest) {


### PR DESCRIPTION
# Pull Request

## Description

- Fixed scatter plot navigation mode desync introduced by the refactoring commit (6c6ef67 - "Refactor and cleanup #480") which extracted navigation logic into MovablePlane
- The refactor left ScatterTrace with its own local mode property (NavMode.COL/NavMode.ROW) while also creating a separate mode property on the MovablePlane delegate — these two were never synchronized
- Navigation logic (moveOnce, isMovable) used this.mode (ScatterTrace), but state getters (audio, text, highlight, highlightValues) used this.movable.mode (MovablePlane), causing wrong audio/text/highlight output after toggling between column and row navigation modes
- Uses this.mode as the single source of truth — all state getters (audio, text, highlight, highlightValues) now reference this.mode instead of this.movable.mode, eliminating the dual-state desync entirely

## Changes Made

Added this.movable.mode sync in all code paths that update this.mode:
- toggleNavigation() — COL→ROW and ROW→COL transitions
- handleInitialEntry() — initial scatter plot setup
- moveToPoint() — mouse hover navigation

## Checklist


- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

