### PR TITLE
docs: add Google Analytics, MS Clarity, and cookie consent

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -5,6 +5,27 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{TITLE}} - MAIDR</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.css">
+  <script defer src="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.umd.js"></script>
+  <script type="text/plain" data-category="analytics">
+    (function(){
+      var s=document.createElement('script');
+      s.async=true;
+      s.src='https://www.googletagmanager.com/gtag/js?id=G-179RKE1KL4';
+      document.head.appendChild(s);
+      window.dataLayer=window.dataLayer||[];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js',new Date());
+      gtag('config','G-179RKE1KL4');
+    })();
+  </script>
+  <script type="text/plain" data-category="analytics">
+    (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "vwqzpug8us");
+  </script>
   <style>
     * {
       margin: 0;
@@ -231,6 +252,62 @@
     <p>MAIDR - Multimodal Access and Interactive Data Representation</p>
     <p><a href="https://github.com/xability/maidr">GitHub</a> | Licensed under GPL-3.0</p>
   </footer>
+  <script>
+    window.addEventListener('DOMContentLoaded', function () {
+      if (typeof CookieConsent !== 'undefined') {
+        CookieConsent.run({
+          guiOptions: {
+            consentModal: {
+              layout: 'box inline',
+              position: 'bottom right',
+            },
+          },
+          categories: {
+            necessary: {
+              enabled: true,
+              readOnly: true,
+            },
+            analytics: {},
+          },
+          language: {
+            default: 'en',
+            translations: {
+              en: {
+                consentModal: {
+                  title: 'We use cookies',
+                  description:
+                    'This site uses cookies to help us understand how it is used. You can choose to accept or decline analytics cookies.',
+                  acceptAllBtn: 'Accept all',
+                  acceptNecessaryBtn: 'Reject all',
+                  showPreferencesBtn: 'Manage preferences',
+                },
+                preferencesModal: {
+                  title: 'Cookie preferences',
+                  acceptAllBtn: 'Accept all',
+                  acceptNecessaryBtn: 'Reject all',
+                  savePreferencesBtn: 'Save preferences',
+                  sections: [
+                    {
+                      title: 'Necessary cookies',
+                      description:
+                        'These cookies are essential for the site to function properly.',
+                      linkedCategory: 'necessary',
+                    },
+                    {
+                      title: 'Analytics cookies',
+                      description:
+                        'These cookies help us understand how visitors interact with the site via Google Analytics and Microsoft Clarity.',
+                      linkedCategory: 'analytics',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        });
+      }
+    });
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Add GA4 tracking (G-179RKE1KL4) and MS Clarity (vwqzpug8us) to the maidr.ai site
- Both tracking scripts are gated behind cookie consent using [orestbida/cookieconsent v3](https://github.com/orestbida/cookieconsent)
- Scripts only execute after the user explicitly accepts analytics cookies (GDPR-compliant)
- GA4 and Clarity are already linked in the Clarity dashboard for unified analytics

## Implementation
- **`docs/template.html`**: Added cookieconsent CSS/JS from CDN, GA4 and Clarity scripts with `type="text/plain" data-category="analytics"`, and CookieConsent.run() initialization before `</body>`

## Test plan
- [ ] Build site with `npm run docs`
- [ ] Verify cookie consent banner appears on all pages (index, examples, API docs)
- [ ] Verify GA4/Clarity scripts are NOT loaded before accepting cookies
- [ ] Accept cookies and verify GA4/Clarity scripts load
- [ ] Reject cookies and verify no tracking scripts execute
- [ ] Confirm data appears in GA4 and Clarity dashboards after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)