### PR TITLE
fix: escape key works in braille mode for subplot exit

### DIFF
--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -1,6 +1,7 @@
 import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
 import type { AutoplayService } from '@service/autoplay';
+import type { BrailleService } from '@service/braille';
 import type { DisplayService } from '@service/display';
 import type { HighContrastService } from '@service/highContrast';
 import type { HighlightService } from '@service/highlight';
@@ -39,6 +40,8 @@ export interface CommandContext {
   audioService: AudioService;
   /** Autoplay service for automated navigation. */
   autoplayService: AutoplayService;
+  /** Braille service for managing braille display. */
+  brailleService: BrailleService;
   /** Display service for managing display state. */
   displayService: DisplayService;
   /** High contrast service for accessibility. */

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -1,6 +1,8 @@
 import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
 import type { AutoplayService } from '@service/autoplay';
+import type { BrailleService } from '@service/braille';
+import type { DisplayService } from '@service/display';
 import type { HighContrastService } from '@service/highContrast';
 import type { HighlightService } from '@service/highlight';
 import type { RotorNavigationService } from '@service/rotor';
@@ -45,6 +47,7 @@ import {
   GoToExtremaSelectCommand,
 } from './goToExtremaNavigation';
 import {
+  ExitBrailleAndSubplotCommand,
   MoveDownCommand,
   MoveLeftCommand,
   MoveRightCommand,
@@ -91,6 +94,8 @@ export class CommandFactory {
 
   private readonly audioService: AudioService;
   private readonly autoplayService: AutoplayService;
+  private readonly brailleService: BrailleService;
+  private readonly displayService: DisplayService;
   private readonly highContrastService: HighContrastService;
   private readonly highlightService: HighlightService;
   private readonly rotorService: RotorNavigationService;
@@ -115,6 +120,8 @@ export class CommandFactory {
 
     this.audioService = commandContext.audioService;
     this.autoplayService = commandContext.autoplayService;
+    this.brailleService = commandContext.brailleService;
+    this.displayService = commandContext.displayService;
     this.highContrastService = commandContext.highContrastService;
     this.highlightService = commandContext.highlightService;
     this.rotorService = commandContext.rotorNavigationService;
@@ -176,9 +183,11 @@ export class CommandFactory {
         return new MoveToRightExtremeCommand(this.context);
 
       case 'MOVE_TO_TRACE_CONTEXT':
-        return new MoveToTraceContextCommand(this.context);
+        return new MoveToTraceContextCommand(this.context, this.brailleService, this.displayService);
       case 'MOVE_TO_SUBPLOT_CONTEXT':
         return new MoveToSubplotContextCommand(this.context);
+      case 'EXIT_BRAILLE_AND_SUBPLOT':
+        return new ExitBrailleAndSubplotCommand(this.context, this.displayService);
       case 'MOVE_TO_NEXT_TRACE':
         return new MoveToNextTraceCommand(this.context);
       case 'MOVE_TO_PREV_TRACE':

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -209,9 +209,11 @@ export class MoveToTraceContextCommand implements Command {
   public execute(): void {
     this.context.enterSubplot();
     if (this.brailleService.isEnabled) {
-      // Notify observers so the braille service encodes the new trace's data.
-      // Without this, the braille textarea would show stale data from the
-      // previous plot until the user navigates.
+      // enterSubplot() does not call notifyStateUpdate() — it only resets
+      // row/col via resetToInitialEntry() and sets the hotkeys scope. This
+      // explicit notification is needed so observers (especially the braille
+      // service) receive the new trace's data. Without it, the braille
+      // textarea would show stale content from the previous subplot.
       this.context.active.notifyStateUpdate();
       this.displayService.toggleFocus(Scope.BRAILLE);
     }
@@ -268,7 +270,7 @@ export class ExitBrailleAndSubplotCommand implements Command {
    * Dismisses braille focus and exits the subplot in a screen-reader-safe sequence.
    */
   public execute(): void {
-    this.displayService.dismissModalScope(Scope.BRAILLE);
+    this.displayService.dismissModalScope(Scope.BRAILLE, Scope.SUBPLOT);
     this.context.exitSubplot();
     this.displayService.notifyFocusChange(Scope.SUBPLOT);
   }

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -209,12 +209,6 @@ export class MoveToTraceContextCommand implements Command {
   public execute(): void {
     this.context.enterSubplot();
     if (this.brailleService.isEnabled) {
-      // enterSubplot() does not call notifyStateUpdate() — it only resets
-      // row/col via resetToInitialEntry() and sets the hotkeys scope. This
-      // explicit notification is needed so observers (especially the braille
-      // service) receive the new trace's data. Without it, the braille
-      // textarea would show stale content from the previous subplot.
-      this.context.active.notifyStateUpdate();
       this.displayService.toggleFocus(Scope.BRAILLE);
     }
   }
@@ -270,7 +264,7 @@ export class ExitBrailleAndSubplotCommand implements Command {
    * Dismisses braille focus and exits the subplot in a screen-reader-safe sequence.
    */
   public execute(): void {
-    this.displayService.dismissModalScope(Scope.BRAILLE, Scope.SUBPLOT);
+    this.displayService.dismissModalScope(Scope.SUBPLOT);
     this.context.exitSubplot();
     this.displayService.notifyFocusChange(Scope.SUBPLOT);
   }

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -215,7 +215,9 @@ export class MoveToTraceContextCommand implements Command {
     if (this.brailleService.isEnabled) {
       const state = this.context.state;
       if (state.type === 'trace') {
-        this.brailleService.update(state);
+        this.brailleService.refreshDisplay(state);
+      } else {
+        console.warn('[MoveToTraceContextCommand] Expected trace state after enterSubplot, got:', state.type);
       }
       this.displayService.toggleFocus(Scope.BRAILLE);
     }

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -1,5 +1,8 @@
 import type { Context } from '@model/context';
+import type { BrailleService } from '@service/braille';
+import type { DisplayService } from '@service/display';
 import type { Command } from './command';
+import { Scope } from '@type/event';
 
 /**
  * Command to move the current position one step upward.
@@ -182,20 +185,36 @@ export class MoveToRightExtremeCommand implements Command {
  */
 export class MoveToTraceContextCommand implements Command {
   private readonly context: Context;
+  private readonly brailleService: BrailleService;
+  private readonly displayService: DisplayService;
 
   /**
    * Creates an instance of MoveToTraceContextCommand.
    * @param {Context} context - The context in which the move operation is performed.
+   * @param {BrailleService} brailleService - The braille service to check enabled state.
+   * @param {DisplayService} displayService - The display service for managing focus.
    */
-  public constructor(context: Context) {
+  public constructor(context: Context, brailleService: BrailleService, displayService: DisplayService) {
     this.context = context;
+    this.brailleService = brailleService;
+    this.displayService = displayService;
   }
 
   /**
    * Executes the move operation to enter the subplot trace context.
+   * If braille was previously enabled, notifies the active trace's observers
+   * so the braille service receives the new trace's data, then restores
+   * braille display focus.
    */
   public execute(): void {
     this.context.enterSubplot();
+    if (this.brailleService.isEnabled) {
+      // Notify observers so the braille service encodes the new trace's data.
+      // Without this, the braille textarea would show stale data from the
+      // previous plot until the user navigates.
+      this.context.active.notifyStateUpdate();
+      this.displayService.toggleFocus(Scope.BRAILLE);
+    }
   }
 }
 
@@ -218,6 +237,40 @@ export class MoveToSubplotContextCommand implements Command {
    */
   public execute(): void {
     this.context.exitSubplot();
+  }
+}
+
+/**
+ * Command to dismiss braille focus and exit the subplot context in a single
+ * action. Used when Escape is pressed while braille mode is active.
+ *
+ * The ordering is important for screen reader compatibility:
+ * 1. dismissModalScope moves focus to the plot and clears the focus stack,
+ * 2. exitSubplot transitions the navigation context to the subplot level,
+ * 3. notifyFocusChange defers the UI update (textarea removal) so NVDA/JAWS
+ *    process the focus change before the braille textarea unmounts.
+ */
+export class ExitBrailleAndSubplotCommand implements Command {
+  private readonly context: Context;
+  private readonly displayService: DisplayService;
+
+  /**
+   * Creates an instance of ExitBrailleAndSubplotCommand.
+   * @param {Context} context - The navigation context.
+   * @param {DisplayService} displayService - The display service for focus management.
+   */
+  public constructor(context: Context, displayService: DisplayService) {
+    this.context = context;
+    this.displayService = displayService;
+  }
+
+  /**
+   * Dismisses braille focus and exits the subplot in a screen-reader-safe sequence.
+   */
+  public execute(): void {
+    this.displayService.dismissModalScope(Scope.BRAILLE);
+    this.context.exitSubplot();
+    this.displayService.notifyFocusChange(Scope.SUBPLOT);
   }
 }
 

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -202,13 +202,21 @@ export class MoveToTraceContextCommand implements Command {
 
   /**
    * Executes the move operation to enter the subplot trace context.
-   * If braille was previously enabled, notifies the active trace's observers
-   * so the braille service receives the new trace's data, then restores
-   * braille display focus.
+   * If braille was previously enabled, directly updates the braille service
+   * with the new trace's data, then restores braille display focus.
+   *
+   * Note: we update the braille service directly rather than calling
+   * notifyStateUpdate() on the trace, because notifying all observers
+   * would also trigger AudioService (playing a tone on entry) and other
+   * services. Only the braille display needs to be refreshed here.
    */
   public execute(): void {
     this.context.enterSubplot();
     if (this.brailleService.isEnabled) {
+      const state = this.context.state;
+      if (state.type === 'trace') {
+        this.brailleService.update(state);
+      }
       this.displayService.toggleFocus(Scope.BRAILLE);
     }
   }

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -221,10 +221,10 @@ export class MoveToTraceContextCommand implements Command {
     this.context.enterSubplot();
     if (this.brailleService.isEnabled) {
       const state = this.context.state;
+      // After enterSubplot(), context.state should always be a trace.
+      // The guard is defensive; if it fails, braille simply shows stale data.
       if (state.type === 'trace') {
         this.brailleService.refreshDisplay(state);
-      } else {
-        console.warn('[MoveToTraceContextCommand] Expected trace state after enterSubplot, got:', state.type);
       }
       this.displayService.toggleFocus(Scope.BRAILLE);
     }

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -182,6 +182,13 @@ export class MoveToRightExtremeCommand implements Command {
 
 /**
  * Command to move into the trace context from the current subplot.
+ *
+ * Architectural note: this command holds references to BrailleService and
+ * DisplayService (not just Context) as a deliberate exception to the usual
+ * pattern where commands only interact with the model layer. This is needed
+ * because the model's notifyStateUpdate() cannot be used here without
+ * triggering unwanted side effects (e.g. audio on entry). Do not copy this
+ * pattern without similar justification.
  */
 export class MoveToTraceContextCommand implements Command {
   private readonly context: Context;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -176,6 +176,7 @@ export class Controller implements Disposable {
 
       audioService: this.audioService,
       autoplayService: this.autoplayService,
+      brailleService: this.brailleService,
       displayService: this.displayService,
       highContrastService: this.highContrastService,
       highlightService: this.highlightService,
@@ -199,6 +200,7 @@ export class Controller implements Disposable {
 
         audioService: this.audioService,
         autoplayService: this.autoplayService,
+        brailleService: this.brailleService,
         displayService: this.displayService,
         highContrastService: this.highContrastService,
         highlightService: this.highlightService,
@@ -226,6 +228,7 @@ export class Controller implements Disposable {
 
         audioService: this.audioService,
         autoplayService: this.autoplayService,
+        brailleService: this.brailleService,
         displayService: this.displayService,
         highContrastService: this.highContrastService,
         highlightService: this.highlightService,

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -221,6 +221,7 @@ export class Context implements Disposable {
       const trace = activeFigure.activeSubplot.activeTrace;
       trace.resetToInitialEntry();
       this.plotContext.push(trace);
+      trace.notifyStateUpdate();
       this.toggleScope(Scope.TRACE);
     }
   }

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -221,7 +221,6 @@ export class Context implements Disposable {
       const trace = activeFigure.activeSubplot.activeTrace;
       trace.resetToInitialEntry();
       this.plotContext.push(trace);
-      trace.notifyStateUpdate();
       this.toggleScope(Scope.TRACE);
     }
   }

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -740,10 +740,11 @@ implements Observer<SubplotState | TraceState>, Disposable {
   }
 
   /**
-   * Refreshes the braille display with the given trace state. Unlike the
-   * observer-driven {@link update} path, this is called explicitly when
-   * entering a new subplot with braille enabled, to avoid triggering
-   * other observers (e.g. AudioService).
+   * Refreshes the braille display with the given trace state. Called
+   * explicitly when entering a new subplot with braille enabled, because
+   * the model's {@link notifyStateUpdate} is not invoked on entry (doing
+   * so would fan out to all observers, including AudioService, causing
+   * an unwanted tone).
    * @param state - The trace state to display
    */
   public refreshDisplay(state: TraceState): void {

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -740,6 +740,17 @@ implements Observer<SubplotState | TraceState>, Disposable {
   }
 
   /**
+   * Refreshes the braille display with the given trace state. Unlike the
+   * observer-driven {@link update} path, this is called explicitly when
+   * entering a new subplot with braille enabled, to avoid triggering
+   * other observers (e.g. AudioService).
+   * @param state - The trace state to display
+   */
+  public refreshDisplay(state: TraceState): void {
+    this.update(state);
+  }
+
+  /**
    * Updates the braille display based on plot state changes.
    * @param state - Updated subplot or trace state
    */

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -733,6 +733,13 @@ implements Observer<SubplotState | TraceState>, Disposable {
   }
 
   /**
+   * Returns whether braille mode is currently enabled.
+   */
+  public get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
    * Updates the braille display based on plot state changes.
    * @param state - Updated subplot or trace state
    */

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -198,6 +198,11 @@ export class DisplayService implements Disposable {
    * @param {Focus} targetScope - The scope the focus stack should reflect
    *   after the modal is dismissed. The stack is reset to this value so it
    *   stays in sync with the hotkeys scope set by the caller.
+   *
+   * **Important:** The caller must ensure the hotkeys scope is set to
+   * `targetScope` (e.g. via `context.exitSubplot()`) before or immediately
+   * after this call. This method only updates the focus stack and DOM focus;
+   * it does not change the hotkeys scope.
    */
   public dismissModalScope(targetScope: Focus): void {
     this.plot.focus();

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -49,6 +49,7 @@ export class DisplayService implements Disposable {
   private isReturningFromModeToggle: boolean = false;
   private textChangeDisposer: Disposable | null = null;
   private hasClearedOnFirstNav: boolean = false;
+  private pendingFocusChangeTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * Creates a new DisplayService instance.
@@ -83,6 +84,11 @@ export class DisplayService implements Disposable {
    */
   public dispose(): void {
     this.addInstruction();
+
+    if (this.pendingFocusChangeTimer !== null) {
+      clearTimeout(this.pendingFocusChangeTimer);
+      this.pendingFocusChangeTimer = null;
+    }
 
     this.textChangeDisposer?.dispose();
     this.textChangeDisposer = null;
@@ -190,10 +196,15 @@ export class DisplayService implements Disposable {
    * follow-up scope transitions (e.g. exitSubplot) to avoid emitting a
    * stale intermediate scope.
    * @param {Focus} focus - The modal scope to remove from the focus stack
+   * @param {Focus} targetScope - The scope the focus stack should reflect
+   *   after the modal is dismissed. The stack is reset to this value so it
+   *   stays in sync with the hotkeys scope set by the caller.
    */
-  public dismissModalScope(focus: Focus): void {
+  public dismissModalScope(focus: Focus, targetScope: Focus): void {
     this.plot.focus();
     this.focusStack.removeLast(focus);
+    this.focusStack.clear();
+    this.focusStack.push(targetScope);
   }
 
   /**
@@ -202,10 +213,17 @@ export class DisplayService implements Disposable {
    * process the preceding focus change before React unmounts the modal
    * element (e.g. the braille textarea). Without this, NVDA/JAWS exit
    * focus mode when the focused element disappears from the DOM.
+   *
+   * Cancels any previously pending notification to avoid stale events
+   * from rapid repeated calls.
    * @param {Focus} scope - The scope to emit as the new display focus
    */
   public notifyFocusChange(scope: Focus): void {
-    setTimeout(() => {
+    if (this.pendingFocusChangeTimer !== null) {
+      clearTimeout(this.pendingFocusChangeTimer);
+    }
+    this.pendingFocusChangeTimer = setTimeout(() => {
+      this.pendingFocusChangeTimer = null;
       this.onChangeEmitter.fire({ value: scope });
     }, 0);
   }

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -190,19 +190,17 @@ export class DisplayService implements Disposable {
   }
 
   /**
-   * Removes a modal scope (e.g. BRAILLE) from the focus stack and moves
-   * focus to the plot element. Does not fire a display change event — the
-   * caller must call {@link notifyFocusChange} after completing any
-   * follow-up scope transitions (e.g. exitSubplot) to avoid emitting a
-   * stale intermediate scope.
-   * @param {Focus} focus - The modal scope to remove from the focus stack
+   * Resets the focus stack to the given scope and moves focus to the plot
+   * element. Does not fire a display change event — the caller must call
+   * {@link notifyFocusChange} after completing any follow-up scope
+   * transitions (e.g. exitSubplot) to avoid emitting a stale intermediate
+   * scope.
    * @param {Focus} targetScope - The scope the focus stack should reflect
    *   after the modal is dismissed. The stack is reset to this value so it
    *   stays in sync with the hotkeys scope set by the caller.
    */
-  public dismissModalScope(focus: Focus, targetScope: Focus): void {
+  public dismissModalScope(targetScope: Focus): void {
     this.plot.focus();
-    this.focusStack.removeLast(focus);
     this.focusStack.clear();
     this.focusStack.push(targetScope);
   }

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -184,6 +184,33 @@ export class DisplayService implements Disposable {
   }
 
   /**
+   * Removes a modal scope (e.g. BRAILLE) from the focus stack and moves
+   * focus to the plot element. Does not fire a display change event — the
+   * caller must call {@link notifyFocusChange} after completing any
+   * follow-up scope transitions (e.g. exitSubplot) to avoid emitting a
+   * stale intermediate scope.
+   * @param {Focus} focus - The modal scope to remove from the focus stack
+   */
+  public dismissModalScope(focus: Focus): void {
+    this.plot.focus();
+    this.focusStack.removeLast(focus);
+  }
+
+  /**
+   * Fires a deferred display change event with the given scope. The
+   * deferral (setTimeout 0) gives screen readers one event-loop cycle to
+   * process the preceding focus change before React unmounts the modal
+   * element (e.g. the braille textarea). Without this, NVDA/JAWS exit
+   * focus mode when the focused element disappears from the DOM.
+   * @param {Focus} scope - The scope to emit as the new display focus
+   */
+  public notifyFocusChange(scope: Focus): void {
+    setTimeout(() => {
+      this.onChangeEmitter.fire({ value: scope });
+    }, 0);
+  }
+
+  /**
    * Updates the focus state and initializes the active trace if needed.
    * @param {Focus} newScope - The new focus scope
    */

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -16,6 +16,7 @@ import hotkeys from 'hotkeys-js';
  */
 const BRAILLE_KEYMAP = {
   ACTIVATE_TRACE_LABEL_SCOPE: `l`,
+  EXIT_BRAILLE_AND_SUBPLOT: `esc`,
 
   // Autoplay
   AUTOPLAY_UPWARD: `${Platform.ctrl}+shift+up`,

--- a/src/ui/component/Braille.tsx
+++ b/src/ui/component/Braille.tsx
@@ -50,7 +50,13 @@ const Braille: React.FC = () => {
   }, [value, index]);
 
   return (
-    <div id={id}>
+    <div
+      id={id}
+      // role="application" ensures screen readers (NVDA/JAWS) pass all keys,
+      // including Escape, through to the web app instead of intercepting them
+      // for browse/virtual-cursor mode. This matches the plot element's role.
+      role="application"
+    >
       <textarea
         id={`${Constant.BRAILLE_TEXT_AREA}-${id}`}
         ref={brailleRef}

--- a/src/ui/component/Braille.tsx
+++ b/src/ui/component/Braille.tsx
@@ -50,18 +50,18 @@ const Braille: React.FC = () => {
   }, [value, index]);
 
   return (
-    <div
-      id={id}
-      // role="application" ensures screen readers (NVDA/JAWS) pass all keys,
-      // including Escape, through to the web app instead of intercepting them
-      // for browse/virtual-cursor mode. This matches the plot element's role.
-      role="application"
-    >
+    <div id={id}>
       <textarea
         id={`${Constant.BRAILLE_TEXT_AREA}-${id}`}
         ref={brailleRef}
         defaultValue={value}
         autoCapitalize="off"
+        // role="application" ensures screen readers (NVDA/JAWS) pass all
+        // keys, including Escape, through to the web app instead of
+        // intercepting them for browse/virtual-cursor mode. Placed on the
+        // textarea (not the wrapper div) to avoid suppressing browse-mode
+        // navigation for any future sibling content.
+        role="application"
         rows={5}
         cols={50}
       />

--- a/test/command/braille-escape.test.ts
+++ b/test/command/braille-escape.test.ts
@@ -39,7 +39,7 @@ function createMockBrailleService(enabled: boolean): BrailleService {
     get isEnabled() {
       return enabled;
     },
-    update: jest.fn(),
+    refreshDisplay: jest.fn(),
   } as unknown as BrailleService;
 }
 

--- a/test/command/braille-escape.test.ts
+++ b/test/command/braille-escape.test.ts
@@ -134,4 +134,23 @@ describe('MoveToTraceContextCommand', () => {
 
     expect(displayService.toggleFocus).not.toHaveBeenCalled();
   });
+
+  test('does not call refreshDisplay when state type is not trace', () => {
+    const context = createMockContext({
+      state: {
+        type: 'subplot',
+        empty: false,
+      },
+    } as any);
+    const brailleService = createMockBrailleService(true);
+    const displayService = createMockDisplayService();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const command = new MoveToTraceContextCommand(context, brailleService, displayService);
+    command.execute();
+
+    expect(brailleService.refreshDisplay).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });

--- a/test/command/braille-escape.test.ts
+++ b/test/command/braille-escape.test.ts
@@ -141,13 +141,12 @@ describe('MoveToTraceContextCommand', () => {
     });
     const brailleService = createMockBrailleService(true);
     const displayService = createMockDisplayService();
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const command = new MoveToTraceContextCommand(context, brailleService, displayService);
     command.execute();
 
     expect(brailleService.refreshDisplay).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
+    // toggleFocus should still be called so braille UI renders
+    expect(displayService.toggleFocus).toHaveBeenCalledWith(Scope.BRAILLE);
   });
 });

--- a/test/command/braille-escape.test.ts
+++ b/test/command/braille-escape.test.ts
@@ -1,0 +1,137 @@
+import type { Context } from '@model/context';
+import type { BrailleService } from '@service/braille';
+import type { DisplayService } from '@service/display';
+import { ExitBrailleAndSubplotCommand, MoveToTraceContextCommand } from '@command/move';
+import { describe, expect, jest, test } from '@jest/globals';
+import { Scope } from '@type/event';
+
+/**
+ * Creates a mock Context with enterSubplot and exitSubplot stubs.
+ */
+function createMockContext(overrides: Partial<Context> = {}): Context {
+  return {
+    enterSubplot: jest.fn(),
+    exitSubplot: jest.fn(),
+    active: { notifyStateUpdate: jest.fn() },
+    state: { type: 'trace', empty: false },
+    ...overrides,
+  } as unknown as Context;
+}
+
+/**
+ * Creates a mock DisplayService with dismissModalScope, notifyFocusChange,
+ * and toggleFocus stubs.
+ */
+function createMockDisplayService(overrides: Partial<DisplayService> = {}): DisplayService {
+  return {
+    dismissModalScope: jest.fn(),
+    notifyFocusChange: jest.fn(),
+    toggleFocus: jest.fn(),
+    ...overrides,
+  } as unknown as DisplayService;
+}
+
+/**
+ * Creates a mock BrailleService with a configurable isEnabled getter.
+ */
+function createMockBrailleService(enabled: boolean): BrailleService {
+  return {
+    get isEnabled() {
+      return enabled;
+    },
+    update: jest.fn(),
+  } as unknown as BrailleService;
+}
+
+describe('ExitBrailleAndSubplotCommand', () => {
+  test('executes the three-step sequence in correct order', () => {
+    const callOrder: string[] = [];
+    const context = createMockContext({
+      exitSubplot: jest.fn(() => {
+        callOrder.push('exitSubplot');
+      }) as any,
+    });
+    const displayService = createMockDisplayService({
+      dismissModalScope: jest.fn(() => {
+        callOrder.push('dismissModalScope');
+      }) as any,
+      notifyFocusChange: jest.fn(() => {
+        callOrder.push('notifyFocusChange');
+      }) as any,
+    });
+
+    const command = new ExitBrailleAndSubplotCommand(context, displayService);
+    command.execute();
+
+    expect(callOrder).toEqual([
+      'dismissModalScope',
+      'exitSubplot',
+      'notifyFocusChange',
+    ]);
+  });
+
+  test('calls dismissModalScope with SUBPLOT as the target scope', () => {
+    const context = createMockContext();
+    const displayService = createMockDisplayService();
+
+    const command = new ExitBrailleAndSubplotCommand(context, displayService);
+    command.execute();
+
+    expect(displayService.dismissModalScope).toHaveBeenCalledWith(Scope.SUBPLOT);
+  });
+
+  test('calls notifyFocusChange with SUBPLOT', () => {
+    const context = createMockContext();
+    const displayService = createMockDisplayService();
+
+    const command = new ExitBrailleAndSubplotCommand(context, displayService);
+    command.execute();
+
+    expect(displayService.notifyFocusChange).toHaveBeenCalledWith(Scope.SUBPLOT);
+  });
+
+  test('calls context.exitSubplot()', () => {
+    const context = createMockContext();
+    const displayService = createMockDisplayService();
+
+    const command = new ExitBrailleAndSubplotCommand(context, displayService);
+    command.execute();
+
+    expect(context.exitSubplot).toHaveBeenCalled();
+  });
+});
+
+describe('MoveToTraceContextCommand', () => {
+  test('calls enterSubplot', () => {
+    const context = createMockContext();
+    const brailleService = createMockBrailleService(false);
+    const displayService = createMockDisplayService();
+
+    const command = new MoveToTraceContextCommand(context, brailleService, displayService);
+    command.execute();
+
+    expect(context.enterSubplot).toHaveBeenCalled();
+  });
+
+  test('toggles braille focus when braille is enabled', () => {
+    const context = createMockContext();
+    const brailleService = createMockBrailleService(true);
+    const displayService = createMockDisplayService();
+
+    const command = new MoveToTraceContextCommand(context, brailleService, displayService);
+    command.execute();
+
+    expect(displayService.toggleFocus).toHaveBeenCalledWith(Scope.BRAILLE);
+  });
+
+  test('does not toggle braille focus when braille is disabled', () => {
+    const context = createMockContext();
+    const brailleService = createMockBrailleService(false);
+    const displayService = createMockDisplayService();
+
+    const command = new MoveToTraceContextCommand(context, brailleService, displayService);
+    command.execute();
+
+    expect(displayService.toggleFocus).not.toHaveBeenCalled();
+  });
+});

--- a/test/command/braille-escape.test.ts
+++ b/test/command/braille-escape.test.ts
@@ -8,7 +8,7 @@ import { Scope } from '@type/event';
 /**
  * Creates a mock Context with enterSubplot and exitSubplot stubs.
  */
-function createMockContext(overrides: Partial<Context> = {}): Context {
+function createMockContext(overrides: Record<string, unknown> = {}): Context {
   return {
     enterSubplot: jest.fn(),
     exitSubplot: jest.fn(),
@@ -22,7 +22,7 @@ function createMockContext(overrides: Partial<Context> = {}): Context {
  * Creates a mock DisplayService with dismissModalScope, notifyFocusChange,
  * and toggleFocus stubs.
  */
-function createMockDisplayService(overrides: Partial<DisplayService> = {}): DisplayService {
+function createMockDisplayService(overrides: Record<string, unknown> = {}): DisplayService {
   return {
     dismissModalScope: jest.fn(),
     notifyFocusChange: jest.fn(),
@@ -47,17 +47,17 @@ describe('ExitBrailleAndSubplotCommand', () => {
   test('executes the three-step sequence in correct order', () => {
     const callOrder: string[] = [];
     const context = createMockContext({
-      exitSubplot: jest.fn(() => {
+      exitSubplot: jest.fn<() => void>().mockImplementation(() => {
         callOrder.push('exitSubplot');
-      }) as any,
+      }),
     });
     const displayService = createMockDisplayService({
-      dismissModalScope: jest.fn(() => {
+      dismissModalScope: jest.fn<() => void>().mockImplementation(() => {
         callOrder.push('dismissModalScope');
-      }) as any,
-      notifyFocusChange: jest.fn(() => {
+      }),
+      notifyFocusChange: jest.fn<() => void>().mockImplementation(() => {
         callOrder.push('notifyFocusChange');
-      }) as any,
+      }),
     });
 
     const command = new ExitBrailleAndSubplotCommand(context, displayService);
@@ -137,11 +137,8 @@ describe('MoveToTraceContextCommand', () => {
 
   test('does not call refreshDisplay when state type is not trace', () => {
     const context = createMockContext({
-      state: {
-        type: 'subplot',
-        empty: false,
-      },
-    } as any);
+      state: { type: 'subplot', empty: false },
+    });
     const brailleService = createMockBrailleService(true);
     const displayService = createMockDisplayService();
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});

--- a/test/service/display.test.ts
+++ b/test/service/display.test.ts
@@ -1,0 +1,171 @@
+import type { Context } from '@model/context';
+import type { TextService } from '@service/text';
+import type { Focus } from '@type/event';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { DisplayService } from '@service/display';
+import { Scope } from '@type/event';
+
+/**
+ * Creates a minimal mock HTMLElement with the methods DisplayService uses.
+ */
+function createMockPlot(): HTMLElement {
+  return {
+    focus: jest.fn(),
+    setAttribute: jest.fn(),
+    removeAttribute: jest.fn(),
+    tabIndex: 0,
+  } as unknown as HTMLElement;
+}
+
+/**
+ * Creates a minimal mock Context.
+ */
+function createMockContext(scope: string = 'SUBPLOT'): Context {
+  return {
+    scope,
+    state: { type: 'subplot', empty: true },
+    getInstruction: jest.fn(() => 'test instruction'),
+    toggleScope: jest.fn(),
+    active: { notifyStateUpdate: jest.fn() },
+  } as unknown as Context;
+}
+
+/**
+ * Creates a minimal mock TextService.
+ */
+function createMockTextService(): TextService {
+  return {
+    onChange: jest.fn(() => ({ dispose: jest.fn() })),
+    format: jest.fn(() => ''),
+  } as unknown as TextService;
+}
+
+describe('DisplayService.dismissModalScope', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('moves focus to the plot element', () => {
+    const plot = createMockPlot();
+    const context = createMockContext();
+    const textService = createMockTextService();
+    const service = new DisplayService(context, plot, textService);
+
+    service.dismissModalScope(Scope.SUBPLOT);
+
+    expect(plot.focus).toHaveBeenCalled();
+  });
+
+  test('resets the focus stack to the target scope', () => {
+    const plot = createMockPlot();
+    const context = createMockContext();
+    const textService = createMockTextService();
+    const service = new DisplayService(context, plot, textService);
+
+    // Verify by listening for change events
+    const events: Focus[] = [];
+    service.onChange((e) => {
+      events.push(e.value);
+    });
+
+    // Dismiss with SUBPLOT as target
+    service.dismissModalScope(Scope.SUBPLOT);
+
+    // Now fire a deferred notification — should emit SUBPLOT
+    service.notifyFocusChange(Scope.SUBPLOT);
+    jest.runAllTimers();
+
+    expect(events).toEqual([Scope.SUBPLOT]);
+  });
+
+  test('does not fire a display change event synchronously', () => {
+    const plot = createMockPlot();
+    const context = createMockContext();
+    const textService = createMockTextService();
+    const service = new DisplayService(context, plot, textService);
+
+    const listener = jest.fn();
+    service.onChange(listener);
+
+    service.dismissModalScope(Scope.SUBPLOT);
+
+    // dismissModalScope itself should not fire any event
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('DisplayService.notifyFocusChange', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('fires the change event after a deferred tick', () => {
+    const plot = createMockPlot();
+    const context = createMockContext();
+    const textService = createMockTextService();
+    const service = new DisplayService(context, plot, textService);
+
+    const events: Focus[] = [];
+    service.onChange((e) => {
+      events.push(e.value);
+    });
+
+    service.notifyFocusChange(Scope.SUBPLOT);
+
+    // Event should not have fired yet (deferred)
+    expect(events).toEqual([]);
+
+    jest.runAllTimers();
+
+    expect(events).toEqual([Scope.SUBPLOT]);
+  });
+
+  test('cancels a pending notification when called again', () => {
+    const plot = createMockPlot();
+    const context = createMockContext();
+    const textService = createMockTextService();
+    const service = new DisplayService(context, plot, textService);
+
+    const events: Focus[] = [];
+    service.onChange((e) => {
+      events.push(e.value);
+    });
+
+    // Fire twice rapidly — first should be cancelled
+    service.notifyFocusChange(Scope.TRACE);
+    service.notifyFocusChange(Scope.SUBPLOT);
+
+    jest.runAllTimers();
+
+    // Only the second call's scope should have fired
+    expect(events).toEqual([Scope.SUBPLOT]);
+  });
+
+  test('cleans up pending timer on dispose', () => {
+    const plot = createMockPlot();
+    const context = createMockContext();
+    const textService = createMockTextService();
+    const service = new DisplayService(context, plot, textService);
+
+    const events: Focus[] = [];
+    service.onChange((e) => {
+      events.push(e.value);
+    });
+
+    service.notifyFocusChange(Scope.SUBPLOT);
+    service.dispose();
+
+    jest.runAllTimers();
+
+    // Event should not fire after dispose
+    expect(events).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes made in this pull request. -->
Escape key now exits the currently opened subplot and focuses on the list of subplots in multipanel and facet plots even if braille mode is on.
## Related Issues

<!-- Specify any related issues or tickets that this pull request addresses. -->
Fixes https://github.com/xability/maidr/issues/574
## Changes Made

<!-- Describe the specific changes made in this pull request. -->
Earlier behavior: In multipanel and facet plots, the escape key was used to exit the currently opened subplot. This did not work with braille mode on. This PR fixes the issue: Escape exits the subplot and focuses on the subplot list even if braille mode is on. Further, it preserves the state of braille mode along with sonification and text I.E. If the user exits the subplot while braille mode is on and opens a new subplot, braille representation of the new subplot is displayed.
## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
