### PR TITLE
fix: capture title from the json

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -7,7 +7,20 @@ import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
 import type { BoxBrailleState, LineBrailleState, NonEmptyTraceState } from '@type/state';
 import type { Command } from './command';
+import { DEFAULT_SUBPLOT_TITLE } from '@model/abstract';
+import { DEFAULT_FIGURE_TITLE } from '@model/plot';
 import { TraceType } from '@type/grammar';
+
+/**
+ * Returns true only when the title was authored in the MAIDR JSON, i.e. it is
+ * not one of the placeholder defaults applied by the Figure/Trace models when
+ * the JSON omits the `title` field. Mirrors the same check used by
+ * {@link DescriptionService.getDescription} so the `l t` announce and `d`
+ * description stay consistent about what counts as a real title.
+ */
+function isAuthoredTitle(title: string): boolean {
+  return title !== DEFAULT_FIGURE_TITLE && title !== DEFAULT_SUBPLOT_TITLE;
+}
 
 /**
  * Abstract base class for describe commands.
@@ -240,7 +253,14 @@ export class AnnounceTitleCommand extends AnnounceCommand {
     }
 
     if (state.type === 'figure') {
-      this.announce(state.title, 'Figure title');
+      // Only announce when the JSON provided a title; the model otherwise
+      // substitutes DEFAULT_FIGURE_TITLE ('MAIDR Plot') which is a placeholder,
+      // not a real title.
+      if (isAuthoredTitle(state.title)) {
+        this.announce(state.title, 'Figure title');
+      } else {
+        this.announceUnavailable();
+      }
       this.restoreScope();
       return;
     }
@@ -269,17 +289,20 @@ export class AnnounceTitleCommand extends AnnounceCommand {
   /**
    * Announces the appropriate title when in trace context:
    * subplot title for multi-panel, figure title for single-panel.
+   * Falls through to "No title available" when neither was authored in JSON.
    */
   private announceTraceTitle(traceTitle: string): void {
-    // Multi-panel: show the subplot-level title if available.
-    if (this.context.isMultiPanel && traceTitle !== 'unavailable') {
+    // Multi-panel: show the subplot-level title only when it was authored
+    // in the layer's JSON (not the DEFAULT_SUBPLOT_TITLE placeholder).
+    if (this.context.isMultiPanel && isAuthoredTitle(traceTitle)) {
       this.announce(traceTitle, 'Subplot title');
       return;
     }
 
-    // Single-panel (or multi-panel without subplot title): show figure title.
+    // Single-panel (or multi-panel without subplot title): show the figure
+    // title only when it was authored in the top-level JSON.
     const figureTitle = this.context.figureTitle;
-    if (figureTitle !== 'unavailable') {
+    if (isAuthoredTitle(figureTitle)) {
       this.announce(figureTitle, 'Title');
       return;
     }
@@ -289,11 +312,13 @@ export class AnnounceTitleCommand extends AnnounceCommand {
 
   /**
    * Announces that the title is not available and plays a warning tone.
+   * Verbose phrasing matches the user-facing "no data" wording used when the
+   * MAIDR JSON omits a title.
    */
   private announceUnavailable(): void {
     const text = this.textService.isTerse()
       ? 'unavailable'
-      : 'Title is not available';
+      : 'No title available';
     this.textViewModel.update(text);
     this.audioService.playWarningToneIfEnabled();
   }

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -13,10 +13,9 @@ import { TraceType } from '@type/grammar';
 
 /**
  * Returns true only when the title was authored in the MAIDR JSON, i.e. it is
- * not one of the placeholder defaults applied by the Figure/Trace models when
- * the JSON omits the `title` field. Mirrors the same check used by
- * {@link DescriptionService.getDescription} so the `l t` announce and `d`
- * description stay consistent about what counts as a real title.
+ * not a placeholder default substituted by the Figure/Trace models when the
+ * JSON omits `title`. Matches the filter used by `DescriptionService` so the
+ * `l t` announce and `d` description agree on what counts as a real title.
  */
 function isAuthoredTitle(title: string): boolean {
   return title !== DEFAULT_FIGURE_TITLE && title !== DEFAULT_SUBPLOT_TITLE;
@@ -237,11 +236,18 @@ export class AnnounceTitleCommand extends AnnounceCommand {
   }
 
   /**
-   * Executes the command to display the title based on state type.
+   * Executes the command to display the title sourced from the MAIDR JSON.
    *
-   * - Single-panel plots: announces the figure title as "Title is ...".
-   * - Multi-panel at figure level: announces "Figure title is ...".
-   * - Multi-panel at trace level: announces "Subplot title is ...".
+   * Only announces titles authored in the JSON; the model's placeholder
+   * defaults are treated as "no title". Announces "No title available"
+   * when nothing was authored at either level.
+   *
+   * - Figure-level scope (multi-panel): "Figure title is ...".
+   * - Trace-level scope, single-panel: prefers the layer title, then the
+   *   figure title, announced as "Title is ...".
+   * - Trace-level scope, multi-panel: prefers the layer title as
+   *   "Subplot title is ...", then falls back to the figure title as
+   *   "Title is ...".
    */
   public execute(): void {
     const state = this.context.state;
@@ -253,9 +259,6 @@ export class AnnounceTitleCommand extends AnnounceCommand {
     }
 
     if (state.type === 'figure') {
-      // Only announce when the JSON provided a title; the model otherwise
-      // substitutes DEFAULT_FIGURE_TITLE ('MAIDR Plot') which is a placeholder,
-      // not a real title.
       if (isAuthoredTitle(state.title)) {
         this.announce(state.title, 'Figure title');
       } else {
@@ -292,8 +295,9 @@ export class AnnounceTitleCommand extends AnnounceCommand {
    * Mirrors {@link DescriptionService.getDescription} precedence: prefer the
    * authored layer/trace title (labeled "Subplot title" in multi-panel figures
    * and "Title" in single-panel figures), then fall back to the figure title,
-   * then to "No title available". This keeps `l t` consistent with `d` for
-   * plots that only set a layer title (e.g. multiline_plot.html).
+   * then to "No title available". Keeps `l t` consistent with `d` for plots
+   * that only set a layer title (e.g. multiline_plot.html).
+   * @param {string} traceTitle - The trace-level title from the current state.
    */
   private announceTraceTitle(traceTitle: string): void {
     if (isAuthoredTitle(traceTitle)) {
@@ -302,8 +306,7 @@ export class AnnounceTitleCommand extends AnnounceCommand {
       return;
     }
 
-    // Trace-level title was a placeholder; fall back to the figure-level
-    // title only when it was authored in the top-level JSON.
+    // Trace title was a placeholder; fall back to the figure-level title.
     const figureTitle = this.context.figureTitle;
     if (isAuthoredTitle(figureTitle)) {
       this.announce(figureTitle, 'Title');
@@ -315,8 +318,6 @@ export class AnnounceTitleCommand extends AnnounceCommand {
 
   /**
    * Announces that the title is not available and plays a warning tone.
-   * Verbose phrasing matches the user-facing "no data" wording used when the
-   * MAIDR JSON omits a title.
    */
   private announceUnavailable(): void {
     const text = this.textService.isTerse()

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -235,7 +235,7 @@ export class AnnounceTitleCommand extends AnnounceCommand {
    *   figure title, announced as "Title is ...".
    * - Trace-level scope, multi-panel: prefers the layer title as
    *   "Subplot title is ...", then falls back to the figure title as
-   *   "Title is ...".
+   *   "Figure title is ..." so the announcement disambiguates the source.
    */
   public execute(): void {
     const state = this.context.state;
@@ -282,9 +282,11 @@ export class AnnounceTitleCommand extends AnnounceCommand {
    *
    * Mirrors {@link DescriptionService.getDescription} precedence: prefer the
    * authored layer/trace title (labeled "Subplot title" in multi-panel figures
-   * and "Title" in single-panel figures), then fall back to the figure title,
-   * then to "No title available". Keeps `l t` consistent with `d` for plots
-   * that only set a layer title (e.g. multiline_plot.html).
+   * and "Title" in single-panel figures), then fall back to the figure title
+   * (labeled "Figure title" in multi-panel and "Title" in single-panel so the
+   * announcement makes the source self-describing), then to "No title
+   * available". Keeps `l t` consistent with `d` for plots that only set a
+   * layer title (e.g. multiline_plot.html).
    * @param {string} traceTitle - The trace-level title from the current state.
    */
   private announceTraceTitle(traceTitle: string): void {
@@ -297,7 +299,8 @@ export class AnnounceTitleCommand extends AnnounceCommand {
     // Trace title was a placeholder; fall back to the figure-level title.
     const figureTitle = this.context.figureTitle;
     if (this.context.isAuthoredTitle(figureTitle)) {
-      this.announce(figureTitle, 'Title');
+      const fallbackLabel = this.context.isMultiPanel ? 'Figure title' : 'Title';
+      this.announce(figureTitle, fallbackLabel);
       return;
     }
 

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -341,11 +341,14 @@ export class AnnounceSubtitleCommand extends AnnounceCommand {
   /**
    * Executes the command to display the subtitle.
    * Accesses subtitle from the figure level via Context, since subtitle
-   * is a figure-level property not available on trace state.
+   * is a figure-level property not available on trace state. Only announces
+   * when the JSON authored a subtitle; otherwise announces "No subtitle
+   * available", matching the unavailable phrasing used by sibling title
+   * and caption commands.
    */
   public execute(): void {
     const subtitle = this.context.figureSubtitle;
-    if (subtitle !== 'unavailable') {
+    if (this.context.isAuthoredSubtitle(subtitle)) {
       const text = this.textService.isTerse()
         ? subtitle
         : `Subtitle is ${subtitle}`;
@@ -353,7 +356,7 @@ export class AnnounceSubtitleCommand extends AnnounceCommand {
     } else {
       const text = this.textService.isTerse()
         ? 'unavailable'
-        : 'Subtitle is not available';
+        : 'No subtitle available';
       this.textViewModel.update(text);
       this.audioService.playWarningToneIfEnabled();
     }
@@ -386,11 +389,14 @@ export class AnnounceCaptionCommand extends AnnounceCommand {
   /**
    * Executes the command to display the caption.
    * Accesses caption from the figure level via Context, since caption
-   * is a figure-level property not available on trace state.
+   * is a figure-level property not available on trace state. Only announces
+   * when the JSON authored a caption; otherwise announces "No caption
+   * available", matching the unavailable phrasing used by sibling title
+   * and subtitle commands.
    */
   public execute(): void {
     const caption = this.context.figureCaption;
-    if (caption !== 'unavailable') {
+    if (this.context.isAuthoredCaption(caption)) {
       const text = this.textService.isTerse()
         ? caption
         : `Caption is ${caption}`;
@@ -398,7 +404,7 @@ export class AnnounceCaptionCommand extends AnnounceCommand {
     } else {
       const text = this.textService.isTerse()
         ? 'unavailable'
-        : 'Caption is not available';
+        : 'No caption available';
       this.textViewModel.update(text);
       this.audioService.playWarningToneIfEnabled();
     }

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -287,19 +287,22 @@ export class AnnounceTitleCommand extends AnnounceCommand {
   }
 
   /**
-   * Announces the appropriate title when in trace context:
-   * subplot title for multi-panel, figure title for single-panel.
-   * Falls through to "No title available" when neither was authored in JSON.
+   * Announces the appropriate title when in trace context.
+   *
+   * Mirrors {@link DescriptionService.getDescription} precedence: prefer the
+   * authored layer/trace title (labeled "Subplot title" in multi-panel figures
+   * and "Title" in single-panel figures), then fall back to the figure title,
+   * then to "No title available". This keeps `l t` consistent with `d` for
+   * plots that only set a layer title (e.g. multiline_plot.html).
    */
   private announceTraceTitle(traceTitle: string): void {
-    // Multi-panel: show the subplot-level title only when it was authored
-    // in the layer's JSON (not the DEFAULT_SUBPLOT_TITLE placeholder).
-    if (this.context.isMultiPanel && isAuthoredTitle(traceTitle)) {
-      this.announce(traceTitle, 'Subplot title');
+    if (isAuthoredTitle(traceTitle)) {
+      const label = this.context.isMultiPanel ? 'Subplot title' : 'Title';
+      this.announce(traceTitle, label);
       return;
     }
 
-    // Single-panel (or multi-panel without subplot title): show the figure
+    // Trace-level title was a placeholder; fall back to the figure-level
     // title only when it was authored in the top-level JSON.
     const figureTitle = this.context.figureTitle;
     if (isAuthoredTitle(figureTitle)) {

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -7,19 +7,7 @@ import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
 import type { BoxBrailleState, LineBrailleState, NonEmptyTraceState } from '@type/state';
 import type { Command } from './command';
-import { DEFAULT_SUBPLOT_TITLE } from '@model/abstract';
-import { DEFAULT_FIGURE_TITLE } from '@model/plot';
 import { TraceType } from '@type/grammar';
-
-/**
- * Returns true only when the title was authored in the MAIDR JSON, i.e. it is
- * not a placeholder default substituted by the Figure/Trace models when the
- * JSON omits `title`. Matches the filter used by `DescriptionService` so the
- * `l t` announce and `d` description agree on what counts as a real title.
- */
-function isAuthoredTitle(title: string): boolean {
-  return title !== DEFAULT_FIGURE_TITLE && title !== DEFAULT_SUBPLOT_TITLE;
-}
 
 /**
  * Abstract base class for describe commands.
@@ -259,7 +247,7 @@ export class AnnounceTitleCommand extends AnnounceCommand {
     }
 
     if (state.type === 'figure') {
-      if (isAuthoredTitle(state.title)) {
+      if (this.context.isAuthoredTitle(state.title)) {
         this.announce(state.title, 'Figure title');
       } else {
         this.announceUnavailable();
@@ -300,7 +288,7 @@ export class AnnounceTitleCommand extends AnnounceCommand {
    * @param {string} traceTitle - The trace-level title from the current state.
    */
   private announceTraceTitle(traceTitle: string): void {
-    if (isAuthoredTitle(traceTitle)) {
+    if (this.context.isAuthoredTitle(traceTitle)) {
       const label = this.context.isMultiPanel ? 'Subplot title' : 'Title';
       this.announce(traceTitle, label);
       return;
@@ -308,7 +296,7 @@ export class AnnounceTitleCommand extends AnnounceCommand {
 
     // Trace title was a placeholder; fall back to the figure-level title.
     const figureTitle = this.context.figureTitle;
-    if (isAuthoredTitle(figureTitle)) {
+    if (this.context.isAuthoredTitle(figureTitle)) {
       this.announce(figureTitle, 'Title');
       return;
     }

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -10,7 +10,7 @@ import { isGridNavigable } from '@type/navigation';
 import { Constant } from '@util/constant';
 import { Stack } from '@util/stack';
 import hotkeys from 'hotkeys-js';
-import { DEFAULT_FIGURE_TITLE } from './plot';
+import { DEFAULT_CAPTION, DEFAULT_FIGURE_TITLE, DEFAULT_SUBTITLE } from './plot';
 
 /**
  * Build a human-readable plot type string with optional orientation prefix.
@@ -134,11 +134,44 @@ export class Context implements Disposable {
    * Returns true when the given title came from the MAIDR JSON, i.e. it is
    * not a placeholder default substituted by the Figure or Trace models
    * when the JSON omits `title`. Encapsulates the model's internal default
-   * constants so the command layer can avoid importing them directly.
+   * constants so callers (commands, services) can avoid importing them.
+   *
+   * Empty / whitespace-only strings are also treated as unauthored, since
+   * announcing a bare label like "Title is " is not useful.
+   *
+   * Known limitation: a title authored as the exact placeholder string
+   * (e.g. "MAIDR Plot" or "unavailable") will be filtered out. The sentinel
+   * defaults are deliberately uncommon strings to minimize collision risk.
    * @param {string} title - The title string to check.
    */
   public isAuthoredTitle(title: string): boolean {
-    return title !== DEFAULT_FIGURE_TITLE && title !== DEFAULT_SUBPLOT_TITLE;
+    return (
+      title.trim() !== ''
+      && title !== DEFAULT_FIGURE_TITLE
+      && title !== DEFAULT_SUBPLOT_TITLE
+    );
+  }
+
+  /**
+   * Returns true when the given subtitle came from the MAIDR JSON, i.e. it
+   * is not the placeholder default the Figure model substitutes when the
+   * JSON omits `subtitle`. Same empty-string and collision caveats apply
+   * as {@link isAuthoredTitle}.
+   * @param {string} subtitle - The subtitle string to check.
+   */
+  public isAuthoredSubtitle(subtitle: string): boolean {
+    return subtitle.trim() !== '' && subtitle !== DEFAULT_SUBTITLE;
+  }
+
+  /**
+   * Returns true when the given caption came from the MAIDR JSON, i.e. it
+   * is not the placeholder default the Figure model substitutes when the
+   * JSON omits `caption`. Same empty-string and collision caveats apply
+   * as {@link isAuthoredTitle}.
+   * @param {string} caption - The caption string to check.
+   */
+  public isAuthoredCaption(caption: string): boolean {
+    return caption.trim() !== '' && caption !== DEFAULT_CAPTION;
   }
 
   /**
@@ -150,25 +183,29 @@ export class Context implements Disposable {
   }
 
   /**
-   * Returns the figure-level subtitle.
+   * Returns the figure-level subtitle, or the unavailable placeholder when
+   * the figure has no state. Use {@link isAuthoredSubtitle} to distinguish
+   * an authored subtitle from the model's default substitution.
    */
   public get figureSubtitle(): string {
     const figureState = this.figure.state;
     if (!figureState.empty) {
       return figureState.subtitle;
     }
-    return 'unavailable';
+    return DEFAULT_SUBTITLE;
   }
 
   /**
-   * Returns the figure-level caption.
+   * Returns the figure-level caption, or the unavailable placeholder when
+   * the figure has no state. Use {@link isAuthoredCaption} to distinguish
+   * an authored caption from the model's default substitution.
    */
   public get figureCaption(): string {
     const figureState = this.figure.state;
     if (!figureState.empty) {
       return figureState.caption;
     }
-    return 'unavailable';
+    return DEFAULT_CAPTION;
   }
 
   public toggleScope(scope: Scope): void {

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -2,6 +2,7 @@ import type { Disposable } from '@type/disposable';
 import type { MovableDirection } from '@type/movable';
 import type { PlotState, SubplotSummary } from '@type/state';
 import type { Figure, Subplot, Trace } from './plot';
+import { DEFAULT_SUBPLOT_TITLE } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Scope } from '@type/event';
 import { Orientation } from '@type/grammar';
@@ -9,6 +10,7 @@ import { isGridNavigable } from '@type/navigation';
 import { Constant } from '@util/constant';
 import { Stack } from '@util/stack';
 import hotkeys from 'hotkeys-js';
+import { DEFAULT_FIGURE_TITLE } from './plot';
 
 /**
  * Build a human-readable plot type string with optional orientation prefix.
@@ -115,14 +117,28 @@ export class Context implements Disposable {
   }
 
   /**
-   * Returns the figure-level title (the top-level plot title).
+   * Returns the figure-level title (the top-level plot title), or the
+   * unavailable placeholder when the figure has no state. Use
+   * {@link isAuthoredTitle} to distinguish an authored title from the
+   * model's default substitutions.
    */
   public get figureTitle(): string {
     const figureState = this.figure.state;
     if (!figureState.empty) {
       return figureState.title;
     }
-    return 'unavailable';
+    return DEFAULT_SUBPLOT_TITLE;
+  }
+
+  /**
+   * Returns true when the given title came from the MAIDR JSON, i.e. it is
+   * not a placeholder default substituted by the Figure or Trace models
+   * when the JSON omits `title`. Encapsulates the model's internal default
+   * constants so the command layer can avoid importing them directly.
+   * @param {string} title - The title string to check.
+   */
+  public isAuthoredTitle(title: string): boolean {
+    return title !== DEFAULT_FIGURE_TITLE && title !== DEFAULT_SUBPLOT_TITLE;
   }
 
   /**

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -121,6 +121,12 @@ export class Context implements Disposable {
    * unavailable placeholder when the figure has no state. Use
    * {@link isAuthoredTitle} to distinguish an authored title from the
    * model's default substitutions.
+   *
+   * The empty-state branch returns DEFAULT_SUBPLOT_TITLE (the generic
+   * "unavailable" sentinel) rather than DEFAULT_FIGURE_TITLE because there
+   * is no figure at all in that case; "MAIDR Plot" would be misleading.
+   * Both sentinels are rejected by isAuthoredTitle, so callers see the
+   * same "not authored" outcome regardless.
    */
   public get figureTitle(): string {
     const figureState = this.figure.state;
@@ -157,6 +163,11 @@ export class Context implements Disposable {
    * is not the placeholder default the Figure model substitutes when the
    * JSON omits `subtitle`. Same empty-string and collision caveats apply
    * as {@link isAuthoredTitle}.
+   *
+   * Currently DEFAULT_SUBTITLE and DEFAULT_CAPTION are both 'unavailable',
+   * so this method is functionally identical to {@link isAuthoredCaption};
+   * they are kept separate so the two can diverge independently without
+   * touching callers.
    * @param {string} subtitle - The subtitle string to check.
    */
   public isAuthoredSubtitle(subtitle: string): boolean {
@@ -167,7 +178,8 @@ export class Context implements Disposable {
    * Returns true when the given caption came from the MAIDR JSON, i.e. it
    * is not the placeholder default the Figure model substitutes when the
    * JSON omits `caption`. Same empty-string and collision caveats apply
-   * as {@link isAuthoredTitle}.
+   * as {@link isAuthoredTitle}; same independence rationale applies as
+   * {@link isAuthoredSubtitle}.
    * @param {string} caption - The caption string to check.
    */
   public isAuthoredCaption(caption: string): boolean {

--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -1,8 +1,7 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
 import type { DescriptionState } from '@type/state';
-import { AbstractTrace, DEFAULT_SUBPLOT_TITLE } from '@model/abstract';
-import { DEFAULT_FIGURE_TITLE } from '@model/plot';
+import { AbstractTrace } from '@model/abstract';
 import { Scope } from '@type/event';
 
 /**
@@ -31,8 +30,8 @@ export class DescriptionService {
       // otherwise clear it.
       const layerTitle = description.title;
       const figureTitle = this.context.figureTitle;
-      const hasLayerTitle = layerTitle && layerTitle !== DEFAULT_SUBPLOT_TITLE;
-      const hasFigureTitle = figureTitle && figureTitle !== DEFAULT_FIGURE_TITLE && figureTitle !== DEFAULT_SUBPLOT_TITLE;
+      const hasLayerTitle = this.context.isAuthoredTitle(layerTitle);
+      const hasFigureTitle = this.context.isAuthoredTitle(figureTitle);
       const title = hasLayerTitle ? layerTitle : hasFigureTitle ? figureTitle : '';
 
       const subplots = this.context.getSubplotSummaries();

--- a/test/command/announce-metadata.test.ts
+++ b/test/command/announce-metadata.test.ts
@@ -1,0 +1,218 @@
+import type { Context } from '@model/context';
+import type { AudioService } from '@service/audio';
+import type { DisplayService } from '@service/display';
+import type { TextService } from '@service/text';
+import type { TextViewModel } from '@state/viewModel/textViewModel';
+import {
+  AnnounceCaptionCommand,
+  AnnounceSubtitleCommand,
+} from '@command/describe';
+import { describe, expect, jest, test } from '@jest/globals';
+import { DEFAULT_CAPTION, DEFAULT_SUBTITLE } from '@model/plot';
+
+/**
+ * Mock factory configuration for the metadata-related context surface.
+ */
+interface ContextOverrides {
+  figureSubtitle?: string;
+  figureCaption?: string;
+  authoredSubtitles?: string[];
+  authoredCaptions?: string[];
+}
+
+/**
+ * Creates a mock Context exposing only the surface AnnounceSubtitleCommand
+ * and AnnounceCaptionCommand need. `authoredSubtitles` / `authoredCaptions`
+ * list the strings that should pass the model's placeholder filter; any
+ * other value is treated as a placeholder default.
+ */
+function createMockContext(overrides: ContextOverrides = {}): Context {
+  const authoredSub = new Set(overrides.authoredSubtitles ?? []);
+  const authoredCap = new Set(overrides.authoredCaptions ?? []);
+  return {
+    figureSubtitle: overrides.figureSubtitle ?? DEFAULT_SUBTITLE,
+    figureCaption: overrides.figureCaption ?? DEFAULT_CAPTION,
+    isAuthoredSubtitle: (subtitle: string) => authoredSub.has(subtitle),
+    isAuthoredCaption: (caption: string) => authoredCap.has(caption),
+  } as unknown as Context;
+}
+
+function createMockTextViewModel(): TextViewModel {
+  return {
+    update: jest.fn(),
+  } as unknown as TextViewModel;
+}
+
+function createMockTextService(terse = false): TextService {
+  return {
+    isTerse: () => terse,
+  } as unknown as TextService;
+}
+
+function createMockAudioService(): AudioService {
+  return {
+    playWarningToneIfEnabled: jest.fn(),
+  } as unknown as AudioService;
+}
+
+function createMockDisplayService(): DisplayService {
+  return {
+    exitLabelScope: jest.fn(),
+  } as unknown as DisplayService;
+}
+
+describe('AnnounceSubtitleCommand', () => {
+  test('announces the authored subtitle verbosely', () => {
+    const context = createMockContext({
+      figureSubtitle: 'A descriptive subtitle',
+      authoredSubtitles: ['A descriptive subtitle'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceSubtitleCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Subtitle is A descriptive subtitle',
+    );
+    expect(audioService.playWarningToneIfEnabled).not.toHaveBeenCalled();
+  });
+
+  test('announces just the value in terse mode', () => {
+    const context = createMockContext({
+      figureSubtitle: 'A descriptive subtitle',
+      authoredSubtitles: ['A descriptive subtitle'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceSubtitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(true),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('A descriptive subtitle');
+  });
+
+  test('announces "No subtitle available" verbosely when no subtitle is authored', () => {
+    const context = createMockContext(); // defaults — nothing authored
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceSubtitleCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('No subtitle available');
+    expect(audioService.playWarningToneIfEnabled).toHaveBeenCalled();
+  });
+
+  test('announces "unavailable" in terse mode when no subtitle is authored', () => {
+    const context = createMockContext();
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceSubtitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(true),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('unavailable');
+  });
+});
+
+describe('AnnounceCaptionCommand', () => {
+  test('announces the authored caption verbosely', () => {
+    const context = createMockContext({
+      figureCaption: 'A figure caption',
+      authoredCaptions: ['A figure caption'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceCaptionCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Caption is A figure caption',
+    );
+    expect(audioService.playWarningToneIfEnabled).not.toHaveBeenCalled();
+  });
+
+  test('announces just the value in terse mode', () => {
+    const context = createMockContext({
+      figureCaption: 'A figure caption',
+      authoredCaptions: ['A figure caption'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceCaptionCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(true),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('A figure caption');
+  });
+
+  test('announces "No caption available" verbosely when no caption is authored', () => {
+    const context = createMockContext();
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceCaptionCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('No caption available');
+    expect(audioService.playWarningToneIfEnabled).toHaveBeenCalled();
+  });
+
+  test('announces "unavailable" in terse mode when no caption is authored', () => {
+    const context = createMockContext();
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceCaptionCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(true),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('unavailable');
+  });
+});

--- a/test/command/announce-title.test.ts
+++ b/test/command/announce-title.test.ts
@@ -6,6 +6,7 @@ import type { TextViewModel } from '@state/viewModel/textViewModel';
 import type { PlotState } from '@type/state';
 import { AnnounceTitleCommand } from '@command/describe';
 import { describe, expect, jest, test } from '@jest/globals';
+import { DEFAULT_SUBPLOT_TITLE } from '@model/abstract';
 
 /**
  * Mock factory configuration for the title-related context surface.
@@ -26,7 +27,7 @@ function createMockContext(overrides: ContextOverrides): Context {
   const authored = new Set(overrides.authoredTitles ?? []);
   return {
     state: overrides.state,
-    figureTitle: overrides.figureTitle ?? 'unavailable',
+    figureTitle: overrides.figureTitle ?? DEFAULT_SUBPLOT_TITLE,
     isMultiPanel: overrides.isMultiPanel ?? false,
     isAuthoredTitle: (title: string) => authored.has(title),
   } as unknown as Context;
@@ -93,10 +94,11 @@ describe('AnnounceTitleCommand', () => {
       authoredTitles: ['Basic Multiline Plot'],
     });
     const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
     const command = new AnnounceTitleCommand(
       context,
       textViewModel,
-      createMockAudioService(),
+      audioService,
       createMockTextService(),
       createMockDisplayService(),
     );
@@ -106,6 +108,8 @@ describe('AnnounceTitleCommand', () => {
     expect(textViewModel.update).toHaveBeenCalledWith(
       'Title is Basic Multiline Plot',
     );
+    // The authored layer title was found — no fallback warning tone.
+    expect(audioService.playWarningToneIfEnabled).not.toHaveBeenCalled();
   });
 
   test('announces "No title available" when neither figure nor layer title is authored', () => {
@@ -210,6 +214,33 @@ describe('AnnounceTitleCommand', () => {
 
     expect(textViewModel.update).toHaveBeenCalledWith(
       'Title is My Authored Figure',
+    );
+  });
+
+  test('labels the figure-title fallback as "Figure title" in multi-panel figures', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'trace',
+        title: 'unavailable',
+      } as unknown as PlotState,
+      figureTitle: 'My Authored Figure',
+      isMultiPanel: true,
+      authoredTitles: ['My Authored Figure'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Figure title is My Authored Figure',
     );
   });
 

--- a/test/command/announce-title.test.ts
+++ b/test/command/announce-title.test.ts
@@ -212,4 +212,73 @@ describe('AnnounceTitleCommand', () => {
       'Title is My Authored Figure',
     );
   });
+
+  test('announces "No title available" when the active state is empty', () => {
+    const context = createMockContext({
+      state: { empty: true, type: 'figure' } as unknown as PlotState,
+      authoredTitles: [],
+    });
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('No title available');
+    expect(audioService.playWarningToneIfEnabled).toHaveBeenCalled();
+  });
+
+  test('announces "No title available" for unexpected (subplot) state types', () => {
+    const context = createMockContext({
+      state: { empty: false, type: 'subplot' } as unknown as PlotState,
+      authoredTitles: [],
+    });
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('No title available');
+    expect(audioService.playWarningToneIfEnabled).toHaveBeenCalled();
+  });
+
+  test('announces "No title available" in multi-panel figures when neither layer nor figure title is authored', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'trace',
+        title: 'unavailable',
+      } as unknown as PlotState,
+      figureTitle: 'MAIDR Plot',
+      isMultiPanel: true,
+      authoredTitles: [],
+    });
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('No title available');
+    expect(audioService.playWarningToneIfEnabled).toHaveBeenCalled();
+  });
 });

--- a/test/command/announce-title.test.ts
+++ b/test/command/announce-title.test.ts
@@ -1,0 +1,215 @@
+import type { Context } from '@model/context';
+import type { AudioService } from '@service/audio';
+import type { DisplayService } from '@service/display';
+import type { TextService } from '@service/text';
+import type { TextViewModel } from '@state/viewModel/textViewModel';
+import type { PlotState } from '@type/state';
+import { AnnounceTitleCommand } from '@command/describe';
+import { describe, expect, jest, test } from '@jest/globals';
+
+/**
+ * Mock factory configuration for the title-related context surface.
+ */
+interface ContextOverrides {
+  state: PlotState;
+  figureTitle?: string;
+  isMultiPanel?: boolean;
+  authoredTitles?: string[];
+}
+
+/**
+ * Creates a mock Context that mimics the title-related surface used by
+ * AnnounceTitleCommand. `authoredTitles` lists the strings that should pass
+ * the model's placeholder filter; any other value is treated as a placeholder.
+ */
+function createMockContext(overrides: ContextOverrides): Context {
+  const authored = new Set(overrides.authoredTitles ?? []);
+  return {
+    state: overrides.state,
+    figureTitle: overrides.figureTitle ?? 'unavailable',
+    isMultiPanel: overrides.isMultiPanel ?? false,
+    isAuthoredTitle: (title: string) => authored.has(title),
+  } as unknown as Context;
+}
+
+function createMockTextViewModel(): TextViewModel {
+  return {
+    update: jest.fn(),
+  } as unknown as TextViewModel;
+}
+
+function createMockTextService(terse = false): TextService {
+  return {
+    isTerse: () => terse,
+  } as unknown as TextService;
+}
+
+function createMockAudioService(): AudioService {
+  return {
+    playWarningToneIfEnabled: jest.fn(),
+  } as unknown as AudioService;
+}
+
+function createMockDisplayService(): DisplayService {
+  return {
+    exitLabelScope: jest.fn(),
+  } as unknown as DisplayService;
+}
+
+describe('AnnounceTitleCommand', () => {
+  test('announces the authored figure title at figure-level scope', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'figure',
+        title: 'My Authored Figure',
+      } as unknown as PlotState,
+      authoredTitles: ['My Authored Figure'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Figure title is My Authored Figure',
+    );
+  });
+
+  test('falls back to the authored layer title in single-panel figures', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'trace',
+        title: 'Basic Multiline Plot',
+      } as unknown as PlotState,
+      isMultiPanel: false,
+      authoredTitles: ['Basic Multiline Plot'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Title is Basic Multiline Plot',
+    );
+  });
+
+  test('announces "No title available" when neither figure nor layer title is authored', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'trace',
+        title: 'unavailable',
+      } as unknown as PlotState,
+      figureTitle: 'MAIDR Plot',
+      isMultiPanel: false,
+      authoredTitles: [],
+    });
+    const textViewModel = createMockTextViewModel();
+    const audioService = createMockAudioService();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      audioService,
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('No title available');
+    expect(audioService.playWarningToneIfEnabled).toHaveBeenCalled();
+  });
+
+  test('announces "unavailable" in terse mode when no title is authored', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'trace',
+        title: 'unavailable',
+      } as unknown as PlotState,
+      figureTitle: 'MAIDR Plot',
+      isMultiPanel: false,
+      authoredTitles: [],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(true),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('unavailable');
+  });
+
+  test('labels the authored layer title as "Subplot title" in multi-panel figures', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'trace',
+        title: 'Layer One',
+      } as unknown as PlotState,
+      isMultiPanel: true,
+      authoredTitles: ['Layer One'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Subplot title is Layer One',
+    );
+  });
+
+  test('falls back to the authored figure title when only the figure title is authored', () => {
+    const context = createMockContext({
+      state: {
+        empty: false,
+        type: 'trace',
+        title: 'unavailable',
+      } as unknown as PlotState,
+      figureTitle: 'My Authored Figure',
+      isMultiPanel: false,
+      authoredTitles: ['My Authored Figure'],
+    });
+    const textViewModel = createMockTextViewModel();
+    const command = new AnnounceTitleCommand(
+      context,
+      textViewModel,
+      createMockAudioService(),
+      createMockTextService(),
+      createMockDisplayService(),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Title is My Authored Figure',
+    );
+  });
+});

--- a/test/model/context-authored.test.ts
+++ b/test/model/context-authored.test.ts
@@ -1,0 +1,79 @@
+import type { Figure } from '@model/plot';
+import { describe, expect, test } from '@jest/globals';
+import { DEFAULT_SUBPLOT_TITLE } from '@model/abstract';
+import { Context } from '@model/context';
+import { DEFAULT_CAPTION, DEFAULT_FIGURE_TITLE, DEFAULT_SUBTITLE } from '@model/plot';
+
+/**
+ * Minimal Figure stub that takes the empty-state branch in Context's
+ * constructor. The isAuthored* predicates do not touch the figure, so
+ * this is sufficient for direct predicate coverage.
+ */
+function createStubFigure(): Figure {
+  return {
+    id: 'test-figure',
+    state: { empty: true, type: 'figure' },
+  } as unknown as Figure;
+}
+
+describe('Context.isAuthoredTitle', () => {
+  const context = new Context(createStubFigure());
+
+  test('returns true for a normal authored title', () => {
+    expect(context.isAuthoredTitle('My Plot')).toBe(true);
+  });
+
+  test('returns false for the figure-level placeholder default', () => {
+    expect(context.isAuthoredTitle(DEFAULT_FIGURE_TITLE)).toBe(false);
+  });
+
+  test('returns false for the subplot-level placeholder default', () => {
+    expect(context.isAuthoredTitle(DEFAULT_SUBPLOT_TITLE)).toBe(false);
+  });
+
+  test('returns false for an empty string', () => {
+    expect(context.isAuthoredTitle('')).toBe(false);
+  });
+
+  test('returns false for a whitespace-only string', () => {
+    expect(context.isAuthoredTitle('   ')).toBe(false);
+  });
+
+  test('returns true for a title that happens to contain a placeholder substring', () => {
+    expect(context.isAuthoredTitle('MAIDR Plot of Annual Revenue')).toBe(true);
+  });
+});
+
+describe('Context.isAuthoredSubtitle', () => {
+  const context = new Context(createStubFigure());
+
+  test('returns true for a normal authored subtitle', () => {
+    expect(context.isAuthoredSubtitle('A subtitle')).toBe(true);
+  });
+
+  test('returns false for the subtitle placeholder default', () => {
+    expect(context.isAuthoredSubtitle(DEFAULT_SUBTITLE)).toBe(false);
+  });
+
+  test('returns false for an empty or whitespace-only string', () => {
+    expect(context.isAuthoredSubtitle('')).toBe(false);
+    expect(context.isAuthoredSubtitle('   ')).toBe(false);
+  });
+});
+
+describe('Context.isAuthoredCaption', () => {
+  const context = new Context(createStubFigure());
+
+  test('returns true for a normal authored caption', () => {
+    expect(context.isAuthoredCaption('A caption')).toBe(true);
+  });
+
+  test('returns false for the caption placeholder default', () => {
+    expect(context.isAuthoredCaption(DEFAULT_CAPTION)).toBe(false);
+  });
+
+  test('returns false for an empty or whitespace-only string', () => {
+    expect(context.isAuthoredCaption('')).toBe(false);
+    expect(context.isAuthoredCaption('   ')).toBe(false);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

<!-- Provide a brief description of the changes made in this pull request. -->
Previously, the `l t` shortcut (announce plot title) was not capturing the title authored in the MAIDR JSON. For plots that omitted a top-level `title`, the announcement read "Title is MAIDR Plot" (the model's internal placeholder); for single-panel plots that authored their title at the layer level (e.g. `examples/multiline_plot.html`), `l t` never consulted the layer title and announced "No title available" — even though the `d` (description) command correctly showed the authored title.
## Related Issues

<!-- Specify any related issues or tickets that this pull request addresses. -->
Closes https://github.com/xability/maidr/issues/613
## Changes Made

<!-- Describe the specific changes made in this pull request. -->
After this change, `l t` reads the title strictly from the MAIDR JSON: it announces the authored title when one is provided (at either the figure or the layer level), and otherwise announces "No title available". The `l t` and `d` commands now agree on what counts as a real title.
All changes are in `src/command/describe.ts`:

- The title-announce command now ignores the model's placeholder defaults (`"MAIDR Plot"`, `"unavailable"`) and only announces titles authored in the JSON.
- For trace-level scope, the authored layer title is now preferred in both single- and multi-panel figures (labeled `"Title"` in single-panel, `"Subplot title"` in multi-panel), falling back to the authored figure title, then to "No title available".
- Verbose unavailable phrasing changed from `"Title is not available"` to `"No title available"`. Terse output stays `"unavailable"` to match the convention used by the X/Y/Z/subtitle/caption announce commands.

No model-layer changes — the placeholder defaults still flow through the model for the UI and description paths that rely on them; only the title-announce command filters them out at announce time.
## Screenshots (if applicable)

<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->

## Checklist

<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
