### PR TITLE
feat: enable automatic keybinding capture in help menu

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -252,6 +252,10 @@ export class Controller implements Disposable {
       },
       this.context.scope,
     );
+
+    // Inject CommandExecutor into CommandPaletteViewModel (deferred due to circular dependency)
+    this.commandPaletteViewModel.setCommandExecutor(this.commandExecutor);
+
     this.registerViewModels();
     this.registerObservers();
     this.keybinding.register(this.context.scope);

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -253,8 +253,10 @@ export class Controller implements Disposable {
       this.context.scope,
     );
 
-    // Inject CommandExecutor into CommandPaletteViewModel (deferred due to circular dependency)
-    this.commandPaletteViewModel.setCommandExecutor(this.commandExecutor);
+    // Inject command execution callback into CommandPaletteViewModel (deferred due to circular dependency)
+    this.commandPaletteViewModel.setExecuteCommandCallback(
+      commandKey => this.commandExecutor.executeCommand(commandKey),
+    );
 
     this.registerViewModels();
     this.registerObservers();

--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -1,56 +1,58 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
+import type { KeybindingEntry } from '@type/event';
 import type { HelpMenuItem } from '@type/help';
+import { SCOPED_KEYMAP } from '@service/keybinding';
 import { Scope } from '@type/event';
-import { Platform } from '@util/platform';
 
 /**
- * Help menu items for trace scope navigation and interactions.
+ * Generates help menu items from a keymap configuration.
+ * Filters entries based on showInHelp flag and uses helpKey for display.
+ * @param keymap - The keymap configuration object
+ * @returns Array of help menu items
  */
