### PR TITLE
docs: clarify empty scatterplot representation without line layer

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -89,8 +89,8 @@ As an example, consider a boxplot with the following distribution: [10, 0, 20, 4
 
 ## Scatter plot
 
-In the Braille representation of a scatter plot, the encoding is performed only for the line layer (layer 2).
-The method is similar to that used for bar plots,
+In the Braille representation of a scatter plot, the encoding is performed only for the line layer (layer 2). Stand alone scatterplots without a line layer are not represented in braille.
+The representation of the line layer is similar to that used for bar plots,
 wherein data values are represented as Braille characters based on their relative magnitude within the plot.
 Low values are denoted by dots along the bottom, while high values are indicated by dots along the top.
 With four height levels of Braille, the encoding is as follows:


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes made in this pull request. -->
Clarified in the documentation that without a line layer, the scatter plot is not represented in braille.
## Related Issues

<!-- Specify any related issues or tickets that this pull request addresses. -->
https://github.com/xability/maidr/issues/578
## Changes Made

<!-- Describe the specific changes made in this pull request. -->
Earlier impression from the documentation was that scatterplots have a second line layer, which is represented in braille. Clarified that if there is no line layer, there is no braille representation.
## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
