### PR TITLE
fix: harden altair adapter pipeline across line, box, count, dodged plots

### DIFF
--- a/examples/vegalite-bindbox-horizontal.html
+++ b/examples/vegalite-bindbox-horizontal.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Vega-Lite Horizontal Box Plot Example</title>
+    <!-- Vega-Lite and its dependencies -->
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+    <!-- MAIDR Vega-Lite adapter (bundles MAIDR core) -->
+    <script src="../dist/vegalite.js"></script>
+  </head>
+  <body>
+    <!--
+      This example validates the horizontal orientation fix for boxplots.
+      When x is quantitative and y is nominal, the converter should set
+      orientation = Orientation.HORIZONTAL so that announcements and
+      DOM pairing are correct.
+    -->
+    <h1>MAIDR + Vega-Lite Horizontal Box Plot</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions.</p>
+    <div
+      id="box-chart-horizontal"
+      aria-label="Horizontal box plot loading"
+      style="min-height: 400px"
+    ></div>
+
+    <script>
+      // Horizontal box plot: x is quantitative (score), y is nominal (group).
+      // This spec should trigger orientation = Orientation.HORIZONTAL in
+      // convertLayerSpec, ensuring correct axis labels in announcements.
+      const spec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        width: 600,
+        height: 400,
+        title: 'Score Distribution by Group (Horizontal)',
+        description: 'Horizontal box plot showing score distributions.',
+        data: {
+          values: [
+            // Group A: tight bulk 60–80 + 2 lower & 2 upper outliers
+            ...Array.from({ length: 28 }, () => ({
+              group: 'A',
+              score: 60 + Math.round(Math.random() * 20),
+            })),
+            { group: 'A', score: 30 },
+            { group: 'A', score: 35 },
+            { group: 'A', score: 95 },
+            { group: 'A', score: 98 },
+            // Group B: tight bulk 65–75 + 1 lower & 2 upper outliers
+            ...Array.from({ length: 28 }, () => ({
+              group: 'B',
+              score: 65 + Math.round(Math.random() * 10),
+            })),
+            { group: 'B', score: 40 },
+            { group: 'B', score: 92 },
+            { group: 'B', score: 96 },
+            // Group C: bulk 50–70 + 2 lower & 1 upper outlier
+            ...Array.from({ length: 28 }, () => ({
+              group: 'C',
+              score: 50 + Math.round(Math.random() * 20),
+            })),
+            { group: 'C', score: 20 },
+            { group: 'C', score: 25 },
+            { group: 'C', score: 100 },
+          ],
+        },
+        mark: { type: 'boxplot', extent: 'min-max' },
+        encoding: {
+          // X is quantitative (the value axis)
+          x: { field: 'score', type: 'quantitative', title: 'Score' },
+          // Y is nominal (the category axis)
+          y: { field: 'group', type: 'nominal', title: 'Group' },
+        },
+      };
+
+      // === MAIDR Integration ===
+      // maidrVegaLite.embed() runs vegaEmbed() internally and mounts the
+      // accessible MAIDR UI on the rendered SVG once it's ready.
+      maidrVegaLite
+        .embed('#box-chart-horizontal', spec, { id: 'scores-box-horizontal' })
+        .catch((err) => console.error('[vegalite-bindbox-horizontal]', err));
+    </script>
+  </body>
+</html>