-const TRACE_HELP_MENU = [
-  { description: 'Navigate Data Points', key: 'arrow keys' },
-  { description: 'Move to Next Layer', key: 'page up' },
-  { description: 'Move to Previous Layer', key: 'page down' },
-  { description: 'Go to Left/Right/Top/Bottom Extreme Point', key: `${Platform.ctrl} + arrow keys` },
+function generateHelpMenuFromKeymap(keymap: Record<string, KeybindingEntry>): HelpMenuItem[] {
+  const items: HelpMenuItem[] = [];
+  const seenGroups = new Set<string>();
 
-  { description: 'Toggle Braille Mode', key: 'b' },
-  { description: 'Toggle Text Mode', key: 't' },
-  { description: 'Toggle Sonification Mode', key: 's' },
-  { description: 'Toggle Review Mode', key: 'r' },
-  { description: 'Toggle High Contrast Mode', key: 'c' },
+  for (const entry of Object.values(keymap)) {
+    // Skip entries explicitly marked as hidden
+    if (entry.showInHelp === false) {
+      continue;
+    }
 
-  { description: 'Autoplay Outward', key: `${Platform.ctrl} + shift + arrow keys` },
-  { description: 'Stop Autoplay', key: `${Platform.ctrl}` },
-  { description: 'Speed Up Autoplay', key: '. (period)' },
-  { description: 'Speed Down Autoplay', key: ', (comma)' },
-  { description: 'Reset Autoplay Speed', key: '/ (slash)' },
-  { description: 'Replay Current Point', key: 'space' },
+    // Handle grouped entries - only show the first one with the group's helpKey
+    if (entry.helpGroup) {
+      if (seenGroups.has(entry.helpGroup)) {
+        continue;
+      }
+      seenGroups.add(entry.helpGroup);
+    }
 
+    items.push({
+      description: entry.description,
+      key: entry.helpKey ?? entry.hotkey,
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Additional help entries for key sequences (multi-step commands).
+ * These represent commands that require entering a sub-scope first.
+ */
+const TRACE_LABEL_SEQUENCE_HELP: HelpMenuItem[] = [
   { description: 'Announce Plot Title', key: 'l t' },
   { description: 'Announce X Label', key: 'l x' },
   { description: 'Announce Y Label', key: 'l y' },
   { description: 'Announce Fill (Z) Label', key: 'l f' },
-
-  { description: 'Open Settings', key: `${Platform.ctrl} + ,` },
-  { description: 'Open Chat', key: `?` },
-
-  { description: 'Move to next navigation mode in Rotor', key: `${Platform.alt}+shift+up` },
-  { description: 'Move to previous navigation mode in Rotor', key: `${Platform.alt}+shift+down` },
-
 ];
 
-/**
- * Help menu items for subplot scope navigation and interactions.
- */
-const SUBPLOT_HELP_MENU = [
-  { description: 'Move around Subplot', key: 'arrow keys' },
-  { description: 'Activate Current Subplot', key: `${Platform.enter}` },
-
+const FIGURE_LABEL_SEQUENCE_HELP: HelpMenuItem[] = [
   { description: 'Announce Plot Title', key: 'l t' },
   { description: 'Announce Subtitle', key: 'l s' },
   { description: 'Announce Caption', key: 'l c' },
-
-  { description: 'Open Settings', key: `${Platform.ctrl} + ,` },
 ];
 
 /**
@@ -63,7 +65,7 @@ export class HelpService {
   private readonly scopedMenuItems: Partial<Record<Scope, HelpMenuItem[]>>;
 
   /**
-   * Creates a new HelpService instance with scoped menu configurations.
+   * Creates a new HelpService instance with auto-generated scoped menu configurations.
    * @param context - The application context for determining current scope
    * @param display - The display service for toggling help UI
    */
@@ -71,12 +73,23 @@ export class HelpService {
     this.context = context;
     this.display = display;
 
+    // Generate help menus from keymaps with additional sequence entries
+    const traceHelpMenu = [
+      ...generateHelpMenuFromKeymap(SCOPED_KEYMAP[Scope.TRACE] as unknown as Record<string, KeybindingEntry>),
+      ...TRACE_LABEL_SEQUENCE_HELP,
+    ];
+
+    const subplotHelpMenu = [
+      ...generateHelpMenuFromKeymap(SCOPED_KEYMAP[Scope.SUBPLOT] as unknown as Record<string, KeybindingEntry>),
+      ...FIGURE_LABEL_SEQUENCE_HELP,
+    ];
+
     this.scopedMenuItems = {
-      [Scope.TRACE]: TRACE_HELP_MENU,
-      [Scope.TRACE_LABEL]: TRACE_HELP_MENU,
-      [Scope.BRAILLE]: TRACE_HELP_MENU,
-      [Scope.SUBPLOT]: SUBPLOT_HELP_MENU,
-      [Scope.FIGURE_LABEL]: SUBPLOT_HELP_MENU,
+      [Scope.TRACE]: traceHelpMenu,
+      [Scope.TRACE_LABEL]: traceHelpMenu,
+      [Scope.BRAILLE]: traceHelpMenu,
+      [Scope.SUBPLOT]: subplotHelpMenu,
+      [Scope.FIGURE_LABEL]: subplotHelpMenu,
     };
   }
 

--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -2,7 +2,7 @@ import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
 import type { KeybindingEntry } from '@type/event';
 import type { HelpMenuItem } from '@type/help';
-import { SCOPED_KEYMAP } from '@service/keybinding';
+import { getKeymapForScope } from '@service/keybinding';
 import { Scope } from '@type/event';
 
 /**
@@ -97,14 +97,14 @@ function generateNestedScopeHelp(
  * @returns Array of help menu items
  */
 function generateCompleteHelpMenu(scope: Scope): HelpMenuItem[] {
-  const keymap = SCOPED_KEYMAP[scope] as unknown as Record<string, KeybindingEntry>;
+  const keymap = getKeymapForScope(scope);
   const items = generateHelpMenuFromKeymap(keymap);
 
   // Add nested scope entries (only commands unique to nested scope)
   const nestedConfigs = NESTED_SCOPE_CONFIG[scope];
   if (nestedConfigs) {
     for (const config of nestedConfigs) {
-      const nestedKeymap = SCOPED_KEYMAP[config.scope] as unknown as Record<string, KeybindingEntry>;
+      const nestedKeymap = getKeymapForScope(config.scope);
       const nestedItems = generateNestedScopeHelp(nestedKeymap, config.entryKey, keymap);
       items.push(...nestedItems);
     }

--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -6,27 +6,38 @@ import { SCOPED_KEYMAP } from '@service/keybinding';
 import { Scope } from '@type/event';
 
 /**
+ * Configuration for nested scopes that are entered via a key from parent scope.
+ */
+interface NestedScopeConfig {
+  scope: Scope;
+  entryKey: string;
+}
+
+/**
+ * Mapping of parent scopes to their nested scopes.
+ */
+const NESTED_SCOPE_CONFIG: Partial<Record<Scope, NestedScopeConfig[]>> = {
+  [Scope.TRACE]: [
+    { scope: Scope.TRACE_LABEL, entryKey: 'l' },
+  ],
+  [Scope.SUBPLOT]: [
+    { scope: Scope.FIGURE_LABEL, entryKey: 'l' },
+  ],
+};
+
+/**
  * Generates help menu items from a keymap configuration.
- * Filters entries based on showInHelp flag and uses helpKey for display.
+ * Each command gets its own entry (no grouping).
  * @param keymap - The keymap configuration object
  * @returns Array of help menu items
  */
 function generateHelpMenuFromKeymap(keymap: Record<string, KeybindingEntry>): HelpMenuItem[] {
   const items: HelpMenuItem[] = [];
-  const seenGroups = new Set<string>();
 
   for (const entry of Object.values(keymap)) {
     // Skip entries explicitly marked as hidden
     if (entry.showInHelp === false) {
       continue;
-    }
-
-    // Handle grouped entries - only show the first one with the group's helpKey
-    if (entry.helpGroup) {
-      if (seenGroups.has(entry.helpGroup)) {
-        continue;
-      }
-      seenGroups.add(entry.helpGroup);
     }
 
     items.push({
@@ -39,21 +50,68 @@ function generateHelpMenuFromKeymap(keymap: Record<string, KeybindingEntry>): He
 }
 
 /**
- * Additional help entries for key sequences (multi-step commands).
- * These represent commands that require entering a sub-scope first.
+ * Generates help menu items for a nested scope with entry key prefix.
+ * Only includes commands that are unique to the nested scope (not in parent).
+ * @param nestedKeymap - The nested scope keymap configuration
+ * @param entryKey - The key used to enter the nested scope (e.g., 'l')
+ * @param parentKeymap - The parent scope keymap to check for duplicates
+ * @returns Array of help menu items with prefixed keys
  */
-const TRACE_LABEL_SEQUENCE_HELP: HelpMenuItem[] = [
-  { description: 'Announce Plot Title', key: 'l t' },
-  { description: 'Announce X Label', key: 'l x' },
-  { description: 'Announce Y Label', key: 'l y' },
-  { description: 'Announce Fill (Z) Label', key: 'l f' },
-];
+function generateNestedScopeHelp(
+  nestedKeymap: Record<string, KeybindingEntry>,
+  entryKey: string,
+  parentKeymap: Record<string, KeybindingEntry>,
+): HelpMenuItem[] {
+  const items: HelpMenuItem[] = [];
+  const parentCommandKeys = new Set(Object.keys(parentKeymap));
 
-const FIGURE_LABEL_SEQUENCE_HELP: HelpMenuItem[] = [
-  { description: 'Announce Plot Title', key: 'l t' },
-  { description: 'Announce Subtitle', key: 'l s' },
-  { description: 'Announce Caption', key: 'l c' },
-];
+  for (const [commandKey, entry] of Object.entries(nestedKeymap)) {
+    // Skip commands that exist in parent scope (they're not nested-specific)
+    if (parentCommandKeys.has(commandKey)) {
+      continue;
+    }
+
+    // Skip entries explicitly marked as hidden
+    if (entry.showInHelp === false) {
+      continue;
+    }
+
+    // Skip the exit/deactivate commands (they use 'escape')
+    const hotkey = entry.helpKey ?? entry.hotkey;
+    if (hotkey === 'escape' || hotkey === 'esc') {
+      continue;
+    }
+
+    items.push({
+      description: entry.description,
+      key: `${entryKey} ${hotkey}`,
+    });
+  }
+
+  return items;
+}
+
+/**
+ * Generates a complete help menu for a scope including nested scope entries.
+ * @param scope - The parent scope
+ * @returns Array of help menu items
+ */
+function generateCompleteHelpMenu(scope: Scope): HelpMenuItem[] {
+  const keymap = SCOPED_KEYMAP[scope] as unknown as Record<string, KeybindingEntry>;
+  const items = generateHelpMenuFromKeymap(keymap);
+
+  // Add nested scope entries (only commands unique to nested scope)
+  const nestedConfigs = NESTED_SCOPE_CONFIG[scope];
+  if (nestedConfigs) {
+    for (const config of nestedConfigs) {
+      const nestedKeymap = SCOPED_KEYMAP[config.scope] as unknown as Record<string, KeybindingEntry>;
+      const nestedItems = generateNestedScopeHelp(nestedKeymap, config.entryKey, keymap);
+      items.push(...nestedItems);
+    }
+  }
+
+  return items;
+}
 
 /**
  * Service for managing context-sensitive help menus across different application scopes.
@@ -73,16 +131,9 @@ export class HelpService {
     this.context = context;
     this.display = display;
 
-    // Generate help menus from keymaps with additional sequence entries
-    const traceHelpMenu = [
-      ...generateHelpMenuFromKeymap(SCOPED_KEYMAP[Scope.TRACE] as unknown as Record<string, KeybindingEntry>),
-      ...TRACE_LABEL_SEQUENCE_HELP,
-    ];
-
-    const subplotHelpMenu = [
-      ...generateHelpMenuFromKeymap(SCOPED_KEYMAP[Scope.SUBPLOT] as unknown as Record<string, KeybindingEntry>),
-      ...FIGURE_LABEL_SEQUENCE_HELP,
-    ];
+    // Auto-generate help menus from keymaps including nested scopes
+    const traceHelpMenu = generateCompleteHelpMenu(Scope.TRACE);
+    const subplotHelpMenu = generateCompleteHelpMenu(Scope.SUBPLOT);
 
     this.scopedMenuItems = {
       [Scope.TRACE]: traceHelpMenu,

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -2,7 +2,7 @@ import type { CommandContext } from '@command/command';
 import type { DisplayService } from '@service/display';
 import type { SettingsService } from '@service/settings';
 import type { Disposable } from '@type/disposable';
-import type { Keys } from '@type/event';
+import type { KeybindingEntry, Keys } from '@type/event';
 import type { Observer } from '@type/observable';
 import type { Settings } from '@type/settings';
 import { CommandFactory } from '@command/factory';
@@ -12,56 +12,67 @@ import { Platform } from '@util/platform';
 import hotkeys from 'hotkeys-js';
 
 /**
+ * Helper to create a keybinding entry with required fields.
+ */
+function key(hotkey: string, description: string, options?: Partial<KeybindingEntry>): KeybindingEntry {
+  return {
+    hotkey,
+    description,
+    ...options,
+  };
+}
+
+/**
  * Keymap configuration for braille mode interactions.
  */
 const BRAILLE_KEYMAP = {
-  ACTIVATE_TRACE_LABEL_SCOPE: `l`,
-  EXIT_BRAILLE_AND_SUBPLOT: `esc`,
+  ACTIVATE_TRACE_LABEL_SCOPE: key(`l`, 'Access Labels'),
+  EXIT_BRAILLE_AND_SUBPLOT: key(`esc`, 'Exit Braille Mode', { showInHelp: false }),
 
   // Autoplay
-  AUTOPLAY_UPWARD: `${Platform.ctrl}+shift+up`,
-  AUTOPLAY_DOWNWARD: `${Platform.ctrl}+shift+down`,
-  AUTOPLAY_FORWARD: `${Platform.ctrl}+shift+right`,
-  AUTOPLAY_BACKWARD: `${Platform.ctrl}+shift+left`,
+  AUTOPLAY_UPWARD: key(`${Platform.ctrl}+shift+up`, 'Autoplay Upward', { helpGroup: 'autoplay', helpKey: `${Platform.ctrl} + shift + arrow keys` }),
+  AUTOPLAY_DOWNWARD: key(`${Platform.ctrl}+shift+down`, 'Autoplay Downward', { helpGroup: 'autoplay', showInHelp: false }),
+  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpGroup: 'autoplay', showInHelp: false }),
+  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpGroup: 'autoplay', showInHelp: false }),
 
-  STOP_AUTOPLAY: `${Platform.ctrl}, up, down, left, right`,
-  SPEED_UP_AUTOPLAY: `.`,
-  SPEED_DOWN_AUTOPLAY: `,`,
-  RESET_AUTOPLAY_SPEED: `/`,
+  STOP_AUTOPLAY: key(`${Platform.ctrl}, up, down, left, right`, 'Stop Autoplay', { helpKey: `${Platform.ctrl}` }),
+  SPEED_UP_AUTOPLAY: key(`.`, 'Speed Up Autoplay', { helpKey: '. (period)' }),
+  SPEED_DOWN_AUTOPLAY: key(`,`, 'Speed Down Autoplay', { helpKey: ', (comma)' }),
+  RESET_AUTOPLAY_SPEED: key(`/`, 'Reset Autoplay Speed', { helpKey: '/ (slash)' }),
 
   // Navigation
-  MOVE_UP: `up`,
-  MOVE_DOWN: `down`,
-  MOVE_RIGHT: `right`,
-  MOVE_LEFT: `left`,
+  MOVE_UP: key(`up`, 'Navigate Data Points', { helpGroup: 'navigate', helpKey: 'arrow keys' }),
+  MOVE_DOWN: key(`down`, 'Navigate Down', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_RIGHT: key(`right`, 'Navigate Right', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_LEFT: key(`left`, 'Navigate Left', { helpGroup: 'navigate', showInHelp: false }),
 
-  MOVE_TO_TOP_EXTREME: `${Platform.ctrl}+up`,
-  MOVE_TO_BOTTOM_EXTREME: `${Platform.ctrl}+down`,
-  MOVE_TO_LEFT_EXTREME: `${Platform.ctrl}+left`,
-  MOVE_TO_RIGHT_EXTREME: `${Platform.ctrl}+right`,
+  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Extreme Point', { helpGroup: 'extreme', helpKey: `${Platform.ctrl} + arrow keys` }),
+  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom Extreme', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpGroup: 'extreme', showInHelp: false }),
 
-  MOVE_TO_NEXT_TRACE: `pageup`,
-  MOVE_TO_PREV_TRACE: `pagedown`,
+  MOVE_TO_NEXT_TRACE: key(`pageup`, 'Move to Next Layer'),
+  MOVE_TO_PREV_TRACE: key(`pagedown`, 'Move to Previous Layer'),
 
   // Modes
-  TOGGLE_BRAILLE: `b`,
-  TOGGLE_TEXT: `t`,
-  TOGGLE_AUDIO: `s`,
-  TOGGLE_REVIEW: `r`,
-  TOGGLE_HIGH_CONTRAST: `c`,
+  TOGGLE_BRAILLE: key(`b`, 'Toggle Braille Mode'),
+  TOGGLE_TEXT: key(`t`, 'Toggle Text Mode'),
+  TOGGLE_AUDIO: key(`s`, 'Toggle Sonification Mode'),
+  TOGGLE_REVIEW: key(`r`, 'Toggle Review Mode'),
+  TOGGLE_HIGH_CONTRAST: key(`c`, 'Toggle High Contrast Mode'),
 
   // Misc
-  TOGGLE_HELP: `${Platform.ctrl}+/`,
-  TOGGLE_CHAT: `shift+/`,
-  TOGGLE_SETTINGS: `${Platform.ctrl}+,`,
+  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
+  TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
 
   // Description
-  ANNOUNCE_POINT: `space`,
-  ANNOUNCE_POSITION: `p`,
+  ANNOUNCE_POINT: key(`space`, 'Replay Current Point'),
+  ANNOUNCE_POSITION: key(`p`, 'Announce Position'),
 
   // rotor functionality
-  ROTOR_NEXT_NAV: `${Platform.alt}+shift+up`,
-  ROTOR_PREV_NAV: `${Platform.alt}+shift+down`,
+  ROTOR_NEXT_NAV: key(`${Platform.alt}+shift+up`, 'Next Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + up` }),
+  ROTOR_PREV_NAV: key(`${Platform.alt}+shift+down`, 'Previous Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + down` }),
 } as const;
 
 /**
@@ -69,22 +80,22 @@ const BRAILLE_KEYMAP = {
  */
 const CHAT_KEYMAP = {
   // Misc
-  TOGGLE_CHAT: `esc`,
+  TOGGLE_CHAT: key(`esc`, 'Close Chat', { showInHelp: false }),
 } as const;
 
 /**
  * Keymap configuration for figure label scope interactions.
  */
 const FIGURE_LABEL_KEYMAP = {
-  DEACTIVATE_FIGURE_LABEL_SCOPE: `escape`,
+  DEACTIVATE_FIGURE_LABEL_SCOPE: key(`escape`, 'Exit Label Mode', { showInHelp: false }),
 
   // Description
-  ANNOUNCE_TITLE: `t`,
-  ANNOUNCE_SUBTITLE: `s`,
-  ANNOUNCE_CAPTION: `c`,
+  ANNOUNCE_TITLE: key(`t`, 'Announce Plot Title'),
+  ANNOUNCE_SUBTITLE: key(`s`, 'Announce Subtitle'),
+  ANNOUNCE_CAPTION: key(`c`, 'Announce Caption'),
 
   // Misc
-  TOGGLE_HELP: `${Platform.ctrl}+/`,
+  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
 } as const;
 
 /**
@@ -92,57 +103,57 @@ const FIGURE_LABEL_KEYMAP = {
  */
 const HELP_KEYMAP = {
   // Misc
-  TOGGLE_HELP: `esc`,
+  TOGGLE_HELP: key(`esc`, 'Close Help', { showInHelp: false }),
 } as const;
 
 /**
  * Keymap configuration for subplot scope interactions.
  */
 const SUBPLOT_KEYMAP = {
-  ACTIVATE_FIGURE_LABEL_SCOPE: `l`,
+  ACTIVATE_FIGURE_LABEL_SCOPE: key(`l`, 'Access Labels'),
 
   // Description
-  ANNOUNCE_TITLE: `t`,
-  ANNOUNCE_POINT: `space`,
-  ANNOUNCE_POSITION: `p`,
+  ANNOUNCE_TITLE: key(`t`, 'Announce Title'),
+  ANNOUNCE_POINT: key(`space`, 'Announce Current Subplot'),
+  ANNOUNCE_POSITION: key(`p`, 'Announce Position'),
 
   // Navigation
-  MOVE_UP: `up`,
-  MOVE_DOWN: `down`,
-  MOVE_RIGHT: `right`,
-  MOVE_LEFT: `left`,
+  MOVE_UP: key(`up`, 'Move Around Subplot', { helpGroup: 'navigate', helpKey: 'arrow keys' }),
+  MOVE_DOWN: key(`down`, 'Move Down', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_RIGHT: key(`right`, 'Move Right', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_LEFT: key(`left`, 'Move Left', { helpGroup: 'navigate', showInHelp: false }),
 
-  MOVE_TO_TOP_EXTREME: `${Platform.ctrl}+up`,
-  MOVE_TO_BOTTOM_EXTREME: `${Platform.ctrl}+down`,
-  MOVE_TO_LEFT_EXTREME: `${Platform.ctrl}+left`,
-  MOVE_TO_RIGHT_EXTREME: `${Platform.ctrl}+right`,
+  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Extreme Subplot', { helpGroup: 'extreme', helpKey: `${Platform.ctrl} + arrow keys`, showInHelp: false }),
+  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right', { helpGroup: 'extreme', showInHelp: false }),
 
-  MOVE_TO_TRACE_CONTEXT: `${Platform.enter}`,
+  MOVE_TO_TRACE_CONTEXT: key(`${Platform.enter}`, 'Activate Current Subplot', { helpKey: `${Platform.enter}` }),
 
-  TOGGLE_HIGH_CONTRAST: `c`,
+  TOGGLE_HIGH_CONTRAST: key(`c`, 'Toggle High Contrast Mode'),
 
   // Misc
-  TOGGLE_HELP: `${Platform.ctrl}+/`,
-  TOGGLE_CHAT: `shift+/`,
-  TOGGLE_SETTINGS: `${Platform.ctrl}+,`,
+  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
+  TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
 } as const;
 
 /**
  * Keymap configuration for trace label scope interactions.
  */
 const TRACE_LABEL_KEYMAP = {
-  DEACTIVATE_TRACE_LABEL_SCOPE: `escape`,
+  DEACTIVATE_TRACE_LABEL_SCOPE: key(`escape`, 'Exit Label Mode', { showInHelp: false }),
 
   // Description
-  ANNOUNCE_X: `x`,
-  ANNOUNCE_Y: `y`,
-  ANNOUNCE_FILL: `f`,
-  ANNOUNCE_TITLE: `t`,
-  ANNOUNCE_SUBTITLE: `s`,
-  ANNOUNCE_CAPTION: `c`,
+  ANNOUNCE_X: key(`x`, 'Announce X Label'),
+  ANNOUNCE_Y: key(`y`, 'Announce Y Label'),
+  ANNOUNCE_FILL: key(`f`, 'Announce Fill (Z) Label'),
+  ANNOUNCE_TITLE: key(`t`, 'Announce Plot Title'),
+  ANNOUNCE_SUBTITLE: key(`s`, 'Announce Subtitle'),
+  ANNOUNCE_CAPTION: key(`c`, 'Announce Caption'),
 
   // Misc
-  TOGGLE_HELP: `${Platform.ctrl}+/`,
+  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
 } as const;
 
 /**
@@ -150,15 +161,15 @@ const TRACE_LABEL_KEYMAP = {
  */
 const REVIEW_KEYMAP = {
   // Modes
-  TOGGLE_BRAILLE: `b`,
-  TOGGLE_REVIEW: `r`,
+  TOGGLE_BRAILLE: key(`b`, 'Toggle Braille Mode'),
+  TOGGLE_REVIEW: key(`r`, 'Exit Review Mode'),
 
   // Allowed actions
-  ALLOW_DEFAULT: `up, down, left, right,
+  ALLOW_DEFAULT: key(`up, down, left, right,
     ${Platform.ctrl}+up, ${Platform.ctrl}+down,
     ${Platform.ctrl}+left, ${Platform.ctrl}+right,
     pageup, pagedown, home, end,
-    tab, ${Platform.ctrl}+a, ${Platform.ctrl}+c`,
+    tab, ${Platform.ctrl}+a, ${Platform.ctrl}+c`, 'Standard Text Selection', { showInHelp: false }),
 } as const;
 
 /**
@@ -166,90 +177,90 @@ const REVIEW_KEYMAP = {
  */
 const SETTINGS_KEYMAP = {
   // Misc
-  TOGGLE_SETTINGS: `esc`,
+  TOGGLE_SETTINGS: key(`esc`, 'Close Settings', { showInHelp: false }),
 } as const;
 
 /**
  * Keymap configuration for trace scope interactions and navigation.
  */
 const TRACE_KEYMAP = {
-  ACTIVATE_TRACE_LABEL_SCOPE: `l`,
+  ACTIVATE_TRACE_LABEL_SCOPE: key(`l`, 'Access Labels'),
 
   // Autoplay
-  AUTOPLAY_UPWARD: `${Platform.ctrl}+shift+up`,
-  AUTOPLAY_DOWNWARD: `${Platform.ctrl}+shift+down`,
-  AUTOPLAY_FORWARD: `${Platform.ctrl}+shift+right`,
-  AUTOPLAY_BACKWARD: `${Platform.ctrl}+shift+left`,
+  AUTOPLAY_UPWARD: key(`${Platform.ctrl}+shift+up`, 'Autoplay Outward', { helpGroup: 'autoplay', helpKey: `${Platform.ctrl} + shift + arrow keys` }),
+  AUTOPLAY_DOWNWARD: key(`${Platform.ctrl}+shift+down`, 'Autoplay Downward', { helpGroup: 'autoplay', showInHelp: false }),
+  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpGroup: 'autoplay', showInHelp: false }),
+  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpGroup: 'autoplay', showInHelp: false }),
 
-  STOP_AUTOPLAY: `${Platform.ctrl}, up, down, left, right`,
-  SPEED_UP_AUTOPLAY: `.`,
-  SPEED_DOWN_AUTOPLAY: `,`,
-  RESET_AUTOPLAY_SPEED: `/`,
+  STOP_AUTOPLAY: key(`${Platform.ctrl}, up, down, left, right`, 'Stop Autoplay', { helpKey: `${Platform.ctrl}` }),
+  SPEED_UP_AUTOPLAY: key(`.`, 'Speed Up Autoplay', { helpKey: '. (period)' }),
+  SPEED_DOWN_AUTOPLAY: key(`,`, 'Speed Down Autoplay', { helpKey: ', (comma)' }),
+  RESET_AUTOPLAY_SPEED: key(`/`, 'Reset Autoplay Speed', { helpKey: '/ (slash)' }),
 
   // Navigation
-  MOVE_UP: `up`,
-  MOVE_DOWN: `down`,
-  MOVE_RIGHT: `right`,
-  MOVE_LEFT: `left`,
+  MOVE_UP: key(`up`, 'Navigate Data Points', { helpGroup: 'navigate', helpKey: 'arrow keys' }),
+  MOVE_DOWN: key(`down`, 'Navigate Down', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_RIGHT: key(`right`, 'Navigate Right', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_LEFT: key(`left`, 'Navigate Left', { helpGroup: 'navigate', showInHelp: false }),
 
-  MOVE_TO_TOP_EXTREME: `${Platform.ctrl}+up`,
-  MOVE_TO_BOTTOM_EXTREME: `${Platform.ctrl}+down`,
-  MOVE_TO_LEFT_EXTREME: `${Platform.ctrl}+left`,
-  MOVE_TO_RIGHT_EXTREME: `${Platform.ctrl}+right`,
+  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Extreme Point', { helpGroup: 'extreme', helpKey: `${Platform.ctrl} + arrow keys` }),
+  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom Extreme', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpGroup: 'extreme', showInHelp: false }),
 
-  MOVE_TO_SUBPLOT_CONTEXT: `esc`,
-  MOVE_TO_NEXT_TRACE: `pageup`,
-  MOVE_TO_PREV_TRACE: `pagedown`,
+  MOVE_TO_SUBPLOT_CONTEXT: key(`esc`, 'Return to Subplot', { showInHelp: false }),
+  MOVE_TO_NEXT_TRACE: key(`pageup`, 'Move to Next Layer'),
+  MOVE_TO_PREV_TRACE: key(`pagedown`, 'Move to Previous Layer'),
 
   // Modes
-  TOGGLE_BRAILLE: `b`,
-  TOGGLE_TEXT: `t`,
-  TOGGLE_AUDIO: `s`,
-  TOGGLE_REVIEW: `r`,
-  TOGGLE_HIGH_CONTRAST: `c`,
+  TOGGLE_BRAILLE: key(`b`, 'Toggle Braille Mode'),
+  TOGGLE_TEXT: key(`t`, 'Toggle Text Mode'),
+  TOGGLE_AUDIO: key(`s`, 'Toggle Sonification Mode'),
+  TOGGLE_REVIEW: key(`r`, 'Toggle Review Mode'),
+  TOGGLE_HIGH_CONTRAST: key(`c`, 'Toggle High Contrast Mode'),
 
   // Misc
-  TOGGLE_HELP: `${Platform.ctrl}+/`,
-  TOGGLE_CHAT: `shift+/`,
-  TOGGLE_COMMAND_PALETTE: `${Platform.ctrl}+shift+p`,
-  TOGGLE_SETTINGS: `${Platform.ctrl}+,`,
+  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
+  TOGGLE_COMMAND_PALETTE: key(`${Platform.ctrl}+shift+p`, 'Open Command Palette', { helpKey: `${Platform.ctrl} + shift + p` }),
+  TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
 
   // Description
-  ANNOUNCE_POINT: `space`,
-  ANNOUNCE_POSITION: `p`,
+  ANNOUNCE_POINT: key(`space`, 'Replay Current Point'),
+  ANNOUNCE_POSITION: key(`p`, 'Announce Position'),
 
   // Go To functionality
-  GO_TO_EXTREMA_TOGGLE: `g`,
+  GO_TO_EXTREMA_TOGGLE: key(`g`, 'Go To Extrema'),
 
   // rotor functionality
-  ROTOR_NEXT_NAV: `${Platform.alt}+shift+up`,
-  ROTOR_PREV_NAV: `${Platform.alt}+shift+down`,
+  ROTOR_NEXT_NAV: key(`${Platform.alt}+shift+up`, 'Next Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + up` }),
+  ROTOR_PREV_NAV: key(`${Platform.alt}+shift+down`, 'Previous Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + down` }),
 
   // Grid cell navigation (enter grid cell when in GRID_MODE)
-  ENTER_GRID_CELL: `${Platform.enter}`,
+  ENTER_GRID_CELL: key(`${Platform.enter}`, 'Enter Grid Cell', { showInHelp: false }),
 } as const;
 
 /**
  * Keymap configuration for extrema navigation modal interactions.
  */
 const GO_TO_EXTREMA_KEYMAP = {
-  // Navigation within the modal
-  GO_TO_EXTREMA_MOVE_UP: 'up',
-  GO_TO_EXTREMA_MOVE_DOWN: 'down',
-  GO_TO_EXTREMA_SELECT: 'enter',
-  GO_TO_EXTREMA_CLOSE: 'esc',
-  GO_TO_EXTREMA_TOGGLE: 'g',
+  // Navigation within the modal (standard UI, not shown in help)
+  GO_TO_EXTREMA_MOVE_UP: key('up', 'Navigate Up', { showInHelp: false }),
+  GO_TO_EXTREMA_MOVE_DOWN: key('down', 'Navigate Down', { showInHelp: false }),
+  GO_TO_EXTREMA_SELECT: key('enter', 'Select', { showInHelp: false }),
+  GO_TO_EXTREMA_CLOSE: key('esc', 'Close', { showInHelp: false }),
+  GO_TO_EXTREMA_TOGGLE: key('g', 'Close', { showInHelp: false }),
 } as const;
 
 /**
  * Keymap configuration for command palette modal interactions.
  */
 const COMMAND_PALETTE_KEYMAP = {
-  // Navigation within the modal
-  COMMAND_PALETTE_MOVE_UP: 'up',
-  COMMAND_PALETTE_MOVE_DOWN: 'down',
-  COMMAND_PALETTE_SELECT: 'enter',
-  COMMAND_PALETTE_CLOSE: 'esc',
+  // Navigation within the modal (standard UI, not shown in help)
+  COMMAND_PALETTE_MOVE_UP: key('up', 'Navigate Up', { showInHelp: false }),
+  COMMAND_PALETTE_MOVE_DOWN: key('down', 'Navigate Down', { showInHelp: false }),
+  COMMAND_PALETTE_SELECT: key('enter', 'Select', { showInHelp: false }),
+  COMMAND_PALETTE_CLOSE: key('esc', 'Close', { showInHelp: false }),
 } as const;
 
 /**
@@ -257,9 +268,9 @@ const COMMAND_PALETTE_KEYMAP = {
  */
 const GRID_CELL_KEYMAP = {
   // Navigation within grid cell points
-  GRID_CELL_MOVE_LEFT: 'left',
-  GRID_CELL_MOVE_RIGHT: 'right',
-  EXIT_GRID_CELL: 'esc',
+  GRID_CELL_MOVE_LEFT: key('left', 'Navigate Left in Cell', { showInHelp: false }),
+  GRID_CELL_MOVE_RIGHT: key('right', 'Navigate Right in Cell', { showInHelp: false }),
+  EXIT_GRID_CELL: key('esc', 'Exit Grid Cell', { showInHelp: false }),
 } as const;
 
 /**
@@ -325,10 +336,12 @@ export class KeybindingService {
       Scope,
       Keymap[Scope],
     ][]) {
-      for (const [commandName, key] of Object.entries(keymap as Record<string, string>) as [
+      for (const [commandName, entry] of Object.entries(keymap as Record<string, KeybindingEntry>) as [
         Keys,
-        string,
+        KeybindingEntry,
       ][]) {
+        const hotkey = entry.hotkey;
+
         // https://github.com/jaywcjlove/hotkeys-js/issues/172
         // Need to remove once the issue is resolved.
         if (commandName === 'STOP_AUTOPLAY') {
@@ -340,7 +353,7 @@ export class KeybindingService {
           });
         }
 
-        hotkeys(key, { scope }, (event: KeyboardEvent): void => {
+        hotkeys(hotkey, { scope }, (event: KeyboardEvent): void => {
           if (commandName !== 'ALLOW_DEFAULT') {
             event.preventDefault();
             const command = this.commandFactory.create(commandName);

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -249,7 +249,7 @@ const GO_TO_EXTREMA_KEYMAP = {
   GO_TO_EXTREMA_MOVE_DOWN: key('down', 'Navigate Down', { showInHelp: false }),
   GO_TO_EXTREMA_SELECT: key('enter', 'Select', { showInHelp: false }),
   GO_TO_EXTREMA_CLOSE: key('esc', 'Close', { showInHelp: false }),
-  GO_TO_EXTREMA_TOGGLE: key('g', 'Close', { showInHelp: false }),
+  GO_TO_EXTREMA_TOGGLE: key('g', 'Go To Extrema', { showInHelp: false }),
 } as const;
 
 /**
@@ -292,11 +292,25 @@ export const SCOPED_KEYMAP = {
 } as const;
 
 /**
+ * Type representing a scope's keymap (command key to keybinding entry mapping).
+ */
+export type ScopeKeymap = Record<string, KeybindingEntry>;
+
+/**
  * Type representing the complete keymap structure for all scopes.
  */
 export type Keymap = {
   [K in Scope]: (typeof SCOPED_KEYMAP)[K];
 };
+
+/**
+ * Gets the keymap for a specific scope with proper typing.
+ * @param scope - The scope to get the keymap for.
+ * @returns The keymap for the scope.
+ */
+export function getKeymapForScope(scope: Scope): ScopeKeymap {
+  return SCOPED_KEYMAP[scope] as ScopeKeymap;
+}
 
 /**
  * Service for registering and managing keyboard bindings across application scopes.

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -26,14 +26,14 @@ function key(hotkey: string, description: string, options?: Partial<KeybindingEn
  * Keymap configuration for braille mode interactions.
  */
 const BRAILLE_KEYMAP = {
-  ACTIVATE_TRACE_LABEL_SCOPE: key(`l`, 'Access Labels'),
+  ACTIVATE_TRACE_LABEL_SCOPE: key(`l`, 'Access Labels', { showInHelp: false }),
   EXIT_BRAILLE_AND_SUBPLOT: key(`esc`, 'Exit Braille Mode', { showInHelp: false }),
 
   // Autoplay
-  AUTOPLAY_UPWARD: key(`${Platform.ctrl}+shift+up`, 'Autoplay Upward', { helpGroup: 'autoplay', helpKey: `${Platform.ctrl} + shift + arrow keys` }),
-  AUTOPLAY_DOWNWARD: key(`${Platform.ctrl}+shift+down`, 'Autoplay Downward', { helpGroup: 'autoplay', showInHelp: false }),
-  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpGroup: 'autoplay', showInHelp: false }),
-  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpGroup: 'autoplay', showInHelp: false }),
+  AUTOPLAY_UPWARD: key(`${Platform.ctrl}+shift+up`, 'Autoplay Upward', { helpKey: `${Platform.ctrl} + shift + up` }),
+  AUTOPLAY_DOWNWARD: key(`${Platform.ctrl}+shift+down`, 'Autoplay Downward', { helpKey: `${Platform.ctrl} + shift + down` }),
+  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpKey: `${Platform.ctrl} + shift + right` }),
+  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpKey: `${Platform.ctrl} + shift + left` }),
 
   STOP_AUTOPLAY: key(`${Platform.ctrl}, up, down, left, right`, 'Stop Autoplay', { helpKey: `${Platform.ctrl}` }),
   SPEED_UP_AUTOPLAY: key(`.`, 'Speed Up Autoplay', { helpKey: '. (period)' }),
@@ -41,15 +41,15 @@ const BRAILLE_KEYMAP = {
   RESET_AUTOPLAY_SPEED: key(`/`, 'Reset Autoplay Speed', { helpKey: '/ (slash)' }),
 
   // Navigation
-  MOVE_UP: key(`up`, 'Navigate Data Points', { helpGroup: 'navigate', helpKey: 'arrow keys' }),
-  MOVE_DOWN: key(`down`, 'Navigate Down', { helpGroup: 'navigate', showInHelp: false }),
-  MOVE_RIGHT: key(`right`, 'Navigate Right', { helpGroup: 'navigate', showInHelp: false }),
-  MOVE_LEFT: key(`left`, 'Navigate Left', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_UP: key(`up`, 'Navigate Up'),
+  MOVE_DOWN: key(`down`, 'Navigate Down'),
+  MOVE_RIGHT: key(`right`, 'Navigate Right'),
+  MOVE_LEFT: key(`left`, 'Navigate Left'),
 
-  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Extreme Point', { helpGroup: 'extreme', helpKey: `${Platform.ctrl} + arrow keys` }),
-  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom Extreme', { helpGroup: 'extreme', showInHelp: false }),
-  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpGroup: 'extreme', showInHelp: false }),
-  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Top Extreme', { helpKey: `${Platform.ctrl} + up` }),
+  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom Extreme', { helpKey: `${Platform.ctrl} + down` }),
+  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpKey: `${Platform.ctrl} + left` }),
+  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpKey: `${Platform.ctrl} + right` }),
 
   MOVE_TO_NEXT_TRACE: key(`pageup`, 'Move to Next Layer'),
   MOVE_TO_PREV_TRACE: key(`pagedown`, 'Move to Previous Layer'),
@@ -110,7 +110,7 @@ const HELP_KEYMAP = {
  * Keymap configuration for subplot scope interactions.
  */
 const SUBPLOT_KEYMAP = {
-  ACTIVATE_FIGURE_LABEL_SCOPE: key(`l`, 'Access Labels'),
+  ACTIVATE_FIGURE_LABEL_SCOPE: key(`l`, 'Access Labels', { showInHelp: false }),
 
   // Description
   ANNOUNCE_TITLE: key(`t`, 'Announce Title'),
@@ -118,15 +118,15 @@ const SUBPLOT_KEYMAP = {
   ANNOUNCE_POSITION: key(`p`, 'Announce Position'),
 
   // Navigation
-  MOVE_UP: key(`up`, 'Move Around Subplot', { helpGroup: 'navigate', helpKey: 'arrow keys' }),
-  MOVE_DOWN: key(`down`, 'Move Down', { helpGroup: 'navigate', showInHelp: false }),
-  MOVE_RIGHT: key(`right`, 'Move Right', { helpGroup: 'navigate', showInHelp: false }),
-  MOVE_LEFT: key(`left`, 'Move Left', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_UP: key(`up`, 'Move Up'),
+  MOVE_DOWN: key(`down`, 'Move Down'),
+  MOVE_RIGHT: key(`right`, 'Move Right'),
+  MOVE_LEFT: key(`left`, 'Move Left'),
 
-  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Extreme Subplot', { helpGroup: 'extreme', helpKey: `${Platform.ctrl} + arrow keys`, showInHelp: false }),
-  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom', { helpGroup: 'extreme', showInHelp: false }),
-  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left', { helpGroup: 'extreme', showInHelp: false }),
-  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Top Extreme', { helpKey: `${Platform.ctrl} + up` }),
+  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom Extreme', { helpKey: `${Platform.ctrl} + down` }),
+  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpKey: `${Platform.ctrl} + left` }),
+  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpKey: `${Platform.ctrl} + right` }),
 
   MOVE_TO_TRACE_CONTEXT: key(`${Platform.enter}`, 'Activate Current Subplot', { helpKey: `${Platform.enter}` }),
 
@@ -184,13 +184,13 @@ const SETTINGS_KEYMAP = {
  * Keymap configuration for trace scope interactions and navigation.
  */
 const TRACE_KEYMAP = {
-  ACTIVATE_TRACE_LABEL_SCOPE: key(`l`, 'Access Labels'),
+  ACTIVATE_TRACE_LABEL_SCOPE: key(`l`, 'Access Labels', { showInHelp: false }),
 
   // Autoplay
-  AUTOPLAY_UPWARD: key(`${Platform.ctrl}+shift+up`, 'Autoplay Outward', { helpGroup: 'autoplay', helpKey: `${Platform.ctrl} + shift + arrow keys` }),
-  AUTOPLAY_DOWNWARD: key(`${Platform.ctrl}+shift+down`, 'Autoplay Downward', { helpGroup: 'autoplay', showInHelp: false }),
-  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpGroup: 'autoplay', showInHelp: false }),
-  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpGroup: 'autoplay', showInHelp: false }),
+  AUTOPLAY_UPWARD: key(`${Platform.ctrl}+shift+up`, 'Autoplay Upward', { helpKey: `${Platform.ctrl} + shift + up` }),
+  AUTOPLAY_DOWNWARD: key(`${Platform.ctrl}+shift+down`, 'Autoplay Downward', { helpKey: `${Platform.ctrl} + shift + down` }),
+  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpKey: `${Platform.ctrl} + shift + right` }),
+  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpKey: `${Platform.ctrl} + shift + left` }),
 
   STOP_AUTOPLAY: key(`${Platform.ctrl}, up, down, left, right`, 'Stop Autoplay', { helpKey: `${Platform.ctrl}` }),
   SPEED_UP_AUTOPLAY: key(`.`, 'Speed Up Autoplay', { helpKey: '. (period)' }),
