### PR TITLE
fix: address violin plot horizonatal orientation bug

### DIFF
--- a/src/maidr-component.tsx
+++ b/src/maidr-component.tsx
@@ -1,6 +1,7 @@
 import type { AppStore } from '@state/store';
 import type { Maidr as MaidrData } from '@type/grammar';
 import type { JSX, ReactNode } from 'react';
+import { Orientation } from '@type/grammar';
 import { useMemo, useRef } from 'react';
 import { useMaidrController } from './state/hook/useMaidrController';
 import { createMaidrStore } from './state/store';
@@ -43,6 +44,23 @@ export interface MaidrProps {
  * Once the Controller is created on focus-in, {@link DisplayService} overwrites
  * these attributes with the authoritative values.
  */
+/**
+ * Build a human-readable plot type string with optional orientation prefix.
+ * Returns just the type when orientation is absent/empty (no extra whitespace).
+ */
+function formatPlotType(plotType: string, orientation?: string): string {
+  if (!orientation) {
+    return plotType;
+  }
+  if (orientation === Orientation.HORIZONTAL || orientation === 'horz') {
+    return `horizontal ${plotType}`;
+  }
+  if (orientation === Orientation.VERTICAL || orientation === 'vert') {
+    return `vertical ${plotType}`;
+  }
+  return plotType;
+}
+
 function getInitialInstruction(data: MaidrData): string {
   const subplots = data.subplots;
   const subplotCount = subplots.flat().length;
@@ -54,13 +72,15 @@ function getInitialInstruction(data: MaidrData): string {
   // Single subplot — describe the first layer's trace type.
   const firstSubplot = subplots[0]?.[0];
   const layerCount = firstSubplot?.layers.length ?? 0;
-  const traceType = firstSubplot?.layers[0]?.type ?? 'chart';
+  const firstLayer = firstSubplot?.layers[0];
+  const traceType = firstLayer?.type ?? 'chart';
+  const displayType = formatPlotType(traceType, firstLayer?.orientation);
 
   if (layerCount > 1) {
-    return `This is a maidr plot containing ${layerCount} layers, and this is layer 1 of ${layerCount}: ${traceType} plot. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
+    return `This is a maidr plot containing ${layerCount} layers, and this is layer 1 of ${layerCount}: ${displayType} plot. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
   }
 
-  return `This is a maidr plot of type: ${traceType}. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
+  return `This is a maidr plot of type: ${displayType}. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
 }
 
 export function Maidr({ data, children }: MaidrProps): JSX.Element {

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -333,6 +333,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
       text: this.text,
       autoplay: this.autoplay,
       highlight: this.highlight,
+      orientation: this.layer.orientation,
     };
   }
 
@@ -430,7 +431,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     return {};
   }
 
