### PR TITLE
fix: honor custom z label in multiline plots and align lz with lx/ly

### DIFF
--- a/examples/multi-lineplot.html
+++ b/examples/multi-lineplot.html
@@ -1,529 +1,507 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8" />
-</head>
-
-<body>
-  <div>
-    <link rel="stylesheet" href="../dist/maidr.css" />
-    <script type="text/javascript" src="../dist/maidr.js"></script>
+  <head>
+    <meta charset="utf-8"/>
+    <script type="application/html-dependencies">maidr[3.64.1]</script>
+  </head>
+  <body>
     <div>
-      <svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt"
-        viewBox="0 0 720 432" version="1.1"
-        maidr-data='{&#10;  "id": "3382a488-fce8-45a1-a9cb-983157d8c080",&#10;  "subplots": [&#10;    [&#10;      {&#10;        "id": "390ecdb3-25c0-4872-8cfb-366cf2e34402",&#10;        "layers": [&#10;          {&#10;            "id": "300de80b-7bf2-4272-9730-28316c77b11b",&#10;            "type": "line",&#10;            "title": "Multiline: Basic Example",&#10;            "axes": {&#10;              "x": {&#10;                "label": "X values"&#10;              },&#10;              "y": {&#10;                "label": "Y values"&#10;              }&#10;            },&#10;            "data": [&#10;              [&#10;                {&#10;                  "x": 1.0,&#10;                  "y": 2.0&#10;                },&#10;                {&#10;                  "x": 2.0,&#10;                  "y": 4.0&#10;                },&#10;                {&#10;                  "x": 3.0,&#10;                  "y": 1.0&#10;                },&#10;                {&#10;                  "x": 4.0,&#10;                  "y": 5.0&#10;                },&#10;                {&#10;                  "x": 5.0,&#10;                  "y": 3.0&#10;                },&#10;                {&#10;                  "x": 6.0,&#10;                  "y": 7.0&#10;                },&#10;                {&#10;                  "x": 7.0,&#10;                  "y": 6.0&#10;                },&#10;                {&#10;                  "x": 8.0,&#10;                  "y": 8.0&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  "x": 1.0,&#10;                  "y": 1.0&#10;                },&#10;                {&#10;                  "x": 2.0,&#10;                  "y": 3.0&#10;                },&#10;                {&#10;                  "x": 3.0,&#10;                  "y": 5.0&#10;                },&#10;                {&#10;                  "x": 4.0,&#10;                  "y": 2.0&#10;                },&#10;                {&#10;                  "x": 5.0,&#10;                  "y": 4.0&#10;                },&#10;                {&#10;                  "x": 6.0,&#10;                  "y": 6.0&#10;                },&#10;                {&#10;                  "x": 7.0,&#10;                  "y": 8.0&#10;                },&#10;                {&#10;                  "x": 8.0,&#10;                  "y": 7.0&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  "x": 1.0,&#10;                  "y": 3.0&#10;                },&#10;                {&#10;                  "x": 2.0,&#10;                  "y": 1.0&#10;                },&#10;                {&#10;                  "x": 3.0,&#10;                  "y": 4.0&#10;                },&#10;                {&#10;                  "x": 4.0,&#10;                  "y": 6.0&#10;                },&#10;                {&#10;                  "x": 5.0,&#10;                  "y": 5.0&#10;                },&#10;                {&#10;                  "x": 6.0,&#10;                  "y": 2.0&#10;                },&#10;                {&#10;                  "x": 7.0,&#10;                  "y": 4.0&#10;                },&#10;                {&#10;                  "x": 8.0,&#10;                  "y": 5.0&#10;                }&#10;              ]&#10;            ],&#10;            "selectors": [&#10;              "g[id=&apos;maidr-05849fab-6135-4db3-99ae-2d6a0025f10a&apos;] path",&#10;              "g[id=&apos;maidr-bd4e1f3d-7f31-4366-9b56-6d61ad89d9a3&apos;] path",&#10;              "g[id=&apos;maidr-4e821293-4277-4f77-8e7e-064a6430d09b&apos;] path"&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
-        <metadata>
-          <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#"
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-            <cc:Work>
-              <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-              <dc:date>2025-09-28T20:49:32.427110</dc:date>
-              <dc:format>image/svg+xml</dc:format>
-              <dc:creator>
-                <cc:Agent>
-                  <dc:title>Matplotlib v3.9.4, https://matplotlib.org/</dc:title>
-                </cc:Agent>
-              </dc:creator>
-            </cc:Work>
-          </rdf:RDF>
-        </metadata>
-        <defs>
-          <style type="text/css">
-            * {
-              stroke-linejoin: round;
-              stroke-linecap: butt;
-            }
-          </style>
-        </defs>
-        <g id="figure_1">
-          <g id="maidr-28263907-b622-426b-a274-4fd3f3f07b2b">
-            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
-          </g>
-          <g id="axes_1">
-            <g id="maidr-320e07a4-1c18-43c5-b015-c6a84a065e67">
-              <path d="M 90 384.48  L 648 384.48  L 648 51.84  L 90 51.84  z " style="fill: #ffffff" />
-            </g>
-            <g id="matplotlib.axis_1">
-              <g id="xtick_1">
-                <g id="maidr-2e91cef0-02f8-4da0-b834-96c492cbd516">
-                  <defs>
-                    <path id="m9faf85644e" d="M 0 0  L 0 3.5  " style="stroke: #000000; stroke-width: 0.8" />
-                  </defs>
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="115.363636" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_1">
-                  <!-- 1 -->
-                  <g transform="translate(112.182386 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-31"
-                        d="M 794 531  L 1825 531  L 1825 4091  L 703 3866  L 703 4441  L 1819 4666  L 2450 4666  L 2450 531  L 3481 531  L 3481 0  L 794 0  L 794 531  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-31" />
-                  </g>
-                </g>
-              </g>
-              <g id="xtick_2">
-                <g id="maidr-d38ca41b-3107-47bd-8c50-de92733c4821">
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="187.831169" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_2">
-                  <!-- 2 -->
-                  <g transform="translate(184.649919 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-32"
-                        d="M 1228 531  L 3431 531  L 3431 0  L 469 0  L 469 531  Q 828 903 1448 1529  Q 2069 2156 2228 2338  Q 2531 2678 2651 2914  Q 2772 3150 2772 3378  Q 2772 3750 2511 3984  Q 2250 4219 1831 4219  Q 1534 4219 1204 4116  Q 875 4013 500 3803  L 500 4441  Q 881 4594 1212 4672  Q 1544 4750 1819 4750  Q 2544 4750 2975 4387  Q 3406 4025 3406 3419  Q 3406 3131 3298 2873  Q 3191 2616 2906 2266  Q 2828 2175 2409 1742  Q 1991 1309 1228 531  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-32" />
-                  </g>
-                </g>
-              </g>
-              <g id="xtick_3">
-                <g id="maidr-857e9ef0-5705-42b2-ac96-3c1712c49fa1">
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="260.298701" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_3">
-                  <!-- 3 -->
-                  <g transform="translate(257.117451 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-33"
-                        d="M 2597 2516  Q 3050 2419 3304 2112  Q 3559 1806 3559 1356  Q 3559 666 3084 287  Q 2609 -91 1734 -91  Q 1441 -91 1130 -33  Q 819 25 488 141  L 488 750  Q 750 597 1062 519  Q 1375 441 1716 441  Q 2309 441 2620 675  Q 2931 909 2931 1356  Q 2931 1769 2642 2001  Q 2353 2234 1838 2234  L 1294 2234  L 1294 2753  L 1863 2753  Q 2328 2753 2575 2939  Q 2822 3125 2822 3475  Q 2822 3834 2567 4026  Q 2313 4219 1838 4219  Q 1578 4219 1281 4162  Q 984 4106 628 3988  L 628 4550  Q 988 4650 1302 4700  Q 1616 4750 1894 4750  Q 2613 4750 3031 4423  Q 3450 4097 3450 3541  Q 3450 3153 3228 2886  Q 3006 2619 2597 2516  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-33" />
-                  </g>
-                </g>
-              </g>
-              <g id="xtick_4">
-                <g id="maidr-6f98fabe-807c-4e7d-8b74-3e61d67462cf">
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="332.766234" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_4">
-                  <!-- 4 -->
-                  <g transform="translate(329.584984 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-34"
-                        d="M 2419 4116  L 825 1625  L 2419 1625  L 2419 4116  z M 2253 4666  L 3047 4666  L 3047 1625  L 3713 1625  L 3713 1100  L 3047 1100  L 3047 0  L 2419 0  L 2419 1100  L 313 1100  L 313 1709  L 2253 4666  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-34" />
-                  </g>
-                </g>
-              </g>
-              <g id="xtick_5">
-                <g id="maidr-105ad211-12d1-4ce8-951e-4bc7bd6ddabd">
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="405.233766" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_5">
-                  <!-- 5 -->
-                  <g transform="translate(402.052516 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-35"
-                        d="M 691 4666  L 3169 4666  L 3169 4134  L 1269 4134  L 1269 2991  Q 1406 3038 1543 3061  Q 1681 3084 1819 3084  Q 2600 3084 3056 2656  Q 3513 2228 3513 1497  Q 3513 744 3044 326  Q 2575 -91 1722 -91  Q 1428 -91 1123 -41  Q 819 9 494 109  L 494 744  Q 775 591 1075 516  Q 1375 441 1709 441  Q 2250 441 2565 725  Q 2881 1009 2881 1497  Q 2881 1984 2565 2268  Q 2250 2553 1709 2553  Q 1456 2553 1204 2497  Q 953 2441 691 2322  L 691 4666  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-35" />
-                  </g>
-                </g>
-              </g>
-              <g id="xtick_6">
-                <g id="maidr-a580e1f1-8adc-4d45-912b-b36c4aacff9a">
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="477.701299" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_6">
-                  <!-- 6 -->
-                  <g transform="translate(474.520049 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-36"
-                        d="M 2113 2584  Q 1688 2584 1439 2293  Q 1191 2003 1191 1497  Q 1191 994 1439 701  Q 1688 409 2113 409  Q 2538 409 2786 701  Q 3034 994 3034 1497  Q 3034 2003 2786 2293  Q 2538 2584 2113 2584  z M 3366 4563  L 3366 3988  Q 3128 4100 2886 4159  Q 2644 4219 2406 4219  Q 1781 4219 1451 3797  Q 1122 3375 1075 2522  Q 1259 2794 1537 2939  Q 1816 3084 2150 3084  Q 2853 3084 3261 2657  Q 3669 2231 3669 1497  Q 3669 778 3244 343  Q 2819 -91 2113 -91  Q 1303 -91 875 529  Q 447 1150 447 2328  Q 447 3434 972 4092  Q 1497 4750 2381 4750  Q 2619 4750 2861 4703  Q 3103 4656 3366 4563  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-36" />
-                  </g>
-                </g>
-              </g>
-              <g id="xtick_7">
-                <g id="maidr-82edb346-931a-4a75-a571-f2bc42687f7f">
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="550.168831" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_7">
-                  <!-- 7 -->
-                  <g transform="translate(546.987581 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-37"
-                        d="M 525 4666  L 3525 4666  L 3525 4397  L 1831 0  L 1172 0  L 2766 4134  L 525 4134  L 525 4666  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-37" />
-                  </g>
-                </g>
-              </g>
-              <g id="xtick_8">
-                <g id="maidr-b4e7f4bb-4b34-453c-80e5-e02fae524b8c">
-                  <g>
-                    <use xlink:href="#m9faf85644e" x="622.636364" y="384.48"
-                      style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_8">
-                  <!-- 8 -->
-                  <g transform="translate(619.455114 399.078438) scale(0.1 -0.1)">
-                    <defs>
-                      <path id="DejaVuSans-38"
-                        d="M 2034 2216  Q 1584 2216 1326 1975  Q 1069 1734 1069 1313  Q 1069 891 1326 650  Q 1584 409 2034 409  Q 2484 409 2743 651  Q 3003 894 3003 1313  Q 3003 1734 2745 1975  Q 2488 2216 2034 2216  z M 1403 2484  Q 997 2584 770 2862  Q 544 3141 544 3541  Q 544 4100 942 4425  Q 1341 4750 2034 4750  Q 2731 4750 3128 4425  Q 3525 4100 3525 3541  Q 3525 3141 3298 2862  Q 3072 2584 2669 2484  Q 3125 2378 3379 2068  Q 3634 1759 3634 1313  Q 3634 634 3220 271  Q 2806 -91 2034 -91  Q 1263 -91 848 271  Q 434 634 434 1313  Q 434 1759 690 2068  Q 947 2378 1403 2484  z M 1172 3481  Q 1172 3119 1398 2916  Q 1625 2713 2034 2713  Q 2441 2713 2670 2916  Q 2900 3119 2900 3481  Q 2900 3844 2670 4047  Q 2441 4250 2034 4250  Q 1625 4250 1398 4047  Q 1172 3844 1172 3481  z "
-                        transform="scale(0.015625)" />
-                    </defs>
-                    <use xlink:href="#DejaVuSans-38" />
-                  </g>
-                </g>
-              </g>
-              <g id="text_9">
-                <!-- X values -->
-                <g transform="translate(347.723437 412.756563) scale(0.1 -0.1)">
-                  <defs>
-                    <path id="DejaVuSans-58"
-                      d="M 403 4666  L 1081 4666  L 2241 2931  L 3406 4666  L 4084 4666  L 2584 2425  L 4184 0  L 3506 0  L 2194 1984  L 872 0  L 191 0  L 1856 2491  L 403 4666  z "
-                      transform="scale(0.015625)" />
-                    <path id="DejaVuSans-20" transform="scale(0.015625)" />
-                    <path id="DejaVuSans-76"
-                      d="M 191 3500  L 800 3500  L 1894 563  L 2988 3500  L 3597 3500  L 2284 0  L 1503 0  L 191 3500  z "
-                      transform="scale(0.015625)" />
-                    <path id="DejaVuSans-61"
-                      d="M 2194 1759  Q 1497 1759 1228 1600  Q 959 1441 959 1056  Q 959 750 1161 570  Q 1363 391 1709 391  Q 2188 391 2477 730  Q 2766 1069 2766 1631  L 2766 1759  L 2194 1759  z M 3341 1997  L 3341 0  L 2766 0  L 2766 531  Q 2569 213 2275 61  Q 1981 -91 1556 -91  Q 1019 -91 701 211  Q 384 513 384 1019  Q 384 1609 779 1909  Q 1175 2209 1959 2209  L 2766 2209  L 2766 2266  Q 2766 2663 2505 2880  Q 2244 3097 1772 3097  Q 1472 3097 1187 3025  Q 903 2953 641 2809  L 641 3341  Q 956 3463 1253 3523  Q 1550 3584 1831 3584  Q 2591 3584 2966 3190  Q 3341 2797 3341 1997  z "
-                      transform="scale(0.015625)" />
-                    <path id="DejaVuSans-6c" d="M 603 4863  L 1178 4863  L 1178 0  L 603 0  L 603 4863  z "
-                      transform="scale(0.015625)" />
-                    <path id="DejaVuSans-75"
-                      d="M 544 1381  L 544 3500  L 1119 3500  L 1119 1403  Q 1119 906 1312 657  Q 1506 409 1894 409  Q 2359 409 2629 706  Q 2900 1003 2900 1516  L 2900 3500  L 3475 3500  L 3475 0  L 2900 0  L 2900 538  Q 2691 219 2414 64  Q 2138 -91 1772 -91  Q 1169 -91 856 284  Q 544 659 544 1381  z M 1991 3584  L 1991 3584  z "
-                      transform="scale(0.015625)" />
-                    <path id="DejaVuSans-65"
-                      d="M 3597 1894  L 3597 1613  L 953 1613  Q 991 1019 1311 708  Q 1631 397 2203 397  Q 2534 397 2845 478  Q 3156 559 3463 722  L 3463 178  Q 3153 47 2828 -22  Q 2503 -91 2169 -91  Q 1331 -91 842 396  Q 353 884 353 1716  Q 353 2575 817 3079  Q 1281 3584 2069 3584  Q 2775 3584 3186 3129  Q 3597 2675 3597 1894  z M 3022 2063  Q 3016 2534 2758 2815  Q 2500 3097 2075 3097  Q 1594 3097 1305 2825  Q 1016 2553 972 2059  L 3022 2063  z "
-                      transform="scale(0.015625)" />
-                    <path id="DejaVuSans-73"
-                      d="M 2834 3397  L 2834 2853  Q 2591 2978 2328 3040  Q 2066 3103 1784 3103  Q 1356 3103 1142 2972  Q 928 2841 928 2578  Q 928 2378 1081 2264  Q 1234 2150 1697 2047  L 1894 2003  Q 2506 1872 2764 1633  Q 3022 1394 3022 966  Q 3022 478 2636 193  Q 2250 -91 1575 -91  Q 1294 -91 989 -36  Q 684 19 347 128  L 347 722  Q 666 556 975 473  Q 1284 391 1588 391  Q 1994 391 2212 530  Q 2431 669 2431 922  Q 2431 1156 2273 1281  Q 2116 1406 1581 1522  L 1381 1569  Q 847 1681 609 1914  Q 372 2147 372 2553  Q 372 3047 722 3315  Q 1072 3584 1716 3584  Q 2034 3584 2315 3537  Q 2597 3491 2834 3397  z "
-                      transform="scale(0.015625)" />
-                  </defs>
-                  <use xlink:href="#DejaVuSans-58" />
-                  <use xlink:href="#DejaVuSans-20" x="68.505859" />
-                  <use xlink:href="#DejaVuSans-76" x="100.292969" />
-                  <use xlink:href="#DejaVuSans-61" x="159.472656" />
-                  <use xlink:href="#DejaVuSans-6c" x="220.751953" />
-                  <use xlink:href="#DejaVuSans-75" x="248.535156" />
-                  <use xlink:href="#DejaVuSans-65" x="311.914062" />
-                  <use xlink:href="#DejaVuSans-73" x="373.4375" />
-                </g>
-              </g>
-            </g>
-            <g id="matplotlib.axis_2">
-              <g id="ytick_1">
-                <g id="maidr-3d9e5b7c-62f3-4a42-a73f-1952aaf2e82c">
-                  <defs>
-                    <path id="m7292a2ad01" d="M 0 0  L -3.5 0  " style="stroke: #000000; stroke-width: 0.8" />
-                  </defs>
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="369.36" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_10">
-                  <!-- 1 -->
-                  <g transform="translate(76.6375 373.159219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-31" />
-                  </g>
-                </g>
-              </g>
-              <g id="ytick_2">
-                <g id="maidr-ee123b3b-6c4b-46b8-b9c7-1bd5e7395e74">
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="326.16" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_11">
-                  <!-- 2 -->
-                  <g transform="translate(76.6375 329.959219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-32" />
-                  </g>
-                </g>
-              </g>
-              <g id="ytick_3">
-                <g id="maidr-0e5d7224-0952-4e4c-86f9-d665bf4d1266">
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="282.96" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_12">
-                  <!-- 3 -->
-                  <g transform="translate(76.6375 286.759219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-33" />
-                  </g>
-                </g>
-              </g>
-              <g id="ytick_4">
-                <g id="maidr-05ad389e-af0b-4890-b83a-121179d33402">
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="239.76" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_13">
-                  <!-- 4 -->
-                  <g transform="translate(76.6375 243.559219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-34" />
-                  </g>
-                </g>
-              </g>
-              <g id="ytick_5">
-                <g id="maidr-2333a206-6504-4533-9914-bc4d0b494779">
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="196.56" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_14">
-                  <!-- 5 -->
-                  <g transform="translate(76.6375 200.359219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-35" />
-                  </g>
-                </g>
-              </g>
-              <g id="ytick_6">
-                <g id="maidr-24aafd07-1576-426e-a414-3dea3fe425ee">
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="153.36" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_15">
-                  <!-- 6 -->
-                  <g transform="translate(76.6375 157.159219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-36" />
-                  </g>
-                </g>
-              </g>
-              <g id="ytick_7">
-                <g id="maidr-142daa43-c98f-4e37-9650-ad37d35bd897">
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="110.16" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_16">
-                  <!-- 7 -->
-                  <g transform="translate(76.6375 113.959219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-37" />
-                  </g>
-                </g>
-              </g>
-              <g id="ytick_8">
-                <g id="maidr-5648143a-db68-4529-a819-2a00870e8253">
-                  <g>
-                    <use xlink:href="#m7292a2ad01" x="90" y="66.96" style="stroke: #000000; stroke-width: 0.8" />
-                  </g>
-                </g>
-                <g id="text_17">
-                  <!-- 8 -->
-                  <g transform="translate(76.6375 70.759219) scale(0.1 -0.1)">
-                    <use xlink:href="#DejaVuSans-38" />
-                  </g>
-                </g>
-              </g>
-              <g id="text_18">
-                <!-- Y values -->
-                <g transform="translate(70.557812 239.065469) rotate(-90) scale(0.1 -0.1)">
-                  <defs>
-                    <path id="DejaVuSans-59"
-                      d="M -13 4666  L 666 4666  L 1959 2747  L 3244 4666  L 3922 4666  L 2272 2222  L 2272 0  L 1638 0  L 1638 2222  L -13 4666  z "
-                      transform="scale(0.015625)" />
-                  </defs>
-                  <use xlink:href="#DejaVuSans-59" />
-                  <use xlink:href="#DejaVuSans-20" x="61.083984" />
-                  <use xlink:href="#DejaVuSans-76" x="92.871094" />
-                  <use xlink:href="#DejaVuSans-61" x="152.050781" />
-                  <use xlink:href="#DejaVuSans-6c" x="213.330078" />
-                  <use xlink:href="#DejaVuSans-75" x="241.113281" />
-                  <use xlink:href="#DejaVuSans-65" x="304.492188" />
-                  <use xlink:href="#DejaVuSans-73" x="366.015625" />
-                </g>
-              </g>
-            </g>
-            <g id="maidr-05849fab-6135-4db3-99ae-2d6a0025f10a" maidr="4138a9ee-459d-44d4-842e-a2c39423ea02">
-              <path
-                d="M 115.363636 326.16  L 187.831169 239.76  L 260.298701 369.36  L 332.766234 196.56  L 405.233766 282.96  L 477.701299 110.16  L 550.168831 153.36  L 622.636364 66.96  "
-                clip-path="url(#p27b822cb4a)"
-                style="fill: none; stroke: #0000ff; stroke-width: 2; stroke-linecap: square" />
-              <defs>
-                <path id="mee3a6df318"
-                  d="M 0 4  C 1.060812 4 2.078319 3.578535 2.828427 2.828427  C 3.578535 2.078319 4 1.060812 4 0  C 4 -1.060812 3.578535 -2.078319 2.828427 -2.828427  C 2.078319 -3.578535 1.060812 -4 0 -4  C -1.060812 -4 -2.078319 -3.578535 -2.828427 -2.828427  C -3.578535 -2.078319 -4 -1.060812 -4 0  C -4 1.060812 -3.578535 2.078319 -2.828427 2.828427  C -2.078319 3.578535 -1.060812 4 0 4  z "
-                  style="stroke: #0000ff" />
-              </defs>
-              <g clip-path="url(#p27b822cb4a)">
-                <use xlink:href="#mee3a6df318" x="115.363636" y="326.16" style="fill: #0000ff; stroke: #0000ff" />
-                <use xlink:href="#mee3a6df318" x="187.831169" y="239.76" style="fill: #0000ff; stroke: #0000ff" />
-                <use xlink:href="#mee3a6df318" x="260.298701" y="369.36" style="fill: #0000ff; stroke: #0000ff" />
-                <use xlink:href="#mee3a6df318" x="332.766234" y="196.56" style="fill: #0000ff; stroke: #0000ff" />
-                <use xlink:href="#mee3a6df318" x="405.233766" y="282.96" style="fill: #0000ff; stroke: #0000ff" />
-                <use xlink:href="#mee3a6df318" x="477.701299" y="110.16" style="fill: #0000ff; stroke: #0000ff" />
-                <use xlink:href="#mee3a6df318" x="550.168831" y="153.36" style="fill: #0000ff; stroke: #0000ff" />
-                <use xlink:href="#mee3a6df318" x="622.636364" y="66.96" style="fill: #0000ff; stroke: #0000ff" />
-              </g>
-            </g>
-            <g id="maidr-bd4e1f3d-7f31-4366-9b56-6d61ad89d9a3" maidr="4138a9ee-459d-44d4-842e-a2c39423ea02">
-              <path
-                d="M 115.363636 369.36  L 187.831169 282.96  L 260.298701 196.56  L 332.766234 326.16  L 405.233766 239.76  L 477.701299 153.36  L 550.168831 66.96  L 622.636364 110.16  "
-                clip-path="url(#p27b822cb4a)"
-                style="fill: none; stroke-dasharray: 7.4, 3.2; stroke-dashoffset: 0; stroke: #ff0000; stroke-width: 2" />
-              <defs>
-                <path id="m192cd84ecc" d="M -4 4  L 4 4  L 4 -4  L -4 -4  z "
-                  style="stroke: #ff0000; stroke-linejoin: miter" />
-              </defs>
-              <g clip-path="url(#p27b822cb4a)">
-                <use xlink:href="#m192cd84ecc" x="115.363636" y="369.36"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-                <use xlink:href="#m192cd84ecc" x="187.831169" y="282.96"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-                <use xlink:href="#m192cd84ecc" x="260.298701" y="196.56"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-                <use xlink:href="#m192cd84ecc" x="332.766234" y="326.16"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-                <use xlink:href="#m192cd84ecc" x="405.233766" y="239.76"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-                <use xlink:href="#m192cd84ecc" x="477.701299" y="153.36"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-                <use xlink:href="#m192cd84ecc" x="550.168831" y="66.96"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-                <use xlink:href="#m192cd84ecc" x="622.636364" y="110.16"
-                  style="fill: #ff0000; stroke: #ff0000; stroke-linejoin: miter" />
-              </g>
-            </g>
-            <g id="maidr-4e821293-4277-4f77-8e7e-064a6430d09b" maidr="4138a9ee-459d-44d4-842e-a2c39423ea02">
-              <path
-                d="M 115.363636 282.96  L 187.831169 369.36  L 260.298701 239.76  L 332.766234 153.36  L 405.233766 196.56  L 477.701299 326.16  L 550.168831 239.76  L 622.636364 196.56  "
-                clip-path="url(#p27b822cb4a)"
-                style="fill: none; stroke-dasharray: 2, 3.3; stroke-dashoffset: 0; stroke: #008000; stroke-width: 2" />
-              <defs>
-                <path id="mbf51f266bb" d="M 0 -4  L -4 4  L 4 4  z " style="stroke: #008000; stroke-linejoin: miter" />
-              </defs>
-              <g clip-path="url(#p27b822cb4a)">
-                <use xlink:href="#mbf51f266bb" x="115.363636" y="282.96"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-                <use xlink:href="#mbf51f266bb" x="187.831169" y="369.36"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-                <use xlink:href="#mbf51f266bb" x="260.298701" y="239.76"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-                <use xlink:href="#mbf51f266bb" x="332.766234" y="153.36"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-                <use xlink:href="#mbf51f266bb" x="405.233766" y="196.56"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-                <use xlink:href="#mbf51f266bb" x="477.701299" y="326.16"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-                <use xlink:href="#mbf51f266bb" x="550.168831" y="239.76"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-                <use xlink:href="#mbf51f266bb" x="622.636364" y="196.56"
-                  style="fill: #008000; stroke: #008000; stroke-linejoin: miter" />
-              </g>
-            </g>
-            <g id="maidr-d1f317c7-118b-4e75-b024-cdb827e920b3">
-              <path d="M 90 384.48  L 90 51.84  "
-                style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square" />
-            </g>
-            <g id="maidr-e5323df5-7ba9-4fb4-8a13-64f755e1dc18">
-              <path d="M 648 384.48  L 648 51.84  "
-                style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square" />
-            </g>
-            <g id="maidr-c5373448-7f56-4784-a1ec-e9010d88046f">
-              <path d="M 90 384.48  L 648 384.48  "
-                style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square" />
-            </g>
-            <g id="maidr-bd630232-4dde-411e-b5b9-ba51377eec15">
-              <path d="M 90 51.84  L 648 51.84  "
-                style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square" />
-            </g>
-            <g id="text_19">
-              <!-- Basic Multiline Plot -->
-              <g transform="translate(312.499687 45.84) scale(0.12 -0.12)">
-                <defs>
-                  <path id="DejaVuSans-42"
-                    d="M 1259 2228  L 1259 519  L 2272 519  Q 2781 519 3026 730  Q 3272 941 3272 1375  Q 3272 1813 3026 2020  Q 2781 2228 2272 2228  L 1259 2228  z M 1259 4147  L 1259 2741  L 2194 2741  Q 2656 2741 2882 2914  Q 3109 3088 3109 3444  Q 3109 3797 2882 3972  Q 2656 4147 2194 4147  L 1259 4147  z M 628 4666  L 2241 4666  Q 2963 4666 3353 4366  Q 3744 4066 3744 3513  Q 3744 3084 3544 2831  Q 3344 2578 2956 2516  Q 3422 2416 3680 2098  Q 3938 1781 3938 1306  Q 3938 681 3513 340  Q 3088 0 2303 0  L 628 0  L 628 4666  z "
-                    transform="scale(0.015625)" />
-                  <path id="DejaVuSans-69"
-                    d="M 603 3500  L 1178 3500  L 1178 0  L 603 0  L 603 3500  z M 603 4863  L 1178 4863  L 1178 4134  L 603 4134  L 603 4863  z "
-                    transform="scale(0.015625)" />
-                  <path id="DejaVuSans-63"
-                    d="M 3122 3366  L 3122 2828  Q 2878 2963 2633 3030  Q 2388 3097 2138 3097  Q 1578 3097 1268 2742  Q 959 2388 959 1747  Q 959 1106 1268 751  Q 1578 397 2138 397  Q 2388 397 2633 464  Q 2878 531 3122 666  L 3122 134  Q 2881 22 2623 -34  Q 2366 -91 2075 -91  Q 1284 -91 818 406  Q 353 903 353 1747  Q 353 2603 823 3093  Q 1294 3584 2113 3584  Q 2378 3584 2631 3529  Q 2884 3475 3122 3366  z "
-                    transform="scale(0.015625)" />
-                  <path id="DejaVuSans-4d"
-                    d="M 628 4666  L 1569 4666  L 2759 1491  L 3956 4666  L 4897 4666  L 4897 0  L 4281 0  L 4281 4097  L 3078 897  L 2444 897  L 1241 4097  L 1241 0  L 628 0  L 628 4666  z "
-                    transform="scale(0.015625)" />
-                  <path id="DejaVuSans-74"
-                    d="M 1172 4494  L 1172 3500  L 2356 3500  L 2356 3053  L 1172 3053  L 1172 1153  Q 1172 725 1289 603  Q 1406 481 1766 481  L 2356 481  L 2356 0  L 1766 0  Q 1100 0 847 248  Q 594 497 594 1153  L 594 3053  L 172 3053  L 172 3500  L 594 3500  L 594 4494  L 1172 4494  z "
-                    transform="scale(0.015625)" />
-                  <path id="DejaVuSans-6e"
-                    d="M 3513 2113  L 3513 0  L 2938 0  L 2938 2094  Q 2938 2591 2744 2837  Q 2550 3084 2163 3084  Q 1697 3084 1428 2787  Q 1159 2491 1159 1978  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1366 3272 1645 3428  Q 1925 3584 2291 3584  Q 2894 3584 3203 3211  Q 3513 2838 3513 2113  z "
-                    transform="scale(0.015625)" />
-                  <path id="DejaVuSans-50"
-                    d="M 1259 4147  L 1259 2394  L 2053 2394  Q 2494 2394 2734 2622  Q 2975 2850 2975 3272  Q 2975 3691 2734 3919  Q 2494 4147 2053 4147  L 1259 4147  z M 628 4666  L 2053 4666  Q 2838 4666 3239 4311  Q 3641 3956 3641 3272  Q 3641 2581 3239 2228  Q 2838 1875 2053 1875  L 1259 1875  L 1259 0  L 628 0  L 628 4666  z "
-                    transform="scale(0.015625)" />
-                  <path id="DejaVuSans-6f"
-                    d="M 1959 3097  Q 1497 3097 1228 2736  Q 959 2375 959 1747  Q 959 1119 1226 758  Q 1494 397 1959 397  Q 2419 397 2687 759  Q 2956 1122 2956 1747  Q 2956 2369 2687 2733  Q 2419 3097 1959 3097  z M 1959 3584  Q 2709 3584 3137 3096  Q 3566 2609 3566 1747  Q 3566 888 3137 398  Q 2709 -91 1959 -91  Q 1206 -91 779 398  Q 353 888 353 1747  Q 353 2609 779 3096  Q 1206 3584 1959 3584  z "
-                    transform="scale(0.015625)" />
-                </defs>
-                <use xlink:href="#DejaVuSans-42" />
-                <use xlink:href="#DejaVuSans-61" x="68.603516" />
-                <use xlink:href="#DejaVuSans-73" x="129.882812" />
-                <use xlink:href="#DejaVuSans-69" x="181.982422" />
-                <use xlink:href="#DejaVuSans-63" x="209.765625" />
-                <use xlink:href="#DejaVuSans-20" x="264.746094" />
-                <use xlink:href="#DejaVuSans-4d" x="296.533203" />
-                <use xlink:href="#DejaVuSans-75" x="382.8125" />
-                <use xlink:href="#DejaVuSans-6c" x="446.191406" />
-                <use xlink:href="#DejaVuSans-74" x="473.974609" />
-                <use xlink:href="#DejaVuSans-69" x="513.183594" />
-                <use xlink:href="#DejaVuSans-6c" x="540.966797" />
-                <use xlink:href="#DejaVuSans-69" x="568.75" />
-                <use xlink:href="#DejaVuSans-6e" x="596.533203" />
-                <use xlink:href="#DejaVuSans-65" x="659.912109" />
-                <use xlink:href="#DejaVuSans-20" x="721.435547" />
-                <use xlink:href="#DejaVuSans-50" x="753.222656" />
-                <use xlink:href="#DejaVuSans-6c" x="813.525391" />
-                <use xlink:href="#DejaVuSans-6f" x="841.308594" />
-                <use xlink:href="#DejaVuSans-74" x="902.490234" />
-              </g>
-            </g>
-            <g id="legend_1">
-              <g id="maidr-859fda75-9dde-4b15-8c2f-6ba9ab8d806e">
-                <path
-                  d="M 637 64.84  L 641 64.84  Q 643 64.84 643 62.84  L 643 58.84  Q 643 56.84 641 56.84  L 637 56.84  Q 635 56.84 635 58.84  L 635 62.84  Q 635 64.84 637 64.84  z "
-                  style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter" />
-              </g>
-            </g>
-          </g>
-        </g>
-        <defs>
-          <clipPath id="p27b822cb4a">
-            <rect x="90" y="51.84" width="558" height="332.64" />
-          </clipPath>
-        </defs>
-      </svg>
-    </div>
-  </div>
-</body>
+      <link rel="stylesheet" href="../dist/maidr.css" />
+      <script type="text/javascript" src="../dist/maidr.js"></script>
 