@@ -198,15 +198,15 @@ const TRACE_KEYMAP = {
   RESET_AUTOPLAY_SPEED: key(`/`, 'Reset Autoplay Speed', { helpKey: '/ (slash)' }),
 
   // Navigation
-  MOVE_UP: key(`up`, 'Navigate Data Points', { helpGroup: 'navigate', helpKey: 'arrow keys' }),
-  MOVE_DOWN: key(`down`, 'Navigate Down', { helpGroup: 'navigate', showInHelp: false }),
-  MOVE_RIGHT: key(`right`, 'Navigate Right', { helpGroup: 'navigate', showInHelp: false }),
-  MOVE_LEFT: key(`left`, 'Navigate Left', { helpGroup: 'navigate', showInHelp: false }),
+  MOVE_UP: key(`up`, 'Navigate Up'),
+  MOVE_DOWN: key(`down`, 'Navigate Down'),
+  MOVE_RIGHT: key(`right`, 'Navigate Right'),
+  MOVE_LEFT: key(`left`, 'Navigate Left'),
 
-  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Extreme Point', { helpGroup: 'extreme', helpKey: `${Platform.ctrl} + arrow keys` }),
-  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom Extreme', { helpGroup: 'extreme', showInHelp: false }),
-  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpGroup: 'extreme', showInHelp: false }),
-  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpGroup: 'extreme', showInHelp: false }),
+  MOVE_TO_TOP_EXTREME: key(`${Platform.ctrl}+up`, 'Go to Top Extreme', { helpKey: `${Platform.ctrl} + up` }),
+  MOVE_TO_BOTTOM_EXTREME: key(`${Platform.ctrl}+down`, 'Go to Bottom Extreme', { helpKey: `${Platform.ctrl} + down` }),
+  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpKey: `${Platform.ctrl} + left` }),
+  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpKey: `${Platform.ctrl} + right` }),
 
   MOVE_TO_SUBPLOT_CONTEXT: key(`esc`, 'Return to Subplot', { showInHelp: false }),
   MOVE_TO_NEXT_TRACE: key(`pageup`, 'Move to Next Layer'),

