### PR TITLE
fix: unify instruction text announcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "maidr",
-
-  "version": "3.53.0",
+  "version": "3.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maidr",
-      "version": "3.53.0",
+      "version": "3.58.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
@@ -40,6 +39,7 @@
         "@types/react-dom": "^19.1.3",
         "@types/webpack": "^5.28.5",
         "@vitejs/plugin-react": "^5.1.1",
+        "baseline-browser-mapping": "^2.10.7",
         "esbuild": "^0.25.4",
         "eslint": "^9.25.1",
         "eslint-plugin-format": "^1.0.1",
@@ -6238,13 +6238,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.21.tgz",
-      "integrity": "sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
+      "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-auth": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/react-dom": "^19.1.3",
     "@types/webpack": "^5.28.5",
     "@vitejs/plugin-react": "^5.1.1",
+    "baseline-browser-mapping": "^2.10.7",
     "esbuild": "^0.25.4",
     "eslint": "^9.25.1",
     "eslint-plugin-format": "^1.0.1",

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -442,18 +442,13 @@ export class AnnouncePositionCommand extends AnnounceCommand {
         // Single smooth/violin plot: 1D position within the curve
         this.announceSmoothPosition(x, cols);
       }
-    }
-    // Check for multi plots (multiline, panel, layer, facet)
-    else if (traceType === TraceType.LINE && state.groupCount && state.groupCount > 1) {
+    } else if (traceType === TraceType.LINE && state.groupCount && state.groupCount > 1) {
       // Multi-line plots: x=position in the line, y=line index
       this.announceMultiLinePosition(x, cols, y, rows);
-    }
-    else if (traceType === TraceType.SCATTER) {
+    } else if (traceType === TraceType.SCATTER) {
       // Scatter plot: use x/y for column/row position, but don't include 'Position' as it sounds weird
       this.announceScatter(x, y, rows, cols);
-    }
-    // Default position announcement
-    else if (this.is2DPlot(rows, cols)) {
+    } else if (this.is2DPlot(rows, cols)) {
       this.announce2DPosition(x, y, rows, cols);
     } else {
       this.announce1DPosition(x, cols);
@@ -616,6 +611,7 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       this.textViewModel.update(`${plotPrefix}, Position is ${pos} of ${totalPos}`);
     }
   }
+
   /**
    * Announces position for 2D plots (e.g., heatmaps).
    */
@@ -633,5 +629,4 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       );
     }
   }
-
 }

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -28,13 +28,13 @@ import {
   StopAutoplayCommand,
 } from './autoplay';
 import {
-  AnnouncePositionCommand,
   AnnounceCaptionCommand,
   AnnounceFillCommand,
   AnnouncePointCommand,
+  AnnouncePositionCommand,
   AnnounceSubtitleCommand,
   AnnounceTitleCommand,
-  AnnounceXCommand as AnnounceXCommand,
+  AnnounceXCommand,
   AnnounceYCommand,
 } from './describe';
 import { GoToExtremaToggleCommand } from './goTo';

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -141,6 +141,7 @@ export class Controller implements Disposable {
       store,
       this.goToExtremaService,
       this.context,
+      this.formatterService,
     );
     this.reviewViewModel = new ReviewViewModel(store, this.reviewService);
     this.displayViewModel = new DisplayViewModel(store, this.displayService);

--- a/src/maidr-component.tsx
+++ b/src/maidr-component.tsx
@@ -1,7 +1,7 @@
 import type { AppStore } from '@state/store';
 import type { Maidr as MaidrData } from '@type/grammar';
 import type { JSX, ReactNode } from 'react';
-import { Orientation } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 import { useMemo, useRef } from 'react';
 import { useMaidrController } from './state/hook/useMaidrController';
 import { createMaidrStore } from './state/store';