+      <div><svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="432pt" height="432pt" viewBox="0 0 432 432" version="1.1" id="3e78443f-14d2-485e-a264-79b91cde0ae4" maidr="{&#10;  &quot;id&quot;: &quot;3e78443f-14d2-485e-a264-79b91cde0ae4&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;2667db9e-c623-4587-b1c1-fe9016a2b1a6&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;942b8678-e5ff-4f61-a1a5-373578ea760e&quot;,&#10;            &quot;type&quot;: &quot;line&quot;,&#10;            &quot;title&quot;: &quot;Seaborn Multiline Plot&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;X values&quot;,&#10;                &quot;format&quot;: {&#10;                  &quot;type&quot;: &quot;fixed&quot;,&#10;                  &quot;decimals&quot;: 0&#10;                }&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Y values&quot;,&#10;                &quot;format&quot;: {&#10;                  &quot;type&quot;: &quot;fixed&quot;,&#10;                  &quot;decimals&quot;: 0&#10;                }&#10;              },&#10;              &quot;z&quot;: {&#10;                &quot;label&quot;: &quot;series&quot;&#10;              }&#10;            },&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;1&quot;,&#10;                  &quot;y&quot;: 2.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2&quot;,&#10;                  &quot;y&quot;: 4.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;3&quot;,&#10;                  &quot;y&quot;: 1.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;4&quot;,&#10;                  &quot;y&quot;: 5.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;5&quot;,&#10;                  &quot;y&quot;: 3.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;6&quot;,&#10;                  &quot;y&quot;: 7.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;7&quot;,&#10;                  &quot;y&quot;: 6.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;8&quot;,&#10;                  &quot;y&quot;: 8.0,&#10;                  &quot;z&quot;: &quot;Series 1&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;1&quot;,&#10;                  &quot;y&quot;: 1.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2&quot;,&#10;                  &quot;y&quot;: 3.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;3&quot;,&#10;                  &quot;y&quot;: 5.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;4&quot;,&#10;                  &quot;y&quot;: 2.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;5&quot;,&#10;                  &quot;y&quot;: 4.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;6&quot;,&#10;                  &quot;y&quot;: 6.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;7&quot;,&#10;                  &quot;y&quot;: 8.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;8&quot;,&#10;                  &quot;y&quot;: 8.0,&#10;                  &quot;z&quot;: &quot;Series 2&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;1&quot;,&#10;                  &quot;y&quot;: 3.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2&quot;,&#10;                  &quot;y&quot;: 1.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;3&quot;,&#10;                  &quot;y&quot;: 4.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;4&quot;,&#10;                  &quot;y&quot;: 6.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;5&quot;,&#10;                  &quot;y&quot;: 5.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;6&quot;,&#10;                  &quot;y&quot;: 2.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;7&quot;,&#10;                  &quot;y&quot;: 4.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;8&quot;,&#10;                  &quot;y&quot;: 8.0,&#10;                  &quot;z&quot;: &quot;Series 3&quot;&#10;                }&#10;              ]&#10;            ],&#10;            &quot;selectors&quot;: [&#10;              &quot;g[id='maidr-bd306eb4-d873-495a-9e2b-bcc86cb24248'] path&quot;,&#10;              &quot;g[id='maidr-f33e0de3-e186-4916-b773-965ebc230fc2'] path&quot;,&#10;              &quot;g[id='maidr-1288931a-f4f4-41d8-89f6-64b2b1aed22a'] path&quot;&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-04-28T10:34:48.889087</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="maidr-2cdd1ca4-9d46-41d0-85ad-ad50ca1033af">
+   <path d="M 0 432  L 432 432  L 432 0  L 0 0  z " style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="maidr-b8b6c481-8bbf-49de-ae09-3a19794e21a3">
+    <path d="M 54 384.48  L 388.8 384.48  L 388.8 51.84  L 54 51.84  z " style="fill: #ffffff"/>
+   </g>
+   <g id="FillBetweenPolyCollection_1"/>
+   <g id="FillBetweenPolyCollection_2"/>
+   <g id="FillBetweenPolyCollection_3"/>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="maidr-ca0de879-9695-4512-9d99-62286dd6fde2">
+      <defs>
+       <path id="m86288210ef" d="M 0 0  L 0 3.5  " style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m86288210ef" x="69.218182" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 1 -->
+      <g transform="translate(66.036932 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531  L 1825 531  L 1825 4091  L 703 3866  L 703 4441  L 1819 4666  L 2450 4666  L 2450 531  L 3481 531  L 3481 0  L 794 0  L 794 531  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="maidr-356be58b-ba5b-4b18-b77b-eba3190282ad">
+      <g>
+       <use xlink:href="#m86288210ef" x="112.698701" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(109.517451 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531  L 3431 531  L 3431 0  L 469 0  L 469 531  Q 828 903 1448 1529  Q 2069 2156 2228 2338  Q 2531 2678 2651 2914  Q 2772 3150 2772 3378  Q 2772 3750 2511 3984  Q 2250 4219 1831 4219  Q 1534 4219 1204 4116  Q 875 4013 500 3803  L 500 4441  Q 881 4594 1212 4672  Q 1544 4750 1819 4750  Q 2544 4750 2975 4387  Q 3406 4025 3406 3419  Q 3406 3131 3298 2873  Q 3191 2616 2906 2266  Q 2828 2175 2409 1742  Q 1991 1309 1228 531  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="maidr-e21fea15-e552-411d-96b7-c06337c8a069">
+      <g>
+       <use xlink:href="#m86288210ef" x="156.179221" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 3 -->
+      <g transform="translate(152.997971 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516  Q 3050 2419 3304 2112  Q 3559 1806 3559 1356  Q 3559 666 3084 287  Q 2609 -91 1734 -91  Q 1441 -91 1130 -33  Q 819 25 488 141  L 488 750  Q 750 597 1062 519  Q 1375 441 1716 441  Q 2309 441 2620 675  Q 2931 909 2931 1356  Q 2931 1769 2642 2001  Q 2353 2234 1838 2234  L 1294 2234  L 1294 2753  L 1863 2753  Q 2328 2753 2575 2939  Q 2822 3125 2822 3475  Q 2822 3834 2567 4026  Q 2313 4219 1838 4219  Q 1578 4219 1281 4162  Q 984 4106 628 3988  L 628 4550  Q 988 4650 1302 4700  Q 1616 4750 1894 4750  Q 2613 4750 3031 4423  Q 3450 4097 3450 3541  Q 3450 3153 3228 2886  Q 3006 2619 2597 2516  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="maidr-25497a80-02d9-417a-a4b6-fc380b6f9c68">
+      <g>
+       <use xlink:href="#m86288210ef" x="199.65974" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 4 -->
+      <g transform="translate(196.47849 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116  L 825 1625  L 2419 1625  L 2419 4116  z M 2253 4666  L 3047 4666  L 3047 1625  L 3713 1625  L 3713 1100  L 3047 1100  L 3047 0  L 2419 0  L 2419 1100  L 313 1100  L 313 1709  L 2253 4666  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="maidr-4e861497-bf09-45ca-b35f-ef0bde9f6fcc">
+      <g>
+       <use xlink:href="#m86288210ef" x="243.14026" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 5 -->
+      <g transform="translate(239.95901 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666  L 3169 4666  L 3169 4134  L 1269 4134  L 1269 2991  Q 1406 3038 1543 3061  Q 1681 3084 1819 3084  Q 2600 3084 3056 2656  Q 3513 2228 3513 1497  Q 3513 744 3044 326  Q 2575 -91 1722 -91  Q 1428 -91 1123 -41  Q 819 9 494 109  L 494 744  Q 775 591 1075 516  Q 1375 441 1709 441  Q 2250 441 2565 725  Q 2881 1009 2881 1497  Q 2881 1984 2565 2268  Q 2250 2553 1709 2553  Q 1456 2553 1204 2497  Q 953 2441 691 2322  L 691 4666  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="maidr-2c7b57d3-6301-4840-879b-9056ec1129dd">
+      <g>
+       <use xlink:href="#m86288210ef" x="286.620779" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 6 -->
+      <g transform="translate(283.439529 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584  Q 1688 2584 1439 2293  Q 1191 2003 1191 1497  Q 1191 994 1439 701  Q 1688 409 2113 409  Q 2538 409 2786 701  Q 3034 994 3034 1497  Q 3034 2003 2786 2293  Q 2538 2584 2113 2584  z M 3366 4563  L 3366 3988  Q 3128 4100 2886 4159  Q 2644 4219 2406 4219  Q 1781 4219 1451 3797  Q 1122 3375 1075 2522  Q 1259 2794 1537 2939  Q 1816 3084 2150 3084  Q 2853 3084 3261 2657  Q 3669 2231 3669 1497  Q 3669 778 3244 343  Q 2819 -91 2113 -91  Q 1303 -91 875 529  Q 447 1150 447 2328  Q 447 3434 972 4092  Q 1497 4750 2381 4750  Q 2619 4750 2861 4703  Q 3103 4656 3366 4563  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="maidr-3f75dd1d-327d-4ee0-bb58-ec1bf077f516">
+      <g>
+       <use xlink:href="#m86288210ef" x="330.101299" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 7 -->
+      <g transform="translate(326.920049 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666  L 3525 4666  L 3525 4397  L 1831 0  L 1172 0  L 2766 4134  L 525 4134  L 525 4666  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="maidr-981fa71e-19d3-44b3-9ae7-92f3f4c99f6e">
+      <g>
+       <use xlink:href="#m86288210ef" x="373.581818" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 8 -->
+      <g transform="translate(370.400568 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216  Q 1584 2216 1326 1975  Q 1069 1734 1069 1313  Q 1069 891 1326 650  Q 1584 409 2034 409  Q 2484 409 2743 651  Q 3003 894 3003 1313  Q 3003 1734 2745 1975  Q 2488 2216 2034 2216  z M 1403 2484  Q 997 2584 770 2862  Q 544 3141 544 3541  Q 544 4100 942 4425  Q 1341 4750 2034 4750  Q 2731 4750 3128 4425  Q 3525 4100 3525 3541  Q 3525 3141 3298 2862  Q 3072 2584 2669 2484  Q 3125 2378 3379 2068  Q 3634 1759 3634 1313  Q 3634 634 3220 271  Q 2806 -91 2034 -91  Q 1263 -91 848 271  Q 434 634 434 1313  Q 434 1759 690 2068  Q 947 2378 1403 2484  z M 1172 3481  Q 1172 3119 1398 2916  Q 1625 2713 2034 2713  Q 2441 2713 2670 2916  Q 2900 3119 2900 3481  Q 2900 3844 2670 4047  Q 2441 4250 2034 4250  Q 1625 4250 1398 4047  Q 1172 3844 1172 3481  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <!-- X values -->
+     <g transform="translate(200.123437 412.756563) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-58" d="M 403 4666  L 1081 4666  L 2241 2931  L 3406 4666  L 4084 4666  L 2584 2425  L 4184 0  L 3506 0  L 2194 1984  L 872 0  L 191 0  L 1856 2491  L 403 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500  L 800 3500  L 1894 563  L 2988 3500  L 3597 3500  L 2284 0  L 1503 0  L 191 3500  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759  Q 1497 1759 1228 1600  Q 959 1441 959 1056  Q 959 750 1161 570  Q 1363 391 1709 391  Q 2188 391 2477 730  Q 2766 1069 2766 1631  L 2766 1759  L 2194 1759  z M 3341 1997  L 3341 0  L 2766 0  L 2766 531  Q 2569 213 2275 61  Q 1981 -91 1556 -91  Q 1019 -91 701 211  Q 384 513 384 1019  Q 384 1609 779 1909  Q 1175 2209 1959 2209  L 2766 2209  L 2766 2266  Q 2766 2663 2505 2880  Q 2244 3097 1772 3097  Q 1472 3097 1187 3025  Q 903 2953 641 2809  L 641 3341  Q 956 3463 1253 3523  Q 1550 3584 1831 3584  Q 2591 3584 2966 3190  Q 3341 2797 3341 1997  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863  L 1178 4863  L 1178 0  L 603 0  L 603 4863  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381  L 544 3500  L 1119 3500  L 1119 1403  Q 1119 906 1312 657  Q 1506 409 1894 409  Q 2359 409 2629 706  Q 2900 1003 2900 1516  L 2900 3500  L 3475 3500  L 3475 0  L 2900 0  L 2900 538  Q 2691 219 2414 64  Q 2138 -91 1772 -91  Q 1169 -91 856 284  Q 544 659 544 1381  z M 1991 3584  L 1991 3584  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894  L 3597 1613  L 953 1613  Q 991 1019 1311 708  Q 1631 397 2203 397  Q 2534 397 2845 478  Q 3156 559 3463 722  L 3463 178  Q 3153 47 2828 -22  Q 2503 -91 2169 -91  Q 1331 -91 842 396  Q 353 884 353 1716  Q 353 2575 817 3079  Q 1281 3584 2069 3584  Q 2775 3584 3186 3129  Q 3597 2675 3597 1894  z M 3022 2063  Q 3016 2534 2758 2815  Q 2500 3097 2075 3097  Q 1594 3097 1305 2825  Q 1016 2553 972 2059  L 3022 2063  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397  L 2834 2853  Q 2591 2978 2328 3040  Q 2066 3103 1784 3103  Q 1356 3103 1142 2972  Q 928 2841 928 2578  Q 928 2378 1081 2264  Q 1234 2150 1697 2047  L 1894 2003  Q 2506 1872 2764 1633  Q 3022 1394 3022 966  Q 3022 478 2636 193  Q 2250 -91 1575 -91  Q 1294 -91 989 -36  Q 684 19 347 128  L 347 722  Q 666 556 975 473  Q 1284 391 1588 391  Q 1994 391 2212 530  Q 2431 669 2431 922  Q 2431 1156 2273 1281  Q 2116 1406 1581 1522  L 1381 1569  Q 847 1681 609 1914  Q 372 2147 372 2553  Q 372 3047 722 3315  Q 1072 3584 1716 3584  Q 2034 3584 2315 3537  Q 2597 3491 2834 3397  z " transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-58"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(68.505859 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(100.292969 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(159.472656 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(220.751953 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(248.535156 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(311.914062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(373.4375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="maidr-7444805c-098e-4a03-bc62-d7401c9b1fff">
+      <defs>
+       <path id="mc0a999ae53" d="M 0 0  L -3.5 0  " style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="369.36" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 1 -->
+      <g transform="translate(40.6375 373.159219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="maidr-c84d04eb-ea26-4f9a-b1cd-0ab5e8898048">
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="326.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 2 -->
+      <g transform="translate(40.6375 329.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="maidr-d8f2f31c-150d-4603-88f9-cf3a18f2bf46">
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="282.96" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 3 -->
+      <g transform="translate(40.6375 286.759219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="maidr-97dbd28f-0060-455c-8cc1-5ad674bfabac">
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="239.76" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 4 -->
+      <g transform="translate(40.6375 243.559219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="maidr-7ef37a13-3c0e-4e05-a6bd-fcad69acf536">
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="196.56" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 5 -->
+      <g transform="translate(40.6375 200.359219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="maidr-a94a91e4-2194-435d-9940-ad502c72c53f">
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="153.36" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 6 -->
+      <g transform="translate(40.6375 157.159219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="maidr-255f78d8-1677-46bf-9ecc-c815d922db60">
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="110.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 7 -->
+      <g transform="translate(40.6375 113.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-37"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="maidr-3e5aeeb7-9029-473a-af16-1d2722ef2ded">
+      <g>
+       <use xlink:href="#mc0a999ae53" x="54" y="66.96" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 8 -->
+      <g transform="translate(40.6375 70.759219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Y values -->
+     <g transform="translate(34.557812 239.065469) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-59" d="M -13 4666  L 666 4666  L 1959 2747  L 3244 4666  L 3922 4666  L 2272 2222  L 2272 0  L 1638 0  L 1638 2222  L -13 4666  z " transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-59"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(61.083984 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(92.871094 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(152.050781 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(213.330078 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(241.113281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(304.492188 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(366.015625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="maidr-bd306eb4-d873-495a-9e2b-bcc86cb24248" maidr="18145e37-40f5-4d70-82b7-56745e554b8d">
+    <path d="M 69.218182 326.16  L 112.698701 239.76  L 156.179221 369.36  L 199.65974 196.56  L 243.14026 282.96  L 286.620779 110.16  L 330.101299 153.36  L 373.581818 66.96  " clip-path="url(#p8ef1ee1e36)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m88c2447911" d="M 0 3  C 0.795609 3 1.55874 2.683901 2.12132 2.12132  C 2.683901 1.55874 3 0.795609 3 0  C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132  C 1.55874 -2.683901 0.795609 -3 0 -3  C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132  C -2.683901 -1.55874 -3 -0.795609 -3 0  C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132  C -1.55874 2.683901 -0.795609 3 0 3  z " style="stroke: #ffffff; stroke-width: 0.75"/>
+    </defs>
+    <g clip-path="url(#p8ef1ee1e36)">
+     <use xlink:href="#m88c2447911" x="69.218182" y="326.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     <use xlink:href="#m88c2447911" x="112.698701" y="239.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     <use xlink:href="#m88c2447911" x="156.179221" y="369.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     <use xlink:href="#m88c2447911" x="199.65974" y="196.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     <use xlink:href="#m88c2447911" x="243.14026" y="282.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     <use xlink:href="#m88c2447911" x="286.620779" y="110.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     <use xlink:href="#m88c2447911" x="330.101299" y="153.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     <use xlink:href="#m88c2447911" x="373.581818" y="66.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+    </g>
+   </g>
+   <g id="maidr-f33e0de3-e186-4916-b773-965ebc230fc2" maidr="18145e37-40f5-4d70-82b7-56745e554b8d">
+    <path d="M 69.218182 369.36  L 112.698701 282.96  L 156.179221 196.56  L 199.65974 326.16  L 243.14026 239.76  L 286.620779 153.36  L 330.101299 66.96  L 373.581818 66.96  " clip-path="url(#p8ef1ee1e36)" style="fill: none; stroke-dasharray: 6,2.25; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <defs>
+     <path id="m9a637d9326" d="M -1.5 3  L 0 1.5  L 1.5 3  L 3 1.5  L 1.5 0  L 3 -1.5  L 1.5 -3  L 0 -1.5  L -1.5 -3  L -3 -1.5  L -1.5 0  L -3 1.5  z " style="stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p8ef1ee1e36)">
+     <use xlink:href="#m9a637d9326" x="69.218182" y="369.36" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m9a637d9326" x="112.698701" y="282.96" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m9a637d9326" x="156.179221" y="196.56" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m9a637d9326" x="199.65974" y="326.16" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m9a637d9326" x="243.14026" y="239.76" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m9a637d9326" x="286.620779" y="153.36" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m9a637d9326" x="330.101299" y="66.96" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m9a637d9326" x="373.581818" y="66.96" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="maidr-1288931a-f4f4-41d8-89f6-64b2b1aed22a" maidr="18145e37-40f5-4d70-82b7-56745e554b8d">
+    <path d="M 69.218182 282.96  L 112.698701 369.36  L 156.179221 239.76  L 199.65974 153.36  L 243.14026 196.56  L 286.620779 326.16  L 330.101299 239.76  L 373.581818 66.96  " clip-path="url(#p8ef1ee1e36)" style="fill: none; stroke-dasharray: 1.5,1.5; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
+    <defs>
+     <path id="m2406071ba7" d="M -2.12132 -2.12132  L -2.12132 2.12132  L 2.12132 2.12132  L 2.12132 -2.12132  z " style="stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p8ef1ee1e36)">
+     <use xlink:href="#m2406071ba7" x="69.218182" y="282.96" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m2406071ba7" x="112.698701" y="369.36" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m2406071ba7" x="156.179221" y="239.76" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m2406071ba7" x="199.65974" y="153.36" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m2406071ba7" x="243.14026" y="196.56" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m2406071ba7" x="286.620779" y="326.16" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m2406071ba7" x="330.101299" y="239.76" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     <use xlink:href="#m2406071ba7" x="373.581818" y="66.96" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="maidr-94ba8fbe-b855-4776-b5d7-094b4ebf3efb"/>
+   <g id="maidr-03b0698a-d632-44c4-b701-f0100ba8f80e"/>
+   <g id="maidr-ced5ba38-41c5-418a-a84d-5a25b2aa04cb"/>
+   <g id="maidr-11635539-11ff-4d21-ad65-babcb3178a9b">
+    <path d="M 54 384.48  L 54 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="maidr-998ec14a-df8f-4a34-80c8-a723c2da51f4">
+    <path d="M 388.8 384.48  L 388.8 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="maidr-ff94089d-0866-463d-8ba3-bf94587d4429">
+    <path d="M 54 384.48  L 388.8 384.48  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="maidr-55d6aec9-9f86-4cfa-9a28-28451728cc06">
+    <path d="M 54 51.84  L 388.8 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Seaborn Multiline Plot -->
+    <g transform="translate(155.9625 45.84) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513  L 3425 3897  Q 3066 4069 2747 4153  Q 2428 4238 2131 4238  Q 1616 4238 1336 4038  Q 1056 3838 1056 3469  Q 1056 3159 1242 3001  Q 1428 2844 1947 2747  L 2328 2669  Q 3034 2534 3370 2195  Q 3706 1856 3706 1288  Q 3706 609 3251 259  Q 2797 -91 1919 -91  Q 1588 -91 1214 -16  Q 841 59 441 206  L 441 856  Q 825 641 1194 531  Q 1563 422 1919 422  Q 2459 422 2753 634  Q 3047 847 3047 1241  Q 3047 1584 2836 1778  Q 2625 1972 2144 2069  L 1759 2144  Q 1053 2284 737 2584  Q 422 2884 422 3419  Q 422 4038 858 4394  Q 1294 4750 2059 4750  Q 2388 4750 2728 4690  Q 3069 4631 3425 4513  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747  Q 3116 2381 2855 2742  Q 2594 3103 2138 3103  Q 1681 3103 1420 2742  Q 1159 2381 1159 1747  Q 1159 1113 1420 752  Q 1681 391 2138 391  Q 2594 391 2855 752  Q 3116 1113 3116 1747  z M 1159 2969  Q 1341 3281 1617 3432  Q 1894 3584 2278 3584  Q 2916 3584 3314 3078  Q 3713 2572 3713 1747  Q 3713 922 3314 415  Q 2916 -91 2278 -91  Q 1894 -91 1617 61  Q 1341 213 1159 525  L 1159 0  L 581 0  L 581 4863  L 1159 4863  L 1159 2969  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097  Q 1497 3097 1228 2736  Q 959 2375 959 1747  Q 959 1119 1226 758  Q 1494 397 1959 397  Q 2419 397 2687 759  Q 2956 1122 2956 1747  Q 2956 2369 2687 2733  Q 2419 3097 1959 3097  z M 1959 3584  Q 2709 3584 3137 3096  Q 3566 2609 3566 1747  Q 3566 888 3137 398  Q 2709 -91 1959 -91  Q 1206 -91 779 398  Q 353 888 353 1747  Q 353 2609 779 3096  Q 1206 3584 1959 3584  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963  Q 2534 3019 2420 3045  Q 2306 3072 2169 3072  Q 1681 3072 1420 2755  Q 1159 2438 1159 1844  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1341 3275 1631 3429  Q 1922 3584 2338 3584  Q 2397 3584 2469 3576  Q 2541 3569 2628 3553  L 2631 2963  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113  L 3513 0  L 2938 0  L 2938 2094  Q 2938 2591 2744 2837  Q 2550 3084 2163 3084  Q 1697 3084 1428 2787  Q 1159 2491 1159 1978  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1366 3272 1645 3428  Q 1925 3584 2291 3584  Q 2894 3584 3203 3211  Q 3513 2838 3513 2113  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4d" d="M 628 4666  L 1569 4666  L 2759 1491  L 3956 4666  L 4897 4666  L 4897 0  L 4281 0  L 4281 4097  L 3078 897  L 2444 897  L 1241 4097  L 1241 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494  L 1172 3500  L 2356 3500  L 2356 3053  L 1172 3053  L 1172 1153  Q 1172 725 1289 603  Q 1406 481 1766 481  L 2356 481  L 2356 0  L 1766 0  Q 1100 0 847 248  Q 594 497 594 1153  L 594 3053  L 172 3053  L 172 3500  L 594 3500  L 594 4494  L 1172 4494  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500  L 1178 3500  L 1178 0  L 603 0  L 603 3500  z M 603 4863  L 1178 4863  L 1178 4134  L 603 4134  L 603 4863  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-50" d="M 1259 4147  L 1259 2394  L 2053 2394  Q 2494 2394 2734 2622  Q 2975 2850 2975 3272  Q 2975 3691 2734 3919  Q 2494 4147 2053 4147  L 1259 4147  z M 628 4666  L 2053 4666  Q 2838 4666 3239 4311  Q 3641 3956 3641 3272  Q 3641 2581 3239 2228  Q 2838 1875 2053 1875  L 1259 1875  L 1259 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(125 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(186.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(249.755859 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(310.9375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(350.300781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(413.679688 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(445.466797 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(531.746094 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(595.125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(622.908203 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(662.117188 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(689.900391 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(717.683594 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(745.466797 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(808.845703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(870.369141 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(902.15625 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(962.458984 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(990.242188 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1051.423828 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="maidr-be8ee6d4-e2a6-4b03-a88a-bc68b36a24ee">
+     <path d="M 61 118.5525  L 133.29375 118.5525  Q 135.29375 118.5525 135.29375 116.5525  L 135.29375 58.84  Q 135.29375 56.84 133.29375 56.84  L 61 56.84  Q 59 56.84 59 58.84  L 59 116.5525  Q 59 118.5525 61 118.5525  z " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- series -->
+     <g transform="translate(82.339844 68.438438) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(52.099609 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(113.623047 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(154.736328 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(182.519531 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(244.042969 0)"/>
+     </g>
+    </g>
+    <g id="maidr-49c73943-6f7d-47f5-805e-c6f278dd6cf2">
+     <path d="M 63 79.616563  L 73 79.616563  L 83 79.616563  " style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m88c2447911" x="73" y="79.616563" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.75"/>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- Series 1 -->
+     <g transform="translate(91 83.116563) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(166.113281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(193.896484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(255.419922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(307.519531 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(339.306641 0)"/>
+     </g>
+    </g>
+    <g id="maidr-bb3c3785-a509-43c9-96e3-c0952c6f017c">
+     <path d="M 63 94.294688  L 73 94.294688  L 83 94.294688  " style="fill: none; stroke-dasharray: 6,2.25; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+     <g>
+      <use xlink:href="#m9a637d9326" x="73" y="94.294688" style="fill: #ff7f0e; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_22">
+     <!-- Series 2 -->
+     <g transform="translate(91 97.794688) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(166.113281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(193.896484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(255.419922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(307.519531 0)"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(339.306641 0)"/>
+     </g>
+    </g>
+    <g id="maidr-86f02557-9336-4cc5-9468-799057358f58">
+     <path d="M 63 108.972813  L 73 108.972813  L 83 108.972813  " style="fill: none; stroke-dasharray: 1.5,1.5; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
+     <g>
+      <use xlink:href="#m2406071ba7" x="73" y="108.972813" style="fill: #2ca02c; stroke: #ffffff; stroke-width: 0.75; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_23">
+     <!-- Series 3 -->
+     <g transform="translate(91 112.472813) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(166.113281 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(193.896484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(255.419922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(307.519531 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(339.306641 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p8ef1ee1e36">
+   <rect x="54" y="51.84" width="334.8" height="332.64"/>
+  </clipPath>
+ </defs>
+</svg>
+</div>
+    </div>
+  </body>
 </html>

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -186,7 +186,10 @@ export class AnnounceZCommand extends AnnounceCommand {
 
     if (hasValidZ) {
       const zLabel = zData!.label;
-      this.textViewModel.update(`${zLabel}`);
+      const text = this.textService.isTerse()
+        ? zLabel
+        : `Z label is ${zLabel}`;
+      this.textViewModel.update(text);
     } else {
       const text = this.textService.isTerse()
         ? 'unavailable'

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -181,6 +181,10 @@ export class LineTrace extends AbstractTrace {
       | { z: { label: string; value: string } }
       | Record<string, never> = {};
 
+    // Resolve z label: honor user-provided spec label, otherwise fall back
+    // to LineTrace-specific default ("Group") rather than the generic "Level".
+    const zLabel = this.layer.axes?.z?.label ?? TYPE;
+
     if (intersections.length > 1) {
       // Multiple lines intersect - create intersection text
       let lineTypes = intersections.map((intersection) => {
@@ -199,13 +203,13 @@ export class LineTrace extends AbstractTrace {
 
       zData = {
         z: {
-          label: TYPE,
+          label: zLabel,
           value: `intersection at (${lineTypes.join(', ')})`,
         },
       };
     } else {
       // Single line or no intersection - use normal z data
-      zData = point.z ? { z: { label: TYPE, value: point.z } } : {};
+      zData = point.z ? { z: { label: zLabel, value: point.z } } : {};
     }
 
     return {


### PR DESCRIPTION

# Pull Request

## Description

For multiline (line trace) plots, the user-provided axes.z.label from the MAIDR spec was being silently overridden by a hardcoded "Group". Additionally, the l z keypress (announce z label) was inconsistent with l x / l y, it didn't follow the same label-only convention.

## Changes Made

1. src/model/line.ts

LineTrace's text() getter now honors this.layer.axes?.z?.label when provided, falling back to "Group" (the LineTrace-specific default) only when the spec omits it. Previously, the hardcoded constant TYPE = 'Group' was always used, ignoring the spec.

2. src/command/describe.ts

AnnounceZCommand now follows the exact AnnounceXCommand / AnnounceYCommand convention, announces the z-axis label only, not the current value:
  - Verbose: "Z label is <zLabel>"
  - Terse: "<zLabel>"

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.