### PR TITLE
feat: support simultaneous representation of multiple traces in multiline braille displays

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
+#!/usr/bin/env sh
 npx --no-install commitlint --edit "$1"

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1,3 +1,33 @@
+/**
+ * Braille service: encodes plot state into a braille character string plus a
+ * bidirectional cursor/index map.
+ *
+ * Physical braille display constraint
+ * -----------------------------------
+ * A physical braille display is cursor-tracking hardware that reads ONE flat
+ * stream of characters from its host textarea. Newline characters (`\n`) do
+ * NOT advance to the next physical display line — the hardware either ignores
+ * them or treats the whole buffer as a single paragraph, so anything placed
+ * after a `\n` is effectively hidden on the display. The only way to push
+ * content onto the next physical line is to pad the preceding line with
+ * ASCII spaces up to the hardware's cells-per-line width (`displaySize`).
+ *
+ * Consequently this service has two distinct output modes:
+ *
+ *   1. Single-line mode (`displayLines === 1`): the encoded string uses
+ *      `\n` as a visual wrap, which is fine for the on-screen textarea that
+ *      sighted users or refreshable-line-only displays see — there is no
+ *      multi-line physical display to break.
+ *
+ *   2. Multiline mode (`displayLines > 1`): no `\n` anywhere. Rows are
+ *      separated by space-padding each row to a `displaySize` boundary so
+ *      every data row occupies exactly one physical braille display line.
+ *      Horizontal windowing (below) is also spaces-only for the same reason.
+ *
+ * Companion textarea detail: the Braille UI component sets `wrap="off"` so
+ * the browser does not introduce visual wraps that would desync the firmware's
+ * index-based cursor tracking from our `cellToIndex` / `indexToCell` maps.
+ */
 import type { Context } from '@model/context';
 import type { Disposable } from '@type/disposable';
 import type { Event } from '@type/event';
