### PR TITLE
feat: let user select name of braille display

### DIFF
--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -6,6 +6,7 @@ import type { Observer } from '@type/observable';
 import type { Settings } from '@type/settings';
 import { Emitter, Scope } from '@type/event';
 import { DEFAULT_SETTINGS } from '@type/settings';
+import { normalizeBrailleDisplay } from '@util/braillePreset';
 import { deepMerge } from '@util/deepMerge';
 
 const SETTINGS_KEY = 'maidr-settings';
@@ -66,7 +67,11 @@ export class SettingsService implements Disposable {
     const saved = this.storage.load<Settings>(SETTINGS_KEY);
     // Deep-merge so that newly added default settings are available even when
     // the user has an older saved object in localStorage that lacks the new keys.
-    this.currentSettings = saved ? deepMerge(this.defaultSettings, saved) : this.defaultSettings;
+    const merged = saved ? deepMerge(this.defaultSettings, saved) : this.defaultSettings;
+    // Repair stale braille display kind / preset id before any consumer
+    // (BrailleService, UI) reads the settings, so they see a coherent state
+    // from page load — not just after the settings dialog opens.
+    this.currentSettings = { ...merged, general: normalizeBrailleDisplay(merged.general) };
   }
 
   public dispose(): void {

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -144,8 +144,14 @@ export function findBraillePreset(
  * Computes the settings slice for switching the braille display kind. When
  * switching to single/multi we keep the user's previously selected preset
  * if it still belongs to that kind, otherwise we fall back to the first
- * preset in the list. Switching to manual leaves cells/lines untouched so
- * the user can edit them directly.
+ * preset in the list.
+ *
+ * Switching to manual intentionally omits `brailleDisplaySize` and
+ * `brailleDisplayLines` from the returned slice, so when the caller spreads
+ * the slice over previous state (`{ ...prev, ...slice }`) the existing
+ * cells/lines numbers are preserved as the starting point for the user's
+ * manual edits, rather than being reset to defaults or to the previous
+ * preset's values.
  * @param kind - Target braille display kind.
  * @param currentPresetId - Currently selected preset id, if any.
  * @returns Settings slice to merge into form state.
@@ -241,20 +247,6 @@ export interface LlmSettings {
   customInstruction: string;
   models: Record<Llm, LlmModelSettings>;
 }
-
-/**
- * Union of every primitive value type accepted by a `GeneralSettings` field.
- * Used by setter helpers that update arbitrary keys on `GeneralSettings` so
- * the value parameter does not have to repeat the full union inline.
- */
-export type GeneralSettingsValue
-  = | string
-    | number
-    | boolean
-    | null
-    | AriaMode
-    | HoverMode
-    | BrailleDisplayKind;
 
 /**
  * General application settings for audio, visual, and accessibility features.

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -78,6 +78,7 @@ export const MULTI_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
   { id: 'monarch', label: 'Monarch', manufacturer: 'APH / HumanWare / NFB', cells: 32, lines: 10 },
   { id: 'orbit-slate-340', label: 'Orbit Slate 340', manufacturer: 'Orbit Research', cells: 40, lines: 3 },
   { id: 'orbit-slate-520', label: 'Orbit Slate 520', manufacturer: 'Orbit Research', cells: 20, lines: 5 },
+  { id: 'dot-pad-x', label: 'Dot Pad X', manufacturer: 'Dot Inc.', cells: 20, lines: 8 },
 ] as const;
 
 // Discriminated union: the manual variant has no preset id and intentionally

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -20,6 +20,36 @@ export const DEFAULT_BRAILLE_LINES = 1;
 export const MAX_BRAILLE_LINES = 20;
 
 /**
+ * Upper bound on the configured number of cells per braille row. The largest
+ * commercial single-line displays we recognize hold 80 cells; 160 leaves
+ * generous headroom for unrecognized hardware while still rejecting
+ * obviously bogus values typed into the manual input.
+ */
+export const MAX_BRAILLE_SIZE = 160;
+
+/**
+ * Clamps an arbitrary numeric value to a valid braille display line count.
+ * Empty / NaN / negative inputs collapse to 1 so the stored value never
+ * leaves the supported range, even mid-keystroke.
+ * @param value - Raw numeric value from the input field.
+ * @returns Clamped integer between 1 and MAX_BRAILLE_LINES.
+ */
+export function clampBrailleLines(value: number): number {
+  return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
+}
+
+/**
+ * Clamps an arbitrary numeric value to a valid braille display cell count.
+ * Mirrors {@link clampBrailleLines} so the manual size input gets the same
+ * defensive treatment as the lines input.
+ * @param value - Raw numeric value from the input field.
+ * @returns Clamped integer between 1 and MAX_BRAILLE_SIZE.
+ */
+export function clampBrailleSize(value: number): number {
+  return Math.min(MAX_BRAILLE_SIZE, Math.max(1, Math.floor(value) || 1));
+}
+
+/**
  * Configuration mode for the braille display. Determines whether the user
  * picks from a list of known displays or enters cells/lines manually.
  */
@@ -81,6 +111,103 @@ export const MULTI_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
 ] as const;
 
 /**
+ * Partial settings slice produced by a braille preset / kind selection. The
+ * UI merges this into the local form state so the relevant fields update
+ * atomically.
+ */
+export interface BraillePresetSelection {
+  brailleDisplayKind: BrailleDisplayKind;
+  brailleDisplayPresetId: string | null;
+  brailleDisplaySize?: number;
+  brailleDisplayLines?: number;
+}
+
+/**
+ * Looks up a preset by id, returning undefined when the id is null or no
+ * matching preset exists. Exported so component handlers and tests share a
+ * single resolution path.
+ * @param presets - Preset list to search.
+ * @param presetId - Preset id to find, or null.
+ * @returns The matching preset, or undefined.
+ */
+export function findBraillePreset(
+  presets: readonly BrailleDisplayPreset[],
+  presetId: string | null,
+): BrailleDisplayPreset | undefined {
+  if (!presetId) {
+    return undefined;
+  }
+  return presets.find(p => p.id === presetId);
+}
+
+/**
+ * Computes the settings slice for switching the braille display kind. When
+ * switching to single/multi we keep the user's previously selected preset
+ * if it still belongs to that kind, otherwise we fall back to the first
+ * preset in the list. Switching to manual leaves cells/lines untouched so
+ * the user can edit them directly.
+ * @param kind - Target braille display kind.
+ * @param currentPresetId - Currently selected preset id, if any.
+ * @returns Settings slice to merge into form state.
+ */
+export function selectBrailleDisplayKind(
+  kind: BrailleDisplayKind,
+  currentPresetId: string | null,
+): BraillePresetSelection {
+  if (kind === 'single') {
+    const preset = findBraillePreset(SINGLE_LINE_BRAILLE_PRESETS, currentPresetId)
+      ?? SINGLE_LINE_BRAILLE_PRESETS[0];
+    return {
+      brailleDisplayKind: 'single',
+      brailleDisplayPresetId: preset.id,
+      brailleDisplaySize: preset.cells,
+      brailleDisplayLines: preset.lines,
+    };
+  }
+  if (kind === 'multi') {
+    const preset = findBraillePreset(MULTI_LINE_BRAILLE_PRESETS, currentPresetId)
+      ?? MULTI_LINE_BRAILLE_PRESETS[0];
+    return {
+      brailleDisplayKind: 'multi',
+      brailleDisplayPresetId: preset.id,
+      brailleDisplaySize: preset.cells,
+      brailleDisplayLines: preset.lines,
+    };
+  }
+  return {
+    brailleDisplayKind: 'manual',
+    brailleDisplayPresetId: null,
+  };
+}
+
+/**
+ * Computes the settings slice for selecting a specific preset within a
+ * single- or multi-line list. Returns null when the preset id is unknown
+ * for the given kind, allowing callers to skip the update.
+ * @param kind - Preset kind, single or multi.
+ * @param presetId - Id of the preset chosen by the user.
+ * @returns Settings slice to merge, or null when the id is invalid.
+ */
+export function selectBraillePreset(
+  kind: 'single' | 'multi',
+  presetId: string,
+): BraillePresetSelection | null {
+  const presets = kind === 'single'
+    ? SINGLE_LINE_BRAILLE_PRESETS
+    : MULTI_LINE_BRAILLE_PRESETS;
+  const preset = findBraillePreset(presets, presetId);
+  if (!preset) {
+    return null;
+  }
+  return {
+    brailleDisplayKind: kind,
+    brailleDisplayPresetId: preset.id,
+    brailleDisplaySize: preset.cells,
+    brailleDisplayLines: preset.lines,
+  };
+}
+
+/**
  * ARIA live region politeness level for screen reader announcements.
  */
 export type AriaMode = 'assertive' | 'polite';
@@ -114,6 +241,20 @@ export interface LlmSettings {
   customInstruction: string;
   models: Record<Llm, LlmModelSettings>;
 }
+
+/**
+ * Union of every primitive value type accepted by a `GeneralSettings` field.
+ * Used by setter helpers that update arbitrary keys on `GeneralSettings` so
+ * the value parameter does not have to repeat the full union inline.
+ */
+export type GeneralSettingsValue
+  = | string
+    | number
+    | boolean
+    | null
+    | AriaMode
+    | HoverMode
+    | BrailleDisplayKind;
 
 /**
  * General application settings for audio, visual, and accessibility features.

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -47,9 +47,8 @@ export type NonEmptyBraillePresets = readonly [
   ...BrailleDisplayPreset[],
 ];
 
-// To add a new device, append a row here (single-line) or in
-// MULTI_LINE_BRAILLE_PRESETS below. Keep ids kebab-case and unique across
-// both lists; the unit test in test/util/braillePreset.test.ts enforces this.
+// To add a new device, append a row here or in MULTI_LINE_BRAILLE_PRESETS.
+// Ids must be kebab-case and unique across both lists.
 export const SINGLE_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
   { id: 'focus-14-blue-5g', label: 'Focus 14 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 14, lines: 1 },
   { id: 'focus-40-blue-5g', label: 'Focus 40 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 40, lines: 1 },

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -24,14 +24,6 @@ export const MAX_BRAILLE_LINES = 20;
 // manual input.
 export const MAX_BRAILLE_SIZE = 160;
 
-export function clampBrailleLines(value: number): number {
-  return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
-}
-
-export function clampBrailleSize(value: number): number {
-  return Math.min(MAX_BRAILLE_SIZE, Math.max(1, Math.floor(value) || 1));
-}
-
 export type BrailleDisplayKind = 'single' | 'multi' | 'manual';
 
 // 'manual' preserves whatever cells/lines numbers an older saved settings
@@ -85,69 +77,6 @@ export interface BraillePresetSelection {
   brailleDisplayPresetId: string | null;
   brailleDisplaySize?: number;
   brailleDisplayLines?: number;
-}
-
-export function findBraillePreset(
-  presets: readonly BrailleDisplayPreset[],
-  presetId: string | null,
-): BrailleDisplayPreset | undefined {
-  if (!presetId) {
-    return undefined;
-  }
-  return presets.find(p => p.id === presetId);
-}
-
-// The 'manual' branch intentionally omits brailleDisplaySize and
-// brailleDisplayLines so callers spreading the slice over previous state
-// (`{ ...prev, ...slice }`) preserve the existing cells/lines numbers as
-// the starting point for the user's manual edits.
-export function selectBrailleDisplayKind(
-  kind: BrailleDisplayKind,
-  currentPresetId: string | null,
-): BraillePresetSelection {
-  if (kind === 'single') {
-    const preset = findBraillePreset(SINGLE_LINE_BRAILLE_PRESETS, currentPresetId)
-      ?? SINGLE_LINE_BRAILLE_PRESETS[0];
-    return {
-      brailleDisplayKind: 'single',
-      brailleDisplayPresetId: preset.id,
-      brailleDisplaySize: preset.cells,
-      brailleDisplayLines: preset.lines,
-    };
-  }
-  if (kind === 'multi') {
-    const preset = findBraillePreset(MULTI_LINE_BRAILLE_PRESETS, currentPresetId)
-      ?? MULTI_LINE_BRAILLE_PRESETS[0];
-    return {
-      brailleDisplayKind: 'multi',
-      brailleDisplayPresetId: preset.id,
-      brailleDisplaySize: preset.cells,
-      brailleDisplayLines: preset.lines,
-    };
-  }
-  return {
-    brailleDisplayKind: 'manual',
-    brailleDisplayPresetId: null,
-  };
-}
-
-export function selectBraillePreset(
-  kind: 'single' | 'multi',
-  presetId: string,
-): BraillePresetSelection | null {
-  const presets = kind === 'single'
-    ? SINGLE_LINE_BRAILLE_PRESETS
-    : MULTI_LINE_BRAILLE_PRESETS;
-  const preset = findBraillePreset(presets, presetId);
-  if (!preset) {
-    return null;
-  }
-  return {
-    brailleDisplayKind: kind,
-    brailleDisplayPresetId: preset.id,
-    brailleDisplaySize: preset.cells,
-    brailleDisplayLines: preset.lines,
-  };
 }
 
 /**

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -19,53 +19,26 @@ export const DEFAULT_BRAILLE_LINES = 1;
  */
 export const MAX_BRAILLE_LINES = 20;
 
-/**
- * Upper bound on the configured number of cells per braille row. The largest
- * commercial single-line displays we recognize hold 80 cells; 160 leaves
- * generous headroom for unrecognized hardware while still rejecting
- * obviously bogus values typed into the manual input.
- */
+// 160 = 2x the largest known single-line display (80 cells) — generous
+// headroom for unrecognized hardware while still rejecting obviously bogus
+// manual input.
 export const MAX_BRAILLE_SIZE = 160;
 
-/**
- * Clamps an arbitrary numeric value to a valid braille display line count.
- * Empty / NaN / negative inputs collapse to 1 so the stored value never
- * leaves the supported range, even mid-keystroke.
- * @param value - Raw numeric value from the input field.
- * @returns Clamped integer between 1 and MAX_BRAILLE_LINES.
- */
 export function clampBrailleLines(value: number): number {
   return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
 }
 
-/**
- * Clamps an arbitrary numeric value to a valid braille display cell count.
- * Mirrors {@link clampBrailleLines} so the manual size input gets the same
- * defensive treatment as the lines input.
- * @param value - Raw numeric value from the input field.
- * @returns Clamped integer between 1 and MAX_BRAILLE_SIZE.
- */
 export function clampBrailleSize(value: number): number {
   return Math.min(MAX_BRAILLE_SIZE, Math.max(1, Math.floor(value) || 1));
 }
 
-/**
- * Configuration mode for the braille display. Determines whether the user
- * picks from a list of known displays or enters cells/lines manually.
- */
 export type BrailleDisplayKind = 'single' | 'multi' | 'manual';
 
-/**
- * Default braille display kind when no user setting is stored. 'manual'
- * preserves whatever cell/line numbers a previous version saved, so existing
- * users see the same effective configuration after upgrading.
- */
+// 'manual' preserves whatever cells/lines numbers an older saved settings
+// object already has, so users upgrading from before the preset selector
+// see the same effective configuration.
 export const DEFAULT_BRAILLE_DISPLAY_KIND: BrailleDisplayKind = 'manual';
 
-/**
- * A named, hard-coded braille display preset. The id is stable so that a
- * stored selection survives label edits in the future.
- */
 export interface BrailleDisplayPreset {
   id: string;
   label: string;
@@ -74,9 +47,9 @@ export interface BrailleDisplayPreset {
   lines: number;
 }
 
-/**
- * Single-line braille display presets (lines = 1).
- */
+// To add a new device, append a row here (single-line) or in
+// MULTI_LINE_BRAILLE_PRESETS below. Keep ids kebab-case and unique across
+// both lists; the unit test in test/type/settings.test.ts enforces this.
 export const SINGLE_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
   { id: 'focus-14-blue-5g', label: 'Focus 14 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 14, lines: 1 },
   { id: 'focus-40-blue-5g', label: 'Focus 40 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 40, lines: 1 },
@@ -100,9 +73,6 @@ export const SINGLE_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
   { id: 'nls-ereader', label: 'NLS eReader', manufacturer: 'HumanWare / Zoomax', cells: 20, lines: 1 },
 ] as const;
 
-/**
- * Multi-line braille display presets (lines > 1).
- */
 export const MULTI_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
   { id: 'canute-360', label: 'Canute 360', manufacturer: 'Bristol Braille Technology', cells: 40, lines: 9 },
   { id: 'monarch', label: 'Monarch', manufacturer: 'APH / HumanWare / NFB', cells: 32, lines: 10 },
@@ -110,11 +80,6 @@ export const MULTI_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
   { id: 'orbit-slate-520', label: 'Orbit Slate 520', manufacturer: 'Orbit Research', cells: 20, lines: 5 },
 ] as const;
 
-/**
- * Partial settings slice produced by a braille preset / kind selection. The
- * UI merges this into the local form state so the relevant fields update
- * atomically.
- */
 export interface BraillePresetSelection {
   brailleDisplayKind: BrailleDisplayKind;
   brailleDisplayPresetId: string | null;
@@ -122,14 +87,6 @@ export interface BraillePresetSelection {
   brailleDisplayLines?: number;
 }
 
-/**
- * Looks up a preset by id, returning undefined when the id is null or no
- * matching preset exists. Exported so component handlers and tests share a
- * single resolution path.
- * @param presets - Preset list to search.
- * @param presetId - Preset id to find, or null.
- * @returns The matching preset, or undefined.
- */
 export function findBraillePreset(
   presets: readonly BrailleDisplayPreset[],
   presetId: string | null,
@@ -140,22 +97,10 @@ export function findBraillePreset(
   return presets.find(p => p.id === presetId);
 }
 
-/**
- * Computes the settings slice for switching the braille display kind. When
- * switching to single/multi we keep the user's previously selected preset
- * if it still belongs to that kind, otherwise we fall back to the first
- * preset in the list.
- *
- * Switching to manual intentionally omits `brailleDisplaySize` and
- * `brailleDisplayLines` from the returned slice, so when the caller spreads
- * the slice over previous state (`{ ...prev, ...slice }`) the existing
- * cells/lines numbers are preserved as the starting point for the user's
- * manual edits, rather than being reset to defaults or to the previous
- * preset's values.
- * @param kind - Target braille display kind.
- * @param currentPresetId - Currently selected preset id, if any.
- * @returns Settings slice to merge into form state.
- */
+// The 'manual' branch intentionally omits brailleDisplaySize and
+// brailleDisplayLines so callers spreading the slice over previous state
+// (`{ ...prev, ...slice }`) preserve the existing cells/lines numbers as
+// the starting point for the user's manual edits.
 export function selectBrailleDisplayKind(
   kind: BrailleDisplayKind,
   currentPresetId: string | null,
@@ -186,14 +131,6 @@ export function selectBrailleDisplayKind(
   };
 }
 
-/**
- * Computes the settings slice for selecting a specific preset within a
- * single- or multi-line list. Returns null when the preset id is unknown
- * for the given kind, allowing callers to skip the update.
- * @param kind - Preset kind, single or multi.
- * @param presetId - Id of the preset chosen by the user.
- * @returns Settings slice to merge, or null when the id is invalid.
- */
 export function selectBraillePreset(
   kind: 'single' | 'multi',
   presetId: string,

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -47,39 +47,6 @@ export type NonEmptyBraillePresets = readonly [
   ...BrailleDisplayPreset[],
 ];
 
-// To add a new device, append a row here or in MULTI_LINE_BRAILLE_PRESETS.
-// Ids must be kebab-case and unique across both lists.
-export const SINGLE_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
-  { id: 'focus-14-blue-5g', label: 'Focus 14 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 14, lines: 1 },
-  { id: 'focus-40-blue-5g', label: 'Focus 40 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 40, lines: 1 },
-  { id: 'focus-80-blue-5g', label: 'Focus 80 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 80, lines: 1 },
-  { id: 'brailliant-bi-20x', label: 'Brailliant BI 20X', manufacturer: 'HumanWare', cells: 20, lines: 1 },
-  { id: 'brailliant-bi-40x', label: 'Brailliant BI 40X', manufacturer: 'HumanWare', cells: 40, lines: 1 },
-  { id: 'brailliant-b-80', label: 'Brailliant B 80', manufacturer: 'HumanWare', cells: 80, lines: 1 },
-  { id: 'brailliant-bi-32', label: 'Brailliant BI 32', manufacturer: 'HumanWare', cells: 32, lines: 1 },
-  { id: 'mantis-q40', label: 'Mantis Q40', manufacturer: 'APH / HumanWare', cells: 40, lines: 1 },
-  { id: 'chameleon-20', label: 'Chameleon 20', manufacturer: 'APH / HumanWare', cells: 20, lines: 1 },
-  { id: 'orbit-reader-20', label: 'Orbit Reader 20', manufacturer: 'Orbit Research', cells: 20, lines: 1 },
-  { id: 'orbit-reader-40', label: 'Orbit Reader 40', manufacturer: 'Orbit Research', cells: 40, lines: 1 },
-  { id: 'qbraille-xl', label: 'QBraille XL', manufacturer: 'HIMS', cells: 40, lines: 1 },
-  { id: 'varioultra-20', label: 'VarioUltra 20', manufacturer: 'VisioBraille', cells: 20, lines: 1 },
-  { id: 'varioultra-40', label: 'VarioUltra 40', manufacturer: 'VisioBraille', cells: 40, lines: 1 },
-  { id: 'active-braille', label: 'Active Braille', manufacturer: 'Help Tech', cells: 40, lines: 1 },
-  { id: 'actilino', label: 'Actilino', manufacturer: 'Help Tech', cells: 16, lines: 1 },
-  { id: 'alva-usb-640', label: 'ALVA USB 640', manufacturer: 'Optelec', cells: 40, lines: 1 },
-  { id: 'alva-bc680', label: 'ALVA BC680', manufacturer: 'Optelec', cells: 80, lines: 1 },
-  { id: 'brailleme', label: 'BrailleMe', manufacturer: 'Innovision', cells: 20, lines: 1 },
-  { id: 'nls-ereader', label: 'NLS eReader', manufacturer: 'HumanWare / Zoomax', cells: 20, lines: 1 },
-] as const;
-
-export const MULTI_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
-  { id: 'canute-360', label: 'Canute 360', manufacturer: 'Bristol Braille Technology', cells: 40, lines: 9 },
-  { id: 'monarch', label: 'Monarch', manufacturer: 'APH / HumanWare / NFB', cells: 32, lines: 10 },
-  { id: 'orbit-slate-340', label: 'Orbit Slate 340', manufacturer: 'Orbit Research', cells: 40, lines: 3 },
-  { id: 'orbit-slate-520', label: 'Orbit Slate 520', manufacturer: 'Orbit Research', cells: 20, lines: 5 },
-  { id: 'dot-pad-x', label: 'Dot Pad X', manufacturer: 'Dot Inc.', cells: 20, lines: 8 },
-] as const;
-
 // Discriminated union: the manual variant has no preset id and intentionally
 // omits cells/lines so callers spreading the slice over previous state
 // (`{ ...prev, ...slice }`) preserve the user's existing values; the preset

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -24,8 +24,6 @@ export const MAX_BRAILLE_LINES = 20;
 // manual input.
 export const MAX_BRAILLE_SIZE = 160;
 
-// Single source of truth for the kind values: drives the BrailleDisplayKind
-// union and the isBrailleDisplayKind type guard so they cannot drift apart.
 export const BRAILLE_DISPLAY_KINDS = ['single', 'multi', 'manual'] as const;
 export type BrailleDisplayKind = (typeof BRAILLE_DISPLAY_KINDS)[number];
 
@@ -42,9 +40,8 @@ export interface BrailleDisplayPreset {
   lines: number;
 }
 
-// Non-empty array type so `presets[0]` is `BrailleDisplayPreset`, not
-// `BrailleDisplayPreset | undefined`. The catalogs below satisfy this at
-// compile time; selectBrailleDisplayKind relies on it for its fallback.
+// Non-empty so `presets[0]` is BrailleDisplayPreset (not | undefined),
+// which lets selectBrailleDisplayKind's fallback be type-safe.
 export type NonEmptyBraillePresets = readonly [
   BrailleDisplayPreset,
   ...BrailleDisplayPreset[],

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -39,6 +39,7 @@ export const DEFAULT_BRAILLE_DISPLAY_KIND: BrailleDisplayKind = 'manual';
 export interface BrailleDisplayPreset {
   id: string;
   label: string;
+  manufacturer: string;
   cells: number;
   lines: number;
 }
@@ -47,21 +48,36 @@ export interface BrailleDisplayPreset {
  * Single-line braille display presets (lines = 1).
  */
 export const SINGLE_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
-  { id: 'brailliant-bi-40x', label: 'Brailliant BI 40X', cells: 40, lines: 1 },
-  { id: 'focus-40-blue', label: 'Focus 40 Blue', cells: 40, lines: 1 },
-  { id: 'mantis-q40', label: 'Mantis Q40', cells: 40, lines: 1 },
-  { id: 'orbit-reader-40', label: 'Orbit Reader 40', cells: 40, lines: 1 },
-  { id: 'qbraille-xl', label: 'QBraille XL', cells: 40, lines: 1 },
-  { id: 'brailliant-bi-20x', label: 'Brailliant BI 20X', cells: 20, lines: 1 },
-  { id: 'focus-14', label: 'Focus 14', cells: 14, lines: 1 },
+  { id: 'focus-14-blue-5g', label: 'Focus 14 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 14, lines: 1 },
+  { id: 'focus-40-blue-5g', label: 'Focus 40 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 40, lines: 1 },
+  { id: 'focus-80-blue-5g', label: 'Focus 80 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 80, lines: 1 },
+  { id: 'brailliant-bi-20x', label: 'Brailliant BI 20X', manufacturer: 'HumanWare', cells: 20, lines: 1 },
+  { id: 'brailliant-bi-40x', label: 'Brailliant BI 40X', manufacturer: 'HumanWare', cells: 40, lines: 1 },
+  { id: 'brailliant-b-80', label: 'Brailliant B 80', manufacturer: 'HumanWare', cells: 80, lines: 1 },
+  { id: 'brailliant-bi-32', label: 'Brailliant BI 32', manufacturer: 'HumanWare', cells: 32, lines: 1 },
+  { id: 'mantis-q40', label: 'Mantis Q40', manufacturer: 'APH / HumanWare', cells: 40, lines: 1 },
+  { id: 'chameleon-20', label: 'Chameleon 20', manufacturer: 'APH / HumanWare', cells: 20, lines: 1 },
+  { id: 'orbit-reader-20', label: 'Orbit Reader 20', manufacturer: 'Orbit Research', cells: 20, lines: 1 },
+  { id: 'orbit-reader-40', label: 'Orbit Reader 40', manufacturer: 'Orbit Research', cells: 40, lines: 1 },
+  { id: 'qbraille-xl', label: 'QBraille XL', manufacturer: 'HIMS', cells: 40, lines: 1 },
+  { id: 'varioultra-20', label: 'VarioUltra 20', manufacturer: 'VisioBraille', cells: 20, lines: 1 },
+  { id: 'varioultra-40', label: 'VarioUltra 40', manufacturer: 'VisioBraille', cells: 40, lines: 1 },
+  { id: 'active-braille', label: 'Active Braille', manufacturer: 'Help Tech', cells: 40, lines: 1 },
+  { id: 'actilino', label: 'Actilino', manufacturer: 'Help Tech', cells: 16, lines: 1 },
+  { id: 'alva-usb-640', label: 'ALVA USB 640', manufacturer: 'Optelec', cells: 40, lines: 1 },
+  { id: 'alva-bc680', label: 'ALVA BC680', manufacturer: 'Optelec', cells: 80, lines: 1 },
+  { id: 'brailleme', label: 'BrailleMe', manufacturer: 'Innovision', cells: 20, lines: 1 },
+  { id: 'nls-ereader', label: 'NLS eReader', manufacturer: 'HumanWare / Zoomax', cells: 20, lines: 1 },
 ] as const;
 
 /**
  * Multi-line braille display presets (lines > 1).
  */
 export const MULTI_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
-  { id: 'orbit-slate-520', label: 'Orbit Slate 520', cells: 20, lines: 5 },
-  { id: 'orbit-slate-340', label: 'Orbit Slate 340', cells: 40, lines: 3 },
+  { id: 'canute-360', label: 'Canute 360', manufacturer: 'Bristol Braille Technology', cells: 40, lines: 9 },
+  { id: 'monarch', label: 'Monarch', manufacturer: 'APH / HumanWare / NFB', cells: 32, lines: 10 },
+  { id: 'orbit-slate-340', label: 'Orbit Slate 340', manufacturer: 'Orbit Research', cells: 40, lines: 3 },
+  { id: 'orbit-slate-520', label: 'Orbit Slate 520', manufacturer: 'Orbit Research', cells: 20, lines: 5 },
 ] as const;
 
 /**

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -20,6 +20,51 @@ export const DEFAULT_BRAILLE_LINES = 1;
 export const MAX_BRAILLE_LINES = 20;
 
 /**
+ * Configuration mode for the braille display. Determines whether the user
+ * picks from a list of known displays or enters cells/lines manually.
+ */
+export type BrailleDisplayKind = 'single' | 'multi' | 'manual';
+
+/**
+ * Default braille display kind when no user setting is stored. 'manual'
+ * preserves whatever cell/line numbers a previous version saved, so existing
+ * users see the same effective configuration after upgrading.
+ */
+export const DEFAULT_BRAILLE_DISPLAY_KIND: BrailleDisplayKind = 'manual';
+
+/**
+ * A named, hard-coded braille display preset. The id is stable so that a
+ * stored selection survives label edits in the future.
+ */
+export interface BrailleDisplayPreset {
+  id: string;
+  label: string;
+  cells: number;
+  lines: number;
+}
+
+/**
+ * Single-line braille display presets (lines = 1).
+ */
+export const SINGLE_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
+  { id: 'brailliant-bi-40x', label: 'Brailliant BI 40X', cells: 40, lines: 1 },
+  { id: 'focus-40-blue', label: 'Focus 40 Blue', cells: 40, lines: 1 },
+  { id: 'mantis-q40', label: 'Mantis Q40', cells: 40, lines: 1 },
+  { id: 'orbit-reader-40', label: 'Orbit Reader 40', cells: 40, lines: 1 },
+  { id: 'qbraille-xl', label: 'QBraille XL', cells: 40, lines: 1 },
+  { id: 'brailliant-bi-20x', label: 'Brailliant BI 20X', cells: 20, lines: 1 },
+  { id: 'focus-14', label: 'Focus 14', cells: 14, lines: 1 },
+] as const;
+
+/**
+ * Multi-line braille display presets (lines > 1).
+ */
+export const MULTI_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
+  { id: 'orbit-slate-520', label: 'Orbit Slate 520', cells: 20, lines: 5 },
+  { id: 'orbit-slate-340', label: 'Orbit Slate 340', cells: 40, lines: 3 },
+] as const;
+
+/**
  * ARIA live region politeness level for screen reader announcements.
  */
 export type AriaMode = 'assertive' | 'polite';
@@ -66,6 +111,8 @@ export interface GeneralSettings {
   highContrastDarkColor: string;
   brailleDisplaySize: number;
   brailleDisplayLines: number;
+  brailleDisplayKind: BrailleDisplayKind;
+  brailleDisplayPresetId: string | null;
   minFrequency: number;
   maxFrequency: number;
   autoplayDuration: number;
@@ -91,6 +138,8 @@ export const DEFAULT_SETTINGS: Settings = {
     highContrastDarkColor: '#000000',
     brailleDisplaySize: DEFAULT_BRAILLE_SIZE,
     brailleDisplayLines: DEFAULT_BRAILLE_LINES,
+    brailleDisplayKind: DEFAULT_BRAILLE_DISPLAY_KIND,
+    brailleDisplayPresetId: null,
     minFrequency: 200,
     maxFrequency: 1000,
     autoplayDuration: 4000,

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -24,7 +24,10 @@ export const MAX_BRAILLE_LINES = 20;
 // manual input.
 export const MAX_BRAILLE_SIZE = 160;
 
-export type BrailleDisplayKind = 'single' | 'multi' | 'manual';
+// Single source of truth for the kind values: drives the BrailleDisplayKind
+// union and the isBrailleDisplayKind type guard so they cannot drift apart.
+export const BRAILLE_DISPLAY_KINDS = ['single', 'multi', 'manual'] as const;
+export type BrailleDisplayKind = (typeof BRAILLE_DISPLAY_KINDS)[number];
 
 // 'manual' preserves whatever cells/lines numbers an older saved settings
 // object already has, so users upgrading from before the preset selector
@@ -39,10 +42,18 @@ export interface BrailleDisplayPreset {
   lines: number;
 }
 
+// Non-empty array type so `presets[0]` is `BrailleDisplayPreset`, not
+// `BrailleDisplayPreset | undefined`. The catalogs below satisfy this at
+// compile time; selectBrailleDisplayKind relies on it for its fallback.
+export type NonEmptyBraillePresets = readonly [
+  BrailleDisplayPreset,
+  ...BrailleDisplayPreset[],
+];
+
 // To add a new device, append a row here (single-line) or in
 // MULTI_LINE_BRAILLE_PRESETS below. Keep ids kebab-case and unique across
-// both lists; the unit test in test/type/settings.test.ts enforces this.
-export const SINGLE_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
+// both lists; the unit test in test/util/braillePreset.test.ts enforces this.
+export const SINGLE_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
   { id: 'focus-14-blue-5g', label: 'Focus 14 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 14, lines: 1 },
   { id: 'focus-40-blue-5g', label: 'Focus 40 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 40, lines: 1 },
   { id: 'focus-80-blue-5g', label: 'Focus 80 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 80, lines: 1 },
@@ -65,19 +76,28 @@ export const SINGLE_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
   { id: 'nls-ereader', label: 'NLS eReader', manufacturer: 'HumanWare / Zoomax', cells: 20, lines: 1 },
 ] as const;
 
-export const MULTI_LINE_BRAILLE_PRESETS: readonly BrailleDisplayPreset[] = [
+export const MULTI_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
   { id: 'canute-360', label: 'Canute 360', manufacturer: 'Bristol Braille Technology', cells: 40, lines: 9 },
   { id: 'monarch', label: 'Monarch', manufacturer: 'APH / HumanWare / NFB', cells: 32, lines: 10 },
   { id: 'orbit-slate-340', label: 'Orbit Slate 340', manufacturer: 'Orbit Research', cells: 40, lines: 3 },
   { id: 'orbit-slate-520', label: 'Orbit Slate 520', manufacturer: 'Orbit Research', cells: 20, lines: 5 },
 ] as const;
 
-export interface BraillePresetSelection {
-  brailleDisplayKind: BrailleDisplayKind;
-  brailleDisplayPresetId: string | null;
-  brailleDisplaySize?: number;
-  brailleDisplayLines?: number;
-}
+// Discriminated union: the manual variant has no preset id and intentionally
+// omits cells/lines so callers spreading the slice over previous state
+// (`{ ...prev, ...slice }`) preserve the user's existing values; the preset
+// variant always supplies cells/lines together with a non-null id.
+export type BraillePresetSelection
+  = | {
+    brailleDisplayKind: 'single' | 'multi';
+    brailleDisplayPresetId: string;
+    brailleDisplaySize: number;
+    brailleDisplayLines: number;
+  }
+  | {
+    brailleDisplayKind: 'manual';
+    brailleDisplayPresetId: null;
+  };
 
 /**
  * ARIA live region politeness level for screen reader announcements.

--- a/src/type/settings.ts
+++ b/src/type/settings.ts
@@ -40,13 +40,6 @@ export interface BrailleDisplayPreset {
   lines: number;
 }
 
-// Non-empty so `presets[0]` is BrailleDisplayPreset (not | undefined),
-// which lets selectBrailleDisplayKind's fallback be type-safe.
-export type NonEmptyBraillePresets = readonly [
-  BrailleDisplayPreset,
-  ...BrailleDisplayPreset[],
-];
-
 // Discriminated union: the manual variant has no preset id and intentionally
 // omits cells/lines so callers spreading the slice over previous state
 // (`{ ...prev, ...slice }`) preserve the user's existing values; the preset

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -373,8 +373,8 @@ const Settings: React.FC = () => {
   // missing or points to a now-removed device, snap back to the first
   // preset in that kind so the dropdown doesn't render its disabled
   // "Select a display" placeholder out of step with the active radio.
-  // The ref captures the values at mount time so the effect can run only
-  // once without going stale or pulling generalSettings into the deps.
+  // The ref captures the values at mount time so the effect runs once
+  // with stable inputs and never goes stale.
   const initialKindRef = useRef({
     kind: generalSettings.brailleDisplayKind,
     presetId: generalSettings.brailleDisplayPresetId,
@@ -390,7 +390,7 @@ const Settings: React.FC = () => {
     if (!findBraillePreset(presets, presetId)) {
       handleBrailleKindChange(kind);
     }
-  }, [handleBrailleKindChange]);
+  }, []);
 
   const handleLlmChange = (
     key: keyof LlmSettings,
@@ -676,6 +676,7 @@ const Settings: React.FC = () => {
                         handleBrailleKindChange(v);
                       }
                     }}
+                    aria-label="Braille display type"
                   >
                     <FormControlLabel
                       value="single"

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -1111,10 +1111,9 @@ const Settings: React.FC = () => {
               variant="outlined"
               color="inherit"
               onClick={handleClose}
-              aria-label="Cancel Settings (Alt+C)"
-              title="Alt+C"
+              aria-label="Close Settings with no changes"
             >
-              Cancel (Alt+C)
+              Close
             </Button>
           </Grid>
           <Grid size="auto">
@@ -1126,11 +1125,11 @@ const Settings: React.FC = () => {
               title={
                 !isCustomInstructionValid
                   ? `Custom instructions must be at least ${MIN_CUSTOM_INSTRUCTION_LENGTH} characters long`
-                  : 'Alt+S'
+                  : ''
               }
-              aria-label="Save & Close Settings (Alt+S)"
+              aria-label="Save & Close Settings"
             >
-              Save & Close (Alt+S)
+              Save & Close
             </Button>
           </Grid>
         </Grid>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -50,7 +50,7 @@ import {
   selectBrailleDisplayKind,
   selectBraillePreset,
 } from '@util/braillePreset';
-import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
@@ -60,6 +60,26 @@ function formatSingleLinePreset(p: BrailleDisplayPreset): string {
 
 function formatMultiLinePreset(p: BrailleDisplayPreset): string {
   return `${p.label} — ${p.manufacturer} (${p.lines} lines × ${p.cells} cells)`;
+}
+
+// If stored settings claim a single/multi kind but the preset id is
+// missing or points to a now-removed device, snap to the first preset
+// in that kind. Applied at state initialization (and on viewModel
+// re-sync) so the dropdown never renders its disabled placeholder out
+// of step with the active radio, even for one paint.
+function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettings {
+  const { brailleDisplayKind: kind, brailleDisplayPresetId } = general;
+  if (kind === 'manual') {
+    return general;
+  }
+  const presets = kind === 'single'
+    ? SINGLE_LINE_BRAILLE_PRESETS
+    : MULTI_LINE_BRAILLE_PRESETS;
+  if (findBraillePreset(presets, brailleDisplayPresetId)) {
+    return general;
+  }
+  const slice = selectBrailleDisplayKind(kind, brailleDisplayPresetId);
+  return { ...general, ...slice };
 }
 
 function getValidVersion(
@@ -98,7 +118,7 @@ interface BraillePresetSelectProps {
   presets: readonly BrailleDisplayPreset[];
   selectedPresetId: string | null;
   formatPreset: (preset: BrailleDisplayPreset) => string;
-  onChange: (kind: 'single' | 'multi', presetId: string) => void;
+  onPresetChange: (kind: 'single' | 'multi', presetId: string) => void;
 }
 
 const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
@@ -108,7 +128,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
   presets,
   selectedPresetId,
   formatPreset,
-  onChange,
+  onPresetChange,
 }) => (
   <SettingRow
     label={rowLabel}
@@ -116,7 +136,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
       <FormControl fullWidth>
         <Select
           value={selectedPresetId ?? ''}
-          onChange={e => onChange(kind, e.target.value)}
+          onChange={e => onPresetChange(kind, e.target.value)}
           fullWidth
           size="small"
           displayEmpty
@@ -327,7 +347,7 @@ const Settings: React.FC = () => {
   const { general, llm } = viewModel.state;
 
   const [generalSettings, setGeneralSettings]
-    = useState<GeneralSettings>(general);
+    = useState<GeneralSettings>(() => normalizeBrailleDisplay(general));
   const [llmSettings, setLlmSettings] = useState<LlmSettings>(llm);
 
   useEffect(() => {
@@ -335,7 +355,7 @@ const Settings: React.FC = () => {
   }, [viewModel]);
 
   useEffect(() => {
-    setGeneralSettings(general);
+    setGeneralSettings(normalizeBrailleDisplay(general));
     setLlmSettings(llm);
   }, [general, llm]);
 
@@ -368,29 +388,6 @@ const Settings: React.FC = () => {
     },
     [],
   );
-
-  // If stored settings claim a single/multi kind but the preset id is
-  // missing or points to a now-removed device, snap back to the first
-  // preset in that kind so the dropdown doesn't render its disabled
-  // "Select a display" placeholder out of step with the active radio.
-  // The ref captures the values at mount time so the effect runs once
-  // with stable inputs and never goes stale.
-  const initialKindRef = useRef({
-    kind: generalSettings.brailleDisplayKind,
-    presetId: generalSettings.brailleDisplayPresetId,
-  });
-  useEffect(() => {
-    const { kind, presetId } = initialKindRef.current;
-    if (kind === 'manual') {
-      return;
-    }
-    const presets = kind === 'single'
-      ? SINGLE_LINE_BRAILLE_PRESETS
-      : MULTI_LINE_BRAILLE_PRESETS;
-    if (!findBraillePreset(presets, presetId)) {
-      handleBrailleKindChange(kind);
-    }
-  }, []);
 
   const handleLlmChange = (
     key: keyof LlmSettings,
@@ -707,7 +704,7 @@ const Settings: React.FC = () => {
                 presets={SINGLE_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatSingleLinePreset}
-                onChange={handleBraillePresetChange}
+                onPresetChange={handleBraillePresetChange}
               />
             </Grid>
           )}
@@ -720,7 +717,7 @@ const Settings: React.FC = () => {
                 presets={MULTI_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatMultiLinePreset}
-                onChange={handleBraillePresetChange}
+                onPresetChange={handleBraillePresetChange}
               />
             </Grid>
           )}

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -2,6 +2,8 @@ import type { SelectChangeEvent } from '@mui/material';
 import type { Llm, LlmVersion } from '@type/llm';
 import type {
   AriaMode,
+  BrailleDisplayKind,
+  BrailleDisplayPreset,
   GeneralSettings,
   HoverMode,
   LlmModelSettings,
@@ -34,13 +36,27 @@ import {
 import { LlmValidationService } from '@service/llmValidation';
 import { MODEL_VERSIONS } from '@service/modelVersions';
 import { useViewModel } from '@state/hook/useViewModel';
-import { MAX_BRAILLE_LINES } from '@type/settings';
+import {
+  MAX_BRAILLE_LINES,
+  MULTI_LINE_BRAILLE_PRESETS,
+  SINGLE_LINE_BRAILLE_PRESETS,
+} from '@type/settings';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
 function clampBrailleLines(value: number): number {
   return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
+}
+
+function findPreset(
+  presets: readonly BrailleDisplayPreset[],
+  presetId: string | null,
+): BrailleDisplayPreset | undefined {
+  if (!presetId) {
+    return undefined;
+  }
+  return presets.find(p => p.id === presetId);
 }
 
 function getValidVersion(
@@ -276,12 +292,62 @@ const Settings: React.FC = () => {
 
   const handleGeneralChange = (
     key: keyof GeneralSettings,
-    value: string | number | AriaMode | boolean | HoverMode,
+    value: string | number | AriaMode | boolean | HoverMode | BrailleDisplayKind | null,
   ): void => {
     // Expanded value type for ariaMode
     setGeneralSettings(prev => ({
       ...prev,
       [key]: value,
+    }));
+  };
+
+  const handleBrailleKindChange = (kind: BrailleDisplayKind): void => {
+    if (kind === 'single') {
+      const preset = findPreset(SINGLE_LINE_BRAILLE_PRESETS, generalSettings.brailleDisplayPresetId)
+        ?? SINGLE_LINE_BRAILLE_PRESETS[0];
+      setGeneralSettings(prev => ({
+        ...prev,
+        brailleDisplayKind: 'single',
+        brailleDisplayPresetId: preset.id,
+        brailleDisplaySize: preset.cells,
+        brailleDisplayLines: preset.lines,
+      }));
+    } else if (kind === 'multi') {
+      const preset = findPreset(MULTI_LINE_BRAILLE_PRESETS, generalSettings.brailleDisplayPresetId)
+        ?? MULTI_LINE_BRAILLE_PRESETS[0];
+      setGeneralSettings(prev => ({
+        ...prev,
+        brailleDisplayKind: 'multi',
+        brailleDisplayPresetId: preset.id,
+        brailleDisplaySize: preset.cells,
+        brailleDisplayLines: preset.lines,
+      }));
+    } else {
+      setGeneralSettings(prev => ({
+        ...prev,
+        brailleDisplayKind: 'manual',
+        brailleDisplayPresetId: null,
+      }));
+    }
+  };
+
+  const handleBraillePresetChange = (
+    kind: 'single' | 'multi',
+    presetId: string,
+  ): void => {
+    const presets = kind === 'single'
+      ? SINGLE_LINE_BRAILLE_PRESETS
+      : MULTI_LINE_BRAILLE_PRESETS;
+    const preset = findPreset(presets, presetId);
+    if (!preset) {
+      return;
+    }
+    setGeneralSettings(prev => ({
+      ...prev,
+      brailleDisplayKind: kind,
+      brailleDisplayPresetId: preset.id,
+      brailleDisplaySize: preset.cells,
+      brailleDisplayLines: preset.lines,
     }));
   };
 
@@ -348,6 +414,27 @@ const Settings: React.FC = () => {
   const isCustomInstructionValid
     = llmSettings.expertiseLevel !== 'custom'
       || llmSettings.customInstruction.length >= MIN_CUSTOM_INSTRUCTION_LENGTH;
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+        return;
+      }
+      const key = e.key.toLowerCase();
+      if (key === 's') {
+        if (!isCustomInstructionValid) {
+          return;
+        }
+        e.preventDefault();
+        handleSave();
+      } else if (key === 'c') {
+        e.preventDefault();
+        handleClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [isCustomInstructionValid, generalSettings, llmSettings]);
 
   return (
     <Dialog
@@ -527,77 +614,200 @@ const Settings: React.FC = () => {
           </Grid>
           <Grid size={12}>
             <SettingRow
-              label="Braille Display Size"
+              label="Braille Display"
+              alignLabel="flex-start"
               input={(
-                <FormControl fullWidth>
-                  <TextField
-                    fullWidth
-                    type="number"
-                    size="small"
-                    value={generalSettings.brailleDisplaySize}
+                <FormControl>
+                  <RadioGroup
+                    row
+                    value={generalSettings.brailleDisplayKind}
                     onChange={e =>
-                      handleGeneralChange(
-                        'brailleDisplaySize',
-                        Number(e.target.value),
-                      )}
-                    slotProps={{
-                      input: {
-                        inputProps: {
-                          'aria-label': 'Braille Display Size',
-                        },
-                      },
-                    }}
-                  />
+                      handleBrailleKindChange(e.target.value as BrailleDisplayKind)}
+                    aria-label="Braille Display"
+                  >
+                    <FormControlLabel
+                      value="single"
+                      control={<Radio size="small" />}
+                      label="Single line"
+                    />
+                    <FormControlLabel
+                      value="multi"
+                      control={<Radio size="small" />}
+                      label="Multi-line"
+                    />
+                    <FormControlLabel
+                      value="manual"
+                      control={<Radio size="small" />}
+                      label="Configure manually"
+                    />
+                  </RadioGroup>
                 </FormControl>
               )}
             />
           </Grid>
-          <Grid size={12}>
-            <SettingRow
-              label="Braille Display Lines"
-              input={(
-                <FormControl fullWidth>
-                  <TextField
-                    fullWidth
-                    type="number"
-                    size="small"
-                    value={generalSettings.brailleDisplayLines}
-                    onChange={(e) => {
-                      // Guard against NaN / empty (e.g. when the user clears
-                      // the field). The stored value stays valid even if blur
-                      // never fires. Clamp/floor on every keystroke so a user
-                      // who types `0` and tabs away is not silently reset.
-                      const raw = e.target.value;
-                      if (raw === '') {
-                        return;
-                      }
-                      const parsed = Number(raw);
-                      if (Number.isNaN(parsed)) {
-                        return;
-                      }
-                      handleGeneralChange('brailleDisplayLines', clampBrailleLines(parsed));
-                    }}
-                    onBlur={e =>
-                      handleGeneralChange(
-                        'brailleDisplayLines',
-                        clampBrailleLines(Number(e.target.value)),
-                      )}
-                    helperText={`Number of rows on a physical braille display (1-${MAX_BRAILLE_LINES}). Set above 1 to enable multi-line output.`}
-                    slotProps={{
-                      input: {
-                        inputProps: {
-                          'aria-label': 'Braille Display Lines',
-                          'min': 1,
-                          'max': MAX_BRAILLE_LINES,
-                          'step': 1,
+          {generalSettings.brailleDisplayKind === 'single' && (
+            <Grid size={12}>
+              <SettingRow
+                label="Single-Line Display"
+                input={(
+                  <FormControl fullWidth>
+                    <Select
+                      value={generalSettings.brailleDisplayPresetId ?? ''}
+                      onChange={e =>
+                        handleBraillePresetChange('single', e.target.value)}
+                      fullWidth
+                      size="small"
+                      displayEmpty
+                      slotProps={{
+                        input: {
+                          'aria-label': 'Single-Line Braille Display',
                         },
-                      },
-                    }}
-                  />
-                </FormControl>
-              )}
-            />
-          </Grid>
+                      }}
+                      MenuProps={{
+                        disablePortal: true,
+                      }}
+                    >
+                      <MenuItem value="" disabled>
+                        Select a display
+                      </MenuItem>
+                      {SINGLE_LINE_BRAILLE_PRESETS.map(preset => (
+                        <MenuItem key={preset.id} value={preset.id}>
+                          {preset.label}
+                          {' '}
+                          (
+                          {preset.cells}
+                          {' '}
+                          cells)
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+              />
+            </Grid>
+          )}
+          {generalSettings.brailleDisplayKind === 'multi' && (
+            <Grid size={12}>
+              <SettingRow
+                label="Multi-Line Display"
+                input={(
+                  <FormControl fullWidth>
+                    <Select
+                      value={generalSettings.brailleDisplayPresetId ?? ''}
+                      onChange={e =>
+                        handleBraillePresetChange('multi', e.target.value)}
+                      fullWidth
+                      size="small"
+                      displayEmpty
+                      slotProps={{
+                        input: {
+                          'aria-label': 'Multi-Line Braille Display',
+                        },
+                      }}
+                      MenuProps={{
+                        disablePortal: true,
+                      }}
+                    >
+                      <MenuItem value="" disabled>
+                        Select a display
+                      </MenuItem>
+                      {MULTI_LINE_BRAILLE_PRESETS.map(preset => (
+                        <MenuItem key={preset.id} value={preset.id}>
+                          {preset.label}
+                          {' '}
+                          (
+                          {preset.lines}
+                          {' '}
+                          lines,
+                          {' '}
+                          {preset.cells}
+                          {' '}
+                          cells each)
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+              />
+            </Grid>
+          )}
+          {generalSettings.brailleDisplayKind === 'manual' && (
+            <>
+              <Grid size={12}>
+                <SettingRow
+                  label="Braille Display Size"
+                  input={(
+                    <FormControl fullWidth>
+                      <TextField
+                        fullWidth
+                        type="number"
+                        size="small"
+                        value={generalSettings.brailleDisplaySize}
+                        onChange={e =>
+                          handleGeneralChange(
+                            'brailleDisplaySize',
+                            Number(e.target.value),
+                          )}
+                        slotProps={{
+                          input: {
+                            inputProps: {
+                              'aria-label': 'Braille Display Size',
+                            },
+                          },
+                        }}
+                      />
+                    </FormControl>
+                  )}
+                />
+              </Grid>
+              <Grid size={12}>
+                <SettingRow
+                  label="Braille Display Lines"
+                  input={(
+                    <FormControl fullWidth>
+                      <TextField
+                        fullWidth
+                        type="number"
+                        size="small"
+                        value={generalSettings.brailleDisplayLines}
+                        onChange={(e) => {
+                          // Guard against NaN / empty (e.g. when the user clears
+                          // the field). The stored value stays valid even if blur
+                          // never fires. Clamp/floor on every keystroke so a user
+                          // who types `0` and tabs away is not silently reset.
+                          const raw = e.target.value;
+                          if (raw === '') {
+                            return;
+                          }
+                          const parsed = Number(raw);
+                          if (Number.isNaN(parsed)) {
+                            return;
+                          }
+                          handleGeneralChange('brailleDisplayLines', clampBrailleLines(parsed));
+                        }}
+                        onBlur={e =>
+                          handleGeneralChange(
+                            'brailleDisplayLines',
+                            clampBrailleLines(Number(e.target.value)),
+                          )}
+                        helperText={`Number of rows on a physical braille display (1-${MAX_BRAILLE_LINES}). Set above 1 to enable multi-line output.`}
+                        slotProps={{
+                          input: {
+                            inputProps: {
+                              'aria-label': 'Braille Display Lines',
+                              'min': 1,
+                              'max': MAX_BRAILLE_LINES,
+                              'step': 1,
+                            },
+                          },
+                        }}
+                      />
+                    </FormControl>
+                  )}
+                />
+              </Grid>
+            </>
+          )}
           <Grid size={12}>
             <SettingRow
               label="Min Frequency (Hz)"
@@ -901,9 +1111,10 @@ const Settings: React.FC = () => {
               variant="outlined"
               color="inherit"
               onClick={handleClose}
-              aria-label="Close Settings with no changes"
+              aria-label="Cancel Settings (Alt+C)"
+              title="Alt+C"
             >
-              Close
+              Cancel (Alt+C)
             </Button>
           </Grid>
           <Grid size="auto">
@@ -915,11 +1126,11 @@ const Settings: React.FC = () => {
               title={
                 !isCustomInstructionValid
                   ? `Custom instructions must be at least ${MIN_CUSTOM_INSTRUCTION_LENGTH} characters long`
-                  : ''
+                  : 'Alt+S'
               }
-              aria-label="Save & Close Settings"
+              aria-label="Save & Close Settings (Alt+S)"
             >
-              Save & Close
+              Save & Close (Alt+S)
             </Button>
           </Grid>
         </Grid>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -45,8 +45,8 @@ import {
 import {
   clampBrailleLines,
   clampBrailleSize,
-  findBraillePreset,
   isBrailleDisplayKind,
+  normalizeBrailleDisplay,
   selectBrailleDisplayKind,
   selectBraillePreset,
 } from '@util/braillePreset';
@@ -62,24 +62,17 @@ function formatMultiLinePreset(p: BrailleDisplayPreset): string {
   return `${p.label} — ${p.manufacturer} (${p.lines} lines × ${p.cells} cells)`;
 }
 
-// If stored settings claim a single/multi kind but the preset id is
-// missing or points to a now-removed device, snap to the first preset
-// in that kind. Applied at state initialization (and on viewModel
-// re-sync) so the dropdown never renders its disabled placeholder out
-// of step with the active radio, even for one paint.
-function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettings {
-  const { brailleDisplayKind: kind, brailleDisplayPresetId } = general;
-  if (kind === 'manual') {
-    return general;
+// Returns the clamped value or null when the raw input is empty / NaN —
+// callers skip the update so a partially-typed field stays editable.
+function parseManualBrailleInput(raw: string, clamp: (n: number) => number): number | null {
+  if (raw === '') {
+    return null;
   }
-  const presets = kind === 'single'
-    ? SINGLE_LINE_BRAILLE_PRESETS
-    : MULTI_LINE_BRAILLE_PRESETS;
-  if (findBraillePreset(presets, brailleDisplayPresetId)) {
-    return general;
+  const parsed = Number(raw);
+  if (Number.isNaN(parsed)) {
+    return null;
   }
-  const slice = selectBrailleDisplayKind(kind, brailleDisplayPresetId);
-  return { ...general, ...slice };
+  return clamp(parsed);
 }
 
 function getValidVersion(
@@ -112,19 +105,19 @@ const SettingRow: React.FC<SettingRowProps> = ({ label, input, alignLabel = 'cen
 );
 
 interface BraillePresetSelectProps {
-  kind: 'single' | 'multi';
   rowLabel: string;
   ariaLabel: string;
+  placeholder: string;
   presets: readonly BrailleDisplayPreset[];
   selectedPresetId: string | null;
   formatPreset: (preset: BrailleDisplayPreset) => string;
-  onPresetChange: (kind: 'single' | 'multi', presetId: string) => void;
+  onPresetChange: (presetId: string) => void;
 }
 
 const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
-  kind,
   rowLabel,
   ariaLabel,
+  placeholder,
   presets,
   selectedPresetId,
   formatPreset,
@@ -136,7 +129,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
       <FormControl fullWidth>
         <Select
           value={selectedPresetId ?? ''}
-          onChange={e => onPresetChange(kind, e.target.value)}
+          onChange={e => onPresetChange(e.target.value)}
           fullWidth
           size="small"
           displayEmpty
@@ -144,7 +137,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
           MenuProps={{ disablePortal: true }}
         >
           <MenuItem value="" disabled>
-            Select a display
+            {placeholder}
           </MenuItem>
           {presets.map(preset => (
             <MenuItem key={preset.id} value={preset.id}>
@@ -389,6 +382,16 @@ const Settings: React.FC = () => {
     [],
   );
 
+  const handleSingleLinePresetChange = useCallback(
+    (presetId: string) => handleBraillePresetChange('single', presetId),
+    [handleBraillePresetChange],
+  );
+
+  const handleMultiLinePresetChange = useCallback(
+    (presetId: string) => handleBraillePresetChange('multi', presetId),
+    [handleBraillePresetChange],
+  );
+
   const handleLlmChange = (
     key: keyof LlmSettings,
     value: string | 'basic' | 'intermediate' | 'advanced' | 'custom',
@@ -453,14 +456,9 @@ const Settings: React.FC = () => {
     = llmSettings.expertiseLevel !== 'custom'
       || llmSettings.customInstruction.length >= MIN_CUSTOM_INSTRUCTION_LENGTH;
 
-  // Dialog-scoped handler instead of a document listener: Alt+s / Alt+c
-  // need to fire even when focus is inside one of the dialog's text inputs
-  // (e.g. the manual cells/lines field). Routing through the global
-  // `KeybindingService` would not work for this case because its
-  // `hotkeys.filter` blocks all bindings while a non-MAIDR `<input>` has
-  // focus. Binding to the Dialog's own onKeyDown keeps the listener
-  // component-scoped (no global capture-phase listener) while still
-  // catching keydowns that bubble up from the dialog's inputs.
+  // Dialog-scoped: KeybindingService's hotkeys.filter blocks shortcuts while
+  // focus is in a non-MAIDR <input>, which would silently break Alt+s / Alt+c
+  // inside the manual cells/lines fields.
   const handleDialogKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>): void => {
       if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
@@ -698,26 +696,26 @@ const Settings: React.FC = () => {
           {generalSettings.brailleDisplayKind === 'single' && (
             <Grid size={12}>
               <BraillePresetSelect
-                kind="single"
                 rowLabel="Single-Line Display"
                 ariaLabel="Single-Line Braille Display"
+                placeholder="Select a single-line display"
                 presets={SINGLE_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatSingleLinePreset}
-                onPresetChange={handleBraillePresetChange}
+                onPresetChange={handleSingleLinePresetChange}
               />
             </Grid>
           )}
           {generalSettings.brailleDisplayKind === 'multi' && (
             <Grid size={12}>
               <BraillePresetSelect
-                kind="multi"
                 rowLabel="Multi-Line Display"
                 ariaLabel="Multi-Line Braille Display"
+                placeholder="Select a multi-line display"
                 presets={MULTI_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatMultiLinePreset}
-                onPresetChange={handleBraillePresetChange}
+                onPresetChange={handleMultiLinePresetChange}
               />
             </Grid>
           )}
@@ -734,15 +732,10 @@ const Settings: React.FC = () => {
                         size="small"
                         value={generalSettings.brailleDisplaySize}
                         onChange={(e) => {
-                          const raw = e.target.value;
-                          if (raw === '') {
-                            return;
+                          const next = parseManualBrailleInput(e.target.value, clampBrailleSize);
+                          if (next !== null) {
+                            handleGeneralChange('brailleDisplaySize', next);
                           }
-                          const parsed = Number(raw);
-                          if (Number.isNaN(parsed)) {
-                            return;
-                          }
-                          handleGeneralChange('brailleDisplaySize', clampBrailleSize(parsed));
                         }}
                         onBlur={e =>
                           handleGeneralChange(
@@ -776,19 +769,10 @@ const Settings: React.FC = () => {
                         size="small"
                         value={generalSettings.brailleDisplayLines}
                         onChange={(e) => {
-                          // Guard against NaN / empty (e.g. when the user clears
-                          // the field). The stored value stays valid even if blur
-                          // never fires. Clamp/floor on every keystroke so a user
-                          // who types `0` and tabs away is not silently reset.
-                          const raw = e.target.value;
-                          if (raw === '') {
-                            return;
+                          const next = parseManualBrailleInput(e.target.value, clampBrailleLines);
+                          if (next !== null) {
+                            handleGeneralChange('brailleDisplayLines', next);
                           }
-                          const parsed = Number(raw);
-                          if (Number.isNaN(parsed)) {
-                            return;
-                          }
-                          handleGeneralChange('brailleDisplayLines', clampBrailleLines(parsed));
                         }}
                         onBlur={e =>
                           handleGeneralChange(

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -37,21 +37,29 @@ import { LlmValidationService } from '@service/llmValidation';
 import { MODEL_VERSIONS } from '@service/modelVersions';
 import { useViewModel } from '@state/hook/useViewModel';
 import {
-  clampBrailleLines,
-  clampBrailleSize,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
   MULTI_LINE_BRAILLE_PRESETS,
-  selectBrailleDisplayKind,
-  selectBraillePreset,
   SINGLE_LINE_BRAILLE_PRESETS,
 } from '@type/settings';
+import {
+  clampBrailleLines,
+  clampBrailleSize,
+  findBraillePreset,
+  isBrailleDisplayKind,
+  selectBrailleDisplayKind,
+  selectBraillePreset,
+} from '@util/braillePreset';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
-function isBrailleDisplayKind(value: string): value is BrailleDisplayKind {
-  return value === 'single' || value === 'multi' || value === 'manual';
+function formatSingleLinePreset(p: BrailleDisplayPreset): string {
+  return `${p.label} — ${p.manufacturer} (${p.cells} cells)`;
+}
+
+function formatMultiLinePreset(p: BrailleDisplayPreset): string {
+  return `${p.label} — ${p.manufacturer} (${p.lines} lines × ${p.cells} cells)`;
 }
 
 function getValidVersion(
@@ -339,25 +347,55 @@ const Settings: React.FC = () => {
     }));
   };
 
-  const handleBrailleKindChange = (kind: BrailleDisplayKind): void => {
+  const handleBrailleKindChange = useCallback((kind: BrailleDisplayKind): void => {
     setGeneralSettings((prev) => {
       // Manual omits size/lines from the slice on purpose so the spread
       // preserves the existing values as the starting point for edits.
       const slice = selectBrailleDisplayKind(kind, prev.brailleDisplayPresetId);
       return { ...prev, ...slice };
     });
-  };
+  }, []);
 
-  const handleBraillePresetChange = (
-    kind: 'single' | 'multi',
-    presetId: string,
-  ): void => {
-    const slice = selectBraillePreset(kind, presetId);
-    if (!slice) {
+  const handleBraillePresetChange = useCallback(
+    (kind: 'single' | 'multi', presetId: string): void => {
+      const slice = selectBraillePreset(kind, presetId);
+      if (!slice) {
+        return;
+      }
+      setGeneralSettings(prev => ({ ...prev, ...slice }));
+    },
+    [],
+  );
+
+  const handleSingleLinePresetChange = useCallback(
+    (presetId: string) => handleBraillePresetChange('single', presetId),
+    [handleBraillePresetChange],
+  );
+
+  const handleMultiLinePresetChange = useCallback(
+    (presetId: string) => handleBraillePresetChange('multi', presetId),
+    [handleBraillePresetChange],
+  );
+
+  // Defensive normalization: if stored settings claim a single/multi kind
+  // but the preset id is missing or refers to a now-removed device, snap
+  // back to the first preset in that kind so the dropdown doesn't render
+  // its disabled "Select a display" placeholder out of step with the
+  // active radio button.
+  useEffect(() => {
+    const kind = generalSettings.brailleDisplayKind;
+    if (kind === 'manual') {
       return;
     }
-    setGeneralSettings(prev => ({ ...prev, ...slice }));
-  };
+    const presets = kind === 'single'
+      ? SINGLE_LINE_BRAILLE_PRESETS
+      : MULTI_LINE_BRAILLE_PRESETS;
+    if (!findBraillePreset(presets, generalSettings.brailleDisplayPresetId)) {
+      handleBrailleKindChange(kind);
+    }
+    // Run once on mount; later user-driven changes always go through
+    // handleBrailleKindChange / handleBraillePresetChange.
+  }, []);
 
   const handleLlmChange = (
     key: keyof LlmSettings,
@@ -672,8 +710,8 @@ const Settings: React.FC = () => {
                 ariaLabel="Single-Line Braille Display"
                 presets={SINGLE_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
-                formatPreset={p => `${p.label} — ${p.manufacturer} (${p.cells} cells)`}
-                onChange={presetId => handleBraillePresetChange('single', presetId)}
+                formatPreset={formatSingleLinePreset}
+                onChange={handleSingleLinePresetChange}
               />
             </Grid>
           )}
@@ -684,8 +722,8 @@ const Settings: React.FC = () => {
                 ariaLabel="Multi-Line Braille Display"
                 presets={MULTI_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
-                formatPreset={p => `${p.label} — ${p.manufacturer} (${p.lines} lines × ${p.cells} cells)`}
-                onChange={presetId => handleBraillePresetChange('multi', presetId)}
+                formatPreset={formatMultiLinePreset}
+                onChange={handleMultiLinePresetChange}
               />
             </Grid>
           )}

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -50,6 +50,10 @@ import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
+function isBrailleDisplayKind(value: string): value is BrailleDisplayKind {
+  return value === 'single' || value === 'multi' || value === 'manual';
+}
+
 function getValidVersion(
   modelKey: Llm,
   currentVersion: string | undefined,
@@ -337,6 +341,8 @@ const Settings: React.FC = () => {
 
   const handleBrailleKindChange = (kind: BrailleDisplayKind): void => {
     setGeneralSettings((prev) => {
+      // Manual omits size/lines from the slice on purpose so the spread
+      // preserves the existing values as the starting point for edits.
       const slice = selectBrailleDisplayKind(kind, prev.brailleDisplayPresetId);
       return { ...prev, ...slice };
     });
@@ -417,7 +423,7 @@ const Settings: React.FC = () => {
     = llmSettings.expertiseLevel !== 'custom'
       || llmSettings.customInstruction.length >= MIN_CUSTOM_INSTRUCTION_LENGTH;
 
-  // Dialog-scoped handler instead of a document listener: Alt+S / Alt+C
+  // Dialog-scoped handler instead of a document listener: Alt+s / Alt+c
   // need to fire even when focus is inside one of the dialog's text inputs
   // (e.g. the manual cells/lines field). Routing through the global
   // `KeybindingService` would not work for this case because its
@@ -631,8 +637,12 @@ const Settings: React.FC = () => {
                   <RadioGroup
                     row
                     value={generalSettings.brailleDisplayKind}
-                    onChange={e =>
-                      handleBrailleKindChange(e.target.value as BrailleDisplayKind)}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (isBrailleDisplayKind(v)) {
+                        handleBrailleKindChange(v);
+                      }
+                    }}
                     aria-label="Braille Display"
                   >
                     <FormControlLabel

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -3,8 +3,8 @@ import type { Llm, LlmVersion } from '@type/llm';
 import type {
   AriaMode,
   BrailleDisplayKind,
+  BrailleDisplayPreset,
   GeneralSettings,
-  GeneralSettingsValue,
   HoverMode,
   LlmModelSettings,
   LlmSettings,
@@ -77,6 +77,50 @@ const SettingRow: React.FC<SettingRowProps> = ({ label, input, alignLabel = 'cen
     </Grid>
     <Grid size={{ xs: 12, sm: 6, md: 8 }}>{input}</Grid>
   </Grid>
+);
+
+interface BraillePresetSelectProps {
+  rowLabel: string;
+  ariaLabel: string;
+  presets: readonly BrailleDisplayPreset[];
+  selectedPresetId: string | null;
+  formatPreset: (preset: BrailleDisplayPreset) => string;
+  onChange: (presetId: string) => void;
+}
+
+const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
+  rowLabel,
+  ariaLabel,
+  presets,
+  selectedPresetId,
+  formatPreset,
+  onChange,
+}) => (
+  <SettingRow
+    label={rowLabel}
+    input={(
+      <FormControl fullWidth>
+        <Select
+          value={selectedPresetId ?? ''}
+          onChange={e => onChange(e.target.value)}
+          fullWidth
+          size="small"
+          displayEmpty
+          slotProps={{ input: { 'aria-label': ariaLabel } }}
+          MenuProps={{ disablePortal: true }}
+        >
+          <MenuItem value="" disabled>
+            Select a display
+          </MenuItem>
+          {presets.map(preset => (
+            <MenuItem key={preset.id} value={preset.id}>
+              {formatPreset(preset)}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    )}
+  />
 );
 
 interface LlmModelSettingRowProps {
@@ -281,9 +325,9 @@ const Settings: React.FC = () => {
     setLlmSettings(llm);
   }, [general, llm]);
 
-  const handleGeneralChange = (
-    key: keyof GeneralSettings,
-    value: GeneralSettingsValue,
+  const handleGeneralChange = <K extends keyof GeneralSettings>(
+    key: K,
+    value: GeneralSettings[K],
   ): void => {
     setGeneralSettings(prev => ({
       ...prev,
@@ -373,8 +417,16 @@ const Settings: React.FC = () => {
     = llmSettings.expertiseLevel !== 'custom'
       || llmSettings.customInstruction.length >= MIN_CUSTOM_INSTRUCTION_LENGTH;
 
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent): void => {
+  // Dialog-scoped handler instead of a document listener: Alt+S / Alt+C
+  // need to fire even when focus is inside one of the dialog's text inputs
+  // (e.g. the manual cells/lines field). Routing through the global
+  // `KeybindingService` would not work for this case because its
+  // `hotkeys.filter` blocks all bindings while a non-MAIDR `<input>` has
+  // focus. Binding to the Dialog's own onKeyDown keeps the listener
+  // component-scoped (no global capture-phase listener) while still
+  // catching keydowns that bubble up from the dialog's inputs.
+  const handleDialogKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>): void => {
       if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
         return;
       }
@@ -389,10 +441,9 @@ const Settings: React.FC = () => {
         e.preventDefault();
         handleClose();
       }
-    };
-    document.addEventListener('keydown', onKeyDown, true);
-    return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [isCustomInstructionValid, handleSave, handleClose]);
+    },
+    [isCustomInstructionValid, handleSave, handleClose],
+  );
 
   return (
     <Dialog
@@ -405,6 +456,7 @@ const Settings: React.FC = () => {
       disablePortal
       disableEnforceFocus
       onClick={e => e.stopPropagation()}
+      onKeyDown={handleDialogKeyDown}
       className="settings-dialog"
     >
       <DialogContent className="settings-dialog-content">
@@ -605,73 +657,25 @@ const Settings: React.FC = () => {
           </Grid>
           {generalSettings.brailleDisplayKind === 'single' && (
             <Grid size={12}>
-              <SettingRow
-                label="Single-Line Display"
-                input={(
-                  <FormControl fullWidth>
-                    <Select
-                      value={generalSettings.brailleDisplayPresetId ?? ''}
-                      onChange={e =>
-                        handleBraillePresetChange('single', e.target.value)}
-                      fullWidth
-                      size="small"
-                      displayEmpty
-                      slotProps={{
-                        input: {
-                          'aria-label': 'Single-Line Braille Display',
-                        },
-                      }}
-                      MenuProps={{
-                        disablePortal: true,
-                      }}
-                    >
-                      <MenuItem value="" disabled>
-                        Select a display
-                      </MenuItem>
-                      {SINGLE_LINE_BRAILLE_PRESETS.map(preset => (
-                        <MenuItem key={preset.id} value={preset.id}>
-                          {`${preset.label} — ${preset.manufacturer} (${preset.cells} cells)`}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                )}
+              <BraillePresetSelect
+                rowLabel="Single-Line Display"
+                ariaLabel="Single-Line Braille Display"
+                presets={SINGLE_LINE_BRAILLE_PRESETS}
+                selectedPresetId={generalSettings.brailleDisplayPresetId}
+                formatPreset={p => `${p.label} — ${p.manufacturer} (${p.cells} cells)`}
+                onChange={presetId => handleBraillePresetChange('single', presetId)}
               />
             </Grid>
           )}
           {generalSettings.brailleDisplayKind === 'multi' && (
             <Grid size={12}>
-              <SettingRow
-                label="Multi-Line Display"
-                input={(
-                  <FormControl fullWidth>
-                    <Select
-                      value={generalSettings.brailleDisplayPresetId ?? ''}
-                      onChange={e =>
-                        handleBraillePresetChange('multi', e.target.value)}
-                      fullWidth
-                      size="small"
-                      displayEmpty
-                      slotProps={{
-                        input: {
-                          'aria-label': 'Multi-Line Braille Display',
-                        },
-                      }}
-                      MenuProps={{
-                        disablePortal: true,
-                      }}
-                    >
-                      <MenuItem value="" disabled>
-                        Select a display
-                      </MenuItem>
-                      {MULTI_LINE_BRAILLE_PRESETS.map(preset => (
-                        <MenuItem key={preset.id} value={preset.id}>
-                          {`${preset.label} — ${preset.manufacturer} (${preset.lines} lines × ${preset.cells} cells)`}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                )}
+              <BraillePresetSelect
+                rowLabel="Multi-Line Display"
+                ariaLabel="Multi-Line Braille Display"
+                presets={MULTI_LINE_BRAILLE_PRESETS}
+                selectedPresetId={generalSettings.brailleDisplayPresetId}
+                formatPreset={p => `${p.label} — ${p.manufacturer} (${p.lines} lines × ${p.cells} cells)`}
+                onChange={presetId => handleBraillePresetChange('multi', presetId)}
               />
             </Grid>
           )}
@@ -1074,7 +1078,7 @@ const Settings: React.FC = () => {
               color="inherit"
               onClick={handleClose}
               aria-label="Close Settings with no changes"
-              aria-keyshortcuts="Alt+C"
+              aria-keyshortcuts="Alt+c"
             >
               Close
             </Button>
@@ -1091,7 +1095,7 @@ const Settings: React.FC = () => {
                   : ''
               }
               aria-label="Save & Close Settings"
-              aria-keyshortcuts="Alt+S"
+              aria-keyshortcuts="Alt+s"
             >
               Save & Close
             </Button>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -39,16 +39,16 @@ import { useViewModel } from '@state/hook/useViewModel';
 import {
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
-  MULTI_LINE_BRAILLE_PRESETS,
-  SINGLE_LINE_BRAILLE_PRESETS,
 } from '@type/settings';
 import {
   clampBrailleLines,
   clampBrailleSize,
   isBrailleDisplayKind,
+  MULTI_LINE_BRAILLE_PRESETS,
   normalizeBrailleDisplay,
   selectBrailleDisplayKind,
   selectBraillePreset,
+  SINGLE_LINE_BRAILLE_PRESETS,
 } from '@util/braillePreset';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
@@ -737,11 +737,12 @@ const Settings: React.FC = () => {
                             handleGeneralChange('brailleDisplaySize', next);
                           }
                         }}
-                        onBlur={e =>
-                          handleGeneralChange(
-                            'brailleDisplaySize',
-                            clampBrailleSize(Number(e.target.value)),
-                          )}
+                        onBlur={(e) => {
+                          const next = parseManualBrailleInput(e.target.value, clampBrailleSize);
+                          if (next !== null) {
+                            handleGeneralChange('brailleDisplaySize', next);
+                          }
+                        }}
                         helperText={`Cells per row on a physical braille display (1-${MAX_BRAILLE_SIZE}).`}
                         slotProps={{
                           input: {
@@ -774,11 +775,12 @@ const Settings: React.FC = () => {
                             handleGeneralChange('brailleDisplayLines', next);
                           }
                         }}
-                        onBlur={e =>
-                          handleGeneralChange(
-                            'brailleDisplayLines',
-                            clampBrailleLines(Number(e.target.value)),
-                          )}
+                        onBlur={(e) => {
+                          const next = parseManualBrailleInput(e.target.value, clampBrailleLines);
+                          if (next !== null) {
+                            handleGeneralChange('brailleDisplayLines', next);
+                          }
+                        }}
                         helperText={`Number of rows on a physical braille display (1-${MAX_BRAILLE_LINES}). Set above 1 to enable multi-line output.`}
                         slotProps={{
                           input: {

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -3,8 +3,8 @@ import type { Llm, LlmVersion } from '@type/llm';
 import type {
   AriaMode,
   BrailleDisplayKind,
-  BrailleDisplayPreset,
   GeneralSettings,
+  GeneralSettingsValue,
   HoverMode,
   LlmModelSettings,
   LlmSettings,
@@ -37,27 +37,18 @@ import { LlmValidationService } from '@service/llmValidation';
 import { MODEL_VERSIONS } from '@service/modelVersions';
 import { useViewModel } from '@state/hook/useViewModel';
 import {
+  clampBrailleLines,
+  clampBrailleSize,
   MAX_BRAILLE_LINES,
+  MAX_BRAILLE_SIZE,
   MULTI_LINE_BRAILLE_PRESETS,
+  selectBrailleDisplayKind,
+  selectBraillePreset,
   SINGLE_LINE_BRAILLE_PRESETS,
 } from '@type/settings';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
-
-function clampBrailleLines(value: number): number {
-  return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
-}
-
-function findPreset(
-  presets: readonly BrailleDisplayPreset[],
-  presetId: string | null,
-): BrailleDisplayPreset | undefined {
-  if (!presetId) {
-    return undefined;
-  }
-  return presets.find(p => p.id === presetId);
-}
 
 function getValidVersion(
   modelKey: Llm,
@@ -292,9 +283,8 @@ const Settings: React.FC = () => {
 
   const handleGeneralChange = (
     key: keyof GeneralSettings,
-    value: string | number | AriaMode | boolean | HoverMode | BrailleDisplayKind | null,
+    value: GeneralSettingsValue,
   ): void => {
-    // Expanded value type for ariaMode
     setGeneralSettings(prev => ({
       ...prev,
       [key]: value,
@@ -302,53 +292,21 @@ const Settings: React.FC = () => {
   };
 
   const handleBrailleKindChange = (kind: BrailleDisplayKind): void => {
-    if (kind === 'single') {
-      const preset = findPreset(SINGLE_LINE_BRAILLE_PRESETS, generalSettings.brailleDisplayPresetId)
-        ?? SINGLE_LINE_BRAILLE_PRESETS[0];
-      setGeneralSettings(prev => ({
-        ...prev,
-        brailleDisplayKind: 'single',
-        brailleDisplayPresetId: preset.id,
-        brailleDisplaySize: preset.cells,
-        brailleDisplayLines: preset.lines,
-      }));
-    } else if (kind === 'multi') {
-      const preset = findPreset(MULTI_LINE_BRAILLE_PRESETS, generalSettings.brailleDisplayPresetId)
-        ?? MULTI_LINE_BRAILLE_PRESETS[0];
-      setGeneralSettings(prev => ({
-        ...prev,
-        brailleDisplayKind: 'multi',
-        brailleDisplayPresetId: preset.id,
-        brailleDisplaySize: preset.cells,
-        brailleDisplayLines: preset.lines,
-      }));
-    } else {
-      setGeneralSettings(prev => ({
-        ...prev,
-        brailleDisplayKind: 'manual',
-        brailleDisplayPresetId: null,
-      }));
-    }
+    setGeneralSettings((prev) => {
+      const slice = selectBrailleDisplayKind(kind, prev.brailleDisplayPresetId);
+      return { ...prev, ...slice };
+    });
   };
 
   const handleBraillePresetChange = (
     kind: 'single' | 'multi',
     presetId: string,
   ): void => {
-    const presets = kind === 'single'
-      ? SINGLE_LINE_BRAILLE_PRESETS
-      : MULTI_LINE_BRAILLE_PRESETS;
-    const preset = findPreset(presets, presetId);
-    if (!preset) {
+    const slice = selectBraillePreset(kind, presetId);
+    if (!slice) {
       return;
     }
-    setGeneralSettings(prev => ({
-      ...prev,
-      brailleDisplayKind: kind,
-      brailleDisplayPresetId: preset.id,
-      brailleDisplaySize: preset.cells,
-      brailleDisplayLines: preset.lines,
-    }));
+    setGeneralSettings(prev => ({ ...prev, ...slice }));
   };
 
   const handleLlmChange = (
@@ -388,14 +346,14 @@ const Settings: React.FC = () => {
     setLlmSettings(llm);
   };
 
-  const handleClose = (): void => {
+  const handleClose = useCallback((): void => {
     viewModel.toggle();
-  };
+  }, [viewModel]);
 
-  const handleSave = (): void => {
+  const handleSave = useCallback((): void => {
     viewModel.saveAndClose({ general: generalSettings, llm: llmSettings });
     chatViewModel.refreshInitialMessage();
-  };
+  }, [viewModel, chatViewModel, generalSettings, llmSettings]);
 
   const handleSelectClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -434,7 +392,7 @@ const Settings: React.FC = () => {
     };
     document.addEventListener('keydown', onKeyDown, true);
     return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [isCustomInstructionValid, generalSettings, llmSettings]);
+  }, [isCustomInstructionValid, handleSave, handleClose]);
 
   return (
     <Dialog
@@ -729,15 +687,33 @@ const Settings: React.FC = () => {
                         type="number"
                         size="small"
                         value={generalSettings.brailleDisplaySize}
-                        onChange={e =>
+                        onChange={(e) => {
+                          // Mirror the lines input: ignore empty and NaN
+                          // mid-edit, clamp/floor everything else so the
+                          // stored value never falls outside [1, MAX].
+                          const raw = e.target.value;
+                          if (raw === '') {
+                            return;
+                          }
+                          const parsed = Number(raw);
+                          if (Number.isNaN(parsed)) {
+                            return;
+                          }
+                          handleGeneralChange('brailleDisplaySize', clampBrailleSize(parsed));
+                        }}
+                        onBlur={e =>
                           handleGeneralChange(
                             'brailleDisplaySize',
-                            Number(e.target.value),
+                            clampBrailleSize(Number(e.target.value)),
                           )}
+                        helperText={`Cells per row on a physical braille display (1-${MAX_BRAILLE_SIZE}).`}
                         slotProps={{
                           input: {
                             inputProps: {
                               'aria-label': 'Braille Display Size',
+                              'min': 1,
+                              'max': MAX_BRAILLE_SIZE,
+                              'step': 1,
                             },
                           },
                         }}

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -50,7 +50,7 @@ import {
   selectBrailleDisplayKind,
   selectBraillePreset,
 } from '@util/braillePreset';
-import React, { useCallback, useEffect, useId, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
@@ -92,15 +92,17 @@ const SettingRow: React.FC<SettingRowProps> = ({ label, input, alignLabel = 'cen
 );
 
 interface BraillePresetSelectProps {
+  kind: 'single' | 'multi';
   rowLabel: string;
   ariaLabel: string;
   presets: readonly BrailleDisplayPreset[];
   selectedPresetId: string | null;
   formatPreset: (preset: BrailleDisplayPreset) => string;
-  onChange: (presetId: string) => void;
+  onChange: (kind: 'single' | 'multi', presetId: string) => void;
 }
 
 const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
+  kind,
   rowLabel,
   ariaLabel,
   presets,
@@ -114,7 +116,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
       <FormControl fullWidth>
         <Select
           value={selectedPresetId ?? ''}
-          onChange={e => onChange(e.target.value)}
+          onChange={e => onChange(kind, e.target.value)}
           fullWidth
           size="small"
           displayEmpty
@@ -367,35 +369,28 @@ const Settings: React.FC = () => {
     [],
   );
 
-  const handleSingleLinePresetChange = useCallback(
-    (presetId: string) => handleBraillePresetChange('single', presetId),
-    [handleBraillePresetChange],
-  );
-
-  const handleMultiLinePresetChange = useCallback(
-    (presetId: string) => handleBraillePresetChange('multi', presetId),
-    [handleBraillePresetChange],
-  );
-
-  // Defensive normalization: if stored settings claim a single/multi kind
-  // but the preset id is missing or refers to a now-removed device, snap
-  // back to the first preset in that kind so the dropdown doesn't render
-  // its disabled "Select a display" placeholder out of step with the
-  // active radio button.
+  // If stored settings claim a single/multi kind but the preset id is
+  // missing or points to a now-removed device, snap back to the first
+  // preset in that kind so the dropdown doesn't render its disabled
+  // "Select a display" placeholder out of step with the active radio.
+  // The ref captures the values at mount time so the effect can run only
+  // once without going stale or pulling generalSettings into the deps.
+  const initialKindRef = useRef({
+    kind: generalSettings.brailleDisplayKind,
+    presetId: generalSettings.brailleDisplayPresetId,
+  });
   useEffect(() => {
-    const kind = generalSettings.brailleDisplayKind;
+    const { kind, presetId } = initialKindRef.current;
     if (kind === 'manual') {
       return;
     }
     const presets = kind === 'single'
       ? SINGLE_LINE_BRAILLE_PRESETS
       : MULTI_LINE_BRAILLE_PRESETS;
-    if (!findBraillePreset(presets, generalSettings.brailleDisplayPresetId)) {
+    if (!findBraillePreset(presets, presetId)) {
       handleBrailleKindChange(kind);
     }
-    // Run once on mount; later user-driven changes always go through
-    // handleBrailleKindChange / handleBraillePresetChange.
-  }, []);
+  }, [handleBrailleKindChange]);
 
   const handleLlmChange = (
     key: keyof LlmSettings,
@@ -681,7 +676,6 @@ const Settings: React.FC = () => {
                         handleBrailleKindChange(v);
                       }
                     }}
-                    aria-label="Braille Display"
                   >
                     <FormControlLabel
                       value="single"
@@ -706,24 +700,26 @@ const Settings: React.FC = () => {
           {generalSettings.brailleDisplayKind === 'single' && (
             <Grid size={12}>
               <BraillePresetSelect
+                kind="single"
                 rowLabel="Single-Line Display"
                 ariaLabel="Single-Line Braille Display"
                 presets={SINGLE_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatSingleLinePreset}
-                onChange={handleSingleLinePresetChange}
+                onChange={handleBraillePresetChange}
               />
             </Grid>
           )}
           {generalSettings.brailleDisplayKind === 'multi' && (
             <Grid size={12}>
               <BraillePresetSelect
+                kind="multi"
                 rowLabel="Multi-Line Display"
                 ariaLabel="Multi-Line Braille Display"
                 presets={MULTI_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatMultiLinePreset}
-                onChange={handleMultiLinePresetChange}
+                onChange={handleBraillePresetChange}
               />
             </Grid>
           )}
@@ -740,9 +736,6 @@ const Settings: React.FC = () => {
                         size="small"
                         value={generalSettings.brailleDisplaySize}
                         onChange={(e) => {
-                          // Mirror the lines input: ignore empty and NaN
-                          // mid-edit, clamp/floor everything else so the
-                          // stored value never falls outside [1, MAX].
                           const raw = e.target.value;
                           if (raw === '') {
                             return;

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -672,12 +672,7 @@ const Settings: React.FC = () => {
                       </MenuItem>
                       {SINGLE_LINE_BRAILLE_PRESETS.map(preset => (
                         <MenuItem key={preset.id} value={preset.id}>
-                          {preset.label}
-                          {' '}
-                          (
-                          {preset.cells}
-                          {' '}
-                          cells)
+                          {`${preset.label} — ${preset.manufacturer} (${preset.cells} cells)`}
                         </MenuItem>
                       ))}
                     </Select>
@@ -713,16 +708,7 @@ const Settings: React.FC = () => {
                       </MenuItem>
                       {MULTI_LINE_BRAILLE_PRESETS.map(preset => (
                         <MenuItem key={preset.id} value={preset.id}>
-                          {preset.label}
-                          {' '}
-                          (
-                          {preset.lines}
-                          {' '}
-                          lines,
-                          {' '}
-                          {preset.cells}
-                          {' '}
-                          cells each)
+                          {`${preset.label} — ${preset.manufacturer} (${preset.lines} lines × ${preset.cells} cells)`}
                         </MenuItem>
                       ))}
                     </Select>
@@ -1112,6 +1098,7 @@ const Settings: React.FC = () => {
               color="inherit"
               onClick={handleClose}
               aria-label="Close Settings with no changes"
+              aria-keyshortcuts="Alt+C"
             >
               Close
             </Button>
@@ -1128,6 +1115,7 @@ const Settings: React.FC = () => {
                   : ''
               }
               aria-label="Save & Close Settings"
+              aria-keyshortcuts="Alt+S"
             >
               Save & Close
             </Button>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -47,6 +47,7 @@ import {
   formatSingleLinePreset,
   isBrailleDisplayKind,
   MULTI_LINE_BRAILLE_PRESETS,
+  parseManualBrailleInput,
   selectBrailleDisplayKind,
   selectBraillePreset,
   SINGLE_LINE_BRAILLE_PRESETS,
@@ -54,22 +55,6 @@ import {
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
-
-// Parses a manual cells / lines input. With `clamp` omitted (the
-// onChange path) only the integer floor is applied, so typing "200" is
-// not snapped to MAX mid-edit. With `clamp` supplied (the onBlur path)
-// the committed value is brought into [1, MAX]. Empty / non-finite raw
-// values return null so callers leave the partially-typed state alone.
-function parseManualBrailleInput(raw: string, clamp?: (n: number) => number): number | null {
-  if (raw === '') {
-    return null;
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed)) {
-    return null;
-  }
-  return clamp ? clamp(parsed) : Math.floor(parsed);
-}
 
 function getValidVersion(
   modelKey: Llm,
@@ -436,7 +421,16 @@ const Settings: React.FC = () => {
   }, [viewModel]);
 
   const handleSave = useCallback((): void => {
-    viewModel.saveAndClose({ general: generalSettings, llm: llmSettings });
+    // Clamp before persisting so a Save click before the field blurs
+    // can't bypass the [1, MAX] bound. The onChange path intentionally
+    // skips range clamping during typing so users can edit through
+    // intermediate out-of-range states; this is the commit point.
+    const safeGeneral: GeneralSettings = {
+      ...generalSettings,
+      brailleDisplaySize: clampBrailleSize(generalSettings.brailleDisplaySize),
+      brailleDisplayLines: clampBrailleLines(generalSettings.brailleDisplayLines),
+    };
+    viewModel.saveAndClose({ general: safeGeneral, llm: llmSettings });
     chatViewModel.refreshInitialMessage();
   }, [viewModel, chatViewModel, generalSettings, llmSettings]);
 
@@ -664,7 +658,7 @@ const Settings: React.FC = () => {
               alignLabel="flex-start"
               labelId={`${id}-braille-kind-label`}
               input={(
-                <FormControl>
+                <FormControl fullWidth>
                   <RadioGroup
                     row
                     value={generalSettings.brailleDisplayKind}
@@ -721,7 +715,11 @@ const Settings: React.FC = () => {
             </Grid>
           )}
           {generalSettings.brailleDisplayKind === 'manual' && (
-            <>
+            <Grid
+              size={12}
+              role="group"
+              aria-label="Manual braille display configuration"
+            >
               <Grid size={12}>
                 <SettingRow
                   label="Braille Display Size"
@@ -798,7 +796,7 @@ const Settings: React.FC = () => {
                   )}
                 />
               </Grid>
-            </>
+            </Grid>
           )}
           <Grid size={12}>
             <SettingRow

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -127,7 +127,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
             fullWidth
             size="small"
             displayEmpty
-            slotProps={{ input: { 'aria-labelledby': labelId } }}
+            slotProps={{ input: { 'aria-labelledby': labelId, 'aria-required': true } }}
             MenuProps={{ disablePortal: true }}
           >
             <MenuItem value="" disabled>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -43,6 +43,8 @@ import {
 import {
   clampBrailleLines,
   clampBrailleSize,
+  formatMultiLinePreset,
+  formatSingleLinePreset,
   isBrailleDisplayKind,
   MULTI_LINE_BRAILLE_PRESETS,
   selectBrailleDisplayKind,
@@ -52,14 +54,6 @@ import {
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
-
-function formatSingleLinePreset(p: BrailleDisplayPreset): string {
-  return `${p.label} — ${p.manufacturer} (${p.cells} cells)`;
-}
-
-function formatMultiLinePreset(p: BrailleDisplayPreset): string {
-  return `${p.label} — ${p.manufacturer} (${p.lines} lines × ${p.cells} cells)`;
-}
 
 // Returns the clamped value or null when the raw input is empty / NaN —
 // callers skip the update so a partially-typed field stays editable.

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -55,17 +55,20 @@ import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
-// Returns the clamped value or null when the raw input is empty / NaN —
-// callers skip the update so a partially-typed field stays editable.
-function parseManualBrailleInput(raw: string, clamp: (n: number) => number): number | null {
+// Parses a manual cells / lines input. With `clamp` omitted (the
+// onChange path) only the integer floor is applied, so typing "200" is
+// not snapped to MAX mid-edit. With `clamp` supplied (the onBlur path)
+// the committed value is brought into [1, MAX]. Empty / non-finite raw
+// values return null so callers leave the partially-typed state alone.
+function parseManualBrailleInput(raw: string, clamp?: (n: number) => number): number | null {
   if (raw === '') {
     return null;
   }
   const parsed = Number(raw);
-  if (Number.isNaN(parsed)) {
+  if (!Number.isFinite(parsed)) {
     return null;
   }
-  return clamp(parsed);
+  return clamp ? clamp(parsed) : Math.floor(parsed);
 }
 
 function getValidVersion(
@@ -730,6 +733,12 @@ const Settings: React.FC = () => {
                         size="small"
                         value={generalSettings.brailleDisplaySize}
                         onChange={(e) => {
+                          const next = parseManualBrailleInput(e.target.value);
+                          if (next !== null) {
+                            handleGeneralChange('brailleDisplaySize', next);
+                          }
+                        }}
+                        onBlur={(e) => {
                           const next = parseManualBrailleInput(e.target.value, clampBrailleSize);
                           if (next !== null) {
                             handleGeneralChange('brailleDisplaySize', next);
@@ -762,6 +771,12 @@ const Settings: React.FC = () => {
                         size="small"
                         value={generalSettings.brailleDisplayLines}
                         onChange={(e) => {
+                          const next = parseManualBrailleInput(e.target.value);
+                          if (next !== null) {
+                            handleGeneralChange('brailleDisplayLines', next);
+                          }
+                        }}
+                        onBlur={(e) => {
                           const next = parseManualBrailleInput(e.target.value, clampBrailleLines);
                           if (next !== null) {
                             handleGeneralChange('brailleDisplayLines', next);

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -119,7 +119,9 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
             fullWidth
             size="small"
             displayEmpty
-            slotProps={{ input: { 'aria-labelledby': labelId } }}
+            slotProps={{
+              input: { 'aria-labelledby': labelId, 'aria-label': rowLabel },
+            }}
             MenuProps={{ disablePortal: true }}
           >
             <MenuItem value="" disabled>
@@ -131,6 +133,9 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
               </MenuItem>
             ))}
           </Select>
+          <Typography variant="caption" sx={{ mt: 0.5, color: 'text.secondary' }}>
+            Don't see your display? Choose "Configure manually".
+          </Typography>
         </FormControl>
       )}
     />
@@ -457,7 +462,8 @@ const Settings: React.FC = () => {
   // inside the manual cells/lines fields.
   const handleDialogKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>): void => {
-      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+      const altOnly = e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+      if (!altOnly) {
         return;
       }
       const key = e.key.toLowerCase();

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -379,9 +379,9 @@ const Settings: React.FC = () => {
     [handleBraillePresetChange],
   );
 
-  const handleLlmChange = (
-    key: keyof LlmSettings,
-    value: string | 'basic' | 'intermediate' | 'advanced' | 'custom',
+  const handleLlmChange = <K extends keyof LlmSettings>(
+    key: K,
+    value: LlmSettings[K],
   ): void => {
     setLlmSettings(prev => ({
       ...prev,

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -115,6 +115,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
   hint,
 }) => {
   const labelId = useId();
+  const hintId = useId();
   return (
     <SettingRow
       label={rowLabel}
@@ -127,7 +128,13 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
             fullWidth
             size="small"
             displayEmpty
-            slotProps={{ input: { 'aria-labelledby': labelId, 'aria-required': true } }}
+            slotProps={{
+              input: {
+                'aria-labelledby': labelId,
+                'aria-required': true,
+                ...(hint ? { 'aria-describedby': hintId } : {}),
+              },
+            }}
             MenuProps={{ disablePortal: true }}
           >
             <MenuItem value="" disabled>
@@ -140,7 +147,11 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
             ))}
           </Select>
           {hint && (
-            <Typography variant="caption" sx={{ mt: 0.5, color: 'text.secondary' }}>
+            <Typography
+              id={hintId}
+              variant="caption"
+              sx={{ mt: 0.5, color: 'text.secondary' }}
+            >
               {hint}
             </Typography>
           )}

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -56,6 +56,12 @@ import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
 
+// Letter portion of the dialog accelerator keys. Shared between the
+// keydown handler and the aria-keyshortcuts attributes so the two
+// cannot drift apart and announce a shortcut that no longer fires.
+const SAVE_SHORTCUT_KEY = 's';
+const CANCEL_SHORTCUT_KEY = 'c';
+
 function getValidVersion(
   modelKey: Llm,
   currentVersion: string | undefined,
@@ -469,13 +475,13 @@ const Settings: React.FC = () => {
         return;
       }
       const key = e.key.toLowerCase();
-      if (key === 's') {
+      if (key === SAVE_SHORTCUT_KEY) {
         if (!isCustomInstructionValid) {
           return;
         }
         e.preventDefault();
         handleSave();
-      } else if (key === 'c') {
+      } else if (key === CANCEL_SHORTCUT_KEY) {
         e.preventDefault();
         handleClose();
       }
@@ -707,7 +713,7 @@ const Settings: React.FC = () => {
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatSingleLinePreset}
                 onPresetChange={handleSingleLinePresetChange}
-                hint={`Don't see your display? Choose "Configure manually".`}
+                hint={'Don\'t see your display? Choose "Configure manually".'}
               />
             </Grid>
           )}
@@ -720,7 +726,7 @@ const Settings: React.FC = () => {
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatMultiLinePreset}
                 onPresetChange={handleMultiLinePresetChange}
-                hint={`Don't see your display? Choose "Configure manually".`}
+                hint={'Don\'t see your display? Choose "Configure manually".'}
               />
             </Grid>
           )}
@@ -1112,7 +1118,7 @@ const Settings: React.FC = () => {
               color="inherit"
               onClick={handleClose}
               aria-label="Close Settings with no changes"
-              aria-keyshortcuts="Alt+c"
+              aria-keyshortcuts={`Alt+${CANCEL_SHORTCUT_KEY}`}
             >
               Close
             </Button>
@@ -1129,7 +1135,7 @@ const Settings: React.FC = () => {
                   : ''
               }
               aria-label="Save & Close Settings"
-              aria-keyshortcuts="Alt+s"
+              aria-keyshortcuts={`Alt+${SAVE_SHORTCUT_KEY}`}
             >
               Save & Close
             </Button>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -109,7 +109,6 @@ const SettingRow: React.FC<SettingRowProps> = ({ label, input, alignLabel = 'cen
 
 interface BraillePresetSelectProps {
   rowLabel: string;
-  ariaLabel: string;
   placeholder: string;
   presets: readonly BrailleDisplayPreset[];
   selectedPresetId: string | null;
@@ -119,39 +118,42 @@ interface BraillePresetSelectProps {
 
 const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
   rowLabel,
-  ariaLabel,
   placeholder,
   presets,
   selectedPresetId,
   formatPreset,
   onPresetChange,
-}) => (
-  <SettingRow
-    label={rowLabel}
-    input={(
-      <FormControl fullWidth>
-        <Select
-          value={selectedPresetId ?? ''}
-          onChange={e => onPresetChange(e.target.value)}
-          fullWidth
-          size="small"
-          displayEmpty
-          slotProps={{ input: { 'aria-label': ariaLabel } }}
-          MenuProps={{ disablePortal: true }}
-        >
-          <MenuItem value="" disabled>
-            {placeholder}
-          </MenuItem>
-          {presets.map(preset => (
-            <MenuItem key={preset.id} value={preset.id}>
-              {formatPreset(preset)}
+}) => {
+  const labelId = useId();
+  return (
+    <SettingRow
+      label={rowLabel}
+      labelId={labelId}
+      input={(
+        <FormControl fullWidth>
+          <Select
+            value={selectedPresetId ?? ''}
+            onChange={e => onPresetChange(e.target.value)}
+            fullWidth
+            size="small"
+            displayEmpty
+            slotProps={{ input: { 'aria-labelledby': labelId } }}
+            MenuProps={{ disablePortal: true }}
+          >
+            <MenuItem value="" disabled>
+              {placeholder}
             </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-    )}
-  />
-);
+            {presets.map(preset => (
+              <MenuItem key={preset.id} value={preset.id}>
+                {formatPreset(preset)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+    />
+  );
+};
 
 interface LlmModelSettingRowProps {
   modelKey: Llm;
@@ -369,8 +371,6 @@ const Settings: React.FC = () => {
 
   const handleBrailleKindChange = useCallback((kind: BrailleDisplayKind): void => {
     setGeneralSettings((prev) => {
-      // Manual omits size/lines from the slice on purpose so the spread
-      // preserves the existing values as the starting point for edits.
       const slice = selectBrailleDisplayKind(kind, prev.brailleDisplayPresetId);
       return { ...prev, ...slice };
     });
@@ -703,7 +703,6 @@ const Settings: React.FC = () => {
             <Grid size={12}>
               <BraillePresetSelect
                 rowLabel="Single-Line Display"
-                ariaLabel="Single-Line Braille Display"
                 placeholder="Select a single-line display"
                 presets={SINGLE_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
@@ -716,7 +715,6 @@ const Settings: React.FC = () => {
             <Grid size={12}>
               <BraillePresetSelect
                 rowLabel="Multi-Line Display"
-                ariaLabel="Multi-Line Braille Display"
                 placeholder="Select a multi-line display"
                 presets={MULTI_LINE_BRAILLE_PRESETS}
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
@@ -738,12 +736,6 @@ const Settings: React.FC = () => {
                         size="small"
                         value={generalSettings.brailleDisplaySize}
                         onChange={(e) => {
-                          const next = parseManualBrailleInput(e.target.value, clampBrailleSize);
-                          if (next !== null) {
-                            handleGeneralChange('brailleDisplaySize', next);
-                          }
-                        }}
-                        onBlur={(e) => {
                           const next = parseManualBrailleInput(e.target.value, clampBrailleSize);
                           if (next !== null) {
                             handleGeneralChange('brailleDisplaySize', next);
@@ -776,12 +768,6 @@ const Settings: React.FC = () => {
                         size="small"
                         value={generalSettings.brailleDisplayLines}
                         onChange={(e) => {
-                          const next = parseManualBrailleInput(e.target.value, clampBrailleLines);
-                          if (next !== null) {
-                            handleGeneralChange('brailleDisplayLines', next);
-                          }
-                        }}
-                        onBlur={(e) => {
                           const next = parseManualBrailleInput(e.target.value, clampBrailleLines);
                           if (next !== null) {
                             handleGeneralChange('brailleDisplayLines', next);

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -96,6 +96,7 @@ interface BraillePresetSelectProps {
   selectedPresetId: string | null;
   formatPreset: (preset: BrailleDisplayPreset) => string;
   onPresetChange: (presetId: string) => void;
+  hint?: string;
 }
 
 const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
@@ -105,6 +106,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
   selectedPresetId,
   formatPreset,
   onPresetChange,
+  hint,
 }) => {
   const labelId = useId();
   return (
@@ -119,9 +121,7 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
             fullWidth
             size="small"
             displayEmpty
-            slotProps={{
-              input: { 'aria-labelledby': labelId, 'aria-label': rowLabel },
-            }}
+            slotProps={{ input: { 'aria-labelledby': labelId } }}
             MenuProps={{ disablePortal: true }}
           >
             <MenuItem value="" disabled>
@@ -133,9 +133,11 @@ const BraillePresetSelect: React.FC<BraillePresetSelectProps> = ({
               </MenuItem>
             ))}
           </Select>
-          <Typography variant="caption" sx={{ mt: 0.5, color: 'text.secondary' }}>
-            Don't see your display? Choose "Configure manually".
-          </Typography>
+          {hint && (
+            <Typography variant="caption" sx={{ mt: 0.5, color: 'text.secondary' }}>
+              {hint}
+            </Typography>
+          )}
         </FormControl>
       )}
     />
@@ -705,6 +707,7 @@ const Settings: React.FC = () => {
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatSingleLinePreset}
                 onPresetChange={handleSingleLinePresetChange}
+                hint={`Don't see your display? Choose "Configure manually".`}
               />
             </Grid>
           )}
@@ -717,6 +720,7 @@ const Settings: React.FC = () => {
                 selectedPresetId={generalSettings.brailleDisplayPresetId}
                 formatPreset={formatMultiLinePreset}
                 onPresetChange={handleMultiLinePresetChange}
+                hint={`Don't see your display? Choose "Configure manually".`}
               />
             </Grid>
           )}

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -45,7 +45,6 @@ import {
   clampBrailleSize,
   isBrailleDisplayKind,
   MULTI_LINE_BRAILLE_PRESETS,
-  normalizeBrailleDisplay,
   selectBrailleDisplayKind,
   selectBraillePreset,
   SINGLE_LINE_BRAILLE_PRESETS,
@@ -91,12 +90,16 @@ interface SettingRowProps {
   label: string;
   input: React.ReactNode;
   alignLabel?: 'center' | 'flex-start';
+  // When set, the visible label gets this id so the input can use
+  // aria-labelledby instead of aria-label, avoiding duplicate
+  // announcement of the same text by screen readers.
+  labelId?: string;
 }
 
-const SettingRow: React.FC<SettingRowProps> = ({ label, input, alignLabel = 'center' }) => (
+const SettingRow: React.FC<SettingRowProps> = ({ label, input, alignLabel = 'center', labelId }) => (
   <Grid container spacing={1} alignItems={alignLabel} className="settings-grid-container" sx={{ py: 1 }}>
     <Grid size={{ xs: 12, sm: 6, md: 4 }} sx={alignLabel === 'flex-start' ? { py: 1 } : undefined}>
-      <Typography variant="body2" fontWeight="normal">
+      <Typography id={labelId} variant="body2" fontWeight="normal">
         {label}
       </Typography>
     </Grid>
@@ -339,8 +342,10 @@ const Settings: React.FC = () => {
   const chatViewModel = useViewModel('chat');
   const { general, llm } = viewModel.state;
 
-  const [generalSettings, setGeneralSettings]
-    = useState<GeneralSettings>(() => normalizeBrailleDisplay(general));
+  // SettingsService normalizes braille display fields at construction
+  // before any consumer reads them, so the component-side state already
+  // arrives in a coherent shape and does not need to re-normalize here.
+  const [generalSettings, setGeneralSettings] = useState<GeneralSettings>(general);
   const [llmSettings, setLlmSettings] = useState<LlmSettings>(llm);
 
   useEffect(() => {
@@ -348,7 +353,7 @@ const Settings: React.FC = () => {
   }, [viewModel]);
 
   useEffect(() => {
-    setGeneralSettings(normalizeBrailleDisplay(general));
+    setGeneralSettings(general);
     setLlmSettings(llm);
   }, [general, llm]);
 
@@ -660,6 +665,7 @@ const Settings: React.FC = () => {
             <SettingRow
               label="Braille Display"
               alignLabel="flex-start"
+              labelId={`${id}-braille-kind-label`}
               input={(
                 <FormControl>
                   <RadioGroup
@@ -671,7 +677,7 @@ const Settings: React.FC = () => {
                         handleBrailleKindChange(v);
                       }
                     }}
-                    aria-label="Braille display type"
+                    aria-labelledby={`${id}-braille-kind-label`}
                   >
                     <FormControlLabel
                       value="single"

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -1,0 +1,86 @@
+import type {
+  BrailleDisplayKind,
+  BrailleDisplayPreset,
+  BraillePresetSelection,
+} from '@type/settings';
+import {
+  MAX_BRAILLE_LINES,
+  MAX_BRAILLE_SIZE,
+  MULTI_LINE_BRAILLE_PRESETS,
+  SINGLE_LINE_BRAILLE_PRESETS,
+} from '@type/settings';
+
+export function isBrailleDisplayKind(value: string): value is BrailleDisplayKind {
+  return value === 'single' || value === 'multi' || value === 'manual';
+}
+
+export function clampBrailleLines(value: number): number {
+  return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
+}
+
+export function clampBrailleSize(value: number): number {
+  return Math.min(MAX_BRAILLE_SIZE, Math.max(1, Math.floor(value) || 1));
+}
+
+export function findBraillePreset(
+  presets: readonly BrailleDisplayPreset[],
+  presetId: string | null,
+): BrailleDisplayPreset | undefined {
+  if (!presetId) {
+    return undefined;
+  }
+  return presets.find(p => p.id === presetId);
+}
+
+// The 'manual' branch intentionally omits brailleDisplaySize and
+// brailleDisplayLines so callers spreading the slice over previous state
+// (`{ ...prev, ...slice }`) preserve the existing cells/lines numbers as
+// the starting point for the user's manual edits.
+export function selectBrailleDisplayKind(
+  kind: BrailleDisplayKind,
+  currentPresetId: string | null,
+): BraillePresetSelection {
+  if (kind === 'single') {
+    const preset = findBraillePreset(SINGLE_LINE_BRAILLE_PRESETS, currentPresetId)
+      ?? SINGLE_LINE_BRAILLE_PRESETS[0];
+    return {
+      brailleDisplayKind: 'single',
+      brailleDisplayPresetId: preset.id,
+      brailleDisplaySize: preset.cells,
+      brailleDisplayLines: preset.lines,
+    };
+  }
+  if (kind === 'multi') {
+    const preset = findBraillePreset(MULTI_LINE_BRAILLE_PRESETS, currentPresetId)
+      ?? MULTI_LINE_BRAILLE_PRESETS[0];
+    return {
+      brailleDisplayKind: 'multi',
+      brailleDisplayPresetId: preset.id,
+      brailleDisplaySize: preset.cells,
+      brailleDisplayLines: preset.lines,
+    };
+  }
+  return {
+    brailleDisplayKind: 'manual',
+    brailleDisplayPresetId: null,
+  };
+}
+
+export function selectBraillePreset(
+  kind: 'single' | 'multi',
+  presetId: string,
+): BraillePresetSelection | null {
+  const presets = kind === 'single'
+    ? SINGLE_LINE_BRAILLE_PRESETS
+    : MULTI_LINE_BRAILLE_PRESETS;
+  const preset = findBraillePreset(presets, presetId);
+  if (!preset) {
+    return null;
+  }
+  return {
+    brailleDisplayKind: kind,
+    brailleDisplayPresetId: preset.id,
+    brailleDisplaySize: preset.cells,
+    brailleDisplayLines: preset.lines,
+  };
+}

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -3,15 +3,47 @@ import type {
   BrailleDisplayPreset,
   BraillePresetSelection,
   GeneralSettings,
+  NonEmptyBraillePresets,
 } from '@type/settings';
 import {
   BRAILLE_DISPLAY_KINDS,
   DEFAULT_BRAILLE_DISPLAY_KIND,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
-  MULTI_LINE_BRAILLE_PRESETS,
-  SINGLE_LINE_BRAILLE_PRESETS,
 } from '@type/settings';
+
+// To add a new device, append a row here or in MULTI_LINE_BRAILLE_PRESETS.
+// Ids must be kebab-case and unique across both lists.
+export const SINGLE_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
+  { id: 'focus-14-blue-5g', label: 'Focus 14 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 14, lines: 1 },
+  { id: 'focus-40-blue-5g', label: 'Focus 40 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 40, lines: 1 },
+  { id: 'focus-80-blue-5g', label: 'Focus 80 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 80, lines: 1 },
+  { id: 'brailliant-bi-20x', label: 'Brailliant BI 20X', manufacturer: 'HumanWare', cells: 20, lines: 1 },
+  { id: 'brailliant-bi-40x', label: 'Brailliant BI 40X', manufacturer: 'HumanWare', cells: 40, lines: 1 },
+  { id: 'brailliant-b-80', label: 'Brailliant B 80', manufacturer: 'HumanWare', cells: 80, lines: 1 },
+  { id: 'brailliant-bi-32', label: 'Brailliant BI 32', manufacturer: 'HumanWare', cells: 32, lines: 1 },
+  { id: 'mantis-q40', label: 'Mantis Q40', manufacturer: 'APH / HumanWare', cells: 40, lines: 1 },
+  { id: 'chameleon-20', label: 'Chameleon 20', manufacturer: 'APH / HumanWare', cells: 20, lines: 1 },
+  { id: 'orbit-reader-20', label: 'Orbit Reader 20', manufacturer: 'Orbit Research', cells: 20, lines: 1 },
+  { id: 'orbit-reader-40', label: 'Orbit Reader 40', manufacturer: 'Orbit Research', cells: 40, lines: 1 },
+  { id: 'qbraille-xl', label: 'QBraille XL', manufacturer: 'HIMS', cells: 40, lines: 1 },
+  { id: 'varioultra-20', label: 'VarioUltra 20', manufacturer: 'VisioBraille', cells: 20, lines: 1 },
+  { id: 'varioultra-40', label: 'VarioUltra 40', manufacturer: 'VisioBraille', cells: 40, lines: 1 },
+  { id: 'active-braille', label: 'Active Braille', manufacturer: 'Help Tech', cells: 40, lines: 1 },
+  { id: 'actilino', label: 'Actilino', manufacturer: 'Help Tech', cells: 16, lines: 1 },
+  { id: 'alva-usb-640', label: 'ALVA USB 640', manufacturer: 'Optelec', cells: 40, lines: 1 },
+  { id: 'alva-bc680', label: 'ALVA BC680', manufacturer: 'Optelec', cells: 80, lines: 1 },
+  { id: 'brailleme', label: 'BrailleMe', manufacturer: 'Innovision', cells: 20, lines: 1 },
+  { id: 'nls-ereader', label: 'NLS eReader', manufacturer: 'HumanWare / Zoomax', cells: 20, lines: 1 },
+] as const;
+
+export const MULTI_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
+  { id: 'canute-360', label: 'Canute 360', manufacturer: 'Bristol Braille Technology', cells: 40, lines: 9 },
+  { id: 'monarch', label: 'Monarch', manufacturer: 'APH / HumanWare / NFB', cells: 32, lines: 10 },
+  { id: 'orbit-slate-340', label: 'Orbit Slate 340', manufacturer: 'Orbit Research', cells: 40, lines: 3 },
+  { id: 'orbit-slate-520', label: 'Orbit Slate 520', manufacturer: 'Orbit Research', cells: 20, lines: 5 },
+  { id: 'dot-pad-x', label: 'Dot Pad X', manufacturer: 'Dot Inc.', cells: 20, lines: 8 },
+] as const;
 
 export function isBrailleDisplayKind(value: string): value is BrailleDisplayKind {
   return (BRAILLE_DISPLAY_KINDS as readonly string[]).includes(value);

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -4,6 +4,7 @@ import type {
   BraillePresetSelection,
 } from '@type/settings';
 import {
+  BRAILLE_DISPLAY_KINDS,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
   MULTI_LINE_BRAILLE_PRESETS,
@@ -11,7 +12,7 @@ import {
 } from '@type/settings';
 
 export function isBrailleDisplayKind(value: string): value is BrailleDisplayKind {
-  return value === 'single' || value === 'multi' || value === 'manual';
+  return (BRAILLE_DISPLAY_KINDS as readonly string[]).includes(value);
 }
 
 export function clampBrailleLines(value: number): number {

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -2,9 +2,11 @@ import type {
   BrailleDisplayKind,
   BrailleDisplayPreset,
   BraillePresetSelection,
+  GeneralSettings,
 } from '@type/settings';
 import {
   BRAILLE_DISPLAY_KINDS,
+  DEFAULT_BRAILLE_DISPLAY_KIND,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
   MULTI_LINE_BRAILLE_PRESETS,
@@ -33,10 +35,7 @@ export function findBraillePreset(
   return presets.find(p => p.id === presetId);
 }
 
-// The 'manual' branch intentionally omits brailleDisplaySize and
-// brailleDisplayLines so callers spreading the slice over previous state
-// (`{ ...prev, ...slice }`) preserve the existing cells/lines numbers as
-// the starting point for the user's manual edits.
+// Manual omits size/lines so spreading the slice preserves prior values.
 export function selectBrailleDisplayKind(
   kind: BrailleDisplayKind,
   currentPresetId: string | null,
@@ -84,4 +83,26 @@ export function selectBraillePreset(
     brailleDisplaySize: preset.cells,
     brailleDisplayLines: preset.lines,
   };
+}
+
+// Repairs stale settings: an unknown / removed / undefined preset id under
+// a single/multi kind, or a missing kind from a pre-feature saved object.
+export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettings {
+  const rawKind: unknown = general.brailleDisplayKind;
+  const kind: BrailleDisplayKind = isBrailleDisplayKind(rawKind as string)
+    ? (rawKind as BrailleDisplayKind)
+    : DEFAULT_BRAILLE_DISPLAY_KIND;
+  if (kind === 'manual') {
+    return kind === general.brailleDisplayKind
+      ? general
+      : { ...general, brailleDisplayKind: 'manual', brailleDisplayPresetId: null };
+  }
+  const presets = kind === 'single'
+    ? SINGLE_LINE_BRAILLE_PRESETS
+    : MULTI_LINE_BRAILLE_PRESETS;
+  if (findBraillePreset(presets, general.brailleDisplayPresetId)) {
+    return general;
+  }
+  const slice = selectBrailleDisplayKind(kind, general.brailleDisplayPresetId);
+  return { ...general, ...slice };
 }

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -153,12 +153,9 @@ export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettin
     ? rawKind
     : DEFAULT_BRAILLE_DISPLAY_KIND;
   if (kind === 'manual') {
-    // Reference-equality fast path: no repair needed when the saved kind
-    // already matched, the preset id was already null, AND the cells/lines
-    // numbers are within bounds. Saved configs that predate MAX_BRAILLE_SIZE
-    // / MAX_BRAILLE_LINES could carry out-of-range values; clamping here
-    // gives every consumer the same guarantee the manual onBlur and
-    // handleSave paths already enforce.
+    // Saved configs predating MAX_BRAILLE_SIZE / MAX_BRAILLE_LINES can
+    // carry out-of-range values; clamp here so every consumer gets the
+    // same guarantee the onBlur and handleSave paths enforce.
     const clampedSize = clampBrailleSize(general.brailleDisplaySize);
     const clampedLines = clampBrailleLines(general.brailleDisplayLines);
     if (

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -60,6 +60,26 @@ export function clampBrailleSize(value: number): number {
   return Math.min(MAX_BRAILLE_SIZE, Math.max(1, floored));
 }
 
+// Parses a manual cells / lines text input. Empty / whitespace-only /
+// non-finite raw values return null so callers leave the partially-typed
+// state alone. Without `clamp` (the onChange path) only the integer floor
+// is applied, so typing "200" is not snapped to MAX mid-edit. With
+// `clamp` (the onBlur path or the pre-save guard) the value is brought
+// into [1, MAX].
+export function parseManualBrailleInput(
+  raw: string,
+  clamp?: (n: number) => number,
+): number | null {
+  if (raw.trim() === '') {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return clamp ? clamp(parsed) : Math.floor(parsed);
+}
+
 export function formatSingleLinePreset(p: BrailleDisplayPreset): string {
   return `${p.label} — ${p.manufacturer} (${p.cells} cells)`;
 }

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -3,7 +3,6 @@ import type {
   BrailleDisplayPreset,
   BraillePresetSelection,
   GeneralSettings,
-  NonEmptyBraillePresets,
 } from '@type/settings';
 import {
   BRAILLE_DISPLAY_KINDS,
@@ -11,6 +10,13 @@ import {
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
 } from '@type/settings';
+
+// Non-empty so `presets[0]` is BrailleDisplayPreset (not | undefined),
+// which lets selectBrailleDisplayKind's fallback be type-safe.
+export type NonEmptyBraillePresets = readonly [
+  BrailleDisplayPreset,
+  ...BrailleDisplayPreset[],
+];
 
 // To add a new device, append a row here or in MULTI_LINE_BRAILLE_PRESETS.
 // Ids must be kebab-case and unique across both lists.

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -11,8 +11,6 @@ import {
   MAX_BRAILLE_SIZE,
 } from '@type/settings';
 
-// Non-empty so `presets[0]` is BrailleDisplayPreset (not | undefined),
-// which lets selectBrailleDisplayKind's fallback be type-safe.
 export type NonEmptyBraillePresets = readonly [
   BrailleDisplayPreset,
   ...BrailleDisplayPreset[],
@@ -162,13 +160,28 @@ export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettin
     : DEFAULT_BRAILLE_DISPLAY_KIND;
   if (kind === 'manual') {
     // Reference-equality fast path: no repair needed when the saved kind
-    // already matched and the preset id was already null. The kind check
-    // is meaningful when rawKind was undefined / invalid and we defaulted
-    // to manual — in that case the field still needs to be written.
-    if (general.brailleDisplayKind === kind && general.brailleDisplayPresetId === null) {
+    // already matched, the preset id was already null, AND the cells/lines
+    // numbers are within bounds. Saved configs that predate MAX_BRAILLE_SIZE
+    // / MAX_BRAILLE_LINES could carry out-of-range values; clamping here
+    // gives every consumer the same guarantee the manual onBlur and
+    // handleSave paths already enforce.
+    const clampedSize = clampBrailleSize(general.brailleDisplaySize);
+    const clampedLines = clampBrailleLines(general.brailleDisplayLines);
+    if (
+      general.brailleDisplayKind === kind
+      && general.brailleDisplayPresetId === null
+      && general.brailleDisplaySize === clampedSize
+      && general.brailleDisplayLines === clampedLines
+    ) {
       return general;
     }
-    return { ...general, brailleDisplayKind: 'manual', brailleDisplayPresetId: null };
+    return {
+      ...general,
+      brailleDisplayKind: 'manual',
+      brailleDisplayPresetId: null,
+      brailleDisplaySize: clampedSize,
+      brailleDisplayLines: clampedLines,
+    };
   }
   const presets = kind === 'single'
     ? SINGLE_LINE_BRAILLE_PRESETS

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -62,12 +62,8 @@ export function clampBrailleSize(value: number): number {
   return Math.min(MAX_BRAILLE_SIZE, Math.max(1, floored));
 }
 
-// Parses a manual cells / lines text input. Empty / whitespace-only /
-// non-finite raw values return null so callers leave the partially-typed
-// state alone. Without `clamp` (the onChange path) only the integer floor
-// is applied, so typing "200" is not snapped to MAX mid-edit. With
-// `clamp` (the onBlur path or the pre-save guard) the value is brought
-// into [1, MAX].
+// `clamp` omitted = onChange path (floor only, no range snap mid-edit);
+// `clamp` supplied = commit path (brings value into [1, MAX]).
 export function parseManualBrailleInput(
   raw: string,
   clamp?: (n: number) => number,
@@ -184,8 +180,22 @@ export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettin
   const presets = kind === 'single'
     ? SINGLE_LINE_BRAILLE_PRESETS
     : MULTI_LINE_BRAILLE_PRESETS;
-  if (findBraillePreset(presets, general.brailleDisplayPresetId)) {
-    return general;
+  const preset = findBraillePreset(presets, general.brailleDisplayPresetId);
+  if (preset) {
+    // Saved settings can drift from the catalog if localStorage is edited
+    // by hand or if a preset's cells/lines change between releases. Force
+    // cells/lines back into agreement with the preset.
+    if (
+      general.brailleDisplaySize === preset.cells
+      && general.brailleDisplayLines === preset.lines
+    ) {
+      return general;
+    }
+    return {
+      ...general,
+      brailleDisplaySize: preset.cells,
+      brailleDisplayLines: preset.lines,
+    };
   }
   const slice = selectBrailleDisplayKind(kind, general.brailleDisplayPresetId);
   return { ...general, ...slice };

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -16,8 +16,6 @@ export type NonEmptyBraillePresets = readonly [
   ...BrailleDisplayPreset[],
 ];
 
-// To add a new device, append a row here or in MULTI_LINE_BRAILLE_PRESETS.
-// Ids must be kebab-case and unique across both lists.
 export const SINGLE_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
   { id: 'focus-14-blue-5g', label: 'Focus 14 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 14, lines: 1 },
   { id: 'focus-40-blue-5g', label: 'Focus 40 Blue (5th Gen)', manufacturer: 'Freedom Scientific', cells: 40, lines: 1 },

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -135,7 +135,11 @@ export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettin
     ? rawKind
     : DEFAULT_BRAILLE_DISPLAY_KIND;
   if (kind === 'manual') {
-    if (general.brailleDisplayKind === 'manual' && general.brailleDisplayPresetId === null) {
+    // Reference-equality fast path: no repair needed when the saved kind
+    // already matched and the preset id was already null. The kind check
+    // is meaningful when rawKind was undefined / invalid and we defaulted
+    // to manual — in that case the field still needs to be written.
+    if (general.brailleDisplayKind === kind && general.brailleDisplayPresetId === null) {
       return general;
     }
     return { ...general, brailleDisplayKind: 'manual', brailleDisplayPresetId: null };

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -45,8 +45,9 @@ export const MULTI_LINE_BRAILLE_PRESETS: NonEmptyBraillePresets = [
   { id: 'dot-pad-x', label: 'Dot Pad X', manufacturer: 'Dot Inc.', cells: 20, lines: 8 },
 ] as const;
 
-export function isBrailleDisplayKind(value: string): value is BrailleDisplayKind {
-  return (BRAILLE_DISPLAY_KINDS as readonly string[]).includes(value);
+export function isBrailleDisplayKind(value: unknown): value is BrailleDisplayKind {
+  return typeof value === 'string'
+    && (BRAILLE_DISPLAY_KINDS as readonly string[]).includes(value);
 }
 
 export function clampBrailleLines(value: number): number {
@@ -121,8 +122,8 @@ export function selectBraillePreset(
 // a single/multi kind, or a missing kind from a pre-feature saved object.
 export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettings {
   const rawKind: unknown = general.brailleDisplayKind;
-  const kind: BrailleDisplayKind = isBrailleDisplayKind(rawKind as string)
-    ? (rawKind as BrailleDisplayKind)
+  const kind: BrailleDisplayKind = isBrailleDisplayKind(rawKind)
+    ? rawKind
     : DEFAULT_BRAILLE_DISPLAY_KIND;
   if (kind === 'manual') {
     return kind === general.brailleDisplayKind

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -51,11 +51,21 @@ export function isBrailleDisplayKind(value: unknown): value is BrailleDisplayKin
 }
 
 export function clampBrailleLines(value: number): number {
-  return Math.min(MAX_BRAILLE_LINES, Math.max(1, Math.floor(value) || 1));
+  const floored = Number.isNaN(value) ? 1 : Math.floor(value);
+  return Math.min(MAX_BRAILLE_LINES, Math.max(1, floored));
 }
 
 export function clampBrailleSize(value: number): number {
-  return Math.min(MAX_BRAILLE_SIZE, Math.max(1, Math.floor(value) || 1));
+  const floored = Number.isNaN(value) ? 1 : Math.floor(value);
+  return Math.min(MAX_BRAILLE_SIZE, Math.max(1, floored));
+}
+
+export function formatSingleLinePreset(p: BrailleDisplayPreset): string {
+  return `${p.label} — ${p.manufacturer} (${p.cells} cells)`;
+}
+
+export function formatMultiLinePreset(p: BrailleDisplayPreset): string {
+  return `${p.label} — ${p.manufacturer} (${p.lines} lines × ${p.cells} cells)`;
 }
 
 export function findBraillePreset(

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -158,6 +158,10 @@ export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettin
     // same guarantee the onBlur and handleSave paths enforce.
     const clampedSize = clampBrailleSize(general.brailleDisplaySize);
     const clampedLines = clampBrailleLines(general.brailleDisplayLines);
+    // Do not delete the `general.brailleDisplayKind === kind` check: when a
+    // pre-feature saved object has rawKind === undefined, kind defaults to
+    // 'manual' but general.brailleDisplayKind is still undefined, so this
+    // line forces the field to actually be written.
     if (
       general.brailleDisplayKind === kind
       && general.brailleDisplayPresetId === null

--- a/src/util/braillePreset.ts
+++ b/src/util/braillePreset.ts
@@ -68,7 +68,6 @@ export function findBraillePreset(
   return presets.find(p => p.id === presetId);
 }
 
-// Manual omits size/lines so spreading the slice preserves prior values.
 export function selectBrailleDisplayKind(
   kind: BrailleDisplayKind,
   currentPresetId: string | null,
@@ -126,9 +125,10 @@ export function normalizeBrailleDisplay(general: GeneralSettings): GeneralSettin
     ? rawKind
     : DEFAULT_BRAILLE_DISPLAY_KIND;
   if (kind === 'manual') {
-    return kind === general.brailleDisplayKind
-      ? general
-      : { ...general, brailleDisplayKind: 'manual', brailleDisplayPresetId: null };
+    if (general.brailleDisplayKind === 'manual' && general.brailleDisplayPresetId === null) {
+      return general;
+    }
+    return { ...general, brailleDisplayKind: 'manual', brailleDisplayPresetId: null };
   }
   const presets = kind === 'single'
     ? SINGLE_LINE_BRAILLE_PRESETS

--- a/test/type/settings.test.ts
+++ b/test/type/settings.test.ts
@@ -100,6 +100,21 @@ describe('selectBrailleDisplayKind', () => {
     expect(slice.brailleDisplaySize).toBeUndefined();
     expect(slice.brailleDisplayLines).toBeUndefined();
   });
+
+  test('spreading manual slice over prior state preserves cells/lines', () => {
+    const prev = {
+      brailleDisplaySize: 40,
+      brailleDisplayLines: 3,
+      brailleDisplayPresetId: 'orbit-slate-340',
+      brailleDisplayKind: 'multi' as const,
+    };
+    const slice = selectBrailleDisplayKind('manual', prev.brailleDisplayPresetId);
+    const next = { ...prev, ...slice };
+    expect(next.brailleDisplayKind).toBe('manual');
+    expect(next.brailleDisplayPresetId).toBeNull();
+    expect(next.brailleDisplaySize).toBe(40);
+    expect(next.brailleDisplayLines).toBe(3);
+  });
 });
 
 describe('selectBraillePreset', () => {

--- a/test/type/settings.test.ts
+++ b/test/type/settings.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  clampBrailleLines,
+  clampBrailleSize,
+  findBraillePreset,
+  MAX_BRAILLE_LINES,
+  MAX_BRAILLE_SIZE,
+  MULTI_LINE_BRAILLE_PRESETS,
+  selectBrailleDisplayKind,
+  selectBraillePreset,
+  SINGLE_LINE_BRAILLE_PRESETS,
+} from '@type/settings';
+
+describe('clampBrailleLines', () => {
+  test('clamps below the minimum to 1', () => {
+    expect(clampBrailleLines(0)).toBe(1);
+    expect(clampBrailleLines(-5)).toBe(1);
+  });
+
+  test('clamps above the maximum to MAX_BRAILLE_LINES', () => {
+    expect(clampBrailleLines(MAX_BRAILLE_LINES + 1)).toBe(MAX_BRAILLE_LINES);
+    expect(clampBrailleLines(9999)).toBe(MAX_BRAILLE_LINES);
+  });
+
+  test('floors fractional values', () => {
+    expect(clampBrailleLines(3.7)).toBe(3);
+  });
+
+  test('coerces NaN to 1', () => {
+    expect(clampBrailleLines(Number.NaN)).toBe(1);
+  });
+});
+
+describe('clampBrailleSize', () => {
+  test('clamps below the minimum to 1', () => {
+    expect(clampBrailleSize(0)).toBe(1);
+    expect(clampBrailleSize(-32)).toBe(1);
+  });
+
+  test('clamps above the maximum to MAX_BRAILLE_SIZE', () => {
+    expect(clampBrailleSize(MAX_BRAILLE_SIZE + 1)).toBe(MAX_BRAILLE_SIZE);
+    expect(clampBrailleSize(100000)).toBe(MAX_BRAILLE_SIZE);
+  });
+
+  test('floors fractional values', () => {
+    expect(clampBrailleSize(40.9)).toBe(40);
+  });
+
+  test('coerces NaN to 1', () => {
+    expect(clampBrailleSize(Number.NaN)).toBe(1);
+  });
+});
+
+describe('findBraillePreset', () => {
+  test('returns undefined for null id', () => {
+    expect(findBraillePreset(SINGLE_LINE_BRAILLE_PRESETS, null)).toBeUndefined();
+  });
+
+  test('returns undefined for unknown id', () => {
+    expect(findBraillePreset(SINGLE_LINE_BRAILLE_PRESETS, 'no-such-id')).toBeUndefined();
+  });
+
+  test('returns the matching preset by id', () => {
+    const preset = findBraillePreset(SINGLE_LINE_BRAILLE_PRESETS, 'mantis-q40');
+    expect(preset?.label).toBe('Mantis Q40');
+    expect(preset?.cells).toBe(40);
+    expect(preset?.lines).toBe(1);
+  });
+});
+
+describe('selectBrailleDisplayKind', () => {
+  test('falls back to first single-line preset when current id is null', () => {
+    const slice = selectBrailleDisplayKind('single', null);
+    expect(slice.brailleDisplayKind).toBe('single');
+    expect(slice.brailleDisplayPresetId).toBe(SINGLE_LINE_BRAILLE_PRESETS[0].id);
+    expect(slice.brailleDisplaySize).toBe(SINGLE_LINE_BRAILLE_PRESETS[0].cells);
+    expect(slice.brailleDisplayLines).toBe(1);
+  });
+
+  test('keeps current single-line preset when it still belongs to the kind', () => {
+    const slice = selectBrailleDisplayKind('single', 'qbraille-xl');
+    expect(slice.brailleDisplayPresetId).toBe('qbraille-xl');
+    expect(slice.brailleDisplaySize).toBe(40);
+    expect(slice.brailleDisplayLines).toBe(1);
+  });
+
+  test('falls back to first multi-line preset when switching from single', () => {
+    // current id belongs to single-line list, so multi-line lookup misses
+    const slice = selectBrailleDisplayKind('multi', 'qbraille-xl');
+    expect(slice.brailleDisplayKind).toBe('multi');
+    expect(slice.brailleDisplayPresetId).toBe(MULTI_LINE_BRAILLE_PRESETS[0].id);
+    expect(slice.brailleDisplaySize).toBe(MULTI_LINE_BRAILLE_PRESETS[0].cells);
+    expect(slice.brailleDisplayLines).toBe(MULTI_LINE_BRAILLE_PRESETS[0].lines);
+  });
+
+  test('clears preset id and leaves cells/lines unset on switch to manual', () => {
+    const slice = selectBrailleDisplayKind('manual', 'qbraille-xl');
+    expect(slice.brailleDisplayKind).toBe('manual');
+    expect(slice.brailleDisplayPresetId).toBeNull();
+    expect(slice.brailleDisplaySize).toBeUndefined();
+    expect(slice.brailleDisplayLines).toBeUndefined();
+  });
+});
+
+describe('selectBraillePreset', () => {
+  test('returns null for an unknown single-line preset id', () => {
+    expect(selectBraillePreset('single', 'no-such-id')).toBeNull();
+  });
+
+  test('returns null for an unknown multi-line preset id', () => {
+    expect(selectBraillePreset('multi', 'no-such-id')).toBeNull();
+  });
+
+  test('returns single-line preset cells and lines', () => {
+    const slice = selectBraillePreset('single', 'focus-14-blue-5g');
+    expect(slice).not.toBeNull();
+    expect(slice!.brailleDisplayKind).toBe('single');
+    expect(slice!.brailleDisplayPresetId).toBe('focus-14-blue-5g');
+    expect(slice!.brailleDisplaySize).toBe(14);
+    expect(slice!.brailleDisplayLines).toBe(1);
+  });
+
+  test('returns multi-line preset cells and lines', () => {
+    const slice = selectBraillePreset('multi', 'monarch');
+    expect(slice).not.toBeNull();
+    expect(slice!.brailleDisplayKind).toBe('multi');
+    expect(slice!.brailleDisplayPresetId).toBe('monarch');
+    expect(slice!.brailleDisplaySize).toBe(32);
+    expect(slice!.brailleDisplayLines).toBe(10);
+  });
+
+  test('rejects a multi-line id when looking up under single', () => {
+    expect(selectBraillePreset('single', 'monarch')).toBeNull();
+  });
+});
+
+describe('preset catalog invariants', () => {
+  test('every single-line preset has lines = 1', () => {
+    for (const preset of SINGLE_LINE_BRAILLE_PRESETS) {
+      expect(preset.lines).toBe(1);
+    }
+  });
+
+  test('every multi-line preset has lines > 1', () => {
+    for (const preset of MULTI_LINE_BRAILLE_PRESETS) {
+      expect(preset.lines).toBeGreaterThan(1);
+    }
+  });
+
+  test('all preset ids are unique across both lists', () => {
+    const ids = [
+      ...SINGLE_LINE_BRAILLE_PRESETS.map(p => p.id),
+      ...MULTI_LINE_BRAILLE_PRESETS.map(p => p.id),
+    ];
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -89,6 +89,9 @@ describe('findBraillePreset', () => {
 describe('selectBrailleDisplayKind', () => {
   test('falls back to first single-line preset when current id is null', () => {
     const slice = selectBrailleDisplayKind('single', null);
+    if (slice.brailleDisplayKind === 'manual') {
+      throw new Error('expected non-manual slice');
+    }
     expect(slice.brailleDisplayKind).toBe('single');
     expect(slice.brailleDisplayPresetId).toBe(SINGLE_LINE_BRAILLE_PRESETS[0].id);
     expect(slice.brailleDisplaySize).toBe(SINGLE_LINE_BRAILLE_PRESETS[0].cells);
@@ -97,6 +100,9 @@ describe('selectBrailleDisplayKind', () => {
 
   test('keeps current single-line preset when it still belongs to the kind', () => {
     const slice = selectBrailleDisplayKind('single', 'qbraille-xl');
+    if (slice.brailleDisplayKind === 'manual') {
+      throw new Error('expected non-manual slice');
+    }
     expect(slice.brailleDisplayPresetId).toBe('qbraille-xl');
     expect(slice.brailleDisplaySize).toBe(40);
     expect(slice.brailleDisplayLines).toBe(1);
@@ -105,6 +111,9 @@ describe('selectBrailleDisplayKind', () => {
   test('falls back to first multi-line preset when switching from single', () => {
     // current id belongs to single-line list, so multi-line lookup misses
     const slice = selectBrailleDisplayKind('multi', 'qbraille-xl');
+    if (slice.brailleDisplayKind === 'manual') {
+      throw new Error('expected non-manual slice');
+    }
     expect(slice.brailleDisplayKind).toBe('multi');
     expect(slice.brailleDisplayPresetId).toBe(MULTI_LINE_BRAILLE_PRESETS[0].id);
     expect(slice.brailleDisplaySize).toBe(MULTI_LINE_BRAILLE_PRESETS[0].cells);
@@ -115,8 +124,10 @@ describe('selectBrailleDisplayKind', () => {
     const slice = selectBrailleDisplayKind('manual', 'qbraille-xl');
     expect(slice.brailleDisplayKind).toBe('manual');
     expect(slice.brailleDisplayPresetId).toBeNull();
-    expect(slice.brailleDisplaySize).toBeUndefined();
-    expect(slice.brailleDisplayLines).toBeUndefined();
+    // Manual variant does not declare size/lines on the slice; spreading
+    // it over prior state preserves the existing values (see next test).
+    expect((slice as Record<string, unknown>).brailleDisplaySize).toBeUndefined();
+    expect((slice as Record<string, unknown>).brailleDisplayLines).toBeUndefined();
   });
 
   test('spreading manual slice over prior state preserves cells/lines', () => {
@@ -146,20 +157,24 @@ describe('selectBraillePreset', () => {
 
   test('returns single-line preset cells and lines', () => {
     const slice = selectBraillePreset('single', 'focus-14-blue-5g');
-    expect(slice).not.toBeNull();
-    expect(slice!.brailleDisplayKind).toBe('single');
-    expect(slice!.brailleDisplayPresetId).toBe('focus-14-blue-5g');
-    expect(slice!.brailleDisplaySize).toBe(14);
-    expect(slice!.brailleDisplayLines).toBe(1);
+    if (!slice || slice.brailleDisplayKind === 'manual') {
+      throw new Error('expected non-manual slice');
+    }
+    expect(slice.brailleDisplayKind).toBe('single');
+    expect(slice.brailleDisplayPresetId).toBe('focus-14-blue-5g');
+    expect(slice.brailleDisplaySize).toBe(14);
+    expect(slice.brailleDisplayLines).toBe(1);
   });
 
   test('returns multi-line preset cells and lines', () => {
     const slice = selectBraillePreset('multi', 'monarch');
-    expect(slice).not.toBeNull();
-    expect(slice!.brailleDisplayKind).toBe('multi');
-    expect(slice!.brailleDisplayPresetId).toBe('monarch');
-    expect(slice!.brailleDisplaySize).toBe(32);
-    expect(slice!.brailleDisplayLines).toBe(10);
+    if (!slice || slice.brailleDisplayKind === 'manual') {
+      throw new Error('expected non-manual slice');
+    }
+    expect(slice.brailleDisplayKind).toBe('multi');
+    expect(slice.brailleDisplayPresetId).toBe('monarch');
+    expect(slice.brailleDisplaySize).toBe(32);
+    expect(slice.brailleDisplayLines).toBe(10);
   });
 
   test('rejects a multi-line id when looking up under single', () => {

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -1,15 +1,33 @@
 import { describe, expect, test } from '@jest/globals';
 import {
-  clampBrailleLines,
-  clampBrailleSize,
-  findBraillePreset,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
   MULTI_LINE_BRAILLE_PRESETS,
-  selectBrailleDisplayKind,
-  selectBraillePreset,
   SINGLE_LINE_BRAILLE_PRESETS,
 } from '@type/settings';
+import {
+  clampBrailleLines,
+  clampBrailleSize,
+  findBraillePreset,
+  isBrailleDisplayKind,
+  selectBrailleDisplayKind,
+  selectBraillePreset,
+} from '@util/braillePreset';
+
+describe('isBrailleDisplayKind', () => {
+  test('accepts the three valid values', () => {
+    expect(isBrailleDisplayKind('single')).toBe(true);
+    expect(isBrailleDisplayKind('multi')).toBe(true);
+    expect(isBrailleDisplayKind('manual')).toBe(true);
+  });
+
+  test('rejects everything else', () => {
+    expect(isBrailleDisplayKind('')).toBe(false);
+    expect(isBrailleDisplayKind('Single')).toBe(false);
+    expect(isBrailleDisplayKind('other')).toBe(false);
+    expect(isBrailleDisplayKind('null')).toBe(false);
+  });
+});
 
 describe('clampBrailleLines', () => {
   test('clamps below the minimum to 1', () => {

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -4,17 +4,17 @@ import {
   DEFAULT_SETTINGS,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
-  MULTI_LINE_BRAILLE_PRESETS,
-  SINGLE_LINE_BRAILLE_PRESETS,
 } from '@type/settings';
 import {
   clampBrailleLines,
   clampBrailleSize,
   findBraillePreset,
   isBrailleDisplayKind,
+  MULTI_LINE_BRAILLE_PRESETS,
   normalizeBrailleDisplay,
   selectBrailleDisplayKind,
   selectBraillePreset,
+  SINGLE_LINE_BRAILLE_PRESETS,
 } from '@util/braillePreset';
 
 describe('isBrailleDisplayKind', () => {

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -1,5 +1,7 @@
+import type { GeneralSettings } from '@type/settings';
 import { describe, expect, test } from '@jest/globals';
 import {
+  DEFAULT_SETTINGS,
   MAX_BRAILLE_LINES,
   MAX_BRAILLE_SIZE,
   MULTI_LINE_BRAILLE_PRESETS,
@@ -10,6 +12,7 @@ import {
   clampBrailleSize,
   findBraillePreset,
   isBrailleDisplayKind,
+  normalizeBrailleDisplay,
   selectBrailleDisplayKind,
   selectBraillePreset,
 } from '@util/braillePreset';
@@ -217,5 +220,57 @@ describe('preset catalog invariants', () => {
       ...MULTI_LINE_BRAILLE_PRESETS.map(p => p.id),
     ];
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('normalizeBrailleDisplay', () => {
+  const baseGeneral = DEFAULT_SETTINGS.general;
+
+  test('returns the same object when manual kind has no preset id', () => {
+    const general: GeneralSettings = { ...baseGeneral, brailleDisplayKind: 'manual', brailleDisplayPresetId: null };
+    expect(normalizeBrailleDisplay(general)).toBe(general);
+  });
+
+  test('returns the same object when single-kind preset id is valid', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'single',
+      brailleDisplayPresetId: 'mantis-q40',
+      brailleDisplaySize: 40,
+      brailleDisplayLines: 1,
+    };
+    expect(normalizeBrailleDisplay(general)).toBe(general);
+  });
+
+  test('snaps to first single-line preset when id is null', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'single',
+      brailleDisplayPresetId: null,
+    };
+    const next = normalizeBrailleDisplay(general);
+    expect(next.brailleDisplayPresetId).toBe(SINGLE_LINE_BRAILLE_PRESETS[0].id);
+    expect(next.brailleDisplaySize).toBe(SINGLE_LINE_BRAILLE_PRESETS[0].cells);
+    expect(next.brailleDisplayLines).toBe(SINGLE_LINE_BRAILLE_PRESETS[0].lines);
+  });
+
+  test('snaps to first multi-line preset when id refers to a removed device', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'multi',
+      brailleDisplayPresetId: 'no-such-device',
+    };
+    const next = normalizeBrailleDisplay(general);
+    expect(next.brailleDisplayPresetId).toBe(MULTI_LINE_BRAILLE_PRESETS[0].id);
+    expect(next.brailleDisplaySize).toBe(MULTI_LINE_BRAILLE_PRESETS[0].cells);
+    expect(next.brailleDisplayLines).toBe(MULTI_LINE_BRAILLE_PRESETS[0].lines);
+  });
+
+  test('falls back to manual when kind is missing from older saved settings', () => {
+    // Simulate a saved object that predates the kind field.
+    const general = { ...baseGeneral, brailleDisplayKind: undefined } as unknown as GeneralSettings;
+    const next = normalizeBrailleDisplay(general);
+    expect(next.brailleDisplayKind).toBe('manual');
+    expect(next.brailleDisplayPresetId).toBeNull();
   });
 });

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -195,6 +195,22 @@ describe('preset catalog invariants', () => {
     }
   });
 
+  test('every preset has cells within [1, MAX_BRAILLE_SIZE]', () => {
+    const all = [...SINGLE_LINE_BRAILLE_PRESETS, ...MULTI_LINE_BRAILLE_PRESETS];
+    for (const preset of all) {
+      expect(preset.cells).toBeGreaterThanOrEqual(1);
+      expect(preset.cells).toBeLessThanOrEqual(MAX_BRAILLE_SIZE);
+    }
+  });
+
+  test('every preset has lines within [1, MAX_BRAILLE_LINES]', () => {
+    const all = [...SINGLE_LINE_BRAILLE_PRESETS, ...MULTI_LINE_BRAILLE_PRESETS];
+    for (const preset of all) {
+      expect(preset.lines).toBeGreaterThanOrEqual(1);
+      expect(preset.lines).toBeLessThanOrEqual(MAX_BRAILLE_LINES);
+    }
+  });
+
   test('all preset ids are unique across both lists', () => {
     const ids = [
       ...SINGLE_LINE_BRAILLE_PRESETS.map(p => p.id),

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -69,9 +69,11 @@ describe('parseManualBrailleInput', () => {
   });
 
   test('passes 0 through editing path; clamp commits to 1', () => {
-    // The editing path intentionally returns 0 so a user can type "10"
-    // by way of "1" → "10" without the leading "0" being rewritten.
-    // The save / blur path lifts it to the [1, MAX] range.
+    // The editing path intentionally returns 0 (no minimum clamp) so a
+    // user typing a leading "0" — for example as the first keystroke of
+    // a longer value like "08" — sees that "0" preserved instead of
+    // jumping to 1. The save / blur path lifts the committed value
+    // back into [1, MAX].
     expect(parseManualBrailleInput('0')).toBe(0);
     expect(parseManualBrailleInput('0', clampBrailleSize)).toBe(1);
   });

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -65,6 +65,14 @@ describe('parseManualBrailleInput', () => {
     expect(parseManualBrailleInput('-5', clampBrailleSize)).toBe(1);
     expect(parseManualBrailleInput('40', clampBrailleSize)).toBe(40);
   });
+
+  test('passes 0 through editing path; clamp commits to 1', () => {
+    // The editing path intentionally returns 0 so a user can type "10"
+    // by way of "1" → "10" without the leading "0" being rewritten.
+    // The save / blur path lifts it to the [1, MAX] range.
+    expect(parseManualBrailleInput('0')).toBe(0);
+    expect(parseManualBrailleInput('0', clampBrailleSize)).toBe(1);
+  });
 });
 
 describe('clampBrailleLines', () => {

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -9,6 +9,8 @@ import {
   clampBrailleLines,
   clampBrailleSize,
   findBraillePreset,
+  formatMultiLinePreset,
+  formatSingleLinePreset,
   isBrailleDisplayKind,
   MULTI_LINE_BRAILLE_PRESETS,
   normalizeBrailleDisplay,
@@ -337,5 +339,58 @@ describe('normalizeBrailleDisplay', () => {
     const next = normalizeBrailleDisplay(general);
     expect(next.brailleDisplayKind).toBe('manual');
     expect(next.brailleDisplayPresetId).toBeNull();
+  });
+
+  test('clamps out-of-range manual brailleDisplaySize on load', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'manual',
+      brailleDisplayPresetId: null,
+      brailleDisplaySize: 9999,
+      brailleDisplayLines: 2,
+    };
+    const next = normalizeBrailleDisplay(general);
+    expect(next.brailleDisplayKind).toBe('manual');
+    expect(next.brailleDisplaySize).toBe(MAX_BRAILLE_SIZE);
+    expect(next.brailleDisplayLines).toBe(2);
+  });
+
+  test('clamps out-of-range manual brailleDisplayLines on load', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'manual',
+      brailleDisplayPresetId: null,
+      brailleDisplaySize: 32,
+      brailleDisplayLines: 0,
+    };
+    const next = normalizeBrailleDisplay(general);
+    expect(next.brailleDisplayKind).toBe('manual');
+    expect(next.brailleDisplaySize).toBe(32);
+    expect(next.brailleDisplayLines).toBe(1);
+  });
+
+  test('preserves reference for already-clean manual settings', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'manual',
+      brailleDisplayPresetId: null,
+      brailleDisplaySize: 40,
+      brailleDisplayLines: 2,
+    };
+    expect(normalizeBrailleDisplay(general)).toBe(general);
+  });
+});
+
+describe('formatSingleLinePreset / formatMultiLinePreset', () => {
+  test('formatSingleLinePreset includes label, manufacturer, and cell count', () => {
+    const preset = SINGLE_LINE_BRAILLE_PRESETS.find(p => p.id === 'mantis-q40')!;
+    expect(formatSingleLinePreset(preset)).toBe('Mantis Q40 — APH / HumanWare (40 cells)');
+  });
+
+  test('formatMultiLinePreset includes lines and cells', () => {
+    const preset = MULTI_LINE_BRAILLE_PRESETS.find(p => p.id === 'canute-360')!;
+    expect(formatMultiLinePreset(preset)).toBe(
+      'Canute 360 — Bristol Braille Technology (9 lines × 40 cells)',
+    );
   });
 });

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -242,6 +242,17 @@ describe('normalizeBrailleDisplay', () => {
     expect(normalizeBrailleDisplay(general)).toBe(general);
   });
 
+  test('returns the same object when multi-kind preset id is valid', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'multi',
+      brailleDisplayPresetId: 'canute-360',
+      brailleDisplaySize: 40,
+      brailleDisplayLines: 9,
+    };
+    expect(normalizeBrailleDisplay(general)).toBe(general);
+  });
+
   test('snaps to first single-line preset when id is null', () => {
     const general: GeneralSettings = {
       ...baseGeneral,

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -12,6 +12,7 @@ import {
   isBrailleDisplayKind,
   MULTI_LINE_BRAILLE_PRESETS,
   normalizeBrailleDisplay,
+  parseManualBrailleInput,
   selectBrailleDisplayKind,
   selectBraillePreset,
   SINGLE_LINE_BRAILLE_PRESETS,
@@ -29,6 +30,40 @@ describe('isBrailleDisplayKind', () => {
     expect(isBrailleDisplayKind('Single')).toBe(false);
     expect(isBrailleDisplayKind('other')).toBe(false);
     expect(isBrailleDisplayKind('null')).toBe(false);
+  });
+
+  test('rejects non-string values', () => {
+    expect(isBrailleDisplayKind(null)).toBe(false);
+    expect(isBrailleDisplayKind(undefined)).toBe(false);
+    expect(isBrailleDisplayKind(42)).toBe(false);
+    expect(isBrailleDisplayKind({})).toBe(false);
+    expect(isBrailleDisplayKind([])).toBe(false);
+  });
+});
+
+describe('parseManualBrailleInput', () => {
+  test('returns null for empty / whitespace-only input', () => {
+    expect(parseManualBrailleInput('')).toBeNull();
+    expect(parseManualBrailleInput('   ')).toBeNull();
+    expect(parseManualBrailleInput('\t\n')).toBeNull();
+  });
+
+  test('returns null for non-finite numeric strings', () => {
+    expect(parseManualBrailleInput('abc')).toBeNull();
+    expect(parseManualBrailleInput('Infinity')).toBeNull();
+    expect(parseManualBrailleInput('NaN')).toBeNull();
+  });
+
+  test('floors integer input without clamping when no clamp is supplied', () => {
+    // Editing path: typing "200" must not snap to MAX mid-keystroke.
+    expect(parseManualBrailleInput('200')).toBe(200);
+    expect(parseManualBrailleInput('5.7')).toBe(5);
+  });
+
+  test('clamps to range when a clamp helper is supplied', () => {
+    expect(parseManualBrailleInput('200', clampBrailleSize)).toBe(MAX_BRAILLE_SIZE);
+    expect(parseManualBrailleInput('-5', clampBrailleSize)).toBe(1);
+    expect(parseManualBrailleInput('40', clampBrailleSize)).toBe(40);
   });
 });
 

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -231,6 +231,17 @@ describe('normalizeBrailleDisplay', () => {
     expect(normalizeBrailleDisplay(general)).toBe(general);
   });
 
+  test('clears stale presetId when kind is already manual', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'manual',
+      brailleDisplayPresetId: 'mantis-q40',
+    };
+    const next = normalizeBrailleDisplay(general);
+    expect(next.brailleDisplayKind).toBe('manual');
+    expect(next.brailleDisplayPresetId).toBeNull();
+  });
+
   test('returns the same object when single-kind preset id is valid', () => {
     const general: GeneralSettings = {
       ...baseGeneral,

--- a/test/util/braillePreset.test.ts
+++ b/test/util/braillePreset.test.ts
@@ -371,6 +371,20 @@ describe('normalizeBrailleDisplay', () => {
     expect(next.brailleDisplayLines).toBe(1);
   });
 
+  test('repairs mismatched cells/lines for a valid preset id', () => {
+    const general: GeneralSettings = {
+      ...baseGeneral,
+      brailleDisplayKind: 'single',
+      brailleDisplayPresetId: 'mantis-q40',
+      brailleDisplaySize: 999,
+      brailleDisplayLines: 7,
+    };
+    const next = normalizeBrailleDisplay(general);
+    expect(next.brailleDisplayPresetId).toBe('mantis-q40');
+    expect(next.brailleDisplaySize).toBe(40);
+    expect(next.brailleDisplayLines).toBe(1);
+  });
+
   test('preserves reference for already-clean manual settings', () => {
     const general: GeneralSettings = {
       ...baseGeneral,


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes made in this pull request. -->
Ask the user to input the braille display in settings dialog.
## Related Issues

<!-- Specify any related issues or tickets that this pull request addresses. -->

## Changes Made

<!-- Describe the specific changes made in this pull request. -->
Earlier, the settings dialog asked for number of lines and number of cells per line of the braille display. This branch introduces options to select the model of the braille display. The user is presented with 3 options: single line, multiline, and configure manually. Each option reveals the next pertinent question.
## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
