### PR TITLE
feat: support plotly plots

### DIFF
--- a/src/adapter/plotly.ts
+++ b/src/adapter/plotly.ts
@@ -1,0 +1,296 @@
+import type { Maidr } from '../type/grammar';
+
+/**
+ * Detects whether an SVG element lives inside a Plotly container.
+ *
+ * @param plot - The DOM element that carries the `maidr` attribute.
+ * @returns `true` when the element is (or is inside) a Plotly-rendered chart.
+ */
+export function isPlotlyPlot(plot: HTMLElement): boolean {
+  return (
+    plot.classList.contains('main-svg') ||
+    plot.closest('.plotly-graph-div') !== null
+  );
+}
+
+/**
+ * Normalize a Plotly-rendered SVG so that maidr's core logic can treat it
+ * the same as a matplotlib SVG.
+ *
+ * Responsibilities handled here (all Plotly-specific):
+ *
+ * 1. **Subplot background wrapping** – wrap bglayer `<rect>` elements in
+ *    `<g id="axes_…">` groups so maidr can highlight subplots.
+ * 2. **Stroke mirroring** – maidr clones elements as hidden backups and
+ *    applies stroke to clones; a MutationObserver mirrors those changes
+ *    back onto the visible originals.
+ * 3. **CSS layout fixes** – Plotly's SVG is `position:absolute` inside a
+ *    `position:relative` container; inject overrides so maidr's
+ *    `<article>/<figure>` wrapper doesn't collapse.
+ * 4. **React-container positioning** – push maidr's react-container below
+ *    the chart by observing when it appears and adding padding.
+ * 5. **Modebar accessibility** – remove Plotly's toolbar from the tab
+ *    order and accessibility tree.
+ * 6. **Click-to-focus** – forward clicks on Plotly's overlay SVGs to
+ *    maidr's focusable wrapper.
+ *
+ * @param svg   - The `<svg class="main-svg">` element.
+ * @param schema - The parsed MAIDR JSON schema.
+ */
+export function normalizePlotlySvg(
+  svg: SVGSVGElement,
+  schema: Maidr,
+): void {
+  wrapSubplotBackgrounds(svg, schema);
+  injectPlotlyStyles();
+  setupLayoutObserver(svg);
+  fixModebarTabOrder();
+  setupClickToFocus();
+}
+
+// ---------------------------------------------------------------------------
+// 1. Subplot background wrapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap Plotly bglayer rects in `<g>` elements for subplot highlighting.
+ *
+ * maidr detects multi-subplot figures via `g[id^="axes_"]` and highlights
+ * the selected subplot by applying stroke to the first rect/path child.
+ * We wrap the *original* Plotly rects (which have visible fill) so the
+ * stroke border appears on the filled background.
+ */
+function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
+  const bglayer = svg.querySelector('.bglayer');
+  if (!bglayer || bglayer.hasAttribute('data-maidr')) {
+    return;
+  }
+  bglayer.setAttribute('data-maidr', '1');
+
+  // Deduplicate rects by position and sort row-major.
+  const bgRects = Array.from(bglayer.querySelectorAll<SVGRectElement>(':scope > rect'));
+  const seen = new Set<string>();
+  const unique: SVGRectElement[] = [];
+  for (const rect of bgRects) {
+    const key = `${rect.getAttribute('x')},${rect.getAttribute('y')}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(rect);
+    }
+  }
+  unique.sort((a, b) => {
+    const ay = Number.parseFloat(a.getAttribute('y') ?? '0');
+    const by = Number.parseFloat(b.getAttribute('y') ?? '0');
+    if (Math.abs(ay - by) > 1) return ay - by;
+    return (
+      Number.parseFloat(a.getAttribute('x') ?? '0') -
+      Number.parseFloat(b.getAttribute('x') ?? '0')
+    );
+  });
+
+  // Extract selector IDs from schema (row-major order).
+  const selectorIds: string[] = [];
+  const subplots = schema.subplots ?? [];
+  for (const row of subplots) {
+    for (const cell of row) {
+      const sel = cell.selector;
+      if (sel) {
+        const m = sel.match(/id="([^"]+)"/);
+        if (m) selectorIds.push(m[1]);
+      }
+    }
+  }
+
+  // Wrap each unique rect in a <g> with the subplot ID.
+  const ns = 'http://www.w3.org/2000/svg';
+  const count = Math.min(unique.length, selectorIds.length);
+  for (let i = 0; i < count; i++) {
+    const rect = unique[i];
+    const g = document.createElementNS(ns, 'g');
+    g.setAttribute('id', selectorIds[i]);
+    rect.parentNode!.insertBefore(g, rect);
+    g.appendChild(rect);
+  }
+
+  // Mirror stroke changes from hidden clones to visible originals.
+  setupStrokeMirror(bglayer as SVGGElement);
+}
+
+/**
+ * maidr clones each `<g id="axes_…">` as a hidden backup and applies
+ * stroke to the clone.  This observer mirrors stroke/stroke-width
+ * changes from hidden clones back to the visible originals so the
+ * user sees the highlight.
+ */
+function setupStrokeMirror(bglayer: SVGGElement): void {
+  new MutationObserver((mutations) => {
+    for (const mut of mutations) {
+      if (mut.type !== 'attributes') continue;
+      const target = mut.target as SVGElement;
+      const hiddenGroup = target.closest(
+        'g[id^="axes_"][visibility="hidden"]',
+      );
+      if (!hiddenGroup) continue;
+
+      const visibleGroup = bglayer.querySelector(
+        `g[id="${hiddenGroup.id}"]:not([visibility])`,
+      );
+      if (!visibleGroup) continue;
+
+      const visibleRect = visibleGroup.querySelector('rect');
+      if (!visibleRect) continue;
+
+      const stroke = target.getAttribute('stroke');
+      if (stroke) {
+        visibleRect.setAttribute('stroke', stroke);
+        visibleRect.setAttribute(
+          'stroke-width',
+          target.getAttribute('stroke-width') ?? '4',
+        );
+      } else {
+        visibleRect.removeAttribute('stroke');
+        visibleRect.removeAttribute('stroke-width');
+      }
+    }
+  }).observe(bglayer, {
+    attributes: true,
+    attributeFilter: ['stroke', 'stroke-width'],
+    subtree: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 2. CSS layout fixes
+// ---------------------------------------------------------------------------
+
+/**
+ * Inject CSS overrides so maidr's `<article>/<figure>` wrapper doesn't
+ * collapse inside Plotly's absolutely-positioned SVG container.
+ */
+function injectPlotlyStyles(): void {
+  if (document.querySelector('style[data-maidr-plotly]')) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.setAttribute('data-maidr-plotly', '1');
+  style.textContent = `
+    .svg-container { overflow: visible !important; }
+    .svg-container article[id^="maidr-article"] {
+      position: relative !important;
+      width: 100% !important;
+    }
+    .svg-container article[id^="maidr-article"] > figure {
+      position: relative !important;
+      width: 100% !important;
+    }
+    .plotly-graph-div { overflow: visible !important; }
+    .svg-container:focus-within {
+      outline: 2px solid #4A90D9;
+      outline-offset: 2px;
+    }
+    figure[id^="maidr-figure"] > div[tabindex="0"]:focus {
+      outline: none !important;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+// ---------------------------------------------------------------------------
+// 3. React-container positioning
+// ---------------------------------------------------------------------------
+
+/**
+ * After maidr wraps the SVG, it remains `position:absolute` (Plotly
+ * default) so the react-container renders at y=0, hidden behind the
+ * chart.  Watch for the react-container to appear and push it below
+ * the chart with padding-top.
+ */
+function setupLayoutObserver(svg: SVGSVGElement): void {
+  function fix(): void {
+    const rc = document.querySelector<HTMLElement>(
+      'div[id^="react-container-"]',
+    );
+    if (rc && svg) {
+      const h =
+        svg.getAttribute('height') ??
+        String(svg.getBoundingClientRect().height);
+      if (h) {
+        rc.style.paddingTop = `${Number.parseFloat(h)}px`;
+        requestAnimationFrame(() => {
+          try {
+            window.dispatchEvent(new Event('resize'));
+          } catch {
+            // ignore
+          }
+        });
+      }
+    }
+  }
+
+  function observe(): void {
+    const article = document.querySelector(
+      'article[id^="maidr-article"]',
+    );
+    if (!article) {
+      requestAnimationFrame(observe);
+      return;
+    }
+    new MutationObserver(() => fix()).observe(article, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  // Defer until maidr has created its article wrapper.
+  requestAnimationFrame(observe);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Modebar accessibility
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove Plotly's modebar (toolbar) from the tab order and accessibility
+ * tree so Tab goes directly to maidr's focusable div.
+ */
+function fixModebarTabOrder(): void {
+  const modebar = document.querySelector('.modebar-container');
+  if (!modebar) return;
+
+  modebar.setAttribute('aria-hidden', 'true');
+  modebar.setAttribute('tabindex', '-1');
+
+  const focusable = modebar.querySelectorAll<HTMLElement>(
+    'a, button, input, [tabindex]',
+  );
+  for (const el of focusable) {
+    el.setAttribute('tabindex', '-1');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Click-to-focus delegation
+// ---------------------------------------------------------------------------
+
+/**
+ * Plotly renders overlay SVGs that capture mouse events.  After maidr
+ * wraps `svg.main-svg`, these overlays are siblings outside the wrapper.
+ * Forward clicks to maidr's focusable div.
+ */
+function setupClickToFocus(): void {
+  const container =
+    document.querySelector('.plotly-graph-div') ??
+    document.querySelector('.svg-container');
+  if (!container) return;
+
+  container.addEventListener(
+    'click',
+    () => {
+      const wrapper = document.querySelector<HTMLElement>(
+        'figure[id^="maidr-figure"] > div[tabindex="0"]',
+      );
+      if (wrapper) wrapper.focus();
+    },
+    true,
+  );
+}

--- a/src/adapter/plotly.ts
+++ b/src/adapter/plotly.ts
@@ -8,8 +8,8 @@ import type { Maidr } from '../type/grammar';
  */
 export function isPlotlyPlot(plot: HTMLElement): boolean {
   return (
-    plot.classList.contains('main-svg') ||
-    plot.closest('.plotly-graph-div') !== null
+    plot.classList.contains('main-svg')
+    || plot.closest('.plotly-graph-div') !== null
   );
 }
 
@@ -81,10 +81,11 @@ function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
   unique.sort((a, b) => {
     const ay = Number.parseFloat(a.getAttribute('y') ?? '0');
     const by = Number.parseFloat(b.getAttribute('y') ?? '0');
-    if (Math.abs(ay - by) > 1) return ay - by;
+    if (Math.abs(ay - by) > 1)
+      return ay - by;
     return (
-      Number.parseFloat(a.getAttribute('x') ?? '0') -
-      Number.parseFloat(b.getAttribute('x') ?? '0')
+      Number.parseFloat(a.getAttribute('x') ?? '0')
+      - Number.parseFloat(b.getAttribute('x') ?? '0')
     );
   });
 
@@ -96,7 +97,8 @@ function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
       const sel = cell.selector;
       if (sel) {
         const m = sel.match(/id="([^"]+)"/);
-        if (m) selectorIds.push(m[1]);
+        if (m)
+          selectorIds.push(m[1]);
       }
     }
   }
@@ -125,20 +127,24 @@ function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
 function setupStrokeMirror(bglayer: SVGGElement): void {
   new MutationObserver((mutations) => {
     for (const mut of mutations) {
-      if (mut.type !== 'attributes') continue;
+      if (mut.type !== 'attributes')
+        continue;
       const target = mut.target as SVGElement;
       const hiddenGroup = target.closest(
         'g[id^="axes_"][visibility="hidden"]',
       );
-      if (!hiddenGroup) continue;
+      if (!hiddenGroup)
+        continue;
 
       const visibleGroup = bglayer.querySelector(
         `g[id="${hiddenGroup.id}"]:not([visibility])`,
       );
-      if (!visibleGroup) continue;
+      if (!visibleGroup)
+        continue;
 
       const visibleRect = visibleGroup.querySelector('rect');
-      if (!visibleRect) continue;
+      if (!visibleRect)
+        continue;
 
       const stroke = target.getAttribute('stroke');
       if (stroke) {
@@ -211,9 +217,9 @@ function setupLayoutObserver(svg: SVGSVGElement): void {
       'div[id^="react-container-"]',
     );
     if (rc && svg) {
-      const h =
-        svg.getAttribute('height') ??
-        String(svg.getBoundingClientRect().height);
+      const h
+        = svg.getAttribute('height')
+          ?? String(svg.getBoundingClientRect().height);
       if (h) {
         rc.style.paddingTop = `${Number.parseFloat(h)}px`;
         requestAnimationFrame(() => {
@@ -255,7 +261,8 @@ function setupLayoutObserver(svg: SVGSVGElement): void {
  */
 function fixModebarTabOrder(): void {
   const modebar = document.querySelector('.modebar-container');
-  if (!modebar) return;
+  if (!modebar)
+    return;
 
   modebar.setAttribute('aria-hidden', 'true');
   modebar.setAttribute('tabindex', '-1');
@@ -278,10 +285,11 @@ function fixModebarTabOrder(): void {
  * Forward clicks to maidr's focusable div.
  */
 function setupClickToFocus(): void {
-  const container =
-    document.querySelector('.plotly-graph-div') ??
-    document.querySelector('.svg-container');
-  if (!container) return;
+  const container
+    = document.querySelector('.plotly-graph-div')
+      ?? document.querySelector('.svg-container');
+  if (!container)
+    return;
 
   container.addEventListener(
     'click',
@@ -289,7 +297,8 @@ function setupClickToFocus(): void {
       const wrapper = document.querySelector<HTMLElement>(
         'figure[id^="maidr-figure"] > div[tabindex="0"]',
       );
-      if (wrapper) wrapper.focus();
+      if (wrapper)
+        wrapper.focus();
     },
     true,
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 import type { Maidr } from './type/grammar';
 import { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
+import { isPlotlyPlot, normalizePlotlySvg } from './adapter/plotly';
 import { Maidr as MaidrComponent } from './maidr-component';
 import { DomEventType } from './type/event';
 import { Constant } from './util/constant';
@@ -27,6 +28,12 @@ function parseAndInit(
 ): void {
   try {
     const maidr = JSON.parse(json) as Maidr;
+
+    // Plotly SVGs need DOM normalization before maidr can process them.
+    if (isPlotlyPlot(plot)) {
+      normalizePlotlySvg(plot as unknown as SVGSVGElement, maidr);
+    }
+
     initMaidr(maidr, plot);
   } catch (error) {
     console.error(`Error parsing ${source} attribute:`, error);

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -125,13 +125,38 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
       return null;
     }
 
-    const svgElements = [Svg.selectAllElements(selector)];
+    const queried = Svg.selectAllElements(selector);
+    const svgElements = [queried];
+
     if (svgElements.length !== this.points.length) {
       return null;
     }
+
     for (let row = 0; row < this.points.length; row++) {
-      if (svgElements[row].length !== this.points[row].length) {
-        return null;
+      if (svgElements[row].length === this.points[row].length) {
+        continue; // exact match — nothing to do
+      }
+
+      // SVG renderers (e.g. Plotly) may omit zero-height bars from the DOM.
+      // When fewer SVG elements than data points exist, align them by
+      // assigning each non-zero data point the next queried element and
+      // inserting an invisible placeholder for zero-value points.
+      if (svgElements[row].length < this.points[row].length) {
+        const aligned: SVGElement[] = [];
+        let svgIdx = 0;
+        for (let col = 0; col < this.points[row].length; col++) {
+          const value = this.orientation === Orientation.VERTICAL
+            ? Number(this.points[row][col].y)
+            : Number(this.points[row][col].x);
+          if (value !== 0 && svgIdx < svgElements[row].length) {
+            aligned.push(svgElements[row][svgIdx++]);
+          } else {
+            aligned.push(Svg.createEmptyElement());
+          }
+        }
+        svgElements[row] = aligned;
+      } else {
+        return null; // more SVG elements than data points — unexpected
       }
     }
 

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -228,6 +228,8 @@ export class BoxTrace extends AbstractTrace {
       max: SVGElement | null;
       iq: SVGElement | null;
       q2: SVGElement | null;
+      q1Direct: SVGElement | null;
+      q3Direct: SVGElement | null;
     }> = [];
 
     selectors.forEach((selector) => {
@@ -243,6 +245,10 @@ export class BoxTrace extends AbstractTrace {
       const iqOriginal = Svg.selectElement(selector.iq, false);
       const q2Original = Svg.selectElement(selector.q2, false);
 
+      // Direct Q1/Q3 selectors bypass iq edge derivation (used by Plotly)
+      const q1DirectOriginal = selector.q1 ? Svg.selectElement(selector.q1, false) : null;
+      const q3DirectOriginal = selector.q3 ? Svg.selectElement(selector.q3, false) : null;
+
       originals.push({
         lowerOutliers: lowerOutliersOriginals,
         upperOutliers: upperOutliersOriginals,
@@ -250,6 +256,8 @@ export class BoxTrace extends AbstractTrace {
         max: maxOriginal,
         iq: iqOriginal,
         q2: q2Original,
+        q1Direct: q1DirectOriginal,
+        q3Direct: q3DirectOriginal,
       });
     });
 
@@ -272,27 +280,35 @@ export class BoxTrace extends AbstractTrace {
       const max = this.cloneElementOrEmpty(original.max);
       const q2 = this.cloneElementOrEmpty(original.q2);
 
-      // Check if IQR direction should be reversed (for Base R vertical boxplots)
-      const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
-      const [q1, q3] = original.iq
-        ? (isVertical
-            ? isIqrReversed
-              ? [
-                  Svg.createLineElement(original.iq, 'top'),
-                  Svg.createLineElement(original.iq, 'bottom'),
-                ]
+      // Use direct Q1/Q3 selectors if provided (Plotly: highlight entire box).
+      // Otherwise, derive Q1/Q3 line elements from iq edges (matplotlib/seaborn).
+      let q1: SVGElement;
+      let q3: SVGElement;
+      if (original.q1Direct && original.q3Direct) {
+        q1 = this.cloneElementOrEmpty(original.q1Direct);
+        q3 = this.cloneElementOrEmpty(original.q3Direct);
+      } else {
+        const isIqrReversed = this.layer.domMapping?.iqrDirection === 'reverse';
+        [q1, q3] = original.iq
+          ? (isVertical
+              ? isIqrReversed
+                ? [
+                    Svg.createLineElement(original.iq, 'top'),
+                    Svg.createLineElement(original.iq, 'bottom'),
+                  ]
+                : [
+                    Svg.createLineElement(original.iq, 'bottom'),
+                    Svg.createLineElement(original.iq, 'top'),
+                  ]
               : [
-                  Svg.createLineElement(original.iq, 'bottom'),
-                  Svg.createLineElement(original.iq, 'top'),
-                ]
-            : [
-                Svg.createLineElement(original.iq, 'left'),
-                Svg.createLineElement(original.iq, 'right'),
-              ])
-        : [
-            Svg.createEmptyElement('line'),
-            Svg.createEmptyElement('line'),
-          ];
+                  Svg.createLineElement(original.iq, 'left'),
+                  Svg.createLineElement(original.iq, 'right'),
+                ])
+          : [
+              Svg.createEmptyElement('line'),
+              Svg.createEmptyElement('line'),
+            ];
+      }
 
       const sections = [lowerOutliers, min, q1, q2, q3, max, upperOutliers];
 

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -112,7 +112,17 @@ export class Heatmap extends AbstractTrace {
 
     const numRows = this.heatmapValues.length;
     const numCols = this.heatmapValues[0].length;
-    const domElements = Svg.selectAllElements(selector);
+    const domElements = Svg.selectAllElements(selector, false);
+
+    // Plotly renders heatmaps as a single <image> element (canvas PNG).
+    // Create transparent overlay rects so the highlight service can work.
+    if (
+      domElements.length === 1
+      && domElements[0] instanceof SVGImageElement
+    ) {
+      return this.createOverlayRects(domElements[0], numRows, numCols);
+    }
+
     if (domElements.length === 0 || domElements.length !== numRows * numCols) {
       return null;
     }
@@ -150,6 +160,54 @@ export class Heatmap extends AbstractTrace {
           svgElements.push(row);
         }
       }
+    }
+
+    return svgElements;
+  }
+
+  /**
+   * Create transparent overlay <rect> elements on top of a Plotly heatmap
+   * <image> element so the highlight service can target individual cells.
+   */
+  private createOverlayRects(
+    imageEl: SVGImageElement,
+    numRows: number,
+    numCols: number,
+  ): SVGElement[][] | null {
+    const imgX = Number.parseFloat(imageEl.getAttribute('x') ?? '0');
+    const imgY = Number.parseFloat(imageEl.getAttribute('y') ?? '0');
+    const imgW = Number.parseFloat(imageEl.getAttribute('width') ?? '0');
+    const imgH = Number.parseFloat(imageEl.getAttribute('height') ?? '0');
+
+    if (imgW === 0 || imgH === 0) {
+      return null;
+    }
+
+    const cellW = imgW / numCols;
+    const cellH = imgH / numRows;
+    const parent = imageEl.parentElement;
+    if (!parent) {
+      return null;
+    }
+
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const svgElements = new Array<Array<SVGElement>>();
+
+    for (let r = 0; r < numRows; r++) {
+      const row = new Array<SVGElement>();
+      for (let c = 0; c < numCols; c++) {
+        const rect = document.createElementNS(svgNS, 'rect') as SVGRectElement;
+        rect.setAttribute('x', String(imgX + c * cellW));
+        rect.setAttribute('y', String(imgY + r * cellH));
+        rect.setAttribute('width', String(cellW));
+        rect.setAttribute('height', String(cellH));
+        rect.setAttribute('fill', 'transparent');
+        rect.setAttribute('stroke', 'none');
+        rect.setAttribute('pointer-events', 'none');
+        parent.appendChild(rect);
+        row.push(rect);
+      }
+      svgElements.push(row);
     }
 
     return svgElements;

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -12,7 +12,7 @@ import { MovableGraph } from './movable';
 
 const TYPE = 'Group';
 const SVG_PATH_LINE_POINT_REGEX
-  = /[ML]\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g;
+  = /[ML]\s*(-?\d+(?:\.\d+)?)[\s,]+(-?\d+(?:\.\d+)?)/g;
 
 /**
  * Represents a line trace plot with support for single and multi-line navigation
@@ -464,20 +464,57 @@ export class LineTrace extends AbstractTrace {
           });
         }
       }
-      if (coordinates.length !== this.lineValues[r].length) {
-        if (coordinates.length < this.lineValues[r].length) {
-          while (coordinates.length < this.lineValues[r].length) {
+      // Handle coordinate count mismatch.
+      // SVG renderers (e.g. Plotly) may simplify paths by removing collinear
+      // points.  When fewer coordinates than data points are found, interpolate
+      // the missing positions along the simplified path segments so every data
+      // point gets a highlight circle at the correct visual position.
+      const expected = this.lineValues[r].length;
+      if (coordinates.length !== expected) {
+        if (coordinates.length >= 2 && coordinates.length < expected) {
+          const pathXMin = Number(coordinates[0].x);
+          const pathXMax = Number(coordinates[coordinates.length - 1].x);
+          const dataPoints = this.points[r];
+          const dataXMin = Number(dataPoints[0].x);
+          const dataXMax = Number(dataPoints[dataPoints.length - 1].x);
+          const dataXRange = dataXMax - dataXMin;
+
+          const full: LinePoint[] = [];
+          for (let i = 0; i < expected; i++) {
+            const dataX = Number(dataPoints[i].x);
+            const svgX = dataXRange > 0
+              ? pathXMin + ((dataX - dataXMin) / dataXRange) * (pathXMax - pathXMin)
+              : pathXMin;
+
+            // Find y by interpolating along the simplified path segments
+            let svgY = Number(coordinates[0].y);
+            for (let j = 0; j < coordinates.length - 1; j++) {
+              const cjx = Number(coordinates[j].x);
+              const cj1x = Number(coordinates[j + 1].x);
+              if (svgX >= cjx - 0.01 && svgX <= cj1x + 0.01) {
+                const segLen = cj1x - cjx;
+                const t = segLen > 0 ? (svgX - cjx) / segLen : 0;
+                svgY = Number(coordinates[j].y) + t * (Number(coordinates[j + 1].y) - Number(coordinates[j].y));
+                break;
+              }
+            }
+            full.push({ x: svgX, y: svgY });
+          }
+          coordinates.length = 0;
+          coordinates.push(...full);
+        } else if (coordinates.length < expected) {
+          while (coordinates.length < expected) {
             coordinates.push({ x: Number.NaN, y: Number.NaN });
           }
-        } else if (coordinates.length > this.lineValues[r].length) {
-          coordinates.length = this.lineValues[r].length;
+        } else {
+          coordinates.length = expected;
         }
       }
 
       const linePointElements: SVGElement[] = [];
       let lineFailed = false;
       for (const coordinate of coordinates) {
-        if (Number.isNaN(coordinate.x) || Number.isNaN(coordinate.y)) {
+        if (Number.isNaN(Number(coordinate.x)) || Number.isNaN(coordinate.y)) {
           lineFailed = true;
           break;
         }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -482,8 +482,22 @@ export class ScatterTrace extends AbstractTrace {
     const xGroups = new Map<number, SVGElement[]>();
     const yGroups = new Map<number, SVGElement[]>();
     elements.forEach((element) => {
-      const x = Number.parseFloat(element.getAttribute('x') || '');
-      const y = Number.parseFloat(element.getAttribute('y') || '');
+      let x = Number.parseFloat(element.getAttribute('x') || '');
+      let y = Number.parseFloat(element.getAttribute('y') || '');
+
+      // Plotly uses transform="translate(x, y)" instead of x/y attributes
+      if (Number.isNaN(x) || Number.isNaN(y)) {
+        const transform = element.getAttribute('transform');
+        if (transform) {
+          const match = transform.match(
+            /translate\s*\(\s*([\d.eE+-]+)[\s,]+([\d.eE+-]+)/,
+          );
+          if (match) {
+            x = Number.parseFloat(match[1]);
+            y = Number.parseFloat(match[2]);
+          }
+        }
+      }
 
       if (!Number.isNaN(x)) {
         if (!xGroups.has(x))

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -211,16 +211,22 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       return new Array<Array<SVGElement>>();
     }
 
+    // Count total expected data points (excluding summary row added later).
+    const totalExpected = this.barValues.reduce((sum, row) => sum + row.length, 0);
+    // Only skip zeros when DOM has fewer elements than data points
+    // (e.g. Plotly histograms omit zero-height bins). When counts match
+    // (e.g. Plotly stacked bars render zero-height segments), map 1:1.
+    const skipZeros = domElements.length < totalExpected;
+
     const svgElements = new Array<Array<SVGElement>>();
     if (domElements[0] instanceof SVGPathElement) {
-      // Use parent implementation for SVGPathElement
       for (let r = 0, domIndex = 0; r < this.barValues.length; r++) {
         const row = new Array<SVGElement>();
         for (let c = 0; c < this.barValues[r].length; c++) {
-          if (domIndex >= domElements.length) {
-            return new Array<Array<SVGElement>>();
-          } else if (this.barValues[r][c] === 0) {
+          if (skipZeros && this.barValues[r][c] === 0) {
             row.push(Svg.createEmptyElement());
+          } else if (domIndex >= domElements.length) {
+            return new Array<Array<SVGElement>>();
           } else {
             row.push(domElements[domIndex++]);
           }
@@ -236,20 +242,20 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       for (let c = 0, domIndex = 0; c < this.barValues[0].length; c++) {
         if (isForward) {
           for (let r = 0; r < this.barValues.length; r++) {
-            if (domIndex >= domElements.length) {
-              return new Array<Array<SVGElement>>();
-            } else if (this.barValues[r][c] === 0) {
+            if (skipZeros && this.barValues[r][c] === 0) {
               svgElements[r].push(Svg.createEmptyElement());
+            } else if (domIndex >= domElements.length) {
+              return new Array<Array<SVGElement>>();
             } else {
               svgElements[r].push(domElements[domIndex++]);
             }
           }
         } else {
           for (let r = this.barValues.length - 1; r >= 0; r--) {
-            if (domIndex >= domElements.length) {
-              return new Array<Array<SVGElement>>();
-            } else if (this.barValues[r][c] === 0) {
+            if (skipZeros && this.barValues[r][c] === 0) {
               svgElements[r].push(Svg.createEmptyElement());
+            } else if (domIndex >= domElements.length) {
+              return new Array<Array<SVGElement>>();
             } else {
               svgElements[r].push(domElements[domIndex++]);
             }

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -232,6 +232,10 @@ export interface BoxSelector {
   upperOutliers: string[];
   /** CSS selector for mean marker element in violin plots. */
   mean?: string;
+  /** Optional direct CSS selector for Q1 element (bypasses iq edge derivation). */
+  q1?: string;
+  /** Optional direct CSS selector for Q3 element (bypasses iq edge derivation). */
+  q3?: string;
 }
 
 /**

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -142,7 +142,7 @@ export abstract class Svg {
     element.setAttribute(Constant.STROKE_WIDTH, strokeWidth);
     element.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
 
-    parent.parentElement?.insertAdjacentElement(Constant.AFTER_END, element);
+    parent.parentElement?.appendChild(element);
     return element;
   }
 


### PR DESCRIPTION
# Pull Request

## Description

- Add Plotly chart support for MAIDR highlighting across all trace types
- Plotly renders SVG differently from matplotlib/seaborn (different element types, attributes, and DOM structures), so each trace type's SVG-to-data mapping is adapted to handle both renderers
- A new Plotly adapter normalizes the DOM before MAIDR initialization, keeping renderer-specific logic isolated from core navigation and accessibility features

## Changes Made


src/adapter/plotly.ts   New adapter that detects Plotly plots and normalizes DOM structure (subplot wrapping, CSS layout, modebar, focus delegation)
                
src/index.tsx           Call Plotly adapter before initMaidr() when a Plotly plot is detected
                
src/model/scatter.ts    Parse transform="translate(x, y)" as fallback when x/y attributes are absent (Plotly uses <path> with transform, not <use> with x/y)

src/model/bar.ts        Align SVG elements to data points when Plotly omits zero-height bars from the DOM; insert invisible placeholders for missing bars
                
src/model/box.ts        Support direct q1/q3 CSS selectors for Plotly, which renders Q1/Q3 as separate elements instead of deriving them from IQR rect edges
                
src/model/heatmap.ts    Detect Plotly's single <image> heatmap and generate transparent overlay <rect> elements so individual cells can be highlighted
                
src/model/line.ts       Accept comma-separated path coordinates; interpolate highlight positions when Plotly simplifies paths by removing collinear points
                
src/model/segmented.ts  Make zero-value skipping conditional — only skip when DOM count < data count (Plotly histograms), map 1:1 when counts match (Plotly stacked bars) 

src/type/grammar.ts     Add optional q1 and q3 fields to BoxSelector interface
                
src/util/svg.ts         Use appendChild() instead of insertAdjacentElement('afterend') for correct DOM ordering in Plotly SVG
                
## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.