### PR TITLE
docs: clarify blank space at beginning for comparison of multiple boxes

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -54,13 +54,14 @@ The sections are encoded as follows:
 - ⠒ represents the left or right whiskers
 - ⠿ represents the second or third quartiles
 - ⠸⠇ represents the 50% midpoint (median)
-- blank spaces represent empty spaces
+- blank spaces represent empty spaces. Blank spaces represent empty spaces. At the beginning of a line, blank space acts as a positional offset to ensure multiple box plots align correctly to the same numerical scale.
 
 We also impose some overarching rules:
 
 1. Each section must be represented with at least one braille character, assuming they have some positive length.
 2. Differences or equalities in whiskers and quartiles must be upheld. That is, if the min and max whisker are of equal length, they must have the same number of braille characters, or if they're different, the number of characters must be different.
 3. A set character always represents zero length sections, such as outliers and the median. ⠂ in the case of outliers, ⠸⠇ in the case of the median.
+4. Spatial Alignment: When comparing multiple box plots, the leading blank space represents the distance from the global minimum to the start of the specific dataset. This allows users to perceive relative differences in value by comparing the "indentation" of each plot.
 
 This tactile encoding enables users to discern the various components of the boxplot, allowing them to comprehend the data distribution, detect outliers, and identify central tendencies and dispersion within the dataset.
 


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes made in this pull request. -->
Clarify purpose of blank spaces in the beginning of a box plot.
## Related Issues

<!-- Specify any related issues or tickets that this pull request addresses. -->
Addresses https://github.com/xability/maidr/issues/571
## Changes Made

<!-- Describe the specific changes made in this pull request. -->
Updated the Box Plot Braille documentation to clarify that blank spaces represent the relative offset between multiple boxes.

## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