@@ -74,13 +74,28 @@ function getInitialInstruction(data: MaidrData): string {
   const layerCount = firstSubplot?.layers.length ?? 0;
   const firstLayer = firstSubplot?.layers[0];
   const traceType = firstLayer?.type ?? 'chart';
-  const displayType = formatPlotType(traceType, firstLayer?.orientation);
+
+  // Normalize line plot type: data is LinePoint[][] where outer array = groups.
+  // A line trace with exactly 1 group is "single line", not "multiline".
+  let plotType: string = traceType;
+  let groupCountText = '';
+  if (traceType === TraceType.LINE && Array.isArray(firstLayer?.data)) {
+    const groupCount = firstLayer.data.length;
+    if (groupCount > 1) {
+      plotType = 'multiline';
+      groupCountText = ` with ${groupCount} groups`;
+    } else {
+      plotType = 'single line';
+    }
+  }
+
+  const displayType = formatPlotType(plotType, firstLayer?.orientation);
 
   if (layerCount > 1) {
     return `This is a maidr plot containing ${layerCount} layers, and this is layer 1 of ${layerCount}: ${displayType} plot. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
   }
 
-  return `This is a maidr plot of type: ${displayType}. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
+  return `This is a maidr plot of type: ${displayType}${groupCountText}. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;
 }
 
 export function Maidr({ data, children }: MaidrProps): JSX.Element {

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -305,6 +305,16 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
     const maxIndex = groupValues.indexOf(groupMax);
     const minIndex = groupValues.indexOf(groupMin);
 
+    // Inline raw x-value lookup using currentGroup (avoids hidden this.row dependency)
+    const maxPoint = this.points[currentGroup]?.[maxIndex];
+    const minPoint = this.points[currentGroup]?.[minIndex];
+    const maxXValue = maxPoint
+      ? (this.orientation === Orientation.VERTICAL ? maxPoint.x : maxPoint.y)
+      : undefined;
+    const minXValue = minPoint
+      ? (this.orientation === Orientation.VERTICAL ? minPoint.x : minPoint.y)
+      : undefined;
+
     // Add max target
     targets.push({
       label: `Max Bar at ${this.getPointLabel(maxIndex)}`,
@@ -313,7 +323,7 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
       segment: 'bar',
       type: 'max',
       navigationType: 'point',
-      xValue: this.getPointRawValue(maxIndex),
+      xValue: maxXValue,
     });
 
     // Add min target
@@ -324,7 +334,7 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
       segment: 'bar',
       type: 'min',
       navigationType: 'point',
-      xValue: this.getPointRawValue(minIndex),
+      xValue: minXValue,
     });
 
     return targets;
@@ -359,14 +369,6 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
     }
 
     return `Point ${pointIndex}`;
-  }
-
-  /** Returns the raw x-axis value for a point (for formatter use). */
-  private getPointRawValue(pointIndex: number): number | string | undefined {
-    const point = this.points[this.row]?.[pointIndex];
-    if (!point)
-      return undefined;
-    return this.orientation === Orientation.VERTICAL ? point.x : point.y;
   }
 
   /**

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -313,6 +313,7 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
       segment: 'bar',
       type: 'max',
       navigationType: 'point',
+      xValue: this.getPointRawValue(maxIndex),
     });
 
     // Add min target
@@ -323,6 +324,7 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
       segment: 'bar',
       type: 'min',
       navigationType: 'point',
+      xValue: this.getPointRawValue(minIndex),
     });
 
     return targets;
@@ -357,6 +359,14 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
     }
 
     return `Point ${pointIndex}`;
+  }
+
+  /** Returns the raw x-axis value for a point (for formatter use). */
+  private getPointRawValue(pointIndex: number): number | string | undefined {
+    const point = this.points[this.row]?.[pointIndex];
+    if (!point)
+      return undefined;
+    return this.orientation === Orientation.VERTICAL ? point.x : point.y;
   }
 
   /**

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -774,6 +774,7 @@ export class Candlestick extends AbstractTrace {
           segment: 'volatility',
           type: 'max',
           navigationType: 'point',
+          xValue: candle.value,
         });
       });
 
@@ -787,6 +788,7 @@ export class Candlestick extends AbstractTrace {
           segment: 'volatility',
           type: 'min',
           navigationType: 'point',
+          xValue: candle.value,
         });
       });
     } else {
@@ -820,6 +822,7 @@ export class Candlestick extends AbstractTrace {
           segment: currentSegment,
           type: 'max',
           navigationType: 'point',
+          xValue: candle.value,
         });
       });
 
@@ -835,6 +838,7 @@ export class Candlestick extends AbstractTrace {
           segment: currentSegment,
           type: 'min',
           navigationType: 'point',
+          xValue: candle.value,
         });
       });
     }

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -410,6 +410,7 @@ export class Heatmap extends AbstractTrace {
         navigationType: 'group',
         groupIndex: globalMax.row,
         categoryIndex: globalMax.col,
+        xValue: this.x[globalMax.col],
       });
     }
 
@@ -425,6 +426,7 @@ export class Heatmap extends AbstractTrace {
         navigationType: 'group',
         groupIndex: globalMin.row,
         categoryIndex: globalMin.col,
+        xValue: this.x[globalMin.col],
       });
     }
 
@@ -440,6 +442,7 @@ export class Heatmap extends AbstractTrace {
         navigationType: 'group',
         groupIndex: currentRow,
         categoryIndex: rowMax.col,
+        xValue: this.x[rowMax.col],
       });
     }
 
@@ -455,6 +458,7 @@ export class Heatmap extends AbstractTrace {
         navigationType: 'group',
         groupIndex: currentRow,
         categoryIndex: rowMin.col,
+        xValue: this.x[rowMin.col],
       });
     }
 
@@ -470,6 +474,7 @@ export class Heatmap extends AbstractTrace {
         navigationType: 'group',
         groupIndex: colMax.row,
         categoryIndex: currentCol,
+        xValue: this.x[currentCol],
       });
     }
 
@@ -485,6 +490,7 @@ export class Heatmap extends AbstractTrace {
         navigationType: 'group',
         groupIndex: colMin.row,
         categoryIndex: currentCol,
+        xValue: this.x[currentCol],
       });
     }
 

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -873,6 +873,7 @@ export class LineTrace extends AbstractTrace {
         segment: 'line',
         type: 'max',
         navigationType: 'point',
+        xValue: this.points[this.row]?.[maxIndex]?.x,
       });
     }
 
@@ -885,6 +886,7 @@ export class LineTrace extends AbstractTrace {
         segment: 'line',
         type: 'min',
         navigationType: 'point',
+        xValue: this.points[this.row]?.[minIndex]?.x,
       });
     }
 

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -75,6 +75,16 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     const maxCategoryLabel = this.getCategoryLabel(maxIndex);
     const minCategoryLabel = this.getCategoryLabel(minIndex);
 
+    // Inline raw x-value lookup using currentGroup (avoids hidden this.row dependency)
+    const maxPoint = this.points[currentGroup]?.[maxIndex];
+    const minPoint = this.points[currentGroup]?.[minIndex];
+    const maxXValue = maxPoint
+      ? (this.orientation === Orientation.VERTICAL ? maxPoint.x : maxPoint.y)
+      : undefined;
+    const minXValue = minPoint
+      ? (this.orientation === Orientation.VERTICAL ? minPoint.x : minPoint.y)
+      : undefined;
+
     // Add max target
     targets.push({
       label: `Max ${groupLabel} at ${maxCategoryLabel}`,
@@ -85,6 +95,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       groupIndex: currentGroup,
       categoryIndex: maxIndex,
       navigationType: 'group',
+      xValue: maxXValue,
     });
 
     // Add min target
@@ -97,6 +108,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       groupIndex: currentGroup,
       categoryIndex: minIndex,
       navigationType: 'group',
+      xValue: minXValue,
     });
 
     return targets;

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -1,4 +1,5 @@
 import type { Context } from '@model/context';
+import type { FormatterService } from '@service/formatter';
 import type { GoToExtremaService } from '@service/goToExtrema';
 import type { AppStore } from '@state/store';
 import type { ExtremaTarget } from '@type/extrema';
@@ -62,11 +63,18 @@ const { show, hide, updateSelectedIndex } = goToExtremaSlice.actions;
 export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
   private readonly goToExtremaService: GoToExtremaService;
   private readonly context: Context;
+  private readonly formatter?: FormatterService;
 
-  public constructor(store: AppStore, goToExtremaService: GoToExtremaService, context: Context) {
+  public constructor(
+    store: AppStore,
+    goToExtremaService: GoToExtremaService,
+    context: Context,
+    formatter?: FormatterService,
+  ) {
     super(store);
     this.goToExtremaService = goToExtremaService;
     this.context = context;
+    this.formatter = formatter;
   }
 
   public dispose(): void {
@@ -91,11 +99,14 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       // Get extrema targets from the plot class
       const extremaTargets = activeTrace.getExtremaTargets();
 
+      // Apply formatting to target labels using FormatterService
+      const formattedTargets = this.formatTargetLabels(extremaTargets, state.layerId);
+
       // Generate description based on current trace type
       const description = this.generateDescription(state.traceType);
 
       // Store the targets and description in the state
-      this.store.dispatch(show({ targets: extremaTargets, description }));
+      this.store.dispatch(show({ targets: formattedTargets, description }));
 
       // Then change scope to show the modal
       this.goToExtremaService.toggle(state);
@@ -167,6 +178,31 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     } else {
       this.goToExtremaService.returnToTraceScope();
     }
+  }
+
+  /**
+   * Format extrema target labels by replacing raw xValues with formatted ones.
+   * When no custom formatter is configured the labels pass through unchanged.
+   */
+  private formatTargetLabels(targets: ExtremaTarget[], layerId: string): ExtremaTarget[] {
+    if (!this.formatter || !this.formatter.hasCustomFormatter(layerId, 'x')) {
+      return targets;
+    }
+
+    return targets.map((target) => {
+      if (target.xValue === undefined) {
+        return target;
+      }
+      const formatted = this.formatter!.formatSingleValue(target.xValue, layerId, 'x');
+      const raw = String(target.xValue);
+      if (formatted === raw) {
+        return target;
+      }
+      return {
+        ...target,
+        label: target.label.replace(raw, formatted),
+      };
+    });
   }
 
   /**

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -200,7 +200,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       }
       return {
         ...target,
-        label: target.label.replace(raw, formatted),
+        label: target.label.replaceAll(raw, formatted),
       };
     });
   }

--- a/src/type/extrema.ts
+++ b/src/type/extrema.ts
@@ -44,6 +44,9 @@ export interface ExtremaTarget {
   /** Type of navigation this extrema requires */
   navigationType: 'point' | 'group';
 
+  /** Raw x-axis value for formatting (e.g., timestamp before date conversion) */
+  xValue?: number | string;
+
   /**
    * For intersection targets: indices of all lines that intersect at this point
    * Used for multiline plots to track which lines are involved in the intersection


### PR DESCRIPTION
# Pull Request

## Description

1. Go To Extrema (G key) shows raw digits instead of formatted values — On candlestick layers with date-formatted x-axes, pressing G displays raw timestamps (e.g., 1234) instead of formatted dates (e.g., "Nov 17, 2026"). Root cause: FormatterService was never wired into the extrema flow. Models generated labels with raw values and nothing in the ViewModel or UI formatted them.

2. Stale instruction text for multiline/single-line plots — The static aria-label/title set at React render time diverged from the dynamic instruction computed at runtime. Context.getInstruction() converts "multiline" to "single line" when groupCount === 1, but getInitialInstruction() in maidr-component.tsx lacked this edge case. JAWS reads the stale attribute before the Controller overwrites it.

## Changes Made

src/type/extrema.ts                          Add optional xValue field to ExtremaTarget so raw x-axis values can be formatted in the ViewModel layer                                            
src/model/candlestick.ts                     Populate xValue: candle.value on all 4 extrema targets (max/min volatility, max/min OHLC)                                     
src/model/bar.ts                             Populate xValue on max/min targets; add getPointRawValue() helper                                    
src/model/line.ts                            Populate xValue on max/min point targets                                         
src/model/heatmap.ts                         Populate xValue on all 6 extrema targets (global/row/col max/min)                                         
src/controller.ts                            Pass FormatterService to GoToExtremaViewModel constructor                                           
src/state/viewModel/goToExtremaViewModel.ts  Accept FormatterService; add formatTargetLabels() that replaces raw xValues in labels with formatted strings before dispatching to Redux                    
src/maidr-component.tsx                      Add multiline→single line normalization to getInitialInstruction() so static aria-label/title matches the dynamic instruction from Context.getInstruction() 
src/command/describe.ts                      Lint: whitespace/formatting cleanup                                   
src/command/factory.ts                       Lint: sort imports alphabetically, remove redundant as alias               

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.