--- a/examples/vegalite-hconcat-box.html
+++ b/examples/vegalite-hconcat-box.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Vega-Lite Horizontal Concat Box Plot Example</title>
+    <!-- Vega-Lite and its dependencies -->
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+    <!-- MAIDR Vega-Lite adapter (bundles MAIDR core) -->
+    <script src="../dist/vegalite.js"></script>
+  </head>
+  <body>
+    <!--
+      Smoke test for buildConcatMaidr — both panels should be independently
+      navigable with their own data. This validates that multi-panel boxplot
+      specs correctly resolve datasets and avoid data-extraction bleed-over.
+    -->
+    <h1>MAIDR + Vega-Lite Horizontal Concat Box Plots</h1>
+    <p>
+      This example shows two box plots side-by-side using hconcat.
+      Click on each chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions.
+    </p>
+    <div
+      id="concat-box-chart"
+      aria-label="Multi-panel box plot loading"
+      style="min-height: 400px"
+    ></div>
+
+    <script>
+      // Two box plots side-by-side with distinct datasets to detect
+      // data-extraction bleed-over.
+      const spec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        title: 'Side-by-Side Box Plots (hconcat)',
+        description: 'Two independent box plots for smoke testing buildConcatMaidr.',
+        hconcat: [
+          // Left panel: Test Scores by Group (A, B, C)
+          {
+            width: 300,
+            height: 400,
+            title: 'Test Scores',
+            data: {
+              values: [
+                // Group A: 60-80
+                ...Array.from({ length: 20 }, () => ({
+                  group: 'A',
+                  score: 60 + Math.round(Math.random() * 20),
+                })),
+                // Group B: 65-75
+                ...Array.from({ length: 20 }, () => ({
+                  group: 'B',
+                  score: 65 + Math.round(Math.random() * 10),
+                })),
+                // Group C: 50-70
+                ...Array.from({ length: 20 }, () => ({
+                  group: 'C',
+                  score: 50 + Math.round(Math.random() * 20),
+                })),
+              ],
+            },
+            mark: 'boxplot',
+            encoding: {
+              x: { field: 'group', type: 'nominal', title: 'Group' },
+              y: { field: 'score', type: 'quantitative', title: 'Score' },
+            },
+          },
+          // Right panel: Product Ratings by Category (X, Y, Z)
+          {
+            width: 300,
+            height: 400,
+            title: 'Product Ratings',
+            data: {
+              values: [
+                // Category X: 3.5-4.5 stars
+                ...Array.from({ length: 20 }, () => ({
+                  category: 'X',
+                  rating: 3.5 + Math.random(),
+                })),
+                // Category Y: 4.0-5.0 stars
+                ...Array.from({ length: 20 }, () => ({
+                  category: 'Y',
+                  rating: 4.0 + Math.random(),
+                })),
+                // Category Z: 2.5-3.5 stars
+                ...Array.from({ length: 20 }, () => ({
+                  category: 'Z',
+                  rating: 2.5 + Math.random(),
+                })),
+              ],
+            },
+            mark: 'boxplot',
+            encoding: {
+              x: { field: 'category', type: 'nominal', title: 'Category' },
+              y: { field: 'rating', type: 'quantitative', title: 'Rating (stars)' },
+            },
+          },
+        ],
+      };
+
+      // === MAIDR Integration ===
+      // maidrVegaLite.embed() should handle hconcat specs by calling
+      // buildConcatMaidr, which creates a multi-subplot MAIDR schema.
+      maidrVegaLite
+        .embed('#concat-box-chart', spec, { id: 'concat-box-smoke-test' })
+        .catch((err) => console.error('[vegalite-hconcat-box]', err));
+    </script>
+  </body>
+</html>

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -87,9 +87,18 @@ export function vegaLiteToMaidr(
   // Handle layered specs.
   const isLayered = spec.layer != null && spec.layer.length > 0;
   if (isLayered) {
-    const layers = spec.layer!.map((layerSpec, i) =>
+    const rawLayers = spec.layer!.map((layerSpec, i) =>
       convertLayerSpec(layerSpec, i, view, spec.encoding, isLayered, domOrder),
     ).filter(Boolean) as MaidrLayer[];
+
+    // Coalesce sibling LINE layers with matching axes into a single
+    // multi-series LINE layer. This handles the common Altair case where
+    // a multi-series KDE / density plot is compiled into N separate
+    // single-line `layer:` objects (one per group) instead of one layer
+    // with a `color` encoding. Without coalescing, maidr core sees N
+    // independent LINE traces and the user can only navigate within one
+    // series at a time.
+    const layers = coalesceSiblingLineLayers(rawLayers);
 
     return buildMaidr(id, title, subtitle, caption, [[{ layers }]]);
   }
@@ -100,6 +109,102 @@ export function vegaLiteToMaidr(
     return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
   }
   return buildMaidr(id, title, subtitle, caption, [[{ layers: [layer] }]]);
+}
+
+/**
+ * Merge runs of consecutive LINE layers whose axes describe the same
+ * coordinate space (matching x and y labels) into a single multi-series
+ * LINE layer.
+ *
+ * Why: Altair compiles `transform_density` + multi-group encodings into
+ * separate `layer:` objects — one mark per group — instead of using a
+ * `color` encoding. The downstream maidr LineTrace expects a 2D
+ * `LinePoint[][]` (one inner array per series); leaving each group as
+ * its own layer makes navigation jump between traces and breaks the
+ * single-plot mental model.
+ *
+ * Layers that don't satisfy the merge predicate (different mark types,
+ * different axes, only one in the run) pass through unchanged. SCATTER +
+ * LINE pairs (linreplot) are NOT collapsed because the SCATTER mark is
+ * not LINE-typed and the predicate skips it.
+ */
+function coalesceSiblingLineLayers(layers: MaidrLayer[]): MaidrLayer[] {
+  if (layers.length < 2)
+    return layers;
+
+  const out: MaidrLayer[] = [];
+  let i = 0;
+
+  while (i < layers.length) {
+    const current = layers[i];
+
+    if (current.type !== TraceType.LINE) {
+      out.push(current);
+      i += 1;
+      continue;
+    }
+
+    // Walk forward gathering consecutive LINE layers whose axes match.
+    const run: MaidrLayer[] = [current];
+    let j = i + 1;
+    while (j < layers.length && layers[j].type === TraceType.LINE
+      && axesAreCompatible(current.axes, layers[j].axes)) {
+      run.push(layers[j]);
+      j += 1;
+    }
+
+    if (run.length === 1) {
+      out.push(current);
+    } else {
+      out.push(mergeLineLayers(run));
+    }
+    i = j;
+  }
+
+  return out;
+}
+
+function axesAreCompatible(
+  a: MaidrLayer['axes'] | undefined,
+  b: MaidrLayer['axes'] | undefined,
+): boolean {
+  if (!a || !b)
+    return false;
+  const ax = a.x?.label;
+  const ay = a.y?.label;
+  const bx = b.x?.label;
+  const by = b.y?.label;
+  return ax === bx && ay === by;
+}
+
+function mergeLineLayers(run: MaidrLayer[]): MaidrLayer {
+  // Each input layer's `data` is already `LinePoint[][]` with exactly
+  // one inner series (because per-layer single-line extraction returns
+  // `[pts]`). Flatten by concatenating those inner arrays so the merged
+  // layer ends up as `[layer0_series, layer1_series, ...]`.
+  const mergedData: LinePoint[][] = [];
+  const mergedSelectors: string[] = [];
+
+  for (const layer of run) {
+    if (Array.isArray(layer.data)) {
+      for (const series of layer.data as LinePoint[][]) {
+        mergedData.push(series);
+      }
+    }
+    if (Array.isArray(layer.selectors)) {
+      for (const sel of layer.selectors as string[]) {
+        mergedSelectors.push(sel);
+      }
+    } else if (typeof layer.selectors === 'string') {
+      mergedSelectors.push(layer.selectors);
+    }
+  }
+
+  return {
+    ...run[0],
+    selectors: mergedSelectors,
+    data: mergedData,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -360,16 +465,21 @@ function extractBarData(
   // alphabetises nominal axes by default); we re-sort the actual SVG
   // children in the bind step so querySelectorAll order matches what
   // the user sees, keeping highlight indices aligned with data indices.
+  //
+  // Vega-Lite emits a synthetic `__count` field whenever the channel uses
+  // `aggregate: 'count'` without an explicit `field`. extractHistogramData
+  // already handles this on its yVal lookup; the same fallback is needed
+  // here for count-only bar plots.
   return rows.map((row) => {
     if (xIsQuantitative && !yIsQuantitative) {
       return {
-        x: Number(row[xField] ?? 0),
+        x: Number((row as Record<string, unknown>).__count ?? row[xField] ?? 0),
         y: String(row[yField] ?? ''),
       };
     }
     return {
       x: String(row[xField] ?? ''),
-      y: Number(row[yField] ?? 0),
+      y: Number((row as Record<string, unknown>).__count ?? row[yField] ?? 0),
     };
   });
 }
@@ -426,12 +536,16 @@ function extractSegmentedData(
   // — `{ order: 'row' }` for stacked/normalised (series-major DOM)
   // or `{ order: 'column', groupDirection: 'forward' }` for dodged
   // (subject-major DOM).
+  //
+  // Vega-Lite emits a synthetic `__count` field whenever the channel uses
+  // `aggregate: 'count'` without an explicit `field`. The same fallback
+  // is required here as in extractBarData / extractHistogramData.
   const groups = new Map<string, SegmentedPoint[]>();
   for (const row of rows) {
     const fill = String(row[colorField] ?? '');
     const pt: SegmentedPoint = {
       x: String(row[xField] ?? ''),
-      y: Number(row[yField] ?? 0),
+      y: Number((row as Record<string, unknown>).__count ?? row[yField] ?? 0),
       z: fill,
     };
     if (!groups.has(fill))
@@ -534,7 +648,13 @@ function extractBoxData(
   rows: Record<string, unknown>[],
   encoding: VegaLiteEncoding,
 ): BoxPoint[] {
-  const catField = encoding.x?.field ?? encoding.y?.field ?? 'x';
+  // Mirror the valField pattern: catField is the NON-quantitative field so
+  // horizontal boxplots (x=quant, y=nominal) group by y, not x. Without
+  // this, horizontal Iris boxplots group by 43 unique petalLength values
+  // instead of 3 species, which causes BOX BUILD count-mismatch SKIP.
+  const catField = encoding.x?.type === 'quantitative'
+    ? (encoding.y?.field ?? 'y')
+    : (encoding.x?.field ?? 'x');
   const valField = encoding.x?.type === 'quantitative'
     ? (encoding.x?.field ?? 'x')
     : (encoding.y?.field ?? 'y');
@@ -552,19 +672,69 @@ function extractBoxData(
   // dataset. We keep that order so highlight indices match the SVG
   // group order.
   if (hasPrecomputed) {
-    return rows.map((row) => {
+    // Vega-Lite's joinaggregate transform produces a denormalized dataset:
+    // each raw row carries both its original value AND the replicated box
+    // stats for its category group. Deduplicate by category, and extract
+    // outliers from raw values that fall outside the whisker bounds.
+    interface BoxAccumulator {
+      stats: { min: number; q1: number; q2: number; q3: number; max: number };
+      lowerOutliers: number[];
+      upperOutliers: number[];
+    }
+    const groups = new Map<string, BoxAccumulator>();
+
+    for (const row of rows) {
       const fill = String(row[catField] ?? '');
-      return {
+
+      // Pre-computed stats (identical for every row in this category).
+      const min = Number(row[lowerWhiskerKey] ?? row[lowerBoxKey] ?? 0);
+      const q1 = Number(row[lowerBoxKey] ?? 0);
+      const q2 = Number(row[midBoxKey] ?? 0);
+      const q3 = Number(row[upperBoxKey] ?? 0);
+      const max = Number(row[upperWhiskerKey] ?? row[upperBoxKey] ?? 0);
+
+      if (!groups.has(fill)) {
+        groups.set(fill, {
+          stats: { min, q1, q2, q3, max },
+          lowerOutliers: [],
+          upperOutliers: [],
+        });
+      }
+
+      // Outlier classification: the raw quantitative value coexists with
+      // the aggregated stats in the denormalized dataset. If the field is
+      // absent (genuinely pre-aggregated dataset with no raw rows),
+      // outliers stay empty — that is the correct behaviour because such
+      // datasets do not carry individual outlier observations.
+      const rawValue = row[valField];
+      if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+        const g = groups.get(fill)!;
+        if (rawValue < g.stats.min) {
+          g.lowerOutliers.push(rawValue);
+        } else if (rawValue > g.stats.max) {
+          g.upperOutliers.push(rawValue);
+        }
+      }
+    }
+
+    // Preserve first-seen category order. Sort outliers ascending per
+    // BoxPoint consumer contract.
+    const result: BoxPoint[] = [];
+    for (const [fill, g] of groups) {
+      g.lowerOutliers.sort((a, b) => a - b);
+      g.upperOutliers.sort((a, b) => a - b);
+      result.push({
         z: fill,
-        lowerOutliers: [],
-        min: Number(row[lowerWhiskerKey] ?? row[lowerBoxKey] ?? 0),
-        q1: Number(row[lowerBoxKey] ?? 0),
-        q2: Number(row[midBoxKey] ?? 0),
-        q3: Number(row[upperBoxKey] ?? 0),
-        max: Number(row[upperWhiskerKey] ?? row[upperBoxKey] ?? 0),
-        upperOutliers: [],
-      };
-    });
+        lowerOutliers: g.lowerOutliers,
+        min: g.stats.min,
+        q1: g.stats.q1,
+        q2: g.stats.q2,
+        q3: g.stats.q3,
+        max: g.stats.max,
+        upperOutliers: g.upperOutliers,
+      });
+    }
+    return result;
   }
 
   // Fall back to computing from raw values.
@@ -641,6 +811,7 @@ function convertLayerSpec(
   };
 
   const traceType = resolveTraceType(mark, encoding);
+
   if (!traceType)
     return null;
 
@@ -708,10 +879,27 @@ function convertLayerSpec(
       data = extractHeatmapData(rows, encoding);
       selectors = buildSelector(mark, index, layered);
       break;
-    case TraceType.BOX:
+    case TraceType.BOX: {
       data = extractBoxData(rows, encoding);
       selectors = buildSelector(mark, index, layered);
+      // Vega-Lite boxplot orientation is implicit from encoding type:
+      // x=quantitative + y=nominal/ordinal => HORIZONTAL.
+      // Mirrors the BAR detection at lines 748-754. maidr core needs the
+      // `orientation` field on the layer to (a) interpret axes labels
+      // correctly (category axis vs value axis) and (b) switch arrow-key
+      // navigation to within-quartile (up/down for horz, left/right for
+      // vert). Without this, horizontal boxplots default to vertical-mode
+      // navigation (species-to-species) and the screen reader confuses
+      // the x and y labels.
+      const xIsQuant = encoding.x?.type === 'quantitative'
+        || encoding.x?.aggregate != null;
+      const yIsQuant = encoding.y?.type === 'quantitative'
+        || encoding.y?.aggregate != null;
+      if (xIsQuant && !yIsQuant) {
+        orientation = Orientation.HORIZONTAL;
+      }
       break;
+    }
     default:
       return null;
   }

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -470,16 +470,22 @@ function extractBarData(
   // `aggregate: 'count'` without an explicit `field`. extractHistogramData
   // already handles this on its yVal lookup; the same fallback is needed
   // here for count-only bar plots.
+  //
+  // Lookup order: explicit field FIRST, `__count` only as fallback. If the
+  // user supplies an explicit field, that field is the source of truth even
+  // when Vega happens to also denormalise `__count` onto the row (e.g. via
+  // a joinaggregate transform). `__count` is consulted only when the named
+  // field is absent or nullish, which is exactly the count-aggregate case.
   return rows.map((row) => {
     if (xIsQuantitative && !yIsQuantitative) {
       return {
-        x: Number((row as Record<string, unknown>).__count ?? row[xField] ?? 0),
+        x: Number(row[xField] ?? (row as Record<string, unknown>).__count ?? 0),
         y: String(row[yField] ?? ''),
       };
     }
     return {
       x: String(row[xField] ?? ''),
-      y: Number((row as Record<string, unknown>).__count ?? row[yField] ?? 0),
+      y: Number(row[yField] ?? (row as Record<string, unknown>).__count ?? 0),
     };
   });
 }
@@ -508,7 +514,9 @@ function extractHistogramData(
   return rows.map((row) => {
     const xMin = Number((binStart ? row[binStart] : undefined) ?? row[xField] ?? 0);
     const xMax = Number((binEnd ? row[binEnd] : undefined) ?? xMin + 1);
-    const yVal = Number(row.__count ?? row[yField] ?? 0);
+    // Lookup order: explicit field FIRST, `__count` only as fallback. See
+    // the matching note in `extractBarData` for why explicit fields win.
+    const yVal = Number(row[yField] ?? row.__count ?? 0);
 
     return {
       x: `${xMin}-${xMax}`,
@@ -540,12 +548,15 @@ function extractSegmentedData(
   // Vega-Lite emits a synthetic `__count` field whenever the channel uses
   // `aggregate: 'count'` without an explicit `field`. The same fallback
   // is required here as in extractBarData / extractHistogramData.
+  //
+  // Lookup order: explicit field FIRST, `__count` only as fallback. See
+  // the matching note in `extractBarData` for why explicit fields win.
   const groups = new Map<string, SegmentedPoint[]>();
   for (const row of rows) {
     const fill = String(row[colorField] ?? '');
     const pt: SegmentedPoint = {
       x: String(row[xField] ?? ''),
-      y: Number((row as Record<string, unknown>).__count ?? row[yField] ?? 0),
+      y: Number(row[yField] ?? (row as Record<string, unknown>).__count ?? 0),
       z: fill,
     };
     if (!groups.has(fill))

--- a/src/adapters/vegalite/selectors.ts
+++ b/src/adapters/vegalite/selectors.ts
@@ -49,6 +49,14 @@ export function markToCssClass(mark: string): string {
  *
  * Used for marks where each datum produces one DOM element
  * (bar, scatter, heatmap, box, histogram).
+ *
+ * Emits a CSS comma-selector covering BOTH the single-view (`.marks`)
+ * and the layered (`.layer_N_marks`) DOM patterns. Vega-Lite expands
+ * mark sugar (`mark.point: true` on lines, `mark.line: true` on areas,
+ * etc.) into additional Vega layers at render time, so even a spec
+ * with a single user-visible mark may produce a `.layer_0_marks`
+ * group instead of `.marks`. Trying both patterns in the same
+ * selector avoids having to detect each Vega expansion in the converter.
  */
 export function buildSelector(
   mark: string,
@@ -57,16 +65,48 @@ export function buildSelector(
 ): string {
   const cssClass = markToCssClass(mark);
   const childElement = mark === 'tick' ? 'line' : 'path';
-  const marksClass = isLayered ? `layer_${layerIndex}_marks` : 'marks';
-  return `g.${cssClass}.role-mark.${marksClass} ${childElement}`;
+  const layeredClass = `layer_${layerIndex}_marks`;
+  if (isLayered) {
+    // Layered specs always render as `.layer_N_marks`; no fallback needed.
+    return `g.${cssClass}.role-mark.${layeredClass} ${childElement}`;
+  }
+  // Single-view specs *usually* render as `.marks`, but Vega may emit
+  // `.layer_0_marks` when mark sugar (e.g. `mark.point: true`) expands
+  // into siblings. Cover both.
+  return (
+    `g.${cssClass}.role-mark.marks ${childElement}, `
+    + `g.${cssClass}.role-mark.${layeredClass} ${childElement}`
+  );
 }
 
 /**
  * Build per-series CSS selectors for line and area charts.
  *
- * Vega renders one `path` per series within the marks group, in the
- * order the series appear in the compiled data, so we use `:nth-child`
- * to address each series individually.
+ * Vega's render shape depends on whether multi-series come from a
+ * user-authored layered spec (`alt.layer(...)` / `c1 + c2`) or from a
+ * single mark with a `color` encoding (Vega's typical multi-series case):
+ *
+ *   - **Layered spec**: each series lives in its own `.layer_N_marks`
+ *     class, e.g. `.layer_0_marks`, `.layer_1_marks`. Per-series
+ *     addressing is by class.
+ *
+ *   - **Color-encoded multi-series in one mark**: Vega emits N sibling
+ *     `<g class="mark-line role-mark layer_0_marks">` groups (NOT
+ *     `.marks`), each containing exactly one `<path>`. All groups share
+ *     the same class chain, so CSS `:nth-child(N)` cannot distinguish
+ *     them and `:nth-of-type(N)` would also count unrelated `<g>`
+ *     siblings (axes, legend). Per-series addressing must be done at
+ *     the JS layer by indexing `querySelectorAll(...)` results in
+ *     document order.
+ *
+ *   - **Single-series**: one `<path>` in either `.marks` or
+ *     `.layer_0_marks` depending on whether mark sugar (`mark.point: true`,
+ *     `mark.line: true`) caused Vega to expand into siblings.
+ *
+ * For ALL non-layered cases, this function emits N copies of the same
+ * selector matching every line `<path>` under any line-mark group; the
+ * caller (`LineTrace.mapViaPathParsing`) is expected to resolve the Nth
+ * series via document-order indexing (`Svg.selectNthElement(sel, r)`).
  */
 export function buildLineSelectors(
   mark: string,
@@ -75,10 +115,29 @@ export function buildLineSelectors(
   isLayered: boolean,
 ): string[] {
   const cssClass = markToCssClass(mark);
-  const marksClass = isLayered ? `layer_${layerIndex}_marks` : 'marks';
+  const layeredClass = `layer_${layerIndex}_marks`;
   const selectors: string[] = [];
   for (let i = 0; i < seriesCount; i++) {
-    selectors.push(`g.${cssClass}.role-mark.${marksClass} path:nth-child(${i + 1})`);
+    if (isLayered) {
+      // Layered specs put each user-visible layer in its own class.
+      // Each layer typically has one `<path>` so first-of-type is fine;
+      // when the layer itself contains color-encoded multi-series, the
+      // caller's selectNthElement(sel, r) indexing still resolves them.
+      selectors.push(`g.${cssClass}.role-mark.${layeredClass} > path`);
+    } else {
+      // Cover both DOM patterns Vega uses for a non-layered single mark:
+      //   - `.marks` (single-series simple line)
+      //   - `.layer_0_marks` (sugar-expanded sibling group, OR each of
+      //     N sibling groups for color-encoded multi-series)
+      // No `:nth-child(N)`: when the chart has N color-encoded series,
+      // Vega creates N sibling groups each with exactly one `<path>`,
+      // so `:nth-child(2)` etc. never match. The caller picks the rth
+      // match in document order via Svg.selectNthElement.
+      selectors.push(
+        `g.${cssClass}.role-mark.marks > path, `
+        + `g.${cssClass}.role-mark.${layeredClass} > path`,
+      );
+    }
   }
   return selectors;
 }

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -528,7 +528,7 @@ export class LineTrace extends AbstractTrace {
     for (let r = 0; r < selectors.length; r++) {
       const lineElement = uniqueSelectors
         ? Svg.selectElement(selectors[r], false)
-        : Svg.selectNthElement(selectors[0], r, false);
+        : Svg.selectNthElement(selectors[0], r);
       if (!lineElement) {
         svgElements.push([]);
         continue;

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -477,7 +477,18 @@ export class LineTrace extends AbstractTrace {
     let allFailed = true;
 
     for (let r = 0; r < selectors.length; r++) {
-      const elements = Svg.selectAllElements(selectors[r]);
+      // Pass shouldClone=false so we DON'T mutate the DOM by inserting a
+      // hidden clone after every match. Inserting a clone shifts
+      // :nth-child(N) indices for subsequent iterations: a multi-series
+      // line chart with sibling <path> elements in the same <g> ends up
+      // with iteration r=1 matching the clone of path0 (instead of path1)
+      // and r=2 matching the clone of clone of path0, etc. The downstream
+      // mapViaPathParsing then reads series 0's `d` for every series, so
+      // all highlights collapse onto series 0 even though navigation
+      // announcement (which uses lineValues, not the DOM) is correct.
+      // Highlighting always re-clones via Svg.createHighlightElement, so
+      // we don't need the pre-cloned hidden elements.
+      const elements = Svg.selectAllElements(selectors[r], false);
       if (elements.length === 0 || elements.length !== this.lineValues[r].length) {
         svgElements.push([]);
         continue;
@@ -500,8 +511,24 @@ export class LineTrace extends AbstractTrace {
     const svgElements: SVGElement[][] = [];
     let allFailed = true;
 
+    // Detect selector layout:
+    //   - Standard case (e.g. matplotlib/seaborn multi-line): each series has
+    //     a UNIQUE selector that resolves to exactly one <path> (e.g.
+    //     "g[id='maidr-<uuid-A>'] path", "g[id='maidr-<uuid-B>'] path", ...).
+    //   - Color-hue case (e.g. Vega-Lite single mark with a color encoding):
+    //     all entries in `selectors` are IDENTICAL — Vega renders N sibling
+    //     `<g class="mark-line role-mark layer_0_marks">` groups, each with
+    //     exactly one `<path>`, so a single shared selector matches all N.
+    // For the standard case, selectNthElement(selectors[r], r) would ask for
+    // the r-th match of a selector that has only 1 match, returning null for
+    // r >= 1 and crashing the highlight pipeline downstream. So branch on
+    // selector uniqueness.
+    const uniqueSelectors = new Set(selectors).size === selectors.length;
+
     for (let r = 0; r < selectors.length; r++) {
-      const lineElement = Svg.selectElement(selectors[r], false);
+      const lineElement = uniqueSelectors
+        ? Svg.selectElement(selectors[r], false)
+        : Svg.selectNthElement(selectors[0], r, false);
       if (!lineElement) {
         svgElements.push([]);
         continue;

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -108,6 +108,35 @@ export abstract class Svg {
   }
 
   /**
+   * Select the Nth element matching a query, in document order.
+   *
+   * Useful when a single CSS selector matches multiple sibling elements
+   * (e.g. multi-series Vega-Lite line charts where each series renders as
+   * a separate `<g class="mark-line role-mark layer_0_marks">` group, all
+   * with the same class). CSS `:nth-child(N)` cannot address the Nth
+   * matching group when classes differ; this helper does it via JS.
+   *
+   * Always returns the live DOM element (no cloning side-effects).
+   *
+   * @template T - The type of SVG element to select
+   * @param query - CSS selector string
+   * @param n - Zero-based index into the query results
+   * @param shouldClone - Reserved for API parity with selectElement; always
+   *   treated as false because the indexed-selection use case is for
+   *   resolving live DOM elements that the caller will pass downstream.
+   * @returns The Nth matching element, or null if no Nth match exists
+   */
+  public static selectNthElement<T extends SVGElement>(
+    query: string,
+    n: number,
+    shouldClone: boolean = false,
+  ): T | null {
+    void shouldClone;
+    const all = document.querySelectorAll<T>(query);
+    return all[n] ?? null;
+  }
+
+  /**
    * Creates an empty, hidden, transparent SVG element of the specified type.
    * @param type - The SVG element type to create (default: 'rect')
    * @returns The newly created SVG element

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -116,22 +116,19 @@ export abstract class Svg {
    * with the same class). CSS `:nth-child(N)` cannot address the Nth
    * matching group when classes differ; this helper does it via JS.
    *
-   * Always returns the live DOM element (no cloning side-effects).
+   * Always returns the live DOM element (no cloning side-effects), since
+   * the indexed-selection use case is for resolving live DOM nodes that
+   * downstream code (highlight pipeline, etc.) operates on directly.
    *
    * @template T - The type of SVG element to select
    * @param query - CSS selector string
    * @param n - Zero-based index into the query results
-   * @param shouldClone - Reserved for API parity with selectElement; always
-   *   treated as false because the indexed-selection use case is for
-   *   resolving live DOM elements that the caller will pass downstream.
    * @returns The Nth matching element, or null if no Nth match exists
    */
   public static selectNthElement<T extends SVGElement>(
     query: string,
     n: number,
-    shouldClone: boolean = false,
   ): T | null {
-    void shouldClone;
     const all = document.querySelectorAll<T>(query);
     return all[n] ?? null;
   }

--- a/src/vegalite-entry.ts
+++ b/src/vegalite-entry.ts
@@ -468,6 +468,156 @@ function reorderSegmentedSeriesByVisualBottom(
 }
 
 /**
+ * For each DODGED layer, ensure that **`data[0]` is the visually
+ * left-most series** (the subgroup whose bars are drawn at the smallest
+ * x-coordinate within each x-category). Mirrors
+ * {@link reorderSegmentedSeriesByVisualBottom} but applies a horizontal
+ * (leftmost-first) sort instead of a vertical (bottom-first) sort,
+ * because DODGED bars are side-by-side rather than stacked.
+ *
+ * Why this is needed: Vega-Lite's `xOffset` encoding draws subgroups
+ * left-to-right by xOffset scale-domain order, but the dataset row
+ * order driving `extractSegmentedData`'s grouping is independent of
+ * that scale order — so without re-sorting, MAIDR's row=0 navigation
+ * lands on whichever fill value happens to appear first in the data
+ * rows, not the leftmost-rendered series.
+ *
+ * Subject-major DOM (`order: 'column'`, the default for DODGED): the
+ * first N DOM elements correspond to the first x-category, one per
+ * series, in series-emission order. We pick the leftmost of those.
+ *
+ * Series-major DOM (`order: 'row'`): each series occupies a contiguous
+ * block of size categoryCount; we sample element[s * categoryCount] to
+ * get each series' first-category bar.
+ */
+function reorderDodgedBarsByVisualPosition(
+  svg: SVGSVGElement,
+  layers: MaidrLayer[],
+): void {
+  // Wrap entire body in try/catch so a runtime exception here cannot
+  // abort the rest of the visual-order pipeline (which includes
+  // buildBoxPlotSelectorsFromDom). The catch logs an error so a real
+  // failure surfaces in the console without breaking subsequent steps.
+  try {
+    for (const layer of layers) {
+      if (layer.type !== TraceType.DODGED) {
+        continue;
+      }
+      if (typeof layer.selectors !== 'string') {
+        continue;
+      }
+      if (!Array.isArray(layer.data) || layer.data.length < 2) {
+        continue;
+      }
+
+      const data = layer.data as Array<Array<{ z?: string }>>;
+      const seriesCount = data.length;
+      const categoryCount = data[0]?.length ?? 0;
+      if (categoryCount === 0) {
+        continue;
+      }
+
+      const elements = Array.from(
+        svg.querySelectorAll<SVGGraphicsElement>(layer.selectors),
+      );
+      if (elements.length !== seriesCount * categoryCount) {
+        continue;
+      }
+
+      if (!isLaidOutForSort(elements[0])) {
+        debugLog(`dodged layer "${layer.id}": skipping leftmost reorder (chart not laid out)`);
+        continue;
+      }
+
+      // Resolve the indices of the elements that belong to the FIRST
+      // x-category. Their bounding boxes tell us which series sits at
+      // the visual left of that category.
+      const order = layer.domMapping?.order ?? 'column';
+      const firstCatDomIndices: number[] = [];
+      if (order === 'column') {
+      // subject-major: first N elements are the first category.
+        for (let s = 0; s < seriesCount; s++) {
+          firstCatDomIndices.push(s);
+        }
+      } else {
+      // series-major: each series occupies a contiguous block of size
+      // categoryCount; the first category is at the start of each block.
+        for (let s = 0; s < seriesCount; s++) {
+          firstCatDomIndices.push(s * categoryCount);
+        }
+      }
+
+      // Sort series by visual x of their first-category bar (ascending).
+      // Stable sort preserves relative order for equal-x cases.
+      const seriesByLeftX = firstCatDomIndices
+        .map((domIdx, dataDomSeries) => ({
+          dataDomSeries,
+          x: elements[domIdx].getBoundingClientRect().x,
+        }))
+        .sort((a, b) => a.x - b.x);
+
+      const newOrder = seriesByLeftX.map(s => s.dataDomSeries);
+
+      // No-op when already left-to-right.
+      const alreadyOrdered = newOrder.every((s, i) => s === i);
+      if (alreadyOrdered) {
+        debugLog(`dodged layer "${layer.id}": series already in left-to-right order`);
+        continue;
+      }
+
+      debugLog(
+        `dodged layer "${layer.id}": re-sorting ${seriesCount} series by `
+        + `visual leftmost x within first category`,
+      );
+
+      // 1. Reorder `data` so series 0 is the leftmost-most.
+      const newData = newOrder.map(s => data[s]);
+      layer.data = newData as MaidrLayer['data'];
+
+      // 2. Reorder DOM elements *within each x-category* so that the
+      //    layout assumed by `domMapping` still holds.
+      const newElements: SVGGraphicsElement[] = [];
+      if (order === 'column') {
+        for (let c = 0; c < categoryCount; c++) {
+          for (const s of newOrder) {
+            newElements.push(elements[c * seriesCount + s]);
+          }
+        }
+      } else {
+        for (const s of newOrder) {
+          for (let c = 0; c < categoryCount; c++) {
+            newElements.push(elements[s * categoryCount + c]);
+          }
+        }
+      }
+
+      // Re-append nodes in `newElements` order, grouped by parent so we
+      // don't disturb cross-group ordering.
+      const byParent = new Map<Element, SVGGraphicsElement[]>();
+      for (const el of newElements) {
+        const parent = el.parentElement;
+        if (!parent) {
+          continue;
+        }
+        const arr = byParent.get(parent);
+        if (arr) {
+          arr.push(el);
+        } else {
+          byParent.set(parent, [el]);
+        }
+      }
+      for (const [parent, group] of byParent) {
+        for (const el of group) {
+          parent.appendChild(el);
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[maidr/vegalite] dodged reorder failed:', err);
+  }
+}
+
+/**
  * For HISTOGRAM layers, pair each data bin with its corresponding DOM
  * element and sort by visual x-position (or y for horizontal). This
  * mirrors {@link sortSimpleBarsByVisualOrder} but applies to histograms
@@ -1450,6 +1600,13 @@ export function bindVegaLite(
   // `applySegmentedDomMappings` because we rely on its `domMapping`
   // output to know how DOM elements are grouped per category.
   reorderSegmentedSeriesByVisualBottom(svg as SVGSVGElement, layers);
+
+  // For DODGED layers, ensure series 0 in `data` is the visually
+  // leftmost subgroup so initial focus (row=0) lands on the leftmost
+  // bar of the first x-category, matching sighted-user expectations
+  // ("first" = leftmost). Must run AFTER `applySegmentedDomMappings`
+  // for the same reason as the segmented bottom-reorder above.
+  reorderDodgedBarsByVisualPosition(svg as SVGSVGElement, layers);
 
   // For HISTOGRAM layers, pair data bins with DOM elements and sort by
   // visual position so `data[i]` lines up with the i-th left-to-right

--- a/test/adapters/vegalite/converters.test.ts
+++ b/test/adapters/vegalite/converters.test.ts
@@ -1,0 +1,412 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { BoxPoint } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { Orientation, TraceType } from '@type/grammar';
+
+describe('vega-Lite converters', () => {
+  describe('boxplot orientation detection', () => {
+    it('sets orientation HORIZONTAL when x is quantitative and y is nominal', () => {
+      // Horizontal boxplot: x is the value axis (quantitative), y is the category axis (nominal)
+      const spec: VegaLiteSpec = {
+        mark: 'boxplot',
+        data: {
+          values: [
+            { group: 'A', value: 10 },
+            { group: 'A', value: 20 },
+            { group: 'A', value: 30 },
+            { group: 'B', value: 15 },
+            { group: 'B', value: 25 },
+            { group: 'B', value: 35 },
+          ],
+        },
+        encoding: {
+          x: { field: 'value', type: 'quantitative' },
+          y: { field: 'group', type: 'nominal' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      const layer = result.subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.BOX);
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    });
+
+    it('leaves orientation undefined for vertical boxplot (x nominal, y quantitative)', () => {
+      // Vertical boxplot: x is the category axis (nominal), y is the value axis (quantitative)
+      const spec: VegaLiteSpec = {
+        mark: 'boxplot',
+        data: {
+          values: [
+            { group: 'A', value: 10 },
+            { group: 'A', value: 20 },
+            { group: 'A', value: 30 },
+            { group: 'B', value: 15 },
+            { group: 'B', value: 25 },
+            { group: 'B', value: 35 },
+          ],
+        },
+        encoding: {
+          x: { field: 'group', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      const layer = result.subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.BOX);
+      // Vertical is the default — orientation should be undefined (or VERTICAL if explicitly set)
+      // The BAR case leaves it undefined for vertical, so BOX should match that pattern
+      expect(layer.orientation).toBeUndefined();
+    });
+
+    it('detects horizontal orientation when x has aggregate', () => {
+      // Test that aggregate on x also triggers horizontal orientation
+      const spec: VegaLiteSpec = {
+        mark: 'boxplot',
+        data: {
+          values: [
+            { group: 'A', value: 10 },
+            { group: 'A', value: 20 },
+          ],
+        },
+        encoding: {
+          x: { field: 'value', type: 'quantitative', aggregate: 'mean' },
+          y: { field: 'group', type: 'nominal' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      const layer = result.subplots[0][0].layers[0];
+
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    });
+  });
+
+  describe('extractBoxData', () => {
+    it('returns expected quartiles for simple dataset', () => {
+      // Test boxplot data extraction indirectly via vegaLiteToMaidr
+      // Use a known dataset where we can hand-calculate the expected quartiles
+      const spec: VegaLiteSpec = {
+        mark: 'boxplot',
+        data: {
+          values: [
+            // Group A: 7 values [10, 20, 30, 40, 50, 60, 70]
+            // Sorted: [10, 20, 30, 40, 50, 60, 70]
+            // Q1 (25th percentile) ≈ 25, Q2 (median) = 40, Q3 (75th percentile) ≈ 55
+            // Min (non-outlier) = 10, Max (non-outlier) = 70
+            { group: 'A', value: 10 },
+            { group: 'A', value: 20 },
+            { group: 'A', value: 30 },
+            { group: 'A', value: 40 },
+            { group: 'A', value: 50 },
+            { group: 'A', value: 60 },
+            { group: 'A', value: 70 },
+            // Group B: 5 values [5, 10, 15, 20, 25]
+            // Q1 ≈ 7.5, Q2 = 15, Q3 ≈ 22.5
+            { group: 'B', value: 5 },
+            { group: 'B', value: 10 },
+            { group: 'B', value: 15 },
+            { group: 'B', value: 20 },
+            { group: 'B', value: 25 },
+          ],
+        },
+        encoding: {
+          x: { field: 'group', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      const layer = result.subplots[0][0].layers[0];
+      const data = layer.data as BoxPoint[];
+
+      // Should have 2 boxes (one per group)
+      expect(data).toHaveLength(2);
+
+      // Check that each box has the expected structure
+      expect(data[0]).toHaveProperty('z');
+      expect(data[0]).toHaveProperty('min');
+      expect(data[0]).toHaveProperty('q1');
+      expect(data[0]).toHaveProperty('q2');
+      expect(data[0]).toHaveProperty('q3');
+      expect(data[0]).toHaveProperty('max');
+      expect(data[0]).toHaveProperty('lowerOutliers');
+      expect(data[0]).toHaveProperty('upperOutliers');
+
+      // Verify we get numbers for quartiles (exact values depend on percentile implementation)
+      const boxA = data.find(b => b.z === 'A');
+      const boxB = data.find(b => b.z === 'B');
+
+      expect(boxA).toBeDefined();
+      expect(boxB).toBeDefined();
+
+      if (boxA) {
+        expect(boxA.min).toBeGreaterThanOrEqual(10);
+        expect(boxA.max).toBeLessThanOrEqual(70);
+        expect(boxA.q2).toBeGreaterThan(boxA.q1);
+        expect(boxA.q3).toBeGreaterThan(boxA.q2);
+      }
+
+      if (boxB) {
+        expect(boxB.min).toBeGreaterThanOrEqual(5);
+        expect(boxB.max).toBeLessThanOrEqual(25);
+        expect(boxB.q2).toBeGreaterThan(boxB.q1);
+        expect(boxB.q3).toBeGreaterThan(boxB.q2);
+      }
+    });
+  });
+
+  describe('metadata', () => {
+    it('passes through title, subtitle, caption', () => {
+      const spec: VegaLiteSpec = {
+        title: {
+          text: 'Test Box Plot',
+          subtitle: 'A test subtitle',
+        },
+        description: 'A test caption',
+        mark: 'boxplot',
+        data: {
+          values: [{ group: 'A', value: 10 }],
+        },
+        encoding: {
+          x: { field: 'group', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      expect(result.title).toBe('Test Box Plot');
+      expect(result.subtitle).toBe('A test subtitle');
+      expect(result.caption).toBe('A test caption');
+    });
+
+    it('uses default title when spec.title is omitted', () => {
+      const spec: VegaLiteSpec = {
+        mark: 'boxplot',
+        data: {
+          values: [{ group: 'A', value: 10 }],
+        },
+        encoding: {
+          x: { field: 'group', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      expect(result.title).toBe('Vega-Lite Chart');
+    });
+  });
+
+  describe('axis labels', () => {
+    it('extracts axis labels from encoding channels', () => {
+      const spec: VegaLiteSpec = {
+        mark: 'boxplot',
+        data: {
+          values: [{ group: 'A', value: 10 }],
+        },
+        encoding: {
+          x: { field: 'group', type: 'nominal', title: 'Group Label' },
+          y: { field: 'value', type: 'quantitative', title: 'Value Label' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      const layer = result.subplots[0][0].layers[0];
+
+      expect(layer.axes?.x?.label).toBe('Group Label');
+      expect(layer.axes?.y?.label).toBe('Value Label');
+    });
+
+    it('falls back to field name when title is omitted', () => {
+      const spec: VegaLiteSpec = {
+        mark: 'boxplot',
+        data: {
+          values: [{ category: 'A', score: 10 }],
+        },
+        encoding: {
+          x: { field: 'category', type: 'nominal' },
+          y: { field: 'score', type: 'quantitative' },
+        },
+      };
+
+      const result = vegaLiteToMaidr(spec);
+      const layer = result.subplots[0][0].layers[0];
+
+      expect(layer.axes?.x?.label).toBe('category');
+      expect(layer.axes?.y?.label).toBe('score');
+    });
+  });
+
+  describe('hconcat boxplot data resolution', () => {
+    it('extracts each panel\'s own categorical and quartile data without bleed-over', () => {
+      // Validates that buildConcatMaidr correctly processes each concat child
+      // independently without data bleed-over. Each child's spec has inline data,
+      // so resolveData uses the fallback path (no View needed).
+      // Regression test for the bug where panel 2 would incorrectly extract
+      // panel 1's data due to naive globalLayerIndex++ logic.
+
+      const spec = {
+        hconcat: [
+          {
+            data: {
+              values: [
+                { group: 'A', score: 60 },
+                { group: 'A', score: 70 },
+                { group: 'A', score: 80 },
+                { group: 'B', score: 65 },
+                { group: 'B', score: 70 },
+                { group: 'B', score: 75 },
+              ],
+            },
+            mark: 'boxplot',
+            encoding: {
+              x: { field: 'group', type: 'nominal' },
+              y: { field: 'score', type: 'quantitative' },
+            },
+          },
+          {
+            data: {
+              values: [
+                { category: 'X', rating: 3.5 },
+                { category: 'X', rating: 4.0 },
+                { category: 'X', rating: 4.5 },
+                { category: 'Y', rating: 4.0 },
+                { category: 'Y', rating: 4.5 },
+                { category: 'Y', rating: 5.0 },
+              ],
+            },
+            mark: 'boxplot',
+            encoding: {
+              x: { field: 'category', type: 'nominal' },
+              y: { field: 'rating', type: 'quantitative' },
+            },
+          },
+        ],
+      };
+
+      // No view provided — tests the fallback path where resolveData uses
+      // spec.data.values. This exercises buildConcatMaidr without needing
+      // to mock Vega's complex dataset structure.
+      const result = vegaLiteToMaidr(spec as any);
+
+      // Result shape: subplots[row][col].layers[]
+      expect(result.subplots).toHaveLength(1);
+      expect(result.subplots[0]).toHaveLength(2);
+
+      const panel1Box = result.subplots[0][0].layers[0].data as Array<{ z: string; q1: number; q2: number }>;
+      expect(panel1Box.map(p => p.z).sort()).toEqual(['A', 'B']);
+      expect(panel1Box.every(p => p.q1 > 0)).toBe(true);
+      expect(panel1Box.every(p => p.q1 >= 60 && p.q1 <= 80)).toBe(true);
+
+      const panel2Box = result.subplots[0][1].layers[0].data as Array<{ z: string; q1: number; q2: number }>;
+      // Verify panel 2 extracts its own data (category, rating) not panel 1's (group, score)
+      expect(panel2Box.map(p => p.z).sort()).toEqual(['X', 'Y']);
+      expect(panel2Box.every(p => p.q1 > 0)).toBe(true);
+      expect(panel2Box.every(p => p.q1 >= 3 && p.q1 <= 5)).toBe(true);
+    });
+
+    it('handles mixed marks (bar + boxplot) in hconcat', () => {
+      // Simplified mock: bar uses data_0, boxplot uses data_1.
+      // Verifies that mixed mark types don't break index advancement.
+      const spec = {
+        hconcat: [
+          {
+            data: {
+              values: [
+                { x: 'A', y: 10 },
+                { x: 'B', y: 20 },
+              ],
+            },
+            mark: 'bar',
+            encoding: {
+              x: { field: 'x', type: 'nominal' },
+              y: { field: 'y', type: 'quantitative' },
+            },
+          },
+          {
+            data: {
+              values: [
+                { group: 'P', score: 5 },
+                { group: 'P', score: 10 },
+                { group: 'P', score: 15 },
+              ],
+            },
+            mark: 'boxplot',
+            encoding: {
+              x: { field: 'group', type: 'nominal' },
+              y: { field: 'score', type: 'quantitative' },
+            },
+          },
+        ],
+      };
+
+      const result = vegaLiteToMaidr(spec as any);
+      expect(result.subplots).toHaveLength(1);
+      expect(result.subplots[0]).toHaveLength(2);
+
+      // Panel 1: bar (should be a BAR trace)
+      const panel1 = result.subplots[0][0].layers[0];
+      expect(panel1.type).toBe(TraceType.BAR);
+
+      // Panel 2: boxplot
+      const panel2 = result.subplots[0][1].layers[0];
+      expect(panel2.type).toBe(TraceType.BOX);
+      const panel2Data = panel2.data as Array<{ z: string }>;
+      expect(panel2Data[0].z).toBe('P');
+    });
+
+    it('handles vconcat of two boxplots', () => {
+      // Validates the fix works for vconcat as well as hconcat.
+      // Simplified mock: data_0 for panel 1, data_1 for panel 2.
+      const spec = {
+        vconcat: [
+          {
+            data: {
+              values: [
+                { group: 'A', score: 60 },
+                { group: 'A', score: 70 },
+                { group: 'A', score: 80 },
+              ],
+            },
+            mark: 'boxplot',
+            encoding: {
+              x: { field: 'group', type: 'nominal' },
+              y: { field: 'score', type: 'quantitative' },
+            },
+          },
+          {
+            data: {
+              values: [
+                { category: 'X', rating: 3.5 },
+                { category: 'X', rating: 4.0 },
+                { category: 'X', rating: 4.5 },
+              ],
+            },
+            mark: 'boxplot',
+            encoding: {
+              x: { field: 'category', type: 'nominal' },
+              y: { field: 'rating', type: 'quantitative' },
+            },
+          },
+        ],
+      };
+
+      const result = vegaLiteToMaidr(spec as any);
+
+      // vconcat: subplots[row][col] where each child is a row
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0]).toHaveLength(1);
+      expect(result.subplots[1]).toHaveLength(1);
+
+      const panel1Box = result.subplots[0][0].layers[0].data as Array<{ z: string; q1: number }>;
+      expect(panel1Box[0].z).toBe('A');
+      expect(panel1Box[0].q1).toBeGreaterThan(0);
+
+      const panel2Box = result.subplots[1][0].layers[0].data as Array<{ z: string; q1: number }>;
+      expect(panel2Box[0].z).toBe('X');
+      expect(panel2Box[0].q1).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

This change set hardens the Vega-Lite adapter (and its underlying multi-line highlight pipeline) against the full range of Altair-generated specs that py-maidr now ships in its docs. The work fixes five distinct bugs surfaced during py-maidr's Altair-adapter testing cycle and adds one helper plus one new visual-order pass.


## Changes Made

1. mapViaDomElements: pass shouldClone=false

  - const elements = Svg.selectAllElements(selectors[r]);
  + const elements = Svg.selectAllElements(selectors[r], false);

Motive: the default cloning side-effect inserts a hidden clone after every match, shifting :nth-child(N) indices across iterations. A multi-series line chart with sibling <path> elements ended up with iteration r=1 matching the clone of path0 (instead of path1) and r=2 matching the clone-of-clone of path0, etc. — every series' highlight collapsed onto series 0. 

Highlights re-clone via Svg.createHighlightElement anyway, so the pre-cloned hidden elements are unnecessary.

mapViaPathParsing: branch on selector uniqueness

const uniqueSelectors = new Set(selectors).size === selectors.length;
for (let r = 0; r < selectors.length; r++) {
  const lineElement = uniqueSelectors
    ? Svg.selectElement(selectors[r], false)            // standard: 1 unique selector per series
    : Svg.selectNthElement(selectors[0], r, false);     // color-hue: shared selector, walk by index
  ...
}

Motive: matplotlib/seaborn multi-line plots use unique selectors per series (g[id='maidr-<uuid-A>'] path, g[id='maidr-<uuid-B>'] path, …). Vega-Lite's color-encoded multi-series uses identical selectors for every series (each series is a separate .layer_0_marks group with its own single <path>). Using selectNthElement(selectors[r],  r) for both was wrong: for unique selectors with one match each, r ≥ 1 returned null and crashed the highlight pipeline downstream (TypeError: Invalid element provided  for highlight creation in highlight.ts:107). The branch picks the right strategy at runtime.

2. src/util/svg.ts — Add Svg.selectNthElement<T> helper

public static selectNthElement<T extends SVGElement>(
  query: string,
  n: number,
  shouldClone: boolean = false,
): T | null {
  const all = document.querySelectorAll<T>(query);
  return all[n] ?? null;
}

Motive: When a single CSS selector matches multiple sibling elements (e.g. multi-series Vega-Lite line charts where each series renders as a separate <g class="mark-line  role-mark layer_0_marks"> group, all with the same class), :nth-child(N) cannot address the Nth match (each path is its parent's only child) and :nth-of-type(N) would
also count unrelated <g> siblings (axes, legend). This helper does the indexing in JS, returning the live DOM element with no cloning side-effects.

 3. src/adapters/vegalite/selectors.ts — Cover Vega's mark-sugar expansion + drop wrong :nth-child

buildSelector: comma-selector covers both DOM patterns

For non-layered specs, emit g.<class>.role-mark.marks <child>, g.<class>.role-mark.layer_0_marks <child>.

Motive: Vega-Lite expands mark sugar (mark.point: true on lines, mark.line: true on areas, etc.) into additional render-time layers, so even a single user-visible mark may produce a .layer_0_marks group instead of .marks. Trying both patterns in one selector avoids encoding every Vega expansion in the converter.

buildLineSelectors: stop using :nth-child(N), emit one selector per series

For non-layered specs, emit N copies of the same selector and let the caller (LineTrace.mapViaPathParsing) resolve the Nth series via Svg.selectNthElement.

Motive: When the chart has N color-encoded series, Vega creates N sibling groups each with exactly one <path> — :nth-child(2) etc. never match (each path is the only child of its group). Document-order indexing via selectNthElement is the only way to address each series in this layout.

4. src/adapters/vegalite/converters.ts — Five data-extraction fixes

4a. coalesceSiblingLineLayers (new)

Merges runs of consecutive LINE layers with matching axes into a single multi-series LINE layer.
Motive: Altair compiles transform_density + multi-group encodings into separate layer: objects (one mark per group) instead of using a color encoding. Without coalescing, maidr core saw N independent LINE traces and the user could only navigate within one series at a time. SCATTER + LINE pairs (regplot-style) are NOT collapsed because the predicate skips non-LINE marks.

4b. extractBarData / extractSegmentedData: read synthetic __count field

y: Number((row as Record<string, unknown>).__count ?? row[yField] ?? 0)
Motive: Vega-Lite emits a synthetic __count field whenever a channel uses aggregate: 'count' without an explicit field. extractHistogramData already handled this; bar/segmented extraction did not, so count-only bar plots silently extracted 0 for every y.

4c. extractBoxData: fix catField for horizontal orientation

const catField = encoding.x?.type === 'quantitative'
  ? (encoding.y?.field ?? 'y')
  : (encoding.x?.field ?? 'x');
Motive: Previously the code unconditionally took encoding.x.field as the category. Horizontal Iris boxplots (x=quant petalLength, y=nominal species) ended up grouping by 43 unique petalLength values instead of 3 species, producing a BOX BUILD count-mismatch SKIP.

4d. extractBoxData: dedup joinaggregate rows + classify outliers

Replaces the naive rows.map(...) (which produced one BoxPoint per raw row with empty outlier arrays) with a Map<category, BoxAccumulator> that:
- deduplicates rows by category (Vega-Lite's joinaggregate denormalizes the dataset, replicating the same stats on every raw row),
- classifies each raw value as a lower/upper outlier when it falls outside the whisker bounds,
- preserves first-seen category order so highlight indices stay aligned.

Motive: Pre-computed boxplots emitted by Vega had N BoxPoint entries per category (one per raw row), with empty lowerOutliers/upperOutliers. py-maidr's BoxTrace expected one BoxPoint per category and showed wrong outlier counts.

4e. convertLayerSpec (BOX case): set Orientation.HORIZONTAL

if (xIsQuant && !yIsQuant) {
  orientation = Orientation.HORIZONTAL;
}
Motive: Without the orientation field, horizontal boxplots defaulted to vertical-mode navigation (species-to-species via left/right) instead of within-quartile navigation (up/down), and the screen reader announced the wrong axis labels.

5. src/vegalite-entry.ts — reorderDodgedBarsByVisualPosition (new)

Mirror of reorderSegmentedSeriesByVisualBottom but applies a horizontal (leftmost-first) sort for DODGED layers; ensures data[0] is the visually leftmost subgroup.

Motive: Vega-Lite's xOffset encoding draws subgroups left-to-right by xOffset scale-domain order, but the dataset row order driving extractSegmentedData's grouping is independent of that scale order. Without re-sorting, MAIDR's row=0 initial focus landed on whichever fill value happened to appear first in the data rows, not the leftmost-rendered series — confusing for sighted/blind co-exploration where "first" should mean "leftmost".

The pass handles both DOM layouts:
- Subject-major (order: 'column', default for DODGED): the first N DOM elements are the first x-category, one per series;
- Series-major (order: 'row'): each series occupies a contiguous block of size categoryCount.

A try/catch wraps the whole body so a runtime exception here cannot abort the rest of the visual-order pipeline (notably buildBoxPlotSelectorsFromDom).


## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.