-  private get autoplay(): AutoplayState {
+  protected get autoplay(): AutoplayState {
     return {
       UPWARD: this.dimension.rows,
       DOWNWARD: this.dimension.rows,

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -4,9 +4,27 @@ import type { PlotState } from '@type/state';
 import type { Figure, Subplot, Trace } from './plot';
 import { NavigationService } from '@service/navigation';
 import { Scope } from '@type/event';
+import { Orientation } from '@type/grammar';
 import { Constant } from '@util/constant';
 import { Stack } from '@util/stack';
 import hotkeys from 'hotkeys-js';
+
+/**
+ * Build a human-readable plot type string with optional orientation prefix.
+ * Returns just the type when orientation is absent/empty (no extra whitespace).
+ */
+function formatPlotType(plotType: string, orientation?: Orientation | string): string {
+  if (!orientation) {
+    return plotType;
+  }
+  if (orientation === Orientation.HORIZONTAL || orientation === 'horz') {
+    return `horizontal ${plotType}`;
+  }
+  if (orientation === Orientation.VERTICAL || orientation === 'vert') {
+    return `vertical ${plotType}`;
+  }
+  return plotType;
+}
 
 type Plot = Figure | Subplot | Trace;
 
@@ -230,11 +248,14 @@ export class Context implements Disposable {
         return `This is a maidr figure containing ${state.size} subplots. ${clickPrompt}
         Use arrow keys to navigate subplots and press 'ENTER'.`;
 
-      case 'subplot':
+      case 'subplot': {
+        const subplotTraceOrientation = !state.trace.empty ? state.trace.orientation : undefined;
+        const subplotPlotType = formatPlotType(state.trace.traceType, subplotTraceOrientation);
         return `This is a maidr plot containing ${state.size} layers, and
-        this is layer 1 of ${state.size}: ${state.trace.traceType} plot. ${clickPrompt}
+        this is layer 1 of ${state.size}: ${subplotPlotType} plot. ${clickPrompt}
         Use Arrows to navigate data points. Toggle B for Braille, T for Text,
         S for Sonification, and R for Review mode.`;
+      }
 
       case 'trace': {
         // Handle edge case: if plotType is 'multiline' but only 1 group, treat as single line
@@ -249,7 +270,9 @@ export class Context implements Disposable {
             ? ` with ${state.groupCount} groups`
             : '';
 
-        return `This is a maidr plot of type: ${effectivePlotType}${groupCountText}. ${clickPrompt} Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
+        const displayType = formatPlotType(effectivePlotType, state.orientation);
+
+        return `This is a maidr plot of type: ${displayType}${groupCountText}. ${clickPrompt} Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
       }
     }
   }

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -550,25 +550,8 @@ export interface Trace extends Movable, Observable<TraceState>, Disposable {
    * - For ViolinKdeTrace: Coordinates map to (violin index, y-value within KDE curve)
    * - For ViolinBoxTrace: Coordinates map to (section index, violin index) for vertical
    *   orientation, or (violin index, section index) for horizontal orientation
-   * - Layer switching between violin layers preserves both X (violin) and Y (section/value) positions
    */
   moveToPoint: (x: number, y: number) => void;
-
-  /**
-   * Handle switching from another trace.
-   * Called by Context when switching layers. Traces can implement this
-   * to handle special layer switching behavior (e.g., preserving Y values).
-   *
-   * IMPORTANT CONTRACT:
-   * - If this method returns true, it MUST have modified the trace position appropriately.
-   * - If this method returns false, it MUST NOT modify the trace position at all.
-   *   The Context will then apply default behavior (moveToXValue) after this returns.
-   *
-   * @param previousTrace - The trace we're switching from
-   * @returns true if this trace handled the switch (and modified position),
-   *          false to use default behavior (position must remain unchanged)
-   */
-  onSwitchFrom?: (previousTrace: Trace) => boolean;
 
   /**
    * Gets extrema targets for navigation.

--- a/src/model/violin.ts
+++ b/src/model/violin.ts
@@ -1,10 +1,9 @@
 import type { MaidrLayer, ViolinKdePoint } from '@type/grammar';
 import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
-import type { AudioState, BrailleState, TextState } from '@type/state';
+import type { AudioState, AutoplayState, BrailleState, TextState } from '@type/state';
 import type { Dimension } from './abstract';
-import type { Trace } from './plot';
-import { TraceType } from '@type/grammar';
+import { Orientation } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
@@ -21,11 +20,15 @@ const MIN_DENSITY_RANGE = 0.001;
  *
  * Data layout: points[violin][curvePosition] = ViolinKdePoint
  *   - Row index = which violin (categorical group)
- *   - Col index = position along the KDE curve (bottom to top)
+ *   - Col index = position along the KDE curve
  *
- * Navigation:
+ * Navigation (vertical):
  *   - Left/Right (FORWARD/BACKWARD) = switch between violins (change row)
  *   - Up/Down (UPWARD/DOWNWARD) = traverse along the curve (change col)
+ *
+ * Navigation (horizontal):
+ *   - Up/Down (UPWARD/DOWNWARD) = switch between violins (change row)
+ *   - Left/Right (FORWARD/BACKWARD) = traverse along the curve (change col)
  *
  * Audio:
  *   - Pitch: derived from density values of the reference violin (row 0)
@@ -39,6 +42,7 @@ export class ViolinKdeTrace extends AbstractTrace {
   protected readonly supportsExtrema = false;
   protected readonly movable: Movable;
 
+  private readonly orientation: Orientation;
   private readonly points: ViolinKdePoint[][];
   private readonly densityValues: number[][];
   private readonly yValues: number[][];
@@ -50,10 +54,26 @@ export class ViolinKdeTrace extends AbstractTrace {
   private readonly minDensity: number[];
   private readonly maxDensity: number[];
 
+  /**
+   * Precomputed safe min/max for the reference violin (row 0) used in audio pitch scaling.
+   * Cached to avoid recomputing Math.min/max over ~200-element arrays on every autoplay tick.
+   */
+  private readonly refSafeMin: number;
+  private readonly refSafeMax: number;
+  private readonly refHasPositive: boolean;
+
   constructor(layer: MaidrLayer) {
     super(layer);
 
-    this.points = layer.data as ViolinKdePoint[][];
+    this.orientation = layer.orientation ?? Orientation.VERTICAL;
+
+    // For horizontal orientation, reverse points to match visual order
+    // (same convention as ViolinBoxTrace)
+    if (this.orientation === Orientation.HORIZONTAL) {
+      this.points = [...(layer.data as ViolinKdePoint[][])].reverse();
+    } else {
+      this.points = layer.data as ViolinKdePoint[][];
+    }
 
     // Extract density and y values for each violin
     // Falls back to `width` when `density` is absent (legacy format support)
@@ -67,7 +87,24 @@ export class ViolinKdeTrace extends AbstractTrace {
     this.minDensity = this.densityValues.map(row => MathUtil.safeMin(row.filter(d => d > 0)));
     this.maxDensity = this.densityValues.map(row => MathUtil.safeMax(row));
 
+    // Cache reference violin (row 0) audio values once at construction
+    const refDensity = this.densityValues[0];
+    if (refDensity && refDensity.length > 0 && this.minDensity[0] > 0) {
+      this.refHasPositive = true;
+      const refMin = this.minDensity[0];
+      const refMax = this.maxDensity[0];
+      this.refSafeMin = refMin === refMax ? Math.max(0, refMin - MIN_DENSITY_RANGE) : refMin;
+      this.refSafeMax = refMin === refMax ? refMax + MIN_DENSITY_RANGE : refMax;
+    } else {
+      this.refHasPositive = false;
+      this.refSafeMin = 0;
+      this.refSafeMax = 1;
+    }
+
     this.highlightValues = this.mapToSvgElements(layer.selectors as string[]);
+    if (this.orientation === Orientation.HORIZONTAL) {
+      this.highlightValues?.reverse();
+    }
     this.highlightCenters = this.mapSvgElementsToCenters();
     this.movable = new MovableGrid<ViolinKdePoint>(this.points, { row: 0 });
   }
@@ -105,9 +142,23 @@ export class ViolinKdeTrace extends AbstractTrace {
       );
     }
 
-    // Swapped navigation for violin plots:
-    // FORWARD/BACKWARD check row bounds (switch between violins)
-    // UPWARD/DOWNWARD check col bounds (traverse along curve)
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+
+    if (isHorizontal) {
+      // Horizontal: UPWARD/DOWNWARD switch violins (row), FORWARD/BACKWARD traverse curve (col)
+      switch (target) {
+        case 'UPWARD':
+          return this.row < this.points.length - 1;
+        case 'DOWNWARD':
+          return this.row > 0;
+        case 'FORWARD':
+          return this.col < (this.points[this.row]?.length ?? 0) - 1;
+        case 'BACKWARD':
+          return this.col > 0;
+      }
+    }
+
+    // Vertical: FORWARD/BACKWARD switch violins (row), UPWARD/DOWNWARD traverse curve (col)
     switch (target) {
       case 'FORWARD':
         return this.row < this.points.length - 1;
@@ -138,10 +189,37 @@ export class ViolinKdeTrace extends AbstractTrace {
       return false;
     }
 
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+
+    if (isHorizontal) {
+      // Horizontal: UPWARD/DOWNWARD switch violins, FORWARD/BACKWARD traverse curve
+      switch (direction) {
+        case 'UPWARD':
+          this.row += 1;
+          this.col = 0;
+          this.notifyStateUpdate();
+          return true;
+        case 'DOWNWARD':
+          this.row -= 1;
+          this.col = 0;
+          this.notifyStateUpdate();
+          return true;
+        case 'FORWARD':
+          this.col += 1;
+          this.notifyStateUpdate();
+          return true;
+        case 'BACKWARD':
+          this.col -= 1;
+          this.notifyStateUpdate();
+          return true;
+      }
+    }
+
+    // Vertical: FORWARD/BACKWARD switch violins, UPWARD/DOWNWARD traverse curve
     switch (direction) {
       case 'FORWARD':
         this.row += 1;
-        this.col = 0; // Reset to bottom when switching violins
+        this.col = 0;
         this.notifyStateUpdate();
         return true;
 
@@ -163,55 +241,94 @@ export class ViolinKdeTrace extends AbstractTrace {
     }
   }
 
+  /**
+   * Override moveToExtreme for violin navigation.
+   * Orientation-aware: swaps violin-switch and curve-traverse directions.
+   */
+  public override moveToExtreme(direction: MovableDirection): boolean {
+    if (this.isInitialEntry) {
+      this.handleInitialEntry();
+      this.notifyStateUpdate();
+      return true;
+    }
+
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+
+    if (isHorizontal) {
+      // Horizontal: UPWARD/DOWNWARD switch violins, FORWARD/BACKWARD traverse curve
+      switch (direction) {
+        case 'UPWARD':
+          this.row = this.points.length - 1;
+          this.col = 0;
+          break;
+        case 'DOWNWARD':
+          this.row = 0;
+          this.col = 0;
+          break;
+        case 'FORWARD':
+          this.col = (this.points[this.row]?.length ?? 1) - 1;
+          break;
+        case 'BACKWARD':
+          this.col = 0;
+          break;
+      }
+    } else {
+      // Vertical: FORWARD/BACKWARD switch violins, UPWARD/DOWNWARD traverse curve
+      switch (direction) {
+        case 'FORWARD':
+          this.row = this.points.length - 1;
+          this.col = 0;
+          break;
+        case 'BACKWARD':
+          this.row = 0;
+          this.col = 0;
+          break;
+        case 'UPWARD':
+          this.col = (this.points[this.row]?.length ?? 1) - 1;
+          break;
+        case 'DOWNWARD':
+          this.col = 0;
+          break;
+      }
+    }
+
+    this.notifyStateUpdate();
+    return true;
+  }
+
   // ── Audio ───────────────────────────────────────────────────────────
 
   protected get audio(): AudioState {
-    // Use the first violin (row 0) for reference density => consistent pitch across violins
-    const referenceRow = 0;
-    const refDensity = this.densityValues[referenceRow];
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+    const colCount = this.points[this.row]?.length ?? 0;
+    const panning = isHorizontal
+      ? { x: this.col, y: this.row, rows: this.points.length, cols: colCount }
+      : { y: this.row, x: this.col, rows: this.points.length, cols: colCount };
 
-    if (!refDensity || refDensity.length === 0) {
-      // Fallback: empty audio
-      return {
-        freq: { min: 0, max: 1, raw: 0 },
-        panning: { y: this.row, x: this.col, rows: this.points.length, cols: this.points[this.row]?.length ?? 0 },
-      };
+    // Use precomputed reference violin values (cached in constructor)
+    if (!this.refHasPositive) {
+      return { freq: { min: 0, max: 1, raw: 0 }, panning };
     }
 
-    const positiveRef = refDensity.filter(d => d > 0);
-    if (positiveRef.length === 0) {
-      return {
-        freq: { min: 0, max: 1, raw: 0 },
-        panning: { y: this.row, x: this.col, rows: this.points.length, cols: this.points[this.row]?.length ?? 0 },
-      };
-    }
-
-    const refMin = Math.min(...positiveRef);
-    const refMax = Math.max(...refDensity);
-
-    // Safety: if min===max, widen range to avoid division by zero
-    const safeMin = refMin === refMax ? Math.max(0, refMin - MIN_DENSITY_RANGE) : refMin;
-    const safeMax = refMin === refMax ? refMax + MIN_DENSITY_RANGE : refMax;
-
-    // Clamp col to reference row bounds for pitch
+    // Pitch from reference violin (row 0) density — use cached safe min/max
+    const refDensity = this.densityValues[0];
     const safeCol = Math.min(this.col, refDensity.length - 1);
-    const getDensity = (i: number): number =>
-      refDensity[Math.max(0, Math.min(i, refDensity.length - 1))];
+    const clamp = (i: number): number => refDensity[Math.max(0, Math.min(i, refDensity.length - 1))];
 
-    const prevDensity = safeCol > 0 ? getDensity(safeCol - 1) : getDensity(safeCol);
-    const currDensity = getDensity(safeCol);
-    const nextDensity = safeCol < refDensity.length - 1 ? getDensity(safeCol + 1) : getDensity(safeCol);
+    const prevDensity = safeCol > 0 ? clamp(safeCol - 1) : clamp(safeCol);
+    const currDensity = clamp(safeCol);
+    const nextDensity = safeCol < refDensity.length - 1 ? clamp(safeCol + 1) : clamp(safeCol);
 
-    // Volume from current violin's density (varies per violin)
-    const currentRowDensity = this.densityValues[this.row];
+    // Volume from current violin's density — use cached min/max per row
     let volumeScale = 1.0;
+    const currentRowDensity = this.densityValues[this.row];
     if (currentRowDensity && currentRowDensity.length > 0) {
       const currentCol = Math.min(this.col, currentRowDensity.length - 1);
       const currentDensity = currentRowDensity[currentCol];
-      const currentMax = Math.max(...currentRowDensity);
+      const currentMax = this.maxDensity[this.row];
 
       if (currentMax > 0 && currentDensity > 0) {
-        const currentMin = Math.min(...currentRowDensity.filter(d => d > 0));
+        const currentMin = this.minDensity[this.row];
         const safeCurrentMax = currentMin === currentMax
           ? currentMax + MIN_DENSITY_RANGE
           : currentMax;
@@ -221,18 +338,41 @@ export class ViolinKdeTrace extends AbstractTrace {
 
     return {
       freq: {
-        min: safeMin,
-        max: safeMax,
+        min: this.refSafeMin,
+        max: this.refSafeMax,
         raw: [prevDensity, currDensity, nextDensity],
       },
-      panning: {
-        y: this.row,
-        x: this.col,
-        rows: this.points.length,
-        cols: this.points[this.row]?.length ?? 0,
-      },
+      panning,
       isContinuous: true,
       volumeScale,
+    };
+  }
+
+  // ── Autoplay ──────────────────────────────────────────────────────
+
+  /**
+   * Override autoplay state for orientation-aware violin navigation.
+   * Maps directions to the number of steps in each direction.
+   */
+  protected override get autoplay(): AutoplayState {
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+
+    if (isHorizontal) {
+      // Horizontal: UPWARD/DOWNWARD switch violins (rows), FORWARD/BACKWARD traverse curve (cols)
+      return {
+        UPWARD: this.dimension.rows,
+        DOWNWARD: this.dimension.rows,
+        FORWARD: this.dimension.cols,
+        BACKWARD: this.dimension.cols,
+      };
+    }
+
+    // Vertical: FORWARD/BACKWARD switch violins (rows), UPWARD/DOWNWARD traverse curve (cols)
+    return {
+      UPWARD: this.dimension.cols,
+      DOWNWARD: this.dimension.cols,
+      FORWARD: this.dimension.rows,
+      BACKWARD: this.dimension.rows,
     };
   }
 
@@ -241,23 +381,28 @@ export class ViolinKdeTrace extends AbstractTrace {
   protected get text(): TextState {
     const currentPoint = this.points[this.row][this.col];
     const roundTo4 = (num: number): number => Math.round(num * 10000) / 10000;
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
 
-    // X label: categorical label for the violin
-    let xDisplayValue: number | string;
+    // Categorical label for the violin (shared across all points in a row)
+    let categoricalValue: number | string;
     if (typeof currentPoint.x === 'string') {
-      xDisplayValue = currentPoint.x;
+      categoricalValue = currentPoint.x;
     } else {
-      // Fallback: try first point in row (all points in a row share same x label)
       const firstInRow = this.points[this.row][0];
-      xDisplayValue = typeof firstInRow?.x === 'string'
+      categoricalValue = typeof firstInRow?.x === 'string'
         ? firstInRow.x
         : `Violin ${this.row + 1}`;
     }
 
     const roundedY = roundTo4(Number(currentPoint.y));
+
+    // For horizontal: main = yAxis (categorical), cross = xAxis (continuous)
+    // For vertical:   main = xAxis (categorical), cross = yAxis (continuous)
     const textState: TextState = {
-      main: { label: this.xAxis, value: xDisplayValue },
-      cross: { label: this.yAxis, value: roundedY },
+      main: { label: isHorizontal ? this.yAxis : this.xAxis, value: categoricalValue },
+      cross: { label: isHorizontal ? this.xAxis : this.yAxis, value: roundedY },
+      mainAxis: isHorizontal ? 'y' : 'x',
+      crossAxis: isHorizontal ? 'x' : 'y',
     };
 
     // Volume (width) in fill field if available
@@ -344,6 +489,10 @@ export class ViolinKdeTrace extends AbstractTrace {
    * Moves to a specific violin (X) and closest Y position on the KDE curve.
    */
   public moveToXAndYValue(xValue: XValue, yValue: number): boolean {
+    if (this.isInitialEntry) {
+      this.isInitialEntry = false;
+    }
+
     if (typeof xValue !== 'number') {
       return false;
     }
@@ -378,44 +527,6 @@ export class ViolinKdeTrace extends AbstractTrace {
     this.updateVisualPointPosition();
     this.notifyStateUpdate();
     return true;
-  }
-
-  /**
-   * Handles layer switching from the violin box layer.
-   * Preserves both violin position (X) and Y value when switching.
-   */
-  public onSwitchFrom(previousTrace: Trace): boolean {
-    const prevState = previousTrace.state;
-    const prevType = prevState.empty ? null : prevState.traceType;
-
-    // Only handle switching from violin box layer
-    if (prevType !== TraceType.VIOLIN_BOX) {
-      return false;
-    }
-
-    const xValue = previousTrace.getCurrentXValue();
-
-    if (previousTrace.getCurrentYValue) {
-      const yValue = previousTrace.getCurrentYValue();
-      if (yValue !== null && xValue !== null) {
-        const handled = this.moveToXAndYValue(xValue, yValue);
-        if (handled) {
-          this.isInitialEntry = false;
-        }
-        return handled;
-      }
-    }
-
-    // Fallback: just set X position
-    if (xValue !== null) {
-      const success = this.moveToXValue(xValue);
-      if (success) {
-        this.isInitialEntry = false;
-      }
-      return success;
-    }
-
-    return false;
   }
 
   // ── SVG highlight ───────────────────────────────────────────────────

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -3,9 +3,8 @@ import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
 import type { AudioState, BrailleState, TextState } from '@type/state';
 import type { Dimension } from './abstract';
-import type { Trace } from './plot';
 import { BoxplotSection } from '@type/boxplotSection';
-import { Orientation, TraceType } from '@type/grammar';
+import { Orientation } from '@type/grammar';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
@@ -16,8 +15,9 @@ import { MovableGrid } from './movable';
  * Concrete trace for violin box (summary statistics) layers.
  *
  * This is the box-plot overlay that sits inside a violin plot, showing
- * configurable summary statistics (median, mean, extrema, outliers)
+ * configurable summary statistics (median, mean, extrema)
  * controlled by ViolinOptions from the backend.
+ * Outliers are excluded — violin plots do not produce outliers.
  *
  * Data layout depends on orientation:
  *   - Vertical: boxValues[section][violinIndex] — row=section, col=violin
@@ -83,23 +83,23 @@ export class ViolinBoxTrace extends AbstractTrace {
 
     this.movable = new MovableGrid<number[] | number>(this.boxValues, { row: 0 });
 
-    // Cache MIN section index
+    // Cache MIN section index (always 0 since outliers are excluded)
     const minIdx = this.sections.indexOf(BoxplotSection.MIN);
-    this.minSectionIndex = minIdx >= 0 ? minIdx : 1;
+    this.minSectionIndex = minIdx >= 0 ? minIdx : 0;
   }
 
   /**
    * Build sections and accessors based on ViolinOptions.
-   * Always includes: LOWER_OUTLIER, MIN, Q1, Q3, MAX, UPPER_OUTLIER.
-   * Conditionally adds: Q2 (median), MEAN based on options.
+   * Always includes: MIN, Q1, Q3.
+   * Conditionally adds: Q2 (median), MEAN, MAX based on options.
+   * Outliers are excluded — violin plots do not produce outliers.
    */
   private buildViolinSections(): {
     sections: string[];
     accessors: ((p: BoxPoint) => number | number[])[];
   } {
-    const sections: string[] = [BoxplotSection.LOWER_OUTLIER, BoxplotSection.MIN];
+    const sections: string[] = [BoxplotSection.MIN];
     const accessors: ((p: BoxPoint) => number | number[])[] = [
-      (p: BoxPoint) => p.lowerOutliers,
       (p: BoxPoint) => p.min,
     ];
 
@@ -128,9 +128,6 @@ export class ViolinBoxTrace extends AbstractTrace {
       sections.push(BoxplotSection.MAX);
       accessors.push((p: BoxPoint) => p.max);
     }
-
-    sections.push(BoxplotSection.UPPER_OUTLIER);
-    accessors.push((p: BoxPoint) => p.upperOutliers);
 
     return { sections, accessors };
   }
@@ -273,6 +270,8 @@ export class ViolinBoxTrace extends AbstractTrace {
       main: { label: mainLabel, value: point.fill },
       cross: { label: crossLabel, value: crossValue },
       section,
+      mainAxis: isHorizontal ? 'y' : 'x',
+      crossAxis: isHorizontal ? 'x' : 'y',
     };
   }
 
@@ -383,6 +382,10 @@ export class ViolinBoxTrace extends AbstractTrace {
    * Moves to a specific violin (X) and finds the closest section matching Y value.
    */
   public moveToXAndYValue(xValue: XValue, yValue: number): boolean {
+    if (this.isInitialEntry) {
+      this.isInitialEntry = false;
+    }
+
     if (typeof xValue !== 'number') {
       return false;
     }
@@ -465,43 +468,6 @@ export class ViolinBoxTrace extends AbstractTrace {
     return true;
   }
 
-  /**
-   * Handles layer switching from the violin KDE layer.
-   * Preserves both violin position (X) and Y value when switching.
-   */
-  public onSwitchFrom(previousTrace: Trace): boolean {
-    const prevState = previousTrace.state;
-    const prevType = prevState.empty ? null : prevState.traceType;
-
-    // Only handle switching from violin KDE layer
-    if (prevType !== TraceType.VIOLIN_KDE) {
-      return false;
-    }
-
-    const xValue = previousTrace.getCurrentXValue();
-
-    if (previousTrace.getCurrentYValue) {
-      const yValue = previousTrace.getCurrentYValue();
-      if (yValue !== null && xValue !== null) {
-        const handled = this.moveToXAndYValue(xValue, yValue);
-        if (handled) {
-          this.isInitialEntry = false;
-        }
-        return handled;
-      }
-    }
-
-    if (xValue !== null) {
-      const success = this.moveToXValue(xValue);
-      if (success) {
-        this.isInitialEntry = false;
-      }
-      return success;
-    }
-
-    return false;
-  }
-
   // ── SVG highlight ───────────────────────────────────────────────────
 
   private mapToSvgElements(
@@ -522,8 +488,6 @@ export class ViolinBoxTrace extends AbstractTrace {
 
     // Phase 1: Collect all original elements without cloning
     const originals: Array<{
-      lowerOutliers: SVGElement[];
-      upperOutliers: SVGElement[];
       min: SVGElement | null;
       max: SVGElement | null;
       iq: SVGElement | null;
@@ -532,12 +496,6 @@ export class ViolinBoxTrace extends AbstractTrace {
     }> = [];
 
     selectors.forEach((selector) => {
-      const lowerOutliersOriginals = selector.lowerOutliers?.flatMap(s =>
-        Svg.selectAllElements(s, false),
-      ) ?? [];
-      const upperOutliersOriginals = selector.upperOutliers?.flatMap(s =>
-        Svg.selectAllElements(s, false),
-      ) ?? [];
       const minOriginal = Svg.selectElement(selector.min, false);
       const maxOriginal = Svg.selectElement(selector.max, false);
       const iqOriginal = Svg.selectElement(selector.iq, false);
@@ -545,8 +503,6 @@ export class ViolinBoxTrace extends AbstractTrace {
       const meanOriginal = selector.mean ? Svg.selectElement(selector.mean, false) : null;
 
       originals.push({
-        lowerOutliers: lowerOutliersOriginals,
-        upperOutliers: upperOutliersOriginals,
         min: minOriginal,
         max: maxOriginal,
         iq: iqOriginal,
@@ -557,19 +513,6 @@ export class ViolinBoxTrace extends AbstractTrace {
 
     // Phase 2: Clone elements
     originals.forEach((original, boxIdx) => {
-      const lowerOutliers = original.lowerOutliers.map((el) => {
-        const clone = el.cloneNode(true) as SVGElement;
-        clone.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
-        el.insertAdjacentElement(Constant.AFTER_END, clone);
-        return clone;
-      });
-      const upperOutliers = original.upperOutliers.map((el) => {
-        const clone = el.cloneNode(true) as SVGElement;
-        clone.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
-        el.insertAdjacentElement(Constant.AFTER_END, clone);
-        return clone;
-      });
-
       const min = this.cloneElementOrEmpty(original.min);
       const max = this.cloneElementOrEmpty(original.max);
       const q2 = this.cloneElementOrEmpty(original.q2);
@@ -591,8 +534,8 @@ export class ViolinBoxTrace extends AbstractTrace {
             Svg.createEmptyElement('line'),
           ];
 
-      // Build sections array matching this.sections
-      const sectionElements: (SVGElement[] | SVGElement)[] = [lowerOutliers];
+      // Build sections array matching this.sections (no outlier sections)
+      const sectionElements: (SVGElement[] | SVGElement)[] = [];
 
       // MIN
       sectionElements.push(min);
@@ -617,9 +560,6 @@ export class ViolinBoxTrace extends AbstractTrace {
       if (this.violinOptions.showExtrema !== false) {
         sectionElements.push(max);
       }
-
-      // UPPER_OUTLIER
-      sectionElements.push(upperOutliers);
 
       if (isVertical) {
         sectionElements.forEach((section, sectionIdx) => {

--- a/src/service/autoplay.ts
+++ b/src/service/autoplay.ts
@@ -10,7 +10,7 @@ import { Emitter } from '@type/event';
 /** Default autoplay speed in milliseconds between movements. */
 const DEFAULT_SPEED = 250;
 /** Minimum speed (fastest playback) in milliseconds between movements. */
-const MIN_SPEED = 50;
+const MIN_SPEED = 10;
 /** Maximum speed (slowest playback) in milliseconds between movements. */
 const MAX_SPEED = 500;
 
@@ -153,7 +153,7 @@ export class AutoplayService implements Disposable {
    */
   public speedUp(): void {
     const newSpeed = this.userSpeed ?? this.autoplayRate;
-    if (newSpeed - this.interval > this.minSpeed) {
+    if (newSpeed - this.interval >= this.minSpeed) {
       this.userSpeed = newSpeed - this.interval;
       this.autoplayRate = this.userSpeed;
       this.restart();

--- a/src/service/navigation.ts
+++ b/src/service/navigation.ts
@@ -43,14 +43,20 @@ export class NavigationService implements Disposable {
       return newTrace;
     }
 
-    // Allow trace-specific switch handling (e.g., preserve Y)
-    let handled = false;
-    if (typeof newTrace.onSwitchFrom === 'function') {
-      handled = newTrace.onSwitchFrom(currentTrace);
+    // Attempt Y-preservation: if both traces support Y values, preserve both X and Y
+    let positioned = false;
+    if (
+      typeof currentTrace.getCurrentYValue === 'function'
+      && typeof newTrace.moveToXAndYValue === 'function'
+    ) {
+      const currentYValue = currentTrace.getCurrentYValue();
+      if (currentYValue !== null && currentXValue !== null) {
+        positioned = newTrace.moveToXAndYValue(currentXValue, currentYValue);
+      }
     }
 
-    // Default: preserve X value when changing layers (only if not handled)
-    if (!handled) {
+    // Default: preserve X value when changing layers
+    if (!positioned) {
       newTrace.moveToXValue(currentXValue);
     }
 

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -115,8 +115,6 @@ export interface ViolinOptions {
   showMean?: boolean;
   /** Show extrema (min/max) markers. Default: true */
   showExtrema?: boolean;
-  /** Show outlier points. Default: true */
-  showOutliers?: boolean;
 }
 
 /**

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -1,4 +1,4 @@
-import type { BoxPoint, CandlestickTrend, TraceType } from '@type/grammar';
+import type { BoxPoint, CandlestickTrend, Orientation, TraceType } from '@type/grammar';
 import type { MovableDirection } from './movable';
 
 /**
@@ -90,6 +90,10 @@ export type TraceState
        * Only present for multiline plots where plotType === 'multiline'.
        */
       groupCount?: number;
+      /**
+       * Plot orientation, if applicable (e.g. bar, box, violin).
+       */
+      orientation?: Orientation;
     };
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Horizontal violin KDE support (src/model/violin.ts)
- Added Orientation field and full horizontal navigation support
- Horizontal: Up/Down switches violins, Left/Right traverses curve (reversed from vertical)
- Orientation-aware isMovable(), moveOnce(), moveToExtreme()
- Audio panning swapped for horizontal; autoplay direction mapping overridden
- Text getter uses correct axis labels (mainAxis/crossAxis) per orientation
- Reversed points and highlight selectors for horizontal to match box layer ordering
- Cached reference violin audio values at construction (perf: avoids Math.min/max on ~200-element arrays per tick)
- Removed onSwitchFrom() — layer switching now handled generically via moveToXAndYValue()

Horizontal violin box cleanup (src/model/violinBox.ts)
- Added mainAxis/crossAxis to text getter for correct axis formatting
- Removed outlier sections (LOWER_OUTLIER/UPPER_OUTLIER) — violin plots don't produce outliers
- Removed onSwitchFrom() — same generic switching path
- Simplified selector mapping (no outlier elements)

Autoplay fix (src/model/abstract.ts, src/service/autoplay.ts)
- Changed autoplay getter from private to protected so ViolinKdeTrace can override it with orientation-aware direction mapping
- Added orientation to TraceState for instruction text

Layer switching (src/service/navigation.ts, src/model/plot.ts)
- Removed onSwitchFrom from Trace interface — Y-value preservation now works generically through getCurrentYValue()/moveToXAndYValue() which both violin traces
 implement

Orientation in instructions (src/model/context.ts, src/maidr-component.tsx)
- Instruction text now includes orientation: "This is a maidr plot of type: horizontal box."
- Added formatPlotType() helper — safely returns just the type name when orientation is absent (no extra spaces/artifacts)
- Applied to both initial instruction (pre-focus) and runtime instruction (post-focus)
- Added orientation?: Orientation to TraceState (src/type/state.ts)

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