@@ -84,11 +114,37 @@ interface EncodedBraille {
  * and bidirectional index mapping. This is the shared wrapping logic used by all
  * encoders that operate on row/col grids.
  *
+ * Two output modes are supported (see the file header for the physical braille
+ * display constraint that drives this split):
+ *
+ *  - Single-line mode (`multiline=false`): rows are separated by `\n`. Safe
+ *    only for the on-screen textarea; a multi-line physical braille display
+ *    would hide everything after the first `\n` because the hardware reads a
+ *    single flat stream.
+ *
+ *  - Multiline mode (`multiline=true`): absolutely NO `\n` is emitted. Rows
+ *    are separated by padding each row with ASCII spaces up to a `displaySize`
+ *    boundary, which is the only way to advance a physical braille display
+ *    to the next line.
+ *
+ * Horizontal windowing (multiline mode only): when any row exceeds
+ * `displaySize`, each row is rendered as exactly `displaySize` characters
+ * drawn from `[colOffset, colOffset + displaySize)`. Short rows under a wide
+ * window are space-padded — again, no `\n` — so every data row still maps to
+ * exactly one physical display line. This lets hardware cursor-tracking page
+ * horizontally the same way it already pages vertically. Out-of-window
+ * columns map to `-1` in `cellToIndex`; the service layer advances
+ * `colOffset` before re-encoding so the cursor always lands in the active
+ * window.
+ *
  * @param rowCount - Number of rows in the data
  * @param colCount - Function returning the number of columns for a given row
  * @param getChar - Function returning the braille character for a given (row, col)
  * @param displaySize - Maximum columns per display line before wrapping
- * @param multiline - When true, uses space padding instead of newlines for physical braille displays
+ * @param multiline - When true, emits only spaces (never `\n`) between rows so
+ *   physical braille displays advance to the next line; `\n` does not render
+ *   on physical hardware.
+ * @param colOffset - Horizontal windowing offset; used only when windowing is active
  * @returns Encoded braille with cell mappings
  */
 function encodeWithWrapping(
@@ -97,6 +153,7 @@ function encodeWithWrapping(
   getChar: (row: number, col: number) => string,
   displaySize: number,
   multiline: boolean = false,
+  colOffset: number = 0,
 ): EncodedBraille {
   const values = new Array<string>();
   const cellToIndex = new Array<Array<number>>();
@@ -104,6 +161,21 @@ function encodeWithWrapping(
 
   for (let i = 0; i < rowCount; i++) {
     cellToIndex.push(new Array<number>());
+  }
+
+  // Horizontal windowing activates only for multi-row plots in multiline mode
+  // where at least one row overflows a single display line. Single-trace and
+  // narrow-row cases keep the existing per-row padding behavior. (Windowing is
+  // never allowed to insert `\n`; output is always space-only — see file
+  // header for why.)
+  let windowed = false;
+  if (multiline && rowCount > 1) {
+    for (let r = 0; r < rowCount; r++) {
+      if (colCount(r) > displaySize) {
+        windowed = true;
+        break;
+      }
+    }
   }
 
   // When multiline, encode from the last row to the first so that
@@ -116,6 +188,34 @@ function encodeWithWrapping(
 
   for (let row = start; row !== end; row += step) {
     const cols = colCount(row);
+
+    if (windowed) {
+      // Pre-fill with -1 so any out-of-window col lookup signals that the
+      // service must re-encode with a new colOffset before the cursor is
+      // valid again.
+      for (let c = 0; c < cols; c++) {
+        cellToIndex[row].push(-1);
+      }
+      const lastDataCol = Math.max(0, cols - 1);
+      const windowEnd = colOffset + displaySize;
+      for (let col = colOffset; col < windowEnd; col++) {
+        if (col >= 0 && col < cols) {
+          cellToIndex[row][col] = indexToCell.length;
+          values.push(getChar(row, col));
+          indexToCell.push({ row, col });
+        } else {
+          // Beyond this row's data (short row under a wide window): pad with
+          // a SPACE — not `\n` — because `\n` does not render on a physical
+          // braille display. Spaces push the next row onto the next physical
+          // display line and keep relative column alignment across rows.
+          // Clicks in padding map to the last data cell of the row.
+          values.push(Constant.SPACE);
+          indexToCell.push({ row, col: lastDataCol });
+        }
+      }
+      cellToIndex[row].push(indexToCell.length - 1);
+      continue;
+    }
 
     for (let col = 0; col < cols; col++) {
       values.push(getChar(row, col));
@@ -130,8 +230,10 @@ function encodeWithWrapping(
     }
 
     if (multiline) {
-      // Space-pad the row to the next multiple of displaySize so the next
-      // data row starts on the next physical braille display line.
+      // Space-pad the row to the next multiple of displaySize so the NEXT
+      // data row begins on the next physical braille display line. A `\n`
+      // here would be hidden on the hardware (the display renders only one
+      // "paragraph"), so spaces are the only working separator.
       const paddedLength = cols === 0
         ? displaySize
         : Math.ceil(cols / displaySize) * displaySize;
@@ -143,9 +245,10 @@ function encodeWithWrapping(
       }
       cellToIndex[row].push(sentinelIdx);
     } else {
-      // End-of-row sentinel: append a newline (unless a mid-row wrap already
-      // emitted one at the exact end) and record a sentinel entry so that
-      // cellToIndex[row] has one more element than data columns.
+      // Single-line mode: a `\n` is safe and useful here because this output
+      // feeds the on-screen textarea (or a one-line braille display that
+      // only ever shows one row at a time). Multi-line physical braille
+      // displays are never in this branch — they always set multiline=true.
       const sentinelIdx = indexToCell.length;
       indexToCell.push({ row, col: cols });
       if (cols === 0 || cols % displaySize !== 0) {
@@ -171,15 +274,26 @@ interface TimeSeries {
  * The `multiline` flag controls two related behaviors that implementors must
  * keep in sync:
  *   1. Row separation — uses space-padding to the next `displaySize` boundary
- *      instead of inserting a newline character, so that each data row occupies
- *      a full physical braille display line.
+ *      and NEVER emits `\n`. Physical multi-line braille displays read a flat
+ *      character stream; a `\n` would be swallowed and hide every subsequent
+ *      row, so spaces are the only way to push content to the next display
+ *      line.
  *   2. Row encoding order — encodes data rows from last to first so that
  *      row 0 (the initially focused / lowest data row) appears at the bottom
- *      of the physical braille display.  This makes UP-arrow navigation
+ *      of the physical braille display. This makes UP-arrow navigation
  *      (which increments `row`) move the cursor upward on the display.
+ *
+ * `colOffset` enables horizontal page-windowing for plots wider than the
+ * display; it is meaningful only when `multiline=true` and the state has
+ * multiple rows with at least one row wider than `size` cells.
  */
 interface BrailleEncoder<BrailleState> {
-  encode: (state: BrailleState, size?: number, multiline?: boolean) => EncodedBraille;
+  encode: (
+    state: BrailleState,
+    size?: number,
+    multiline?: boolean,
+    colOffset?: number,
+  ) => EncodedBraille;
 }
 
 /**
@@ -197,6 +311,7 @@ class BarBrailleEncoder implements BrailleEncoder<BarBrailleState> {
     state: BarBrailleState,
     size: number = DEFAULT_BRAILLE_SIZE,
     multiline: boolean = false,
+    colOffset: number = 0,
   ): EncodedBraille {
     const displaySize = normalizeDisplaySize(size);
 
@@ -222,6 +337,7 @@ class BarBrailleEncoder implements BrailleEncoder<BarBrailleState> {
       },
       displaySize,
       multiline,
+      colOffset,
     );
   }
 }
@@ -255,7 +371,10 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
     state: BoxBrailleState,
     size: number = DEFAULT_BRAILLE_SIZE,
     multiline: boolean = false,
+    _colOffset: number = 0,
   ): EncodedBraille {
+    // colOffset is intentionally ignored: each box always spans exactly
+    // displaySize chars, so there is never anything to window horizontally.
     const displaySize = normalizeDisplaySize(size);
     const values = new Array<string>();
     const indexToCell = new Array<Cell>();
@@ -466,8 +585,10 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
       if (multiline) {
         // The box encoder already produces exactly `displaySize` characters
         // per row, so the row naturally ends on a display-line boundary.
-        // The defensive padding below covers any future code path that might
-        // emit a different number of characters.
+        // Defensive SPACE padding below covers any future code path that
+        // might emit a different number of characters — `\n` would be
+        // hidden on a physical braille display, so spaces are the only
+        // way to advance to the next display line.
         const rowCharCount = values.length - rowStartIdx;
         const paddedLength = rowCharCount === 0
           ? displaySize
@@ -478,6 +599,9 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
           indexToCell.push({ row, col: lastCol });
         }
       } else {
+        // Single-line mode: `\n` is safe here because the output feeds the
+        // on-screen textarea (or a one-line refreshable display), not a
+        // multi-line physical display.
         values.push(Constant.NEW_LINE);
         indexToCell.push({ row, col });
       }
@@ -502,6 +626,7 @@ class HeatmapBrailleEncoder implements BrailleEncoder<HeatmapBrailleState> {
     state: HeatmapBrailleState,
     size: number = DEFAULT_BRAILLE_SIZE,
     multiline: boolean = false,
+    colOffset: number = 0,
   ): EncodedBraille {
     const displaySize = normalizeDisplaySize(size);
     const range = (state.max - state.min) / 3;
@@ -524,6 +649,7 @@ class HeatmapBrailleEncoder implements BrailleEncoder<HeatmapBrailleState> {
       },
       displaySize,
       multiline,
+      colOffset,
     );
   }
 }
@@ -566,6 +692,7 @@ implements BrailleEncoder<T> {
     state: T,
     size: number = DEFAULT_BRAILLE_SIZE,
     multiline: boolean = false,
+    colOffset: number = 0,
   ): EncodedBraille {
     const displaySize = normalizeDisplaySize(size);
 
@@ -575,6 +702,7 @@ implements BrailleEncoder<T> {
       (row, col) => this.encodeCell(state, row, col),
       displaySize,
       multiline,
+      colOffset,
     );
   }
 
@@ -816,6 +944,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
   private enabled: boolean;
   private displaySize: number;
   private displayLines: number;
+  private colOffset: number;
   private cacheId: string;
   private cache: EncodedBraille | null;
   private readonly disposables: Disposable[];
@@ -847,6 +976,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
     this.displayLines = normalizeDisplayLines(
       settings.get<number>(BRAILLE_DISPLAY_LINES_SETTING),
     );
+    this.colOffset = 0;
     this.cacheId = Constant.EMPTY;
     this.cache = null;
     this.disposables = [];
@@ -891,6 +1021,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
 
       this.cache = null;
       this.cacheId = Constant.EMPTY;
+      this.colOffset = 0;
 
       if (!this.enabled) {
         return;
@@ -953,13 +1084,36 @@ implements Observer<SubplotState | TraceState>, Disposable {
     }
 
     const braille = trace.braille;
-    if (this.cache === null || this.cacheId !== braille.id) {
+    // multiline=true switches the encoder to physical-display mode:
+    //   - row separation uses ONLY ASCII spaces (no `\n`), because `\n` does
+    //     not render on a multi-line physical braille display — anything
+    //     after a `\n` is hidden. Spaces padded to `displaySize` are the
+    //     only way to push content onto the next physical display line.
+    //   - row order is reversed so row 0 (initially focused) appears at the
+    //     bottom of the display and UP-arrow moves the cursor upward.
+    const isMultilineMode = this.displayLines > 1;
+
+    // For plots whose rows can overflow a single display line, compute the
+    // page-aligned horizontal window that contains the cursor. When no
+    // windowing is needed (box plots, narrow rows, single-row data), this
+    // still resolves to zero without affecting the cached output — the
+    // encoder simply ignores it.
+    const willWindow = isMultilineMode && this.willWindowHorizontally(braille);
+    const targetOffset = willWindow
+      ? Math.max(0, Math.floor(braille.col / this.displaySize) * this.displaySize)
+      : 0;
+    const cacheKey = willWindow ? `${braille.id}|${targetOffset}` : braille.id;
+
+    if (this.cache === null || this.cacheId !== cacheKey) {
       const encoder = this.encoders.get(trace.traceType)!;
-      // multiline=true switches the encoder to physical-display mode:
-      // space-padded rows (no newlines) and reversed row order so UP moves up.
-      const isMultilineMode = this.displayLines > 1;
-      this.cache = encoder.encode(braille as any, this.displaySize, isMultilineMode);
-      this.cacheId = braille.id;
+      this.colOffset = targetOffset;
+      this.cache = encoder.encode(
+        braille as any,
+        this.displaySize,
+        isMultilineMode,
+        this.colOffset,
+      );
+      this.cacheId = cacheKey;
     }
 
     this.onChangeEmitter.fire({
@@ -968,6 +1122,31 @@ implements Observer<SubplotState | TraceState>, Disposable {
       displaySize: this.displaySize,
       displayLines: this.displayLines,
     });
+  }
+
+  /**
+   * Returns true when the active braille state is wide enough to require
+   * horizontal page-windowing in multiline mode. Box-plot style braille
+   * states are flat arrays of objects and are excluded — each box already
+   * spans exactly one display line.
+   * @param braille - Current braille state from the active trace
+   * @returns Whether horizontal windowing will apply for this state
+   */
+  private willWindowHorizontally(braille: any): boolean {
+    const values = braille?.values;
+    if (!Array.isArray(values) || values.length <= 1) {
+      return false;
+    }
+    // Box-plot states store BoxPoint objects (not arrays) per row.
+    if (!Array.isArray(values[0])) {
+      return false;
+    }
+    for (const row of values) {
+      if (Array.isArray(row) && row.length > this.displaySize) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -101,8 +101,19 @@ function encodeWithWrapping(
   const cellToIndex = new Array<Array<number>>();
   const indexToCell = new Array<Cell>();
 
-  for (let row = 0; row < rowCount; row++) {
+  for (let i = 0; i < rowCount; i++) {
     cellToIndex.push(new Array<number>());
+  }
+
+  // When multiline, encode from the last row to the first so that
+  // row 0 (the initially focused / lowest element) appears at the
+  // bottom of the physical braille display and UP (row++) moves the
+  // cursor upward.
+  const start = multiline ? rowCount - 1 : 0;
+  const end = multiline ? -1 : rowCount;
+  const step = multiline ? -1 : 1;
+
+  for (let row = start; row !== end; row += step) {
     const cols = colCount(row);
 
     for (let col = 0; col < cols; col++) {
@@ -238,7 +249,30 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
     const indexToCell = new Array<Cell>();
     const cellToIndex = new Array<Array<number>>();
 
-    for (let row = 0; row < state.values.length; row++) {
+    const sections = [
+      this.LOWER_OUTLIER,
+      this.MIN,
+      this.Q1,
+      this.Q2,
+      this.Q3,
+      this.MAX,
+      this.UPPER_OUTLIER,
+    ];
+
+    const rowCount = state.values.length;
+    for (let i = 0; i < rowCount; i++) {
+      cellToIndex.push(
+        Array.from({ length: sections.length }).fill(-1) as number[],
+      );
+    }
+
+    // When multiline, encode from the last row to the first so UP
+    // moves the cursor upward on the physical braille display.
+    const start = multiline ? rowCount - 1 : 0;
+    const end = multiline ? -1 : rowCount;
+    const step = multiline ? -1 : 1;
+
+    for (let row = start; row !== end; row += step) {
       const box = state.values[row];
       const boxValData = [
         { type: this.GLOBAL_MIN, value: state.min },
@@ -363,18 +397,6 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
       }
 
       let col = -1;
-      const sections = [
-        this.LOWER_OUTLIER,
-        this.MIN,
-        this.Q1,
-        this.Q2,
-        this.Q3,
-        this.MAX,
-        this.UPPER_OUTLIER,
-      ];
-      cellToIndex.push(
-        Array.from({ length: sections.length }).fill(-1) as number[],
-      );
       for (const section of lenData) {
         if (
           section.type !== this.BLANK

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -19,6 +19,7 @@ import { TraceType } from '@type/grammar';
 import { Constant } from '@util/constant';
 
 export const DEFAULT_BRAILLE_SIZE = 32;
+export const DEFAULT_BRAILLE_LINES = 1;
 
 /**
  * Normalizes configured braille display size to a safe positive integer.
@@ -35,6 +36,20 @@ function normalizeDisplaySize(size: number | undefined): number {
 }
 
 const BRAILLE_DISPLAY_SIZE_SETTING = 'general.brailleDisplaySize';
+const BRAILLE_DISPLAY_LINES_SETTING = 'general.brailleDisplayLines';
+
+/**
+ * Normalizes configured braille display lines to a safe positive integer.
+ * Falls back to default when the value is missing or invalid.
+ * @param lines - Raw display lines value from settings or caller
+ * @returns Normalized display lines
+ */
+function normalizeDisplayLines(lines: number | undefined): number {
+  if (lines === undefined || !Number.isFinite(lines)) {
+    return DEFAULT_BRAILLE_LINES;
+  }
+  return Math.max(1, Math.floor(lines));
+}
 
 /**
  * Represents a cell position in a 2D grid.
@@ -51,6 +66,7 @@ interface BrailleChangedEvent {
   value: string;
   index: number;
   displaySize: number;
+  displayLines: number;
 }
 
 /**
@@ -71,6 +87,7 @@ interface EncodedBraille {
  * @param colCount - Function returning the number of columns for a given row
  * @param getChar - Function returning the braille character for a given (row, col)
  * @param displaySize - Maximum columns per display line before wrapping
+ * @param multiline - When true, uses space padding instead of newlines for physical braille displays
  * @returns Encoded braille with cell mappings
  */
 function encodeWithWrapping(
@@ -78,6 +95,7 @@ function encodeWithWrapping(
   colCount: (row: number) => number,
   getChar: (row: number, col: number) => string,
   displaySize: number,
+  multiline: boolean = false,
 ): EncodedBraille {
   const values = new Array<string>();
   const cellToIndex = new Array<Array<number>>();
@@ -93,24 +111,36 @@ function encodeWithWrapping(
       cellToIndex[row].push(indexToCell.length);
       indexToCell.push({ row, col });
 
-      // Insert a mid-row display-line wrap. The newline's indexToCell entry
-      // maps back to the last data cell so that clicking the newline position
-      // navigates to the preceding data point rather than an invalid location.
-      if ((col + 1) % displaySize === 0) {
+      if (!multiline && (col + 1) % displaySize === 0) {
         values.push(Constant.NEW_LINE);
         indexToCell.push({ row, col });
       }
     }
 
-    // End-of-row sentinel: append a newline (unless a mid-row wrap already
-    // emitted one at the exact end) and record a sentinel entry so that
-    // cellToIndex[row] has one more element than data columns.
-    const sentinelIdx = indexToCell.length;
-    indexToCell.push({ row, col: cols });
-    if (cols === 0 || cols % displaySize !== 0) {
-      values.push(Constant.NEW_LINE);
+    if (multiline) {
+      // Space-pad the row to the next multiple of displaySize so the next
+      // data row starts on the next physical braille display line.
+      const paddedLength = cols === 0
+        ? displaySize
+        : Math.ceil(cols / displaySize) * displaySize;
+      const sentinelIdx = indexToCell.length;
+      const lastCol = Math.max(0, cols - 1);
+      for (let p = cols; p < paddedLength; p++) {
+        values.push(Constant.SPACE);
+        indexToCell.push({ row, col: lastCol });
+      }
+      cellToIndex[row].push(sentinelIdx);
+    } else {
+      // End-of-row sentinel: append a newline (unless a mid-row wrap already
+      // emitted one at the exact end) and record a sentinel entry so that
+      // cellToIndex[row] has one more element than data columns.
+      const sentinelIdx = indexToCell.length;
+      indexToCell.push({ row, col: cols });
+      if (cols === 0 || cols % displaySize !== 0) {
+        values.push(Constant.NEW_LINE);
+      }
+      cellToIndex[row].push(sentinelIdx);
     }
-    cellToIndex[row].push(sentinelIdx);
   }
 
   return { value: values.join(Constant.EMPTY), cellToIndex, indexToCell };
@@ -127,7 +157,7 @@ interface TimeSeries {
  * Interface for encoding plot states into braille representations.
  */
 interface BrailleEncoder<BrailleState> {
-  encode: (state: BrailleState, size?: number) => EncodedBraille;
+  encode: (state: BrailleState, size?: number, multiline?: boolean) => EncodedBraille;
 }
 
 /**
@@ -137,11 +167,14 @@ class BarBrailleEncoder implements BrailleEncoder<BarBrailleState> {
   /**
    * Encodes bar chart state into braille representation.
    * @param state - Bar chart braille state
+   * @param size - Target display size
+   * @param multiline - When true, uses space padding for physical braille displays
    * @returns Encoded braille with cell mappings
    */
   public encode(
     state: BarBrailleState,
     size: number = DEFAULT_BRAILLE_SIZE,
+    multiline: boolean = false,
   ): EncodedBraille {
     const displaySize = normalizeDisplaySize(size);
 
@@ -166,6 +199,7 @@ class BarBrailleEncoder implements BrailleEncoder<BarBrailleState> {
         return '⠉';
       },
       displaySize,
+      multiline,
     );
   }
 }
@@ -192,11 +226,13 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
    * Encodes box plot state into braille representation with quartiles and outliers.
    * @param state - Box plot braille state
    * @param size - Target size for braille output
+   * @param multiline - When true, uses space padding for physical braille displays
    * @returns Encoded braille with cell mappings
    */
   public encode(
     state: BoxBrailleState,
     size: number = DEFAULT_BRAILLE_SIZE,
+    multiline: boolean = false,
   ): EncodedBraille {
     const values = new Array<string>();
     const indexToCell = new Array<Cell>();
@@ -392,7 +428,9 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
         }
       }
 
-      values.push(Constant.NEW_LINE);
+      if (!multiline) {
+        values.push(Constant.NEW_LINE);
+      }
       indexToCell.push({ row, col });
     }
 
@@ -407,11 +445,14 @@ class HeatmapBrailleEncoder implements BrailleEncoder<HeatmapBrailleState> {
   /**
    * Encodes heatmap state into braille representation.
    * @param state - Heatmap braille state
+   * @param size - Target display size
+   * @param multiline - When true, uses space padding for physical braille displays
    * @returns Encoded braille with cell mappings
    */
   public encode(
     state: HeatmapBrailleState,
     size: number = DEFAULT_BRAILLE_SIZE,
+    multiline: boolean = false,
   ): EncodedBraille {
     const displaySize = normalizeDisplaySize(size);
     const range = (state.max - state.min) / 3;
@@ -433,6 +474,7 @@ class HeatmapBrailleEncoder implements BrailleEncoder<HeatmapBrailleState> {
         return '⠉';
       },
       displaySize,
+      multiline,
     );
   }
 }
@@ -467,11 +509,14 @@ implements BrailleEncoder<T> {
   /**
    * Encodes time series state into braille representation with trend indicators.
    * @param state - Time series braille state
+   * @param size - Target display size
+   * @param multiline - When true, uses space padding for physical braille displays
    * @returns Encoded braille with cell mappings
    */
   public encode(
     state: T,
     size: number = DEFAULT_BRAILLE_SIZE,
+    multiline: boolean = false,
   ): EncodedBraille {
     const displaySize = normalizeDisplaySize(size);
 
@@ -480,6 +525,7 @@ implements BrailleEncoder<T> {
       row => state.values[row].length,
       (row, col) => this.encodeCell(state, row, col),
       displaySize,
+      multiline,
     );
   }
 
@@ -720,6 +766,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
 
   private enabled: boolean;
   private displaySize: number;
+  private displayLines: number;
   private cacheId: string;
   private cache: EncodedBraille | null;
   private readonly disposables: Disposable[];
@@ -748,6 +795,9 @@ implements Observer<SubplotState | TraceState>, Disposable {
     this.displaySize = normalizeDisplaySize(
       settings.get<number>(BRAILLE_DISPLAY_SIZE_SETTING),
     );
+    this.displayLines = normalizeDisplayLines(
+      settings.get<number>(BRAILLE_DISPLAY_LINES_SETTING),
+    );
     this.cacheId = Constant.EMPTY;
     this.cache = null;
     this.disposables = [];
@@ -772,13 +822,24 @@ implements Observer<SubplotState | TraceState>, Disposable {
     this.onChange = this.onChangeEmitter.event;
 
     this.disposables.push(settings.onChange((event) => {
-      if (!event.affectsSetting(BRAILLE_DISPLAY_SIZE_SETTING)) {
+      const affectsSize = event.affectsSetting(BRAILLE_DISPLAY_SIZE_SETTING);
+      const affectsLines = event.affectsSetting(BRAILLE_DISPLAY_LINES_SETTING);
+
+      if (!affectsSize && !affectsLines) {
         return;
       }
 
-      this.displaySize = normalizeDisplaySize(
-        event.get<number>(BRAILLE_DISPLAY_SIZE_SETTING),
-      );
+      if (affectsSize) {
+        this.displaySize = normalizeDisplaySize(
+          event.get<number>(BRAILLE_DISPLAY_SIZE_SETTING),
+        );
+      }
+      if (affectsLines) {
+        this.displayLines = normalizeDisplayLines(
+          event.get<number>(BRAILLE_DISPLAY_LINES_SETTING),
+        );
+      }
+
       this.cache = null;
       this.cacheId = Constant.EMPTY;
 
@@ -845,7 +906,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
     const braille = trace.braille;
     if (this.cache === null || this.cacheId !== braille.id) {
       const encoder = this.encoders.get(trace.traceType)!;
-      this.cache = encoder.encode(braille as any, this.displaySize);
+      this.cache = encoder.encode(braille as any, this.displaySize, this.displayLines > 1);
       this.cacheId = braille.id;
     }
 
@@ -853,6 +914,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
       value: this.cache.value,
       index: this.cache.cellToIndex[braille.row][braille.col],
       displaySize: this.displaySize,
+      displayLines: this.displayLines,
     });
   }
 

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -957,8 +957,8 @@ implements Observer<SubplotState | TraceState>, Disposable {
       const encoder = this.encoders.get(trace.traceType)!;
       // multiline=true switches the encoder to physical-display mode:
       // space-padded rows (no newlines) and reversed row order so UP moves up.
-      const useMultilinePadding = this.displayLines > 1;
-      this.cache = encoder.encode(braille as any, this.displaySize, useMultilinePadding);
+      const isMultilineMode = this.displayLines > 1;
+      this.cache = encoder.encode(braille as any, this.displaySize, isMultilineMode);
       this.cacheId = braille.id;
     }
 

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -35,10 +35,12 @@ import type { Observer } from '@type/observable';
 import type {
   BarBrailleState,
   BoxBrailleState,
+  BrailleState,
   CandlestickBrailleState,
   HeatmapBrailleState,
   LineBrailleState,
   SubplotState,
+  TraceEmptyState,
   TraceState,
 } from '@type/state';
 import type { DisplayService } from './display';
@@ -88,6 +90,39 @@ function normalizeDisplayLines(lines: number | undefined): number {
 interface Cell {
   row: number;
   col: number;
+}
+
+/**
+ * Non-empty braille state: every concrete variant that an encoder can read.
+ * Used to type the heterogeneous encoder map without resorting to `any`.
+ */
+type NonEmptyBrailleState = Exclude<BrailleState, TraceEmptyState>;
+
+/**
+ * Grid-shaped braille states: those whose `values` is a 2D `number[][]`
+ * (bar, heatmap, line, candlestick). Excludes box plot, whose `values` is a
+ * flat `BoxPoint[]`. Used by {@link isGridBrailleState} to narrow for
+ * horizontal-windowing checks that iterate rows.
+ */
+type GridBrailleState
+  = | BarBrailleState
+    | CandlestickBrailleState
+    | HeatmapBrailleState
+    | LineBrailleState;
+
+/**
+ * Typed guard: narrows a {@link BrailleState} to the grid-shaped variants
+ * that expose `number[][]` rows. Box states are filtered out because their
+ * per-row element is a single `BoxPoint`, not a row array.
+ * @param state - Any braille state to inspect
+ * @returns Whether the state has a 2D numeric value grid
+ */
+function isGridBrailleState(state: BrailleState): state is GridBrailleState {
+  if (state.empty) {
+    return false;
+  }
+  const values = (state as { values: unknown }).values;
+  return Array.isArray(values) && values.length > 0 && Array.isArray(values[0]);
 }
 
 /**
@@ -186,6 +221,27 @@ function encodeWithWrapping(
   const end = multiline ? -1 : rowCount;
   const step = multiline ? -1 : 1;
 
+  // Per-row sentinel semantics differ across the three output modes and are
+  // documented here once because all three paths append to
+  // `cellToIndex[row]`:
+  //
+  //   - Single-line (multiline=false): sentinel is a synthetic virtual cell
+  //     at `{row, col: cols}` (one past the last data column). It exists
+  //     only in `indexToCell`, never in the emitted string.
+  //   - Multiline windowed: sentinel points to the LAST cell in the window
+  //     (`indexToCell.length - 1`), which is always a real data or padding
+  //     cell resolving to `{row, col: lastDataCol}`.
+  //   - Multiline non-windowed: sentinel is captured BEFORE padding
+  //     (`indexToCell.length` at that moment). If the row requires padding,
+  //     it points to the FIRST padding cell and resolves to
+  //     `{row, col: lastCol}`. If the row exactly fills `displaySize`
+  //     (no padding added), the sentinel points past the end of
+  //     `indexToCell` — `moveToIndex` guards against that via its bounds
+  //     check, so it is harmless, but callers must treat the sentinel as
+  //     advisory only, never as a valid index.
+  //
+  // The sentinel is never emitted to the onChange event; it is used only to
+  // allow internal lookups like `cellToIndex[row][cols]`.
   for (let row = start; row !== end; row += step) {
     const cols = colCount(row);
 
@@ -949,7 +1005,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
   private cache: EncodedBraille | null;
   private readonly disposables: Disposable[];
 
-  private readonly encoders: Map<TraceType, BrailleEncoder<any>>;
+  private readonly encoders: Map<TraceType, BrailleEncoder<NonEmptyBrailleState>>;
   private readonly onChangeEmitter: Emitter<BrailleChangedEvent>;
   public readonly onChange: Event<BrailleChangedEvent>;
 
@@ -981,20 +1037,30 @@ implements Observer<SubplotState | TraceState>, Disposable {
     this.cache = null;
     this.disposables = [];
 
-    this.encoders = new Map<TraceType, BrailleEncoder<any>>([
-      [TraceType.BAR, new BarBrailleEncoder()],
-      [TraceType.BOX, new BoxBrailleEncoder()],
-      [TraceType.CANDLESTICK, new CandlestickBrailleEncoder()],
-      [TraceType.DODGED, new BarBrailleEncoder()],
-      [TraceType.HEATMAP, new HeatmapBrailleEncoder()],
-      [TraceType.HISTOGRAM, new BarBrailleEncoder()],
-      [TraceType.LINE, new LineBrailleEncoder()],
-      [TraceType.NORMALIZED, new BarBrailleEncoder()],
-      [TraceType.SCATTER, new HeatmapBrailleEncoder()],
-      [TraceType.SMOOTH, new LineBrailleEncoder()],
-      [TraceType.STACKED, new BarBrailleEncoder()],
-      [TraceType.VIOLIN_KDE, new LineBrailleEncoder()],
-      [TraceType.VIOLIN_BOX, new BoxBrailleEncoder()],
+    // Encoders are heterogeneous: each one accepts only its own concrete
+    // braille-state variant. Dispatch is by TraceType, so the map's value type
+    // is widened to `BrailleEncoder<NonEmptyBrailleState>` via an `unknown`
+    // cast at insertion only — the dispatch guarantees the state passed to
+    // `encode()` matches the encoder's expected variant.
+    const asGeneric = <T extends NonEmptyBrailleState>(
+      encoder: BrailleEncoder<T>,
+    ): BrailleEncoder<NonEmptyBrailleState> =>
+      encoder as unknown as BrailleEncoder<NonEmptyBrailleState>;
+
+    this.encoders = new Map<TraceType, BrailleEncoder<NonEmptyBrailleState>>([
+      [TraceType.BAR, asGeneric(new BarBrailleEncoder())],
+      [TraceType.BOX, asGeneric(new BoxBrailleEncoder())],
+      [TraceType.CANDLESTICK, asGeneric(new CandlestickBrailleEncoder())],
+      [TraceType.DODGED, asGeneric(new BarBrailleEncoder())],
+      [TraceType.HEATMAP, asGeneric(new HeatmapBrailleEncoder())],
+      [TraceType.HISTOGRAM, asGeneric(new BarBrailleEncoder())],
+      [TraceType.LINE, asGeneric(new LineBrailleEncoder())],
+      [TraceType.NORMALIZED, asGeneric(new BarBrailleEncoder())],
+      [TraceType.SCATTER, asGeneric(new HeatmapBrailleEncoder())],
+      [TraceType.SMOOTH, asGeneric(new LineBrailleEncoder())],
+      [TraceType.STACKED, asGeneric(new BarBrailleEncoder())],
+      [TraceType.VIOLIN_KDE, asGeneric(new LineBrailleEncoder())],
+      [TraceType.VIOLIN_BOX, asGeneric(new BoxBrailleEncoder())],
     ]);
 
     this.onChangeEmitter = new Emitter<BrailleChangedEvent>();
@@ -1108,7 +1174,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
       const encoder = this.encoders.get(trace.traceType)!;
       this.colOffset = targetOffset;
       this.cache = encoder.encode(
-        braille as any,
+        braille,
         this.displaySize,
         isMultilineMode,
         this.colOffset,
@@ -1132,17 +1198,12 @@ implements Observer<SubplotState | TraceState>, Disposable {
    * @param braille - Current braille state from the active trace
    * @returns Whether horizontal windowing will apply for this state
    */
-  private willWindowHorizontally(braille: any): boolean {
-    const values = braille?.values;
-    if (!Array.isArray(values) || values.length <= 1) {
+  private willWindowHorizontally(braille: NonEmptyBrailleState): boolean {
+    if (!isGridBrailleState(braille) || braille.values.length <= 1) {
       return false;
     }
-    // Box-plot states store BoxPoint objects (not arrays) per row.
-    if (!Array.isArray(values[0])) {
-      return false;
-    }
-    for (const row of values) {
-      if (Array.isArray(row) && row.length > this.displaySize) {
+    for (const row of braille.values) {
+      if (row.length > this.displaySize) {
         return true;
       }
     }

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -77,7 +77,7 @@ const BRAILLE_DISPLAY_LINES_SETTING = 'general.brailleDisplayLines';
  * @param lines - Raw display lines value from settings or caller
  * @returns Normalized display lines
  */
-function normalizeDisplayLines(lines: number | undefined): number {
+export function normalizeDisplayLines(lines: number | undefined): number {
   if (lines === undefined || !Number.isFinite(lines)) {
     return DEFAULT_BRAILLE_LINES;
   }

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -273,6 +273,7 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
     const step = multiline ? -1 : 1;
 
     for (let row = start; row !== end; row += step) {
+      const rowStartIdx = values.length;
       const box = state.values[row];
       const boxValData = [
         { type: this.GLOBAL_MIN, value: state.min },
@@ -450,10 +451,24 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
         }
       }
 
-      if (!multiline) {
+      if (multiline) {
+        // The box encoder already produces exactly `size` characters per row,
+        // which equals displaySize, so no space-padding is needed — the row
+        // naturally ends on a display-line boundary.  However, if the encoded
+        // char count is not a multiple of displaySize (defensive), pad it.
+        const rowCharCount = values.length - rowStartIdx;
+        const paddedLength = rowCharCount === 0
+          ? size
+          : Math.ceil(rowCharCount / size) * size;
+        const lastCol = Math.max(0, col);
+        for (let p = rowCharCount; p < paddedLength; p++) {
+          values.push(Constant.SPACE);
+          indexToCell.push({ row, col: lastCol });
+        }
+      } else {
         values.push(Constant.NEW_LINE);
+        indexToCell.push({ row, col });
       }
-      indexToCell.push({ row, col });
     }
 
     return { value: values.join(Constant.EMPTY), cellToIndex, indexToCell };

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -48,11 +48,8 @@ import type { NotificationService } from './notification';
 import type { SettingsService } from './settings';
 import { Emitter, Scope } from '@type/event';
 import { TraceType } from '@type/grammar';
+import { DEFAULT_BRAILLE_LINES, DEFAULT_BRAILLE_SIZE, MAX_BRAILLE_LINES } from '@type/settings';
 import { Constant } from '@util/constant';
-
-export const DEFAULT_BRAILLE_SIZE = 32;
-export const DEFAULT_BRAILLE_LINES = 1;
-export const MAX_BRAILLE_LINES = 20;
 
 /**
  * Normalizes configured braille display size to a safe positive integer.

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -112,8 +112,15 @@ type GridBrailleState
 
 /**
  * Typed guard: narrows a {@link BrailleState} to the grid-shaped variants
- * that expose `number[][]` rows. Box states are filtered out because their
- * per-row element is a single `BoxPoint`, not a row array.
+ * that expose `number[][]` rows.
+ *
+ * Box states are filtered out because `BoxBrailleState.values` is a flat
+ * `BoxPoint[]` (one object per row) rather than a `number[][]` grid — so
+ * `Array.isArray(values[0])` is true for grid states and false for box
+ * states. This distinction matters for horizontal-windowing checks that
+ * need to iterate per-row column counts; box plots always fill exactly
+ * `displaySize` cells per row and never window, so excluding them here
+ * short-circuits the windowing path cleanly.
  * @param state - Any braille state to inspect
  * @returns Whether the state has a 2D numeric value grid
  */
@@ -342,12 +349,17 @@ interface TimeSeries {
  * `colOffset` enables horizontal page-windowing for plots wider than the
  * display; it is meaningful only when `multiline=true` and the state has
  * multiple rows with at least one row wider than `size` cells.
+ *
+ * Note: `BoxBrailleEncoder` intentionally ignores `colOffset` — each box
+ * always fills exactly `size` cells, so there is never anything to window
+ * horizontally. All other encoders honor it.
  */
 interface BrailleEncoder<BrailleState> {
   encode: (
     state: BrailleState,
     size?: number,
     multiline?: boolean,
+    /** Horizontal page offset for wide rows. Ignored by BoxBrailleEncoder. */
     colOffset?: number,
   ) => EncodedBraille;
 }

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -20,6 +20,7 @@ import { Constant } from '@util/constant';
 
 export const DEFAULT_BRAILLE_SIZE = 32;
 export const DEFAULT_BRAILLE_LINES = 1;
+export const MAX_BRAILLE_LINES = 20;
 
 /**
  * Normalizes configured braille display size to a safe positive integer.
@@ -48,7 +49,7 @@ function normalizeDisplayLines(lines: number | undefined): number {
   if (lines === undefined || !Number.isFinite(lines)) {
     return DEFAULT_BRAILLE_LINES;
   }
-  return Math.max(1, Math.floor(lines));
+  return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(lines)));
 }
 
 /**
@@ -166,6 +167,16 @@ interface TimeSeries {
 
 /**
  * Interface for encoding plot states into braille representations.
+ *
+ * The `multiline` flag controls two related behaviors that implementors must
+ * keep in sync:
+ *   1. Row separation — uses space-padding to the next `displaySize` boundary
+ *      instead of inserting a newline character, so that each data row occupies
+ *      a full physical braille display line.
+ *   2. Row encoding order — encodes data rows from last to first so that
+ *      row 0 (the initially focused / lowest data row) appears at the bottom
+ *      of the physical braille display.  This makes UP-arrow navigation
+ *      (which increments `row`) move the cursor upward on the display.
  */
 interface BrailleEncoder<BrailleState> {
   encode: (state: BrailleState, size?: number, multiline?: boolean) => EncodedBraille;
@@ -245,6 +256,7 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
     size: number = DEFAULT_BRAILLE_SIZE,
     multiline: boolean = false,
   ): EncodedBraille {
+    const displaySize = normalizeDisplaySize(size);
     const values = new Array<string>();
     const indexToCell = new Array<Cell>();
     const cellToIndex = new Array<Array<number>>();
@@ -367,7 +379,7 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
         }
       }
 
-      const available = Math.max(0, size - preAllocated);
+      const available = Math.max(0, displaySize - preAllocated);
       const totalLength = lenData.reduce(
         (sum, l) => sum + (l.type !== this.Q2 && l.length > 0 ? l.length : 0),
         0,
@@ -382,7 +394,7 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
       }
 
       const totalChars = lenData.reduce((sum, l) => sum + l.numChars, 0);
-      let diff = size - totalChars;
+      let diff = displaySize - totalChars;
       let adjustIndex = 0;
       while (diff !== 0) {
         const section = lenData[adjustIndex % lenData.length];
@@ -452,14 +464,14 @@ class BoxBrailleEncoder implements BrailleEncoder<BoxBrailleState> {
       }
 
       if (multiline) {
-        // The box encoder already produces exactly `size` characters per row,
-        // which equals displaySize, so no space-padding is needed — the row
-        // naturally ends on a display-line boundary.  However, if the encoded
-        // char count is not a multiple of displaySize (defensive), pad it.
+        // The box encoder already produces exactly `displaySize` characters
+        // per row, so the row naturally ends on a display-line boundary.
+        // The defensive padding below covers any future code path that might
+        // emit a different number of characters.
         const rowCharCount = values.length - rowStartIdx;
         const paddedLength = rowCharCount === 0
-          ? size
-          : Math.ceil(rowCharCount / size) * size;
+          ? displaySize
+          : Math.ceil(rowCharCount / displaySize) * displaySize;
         const lastCol = Math.max(0, col);
         for (let p = rowCharCount; p < paddedLength; p++) {
           values.push(Constant.SPACE);
@@ -943,7 +955,10 @@ implements Observer<SubplotState | TraceState>, Disposable {
     const braille = trace.braille;
     if (this.cache === null || this.cacheId !== braille.id) {
       const encoder = this.encoders.get(trace.traceType)!;
-      this.cache = encoder.encode(braille as any, this.displaySize, this.displayLines > 1);
+      // multiline=true switches the encoder to physical-display mode:
+      // space-padded rows (no newlines) and reversed row order so UP moves up.
+      const useMultilinePadding = this.displayLines > 1;
+      this.cache = encoder.encode(braille as any, this.displaySize, useMultilinePadding);
       this.cacheId = braille.id;
     }
 

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -8,6 +8,33 @@ import { Emitter, Scope } from '@type/event';
 
 const SETTINGS_KEY = 'maidr-settings';
 
+/**
+ * Deep-merges `override` into `defaults`, filling any keys that are present
+ * in `defaults` but absent from `override`. This ensures that newly added
+ * settings are available even when the user has an older saved settings object
+ * in localStorage that predates the new keys.
+ */
+function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
+  const result = { ...defaults };
+  for (const key of Object.keys(override) as (keyof T)[]) {
+    const overrideVal = override[key];
+    const defaultVal = defaults[key];
+    if (
+      overrideVal !== null
+      && overrideVal !== undefined
+      && typeof overrideVal === 'object'
+      && !Array.isArray(overrideVal)
+      && typeof defaultVal === 'object'
+      && defaultVal !== null
+    ) {
+      result[key] = deepMerge(defaultVal as object, overrideVal as Partial<object>) as T[keyof T];
+    } else if (overrideVal !== undefined) {
+      result[key] = overrideVal as T[keyof T];
+    }
+  }
+  return result;
+}
+
 function getValue<T>(settings: any, key: string): T | undefined {
   return key.split('.').reduce((acc, part) => {
     return acc && acc[part];
@@ -67,6 +94,7 @@ export class SettingsService implements Disposable {
         highContrastLightColor: '#ffffff',
         highContrastDarkColor: '#000000',
         brailleDisplaySize: 32,
+        brailleDisplayLines: 1,
         minFrequency: 200,
         maxFrequency: 1000,
         autoplayDuration: 4000,
@@ -101,7 +129,9 @@ export class SettingsService implements Disposable {
     this.onChangeEmitter = new Emitter<SettingsChangedEvent>();
     this.onChange = this.onChangeEmitter.event;
     const saved = this.storage.load<Settings>(SETTINGS_KEY);
-    this.currentSettings = saved ?? this.defaultSettings;
+    // Deep-merge so that newly added default settings are available even when
+    // the user has an older saved object in localStorage that lacks the new keys.
+    this.currentSettings = saved ? deepMerge(this.defaultSettings, saved) : this.defaultSettings;
   }
 
   public dispose(): void {

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -16,7 +16,7 @@ const SETTINGS_KEY = 'maidr-settings';
  *
  * null override values are treated as absent and fall back to defaults.
  */
-function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
+export function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
   const result = { ...defaults };
   for (const key of Object.keys(override) as (keyof T)[]) {
     const overrideVal = override[key];
@@ -30,7 +30,7 @@ function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
       && defaultVal !== null
     ) {
       result[key] = deepMerge(defaultVal as object, overrideVal as Partial<object>) as T[keyof T];
-    } else if (overrideVal !== undefined) {
+    } else if (overrideVal !== undefined && overrideVal !== null) {
       result[key] = overrideVal as T[keyof T];
     }
   }

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -13,6 +13,8 @@ const SETTINGS_KEY = 'maidr-settings';
  * in `defaults` but absent from `override`. This ensures that newly added
  * settings are available even when the user has an older saved settings object
  * in localStorage that predates the new keys.
+ *
+ * null override values are treated as absent and fall back to defaults.
  */
 function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
   const result = { ...defaults };

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -15,6 +15,10 @@ const SETTINGS_KEY = 'maidr-settings';
  * in localStorage that predates the new keys.
  *
  * null override values are treated as absent and fall back to defaults.
+ *
+ * Arrays are replaced wholesale rather than recursed into. If any future
+ * setting is array-typed, a saved older value will overwrite the default
+ * array instead of being merged element-by-element.
  */
 export function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
   const result = { ...defaults };

--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -5,41 +5,10 @@ import type { Event } from '@type/event';
 import type { Observer } from '@type/observable';
 import type { Settings } from '@type/settings';
 import { Emitter, Scope } from '@type/event';
+import { DEFAULT_SETTINGS } from '@type/settings';
+import { deepMerge } from '@util/deepMerge';
 
 const SETTINGS_KEY = 'maidr-settings';
-
-/**
- * Deep-merges `override` into `defaults`, filling any keys that are present
- * in `defaults` but absent from `override`. This ensures that newly added
- * settings are available even when the user has an older saved settings object
- * in localStorage that predates the new keys.
- *
- * null override values are treated as absent and fall back to defaults.
- *
- * Arrays are replaced wholesale rather than recursed into. If any future
- * setting is array-typed, a saved older value will overwrite the default
- * array instead of being merged element-by-element.
- */
-export function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
-  const result = { ...defaults };
-  for (const key of Object.keys(override) as (keyof T)[]) {
-    const overrideVal = override[key];
-    const defaultVal = defaults[key];
-    if (
-      overrideVal !== null
-      && overrideVal !== undefined
-      && typeof overrideVal === 'object'
-      && !Array.isArray(overrideVal)
-      && typeof defaultVal === 'object'
-      && defaultVal !== null
-    ) {
-      result[key] = deepMerge(defaultVal as object, overrideVal as Partial<object>) as T[keyof T];
-    } else if (overrideVal !== undefined && overrideVal !== null) {
-      result[key] = overrideVal as T[keyof T];
-    }
-  }
-  return result;
-}
 
 function getValue<T>(settings: any, key: string): T | undefined {
   return key.split('.').reduce((acc, part) => {
@@ -91,47 +60,7 @@ export class SettingsService implements Disposable {
     this.display = display;
     this.observers = [];
 
-    this.defaultSettings = {
-      general: {
-        volume: 50,
-        highlightColor: '#03c809',
-        highContrastMode: false,
-        highContrastLevels: 2,
-        highContrastLightColor: '#ffffff',
-        highContrastDarkColor: '#000000',
-        brailleDisplaySize: 32,
-        brailleDisplayLines: 1,
-        minFrequency: 200,
-        maxFrequency: 1000,
-        autoplayDuration: 4000,
-        ariaMode: 'assertive',
-        hoverMode: 'pointermove',
-      },
-      llm: {
-        expertiseLevel: 'basic',
-        customInstruction: '',
-        models: {
-          OPENAI: {
-            enabled: false,
-            apiKey: '',
-            name: 'OpenAI',
-            version: 'gpt-4o',
-          },
-          ANTHROPIC_CLAUDE: {
-            enabled: false,
-            apiKey: '',
-            name: 'Anthropic Claude',
-            version: 'claude-3-7-sonnet-latest',
-          },
-          GOOGLE_GEMINI: {
-            enabled: false,
-            apiKey: '',
-            name: 'Google Gemini',
-            version: 'gemini-2.0-flash',
-          },
-        },
-      },
-    };
+    this.defaultSettings = structuredClone(DEFAULT_SETTINGS);
     this.onChangeEmitter = new Emitter<SettingsChangedEvent>();
     this.onChange = this.onChangeEmitter.event;
     const saved = this.storage.load<Settings>(SETTINGS_KEY);

--- a/src/state/viewModel/brailleViewModel.ts
+++ b/src/state/viewModel/brailleViewModel.ts
@@ -3,7 +3,7 @@ import type { BrailleService } from '@service/braille';
 import type { AppStore } from '@state/store';
 import type { TraceState } from '@type/state';
 import { createSlice } from '@reduxjs/toolkit';
-import { DEFAULT_BRAILLE_LINES, DEFAULT_BRAILLE_SIZE } from '@service/braille';
+import { DEFAULT_BRAILLE_LINES, DEFAULT_BRAILLE_SIZE } from '@type/settings';
 import { AbstractViewModel } from './viewModel';
 
 /**

--- a/src/state/viewModel/brailleViewModel.ts
+++ b/src/state/viewModel/brailleViewModel.ts
@@ -3,7 +3,7 @@ import type { BrailleService } from '@service/braille';
 import type { AppStore } from '@state/store';
 import type { TraceState } from '@type/state';
 import { createSlice } from '@reduxjs/toolkit';
-import { DEFAULT_BRAILLE_SIZE } from '@service/braille';
+import { DEFAULT_BRAILLE_LINES, DEFAULT_BRAILLE_SIZE } from '@service/braille';
 import { AbstractViewModel } from './viewModel';
 
 /**
@@ -13,12 +13,14 @@ export interface BrailleState {
   value: string;
   index: number;
   displaySize: number;
+  displayLines: number;
 }
 
 const initialState: BrailleState = {
   value: '',
   index: -1,
   displaySize: DEFAULT_BRAILLE_SIZE,
+  displayLines: DEFAULT_BRAILLE_LINES,
 };
 
 const brailleSlice = createSlice({

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -46,6 +46,7 @@ export interface GeneralSettings {
   highContrastLightColor: string;
   highContrastDarkColor: string;
   brailleDisplaySize: number;
+  brailleDisplayLines: number;
   minFrequency: number;
   maxFrequency: number;
   autoplayDuration: number;
@@ -70,6 +71,7 @@ export const DEFAULT_SETTINGS: Settings = {
     highContrastLightColor: '#ffffff',
     highContrastDarkColor: '#000000',
     brailleDisplaySize: 32,
+    brailleDisplayLines: 1,
     minFrequency: 200,
     maxFrequency: 1000,
     autoplayDuration: 4000,

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -1,5 +1,23 @@
 import type { Llm, LlmVersion } from './llm';
-import { DEFAULT_BRAILLE_LINES } from '@service/braille';
+
+/**
+ * Default number of characters rendered per braille row when no user setting
+ * is configured. 32 matches the most common physical braille display width.
+ */
+export const DEFAULT_BRAILLE_SIZE = 32;
+
+/**
+ * Default number of physical braille rows. 1 means single-line mode, where
+ * the braille output is a flat string without row reversal or space-padding.
+ */
+export const DEFAULT_BRAILLE_LINES = 1;
+
+/**
+ * Upper bound on the configured number of braille rows. Acts as a sanity cap
+ * so that pathological settings cannot produce extremely large braille
+ * strings at render time.
+ */
+export const MAX_BRAILLE_LINES = 20;
 
 /**
  * ARIA live region politeness level for screen reader announcements.
@@ -71,7 +89,7 @@ export const DEFAULT_SETTINGS: Settings = {
     highContrastLevels: 2,
     highContrastLightColor: '#ffffff',
     highContrastDarkColor: '#000000',
-    brailleDisplaySize: 32,
+    brailleDisplaySize: DEFAULT_BRAILLE_SIZE,
     brailleDisplayLines: DEFAULT_BRAILLE_LINES,
     minFrequency: 200,
     maxFrequency: 1000,

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -1,4 +1,5 @@
 import type { Llm, LlmVersion } from './llm';
+import { DEFAULT_BRAILLE_LINES } from '@service/braille';
 
 /**
  * ARIA live region politeness level for screen reader announcements.
@@ -71,7 +72,7 @@ export const DEFAULT_SETTINGS: Settings = {
     highContrastLightColor: '#ffffff',
     highContrastDarkColor: '#000000',
     brailleDisplaySize: 32,
-    brailleDisplayLines: 1,
+    brailleDisplayLines: DEFAULT_BRAILLE_LINES,
     minFrequency: 200,
     maxFrequency: 1000,
     autoplayDuration: 4000,

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -49,7 +49,7 @@ export type SubplotState
 /**
  * Empty trace state used as a placeholder when no data is available.
  */
-interface TraceEmptyState {
+export interface TraceEmptyState {
   empty: true;
   type: 'trace';
   traceType: TraceType;

--- a/src/ui/component/Braille.tsx
+++ b/src/ui/component/Braille.tsx
@@ -65,6 +65,15 @@ const Braille: React.FC = () => {
         autoCapitalize="off"
         autoCorrect="off"
         spellCheck={false}
+        // `wrap="off"` is load-bearing: the browser must not insert any visual
+        // line breaks. A physical braille display reads the textarea as one
+        // flat character stream indexed by cursor position, which is also how
+        // BrailleService's `cellToIndex`/`indexToCell` maps are built. Any
+        // browser-inserted wrap would desync those indices from the hardware
+        // cursor. Row separation on physical hardware is achieved by
+        // space-padding inside the encoded string (see braille.ts) — `\n` is
+        // not used in multiline mode because it does not render on a physical
+        // braille display.
         wrap="off"
         // Keep a 5-row minimum visible height so the textarea is comfortable to
         // read on a regular screen even when displayLines=1 (the default for

--- a/src/ui/component/Braille.tsx
+++ b/src/ui/component/Braille.tsx
@@ -66,6 +66,10 @@ const Braille: React.FC = () => {
         autoCorrect="off"
         spellCheck={false}
         wrap="off"
+        // Keep a 5-row minimum visible height so the textarea is comfortable to
+        // read on a regular screen even when displayLines=1 (the default for
+        // users without a physical multi-line braille display).  Users with a
+        // larger physical display still see all their lines.
         rows={Math.max(displayLines, 5)}
         cols={displaySize}
       />

--- a/src/ui/component/Braille.tsx
+++ b/src/ui/component/Braille.tsx
@@ -66,7 +66,7 @@ const Braille: React.FC = () => {
         autoCorrect="off"
         spellCheck={false}
         wrap="off"
-        rows={displayLines}
+        rows={Math.max(displayLines, 5)}
         cols={displaySize}
       />
     </div>

--- a/src/ui/component/Braille.tsx
+++ b/src/ui/component/Braille.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useId, useRef } from 'react';
 const Braille: React.FC = () => {
   const id = useId();
   const viewModel = useViewModel('braille');
-  const { value, index, displaySize } = useViewModelState('braille');
+  const { value, index, displaySize, displayLines } = useViewModelState('braille');
 
   const brailleRef = useRef<HTMLTextAreaElement>(null);
   const lastIndexRef = useRef<number>(index);
@@ -66,7 +66,7 @@ const Braille: React.FC = () => {
         autoCorrect="off"
         spellCheck={false}
         wrap="off"
-        rows={5}
+        rows={displayLines}
         cols={displaySize}
       />
     </div>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -31,6 +31,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { MAX_BRAILLE_LINES } from '@service/braille';
 import { LlmValidationService } from '@service/llmValidation';
 import { MODEL_VERSIONS } from '@service/modelVersions';
 import { useViewModel } from '@state/hook/useViewModel';
@@ -573,15 +574,15 @@ const Settings: React.FC = () => {
                     onBlur={e =>
                       handleGeneralChange(
                         'brailleDisplayLines',
-                        Math.min(20, Math.max(1, Math.floor(Number(e.target.value)) || 1)),
+                        Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(Number(e.target.value)) || 1)),
                       )}
-                    helperText="Number of rows on a physical braille display (1-20). Set above 1 to enable multi-line output."
+                    helperText={`Number of rows on a physical braille display (1-${MAX_BRAILLE_LINES}). Set above 1 to enable multi-line output.`}
                     slotProps={{
                       input: {
                         inputProps: {
                           'aria-label': 'Braille Display Lines',
                           'min': 1,
-                          'max': 20,
+                          'max': MAX_BRAILLE_LINES,
                           'step': 1,
                         },
                       },

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -557,11 +557,19 @@ const Settings: React.FC = () => {
                     type="number"
                     size="small"
                     value={generalSettings.brailleDisplayLines}
-                    onChange={e =>
-                      handleGeneralChange(
-                        'brailleDisplayLines',
-                        Number(e.target.value),
-                      )}
+                    onChange={(e) => {
+                      // Guard against NaN (e.g. when the user clears the field).
+                      // The stored value stays valid even if blur never fires.
+                      const raw = e.target.value;
+                      if (raw === '') {
+                        return;
+                      }
+                      const parsed = Number(raw);
+                      if (Number.isNaN(parsed)) {
+                        return;
+                      }
+                      handleGeneralChange('brailleDisplayLines', parsed);
+                    }}
                     onBlur={e =>
                       handleGeneralChange(
                         'brailleDisplayLines',

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -567,6 +567,8 @@ const Settings: React.FC = () => {
                         inputProps: {
                           'aria-label': 'Braille Display Lines',
                           'min': 1,
+                          'max': 20,
+                          'step': 1,
                         },
                       },
                     }}

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -39,6 +39,10 @@ import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
+function clampBrailleLines(value: number): number {
+  return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
+}
+
 function getValidVersion(
   modelKey: Llm,
   currentVersion: string | undefined,
@@ -571,15 +575,12 @@ const Settings: React.FC = () => {
                       if (Number.isNaN(parsed)) {
                         return;
                       }
-                      handleGeneralChange(
-                        'brailleDisplayLines',
-                        Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(parsed) || 1)),
-                      );
+                      handleGeneralChange('brailleDisplayLines', clampBrailleLines(parsed));
                     }}
                     onBlur={e =>
                       handleGeneralChange(
                         'brailleDisplayLines',
-                        Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(Number(e.target.value)) || 1)),
+                        clampBrailleLines(Number(e.target.value)),
                       )}
                     helperText={`Number of rows on a physical braille display (1-${MAX_BRAILLE_LINES}). Set above 1 to enable multi-line output.`}
                     slotProps={{

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -562,6 +562,7 @@ const Settings: React.FC = () => {
                         'brailleDisplayLines',
                         Number(e.target.value),
                       )}
+                    helperText="Number of rows on a physical braille display (1-20). Set above 1 to enable multi-line output."
                     slotProps={{
                       input: {
                         inputProps: {

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -562,6 +562,11 @@ const Settings: React.FC = () => {
                         'brailleDisplayLines',
                         Number(e.target.value),
                       )}
+                    onBlur={e =>
+                      handleGeneralChange(
+                        'brailleDisplayLines',
+                        Math.min(20, Math.max(1, Math.floor(Number(e.target.value)) || 1)),
+                      )}
                     helperText="Number of rows on a physical braille display (1-20). Set above 1 to enable multi-line output."
                     slotProps={{
                       input: {

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -31,10 +31,10 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { MAX_BRAILLE_LINES } from '@service/braille';
 import { LlmValidationService } from '@service/llmValidation';
 import { MODEL_VERSIONS } from '@service/modelVersions';
 import { useViewModel } from '@state/hook/useViewModel';
+import { MAX_BRAILLE_LINES } from '@type/settings';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -549,6 +549,34 @@ const Settings: React.FC = () => {
           </Grid>
           <Grid size={12}>
             <SettingRow
+              label="Braille Display Lines"
+              input={(
+                <FormControl fullWidth>
+                  <TextField
+                    fullWidth
+                    type="number"
+                    size="small"
+                    value={generalSettings.brailleDisplayLines}
+                    onChange={e =>
+                      handleGeneralChange(
+                        'brailleDisplayLines',
+                        Number(e.target.value),
+                      )}
+                    slotProps={{
+                      input: {
+                        inputProps: {
+                          'aria-label': 'Braille Display Lines',
+                          'min': 1,
+                        },
+                      },
+                    }}
+                  />
+                </FormControl>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
               label="Min Frequency (Hz)"
               input={(
                 <FormControl fullWidth>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -559,8 +559,10 @@ const Settings: React.FC = () => {
                     size="small"
                     value={generalSettings.brailleDisplayLines}
                     onChange={(e) => {
-                      // Guard against NaN (e.g. when the user clears the field).
-                      // The stored value stays valid even if blur never fires.
+                      // Guard against NaN / empty (e.g. when the user clears
+                      // the field). The stored value stays valid even if blur
+                      // never fires. Clamp/floor on every keystroke so a user
+                      // who types `0` and tabs away is not silently reset.
                       const raw = e.target.value;
                       if (raw === '') {
                         return;
@@ -569,7 +571,10 @@ const Settings: React.FC = () => {
                       if (Number.isNaN(parsed)) {
                         return;
                       }
-                      handleGeneralChange('brailleDisplayLines', parsed);
+                      handleGeneralChange(
+                        'brailleDisplayLines',
+                        Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(parsed) || 1)),
+                      );
                     }}
                     onBlur={e =>
                       handleGeneralChange(

--- a/src/util/deepMerge.ts
+++ b/src/util/deepMerge.ts
@@ -1,0 +1,32 @@
+/**
+ * Deep-merges `override` into `defaults`, filling any keys that are present
+ * in `defaults` but absent from `override`. This ensures that newly added
+ * defaults are available even when the caller supplies a partial object that
+ * predates those keys (for example, an older settings object in localStorage).
+ *
+ * null override values are treated as absent and fall back to defaults.
+ *
+ * Arrays are replaced wholesale rather than recursed into. If a key holds an
+ * array, a supplied override array will overwrite the default array instead of
+ * being merged element-by-element.
+ */
+export function deepMerge<T extends object>(defaults: T, override: Partial<T>): T {
+  const result = { ...defaults };
+  for (const key of Object.keys(override) as (keyof T)[]) {
+    const overrideVal = override[key];
+    const defaultVal = defaults[key];
+    if (
+      overrideVal !== null
+      && overrideVal !== undefined
+      && typeof overrideVal === 'object'
+      && !Array.isArray(overrideVal)
+      && typeof defaultVal === 'object'
+      && defaultVal !== null
+    ) {
+      result[key] = deepMerge(defaultVal as object, overrideVal as Partial<object>) as T[keyof T];
+    } else if (overrideVal !== undefined && overrideVal !== null) {
+      result[key] = overrideVal as T[keyof T];
+    }
+  }
+  return result;
+}

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -931,6 +931,45 @@ describe('BrailleService display-size encoding', () => {
     service.dispose();
   });
 
+  test('multiline mode: row that exactly fills displaySize has valid out-of-bounds sentinel', () => {
+    // When a row's length is exactly divisible by displaySize, no padding is
+    // appended and the sentinel stored in cellToIndex[row][cols] points past
+    // the end of indexToCell. moveToIndex's bounds check makes that harmless.
+    // This test locks that invariant: emission is correct (no padding, no
+    // newlines), real cells navigate correctly, and the sentinel index is
+    // silently ignored rather than crashing or dispatching a bogus move.
+    const { service, contextMoveToIndex } = createMultilineBrailleService(4, 2);
+
+    // 2 rows × 4 cols, displaySize=4 → each row exactly fills; paddedLength=cols.
+    const state = createLineTraceState([[1, 2, 3, 4], [5, 6, 7, 8]], 0, 3);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    // No padding, no newlines: 2 × 4 = 8 chars total.
+    expect(emitted.length).toBe(8);
+    expect(emitted.includes('\n')).toBe(false);
+
+    // Rows encoded in reverse (UP = upward): row1 at indices 0..3, row0 at 4..7.
+    service.moveToIndex(0);
+    expect(contextMoveToIndex).toHaveBeenLastCalledWith(1, 0);
+    service.moveToIndex(7);
+    expect(contextMoveToIndex).toHaveBeenLastCalledWith(0, 3);
+
+    const callsBeforeSentinel = contextMoveToIndex.mock.calls.length;
+    // Sentinel index == indexToCell.length (== emitted.length here). The bounds
+    // check should make this a no-op — no additional dispatch.
+    service.moveToIndex(emitted.length);
+    expect(contextMoveToIndex.mock.calls.length).toBe(callsBeforeSentinel);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
   test('horizontal windowing: click on padding inside window maps to last data col', () => {
     const { service, contextMoveToIndex } = createMultilineBrailleService(4, 2);
 

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -333,6 +333,52 @@ function createBrailleService(displaySize: number): {
 }
 
 /**
+ * Builds a BrailleService with configurable display size and display lines.
+ * Consolidates the context/notification/display/settings mock boilerplate
+ * that multiline and windowing tests otherwise reconstruct inline.
+ * @param displaySize - Braille display size (cells per line)
+ * @param displayLines - Number of physical braille display lines
+ * @returns Service instance and a context `moveToIndex` spy
+ */
+function createMultilineBrailleService(
+  displaySize: number,
+  displayLines: number,
+): {
+  service: BrailleService;
+  contextMoveToIndex: ReturnType<typeof jest.fn>;
+} {
+  const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
+  const context = {
+    moveToIndex: contextMoveToIndex,
+    get state(): undefined {
+      return undefined;
+    },
+  } as unknown as Context;
+
+  const notification = {
+    notify: jest.fn<(message: string) => void>(),
+  } as unknown as NotificationService;
+
+  const display = {
+    toggleFocus: jest.fn(),
+  } as unknown as DisplayService;
+
+  const settings = {
+    get: <T>(path: string): T => {
+      if (path === 'general.brailleDisplaySize')
+        return displaySize as T;
+      if (path === 'general.brailleDisplayLines')
+        return displayLines as T;
+      return undefined as T;
+    },
+    onChange: () => ({ dispose: () => {} }),
+  } as unknown as SettingsService;
+
+  const service = new BrailleService(context, notification, display, settings);
+  return { service, contextMoveToIndex };
+}
+
+/**
  * Builds a BrailleService with a settings mock that can emit runtime changes.
  * @param displaySize - Initial braille display size setting to use
  * @returns Service instance and settings trigger for change-event assertions
@@ -658,34 +704,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('multiline mode: space-pads each row to displaySize boundary', () => {
-    // We need to test the encoder directly via the BrailleService with displayLines > 1.
-    // Since BrailleService reads displayLines from settings, create a mock with displayLines=2.
-    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
-    const context = {
-      moveToIndex: contextMoveToIndex,
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = {
-      notify: jest.fn<(message: string) => void>(),
-    } as unknown as NotificationService;
-    const display = {
-      toggleFocus: jest.fn(),
-    } as unknown as DisplayService;
-
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 10 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 2 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service } = createMultilineBrailleService(10, 2);
 
     // 2 rows: [5 items, 3 items], displaySize=10, displayLines=2
     const state = createLineTraceState([[1, 2, 3, 4, 5], [10, 20, 30]], 0, 0);
@@ -711,28 +730,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('multiline mode: navigation maps correctly in space-padded rows', () => {
-    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
-    const context = {
-      moveToIndex: contextMoveToIndex,
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 10 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 2 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service, contextMoveToIndex } = createMultilineBrailleService(10, 2);
 
     // Navigate to row=1, col=2 in a 2-row dataset
     const state = createLineTraceState([[1, 2, 3, 4, 5], [10, 20, 30]], 1, 2);
@@ -761,27 +759,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('multiline mode: emits displayLines in onChange event', () => {
-    const context = {
-      moveToIndex: jest.fn(),
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 32 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 3 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service } = createMultilineBrailleService(32, 3);
 
     const state = createLineTraceState([[1, 2, 3]], 0, 0);
 
@@ -798,28 +776,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('multiline mode: box encoder space-pads rows to displaySize boundary', () => {
-    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
-    const context = {
-      moveToIndex: contextMoveToIndex,
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 32 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 2 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service } = createMultilineBrailleService(32, 2);
 
     const box = {
       lowerOutliers: [] as number[],
@@ -851,26 +808,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('horizontal windowing: multi-row plot with cols > displaySize produces displaySize chars per row', () => {
-    const context = {
-      moveToIndex: jest.fn<(row: number, col: number) => void>(),
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 3 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 2 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service } = createMultilineBrailleService(3, 2);
 
     // 3 rows of 5 cols, displaySize=3. maxCols (5) > displaySize (3) → windowing activates.
     const state = createLineTraceState(
@@ -896,26 +834,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('horizontal windowing: cursor past displaySize triggers page-aligned re-encode', () => {
-    const context = {
-      moveToIndex: jest.fn<(row: number, col: number) => void>(),
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 3 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 2 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service } = createMultilineBrailleService(3, 2);
 
     // Enable at cursor (row=0, col=0) → window [0, 3).
     const firstState = createLineTraceState(
@@ -956,26 +875,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('horizontal windowing: single-row plot keeps existing overflow behavior (no windowing)', () => {
-    const context = {
-      moveToIndex: jest.fn<(row: number, col: number) => void>(),
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 4 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 2 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service } = createMultilineBrailleService(4, 2);
 
     // Single row of 10 cols, displaySize=4 → current behavior: pad to ceil(10/4)*4 = 12.
     const state = createLineTraceState(
@@ -1000,26 +900,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('horizontal windowing: multi-row where all rows fit keeps per-row padding (no windowing)', () => {
-    const context = {
-      moveToIndex: jest.fn<(row: number, col: number) => void>(),
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 10 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 3 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service } = createMultilineBrailleService(10, 3);
 
     // 3 rows of 5 cols, displaySize=10. All rows fit → no windowing; each row
     // padded to 10 chars = 30 total.
@@ -1044,27 +925,7 @@ describe('BrailleService display-size encoding', () => {
   });
 
   test('horizontal windowing: click on padding inside window maps to last data col', () => {
-    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
-    const context = {
-      moveToIndex: contextMoveToIndex,
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 4 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 2 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
-
-    const service = new BrailleService(context, notification, display, settings);
+    const { service, contextMoveToIndex } = createMultilineBrailleService(4, 2);
 
     // Row 0: 5 cols. Row 1: 2 cols. displaySize=4 → windowing activates.
     // Window [0, 4): row 1 has cols 0,1 then 2 padding chars. Row 0 fills all 4.
@@ -1087,27 +948,46 @@ describe('BrailleService display-size encoding', () => {
     service.dispose();
   });
 
-  test('horizontal windowing: single-line mode never windows', () => {
-    const context = {
-      moveToIndex: jest.fn<(row: number, col: number) => void>(),
-      get state(): undefined {
-        return undefined;
-      },
-    } as unknown as Context;
-    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
-    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
-    const settings = {
-      get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize')
-          return 3 as T;
-        if (path === 'general.brailleDisplayLines')
-          return 1 as T;
-        return undefined as T;
-      },
-      onChange: () => ({ dispose: () => {} }),
-    } as unknown as SettingsService;
+  test('horizontal windowing: cursor on page-boundary columns selects the correct window', () => {
+    const { service } = createMultilineBrailleService(3, 2);
 
-    const service = new BrailleService(context, notification, display, settings);
+    // Two rows of 9 cols, displaySize=3 → windows are [0,3), [3,6), [6,9).
+    const values = [[1, 2, 3, 4, 5, 6, 7, 8, 9], [10, 20, 30, 40, 50, 60, 70, 80, 90]];
+
+    const emissions: Array<{ value: string; index: number }> = [];
+    const disposable = service.onChange((event) => {
+      emissions.push({ value: event.value, index: event.index });
+    });
+
+    // Cursor at col=2 (last col of window [0,3)) → stays in first window.
+    service.toggle(createLineTraceState(values, 0, 2));
+    const atEndOfFirst = emissions[emissions.length - 1];
+    // Row 0 is encoded last (reversed) → occupies indices [3..5]; col 2 → index 5.
+    expect(atEndOfFirst.index).toBe(5);
+
+    // Cursor at col=3 (first col of window [3,6)) → pages to second window.
+    service.update(createLineTraceState(values, 0, 3));
+    const atStartOfSecond = emissions[emissions.length - 1];
+    // New window means fresh encode; row 0's slice occupies indices [3..5];
+    // col 3 is the first in-window col → index 3.
+    expect(atStartOfSecond.index).toBe(3);
+
+    // Cursor at col=5 (last col of window [3,6)) → stays in second window.
+    service.update(createLineTraceState(values, 0, 5));
+    const atEndOfSecond = emissions[emissions.length - 1];
+    expect(atEndOfSecond.index).toBe(5);
+
+    // Cursor at col=6 (first col of window [6,9)) → pages to third window.
+    service.update(createLineTraceState(values, 0, 6));
+    const atStartOfThird = emissions[emissions.length - 1];
+    expect(atStartOfThird.index).toBe(3);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: single-line mode never windows', () => {
+    const { service } = createMultilineBrailleService(3, 1);
 
     // 2 rows of 5 cols, displaySize=3. In single-line mode, newline wrapping applies.
     const state = createLineTraceState(

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -849,4 +849,84 @@ describe('BrailleService display-size encoding', () => {
     disposable.dispose();
     service.dispose();
   });
+
+  test('multiline mode: settings change for brailleDisplayLines re-encodes and flips mode', () => {
+    // Start in single-line mode (displayLines=1), switch to multiline (displayLines=2),
+    // and verify the cache is invalidated and the output re-encodes without newlines.
+    let currentDisplayLines = 1;
+    let onChangeListener:
+      | ((event: SettingsChangeEventMock) => void)
+      | null = null;
+
+    const state = createLineTraceState([[1, 2, 3, 4, 5], [10, 20, 30]], 0, 0);
+
+    const context = {
+      moveToIndex: jest.fn<(row: number, col: number) => void>(),
+      get state(): TraceState {
+        return state;
+      },
+    } as unknown as Context;
+    const notification = {
+      notify: jest.fn<(message: string) => void>(),
+    } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 10 as T;
+        if (path === 'general.brailleDisplayLines')
+          return currentDisplayLines as T;
+        return undefined as T;
+      },
+      onChange: (listener: (event: SettingsChangeEventMock) => void) => {
+        onChangeListener = listener;
+        return {
+          dispose: () => {
+            onChangeListener = null;
+          },
+        };
+      },
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    const emissions: Array<{ value: string; displayLines: number }> = [];
+    const disposable = service.onChange((event) => {
+      emissions.push({ value: event.value, displayLines: event.displayLines });
+    });
+
+    service.toggle(state);
+
+    // Before the setting change: single-line mode → newlines present, displayLines=1.
+    expect(emissions.length).toBeGreaterThan(0);
+    const before = emissions[emissions.length - 1];
+    expect(before.value.includes('\n')).toBe(true);
+    expect(before.displayLines).toBe(1);
+
+    // Flip the setting and fire the change event.
+    currentDisplayLines = 2;
+    expect(onChangeListener).not.toBeNull();
+    onChangeListener!({
+      affectsSetting: (path: string): boolean =>
+        path === 'general.brailleDisplayLines',
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplayLines')
+          return currentDisplayLines as T;
+        return 10 as T;
+      },
+    });
+
+    // After the setting change: the service must re-encode and re-emit in
+    // multiline mode (no newlines) with the new displayLines value.
+    const after = emissions[emissions.length - 1];
+    expect(after).not.toBe(before);
+    expect(after.value.includes('\n')).toBe(false);
+    expect(after.displayLines).toBe(2);
+    // Each row padded to displaySize=10 → 2 rows → total length 20.
+    expect(after.value.length).toBe(20);
+
+    disposable.dispose();
+    service.dispose();
+  });
 });

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -10,7 +10,7 @@ import type {
   TraceState,
 } from '@type/state';
 import { describe, expect, jest, test } from '@jest/globals';
-import { BrailleService } from '@service/braille';
+import { BrailleService, normalizeDisplayLines } from '@service/braille';
 import { TraceType } from '@type/grammar';
 
 interface SettingsChangeEventMock {
@@ -1155,6 +1155,36 @@ describe('BrailleService display-size encoding', () => {
     service.dispose();
   });
 
+  test('multiline mode: single-row trace reverses to a no-op', () => {
+    // Single-row data should be unaffected by row reversal. Output width and
+    // the cursor index should match what single-line mode would produce for
+    // the same data (within the shared displaySize/padding rules).
+    const { service, contextMoveToIndex } = createMultilineBrailleService(10, 3);
+
+    // Single row of 4 values; displaySize=10 pads to 10 characters.
+    const state = createLineTraceState([[1, 2, 3, 4]], 0, 2);
+
+    let emitted = '';
+    let emittedIndex = -1;
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+      emittedIndex = event.index;
+    });
+
+    service.toggle(state);
+
+    expect(emitted.includes('\n')).toBe(false);
+    expect(emitted.length).toBe(10); // 4 data + 6 padding, single row.
+    expect(emittedIndex).toBe(2); // Cursor at col 2 → index 2 in row 0.
+
+    // Navigation within the single row: clicking padding maps to last data col.
+    service.moveToIndex(5);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 3);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
   test('horizontal windowing: colOffset resets to 0 when brailleDisplayLines changes', () => {
     // Before the settings change, place the cursor in a non-zero window.
     // After changing the setting (with the cursor moved back to col=0 in
@@ -1232,5 +1262,43 @@ describe('BrailleService display-size encoding', () => {
 
     disposable.dispose();
     service.dispose();
+  });
+});
+
+describe('normalizeDisplayLines boundaries', () => {
+  test('undefined falls back to default 1', () => {
+    expect(normalizeDisplayLines(undefined)).toBe(1);
+  });
+
+  test('NaN falls back to default 1', () => {
+    expect(normalizeDisplayLines(Number.NaN)).toBe(1);
+  });
+
+  test('Infinity falls back to default 1', () => {
+    expect(normalizeDisplayLines(Number.POSITIVE_INFINITY)).toBe(1);
+  });
+
+  test('0 clamps up to min 1', () => {
+    expect(normalizeDisplayLines(0)).toBe(1);
+  });
+
+  test('-1 clamps up to min 1', () => {
+    expect(normalizeDisplayLines(-1)).toBe(1);
+  });
+
+  test('0.9 floors to 0 then clamps up to 1', () => {
+    expect(normalizeDisplayLines(0.9)).toBe(1);
+  });
+
+  test('1 passes through', () => {
+    expect(normalizeDisplayLines(1)).toBe(1);
+  });
+
+  test('20 (max) passes through', () => {
+    expect(normalizeDisplayLines(20)).toBe(20);
+  });
+
+  test('21 clamps down to max 20', () => {
+    expect(normalizeDisplayLines(21)).toBe(20);
   });
 });

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -186,7 +186,10 @@ function createSettingsMockController(displaySize: number): SettingsMockControll
   let onChangeListener: ((event: SettingsChangeEventMock) => void) | null = null;
 
   const settings = {
-    get: <T>(_settingPath: string): T => currentDisplaySize as T,
+    get: <T>(settingPath: string): T => {
+      if (settingPath === 'general.brailleDisplayLines') return 1 as T;
+      return currentDisplaySize as T;
+    },
     onChange: (listener: (event: SettingsChangeEventMock) => void) => {
       onChangeListener = listener;
       return {
@@ -220,7 +223,10 @@ function createSettingsMockController(displaySize: number): SettingsMockControll
  */
 function createStaticSettingsMock(displaySize: number): SettingsService {
   return {
-    get: <T>(_settingPath: string): T => displaySize as T,
+    get: <T>(settingPath: string): T => {
+      if (settingPath === 'general.brailleDisplayLines') return 1 as T;
+      return displaySize as T;
+    },
     onChange: () => ({
       dispose: () => {},
     }),
@@ -575,6 +581,160 @@ describe('BrailleService display-size encoding', () => {
     triggerDisplaySizeChange(20);
 
     expect(emitCount).toBe(0);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('multiline mode: uses space padding instead of newlines between rows', () => {
+    // Create a braille service where displayLines > 1 is triggered via multiline encoder call
+    // We test this by calling the service with a state and checking no \n in output
+    // Use a custom setup with displayLines=2 by extending the service mock
+    const { service } = createBrailleService(10);
+    // Single row with 5 chars, displaySize=10 → should produce 10 chars (5 data + 5 spaces) and no \n in multiline
+    // We test this via the multiline path indirectly - we verify the single-line path still works
+    const state = createLineTraceState([[1, 2, 3]], 0, 0);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    // Single-line mode (default displayLines=1): should still use \n
+    expect(emitted.includes('\n')).toBe(true);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('multiline mode: space-pads each row to displaySize boundary', () => {
+    // We need to test the encoder directly via the BrailleService with displayLines > 1.
+    // Since BrailleService reads displayLines from settings, create a mock with displayLines=2.
+    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
+    const context = {
+      moveToIndex: contextMoveToIndex,
+      get state(): undefined { return undefined; },
+    } as unknown as Context;
+    const notification = {
+      notify: jest.fn<(message: string) => void>(),
+    } as unknown as NotificationService;
+    const display = {
+      toggleFocus: jest.fn(),
+    } as unknown as DisplayService;
+
+    let onChangeLinesListener: ((event: SettingsChangeEventMock) => void) | null = null;
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize') return 10 as T;
+        if (path === 'general.brailleDisplayLines') return 2 as T;
+        return undefined as T;
+      },
+      onChange: (listener: (event: SettingsChangeEventMock) => void) => {
+        onChangeLinesListener = listener;
+        return { dispose: () => {} };
+      },
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // 2 rows: [5 items, 3 items], displaySize=10, displayLines=2
+    const state = createLineTraceState([[1, 2, 3, 4, 5], [10, 20, 30]], 0, 0);
+
+    let emitted = '';
+    let emittedDisplayLines = -1;
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+      emittedDisplayLines = event.displayLines;
+    });
+
+    service.toggle(state);
+
+    // With multiline (displayLines=2): no \n, each row padded to 10 chars
+    expect(emitted.includes('\n')).toBe(false);
+    // Total length: row0=10 chars (5 data + 5 spaces) + row1=10 chars (3 data + 7 spaces) = 20
+    expect(emitted.length).toBe(20);
+    // displayLines emitted correctly
+    expect(emittedDisplayLines).toBe(2);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('multiline mode: navigation maps correctly in space-padded rows', () => {
+    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
+    const context = {
+      moveToIndex: contextMoveToIndex,
+      get state(): undefined { return undefined; },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize') return 10 as T;
+        if (path === 'general.brailleDisplayLines') return 2 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // Navigate to row=1, col=2 in a 2-row dataset
+    const state = createLineTraceState([[1, 2, 3, 4, 5], [10, 20, 30]], 1, 2);
+
+    let cursorIndex = -1;
+    const disposable = service.onChange((event) => {
+      cursorIndex = event.index;
+    });
+
+    service.toggle(state);
+
+    // row1, col2: should be at index 10+2=12 (row0 padded to 10, then col2 of row1)
+    expect(cursorIndex).toBe(12);
+
+    // clicking at index 12 should navigate to (1, 2)
+    service.moveToIndex(12);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(1, 2);
+
+    // clicking in padding of row0 (e.g. index 7) should navigate to (0, 4) - last col of row0
+    service.moveToIndex(7);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 4);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('multiline mode: emits displayLines in onChange event', () => {
+    const context = {
+      moveToIndex: jest.fn(),
+      get state(): undefined { return undefined; },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize') return 32 as T;
+        if (path === 'general.brailleDisplayLines') return 3 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    const state = createLineTraceState([[1, 2, 3]], 0, 0);
+
+    let emittedDisplayLines = -1;
+    const disposable = service.onChange((event) => {
+      emittedDisplayLines = event.displayLines;
+    });
+
+    service.toggle(state);
+    expect(emittedDisplayLines).toBe(3);
 
     disposable.dispose();
     service.dispose();

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -334,6 +334,13 @@ function createBrailleService(displaySize: number): {
 
 /**
  * Builds a BrailleService with configurable display size and display lines.
+ *
+ * Prefer this over {@link createBrailleService} whenever a test needs to
+ * exercise multiline mode (`displayLines > 1`), horizontal windowing, or
+ * any behavior that depends on the `brailleDisplayLines` setting.
+ * {@link createBrailleService} hard-codes `displayLines = 1`, so it is only
+ * suitable for single-line tests.
+ *
  * Consolidates the context/notification/display/settings mock boilerplate
  * that multiline and windowing tests otherwise reconstruct inline.
  * @param displaySize - Braille display size (cells per line)
@@ -1085,6 +1092,143 @@ describe('BrailleService display-size encoding', () => {
     expect(after.displayLines).toBe(2);
     // Each row padded to displaySize=10 → 2 rows → total length 20.
     expect(after.value.length).toBe(20);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: cache hit within the same window never emits a stale -1 index', () => {
+    // Out-of-window columns are marked with -1 in cellToIndex; the service
+    // guarantees the cursor is in-window by recomputing targetOffset before
+    // any emit and including it in the cache key. This test pins that
+    // invariant by moving the cursor across every in-window column while the
+    // cache is warm — if the service ever leaked an out-of-window -1, the
+    // assertion below would catch it.
+    const { service } = createMultilineBrailleService(3, 2);
+
+    // 2 rows × 6 cols, displaySize=3 → windows [0,3) and [3,6).
+    const values = [[1, 2, 3, 4, 5, 6], [10, 20, 30, 40, 50, 60]];
+
+    const indices: number[] = [];
+    const disposable = service.onChange(event => indices.push(event.index));
+
+    // Enable at (0, 0): fresh encode with window [0,3).
+    service.toggle(createLineTraceState(values, 0, 0));
+    // Same-window moves (0,1) and (0,2): must be cache hits, never -1.
+    service.update(createLineTraceState(values, 0, 1));
+    service.update(createLineTraceState(values, 0, 2));
+
+    expect(indices.length).toBeGreaterThanOrEqual(3);
+    for (const index of indices) {
+      expect(index).toBeGreaterThanOrEqual(0);
+    }
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('multiline mode: bar chart renders with space-padded rows (no newlines)', () => {
+    // The bar encoder shares encodeWithWrapping with line/heatmap, but no
+    // existing test exercises the BarBrailleEncoder path end-to-end in
+    // multiline mode. This pins that the shared wrapping behavior holds.
+    const { service } = createMultilineBrailleService(10, 2);
+
+    // 2 rows of 5 items each, displaySize=10, displayLines=2.
+    const state = createBarTraceState([[1, 2, 3, 4, 5], [10, 20, 30, 40, 50]], 0, 0);
+
+    let emitted = '';
+    let emittedDisplayLines = -1;
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+      emittedDisplayLines = event.displayLines;
+    });
+
+    service.toggle(state);
+
+    // Multiline: no newlines, each row padded to displaySize boundary.
+    expect(emitted.includes('\n')).toBe(false);
+    // 2 rows × 10 chars = 20 total (each row: 5 data + 5 padding).
+    expect(emitted.length).toBe(20);
+    expect(emittedDisplayLines).toBe(2);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: colOffset resets to 0 when brailleDisplayLines changes', () => {
+    // Before the settings change, place the cursor in a non-zero window.
+    // After changing the setting (with the cursor moved back to col=0 in
+    // context state), the next encode should use window [0, displaySize),
+    // proving the service did not reuse the prior non-zero offset.
+    let currentDisplayLines = 2;
+    let onChangeListener: ((event: SettingsChangeEventMock) => void) | null = null;
+
+    const wideValues = [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      [10, 20, 30, 40, 50, 60, 70, 80, 90],
+    ];
+    // Start with cursor at col=5: window [3,6) with displaySize=3.
+    let currentState = createLineTraceState(wideValues, 0, 5);
+
+    const context = {
+      moveToIndex: jest.fn<(row: number, col: number) => void>(),
+      get state(): TraceState {
+        return currentState;
+      },
+    } as unknown as Context;
+    const notification = {
+      notify: jest.fn<(message: string) => void>(),
+    } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 3 as T;
+        if (path === 'general.brailleDisplayLines')
+          return currentDisplayLines as T;
+        return undefined as T;
+      },
+      onChange: (listener: (event: SettingsChangeEventMock) => void) => {
+        onChangeListener = listener;
+        return {
+          dispose: () => {
+            onChangeListener = null;
+          },
+        };
+      },
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    const indices: number[] = [];
+    const disposable = service.onChange(event => indices.push(event.index));
+
+    service.toggle(currentState);
+    // Window [3,6); rows reversed so row 0 occupies indices [3..5]; col 5 → index 5.
+    expect(indices[indices.length - 1]).toBe(5);
+
+    // Move cursor back to col=0 in context state so the post-change re-encode
+    // reads the reset-relevant cursor.
+    currentState = createLineTraceState(wideValues, 0, 0);
+
+    // Flip displayLines; service should invalidate cache, reset colOffset to 0,
+    // then re-encode from the current context state.
+    currentDisplayLines = 3;
+    expect(onChangeListener).not.toBeNull();
+    onChangeListener!({
+      affectsSetting: (path: string): boolean =>
+        path === 'general.brailleDisplayLines',
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplayLines')
+          return currentDisplayLines as T;
+        return 3 as T;
+      },
+    });
+
+    // If colOffset reset correctly, window is [0,3); row 0 occupies [3..5];
+    // col 0 → index 3. If offset leaked, index would not be 3.
+    expect(indices[indices.length - 1]).toBe(3);
 
     disposable.dispose();
     service.dispose();

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -657,29 +657,6 @@ describe('BrailleService display-size encoding', () => {
     service.dispose();
   });
 
-  test('multiline mode: uses space padding instead of newlines between rows', () => {
-    // Create a braille service where displayLines > 1 is triggered via multiline encoder call
-    // We test this by calling the service with a state and checking no \n in output
-    // Use a custom setup with displayLines=2 by extending the service mock
-    const { service } = createBrailleService(10);
-    // Single row with 5 chars, displaySize=10 → should produce 10 chars (5 data + 5 spaces) and no \n in multiline
-    // We test this via the multiline path indirectly - we verify the single-line path still works
-    const state = createLineTraceState([[1, 2, 3]], 0, 0);
-
-    let emitted = '';
-    const disposable = service.onChange((event) => {
-      emitted = event.value;
-    });
-
-    service.toggle(state);
-
-    // Single-line mode (default displayLines=1): should still use \n
-    expect(emitted.includes('\n')).toBe(true);
-
-    disposable.dispose();
-    service.dispose();
-  });
-
   test('multiline mode: space-pads each row to displaySize boundary', () => {
     // We need to test the encoder directly via the BrailleService with displayLines > 1.
     // Since BrailleService reads displayLines from settings, create a mock with displayLines=2.

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -692,16 +692,17 @@ describe('BrailleService display-size encoding', () => {
 
     service.toggle(state);
 
-    // row1, col2: should be at index 10+2=12 (row0 padded to 10, then col2 of row1)
-    expect(cursorIndex).toBe(12);
+    // row1, col2: row 1 is encoded first (rows reversed so UP moves cursor upward),
+    // so cursor is at index 2
+    expect(cursorIndex).toBe(2);
 
-    // clicking at index 12 should navigate to (1, 2)
-    service.moveToIndex(12);
+    // clicking at index 2 should navigate to (1, 2)
+    service.moveToIndex(2);
     expect(contextMoveToIndex).toHaveBeenCalledWith(1, 2);
 
-    // clicking in padding of row0 (e.g. index 7) should navigate to (0, 4) - last col of row0
+    // clicking in padding of row1 (e.g. index 7) should navigate to (1, 2) - last data col of row1
     service.moveToIndex(7);
-    expect(contextMoveToIndex).toHaveBeenCalledWith(0, 4);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(1, 2);
 
     disposable.dispose();
     service.dispose();

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -4,6 +4,7 @@ import type { NotificationService } from '@service/notification';
 import type { SettingsService } from '@service/settings';
 import type {
   BarBrailleState,
+  BoxBrailleState,
   HeatmapBrailleState,
   LineBrailleState,
   TraceState,
@@ -177,6 +178,74 @@ function createHeatmapTraceState(values: number[][], row: number, col: number): 
 }
 
 /**
+ * Creates a box plot trace state with configurable braille cursor position.
+ * @param boxes - Array of box point data (one per row)
+ * @param globalMin - Global minimum across all boxes
+ * @param globalMax - Global maximum across all boxes
+ * @param row - Active braille row
+ * @param col - Active braille column (section index: 0=lowerOutlier..6=upperOutlier)
+ * @returns Non-empty trace state for box braille updates
+ */
+function createBoxTraceState(
+  boxes: Array<{ lowerOutliers: number[]; min: number; q1: number; q2: number; q3: number; max: number; upperOutliers: number[] }>,
+  globalMin: number,
+  globalMax: number,
+  row: number,
+  col: number,
+): TraceState {
+  const braille: BoxBrailleState = {
+    id: `box-braille-${boxes.length}-${row}-${col}`,
+    empty: false,
+    row,
+    col,
+    values: boxes.map(b => ({
+      fill: '#000',
+      lowerOutliers: b.lowerOutliers,
+      min: b.min,
+      q1: b.q1,
+      q2: b.q2,
+      q3: b.q3,
+      max: b.max,
+      upperOutliers: b.upperOutliers,
+    })),
+    min: globalMin,
+    max: globalMax,
+  };
+
+  return {
+    empty: false,
+    type: 'trace',
+    layerId: 'test-layer',
+    traceType: TraceType.BOX,
+    plotType: 'box',
+    title: 'Box test trace',
+    xAxis: 'x',
+    yAxis: 'y',
+    fill: 'none',
+    hasMultiPoints: false,
+    audio: {
+      freq: { min: 200, max: 1000, raw: 300 },
+      panning: { y: 0, x: 0, rows: 1, cols: 1 },
+    },
+    braille,
+    text: {
+      main: { label: 'x', value: 0 },
+      cross: { label: 'y', value: 0 },
+    },
+    autoplay: {
+      UPWARD: 0,
+      DOWNWARD: 0,
+      FORWARD: 0,
+      BACKWARD: 0,
+    },
+    highlight: {
+      empty: false,
+      elements: [] as unknown as SVGElement[],
+    },
+  };
+}
+
+/**
  * Creates a settings mock and exposes a helper to emit display-size change events.
  * @param displaySize - Initial display width used by the encoder
  * @returns Settings service mock and change trigger
@@ -187,7 +256,8 @@ function createSettingsMockController(displaySize: number): SettingsMockControll
 
   const settings = {
     get: <T>(settingPath: string): T => {
-      if (settingPath === 'general.brailleDisplayLines') return 1 as T;
+      if (settingPath === 'general.brailleDisplayLines')
+        return 1 as T;
       return currentDisplaySize as T;
     },
     onChange: (listener: (event: SettingsChangeEventMock) => void) => {
@@ -224,7 +294,8 @@ function createSettingsMockController(displaySize: number): SettingsMockControll
 function createStaticSettingsMock(displaySize: number): SettingsService {
   return {
     get: <T>(settingPath: string): T => {
-      if (settingPath === 'general.brailleDisplayLines') return 1 as T;
+      if (settingPath === 'general.brailleDisplayLines')
+        return 1 as T;
       return displaySize as T;
     },
     onChange: () => ({
@@ -615,7 +686,9 @@ describe('BrailleService display-size encoding', () => {
     const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
     const context = {
       moveToIndex: contextMoveToIndex,
-      get state(): undefined { return undefined; },
+      get state(): undefined {
+        return undefined;
+      },
     } as unknown as Context;
     const notification = {
       notify: jest.fn<(message: string) => void>(),
@@ -624,17 +697,15 @@ describe('BrailleService display-size encoding', () => {
       toggleFocus: jest.fn(),
     } as unknown as DisplayService;
 
-    let onChangeLinesListener: ((event: SettingsChangeEventMock) => void) | null = null;
     const settings = {
       get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize') return 10 as T;
-        if (path === 'general.brailleDisplayLines') return 2 as T;
+        if (path === 'general.brailleDisplaySize')
+          return 10 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 2 as T;
         return undefined as T;
       },
-      onChange: (listener: (event: SettingsChangeEventMock) => void) => {
-        onChangeLinesListener = listener;
-        return { dispose: () => {} };
-      },
+      onChange: () => ({ dispose: () => {} }),
     } as unknown as SettingsService;
 
     const service = new BrailleService(context, notification, display, settings);
@@ -666,15 +737,19 @@ describe('BrailleService display-size encoding', () => {
     const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
     const context = {
       moveToIndex: contextMoveToIndex,
-      get state(): undefined { return undefined; },
+      get state(): undefined {
+        return undefined;
+      },
     } as unknown as Context;
     const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
     const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
 
     const settings = {
       get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize') return 10 as T;
-        if (path === 'general.brailleDisplayLines') return 2 as T;
+        if (path === 'general.brailleDisplaySize')
+          return 10 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 2 as T;
         return undefined as T;
       },
       onChange: () => ({ dispose: () => {} }),
@@ -711,15 +786,19 @@ describe('BrailleService display-size encoding', () => {
   test('multiline mode: emits displayLines in onChange event', () => {
     const context = {
       moveToIndex: jest.fn(),
-      get state(): undefined { return undefined; },
+      get state(): undefined {
+        return undefined;
+      },
     } as unknown as Context;
     const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
     const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
 
     const settings = {
       get: <T>(path: string): T => {
-        if (path === 'general.brailleDisplaySize') return 32 as T;
-        if (path === 'general.brailleDisplayLines') return 3 as T;
+        if (path === 'general.brailleDisplaySize')
+          return 32 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 3 as T;
         return undefined as T;
       },
       onChange: () => ({ dispose: () => {} }),
@@ -736,6 +815,59 @@ describe('BrailleService display-size encoding', () => {
 
     service.toggle(state);
     expect(emittedDisplayLines).toBe(3);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('multiline mode: box encoder space-pads rows to displaySize boundary', () => {
+    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
+    const context = {
+      moveToIndex: contextMoveToIndex,
+      get state(): undefined {
+        return undefined;
+      },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 32 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 2 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    const box = {
+      lowerOutliers: [] as number[],
+      min: 10,
+      q1: 25,
+      q2: 50,
+      q3: 75,
+      max: 90,
+      upperOutliers: [] as number[],
+    };
+    const state = createBoxTraceState([box, box], 0, 100, 0, 3);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    // Multiline: no newlines
+    expect(emitted.includes('\n')).toBe(false);
+    // Each row should be a multiple of displaySize (32)
+    expect(emitted.length % 32).toBe(0);
+    // Two rows → total length should be 64
+    expect(emitted.length).toBe(64);
 
     disposable.dispose();
     service.dispose();

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -850,6 +850,286 @@ describe('BrailleService display-size encoding', () => {
     service.dispose();
   });
 
+  test('horizontal windowing: multi-row plot with cols > displaySize produces displaySize chars per row', () => {
+    const context = {
+      moveToIndex: jest.fn<(row: number, col: number) => void>(),
+      get state(): undefined {
+        return undefined;
+      },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 3 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 2 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // 3 rows of 5 cols, displaySize=3. maxCols (5) > displaySize (3) → windowing activates.
+    const state = createLineTraceState(
+      [[1, 2, 3, 4, 5], [10, 20, 30, 40, 50], [100, 200, 300, 400, 500]],
+      0,
+      0,
+    );
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    // Each of the 3 rows is sliced to exactly displaySize=3 → total = 9 chars.
+    expect(emitted.length).toBe(9);
+    // No newlines in multiline mode.
+    expect(emitted.includes('\n')).toBe(false);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: cursor past displaySize triggers page-aligned re-encode', () => {
+    const context = {
+      moveToIndex: jest.fn<(row: number, col: number) => void>(),
+      get state(): undefined {
+        return undefined;
+      },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 3 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 2 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // Enable at cursor (row=0, col=0) → window [0, 3).
+    const firstState = createLineTraceState(
+      [[1, 2, 3, 4, 5], [10, 20, 30, 40, 50]],
+      0,
+      0,
+    );
+
+    const emissions: Array<{ value: string; index: number }> = [];
+    const disposable = service.onChange((event) => {
+      emissions.push({ value: event.value, index: event.index });
+    });
+
+    service.toggle(firstState);
+    // Window [0, 3): rows reversed (row 1 first, row 0 last), each 3 chars → total 6.
+    expect(emissions[0].value.length).toBe(6);
+
+    // Cursor jumps to col 3 → must page to window [3, 6). Same braille.id because
+    // the service re-reads the state via update(), so we emit a state whose id and
+    // values match but cursor moves.  Use a different id to force a fresh encode.
+    const secondState = createLineTraceState(
+      [[1, 2, 3, 4, 5], [10, 20, 30, 40, 50]],
+      0,
+      3,
+    );
+    service.update(secondState);
+
+    // Window should shift to [3, 6).  Row 0 has 5 cols → in-window cols 3, 4 are
+    // data, col 5 is padding (space).
+    const after = emissions[emissions.length - 1];
+    expect(after.value.length).toBe(6);
+    // Cursor index in the output: row 0 is encoded last (reversed), so its window
+    // occupies positions [3..5]. col=3 is the first in-window col → index 3.
+    expect(after.index).toBe(3);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: single-row plot keeps existing overflow behavior (no windowing)', () => {
+    const context = {
+      moveToIndex: jest.fn<(row: number, col: number) => void>(),
+      get state(): undefined {
+        return undefined;
+      },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 4 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 2 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // Single row of 10 cols, displaySize=4 → current behavior: pad to ceil(10/4)*4 = 12.
+    const state = createLineTraceState(
+      [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
+      0,
+      0,
+    );
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    // Windowing does NOT apply for single-row: length = 12 (10 data + 2 pad).
+    expect(emitted.length).toBe(12);
+    expect(emitted.includes('\n')).toBe(false);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: multi-row where all rows fit keeps per-row padding (no windowing)', () => {
+    const context = {
+      moveToIndex: jest.fn<(row: number, col: number) => void>(),
+      get state(): undefined {
+        return undefined;
+      },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 10 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 3 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // 3 rows of 5 cols, displaySize=10. All rows fit → no windowing; each row
+    // padded to 10 chars = 30 total.
+    const state = createHeatmapTraceState(
+      [[1, 2, 3, 4, 5], [10, 20, 30, 40, 50], [100, 200, 300, 400, 500]],
+      0,
+      0,
+    );
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    expect(emitted.length).toBe(30);
+    expect(emitted.includes('\n')).toBe(false);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: click on padding inside window maps to last data col', () => {
+    const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
+    const context = {
+      moveToIndex: contextMoveToIndex,
+      get state(): undefined {
+        return undefined;
+      },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 4 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 2 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // Row 0: 5 cols. Row 1: 2 cols. displaySize=4 → windowing activates.
+    // Window [0, 4): row 1 has cols 0,1 then 2 padding chars. Row 0 fills all 4.
+    // Rows reversed in multiline → output: row1 chunk (4 chars) + row0 chunk (4 chars) = 8.
+    const state = createLineTraceState(
+      [[1, 2, 3, 4, 5], [10, 20]],
+      0,
+      0,
+    );
+
+    const disposable = service.onChange(() => {});
+    service.toggle(state);
+
+    // Row 1 is encoded first (reversed). Its cols 0,1 are indices 0,1.
+    // Indices 2,3 are padding → should map to row=1, col=1 (last data col).
+    service.moveToIndex(3);
+    expect(contextMoveToIndex).toHaveBeenCalledWith(1, 1);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('horizontal windowing: single-line mode never windows', () => {
+    const context = {
+      moveToIndex: jest.fn<(row: number, col: number) => void>(),
+      get state(): undefined {
+        return undefined;
+      },
+    } as unknown as Context;
+    const notification = { notify: jest.fn<(message: string) => void>() } as unknown as NotificationService;
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+    const settings = {
+      get: <T>(path: string): T => {
+        if (path === 'general.brailleDisplaySize')
+          return 3 as T;
+        if (path === 'general.brailleDisplayLines')
+          return 1 as T;
+        return undefined as T;
+      },
+      onChange: () => ({ dispose: () => {} }),
+    } as unknown as SettingsService;
+
+    const service = new BrailleService(context, notification, display, settings);
+
+    // 2 rows of 5 cols, displaySize=3. In single-line mode, newline wrapping applies.
+    const state = createLineTraceState(
+      [[1, 2, 3, 4, 5], [10, 20, 30, 40, 50]],
+      0,
+      0,
+    );
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    // Single-line mode preserves newline wrapping behavior.
+    expect(emitted.includes('\n')).toBe(true);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
   test('multiline mode: settings change for brailleDisplayLines re-encodes and flips mode', () => {
     // Start in single-line mode (displayLines=1), switch to multiline (displayLines=2),
     // and verify the cache is invalidated and the output re-encodes without newlines.

--- a/test/service/settings.test.ts
+++ b/test/service/settings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from '@jest/globals';
+import { deepMerge } from '@service/settings';
+
+describe('deepMerge', () => {
+  test('fills missing keys from defaults', () => {
+    const defaults = { a: 1, b: 2, c: 3 };
+    const override = { b: 20 };
+    const result = deepMerge(defaults, override);
+    expect(result).toEqual({ a: 1, b: 20, c: 3 });
+  });
+
+  test('recurses into nested objects', () => {
+    const defaults = { outer: { a: 1, b: 2 }, flag: false };
+    const override = { outer: { b: 20 } as { a: number; b: number } };
+    const result = deepMerge(defaults, override);
+    expect(result).toEqual({ outer: { a: 1, b: 20 }, flag: false });
+  });
+
+  test('null primitive override value falls back to default', () => {
+    const defaults = { a: 1, b: 'hello' };
+    const override = { a: null as unknown as number, b: null as unknown as string };
+    const result = deepMerge(defaults, override);
+    expect(result).toEqual({ a: 1, b: 'hello' });
+  });
+
+  test('null nested override value falls back to default', () => {
+    const defaults = { nested: { x: 1, y: 2 } };
+    const override = { nested: null as unknown as { x: number; y: number } };
+    const result = deepMerge(defaults, override);
+    expect(result).toEqual({ nested: { x: 1, y: 2 } });
+  });
+
+  test('undefined override value falls back to default', () => {
+    const defaults = { a: 1, b: 2 };
+    const override = { a: undefined };
+    const result = deepMerge(defaults, override);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  test('does not mutate the defaults object', () => {
+    const defaults = { outer: { a: 1 } };
+    const override = { outer: { a: 2 } };
+    deepMerge(defaults, override);
+    expect(defaults).toEqual({ outer: { a: 1 } });
+  });
+});

--- a/test/util/deepMerge.test.ts
+++ b/test/util/deepMerge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { deepMerge } from '@service/settings';
+import { deepMerge } from '@util/deepMerge';
 
 describe('deepMerge', () => {
   test('fills missing keys from defaults', () => {
@@ -42,5 +42,23 @@ describe('deepMerge', () => {
     const override = { outer: { a: 2 } };
     deepMerge(defaults, override);
     expect(defaults).toEqual({ outer: { a: 1 } });
+  });
+
+  test('array-typed override replaces the default array (not merged element-wise)', () => {
+    // Pins the documented behavior: arrays are not recursed into. A saved
+    // older value will overwrite the default array rather than merging.
+    const defaults = { tags: ['a', 'b', 'c'], count: 3 };
+    const override = { tags: ['x'] };
+    const result = deepMerge(defaults, override);
+    expect(result).toEqual({ tags: ['x'], count: 3 });
+  });
+
+  test('array-typed override with shorter array does not retain default tail', () => {
+    // Belt-and-suspenders: confirm no element-wise merge leaks through.
+    const defaults = { items: [1, 2, 3, 4, 5] };
+    const override = { items: [9] };
+    const result = deepMerge(defaults, override);
+    expect(result.items).toEqual([9]);
+    expect(result.items.length).toBe(1);
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes made in this pull request. -->
Introduce multiline braille display support. Plots with multiple traces such as heatmap, multiline plot, dodged barplot are simultaneously represented in the different lines of the braille display.
## Related Issues

<!-- Specify any related issues or tickets that this pull request addresses. -->
https://github.com/xability/maidr/issues/576
https://github.com/xability/maidr/issues/575
https://github.com/xability/maidr/issues/573
https://github.com/xability/maidr/issues/572

## Changes Made

<!-- Describe the specific changes made in this pull request. -->
- Settings accessible by ctrl+comma now asks for number of lines in braille display.
- Depending on the selection of the two values- number of lines and number of cells, if there are multiple traces, they are displayed in separate lines. This is accomplished by adding appropriate number of spaces to force the braille character to the next line.
- Row encoding is reversed so that pressing UP moves the braille cursor upward on the display.
## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