--- a/src/state/viewModel/commandPaletteViewModel.ts
+++ b/src/state/viewModel/commandPaletteViewModel.ts
@@ -1,4 +1,5 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
+import type { CommandExecutor } from '@service/commandExecutor';
 import type { CommandPaletteService } from '@service/commandPalette';
 import type { AppStore } from '@state/store';
 import type { Keys } from '@type/event';
@@ -66,6 +67,7 @@ const { show, hide, updateSelectedIndex, updateSearch } = commandPaletteSlice.ac
  */
 export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteState> {
   private readonly commandPaletteService: CommandPaletteService;
+  private commandExecutor: CommandExecutor | null = null;
 
   /**
    * Creates a new CommandPaletteViewModel instance.
@@ -75,6 +77,15 @@ export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteSta
   public constructor(store: AppStore, commandPaletteService: CommandPaletteService) {
     super(store);
     this.commandPaletteService = commandPaletteService;
+  }
+
+  /**
+   * Sets the command executor for executing commands from the palette.
+   * Called after CommandExecutor is created due to circular dependency.
+   * @param {CommandExecutor} executor - The command executor instance.
+   */
+  public setCommandExecutor(executor: CommandExecutor): void {
+    this.commandExecutor = executor;
   }
 
   /**
@@ -114,9 +125,9 @@ export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteSta
     const scopeKeymap = SCOPED_KEYMAP.TRACE; // Default to TRACE scope
     const commands = Object.entries(scopeKeymap)
       .filter(([commandKey]) => !commandKey.startsWith('ALLOW_'))
-      .map(([commandKey, key]) => ({
-        key,
-        description: this.toTitleCase(commandKey.replace(/_/g, ' ').toLowerCase()),
+      .map(([commandKey, entry]) => ({
+        key: entry.helpKey ?? entry.hotkey,
+        description: entry.description,
         commandKey: commandKey as Keys,
       }));
 
@@ -178,15 +189,23 @@ export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteSta
   }
 
   /**
-   * Selects the currently highlighted command without executing it.
+   * Selects and executes the currently highlighted command.
    */
   public selectCurrent(): void {
     const currentState = this.state;
 
-    if (currentState.commands.length > 0 && currentState.selectedIndex !== undefined) {
-      // Don't automatically execute the command, just return it
-      // The actual execution should be handled by the component
-      // this.handleCommandSelect(command);
+    if (currentState.commands.length > 0 && currentState.selectedIndex >= 0) {
+      const command = currentState.commands[currentState.selectedIndex];
+      if (command && this.commandExecutor) {
+        const commandKey = command.commandKey;
+        const executor = this.commandExecutor;
+        // Hide the palette first (returns to TRACE scope), then execute the command
+        this.hide();
+        // Small delay to ensure scope has changed before executing
+        setTimeout(() => {
+          executor.executeCommand(commandKey);
+        }, 0);
+      }
     }
   }
 

--- a/src/state/viewModel/commandPaletteViewModel.ts
+++ b/src/state/viewModel/commandPaletteViewModel.ts
@@ -1,5 +1,4 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
-import type { CommandExecutor } from '@service/commandExecutor';
 import type { CommandPaletteService } from '@service/commandPalette';
 import type { AppStore } from '@state/store';
 import type { Keys } from '@type/event';
@@ -63,11 +62,16 @@ const commandPaletteSlice = createSlice({
 const { show, hide, updateSelectedIndex, updateSearch } = commandPaletteSlice.actions;
 
 /**
+ * Callback type for executing commands.
+ */
+export type ExecuteCommandCallback = (commandKey: Keys) => void;
+
+/**
  * View model for managing command palette state and navigation.
  */
 export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteState> {
   private readonly commandPaletteService: CommandPaletteService;
-  private commandExecutor: CommandExecutor | null = null;
+  private executeCommandCallback: ExecuteCommandCallback | null = null;
 
   /**
    * Creates a new CommandPaletteViewModel instance.
@@ -80,12 +84,12 @@ export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteSta
   }
 
   /**
-   * Sets the command executor for executing commands from the palette.
+   * Sets the command execution callback.
    * Called after CommandExecutor is created due to circular dependency.
-   * @param {CommandExecutor} executor - The command executor instance.
+   * @param {ExecuteCommandCallback} callback - The callback to execute commands.
    */
-  public setCommandExecutor(executor: CommandExecutor): void {
-    this.commandExecutor = executor;
+  public setExecuteCommandCallback(callback: ExecuteCommandCallback): void {
+    this.executeCommandCallback = callback;
   }
 
   /**
@@ -147,6 +151,41 @@ export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteSta
   }
 
   /**
+   * Executes a command and closes the palette.
+   * This is the single entry point for command execution from the palette.
+   * @param {Keys} commandKey - The command key to execute.
+   */
+  public executeAndClose(commandKey: Keys): void {
+    if (!this.executeCommandCallback) {
+      throw new Error('Command execution callback not set. Call setExecuteCommandCallback first.');
+    }
+
+    const callback = this.executeCommandCallback;
+
+    // Hide the palette first (returns to TRACE scope)
+    this.hide();
+
+    // Small delay to ensure scope has changed before executing
+    setTimeout(() => {
+      callback(commandKey);
+    }, 0);
+  }
+
+  /**
+   * Selects and executes the currently highlighted command.
+   */
+  public selectCurrent(): void {
+    const currentState = this.state;
+
+    if (currentState.commands.length > 0 && currentState.selectedIndex >= 0) {
+      const command = currentState.commands[currentState.selectedIndex];
+      if (command) {
+        this.executeAndClose(command.commandKey);
+      }
+    }
+  }
+
+  /**
    * Moves the selection up in the command list.
    */
   public moveUp(): void {
@@ -189,62 +228,11 @@ export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteSta
   }
 
   /**
-   * Selects and executes the currently highlighted command.
-   */
-  public selectCurrent(): void {
-    const currentState = this.state;
-
-    if (currentState.commands.length > 0 && currentState.selectedIndex >= 0) {
-      const command = currentState.commands[currentState.selectedIndex];
-      if (command && this.commandExecutor) {
-        const commandKey = command.commandKey;
-        const executor = this.commandExecutor;
-        // Hide the palette first (returns to TRACE scope), then execute the command
-        this.hide();
-        // Small delay to ensure scope has changed before executing
-        setTimeout(() => {
-          executor.executeCommand(commandKey);
-        }, 0);
-      }
-    }
-  }
-
-  /**
    * Updates the search filter text for the command palette.
    * @param {string} search - The search text to filter commands.
    */
   public updateSearch(search: string): void {
     this.store.dispatch(updateSearch(search));
-  }
-
-  /**
-   * Executes the specified command and hides the command palette.
-   * @param {Keys} _commandKey - The command key to execute.
-   */
-  public executeCommand(_commandKey: Keys): void {
-    // Execute the command via CommandExecutor
-    // This will be called by the CommandPalette component
-    this.hide();
-  }
-
-  /**
-   * Handles command selection and hides the palette.
-   * @param {CommandItem} _command - The selected command item.
-   */
-  private handleCommandSelect(_command: CommandItem): void {
-    // Execute the selected command
-    // This will be handled by the CommandPalette component
-    this.hide();
-  }
-
-  /**
-   * Converts a string to title case format.
-   * @param {string} str - The string to convert.
-   * @returns {string} The title-cased string.
-   */
-  private toTitleCase(str: string): string {
-    return str.replace(/\w\S*/g, txt =>
-      txt.charAt(0).toUpperCase() + txt.slice(1));
   }
 }
 

--- a/src/type/event.ts
+++ b/src/type/event.ts
@@ -9,10 +9,8 @@ export interface KeybindingEntry {
   hotkey: string;
   /** Human-readable description for the help menu */
   description: string;
-  /** Override the key display in help menu (e.g., 'arrow keys' instead of 'up') */
+  /** Override the key display in help menu (e.g., 'cmd + up' instead of 'cmd+up') */
   helpKey?: string;
-  /** Group identifier for consolidating related shortcuts in help menu */
-  helpGroup?: string;
   /** Whether to show this entry in the help menu (default: true) */
   showInHelp?: boolean;
 }

--- a/src/type/event.ts
+++ b/src/type/event.ts
@@ -2,6 +2,22 @@ import type { Keymap } from '@service/keybinding';
 import type { Disposable } from './disposable';
 
 /**
+ * Configuration for a single keyboard binding entry.
+ */
+export interface KeybindingEntry {
+  /** The hotkey string (e.g., 's', 'ctrl+up', 'shift+/') */
+  hotkey: string;
+  /** Human-readable description for the help menu */
+  description: string;
+  /** Override the key display in help menu (e.g., 'arrow keys' instead of 'up') */
+  helpKey?: string;
+  /** Group identifier for consolidating related shortcuts in help menu */
+  helpGroup?: string;
+  /** Whether to show this entry in the help menu (default: true) */
+  showInHelp?: boolean;
+}
+
+/**
  * Standard DOM event types used throughout the application.
  */
 export enum DomEventType {

--- a/src/ui/component/CommandPalette.tsx
+++ b/src/ui/component/CommandPalette.tsx
@@ -1,6 +1,5 @@
 import type { Keys } from '@type/event';
 import { Box, Dialog, DialogContent, List, ListItemButton, ListItemText, TextField, Typography } from '@mui/material';
-import { useCommandExecutor } from '@state/hook/useCommandExecutor';
 import { useViewModel, useViewModelState } from '@state/hook/useViewModel';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -13,7 +12,6 @@ interface CommandItem {
 const CommandPalette: React.FC = () => {
   const commandPaletteViewModel = useViewModel('commandPalette');
   const state = useViewModelState('commandPalette');
-  const { executeCommand } = useCommandExecutor();
   const [announcement] = useState('');
   const searchInputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -80,13 +78,9 @@ const CommandPalette: React.FC = () => {
   }, [commandPaletteViewModel]);
 
   const handleCommandSelect = useCallback((commandKey: Keys) => {
-    // Close the palette first (returns to TRACE scope), then execute the command
-    handleClose();
-    // Small delay to ensure scope has changed before executing
-    setTimeout(() => {
-      executeCommand(commandKey);
-    }, 0);
-  }, [executeCommand, handleClose]);
+    // Delegate to ViewModel which handles close + execute
+    commandPaletteViewModel.executeAndClose(commandKey);
+  }, [commandPaletteViewModel]);
 
   const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     commandPaletteViewModel.updateSearch(event.target.value);

--- a/src/ui/component/CommandPalette.tsx
+++ b/src/ui/component/CommandPalette.tsx
@@ -80,9 +80,12 @@ const CommandPalette: React.FC = () => {
   }, [commandPaletteViewModel]);
 
   const handleCommandSelect = useCallback((commandKey: Keys) => {
-    // Execute the command first, then close
-    executeCommand(commandKey);
+    // Close the palette first (returns to TRACE scope), then execute the command
     handleClose();
+    // Small delay to ensure scope has changed before executing
+    setTimeout(() => {
+      executeCommand(commandKey);
+    }, 0);
   }, [executeCommand, handleClose]);
 
   const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
# Pull Request

## Description

Refactored the Help menu to auto-generate its content from keybinding definitions, eliminating manual maintenance.

Approach:
  - Added KeybindingEntry type with hotkey, description, helpKey, and showInHelp properties
  - Refactored all keymaps to use this structured format
  - Help menu now reads directly from SCOPED_KEYMAP to generate menu items
  - Nested scope commands (e.g., l x, l t) are auto-generated by detecting parent-child scope relationships and prefixing with entry key
  - Duplicate commands between parent/child scopes are skipped to avoid redundancy

## Changes Made

src/type/event.ts: Added KeybindingEntry interface
src/service/keybinding.ts: Refactored all keymaps to use KeybindingEntry structure
src/service/help.ts: Auto-generation logic with nested scope support
src/state/viewModel/commandPaletteViewModel.ts: Updated to use new keybinding structure
src/ui/component/CommandPalette.tsx: Fixed command execution order (close before execute)
src/controller.ts: Inject CommandExecutor into CommandPaletteViewModel

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.