### PR TITLE
feat: support multi-panel and faceted plots across all chart-library adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,81 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: [commitlint, lint]
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    needs: [commitlint, lint]
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npm run type-check
+
+  # Mirrors the build steps of the Deploy Documentation workflow (docs.yml),
+  # which otherwise only runs on pushes to main — so docs/example-app build
+  # breakage surfaces on the PR instead of after merge.
+  docs-build:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    needs: [commitlint, lint]
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Build documentation site
+        run: npm run docs

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -70,7 +70,7 @@ There are two entry points:
 - **`bindAmCharts(root, options?)`** (recommended) — mounts the MAIDR UI over the chart and returns `{ maidr, dispose }`. Because it hands a live data object (not JSON) to MAIDR's React component, it can wire an `onNavigate` callback that drives the **canvas highlight overlay**. This is the only way to get visual highlighting (see below). `bindXYChart(chart, root, options?)` is the same when you already hold the chart reference.
 - **`fromAmCharts(root, options?)`** — returns plain MAIDR JSON for the `maidr` HTML attribute or `<Maidr data={...}>`. Enables audio, text, and braille, but **not** visual highlighting, because the highlight callback is a function and cannot survive JSON serialization.
 
-Both walk the chart's series, classify each one, and extract its data into MAIDR's [schema](SCHEMA.html). Each series becomes a layer; all line series merge into a single multi-line layer.
+Both walk the chart's series, classify each one, and extract its data into MAIDR's [schema](SCHEMA.html). Each series becomes a layer; all line series merge into a single multi-line layer. If no chart contains a supported series *with data*, both entry points throw a descriptive error — bind after your data has been set (see the `datavalidated` note in the Quick Start).
 
 Series are classified by their amCharts class name and field configuration:
 
@@ -114,7 +114,7 @@ maidrAmCharts.bindAmCharts(root); // one MAIDR figure, two subplots
 Details:
 
 - **Navigation:** a multi-panel figure starts in subplot mode — arrow keys move between panels, Enter drills into a panel, Escape returns. Inside a panel, the usual data-point navigation applies.
-- **Panel grid:** panels are arranged by their rendered position (rows clustered by top coordinate, sorted left-to-right), so vertical, horizontal, and grid layouts all map naturally. If geometry is not available yet (e.g. `fromAmCharts` called before layout), panels fall back to a single row in insertion order.
+- **Panel grid:** panels are arranged by their rendered position (rows clustered by top coordinate, sorted left-to-right), so vertical, horizontal, and grid layouts all map naturally. Rows are ordered **bottom-first** — amCharts renders to canvas, so MAIDR cannot measure panel positions in the DOM, and bottom-first row order is what makes ArrowUp move to the visually *upper* panel. Consequently panel numbering starts at the bottom-left panel ("Subplot 1" is the bottom row). If geometry is not available yet (e.g. `fromAmCharts` called before layout), panels fall back to a single row in insertion order.
 - **Panel names:** each chart's title (an `am5.Label` child of the chart) becomes the panel's display name in subplot summaries. Axis labels are read from each chart's own axes; the `axisLabels` option remains a figure-wide override.
 - **Highlighting:** one overlay covers the whole root; each highlight box is clipped to the owning panel's plot area.
 - `bindXYChart(chart, root)` / `fromXYChart(chart, containerEl)` still bind exactly one chart; `fromXYCharts(charts, containerEl)` converts a specific set of charts; `findXYCharts(root)` returns every chart the binder would find.

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -98,6 +98,29 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 
 > Box plots, candlestick, scatter, violin, and smooth/regression layers are **not** supported by the amCharts binder. amCharts 5 has no dedicated scatter or box series, and there is no reliable runtime signal to distinguish a scatter (hidden-stroke `LineSeries`) from a normal line chart.
 
+## Multi-Panel Charts
+
+When one amCharts `Root` contains **multiple XYCharts** — amCharts' native multi-panel pattern (`root.container.set("layout", root.verticalLayout)` plus several `XYChart` children, or a `horizontalLayout`/`GridLayout`) — both `bindAmCharts` and `fromAmCharts` convert **each chart into its own MAIDR subplot**. The same applies to **am5stock `StockChart` panels** (`StockPanel` extends `XYChart`), which the binder finds by walking the root's container tree; scrollbar preview charts (`XYChartScrollbar`) are excluded.
+
+```js
+var root = am5.Root.new("chartdiv");
+root.container.set("layout", root.verticalLayout);
+var priceChart = root.container.children.push(am5xy.XYChart.new(root, { height: am5.percent(60) }));
+var volumeChart = root.container.children.push(am5xy.XYChart.new(root, { height: am5.percent(40) }));
+// ... axes, series, data for each chart ...
+maidrAmCharts.bindAmCharts(root); // one MAIDR figure, two subplots
+```
+
+Details:
+
+- **Navigation:** a multi-panel figure starts in subplot mode — arrow keys move between panels, Enter drills into a panel, Escape returns. Inside a panel, the usual data-point navigation applies.
+- **Panel grid:** panels are arranged by their rendered position (rows clustered by top coordinate, sorted left-to-right), so vertical, horizontal, and grid layouts all map naturally. If geometry is not available yet (e.g. `fromAmCharts` called before layout), panels fall back to a single row in insertion order.
+- **Panel names:** each chart's title (an `am5.Label` child of the chart) becomes the panel's display name in subplot summaries. Axis labels are read from each chart's own axes; the `axisLabels` option remains a figure-wide override.
+- **Highlighting:** one overlay covers the whole root; each highlight box is clipped to the owning panel's plot area.
+- `bindXYChart(chart, root)` / `fromXYChart(chart, containerEl)` still bind exactly one chart; `fromXYCharts(charts, containerEl)` converts a specific set of charts; `findXYCharts(root)` returns every chart the binder would find.
+
+> Stacked value axes **within one** `XYChart` (the classic price+volume single-chart pattern) are *not* split into panels — amCharts cannot reliably distinguish that layout from a dual-scale overlay, so all series stay in one subplot. Charts in **separate Roots** (one `div` each) remain separate MAIDR figures.
+
 ## Code Examples
 
 A complete, runnable page covering every supported type lives at [`examples/amcharts.html`](https://github.com/xability/maidr/blob/main/examples/amcharts.html). The snippets below show the per-type series configuration; the surrounding root/chart/axis boilerplate and the `fromAmCharts` conversion are identical to the Quick Start.
@@ -218,7 +241,7 @@ const binding = bindAmCharts(root, { title: 'Sales by Day' });
 // later: binding.dispose();
 ```
 
-`bindAmCharts(root, options?)` finds the first `XYChart` in `root.container`; `bindXYChart(chart, root, options?)` takes a chart you already hold. Options accept `title`, `subtitle`, `axisLabels: { x, y }`, plus `highlight` (default `true`) and `highlightColor`. Pass `{ highlight: false }` to mount the accessible UI without the overlay.
+`bindAmCharts(root, options?)` finds every `XYChart` in `root.container` (one subplot per chart — see [Multi-Panel Charts](#multi-panel-charts)); `bindXYChart(chart, root, options?)` takes a chart you already hold. Options accept `title`, `subtitle`, `axisLabels: { x, y }`, plus `highlight` (default `true`) and `highlightColor`. Pass `{ highlight: false }` to mount the accessible UI without the overlay.
 
 For the data-only path (no highlighting), use `fromAmCharts(root, options?)` / `fromXYChart(chart, containerEl, options?)`, which return MAIDR JSON for the `maidr` attribute or `<Maidr data={...}>`.
 

--- a/docs/anychart.md
+++ b/docs/anychart.md
@@ -342,12 +342,14 @@ How it fits together:
 
 - **Panel names** — each chart's own `title()` becomes its panel's display name in MAIDR's subplot summaries. `options.title` names the whole figure, and `options.axes` (when set) overrides every panel's axis labels; otherwise axis titles are extracted per chart.
 - **Per-panel highlighting** — the adapter stamps `data-maidr-anychart-panel="<figureId>-<row>-<col>"` on each chart's own `<svg>` and scopes every highlight selector to that panel, so highlighting can never leak between panels (or between figures on the same page).
+- **Visual navigation order** — MAIDR resolves each panel's on-screen position by measuring the element matched by that same per-panel `svg[data-maidr-anychart-panel="…"]` selector, so panel numbering follows visual reading order (top-left is "Subplot 1") and the Up/Down arrows on multi-ROW grids move visually up/down.
 - **One mount point** — the combined `maidr-data` attribute goes on a transparent host `<div>` wrapping the panels' common ancestor, so place all panel containers inside one wrapper element (or under one common parent). Charts drawn onto a shared Stage/container are **not** supported — give each chart its own container.
+- **Panel CSS** — binding may move contiguous panel containers into MAIDR's transparent host `<div>`, so they are no longer direct children of your wrapper. Size panel containers with a class or descendant selector (e.g. `#dashboard .panel { … }`), **not** a child combinator like `#dashboard > div`, which stops matching after binding and breaks later AnyChart re-layouts (window resize, `chart.draw()` on data updates). Panels with other content interleaved between them (headings, captions) are fine: the adapter then wraps their shared ancestor in place instead of moving them, preserving page order.
 - **Options** — `bindAnyCharts(charts, { id?, title?, axes?, layout? })`. The per-series `selectors` override is not available in grouped mode.
 
 `anyChartsToMaidr(charts, options)` is the matching data-only converter (same relationship as `anyChartToMaidr()` to `bindAnyChart()`): it returns the combined `Maidr | null` without touching the DOM. Note that its default selectors refer to panel attributes that only `bindAnyCharts()` stamps, and that you should pass a stable `id` if you need deterministic output.
 
-Known limitation: because AnyChart SVGs contain no per-panel `g[id^="axes_"]` groups, MAIDR cannot compute the visual layout from the DOM — panel order follows the emitted grid (reading order), there is no visual panel-outline highlight, and on multi-ROW grids the Up/Down arrows at the panel level may feel inverted (Up moves down the rows). Single-row layouts are unaffected.
+Known limitation: because AnyChart SVGs contain no per-panel `g[id^="axes_"]` groups, there is no visual panel-outline highlight while navigating between panels (panel navigation, text, audio, and per-point highlighting inside each panel are unaffected).
 
 See [`examples/anychart/multipanel.html`](https://github.com/xability/maidr/blob/main/examples/anychart/multipanel.html) for a complete 2×2 dashboard.
 

--- a/docs/anychart.md
+++ b/docs/anychart.md
@@ -298,6 +298,59 @@ bindAnyChart(chart, {
 
 Selectors are resolved against the chart container, so they may be scoped relatively (e.g. `'.series-0 rect'` rather than `'#container .series-0 rect'`).
 
+## Multi-Panel Figures
+
+AnyChart has no native facet/small-multiples concept — the idiom is one chart instance per container. `bindAnyCharts()` groups several drawn charts into ONE multi-panel MAIDR figure: users navigate between panels with arrow keys, press <kbd>Enter</kbd> to drill into a panel, and <kbd>Esc</kbd> to return to panel navigation.
+
+```html
+<!-- Keep all panel containers inside ONE wrapper element. -->
+<div id="dashboard">
+  <div id="panel-q1"></div>
+  <div id="panel-q2"></div>
+  <div id="panel-q3"></div>
+  <div id="panel-q4"></div>
+</div>
+<script type="module">
+  import { bindAnyCharts } from 'https://cdn.jsdelivr.net/npm/maidr/dist/anychart.mjs';
+
+  // q1…q4 are ordinary drawn AnyChart instances, one per container.
+  // A 2D array maps 1:1 onto the subplot grid (visual reading order,
+  // top-left panel first). Ragged rows are fine; empty rows are not.
+  bindAnyCharts(
+    [
+      [q1, q2],
+      [q3, q4],
+    ],
+    { id: 'sales-by-quarter', title: 'Sales by Quarter' },
+  );
+</script>
+```
+
+A flat array works too — arrange it with `options.layout`:
+
+```js
+// Chunk row-major into 2 columns → [[q1, q2], [q3, q4]].
+bindAnyCharts([q1, q2, q3, q4], { layout: { columns: 2 } });
+
+// Or derive the grid from each container's on-page position:
+// containers are clustered into rows by their top edge and sorted
+// left-to-right within each row.
+bindAnyCharts([q1, q2, q3, q4], { layout: 'auto' });
+```
+
+How it fits together:
+
+- **Panel names** — each chart's own `title()` becomes its panel's display name in MAIDR's subplot summaries. `options.title` names the whole figure, and `options.axes` (when set) overrides every panel's axis labels; otherwise axis titles are extracted per chart.
+- **Per-panel highlighting** — the adapter stamps `data-maidr-anychart-panel="<figureId>-<row>-<col>"` on each chart's own `<svg>` and scopes every highlight selector to that panel, so highlighting can never leak between panels (or between figures on the same page).
+- **One mount point** — the combined `maidr-data` attribute goes on a transparent host `<div>` wrapping the panels' common ancestor, so place all panel containers inside one wrapper element (or under one common parent). Charts drawn onto a shared Stage/container are **not** supported — give each chart its own container.
+- **Options** — `bindAnyCharts(charts, { id?, title?, axes?, layout? })`. The per-series `selectors` override is not available in grouped mode.
+
+`anyChartsToMaidr(charts, options)` is the matching data-only converter (same relationship as `anyChartToMaidr()` to `bindAnyChart()`): it returns the combined `Maidr | null` without touching the DOM. Note that its default selectors refer to panel attributes that only `bindAnyCharts()` stamps, and that you should pass a stable `id` if you need deterministic output.
+
+Known limitation: because AnyChart SVGs contain no per-panel `g[id^="axes_"]` groups, MAIDR cannot compute the visual layout from the DOM — panel order follows the emitted grid (reading order), there is no visual panel-outline highlight, and on multi-ROW grids the Up/Down arrows at the panel level may feel inverted (Up moves down the rows). Single-row layouts are unaffected.
+
+See [`examples/anychart/multipanel.html`](https://github.com/xability/maidr/blob/main/examples/anychart/multipanel.html) for a complete 2×2 dashboard.
+
 ## How Highlighting Works (Advanced)
 
 AnyChart's SVG output uses opaque, internally-generated ids (`ac_path_*`, `ac_rect_*`, `ac_layer_*`) and does not expose stable CSS classes. To still provide reliable per-point highlighting without forcing every consumer to write selectors, `bindAnyChart()` stamps stable `data-maidr-anychart-*` attributes onto the relevant SVG elements after the chart renders:

--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -382,6 +382,48 @@ Requires [`chartjs-chart-matrix`](https://github.com/kurkle/chartjs-chart-matrix
 </script>
 ```
 
+## Multi-Panel Charts (Axis Stacking)
+
+Chart.js has no facet API, but since v3.7 a single chart can render stacked panels via **axis stacking**: two or more scales of the same axis kind share a `stack` name and are laid out in separate, non-overlapping bands. Datasets pick their panel with `yAxisID` (or `xAxisID`).
+
+MAIDR detects this layout automatically and exposes each panel as its own **subplot**: y-stacked scales become an N-rows-by-1-column figure, x-stacked scales become 1-row-by-N-columns, ordered by on-canvas position. Navigation starts at the subplot level — arrow keys move between panels, `Enter` drills into a panel, `Escape` returns. Each panel announces its own value-axis label (from that scale's `title.text`, which also names the panel) while sharing the common index axis.
+
+```html
+<div style="width: 700px; height: 500px">
+  <canvas id="stacked-panels-chart"></canvas>
+</div>
+<script>
+  Chart.register(maidrChartjs.maidrPlugin);
+
+  new Chart(document.getElementById('stacked-panels-chart'), {
+    type: 'line',
+    data: {
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+      datasets: [
+        { label: 'Price', data: [102, 110, 108, 121, 119, 127] }, // default yAxisID: 'y'
+        { label: 'Volume', data: [34, 51, 42, 65, 48, 70], yAxisID: 'y2' },
+      ],
+    },
+    options: {
+      plugins: { title: { display: true, text: 'Stock Price and Trading Volume' } },
+      scales: {
+        x: { title: { display: true, text: 'Month' } },
+        y: { stack: 'panels', stackWeight: 2, title: { display: true, text: 'Price ($)' } },
+        y2: { stack: 'panels', stackWeight: 1, offset: true, title: { display: true, text: 'Volume (M shares)' } },
+      },
+    },
+  });
+</script>
+```
+
+Notes:
+
+- Every supported chart type works inside panels; each panel's datasets are extracted with that panel's own scale, so per-panel `stacked: true` still maps to the `STACKED` trace type while another panel stays `DODGED`.
+- Classic **dual-axis** charts (two y scales overlaying the same plot area, no `stack` option) are *not* panels and remain a single subplot, exactly as before.
+- Multiple `Chart` instances arranged in a page grid are still separate MAIDR figures; grouping several charts into one figure is not yet supported.
+
+For programmatic use, `extractChartData(chart)` returns the extracted MAIDR schema together with a `layerDatasetIndices` map that ties each figure-unique layer id back to the Chart.js datasets that produced it.
+
 ## Keyboard Controls
 
 Once a chart is focused, use standard MAIDR keyboard shortcuts:

--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -386,7 +386,9 @@ Requires [`chartjs-chart-matrix`](https://github.com/kurkle/chartjs-chart-matrix
 
 Chart.js has no facet API, but since v3.7 a single chart can render stacked panels via **axis stacking**: two or more scales of the same axis kind share a `stack` name and are laid out in separate, non-overlapping bands. Datasets pick their panel with `yAxisID` (or `xAxisID`).
 
-MAIDR detects this layout automatically and exposes each panel as its own **subplot**: y-stacked scales become an N-rows-by-1-column figure, x-stacked scales become 1-row-by-N-columns, ordered by on-canvas position. Navigation starts at the subplot level — arrow keys move between panels, `Enter` drills into a panel, `Escape` returns. Each panel announces its own value-axis label (from that scale's `title.text`, which also names the panel) while sharing the common index axis.
+MAIDR detects this layout automatically and exposes each panel as its own **subplot**: y-stacked scales become an N-rows-by-1-column figure, x-stacked scales become 1-row-by-N-columns (left to right). Navigation starts at the subplot level — arrow keys move between panels, `Enter` drills into a panel, `Escape` returns. Each panel announces its own value-axis label (from that scale's `title.text`, which also names the panel) while sharing the common index axis.
+
+Because Chart.js draws to a `<canvas>`, MAIDR cannot measure panel geometry from the DOM the way it does for SVG charts, so y-stacked figures follow the MAIDR grammar's native (matplotlib-style) row convention: **grid rows are ordered bottom-first**. Up/Down arrows always move the way the panels look on canvas (Up goes to the panel above), but panel *numbering* is announced bottom-up — "Subplot 1" is the bottom panel and navigation enters the figure there.
 
 ```html
 <div style="width: 700px; height: 500px">
@@ -419,7 +421,8 @@ MAIDR detects this layout automatically and exposes each panel as its own **subp
 Notes:
 
 - Every supported chart type works inside panels; each panel's datasets are extracted with that panel's own scale, so per-panel `stacked: true` still maps to the `STACKED` trace type while another panel stays `DODGED`.
-- Classic **dual-axis** charts (two y scales overlaying the same plot area, no `stack` option) are *not* panels and remain a single subplot, exactly as before.
+- Datasets that omit `yAxisID`/`xAxisID` are assigned to the **first declared** scale of that axis kind, exactly as Chart.js resolves them — including when your scales use custom ids like `price`/`volume`.
+- Classic **dual-axis** charts (two y scales overlaying the same plot area) are *not* panels and remain a single subplot, exactly as before. Matching Chart.js layout rules, scales only band together when they share **both** the same `stack` name **and** the same `position` — different stack names, or the same name on opposite edges (e.g. `left`/`right`), stay a dual-axis overlay.
 - Multiple `Chart` instances arranged in a page grid are still separate MAIDR figures; grouping several charts into one figure is not yet supported.
 
 For programmatic use, `extractChartData(chart)` returns the extracted MAIDR schema together with a `layerDatasetIndices` map that ties each figure-unique layer id back to the Chart.js datasets that produced it.

--- a/docs/d3.md
+++ b/docs/d3.md
@@ -202,6 +202,85 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Segmented` | Stacked / dodged / normalized bars | `<rect>` per segment | [Stacked](examples.html), [Dodged](examples.html) |
 | `bindD3Smooth` | Smooth / regression curve | `<circle>` per sample | [Smooth curve](examples.html) |
 
+## Multi-Panel Charts
+
+D3 has no declarative facet API — the community idiom is one translated `<g>` per panel inside a single `<svg>`. Two binders turn that idiom into a navigable MAIDR figure: arrow keys move *between* panels, `ENTER` drills into a panel, `ESC` returns.
+
+### `bindD3Facets` — homogeneous small multiples
+
+Use when every panel repeats the **same** chart type (the `d3.groups()` + one-`<g>`-per-group pattern). You provide a `panelSelector`; each matched panel element becomes the extraction root for the per-type binder, so `config.selector` only needs to match marks *within* a panel:
+
+```js
+// One <g class="panel"> per d3.groups() entry, each holding rect.bar marks
+svg.selectAll('g.panel')
+  .data(d3.groups(flat, d => d.region))
+  .join('g')
+  .attr('class', 'panel')
+  .attr('transform', (d, i) => `translate(${(i % 2) * w}, ${Math.floor(i / 2) * h})`);
+// ... draw rect.bar marks inside each panel ...
+
+maidrD3.bindD3Facets(svgElement, {
+  panelSelector: 'g.panel',
+  chartType: 'bar',                       // any of the nine chart types
+  config: {                               // the usual per-type config;
+    selector: 'rect.bar',                 // resolved inside each panel
+    title: 'Sales by Day, faceted by Region',  // figure title
+    axes: { x: 'Day', y: 'Sales' },
+    x: 'day',
+    y: 'sales',
+  },
+  panelTitle: d => `Region: ${d[0]}`,     // resolved against the panel's __data__
+  // layout: 'row' | 'column' | { columns: 2 }   // optional; geometry-inferred by default
+});
+```
+
+- **Panel titles.** Each panel's display name (announced during panel navigation) comes from `panelTitle`, resolved against the panel element's D3-bound `__data__`. Panels joined from `d3.groups()` (`[key, values]` tuples) or nest-style `{ key, values }` objects get their group key automatically; the fallback is `Panel <n>`.
+- **Grid shape.** An explicit `layout` always wins. Otherwise the grid is inferred from panel geometry (bounding-box centers clustered into rows, left-to-right within a row), falling back to `transform="translate(x,y)"` values, then to a single row in DOM order. Ragged grids (e.g. 5 panels as 2+2+1) are supported.
+
+### `bindD3Subplots` — heterogeneous grids
+
+Use when panels hold **different** chart types, each drawn independently. Every entry names a chart type, its usual binder config, and the panel's DOM `root` (an element or a selector resolved against the container):
+
+```js
+maidrD3.bindD3Subplots(svgElement, {
+  title: 'Quarterly Performance',        // figure title
+  subplots: [[                           // 2D row-major grid (ragged rows OK)…
+    { chartType: 'bar', root: 'g.revenue', config: { selector: 'rect.bar', title: 'Revenue' } },
+    { chartType: 'line', root: 'g.growth', config: { selector: 'path.line', title: 'Growth' } },
+  ]],
+  // …or a flat array plus layout: 'row' | 'column' | { columns: 2 }
+});
+```
+
+Each entry's `config.title` is that panel's display name; figure-level fields (`id`, `title`, `subtitle`, `caption`, `autoApply`) live on the spec itself.
+
+### How panel isolation works
+
+MAIDR resolves selectors page-globally, so the binders stamp each panel element with `data-maidr-panel="<i>"` and emit every layer selector as `#<svgId> [data-maidr-panel="<i>"] <yourSelector>` — panel A's selector can never highlight panel B's marks. Panels that are anonymous `<g>` elements also receive `id="axes_<svgId>_<i>"` so MAIDR can outline the active panel; user-assigned ids are never overwritten (stamping is skipped entirely in that case — navigation still works, only the visual panel outline is lost).
+
+Both binders return `{ maidr, layers }` (`D3MultiPanelResult`) — one layer per panel in reading order — and auto-apply `maidr-data` to the SVG unless `autoApply: false`.
+
+### React
+
+`<MaidrD3>` and `useD3Adapter` accept the multi-panel binders via `chartType: 'facets'` and `chartType: 'subplots'`:
+
+```tsx
+<MaidrD3
+  svgRef={svgRef}
+  chartType="facets"
+  config={{
+    panelSelector: 'g.panel',
+    chartType: 'bar',
+    config: { selector: 'rect.bar', x: 'day', y: 'sales' },
+  }}
+  deps={[data]}
+>
+  <svg ref={svgRef} />
+</MaidrD3>
+```
+
+See [`examples/d3-bindfacets.html`](https://github.com/xability/maidr/blob/main/examples/d3-bindfacets.html) and [`examples/d3-bindsubplots.html`](https://github.com/xability/maidr/blob/main/examples/d3-bindsubplots.html) for complete runnable pages.
+
 ## Data Examples by Chart Type
 
 ### Bar Chart
@@ -443,6 +522,13 @@ import type {
   D3CandlestickConfig,
   D3SegmentedConfig,
   D3SmoothConfig,
+  // Multi-panel
+  D3FacetsConfig,
+  D3SubplotsConfig,
+  D3SubplotEntry,
+  D3PanelChartSpec,
+  D3PanelLayout,
+  D3MultiPanelResult,
   // Shared
   D3BinderConfig,
   D3BinderResult,

--- a/docs/d3.md
+++ b/docs/d3.md
@@ -234,7 +234,7 @@ maidrD3.bindD3Facets(svgElement, {
 });
 ```
 
-- **Panel titles.** Each panel's display name (announced during panel navigation) comes from `panelTitle`, resolved against the panel element's D3-bound `__data__`. Panels joined from `d3.groups()` (`[key, values]` tuples) or nest-style `{ key, values }` objects get their group key automatically; the fallback is `Panel <n>`.
+- **Panel titles.** Each panel's display name (announced during panel navigation) comes from `panelTitle`, resolved against the panel element's D3-bound `__data__`. Function accessors are invoked even when a panel has no bound datum (their first argument is then `undefined`), so index-based accessors like `(_d, i) => keys[i]` work for panels appended without a data join. Panels joined from `d3.groups()` (`[key, values]` tuples) or nest-style `{ key, values }` objects get their group key automatically; the fallback is `Panel <n>`.
 - **Grid shape.** An explicit `layout` always wins. Otherwise the grid is inferred from panel geometry (bounding-box centers clustered into rows, left-to-right within a row), falling back to `transform="translate(x,y)"` values, then to a single row in DOM order. Ragged grids (e.g. 5 panels as 2+2+1) are supported.
 
 ### `bindD3Subplots` — heterogeneous grids
@@ -256,7 +256,7 @@ Each entry's `config.title` is that panel's display name; figure-level fields (`
 
 ### How panel isolation works
 
-MAIDR resolves selectors page-globally, so the binders stamp each panel element with `data-maidr-panel="<i>"` and emit every layer selector as `#<svgId> [data-maidr-panel="<i>"] <yourSelector>` — panel A's selector can never highlight panel B's marks. Panels that are anonymous `<g>` elements also receive `id="axes_<svgId>_<i>"` so MAIDR can outline the active panel; user-assigned ids are never overwritten (stamping is skipped entirely in that case — navigation still works, only the visual panel outline is lost).
+MAIDR resolves selectors page-globally, so the binders stamp each panel element with `data-maidr-panel="<i>"` and emit every layer selector as `#<svgId> [data-maidr-panel="<i>"] <yourSelector>` — panel A's selector can never highlight panel B's marks. Panels that are anonymous `<g>` elements also receive `id="axes_<svgId>_<i>"` so MAIDR can outline the active panel; user-assigned ids are never overwritten (stamping is skipped entirely in that case — navigation order and arrow directions still resolve from the rendered panel geometry, only the visual panel outline is lost). Each panel root must be its own element: `bindD3Subplots` throws if two entries resolve to the same root.
 
 Both binders return `{ maidr, layers }` (`D3MultiPanelResult`) — one layer per panel in reading order — and auto-apply `maidr-data` to the SVG unless `autoApply: false`.
 

--- a/docs/frappe.md
+++ b/docs/frappe.md
@@ -236,6 +236,68 @@ The `activateMaidrWhenSettled` helper in the Quick Start handles this: it waits 
 </script>
 ```
 
+## Multi-Panel Figures
+
+Frappe Charts has no native facet/subplot concept — a "multi-panel" chart is simply several `new frappe.Chart(...)` instances laid out with CSS. `createMaidrFromFrappeCharts` groups such charts into **one** MAIDR figure with cross-panel navigation: arrow keys move between panels, <kbd>Enter</kbd> drills into a panel, <kbd>Esc</kbd> returns to panel navigation.
+
+```html
+<div id="dashboard" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+  <div id="panel-bar"></div>
+  <div id="panel-line"></div>
+</div>
+
+<script>
+  const barChart = new frappe.Chart('#panel-bar', { type: 'bar', height: 300, data: barData });
+  const lineChart = new frappe.Chart('#panel-line', {
+    type: 'line',
+    height: 300,
+    lineOptions: { dotSize: 5 },
+    data: lineData,
+  });
+
+  // The panel grid, in visual reading order (row-major, top-left first),
+  // matching your CSS layout. A flat array + `columns` also works:
+  // createMaidrFromFrappeCharts(flatPanels, wrapper, { columns: 2 }).
+  const panels = [
+    [
+      {
+        chart: barChart,
+        container: document.querySelector('#panel-bar'),
+        chartType: 'bar',
+        title: 'Weekly Visitors',
+        axes: { x: 'Day', y: 'Visitors' },
+      },
+      {
+        chart: lineChart,
+        container: document.querySelector('#panel-line'),
+        chartType: 'line',
+        title: 'Annual Revenue',
+        axes: { x: 'Year', y: 'Revenue' },
+      },
+    ],
+  ];
+
+  // Wait until EVERY panel has settled (see "Wait for the chart to settle"),
+  // then set the `maidr` attribute on the WRAPPER element.
+  const wrapper = document.querySelector('#dashboard');
+  Promise.all(panels.flat().map(p => whenChartSettled(p.container))).then(() => {
+    const maidr = maidrFrappe.createMaidrFromFrappeCharts(panels, wrapper, {
+      title: 'Store Performance Dashboard',
+    });
+    wrapper.setAttribute('maidr', JSON.stringify(maidr));
+  });
+</script>
+```
+
+Key points:
+
+- **Each panel** is a `FrappePanel`: `{ chart, container, chartType, title?, axes? }` — the same per-chart options as the single-chart API, plus the panel's `title`, which MAIDR announces when navigating between panels.
+- **Grid shape**: a 2D array maps 1:1 to subplot rows (ragged rows are fine); a flat array is chunked into rows of `options.columns` panels, or placed in a single row when `columns` is omitted. Order panels in visual reading order (row-major, top-left first) to match your CSS layout.
+- **Set the `maidr` attribute on the wrapper**, not on individual panel containers — a per-panel attribute would create N separate MAIDR figures instead of one grid. Every panel container must be a descendant of the wrapper (the adapter throws otherwise).
+- **Wait for all panels to settle** before calling the adapter — Frappe's entrance animation re-creates SVG nodes per chart, so wrap the per-container settle wait in `Promise.all` (see [`examples/frappe-multipanel.html`](https://github.com/xability/maidr/blob/main/examples/frappe-multipanel.html) for a complete 2x2 example, including a promise-based `whenChartSettled` helper).
+- **Figure-level options** (`FrappeChartsGridOptions`): `id` (defaults to the wrapper's `id`), `title`, `subtitle`, `caption`, and `columns` (flat input only).
+- **Live updates are not supported** for grouped charts: calling `chart.update(...)` on a panel after binding re-creates its SVG nodes and invalidates the captured highlight elements. Rebuild and re-set the `maidr` attribute if panel data changes.
+
 ## Configuration Options
 
 The adapter accepts a `FrappeChartAdapterOptions` object:
@@ -252,7 +314,7 @@ The adapter accepts a `FrappeChartAdapterOptions` object:
 For bundled projects, import the adapter directly:
 
 ```typescript
-import { createMaidrFromFrappeChart } from 'maidr/frappe';
+import { createMaidrFromFrappeChart, createMaidrFromFrappeCharts } from 'maidr/frappe';
 
 // Use after the chart has rendered
 const maidr = createMaidrFromFrappeChart(chart, container, {

--- a/docs/google-charts.md
+++ b/docs/google-charts.md
@@ -302,6 +302,75 @@ The adapter must be called inside the chart's `ready` event to ensure the SVG is
 </script>
 ```
 
+## Multi-Panel (Faceted) Figures
+
+Google Charts has no native facet/trellis concept — a "faceted" page is several chart instances drawn into separate containers. `createMaidrFromGoogleCharts` (plural) groups those instances into **one** MAIDR figure: arrow keys move between panels, `Enter` drills into a panel's data, and `Esc` returns to panel navigation.
+
+Each panel is the same `{ chart, dataTable, container, chartType }` tuple the single-chart API takes, plus an optional `title` announced during panel navigation. All panel containers must live inside a single wrapper element, passed as `options.root` — and the combined `maidr` attribute is set on that wrapper, **not** on the individual containers.
+
+Because every chart fires its `ready` event independently, use the `whenGoogleChartsReady` helper to build the figure only after all panels have rendered. Register the gate before calling `draw()` on any chart.
+
+```html
+<div id="facet-grid">
+  <div id="panel-east"></div>
+  <div id="panel-west"></div>
+</div>
+<script>
+  var root = document.getElementById('facet-grid');
+
+  var panels = [
+    { id: 'panel-east', title: 'East', rows: [['Q1', 100], ['Q2', 200]] },
+    { id: 'panel-west', title: 'West', rows: [['Q1', 80], ['Q2', 140]] },
+  ].map(function (facet) {
+    var container = document.getElementById(facet.id);
+    return {
+      chart: new google.visualization.ColumnChart(container),
+      dataTable: google.visualization.arrayToDataTable([['Quarter', 'Revenue']].concat(facet.rows)),
+      container: container,
+      chartType: 'ColumnChart',
+      title: facet.title,
+    };
+  });
+
+  var charts = panels.map(function (panel) { return panel.chart; });
+
+  // Build the combined figure once ALL panels have rendered.
+  maidrGoogleCharts.whenGoogleChartsReady(charts, google.visualization.events, function () {
+    var maidr = maidrGoogleCharts.createMaidrFromGoogleCharts(panels, {
+      root: root,
+      title: 'Revenue by Region',
+      layout: { columns: 2 },
+    });
+    root.setAttribute('maidr', JSON.stringify(maidr));
+  });
+
+  panels.forEach(function (panel) {
+    panel.chart.draw(panel.dataTable, { legend: { position: 'none' }, width: 360, height: 260 });
+  });
+</script>
+```
+
+### Grid Shape
+
+The grid shape is resolved in priority order:
+
+1. **2D array** — pass `panels` as `GoogleChartPanel[][]` to use it directly as the subplot grid (rows may be ragged, but never empty).
+2. **Flat array + `options.layout`** — `{ columns: n }` chunks the panels row-major into rows of `n`; `{ rows: n }` derives the column count instead.
+3. **Neither** — the grid is inferred from each container's on-screen position (clustered into rows by top edge, sorted left-to-right).
+
+Always supply panels in visual reading order (top-left panel first) so announcements match what sighted users see.
+
+### `createMaidrFromGoogleCharts` Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `root` | `HTMLElement` | Yes | Wrapper element containing all panel containers; receives the `maidr` attribute |
+| `title` | `string` | No | Figure-level title announced when the figure receives focus |
+| `id` | `string` | No | Unique ID for the MAIDR instance (defaults to the root's `id`) |
+| `layout` | `{ rows?, columns? }` | No | Grid shape for a flat panel array (ignored for 2D arrays) |
+
+Panel titles (e.g. the facet value, `'East'`) are announced in subplot summaries; per-panel axis labels come from each panel's own DataTable. Mixed chart types across panels are supported — any type from the table above works per panel.
+
 ## Configuration Options
 
 The adapter accepts a `GoogleChartAdapterOptions` object:
@@ -317,7 +386,11 @@ The adapter accepts a `GoogleChartAdapterOptions` object:
 For bundled projects, import the adapter directly:
 
 ```typescript
-import { createMaidrFromGoogleChart } from 'maidr/google-charts';
+import {
+  createMaidrFromGoogleChart,
+  createMaidrFromGoogleCharts,
+  whenGoogleChartsReady,
+} from 'maidr/google-charts';
 
 // Use in your chart's ready callback
 const maidr = createMaidrFromGoogleChart(chart, dataTable, container, {

--- a/docs/google-charts.md
+++ b/docs/google-charts.md
@@ -306,7 +306,7 @@ The adapter must be called inside the chart's `ready` event to ensure the SVG is
 
 Google Charts has no native facet/trellis concept — a "faceted" page is several chart instances drawn into separate containers. `createMaidrFromGoogleCharts` (plural) groups those instances into **one** MAIDR figure: arrow keys move between panels, `Enter` drills into a panel's data, and `Esc` returns to panel navigation.
 
-Each panel is the same `{ chart, dataTable, container, chartType }` tuple the single-chart API takes, plus an optional `title` announced during panel navigation. All panel containers must live inside a single wrapper element, passed as `options.root` — and the combined `maidr` attribute is set on that wrapper, **not** on the individual containers.
+Each panel is the same `{ chart, dataTable, container, chartType }` tuple the single-chart API takes, plus an optional `title` announced during panel navigation. All panel containers must live inside a single wrapper element, passed as `options.root` — and the combined `maidr` attribute is set on that wrapper, **not** on the individual containers. Panel containers must not be nested inside one another (e.g. don't pass a card `<div>` that wraps another panel's chart `<div>`): the adapter's container-scoped selectors would match both charts' elements, so nested containers are rejected with an error.
 
 Because every chart fires its `ready` event independently, use the `whenGoogleChartsReady` helper to build the figure only after all panels have rendered. Register the gate before calling `draw()` on any chart.
 

--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -114,6 +114,61 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 | Dodged (Grouped) Bar | `column`/`bar` (default, no stacking) with multiple series | [highcharts-dodged.html](highcharts-dodged.html) |
 | Normalized Bar | `column`/`bar` + `plotOptions.column.stacking: 'percent'` | [highcharts-normalized.html](highcharts-normalized.html) |
 
+## Multi-Panel Charts
+
+MAIDR supports two multi-panel patterns. In both cases the panels become a MAIDR subplot grid: arrow keys move between panels, `Enter` drills into a panel, and `Escape` returns to panel navigation.
+
+### Panes within one chart
+
+A single Highcharts chart can stack multiple panes via `yAxis` `top`/`height` (and side-by-side via `xAxis` `left`/`width`) — the classic Highstock price + volume layout. `highchartsToMaidr()` detects panes automatically from the rendered axis geometry and emits one subplot per pane. No new API is needed:
+
+```js
+const chart = Highcharts.chart('panes-chart', {
+  title: { text: 'ACME Stock — Price and Volume' },
+  xAxis: { categories: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'] },
+  yAxis: [
+    { title: { text: 'Price ($)' }, height: '60%' },
+    { title: { text: 'Volume' }, top: '70%', height: '30%', offset: 0 },
+  ],
+  series: [
+    { type: 'line', name: 'Price', data: [150, 152, 149, 153, 155], yAxis: 0 },
+    { type: 'column', name: 'Volume', data: [1200, 1450, 980, 1610, 1330], yAxis: 1 },
+  ],
+});
+
+const maidrData = maidrHighcharts.highchartsToMaidr(chart, { id: 'panes-chart' });
+```
+
+Notes:
+
+- Each pane's panel name comes from its first series' name, falling back to the pane's y-axis title.
+- Highstock's internal navigator series is excluded automatically.
+- Ambiguous layouts (overlapping axis bands, dual-axis overlays sharing the same plot area) safely fall back to today's single-panel output.
+
+See [highcharts-panes.html](highcharts-panes.html) for a full example.
+
+### Multiple chart instances (small multiples)
+
+Highcharts has no native faceting API — small multiples are built as separate chart instances in separate divs. `highchartsGridToMaidr()` combines them into one MAIDR figure (one subplot per chart). Attach the result to a wrapper element enclosing all the chart divs:
+
+```js
+const charts = [
+  Highcharts.chart('region-north', { title: { text: 'North' }, /* ... */ }),
+  Highcharts.chart('region-east', { title: { text: 'East' }, /* ... */ }),
+  Highcharts.chart('region-south', { title: { text: 'South' }, /* ... */ }),
+  Highcharts.chart('region-west', { title: { text: 'West' }, /* ... */ }),
+];
+
+const maidrData = maidrHighcharts.highchartsGridToMaidr(charts, {
+  title: 'Quarterly Sales by Region',
+  layout: { columns: 2 }, // chunk the flat list into a 2x2 grid
+});
+
+document.getElementById('wrapper').setAttribute('maidr-data', JSON.stringify(maidrData));
+```
+
+Pass charts in visual reading order (top-left first). A 2D array (`Chart[][]`) maps rows 1:1 instead of using `layout`. Each chart's own title becomes its panel name. See [highcharts-grid.html](highcharts-grid.html) for a full example.
+
 ## API Reference
 
 ### `highchartsToMaidr(chart, options?)`
@@ -127,7 +182,22 @@ Converts a rendered Highcharts chart into a `Maidr` data object.
 | `options.title` | `string?` | Override the chart title. Defaults to `chart.title.textStr`. |
 | `options.seriesIndices` | `number[]?` | Convert only specific series by index. Default: all visible series. |
 
-Returns a `Maidr` object ready to assign to a `maidr-data` attribute, pass to the `<Maidr>` React component, or serialize for downstream tooling.
+Returns a `Maidr` object ready to assign to a `maidr-data` attribute, pass to the `<Maidr>` React component, or serialize for downstream tooling. Multi-pane charts produce a subplot grid (see [Multi-Panel Charts](#multi-panel-charts)).
+
+### `highchartsGridToMaidr(charts, options?)`
+
+Combines multiple rendered chart instances into one `Maidr` figure with subplot navigation.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `charts` | `HighchartsChart[]` or `HighchartsChart[][]` | Rendered chart instances in visual reading order. A 2D array maps 1:1 to the subplot grid (ragged rows OK). |
+| `options.id` | `string?` | Override the generated figure ID. Defaults to `highcharts-grid-{n}`. |
+| `options.title` | `string?` | Figure-level title announced for the whole grid. |
+| `options.subtitle` | `string?` | Figure-level subtitle. |
+| `options.caption` | `string?` | Figure-level caption. |
+| `options.layout` | `{ rows?: number; columns?: number }?` | Chunks a flat chart list into a grid (`columns` = charts per row). Ignored for 2D input. |
+
+Charts with no convertible series are skipped with a console warning. Attach the returned JSON as `maidr-data` on a wrapper element that encloses all the chart containers.
 
 ### `createHighchartsSync(chart)`
 
@@ -146,6 +216,7 @@ import type {
   HighchartsAdapterOptions,
   HighchartsAxis,
   HighchartsChart,
+  HighchartsGridOptions,
   HighchartsPoint,
   HighchartsSeries,
   HighchartsSync,

--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -167,7 +167,7 @@ const maidrData = maidrHighcharts.highchartsGridToMaidr(charts, {
 document.getElementById('wrapper').setAttribute('maidr-data', JSON.stringify(maidrData));
 ```
 
-Pass charts in visual reading order (top-left first). A 2D array (`Chart[][]`) maps rows 1:1 instead of using `layout`. Each chart's own title becomes its panel name. See [highcharts-grid.html](highcharts-grid.html) for a full example.
+Pass charts in visual reading order (top-left first). A 2D array (`Chart[][]`) maps rows 1:1 instead of using `layout`. Each chart's own title becomes its panel name. If a member chart itself contains multiple panes (stacked `yAxis` bands), the same pane detection as `highchartsToMaidr()` applies: each pane becomes its own cell, flattened into that chart's grid row (a console warning notes the flattening). See [highcharts-grid.html](highcharts-grid.html) for a full example.
 
 ## API Reference
 
@@ -197,7 +197,7 @@ Combines multiple rendered chart instances into one `Maidr` figure with subplot 
 | `options.caption` | `string?` | Figure-level caption. |
 | `options.layout` | `{ rows?: number; columns?: number }?` | Chunks a flat chart list into a grid (`columns` = charts per row). Ignored for 2D input. |
 
-Charts with no convertible series are skipped with a console warning. Attach the returned JSON as `maidr-data` on a wrapper element that encloses all the chart containers.
+Charts with no convertible series are skipped with a console warning; if **no** chart in the grid produces any convertible series, an `Error` is thrown (attaching an empty figure would break MAIDR on focus). A member chart with multiple panes contributes one cell per pane, flattened into its row. Attach the returned JSON as `maidr-data` on a wrapper element that encloses all the chart containers.
 
 ### `createHighchartsSync(chart)`
 

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -280,6 +280,11 @@ Faceted figures — shared `matches:` axes plus facet-label annotations, the pat
 - Facet labels (e.g. `"sex=Male"`) become the panel names announced during navigation.
 - Axis titles carried only by the outer (matched) axis are resolved for every inner panel.
 
+Both annotation shapes are recognized:
+
+- **Paper refs** (`xref: 'paper'`, `yref: 'paper'`) — what plotly.py actually emits for Plotly Express facet labels and `make_subplots` `row_titles`/`column_titles`/`subplot_titles`. These are matched to panels geometrically: column titles above the top row, rotated row titles at the right edge, and per-panel titles (e.g. `facet_col_wrap`) just above each panel.
+- **Axis-domain refs** (`xref: 'x2 domain'`) — hand-authored facet labels tied explicitly to a panel's axes, as in the example below.
+
 ```html
 <div id="facet-chart" style="width: 900px; height: 450px"></div>
 <script>

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -69,6 +69,7 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Candlestick | `type: 'candlestick'` | [Candlestick](examples.html) |
 | Grouped Bar | `barmode: 'group'` + multiple bar traces | [Grouped bar](examples.html) |
 | Stacked Bar | `barmode: 'stack'` + multiple bar traces | [Stacked bar](examples.html) |
+| Subplots / Facets | multiple `xaxis`/`yaxis` pairs, `layout.grid`, or Plotly Express facets | [Subplots](examples.html) |
 
 ## Code Examples
 
@@ -250,6 +251,55 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   });
 </script>
 ```
+
+### Subplots (2x2 Grid)
+
+Figures with multiple panels — whether built with manual axis pairs, `layout.grid`, or Python's `make_subplots` — become a navigable 2D grid. MAIDR reads each panel's axis domains to recover the visual layout (including ragged grids), so arrow keys move between panels in reading order, `Enter` drills into a panel, and `Escape` returns to panel navigation. The selected panel is outlined visually.
+
+```html
+<div id="subplot-chart" style="width: 900px; height: 600px"></div>
+<script>
+  Plotly.newPlot('subplot-chart', [
+    { x: ['Mon', 'Tue'], y: [20, 14], type: 'bar', name: 'Tips' },
+    { x: [1, 2, 3], y: [10, 15, 13], type: 'scatter', mode: 'lines+markers', name: 'Sales', xaxis: 'x2', yaxis: 'y2' },
+    { x: [5.1, 4.9, 4.7], y: [1.4, 1.4, 1.3], type: 'scatter', mode: 'markers', name: 'Iris', xaxis: 'x3', yaxis: 'y3' },
+    { x: [1.2, 1.9, 2.1, 2.4, 3.0], type: 'histogram', name: 'Distribution', xaxis: 'x4', yaxis: 'y4' }
+  ], {
+    title: { text: 'Four Views of the Data' },
+    grid: { rows: 2, columns: 2, pattern: 'independent' }
+  });
+</script>
+```
+
+Each panel announces its trace name (e.g. "Subplot 1 of 4") while navigating; inset plots and overlaid dual-axis charts are kept as a flat panel list rather than forced into a grid.
+
+### Facets (Plotly Express style)
+
+Faceted figures — shared `matches:` axes plus facet-label annotations, the pattern Plotly Express emits for `facet_row`/`facet_col` — are fully supported:
+
+- Facet labels (e.g. `"sex=Male"`) become the panel names announced during navigation.
+- Axis titles carried only by the outer (matched) axis are resolved for every inner panel.
+
+```html
+<div id="facet-chart" style="width: 900px; height: 450px"></div>
+<script>
+  Plotly.newPlot('facet-chart', [
+    { x: [16.99, 10.34, 21.01], y: [1.01, 1.66, 3.5], type: 'scatter', mode: 'markers' },
+    { x: [8.77, 26.88, 15.04], y: [2.0, 3.12, 1.96], type: 'scatter', mode: 'markers', xaxis: 'x2', yaxis: 'y2' }
+  ], {
+    xaxis: { domain: [0, 0.48], title: { text: 'Total Bill ($)' } },
+    xaxis2: { domain: [0.52, 1], matches: 'x' },
+    yaxis: { title: { text: 'Tip ($)' } },
+    yaxis2: { matches: 'y', anchor: 'x2' },
+    annotations: [
+      { text: 'sex=Female', xref: 'x domain', yref: 'y domain', x: 0.5, y: 1.05, showarrow: false },
+      { text: 'sex=Male', xref: 'x2 domain', yref: 'y2 domain', x: 0.5, y: 1.05, showarrow: false }
+    ]
+  });
+</script>
+```
+
+Charts generated from Python (`plotly.express` facets, `make_subplots`) work the same way — the adapter reads the rendered figure, so no extra configuration is needed.
 
 ## Dynamic Charts
 

--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -63,11 +63,13 @@ function AccessibleBarChart() {
 |------|------|----------|-------------|
 | `id` | `string` | Yes | Unique identifier for the chart (used for DOM IDs). |
 | `children` | `ReactNode` | Yes | Recharts chart component(s) to make accessible. |
-| `data` | `Record<string, unknown>[]` | Yes | Recharts data array. Each item is one data point with named fields. |
+| `data` | `Record<string, unknown>[]` | Simple/composed mode | Recharts data array. Each item is one data point with named fields. In subplot mode it is the default data for panels without their own `data`. |
 | `xKey` | `string` | Yes | Key in data objects for x-axis values. |
 | `chartType` | `RechartsChartType` | Simple mode | Chart type (see supported types below). |
 | `yKeys` | `string[]` | Simple mode | Keys in data objects for y-axis values. Each key is a data series. |
 | `layers` | `RechartsLayerConfig[]` | Composed mode | Layer configs for mixed chart types (see Composed Charts). |
+| `subplots` | `RechartsSubplotConfig[][]` or `RechartsSubplotConfig[]` | Subplot mode | Panel grid for multi-panel (faceted) figures (see Multi-Panel Charts). Mutually exclusive with `chartType`/`layers`. |
+| `columns` | `number` | No | Panels per row when `subplots` is a flat array. Ignored for 2D grids. |
 | `title` | `string` | No | Chart title displayed in text descriptions. |
 | `subtitle` | `string` | No | Chart subtitle. |
 | `caption` | `string` | No | Chart caption. |
@@ -117,6 +119,10 @@ Use `layers` when your chart mixes different chart types (e.g., bar + line):
   {/* Recharts ComposedChart component */}
 </MaidrRecharts>
 ```
+
+### Subplot Mode (Multi-Panel)
+
+Use `subplots` when your figure is a grid of small multiples (faceted charts). See [Multi-Panel (Faceted) Charts](#multi-panel-faceted-charts) below.
 
 ## Supported Chart Types
 
@@ -342,6 +348,69 @@ const data = [
 </MaidrRecharts>
 ```
 
+## Multi-Panel (Faceted) Charts
+
+Recharts has no native facet concept — multi-panel layouts are several sibling chart components. The adapter's **subplot mode** turns such a grid into ONE accessible MAIDR figure: arrow keys move between panels, ENTER drills into a panel, ESCAPE returns to panel navigation, and PageUp/PageDown steps through a panel's layers.
+
+Describe the grid with the `subplots` prop and pass **one Recharts chart per panel as children, in row-major order** (first child = top-left panel `[0][0]`, then across the row, then the next row). `<MaidrRecharts>` wraps each child in a generated `.maidr-panel-<row>-<col>` div and lays each grid row out as a flex row, so highlighting and announcements stay scoped to the correct panel — a mismatched children order narrates one panel while highlighting another.
+
+Top-level props (`data`, `xKey`, `yKeys`, `xLabel`, `yLabel`, `orientation`, `fillKeys`, `binConfig`) act as defaults that each panel may override. Every panel must define its own `chartType` + `yKeys` (or `layers` for a composed panel), and `subplots` is mutually exclusive with the top-level `chartType`/`layers`. A panel's `title` is its announced display name (e.g. the facet value).
+
+```tsx
+const east = [{ quarter: 'Q1', revenue: 4200 }, { quarter: 'Q2', revenue: 5800 }];
+const west = [{ quarter: 'Q1', revenue: 3100 }, { quarter: 'Q2', revenue: 4400 }];
+
+<MaidrRecharts
+  id="sales-by-region"
+  title="Quarterly Revenue by Region"
+  xKey="quarter"
+  yKeys={['revenue']}
+  xLabel="Quarter"
+  yLabel="Revenue ($)"
+  subplots={[[
+    { title: 'East', chartType: 'bar', data: east },
+    { title: 'West', chartType: 'bar', data: west },
+  ]]}
+>
+  {/* One chart per panel, in row-major grid order */}
+  <BarChart width={320} height={220} data={east}>
+    <XAxis dataKey="quarter" />
+    <YAxis />
+    <Bar dataKey="revenue" fill="#8884d8" />
+  </BarChart>
+  <BarChart width={320} height={220} data={west}>
+    <XAxis dataKey="quarter" />
+    <YAxis />
+    <Bar dataKey="revenue" fill="#82ca9d" />
+  </BarChart>
+</MaidrRecharts>
+```
+
+### Grid Shapes
+
+- **2D array** — `subplots={[[a, b], [c, d]]}` is a 2x2 grid in visual reading order. Ragged rows (`[[a, b], [c]]`) are allowed; empty rows are not.
+- **Flat array + `columns`** — `subplots={[a, b, c]} columns={2}` chunks into `[[a, b], [c]]`. Without `columns`, a flat array becomes a single row.
+
+### Custom Panel DOM (`panelSelector`)
+
+If you render the panel containers yourself — for example with the `useRechartsAdapter` hook and `<Maidr>` directly, where no wrapper divs are generated — give each panel config a `panelSelector` that uniquely matches that panel's own container:
+
+```tsx
+subplots={[[
+  { title: 'East', chartType: 'bar', data: east, panelSelector: '.east-panel' },
+  { title: 'West', chartType: 'bar', data: west, panelSelector: '.west-panel' },
+]]}
+```
+
+The selector is used to scope that panel's highlight selectors, so it must match **only** that panel.
+
+### Notes and Limitations
+
+- The visual grid must match the `subplots` config shape. `<MaidrRecharts>` guarantees this by generating the layout; with `panelSelector` it is your responsibility.
+- Per-panel `selectorOverride` is applied verbatim (it is NOT combined with the panel scope and does not inherit the top-level `selectorOverride`) — provide an already panel-scoped selector.
+- The multi-series highlighting limitation applies per panel: a panel with multiple `yKeys` gets audio/text/braille but no visual highlighting unless it has a `selectorOverride`.
+- For grids with more than one row, the Up/Down arrow direction at the panel level may feel inverted (MAIDR detects visual row order from matplotlib-style SVG markers that Recharts does not emit). Single-row grids are unaffected.
+
 ## TypeScript Types
 
 All types are exported from `maidr/recharts`:
@@ -353,6 +422,7 @@ import {
   type RechartsAdapterConfig,  // Adapter configuration
   type RechartsChartType,      // Supported chart types
   type RechartsLayerConfig,    // Layer config for composed mode
+  type RechartsSubplotConfig,  // Panel config for subplot mode
   type HistogramBinConfig,     // Histogram bin configuration
 } from 'maidr/recharts';
 ```
@@ -377,6 +447,26 @@ interface RechartsLayerConfig {
   yKey: string;              // Key in data for this series' y-values
   chartType: RechartsChartType; // Chart type for this series
   name?: string;             // Display name (used in legends/descriptions)
+}
+```
+
+### `RechartsSubplotConfig`
+
+```typescript
+interface RechartsSubplotConfig {
+  title?: string;               // Panel display name (e.g. the facet value)
+  chartType?: RechartsChartType; // Panel chart type (simple mode)
+  yKeys?: string[];             // Panel series keys (simple mode)
+  layers?: RechartsLayerConfig[]; // Composed-mode layers for this panel
+  data?: Record<string, unknown>[]; // Panel data (defaults to top-level data)
+  xKey?: string;                // Defaults to top-level xKey
+  xLabel?: string;              // Defaults to top-level xLabel
+  yLabel?: string;              // Defaults to top-level yLabel
+  orientation?: Orientation;    // Defaults to top-level orientation
+  fillKeys?: string[];          // Defaults to top-level fillKeys
+  binConfig?: HistogramBinConfig; // Defaults to top-level binConfig
+  selectorOverride?: string;    // Panel-scoped highlight selector override
+  panelSelector?: string;       // Custom panel container selector (escape hatch)
 }
 ```
 

--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -409,7 +409,7 @@ The selector is used to scope that panel's highlight selectors, so it must match
 - The visual grid must match the `subplots` config shape. `<MaidrRecharts>` guarantees this by generating the layout; with `panelSelector` it is your responsibility.
 - Per-panel `selectorOverride` is applied verbatim (it is NOT combined with the panel scope and does not inherit the top-level `selectorOverride`) — provide an already panel-scoped selector.
 - The multi-series highlighting limitation applies per panel: a panel with multiple `yKeys` gets audio/text/braille but no visual highlighting unless it has a `selectorOverride`.
-- For grids with more than one row, the Up/Down arrow direction at the panel level may feel inverted (MAIDR detects visual row order from matplotlib-style SVG markers that Recharts does not emit). Single-row grids are unaffected.
+- For grids with more than one row, MAIDR measures each panel's on-screen position (via the per-panel container the adapter emits as the subplot `selector`) to determine the visual row order, so the Up/Down arrows match the visual layout. If that geometry cannot be measured — e.g. a `panelSelector` that matches nothing, or panels rendered without layout boxes — MAIDR falls back to data-array order and the Up/Down arrows are deterministically reversed (Up moves to the visually lower row). Single-row grids are unaffected either way.
 
 ## TypeScript Types
 

--- a/docs/vegalite.md
+++ b/docs/vegalite.md
@@ -409,13 +409,13 @@ const spec = {
 maidrVegaLite.embed('#chart', spec, { id: 'barley-facet' });
 ```
 
-Each panel announces its facet value (e.g. "site: Crookston") or repeated field name as its title, and highlighting is scoped per panel — the adapter stamps each rendered facet cell with a `data-maidr-cell` attribute at bind time so selectors only ever match their own panel's marks.
+Each panel announces its facet value (e.g. "site: Crookston") or repeated field name as its title, and highlighting is scoped per panel — the adapter stamps each rendered facet cell with a `data-maidr-cell` attribute at bind time so selectors only ever match their own panel's marks. All selectors are additionally prefixed with the chart container's id (one is generated if the container has none), so several charts on one page — even two copies of the same spec — never highlight each other's elements.
 
 Notes and current limitations:
 
 - Custom facet `sort` orders are honoured when the chart is bound with a compiled view (the normal `embed()` / `bindVegaLite()` paths); converting a spec standalone with `vegaLiteToMaidr(spec)` falls back to ascending value order.
 - Panels with **independent scales** (`resolve: { scale: independent }`) navigate fine, but visual-order corrections for line charts assume shared axes.
-- For multi-**row** panel grids, the Up/Down arrow direction at the panel level follows data order rather than screen direction (Vega-Lite SVGs carry no per-panel axes ids for MAIDR core to infer the visual layout from).
+- For multi-**row** panel grids, MAIDR core measures each panel's rendered geometry (via the per-panel background selectors the adapter emits) to order panels visually and keep Up/Down arrows matching screen direction. If the chart is not laid out when it receives focus (e.g. inside a `display: none` tab), panel navigation falls back to data order.
 
 See [`examples/vegalite-facet-bar.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-facet-bar.html) (facet operator, wrapped facet, shorthand, and repeat) and [`examples/vegalite-hconcat-box.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-hconcat-box.html) (concatenation) for runnable versions.
 

--- a/docs/vegalite.md
+++ b/docs/vegalite.md
@@ -77,7 +77,7 @@ Once the page loads, click on the chart (or Tab to it) and MAIDR activates with:
 
 The Vega-Lite adapter:
 
-1. **Inspects the spec** — reads the `mark`, `encoding`, and any composite blocks (`layer`, `hconcat`, `vconcat`, `concat`).
+1. **Inspects the spec** — reads the `mark`, `encoding`, and any composite blocks (`layer`, `hconcat`, `vconcat`, `concat`, `facet`, `repeat`).
 2. **Resolves the data** — queries the compiled Vega `View` for runtime datasets (so transforms such as `bin` and `aggregate` are honoured), and falls back to inline `data.values` when the view isn't available.
 3. **Maps the mark to a MAIDR trace type** — see the table below.
 4. **Builds CSS selectors** for visual highlighting against the SVG that Vega renders inside the embed container.
@@ -376,6 +376,48 @@ const spec = {
 ```
 
 Both **vertical** (categorical x, quantitative y) and **horizontal** (categorical y, quantitative x) box plots are supported. See [`examples/vegalite-bindbox.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-bindbox.html) for a runnable version.
+
+## Multi-panel charts (facet, repeat, concat)
+
+Vega-Lite's view-composition operators all convert to a multi-subplot MAIDR figure — one accessible panel per chart cell. Multi-panel figures start in **subplot navigation**: arrow keys move between panels (each announces its facet value or repeated field), <kbd>Enter</kbd> drills into a panel's data points, <kbd>Escape</kbd> returns to panel navigation, and <kbd>PageUp</kbd>/<kbd>PageDown</kbd> switch layers inside a panel.
+
+Supported compositions:
+
+| Composition | Spec shape | Panel grid |
+|---|---|---|
+| Row/column facet | `facet: { row?, column? }` + `spec` | facet values → grid rows × columns (missing row×column combinations are skipped, matching the rendered chart) |
+| Facet shorthand | `row` / `column` channels inside `encoding` | same as the facet operator |
+| Wrapped facet | `facet: { field }` + `columns: N` | values wrap into rows of N panels |
+| Repeat | `repeat: { row?, column? }` or `repeat: [...]` + `columns` | one panel per repeated field (the child's `{ repeat: ... }` field references are substituted per panel) |
+| Concatenation | `hconcat` / `vconcat` / `concat` + `columns` | one panel per child spec; `concat` wraps into rows of `columns` panels |
+
+```js
+const spec = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+  title: 'Barley Yield by Site',
+  data: { values: barleyYields },
+  facet: { column: { field: 'site', type: 'nominal' } },
+  spec: {
+    mark: 'bar',
+    encoding: {
+      x: { field: 'variety', type: 'nominal' },
+      y: { field: 'yield', type: 'quantitative' },
+    },
+  },
+};
+
+maidrVegaLite.embed('#chart', spec, { id: 'barley-facet' });
+```
+
+Each panel announces its facet value (e.g. "site: Crookston") or repeated field name as its title, and highlighting is scoped per panel — the adapter stamps each rendered facet cell with a `data-maidr-cell` attribute at bind time so selectors only ever match their own panel's marks.
+
+Notes and current limitations:
+
+- Custom facet `sort` orders are honoured when the chart is bound with a compiled view (the normal `embed()` / `bindVegaLite()` paths); converting a spec standalone with `vegaLiteToMaidr(spec)` falls back to ascending value order.
+- Panels with **independent scales** (`resolve: { scale: independent }`) navigate fine, but visual-order corrections for line charts assume shared axes.
+- For multi-**row** panel grids, the Up/Down arrow direction at the panel level follows data order rather than screen direction (Vega-Lite SVGs carry no per-panel axes ids for MAIDR core to infer the visual layout from).
+
+See [`examples/vegalite-facet-bar.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-facet-bar.html) (facet operator, wrapped facet, shorthand, and repeat) and [`examples/vegalite-hconcat-box.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-hconcat-box.html) (concatenation) for runnable versions.
 
 ## API Reference
 

--- a/docs/victory.md
+++ b/docs/victory.md
@@ -252,7 +252,8 @@ Notes and limitations:
 - Charts must be **direct children** of `<MaidrVictory>`; charts wrapped in your own components are not detected. Lay panels out visually with CSS on the surrounding page.
 - Charts rendered with `standalone={false}` into a shared parent SVG are not supported for multi-panel detection.
 - In multi-panel mode, standalone data components (e.g. a bare `<VictoryScatter>`) outside any `<VictoryChart>` are ignored with a console warning. With at most one `<VictoryChart>`, everything is flattened into a single panel exactly as before.
-- For multi-row grids (`rows` ≥ 2), the Up/Down arrow direction at panel level may feel inverted because Victory's SVG carries no panel-position metadata MAIDR can read; single-row layouts are unaffected.
+- A `<VictoryChart>` that contains no supported data components is omitted from subplot navigation (with a console warning). The remaining panels keep the grid cells of your `layout` — only the dropped chart's cell disappears from its row.
+- For multi-row grids (`rows` ≥ 2), MAIDR measures each panel's rendered position, so the Up/Down arrows follow the visual arrangement of your CSS layout. If panel positions cannot be measured (for example, panels that overlap at the same position), navigation conservatively falls back to children order, where Up/Down may not match the visual arrangement. Single-row layouts are unaffected.
 
 ## Using the Hook
 

--- a/docs/victory.md
+++ b/docs/victory.md
@@ -55,6 +55,7 @@ Unlike config-driven adapters, you do not pass `data`/`chartType` props to `<Mai
 | `title` | `string` | No | Chart title displayed in text descriptions. |
 | `subtitle` | `string` | No | Chart subtitle. |
 | `caption` | `string` | No | Chart caption. |
+| `layout` | `{ rows?: number; columns?: number }` | No | Row-major grid for [multi-panel figures](#multi-panel-figures). Only consulted with two or more `<VictoryChart>` children. |
 
 ## Supported Chart Types
 
@@ -209,6 +210,50 @@ Provide pre-computed quartile statistics. The adapter reads these directly and d
 </MaidrVictory>
 ```
 
+## Multi-Panel Figures
+
+Nest two or more `<VictoryChart>` components inside one `<MaidrVictory>` to build a multi-panel (small-multiples) figure. Each chart becomes one MAIDR subplot: arrow keys move between panels, `Enter` drills into the focused panel, and `Escape` returns to panel navigation. Give each chart a `title` prop — it becomes the panel's name in subplot announcements.
+
+```tsx
+<MaidrVictory
+  id="regional-sales"
+  title="Quarterly Sales by Region"
+  layout={{ columns: 2 }}
+>
+  <VictoryChart title="North Region" domainPadding={24}>
+    <VictoryAxis label="Quarter" />
+    <VictoryAxis dependentAxis label="Revenue ($)" />
+    <VictoryBar data={northData} />
+  </VictoryChart>
+  <VictoryChart title="South Region" domainPadding={24}>
+    <VictoryAxis label="Quarter" />
+    <VictoryAxis dependentAxis label="Revenue ($)" />
+    <VictoryBar data={southData} />
+  </VictoryChart>
+  <VictoryChart title="East Region" domainPadding={24}>
+    <VictoryAxis label="Quarter" />
+    <VictoryAxis dependentAxis label="Revenue ($)" />
+    <VictoryBar data={eastData} />
+  </VictoryChart>
+  <VictoryChart title="West Region" domainPadding={24}>
+    <VictoryAxis label="Quarter" />
+    <VictoryAxis dependentAxis label="Revenue ($)" />
+    <VictoryBar data={westData} />
+  </VictoryChart>
+</MaidrVictory>
+```
+
+By default the panels form a single navigable row in children order. The `layout` prop chunks them row-major into a grid: `columns` fixes the panels per row (the last row may be shorter), or `rows` derives the column count when `columns` is omitted. Match `layout` to how you visually arrange the charts with CSS.
+
+Each panel keeps its own axis labels (from its own `<VictoryAxis>` children), its own layers (a chart with several data components stays a multi-layer panel, switchable with `Page Up`/`Page Down` after drilling in), and its own highlight scope — one panel's highlighting can never bleed into another.
+
+Notes and limitations:
+
+- Charts must be **direct children** of `<MaidrVictory>`; charts wrapped in your own components are not detected. Lay panels out visually with CSS on the surrounding page.
+- Charts rendered with `standalone={false}` into a shared parent SVG are not supported for multi-panel detection.
+- In multi-panel mode, standalone data components (e.g. a bare `<VictoryScatter>`) outside any `<VictoryChart>` are ignored with a console warning. With at most one `<VictoryChart>`, everything is flattened into a single panel exactly as before.
+- For multi-row grids (`rows` ≥ 2), the Up/Down arrow direction at panel level may feel inverted because Victory's SVG carries no panel-position metadata MAIDR can read; single-row layouts are unaffected.
+
 ## Using the Hook
 
 For full control over rendering, use the `useVictoryAdapter` hook with the low-level `<Maidr>` component. Provide a container ref so the adapter can tag the rendered SVG elements.
@@ -247,13 +292,17 @@ All types are exported from `maidr/victory`:
 import {
   MaidrVictory, // The wrapper component
   useVictoryAdapter, // The conversion hook
-  extractVictoryLayers, // Lower-level: children → layer info
+  extractVictoryLayers, // Lower-level: children → flat layer info
+  extractVictorySubplots, // Lower-level: children → per-panel subplot info
+  computeSubplotGrid, // Lower-level: panels + layout → row-major grid
   toMaidrLayer, // Lower-level: layer info → MAIDR layer
   type MaidrVictoryProps, // Props for MaidrVictory
   type VictoryAdapterConfig, // Config accepted by the hook
   type VictoryComponentType, // Supported Victory component names
   type VictoryLayerData, // Extracted layer data union
   type VictoryLayerInfo, // Intermediate layer representation
+  type VictoryPanelLayout, // Multi-panel grid layout ({ rows?, columns? })
+  type VictorySubplotInfo, // Intermediate panel representation
 } from 'maidr/victory';
 ```
 
@@ -276,8 +325,8 @@ type VictoryComponentType =
 
 `<MaidrVictory>` is a convenience wrapper that:
 
-1. Introspects the Victory components passed as `children` to extract their data and axis labels (`extractVictoryLayers`).
-2. Tags the rendered Victory SVG elements with `data-maidr-victory-*` attributes so MAIDR can highlight them by CSS selector.
+1. Introspects the Victory components passed as `children` to extract their data and axis labels, grouping top-level `<VictoryChart>` components into panels (`extractVictorySubplots`).
+2. Tags the rendered Victory SVG elements with `data-maidr-victory-*` attributes so MAIDR can highlight them by CSS selector. In multi-panel mode, each panel's `<svg>` is stamped with `data-maidr-victory-panel="<i>"` and all selectors are scoped to it, so panels never cross-highlight.
 3. Converts each layer into MAIDR's internal format (`toMaidrLayer`) and renders the children inside the `<Maidr>` component.
 
 Selector tagging relies on Victory's `role="presentation"` attribute on data elements (a stable Victory convention, tested with v37). If that convention changes, highlighting degrades gracefully — audio, text, and braille are unaffected.

--- a/examples/amcharts.html
+++ b/examples/amcharts.html
@@ -63,7 +63,8 @@
     <p>
       One amCharts Root with a vertical layout and two stacked XYCharts. MAIDR
       exposes each chart as a subplot: use the arrow keys to move between
-      panels, Enter to drill into a panel, and Escape to return.
+      panels (Up moves to the visually upper panel; numbering starts at the
+      bottom panel), Enter to drill into a panel, and Escape to return.
     </p>
     <div id="multipanel-chart" class="chart" style="height: 560px"></div>
 
@@ -348,8 +349,9 @@
       // -------------------------------------------------------------------
       // Multi-panel: two XYCharts stacked vertically in ONE Root.
       // MAIDR converts each chart into its own subplot (arrow keys move
-      // between panels; Enter drills in, Escape returns). Each chart's Label
-      // child becomes the panel's display name.
+      // between panels — Up moves visually up, and "Subplot 1" is the bottom
+      // panel; Enter drills in, Escape returns). Each chart's Label child
+      // becomes the panel's display name.
       // -------------------------------------------------------------------
       (function () {
         var root = am5.Root.new("multipanel-chart");

--- a/examples/amcharts.html
+++ b/examples/amcharts.html
@@ -59,6 +59,14 @@
     <h2>Heatmap</h2>
     <div id="heatmap-chart" class="chart"></div>
 
+    <h2>Multi-Panel (two XYCharts in one Root)</h2>
+    <p>
+      One amCharts Root with a vertical layout and two stacked XYCharts. MAIDR
+      exposes each chart as a subplot: use the arrow keys to move between
+      panels, Enter to drill into a panel, and Escape to return.
+    </p>
+    <div id="multipanel-chart" class="chart" style="height: 560px"></div>
+
     <script>
       // Collects { el, root, options } for each chart so the ES-module block
       // below can convert them to MAIDR data once amCharts finishes rendering.
@@ -335,6 +343,73 @@
           heatLegend.set("endValue", series.getPrivate("valueHigh"));
         });
         register("heatmap-chart", root, { title: "Activity by Weekday and Hour", axisLabels: { x: "Weekday", y: "Hour" } });
+      })();
+
+      // -------------------------------------------------------------------
+      // Multi-panel: two XYCharts stacked vertically in ONE Root.
+      // MAIDR converts each chart into its own subplot (arrow keys move
+      // between panels; Enter drills in, Escape returns). Each chart's Label
+      // child becomes the panel's display name.
+      // -------------------------------------------------------------------
+      (function () {
+        var root = am5.Root.new("multipanel-chart");
+        root.container.set("layout", root.verticalLayout);
+
+        var data = [
+          { month: "Jan", revenue: 120, growth: 4.1 },
+          { month: "Feb", revenue: 132, growth: 5.2 },
+          { month: "Mar", revenue: 101, growth: -2.3 },
+          { month: "Apr", revenue: 134, growth: 6.1 },
+          { month: "May", revenue: 190, growth: 8.4 },
+        ];
+
+        // Top panel: revenue columns.
+        var topChart = root.container.children.push(
+          am5xy.XYChart.new(root, {
+            height: am5.percent(50),
+            panX: false, panY: false, wheelX: "none", wheelY: "none",
+          })
+        );
+        topChart.children.unshift(am5.Label.new(root, { text: "Monthly Revenue", fontSize: 16, x: am5.p50, centerX: am5.p50 }));
+        var topX = topChart.xAxes.push(
+          am5xy.CategoryAxis.new(root, { categoryField: "month", renderer: am5xy.AxisRendererX.new(root, {}) })
+        );
+        var topY = topChart.yAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) })
+        );
+        var revenueSeries = topChart.series.push(
+          am5xy.ColumnSeries.new(root, {
+            name: "Revenue", xAxis: topX, yAxis: topY,
+            valueYField: "revenue", categoryXField: "month",
+          })
+        );
+        topX.data.setAll(data);
+        revenueSeries.data.setAll(data);
+
+        // Bottom panel: growth line.
+        var bottomChart = root.container.children.push(
+          am5xy.XYChart.new(root, {
+            height: am5.percent(50),
+            panX: false, panY: false, wheelX: "none", wheelY: "none",
+          })
+        );
+        bottomChart.children.unshift(am5.Label.new(root, { text: "Growth Rate", fontSize: 16, x: am5.p50, centerX: am5.p50 }));
+        var bottomX = bottomChart.xAxes.push(
+          am5xy.CategoryAxis.new(root, { categoryField: "month", renderer: am5xy.AxisRendererX.new(root, {}) })
+        );
+        var bottomY = bottomChart.yAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) })
+        );
+        var growthSeries = bottomChart.series.push(
+          am5xy.LineSeries.new(root, {
+            name: "Growth", xAxis: bottomX, yAxis: bottomY,
+            valueYField: "growth", categoryXField: "month",
+          })
+        );
+        bottomX.data.setAll(data);
+        growthSeries.data.setAll(data);
+
+        register("multipanel-chart", root, { title: "Revenue and Growth by Month" });
       })();
     </script>
 

--- a/examples/anychart/multipanel.html
+++ b/examples/anychart/multipanel.html
@@ -13,7 +13,12 @@
         gap: 1rem;
         margin-bottom: 1rem;
       }
-      #dashboard > div { width: 480px; height: 320px; }
+      /* Size panel containers via a class (or any descendant selector), NOT a
+         child combinator like `#dashboard > div`: binding moves the panels
+         into MAIDR's transparent host <div>, after which child-combinator
+         rules would stop matching and AnyChart re-layouts (window resize,
+         chart.draw() on data updates) would re-measure unstyled containers. */
+      #dashboard .panel { width: 480px; height: 320px; }
       p { max-width: 980px; }
     </style>
     <!-- 1. Load AnyChart (CDN). -->
@@ -79,10 +84,10 @@
       <kbd>S</kbd> to toggle sonification.
     </p>
     <div id="dashboard">
-      <div id="panel-q1"></div>
-      <div id="panel-q2"></div>
-      <div id="panel-q3"></div>
-      <div id="panel-q4"></div>
+      <div id="panel-q1" class="panel"></div>
+      <div id="panel-q2" class="panel"></div>
+      <div id="panel-q3" class="panel"></div>
+      <div id="panel-q4" class="panel"></div>
     </div>
   </body>
 </html>

--- a/examples/anychart/multipanel.html
+++ b/examples/anychart/multipanel.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + AnyChart Multi-Panel Example</title>
+    <style>
+      body { font-family: sans-serif; margin: 2rem; }
+      /* All panel containers live inside ONE wrapper element; bindAnyCharts
+         mounts MAIDR once over the whole group. */
+      #dashboard {
+        display: grid;
+        grid-template-columns: repeat(2, 480px);
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      #dashboard > div { width: 480px; height: 320px; }
+      p { max-width: 980px; }
+    </style>
+    <!-- 1. Load AnyChart (CDN). -->
+    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-base.min.js"></script>
+    <!-- 2. Load the core MAIDR runtime. -->
+    <script src="../../dist/maidr.js"></script>
+    <!-- 3. Load the MAIDR AnyChart adapter (UMD build — exposes window.maidrAnyChart). -->
+    <script src="../../dist/anychart.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        // Four independent AnyChart instances, one per container — AnyChart's
+        // standard small-multiples idiom. Each chart's own title becomes its
+        // panel name in MAIDR's subplot navigation.
+        function quarterChart(title, containerId, data) {
+          const chart = anychart.column(data);
+          chart.title(title);
+          chart.xAxis().title('Product');
+          chart.yAxis().title('Units sold');
+          chart.container(containerId);
+          chart.draw();
+          return chart;
+        }
+
+        const q1 = quarterChart('Q1 Sales', 'panel-q1', [
+          ['Laptops', 42], ['Phones', 61], ['Tablets', 18],
+        ]);
+        const q2 = quarterChart('Q2 Sales', 'panel-q2', [
+          ['Laptops', 48], ['Phones', 55], ['Tablets', 24],
+        ]);
+        const q3 = quarterChart('Q3 Sales', 'panel-q3', [
+          ['Laptops', 39], ['Phones', 70], ['Tablets', 21],
+        ]);
+        const q4 = quarterChart('Q4 Sales', 'panel-q4', [
+          ['Laptops', 57], ['Phones', 66], ['Tablets', 30],
+        ]);
+
+        // Group the four charts into ONE multi-panel MAIDR figure. The 2D
+        // array maps 1:1 onto the subplot grid in visual reading order
+        // (top-left first). Alternatively pass a flat array with
+        // `layout: { columns: 2 }` or `layout: 'auto'`.
+        maidrAnyChart.bindAnyCharts(
+          [
+            [q1, q2],
+            [q3, q4],
+          ],
+          {
+            id: 'sales-by-quarter',
+            title: 'Sales by Quarter',
+          },
+        );
+      });
+    </script>
+  </head>
+  <body>
+    <h1>MAIDR + AnyChart Multi-Panel Figure</h1>
+    <p>
+      Four AnyChart column charts bound as ONE accessible multi-panel figure.
+      Click on (or Tab to) the figure: MAIDR starts in subplot navigation —
+      use arrow keys to move between the four panels, press
+      <kbd>Enter</kbd> to drill into a panel and explore its bars, and
+      <kbd>Esc</kbd> to return to panel navigation. Inside a panel press
+      <kbd>B</kbd> for braille, <kbd>T</kbd> for text descriptions, and
+      <kbd>S</kbd> to toggle sonification.
+    </p>
+    <div id="dashboard">
+      <div id="panel-q1"></div>
+      <div id="panel-q2"></div>
+      <div id="panel-q3"></div>
+      <div id="panel-q4"></div>
+    </div>
+  </body>
+</html>

--- a/examples/chartjs/line-stacked-panels.html
+++ b/examples/chartjs/line-stacked-panels.html
@@ -12,8 +12,10 @@
       A single Chart.js chart using axis stacking (<code>scales.y.stack</code> /
       <code>scales.y2.stack</code>) renders two vertically stacked panels — price
       on top, volume below. MAIDR exposes each panel as its own subplot: use
-      arrow keys to move between subplots, press 'Enter' to drill into a panel,
-      and 'Escape' to return to subplot navigation.
+      arrow keys to move between subplots (Up Arrow moves to the panel above),
+      press 'Enter' to drill into a panel, and 'Escape' to return to subplot
+      navigation. Panels are numbered bottom-up — "Subplot 1" is the volume
+      panel at the bottom, where navigation starts.
     </p>
 
     <div style="width: 700px; height: 500px">

--- a/examples/chartjs/line-stacked-panels.html
+++ b/examples/chartjs/line-stacked-panels.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Stacked Panels (Multi-Panel) Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Stacked Axis Panels</h1>
+    <p>
+      A single Chart.js chart using axis stacking (<code>scales.y.stack</code> /
+      <code>scales.y2.stack</code>) renders two vertically stacked panels — price
+      on top, volume below. MAIDR exposes each panel as its own subplot: use
+      arrow keys to move between subplots, press 'Enter' to drill into a panel,
+      and 'Escape' to return to subplot navigation.
+    </p>
+
+    <div style="width: 700px; height: 500px">
+      <canvas id="stacked-panels-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      new Chart(document.getElementById('stacked-panels-chart'), {
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          datasets: [
+            {
+              label: 'Price',
+              data: [102, 110, 108, 121, 119, 127],
+              borderColor: '#2ca02c',
+              tension: 0.2,
+              // Defaults to yAxisID: 'y' — the top panel.
+            },
+            {
+              label: 'Volume',
+              data: [34, 51, 42, 65, 48, 70],
+              borderColor: '#1f77b4',
+              tension: 0.2,
+              yAxisID: 'y2', // the bottom panel
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Stock Price and Trading Volume' },
+          },
+          scales: {
+            x: { title: { display: true, text: 'Month' } },
+            y: {
+              stack: 'panels',
+              stackWeight: 2,
+              title: { display: true, text: 'Price ($)' },
+            },
+            y2: {
+              stack: 'panels',
+              stackWeight: 1,
+              offset: true,
+              title: { display: true, text: 'Volume (M shares)' },
+            },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindfacets.html
+++ b/examples/d3-bindfacets.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Faceted Bar Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Faceted Bar Chart (small multiples)</h1>
+    <p>
+      Click on the chart and use arrow keys to move between panels. Press 'ENTER' to
+      drill into a panel, then arrow keys to navigate its bars and 'ESC' to return
+      to panel navigation.
+    </p>
+    <div id="chart"></div>
+
+    <script>
+      // Sales by weekday, faceted by region — the canonical D3 small-multiples
+      // idiom: one translated <g class="panel"> per d3.groups() entry.
+      const flat = [
+        { region: 'North', day: 'Mon', sales: 42 }, { region: 'North', day: 'Tue', sales: 58 },
+        { region: 'North', day: 'Wed', sales: 71 }, { region: 'North', day: 'Thu', sales: 49 },
+        { region: 'South', day: 'Mon', sales: 65 }, { region: 'South', day: 'Tue', sales: 39 },
+        { region: 'South', day: 'Wed', sales: 44 }, { region: 'South', day: 'Thu', sales: 80 },
+        { region: 'East', day: 'Mon', sales: 30 }, { region: 'East', day: 'Tue', sales: 52 },
+        { region: 'East', day: 'Wed', sales: 61 }, { region: 'East', day: 'Thu', sales: 47 },
+        { region: 'West', day: 'Mon', sales: 74 }, { region: 'West', day: 'Tue', sales: 68 },
+        { region: 'West', day: 'Wed', sales: 35 }, { region: 'West', day: 'Thu', sales: 56 },
+      ];
+      const grouped = d3.groups(flat, d => d.region); // [ [key, values], ... ]
+
+      // 2x2 grid of panels
+      const panelWidth = 260;
+      const panelHeight = 200;
+      const margin = { top: 30, right: 15, bottom: 35, left: 40 };
+      const innerW = panelWidth - margin.left - margin.right;
+      const innerH = panelHeight - margin.top - margin.bottom;
+      const columns = 2;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-facet-chart')
+        .attr('width', panelWidth * columns)
+        .attr('height', panelHeight * Math.ceil(grouped.length / columns));
+
+      const x = d3.scaleBand()
+        .domain(['Mon', 'Tue', 'Wed', 'Thu'])
+        .range([0, innerW])
+        .padding(0.2);
+      const y = d3.scaleLinear()
+        .domain([0, d3.max(flat, d => d.sales)])
+        .nice()
+        .range([innerH, 0]);
+
+      // One <g class="panel"> per region, translated into a 2x2 grid. The
+      // d3.groups() [key, values] tuple stays bound to the panel element, so
+      // the MAIDR binder can read the facet key for the panel title.
+      const panels = svg.selectAll('g.panel')
+        .data(grouped)
+        .join('g')
+        .attr('class', 'panel')
+        .attr('transform', (d, i) => {
+          const col = i % columns;
+          const row = Math.floor(i / columns);
+          return `translate(${col * panelWidth + margin.left}, ${row * panelHeight + margin.top})`;
+        });
+
+      panels.append('text')
+        .attr('x', innerW / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '13px')
+        .text(d => d[0]);
+
+      panels.each(function ([, values]) {
+        const panel = d3.select(this);
+        panel.selectAll('rect.bar')
+          .data(values)
+          .join('rect')
+          .attr('class', 'bar')
+          .attr('x', d => x(d.day))
+          .attr('y', d => y(d.sales))
+          .attr('width', x.bandwidth())
+          .attr('height', d => innerH - y(d.sales))
+          .attr('fill', '#4682b4');
+        panel.append('g')
+          .attr('transform', `translate(0, ${innerH})`)
+          .call(d3.axisBottom(x));
+        panel.append('g')
+          .call(d3.axisLeft(y).ticks(4));
+      });
+
+      // === MAIDR Integration ===
+      // One call binds all panels: each g.panel becomes a navigable MAIDR
+      // subplot, with per-panel selector scoping handled automatically.
+      const svgElement = document.getElementById('d3-facet-chart');
+      const result = maidrD3.bindD3Facets(svgElement, {
+        panelSelector: 'g.panel',
+        chartType: 'bar',
+        config: {
+          selector: 'rect.bar',
+          title: 'Sales by Day, faceted by Region',
+          axes: { x: 'Day', y: 'Sales' },
+          x: 'day',
+          y: 'sales',
+        },
+        // Panel title from the d3.groups() key bound to each panel.
+        panelTitle: d => `Region: ${d[0]}`,
+        // The grid shape is inferred from panel geometry; pass an explicit
+        // layout ('row' | 'column' | { columns: 2 }) to override.
+      });
+      // The binder auto-applies `maidr-data` to the SVG. Pass `autoApply: false`
+      // in the config above if you want to handle the attribute yourself.
+      void result;
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindsubplots.html
+++ b/examples/d3-bindsubplots.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Heterogeneous Subplots Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Heterogeneous Subplots (bar + line)</h1>
+    <p>
+      Click on the chart and use arrow keys to move between panels. Press 'ENTER' to
+      drill into a panel, then arrow keys to navigate its data and 'ESC' to return
+      to panel navigation.
+    </p>
+    <div id="chart"></div>
+
+    <script>
+      const revenue = [
+        { quarter: 'Q1', value: 120 }, { quarter: 'Q2', value: 180 },
+        { quarter: 'Q3', value: 150 }, { quarter: 'Q4', value: 210 },
+      ];
+      const growth = [
+        { quarter: 'Q1', value: 4 }, { quarter: 'Q2', value: 9 },
+        { quarter: 'Q3', value: 6 }, { quarter: 'Q4', value: 12 },
+      ];
+
+      const panelWidth = 320;
+      const panelHeight = 240;
+      const margin = { top: 30, right: 15, bottom: 35, left: 45 };
+      const innerW = panelWidth - margin.left - margin.right;
+      const innerH = panelHeight - margin.top - margin.bottom;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-subplots-chart')
+        .attr('width', panelWidth * 2)
+        .attr('height', panelHeight);
+
+      // --- Left panel: revenue bar chart ---
+      const barPanel = svg.append('g')
+        .attr('class', 'revenue')
+        .attr('transform', `translate(${margin.left}, ${margin.top})`);
+      const xBar = d3.scaleBand()
+        .domain(revenue.map(d => d.quarter))
+        .range([0, innerW])
+        .padding(0.2);
+      const yBar = d3.scaleLinear()
+        .domain([0, d3.max(revenue, d => d.value)])
+        .nice()
+        .range([innerH, 0]);
+      barPanel.selectAll('rect.bar')
+        .data(revenue)
+        .join('rect')
+        .attr('class', 'bar')
+        .attr('x', d => xBar(d.quarter))
+        .attr('y', d => yBar(d.value))
+        .attr('width', xBar.bandwidth())
+        .attr('height', d => innerH - yBar(d.value))
+        .attr('fill', '#4682b4');
+      barPanel.append('g').attr('transform', `translate(0, ${innerH})`).call(d3.axisBottom(xBar));
+      barPanel.append('g').call(d3.axisLeft(yBar).ticks(4));
+
+      // --- Right panel: growth line chart ---
+      const linePanel = svg.append('g')
+        .attr('class', 'growth')
+        .attr('transform', `translate(${panelWidth + margin.left}, ${margin.top})`);
+      const xLine = d3.scalePoint()
+        .domain(growth.map(d => d.quarter))
+        .range([0, innerW])
+        .padding(0.5);
+      const yLine = d3.scaleLinear()
+        .domain([0, d3.max(growth, d => d.value)])
+        .nice()
+        .range([innerH, 0]);
+      linePanel.selectAll('path.line')
+        .data([growth])
+        .join('path')
+        .attr('class', 'line')
+        .attr('fill', 'none')
+        .attr('stroke', '#e4572e')
+        .attr('stroke-width', 2)
+        .attr('d', d3.line()
+          .x(d => xLine(d.quarter))
+          .y(d => yLine(d.value)));
+      linePanel.append('g').attr('transform', `translate(0, ${innerH})`).call(d3.axisBottom(xLine));
+      linePanel.append('g').call(d3.axisLeft(yLine).ticks(4));
+
+      // === MAIDR Integration ===
+      // Compose the two independently drawn charts into one navigable figure:
+      // each entry runs its usual per-type binder against its own panel root.
+      const svgElement = document.getElementById('d3-subplots-chart');
+      const result = maidrD3.bindD3Subplots(svgElement, {
+        title: 'Quarterly Performance',
+        subplots: [[
+          {
+            chartType: 'bar',
+            root: 'g.revenue',
+            config: {
+              selector: 'rect.bar',
+              title: 'Revenue ($K)',
+              axes: { x: 'Quarter', y: 'Revenue ($K)' },
+              x: 'quarter',
+              y: 'value',
+            },
+          },
+          {
+            chartType: 'line',
+            root: 'g.growth',
+            config: {
+              selector: 'path.line',
+              title: 'Growth (%)',
+              axes: { x: 'Quarter', y: 'Growth (%)' },
+              x: 'quarter',
+              y: 'value',
+            },
+          },
+        ]],
+      });
+      // The binder auto-applies `maidr-data` to the SVG. Pass `autoApply: false`
+      // if you want to handle the attribute yourself.
+      void result;
+    </script>
+  </body>
+</html>

--- a/examples/frappe-multipanel.html
+++ b/examples/frappe-multipanel.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frappe Charts Multi-Panel - MAIDR Example</title>
+    <!-- Frappe Charts v1.6.2 - the adapter's CSS selectors are specific to this
+         version. If upgrading, verify SVG class names match. -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.umd.js"
+      integrity="sha384-JQa9VKO4+ZAEaRWDOmQM5LPHQTv8t9B4y8kBn36iar33TxUZByrYAa3o+PsU7hYk"
+      crossorigin="anonymous"
+    ></script>
+    <!-- MAIDR core + Frappe Charts adapter -->
+    <script src="../dist/maidr.js"></script>
+    <script src="../dist/frappe.js"></script>
+    <style>
+      #dashboard {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+        max-width: 1200px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <main>
+      <h1>Frappe Charts Multi-Panel Figure with MAIDR</h1>
+      <p>
+        Four independent Frappe charts grouped into one MAIDR figure. Arrow keys
+        move between panels, <kbd>Enter</kbd> drills into a panel,
+        <kbd>Esc</kbd> returns to panel navigation.
+      </p>
+      <p id="error" hidden>
+        Failed to load Frappe Charts from CDN. Please check your internet
+        connection.
+      </p>
+      <!-- The `maidr` attribute goes on THIS wrapper (set by the script below),
+           not on the individual panel containers - a per-panel attribute would
+           create four separate MAIDR figures instead of one 2x2 grid. -->
+      <div id="dashboard">
+        <div id="panel-bar"></div>
+        <div id="panel-line"></div>
+        <div id="panel-scatter"></div>
+        <div id="panel-mixed"></div>
+      </div>
+    </main>
+
+    <script>
+      // Surface an error if Frappe Charts failed to load from CDN; otherwise
+      // build the four panels and hand them to the MAIDR adapter as one figure.
+      const errorEl = document.getElementById('error');
+      if (typeof frappe === 'undefined') {
+        if (errorEl) {
+          errorEl.hidden = false;
+        }
+      } else {
+        const barChart = new frappe.Chart('#panel-bar', {
+          title: 'Weekly Visitors',
+          type: 'bar',
+          height: 300,
+          data: {
+            labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+            datasets: [{ name: 'Visitors', values: [120, 240, 180, 300, 150] }],
+          },
+        });
+
+        // dotSize > 0 renders per-point <circle> dots, which the adapter's line
+        // selector targets for highlighting.
+        const lineChart = new frappe.Chart('#panel-line', {
+          title: 'Annual Revenue',
+          type: 'line',
+          height: 300,
+          lineOptions: { dotSize: 5 },
+          data: {
+            labels: ['2021', '2022', '2023', '2024', '2025'],
+            datasets: [{ name: 'Revenue', values: [71, 85, 93, 110, 125] }],
+          },
+        });
+
+        // Frappe has no native scatter type: a line chart with the line hidden
+        // renders only the dots, which the adapter treats as scatter points.
+        const scatterChart = new frappe.Chart('#panel-scatter', {
+          title: 'Temperature vs Altitude',
+          type: 'line',
+          height: 300,
+          lineOptions: { hideLine: 1, dotSize: 6 },
+          data: {
+            labels: [10, 20, 30, 40, 50, 60],
+            datasets: [{ name: 'Temperature', values: [22, 25, 28, 24, 31, 35] }],
+          },
+        });
+
+        const mixedChart = new frappe.Chart('#panel-mixed', {
+          title: 'Sales with Trend',
+          type: 'axis-mixed',
+          height: 300,
+          lineOptions: { dotSize: 5 },
+          data: {
+            labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+            datasets: [
+              { name: 'Sales', chartType: 'bar', values: [50, 70, 85, 60, 95] },
+              { name: 'Trend', chartType: 'line', values: [55, 65, 75, 70, 80] },
+            ],
+          },
+        });
+
+        // The panel grid, in visual reading order (row-major, top-left first),
+        // matching the CSS grid layout above.
+        const panels = [
+          [
+            {
+              chart: barChart,
+              container: document.querySelector('#panel-bar'),
+              chartType: 'bar',
+              title: 'Weekly Visitors',
+              axes: { x: 'Day', y: 'Visitors' },
+            },
+            {
+              chart: lineChart,
+              container: document.querySelector('#panel-line'),
+              chartType: 'line',
+              title: 'Annual Revenue',
+              axes: { x: 'Year', y: 'Revenue (thousands USD)' },
+            },
+          ],
+          [
+            {
+              chart: scatterChart,
+              container: document.querySelector('#panel-scatter'),
+              chartType: 'scatter',
+              title: 'Temperature vs Altitude',
+              axes: { x: 'Altitude (m)', y: 'Temperature (C)' },
+            },
+            {
+              chart: mixedChart,
+              container: document.querySelector('#panel-mixed'),
+              chartType: 'axis-mixed',
+              title: 'Sales with Trend',
+              axes: { x: 'Month', y: 'Value (units)' },
+            },
+          ],
+        ];
+
+        // Frappe runs an entrance animation and re-creates the SVG nodes once it
+        // finishes. Wait until EVERY panel's DOM stops mutating before handing
+        // the group to MAIDR, so MAIDR captures the final, stable elements for
+        // highlighting in all four panels.
+        const wrapper = document.querySelector('#dashboard');
+        Promise.all(
+          panels.flat().map(panel => whenChartSettled(panel.container)),
+        ).then(() => {
+          const maidr = maidrFrappe.createMaidrFromFrappeCharts(panels, wrapper, {
+            title: 'Store Performance Dashboard',
+          });
+          wrapper.setAttribute('maidr', JSON.stringify(maidr));
+        });
+
+        function whenChartSettled(container) {
+          return new Promise((resolve) => {
+            requestAnimationFrame(function waitForSvg() {
+              if (!container.querySelector('svg.frappe-chart')) {
+                requestAnimationFrame(waitForSvg);
+                return;
+              }
+              let settleTimer;
+              const observer = new MutationObserver(scheduleSettle);
+              function scheduleSettle() {
+                clearTimeout(settleTimer);
+                settleTimer = setTimeout(() => {
+                  observer.disconnect();
+                  resolve();
+                }, 300);
+              }
+              observer.observe(container, { childList: true, subtree: true, attributes: true });
+              scheduleSettle();
+            });
+          });
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/examples/google-charts.html
+++ b/examples/google-charts.html
@@ -26,6 +26,7 @@
         drawStackedBarChart();
         drawDodgedBarChart();
         drawCandlestickChart();
+        drawFacetedCharts();
       }
 
       // Helper: wire up a Google Charts chart with MAIDR.
@@ -217,6 +218,60 @@
           height: 400,
         });
       }
+
+      // ---------------------------------------------------------------
+      // Multi-Panel (Faceted) Charts — one MAIDR figure, four panels
+      // ---------------------------------------------------------------
+      function drawFacetedCharts() {
+        // Google Charts has no native facet concept: a faceted figure is
+        // several chart instances grouped into ONE MAIDR figure. Arrow keys
+        // then move between panels; Enter drills into a panel.
+        var facets = [
+          { id: 'facet-lunch-no', title: 'Lunch, Non-Smoker', rows: [['Thur', 61], ['Fri', 3]] },
+          { id: 'facet-lunch-yes', title: 'Lunch, Smoker', rows: [['Thur', 17], ['Fri', 4]] },
+          { id: 'facet-dinner-no', title: 'Dinner, Non-Smoker', rows: [['Thur', 1], ['Fri', 4], ['Sat', 45], ['Sun', 57]] },
+          { id: 'facet-dinner-yes', title: 'Dinner, Smoker', rows: [['Fri', 8], ['Sat', 42], ['Sun', 19]] },
+        ];
+
+        var panels = facets.map(function (facet) {
+          var data = google.visualization.arrayToDataTable(
+            [['Day', 'Tips']].concat(facet.rows)
+          );
+          var container = document.getElementById(facet.id);
+          var chart = new google.visualization.ColumnChart(container);
+          return {
+            chart: chart,
+            dataTable: data,
+            container: container,
+            chartType: 'ColumnChart',
+            title: facet.title,
+          };
+        });
+
+        var root = document.getElementById('facet-grid');
+        var charts = panels.map(function (panel) { return panel.chart; });
+
+        // Each chart fires 'ready' independently — build the combined figure
+        // only after ALL panels have rendered, then stamp the maidr attribute
+        // on the wrapper element (NOT on the individual panel containers).
+        maidrGoogleCharts.whenGoogleChartsReady(charts, google.visualization.events, function () {
+          var maidr = maidrGoogleCharts.createMaidrFromGoogleCharts(panels, {
+            root: root,
+            title: 'Tips by Day, faceted by Time and Smoker',
+            layout: { columns: 2 },
+          });
+          root.setAttribute('maidr', JSON.stringify(maidr));
+        });
+
+        panels.forEach(function (panel, i) {
+          panel.chart.draw(panel.dataTable, {
+            title: facets[i].title,
+            legend: { position: 'none' },
+            width: 360,
+            height: 260,
+          });
+        });
+      }
     </script>
 
     <style>
@@ -229,6 +284,11 @@
       h1 { margin-bottom: 4px; }
       h2 { margin-top: 32px; }
       .chart-container { margin-bottom: 24px; }
+      .facet-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 360px);
+        gap: 8px;
+      }
     </style>
   </head>
   <body>
@@ -256,5 +316,18 @@
 
     <h2>Candlestick Chart</h2>
     <div id="candlestick-chart" class="chart-container"></div>
+
+    <h2>Multi-Panel (Faceted) Charts</h2>
+    <p>
+      Four column charts grouped into a single MAIDR figure. Focus the grid and
+      use arrow keys to move between panels, <kbd>Enter</kbd> to explore a
+      panel's data, and <kbd>Esc</kbd> to return to panel navigation.
+    </p>
+    <div id="facet-grid" class="chart-container facet-grid">
+      <div id="facet-lunch-no"></div>
+      <div id="facet-lunch-yes"></div>
+      <div id="facet-dinner-no"></div>
+      <div id="facet-dinner-yes"></div>
+    </div>
   </body>
 </html>

--- a/examples/highcharts-grid.html
+++ b/examples/highcharts-grid.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Highcharts Small Multiples Grid - MAIDR</title>
+    <script src="https://cdn.jsdelivr.net/npm/highcharts/highcharts.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/highcharts.js"></script>
+    <style>
+      .chart-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 380px);
+        gap: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Highcharts Small Multiples (2×2 Grid)</h1>
+    <p>
+      Four separate Highcharts chart instances — one per region — combined into a single MAIDR
+      figure with <code>highchartsGridToMaidr()</code>. Click on the grid, use arrow keys to move
+      between panels, press Enter to drill into a panel, and Escape to return to panel navigation.
+    </p>
+
+    <div id="sales-grid" class="chart-grid">
+      <div id="region-north" style="height: 280px"></div>
+      <div id="region-east" style="height: 280px"></div>
+      <div id="region-south" style="height: 280px"></div>
+      <div id="region-west" style="height: 280px"></div>
+    </div>
+
+    <script>
+      const categories = ['Q1', 'Q2', 'Q3', 'Q4'];
+
+      function regionChart(containerId, regionName, values) {
+        return Highcharts.chart(containerId, {
+          chart: { type: 'column' },
+          title: { text: regionName },
+          legend: { enabled: false },
+          xAxis: { categories, title: { text: 'Quarter' } },
+          yAxis: { title: { text: 'Sales ($K)' } },
+          series: [{ name: 'Sales', data: values }],
+        });
+      }
+
+      // Charts in visual reading order (top-left first).
+      const charts = [
+        regionChart('region-north', 'North', [42, 51, 47, 60]),
+        regionChart('region-east', 'East', [35, 38, 44, 41]),
+        regionChart('region-south', 'South', [28, 33, 30, 39]),
+        regionChart('region-west', 'West', [50, 46, 58, 62]),
+      ];
+
+      const maidrData = maidrHighcharts.highchartsGridToMaidr(charts, {
+        id: 'sales-grid',
+        title: 'Quarterly Sales by Region',
+        layout: { columns: 2 },
+      });
+
+      // Attach to the wrapper enclosing all four chart divs.
+      document.getElementById('sales-grid').setAttribute('maidr-data', JSON.stringify(maidrData));
+      charts.forEach((chart) => maidrHighcharts.createHighchartsSync(chart));
+    </script>
+  </body>
+</html>

--- a/examples/highcharts-panes.html
+++ b/examples/highcharts-panes.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Highcharts Multi-Pane Chart - MAIDR</title>
+    <script src="https://cdn.jsdelivr.net/npm/highcharts/highcharts.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/highcharts.js"></script>
+  </head>
+  <body>
+    <h1>Highcharts Multi-Pane Chart (Price + Volume)</h1>
+    <p>
+      A single Highcharts chart with two stacked panes (a price line on the top y-axis and a
+      volume column series on the bottom y-axis), made accessible by the MAIDR Highcharts adapter.
+      The adapter detects the panes from the axis layout and emits one MAIDR subplot per pane:
+      click on the chart, use Up/Down arrows to move between panes, press Enter to drill into a
+      pane, and Escape to return to pane navigation.
+    </p>
+
+    <div id="panes-chart" style="width: 700px; height: 500px"></div>
+
+    <script>
+      const chart = Highcharts.chart('panes-chart', {
+        title: { text: 'ACME Stock — Price and Volume' },
+        xAxis: {
+          categories: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+          title: { text: 'Day' },
+        },
+        // Two stacked panes: price occupies the top 60%, volume the bottom 30%.
+        yAxis: [
+          { title: { text: 'Price ($)' }, height: '60%' },
+          { title: { text: 'Volume' }, top: '70%', height: '30%', offset: 0 },
+        ],
+        series: [
+          { type: 'line', name: 'Price', data: [150, 152, 149, 153, 155], yAxis: 0 },
+          { type: 'column', name: 'Volume', data: [1200, 1450, 980, 1610, 1330], yAxis: 1 },
+        ],
+      });
+
+      const maidrData = maidrHighcharts.highchartsToMaidr(chart, { id: 'panes-chart' });
+      document.getElementById('panes-chart').setAttribute('maidr-data', JSON.stringify(maidrData));
+      maidrHighcharts.createHighchartsSync(chart);
+    </script>
+  </body>
+</html>

--- a/examples/plotly-subplots.html
+++ b/examples/plotly-subplots.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Subplots (2x2 Grid) - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Subplots (2x2 Grid)</h1>
+    <p>
+      A plotly.js figure with four subplots arranged in a 2x2 grid,
+      auto-detected by MAIDR. Click on the chart, use arrow keys to move
+      between panels, press Enter to drill into a panel, and Escape to
+      return to panel navigation.
+    </p>
+
+    <div id="subplot-chart" style="width: 900px; height: 600px"></div>
+
+    <h1>Plotly.js Facets (shared axes + panel labels)</h1>
+    <p>
+      A faceted figure in the style of Plotly Express: the second panel's
+      x-axis <code>matches</code> the first (title only on the outer axis),
+      and each panel is labeled with an axis-domain annotation. MAIDR uses
+      the annotations as panel names and resolves the shared axis label.
+    </p>
+
+    <div id="facet-chart" style="width: 900px; height: 450px"></div>
+
+    <script>
+      // --- 2x2 subplot grid (make_subplots-style manual axes) ------------
+      var gridData = [
+        {
+          x: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+          y: [20, 14, 23, 25, 22],
+          type: 'bar',
+          name: 'Tips'
+          // xaxis/yaxis default to 'x'/'y' → top-left panel
+        },
+        {
+          x: [1, 2, 3, 4, 5, 6, 7],
+          y: [10, 15, 13, 17, 22, 19, 25],
+          type: 'scatter',
+          mode: 'lines+markers',
+          name: 'Sales',
+          xaxis: 'x2',
+          yaxis: 'y2'
+        },
+        {
+          x: [5.1, 4.9, 4.7, 4.6, 5.0, 5.4, 4.6, 5.0, 4.4, 4.9],
+          y: [1.4, 1.4, 1.3, 1.5, 1.4, 1.7, 1.4, 1.5, 1.4, 1.5],
+          type: 'scatter',
+          mode: 'markers',
+          name: 'Iris',
+          xaxis: 'x3',
+          yaxis: 'y3'
+        },
+        {
+          x: [1.2, 1.9, 2.1, 2.4, 2.5, 2.6, 3.0, 3.1, 3.4, 3.9, 4.2, 4.5],
+          type: 'histogram',
+          name: 'Distribution',
+          xbins: { size: 1 },
+          xaxis: 'x4',
+          yaxis: 'y4'
+        }
+      ];
+
+      var gridLayout = {
+        title: { text: 'Four Views of the Data' },
+        grid: { rows: 2, columns: 2, pattern: 'independent' },
+        xaxis: { title: { text: 'Day' } },
+        yaxis: { title: { text: 'Count' } },
+        xaxis2: { title: { text: 'Week' } },
+        yaxis2: { title: { text: 'Sales ($K)' } },
+        xaxis3: { title: { text: 'Sepal Length (cm)' } },
+        yaxis3: { title: { text: 'Petal Length (cm)' } },
+        xaxis4: { title: { text: 'Value' } },
+        yaxis4: { title: { text: 'Frequency' } },
+        showlegend: false
+      };
+
+      Plotly.newPlot('subplot-chart', gridData, gridLayout);
+
+      // --- Faceted panels (plotly-express style) --------------------------
+      var facetData = [
+        {
+          x: [16.99, 10.34, 21.01, 23.68, 24.59, 25.29],
+          y: [1.01, 1.66, 3.5, 3.31, 3.61, 4.71],
+          type: 'scatter',
+          mode: 'markers'
+          // first facet panel: x/y
+        },
+        {
+          x: [8.77, 26.88, 15.04, 14.78, 10.27, 35.26],
+          y: [2.0, 3.12, 1.96, 3.23, 1.71, 5.0],
+          type: 'scatter',
+          mode: 'markers',
+          xaxis: 'x2',
+          yaxis: 'y2'
+        }
+      ];
+
+      var facetLayout = {
+        title: { text: 'Tips by Sex' },
+        xaxis: { domain: [0, 0.48], title: { text: 'Total Bill ($)' } },
+        xaxis2: { domain: [0.52, 1], matches: 'x' },
+        yaxis: { title: { text: 'Tip ($)' } },
+        yaxis2: { matches: 'y', anchor: 'x2' },
+        annotations: [
+          {
+            text: 'sex=Female',
+            xref: 'x domain',
+            yref: 'y domain',
+            x: 0.5,
+            y: 1.05,
+            showarrow: false
+          },
+          {
+            text: 'sex=Male',
+            xref: 'x2 domain',
+            yref: 'y2 domain',
+            x: 0.5,
+            y: 1.05,
+            showarrow: false
+          }
+        ],
+        showlegend: false
+      };
+
+      Plotly.newPlot('facet-chart', facetData, facetLayout);
+    </script>
+  </body>
+</html>

--- a/examples/plotly-subplots.html
+++ b/examples/plotly-subplots.html
@@ -27,6 +27,16 @@
 
     <div id="facet-chart" style="width: 900px; height: 450px"></div>
 
+    <h1>Plotly.js Facets (plotly.py-style paper-ref labels)</h1>
+    <p>
+      The same faceted figure, but labeled the way Python's Plotly Express
+      and <code>make_subplots</code> actually emit facet titles: annotations
+      with <code>xref/yref: 'paper'</code> positioned above each panel.
+      MAIDR resolves them geometrically against the panel axis domains.
+    </p>
+
+    <div id="paper-facet-chart" style="width: 900px; height: 450px"></div>
+
     <script>
       // --- 2x2 subplot grid (make_subplots-style manual axes) ------------
       var gridData = [
@@ -128,6 +138,46 @@
       };
 
       Plotly.newPlot('facet-chart', facetData, facetLayout);
+
+      // --- Faceted panels (plotly.py-style paper-ref labels) ---------------
+      // This is the annotation shape plotly.express and make_subplots emit:
+      // xref/yref are 'paper', and each label sits above its panel.
+      var paperFacetLayout = {
+        title: { text: 'Tips by Sex (paper-ref labels)' },
+        xaxis: { domain: [0, 0.48], title: { text: 'Total Bill ($)' } },
+        xaxis2: { domain: [0.52, 1], matches: 'x' },
+        yaxis: { domain: [0, 1], title: { text: 'Tip ($)' } },
+        yaxis2: { domain: [0, 1], matches: 'y', anchor: 'x2' },
+        annotations: [
+          {
+            text: 'sex=Female',
+            x: 0.24,
+            y: 1,
+            xref: 'paper',
+            yref: 'paper',
+            xanchor: 'center',
+            yanchor: 'bottom',
+            showarrow: false
+          },
+          {
+            text: 'sex=Male',
+            x: 0.76,
+            y: 1,
+            xref: 'paper',
+            yref: 'paper',
+            xanchor: 'center',
+            yanchor: 'bottom',
+            showarrow: false
+          }
+        ],
+        showlegend: false
+      };
+
+      Plotly.newPlot(
+        'paper-facet-chart',
+        JSON.parse(JSON.stringify(facetData)),
+        paperFacetLayout
+      );
     </script>
   </body>
 </html>

--- a/examples/react-app/vite.config.ts
+++ b/examples/react-app/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
   resolve: {
     alias: {
       'maidr/react': path.resolve(__dirname, '../../src/react-entry.ts'),
+      '@adapters': path.resolve(__dirname, '../../src/adapters'),
       '@command': path.resolve(__dirname, '../../src/command'),
       '@model': path.resolve(__dirname, '../../src/model'),
       '@state': path.resolve(__dirname, '../../src/state'),

--- a/examples/recharts/App.tsx
+++ b/examples/recharts/App.tsx
@@ -8,6 +8,7 @@ import { HistogramExample } from './examples/HistogramExample';
 import { LineChartExample } from './examples/LineChartExample';
 import { ScatterChartExample } from './examples/ScatterChartExample';
 import { ComposedChartExample } from './examples/ComposedChartExample';
+import { FacetExample } from './examples/FacetExample';
 
 const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Bar Chart', component: BarChartExample },
@@ -18,6 +19,7 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Line Chart', component: LineChartExample },
   { name: 'Scatter Chart', component: ScatterChartExample },
   { name: 'Composed Chart', component: ComposedChartExample },
+  { name: 'Faceted (Multi-Panel)', component: FacetExample },
 ];
 
 export function App(): JSX.Element {

--- a/examples/recharts/examples/FacetExample.tsx
+++ b/examples/recharts/examples/FacetExample.tsx
@@ -1,0 +1,83 @@
+import type { JSX } from 'react';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const east = [
+  { quarter: 'Q1', revenue: 4200 },
+  { quarter: 'Q2', revenue: 5800 },
+  { quarter: 'Q3', revenue: 3900 },
+  { quarter: 'Q4', revenue: 7100 },
+];
+const west = [
+  { quarter: 'Q1', revenue: 3100 },
+  { quarter: 'Q2', revenue: 4400 },
+  { quarter: 'Q3', revenue: 5200 },
+  { quarter: 'Q4', revenue: 4800 },
+];
+const north = [
+  { quarter: 'Q1', revenue: 2500 },
+  { quarter: 'Q2', revenue: 2900 },
+  { quarter: 'Q3', revenue: 3300 },
+  { quarter: 'Q4', revenue: 3600 },
+];
+const south = [
+  { quarter: 'Q1', revenue: 5100 },
+  { quarter: 'Q2', revenue: 4700 },
+  { quarter: 'Q3', revenue: 6200 },
+  { quarter: 'Q4', revenue: 6900 },
+];
+
+function RegionChart({ data, fill }: { data: typeof east; fill: string }): JSX.Element {
+  return (
+    <BarChart width={320} height={220} data={data}>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="quarter" />
+      <YAxis />
+      <Tooltip />
+      <Bar dataKey="revenue" fill={fill} name="Revenue" />
+    </BarChart>
+  );
+}
+
+/**
+ * Multi-panel (faceted) figure: a 2x2 grid of bar charts, one per region.
+ *
+ * The `subplots` grid describes the panels; the children must be one chart
+ * per panel in row-major order (East, West, North, South). Arrow keys move
+ * between panels, ENTER drills into a panel, ESCAPE returns to panel
+ * navigation.
+ */
+export function FacetExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Faceted Bar Charts</h2>
+      <p>
+        Quarterly revenue by region in a 2x2 panel grid. Use arrow keys to
+        move between panels, ENTER to enter a panel, ESCAPE to leave it.
+      </p>
+      <MaidrRecharts
+        id="facet-example"
+        title="Quarterly Revenue by Region"
+        xKey="quarter"
+        yKeys={['revenue']}
+        xLabel="Quarter"
+        yLabel="Revenue ($)"
+        subplots={[
+          [
+            { title: 'East', chartType: 'bar', data: east },
+            { title: 'West', chartType: 'bar', data: west },
+          ],
+          [
+            { title: 'North', chartType: 'bar', data: north },
+            { title: 'South', chartType: 'bar', data: south },
+          ],
+        ]}
+      >
+        <RegionChart data={east} fill="#8884d8" />
+        <RegionChart data={west} fill="#82ca9d" />
+        <RegionChart data={north} fill="#ffc658" />
+        <RegionChart data={south} fill="#ff8042" />
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/vegalite-facet-bar.html
+++ b/examples/vegalite-facet-bar.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Vega-Lite Faceted &amp; Repeated Charts Example</title>
+    <!-- Vega-Lite and its dependencies -->
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+    <!-- MAIDR Vega-Lite adapter (bundles MAIDR core) -->
+    <script src="../dist/vegalite.js"></script>
+  </head>
+  <body>
+    <!--
+      Smoke test for multi-panel (faceted / repeated) Vega-Lite support.
+      Each chart converts to a multi-subplot MAIDR figure: arrow keys move
+      between panels, Enter drills into a panel, Escape returns to the
+      panel level, PageUp / PageDown switch layers inside a panel.
+    -->
+    <h1>MAIDR + Vega-Lite Faceted &amp; Repeated Charts</h1>
+    <p>
+      Click (or Tab to) each chart. Arrow keys navigate between panels;
+      press Enter to explore a panel's data points; Escape returns to
+      panel navigation. Press 'b' for braille, 't' for text descriptions.
+    </p>
+
+    <h2>1. Column facet (facet operator)</h2>
+    <div id="facet-column-chart" aria-label="Faceted bar chart loading" style="min-height: 300px"></div>
+
+    <h2>2. Wrapped facet (facet.field + columns)</h2>
+    <div id="facet-wrap-chart" aria-label="Wrapped facet chart loading" style="min-height: 500px"></div>
+
+    <h2>3. Facet shorthand (encoding.column)</h2>
+    <div id="facet-shorthand-chart" aria-label="Facet shorthand chart loading" style="min-height: 300px"></div>
+
+    <h2>4. Repeated rows (repeat.row)</h2>
+    <div id="repeat-row-chart" aria-label="Repeated scatter chart loading" style="min-height: 500px"></div>
+
+    <script>
+      const barleyYields = [
+        { site: 'Crookston', variety: 'Manchuria', yield: 32.9, year: 1931 },
+        { site: 'Crookston', variety: 'Velvet', yield: 38.5, year: 1931 },
+        { site: 'Crookston', variety: 'Peatland', yield: 34.5, year: 1931 },
+        { site: 'Duluth', variety: 'Manchuria', yield: 28.9, year: 1931 },
+        { site: 'Duluth', variety: 'Velvet', yield: 25.1, year: 1931 },
+        { site: 'Duluth', variety: 'Peatland', yield: 31.2, year: 1931 },
+        { site: 'Morris', variety: 'Manchuria', yield: 26.9, year: 1931 },
+        { site: 'Morris', variety: 'Velvet', yield: 23.8, year: 1931 },
+        { site: 'Morris', variety: 'Peatland', yield: 30.1, year: 1931 },
+      ];
+
+      // 1. The `facet` operator: one panel per site, shared child template.
+      const facetColumnSpec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        title: 'Barley Yield by Site (column facet)',
+        data: { values: barleyYields },
+        facet: { column: { field: 'site', type: 'nominal', title: 'Site' } },
+        spec: {
+          width: 160,
+          height: 220,
+          mark: 'bar',
+          encoding: {
+            x: { field: 'variety', type: 'nominal', title: 'Variety' },
+            y: { field: 'yield', type: 'quantitative', title: 'Yield (bu/acre)' },
+          },
+        },
+      };
+
+      // 2. Wrapped facet: a single facet field chunked into rows of 2.
+      const facetWrapSpec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        title: 'Barley Yield by Site (wrapped facet, 2 columns)',
+        data: { values: barleyYields },
+        facet: { field: 'site', type: 'nominal', title: 'Site' },
+        columns: 2,
+        spec: {
+          width: 160,
+          height: 180,
+          mark: 'bar',
+          encoding: {
+            x: { field: 'variety', type: 'nominal', title: 'Variety' },
+            y: { field: 'yield', type: 'quantitative', title: 'Yield (bu/acre)' },
+          },
+        },
+      };
+
+      // 3. Facet shorthand: row/column channels directly in the encoding.
+      const facetShorthandSpec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        title: 'Barley Yield by Site (encoding.column shorthand)',
+        width: 160,
+        height: 220,
+        data: { values: barleyYields },
+        mark: 'bar',
+        encoding: {
+          x: { field: 'variety', type: 'nominal', title: 'Variety' },
+          y: { field: 'yield', type: 'quantitative', title: 'Yield (bu/acre)' },
+          column: { field: 'site', type: 'nominal', title: 'Site' },
+        },
+      };
+
+      // 4. Repeat: same template plotted once per repeated field.
+      const repeatRowSpec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        title: 'Yield and Year vs Variety (repeat rows)',
+        data: { values: barleyYields },
+        repeat: { row: ['yield', 'year'] },
+        spec: {
+          width: 420,
+          height: 180,
+          mark: 'point',
+          encoding: {
+            x: { field: 'variety', type: 'nominal', title: 'Variety' },
+            y: { field: { repeat: 'row' }, type: 'quantitative' },
+          },
+        },
+      };
+
+      // === MAIDR Integration ===
+      maidrVegaLite
+        .embed('#facet-column-chart', facetColumnSpec, { id: 'facet-column-demo' })
+        .catch((err) => console.error('[vegalite-facet-bar]', err));
+      maidrVegaLite
+        .embed('#facet-wrap-chart', facetWrapSpec, { id: 'facet-wrap-demo' })
+        .catch((err) => console.error('[vegalite-facet-bar]', err));
+      maidrVegaLite
+        .embed('#facet-shorthand-chart', facetShorthandSpec, { id: 'facet-shorthand-demo' })
+        .catch((err) => console.error('[vegalite-facet-bar]', err));
+      maidrVegaLite
+        .embed('#repeat-row-chart', repeatRowSpec, { id: 'repeat-row-demo' })
+        .catch((err) => console.error('[vegalite-facet-bar]', err));
+    </script>
+  </body>
+</html>

--- a/examples/victory/App.tsx
+++ b/examples/victory/App.tsx
@@ -5,6 +5,7 @@ import { BoxPlotExample } from './examples/BoxPlotExample';
 import { CandlestickExample } from './examples/CandlestickExample';
 import { HistogramExample } from './examples/HistogramExample';
 import { LineChartExample } from './examples/LineChartExample';
+import { MultiPanelExample } from './examples/MultiPanelExample';
 import { ScatterChartExample } from './examples/ScatterChartExample';
 import { StackedBarExample } from './examples/StackedBarExample';
 
@@ -16,6 +17,7 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Histogram', component: HistogramExample },
   { name: 'Box Plot', component: BoxPlotExample },
   { name: 'Candlestick', component: CandlestickExample },
+  { name: 'Multi-Panel', component: MultiPanelExample },
 ];
 
 export function App(): JSX.Element {

--- a/examples/victory/examples/MultiPanelExample.tsx
+++ b/examples/victory/examples/MultiPanelExample.tsx
@@ -1,0 +1,62 @@
+import type { JSX } from 'react';
+import { VictoryAxis, VictoryBar, VictoryChart, VictoryLine } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+const northData = [
+  { x: 'Q1', y: 4200 },
+  { x: 'Q2', y: 5800 },
+  { x: 'Q3', y: 3900 },
+  { x: 'Q4', y: 7100 },
+];
+
+const southData = [
+  { x: 'Q1', y: 3100 },
+  { x: 'Q2', y: 4400 },
+  { x: 'Q3', y: 5200 },
+  { x: 'Q4', y: 4800 },
+];
+
+const trendData = [
+  { x: 'Q1', y: 7300 },
+  { x: 'Q2', y: 10200 },
+  { x: 'Q3', y: 9100 },
+  { x: 'Q4', y: 11900 },
+];
+
+export function MultiPanelExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Multi-Panel Figure</h2>
+      <p>
+        Three VictoryChart panels inside one MaidrVictory figure. Use arrow
+        keys to move between panels, press Enter to drill into a panel, and
+        Escape to return to panel navigation. Each chart&apos;s
+        {' '}
+        <code>title</code>
+        {' '}
+        prop names its panel.
+      </p>
+      <MaidrVictory
+        id="victory-multi-panel"
+        title="Quarterly Sales by Region"
+        subtitle="2024 Fiscal Year"
+      >
+        <VictoryChart title="North Region" domainPadding={24} height={220}>
+          <VictoryAxis label="Quarter" />
+          <VictoryAxis dependentAxis label="Revenue ($)" />
+          <VictoryBar data={northData} />
+        </VictoryChart>
+        <VictoryChart title="South Region" domainPadding={24} height={220}>
+          <VictoryAxis label="Quarter" />
+          <VictoryAxis dependentAxis label="Revenue ($)" />
+          <VictoryBar data={southData} />
+        </VictoryChart>
+        <VictoryChart title="Combined Trend" domainPadding={24} height={220}>
+          <VictoryAxis label="Quarter" />
+          <VictoryAxis dependentAxis label="Total Revenue ($)" />
+          <VictoryLine data={trendData} />
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -1,6 +1,11 @@
 /**
  * Main adapter that converts an amCharts 5 chart into a MAIDR data object.
  *
+ * Supports single charts and multi-panel roots: every `XYChart` found in the
+ * root's container tree (including am5stock `StockPanel`s, which extend
+ * `XYChart`) becomes one MAIDR subplot, arranged in a grid mirroring the
+ * on-screen layout.
+ *
  * @example
  * ```ts
  * import { fromAmCharts } from 'maidr/amcharts';
@@ -41,6 +46,7 @@ import {
   extractSegmentedPoints,
   readAxisLabel,
 } from './extractor';
+import { computeChartGrid } from './geometry';
 import {
   buildColumnSelector,
   buildLineSelector,
@@ -51,10 +57,31 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
+ * A converted panel: the source chart paired with the MAIDR layers built from
+ * it. One entry per emitted subplot, in row-major grid order.
+ */
+export interface AmChartPanel {
+  chart: AmXYChart;
+  layers: MaidrLayer[];
+}
+
+/**
+ * Result of {@link convertCharts}: the MAIDR data object plus the
+ * chart-to-subplot mapping the binder needs to route highlights back to the
+ * owning panel.
+ */
+export interface AmChartsConversion {
+  maidr: Maidr;
+  panels: AmChartPanel[];
+}
+
+/**
  * Convert an amCharts 5 {@link AmRoot} into a MAIDR data object.
  *
- * The function inspects the root's container children, finds the first
- * XY chart, and converts each of its series into a MAIDR layer.
+ * The function walks the root's container tree, collects every XY chart
+ * (including am5stock `StockPanel`s), and converts each one into a MAIDR
+ * subplot. A single chart produces a 1x1 grid; multiple charts are arranged
+ * in a grid mirroring their on-screen layout.
  *
  * @param root    The amCharts 5 `Root` instance.
  * @param options Optional overrides for title, subtitle, and axis labels.
@@ -63,15 +90,15 @@ import {
  * @throws If no supported chart is found inside the root.
  */
 export function fromAmCharts(root: AmRoot, options?: AmChartsBinderOptions): Maidr {
-  const chart = findXYChart(root);
-  if (!chart) {
+  const charts = findXYCharts(root);
+  if (charts.length === 0) {
     throw new Error(
       'maidr amCharts binder: no XYChart found in root.container. '
       + 'Ensure the chart is fully initialized before calling fromAmCharts().',
     );
   }
 
-  return fromXYChart(chart, root.dom, options);
+  return convertCharts(charts, root.dom, options).maidr;
 }
 
 /**
@@ -88,8 +115,106 @@ export function fromXYChart(
   containerEl: HTMLElement,
   options?: AmChartsBinderOptions,
 ): Maidr {
-  const title = options?.title ?? readChartTitle(chart);
+  return convertCharts([chart], containerEl, options).maidr;
+}
+
+/**
+ * Convert several amCharts 5 {@link AmXYChart}s (all sharing one root/DOM
+ * element) into a single multi-panel MAIDR data object — one subplot per
+ * chart, arranged in a grid mirroring the rendered layout.
+ *
+ * @param charts       The amCharts 5 XY chart instances (same `Root`).
+ * @param containerEl  The DOM element that contains the charts' rendered output.
+ * @param options      Optional overrides (applied figure-wide).
+ */
+export function fromXYCharts(
+  charts: AmXYChart[],
+  containerEl: HTMLElement,
+  options?: AmChartsBinderOptions,
+): Maidr {
+  return convertCharts(charts, containerEl, options).maidr;
+}
+
+/**
+ * Core conversion shared by the JSON entry points and the binder.
+ *
+ * Single chart: identical output to the original single-panel adapter.
+ * Multiple charts: one subplot per chart, positioned via {@link computeChartGrid}
+ * (falls back to one row in insertion order when geometry is unavailable).
+ * Charts yielding no supported layers are dropped — the core model crashes on
+ * empty subplots or empty grid rows.
+ */
+export function convertCharts(
+  charts: AmXYChart[],
+  containerEl: HTMLElement,
+  options?: AmChartsBinderOptions,
+): AmChartsConversion {
+  if (charts.length === 0) {
+    throw new Error('maidr amCharts binder: convertCharts requires at least one chart.');
+  }
+
+  const id = `amcharts-${containerEl.id || uid()}`;
   const subtitle = options?.subtitle;
+
+  if (charts.length === 1) {
+    const chart = charts[0];
+    const title = options?.title ?? readChartTitle(chart);
+    const layers = buildChartLayers(chart, containerEl, options);
+    const subplot: MaidrSubplot = { layers };
+
+    return {
+      maidr: { id, title, subtitle, subplots: [[subplot]] },
+      panels: [{ chart, layers }],
+    };
+  }
+
+  const grid = computeChartGrid(charts);
+  const subplotRows: MaidrSubplot[][] = [];
+  const panels: AmChartPanel[] = [];
+
+  for (const chartRow of grid) {
+    const subplotRow: MaidrSubplot[] = [];
+    for (const chart of chartRow) {
+      const layers = buildChartLayers(chart, containerEl, options);
+      if (layers.length === 0) {
+        // Never emit `layers: []` inside a grid — it crashes the core model.
+        continue;
+      }
+      // MaidrSubplot has no title field; the FIRST layer's title is the
+      // panel's display name in subplot summaries.
+      const panelTitle = readChartTitle(chart);
+      if (panelTitle) {
+        layers[0] = { ...layers[0], title: panelTitle };
+      }
+      subplotRow.push({ layers });
+      panels.push({ chart, layers });
+    }
+    // Never emit empty rows — they crash the core model.
+    if (subplotRow.length > 0) {
+      subplotRows.push(subplotRow);
+    }
+  }
+
+  if (panels.length === 0) {
+    // No chart produced layers; keep the original single-chart output shape.
+    return convertCharts([charts[0]], containerEl, options);
+  }
+
+  return {
+    maidr: { id, title: options?.title, subtitle, subplots: subplotRows },
+    panels,
+  };
+}
+
+/**
+ * Build the MAIDR layers for one chart. Axis labels come from THAT chart's
+ * first x/y axis; `options.axisLabels` acts as a figure-wide override.
+ */
+function buildChartLayers(
+  chart: AmXYChart,
+  containerEl: HTMLElement,
+  options?: AmChartsBinderOptions,
+): MaidrLayer[] {
   const xLabel = options?.axisLabels?.x ?? readAxisLabel(chart.xAxes.values[0], 'x');
   const yLabel = options?.axisLabels?.y ?? readAxisLabel(chart.yAxes.values[0], 'y');
 
@@ -168,16 +293,7 @@ export function fromXYChart(
     layers.push(buildLineLayer(lineLayers, lineLayerSelectors, xLabel, yLabel, lineTitle));
   }
 
-  const id = `amcharts-${containerEl.id || uid()}`;
-
-  const subplot: MaidrSubplot = { layers };
-
-  return {
-    id,
-    title,
-    subtitle,
-    subplots: [[subplot]],
-  };
+  return layers;
 }
 
 // ---------------------------------------------------------------------------
@@ -310,15 +426,49 @@ function buildLineLayer(
 // Helpers
 // ---------------------------------------------------------------------------
 
-function findXYChart(root: AmRoot): AmXYChart | undefined {
-  for (const child of root.container.children.values) {
-    // Duck-type check: XYChart has series, xAxes, yAxes.
-    const c = child as Partial<AmXYChart>;
-    if (c.series && c.xAxes && c.yAxes) {
-      return c as AmXYChart;
+/**
+ * Collect every XY chart in the root's container tree, in depth-first
+ * (insertion) order.
+ *
+ * Recursion reaches charts nested inside intermediate containers — notably
+ * am5stock `StockPanel`s (which extend `XYChart`) inside a `StockChart`'s
+ * panels container. Found charts are not descended into, so a chart's own
+ * `XYChartScrollbar` preview (which duck-types as an XYChart) never becomes a
+ * phantom panel; a class-name guard covers scrollbars mounted elsewhere.
+ */
+export function findXYCharts(root: AmRoot): AmXYChart[] {
+  const found: AmXYChart[] = [];
+  collectXYCharts(root.container, found);
+  return found;
+}
+
+function collectXYCharts(node: unknown, found: AmXYChart[]): void {
+  for (const child of childValues(node)) {
+    if (isXYChartLike(child)) {
+      if (child.className !== 'XYChartScrollbar') {
+        found.push(child);
+      }
+      continue;
     }
+    collectXYCharts(child, found);
   }
-  return undefined;
+}
+
+/** Read a container-like entity's `children.values`, or `[]` if absent. */
+function childValues(node: unknown): unknown[] {
+  if (node == null || typeof node !== 'object')
+    return [];
+  const children = (node as { children?: { values?: unknown[] } }).children;
+  const values = children?.values;
+  return Array.isArray(values) ? values : [];
+}
+
+/** Duck-type check: an XYChart has series, xAxes, and yAxes. */
+function isXYChartLike(candidate: unknown): candidate is AmXYChart {
+  if (candidate == null || typeof candidate !== 'object')
+    return false;
+  const c = candidate as Partial<AmXYChart>;
+  return Boolean(c.series && c.xAxes && c.yAxes);
 }
 
 /**

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -4,7 +4,9 @@
  * Supports single charts and multi-panel roots: every `XYChart` found in the
  * root's container tree (including am5stock `StockPanel`s, which extend
  * `XYChart`) becomes one MAIDR subplot, arranged in a grid mirroring the
- * on-screen layout.
+ * on-screen layout with rows emitted bottom-first (see
+ * {@link computeChartGrid}) so the core's UPWARD = row+1 mapping moves
+ * visually up.
  *
  * @example
  * ```ts
@@ -81,13 +83,15 @@ export interface AmChartsConversion {
  * The function walks the root's container tree, collects every XY chart
  * (including am5stock `StockPanel`s), and converts each one into a MAIDR
  * subplot. A single chart produces a 1x1 grid; multiple charts are arranged
- * in a grid mirroring their on-screen layout.
+ * in a grid mirroring their on-screen layout, rows ordered bottom-first so
+ * that pressing Up moves to the visually upper panel.
  *
  * @param root    The amCharts 5 `Root` instance.
  * @param options Optional overrides for title, subtitle, and axis labels.
  * @returns       A {@link Maidr} object ready for `<Maidr data={...}>`.
  *
- * @throws If no supported chart is found inside the root.
+ * @throws If no supported chart is found inside the root, or if no chart
+ *         contains a supported series with data.
  */
 export function fromAmCharts(root: AmRoot, options?: AmChartsBinderOptions): Maidr {
   const charts = findXYCharts(root);
@@ -142,7 +146,11 @@ export function fromXYCharts(
  * Multiple charts: one subplot per chart, positioned via {@link computeChartGrid}
  * (falls back to one row in insertion order when geometry is unavailable).
  * Charts yielding no supported layers are dropped — the core model crashes on
- * empty subplots or empty grid rows.
+ * empty subplots or empty grid rows. When NO chart yields a layer, a
+ * descriptive error is thrown instead of emitting the `[[{ layers: [] }]]`
+ * shape, which would crash the core model at Controller construction.
+ *
+ * @throws If no chart contains a supported series with data.
  */
 export function convertCharts(
   charts: AmXYChart[],
@@ -160,6 +168,9 @@ export function convertCharts(
     const chart = charts[0];
     const title = options?.title ?? readChartTitle(chart);
     const layers = buildChartLayers(chart, containerEl, options);
+    if (layers.length === 0) {
+      throw noSupportedDataError();
+    }
     const subplot: MaidrSubplot = { layers };
 
     return {
@@ -196,8 +207,9 @@ export function convertCharts(
   }
 
   if (panels.length === 0) {
-    // No chart produced layers; keep the original single-chart output shape.
-    return convertCharts([charts[0]], containerEl, options);
+    // Never emit `[[{ layers: [] }]]` — it crashes the core model the moment
+    // the Controller is constructed. Fail with an actionable adapter error.
+    throw noSupportedDataError();
   }
 
   return {
@@ -426,15 +438,26 @@ function buildLineLayer(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Error thrown when no chart yields a supported series with data. */
+function noSupportedDataError(): Error {
+  return new Error(
+    'maidr amCharts binder: no supported series with data found in any chart. '
+    + 'Ensure series data is set before calling fromAmCharts()/bindAmCharts().',
+  );
+}
+
 /**
  * Collect every XY chart in the root's container tree, in depth-first
  * (insertion) order.
  *
  * Recursion reaches charts nested inside intermediate containers — notably
  * am5stock `StockPanel`s (which extend `XYChart`) inside a `StockChart`'s
- * panels container. Found charts are not descended into, so a chart's own
- * `XYChartScrollbar` preview (which duck-types as an XYChart) never becomes a
- * phantom panel; a class-name guard covers scrollbars mounted elsewhere.
+ * panels container. `XYChartScrollbar` subtrees are pruned before recursion:
+ * a real scrollbar is a plain `Scrollbar` container (NOT chart-like itself)
+ * whose child is a preview `XYChart` — descending into it would surface that
+ * preview as a phantom panel (e.g. a scrollbar mounted in a StockChart's
+ * toolsContainer, the standard am5stock pattern). Found charts are also not
+ * descended into, so an in-chart scrollbar preview is never visited either.
  */
 export function findXYCharts(root: AmRoot): AmXYChart[] {
   const found: AmXYChart[] = [];
@@ -444,10 +467,13 @@ export function findXYCharts(root: AmRoot): AmXYChart[] {
 
 function collectXYCharts(node: unknown, found: AmXYChart[]): void {
   for (const child of childValues(node)) {
+    const cls = (child as { className?: string } | null)?.className;
+    if (cls === 'XYChartScrollbar') {
+      // Never a panel; its child preview XYChart must not be found either.
+      continue;
+    }
     if (isXYChartLike(child)) {
-      if (child.className !== 'XYChartScrollbar') {
-        found.push(child);
-      }
+      found.push(child);
       continue;
     }
     collectXYCharts(child, found);

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -258,7 +258,8 @@ function renderMaidr(maidrData: MaidrData, rootDom: HTMLElement): RenderResult |
  * container tree (including am5stock StockPanels); each chart becomes one
  * MAIDR subplot, navigable with the arrow keys.
  *
- * @throws If no supported XYChart is found in `root.container`.
+ * @throws If no supported XYChart is found in `root.container`, or if no
+ *         chart contains a supported series with data.
  */
 export function bindAmCharts(root: AmRoot, options?: AmChartsBindOptions): AmChartsBinding {
   const charts = findXYCharts(root);

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -128,6 +128,15 @@ function applyHighlight(
   const chart = navMap.chartFor(event.layerId);
   const plotBounds = chart ? readPlotBounds(chart) : null;
 
+  // Without readable panel bounds an unclipped rect could bleed into a
+  // sibling panel (all panels share one overlay canvas), so suppress the
+  // highlight in multi-panel roots. Single charts keep the unclipped
+  // fallback: there is no neighbor to bleed into.
+  if (!plotBounds && navMap.chartCount > 1) {
+    overlay.clear();
+    return;
+  }
+
   const rects = [];
   for (const target of targets) {
     const rect = dataItemToOverlayRect(target, plotBounds);

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -26,7 +26,6 @@ import type { JSX } from 'react';
 import type { Root as ReactRoot } from 'react-dom/client';
 import type { NavMap } from './navmap';
 import type {
-  AmBounds,
   AmChartsBinderOptions,
   AmRoot,
   AmXYChart,
@@ -35,8 +34,9 @@ import type {
 import { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
-import { fromXYChart } from './adapter';
+import { convertCharts, findXYCharts } from './adapter';
 import { classifySeriesKind } from './extractor';
+import { readPlotBounds } from './geometry';
 import { getHighlightColor } from './highlightColor';
 import { buildNavigationMap } from './navmap';
 import { dataItemToOverlayRect, HighlightOverlay } from './overlay';
@@ -111,36 +111,9 @@ function AmHost({ node, width, height, onHost }: AmHostProps): JSX.Element {
 // Highlight bridge
 // ---------------------------------------------------------------------------
 
-/**
- * Read the plot-area bounds (CSS px, root-relative) used to clip highlights.
- * Tries `globalBounds()`, then `toGlobal()` + `width()/height()`; returns
- * `null` if neither is available (the overlay's `overflow:hidden` still clips
- * to the chart box).
- */
-function readPlotBounds(chart: AmXYChart): AmBounds | null {
-  const pc = chart.plotContainer;
-  if (!pc) {
-    return null;
-  }
-  try {
-    const bounds = pc.globalBounds?.();
-    if (bounds && Number.isFinite(bounds.left) && Number.isFinite(bounds.bottom)) {
-      return bounds;
-    }
-    if (pc.toGlobal && pc.width && pc.height) {
-      const tl = pc.toGlobal({ x: 0, y: 0 });
-      return { left: tl.x, top: tl.y, right: tl.x + pc.width(), bottom: tl.y + pc.height() };
-    }
-  } catch {
-    // Fall through; overlay overflow:hidden still clips to the chart box.
-  }
-  return null;
-}
-
 function applyHighlight(
   overlay: HighlightOverlay,
   navMap: NavMap,
-  chart: AmXYChart,
   event: NavEvent,
 ): void {
   const targets = navMap.resolve(event.layerId, event.row, event.col);
@@ -149,9 +122,11 @@ function applyHighlight(
     return;
   }
 
-  // Clip the highlight to the visible plot area; a column's geometry can
-  // extend to the value=0 baseline beyond a clipped (min > 0) axis.
-  const plotBounds = readPlotBounds(chart);
+  // Clip the highlight to the OWNING panel's visible plot area; a column's
+  // geometry can extend to the value=0 baseline beyond a clipped (min > 0)
+  // axis, and in multi-panel roots it must not bleed into sibling panels.
+  const chart = navMap.chartFor(event.layerId);
+  const plotBounds = chart ? readPlotBounds(chart) : null;
 
   const rects = [];
   for (const target of targets) {
@@ -168,7 +143,6 @@ function applyHighlight(
 
 function createHighlightCallback(
   navMap: NavMap,
-  chart: AmXYChart,
   getOverlay: () => HighlightOverlay | null,
   recordActive: (event: NavEvent) => void,
 ): NavigateCallback {
@@ -178,7 +152,7 @@ function createHighlightCallback(
       const overlay = getOverlay();
       if (!overlay)
         return;
-      applyHighlight(overlay, navMap, chart, event);
+      applyHighlight(overlay, navMap, event);
     } catch {
       // Ignore highlight errors (e.g., during teardown or before layout).
     }
@@ -220,16 +194,6 @@ function groupSeries(chart: AmXYChart): {
   }
 
   return { barSeriesList, lineSeriesList, histogramSeries, heatmapSeries };
-}
-
-function findXYChart(root: AmRoot): AmXYChart | undefined {
-  for (const child of root.container.children.values) {
-    const candidate = child as Partial<AmXYChart>;
-    if (candidate.series && candidate.xAxes && candidate.yAxes) {
-      return candidate as AmXYChart;
-    }
-  }
-  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -290,19 +254,21 @@ function renderMaidr(maidrData: MaidrData, rootDom: HTMLElement): RenderResult |
 
 /**
  * Bind MAIDR to an amCharts 5 {@link AmRoot}, mounting the accessible UI and
- * (by default) a canvas highlight overlay. Finds the first XYChart in the root.
+ * (by default) a canvas highlight overlay. Finds every XYChart in the root's
+ * container tree (including am5stock StockPanels); each chart becomes one
+ * MAIDR subplot, navigable with the arrow keys.
  *
  * @throws If no supported XYChart is found in `root.container`.
  */
 export function bindAmCharts(root: AmRoot, options?: AmChartsBindOptions): AmChartsBinding {
-  const chart = findXYChart(root);
-  if (!chart) {
+  const charts = findXYCharts(root);
+  if (charts.length === 0) {
     throw new Error(
       'maidr amCharts binder: no XYChart found in root.container. '
       + 'Ensure the chart is fully initialized before calling bindAmCharts().',
     );
   }
-  return bindXYChart(chart, root, options);
+  return bindCharts(charts, root, options);
 }
 
 /**
@@ -314,7 +280,22 @@ export function bindXYChart(
   root: AmRoot,
   options?: AmChartsBindOptions,
 ): AmChartsBinding {
-  const data = fromXYChart(chart, root.dom, options);
+  return bindCharts([chart], root, options);
+}
+
+/**
+ * Shared binding path: converts the charts (one subplot each), mounts MAIDR
+ * over `root.dom`, and wires one highlight overlay for the whole root — all
+ * panels of one root render into the same canvases, and highlight geometry is
+ * already root-relative. Each highlight clips against its own panel's plot
+ * bounds via the navigation map's owning-chart record.
+ */
+function bindCharts(
+  charts: AmXYChart[],
+  root: AmRoot,
+  options?: AmChartsBindOptions,
+): AmChartsBinding {
+  const { maidr: data, panels } = convertCharts(charts, root.dom, options);
   const highlightEnabled = options?.highlight !== false;
 
   let overlay: HighlightOverlay | null = null;
@@ -322,13 +303,15 @@ export function bindXYChart(
 
   let maidrData: MaidrData = data;
   if (highlightEnabled) {
-    const groups = groupSeries(chart);
-    const navMap = buildNavigationMap(data.subplots[0][0].layers, groups);
+    const navMap = buildNavigationMap(panels.map(panel => ({
+      layers: panel.layers,
+      groups: groupSeries(panel.chart),
+      chart: panel.chart,
+    })));
     maidrData = {
       ...data,
       onNavigate: createHighlightCallback(
         navMap,
-        chart,
         () => overlay,
         (event) => {
           lastActive = event;
@@ -348,7 +331,7 @@ export function bindXYChart(
       overlay = new HighlightOverlay(host, root.dom, getColor);
       // Paint the initial position if navigation already happened.
       if (lastActive)
-        applyHighlight(overlay, navMap, chart, lastActive);
+        applyHighlight(overlay, navMap, lastActive);
       return overlay;
     });
 
@@ -357,7 +340,7 @@ export function bindXYChart(
         if (!ov || !lastActive)
           return;
         try {
-          applyHighlight(ov, navMap, chart, lastActive);
+          applyHighlight(ov, navMap, lastActive);
         } catch {
           // Ignore; chart may be mid-teardown.
         }

--- a/src/adapters/amcharts/geometry.ts
+++ b/src/adapters/amcharts/geometry.ts
@@ -49,9 +49,16 @@ interface ChartCell {
  *
  * Charts are grouped into rows by root-relative top coordinate (tolerance:
  * half the smaller chart height, so slight offsets from titles or legends do
- * not split a row) and sorted left-to-right within each row — visual reading
- * order, top-left first. Handles vertical, horizontal, and Grid layouts
- * uniformly without depending on layout internals.
+ * not split a row) and sorted left-to-right within each row. Handles
+ * vertical, horizontal, and Grid layouts uniformly without depending on
+ * layout internals.
+ *
+ * Rows are emitted BOTTOM-first (the grammar's native matplotlib convention:
+ * the core's `MovableGrid` maps UPWARD to `row + 1`). amCharts renders to
+ * canvas, so the core's DOM layout pass cannot measure panel positions and
+ * always takes its no-inversion fallback — emitting the bottom row as data
+ * row 0 is the only way to make ArrowUp move visually up. The trade-off is
+ * that panel numbering ("Subplot 1") starts at the bottom-left panel.
  *
  * Falls back to a single row in insertion order when any chart's geometry is
  * unavailable (e.g. before layout, on the JSON `fromAmCharts` path).
@@ -93,7 +100,8 @@ export function computeChartGrid(charts: AmXYChart[]): AmXYChart[][] {
   }
   rows.push(currentRow);
 
-  return rows.map(row =>
-    [...row].sort((a, b) => a.left - b.left).map(cell => cell.chart),
-  );
+  // Bottom row first (see doc comment): reverse the top-sorted row order.
+  return rows
+    .reverse()
+    .map(row => [...row].sort((a, b) => a.left - b.left).map(cell => cell.chart));
 }

--- a/src/adapters/amcharts/geometry.ts
+++ b/src/adapters/amcharts/geometry.ts
@@ -1,0 +1,99 @@
+/**
+ * Chart geometry helpers for the amCharts 5 adapter.
+ *
+ * amCharts renders every chart of one `Root` into shared canvases, so the only
+ * way to know where a panel sits is to ask its sprites for pixel geometry.
+ * These helpers read a chart's plot-area bounds (used to clip highlight boxes
+ * to the owning panel) and cluster multiple charts into a row-major grid that
+ * mirrors their on-screen arrangement (vertical/horizontal/Grid layouts).
+ */
+
+import type { AmBounds, AmXYChart } from './types';
+
+/**
+ * Read the plot-area bounds (CSS px, root-relative) used to clip highlights.
+ * Tries `globalBounds()`, then `toGlobal()` + `width()/height()`; returns
+ * `null` if neither is available (the overlay's `overflow:hidden` still clips
+ * to the chart box).
+ */
+export function readPlotBounds(chart: AmXYChart): AmBounds | null {
+  const pc = chart.plotContainer;
+  if (!pc) {
+    return null;
+  }
+  try {
+    const bounds = pc.globalBounds?.();
+    if (bounds && Number.isFinite(bounds.left) && Number.isFinite(bounds.bottom)) {
+      return bounds;
+    }
+    if (pc.toGlobal && pc.width && pc.height) {
+      const tl = pc.toGlobal({ x: 0, y: 0 });
+      return { left: tl.x, top: tl.y, right: tl.x + pc.width(), bottom: tl.y + pc.height() };
+    }
+  } catch {
+    // Fall through; overlay overflow:hidden still clips to the chart box.
+  }
+  return null;
+}
+
+/** A chart paired with the normalized geometry used for grid clustering. */
+interface ChartCell {
+  chart: AmXYChart;
+  top: number;
+  left: number;
+  height: number;
+}
+
+/**
+ * Cluster charts into a row-major grid matching their visual arrangement.
+ *
+ * Charts are grouped into rows by root-relative top coordinate (tolerance:
+ * half the smaller chart height, so slight offsets from titles or legends do
+ * not split a row) and sorted left-to-right within each row — visual reading
+ * order, top-left first. Handles vertical, horizontal, and Grid layouts
+ * uniformly without depending on layout internals.
+ *
+ * Falls back to a single row in insertion order when any chart's geometry is
+ * unavailable (e.g. before layout, on the JSON `fromAmCharts` path).
+ */
+export function computeChartGrid(charts: AmXYChart[]): AmXYChart[][] {
+  if (charts.length <= 1) {
+    return [charts];
+  }
+
+  const cells: ChartCell[] = [];
+  for (const chart of charts) {
+    const bounds = readPlotBounds(chart);
+    const height = bounds ? Math.abs(bounds.bottom - bounds.top) : 0;
+    if (!bounds || height <= 0) {
+      return [charts];
+    }
+    cells.push({
+      chart,
+      top: Math.min(bounds.top, bounds.bottom),
+      left: Math.min(bounds.left, bounds.right),
+      height,
+    });
+  }
+
+  cells.sort((a, b) => a.top - b.top);
+
+  const rows: ChartCell[][] = [];
+  let currentRow: ChartCell[] = [cells[0]];
+  for (let i = 1; i < cells.length; i++) {
+    const cell = cells[i];
+    const rowRef = currentRow[0];
+    const tolerance = Math.min(cell.height, rowRef.height) / 2;
+    if (cell.top - rowRef.top < tolerance) {
+      currentRow.push(cell);
+    } else {
+      rows.push(currentRow);
+      currentRow = [cell];
+    }
+  }
+  rows.push(currentRow);
+
+  return rows.map(row =>
+    [...row].sort((a, b) => a.left - b.left).map(cell => cell.chart),
+  );
+}

--- a/src/adapters/amcharts/index.ts
+++ b/src/adapters/amcharts/index.ts
@@ -21,6 +21,11 @@
  *    attribute or `<Maidr data={...}>`. Enables audio/text/braille but NOT
  *    visual highlighting (the highlight callback cannot survive JSON).
  *
+ * Multi-panel roots are supported by both paths: every `XYChart` in the
+ * root's container tree (including am5stock `StockPanel`s) becomes one MAIDR
+ * subplot, arranged in a grid matching the rendered layout. Arrow keys move
+ * between panels; Enter drills into a panel and Escape returns.
+ *
  * @example
  * ```ts
  * import { bindAmCharts } from 'maidr/amcharts';
@@ -34,7 +39,7 @@
  * @packageDocumentation
  */
 
-export { fromAmCharts, fromXYChart } from './adapter';
+export { findXYCharts, fromAmCharts, fromXYChart, fromXYCharts } from './adapter';
 export { bindAmCharts, bindXYChart } from './binder';
 export type { AmChartsBinding, AmChartsBindOptions } from './binder';
 export type { AmChartsBinderOptions, AmRoot, AmXYChart, AmXYSeries } from './types';

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -34,6 +34,8 @@ export interface NavMap {
    * disambiguates the panel.
    */
   chartFor: (layerId: string) => AmXYChart | undefined;
+  /** Number of distinct charts (panels) in the map. */
+  chartCount: number;
 }
 
 /**
@@ -188,6 +190,7 @@ export function buildNavigationMap(entries: readonly NavMapEntry[]): NavMap {
   return {
     resolve: (layerId, row, col) => resolvers.get(layerId)?.(row, col) ?? [],
     chartFor: layerId => owners.get(layerId),
+    chartCount: new Set(entries.map(entry => entry.chart)).size,
   };
 }
 

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -4,11 +4,13 @@
  * MAIDR navigation fires `{ layerId, row, col }`. To highlight the active data
  * point we must map that back to the live amCharts series + dataItem so the
  * overlay can read its pixel geometry. The grouping mirrors how the adapter
- * builds layers in `adapter.ts` (`fromXYChart`).
+ * builds layers in `adapter.ts` (`convertCharts`). Multi-panel figures pass
+ * one entry per subplot; the merged map also records each layer's owning
+ * chart so highlights clip against the correct panel's plot area.
  */
 
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
-import type { AmDataItem, AmXYSeries } from './types';
+import type { AmDataItem, AmXYChart, AmXYSeries } from './types';
 import { TraceType } from '@type/grammar';
 
 /**
@@ -26,6 +28,23 @@ export interface NavTarget {
  */
 export interface NavMap {
   resolve: (layerId: string, row: number, col: number) => NavTarget[];
+  /**
+   * The chart owning a layer, so highlights can be clipped against the owning
+   * panel's plot bounds. Layer ids are unique figure-wide, so the id alone
+   * disambiguates the panel.
+   */
+  chartFor: (layerId: string) => AmXYChart | undefined;
+}
+
+/**
+ * One subplot's worth of navigation-map input: the MAIDR layers built from a
+ * chart, the live series grouped as the adapter grouped them, and the owning
+ * chart itself.
+ */
+export interface NavMapEntry {
+  layers: MaidrLayer[];
+  groups: SeriesGroups;
+  chart: AmXYChart;
 }
 
 /**
@@ -153,16 +172,31 @@ function buildHeatmapResolver(series: AmXYSeries, data: HeatmapData): Resolver {
 }
 
 /**
- * Build the navigation map from the MAIDR layers (for IDs + types) and the
- * grouped live series. Layers are matched to series by type and order, which
- * avoids depending on the exact generated ID strings.
+ * Build the navigation map from one entry per subplot. Each entry's layers
+ * are matched to its grouped live series by type and order (avoiding any
+ * dependence on the exact generated ID strings), and all resolvers merge into
+ * one layerId-keyed map — layer ids are unique across the whole figure.
  */
-export function buildNavigationMap(
-  layers: MaidrLayer[],
-  groups: SeriesGroups,
-): NavMap {
+export function buildNavigationMap(entries: readonly NavMapEntry[]): NavMap {
   const resolvers = new Map<string, Resolver>();
+  const owners = new Map<string, AmXYChart>();
 
+  for (const entry of entries) {
+    addEntryResolvers(entry, resolvers, owners);
+  }
+
+  return {
+    resolve: (layerId, row, col) => resolvers.get(layerId)?.(row, col) ?? [],
+    chartFor: layerId => owners.get(layerId),
+  };
+}
+
+/** Register the resolvers (and owning chart) for one subplot's layers. */
+function addEntryResolvers(
+  { layers, groups, chart }: NavMapEntry,
+  resolvers: Map<string, Resolver>,
+  owners: Map<string, AmXYChart>,
+): void {
   // Precompute gap-filtered items per series, then drop empty series exactly as
   // the adapter does when building layers (`buildSegmentedLayer` / `fromXYChart`
   // skip series that yield no points). This keeps MAIDR row/col indices aligned
@@ -182,21 +216,26 @@ export function buildNavigationMap(
   let histIdx = 0;
   let heatIdx = 0;
 
+  const register = (layerId: string, resolver: Resolver): void => {
+    resolvers.set(layerId, resolver);
+    owners.set(layerId, chart);
+  };
+
   for (const layer of layers) {
     switch (layer.type) {
       case TraceType.BAR: {
         const entry = barItems[0];
-        resolvers.set(layer.id, (_row, col) => columnTargetFrom(entry, col));
+        register(layer.id, (_row, col) => columnTargetFrom(entry, col));
         break;
       }
       case TraceType.STACKED:
       case TraceType.DODGED:
       case TraceType.NORMALIZED: {
-        resolvers.set(layer.id, (row, col) => columnTargetFrom(segmentedBars[row], col));
+        register(layer.id, (row, col) => columnTargetFrom(segmentedBars[row], col));
         break;
       }
       case TraceType.LINE: {
-        resolvers.set(layer.id, (row, col) => {
+        register(layer.id, (row, col) => {
           const entry = lineSeries[row];
           const dataItem = entry?.items[col];
           return entry && dataItem
@@ -207,13 +246,13 @@ export function buildNavigationMap(
       }
       case TraceType.HISTOGRAM: {
         const entry = histogramSeries[histIdx++];
-        resolvers.set(layer.id, (_row, col) => columnTargetFrom(entry, col));
+        register(layer.id, (_row, col) => columnTargetFrom(entry, col));
         break;
       }
       case TraceType.HEATMAP: {
         const series = groups.heatmapSeries[heatIdx++];
         if (series) {
-          resolvers.set(layer.id, buildHeatmapResolver(series, layer.data as HeatmapData));
+          register(layer.id, buildHeatmapResolver(series, layer.data as HeatmapData));
         }
         break;
       }
@@ -221,8 +260,4 @@ export function buildNavigationMap(
         break;
     }
   }
-
-  return {
-    resolve: (layerId, row, col) => resolvers.get(layerId)?.(row, col) ?? [],
-  };
 }

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -34,11 +34,14 @@ import type {
 } from '@type/grammar';
 import type {
   AnyChartBinderOptions,
+  AnyChartGridInput,
   AnyChartInstance,
   AnyChartIterator,
+  AnyChartsBinderOptions,
   AnyChartSeries,
   AnyChartTitle,
 } from './types';
+import { nextId } from '@adapters/shared/selectorUtil';
 import { TraceType } from '@type/grammar';
 
 // ---------------------------------------------------------------------------
@@ -334,6 +337,59 @@ const HEATMAP_ATTR = 'data-maidr-anychart-heatmap-cell';
 const CANDLESTICK_ATTR = 'data-maidr-anychart-candlestick-cell';
 
 /**
+ * Attribute name stamped onto each panel's own `<svg>` root by
+ * {@link bindAnyCharts}. Its value is the panel token
+ * (`<figureId>-<row>-<col>`), which uniquely identifies one chart's SVG
+ * within the page. Every layer selector emitted for a multi-panel figure is
+ * prefixed with `[data-maidr-anychart-panel="<token>"] ` so MAIDR's
+ * document-global selector resolution can never leak into another panel
+ * (or another figure).
+ */
+const PANEL_ATTR = 'data-maidr-anychart-panel';
+
+/**
+ * Identifies one panel (subplot cell) of a multi-panel AnyChart figure.
+ * `undefined` everywhere a panel context is accepted means "single-panel
+ * mode" — selectors and stamped attribute values then keep their original,
+ * un-prefixed shape so existing single-chart behavior is unchanged.
+ */
+interface PanelContext {
+  /** Page-unique token: `<sanitized figureId>-<row>-<col>`. */
+  token: string;
+  /** Subplot grid row (row-major, visual reading order). */
+  row: number;
+  /** Subplot grid column. */
+  col: number;
+}
+
+/**
+ * Descendant-combinator prefix scoping a selector to one panel's SVG.
+ * Empty string in single-panel mode.
+ */
+function panelScope(panel: PanelContext | undefined): string {
+  return panel ? `[${PANEL_ATTR}="${panel.token}"] ` : '';
+}
+
+/**
+ * Prefix baked into every stamped attribute VALUE for a panel (e.g.
+ * `data-maidr-anychart-bar="<token>:0-3"`). Scoping the values themselves —
+ * not just the selectors — also fixes cross-figure collisions between two
+ * independently bound charts whose bare `<series>-<point>` values would
+ * otherwise be identical. Empty string in single-panel mode.
+ */
+function panelStampPrefix(panel: PanelContext | undefined): string {
+  return panel ? `${panel.token}:` : '';
+}
+
+/**
+ * Sanitize a figure id for embedding in attribute values / CSS attribute
+ * selectors (quotes and other CSS-hostile characters become underscores).
+ */
+function sanitizePanelToken(value: string): string {
+  return value.replace(/[^\w-]/g, '_');
+}
+
+/**
  * Resolve the CSS selector for a specific series index.
  *
  * AnyChart's internal SVG structure does not use stable, predictable class
@@ -357,6 +413,7 @@ function resolveSelector(
   seriesIndex: number,
   traceType: TraceType,
   options?: AnyChartBinderOptions,
+  panel?: PanelContext,
 ): string | string[] | undefined {
   const userSelectors = options?.selectors;
   if (userSelectors && userSelectors.length > 0) {
@@ -372,17 +429,21 @@ function resolveSelector(
   // BAR uses `data-maidr-anychart-bar`; LINE uses
   // `data-maidr-anychart-line-point` (requires markers enabled on the series,
   // which {@link enableLineMarkersIfNeeded} handles).
+  // In multi-panel mode both the selector (descendant of the panel's SVG)
+  // and the attribute value (token prefix) are scoped to the panel.
+  const scope = panelScope(panel);
+  const stamp = panelStampPrefix(panel);
   if (traceType === TraceType.BAR)
-    return `[${BAR_ATTR}^="${seriesIndex}-"]`;
+    return `${scope}[${BAR_ATTR}^="${stamp}${seriesIndex}-"]`;
   if (traceType === TraceType.LINE)
-    return `[${LINE_ATTR}^="${seriesIndex}-"]`;
+    return `${scope}[${LINE_ATTR}^="${stamp}${seriesIndex}-"]`;
   if (traceType === TraceType.SCATTER)
-    return `[${POINT_ATTR}^="${seriesIndex}-"]`;
+    return `${scope}[${POINT_ATTR}^="${stamp}${seriesIndex}-"]`;
   // Heatmaps are single-series (no series-index prefix); the chart-level
   // builder constructs the selector itself, so this branch only matters as
   // a defensive default when the heatmap path is bypassed.
   if (traceType === TraceType.HEATMAP)
-    return `[${HEATMAP_ATTR}]`;
+    return `${scope}[${HEATMAP_ATTR}]`;
 
   return undefined;
 }
@@ -451,6 +512,7 @@ function collectShapeCandidatesFromRoot(
 function stampBarAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
+  stampPrefix = '',
 ): void {
   const seriesCount = chart.getSeriesCount();
   if (seriesCount === 0)
@@ -520,7 +582,7 @@ function stampBarAttributes(
     for (let p = 0; p < stampCount; p++) {
       const el = candidates[cursor++];
       if (!el.hasAttribute(BAR_ATTR))
-        el.setAttribute(BAR_ATTR, `${s}-${p}`);
+        el.setAttribute(BAR_ATTR, `${stampPrefix}${s}-${p}`);
     }
   }
 }
@@ -713,6 +775,7 @@ function collectLineMarkerCandidates(
 function stampLineAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
+  stampPrefix = '',
 ): void {
   const seriesCount = chart.getSeriesCount();
   if (seriesCount === 0)
@@ -778,7 +841,7 @@ function stampLineAttributes(
     for (let i = stampStart; i < stampEnd; i++) {
       const el = candidates[i].el;
       if (!el.hasAttribute(LINE_ATTR))
-        el.setAttribute(LINE_ATTR, `${s}-${i - stampStart}`);
+        el.setAttribute(LINE_ATTR, `${stampPrefix}${s}-${i - stampStart}`);
     }
   }
 }
@@ -816,6 +879,7 @@ const SCATTER_LIKE_SERIES_TYPES = new Set([
 function stampScatterAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
+  stampPrefix = '',
 ): void {
   const seriesCount = chart.getSeriesCount();
   if (seriesCount === 0)
@@ -921,7 +985,7 @@ function stampScatterAttributes(
       const c = candidates[i];
       if (c.el.hasAttribute(POINT_ATTR))
         continue;
-      c.el.setAttribute(POINT_ATTR, `${s}-${i - stampStart}`);
+      c.el.setAttribute(POINT_ATTR, `${stampPrefix}${s}-${i - stampStart}`);
       // Stamp the bbox-center as `cx` / `cy` so MAIDR's
       // `ScatterTrace.groupSvgElements` can extract coordinates from these
       // <path> elements directly. AnyChart scatter markers render as
@@ -1329,6 +1393,7 @@ function findWhiskerElements(
 function stampBoxAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
+  stampPrefix = '',
 ): void {
   const seriesCount = chart.getSeriesCount();
   if (seriesCount === 0)
@@ -1387,13 +1452,13 @@ function stampBoxAttributes(
     for (let b = 0; b < end - start; b++) {
       const iq = allIqCandidates[start + b];
       if (!iq.el.hasAttribute(BOX_ATTR)) {
-        iq.el.setAttribute(BOX_ATTR, `${s}-${b}`);
+        iq.el.setAttribute(BOX_ATTR, `${stampPrefix}${s}-${b}`);
         iq.el.setAttribute(BOX_PART_ATTR, 'iq');
       }
 
       const median = findMedianElement(svg, iq);
       if (median && !median.hasAttribute(BOX_ATTR)) {
-        median.setAttribute(BOX_ATTR, `${s}-${b}`);
+        median.setAttribute(BOX_ATTR, `${stampPrefix}${s}-${b}`);
         median.setAttribute(BOX_PART_ATTR, 'q2');
       } else if (!median) {
         // DIAGNOSTIC (temporary, removed once box highlighting is verified):
@@ -1419,7 +1484,7 @@ function stampBoxAttributes(
       for (const { el, isUpper } of whiskers) {
         if (el.hasAttribute(BOX_ATTR))
           continue;
-        el.setAttribute(BOX_ATTR, `${s}-${b}`);
+        el.setAttribute(BOX_ATTR, `${stampPrefix}${s}-${b}`);
         el.setAttribute(BOX_PART_ATTR, isUpper ? 'max' : 'min');
       }
     }
@@ -1428,16 +1493,16 @@ function stampBoxAttributes(
     // per-part stamps succeeded without browser DevTools. Remove once
     // box highlighting is confirmed working end-to-end.
     const stampedIq = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${s}-"][${BOX_PART_ATTR}="iq"]`,
+      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="iq"]`,
     ).length;
     const stampedQ2 = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${s}-"][${BOX_PART_ATTR}="q2"]`,
+      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="q2"]`,
     ).length;
     const stampedMin = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${s}-"][${BOX_PART_ATTR}="min"]`,
+      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="min"]`,
     ).length;
     const stampedMax = svg.querySelectorAll(
-      `[${BOX_ATTR}^="${s}-"][${BOX_PART_ATTR}="max"]`,
+      `[${BOX_ATTR}^="${stampPrefix}${s}-"][${BOX_PART_ATTR}="max"]`,
     ).length;
     // Using console.warn (not console.log) so the diagnostic surfaces under
     // the repo's no-console ESLint rule. This whole block is temporary.
@@ -1450,7 +1515,7 @@ function stampBoxAttributes(
     // Per-box detail: report any box missing one or more parts so we can
     // pinpoint failures from a single console line. Temporary diagnostic.
     for (let b = 0; b < boxCount; b++) {
-      const base = `[${BOX_ATTR}="${s}-${b}"]`;
+      const base = `[${BOX_ATTR}="${stampPrefix}${s}-${b}"]`;
       const missing: string[] = [];
       if (!svg.querySelector(`${base}[${BOX_PART_ATTR}="iq"]`))
         missing.push('iq');
@@ -1543,6 +1608,7 @@ function findHeatmapCellLayer(svg: SVGElement): Element {
 function stampHeatmapAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
+  stampPrefix = '',
 ): void {
   let chartType: string | undefined;
   try {
@@ -1641,7 +1707,7 @@ function stampHeatmapAttributes(
     const c = i % cols;
     const el = cellCandidates[i];
     if (!el.hasAttribute(HEATMAP_ATTR))
-      el.setAttribute(HEATMAP_ATTR, `${r}-${c}`);
+      el.setAttribute(HEATMAP_ATTR, `${stampPrefix}${r}-${c}`);
   }
 }
 
@@ -1707,6 +1773,7 @@ function findCandlestickPathLayer(svg: SVGElement): Element {
 function stampCandlestickAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
+  stampPrefix = '',
 ): void {
   const seriesCount = chart.getSeriesCount?.() ?? 0;
   if (seriesCount === 0)
@@ -1773,7 +1840,7 @@ function stampCandlestickAttributes(
       continue;
     const rows = extractRawRows(series);
     for (let i = 0; i < rows.length && cursor < pathCandidates.length; i++, cursor++) {
-      pathCandidates[cursor].setAttribute(CANDLESTICK_ATTR, `${s}-${i}`);
+      pathCandidates[cursor].setAttribute(CANDLESTICK_ATTR, `${stampPrefix}${s}-${i}`);
     }
   }
 }
@@ -1853,6 +1920,7 @@ function buildBoxLayer(
   series: AnyChartSeries,
   seriesIndex: number,
   selectors: string | string[] | undefined,
+  panel?: PanelContext,
 ): MaidrLayer {
   const rows = extractRawRows(series);
   const data: BoxPoint[] = rows.map(r => ({
@@ -1876,8 +1944,10 @@ function buildBoxLayer(
   // them from the `iq` element's top/bottom edges via
   // `Svg.createLineElement(iq, 'top'|'bottom')`. Outlier arrays are empty
   // because AnyChart's iterator API does not expose outliers.
+  const scope = panelScope(panel);
+  const stamp = panelStampPrefix(panel);
   const stampedBoxSelectors: BoxSelector[] = data.map((_, b) => {
-    const base = `[${BOX_ATTR}="${seriesIndex}-${b}"]`;
+    const base = `${scope}[${BOX_ATTR}="${stamp}${seriesIndex}-${b}"]`;
     return {
       lowerOutliers: [],
       min: `${base}[${BOX_PART_ATTR}="min"]`,
@@ -1962,6 +2032,7 @@ function buildHeatmapLayer(
 function buildHeatmapLayerFromChart(
   chart: AnyChartInstance,
   selectors: string | string[] | undefined,
+  panel?: PanelContext,
 ): MaidrLayer | null {
   const dataView = chart.data?.();
   if (!dataView)
@@ -2015,7 +2086,7 @@ function buildHeatmapLayerFromChart(
   }
 
   const data: HeatmapData = { x: xLabels, y: yLabels, points };
-  const defaultSelector = `[${HEATMAP_ATTR}]`;
+  const defaultSelector = `${panelScope(panel)}[${HEATMAP_ATTR}]`;
   return {
     id: '0',
     type: TraceType.HEATMAP,
@@ -2044,6 +2115,7 @@ function buildCandlestickLayer(
   series: AnyChartSeries,
   seriesIndex: number,
   selectors: string | string[] | undefined,
+  panel?: PanelContext,
 ): MaidrLayer {
   const rows = extractRawRows(series);
   const data: CandlestickPoint[] = rows.map((r) => {
@@ -2074,7 +2146,8 @@ function buildCandlestickLayer(
   // {@link stampCandlestickAttributes}, scoped to this series index. The
   // candlestick model duplicates the matched element across all OHLC
   // segments, so a single attribute per candle is sufficient.
-  const defaultSelector = `[${CANDLESTICK_ATTR}^="${seriesIndex}-"]`;
+  const defaultSelector
+    = `${panelScope(panel)}[${CANDLESTICK_ATTR}^="${panelStampPrefix(panel)}${seriesIndex}-"]`;
   return {
     id: String(seriesIndex),
     type: TraceType.CANDLESTICK,
@@ -2098,6 +2171,7 @@ function buildLayer(
   seriesIndex: number,
   traceType: AnyChartTraceType,
   selectors: string | string[] | undefined,
+  panel?: PanelContext,
 ): MaidrLayer {
   switch (traceType) {
     case TraceType.BAR:
@@ -2107,11 +2181,11 @@ function buildLayer(
     case TraceType.SCATTER:
       return buildScatterLayer(series, seriesIndex, selectors);
     case TraceType.BOX:
-      return buildBoxLayer(series, seriesIndex, selectors);
+      return buildBoxLayer(series, seriesIndex, selectors, panel);
     case TraceType.HEATMAP:
       return buildHeatmapLayer(series, seriesIndex, selectors);
     case TraceType.CANDLESTICK:
-      return buildCandlestickLayer(series, seriesIndex, selectors);
+      return buildCandlestickLayer(series, seriesIndex, selectors, panel);
   }
 }
 
@@ -2120,26 +2194,60 @@ function buildLayer(
 // ---------------------------------------------------------------------------
 
 /**
- * Convert an AnyChart chart instance into a MAIDR data object.
+ * Build one {@link MaidrSubplot} from a single AnyChart chart instance.
  *
- * This function inspects the chart's series and metadata after it has been
- * drawn, then constructs a {@link Maidr} JSON structure that can be passed
- * to the `<Maidr>` React component or used with `bindAnyChart()`.
+ * This is the per-chart body shared by {@link anyChartToMaidr} (single
+ * panel, `panel === undefined`) and {@link anyChartsToMaidr} (one call per
+ * grid cell). Axis titles are extracted per chart, with `options.axes`
+ * acting as an override. In panel mode:
  *
- * @param chart - A drawn AnyChart chart instance.
- * @param options - Optional overrides for id, title, axes, and selectors.
- * @returns The MAIDR data object, or `null` if no convertible series found.
+ * - every default selector is scoped to the panel's SVG via
+ *   {@link PANEL_ATTR} and the token-prefixed stamp values,
+ * - layer ids are prefixed `<row>_<col>_` so they stay unique across the
+ *   whole figure,
+ * - the chart's own title is placed on the FIRST layer, which is what the
+ *   core uses as the panel's display name in subplot summaries,
+ * - `subplot.selector` points at the panel's SVG root so the core can
+ *   resolve the panel container.
+ *
+ * @returns The subplot, or `null` when the chart has no convertible series.
  */
-export function anyChartToMaidr(
+function buildSubplot(
   chart: AnyChartInstance,
+  panel: PanelContext | undefined,
   options?: AnyChartBinderOptions,
-): Maidr | null {
-  // Resolve chart metadata.
-  const container = resolveContainerElement(chart);
-  const id = options?.id ?? container?.id ?? 'anychart-maidr';
-  const title = options?.title ?? extractTitle(chart);
+): MaidrSubplot | null {
   const xAxisLabel = options?.axes?.x ?? extractAxisTitle(chart, 'x');
   const yAxisLabel = options?.axes?.y ?? extractAxisTitle(chart, 'y');
+
+  const attachAxes = (layer: MaidrLayer): void => {
+    if (xAxisLabel || yAxisLabel) {
+      layer.axes = {
+        ...(xAxisLabel ? { x: { label: xAxisLabel } } : {}),
+        ...(yAxisLabel ? { y: { label: yAxisLabel } } : {}),
+      };
+    }
+  };
+
+  const finalize = (layers: MaidrLayer[]): MaidrSubplot => {
+    if (panel) {
+      for (const layer of layers) {
+        // Layer ids must be unique across the WHOLE figure, not just within
+        // one panel; prefix with the grid position (vegalite convention).
+        layer.id = `${panel.row}_${panel.col}_${layer.id}`;
+      }
+      // The first layer's title is the panel's display name in the core's
+      // subplot summaries (there is no subplot-level title field).
+      const panelTitle = extractTitle(chart);
+      if (layers.length > 0 && panelTitle && !layers[0].title)
+        layers[0].title = panelTitle;
+      return {
+        layers,
+        selector: `svg[${PANEL_ATTR}="${panel.token}"]`,
+      };
+    }
+    return { layers };
+  };
 
   // Heatmap is a single-dataset chart and does NOT expose
   // getSeriesCount()/getSeriesAt(). Detect it first and route to the
@@ -2161,21 +2269,11 @@ export function anyChartToMaidr(
       | string
       | string[]
       | undefined;
-    const layer = buildHeatmapLayerFromChart(chart, userHeatmapSelector);
+    const layer = buildHeatmapLayerFromChart(chart, userHeatmapSelector, panel);
     if (!layer)
       return null;
-    if (xAxisLabel || yAxisLabel) {
-      layer.axes = {
-        ...(xAxisLabel ? { x: { label: xAxisLabel } } : {}),
-        ...(yAxisLabel ? { y: { label: yAxisLabel } } : {}),
-      };
-    }
-    const subplot: MaidrSubplot = { layers: [layer] };
-    return {
-      id,
-      ...(title ? { title } : {}),
-      subplots: [[subplot]],
-    };
+    attachAxes(layer);
+    return finalize([layer]);
   }
 
   // Defensive fallback: if getType is unavailable but getSeriesCount throws
@@ -2188,24 +2286,14 @@ export function anyChartToMaidr(
       | string
       | string[]
       | undefined;
-    const layer = buildHeatmapLayerFromChart(chart, userHeatmapSelector);
+    const layer = buildHeatmapLayerFromChart(chart, userHeatmapSelector, panel);
     if (!layer)
       return null;
     // Attach axis labels just like the primary heatmap path above, so
     // production heatmaps that reach this fallback (getType() unavailable)
     // still expose their axis titles.
-    if (xAxisLabel || yAxisLabel) {
-      layer.axes = {
-        ...(xAxisLabel ? { x: { label: xAxisLabel } } : {}),
-        ...(yAxisLabel ? { y: { label: yAxisLabel } } : {}),
-      };
-    }
-    const subplot: MaidrSubplot = { layers: [layer] };
-    return {
-      id,
-      ...(title ? { title } : {}),
-      subplots: [[subplot]],
-    };
+    attachAxes(layer);
+    return finalize([layer]);
   }
   if (seriesCount === 0)
     return null;
@@ -2226,16 +2314,11 @@ export function anyChartToMaidr(
       continue;
     }
 
-    const selectors = resolveSelector(i, traceType, options);
-    const layer = buildLayer(series, i, traceType, selectors);
+    const selectors = resolveSelector(i, traceType, options, panel);
+    const layer = buildLayer(series, i, traceType, selectors, panel);
 
     // Attach axis labels.
-    if (xAxisLabel || yAxisLabel) {
-      layer.axes = {
-        ...(xAxisLabel ? { x: { label: xAxisLabel } } : {}),
-        ...(yAxisLabel ? { y: { label: yAxisLabel } } : {}),
-      };
-    }
+    attachAxes(layer);
 
     layers.push(layer);
   }
@@ -2243,14 +2326,38 @@ export function anyChartToMaidr(
   if (layers.length === 0)
     return null;
 
-  const subplot: MaidrSubplot = { layers };
-  const maidr: Maidr = {
+  return finalize(layers);
+}
+
+/**
+ * Convert an AnyChart chart instance into a MAIDR data object.
+ *
+ * This function inspects the chart's series and metadata after it has been
+ * drawn, then constructs a {@link Maidr} JSON structure that can be passed
+ * to the `<Maidr>` React component or used with `bindAnyChart()`.
+ *
+ * @param chart - A drawn AnyChart chart instance.
+ * @param options - Optional overrides for id, title, axes, and selectors.
+ * @returns The MAIDR data object, or `null` if no convertible series found.
+ */
+export function anyChartToMaidr(
+  chart: AnyChartInstance,
+  options?: AnyChartBinderOptions,
+): Maidr | null {
+  // Resolve chart metadata.
+  const container = resolveContainerElement(chart);
+  const id = options?.id ?? container?.id ?? 'anychart-maidr';
+  const title = options?.title ?? extractTitle(chart);
+
+  const subplot = buildSubplot(chart, undefined, options);
+  if (!subplot)
+    return null;
+
+  return {
     id,
     ...(title ? { title } : {}),
     subplots: [[subplot]],
   };
-
-  return maidr;
 }
 
 /** Elements that have already been bound via {@link bindAnyChart}. */
@@ -2390,6 +2497,533 @@ export function bindAnyChart(
   });
 
   return maidr;
+}
+
+// ---------------------------------------------------------------------------
+// Multi-panel public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Distance (in CSS pixels) two containers' tops may differ while still being
+ * clustered into the same visual row by `layout: 'auto'`.
+ */
+const AUTO_ROW_TOLERANCE_PX = 10;
+
+/** One chart entry with its on-page position, used by the auto layout. */
+interface AutoLayoutEntry {
+  chart: AnyChartInstance;
+  top: number;
+  left: number;
+}
+
+/**
+ * Derive a 2D grid from each chart container's on-page position: cluster
+ * containers into rows by bounding-rect top (within
+ * {@link AUTO_ROW_TOLERANCE_PX}), then sort each row left-to-right. The
+ * result is in visual reading order (top-left panel first), which is the
+ * order the MAIDR core expects.
+ */
+function autoLayoutGrid(charts: AnyChartInstance[]): AnyChartInstance[][] | null {
+  const entries: AutoLayoutEntry[] = [];
+  for (const chart of charts) {
+    const container = resolveContainerElement(chart);
+    if (!container) {
+      console.warn(
+        '[maidr/anychart] layout: "auto" requires every chart to have a '
+        + 'resolvable, attached container. Draw all charts before binding, '
+        + 'or pass an explicit 2D grid / { rows, columns } layout.',
+      );
+      return null;
+    }
+    const rect = container.getBoundingClientRect();
+    entries.push({ chart, top: rect.top, left: rect.left });
+  }
+
+  entries.sort((a, b) => (a.top - b.top) || (a.left - b.left));
+
+  const rows: Array<{ top: number; entries: AutoLayoutEntry[] }> = [];
+  for (const entry of entries) {
+    const current = rows[rows.length - 1];
+    if (current && Math.abs(entry.top - current.top) <= AUTO_ROW_TOLERANCE_PX)
+      current.entries.push(entry);
+    else
+      rows.push({ top: entry.top, entries: [entry] });
+  }
+
+  return rows.map(row =>
+    row.entries.sort((a, b) => a.left - b.left).map(e => e.chart),
+  );
+}
+
+/**
+ * Normalize the {@link AnyChartGridInput} into a validated 2D grid.
+ *
+ * - An explicit 2D array is used as-is (row-major, visual reading order);
+ *   empty rows and missing entries are rejected because they crash the MAIDR
+ *   core's Figure model.
+ * - A flat array is chunked row-major according to `layout`, arranged by
+ *   container position (`'auto'`), or kept as a single row when no layout is
+ *   given.
+ *
+ * @returns The grid, or `null` (with a console warning) on invalid input.
+ */
+function normalizeChartGrid(
+  charts: AnyChartGridInput,
+  layout: AnyChartsBinderOptions['layout'],
+): AnyChartInstance[][] | null {
+  if (!Array.isArray(charts) || charts.length === 0) {
+    console.warn(
+      '[maidr/anychart] Expected a non-empty array of AnyChart instances.',
+    );
+    return null;
+  }
+
+  const mixed = charts as Array<AnyChartInstance | AnyChartInstance[]>;
+  const rowCount = mixed.filter(entry => Array.isArray(entry)).length;
+
+  // Explicit 2D grid → subplots 1:1.
+  if (rowCount > 0) {
+    if (rowCount !== mixed.length) {
+      console.warn(
+        '[maidr/anychart] Chart grid mixes rows (arrays) and bare chart '
+        + 'instances. Pass either a flat array or a full 2D array.',
+      );
+      return null;
+    }
+    const grid = charts as AnyChartInstance[][];
+    for (const row of grid) {
+      if (row.length === 0) {
+        console.warn(
+          '[maidr/anychart] Chart grid contains an empty row. Empty rows '
+          + 'are not allowed (the MAIDR figure model cannot represent them).',
+        );
+        return null;
+      }
+      if (row.some(chart => !chart)) {
+        console.warn('[maidr/anychart] Chart grid contains a missing chart entry.');
+        return null;
+      }
+    }
+    return grid;
+  }
+
+  const flat = charts as AnyChartInstance[];
+  if (flat.some(chart => !chart)) {
+    console.warn('[maidr/anychart] Chart array contains a missing chart entry.');
+    return null;
+  }
+
+  if (layout === 'auto')
+    return autoLayoutGrid(flat);
+
+  const total = flat.length;
+  const columns
+    = layout?.columns
+      ?? (layout?.rows ? Math.ceil(total / layout.rows) : total);
+  if (!Number.isInteger(columns) || columns < 1) {
+    console.warn(
+      '[maidr/anychart] Invalid layout: `columns` (or `ceil(total / rows)`) '
+      + 'must be a positive integer.',
+    );
+    return null;
+  }
+
+  const grid: AnyChartInstance[][] = [];
+  for (let i = 0; i < total; i += columns)
+    grid.push(flat.slice(i, i + columns));
+  return grid;
+}
+
+/** One panel's chart + token, produced by {@link buildMaidrFromGrid}. */
+interface PanelBinding {
+  chart: AnyChartInstance;
+  token: string;
+}
+
+/**
+ * Build a multi-panel {@link Maidr} figure from a validated chart grid.
+ *
+ * Panels whose chart yields no convertible series are dropped (with a
+ * warning) rather than emitted as empty subplots, because a subplot with
+ * `layers: []` crashes the MAIDR core. Rows that end up empty are dropped
+ * entirely. Panel tokens are always derived from the ORIGINAL grid position
+ * so selector emission and DOM stamping stay in agreement even when panels
+ * are dropped.
+ */
+function buildMaidrFromGrid(
+  grid: AnyChartInstance[][],
+  options?: AnyChartsBinderOptions,
+): { maidr: Maidr | null; panels: PanelBinding[] } {
+  const id = options?.id ?? nextId('anychart-maidr');
+  const tokenBase = sanitizePanelToken(id);
+  const subplotOptions: AnyChartBinderOptions | undefined
+    = options?.axes ? { axes: options.axes } : undefined;
+
+  const panels: PanelBinding[] = [];
+  const subplots: MaidrSubplot[][] = [];
+
+  grid.forEach((row, r) => {
+    const subplotRow: MaidrSubplot[] = [];
+    row.forEach((chart, c) => {
+      const token = `${tokenBase}-${r}-${c}`;
+      const subplot = buildSubplot(chart, { token, row: r, col: c }, subplotOptions);
+      if (!subplot) {
+        console.warn(
+          `[maidr/anychart] Panel (${r}, ${c}) has no convertible series; `
+          + 'dropping it from the figure.',
+        );
+        return;
+      }
+      panels.push({ chart, token });
+      subplotRow.push(subplot);
+    });
+    if (subplotRow.length > 0)
+      subplots.push(subplotRow);
+  });
+
+  if (subplots.length === 0) {
+    console.warn('[maidr/anychart] No chart in the grid produced convertible data.');
+    return { maidr: null, panels: [] };
+  }
+
+  const maidr: Maidr = {
+    id,
+    ...(options?.title ? { title: options.title } : {}),
+    subplots,
+  };
+  return { maidr, panels };
+}
+
+/**
+ * Convert a group of AnyChart chart instances into ONE multi-panel MAIDR
+ * figure (a 2D subplot grid navigable with arrow keys + Enter).
+ *
+ * AnyChart has no native facet/small-multiples concept — the idiom is one
+ * chart instance per container — so the grouping here is explicit:
+ *
+ * - `charts` as a 2D array maps 1:1 onto the subplot grid, row-major in
+ *   visual reading order (top-left panel first).
+ * - `charts` as a flat array is arranged according to `options.layout`
+ *   (`{ rows?, columns? }` chunked row-major, `'auto'` derived from the
+ *   containers' on-page positions, or a single row when omitted).
+ *
+ * Each panel's display name is its own chart title; `options.title` names
+ * the whole figure and `options.axes` overrides every panel's axis labels.
+ *
+ * Prefer {@link bindAnyCharts}, which also stamps the per-panel highlight
+ * attributes this function's selectors refer to. Use this directly only for
+ * inspection or custom mounting flows. Pass a stable `options.id` if you
+ * need deterministic output across calls (the default id is generated).
+ *
+ * @param charts - Drawn AnyChart instances, each in its own container.
+ * @param options - Figure-level overrides and flat-array layout.
+ * @returns The MAIDR data object, or `null` if nothing was convertible.
+ */
+export function anyChartsToMaidr(
+  charts: AnyChartGridInput,
+  options?: AnyChartsBinderOptions,
+): Maidr | null {
+  const grid = normalizeChartGrid(charts, options?.layout);
+  if (!grid)
+    return null;
+  return buildMaidrFromGrid(grid, options).maidr;
+}
+
+/**
+ * Stamp one panel's SVG with the panel token and all per-point highlight
+ * attributes (token-prefixed so they are unique page-wide). Each stamp
+ * family is best-effort: a failure in one must not block the others or the
+ * bind itself.
+ */
+function stampPanelAttributes(
+  chart: AnyChartInstance,
+  svg: SVGElement,
+  token: string,
+): void {
+  if (!svg.hasAttribute(PANEL_ATTR))
+    svg.setAttribute(PANEL_ATTR, token);
+
+  const prefix = `${token}:`;
+  try {
+    stampBarAttributes(chart, svg, prefix);
+  } catch (err) {
+    console.warn('[maidr/anychart] Failed to stamp bar attributes:', err);
+  }
+  try {
+    stampLineAttributes(chart, svg, prefix);
+  } catch (err) {
+    console.warn('[maidr/anychart] Failed to stamp line attributes:', err);
+  }
+  try {
+    stampScatterAttributes(chart, svg, prefix);
+  } catch (err) {
+    console.warn('[maidr/anychart] Failed to stamp scatter attributes:', err);
+  }
+  try {
+    stampBoxAttributes(chart, svg, prefix);
+  } catch (err) {
+    console.warn('[maidr/anychart] Failed to stamp box attributes:', err);
+  }
+  try {
+    stampHeatmapAttributes(chart, svg, prefix);
+  } catch (err) {
+    console.warn('[maidr/anychart] Failed to stamp heatmap attributes:', err);
+  }
+  try {
+    stampCandlestickAttributes(chart, svg, prefix);
+  } catch (err) {
+    console.warn('[maidr/anychart] Failed to stamp candlestick attributes:', err);
+  }
+}
+
+/**
+ * Bind a group of AnyChart charts to MAIDR as ONE multi-panel figure.
+ *
+ * This is the multi-panel counterpart of {@link bindAnyChart}. It accepts
+ * the same chart-grid input as {@link anyChartsToMaidr}, then:
+ *
+ * 1. builds the combined {@link Maidr} object (one subplot per chart),
+ * 2. stamps `data-maidr-anychart-panel="<token>"` on each chart's own
+ *    `<svg>` and token-prefixed highlight attributes on its marks, so every
+ *    selector resolves ONLY inside its own panel,
+ * 3. wraps the panels' common ancestor in a transparent host `<div>`, sets
+ *    the combined `maidr-data` attribute on it, and dispatches a single
+ *    `maidr:bindchart` event once every panel's SVG has rendered.
+ *
+ * Requirements: every chart must be drawn into its OWN container element
+ * (the standard AnyChart idiom), and all panel containers should live under
+ * a common wrapper element — the host wraps that wrapper (or groups
+ * same-parent siblings) so MAIDR mounts once for the whole figure.
+ * Shared-Stage dashboards (multiple charts on one Stage/container) are not
+ * supported.
+ *
+ * Calling this again for the same group is safe: the existing binding is
+ * reused and the current {@link Maidr} object is returned.
+ *
+ * @param charts - Drawn AnyChart instances, each in its own container.
+ * @param options - Figure-level overrides and flat-array layout.
+ * @returns The generated {@link Maidr} object, or `null` on failure.
+ *
+ * @example
+ * ```ts
+ * const q1 = anychart.column([['A', 4], ['B', 2]]);
+ * q1.title('Q1'); q1.container('panel-1').draw();
+ * const q2 = anychart.column([['A', 6], ['B', 3]]);
+ * q2.title('Q2'); q2.container('panel-2').draw();
+ *
+ * bindAnyCharts([[q1, q2]], { id: 'sales', title: 'Sales by Quarter' });
+ * ```
+ */
+export function bindAnyCharts(
+  charts: AnyChartGridInput,
+  options?: AnyChartsBinderOptions,
+): Maidr | null {
+  const grid = normalizeChartGrid(charts, options?.layout);
+  if (!grid)
+    return null;
+
+  // Every panel needs its own resolvable container before anything else.
+  const flatCharts = grid.flat();
+  const containers: HTMLElement[] = [];
+  for (const chart of flatCharts) {
+    const container = resolveContainerElement(chart);
+    if (!container) {
+      console.warn(
+        '[maidr/anychart] Could not find a container element for one of the '
+        + 'charts. Make sure every chart has been drawn before calling '
+        + 'bindAnyCharts().',
+      );
+      return null;
+    }
+    containers.push(container);
+  }
+  if (new Set(containers).size !== containers.length) {
+    console.warn(
+      '[maidr/anychart] bindAnyCharts requires each chart to live in its own '
+      + 'container element. Shared-Stage dashboards (multiple charts drawn '
+      + 'on one Stage) are not supported.',
+    );
+    return null;
+  }
+
+  const { maidr, panels } = buildMaidrFromGrid(grid, options);
+  if (!maidr) {
+    console.warn('[maidr/anychart] Could not extract data from the AnyChart charts.');
+    return null;
+  }
+
+  // Enable line markers per chart (same best-effort flow as bindAnyChart).
+  for (const chart of flatCharts) {
+    let markersMutated = false;
+    try {
+      markersMutated = enableLineMarkersIfNeeded(chart);
+    } catch (err) {
+      console.warn(
+        '[maidr/anychart] enableLineMarkersIfNeeded failed; continuing without marker mutation:',
+        err,
+      );
+    }
+    if (markersMutated) {
+      try {
+        (chart as unknown as { draw?: () => void }).draw?.();
+      } catch (err) {
+        console.warn(
+          '[maidr/anychart] Failed to force re-draw after enabling markers:',
+          err,
+        );
+      }
+    }
+  }
+
+  const host = ensureGroupHostWrapper(containers);
+  if (!host)
+    return null;
+  if (boundElements.has(host))
+    return maidr;
+
+  const containerByChart = new Map<AnyChartInstance, HTMLElement>(
+    flatCharts.map((chart, i) => [chart, containers[i]]),
+  );
+
+  // Stamp each panel as its SVG becomes available; bind the whole figure
+  // once the LAST panel is stamped so `maidr-data` never references
+  // attributes that do not exist yet.
+  let pending = panels.length;
+  const finalize = (): void => {
+    pending -= 1;
+    if (pending > 0)
+      return;
+    if (boundElements.has(host))
+      return;
+    boundElements.add(host);
+    host.setAttribute('maidr-data', JSON.stringify(maidr));
+    host.dispatchEvent(
+      new CustomEvent('maidr:bindchart', { bubbles: true, detail: maidr }),
+    );
+  };
+
+  for (const { chart, token } of panels) {
+    const container = containerByChart.get(chart);
+    if (!container) {
+      // Defensive: cannot happen (panels ⊆ flatCharts), but never stall the bind.
+      finalize();
+      continue;
+    }
+    whenChartRendered(chart, container, (svg) => {
+      stampPanelAttributes(chart, svg, token);
+      finalize();
+    });
+  }
+
+  return maidr;
+}
+
+/**
+ * Find the deepest element containing every given element.
+ */
+function lowestCommonAncestor(elements: HTMLElement[]): HTMLElement | null {
+  for (
+    let candidate: HTMLElement | null = elements[0];
+    candidate;
+    candidate = candidate.parentElement
+  ) {
+    const current = candidate;
+    if (elements.every(el => current.contains(el)))
+      return current;
+  }
+  return null;
+}
+
+/** Compare two nodes by document order (for stable panel ordering). */
+function documentOrder(a: Node, b: Node): number {
+  const pos = a.compareDocumentPosition(b);
+  if (pos & Node.DOCUMENT_POSITION_FOLLOWING)
+    return -1;
+  if (pos & Node.DOCUMENT_POSITION_PRECEDING)
+    return 1;
+  return 0;
+}
+
+/**
+ * Ensure ALL panel containers of a multi-panel figure live inside one
+ * transparent host `<div>` and return that host.
+ *
+ * Mirrors {@link ensureHostWrapper} but over a group: the combined
+ * `maidr-data` attribute must sit on a single wrapper element containing
+ * every panel container, because MAIDR mounts one React root per bound
+ * element.
+ *
+ * Strategy:
+ * - If an existing host already contains every panel, reuse it.
+ * - If all containers share one parent, insert a `display: contents` host
+ *   before the first container (in document order) and move the containers
+ *   into it — `display: contents` keeps them participating in the parent's
+ *   flex/grid layout exactly as before.
+ * - Otherwise wrap the containers' lowest common ancestor, unless that
+ *   ancestor is `<body>` / `<html>` (which cannot be reparented) — in that
+ *   case the bind fails with guidance to add a wrapper element.
+ *
+ * The host carries the union bounding box of all panels via the
+ * `data-maidr-host-width` / `-height` attributes consumed by
+ * `SizedDomNodeAdapter`, keeping MAIDR's focusable wrapper non-zero-sized.
+ */
+function ensureGroupHostWrapper(containers: HTMLElement[]): HTMLElement | null {
+  const existing = containers[0].parentElement?.closest<HTMLElement>(
+    '[data-maidr-anychart-host]',
+  );
+  if (existing && containers.every(c => existing.contains(c)))
+    return existing;
+
+  // Union bounding box of all panels for the sized-host data attributes.
+  let left = Number.POSITIVE_INFINITY;
+  let top = Number.POSITIVE_INFINITY;
+  let right = Number.NEGATIVE_INFINITY;
+  let bottom = Number.NEGATIVE_INFINITY;
+  for (const container of containers) {
+    const rect = container.getBoundingClientRect();
+    left = Math.min(left, rect.left);
+    top = Math.min(top, rect.top);
+    right = Math.max(right, rect.right);
+    bottom = Math.max(bottom, rect.bottom);
+  }
+  const width = right - left > 0 ? right - left : 600;
+  const height = bottom - top > 0 ? bottom - top : 400;
+
+  const host = document.createElement('div');
+  host.setAttribute('data-maidr-anychart-host', '');
+  host.style.display = 'contents';
+  host.dataset.maidrHostWidth = String(width);
+  host.dataset.maidrHostHeight = String(height);
+
+  const firstParent = containers[0].parentElement;
+  const sameParent
+    = firstParent !== null
+      && containers.every(c => c.parentElement === firstParent);
+  if (sameParent) {
+    const ordered = [...containers].sort(documentOrder);
+    firstParent.insertBefore(host, ordered[0]);
+    for (const container of ordered)
+      host.appendChild(container);
+    return host;
+  }
+
+  const lca = lowestCommonAncestor(containers);
+  if (
+    !lca
+    || lca === document.body
+    || lca === document.documentElement
+    || !lca.parentNode
+  ) {
+    console.warn(
+      '[maidr/anychart] bindAnyCharts could not find a wrappable common '
+      + 'ancestor for the panel containers. Place all panel containers '
+      + 'inside one wrapper element and try again.',
+    );
+    return null;
+  }
+  lca.parentNode.insertBefore(host, lca);
+  host.appendChild(lca);
+  return host;
 }
 
 /**

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -2364,6 +2364,16 @@ export function anyChartToMaidr(
 const boundElements = new WeakSet<Element>();
 
 /**
+ * The {@link Maidr} object each group host was bound with, so repeat
+ * {@link bindAnyCharts} calls can honor their documented contract and return
+ * the CURRENTLY BOUND object. Without this cache a re-bind without an
+ * explicit `options.id` would return a freshly built Maidr whose generated
+ * id — and therefore every panel-token selector — references attributes
+ * that were never stamped into the DOM (stamping only runs on first bind).
+ */
+const boundGroupData = new WeakMap<Element, Maidr>();
+
+/**
  * Bind an AnyChart chart to MAIDR for accessible interaction.
  *
  * This is the primary high-level API. It extracts data from a drawn
@@ -2878,8 +2888,12 @@ export function bindAnyCharts(
   const host = ensureGroupHostWrapper(containers);
   if (!host)
     return null;
-  if (boundElements.has(host))
-    return maidr;
+  if (boundElements.has(host)) {
+    // Reuse path: return the Maidr the host was actually bound with. The
+    // freshly built `maidr` above may carry a newly generated id whose
+    // panel-token selectors were never stamped into the DOM.
+    return boundGroupData.get(host) ?? maidr;
+  }
 
   const containerByChart = new Map<AnyChartInstance, HTMLElement>(
     flatCharts.map((chart, i) => [chart, containers[i]]),
@@ -2896,6 +2910,7 @@ export function bindAnyCharts(
     if (boundElements.has(host))
       return;
     boundElements.add(host);
+    boundGroupData.set(host, maidr);
     host.setAttribute('maidr-data', JSON.stringify(maidr));
     host.dispatchEvent(
       new CustomEvent('maidr:bindchart', { bubbles: true, detail: maidr }),
@@ -2955,13 +2970,17 @@ function documentOrder(a: Node, b: Node): number {
  *
  * Strategy:
  * - If an existing host already contains every panel, reuse it.
- * - If all containers share one parent, insert a `display: contents` host
- *   before the first container (in document order) and move the containers
- *   into it — `display: contents` keeps them participating in the parent's
- *   flex/grid layout exactly as before.
- * - Otherwise wrap the containers' lowest common ancestor, unless that
- *   ancestor is `<body>` / `<html>` (which cannot be reparented) — in that
- *   case the bind fails with guidance to add a wrapper element.
+ * - If all containers are CONTIGUOUS siblings (same parent, nothing
+ *   interleaved between them), insert a `display: contents` host before the
+ *   first container (in document order) and move the containers into it —
+ *   `display: contents` keeps them participating in the parent's flex/grid
+ *   layout exactly as before, and contiguity guarantees the move cannot
+ *   reorder any other page content (captions, headings, ...).
+ * - Otherwise wrap the containers' lowest common ancestor (for
+ *   non-contiguous same-parent panels that is the shared parent itself,
+ *   wrapped in place), unless that ancestor is `<body>` / `<html>` (which
+ *   cannot be reparented) — in that case the bind fails with guidance to
+ *   add a wrapper element.
  *
  * The host carries the union bounding box of all panels via the
  * `data-maidr-host-width` / `-height` attributes consumed by
@@ -3001,10 +3020,22 @@ function ensureGroupHostWrapper(containers: HTMLElement[]): HTMLElement | null {
       && containers.every(c => c.parentElement === firstParent);
   if (sameParent) {
     const ordered = [...containers].sort(documentOrder);
-    firstParent.insertBefore(host, ordered[0]);
-    for (const container of ordered)
-      host.appendChild(container);
-    return host;
+    // Move the containers into the host ONLY when they are contiguous
+    // siblings. Pulling non-adjacent panels together would drag them past
+    // interleaved content (captions, headings, ...), visibly reordering the
+    // page — in that case fall through to the LCA path below, which wraps
+    // the shared parent in place and never changes internal order.
+    const contiguous = ordered.every(
+      (container, i) =>
+        i === ordered.length - 1
+        || container.nextElementSibling === ordered[i + 1],
+    );
+    if (contiguous) {
+      firstParent.insertBefore(host, ordered[0]);
+      for (const container of ordered)
+        host.appendChild(container);
+      return host;
+    }
   }
 
   const lca = lowestCommonAncestor(containers);

--- a/src/adapters/anychart/index.ts
+++ b/src/adapters/anychart/index.ts
@@ -8,8 +8,16 @@
  * @packageDocumentation
  */
 
-export { anyChartToMaidr, bindAnyChart } from './converters';
+export {
+  anyChartsToMaidr,
+  anyChartToMaidr,
+  bindAnyChart,
+  bindAnyCharts,
+} from './converters';
 export type {
   AnyChartBinderOptions,
+  AnyChartGridInput,
   AnyChartInstance,
+  AnyChartsBinderOptions,
+  AnyChartsLayout,
 } from './types';

--- a/src/adapters/anychart/types.ts
+++ b/src/adapters/anychart/types.ts
@@ -185,3 +185,63 @@ export interface AnyChartBinderOptions {
    */
   selectors?: Array<string | string[] | undefined>;
 }
+
+/**
+ * Chart input accepted by {@link anyChartsToMaidr} / {@link bindAnyCharts}.
+ *
+ * - A 2D array maps 1:1 onto the MAIDR subplot grid (`charts[row][col]`),
+ *   in visual reading order (top-left panel first). Ragged rows are allowed;
+ *   empty rows are not.
+ * - A flat array is arranged into a grid according to
+ *   {@link AnyChartsBinderOptions.layout}.
+ */
+export type AnyChartGridInput = AnyChartInstance[] | AnyChartInstance[][];
+
+/**
+ * Grid arrangement for a flat array of charts passed to
+ * {@link anyChartsToMaidr} / {@link bindAnyCharts}.
+ *
+ * Charts are chunked row-major: with `columns: 2` and five charts, the grid
+ * becomes `[[a, b], [c, d], [e]]`. When only `rows` is given, `columns`
+ * defaults to `ceil(total / rows)`.
+ */
+export interface AnyChartsLayout {
+  rows?: number;
+  columns?: number;
+}
+
+/**
+ * Options the consumer can pass when binding a multi-panel group of AnyChart
+ * charts to MAIDR.
+ *
+ * Unlike {@link AnyChartBinderOptions}, `title` and `axes` here are
+ * figure-level overrides: `title` becomes the whole figure's title, and
+ * `axes` (when set) replaces the per-panel axis titles extracted from each
+ * chart. Each panel's display name always comes from its own chart title.
+ */
+export interface AnyChartsBinderOptions {
+  /** Override the figure ID used in the MAIDR schema. */
+  id?: string;
+
+  /** Figure-level title. Panel names come from each chart's own title. */
+  title?: string;
+
+  /** Figure-level axis-label overrides applied to every panel's layers. */
+  axes?: {
+    x?: string;
+    y?: string;
+  };
+
+  /**
+   * How to arrange a FLAT chart array into a grid. Ignored when `charts`
+   * is already a 2D array.
+   *
+   * - `{ rows?, columns? }` — chunk row-major (see {@link AnyChartsLayout}).
+   * - `'auto'` — derive the grid from each chart container's on-page
+   *   position: containers are clustered into rows by their bounding-rect
+   *   top and sorted left-to-right within each row. Requires every chart
+   *   to have a resolvable, attached container.
+   * - Omitted — a flat array becomes a single row.
+   */
+  layout?: AnyChartsLayout | 'auto';
+}

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -60,9 +60,10 @@ export function extractMaidrData(
  * Charts using Chart.js axis stacking (2+ scales of the same axis kind laid
  * out in separate bands via the scale `stack` option) become multi-subplot
  * figures: one MAIDR subplot per stacked panel, arranged as N rows × 1 column
- * for y-stacks and 1 row × N columns for x-stacks, ordered by on-canvas
- * position. All other charts — including classic dual-axis overlays — remain
- * a single subplot.
+ * for y-stacks (rows bottom-first, matching the grammar's matplotlib row
+ * convention so Up/Down arrows track the on-canvas direction) and 1 row × N
+ * columns for x-stacks (left-to-right). All other charts — including classic
+ * dual-axis overlays — remain a single subplot.
  */
 export function extractChartData(
   chart: ChartJsChart,
@@ -132,10 +133,41 @@ function scaleAxisKind(chart: ChartJsChart, scaleId: string): AxisKind | null {
   return prefix === 'x' || prefix === 'y' ? prefix : null;
 }
 
+/** The static edge positions Chart.js lays scales out against. */
+const STATIC_SCALE_POSITIONS = ['left', 'right', 'top', 'bottom'] as const;
+type StaticScalePosition = (typeof STATIC_SCALE_POSITIONS)[number];
+
+function isStaticScalePosition(value: unknown): value is StaticScalePosition {
+  return STATIC_SCALE_POSITIONS.includes(value as StaticScalePosition);
+}
+
+/**
+ * Where a scale is placed: the declared static position, the laid-out runtime
+ * position, or the Chart.js default for the axis kind.
+ */
+function scalePosition(
+  chart: ChartJsChart,
+  scaleId: string,
+  axisKind: AxisKind,
+): StaticScalePosition {
+  const declared = chart.options.scales?.[scaleId]?.position;
+  if (isStaticScalePosition(declared))
+    return declared;
+  const runtime = chart.scales?.[scaleId]?.position;
+  if (isStaticScalePosition(runtime))
+    return runtime;
+  return axisKind === 'y' ? 'left' : 'bottom';
+}
+
 /**
  * Whether the given same-kind scales are laid out as stacked (non-overlapping)
- * bands: either 2+ of them opt into axis stacking via the `stack` option, or
- * the runtime geometry shows disjoint bands along the axis direction.
+ * bands: either 2+ of them share the same axis-stacking group, or the runtime
+ * geometry shows disjoint bands along the axis direction.
+ *
+ * Chart.js only bands scales that share BOTH the same `stack` name AND the
+ * same position (core layouts key stacks by `position + stack`); scales with
+ * different stack names, or the same name on opposite edges, each occupy the
+ * full chart area as a classic dual-axis overlay.
  */
 function isStackedScaleLayout(
   chart: ChartJsChart,
@@ -143,11 +175,17 @@ function isStackedScaleLayout(
   axisKind: AxisKind,
 ): boolean {
   const scales = chart.options.scales ?? {};
-  const stackCount = scaleIds
-    .filter(id => typeof scales[id]?.stack === 'string' && scales[id]?.stack !== '')
-    .length;
-  if (stackCount >= 2)
-    return true;
+  const stackGroupSizes = new Map<string, number>();
+  for (const id of scaleIds) {
+    const stack = scales[id]?.stack;
+    if (typeof stack !== 'string' || stack === '')
+      continue;
+    const key = `${scalePosition(chart, id, axisKind)}|${stack}`;
+    const size = (stackGroupSizes.get(key) ?? 0) + 1;
+    if (size >= 2)
+      return true;
+    stackGroupSizes.set(key, size);
+  }
   return hasDisjointBands(chart, scaleIds, axisKind);
 }
 
@@ -218,9 +256,13 @@ function partitionDatasets(
   const byScale = new Map<string, PanelPartition>();
 
   chart.data.datasets.forEach((dataset, index) => {
-    const axisId = (axisKind === 'y' ? dataset.yAxisID : dataset.xAxisID) ?? axisKind;
-    // Datasets referencing an unknown scale fold into the default panel.
-    const scaleId = kindIds.includes(axisId) ? axisId : axisKind;
+    const explicitId = axisKind === 'y' ? dataset.yAxisID : dataset.xAxisID;
+    // Chart.js resolves a missing/unknown axis id to the FIRST declared
+    // same-kind scale (mergeScaleConfig `firstIDs` / `getFirstScaleId`), not
+    // to the literal 'y'/'x' — mirror that so no phantom panel is invented.
+    const scaleId = explicitId !== undefined && kindIds.includes(explicitId)
+      ? explicitId
+      : kindIds[0];
     let panel = byScale.get(scaleId);
     if (!panel) {
       panel = { scaleId, datasets: [], datasetIndices: [] };
@@ -234,9 +276,14 @@ function partitionDatasets(
 }
 
 /**
- * Order panels in visual reading order: by the runtime scale band position
- * (`top` for y-stacks, `left` for x-stacks) when the chart is laid out, with
- * scale declaration order as the fallback.
+ * Order panels to match MAIDR grid-row semantics. Chart.js draws to a
+ * `<canvas>`, so the core layout pass has no DOM geometry to measure and uses
+ * raw data order with the grammar's native matplotlib convention: grid row 0
+ * is the BOTTOM row and Up Arrow moves to row+1. y-stack panels are therefore
+ * ordered bottom-first (descending runtime `top`) so vertical arrow keys move
+ * the way the panels look on canvas; x-stack panels read left-to-right
+ * (ascending runtime `left`). Without runtime layout, scale declaration order
+ * stands in for top-to-bottom / left-to-right on-canvas order.
  */
 function orderPanelsByGeometry(
   chart: ChartJsChart,
@@ -249,10 +296,11 @@ function orderPanelsByGeometry(
     const runtimeB = chart.scales?.[b.scaleId];
     if (runtimeA && runtimeB) {
       return axisKind === 'y'
-        ? runtimeA.top - runtimeB.top
+        ? runtimeB.top - runtimeA.top
         : runtimeA.left - runtimeB.left;
     }
-    return declarationOrder.indexOf(a.scaleId) - declarationOrder.indexOf(b.scaleId);
+    const declared = declarationOrder.indexOf(a.scaleId) - declarationOrder.indexOf(b.scaleId);
+    return axisKind === 'y' ? -declared : declared;
   });
 }
 
@@ -331,8 +379,11 @@ function extractPanelSubplots(
   if (panelSubplots.length < 2)
     return null;
 
-  // y-stacks read top-to-bottom (N rows × 1 col); x-stacks left-to-right
-  // (1 row × N cols) — both already in visual reading order.
+  // y-stacks become N rows × 1 col with rows BOTTOM-FIRST (see
+  // orderPanelsByGeometry): row 0 is the bottom panel, so the core's
+  // Up Arrow (row+1) moves visually up. Panel numbering consequently
+  // announces bottom-up ("Subplot 1" = bottom panel). x-stacks become
+  // 1 row × N cols in left-to-right reading order.
   const subplots = layout.axisKind === 'y'
     ? panelSubplots.map(subplot => [subplot])
     : [panelSubplots];

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -11,7 +11,7 @@
  * chart, because MAIDR has no semantically equivalent trace for them.
  */
 
-import type { BarPoint, BoxPoint, CandlestickPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, NavigateCallback, ScatterPoint, SegmentedPoint } from '../../type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, ScatterPoint, SegmentedPoint } from '../../type/grammar';
 import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 
@@ -20,6 +20,22 @@ import { Orientation, TraceType } from '../../type/grammar';
 // ---------------------------------------------------------------------------
 
 let nextId = 0;
+
+/**
+ * Result of extracting a Chart.js chart, pairing the MAIDR schema with the
+ * bookkeeping the plugin needs to route navigation back into the chart.
+ */
+export interface ChartJsExtraction {
+  /** The MAIDR data object, ready to be passed to `<Maidr data={...}>`. */
+  maidr: Maidr;
+  /**
+   * Figure-unique layer id → original Chart.js dataset indices backing that
+   * layer, in MAIDR row order. For axis-stacked panels each subplot only sees
+   * a partition of `chart.data.datasets`, so MAIDR row indices no longer equal
+   * Chart.js dataset indices — this map restores that correspondence.
+   */
+  layerDatasetIndices: Map<string, number[]>;
+}
 
 /**
  * Extracts a complete {@link Maidr} data object from a Chart.js chart instance.
@@ -34,15 +50,330 @@ export function extractMaidrData(
   pluginOptions?: MaidrPluginOptions,
   onNavigate?: NavigateCallback,
 ): Maidr {
+  return extractChartData(chart, pluginOptions, onNavigate).maidr;
+}
+
+/**
+ * Extracts MAIDR data plus the layer→dataset routing map from a Chart.js
+ * chart instance.
+ *
+ * Charts using Chart.js axis stacking (2+ scales of the same axis kind laid
+ * out in separate bands via the scale `stack` option) become multi-subplot
+ * figures: one MAIDR subplot per stacked panel, arranged as N rows × 1 column
+ * for y-stacks and 1 row × N columns for x-stacks, ordered by on-canvas
+ * position. All other charts — including classic dual-axis overlays — remain
+ * a single subplot.
+ */
+export function extractChartData(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+  onNavigate?: NavigateCallback,
+): ChartJsExtraction {
   const chartType = chart.config.type;
+
+  const layout = detectStackedPanels(chart);
+  const paneled = layout === null
+    ? null
+    : extractPanelSubplots(chart, chartType, layout, pluginOptions);
+
+  if (paneled !== null) {
+    return {
+      maidr: {
+        id: `maidr-chartjs-${chart.canvas.id || 'chart'}-${nextId++}`,
+        title: pluginOptions?.title ?? getChartTitle(chart),
+        subplots: paneled.subplots,
+        ...(onNavigate ? { onNavigate } : {}),
+      },
+      layerDatasetIndices: paneled.layerDatasetIndices,
+    };
+  }
+
   const layers = extractLayers(chart, chartType, pluginOptions);
 
   return {
-    id: `maidr-chartjs-${chart.canvas.id || 'chart'}-${nextId++}`,
-    title: pluginOptions?.title ?? getChartTitle(chart),
-    subplots: [[{ layers }]],
-    ...(onNavigate ? { onNavigate } : {}),
+    maidr: {
+      id: `maidr-chartjs-${chart.canvas.id || 'chart'}-${nextId++}`,
+      title: pluginOptions?.title ?? getChartTitle(chart),
+      subplots: [[{ layers }]],
+      ...(onNavigate ? { onNavigate } : {}),
+    },
+    layerDatasetIndices: singleSubplotDatasetIndices(chart, layers),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Axis-stacked panel detection & extraction
+// ---------------------------------------------------------------------------
+
+type AxisKind = 'x' | 'y';
+
+/** One stacked panel: the scale it hangs off plus its dataset partition. */
+interface PanelPartition {
+  scaleId: string;
+  datasets: ChartJsDataset[];
+  /** Original indices of `datasets` within `chart.data.datasets`. */
+  datasetIndices: number[];
+}
+
+interface StackedPanelLayout {
+  axisKind: AxisKind;
+  panels: PanelPartition[];
+}
+
+/** Which axis a scale belongs to: explicit option, runtime, or id prefix. */
+function scaleAxisKind(chart: ChartJsChart, scaleId: string): AxisKind | null {
+  const declared = chart.options.scales?.[scaleId]?.axis;
+  if (declared === 'x' || declared === 'y')
+    return declared;
+  const runtime = chart.scales?.[scaleId]?.axis;
+  if (runtime === 'x' || runtime === 'y')
+    return runtime;
+  const prefix = scaleId.charAt(0);
+  return prefix === 'x' || prefix === 'y' ? prefix : null;
+}
+
+/**
+ * Whether the given same-kind scales are laid out as stacked (non-overlapping)
+ * bands: either 2+ of them opt into axis stacking via the `stack` option, or
+ * the runtime geometry shows disjoint bands along the axis direction.
+ */
+function isStackedScaleLayout(
+  chart: ChartJsChart,
+  scaleIds: string[],
+  axisKind: AxisKind,
+): boolean {
+  const scales = chart.options.scales ?? {};
+  const stackCount = scaleIds
+    .filter(id => typeof scales[id]?.stack === 'string' && scales[id]?.stack !== '')
+    .length;
+  if (stackCount >= 2)
+    return true;
+  return hasDisjointBands(chart, scaleIds, axisKind);
+}
+
+/** True when every scale occupies its own band (no pixel-range overlap). */
+function hasDisjointBands(
+  chart: ChartJsChart,
+  scaleIds: string[],
+  axisKind: AxisKind,
+): boolean {
+  const runtime = chart.scales;
+  if (!runtime)
+    return false;
+
+  const bands: [number, number][] = [];
+  for (const id of scaleIds) {
+    const scale = runtime[id];
+    if (!scale)
+      return false;
+    bands.push(axisKind === 'y' ? [scale.top, scale.bottom] : [scale.left, scale.right]);
+  }
+
+  bands.sort((a, b) => a[0] - b[0]);
+  for (let i = 1; i < bands.length; i++) {
+    // 1px tolerance for adjacent bands sharing a boundary pixel.
+    if (bands[i][0] < bands[i - 1][1] - 1)
+      return false;
+  }
+  return true;
+}
+
+/**
+ * Detect Chart.js axis-stacked panels: 2+ scales of the same axis kind laid
+ * out in separate bands, with datasets partitioned among them. Returns `null`
+ * for everything else (single-scale charts, dual-axis overlays, stacks that
+ * all datasets ignore), which keeps those charts a single subplot.
+ */
+function detectStackedPanels(chart: ChartJsChart): StackedPanelLayout | null {
+  const scales = chart.options.scales;
+  if (!scales)
+    return null;
+
+  const scaleIdsInDeclarationOrder = Object.keys(scales);
+
+  for (const axisKind of ['y', 'x'] as const) {
+    const kindIds = scaleIdsInDeclarationOrder
+      .filter(id => scaleAxisKind(chart, id) === axisKind);
+    if (kindIds.length < 2)
+      continue;
+    if (!isStackedScaleLayout(chart, kindIds, axisKind))
+      continue;
+
+    const panels = partitionDatasets(chart, kindIds, axisKind);
+    if (panels.length < 2)
+      continue;
+
+    return { axisKind, panels: orderPanelsByGeometry(chart, panels, axisKind) };
+  }
+
+  return null;
+}
+
+/** Group datasets by the scale id they are plotted against. */
+function partitionDatasets(
+  chart: ChartJsChart,
+  kindIds: string[],
+  axisKind: AxisKind,
+): PanelPartition[] {
+  const byScale = new Map<string, PanelPartition>();
+
+  chart.data.datasets.forEach((dataset, index) => {
+    const axisId = (axisKind === 'y' ? dataset.yAxisID : dataset.xAxisID) ?? axisKind;
+    // Datasets referencing an unknown scale fold into the default panel.
+    const scaleId = kindIds.includes(axisId) ? axisId : axisKind;
+    let panel = byScale.get(scaleId);
+    if (!panel) {
+      panel = { scaleId, datasets: [], datasetIndices: [] };
+      byScale.set(scaleId, panel);
+    }
+    panel.datasets.push(dataset);
+    panel.datasetIndices.push(index);
+  });
+
+  return [...byScale.values()];
+}
+
+/**
+ * Order panels in visual reading order: by the runtime scale band position
+ * (`top` for y-stacks, `left` for x-stacks) when the chart is laid out, with
+ * scale declaration order as the fallback.
+ */
+function orderPanelsByGeometry(
+  chart: ChartJsChart,
+  panels: PanelPartition[],
+  axisKind: AxisKind,
+): PanelPartition[] {
+  const declarationOrder = Object.keys(chart.options.scales ?? {});
+  return [...panels].sort((a, b) => {
+    const runtimeA = chart.scales?.[a.scaleId];
+    const runtimeB = chart.scales?.[b.scaleId];
+    if (runtimeA && runtimeB) {
+      return axisKind === 'y'
+        ? runtimeA.top - runtimeB.top
+        : runtimeA.left - runtimeB.left;
+    }
+    return declarationOrder.indexOf(a.scaleId) - declarationOrder.indexOf(b.scaleId);
+  });
+}
+
+/**
+ * A read-only view of the chart restricted to one panel: only the panel's
+ * datasets, and with the panel's own scale substituted as the default value
+ * scale so the existing per-type extractors (which read `scales.x`/`scales.y`)
+ * pick up the panel's axis label and stacked flag unchanged.
+ */
+function createPanelView(
+  chart: ChartJsChart,
+  panel: PanelPartition,
+  axisKind: AxisKind,
+): ChartJsChart {
+  const scales = chart.options.scales ?? {};
+  const panelScale = scales[panel.scaleId];
+
+  return {
+    canvas: chart.canvas,
+    config: chart.config,
+    data: { labels: chart.data.labels, datasets: panel.datasets },
+    options: {
+      ...chart.options,
+      scales: panelScale ? { ...scales, [axisKind]: panelScale } : scales,
+    },
+    scales: chart.scales,
+    getDatasetMeta: datasetIndex => chart.getDatasetMeta(datasetIndex),
+    setActiveElements: elements => chart.setActiveElements(elements),
+    tooltip: chart.tooltip,
+    update: mode => chart.update(mode),
+  };
+}
+
+/**
+ * Build one MAIDR subplot per stacked panel by running the existing per-type
+ * layer extraction on each dataset partition. Layer ids are rewritten to
+ * `{panelIndex}_{localId}` so they stay unique across the whole figure, and
+ * the first layer's title carries the panel display name. Returns `null`
+ * when fewer than two panels yield layers, so callers fall back to the
+ * single-subplot path.
+ */
+function extractPanelSubplots(
+  chart: ChartJsChart,
+  chartType: string,
+  layout: StackedPanelLayout,
+  pluginOptions?: MaidrPluginOptions,
+): { subplots: MaidrSubplot[][]; layerDatasetIndices: Map<string, number[]> } | null {
+  const panelSubplots: MaidrSubplot[] = [];
+  const layerDatasetIndices = new Map<string, number[]>();
+
+  for (const panel of layout.panels) {
+    const view = createPanelView(chart, panel, layout.axisKind);
+    const layers = extractLayers(view, chartType, pluginOptions);
+    // Never emit a subplot with no layers — it crashes the core Figure model.
+    if (layers.length === 0)
+      continue;
+
+    const panelIndex = panelSubplots.length;
+    for (const layer of layers) {
+      const localId = layer.id;
+      layer.id = `${panelIndex}_${localId}`;
+      layerDatasetIndices.set(layer.id, layerDatasets(layer, localId, panel));
+    }
+
+    // The first layer's title is the panel's display name in subplot
+    // summaries: prefer the panel scale's own title, then whatever the
+    // extractor set, then the first dataset label.
+    const scaleTitle = chart.options.scales?.[panel.scaleId]?.title?.text;
+    const panelTitle = scaleTitle ?? layers[0].title ?? panel.datasets[0]?.label;
+    if (panelTitle !== undefined)
+      layers[0].title = panelTitle;
+
+    panelSubplots.push({ layers });
+  }
+
+  if (panelSubplots.length < 2)
+    return null;
+
+  // y-stacks read top-to-bottom (N rows × 1 col); x-stacks left-to-right
+  // (1 row × N cols) — both already in visual reading order.
+  const subplots = layout.axisKind === 'y'
+    ? panelSubplots.map(subplot => [subplot])
+    : [panelSubplots];
+
+  return { subplots, layerDatasetIndices };
+}
+
+/** Original chart dataset indices backing one panel layer, in MAIDR row order. */
+function layerDatasets(
+  layer: MaidrLayer,
+  localId: string,
+  panel: PanelPartition,
+): number[] {
+  if (layer.type === TraceType.SCATTER) {
+    // Scatter emits one layer per dataset with local id = partition position.
+    const localIndex = Number.parseInt(localId, 10) || 0;
+    return [panel.datasetIndices[localIndex] ?? panel.datasetIndices[0] ?? 0];
+  }
+  return panel.datasetIndices;
+}
+
+/**
+ * Layer→dataset map for the single-subplot path, mirroring the historical
+ * conventions: scatter layer ids are the dataset index, every other layer is
+ * backed by all datasets in order (MAIDR row = Chart.js dataset index).
+ */
+function singleSubplotDatasetIndices(
+  chart: ChartJsChart,
+  layers: MaidrLayer[],
+): Map<string, number[]> {
+  const allIndices = chart.data.datasets.map((_, index) => index);
+  const map = new Map<string, number[]>();
+  for (const layer of layers) {
+    map.set(
+      layer.id,
+      layer.type === TraceType.SCATTER
+        ? [Number.parseInt(layer.id, 10) || 0]
+        : allIndices,
+    );
+  }
+  return map;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -1,0 +1,230 @@
+/**
+ * Pure logic for translating MAIDR navigation positions back into Chart.js
+ * element indices (dataset index + element index).
+ *
+ * MAIDR extraction skips gap markers and, for axis-stacked panels, partitions
+ * `chart.data.datasets` across subplots — so neither MAIDR's `col` nor its
+ * `row` can be used as a Chart.js index directly. The lookups built here keep
+ * highlight resolution O(1) and aligned with the original chart elements.
+ */
+
+import type { HeatmapData, MaidrLayer } from '../../type/grammar';
+import type { ChartJsActiveElement, ChartJsChart, ChartJsDataValue } from './types';
+import { TraceType } from '../../type/grammar';
+import { isMatrixValue, isPointValue, toFiniteNumber } from './extractor';
+
+/**
+ * Figure-unique layer id → original Chart.js dataset indices backing that
+ * layer, in MAIDR row order. Produced by `extractChartData`.
+ */
+export type LayerDatasetIndices = ReadonlyMap<string, number[]>;
+
+/**
+ * Per-layer lookups that translate a MAIDR navigation position into the
+ * original Chart.js element index. MAIDR extraction skips gap markers, so these
+ * maps re-derive the raw indices from the chart to keep highlights aligned.
+ */
+export interface TargetMaps {
+  /** Scatter: `scatterBuckets[layerId][col]` lists the Chart.js dataset indices sharing that X. */
+  scatterBuckets: Map<string, number[][]>;
+  /** Bar/line: `barLineIndices[layerId][row][col]` is the original Chart.js element index (gaps skipped). */
+  barLineIndices: Map<string, number[][]>;
+  /** Heatmap: `heatmapIndices[layerId]` maps `"x\0y"` to the flat Chart.js element index. */
+  heatmapIndices: Map<string, Map<string, number>>;
+}
+
+function isSegmentedType(type: string): boolean {
+  return type === TraceType.STACKED || type === TraceType.DODGED || type === TraceType.NORMALIZED;
+}
+
+/**
+ * Original indices of a dataset's finite (non-gap) entries, in dataset order.
+ * Mirrors the extractor's gap-skipping so MAIDR's `col` (an index into the
+ * skipped list) maps back to the Chart.js element index.
+ */
+function finiteIndices(data: ChartJsDataValue[]): number[] {
+  const indices: number[] = [];
+  data.forEach((value, i) => {
+    if (toFiniteNumber(value) !== null)
+      indices.push(i);
+  });
+  return indices;
+}
+
+/**
+ * Mirror `ScatterTrace`'s X-bucket construction (`src/model/scatter.ts:86-100`)
+ * to map MAIDR's `col` (an X-bucket index) back to one or more original
+ * Chart.js dataset indices. Points are sorted by X, then Y; consecutive points
+ * sharing an X form a bucket. Reads the raw dataset (not the filtered layer
+ * data) so bucket entries are original, highlight-aligned indices.
+ */
+function buildScatterBuckets(data: ChartJsDataValue[]): number[][] {
+  // Track original dataset indices through the (x, y) sort so bucket entries are
+  // Chart.js element indices, not positions in the gap-filtered point list.
+  const indexed: { x: number; y: number; i: number }[] = [];
+  data.forEach((value, i) => {
+    if (isPointValue(value))
+      indexed.push({ x: value.x, y: value.y, i });
+  });
+  indexed.sort((a, b) => a.x - b.x || a.y - b.y);
+  const buckets: number[][] = [];
+  let currentX: number | null = null;
+  for (const { x, i } of indexed) {
+    if (currentX === null || currentX !== x) {
+      currentX = x;
+      buckets.push([]);
+    }
+    buckets[buckets.length - 1].push(i);
+  }
+  return buckets;
+}
+
+/**
+ * Map each `"x\0y"` cell key to its flat Chart.js element index. The matrix
+ * plugin's data order is arbitrary (commonly x-major), so highlighting must
+ * look up cells by coordinate rather than assuming a y-major grid.
+ */
+function buildHeatmapIndex(data: ChartJsDataValue[]): Map<string, number> {
+  const index = new Map<string, number>();
+  data.forEach((value, i) => {
+    if (isMatrixValue(value))
+      index.set(`${String(value.x)}\0${String(value.y)}`, i);
+  });
+  return index;
+}
+
+/** Chart.js dataset index backing the given MAIDR row of a layer. */
+function rowDatasetIndex(
+  layerDatasetIndices: LayerDatasetIndices,
+  layerId: string,
+  row: number,
+): number {
+  return layerDatasetIndices.get(layerId)?.[row] ?? row;
+}
+
+/** Chart.js dataset index backing a single-dataset layer. */
+function firstDatasetIndex(
+  layerDatasetIndices: LayerDatasetIndices,
+  layerId: string,
+): number {
+  return layerDatasetIndices.get(layerId)?.[0] ?? 0;
+}
+
+/**
+ * Precompute all per-layer position→index lookups from the raw chart, once at
+ * init. This keeps highlight resolution O(1) and aligned with the original
+ * Chart.js element indices even though MAIDR extraction skips gap markers and
+ * axis-stacked panels see only a partition of the datasets.
+ */
+export function computeTargetMaps(
+  chart: ChartJsChart,
+  layers: MaidrLayer[],
+  layerDatasetIndices: LayerDatasetIndices,
+): TargetMaps {
+  const scatterBuckets = new Map<string, number[][]>();
+  const barLineIndices = new Map<string, number[][]>();
+  const heatmapIndices = new Map<string, Map<string, number>>();
+  const datasets = chart.data.datasets;
+
+  for (const layer of layers) {
+    switch (layer.type) {
+      case TraceType.SCATTER: {
+        const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
+        scatterBuckets.set(layer.id, buildScatterBuckets(datasets[dsIdx]?.data ?? []));
+        break;
+      }
+      case TraceType.BAR: {
+        // Single-dataset bar: one MAIDR row backed by the layer's dataset.
+        const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
+        barLineIndices.set(layer.id, [finiteIndices(datasets[dsIdx]?.data ?? [])]);
+        break;
+      }
+      case TraceType.LINE: {
+        // One MAIDR row per backing dataset, in MAIDR row order.
+        const dsIndices = layerDatasetIndices.get(layer.id) ?? datasets.map((_, i) => i);
+        barLineIndices.set(
+          layer.id,
+          dsIndices.map(dsIdx => finiteIndices(datasets[dsIdx]?.data ?? [])),
+        );
+        break;
+      }
+      case TraceType.HEATMAP: {
+        const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
+        heatmapIndices.set(layer.id, buildHeatmapIndex(datasets[dsIdx]?.data ?? []));
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return { scatterBuckets, barLineIndices, heatmapIndices };
+}
+
+/**
+ * Resolve a MAIDR navigation event into the Chart.js active elements that
+ * should be highlighted. Returns an array because scatter X-buckets can
+ * contain multiple points that share an X coordinate.
+ */
+export function resolveActiveTargets(
+  layers: MaidrLayer[],
+  maps: TargetMaps,
+  layerDatasetIndices: LayerDatasetIndices,
+  layerId: string,
+  row: number,
+  col: number,
+): ChartJsActiveElement[] {
+  const layer = layers.find(l => l.id === layerId);
+  if (!layer)
+    return [];
+
+  // Segmented bars: MAIDR row = group (dataset), col = category (index).
+  // The category grid is kept rectangular (gaps collapse to 0), so col is the
+  // native Chart.js element index and needs no remapping.
+  if (isSegmentedType(layer.type))
+    return [{ datasetIndex: rowDatasetIndex(layerDatasetIndices, layerId, row), index: col }];
+
+  // Scatter: col is an X-bucket; expand to all points sharing that X.
+  if (layer.type === TraceType.SCATTER) {
+    const buckets = maps.scatterBuckets.get(layer.id);
+    if (!buckets || col < 0 || col >= buckets.length)
+      return [];
+    const datasetIndex = firstDatasetIndex(layerDatasetIndices, layer.id);
+    return buckets[col].map(index => ({ datasetIndex, index }));
+  }
+
+  // Candlestick / OHLC: a single dataset of candles. MAIDR `col` selects the
+  // candle; MAIDR `row` picks the OHLC field (volatility/open/high/low/close)
+  // for audio/text and does NOT change which element to highlight.
+  if (layer.type === TraceType.CANDLESTICK)
+    return [{ datasetIndex: firstDatasetIndex(layerDatasetIndices, layer.id), index: col }];
+
+  // Heatmap / Matrix: look the active cell up by coordinate (the matrix data
+  // order is arbitrary). MAIDR's Heatmap model reverses the Y axis (row 0 =
+  // bottom), so un-reverse to recover the original yLabel before the lookup.
+  if (layer.type === TraceType.HEATMAP) {
+    const hd = layer.data as HeatmapData;
+    const originalYi = (hd.y.length - 1) - row;
+    const xLabel = hd.x[col];
+    const yLabel = hd.y[originalYi];
+    if (xLabel === undefined || yLabel === undefined)
+      return [];
+    const flatIndex = maps.heatmapIndices.get(layer.id)?.get(`${xLabel}\0${yLabel}`);
+    if (flatIndex === undefined)
+      return [];
+    return [{ datasetIndex: firstDatasetIndex(layerDatasetIndices, layer.id), index: flatIndex }];
+  }
+
+  // Bar / line: MAIDR row = dataset, col = point (into the gap-skipped list).
+  // Map col back to the original Chart.js element index so highlights stay
+  // aligned when the dataset contains gap markers.
+  const indexMap = maps.barLineIndices.get(layer.id);
+  const datasetIndex = rowDatasetIndex(layerDatasetIndices, layerId, row);
+  if (indexMap) {
+    const index = indexMap[row]?.[col];
+    if (index === undefined)
+      return [];
+    return [{ datasetIndex, index }];
+  }
+  return [{ datasetIndex, index: col }];
+}

--- a/src/adapters/chartjs/index.ts
+++ b/src/adapters/chartjs/index.ts
@@ -37,6 +37,7 @@
  * @packageDocumentation
  */
 
-export { extractMaidrData } from './extractor';
+export { extractChartData, extractMaidrData } from './extractor';
+export type { ChartJsExtraction } from './extractor';
 export { maidrPlugin } from './plugin';
 export type { ChartJsChart, ChartJsPlugin, MaidrPluginOptions } from './types';

--- a/src/adapters/chartjs/plugin.tsx
+++ b/src/adapters/chartjs/plugin.tsx
@@ -24,13 +24,14 @@
 
 import type { JSX } from 'react';
 import type { Root } from 'react-dom/client';
-import type { HeatmapData, Maidr as MaidrData, MaidrLayer, NavigateCallback } from '../../type/grammar';
-import type { ChartJsActiveElement, ChartJsChart, ChartJsDataValue, ChartJsPlugin, MaidrPluginOptions } from './types';
+import type { Maidr as MaidrData, MaidrLayer, NavigateCallback } from '../../type/grammar';
+import type { LayerDatasetIndices, TargetMaps } from './highlightTargets';
+import type { ChartJsActiveElement, ChartJsChart, ChartJsPlugin, MaidrPluginOptions } from './types';
 import { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
-import { TraceType } from '../../type/grammar';
-import { extractMaidrData, isMatrixValue, isPointValue, toFiniteNumber } from './extractor';
+import { extractChartData } from './extractor';
+import { computeTargetMaps, resolveActiveTargets } from './highlightTargets';
 import { elementToOverlayRect, HighlightOverlay } from './overlay';
 
 // ---------------------------------------------------------------------------
@@ -48,28 +49,16 @@ interface MaidrChartBinding {
   maidrData: MaidrData;
   root: Root;
   container: HTMLElement;
-  /** Layers as extracted; needed to resolve targets on resize replay. */
+  /** All layers across all subplots; needed to resolve targets on resize replay. */
   layers: MaidrLayer[];
+  /** Layer id → original Chart.js dataset indices, from `extractChartData`. */
+  layerDatasetIndices: LayerDatasetIndices;
   /** Per-layer lookups mapping MAIDR positions back to Chart.js element indices. */
   targetMaps: TargetMaps;
   /** Resolved once the React tree mounts and provides the host wrapper. */
   overlayPromise: Promise<HighlightOverlay | null>;
   /** Latest MAIDR navigation event, replayed on resize. */
   lastActive: NavEvent | null;
-}
-
-/**
- * Per-layer lookups that translate a MAIDR navigation position into the
- * original Chart.js element index. MAIDR extraction skips gap markers, so these
- * maps re-derive the raw indices from the chart to keep highlights aligned.
- */
-interface TargetMaps {
-  /** Scatter: `scatterBuckets[layerId][col]` lists the Chart.js dataset indices sharing that X. */
-  scatterBuckets: Map<string, number[][]>;
-  /** Bar/line: `barLineIndices[layerId][row][col]` is the original Chart.js element index (gaps skipped). */
-  barLineIndices: Map<string, number[][]>;
-  /** Heatmap: `heatmapIndices[layerId]` maps `"x\0y"` to the flat Chart.js element index. */
-  heatmapIndices: Map<string, Map<string, number>>;
 }
 
 const chartBindings = new WeakMap<ChartJsChart, MaidrChartBinding>();
@@ -127,171 +116,6 @@ function CanvasHost({ node, width, height, onHost }: CanvasHostProps): JSX.Eleme
 // Chart.js highlight bridge
 // ---------------------------------------------------------------------------
 
-function isSegmentedType(type: string): boolean {
-  return type === TraceType.STACKED || type === TraceType.DODGED || type === TraceType.NORMALIZED;
-}
-
-/**
- * Original indices of a dataset's finite (non-gap) entries, in dataset order.
- * Mirrors the extractor's gap-skipping so MAIDR's `col` (an index into the
- * skipped list) maps back to the Chart.js element index.
- */
-function finiteIndices(data: ChartJsDataValue[]): number[] {
-  const indices: number[] = [];
-  data.forEach((value, i) => {
-    if (toFiniteNumber(value) !== null)
-      indices.push(i);
-  });
-  return indices;
-}
-
-/**
- * Mirror `ScatterTrace`'s X-bucket construction (`src/model/scatter.ts:86-100`)
- * to map MAIDR's `col` (an X-bucket index) back to one or more original
- * Chart.js dataset indices. Points are sorted by X, then Y; consecutive points
- * sharing an X form a bucket. Reads the raw dataset (not the filtered layer
- * data) so bucket entries are original, highlight-aligned indices.
- */
-function buildScatterBuckets(data: ChartJsDataValue[]): number[][] {
-  // Track original dataset indices through the (x, y) sort so bucket entries are
-  // Chart.js element indices, not positions in the gap-filtered point list.
-  const indexed: { x: number; y: number; i: number }[] = [];
-  data.forEach((value, i) => {
-    if (isPointValue(value))
-      indexed.push({ x: value.x, y: value.y, i });
-  });
-  indexed.sort((a, b) => a.x - b.x || a.y - b.y);
-  const buckets: number[][] = [];
-  let currentX: number | null = null;
-  for (const { x, i } of indexed) {
-    if (currentX === null || currentX !== x) {
-      currentX = x;
-      buckets.push([]);
-    }
-    buckets[buckets.length - 1].push(i);
-  }
-  return buckets;
-}
-
-/**
- * Map each `"x\0y"` cell key to its flat Chart.js element index. The matrix
- * plugin's data order is arbitrary (commonly x-major), so highlighting must
- * look up cells by coordinate rather than assuming a y-major grid.
- */
-function buildHeatmapIndex(data: ChartJsDataValue[]): Map<string, number> {
-  const index = new Map<string, number>();
-  data.forEach((value, i) => {
-    if (isMatrixValue(value))
-      index.set(`${String(value.x)}\0${String(value.y)}`, i);
-  });
-  return index;
-}
-
-/**
- * Precompute all per-layer position→index lookups from the raw chart, once at
- * init. This keeps highlight resolution O(1) and aligned with the original
- * Chart.js element indices even though MAIDR extraction skips gap markers.
- */
-function computeTargetMaps(chart: ChartJsChart, layers: MaidrLayer[]): TargetMaps {
-  const scatterBuckets = new Map<string, number[][]>();
-  const barLineIndices = new Map<string, number[][]>();
-  const heatmapIndices = new Map<string, Map<string, number>>();
-  const datasets = chart.data.datasets;
-
-  for (const layer of layers) {
-    switch (layer.type) {
-      case TraceType.SCATTER: {
-        // The extractor assigns `layer.id = String(datasetIndex)` for scatter.
-        const dsIdx = Number.parseInt(layer.id, 10) || 0;
-        scatterBuckets.set(layer.id, buildScatterBuckets(datasets[dsIdx]?.data ?? []));
-        break;
-      }
-      case TraceType.BAR:
-        // Single-dataset bar: one MAIDR row backed by dataset 0.
-        barLineIndices.set(layer.id, [finiteIndices(datasets[0]?.data ?? [])]);
-        break;
-      case TraceType.LINE:
-        // One MAIDR row per dataset, in dataset order.
-        barLineIndices.set(layer.id, datasets.map(ds => finiteIndices(ds.data)));
-        break;
-      case TraceType.HEATMAP:
-        heatmapIndices.set(layer.id, buildHeatmapIndex(datasets[0]?.data ?? []));
-        break;
-      default:
-        break;
-    }
-  }
-
-  return { scatterBuckets, barLineIndices, heatmapIndices };
-}
-
-/**
- * Resolve a MAIDR navigation event into the Chart.js active elements that
- * should be highlighted. Returns an array because scatter X-buckets can
- * contain multiple points that share an X coordinate.
- */
-function resolveActiveTargets(
-  layers: MaidrLayer[],
-  maps: TargetMaps,
-  layerId: string,
-  row: number,
-  col: number,
-): ChartJsActiveElement[] {
-  const layer = layers.find(l => l.id === layerId);
-  if (!layer)
-    return [];
-
-  // Segmented bars: MAIDR row = group (dataset), col = category (index).
-  // The category grid is kept rectangular (gaps collapse to 0), so col is the
-  // native Chart.js element index and needs no remapping.
-  if (isSegmentedType(layer.type))
-    return [{ datasetIndex: row, index: col }];
-
-  // Scatter: col is an X-bucket; expand to all points sharing that X.
-  if (layer.type === TraceType.SCATTER) {
-    const buckets = maps.scatterBuckets.get(layer.id);
-    if (!buckets || col < 0 || col >= buckets.length)
-      return [];
-    // The extractor assigns `layer.id = String(datasetIndex)` for scatter.
-    const datasetIndex = Number.parseInt(layer.id, 10) || 0;
-    return buckets[col].map(index => ({ datasetIndex, index }));
-  }
-
-  // Candlestick / OHLC: a single dataset of candles. MAIDR `col` selects the
-  // candle; MAIDR `row` picks the OHLC field (volatility/open/high/low/close)
-  // for audio/text and does NOT change which element to highlight.
-  if (layer.type === TraceType.CANDLESTICK)
-    return [{ datasetIndex: 0, index: col }];
-
-  // Heatmap / Matrix: look the active cell up by coordinate (the matrix data
-  // order is arbitrary). MAIDR's Heatmap model reverses the Y axis (row 0 =
-  // bottom), so un-reverse to recover the original yLabel before the lookup.
-  if (layer.type === TraceType.HEATMAP) {
-    const hd = layer.data as HeatmapData;
-    const originalYi = (hd.y.length - 1) - row;
-    const xLabel = hd.x[col];
-    const yLabel = hd.y[originalYi];
-    if (xLabel === undefined || yLabel === undefined)
-      return [];
-    const flatIndex = maps.heatmapIndices.get(layer.id)?.get(`${xLabel}\0${yLabel}`);
-    if (flatIndex === undefined)
-      return [];
-    return [{ datasetIndex: 0, index: flatIndex }];
-  }
-
-  // Bar / line: MAIDR row = dataset, col = point (into the gap-skipped list).
-  // Map col back to the original Chart.js element index so highlights stay
-  // aligned when the dataset contains gap markers.
-  const indexMap = maps.barLineIndices.get(layer.id);
-  if (indexMap) {
-    const index = indexMap[row]?.[col];
-    if (index === undefined)
-      return [];
-    return [{ datasetIndex: row, index }];
-  }
-  return [{ datasetIndex: row, index: col }];
-}
-
 /**
  * Drive both Chart.js's native active state (for canvas redraw + tooltip)
  * and the MAIDR DOM overlay (for accessible visual highlight). Supports
@@ -346,6 +170,7 @@ function createHighlightCallback(
   chart: ChartJsChart,
   layers: MaidrLayer[],
   maps: TargetMaps,
+  layerDatasetIndices: LayerDatasetIndices,
   getOverlay: () => HighlightOverlay | null,
   recordActive: (event: NavEvent) => void,
 ): NavigateCallback {
@@ -355,6 +180,7 @@ function createHighlightCallback(
       const targets = resolveActiveTargets(
         layers,
         maps,
+        layerDatasetIndices,
         event.layerId,
         event.row,
         event.col,
@@ -465,8 +291,9 @@ function initMaidrForChart(chart: ChartJsChart): void {
   // radar, polarArea, ...) reach this hook too; extraction throws for them, so
   // catch it and leave the chart untouched rather than breaking construction.
   let extracted: MaidrData;
+  let layerDatasetIndices: LayerDatasetIndices;
   try {
-    extracted = extractMaidrData(chart, pluginOptions);
+    ({ maidr: extracted, layerDatasetIndices } = extractChartData(chart, pluginOptions));
   } catch (error) {
     console.warn(
       `MAIDR Chart.js plugin: skipping chart. ${
@@ -475,11 +302,13 @@ function initMaidrForChart(chart: ChartJsChart): void {
     );
     return;
   }
-  const layers = extracted.subplots[0][0].layers;
+  // Axis-stacked panels produce a multi-subplot grid; flatten every panel's
+  // layers (layer ids are figure-unique) for target resolution.
+  const layers = extracted.subplots.flat().flatMap(subplot => subplot.layers);
 
   // Precompute per-layer position→index lookups so navigation can be mapped to
   // one or more Chart.js indices in O(1) at highlight time.
-  const targetMaps = computeTargetMaps(chart, layers);
+  const targetMaps = computeTargetMaps(chart, layers, layerDatasetIndices);
 
   // The overlay is created asynchronously once the React tree mounts.
   // The highlight callback closes over a getter so it always reads the
@@ -500,6 +329,7 @@ function initMaidrForChart(chart: ChartJsChart): void {
       chart,
       layers,
       targetMaps,
+      layerDatasetIndices,
       () => overlay,
       recordActive,
     ),
@@ -523,6 +353,7 @@ function initMaidrForChart(chart: ChartJsChart): void {
     root: result.root,
     container: result.container,
     layers,
+    layerDatasetIndices,
     targetMaps,
     overlayPromise,
     lastActive: null,
@@ -548,6 +379,7 @@ function handleResize(chart: ChartJsChart): void {
       const targets = resolveActiveTargets(
         binding.layers,
         binding.targetMaps,
+        binding.layerDatasetIndices,
         active.layerId,
         active.row,
         active.col,

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -89,6 +89,12 @@ export interface ChartJsScale {
   /** Which axis this scale belongs to; defaults from the scale id's first letter. */
   axis?: 'x' | 'y';
   /**
+   * Which chart edge the scale is placed against. Chart.js also accepts
+   * dynamic positions (`'center'` or an `{ [scaleId]: value }` object), hence
+   * the loose type; only the static edge strings participate in axis stacking.
+   */
+  position?: string | Record<string, number>;
+  /**
    * Axis-stacking group name (Chart.js >= 3.7). Scales of the same axis kind
    * sharing a `stack` are laid out in separate, non-overlapping bands — the
    * native Chart.js way to express stacked panels within one canvas.
@@ -104,6 +110,8 @@ export interface ChartJsScale {
  */
 export interface ChartJsRuntimeScale {
   axis?: 'x' | 'y' | 'r';
+  /** Resolved edge the scale was laid out against. */
+  position?: string;
   top: number;
   bottom: number;
   left: number;

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -33,6 +33,8 @@ export interface ChartJsChart {
   readonly data: ChartJsData;
   readonly options: ChartJsOptions;
   readonly config: { readonly type: string };
+  /** Runtime scale instances keyed by scale id, laid out with pixel geometry. */
+  readonly scales?: Record<string, ChartJsRuntimeScale>;
   getDatasetMeta: (datasetIndex: number) => ChartJsDatasetMeta;
   setActiveElements: (elements: ChartJsActiveElement[]) => void;
   tooltip?: {
@@ -60,6 +62,10 @@ export interface ChartJsDataset {
   data: ChartJsDataValue[];
   type?: string;
   stack?: string;
+  /** Id of the x scale this dataset is plotted against (defaults to `'x'`). */
+  xAxisID?: string;
+  /** Id of the y scale this dataset is plotted against (defaults to `'y'`). */
+  yAxisID?: string;
   backgroundColor?: string | string[];
   borderColor?: string | string[];
 }
@@ -80,6 +86,28 @@ export interface ChartJsScale {
   title?: { text?: string; display?: boolean };
   type?: string;
   stacked?: boolean;
+  /** Which axis this scale belongs to; defaults from the scale id's first letter. */
+  axis?: 'x' | 'y';
+  /**
+   * Axis-stacking group name (Chart.js >= 3.7). Scales of the same axis kind
+   * sharing a `stack` are laid out in separate, non-overlapping bands — the
+   * native Chart.js way to express stacked panels within one canvas.
+   */
+  stack?: string;
+  /** Relative size of this scale's band within its axis stack. */
+  stackWeight?: number;
+}
+
+/**
+ * A laid-out runtime scale instance (from `chart.scales`), exposing the pixel
+ * band it occupies. Used to order axis-stacked panels by visual position.
+ */
+export interface ChartJsRuntimeScale {
+  axis?: 'x' | 'y' | 'r';
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
 }
 
 /**

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -164,5 +164,9 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'segmented', config: props.config };
     case 'smooth':
       return { chartType: 'smooth', config: props.config };
+    case 'facets':
+      return { chartType: 'facets', config: props.config };
+    case 'subplots':
+      return { chartType: 'subplots', config: props.config };
   }
 }

--- a/src/adapters/d3/binders/bar.ts
+++ b/src/adapters/d3/binders/bar.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible bar chart interaction.
  */
 
-import type { BarPoint, Maidr, MaidrLayer } from '../../../type/grammar';
-import type { D3BarConfig, D3BinderResult } from '../types';
+import type { BarPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BarConfig, D3BinderResult, D3BuiltLayer } from '../types';
 import { Orientation, TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
 
 /**
  * Binds a D3.js bar chart to MAIDR, generating the accessible data representation.
@@ -58,21 +59,30 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Bar(svg: Element, config: D3BarConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildBarLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for bar charts: reads D3-bound data under `root` and
+ * builds the MAIDR layer, without wrapping it in a figure or touching
+ * `maidr-data`. Used by {@link bindD3Bar} (root = the SVG) and by the
+ * multi-panel binders in `binders/subplots.ts` (root = one panel element,
+ * with `panel` scoping the emitted selectors to that panel).
+ *
+ * @internal
+ */
+export function buildBarLayer(root: Element, config: D3BarConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
     orientation = Orientation.VERTICAL,
-    autoApply,
   } = config;
 
-  const elements = queryD3Elements(svg, selector);
+  const elements = queryD3Elements(root, selector);
   if (elements.length === 0) {
-    throw buildNoElementsError(svg, selector, 'bar');
+    throw buildNoElementsError(root, selector, 'bar');
   }
 
   // Infer accessors from the first datum's keys when the user did not specify.
@@ -102,25 +112,15 @@ export function bindD3Bar(svg: Element, config: D3BarConfig): D3BinderResult {
     };
   });
 
-  const layerId = generateId();
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.BAR,
     title,
-    selectors: scopeSelector(svg, selector),
+    selectors: scopeSelector(root, selector, panel),
     orientation,
     axes: buildAxes(axes, format),
     data,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{ layers: [layer] }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer };
 }

--- a/src/adapters/d3/binders/box.ts
+++ b/src/adapters/d3/binders/box.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible box plot interaction.
  */
 
-import type { BoxPoint, BoxSelector, Maidr, MaidrLayer } from '../../../type/grammar';
-import type { D3BinderResult, D3BoxConfig } from '../types';
+import type { BoxPoint, BoxSelector, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BoxConfig, D3BuiltLayer } from '../types';
 import { Orientation, TraceType } from '../../../type/grammar';
-import { cssEscape, ensureContainerId } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, getD3Datum, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+import { selectorPrefix } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, getD3Datum, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
 
 /**
  * Binds a D3.js box plot to MAIDR, generating the accessible data representation.
@@ -58,11 +59,18 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildBoxLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for box plots. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildBoxLayer(root: Element, config: D3BoxConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
@@ -75,12 +83,11 @@ export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
     lowerOutliers: lowerOutliersAccessor = 'lowerOutliers',
     upperOutliers: upperOutliersAccessor = 'upperOutliers',
     orientation = Orientation.VERTICAL,
-    autoApply,
   } = config;
 
-  const boxGroups = queryD3Elements(svg, selector);
+  const boxGroups = queryD3Elements(root, selector);
   if (boxGroups.length === 0) {
-    throw buildNoElementsError(svg, selector, 'box group');
+    throw buildNoElementsError(root, selector, 'box group');
   }
 
   const data: BoxPoint[] = boxGroups.map(({ element, datum, index }) => {
@@ -115,13 +122,12 @@ export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
     };
   });
 
-  const layerId = generateId();
-
   // Ensure the SVG has a stable id so selectors can be absolutely scoped
   // (consumers resolve selectors via global `document.querySelector`, so they
-  // must be unique page-wide). `ensureContainerId` auto-assigns an id when
-  // the user-supplied SVG lacks one, mirroring `scopeSelector`'s behaviour.
-  const svgId = ensureContainerId(svg);
+  // must be unique page-wide). `selectorPrefix` auto-assigns an id when the
+  // container lacks one, mirroring `scopeSelector`'s behaviour, and appends
+  // the `data-maidr-panel` segment on multi-panel binds.
+  const prefix = selectorPrefix(root, panel);
 
   // BoxTrace.mapToSvgElements (src/model/box.ts) requires one BoxSelector
   // object per box (it bails when `selectors.length !== points.length`). A
@@ -220,7 +226,7 @@ export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
       (isLower ? lowerOutlierIndices : upperOutlierIndices).push(outlierIndex);
     });
 
-    const base = `#${cssEscape(svgId)} ${selector}[data-maidr-box-index="${boxIndex}"]`;
+    const base = `${prefix} ${selector}[data-maidr-box-index="${boxIndex}"]`;
     return {
       lowerOutliers: lowerOutlierIndices.map(
         i => `${base} [data-maidr-box-part="lower-outlier"][data-maidr-outlier-index="${i}"]`,
@@ -236,7 +242,7 @@ export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
   });
 
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.BOX,
     title,
     selectors: boxSelectors,
@@ -245,14 +251,5 @@ export function bindD3Box(svg: Element, config: D3BoxConfig): D3BinderResult {
     data,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{ layers: [layer] }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer };
 }

--- a/src/adapters/d3/binders/candlestick.ts
+++ b/src/adapters/d3/binders/candlestick.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible candlestick chart interaction.
  */
 
-import type { CandlestickPoint, CandlestickTrend, Maidr, MaidrLayer } from '../../../type/grammar';
-import type { D3BinderResult, D3CandlestickConfig } from '../types';
+import type { CandlestickPoint, CandlestickTrend, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3CandlestickConfig } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
 
 /**
  * Binds a D3.js candlestick chart to MAIDR.
@@ -55,11 +56,18 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Candlestick(svg: Element, config: D3CandlestickConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildCandlestickLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for candlestick charts. See {@link buildBarLayer} for
+ * the single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildCandlestickLayer(root: Element, config: D3CandlestickConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
@@ -70,12 +78,11 @@ export function bindD3Candlestick(svg: Element, config: D3CandlestickConfig): D3
     close: closeAccessor = 'close',
     volume: volumeAccessor = 'volume',
     trend: trendAccessor,
-    autoApply,
   } = config;
 
-  const elements = queryD3Elements(svg, selector);
+  const elements = queryD3Elements(root, selector);
   if (elements.length === 0) {
-    throw buildNoElementsError(svg, selector, 'candlestick');
+    throw buildNoElementsError(root, selector, 'candlestick');
   }
 
   const data: CandlestickPoint[] = elements.map(({ datum, index }) => {
@@ -114,24 +121,14 @@ export function bindD3Candlestick(svg: Element, config: D3CandlestickConfig): D3
     };
   });
 
-  const layerId = generateId();
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.CANDLESTICK,
     title,
-    selectors: scopeSelector(svg, selector),
+    selectors: scopeSelector(root, selector, panel),
     axes: buildAxes(axes, format),
     data,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{ layers: [layer] }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer };
 }

--- a/src/adapters/d3/binders/heatmap.ts
+++ b/src/adapters/d3/binders/heatmap.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible heatmap interaction.
  */
 
-import type { HeatmapData, Maidr, MaidrLayer } from '../../../type/grammar';
-import type { D3BinderResult, D3HeatmapConfig } from '../types';
+import type { HeatmapData, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3HeatmapConfig } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
 
 /**
  * Binds a D3.js heatmap to MAIDR, generating the accessible data representation.
@@ -53,20 +54,26 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Heatmap(svg: Element, config: D3HeatmapConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildHeatmapLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for heatmaps. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildHeatmapLayer(root: Element, config: D3HeatmapConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
-    autoApply,
   } = config;
 
-  const elements = queryD3Elements(svg, selector);
+  const elements = queryD3Elements(root, selector);
   if (elements.length === 0) {
-    throw buildNoElementsError(svg, selector, 'heatmap cell');
+    throw buildNoElementsError(root, selector, 'heatmap cell');
   }
 
   // Infer accessors from the first datum's keys when the user did not specify.
@@ -157,12 +164,11 @@ export function bindD3Heatmap(svg: Element, config: D3HeatmapConfig): D3BinderRe
     points,
   };
 
-  const layerId = generateId();
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.HEATMAP,
     title,
-    selectors: scopeSelector(svg, selector),
+    selectors: scopeSelector(root, selector, panel),
     axes: buildAxes(axes, format),
     data,
     // D3 heatmaps typically join rects in row-major order (outer loop over
@@ -173,14 +179,5 @@ export function bindD3Heatmap(svg: Element, config: D3HeatmapConfig): D3BinderRe
     domMapping: { order: 'row' },
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{ layers: [layer] }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer };
 }

--- a/src/adapters/d3/binders/histogram.ts
+++ b/src/adapters/d3/binders/histogram.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible histogram interaction.
  */
 
-import type { HistogramPoint, Maidr, MaidrLayer } from '../../../type/grammar';
-import type { D3BinderResult, D3HistogramConfig } from '../types';
+import type { HistogramPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3HistogramConfig } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
 
 /**
  * Binds a D3.js histogram to MAIDR, generating the accessible data representation.
@@ -56,11 +57,18 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Histogram(svg: Element, config: D3HistogramConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildHistogramLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for histograms. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildHistogramLayer(root: Element, config: D3HistogramConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
@@ -70,12 +78,11 @@ export function bindD3Histogram(svg: Element, config: D3HistogramConfig): D3Bind
     xMax: xMaxAccessor = 'x1',
     yMin: yMinAccessor = (_d: unknown, _i: number) => 0,
     yMax: yMaxAccessor,
-    autoApply,
   } = config;
 
-  const elements = queryD3Elements(svg, selector);
+  const elements = queryD3Elements(root, selector);
   if (elements.length === 0) {
-    throw buildNoElementsError(svg, selector, 'histogram bar');
+    throw buildNoElementsError(root, selector, 'histogram bar');
   }
 
   // Fallback: when the user did NOT specify xMin/xMax accessors AND the
@@ -117,24 +124,14 @@ export function bindD3Histogram(svg: Element, config: D3HistogramConfig): D3Bind
     };
   });
 
-  const layerId = generateId();
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.HISTOGRAM,
     title,
-    selectors: scopeSelector(svg, selector),
+    selectors: scopeSelector(root, selector, panel),
     axes: buildAxes(axes, format),
     data,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{ layers: [layer] }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer };
 }

--- a/src/adapters/d3/binders/line.ts
+++ b/src/adapters/d3/binders/line.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible line chart interaction.
  */
 
-import type { LinePoint, Maidr, MaidrLayer } from '../../../type/grammar';
-import type { D3BinderResult, D3LineConfig, DataAccessor } from '../types';
+import type { LinePoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3LineConfig, DataAccessor } from '../types';
 import { TraceType } from '../../../type/grammar';
-import { cssEscape, ensureContainerId, scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, getD3Datum, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+import { scopeSelector, selectorPrefix } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, getD3Datum, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
 
 /**
  * Binds a D3.js line chart to MAIDR, generating the accessible data representation.
@@ -56,21 +57,27 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildLineLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for line charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildLineLayer(root: Element, config: D3LineConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
     pointSelector,
-    autoApply,
   } = config;
 
-  const lineElements = queryD3Elements(svg, selector);
+  const lineElements = queryD3Elements(root, selector);
   if (lineElements.length === 0) {
-    throw buildNoElementsError(svg, selector, 'line path');
+    throw buildNoElementsError(root, selector, 'line path');
   }
 
   // Infer accessors from a sample point-level datum when the user was silent.
@@ -78,7 +85,7 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
   // the path's datum is typically an array of points — take its first item.
   let sampleDatum: unknown;
   if (pointSelector) {
-    const samplePointEl = svg.querySelector(pointSelector);
+    const samplePointEl = root.querySelector(pointSelector);
     sampleDatum = samplePointEl ? getD3Datum(samplePointEl) : undefined;
   } else {
     const pathDatum = lineElements[0].datum;
@@ -118,13 +125,13 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
     // Pattern A: Each <path> lives in its own <g> with its <circle> points.
     // Pattern B: All <path>s and <circle>s share a single parent <g>.
     const parents = new Set(
-      lineElements.map(({ element }) => element.parentElement ?? svg),
+      lineElements.map(({ element }) => element.parentElement ?? root),
     );
 
     if (parents.size >= lineElements.length) {
       // Pattern A: distinct parents – scope point queries per parent
       for (const { element } of lineElements) {
-        const parent = element.parentElement ?? svg;
+        const parent = element.parentElement ?? root;
         const points = queryD3Elements(parent, pointSelector);
         const lineData = extractPointsFromElements(
           points,
@@ -142,7 +149,7 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
       }
     } else {
       // Pattern B: shared parent – query all points once and group by fill
-      const allPoints = queryD3Elements(svg, pointSelector);
+      const allPoints = queryD3Elements(root, pointSelector);
       if (allPoints.length === 0) {
         throw new Error(
           `No point elements found for selector "${pointSelector}" within the SVG.`,
@@ -227,13 +234,12 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
     }
   }
 
-  const layerId = generateId();
-
   // Ensure the SVG has a stable id so we can emit absolutely-scoped selectors
   // (the model resolves selectors via global `document.querySelector`, so they
-  // MUST be unique page-wide). `ensureContainerId` auto-assigns an id when
-  // the user-supplied SVG lacks one, mirroring `scopeSelector`'s behaviour.
-  const svgId = ensureContainerId(svg);
+  // MUST be unique page-wide). `selectorPrefix` auto-assigns an id when the
+  // container lacks one, mirroring `scopeSelector`'s behaviour, and appends
+  // the `data-maidr-panel` segment on multi-panel binds.
+  const prefix = selectorPrefix(root, panel);
 
   // LineTrace's `mapToSvgElements` requires one selector per line (it uses
   // `Svg.selectElement(selectors[r])` to grab a single <path> per series for
@@ -270,17 +276,17 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
         // a clean, deterministic state.
         element!.removeAttribute('data-maidr-line-index');
         element!.setAttribute('data-maidr-line-index', String(rowIndex));
-        return `#${cssEscape(svgId)} ${selector}[data-maidr-line-index="${rowIndex}"]`;
+        return `${prefix} ${selector}[data-maidr-line-index="${rowIndex}"]`;
       });
     } else {
       selectorValue = undefined;
     }
   } else {
     // Exactly one path matched → a single scoped selector highlights it.
-    selectorValue = scopeSelector(svg, selector);
+    selectorValue = scopeSelector(root, selector, panel);
   }
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.LINE,
     title,
     selectors: selectorValue,
@@ -288,19 +294,7 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
     data,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{
-      ...(legend.length > 0 ? { legend } : {}),
-      layers: [layer],
-    }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer, legend };
 }
 
 /**

--- a/src/adapters/d3/binders/scatter.ts
+++ b/src/adapters/d3/binders/scatter.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible scatter plot interaction.
  */
 
-import type { Maidr, MaidrLayer, ScatterPoint } from '../../../type/grammar';
-import type { D3BinderResult, D3ScatterConfig } from '../types';
+import type { MaidrLayer, ScatterPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3ScatterConfig } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
 
 /**
  * Binds a D3.js scatter plot to MAIDR, generating the accessible data representation.
@@ -50,20 +51,26 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Scatter(svg: Element, config: D3ScatterConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildScatterLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for scatter plots. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildScatterLayer(root: Element, config: D3ScatterConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
-    autoApply,
   } = config;
 
-  const elements = queryD3Elements(svg, selector);
+  const elements = queryD3Elements(root, selector);
   if (elements.length === 0) {
-    throw buildNoElementsError(svg, selector, 'scatter point');
+    throw buildNoElementsError(root, selector, 'scatter point');
   }
 
   // Infer accessors from the first datum's keys when the user did not specify.
@@ -93,24 +100,14 @@ export function bindD3Scatter(svg: Element, config: D3ScatterConfig): D3BinderRe
     };
   });
 
-  const layerId = generateId();
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.SCATTER,
     title,
-    selectors: scopeSelector(svg, selector),
+    selectors: scopeSelector(root, selector, panel),
     axes: buildAxes(axes, format),
     data,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{ layers: [layer] }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer };
 }

--- a/src/adapters/d3/binders/segmented.ts
+++ b/src/adapters/d3/binders/segmented.ts
@@ -5,11 +5,12 @@
  * and generates the MAIDR JSON schema for accessible interaction.
  */
 
-import type { Maidr, MaidrLayer, SegmentedPoint } from '../../../type/grammar';
-import type { D3BinderResult, D3SegmentedConfig } from '../types';
+import type { MaidrLayer, SegmentedPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3SegmentedConfig } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
 
 /**
  * Binds a D3.js segmented bar chart (stacked, dodged, or normalized) to MAIDR.
@@ -65,18 +66,24 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildSegmentedLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for segmented bar charts. See {@link buildBarLayer}
+ * for the single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildSegmentedLayer(root: Element, config: D3SegmentedConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
     groupSelector,
     type = TraceType.STACKED,
     domOrder: domOrderOverride,
-    autoApply,
   } = config;
 
   const groupOrder: string[] = [];
@@ -96,9 +103,9 @@ export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3Bind
     // then all of group 1, …) ⇒ series-major DOM order.
     detectedDomOrder = 'series-major';
 
-    const groupElements = queryD3Elements(svg, groupSelector);
+    const groupElements = queryD3Elements(root, groupSelector);
     if (groupElements.length === 0) {
-      throw buildNoElementsError(svg, groupSelector, 'segmented-bar group');
+      throw buildNoElementsError(root, groupSelector, 'segmented-bar group');
     }
 
     // Sample the first group's first segment for accessor inference.
@@ -153,9 +160,9 @@ export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3Bind
     }
   } else {
     // Flat structure: all segments in one container, grouped by fill value
-    const elements = queryD3Elements(svg, selector);
+    const elements = queryD3Elements(root, selector);
     if (elements.length === 0) {
-      throw buildNoElementsError(svg, selector, 'segmented bar');
+      throw buildNoElementsError(root, selector, 'segmented bar');
     }
 
     // Pattern detection: if the datum looks like a d3.stack() tuple
@@ -258,10 +265,9 @@ export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3Bind
     }
   }
 
-  const layerId = generateId();
   const selectorValue = groupSelector
-    ? scopeSelector(svg, `${groupSelector} ${selector}`)
-    : scopeSelector(svg, selector);
+    ? scopeSelector(root, `${groupSelector} ${selector}`, panel)
+    : scopeSelector(root, selector, panel);
 
   // Resolve final DOM order: explicit user override wins; else detected value;
   // else fall back to the chart type (stacked/normalized render series-major,
@@ -280,7 +286,7 @@ export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3Bind
     : { order: 'column' as const, groupDirection: 'forward' as const };
 
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type,
     title,
     selectors: selectorValue,
@@ -289,17 +295,5 @@ export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3Bind
     domMapping,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{
-      legend: groupOrder,
-      layers: [layer],
-    }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer, legend: groupOrder };
 }

--- a/src/adapters/d3/binders/smooth.ts
+++ b/src/adapters/d3/binders/smooth.ts
@@ -5,11 +5,12 @@
  * the MAIDR JSON schema for accessible smooth plot interaction.
  */
 
-import type { Maidr, MaidrLayer, SmoothPoint } from '../../../type/grammar';
-import type { D3BinderResult, D3SmoothConfig } from '../types';
+import type { MaidrLayer, SmoothPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3SmoothConfig } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, generateId, queryD3Elements, resolveAccessor } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, queryD3Elements, resolveAccessor } from '../util';
 
 /**
  * Binds a D3.js smooth/regression curve to MAIDR.
@@ -53,11 +54,18 @@ import { applyMaidrData, buildAxes, buildNoDatumError, buildNoElementsError, gen
  * ```
  */
 export function bindD3Smooth(svg: Element, config: D3SmoothConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildSmoothLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for smooth/regression curves. See {@link buildBarLayer}
+ * for the single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildSmoothLayer(root: Element, config: D3SmoothConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
-    id = generateId(),
     title,
-    subtitle,
-    caption,
     axes,
     format,
     selector,
@@ -65,12 +73,11 @@ export function bindD3Smooth(svg: Element, config: D3SmoothConfig): D3BinderResu
     y: yAccessor = 'y',
     svgX: svgXAccessor = 'svg_x',
     svgY: svgYAccessor = 'svg_y',
-    autoApply,
   } = config;
 
-  const elements = queryD3Elements(svg, selector);
+  const elements = queryD3Elements(root, selector);
   if (elements.length === 0) {
-    throw buildNoElementsError(svg, selector, 'smooth curve point');
+    throw buildNoElementsError(root, selector, 'smooth curve point');
   }
 
   // Guard: smooth curves need SVG-space coords so MAIDR can highlight points
@@ -115,27 +122,17 @@ export function bindD3Smooth(svg: Element, config: D3SmoothConfig): D3BinderResu
 
   const data: SmoothPoint[][] = [points];
 
-  const layerId = generateId();
   const layer: MaidrLayer = {
-    id: layerId,
+    id: generateId(),
     type: TraceType.SMOOTH,
     title,
     // Wrap in an array so the per-line length check inside
     // `mapToSvgElements` compares array length to line count (1). A bare
     // string would compare character count to 1 and always fail.
-    selectors: [scopeSelector(svg, selector)],
+    selectors: [scopeSelector(root, selector, panel)],
     axes: buildAxes(axes, format),
     data,
   };
 
-  const maidr: Maidr = {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[{ layers: [layer] }]],
-  };
-
-  applyMaidrData(svg, maidr, autoApply);
-  return { maidr, layer };
+  return { layer };
 }

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -34,8 +34,8 @@ import type {
   D3SubplotsConfig,
   DataAccessor,
 } from '../types';
-import { cssEscape, ensureContainerId, PANEL_ATTRIBUTE } from '../selectors';
-import { applyMaidrData, generateId, getD3Datum, resolveAccessorOptional } from '../util';
+import { ensureContainerId, PANEL_ATTRIBUTE } from '../selectors';
+import { applyMaidrData, generateId, getD3Datum, isMaidrOwned, resolveAccessorOptional } from '../util';
 import { buildBarLayer } from './bar';
 import { buildBoxLayer } from './box';
 import { buildCandlestickLayer } from './candlestick';
@@ -91,7 +91,11 @@ import { buildSmoothLayer } from './smooth';
 export function bindD3Facets(svg: Element, config: D3FacetsConfig): D3MultiPanelResult {
   const { panelSelector, panelTitle, layout } = config;
 
-  const panels = Array.from(svg.querySelectorAll(panelSelector));
+  // Skip MAIDR-owned hidden clones: while the chart is focused, the core
+  // keeps a hidden copy of highlighted geometry next to the originals, and
+  // those copies can match panelSelector on a live-data rebind.
+  const panels = Array.from(svg.querySelectorAll(panelSelector))
+    .filter(panel => !isMaidrOwned(panel));
   if (panels.length === 0) {
     throw new Error(
       `bindD3Facets: no panel elements found for panelSelector "${panelSelector}". `
@@ -203,11 +207,15 @@ function buildPanelGrid(
     built.layer.title = titleFor(cell.panelEl, index, built.layer.title);
     layers.push(built.layer);
 
+    // Deliberately NO subplot-level `selector`: the core deep-clones whatever
+    // it matches into a hidden copy, and for a stamped panel that clone would
+    // carry the copied `axes_*` id — the active-panel outline would then be
+    // drawn inside the invisible clone. With the selector absent, the core
+    // anchors axes lookup and panel geometry on the first layer selector's
+    // first match (an original mark inside the original panel), the same
+    // convention the known-good examples/facet_barplot.html uses.
     return {
       ...(built.legend && built.legend.length > 0 ? { legend: built.legend } : {}),
-      // The panel's own container element: used by the core for the
-      // subplot-level highlight and as the anchor for axes-group lookup.
-      selector: `#${cssEscape(containerId)} [${PANEL_ATTRIBUTE}="${index}"]`,
       layers: [built.layer],
     };
   }));
@@ -242,11 +250,14 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
 }
 
 /**
- * Resolves a facet panel's display title from its D3-bound datum.
+ * Resolves a facet panel's display title.
  *
- * Priority: the user's `panelTitle` accessor; then automatic detection of the
- * `d3.groups` tuple (`[key, values]`) or nest-style (`{ key, values }`)
- * shapes; finally the positional fallback `Panel <n>`.
+ * Priority: the user's `panelTitle` accessor — function accessors are always
+ * invoked (with an `undefined` datum when the panel was appended without a
+ * D3 data join, so index-only accessors like `(_d, i) => keys[i]` keep
+ * working), while string-key accessors require a bound datum; then automatic
+ * detection of the `d3.groups` tuple (`[key, values]`) or nest-style
+ * (`{ key, values }`) shapes; finally the positional fallback `Panel <n>`.
  */
 function resolvePanelTitle(
   panelEl: Element,
@@ -254,15 +265,17 @@ function resolvePanelTitle(
   index: number,
 ): string {
   const datum = getD3Datum(panelEl);
-  if (datum !== undefined && datum !== null) {
-    if (accessor !== undefined) {
-      const value = resolveAccessorOptional<string>(datum, accessor, index);
-      if (value !== undefined && value !== null) {
-        return String(value);
-      }
-    } else if (Array.isArray(datum) && datum.length === 2) {
+  const hasDatum = datum !== undefined && datum !== null;
+  if (accessor !== undefined && (typeof accessor === 'function' || hasDatum)) {
+    const value = resolveAccessorOptional<string>(datum, accessor, index);
+    if (value !== undefined && value !== null) {
+      return String(value);
+    }
+  } else if (hasDatum) {
+    if (Array.isArray(datum) && datum.length === 2) {
       return String(datum[0]);
-    } else if (typeof datum === 'object' && 'key' in (datum as Record<string, unknown>)) {
+    }
+    if (typeof datum === 'object' && 'key' in (datum as Record<string, unknown>)) {
       return String((datum as Record<string, unknown>).key);
     }
   }
@@ -283,9 +296,12 @@ function clearPanelStamps(container: Element): void {
  *
  * Applied only when it cannot clobber user state: every panel must be a
  * `<g>` element whose id is either absent or already an `axes_*` id (from a
- * previous bind, keeping rebinds stable). Skipping is safe — navigation,
- * text, and audio work without the ids; only the visual panel outline and
- * DOM-based ordering are lost.
+ * previous bind, keeping rebinds stable). When stamping is skipped only the
+ * visual active-panel outline is lost: the core still resolves visual
+ * ordering and vertical arrow direction by measuring each panel's rendered
+ * geometry through the first element matched by the subplot's first layer
+ * selector (`resolveSubplotLayout`'s panel-geometry fallback), which the
+ * emitted `#<svgId> [data-maidr-panel="<i>"] …` selectors satisfy.
  */
 function stampAxesIdsIfClean(panels: Element[], containerId: string): void {
   const clean = panels.every(
@@ -334,7 +350,7 @@ function arrangeEntries(
   if (Array.isArray(entries[0])) {
     // Explicit 2D grid: preserve the user's shape (ragged rows allowed).
     const rows = entries as D3SubplotEntry[][];
-    return rows.map((row, rowIndex) => {
+    const grid = rows.map((row, rowIndex) => {
       if (row.length === 0) {
         throw new Error(
           `bindD3Subplots: row ${rowIndex} of \`subplots\` is empty. `
@@ -343,12 +359,15 @@ function arrangeEntries(
       }
       return row.map(entry => ({ root: resolveRoot(container, entry.root), entry }));
     });
+    assertUniqueRoots(grid.flat());
+    return grid;
   }
 
   const flat = (entries as D3SubplotEntry[]).map(entry => ({
     root: resolveRoot(container, entry.root),
     entry,
   }));
+  assertUniqueRoots(flat);
 
   if (layout === 'row') {
     return [flat];
@@ -366,12 +385,41 @@ function arrangeEntries(
     .map(row => row.map(root => cellByRoot.get(root)!));
 }
 
-/** Resolves an entry's `root` (element or selector) against the container. */
+/**
+ * Rejects subplot entries whose `root` resolves to the same panel element.
+ *
+ * Without this guard duplicates degrade silently instead of erroring: the
+ * geometry-inference path deduplicates the shared element (dropping one
+ * entry's chart entirely), and on every layout path the second panel stamp
+ * overwrites the first, leaving the first subplot with dead selectors and no
+ * highlighting.
+ */
+function assertUniqueRoots(cells: { root: Element; entry: D3SubplotEntry }[]): void {
+  const firstIndexByRoot = new Map<Element, number>();
+  cells.forEach(({ root }, index) => {
+    const first = firstIndexByRoot.get(root);
+    if (first !== undefined) {
+      throw new Error(
+        `bindD3Subplots: subplot entries ${first} and ${index} resolve to the `
+        + `same panel root element. Each subplot must have its own container `
+        + `element — check for duplicate \`root\` selectors.`,
+      );
+    }
+    firstIndexByRoot.set(root, index);
+  });
+}
+
+/**
+ * Resolves an entry's `root` (element or selector) against the container.
+ * MAIDR-owned hidden clones are skipped so a live-data rebind can never
+ * mistake the core's highlight copies for a panel root.
+ */
 function resolveRoot(container: Element, root: Element | string): Element {
   if (typeof root !== 'string') {
     return root;
   }
-  const resolved = container.querySelector(root);
+  const resolved = Array.from(container.querySelectorAll(root))
+    .find(candidate => !isMaidrOwned(candidate));
   if (!resolved) {
     throw new Error(
       `bindD3Subplots: no element found for panel root selector "${root}" `

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -1,0 +1,466 @@
+/**
+ * Multi-panel D3 binders: faceted small multiples and heterogeneous
+ * subplot grids.
+ *
+ * D3 has no declarative facet API — the community idiom is one translated
+ * `<g>` per panel inside a single `<svg>`. These binders compose the existing
+ * per-type extraction cores (`buildBarLayer`, `buildLineLayer`, …) across
+ * panels and assemble a multi-subplot MAIDR figure:
+ *
+ * - {@link bindD3Facets} — the SAME chart type repeated in every panel
+ *   (small multiples), panels discovered via a `panelSelector`.
+ * - {@link bindD3Subplots} — DIFFERENT chart types per panel, each with its
+ *   own config and DOM root.
+ *
+ * Panel isolation: MAIDR resolves selectors via page-global
+ * `document.querySelector`, so each panel element is stamped with a
+ * `data-maidr-panel="<i>"` attribute and every emitted layer selector is
+ * prefixed `#<svgId> [data-maidr-panel="<i>"]` — panel A's selector can never
+ * match panel B's marks. Panels that are anonymous `<g>` elements are
+ * additionally given `id="axes_<svgId>_<i>"` so the MAIDR core can outline
+ * the active panel and resolve visual navigation order (same convention the
+ * Plotly adapter uses).
+ */
+
+import type { Maidr, MaidrLayer, MaidrSubplot } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type {
+  D3BuiltLayer,
+  D3FacetsConfig,
+  D3MultiPanelResult,
+  D3PanelChartSpec,
+  D3PanelLayout,
+  D3SubplotEntry,
+  D3SubplotsConfig,
+  DataAccessor,
+} from '../types';
+import { cssEscape, ensureContainerId, PANEL_ATTRIBUTE } from '../selectors';
+import { applyMaidrData, generateId, getD3Datum, resolveAccessorOptional } from '../util';
+import { buildBarLayer } from './bar';
+import { buildBoxLayer } from './box';
+import { buildCandlestickLayer } from './candlestick';
+import { buildHeatmapLayer } from './heatmap';
+import { buildHistogramLayer } from './histogram';
+import { buildLineLayer } from './line';
+import { buildScatterLayer } from './scatter';
+import { buildSegmentedLayer } from './segmented';
+import { buildSmoothLayer } from './smooth';
+
+/**
+ * Binds a faceted D3 chart (homogeneous small multiples) to MAIDR.
+ *
+ * Every element matched by `panelSelector` inside the SVG becomes one MAIDR
+ * subplot; the per-type binder selected by `chartType` runs with that panel
+ * element as its extraction root, so `config.selector` (e.g. `'rect.bar'`)
+ * only needs to match marks *within* a panel.
+ *
+ * Panel display titles come from `panelTitle`, resolved against each panel
+ * element's D3-bound `__data__`. When panels were joined with `d3.groups`
+ * output (`[key, values]` tuples) or nest-style `{ key, values }` objects,
+ * the group key is used automatically; otherwise the fallback is `Panel <n>`.
+ *
+ * The grid shape follows `layout` when given, else panel geometry (bounding
+ * boxes, then `transform="translate(x,y)"`), else a single row in DOM order.
+ * Panels are emitted in visual reading order (top-left first).
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered**, exactly like the single-chart
+ * binders: panel elements and their marks must exist with `__data__` bound.
+ *
+ * @param svg - The SVG element containing all panels.
+ * @param config - Panel selector, chart type + per-type config, and options.
+ * @returns A {@link D3MultiPanelResult} with the multi-subplot MAIDR data.
+ *
+ * @example
+ * ```ts
+ * // One <g class="panel"> per cylinder count, each holding rect.bar marks
+ * const result = bindD3Facets(svgElement, {
+ *   panelSelector: 'g.panel',
+ *   chartType: 'bar',
+ *   config: {
+ *     selector: 'rect.bar',
+ *     title: 'MPG by Origin, faceted by Cylinders',
+ *     axes: { x: 'Origin', y: 'MPG' },
+ *     x: 'origin',
+ *     y: 'mpg',
+ *   },
+ *   panelTitle: d => `cyl = ${d[0]}`, // d3.groups tuple
+ * });
+ * ```
+ */
+export function bindD3Facets(svg: Element, config: D3FacetsConfig): D3MultiPanelResult {
+  const { panelSelector, panelTitle, layout } = config;
+
+  const panels = Array.from(svg.querySelectorAll(panelSelector));
+  if (panels.length === 0) {
+    throw new Error(
+      `bindD3Facets: no panel elements found for panelSelector "${panelSelector}". `
+      + `Each facet panel should be a container element (typically a translated `
+      + `<g>) inside the SVG, created before the binder runs.`,
+    );
+  }
+
+  const grid = arrangePanels(panels, layout);
+  const { id = generateId(), title, subtitle, caption, autoApply } = config.config;
+
+  const { subplots, layers } = buildPanelGrid(
+    svg,
+    grid.map(row => row.map(panelEl => ({ panelEl, spec: config }))),
+    (panelEl, index) => resolvePanelTitle(panelEl, panelTitle, index),
+  );
+
+  const maidr: Maidr = { id, title, subtitle, caption, subplots };
+  applyMaidrData(svg, maidr, autoApply);
+  return { maidr, layers };
+}
+
+/**
+ * Binds a heterogeneous grid of D3 charts (one SVG, several independently
+ * drawn panels of possibly different chart types) to MAIDR.
+ *
+ * Each entry names a chart type, its binder config, and the panel's DOM
+ * `root` (an element or a CSS selector resolved against `container`). The
+ * matching per-type binder runs against that root and the resulting layer
+ * becomes one MAIDR subplot.
+ *
+ * Pass `subplots` as a 2D array for an explicit row-major grid (ragged rows
+ * allowed), or as a flat array arranged via `layout` / geometry inference —
+ * see {@link D3PanelLayout}.
+ *
+ * @param container - The SVG (or wrapping element) containing all panels.
+ * @param spec - Figure-level fields plus the panel entries.
+ * @returns A {@link D3MultiPanelResult} with the multi-subplot MAIDR data.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Subplots(svgElement, {
+ *   title: 'Sales Overview',
+ *   subplots: [[
+ *     { chartType: 'bar', root: 'g.revenue', config: { selector: 'rect.bar', title: 'Revenue' } },
+ *     { chartType: 'line', root: 'g.trend', config: { selector: 'path.line', title: 'Trend' } },
+ *   ]],
+ * });
+ * ```
+ */
+export function bindD3Subplots(container: Element, spec: D3SubplotsConfig): D3MultiPanelResult {
+  const { id = generateId(), title, subtitle, caption, autoApply, layout } = spec;
+
+  const grid = arrangeEntries(container, spec.subplots, layout);
+
+  const { subplots, layers } = buildPanelGrid(
+    container,
+    grid.map(row => row.map(({ root, entry }) => ({ panelEl: root, spec: entry }))),
+    (_panelEl, index, layerTitle) => layerTitle ?? `Panel ${index + 1}`,
+  );
+
+  const maidr: Maidr = { id, title, subtitle, caption, subplots };
+  applyMaidrData(container, maidr, autoApply);
+  return { maidr, layers };
+}
+
+/** One cell of the resolved panel grid: the extraction root + what to bind. */
+interface PanelCell {
+  panelEl: Element;
+  spec: D3PanelChartSpec;
+}
+
+/**
+ * Shared assembly for both multi-panel binders: stamps panels, runs the
+ * per-type builder for each cell, applies panel titles, and produces the
+ * `MaidrSubplot[][]` grid plus the flat layer list.
+ *
+ * @param container - The outer SVG/container that anchors all selectors.
+ * @param grid - Row-major grid of panel cells (visual reading order).
+ * @param titleFor - Resolves the panel display title; receives the panel
+ *                   element, its running index, and the layer title the
+ *                   builder produced from the cell's own config.
+ */
+function buildPanelGrid(
+  container: Element,
+  grid: PanelCell[][],
+  titleFor: (panelEl: Element, index: number, layerTitle?: string) => string,
+): { subplots: MaidrSubplot[][]; layers: MaidrLayer[] } {
+  clearPanelStamps(container);
+  const containerId = ensureContainerId(container);
+
+  let panelIndex = 0;
+  const layers: MaidrLayer[] = [];
+  const subplots: MaidrSubplot[][] = grid.map(row => row.map((cell) => {
+    const index = panelIndex++;
+    cell.panelEl.setAttribute(PANEL_ATTRIBUTE, String(index));
+
+    const panelScope: D3PanelScope = { container, panelIndex: index };
+    let built: D3BuiltLayer;
+    try {
+      built = buildPanelLayer(cell.panelEl, cell.spec, panelScope);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`D3 multi-panel bind failed in panel ${index}: ${message}`);
+    }
+
+    // The FIRST layer's title is the panel's display name in the core's
+    // subplot navigation summaries — there is no subplot-level title field.
+    built.layer.title = titleFor(cell.panelEl, index, built.layer.title);
+    layers.push(built.layer);
+
+    return {
+      ...(built.legend && built.legend.length > 0 ? { legend: built.legend } : {}),
+      // The panel's own container element: used by the core for the
+      // subplot-level highlight and as the anchor for axes-group lookup.
+      selector: `#${cssEscape(containerId)} [${PANEL_ATTRIBUTE}="${index}"]`,
+      layers: [built.layer],
+    };
+  }));
+
+  stampAxesIdsIfClean(grid.flat().map(cell => cell.panelEl), containerId);
+
+  return { subplots, layers };
+}
+
+/** Dispatches a panel cell to the matching per-type extraction core. */
+function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelScope): D3BuiltLayer {
+  switch (spec.chartType) {
+    case 'bar':
+      return buildBarLayer(root, spec.config, panel);
+    case 'box':
+      return buildBoxLayer(root, spec.config, panel);
+    case 'candlestick':
+      return buildCandlestickLayer(root, spec.config, panel);
+    case 'heatmap':
+      return buildHeatmapLayer(root, spec.config, panel);
+    case 'histogram':
+      return buildHistogramLayer(root, spec.config, panel);
+    case 'line':
+      return buildLineLayer(root, spec.config, panel);
+    case 'scatter':
+      return buildScatterLayer(root, spec.config, panel);
+    case 'segmented':
+      return buildSegmentedLayer(root, spec.config, panel);
+    case 'smooth':
+      return buildSmoothLayer(root, spec.config, panel);
+  }
+}
+
+/**
+ * Resolves a facet panel's display title from its D3-bound datum.
+ *
+ * Priority: the user's `panelTitle` accessor; then automatic detection of the
+ * `d3.groups` tuple (`[key, values]`) or nest-style (`{ key, values }`)
+ * shapes; finally the positional fallback `Panel <n>`.
+ */
+function resolvePanelTitle(
+  panelEl: Element,
+  accessor: DataAccessor<string> | undefined,
+  index: number,
+): string {
+  const datum = getD3Datum(panelEl);
+  if (datum !== undefined && datum !== null) {
+    if (accessor !== undefined) {
+      const value = resolveAccessorOptional<string>(datum, accessor, index);
+      if (value !== undefined && value !== null) {
+        return String(value);
+      }
+    } else if (Array.isArray(datum) && datum.length === 2) {
+      return String(datum[0]);
+    } else if (typeof datum === 'object' && 'key' in (datum as Record<string, unknown>)) {
+      return String((datum as Record<string, unknown>).key);
+    }
+  }
+  return `Panel ${index + 1}`;
+}
+
+/** Removes stale panel stamps so rebinding after a data update is idempotent. */
+function clearPanelStamps(container: Element): void {
+  for (const el of Array.from(container.querySelectorAll(`[${PANEL_ATTRIBUTE}]`))) {
+    el.removeAttribute(PANEL_ATTRIBUTE);
+  }
+}
+
+/**
+ * Stamps `id="axes_<containerId>_<i>"` on panel elements so the MAIDR core
+ * can outline the active panel and resolve visual navigation order (it keys
+ * off `g[id^="axes_"]` groups — the matplotlib/Plotly convention).
+ *
+ * Applied only when it cannot clobber user state: every panel must be a
+ * `<g>` element whose id is either absent or already an `axes_*` id (from a
+ * previous bind, keeping rebinds stable). Skipping is safe — navigation,
+ * text, and audio work without the ids; only the visual panel outline and
+ * DOM-based ordering are lost.
+ */
+function stampAxesIdsIfClean(panels: Element[], containerId: string): void {
+  const clean = panels.every(
+    panel => panel.localName === 'g' && (!panel.id || panel.id.startsWith('axes_')),
+  );
+  if (!clean) {
+    return;
+  }
+  panels.forEach((panel, index) => {
+    if (!panel.id) {
+      panel.id = `axes_${containerId}_${index}`;
+    }
+  });
+}
+
+/**
+ * Arranges facet panel elements into a row-major grid per the explicit
+ * `layout` (which always wins) or geometry inference.
+ */
+function arrangePanels(panels: Element[], layout?: D3PanelLayout): Element[][] {
+  if (layout === 'row') {
+    return [panels.slice()];
+  }
+  if (layout === 'column') {
+    return panels.map(panel => [panel]);
+  }
+  if (layout && typeof layout === 'object') {
+    return chunkIntoRows(panels, layout);
+  }
+  return clusterByGeometry(panels);
+}
+
+/**
+ * Resolves subplot entries (2D or flat) into a grid of `{ root, entry }`
+ * cells, applying `layout` / geometry inference for flat arrays.
+ */
+function arrangeEntries(
+  container: Element,
+  entries: D3SubplotEntry[][] | D3SubplotEntry[],
+  layout?: D3PanelLayout,
+): { root: Element; entry: D3SubplotEntry }[][] {
+  if (entries.length === 0) {
+    throw new Error('bindD3Subplots: `subplots` must contain at least one entry.');
+  }
+
+  if (Array.isArray(entries[0])) {
+    // Explicit 2D grid: preserve the user's shape (ragged rows allowed).
+    const rows = entries as D3SubplotEntry[][];
+    return rows.map((row, rowIndex) => {
+      if (row.length === 0) {
+        throw new Error(
+          `bindD3Subplots: row ${rowIndex} of \`subplots\` is empty. `
+          + `Every row of the grid must contain at least one panel.`,
+        );
+      }
+      return row.map(entry => ({ root: resolveRoot(container, entry.root), entry }));
+    });
+  }
+
+  const flat = (entries as D3SubplotEntry[]).map(entry => ({
+    root: resolveRoot(container, entry.root),
+    entry,
+  }));
+
+  if (layout === 'row') {
+    return [flat];
+  }
+  if (layout === 'column') {
+    return flat.map(cell => [cell]);
+  }
+  if (layout && typeof layout === 'object') {
+    return chunkIntoRows(flat, layout);
+  }
+
+  // Geometry inference: cluster the roots, then map back to their entries.
+  const cellByRoot = new Map(flat.map(cell => [cell.root, cell]));
+  return clusterByGeometry(flat.map(cell => cell.root))
+    .map(row => row.map(root => cellByRoot.get(root)!));
+}
+
+/** Resolves an entry's `root` (element or selector) against the container. */
+function resolveRoot(container: Element, root: Element | string): Element {
+  if (typeof root !== 'string') {
+    return root;
+  }
+  const resolved = container.querySelector(root);
+  if (!resolved) {
+    throw new Error(
+      `bindD3Subplots: no element found for panel root selector "${root}" `
+      + `inside the container. Panel roots must exist before the binder runs.`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Chunks items row-major into a grid with the requested column count
+ * (or `ceil(count / rows)` columns when only `rows` is given). The final
+ * row may be shorter; it is never empty.
+ */
+function chunkIntoRows<T>(items: T[], layout: { rows?: number; columns?: number }): T[][] {
+  const columns = layout.columns
+    ?? (layout.rows ? Math.ceil(items.length / layout.rows) : items.length);
+  const size = Math.max(1, columns);
+  const rows: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    rows.push(items.slice(i, i + size));
+  }
+  return rows;
+}
+
+/**
+ * Infers the grid from panel geometry, emitting rows in visual reading order
+ * (top row first, left-to-right within a row):
+ *
+ * 1. Bounding-box centers, clustered by y with a tolerance of half the
+ *    median panel height.
+ * 2. When bounding boxes are unavailable (all zero — e.g. jsdom, detached
+ *    nodes), `transform="translate(x,y)"` values with a small tolerance.
+ * 3. When neither yields positions, a single row in DOM order.
+ */
+function clusterByGeometry(panels: Element[]): Element[][] {
+  const rects = panels.map(panel => panel.getBoundingClientRect());
+  const hasBoxes = rects.some(
+    rect => rect.width > 0 || rect.height > 0 || rect.left !== 0 || rect.top !== 0,
+  );
+
+  let positions: { el: Element; x: number; y: number }[];
+  let tolerance: number;
+
+  if (hasBoxes) {
+    positions = panels.map((el, i) => ({
+      el,
+      x: rects[i].left + rects[i].width / 2,
+      y: rects[i].top + rects[i].height / 2,
+    }));
+    const heights = rects
+      .map(rect => rect.height)
+      .filter(height => height > 0)
+      .sort((a, b) => a - b);
+    tolerance = heights.length > 0 ? heights[Math.floor(heights.length / 2)] / 2 : 1;
+  } else {
+    const translates = panels.map(panel => parseTranslate(panel.getAttribute('transform')));
+    if (translates.every(translate => translate === null)) {
+      return [panels.slice()];
+    }
+    positions = panels.map((el, i) => ({
+      el,
+      x: translates[i]?.x ?? 0,
+      y: translates[i]?.y ?? 0,
+    }));
+    tolerance = 0.5;
+  }
+
+  const sorted = positions.slice().sort((a, b) => a.y - b.y || a.x - b.x);
+  const rows: { el: Element; x: number; y: number }[][] = [];
+  for (const position of sorted) {
+    const currentRow = rows[rows.length - 1];
+    if (currentRow && Math.abs(position.y - currentRow[0].y) <= tolerance) {
+      currentRow.push(position);
+    } else {
+      rows.push([position]);
+    }
+  }
+  return rows.map(row => row.slice().sort((a, b) => a.x - b.x).map(position => position.el));
+}
+
+/** Parses the x/y of a `translate(x[, y])` transform, or `null` when absent. */
+function parseTranslate(transform: string | null): { x: number; y: number } | null {
+  if (!transform) {
+    return null;
+  }
+  const match = /translate\(\s*(-?[\d.]+(?:e[-+]?\d+)?)(?:[\s,]+(-?[\d.]+(?:e[-+]?\d+)?))?\s*\)/i.exec(transform);
+  if (!match) {
+    return null;
+  }
+  return { x: Number(match[1]), y: Number(match[2] ?? 0) };
+}

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -21,6 +21,13 @@
  * - **Segmented bar charts** (stacked, dodged, normalized) via {@link bindD3Segmented}
  * - **Smooth/regression curves** via {@link bindD3Smooth}
  *
+ * ## Multi-Panel Charts
+ *
+ * - **Faceted small multiples** (one chart type repeated per panel inside a
+ *   single SVG) via {@link bindD3Facets}
+ * - **Heterogeneous subplot grids** (different chart types per panel) via
+ *   {@link bindD3Subplots}
+ *
  * ## How It Works
  *
  * D3.js binds data to DOM elements via the `__data__` property during `.data()`
@@ -94,6 +101,7 @@ export { bindD3Line } from './binders/line';
 export { bindD3Scatter } from './binders/scatter';
 export { bindD3Segmented } from './binders/segmented';
 export { bindD3Smooth } from './binders/smooth';
+export { bindD3Facets, bindD3Subplots } from './binders/subplots';
 
 // Types
 export type {
@@ -102,12 +110,18 @@ export type {
   D3BinderResult,
   D3BoxConfig,
   D3CandlestickConfig,
+  D3FacetsConfig,
   D3HeatmapConfig,
   D3HistogramConfig,
   D3LineConfig,
+  D3MultiPanelResult,
+  D3PanelChartSpec,
+  D3PanelLayout,
   D3ScatterConfig,
   D3SegmentedConfig,
   D3SmoothConfig,
+  D3SubplotEntry,
+  D3SubplotsConfig,
   DataAccessor,
   SegmentedTraceType,
 } from './types';

--- a/src/adapters/d3/selectors.ts
+++ b/src/adapters/d3/selectors.ts
@@ -39,6 +39,43 @@ export function ensureContainerId(container: Element): string {
   return ensureSharedContainerId(container, D3_ID_PREFIX);
 }
 
+/** Attribute stamped on each panel element by the multi-panel binders. */
+export const PANEL_ATTRIBUTE = 'data-maidr-panel';
+
+/**
+ * Panel scope for multi-panel (faceted / composed) binds.
+ *
+ * When a binder extracts one panel of a multi-panel figure, its extraction
+ * root is the panel element — not the outer SVG. Emitted selectors must still
+ * be anchored to the OUTER SVG's page-unique id (MAIDR resolves selectors via
+ * `document.querySelector`) and additionally narrowed to the panel via the
+ * `data-maidr-panel` attribute, so panel A's selector can never match panel
+ * B's marks.
+ */
+export interface D3PanelScope {
+  /** The outer SVG (or container) whose id anchors all emitted selectors. */
+  container: Element;
+  /** The index stamped on the panel element as `data-maidr-panel`. */
+  panelIndex: number;
+}
+
+/**
+ * Returns the absolute selector prefix for a container — `#<id>` for
+ * single-panel binds, `#<id> [data-maidr-panel="<i>"]` when a panel scope is
+ * given. Binders that build custom selector strings (line, box) concatenate
+ * this prefix with their own per-element attribute selectors.
+ *
+ * @param container - The extraction root (the SVG, or a panel element).
+ * @param panel - Optional panel scope; when present, its `container` (the
+ *                outer SVG) supplies the id and the panel segment is appended.
+ * @returns The selector prefix, without a trailing space.
+ */
+export function selectorPrefix(container: Element, panel?: D3PanelScope): string {
+  const id = ensureContainerId(panel?.container ?? container);
+  const base = `#${cssEscape(id)}`;
+  return panel ? `${base} [${PANEL_ATTRIBUTE}="${panel.panelIndex}"]` : base;
+}
+
 /**
  * Scopes a user-provided selector to a container, prefixing the result with
  * the container's id so it resolves uniquely under page-global lookups
@@ -46,11 +83,14 @@ export function ensureContainerId(container: Element): string {
  * auto-assigned via {@link ensureContainerId} so every binder emits an
  * absolutely-scoped selector without per-binder boilerplate.
  *
- * @param container - The root SVG container.
+ * With a {@link D3PanelScope}, the emitted selector is additionally narrowed
+ * to the panel: `#<svgId> [data-maidr-panel="<i>"] <selector>`.
+ *
+ * @param container - The root SVG container (or panel extraction root).
  * @param selector - The user-provided CSS selector.
+ * @param panel - Optional panel scope for multi-panel binds.
  * @returns The id-scoped selector string, e.g. `#<svgId> <selector>`.
  */
-export function scopeSelector(container: Element, selector: string): string {
-  const id = ensureContainerId(container);
-  return `#${cssEscape(id)} ${selector}`;
+export function scopeSelector(container: Element, selector: string, panel?: D3PanelScope): string {
+  return `${selectorPrefix(container, panel)} ${selector}`;
 }

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -388,7 +388,12 @@ export type D3FacetsConfig = D3PanelChartSpec & {
    * Accessor for each panel's display title, resolved against the panel
    * element's D3-bound `__data__` (for `d3.groups` output, the `[key,
    * values]` tuple — pass `d => d[0]` or rely on the automatic key
-   * detection). Falls back to `Panel <n>` when unresolvable.
+   * detection). Function accessors receive `(datum, index)` and are invoked
+   * even when the panel has no bound datum (`datum` is then `undefined`),
+   * so index-only accessors like `(_d, i) => keys[i]` work for panels
+   * appended without a data join; string-key accessors and the automatic
+   * key detection require a bound datum. Falls back to `Panel <n>` when
+   * unresolvable.
    */
   panelTitle?: DataAccessor<string>;
   /** Explicit grid layout. When omitted, inferred from panel geometry. */

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -324,6 +324,132 @@ export interface D3BinderResult {
 }
 
 /**
+ * Output of a per-type layer builder (the pure extraction core each binder
+ * shares between its single-chart export and the multi-panel binders).
+ */
+export interface D3BuiltLayer {
+  /** The extracted MAIDR layer. */
+  layer: MaidrLayer;
+  /** Legend labels (line / segmented charts only). */
+  legend?: string[];
+}
+
+/**
+ * Discriminated union pairing a chart type with its binder-specific config.
+ * This is the per-panel unit consumed by the multi-panel binders and the
+ * base of the React adapter's {@link D3AdapterSpec}.
+ */
+export type D3PanelChartSpec
+  = | { chartType: 'bar'; config: D3BarConfig }
+    | { chartType: 'box'; config: D3BoxConfig }
+    | { chartType: 'candlestick'; config: D3CandlestickConfig }
+    | { chartType: 'heatmap'; config: D3HeatmapConfig }
+    | { chartType: 'histogram'; config: D3HistogramConfig }
+    | { chartType: 'line'; config: D3LineConfig }
+    | { chartType: 'scatter'; config: D3ScatterConfig }
+    | { chartType: 'segmented'; config: D3SegmentedConfig }
+    | { chartType: 'smooth'; config: D3SmoothConfig };
+
+/**
+ * Grid layout hint for multi-panel binds.
+ *
+ * - `'row'` — all panels in a single row (side by side).
+ * - `'column'` — all panels in a single column (stacked).
+ * - `{ rows?, columns? }` — chunk panels into a grid with the given number of
+ *   columns (or `ceil(count / rows)` columns when only `rows` is set). The
+ *   last row may be shorter (ragged grids are supported).
+ *
+ * When omitted, the binders infer the grid from panel geometry: panel
+ * bounding-box centers are clustered by y (rows) and sorted by x within each
+ * row, falling back to parsing `transform="translate(x,y)"` when bounding
+ * boxes are unavailable (e.g. jsdom), and finally to a single row in DOM
+ * order. An explicit `layout` always wins over geometry.
+ */
+export type D3PanelLayout = 'row' | 'column' | { rows?: number; columns?: number };
+
+/**
+ * Configuration for {@link bindD3Facets} — homogeneous small multiples
+ * (one chart type repeated across panels inside a single SVG).
+ *
+ * The `chartType` / `config` pair selects the per-panel binder; the inner
+ * `config` also carries the figure-level fields (`id`, `title`, `subtitle`,
+ * `caption`, `autoApply`). Each matched panel element becomes the extraction
+ * root for the per-type binder, so `config.selector` is resolved *within*
+ * each panel.
+ */
+export type D3FacetsConfig = D3PanelChartSpec & {
+  /**
+   * CSS selector for the panel container elements inside the SVG — the
+   * canonical D3 facet idiom is one translated `<g>` per panel (e.g.
+   * `'g.panel'`). Each match becomes one MAIDR subplot.
+   */
+  panelSelector: string;
+  /**
+   * Accessor for each panel's display title, resolved against the panel
+   * element's D3-bound `__data__` (for `d3.groups` output, the `[key,
+   * values]` tuple — pass `d => d[0]` or rely on the automatic key
+   * detection). Falls back to `Panel <n>` when unresolvable.
+   */
+  panelTitle?: DataAccessor<string>;
+  /** Explicit grid layout. When omitted, inferred from panel geometry. */
+  layout?: D3PanelLayout;
+};
+
+/**
+ * One panel of a {@link bindD3Subplots} composition: which binder to run,
+ * its config, and the DOM subtree to extract from. The entry config's
+ * `title` becomes the panel's display name in subplot navigation summaries;
+ * its `id`, `subtitle`, `caption`, and `autoApply` are ignored (figure-level
+ * fields live on {@link D3SubplotsConfig}).
+ */
+export type D3SubplotEntry = D3PanelChartSpec & {
+  /**
+   * The panel's root element, or a CSS selector resolved against the outer
+   * container passed to `bindD3Subplots`.
+   */
+  root: Element | string;
+};
+
+/**
+ * Configuration for {@link bindD3Subplots} — a heterogeneous grid of
+ * independently-drawn charts inside one SVG (or container).
+ */
+export interface D3SubplotsConfig {
+  /**
+   * The panels, either as an explicit 2D grid (row-major, ragged rows
+   * allowed, empty rows not) or as a flat array arranged via `layout` /
+   * geometry inference.
+   */
+  subplots: D3SubplotEntry[][] | D3SubplotEntry[];
+  /** Grid layout for a flat `subplots` array. Ignored for 2D arrays. */
+  layout?: D3PanelLayout;
+  /** Unique identifier for the figure. Auto-generated when omitted. */
+  id?: string;
+  /** Figure title displayed in text descriptions. */
+  title?: string;
+  /** Figure subtitle. */
+  subtitle?: string;
+  /** Figure caption. */
+  caption?: string;
+  /**
+   * When `true` (the default), writes the generated MAIDR schema to the
+   * container as a `maidr-data` attribute. See {@link D3BinderConfig.autoApply}.
+   */
+  autoApply?: boolean;
+}
+
+/**
+ * Result of a multi-panel D3 binder ({@link bindD3Facets},
+ * {@link bindD3Subplots}).
+ */
+export interface D3MultiPanelResult {
+  /** Complete multi-subplot MAIDR JSON data. */
+  maidr: Maidr;
+  /** One generated layer per panel, in row-major (visual reading) order. */
+  layers: MaidrLayer[];
+}
+
+/**
  * Union of all supported data point types extracted by the D3 binder.
  */
 export type D3ExtractedData

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -56,16 +56,11 @@
 import type { RefObject } from 'react';
 import type { Maidr } from '../../type/grammar';
 import type {
-  D3BarConfig,
   D3BinderResult,
-  D3BoxConfig,
-  D3CandlestickConfig,
-  D3HeatmapConfig,
-  D3HistogramConfig,
-  D3LineConfig,
-  D3ScatterConfig,
-  D3SegmentedConfig,
-  D3SmoothConfig,
+  D3FacetsConfig,
+  D3MultiPanelResult,
+  D3PanelChartSpec,
+  D3SubplotsConfig,
 } from './types';
 import { useEffect, useRef, useState } from 'react';
 import { bindD3Bar } from './binders/bar';
@@ -77,23 +72,22 @@ import { bindD3Line } from './binders/line';
 import { bindD3Scatter } from './binders/scatter';
 import { bindD3Segmented } from './binders/segmented';
 import { bindD3Smooth } from './binders/smooth';
+import { bindD3Facets, bindD3Subplots } from './binders/subplots';
 
 /**
  * Discriminated union describing which binder to run and the config to pass it.
  *
  * The `chartType` field narrows the associated `config` to the correct
  * binder-specific type. This is what `useD3Adapter` and `<MaidrD3>` consume.
+ *
+ * Besides the nine single-chart types, `'facets'` (homogeneous small
+ * multiples) and `'subplots'` (heterogeneous panel grids) select the
+ * multi-panel binders.
  */
 export type D3AdapterSpec
-  = | { chartType: 'bar'; config: D3BarConfig }
-    | { chartType: 'box'; config: D3BoxConfig }
-    | { chartType: 'candlestick'; config: D3CandlestickConfig }
-    | { chartType: 'heatmap'; config: D3HeatmapConfig }
-    | { chartType: 'histogram'; config: D3HistogramConfig }
-    | { chartType: 'line'; config: D3LineConfig }
-    | { chartType: 'scatter'; config: D3ScatterConfig }
-    | { chartType: 'segmented'; config: D3SegmentedConfig }
-    | { chartType: 'smooth'; config: D3SmoothConfig };
+  = | D3PanelChartSpec
+    | { chartType: 'facets'; config: D3FacetsConfig }
+    | { chartType: 'subplots'; config: D3SubplotsConfig };
 
 /** The set of chart-type keys accepted by the D3 React adapter. */
 export type D3ChartType = D3AdapterSpec['chartType'];
@@ -117,7 +111,7 @@ export interface UseD3AdapterResult {
  * {@link Maidr}. The user's own `autoApply` (if any) is intentionally
  * ignored in the React path.
  */
-function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult {
+function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiPanelResult {
   switch (spec.chartType) {
     case 'bar':
       return bindD3Bar(svg, { ...spec.config, autoApply: false });
@@ -137,6 +131,38 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult {
       return bindD3Segmented(svg, { ...spec.config, autoApply: false });
     case 'smooth':
       return bindD3Smooth(svg, { ...spec.config, autoApply: false });
+    case 'facets':
+      return bindD3Facets(svg, withFacetsAutoApplyOff(spec.config));
+    case 'subplots':
+      return bindD3Subplots(svg, { ...spec.config, autoApply: false });
+  }
+}
+
+/**
+ * Forces `autoApply: false` on a facets config's inner per-type config
+ * (where the figure-level fields live). The switch re-narrows each arm so
+ * the `chartType` ↔ `config` correlation survives the spread.
+ */
+function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
+  switch (cfg.chartType) {
+    case 'bar':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'box':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'candlestick':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'heatmap':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'histogram':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'line':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'scatter':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'segmented':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'smooth':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
   }
 }
 

--- a/src/adapters/d3/util.ts
+++ b/src/adapters/d3/util.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AxisConfig, AxisFormat, Maidr, MaidrLayer } from '../../type/grammar';
-import type { D3AxisInput, D3BinderConfig, DataAccessor } from './types';
+import type { D3AxisInput, D3BinderConfig, D3BinderResult, D3BuiltLayer, DataAccessor } from './types';
 
 /**
  * Interface for DOM elements with D3's `__data__` property.
@@ -360,4 +360,35 @@ export function applyMaidrData(
   if (typeof svg.setAttribute !== 'function')
     return;
   svg.setAttribute('maidr-data', JSON.stringify(maidr));
+}
+
+/**
+ * Wraps a built layer into the single-chart (1x1) {@link Maidr} structure and
+ * applies it to the SVG. This is the tail every single-chart binder shares;
+ * the multi-panel binders in `binders/subplots.ts` assemble their own grid
+ * instead and call `applyMaidrData` directly.
+ *
+ * @param svg   - The SVG the binder was invoked on.
+ * @param config - The user's binder config (source of figure-level fields).
+ * @param built - The layer (and optional legend) produced by the builder core.
+ * @returns The standard {@link D3BinderResult}.
+ */
+export function finalizeSingleChart(
+  svg: Element,
+  config: D3BinderConfig,
+  built: D3BuiltLayer,
+): D3BinderResult {
+  const { id = generateId(), title, subtitle, caption, autoApply } = config;
+  const maidr: Maidr = {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: [[{
+      ...(built.legend && built.legend.length > 0 ? { legend: built.legend } : {}),
+      layers: [built.layer],
+    }]],
+  };
+  applyMaidrData(svg, maidr, autoApply);
+  return { maidr, layer: built.layer };
 }

--- a/src/adapters/d3/util.ts
+++ b/src/adapters/d3/util.ts
@@ -31,6 +31,31 @@ export function getD3Datum(element: Element): unknown {
 }
 
 /**
+ * Selector for elements created by the MAIDR core itself — hidden highlight
+ * clones and markers inserted next to the user's chart geometry. The
+ * attribute string mirrors the private `Svg.OWNED_ATTRIBUTE` constant in
+ * `src/util/svg.ts`; keep the two in sync.
+ */
+const MAIDR_OWNED_SELECTOR = '[data-maidr-owned]';
+
+/**
+ * Whether an element was created by the MAIDR core, or lives inside one that
+ * was. Only the ROOT of a cloned subtree carries the ownership stamp, so the
+ * `closest()` ancestor check is required to also exclude descendants of a
+ * cloned container.
+ *
+ * Binders must skip owned elements whenever they read the live DOM: while a
+ * chart is focused, the core keeps hidden `cloneNode` copies of marks (and
+ * potentially whole panels) right next to the originals. Those clones match
+ * the same user selectors but carry no D3 `__data__` (cloneNode does not copy
+ * JS expando properties), so a rebind that picks them up either doubles the
+ * element count or throws a "no D3-bound data" error.
+ */
+export function isMaidrOwned(element: Element): boolean {
+  return element.closest(MAIDR_OWNED_SELECTOR) !== null;
+}
+
+/**
  * Resolves a {@link DataAccessor} to extract a value from a datum.
  *
  * Two accessor shapes are supported:
@@ -177,6 +202,11 @@ export function resolveAccessorOptional<T>(
  * Queries all matching elements within a container and returns them with
  * their D3-bound data.
  *
+ * Elements created by the MAIDR core (hidden highlight clones, stamped with
+ * `data-maidr-owned`) are excluded, so rebinding while a chart is focused —
+ * when those clones are present in the live DOM — still sees only the user's
+ * real marks with contiguous indexes.
+ *
  * @param container - The root element (typically an SVG) to query within.
  * @param selector - CSS selector for the target elements.
  * @returns Array of `{ element, datum, index }` tuples.
@@ -189,7 +219,8 @@ export function queryD3Elements(
   if (!selector) {
     throw new Error('CSS selector must not be empty.');
   }
-  const elements = Array.from(container.querySelectorAll(selector));
+  const elements = Array.from(container.querySelectorAll(selector))
+    .filter(element => !isMaidrOwned(element));
   return elements.map((element, index) => ({
     element,
     datum: getD3Datum(element),

--- a/src/adapters/frappe/converters.ts
+++ b/src/adapters/frappe/converters.ts
@@ -20,7 +20,7 @@ import type {
   MaidrSubplot,
   ScatterPoint,
 } from '@type/grammar';
-import type { FrappeChart, FrappeChartType, FrappeData } from './types';
+import type { FrappeChart, FrappeChartType, FrappeData, FrappePanel } from './types';
 import { Orientation, TraceType } from '@type/grammar';
 import {
   barSelectorForDataset,
@@ -87,27 +87,212 @@ export function createMaidrFromFrappeChart(
   container: HTMLElement,
   options: FrappeChartAdapterOptions,
 ): Maidr {
-  const data = chart.data;
-
   // Assign a stable container id up-front (used for scoped CSS selectors).
   ensureContainerId(container);
 
   const id = options.id ?? container.id ?? nextId('maidr-frappe');
   const title = options.title ?? '';
 
-  const layers = buildLayers(data, container.id, options);
-
-  const isMultiLine = options.chartType === 'line' && data.datasets.length > 1;
-  const subplot: MaidrSubplot = {
-    ...(isMultiLine ? { legend: data.datasets.map((d, i) => d.name ?? `Series ${i + 1}`) } : {}),
-    layers,
-  };
+  const subplot = buildSubplot(chart, container, {
+    chartType: options.chartType,
+    axes: options.axes,
+  });
 
   return {
     id,
     ...(title ? { title } : {}),
     subplots: [[subplot]],
   };
+}
+
+/**
+ * Options accepted by {@link createMaidrFromFrappeCharts}.
+ */
+export interface FrappeChartsGridOptions {
+  /** Unique ID for the MAIDR instance. Defaults to the wrapper element's `id`. */
+  id?: string;
+  /** Figure title. */
+  title?: string;
+  /** Figure subtitle. */
+  subtitle?: string;
+  /** Figure caption. */
+  caption?: string;
+  /**
+   * When `panels` is a flat array, chunk it into rows of this many panels
+   * (row-major). Ignored for 2D input; omit to place all panels in one row.
+   */
+  columns?: number;
+}
+
+/**
+ * Creates a single MAIDR figure from a grid of independently rendered Frappe
+ * charts, enabling cross-panel arrow-key navigation (arrows move between
+ * panels, `Enter` drills into a panel, `Esc` returns).
+ *
+ * Frappe Charts has no native multi-panel concept, so panel grouping is
+ * explicit: lay the chart containers out inside one wrapper element (e.g. a
+ * CSS grid) and describe the grid here in visual reading order (row-major,
+ * top-left first).
+ *
+ * Call this **after every panel** has finished rendering (Frappe's entrance
+ * animation re-creates SVG nodes, so wait for all panels to settle), then set
+ * the `maidr` attribute on the **wrapper** element — not on the individual
+ * panel containers, which would create N separate MAIDR figures.
+ *
+ * @param panels  - The panel grid. A 2D array maps 1:1 to subplot rows; a flat
+ *                  array is chunked into rows of `options.columns` panels
+ *                  (row-major), or a single row when `columns` is omitted.
+ * @param wrapper - The element containing every panel's container. Its `id`
+ *                  (generated when missing) becomes the default figure id.
+ * @param options - Figure-level options.
+ * @returns A {@link Maidr} object ready to be set as the wrapper's `maidr`
+ *          attribute.
+ *
+ * @example
+ * ```js
+ * const maidr = maidrFrappe.createMaidrFromFrappeCharts(
+ *   [
+ *     [
+ *       { chart: barChart, container: barEl, chartType: 'bar', title: 'Sales' },
+ *       { chart: lineChart, container: lineEl, chartType: 'line', title: 'Trend' },
+ *     ],
+ *   ],
+ *   wrapper,
+ *   { title: 'Quarterly Dashboard' },
+ * );
+ * wrapper.setAttribute('maidr', JSON.stringify(maidr));
+ * ```
+ */
+export function createMaidrFromFrappeCharts(
+  panels: FrappePanel[][] | FrappePanel[],
+  wrapper: HTMLElement,
+  options: FrappeChartsGridOptions = {},
+): Maidr {
+  const grid = normalizePanelGrid(panels, options.columns);
+
+  // Assign a stable wrapper id up-front (used as the default figure id).
+  ensureContainerId(wrapper);
+  const id = options.id ?? wrapper.id;
+
+  const subplots = grid.map((row, rowIndex) =>
+    row.map((panel, colIndex) => {
+      if (panel.container === wrapper || !wrapper.contains(panel.container)) {
+        throw new Error(
+          `[maidr/frappe] Panel [${rowIndex}][${colIndex}]'s container must be a `
+          + 'descendant of the wrapper element passed to createMaidrFromFrappeCharts.',
+        );
+      }
+      return buildSubplot(panel.chart, panel.container, {
+        chartType: panel.chartType,
+        axes: panel.axes,
+        panelTitle: panel.title,
+        includePanelSelector: true,
+      });
+    }),
+  );
+
+  return {
+    id,
+    ...(options.title ? { title: options.title } : {}),
+    ...(options.subtitle ? { subtitle: options.subtitle } : {}),
+    ...(options.caption ? { caption: options.caption } : {}),
+    subplots,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Subplot builder — shared by the single-chart and grid APIs
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link buildSubplot}.
+ */
+interface BuildSubplotOptions {
+  /** The panel's Frappe chart type. */
+  chartType: FrappeChartType;
+  /** Axis labels for the panel's layers. */
+  axes?: { x?: string; y?: string };
+  /**
+   * Panel display name. MAIDR has no subplot-level title field — the FIRST
+   * layer's `title` is the panel's display name in subplot summaries, so this
+   * is stamped onto `layers[0]`.
+   */
+  panelTitle?: string;
+  /**
+   * When true, sets `MaidrSubplot.selector` to the panel's own SVG so the core
+   * can resolve per-panel highlight and axes elements. Only useful in
+   * multi-panel figures; omitted for single charts to keep their output
+   * unchanged.
+   */
+  includePanelSelector?: boolean;
+}
+
+/**
+ * Builds one {@link MaidrSubplot} from a rendered Frappe chart. All layer
+ * selectors are scoped to the container's `id`, so panels never match each
+ * other's SVG elements.
+ */
+function buildSubplot(
+  chart: FrappeChart,
+  container: HTMLElement,
+  options: BuildSubplotOptions,
+): MaidrSubplot {
+  const data = chart.data;
+
+  // Assign a stable container id (used for scoped CSS selectors).
+  ensureContainerId(container);
+
+  const layers = buildLayers(data, container.id, options);
+  if (options.panelTitle && layers.length > 0) {
+    layers[0] = { ...layers[0], title: options.panelTitle };
+  }
+
+  const isMultiLine = options.chartType === 'line' && data.datasets.length > 1;
+  return {
+    ...(isMultiLine ? { legend: data.datasets.map((d, i) => d.name ?? `Series ${i + 1}`) } : {}),
+    ...(options.includePanelSelector
+      ? { selector: `#${container.id} svg.frappe-chart` }
+      : {}),
+    layers,
+  };
+}
+
+/**
+ * Normalizes the panel input of {@link createMaidrFromFrappeCharts} into a 2D
+ * grid, validating that the grid has at least one panel and no empty rows
+ * (both crash the core figure model).
+ */
+function normalizePanelGrid(
+  panels: FrappePanel[][] | FrappePanel[],
+  columns?: number,
+): FrappePanel[][] {
+  if (panels.length === 0) {
+    throw new Error('[maidr/frappe] createMaidrFromFrappeCharts requires at least one panel.');
+  }
+
+  if (Array.isArray(panels[0])) {
+    const grid = panels as FrappePanel[][];
+    grid.forEach((row, rowIndex) => {
+      if (row.length === 0) {
+        throw new Error(`[maidr/frappe] Panel grid row ${rowIndex} is empty.`);
+      }
+    });
+    return grid;
+  }
+
+  const flat = panels as FrappePanel[];
+  if (columns === undefined) {
+    return [flat];
+  }
+  if (!Number.isInteger(columns) || columns < 1) {
+    throw new Error(`[maidr/frappe] \`columns\` must be a positive integer, got ${columns}.`);
+  }
+
+  const grid: FrappePanel[][] = [];
+  for (let i = 0; i < flat.length; i += columns) {
+    grid.push(flat.slice(i, i + columns));
+  }
+  return grid;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/frappe/converters.ts
+++ b/src/adapters/frappe/converters.ts
@@ -186,7 +186,6 @@ export function createMaidrFromFrappeCharts(
         chartType: panel.chartType,
         axes: panel.axes,
         panelTitle: panel.title,
-        includePanelSelector: true,
       });
     }),
   );
@@ -218,19 +217,21 @@ interface BuildSubplotOptions {
    * is stamped onto `layers[0]`.
    */
   panelTitle?: string;
-  /**
-   * When true, sets `MaidrSubplot.selector` to the panel's own SVG so the core
-   * can resolve per-panel highlight and axes elements. Only useful in
-   * multi-panel figures; omitted for single charts to keep their output
-   * unchanged.
-   */
-  includePanelSelector?: boolean;
 }
 
 /**
  * Builds one {@link MaidrSubplot} from a rendered Frappe chart. All layer
  * selectors are scoped to the container's `id`, so panels never match each
  * other's SVG elements.
+ *
+ * No `MaidrSubplot.selector` is emitted deliberately: the core resolves that
+ * selector into a `visibility: hidden` clone inserted right after the match,
+ * and the only whole-panel target in Frappe output is the top-level
+ * `svg.frappe-chart` — an element in normal HTML flow, whose hidden clone
+ * would double the panel's height on every focus. The core's visual-layout
+ * pass instead measures the first element matched by each panel's first
+ * layer selector (all container-id-scoped, so per-panel unique), which keeps
+ * multi-row grids ordered and vertically oriented correctly.
  */
 function buildSubplot(
   chart: FrappeChart,
@@ -250,9 +251,6 @@ function buildSubplot(
   const isMultiLine = options.chartType === 'line' && data.datasets.length > 1;
   return {
     ...(isMultiLine ? { legend: data.datasets.map((d, i) => d.name ?? `Series ${i + 1}`) } : {}),
-    ...(options.includePanelSelector
-      ? { selector: `#${container.id} svg.frappe-chart` }
-      : {}),
     layers,
   };
 }

--- a/src/adapters/frappe/index.ts
+++ b/src/adapters/frappe/index.ts
@@ -13,6 +13,10 @@
  * The selectors target Frappe Charts **v1.6.2**; verify SVG class names if you
  * upgrade Frappe.
  *
+ * Multiple charts laid out in one wrapper element can be grouped into a single
+ * multi-panel MAIDR figure with {@link createMaidrFromFrappeCharts} — set the
+ * `maidr` attribute on the wrapper, not the individual panel containers.
+ *
  * @example
  * ```html
  * <script src="https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.iife.js"></script>
@@ -46,7 +50,9 @@
 
 export {
   createMaidrFromFrappeChart,
+  createMaidrFromFrappeCharts,
   type FrappeChartAdapterOptions,
+  type FrappeChartsGridOptions,
 } from './converters';
 
 export type {
@@ -54,4 +60,5 @@ export type {
   FrappeChartType,
   FrappeData,
   FrappeDataset,
+  FrappePanel,
 } from './types';

--- a/src/adapters/frappe/types.ts
+++ b/src/adapters/frappe/types.ts
@@ -48,3 +48,25 @@ export interface FrappeChart {
  * supported by this adapter.
  */
 export type FrappeChartType = 'axis-mixed' | 'bar' | 'line' | 'scatter';
+
+/**
+ * One panel of a multi-panel (small-multiples) figure built from several
+ * independently rendered Frappe charts.
+ *
+ * Frappe Charts has no native facet/subplot concept — a "multi-panel" chart is
+ * simply N `new frappe.Chart(...)` instances laid out by the host page's CSS.
+ * A `FrappePanel` pairs one such instance with its container and the adapter
+ * options that would otherwise be passed to `createMaidrFromFrappeChart`.
+ */
+export interface FrappePanel {
+  /** The rendered Frappe chart instance for this panel (only `data` is read). */
+  chart: FrappeChart;
+  /** The element the chart was drawn into. Must be inside the wrapper element. */
+  container: HTMLElement;
+  /** The Frappe chart type of this panel. */
+  chartType: FrappeChartType;
+  /** Panel display name, announced when navigating between subplots. */
+  title?: string;
+  /** Axis labels for this panel. */
+  axes?: { x?: string; y?: string };
+}

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -295,9 +295,9 @@ export function whenGoogleChartsReady(
   }
 
   for (const chart of charts) {
-    const listener = events.addListener(chart, 'ready', () => {
-      // One-shot per chart: redraws must not double-count.
-      listener.remove();
+    // One-shot per chart (redraws must not double-count): the real
+    // `google.visualization.events` API detaches one-time listeners itself.
+    events.addOneTimeListener(chart, 'ready', () => {
       remaining -= 1;
       if (remaining === 0) {
         callback();
@@ -393,8 +393,11 @@ function inferGridFromGeometry(flat: GoogleChartPanel[]): GoogleChartPanel[][] {
 
 /**
  * Ensures every panel container is a proper descendant of `root` (so the
- * `maidr` attribute on `root` covers all panels) and that no two panels
- * share a container (marking attributes would collide).
+ * `maidr` attribute on `root` covers all panels), that no two panels share a
+ * container (marking attributes would collide), and that no panel container
+ * is nested inside another panel's container (the id-scoped descendant
+ * selectors of the outer panel would also match the inner chart's elements,
+ * silently disabling the outer panel's highlighting).
  */
 function validatePanelContainers(grid: GoogleChartPanel[][], root: HTMLElement): void {
   const seen = new Set<HTMLElement>();
@@ -409,6 +412,15 @@ function validatePanelContainers(grid: GoogleChartPanel[][], root: HTMLElement):
       throw new Error(
         `createMaidrFromGoogleCharts: panel [${r}][${c}] reuses a container already used by another panel.`,
       );
+    }
+    for (const prev of seen) {
+      if (prev.contains(container) || container.contains(prev)) {
+        throw new Error(
+          `createMaidrFromGoogleCharts: panel [${r}][${c}] container is nested inside `
+          + '(or contains) another panel\'s container; id-scoped selectors would match '
+          + 'both charts\' elements.',
+        );
+      }
     }
     seen.add(container);
   }));

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -26,7 +26,7 @@ import type {
   ScatterPoint,
   SegmentedPoint,
 } from '@type/grammar';
-import type { GoogleBoundingBox, GoogleChart, GoogleChartType, GoogleDataTable } from './types';
+import type { GoogleBoundingBox, GoogleChart, GoogleChartType, GoogleDataTable, GoogleEvents } from './types';
 import { Orientation, TraceType } from '@type/grammar';
 import { buildDataSelector, ensureContainerId, nextId } from './selectors';
 
@@ -138,6 +138,280 @@ export function createMaidrFromGoogleChart(
     ...(title ? { title } : {}),
     subplots: [[subplot]],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Public API — multi-panel (faceted) figures
+// ---------------------------------------------------------------------------
+
+/**
+ * One panel of a multi-panel figure — the same (chart, dataTable, container,
+ * chartType) tuple {@link createMaidrFromGoogleChart} takes, plus an optional
+ * panel title announced during subplot navigation.
+ */
+export interface GoogleChartPanel {
+  /** The rendered Google Charts chart instance for this panel. */
+  chart: GoogleChart;
+  /** The DataTable (or DataView) the panel was drawn from. */
+  dataTable: GoogleDataTable;
+  /** The DOM element the panel was drawn into. Must be inside `options.root`. */
+  container: HTMLElement;
+  /** The Google Charts chart type string (see {@link GoogleChartAdapterOptions.chartType}). */
+  chartType: GoogleChartType;
+  /** Panel name announced in subplot summaries (e.g. the facet value). */
+  title?: string;
+}
+
+/**
+ * Options accepted by {@link createMaidrFromGoogleCharts}.
+ */
+export interface GoogleChartsGridOptions {
+  /**
+   * Wrapper element containing ALL panel containers. The combined `maidr`
+   * attribute must be set on this element (not on the individual panel
+   * containers): `root.setAttribute('maidr', JSON.stringify(maidr))`.
+   */
+  root: HTMLElement;
+  /** Unique ID for the MAIDR instance. Defaults to the root element's `id`. */
+  id?: string;
+  /** Figure-level title announced when the figure receives focus. */
+  title?: string;
+  /**
+   * Grid shape for a FLAT `panels` array, chunked row-major. `columns` wins
+   * when both are given; with only `rows`, columns = ceil(n / rows). Ignored
+   * when `panels` is already a 2D array.
+   */
+  layout?: { rows?: number; columns?: number };
+}
+
+/**
+ * Tolerance (in pixels) when clustering panel containers into visual rows
+ * by their `getBoundingClientRect().top`. Panels whose tops differ by no
+ * more than this are considered part of the same row.
+ */
+const ROW_CLUSTER_TOLERANCE = 10;
+
+/**
+ * Creates a single multi-panel MAIDR figure from several rendered Google
+ * Charts instances (Google Charts has no native facet/trellis concept — a
+ * "faceted" page is N chart instances in N containers).
+ *
+ * Users navigate the resulting figure at subplot level first (arrow keys move
+ * between panels, `Enter` drills into a panel, `Esc` returns).
+ *
+ * Grid shape, in priority order:
+ * 1. `panels` is a 2D array (`GoogleChartPanel[][]`) — used directly as the
+ *    subplot grid (rows may be ragged, but never empty).
+ * 2. `panels` is flat and `options.layout` is given — chunked row-major.
+ * 3. Otherwise the grid is inferred from the containers' on-screen geometry
+ *    (clustered into rows by top edge, sorted left-to-right within a row).
+ *
+ * Always supply the grid in visual reading order (top-left panel first).
+ *
+ * Call this **after every panel has finished rendering** — see
+ * {@link whenGoogleChartsReady} — then set the returned object as the `maidr`
+ * attribute on `options.root` (NOT on the individual panel containers):
+ *
+ * @param panels  - Panel specs, flat or as a 2D grid in reading order.
+ * @param options - Grid options; `root` is required.
+ * @returns A single {@link Maidr} object spanning all panels.
+ *
+ * @example
+ * ```js
+ * whenGoogleChartsReady(charts, google.visualization.events, () => {
+ *   const maidr = createMaidrFromGoogleCharts(
+ *     panels, // [{ chart, dataTable, container, chartType, title }, …]
+ *     { root: document.getElementById('grid'), layout: { columns: 2 } },
+ *   );
+ *   root.setAttribute('maidr', JSON.stringify(maidr));
+ * });
+ * charts.forEach((chart, i) => chart.draw(dataTables[i], drawOptions[i]));
+ * ```
+ */
+export function createMaidrFromGoogleCharts(
+  panels: GoogleChartPanel[] | GoogleChartPanel[][],
+  options: GoogleChartsGridOptions,
+): Maidr {
+  const root = options.root;
+  if (!root) {
+    throw new Error('createMaidrFromGoogleCharts: options.root is required '
+      + '(a wrapper element containing all panel containers).');
+  }
+
+  const grid = resolvePanelGrid(panels, options.layout);
+  validatePanelContainers(grid, root);
+
+  if (!root.id) {
+    root.id = nextId('maidr-gc');
+  }
+  const id = options.id ?? root.id;
+  const title = options.title ?? '';
+
+  const subplots: MaidrSubplot[][] = grid.map(row => row.map((panel) => {
+    ensureContainerId(panel.container);
+    const layer = buildLayer(panel.chart, panel.dataTable, panel.container, panel.chartType);
+    if (panel.title) {
+      layer.title = panel.title;
+    }
+    return {
+      layers: [layer],
+      selector: `#${panel.container.id} svg`,
+    };
+  }));
+
+  return {
+    id,
+    ...(title ? { title } : {}),
+    subplots,
+  };
+}
+
+/**
+ * Invokes `callback` once EVERY given chart has fired its `'ready'` event.
+ *
+ * Each Google chart fires `'ready'` independently, so a multi-panel figure
+ * must not be assembled until all panels have rendered. Register the gate
+ * **before** calling `chart.draw(…)` on any of the charts.
+ *
+ * @param charts   - The chart instances to wait for.
+ * @param events   - The Google Charts event helper, `google.visualization.events`.
+ * @param callback - Invoked once, after every chart has fired `'ready'`.
+ *
+ * @example
+ * ```js
+ * whenGoogleChartsReady(charts, google.visualization.events, buildMaidr);
+ * charts.forEach((chart, i) => chart.draw(dataTables[i], drawOptions[i]));
+ * ```
+ */
+export function whenGoogleChartsReady(
+  charts: readonly GoogleChart[],
+  events: GoogleEvents,
+  callback: () => void,
+): void {
+  let remaining = charts.length;
+  if (remaining === 0) {
+    callback();
+    return;
+  }
+
+  for (const chart of charts) {
+    const listener = events.addListener(chart, 'ready', () => {
+      // One-shot per chart: redraws must not double-count.
+      listener.remove();
+      remaining -= 1;
+      if (remaining === 0) {
+        callback();
+      }
+    });
+  }
+}
+
+/**
+ * Normalizes the `panels` argument of {@link createMaidrFromGoogleCharts}
+ * into a 2D grid in visual reading order (see the strategy list there).
+ */
+function resolvePanelGrid(
+  panels: GoogleChartPanel[] | GoogleChartPanel[][],
+  layout?: { rows?: number; columns?: number },
+): GoogleChartPanel[][] {
+  if (panels.length === 0) {
+    throw new Error('createMaidrFromGoogleCharts: at least one panel is required.');
+  }
+
+  if (Array.isArray(panels[0])) {
+    const grid = panels as GoogleChartPanel[][];
+    grid.forEach((row, r) => {
+      if (row.length === 0) {
+        throw new Error(`createMaidrFromGoogleCharts: grid row ${r} is empty.`);
+      }
+    });
+    return grid;
+  }
+
+  const flat = panels as GoogleChartPanel[];
+  const columns = resolveColumnCount(flat.length, layout);
+  if (columns !== undefined) {
+    return chunkRowMajor(flat, columns);
+  }
+  return inferGridFromGeometry(flat);
+}
+
+/**
+ * Derives the column count from `options.layout`, or `undefined` when no
+ * layout was requested (geometry inference applies instead).
+ */
+function resolveColumnCount(
+  panelCount: number,
+  layout?: { rows?: number; columns?: number },
+): number | undefined {
+  if (!layout || (layout.columns === undefined && layout.rows === undefined)) {
+    return undefined;
+  }
+  const requested = layout.columns ?? layout.rows!;
+  if (!Number.isInteger(requested) || requested < 1) {
+    throw new Error('createMaidrFromGoogleCharts: layout rows/columns must be a positive integer.');
+  }
+  return layout.columns ?? Math.ceil(panelCount / layout.rows!);
+}
+
+/** Splits a flat panel list into rows of `columns` panels (last row may be shorter). */
+function chunkRowMajor(flat: GoogleChartPanel[], columns: number): GoogleChartPanel[][] {
+  const grid: GoogleChartPanel[][] = [];
+  for (let i = 0; i < flat.length; i += columns) {
+    grid.push(flat.slice(i, i + columns));
+  }
+  return grid;
+}
+
+/**
+ * Infers the grid from on-screen container geometry: panels are clustered
+ * into rows by their bounding-rect top edge (within
+ * {@link ROW_CLUSTER_TOLERANCE} pixels) and sorted left-to-right within each
+ * row, yielding visual reading order.
+ */
+function inferGridFromGeometry(flat: GoogleChartPanel[]): GoogleChartPanel[][] {
+  const entries = flat.map((panel) => {
+    const rect = panel.container.getBoundingClientRect();
+    return { panel, top: rect.top, left: rect.left };
+  });
+  entries.sort((a, b) => a.top - b.top || a.left - b.left);
+
+  const rows: (typeof entries)[] = [];
+  for (const entry of entries) {
+    const currentRow = rows[rows.length - 1];
+    if (currentRow && Math.abs(entry.top - currentRow[0].top) <= ROW_CLUSTER_TOLERANCE) {
+      currentRow.push(entry);
+    } else {
+      rows.push([entry]);
+    }
+  }
+
+  return rows.map(row =>
+    row.sort((a, b) => a.left - b.left).map(entry => entry.panel),
+  );
+}
+
+/**
+ * Ensures every panel container is a proper descendant of `root` (so the
+ * `maidr` attribute on `root` covers all panels) and that no two panels
+ * share a container (marking attributes would collide).
+ */
+function validatePanelContainers(grid: GoogleChartPanel[][], root: HTMLElement): void {
+  const seen = new Set<HTMLElement>();
+  grid.forEach((row, r) => row.forEach((panel, c) => {
+    const container = panel.container;
+    if (!container || container === root || !root.contains(container)) {
+      throw new Error(
+        `createMaidrFromGoogleCharts: panel [${r}][${c}] container must be a descendant of options.root.`,
+      );
+    }
+    if (seen.has(container)) {
+      throw new Error(
+        `createMaidrFromGoogleCharts: panel [${r}][${c}] reuses a container already used by another panel.`,
+      );
+    }
+    seen.add(container);
+  }));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/google-charts/index.ts
+++ b/src/adapters/google-charts/index.ts
@@ -57,5 +57,6 @@ export type {
   GoogleChartType,
   GoogleDataTable,
   GoogleEvents,
+  GoogleListenerHandle,
   GoogleSelectionItem,
 } from './types';

--- a/src/adapters/google-charts/index.ts
+++ b/src/adapters/google-charts/index.ts
@@ -45,7 +45,11 @@
 
 export {
   createMaidrFromGoogleChart,
+  createMaidrFromGoogleCharts,
   type GoogleChartAdapterOptions,
+  type GoogleChartPanel,
+  type GoogleChartsGridOptions,
+  whenGoogleChartsReady,
 } from './converters';
 
 export type {

--- a/src/adapters/google-charts/types.ts
+++ b/src/adapters/google-charts/types.ts
@@ -92,14 +92,33 @@ export interface GoogleChart {
 }
 
 /**
- * Google Charts event helper namespace.
+ * Opaque listener handle returned by the Google Charts event helpers.
+ *
+ * The real handle exposes only `getKey()`; listeners are detached by passing
+ * the handle back to {@link GoogleEvents.removeListener} (there is no
+ * `remove()` method on the handle itself).
+ */
+export interface GoogleListenerHandle {
+  getKey: () => unknown;
+}
+
+/**
+ * Google Charts event helper namespace (`google.visualization.events`).
+ *
+ * @see https://developers.google.com/chart/interactive/docs/reference#events
  */
 export interface GoogleEvents {
   addListener: (
     chart: GoogleChart,
     eventName: string,
     handler: (...args: unknown[]) => void,
-  ) => { remove: () => void };
+  ) => GoogleListenerHandle;
+  addOneTimeListener: (
+    chart: GoogleChart,
+    eventName: string,
+    handler: (...args: unknown[]) => void,
+  ) => GoogleListenerHandle;
+  removeListener: (handle: GoogleListenerHandle) => boolean;
   removeAllListeners: (chart: GoogleChart) => void;
 }
 

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -29,7 +29,7 @@ import type {
   ScatterPoint,
   SegmentedPoint,
 } from '../../type/grammar';
-import type { HighchartsAdapterOptions, HighchartsChart, HighchartsPoint, HighchartsSeries } from './types';
+import type { HighchartsAdapterOptions, HighchartsAxis, HighchartsChart, HighchartsPoint, HighchartsSeries } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 import {
   barSelector,
@@ -62,6 +62,12 @@ let chartCounter = 0;
  * - Grouped (dodged) `column`/`bar` → {@link TraceType.DODGED}
  * - Percent-stacked `column`/`bar` → {@link TraceType.NORMALIZED}
  *
+ * Multi-pane charts (multiple `yAxis`/`xAxis` entries laid out as separate
+ * bands, e.g. the Highstock price + volume pattern) are detected from the
+ * rendered axis geometry and emitted as a MAIDR subplot grid — one subplot
+ * per pane, navigable with arrow keys. Ambiguous layouts (overlapping bands,
+ * dual-axis overlays) fall back to today's single-subplot output.
+ *
  * @param chart - A Highcharts chart instance (the return value of `Highcharts.chart()`).
  * @param options - Optional overrides for ID, title, or series filtering.
  * @returns A {@link Maidr} object ready for use with the MAIDR library.
@@ -77,8 +83,66 @@ export function highchartsToMaidr(
 
   const containerId = ensureContainerId(chart);
 
-  const seriesToConvert = filterSeries(chart, options?.seriesIndices);
+  const seriesToConvert = collectUsableSeries(chart, options?.seriesIndices);
 
+  return {
+    id,
+    title,
+    subtitle,
+    caption,
+    subplots: buildSubplotGrid(seriesToConvert, chart, containerId),
+  };
+}
+
+/**
+ * Builds the subplot grid for one chart: a multi-pane chart becomes one
+ * subplot per detected pane; everything else keeps the single-subplot path.
+ */
+function buildSubplotGrid(
+  seriesList: HighchartsSeries[],
+  chart: HighchartsChart,
+  containerId: string,
+): MaidrSubplot[][] {
+  const paneGrid = detectPaneGrid(seriesList);
+
+  if (paneGrid) {
+    // Never emit `{ layers: [] }` cells or empty rows — the MAIDR model
+    // crashes on both — so compact ragged rows instead.
+    const rows = paneGrid
+      .map(row => row
+        .map((group) => {
+          const subplot = buildSubplot(group, chart, containerId);
+          applyPaneTitleFallback(subplot, group);
+          return subplot;
+        })
+        .filter(subplot => subplot.layers.length > 0))
+      .filter(row => row.length > 0);
+
+    const total = rows.reduce((count, row) => count + row.length, 0);
+    if (total > 1) {
+      return rows;
+    }
+    // Fewer than two usable panes survived conversion — fall through to the
+    // single-subplot path so the output matches a plain chart exactly.
+  }
+
+  return [[buildSubplot(seriesList, chart, containerId)]];
+}
+
+/**
+ * Converts a list of Highcharts series into one MAIDR subplot.
+ *
+ * Bar/column series are grouped into a single stacked/dodged/normalized
+ * layer, line-like series merge into one multi-line layer, and every other
+ * supported series becomes its own layer.
+ *
+ * @internal
+ */
+export function buildSubplot(
+  seriesToConvert: HighchartsSeries[],
+  chart: HighchartsChart,
+  containerId: string,
+): MaidrSubplot {
   // Categorize series by how they need to be converted.
   const lineTypes = new Set(['line', 'spline', 'area', 'areaspline']);
   const barTypes = new Set(['bar', 'column']);
@@ -119,18 +183,34 @@ export function highchartsToMaidr(
     subplot.legend = layers.map(l => l.title ?? `Series ${l.id}`);
   }
 
-  return {
-    id,
-    title,
-    subtitle,
-    caption,
-    subplots: [[subplot]],
-  };
+  return subplot;
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Returns the chart's convertible series: visible (optionally restricted to
+ * `indices`) and not internal. Highstock injects internal helper series (the
+ * navigator preview, marked via `isInternal` / the `highcharts-navigator-series`
+ * class) that mirror real data and must never become their own layers.
+ *
+ * @internal
+ */
+export function collectUsableSeries(
+  chart: HighchartsChart,
+  indices?: number[],
+): HighchartsSeries[] {
+  return filterSeries(chart, indices).filter(series => !isInternalSeries(series));
+}
+
+function isInternalSeries(series: HighchartsSeries): boolean {
+  const { isInternal, className } = series.options;
+  return isInternal === true
+    || (typeof className === 'string' && className.includes('highcharts-navigator-series'))
+    || series.name === 'Navigator';
+}
 
 function filterSeries(
   chart: HighchartsChart,
@@ -189,6 +269,155 @@ function getStackingMode(series: HighchartsSeries, chart: HighchartsChart): stri
     return plotOptions.bar.stacking;
   }
   return plotOptions?.series?.stacking;
+}
+
+// ---------------------------------------------------------------------------
+// Pane detection (multi-axis charts → subplot grid)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pixel tolerance when clustering axis positions into pane bands. Axes whose
+ * `top` (or `left`) differ by no more than this are treated as the same band.
+ */
+const PANE_BAND_TOLERANCE_PX = 4;
+
+/**
+ * Detects a pane grid within a single chart from the rendered axis geometry.
+ *
+ * Highcharts expresses panes as multiple `yAxis` entries stacked via
+ * `top`/`height` (rows) and/or multiple `xAxis` entries split via
+ * `left`/`width` (columns); each series is pinned to one axis pair. There is
+ * no per-pane DOM group, so pane membership is derived purely from the
+ * series → axis assignment.
+ *
+ * Returns series grouped as `grid[row][col]` in visual reading order
+ * (top-left first), with empty cells/rows already compacted away, or `null`
+ * when the chart is single-pane or the layout is ambiguous (missing axis
+ * geometry, overlapping bands, or coinciding dual-axis overlays) — callers
+ * must then fall back to the single-subplot path.
+ */
+function detectPaneGrid(seriesList: HighchartsSeries[]): HighchartsSeries[][][] | null {
+  if (seriesList.length < 2) {
+    return null;
+  }
+  if (seriesList.some(series => !series.xAxis || !series.yAxis)) {
+    return null;
+  }
+
+  const yAxes = [...new Set(seriesList.map(series => series.yAxis))];
+  const xAxes = [...new Set(seriesList.map(series => series.xAxis))];
+  if (yAxes.length <= 1 && xAxes.length <= 1) {
+    return null;
+  }
+
+  const rowByAxis = yAxes.length > 1
+    ? assignAxisBands(yAxes, axis => axis.top, axis => axis.height)
+    : new Map<HighchartsAxis, number>(yAxes.map(axis => [axis, 0]));
+  const colByAxis = xAxes.length > 1
+    ? assignAxisBands(xAxes, axis => axis.left, axis => axis.width)
+    : new Map<HighchartsAxis, number>(xAxes.map(axis => [axis, 0]));
+  if (!rowByAxis || !colByAxis) {
+    return null;
+  }
+
+  const rowCount = Math.max(...rowByAxis.values()) + 1;
+  const colCount = Math.max(...colByAxis.values()) + 1;
+
+  // Group series by (row, col) cell, preserving series order within a cell.
+  const cells: (HighchartsSeries[] | undefined)[][] = Array.from(
+    { length: rowCount },
+    () => Array.from({ length: colCount }, () => undefined),
+  );
+  let cellCount = 0;
+  for (const series of seriesList) {
+    const row = rowByAxis.get(series.yAxis) ?? 0;
+    const col = colByAxis.get(series.xAxis) ?? 0;
+    if (!cells[row][col]) {
+      cells[row][col] = [];
+      cellCount++;
+    }
+    cells[row][col]?.push(series);
+  }
+
+  // A single occupied cell means every series shares one geometry band
+  // (e.g. a dual-axis overlay) — that is not a multi-pane chart.
+  if (cellCount <= 1) {
+    return null;
+  }
+
+  // Compact ragged rows: drop unoccupied cells and rows entirely.
+  const grid: HighchartsSeries[][][] = [];
+  for (const row of cells) {
+    const compacted = row.filter((cell): cell is HighchartsSeries[] => cell !== undefined);
+    if (compacted.length > 0) {
+      grid.push(compacted);
+    }
+  }
+  return grid;
+}
+
+/**
+ * Clusters axes into position bands along one dimension and assigns each
+ * axis its band index (0 = topmost/leftmost).
+ *
+ * Returns `null` when any axis lacks rendered geometry or when two distinct
+ * bands overlap beyond the tolerance — pane membership would be ambiguous
+ * and the caller must fall back to single-subplot output.
+ */
+function assignAxisBands(
+  axes: HighchartsAxis[],
+  getStart: (axis: HighchartsAxis) => number | undefined,
+  getLength: (axis: HighchartsAxis) => number | undefined,
+): Map<HighchartsAxis, number> | null {
+  const measured: { axis: HighchartsAxis; start: number; end: number }[] = [];
+  for (const axis of axes) {
+    const start = getStart(axis);
+    const length = getLength(axis);
+    if (typeof start !== 'number' || !Number.isFinite(start)
+      || typeof length !== 'number' || !Number.isFinite(length)) {
+      return null;
+    }
+    measured.push({ axis, start, end: start + length });
+  }
+  measured.sort((a, b) => a.start - b.start);
+
+  const bands: { start: number; end: number }[] = [];
+  const bandByAxis = new Map<HighchartsAxis, number>();
+  for (const { axis, start, end } of measured) {
+    const current = bands[bands.length - 1];
+    if (current && start - current.start <= PANE_BAND_TOLERANCE_PX) {
+      current.end = Math.max(current.end, end);
+    } else {
+      bands.push({ start, end });
+    }
+    bandByAxis.set(axis, bands.length - 1);
+  }
+
+  // Distinct bands that overlap (beyond tolerance) make membership ambiguous.
+  for (let i = 1; i < bands.length; i++) {
+    if (bands[i - 1].end > bands[i].start + PANE_BAND_TOLERANCE_PX) {
+      return null;
+    }
+  }
+
+  return bandByAxis;
+}
+
+/**
+ * MAIDR has no subplot-title field: the FIRST layer's `title` is the panel's
+ * display name in subplot summaries. Panes have no native titles either, so
+ * when the first layer ended up untitled (unnamed series), fall back to the
+ * pane's own y-axis title.
+ */
+function applyPaneTitleFallback(subplot: MaidrSubplot, group: HighchartsSeries[]): void {
+  const firstLayer = subplot.layers[0];
+  if (!firstLayer || firstLayer.title !== undefined) {
+    return;
+  }
+  const axisTitle = group[0]?.yAxis?.options?.title?.text;
+  if (axisTitle) {
+    firstLayer.title = axisTitle;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -433,7 +662,7 @@ function convertSeries(
     case 'boxplot':
       return convertBoxSeries(series, chart, containerId);
     case 'heatmap':
-      return convertHeatmapSeries(series, chart, containerId);
+      return convertHeatmapSeries(series, containerId);
     case 'histogram':
       return convertHistogramSeries(series, containerId);
     case 'candlestick':
@@ -759,11 +988,12 @@ function subpathMidpoint(subpath: string): { x: number; y: number } | null {
 
 function convertHeatmapSeries(
   series: HighchartsSeries,
-  chart: HighchartsChart,
   containerId: string,
 ): MaidrLayer {
-  const xCategories = chart.xAxis[0]?.categories ?? [];
-  const yCategories = chart.yAxis[0]?.categories ?? [];
+  // Read categories from the series' OWN axes (not chart.xAxis[0]/yAxis[0])
+  // so heatmaps bound to secondary/pane axes get the right labels.
+  const xCategories = series.xAxis?.categories ?? [];
+  const yCategories = series.yAxis?.categories ?? [];
 
   // Determine grid dimensions. If numeric axes are used, infer from data.
   let rows = yCategories.length;

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -40,6 +40,7 @@ import {
   histogramSelector,
   lineSelectors,
   scatterSelector,
+  seriesGroupSelector,
 } from './selectors';
 
 let chartCounter = 0;
@@ -97,8 +98,10 @@ export function highchartsToMaidr(
 /**
  * Builds the subplot grid for one chart: a multi-pane chart becomes one
  * subplot per detected pane; everything else keeps the single-subplot path.
+ *
+ * @internal
  */
-function buildSubplotGrid(
+export function buildSubplotGrid(
   seriesList: HighchartsSeries[],
   chart: HighchartsChart,
   containerId: string,
@@ -178,6 +181,16 @@ export function buildSubplot(
 
   const subplot: MaidrSubplot = { layers };
 
+  // Point the subplot at its own panel geometry (the first series' rendered
+  // group). Highcharts SVG has no `g[id^="axes_"]` groups, so MAIDR's layout
+  // pass relies on this element to compute the panels' visual order and the
+  // vertical arrow-key direction for multi-row grids. The first layer's
+  // selectors cannot serve as a fallback for every trace type (box,
+  // candlestick, and heatmap layers carry structured selector objects).
+  if (layers.length > 0 && seriesToConvert.length > 0) {
+    subplot.selector = seriesGroupSelector(containerId, seriesToConvert[0].index);
+  }
+
   // Add legend labels when multiple layers are present, aligned to layers.
   if (layers.length > 1) {
     subplot.legend = layers.map(l => l.title ?? `Series ${l.id}`);
@@ -206,10 +219,12 @@ export function collectUsableSeries(
 }
 
 function isInternalSeries(series: HighchartsSeries): boolean {
+  // Highcharts reliably marks the real Highstock navigator series with both
+  // `isInternal` and the `highcharts-navigator-series` class. Do NOT match on
+  // the series name — a legitimate user series named "Navigator" must convert.
   const { isInternal, className } = series.options;
   return isInternal === true
-    || (typeof className === 'string' && className.includes('highcharts-navigator-series'))
-    || series.name === 'Navigator';
+    || (typeof className === 'string' && className.includes('highcharts-navigator-series'));
 }
 
 function filterSeries(

--- a/src/adapters/highcharts/grid.ts
+++ b/src/adapters/highcharts/grid.ts
@@ -1,0 +1,147 @@
+/**
+ * Multi-instance grid API: combines several separate Highcharts chart
+ * instances (the Highcharts small-multiples / faceting pattern — one chart
+ * per div) into a single MAIDR figure with subplot navigation.
+ *
+ * Each chart becomes one subplot cell. Since every chart renders into its own
+ * container (whose id is embedded in every generated selector), highlighting
+ * stays scoped per panel without extra work. Attach the resulting JSON as a
+ * `maidr-data` attribute on a wrapper element enclosing all chart divs.
+ *
+ * @example
+ * ```ts
+ * import Highcharts from 'highcharts';
+ * import { highchartsGridToMaidr } from 'maidr/highcharts';
+ *
+ * const east = Highcharts.chart('east', { title: { text: 'East' }, ... });
+ * const west = Highcharts.chart('west', { title: { text: 'West' }, ... });
+ *
+ * const maidrData = highchartsGridToMaidr([east, west], { title: 'Sales by region' });
+ * document.getElementById('wrapper').setAttribute('maidr-data', JSON.stringify(maidrData));
+ * ```
+ */
+
+import type { Maidr, MaidrSubplot } from '../../type/grammar';
+import type { HighchartsChart, HighchartsGridOptions } from './types';
+import { buildSubplot, collectUsableSeries } from './adapter';
+import { ensureContainerId } from './selectors';
+
+let gridCounter = 0;
+
+/**
+ * Converts multiple rendered Highcharts chart instances into one MAIDR figure
+ * with a subplot grid (one subplot per chart).
+ *
+ * Input shapes:
+ * - `Chart[][]` — maps 1:1 to the subplot grid, row-major (ragged rows OK).
+ * - `Chart[]` — a single row, or chunked into rows via `options.layout`
+ *   (`columns` = charts per row; `rows` derives columns when set alone).
+ *
+ * Panel naming: each chart's own title becomes its panel's display name
+ * (written into the first layer's `title`); the figure title comes from
+ * `options.title`. Charts with no convertible series are skipped (with a
+ * warning) and their row compacted, because MAIDR crashes on empty subplots.
+ *
+ * @param charts - Rendered chart instances in visual reading order (top-left first).
+ * @param options - Optional figure metadata and flat-list layout.
+ * @returns A {@link Maidr} object ready for use with the MAIDR library.
+ */
+export function highchartsGridToMaidr(
+  charts: HighchartsChart[] | HighchartsChart[][],
+  options?: HighchartsGridOptions,
+): Maidr {
+  const chartGrid = toChartGrid(charts, options?.layout);
+
+  let subplotIndex = 0;
+  const subplots: MaidrSubplot[][] = [];
+  for (const chartRow of chartGrid) {
+    const row: MaidrSubplot[] = [];
+    for (const chart of chartRow) {
+      const containerId = ensureContainerId(chart);
+      const subplot = buildSubplot(collectUsableSeries(chart), chart, containerId);
+
+      if (subplot.layers.length === 0) {
+        console.warn(
+          `[MAIDR Highcharts] Grid chart "${containerId}" has no convertible series; skipping panel.`,
+        );
+        continue;
+      }
+
+      // Series indices restart at 0 in every chart, but MAIDR requires layer
+      // ids to be unique across the WHOLE figure — prefix with the panel index.
+      for (const layer of subplot.layers) {
+        layer.id = `${subplotIndex}_${layer.id}`;
+      }
+
+      // The chart's own title is the panel's display name; MAIDR reads it
+      // from the first layer's title (there is no subplot-title field).
+      const paneTitle = chart.title?.textStr;
+      if (paneTitle) {
+        subplot.layers[0].title = paneTitle;
+      }
+
+      row.push(subplot);
+      subplotIndex++;
+    }
+    if (row.length > 0) {
+      subplots.push(row);
+    }
+  }
+
+  if (subplots.length === 0) {
+    // Mirror highchartsToMaidr's degenerate no-series shape rather than
+    // emitting an empty grid (which the MAIDR model cannot represent).
+    console.warn('[MAIDR Highcharts] No grid chart produced any layers.');
+    subplots.push([{ layers: [] }]);
+  }
+
+  return {
+    id: options?.id ?? `highcharts-grid-${gridCounter++}`,
+    title: options?.title ?? '',
+    subtitle: options?.subtitle,
+    caption: options?.caption,
+    subplots,
+  };
+}
+
+/**
+ * Normalizes the accepted chart input shapes into a row-major 2D grid.
+ */
+function toChartGrid(
+  charts: HighchartsChart[] | HighchartsChart[][],
+  layout?: HighchartsGridOptions['layout'],
+): HighchartsChart[][] {
+  if (charts.length === 0) {
+    throw new Error('[MAIDR Highcharts] highchartsGridToMaidr requires at least one chart.');
+  }
+
+  // 2D input maps 1:1; drop empty rows (the model crashes on them).
+  if (Array.isArray(charts[0])) {
+    const grid = (charts as HighchartsChart[][]).filter(row => row.length > 0);
+    if (grid.length === 0) {
+      throw new Error('[MAIDR Highcharts] highchartsGridToMaidr requires at least one chart.');
+    }
+    return grid;
+  }
+
+  const flat = charts as HighchartsChart[];
+  const columns = resolveColumns(flat.length, layout);
+  const grid: HighchartsChart[][] = [];
+  for (let i = 0; i < flat.length; i += columns) {
+    grid.push(flat.slice(i, i + columns));
+  }
+  return grid;
+}
+
+function resolveColumns(
+  count: number,
+  layout?: HighchartsGridOptions['layout'],
+): number {
+  if (layout?.columns && layout.columns >= 1) {
+    return Math.floor(layout.columns);
+  }
+  if (layout?.rows && layout.rows >= 1) {
+    return Math.ceil(count / Math.min(Math.floor(layout.rows), count));
+  }
+  return count; // Single row by default.
+}

--- a/src/adapters/highcharts/grid.ts
+++ b/src/adapters/highcharts/grid.ts
@@ -23,7 +23,7 @@
 
 import type { Maidr, MaidrSubplot } from '../../type/grammar';
 import type { HighchartsChart, HighchartsGridOptions } from './types';
-import { buildSubplot, collectUsableSeries } from './adapter';
+import { buildSubplotGrid, collectUsableSeries } from './adapter';
 import { ensureContainerId } from './selectors';
 
 let gridCounter = 0;
@@ -41,10 +41,16 @@ let gridCounter = 0;
  * (written into the first layer's `title`); the figure title comes from
  * `options.title`. Charts with no convertible series are skipped (with a
  * warning) and their row compacted, because MAIDR crashes on empty subplots.
+ * A member chart that itself contains multiple panes (stacked `yAxis` bands)
+ * is expanded with the same pane detection as {@link highchartsToMaidr}: each
+ * pane becomes its own cell, flattened into that chart's grid row.
  *
  * @param charts - Rendered chart instances in visual reading order (top-left first).
  * @param options - Optional figure metadata and flat-list layout.
  * @returns A {@link Maidr} object ready for use with the MAIDR library.
+ * @throws When no chart in the grid produces any convertible series — the
+ *         resulting figure would have no navigable data, and attaching it
+ *         would crash MAIDR on focus.
  */
 export function highchartsGridToMaidr(
   charts: HighchartsChart[] | HighchartsChart[][],
@@ -58,30 +64,48 @@ export function highchartsGridToMaidr(
     const row: MaidrSubplot[] = [];
     for (const chart of chartRow) {
       const containerId = ensureContainerId(chart);
-      const subplot = buildSubplot(collectUsableSeries(chart), chart, containerId);
 
-      if (subplot.layers.length === 0) {
+      // Reuse the single-chart pane detection so a multi-pane member chart
+      // (e.g. a Highstock price + volume chart) is never fused into one
+      // subplot — cross-pane bar series would otherwise merge into a single
+      // dodged/stacked layer mixing unrelated scales. The pane path already
+      // drops empty-layer cells; the single-subplot path may still yield one.
+      const paneSubplots = buildSubplotGrid(collectUsableSeries(chart), chart, containerId)
+        .flat()
+        .filter(subplot => subplot.layers.length > 0);
+
+      if (paneSubplots.length === 0) {
         console.warn(
           `[MAIDR Highcharts] Grid chart "${containerId}" has no convertible series; skipping panel.`,
         );
         continue;
       }
 
-      // Series indices restart at 0 in every chart, but MAIDR requires layer
-      // ids to be unique across the WHOLE figure — prefix with the panel index.
-      for (const layer of subplot.layers) {
-        layer.id = `${subplotIndex}_${layer.id}`;
+      if (paneSubplots.length > 1) {
+        console.warn(
+          `[MAIDR Highcharts] Grid chart "${containerId}" contains ${paneSubplots.length} panes; `
+          + `flattening them into adjacent cells of the same grid row.`,
+        );
       }
 
       // The chart's own title is the panel's display name; MAIDR reads it
-      // from the first layer's title (there is no subplot-title field).
+      // from the first layer's title (there is no subplot-title field). For a
+      // multi-pane chart it names the first pane only — the remaining panes
+      // keep their pane-level names (series name or y-axis title fallback).
       const paneTitle = chart.title?.textStr;
       if (paneTitle) {
-        subplot.layers[0].title = paneTitle;
+        paneSubplots[0].layers[0].title = paneTitle;
       }
 
-      row.push(subplot);
-      subplotIndex++;
+      for (const subplot of paneSubplots) {
+        // Series indices restart at 0 in every chart, but MAIDR requires layer
+        // ids to be unique across the WHOLE figure — prefix with the cell index.
+        for (const layer of subplot.layers) {
+          layer.id = `${subplotIndex}_${layer.id}`;
+        }
+        row.push(subplot);
+        subplotIndex++;
+      }
     }
     if (row.length > 0) {
       subplots.push(row);
@@ -89,10 +113,12 @@ export function highchartsGridToMaidr(
   }
 
   if (subplots.length === 0) {
-    // Mirror highchartsToMaidr's degenerate no-series shape rather than
-    // emitting an empty grid (which the MAIDR model cannot represent).
-    console.warn('[MAIDR Highcharts] No grid chart produced any layers.');
-    subplots.push([{ layers: [] }]);
+    // Fail loudly at conversion time (where the developer can see it) instead
+    // of emitting an empty-layers subplot whose JSON would crash MAIDR with an
+    // uncaught TypeError inside Context construction on first focus.
+    throw new Error(
+      '[MAIDR Highcharts] highchartsGridToMaidr: no chart in the grid produced any convertible series.',
+    );
   }
 
   return {

--- a/src/adapters/highcharts/index.ts
+++ b/src/adapters/highcharts/index.ts
@@ -2,8 +2,11 @@
  * Public Highcharts adapter API for MAIDR.
  *
  * Provides the {@link highchartsToMaidr} function to convert Highcharts chart
- * instances into MAIDR-compatible data, and {@link createHighchartsSync} for
- * bidirectional visual synchronization (tooltip and point highlighting).
+ * instances into MAIDR-compatible data (including multi-pane charts, which
+ * become MAIDR subplot grids), {@link highchartsGridToMaidr} to combine
+ * several chart instances into one figure with subplot navigation, and
+ * {@link createHighchartsSync} for bidirectional visual synchronization
+ * (tooltip and point highlighting).
  *
  * @remarks
  * Highcharts is **not** bundled — users must provide their own Highcharts
@@ -30,12 +33,14 @@
  */
 
 export { highchartsToMaidr } from './adapter';
+export { highchartsGridToMaidr } from './grid';
 export { createHighchartsSync } from './sync';
 export type { HighchartsSync } from './sync';
 export type {
   HighchartsAdapterOptions,
   HighchartsAxis,
   HighchartsChart,
+  HighchartsGridOptions,
   HighchartsPoint,
   HighchartsSeries,
 } from './types';

--- a/src/adapters/highcharts/selectors.ts
+++ b/src/adapters/highcharts/selectors.ts
@@ -45,6 +45,23 @@ export function ensureContainerId(chart: HighchartsChart): string {
 }
 
 /**
+ * Generates a CSS selector for a series' rendered group element — the
+ * `<g class="highcharts-series highcharts-series-N">` wrapping all of the
+ * series' marks inside `.highcharts-series-group`.
+ *
+ * Used as the per-panel `MaidrSubplot.selector`: MAIDR's subplot-layout pass
+ * measures this element's bounding box to derive the panels' visual order and
+ * the vertical arrow-key direction (Highcharts SVG has no `g[id^="axes_"]`
+ * groups, so without a measurable per-panel element the core falls back to
+ * data order and Up/Down are inverted for multi-row grids). The first layer's
+ * selectors are not a reliable substitute — box, candlestick, and heatmap
+ * layers carry structured selector objects the layout pass cannot query.
+ */
+export function seriesGroupSelector(containerId: string, seriesIndex: number): string {
+  return `#${containerId} .highcharts-series-group .highcharts-series-${seriesIndex}`;
+}
+
+/**
  * Generates a CSS selector for all point elements in a bar/column series.
  *
  * Highcharts renders bar/column points with the `highcharts-point` class. The

--- a/src/adapters/highcharts/types.ts
+++ b/src/adapters/highcharts/types.ts
@@ -19,6 +19,31 @@ export interface HighchartsAdapterOptions {
 }
 
 /**
+ * Options for customizing the {@link highchartsGridToMaidr} adapter output.
+ */
+export interface HighchartsGridOptions {
+  /** Override the generated figure ID. Defaults to `highcharts-grid-{n}`. */
+  id?: string;
+  /** Figure-level title announced for the whole grid. */
+  title?: string;
+  /** Figure-level subtitle. */
+  subtitle?: string;
+  /** Figure-level caption. */
+  caption?: string;
+  /**
+   * Chunks a flat chart list into a grid. Ignored when a 2D chart array is
+   * passed (2D input maps 1:1 to the subplot grid). When omitted, a flat
+   * list becomes a single row.
+   */
+  layout?: {
+    /** Number of grid rows (columns are derived when only rows is set). */
+    rows?: number;
+    /** Number of charts per row. Takes precedence over `rows`. */
+    columns?: number;
+  };
+}
+
+/**
  * Represents a Highcharts chart instance.
  * Passed to {@link highchartsToMaidr} to generate MAIDR-compatible data.
  */
@@ -61,6 +86,10 @@ export interface HighchartsSeries {
   options: {
     type?: string;
     stacking?: string;
+    /** Set by Highcharts on internal series (e.g. the Highstock navigator). */
+    isInternal?: boolean;
+    /** User- or Highcharts-assigned class name (e.g. `highcharts-navigator-series`). */
+    className?: string;
   };
 }
 
@@ -103,6 +132,14 @@ export interface HighchartsAxis {
   categories?: string[];
   getExtremes: () => { min: number; max: number };
   isDatetimeAxis?: boolean;
+  /** Rendered distance from the chart top in px (present after render). */
+  top?: number;
+  /** Rendered distance from the chart left in px (present after render). */
+  left?: number;
+  /** Rendered axis height in px (present after render). */
+  height?: number;
+  /** Rendered axis width in px (present after render). */
+  width?: number;
   options: {
     title?: { text?: string };
     type?: string;

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -32,6 +32,7 @@ import type {
   PlotlyTrace,
 } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
+import { collectUniqueBgRects } from './normalizer';
 import { generatePlotlySelectors, subplotCssPrefix } from './selectors';
 
 // Monotonic counter for generating unique IDs when the graph div has no id.
@@ -68,7 +69,7 @@ export function extractPlotlyData(element: HTMLElement): Maidr | null {
   const subplotMap = groupTracesBySubplot(fullData, gd.calcdata);
 
   // Build 2D subplot grid.
-  const subplotGrid = buildSubplotGrid(subplotMap, fullLayout, gd);
+  const subplotGrid = buildSubplotGrid(subplotMap, fullLayout, gd, id);
 
   if (subplotGrid.length === 0) {
     console.warn('[maidr] No supported traces found in plotly chart.');
@@ -288,111 +289,342 @@ function groupTracesBySubplot(
     const group = map.get(key)!;
     group.traces.push(trace);
     group.traceIndices.push(i);
-    if (calcdata && calcdata[i]) {
-      group.calcdata.push(calcdata[i]);
+    if (calcdata) {
+      // Push a placeholder for traces without calcdata so `calcIdx` stays
+      // aligned with the group's trace order.
+      group.calcdata.push(calcdata[i] ?? []);
     }
   }
 
   return map;
 }
 
+/** A kept subplot together with the trace group it was built from. */
+interface PanelEntry {
+  group: SubplotGroup;
+  subplot: MaidrSubplot;
+}
+
 function buildSubplotGrid(
   subplotMap: Map<string, SubplotGroup>,
   layout: PlotlyFullLayout,
   gd: PlotlyGraphDiv,
+  maidrId: string,
 ): MaidrSubplot[][] {
-  // For now, treat all subplots as a single row.
-  // TODO: Use layout.grid to arrange into proper 2D grid.
-  const subplots: MaidrSubplot[] = [];
+  const panels: PanelEntry[] = [];
 
   for (const [, group] of subplotMap) {
-    const xAxis = getAxis(layout, group.xAxisId);
-    const yAxis = getAxis(layout, group.yAxisId);
-    const xLabel = extractAxisLabel(xAxis);
-    const yLabel = extractAxisLabel(yAxis);
-
-    const layers: MaidrLayer[] = [];
-
-    // Group traces that need multi-trace handling.
-    const lineTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
-    const boxTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
-    const barTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
-    const otherTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
-
-    for (let i = 0; i < group.traces.length; i++) {
-      const trace = group.traces[i];
-      const maidrType = mapTraceType(trace);
-      if (maidrType === TraceType.LINE) {
-        lineTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
-      } else if (maidrType === TraceType.BOX) {
-        boxTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
-      } else if (maidrType === TraceType.BAR) {
-        barTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
-      } else {
-        otherTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
-      }
-    }
-
-    // Build multi-line layer if applicable.
-    if (lineTraces.length > 0) {
-      const layer = extractMultiLineLayer(lineTraces, xLabel, yLabel, gd);
-      if (layer)
-        layers.push(layer);
-    }
-
-    // Build multi-box layer: all box traces in one layer.
-    if (boxTraces.length > 0) {
-      const layer = extractMultiBoxLayer(boxTraces, group, xLabel, yLabel, gd);
-      if (layer)
-        layers.push(layer);
-    }
-
-    // Build bar layers: grouped/stacked/normalized for multiple bar traces.
-    if (barTraces.length > 1) {
-      const barmode = layout.barmode ?? 'group';
-      const barnorm = layout.barnorm ?? '';
-
-      if (barmode === 'group') {
-        const layer = extractSegmentedBarLayer(barTraces, TraceType.DODGED, xLabel, yLabel, gd);
-        if (layer)
-          layers.push(layer);
-      } else if (barmode === 'stack' || barmode === 'relative') {
-        const type = barnorm === 'percent' || barnorm === 'fraction'
-          ? TraceType.NORMALIZED
-          : TraceType.STACKED;
-        const layer = extractSegmentedBarLayer(barTraces, type, xLabel, yLabel, gd);
-        if (layer)
-          layers.push(layer);
-      } else {
-        // 'overlay' or unknown: treat as individual bars.
-        for (const bt of barTraces) {
-          otherTraces.push(bt);
-        }
-      }
-    } else if (barTraces.length === 1) {
-      otherTraces.push(barTraces[0]);
-    }
-
-    // Build individual layers for remaining traces.
-    for (const { trace, calcIdx, globalIdx } of otherTraces) {
-      const maidrType = mapTraceType(trace);
-      if (!maidrType)
-        continue;
-
-      const cd = group.calcdata[calcIdx] ?? [];
-      const layer = extractLayer(trace, maidrType, cd, globalIdx, xLabel, yLabel, gd);
-      if (layer)
-        layers.push(layer);
-    }
-
+    const layers = buildSubplotLayers(group, layout, gd);
     if (layers.length > 0) {
-      subplots.push({ layers });
+      panels.push({ group, subplot: { layers } });
     }
   }
 
-  if (subplots.length === 0)
+  if (panels.length === 0)
     return [];
-  return [subplots]; // Single row for now.
+  if (panels.length === 1)
+    return [[panels[0].subplot]];
+
+  const grid = arrangePanelsIntoGrid(panels, layout);
+  if (!grid) {
+    // Overlapping axis domains (inset/overlaid axes) or missing domain
+    // info: not a grid — keep the flat single-row arrangement.
+    return [panels.map(panel => panel.subplot)];
+  }
+
+  applyFacetTitles(grid, layout);
+  assignSubplotSelectors(grid, gd, maidrId);
+  return grid.map(row => row.map(panel => panel.subplot));
+}
+
+/**
+ * Builds all MAIDR layers for one subplot (one x/y axis-pair group).
+ */
+function buildSubplotLayers(
+  group: SubplotGroup,
+  layout: PlotlyFullLayout,
+  gd: PlotlyGraphDiv,
+): MaidrLayer[] {
+  const xLabel = resolveAxisLabel(layout, group.xAxisId);
+  const yLabel = resolveAxisLabel(layout, group.yAxisId);
+
+  const layers: MaidrLayer[] = [];
+
+  // Group traces that need multi-trace handling.
+  const lineTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
+  const boxTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
+  const barTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
+  const otherTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
+
+  for (let i = 0; i < group.traces.length; i++) {
+    const trace = group.traces[i];
+    const maidrType = mapTraceType(trace);
+    if (maidrType === TraceType.LINE) {
+      lineTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
+    } else if (maidrType === TraceType.BOX) {
+      boxTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
+    } else if (maidrType === TraceType.BAR) {
+      barTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
+    } else {
+      otherTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
+    }
+  }
+
+  // Build multi-line layer if applicable.
+  if (lineTraces.length > 0) {
+    const layer = extractMultiLineLayer(lineTraces, xLabel, yLabel, gd);
+    if (layer)
+      layers.push(layer);
+  }
+
+  // Build multi-box layer: all box traces in one layer.
+  if (boxTraces.length > 0) {
+    const layer = extractMultiBoxLayer(boxTraces, group, xLabel, yLabel, gd);
+    if (layer)
+      layers.push(layer);
+  }
+
+  // Build bar layers: grouped/stacked/normalized for multiple bar traces.
+  if (barTraces.length > 1) {
+    const barmode = layout.barmode ?? 'group';
+    const barnorm = layout.barnorm ?? '';
+
+    if (barmode === 'group') {
+      const layer = extractSegmentedBarLayer(barTraces, TraceType.DODGED, xLabel, yLabel, gd);
+      if (layer)
+        layers.push(layer);
+    } else if (barmode === 'stack' || barmode === 'relative') {
+      const type = barnorm === 'percent' || barnorm === 'fraction'
+        ? TraceType.NORMALIZED
+        : TraceType.STACKED;
+      const layer = extractSegmentedBarLayer(barTraces, type, xLabel, yLabel, gd);
+      if (layer)
+        layers.push(layer);
+    } else {
+      // 'overlay' or unknown: treat as individual bars.
+      for (const bt of barTraces) {
+        otherTraces.push(bt);
+      }
+    }
+  } else if (barTraces.length === 1) {
+    otherTraces.push(barTraces[0]);
+  }
+
+  // Build individual layers for remaining traces.
+  for (const { trace, calcIdx, globalIdx } of otherTraces) {
+    const maidrType = mapTraceType(trace);
+    if (!maidrType)
+      continue;
+
+    const cd = group.calcdata[calcIdx] ?? [];
+    const layer = extractLayer(trace, maidrType, cd, globalIdx, xLabel, yLabel, gd);
+    if (layer)
+      layers.push(layer);
+  }
+
+  return layers;
+}
+
+// ---------------------------------------------------------------------------
+// Grid arrangement from axis domains
+// ---------------------------------------------------------------------------
+
+/** Tolerance when comparing axis-domain fractions (which lie in [0, 1]). */
+const DOMAIN_EPS = 1e-3;
+
+type DomainInterval = [number, number];
+
+interface PositionedPanel extends PanelEntry {
+  xDomain: DomainInterval;
+  yDomain: DomainInterval;
+}
+
+/**
+ * Arranges panels into a 2D grid (row-major, visual reading order) by
+ * clustering their axis domains: distinct y-domain intervals become rows
+ * (top first) and distinct x-domain intervals become columns (left first).
+ *
+ * Returns `null` when the panels do not form a grid — missing domain info,
+ * overlapping domains (inset plots), or two panels sharing one cell
+ * (overlaid axes) — so the caller can fall back to a flat single row.
+ */
+function arrangePanelsIntoGrid(
+  panels: PanelEntry[],
+  layout: PlotlyFullLayout,
+): PanelEntry[][] | null {
+  const positioned: PositionedPanel[] = [];
+  for (const panel of panels) {
+    const xDomain = readAxisDomain(getAxis(layout, panel.group.xAxisId));
+    const yDomain = readAxisDomain(getAxis(layout, panel.group.yAxisId));
+    if (!xDomain || !yDomain)
+      return null;
+    positioned.push({ ...panel, xDomain, yDomain });
+  }
+
+  const rowIntervals = clusterIntervals(positioned.map(panel => panel.yDomain));
+  const colIntervals = clusterIntervals(positioned.map(panel => panel.xDomain));
+  if (!rowIntervals || !colIntervals)
+    return null;
+
+  // Visual reading order: y-domain 0 is the BOTTOM of the plot area, so a
+  // larger domain start renders higher on screen — sort rows descending
+  // (top row first) and columns ascending (left column first).
+  rowIntervals.sort((a, b) => b[0] - a[0]);
+  colIntervals.sort((a, b) => a[0] - b[0]);
+
+  // Validate against layout.grid when present.
+  const gridConfig = layout.grid;
+  if (gridConfig?.rows != null && rowIntervals.length > gridConfig.rows)
+    return null;
+  if (gridConfig?.columns != null && colIntervals.length > gridConfig.columns)
+    return null;
+
+  const cells: (PanelEntry | null)[][] = rowIntervals.map(
+    () => colIntervals.map(() => null),
+  );
+  for (const panel of positioned) {
+    const row = findIntervalIndex(rowIntervals, panel.yDomain);
+    const col = findIntervalIndex(colIntervals, panel.xDomain);
+    if (row < 0 || col < 0 || cells[row][col])
+      return null; // Two panels in one cell: overlaid axes, not a grid.
+    cells[row][col] = panel;
+  }
+
+  // Compact ragged rows. A row can never end up empty because every row
+  // interval came from at least one panel.
+  return cells
+    .map(row => row.filter((cell): cell is PanelEntry => cell !== null))
+    .filter(row => row.length > 0);
+}
+
+/**
+ * Deduplicates domain intervals (within {@link DOMAIN_EPS}) into the
+ * distinct grid bands. Returns `null` when two DISTINCT intervals overlap,
+ * which means the panels are inset/overlaid rather than gridded.
+ */
+function clusterIntervals(intervals: DomainInterval[]): DomainInterval[] | null {
+  const unique: DomainInterval[] = [];
+  for (const interval of intervals) {
+    if (findIntervalIndex(unique, interval) === -1)
+      unique.push(interval);
+  }
+  for (let i = 0; i < unique.length; i++) {
+    for (let j = i + 1; j < unique.length; j++) {
+      const overlap = Math.min(unique[i][1], unique[j][1])
+        - Math.max(unique[i][0], unique[j][0]);
+      if (overlap > DOMAIN_EPS)
+        return null;
+    }
+  }
+  return unique;
+}
+
+function findIntervalIndex(intervals: DomainInterval[], target: DomainInterval): number {
+  return intervals.findIndex(
+    interval =>
+      Math.abs(interval[0] - target[0]) < DOMAIN_EPS
+      && Math.abs(interval[1] - target[1]) < DOMAIN_EPS,
+  );
+}
+
+function readAxisDomain(axis: PlotlyAxis | undefined): DomainInterval | null {
+  const domain = axis?.domain;
+  if (!domain || domain.length < 2)
+    return null;
+  const start = Number(domain[0]);
+  const end = Number(domain[1]);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start)
+    return null;
+  return [start, end];
+}
+
+/**
+ * Resolves an axis label, following facet-style `matches:` chains: Plotly
+ * Express facets keep the title only on the matched outer axis, so inner
+ * axes inherit the label from the axis they match.
+ */
+function resolveAxisLabel(layout: PlotlyFullLayout, axisId: string): string | undefined {
+  let currentId = axisId;
+  for (let hop = 0; hop < 8; hop++) {
+    const axis = getAxis(layout, currentId);
+    if (!axis)
+      return undefined;
+    const label = extractAxisLabel(axis);
+    if (label)
+      return label;
+    if (!axis.matches || axis.matches === currentId)
+      return undefined;
+    currentId = axis.matches;
+  }
+  return undefined;
+}
+
+/**
+ * Applies Plotly Express facet labels (layout annotations with axis-domain
+ * refs like `xref: 'x2 domain'`) as each panel's first-layer title — the
+ * first layer's title is the panel's display name in MAIDR's subplot
+ * summaries. Only annotations whose BOTH refs point at the panel's own axes
+ * are used, so labels are never attributed to the wrong panel.
+ */
+function applyFacetTitles(grid: PanelEntry[][], layout: PlotlyFullLayout): void {
+  const annotations = layout.annotations;
+  if (!Array.isArray(annotations) || annotations.length === 0)
+    return;
+
+  for (const row of grid) {
+    for (const panel of row) {
+      const xRef = `${panel.group.xAxisId} domain`;
+      const yRef = `${panel.group.yAxisId} domain`;
+      const labels: string[] = [];
+      for (const annotation of annotations) {
+        if (
+          annotation
+          && typeof annotation.text === 'string'
+          && annotation.text.length > 0
+          && annotation.xref === xRef
+          && annotation.yref === yRef
+        ) {
+          labels.push(annotation.text);
+        }
+      }
+      if (labels.length > 0) {
+        panel.subplot.layers[0].title = labels.join(', ');
+      }
+    }
+  }
+}
+
+/**
+ * Emits a per-panel `selector` (`g[id="axes_…"]`) in row-major visual order.
+ * The normalizer's `wrapSubplotBackgrounds` wraps the `.bglayer` rects in
+ * matching `<g>` groups, enabling MAIDR's subplot outline highlight.
+ *
+ * The rect↔panel association is positional, so selectors are only emitted
+ * when the kept-panel count equals the unique background-rect count —
+ * otherwise (e.g. a panel dropped for unsupported trace types) a wrong
+ * panel could be highlighted. Ids are prefixed with the chart id to avoid
+ * collisions between multiple charts on one page, while still matching the
+ * core's `g[id^="axes_"]` detection.
+ */
+function assignSubplotSelectors(
+  grid: PanelEntry[][],
+  gd: PlotlyGraphDiv,
+  maidrId: string,
+): void {
+  const panelCount = grid.reduce((count, row) => count + row.length, 0);
+
+  const bglayer = gd.querySelector('.bglayer');
+  if (!bglayer || collectUniqueBgRects(bglayer).length !== panelCount)
+    return;
+
+  const tag = maidrId.replace(/[^\w-]/g, '_');
+  let index = 0;
+  for (const row of grid) {
+    for (const panel of row) {
+      index += 1;
+      panel.subplot.selector = `g[id="axes_${tag}_${index}"]`;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -24,6 +24,7 @@ import type {
   SegmentedPoint,
 } from '../../type/grammar';
 import type {
+  PlotlyAnnotation,
   PlotlyAxis,
   PlotlyCalcData,
   PlotlyFullLayout,
@@ -32,7 +33,6 @@ import type {
   PlotlyTrace,
 } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
-import { collectUniqueBgRects } from './normalizer';
 import { generatePlotlySelectors, subplotCssPrefix } from './selectors';
 
 // Monotonic counter for generating unique IDs when the graph div has no id.
@@ -333,7 +333,7 @@ function buildSubplotGrid(
   }
 
   applyFacetTitles(grid, layout);
-  assignSubplotSelectors(grid, gd, maidrId);
+  assignSubplotSelectors(grid, maidrId);
   return grid.map(row => row.map(panel => panel.subplot));
 }
 
@@ -451,7 +451,7 @@ interface PositionedPanel extends PanelEntry {
 function arrangePanelsIntoGrid(
   panels: PanelEntry[],
   layout: PlotlyFullLayout,
-): PanelEntry[][] | null {
+): PositionedPanel[][] | null {
   const positioned: PositionedPanel[] = [];
   for (const panel of panels) {
     const xDomain = readAxisDomain(getAxis(layout, panel.group.xAxisId));
@@ -479,7 +479,7 @@ function arrangePanelsIntoGrid(
   if (gridConfig?.columns != null && colIntervals.length > gridConfig.columns)
     return null;
 
-  const cells: (PanelEntry | null)[][] = rowIntervals.map(
+  const cells: (PositionedPanel | null)[][] = rowIntervals.map(
     () => colIntervals.map(() => null),
   );
   for (const panel of positioned) {
@@ -493,7 +493,7 @@ function arrangePanelsIntoGrid(
   // Compact ragged rows. A row can never end up empty because every row
   // interval came from at least one panel.
   return cells
-    .map(row => row.filter((cell): cell is PanelEntry => cell !== null))
+    .map(row => row.filter((cell): cell is PositionedPanel => cell !== null))
     .filter(row => row.length > 0);
 }
 
@@ -520,11 +520,15 @@ function clusterIntervals(intervals: DomainInterval[]): DomainInterval[] | null 
 }
 
 function findIntervalIndex(intervals: DomainInterval[], target: DomainInterval): number {
-  return intervals.findIndex(
-    interval =>
-      Math.abs(interval[0] - target[0]) < DOMAIN_EPS
-      && Math.abs(interval[1] - target[1]) < DOMAIN_EPS,
-  );
+  return intervals.findIndex(interval => intervalsEqual(interval, target));
+}
+
+function intervalsEqual(a: DomainInterval, b: DomainInterval): boolean {
+  return Math.abs(a[0] - b[0]) < DOMAIN_EPS && Math.abs(a[1] - b[1]) < DOMAIN_EPS;
+}
+
+function containsValue(interval: DomainInterval, value: number): boolean {
+  return value >= interval[0] - DOMAIN_EPS && value <= interval[1] + DOMAIN_EPS;
 }
 
 function readAxisDomain(axis: PlotlyAxis | undefined): DomainInterval | null {
@@ -560,22 +564,58 @@ function resolveAxisLabel(layout: PlotlyFullLayout, axisId: string): string | un
 }
 
 /**
- * Applies Plotly Express facet labels (layout annotations with axis-domain
- * refs like `xref: 'x2 domain'`) as each panel's first-layer title — the
- * first layer's title is the panel's display name in MAIDR's subplot
- * summaries. Only annotations whose BOTH refs point at the panel's own axes
- * are used, so labels are never attributed to the wrong panel.
+ * Applies facet/subplot titles from layout annotations as each panel's
+ * first-layer title — the first layer's title is the panel's display name
+ * in MAIDR's subplot summaries.
+ *
+ * Two annotation shapes are recognised:
+ *
+ * 1. Axis-domain refs (`xref: 'x2 domain'`) — hand-authored facet labels.
+ *    Only annotations whose BOTH refs point at the panel's own axes are
+ *    used, so labels are never attributed to the wrong panel.
+ * 2. Paper refs (`xref: 'paper'` / `yref: 'paper'`) — what plotly.py emits
+ *    for Plotly Express facet labels and `make_subplots`
+ *    row/column/subplot titles. These carry no axis association, so they
+ *    are resolved geometrically against each panel's axis domains.
  */
-function applyFacetTitles(grid: PanelEntry[][], layout: PlotlyFullLayout): void {
+function applyFacetTitles(grid: PositionedPanel[][], layout: PlotlyFullLayout): void {
   const annotations = layout.annotations;
   if (!Array.isArray(annotations) || annotations.length === 0)
     return;
 
+  const labels = new Map<PositionedPanel, string[]>();
+  const addLabel = (panel: PositionedPanel, text: string): void => {
+    const existing = labels.get(panel);
+    if (existing) {
+      existing.push(text);
+    } else {
+      labels.set(panel, [text]);
+    }
+  };
+
+  applyDomainRefTitles(grid, annotations, addLabel);
+  applyPaperRefTitles(grid, annotations, addLabel);
+
+  for (const [panel, texts] of labels) {
+    panel.subplot.layers[0].title = texts.join(', ');
+  }
+}
+
+type AddLabel = (panel: PositionedPanel, text: string) => void;
+
+/**
+ * Matches annotations with axis-domain refs (`xref: 'x2 domain'`) to the
+ * panel owning those axes.
+ */
+function applyDomainRefTitles(
+  grid: PositionedPanel[][],
+  annotations: PlotlyAnnotation[],
+  addLabel: AddLabel,
+): void {
   for (const row of grid) {
     for (const panel of row) {
       const xRef = `${panel.group.xAxisId} domain`;
       const yRef = `${panel.group.yAxisId} domain`;
-      const labels: string[] = [];
       for (const annotation of annotations) {
         if (
           annotation
@@ -584,45 +624,197 @@ function applyFacetTitles(grid: PanelEntry[][], layout: PlotlyFullLayout): void 
           && annotation.xref === xRef
           && annotation.yref === yRef
         ) {
-          labels.push(annotation.text);
+          addLabel(panel, annotation.text);
         }
-      }
-      if (labels.length > 0) {
-        panel.subplot.layers[0].title = labels.join(', ');
       }
     }
   }
 }
 
 /**
- * Emits a per-panel `selector` (`g[id="axes_…"]`) in row-major visual order.
- * The normalizer's `wrapSubplotBackgrounds` wraps the `.bglayer` rects in
- * matching `<g>` groups, enabling MAIDR's subplot outline highlight.
- *
- * The rect↔panel association is positional, so selectors are only emitted
- * when the kept-panel count equals the unique background-rect count —
- * otherwise (e.g. a panel dropped for unsupported trace types) a wrong
- * panel could be highlighted. Ids are prefixed with the chart id to avoid
- * collisions between multiple charts on one page, while still matching the
- * core's `g[id^="axes_"]` detection.
+ * How far above a top-row panel's y-domain end a title annotation may sit
+ * (in paper units) and still be treated as that panel's title.
  */
-function assignSubplotSelectors(
-  grid: PanelEntry[][],
-  gd: PlotlyGraphDiv,
-  maidrId: string,
-): void {
-  const panelCount = grid.reduce((count, row) => count + row.length, 0);
+const TITLE_BAND = 0.25;
 
-  const bglayer = gd.querySelector('.bglayer');
-  if (!bglayer || collectUniqueBgRects(bglayer).length !== panelCount)
+/** A paper-ref annotation that is a candidate facet/subplot title. */
+interface PaperTitle {
+  text: string;
+  x: number;
+  y: number;
+  angle: number;
+}
+
+/**
+ * Extracts arrow-less paper-ref annotations with usable text and finite
+ * coordinates — the shape plotly.py uses for every facet and subplot title.
+ */
+function collectPaperTitles(annotations: PlotlyAnnotation[]): PaperTitle[] {
+  const titles: PaperTitle[] = [];
+  for (const annotation of annotations) {
+    if (
+      !annotation
+      || annotation.xref !== 'paper'
+      || annotation.yref !== 'paper'
+      || annotation.showarrow !== false
+      || typeof annotation.text !== 'string'
+      || annotation.text.length === 0
+    ) {
+      continue;
+    }
+    const x = Number(annotation.x);
+    const y = Number(annotation.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y))
+      continue;
+    const angle = Number(annotation.textangle ?? 0);
+    titles.push({
+      text: annotation.text,
+      x,
+      y,
+      angle: Number.isFinite(angle) ? angle : 0,
+    });
+  }
+  return titles;
+}
+
+/**
+ * Resolves plotly.py-style paper-ref titles geometrically:
+ *
+ * - Row titles (px `facet_row`, `make_subplots` `row_titles`): rotated 90°,
+ *   at/right of the plot area, vertically inside a row's y-domain — applied
+ *   to every panel in that row.
+ * - Column titles (px `facet_col`, `column_titles`) and per-panel subplot
+ *   titles (px `facet_col_wrap`, `subplot_titles`): both sit just above a
+ *   panel's top edge, so each is attributed to the nearest panel top below
+ *   it. A title above the TOP row is promoted to a whole-column title only
+ *   when no lower panel in that column has its own title.
+ *
+ * Global x/y axis-title annotations (below or left of the plot area) match
+ * no panel and are skipped naturally.
+ */
+function applyPaperRefTitles(
+  grid: PositionedPanel[][],
+  annotations: PlotlyAnnotation[],
+  addLabel: AddLabel,
+): void {
+  const titles = collectPaperTitles(annotations);
+  if (titles.length === 0)
     return;
 
-  const tag = maidrId.replace(/[^\w-]/g, '_');
-  let index = 0;
+  const panels = grid.flat();
+  const maxXEnd = Math.max(...panels.map(panel => panel.xDomain[1]));
+  const maxYEnd = Math.max(...panels.map(panel => panel.yDomain[1]));
+
+  const rowMatches: { row: PositionedPanel[]; text: string }[] = [];
+  const remaining: PaperTitle[] = [];
+  for (const title of titles) {
+    const row = Math.abs(title.angle) === 90 && title.x >= maxXEnd - DOMAIN_EPS
+      ? grid.find(gridRow => containsValue(gridRow[0].yDomain, title.y))
+      : undefined;
+    if (row) {
+      rowMatches.push({ row, text: title.text });
+    } else {
+      remaining.push(title);
+    }
+  }
+
+  const pending: { title: PaperTitle; panel: PositionedPanel }[] = [];
+  for (const title of remaining) {
+    const panel = matchPanelBelowTitle(grid, title);
+    if (panel)
+      pending.push({ title, panel });
+  }
+
+  for (const { title, panel } of pending) {
+    const isTopRow = panel.yDomain[1] >= maxYEnd - DOMAIN_EPS;
+    const columnHasOwnTitles = pending.some(
+      other => other.panel !== panel && intervalsEqual(other.panel.xDomain, panel.xDomain),
+    );
+    if (isTopRow && !columnHasOwnTitles) {
+      for (const columnPanel of panels) {
+        if (intervalsEqual(columnPanel.xDomain, panel.xDomain))
+          addLabel(columnPanel, title.text);
+      }
+    } else {
+      addLabel(panel, title.text);
+    }
+  }
+
+  for (const { row, text } of rowMatches) {
+    for (const panel of row)
+      addLabel(panel, text);
+  }
+}
+
+/**
+ * Finds the panel whose top edge is nearest below a title annotation, with
+ * the annotation horizontally inside the panel's x-domain. Rejects
+ * annotations floating too far above the panel (e.g. mid-figure notes or
+ * `make_subplots`' global axis titles).
+ */
+function matchPanelBelowTitle(
+  grid: PositionedPanel[][],
+  title: PaperTitle,
+): PositionedPanel | null {
+  let best: PositionedPanel | null = null;
   for (const row of grid) {
     for (const panel of row) {
-      index += 1;
-      panel.subplot.selector = `g[id="axes_${tag}_${index}"]`;
+      if (!containsValue(panel.xDomain, title.x))
+        continue;
+      if (panel.yDomain[1] > title.y + DOMAIN_EPS)
+        continue;
+      if (!best || panel.yDomain[1] > best.yDomain[1])
+        best = panel;
+    }
+  }
+  if (!best)
+    return null;
+
+  const offset = title.y - best.yDomain[1];
+  return offset <= titleBandAbove(grid, best) + DOMAIN_EPS ? best : null;
+}
+
+/**
+ * Vertical space above a panel in which a title annotation may sit: half
+ * the gap to the row above in the same column, or a fixed band for top-row
+ * panels (titles sit between the panel top and the paper edge).
+ */
+function titleBandAbove(grid: PositionedPanel[][], panel: PositionedPanel): number {
+  let gap = Infinity;
+  for (const row of grid) {
+    for (const other of row) {
+      if (!intervalsEqual(other.xDomain, panel.xDomain))
+        continue;
+      if (other.yDomain[0] > panel.yDomain[1] + DOMAIN_EPS)
+        gap = Math.min(gap, other.yDomain[0] - panel.yDomain[1]);
+    }
+  }
+  return gap === Infinity ? TITLE_BAND : gap / 2;
+}
+
+/**
+ * Emits a per-panel `selector` (`g[id="axes_…"]`) carrying the panel's axis
+ * pair (e.g. `x2y2`) as the id suffix. The normalizer's
+ * `wrapSubplotBackgrounds` creates matching `<g>` groups around each
+ * panel's background rect — wrapping the rendered `.bglayer` rect when one
+ * exists, or injecting a transparent rect sized from the panel's computed
+ * axis offsets when plotly drew no per-panel backgrounds at all (its
+ * default styling: `paper_bgcolor === plot_bgcolor`). The axis pair in the
+ * id keys the panel↔DOM association, so it stays correct even when a panel
+ * is dropped for unsupported trace types. Ids are prefixed with the chart
+ * id to avoid collisions between multiple charts on one page, while still
+ * matching the core's `g[id^="axes_"]` detection.
+ *
+ * These groups also give the core real per-panel geometry, so visual
+ * ordering and vertical arrow-key direction are resolved correctly for
+ * multi-row grids (the grid rows are emitted top-first).
+ */
+function assignSubplotSelectors(grid: PanelEntry[][], maidrId: string): void {
+  const tag = maidrId.replace(/[^\w-]/g, '_');
+  for (const row of grid) {
+    for (const panel of row) {
+      const axisPair = `${panel.group.xAxisId}${panel.group.yAxisId}`;
+      panel.subplot.selector = `g[id="axes_${tag}_${axisPair}"]`;
     }
   }
 }

--- a/src/adapters/plotly/normalizer.ts
+++ b/src/adapters/plotly/normalizer.ts
@@ -70,7 +70,57 @@ function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
   }
   bglayer.setAttribute('data-maidr', '1');
 
-  // Deduplicate rects by position and sort row-major.
+  const unique = collectUniqueBgRects(bglayer);
+
+  // Extract selector IDs from schema (row-major order).
+  const selectorIds: string[] = [];
+  const subplots = schema.subplots ?? [];
+  for (const row of subplots) {
+    for (const cell of row) {
+      const sel = cell.selector;
+      if (sel) {
+        const m = sel.match(/id="([^"]+)"/);
+        if (m)
+          selectorIds.push(m[1]);
+      }
+    }
+  }
+
+  // The rect↔panel association is positional (both sides sorted row-major),
+  // so it is only safe when the counts agree exactly. A mismatch (e.g. a
+  // panel dropped from the schema while its background rect remains) would
+  // shift every later panel's highlight onto the wrong rect.
+  if (selectorIds.length > 0 && selectorIds.length !== unique.length) {
+    console.warn(
+      '[maidr] Plotly subplot backgrounds do not match schema panels; skipping subplot highlight wrapping.',
+    );
+    selectorIds.length = 0;
+  }
+
+  // Wrap each unique rect in a <g> with the subplot ID.
+  const ns = 'http://www.w3.org/2000/svg';
+  const count = Math.min(unique.length, selectorIds.length);
+  for (let i = 0; i < count; i++) {
+    const rect = unique[i];
+    const g = document.createElementNS(ns, 'g');
+    g.setAttribute('id', selectorIds[i]);
+    rect.parentNode!.insertBefore(g, rect);
+    g.appendChild(rect);
+  }
+
+  // Mirror stroke changes from hidden clones to visible originals.
+  setupStrokeMirror(bglayer as SVGGElement);
+}
+
+/**
+ * Collects the panel background `<rect>` elements of a Plotly `.bglayer`,
+ * deduplicated by position and sorted row-major (top-left first).
+ *
+ * Shared by the normalizer (to wrap rects in `<g id="axes_…">` groups) and
+ * the extractor (to verify that the kept-panel count matches the rendered
+ * background count before emitting subplot selectors).
+ */
+export function collectUniqueBgRects(bglayer: Element): SVGRectElement[] {
   const bgRects = Array.from(bglayer.querySelectorAll<SVGRectElement>(':scope > rect'));
   const seen = new Set<string>();
   const unique: SVGRectElement[] = [];
@@ -91,34 +141,7 @@ function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
       - Number.parseFloat(b.getAttribute('x') ?? '0')
     );
   });
-
-  // Extract selector IDs from schema (row-major order).
-  const selectorIds: string[] = [];
-  const subplots = schema.subplots ?? [];
-  for (const row of subplots) {
-    for (const cell of row) {
-      const sel = cell.selector;
-      if (sel) {
-        const m = sel.match(/id="([^"]+)"/);
-        if (m)
-          selectorIds.push(m[1]);
-      }
-    }
-  }
-
-  // Wrap each unique rect in a <g> with the subplot ID.
-  const ns = 'http://www.w3.org/2000/svg';
-  const count = Math.min(unique.length, selectorIds.length);
-  for (let i = 0; i < count; i++) {
-    const rect = unique[i];
-    const g = document.createElementNS(ns, 'g');
-    g.setAttribute('id', selectorIds[i]);
-    rect.parentNode!.insertBefore(g, rect);
-    g.appendChild(rect);
-  }
-
-  // Mirror stroke changes from hidden clones to visible originals.
-  setupStrokeMirror(bglayer as SVGGElement);
+  return unique;
 }
 
 /**

--- a/src/adapters/plotly/normalizer.ts
+++ b/src/adapters/plotly/normalizer.ts
@@ -1,4 +1,5 @@
 import type { Maidr } from '../../type/grammar';
+import type { PlotlyAxis, PlotlyFullLayout, PlotlyGraphDiv } from './types';
 
 /**
  * Detects whether an SVG element lives inside a Plotly container.
@@ -62,6 +63,16 @@ export function normalizePlotlySvg(
  * the selected subplot by applying stroke to the first rect/path child.
  * We wrap the *original* Plotly rects (which have visible fill) so the
  * stroke border appears on the filled background.
+ *
+ * plotly draws NO per-panel background rects with its default styling
+ * (`paper_bgcolor === plot_bgcolor`, both opaque), and a panel dropped from
+ * the schema (unsupported trace types) leaves an extra rect behind. In both
+ * cases positional rect↔panel matching is unsafe, so the association falls
+ * back to each panel's axis pair (parsed from the selector id suffix): a
+ * transparent rect sized from the panel's computed axis offsets is injected
+ * into the `.bglayer` and wrapped instead. The resulting `g[id="axes_…"]`
+ * groups also give the core real per-panel geometry for visual ordering and
+ * vertical arrow-key direction.
  */
 function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
   const bglayer = svg.querySelector('.bglayer');
@@ -71,45 +82,145 @@ function wrapSubplotBackgrounds(svg: SVGSVGElement, schema: Maidr): void {
   bglayer.setAttribute('data-maidr', '1');
 
   const unique = collectUniqueBgRects(bglayer);
+  const panelIds = collectPanelSelectorIds(schema);
 
-  // Extract selector IDs from schema (row-major order).
-  const selectorIds: string[] = [];
-  const subplots = schema.subplots ?? [];
-  for (const row of subplots) {
-    for (const cell of row) {
-      const sel = cell.selector;
-      if (sel) {
-        const m = sel.match(/id="([^"]+)"/);
-        if (m)
-          selectorIds.push(m[1]);
-      }
+  if (panelIds.length > 0) {
+    if (unique.length === panelIds.length) {
+      // One rendered background rect per panel: associate positionally
+      // (both sides are sorted row-major).
+      wrapRects(unique, panelIds.map(panel => panel.id));
+    } else {
+      injectPanelRects(svg, bglayer, panelIds);
     }
-  }
-
-  // The rect↔panel association is positional (both sides sorted row-major),
-  // so it is only safe when the counts agree exactly. A mismatch (e.g. a
-  // panel dropped from the schema while its background rect remains) would
-  // shift every later panel's highlight onto the wrong rect.
-  if (selectorIds.length > 0 && selectorIds.length !== unique.length) {
-    console.warn(
-      '[maidr] Plotly subplot backgrounds do not match schema panels; skipping subplot highlight wrapping.',
-    );
-    selectorIds.length = 0;
-  }
-
-  // Wrap each unique rect in a <g> with the subplot ID.
-  const ns = 'http://www.w3.org/2000/svg';
-  const count = Math.min(unique.length, selectorIds.length);
-  for (let i = 0; i < count; i++) {
-    const rect = unique[i];
-    const g = document.createElementNS(ns, 'g');
-    g.setAttribute('id', selectorIds[i]);
-    rect.parentNode!.insertBefore(g, rect);
-    g.appendChild(rect);
   }
 
   // Mirror stroke changes from hidden clones to visible originals.
   setupStrokeMirror(bglayer as SVGGElement);
+}
+
+/** A panel's `g[id="axes_…"]` id together with its parsed axis-pair key. */
+interface PanelSelectorId {
+  id: string;
+  /** Axis-pair key (e.g. `x2y2`) parsed from the id suffix, if present. */
+  axisPair: string | null;
+}
+
+/**
+ * Extracts the subplot selector ids from the schema (row-major order),
+ * parsing the trailing axis-pair key the extractor embeds in each id.
+ */
+function collectPanelSelectorIds(schema: Maidr): PanelSelectorId[] {
+  const ids: PanelSelectorId[] = [];
+  for (const row of schema.subplots ?? []) {
+    for (const cell of row) {
+      const sel = cell.selector;
+      if (!sel)
+        continue;
+      const idMatch = sel.match(/id="([^"]+)"/);
+      if (!idMatch)
+        continue;
+      const pairMatch = idMatch[1].match(/_(x\d*y\d*)$/);
+      ids.push({ id: idMatch[1], axisPair: pairMatch ? pairMatch[1] : null });
+    }
+  }
+  return ids;
+}
+
+/**
+ * Wraps each rect in a `<g>` carrying the panel id, in matching order.
+ */
+function wrapRects(rects: SVGRectElement[], ids: string[]): void {
+  const ns = 'http://www.w3.org/2000/svg';
+  const count = Math.min(rects.length, ids.length);
+  for (let i = 0; i < count; i++) {
+    const rect = rects[i];
+    const g = document.createElementNS(ns, 'g');
+    g.setAttribute('id', ids[i]);
+    rect.parentNode!.insertBefore(g, rect);
+    g.appendChild(rect);
+  }
+}
+
+/**
+ * Injects one invisible rect per panel (sized from the panel's computed
+ * axis `_offset`/`_length`) into the `.bglayer` and wraps each in its
+ * `g[id="axes_…"]` group. Used when the rendered background rects cannot be
+ * matched to panels positionally.
+ */
+function injectPanelRects(
+  svg: SVGSVGElement,
+  bglayer: Element,
+  panelIds: PanelSelectorId[],
+): void {
+  const gd = svg.closest('.js-plotly-plot') as PlotlyGraphDiv | null;
+  const layout = gd?._fullLayout;
+  if (!layout) {
+    console.warn(
+      '[maidr] Plotly panel geometry unavailable; skipping subplot highlight wrapping.',
+    );
+    return;
+  }
+
+  const ns = 'http://www.w3.org/2000/svg';
+  for (const { id, axisPair } of panelIds) {
+    const frame = axisPair ? readPanelFrame(layout, axisPair) : null;
+    if (!frame) {
+      console.warn(
+        `[maidr] Could not resolve plotly panel geometry for "${id}"; skipping its subplot highlight.`,
+      );
+      continue;
+    }
+    const rect = document.createElementNS(ns, 'rect');
+    rect.setAttribute('x', String(frame.x));
+    rect.setAttribute('y', String(frame.y));
+    rect.setAttribute('width', String(frame.width));
+    rect.setAttribute('height', String(frame.height));
+    rect.setAttribute('fill', 'none');
+    rect.setAttribute('pointer-events', 'none');
+    const g = document.createElementNS(ns, 'g');
+    g.setAttribute('id', id);
+    g.appendChild(rect);
+    bglayer.appendChild(g);
+  }
+}
+
+/** Splits an axis-pair key like `x2y2` into its x/y axis ids. */
+function splitAxisPair(axisPair: string): [string, string] | null {
+  const match = axisPair.match(/^(x\d*)(y\d*)$/);
+  return match ? [match[1], match[2]] : null;
+}
+
+/**
+ * Reads a panel's pixel frame from plotly's computed axis offsets
+ * (`xaxis2._offset` is the panel's left edge, `yaxis2._offset` its top).
+ */
+function readPanelFrame(
+  layout: PlotlyFullLayout,
+  axisPair: string,
+): { x: number; y: number; width: number; height: number } | null {
+  const pair = splitAxisPair(axisPair);
+  if (!pair)
+    return null;
+  const xAxis = getLayoutAxis(layout, pair[0]);
+  const yAxis = getLayoutAxis(layout, pair[1]);
+  if (
+    xAxis?._offset == null || xAxis._length == null
+    || yAxis?._offset == null || yAxis._length == null
+  ) {
+    return null;
+  }
+  return {
+    x: xAxis._offset,
+    y: yAxis._offset,
+    width: xAxis._length,
+    height: yAxis._length,
+  };
+}
+
+/** Resolves `'x2'` → `layout.xaxis2`, `'y'` → `layout.yaxis`, etc. */
+function getLayoutAxis(layout: PlotlyFullLayout, axisId: string): PlotlyAxis | undefined {
+  const name = `${axisId.charAt(0)}axis${axisId.slice(1)}`;
+  return layout[name] as PlotlyAxis | undefined;
 }
 
 /**

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -56,9 +56,11 @@ export interface PlotlyLayout {
 }
 
 /**
- * A layout annotation. Plotly Express emits facet labels (e.g. "sex=Male")
- * as annotations whose `xref`/`yref` are axis-domain references such as
- * `'x2 domain'`.
+ * A layout annotation. plotly.py (Plotly Express facets, `make_subplots`
+ * row/column/subplot titles) emits facet labels (e.g. "sex=Male") as
+ * annotations with `xref: 'paper'` / `yref: 'paper'` positioned via paper
+ * coordinates; hand-authored charts may instead use axis-domain references
+ * such as `'x2 domain'`. Both shapes are recognised by the extractor.
  */
 export interface PlotlyAnnotation {
   text?: string;
@@ -91,6 +93,10 @@ export interface PlotlyAxis {
   anchor?: string;
   /** Axis id whose range this axis mirrors (facet-style shared axes). */
   matches?: string;
+  /** Computed pixel offset of the axis within the SVG (plotly internal). */
+  _offset?: number;
+  /** Computed pixel length of the axis within the SVG (plotly internal). */
+  _length?: number;
 }
 
 export interface PlotlyCalcData {

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -45,8 +45,29 @@ export interface PlotlyLayout {
   title?: { text?: string } | string;
   xaxis?: PlotlyAxis;
   yaxis?: PlotlyAxis;
-  grid?: { rows?: number; columns?: number };
+  grid?: {
+    rows?: number;
+    columns?: number;
+    pattern?: string;
+    roworder?: string;
+  };
+  annotations?: PlotlyAnnotation[];
   [key: string]: unknown;
+}
+
+/**
+ * A layout annotation. Plotly Express emits facet labels (e.g. "sex=Male")
+ * as annotations whose `xref`/`yref` are axis-domain references such as
+ * `'x2 domain'`.
+ */
+export interface PlotlyAnnotation {
+  text?: string;
+  xref?: string;
+  yref?: string;
+  x?: number | string;
+  y?: number | string;
+  showarrow?: boolean;
+  textangle?: number | string;
 }
 
 export interface PlotlyFullLayout extends PlotlyLayout {
@@ -64,6 +85,12 @@ export interface PlotlyAxis {
   tickvals?: number[];
   type?: string;
   categories?: string[];
+  /** Fraction of the plot area this axis spans: `[start, end]` in [0, 1]. */
+  domain?: [number, number];
+  /** The axis this one is anchored to (e.g. `'y2'`). */
+  anchor?: string;
+  /** Axis id whose range this axis mirrors (facet-style shared axes). */
+  matches?: string;
 }
 
 export interface PlotlyCalcData {

--- a/src/adapters/recharts/MaidrRecharts.tsx
+++ b/src/adapters/recharts/MaidrRecharts.tsx
@@ -38,11 +38,61 @@
  * ```
  */
 
-import type { JSX } from 'react';
-import type { MaidrRechartsProps } from './types';
-import { useMemo } from 'react';
+import type { JSX, ReactNode } from 'react';
+import type { MaidrRechartsProps, RechartsSubplotConfig } from './types';
+import { Children, useMemo } from 'react';
 import { Maidr } from '../../maidr-component';
-import { convertRechartsToMaidr } from './converters';
+import { convertRechartsToMaidr, normalizeRechartsSubplotGrid } from './converters';
+import { getPanelClassName } from './selectors';
+
+/**
+ * Renders the multi-panel grid for subplot mode.
+ *
+ * Children-order contract: pass exactly one Recharts chart per panel, in
+ * ROW-MAJOR order matching the `subplots` grid — the 1st child is panel
+ * [0][0] (top-left), the 2nd is [0][1], and so on row by row. Each child is
+ * wrapped in a generated `div.maidr-panel-<row>-<col>`; the adapter's
+ * highlight selectors are scoped to that class, so a mismatched order means
+ * a panel's narration would highlight a different panel's marks.
+ *
+ * Each grid row renders as a flex row so the visual layout matches the
+ * config grid shape (MAIDR announces panels in visual reading order).
+ */
+function renderPanelGrid(
+  subplots: RechartsSubplotConfig[] | RechartsSubplotConfig[][],
+  columns: number | undefined,
+  children: ReactNode,
+): JSX.Element {
+  const grid = normalizeRechartsSubplotGrid(subplots, columns);
+  const childArray = Children.toArray(children);
+  const panelCount = grid.reduce((count, row) => count + row.length, 0);
+  if (childArray.length !== panelCount) {
+    console.warn(
+      `MaidrRecharts: expected ${panelCount} children (one chart per subplot panel, in row-major order), got ${childArray.length}`,
+    );
+  }
+
+  // Flat child index of each row's first panel (row-major order).
+  const rowOffsets: number[] = [];
+  grid.reduce((offset, row) => {
+    rowOffsets.push(offset);
+    return offset + row.length;
+  }, 0);
+
+  return (
+    <>
+      {grid.map((row, rowIndex) => (
+        <div key={rowIndex} style={{ display: 'flex' }}>
+          {row.map((_, colIndex) => (
+            <div key={colIndex} className={getPanelClassName(rowIndex, colIndex)}>
+              {childArray[rowOffsets[rowIndex] + colIndex]}
+            </div>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}
 
 /**
  * Wrapper component that makes Recharts charts accessible via MAIDR.
@@ -51,6 +101,11 @@ import { convertRechartsToMaidr } from './converters';
  * MAIDR's data format, and renders the Recharts children inside a `<Maidr>`
  * component for audio sonification, text descriptions, braille output,
  * and keyboard navigation.
+ *
+ * In subplot mode (`subplots` prop set) the children must be one Recharts
+ * chart per panel in row-major grid order; each is wrapped in a generated
+ * `.maidr-panel-<row>-<col>` div used to scope highlighting to that panel.
+ * See {@link renderPanelGrid} for the full children-order contract.
  */
 export function MaidrRecharts({
   id,
@@ -62,6 +117,8 @@ export function MaidrRecharts({
   xKey,
   yKeys,
   layers,
+  subplots,
+  columns,
   xLabel,
   yLabel,
   orientation,
@@ -81,6 +138,8 @@ export function MaidrRecharts({
       xKey,
       yKeys,
       layers,
+      subplots,
+      columns,
       xLabel,
       yLabel,
       orientation,
@@ -88,12 +147,12 @@ export function MaidrRecharts({
       binConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, xLabel, yLabel, orientation, fillKeys, binConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, selectorOverride],
   );
 
   return (
     <Maidr data={maidrData}>
-      {children}
+      {subplots ? renderPanelGrid(subplots, columns, children) : children}
     </Maidr>
   );
 }

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -23,9 +23,10 @@ import type {
   ScatterPoint,
   SegmentedPoint,
 } from '@type/grammar';
-import type { RechartsAdapterConfig, RechartsChartType, RechartsLayerConfig } from './types';
+import type { RechartsAdapterConfig, RechartsChartType, RechartsLayerConfig, RechartsSubplotConfig } from './types';
+import { cssEscape } from '@adapters/shared/selectorUtil';
 import { Orientation, TraceType } from '@type/grammar';
-import { getRechartsSelector } from './selectors';
+import { getPanelClassSelector, getRechartsSelector } from './selectors';
 
 /**
  * Converts a Recharts adapter config into MAIDR's root data structure.
@@ -34,6 +35,10 @@ import { getRechartsSelector } from './selectors';
  * @returns MaidrData ready to pass to the `<Maidr>` component
  */
 export function convertRechartsToMaidr(config: RechartsAdapterConfig): Maidr {
+  if (config.subplots) {
+    return buildSubplotMaidr(config);
+  }
+
   const layers = buildLayers(config);
 
   const subplot: MaidrSubplot = {
@@ -50,26 +55,148 @@ export function convertRechartsToMaidr(config: RechartsAdapterConfig): Maidr {
 }
 
 /**
+ * Normalizes the `subplots` config into a 2D panel grid in row-major
+ * visual reading order.
+ *
+ * A flat array is chunked into rows of `columns` panels (a single row when
+ * `columns` is omitted). A 2D array is validated and returned as-is —
+ * ragged rows are allowed, empty rows and empty grids are not (the core
+ * navigation model cannot represent them).
+ */
+export function normalizeRechartsSubplotGrid(
+  subplots: RechartsSubplotConfig[] | RechartsSubplotConfig[][],
+  columns?: number,
+): RechartsSubplotConfig[][] {
+  if (subplots.length === 0) {
+    throw new Error('RechartsAdapter: subplots must contain at least one panel');
+  }
+
+  if (Array.isArray(subplots[0])) {
+    const grid = subplots as RechartsSubplotConfig[][];
+    for (const [rowIndex, row] of grid.entries()) {
+      if (!Array.isArray(row) || row.length === 0) {
+        throw new Error(`RechartsAdapter: subplots row ${rowIndex} must be a non-empty array of panels`);
+      }
+    }
+    return grid;
+  }
+
+  const flat = subplots as RechartsSubplotConfig[];
+  const cols = columns ?? flat.length;
+  if (!Number.isInteger(cols) || cols < 1) {
+    throw new Error('RechartsAdapter: columns must be a positive integer');
+  }
+
+  const grid: RechartsSubplotConfig[][] = [];
+  for (let i = 0; i < flat.length; i += cols) {
+    grid.push(flat.slice(i, i + cols));
+  }
+  return grid;
+}
+
+/**
+ * Builds a multi-panel (subplot mode) MAIDR figure: one MaidrSubplot per
+ * panel, arranged in the same grid shape as the config.
+ */
+function buildSubplotMaidr(config: RechartsAdapterConfig): Maidr {
+  if (config.chartType || config.layers) {
+    throw new Error('RechartsAdapter: subplots is mutually exclusive with top-level chartType/layers');
+  }
+
+  const grid = normalizeRechartsSubplotGrid(config.subplots ?? [], config.columns);
+  const subplots = grid.map((row, rowIndex) =>
+    row.map((panel, colIndex) => buildPanelSubplot(config, panel, rowIndex, colIndex)),
+  );
+
+  return {
+    id: config.id,
+    title: config.title,
+    subtitle: config.subtitle,
+    caption: config.caption,
+    subplots,
+  };
+}
+
+/**
+ * Builds one MaidrSubplot for a panel at grid position (row, col).
+ *
+ * Panel fields are merged over the top-level defaults, then the regular
+ * layer builders run with a panel scope so every generated selector matches
+ * only this panel's marks. Layer ids are prefixed with the grid position to
+ * stay unique across the whole figure, and the panel title (when provided)
+ * lands on the FIRST layer — the core uses it as the panel's display name
+ * in subplot summaries.
+ */
+function buildPanelSubplot(
+  config: RechartsAdapterConfig,
+  panel: RechartsSubplotConfig,
+  row: number,
+  col: number,
+): MaidrSubplot {
+  if (!panel.chartType && !panel.layers) {
+    throw new Error(
+      `RechartsAdapter: subplot panel [${row}][${col}] must define chartType + yKeys (simple mode) or layers (composed mode)`,
+    );
+  }
+
+  const merged: RechartsAdapterConfig = {
+    id: config.id,
+    data: panel.data ?? config.data,
+    chartType: panel.chartType,
+    xKey: panel.xKey ?? config.xKey,
+    yKeys: panel.yKeys ?? config.yKeys,
+    layers: panel.layers,
+    xLabel: panel.xLabel ?? config.xLabel,
+    yLabel: panel.yLabel ?? config.yLabel,
+    orientation: panel.orientation ?? config.orientation,
+    fillKeys: panel.fillKeys ?? config.fillKeys,
+    binConfig: panel.binConfig ?? config.binConfig,
+    selectorOverride: panel.selectorOverride,
+  };
+
+  const panelScope = panel.panelSelector ?? getPanelClassSelector(row, col);
+  const layers = buildLayers(merged, panelScope).map((layer, layerIndex) => ({
+    ...layer,
+    // Layer ids must be unique across the WHOLE figure, not per subplot.
+    id: `${row}_${col}_${layer.id}`,
+    // The first layer's title doubles as the panel display name.
+    title: layerIndex === 0 && panel.title !== undefined ? panel.title : layer.title,
+  }));
+
+  return {
+    layers,
+    selector: `#maidr-article-${cssEscape(config.id)} ${panelScope} svg.recharts-surface`,
+  };
+}
+
+/**
  * Builds MAIDR layers from the adapter config.
  * Handles both simple mode (chartType + yKeys) and composed mode (layers).
+ *
+ * @param config - Adapter (or merged per-panel) configuration
+ * @param panelScope - Optional selector scoping generated selectors to one
+ *                     panel's container (subplot mode only)
  */
-function buildLayers(config: RechartsAdapterConfig): MaidrLayer[] {
+function buildLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
   if (config.layers) {
-    return buildComposedLayers(config);
+    return buildComposedLayers(config, panelScope);
   }
-  return buildSimpleLayers(config);
+  return buildSimpleLayers(config, panelScope);
 }
 
 /**
  * Builds layers for simple mode (single chart type, one or more yKeys).
  */
-function buildSimpleLayers(config: RechartsAdapterConfig): MaidrLayer[] {
+function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
   const { data, chartType, xKey, yKeys, xLabel, yLabel, orientation, fillKeys, selectorOverride } = config;
 
   if (!chartType || !yKeys || yKeys.length === 0) {
     throw new Error(
       'RechartsAdapter: either provide chartType + yKeys (simple mode) or layers (composed mode)',
     );
+  }
+  if (!data) {
+    throw new Error('RechartsAdapter: data is required (top-level or per subplot panel)');
   }
 
   const hasMultipleSeries = yKeys.length > 1;
@@ -78,12 +205,12 @@ function buildSimpleLayers(config: RechartsAdapterConfig): MaidrLayer[] {
   // produce a single layer with SegmentedPoint[][] data.
   // With a single yKey, fall back to regular BAR.
   if (isSegmentedBarType(chartType) && hasMultipleSeries) {
-    return [buildSegmentedBarLayer(data, xKey, yKeys, chartType, xLabel, yLabel, orientation, fillKeys, selectorOverride, config.id)];
+    return [buildSegmentedBarLayer(data, xKey, yKeys, chartType, xLabel, yLabel, orientation, fillKeys, selectorOverride, config.id, panelScope)];
   }
 
   // Histogram: produce HistogramPoint[] data
   if (chartType === 'histogram') {
-    return [buildHistogramLayer(data, xKey, yKeys[0], chartType, xLabel, yLabel, orientation, config.binConfig, selectorOverride, config.id)];
+    return [buildHistogramLayer(data, xKey, yKeys[0], chartType, xLabel, yLabel, orientation, config.binConfig, selectorOverride, config.id, panelScope)];
   }
 
   // Line with multiple series: single layer with 2D LinePoint[][] data
@@ -100,7 +227,7 @@ function buildSimpleLayers(config: RechartsAdapterConfig): MaidrLayer[] {
   // Simple single-series or multiple separate layers
   return yKeys.map((yKey, index) => {
     const seriesIndex = hasMultipleSeries ? index : undefined;
-    const selector = selectorOverride ?? getRechartsSelector(chartType, seriesIndex, config.id);
+    const selector = selectorOverride ?? getRechartsSelector(chartType, seriesIndex, config.id, panelScope);
     const layerData = convertData(chartType, data, xKey, yKey);
 
     return {
@@ -137,6 +264,7 @@ function buildSegmentedBarLayer(
   fillKeys?: string[],
   selectorOverride?: string,
   chartId?: string,
+  panelScope?: string,
 ): MaidrLayer {
   // SegmentedTrace expects [group/segment][category]:
   //   outer array = series (one per yKey/fill)
@@ -149,7 +277,7 @@ function buildSegmentedBarLayer(
     }));
   });
 
-  const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId);
+  const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope);
 
   return {
     id: '0',
@@ -179,6 +307,7 @@ function buildHistogramLayer(
   binConfig?: RechartsAdapterConfig['binConfig'],
   selectorOverride?: string,
   chartId?: string,
+  panelScope?: string,
 ): MaidrLayer {
   const histData: HistogramPoint[] = data.map((item) => {
     const x = item[xKey] as string | number;
@@ -191,7 +320,7 @@ function buildHistogramLayer(
     return { x, y, xMin, xMax, yMin, yMax };
   });
 
-  const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId);
+  const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope);
 
   return {
     id: '0',
@@ -250,11 +379,14 @@ function buildMultiSeriesLineLayer(
 /**
  * Builds layers for composed mode (mixed chart types via layers config).
  */
-function buildComposedLayers(config: RechartsAdapterConfig): MaidrLayer[] {
+function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
   const { data, xKey, xLabel, yLabel, orientation, layers, selectorOverride } = config;
 
   if (!layers || layers.length === 0) {
     throw new Error('RechartsAdapter: layers array must not be empty in composed mode');
+  }
+  if (!data) {
+    throw new Error('RechartsAdapter: data is required (top-level or per subplot panel)');
   }
 
   // Count how many layers use each chart type to decide multi-series indexing.
@@ -275,7 +407,7 @@ function buildComposedLayers(config: RechartsAdapterConfig): MaidrLayer[] {
     const seriesIndex = (typeTotals.get(chartType) ?? 0) > 1 ? currentIndex : undefined;
 
     const maidrType = toTraceType(chartType);
-    const selector = selectorOverride ?? getRechartsSelector(chartType, seriesIndex, config.id);
+    const selector = selectorOverride ?? getRechartsSelector(chartType, seriesIndex, config.id, panelScope);
     const layerData = convertData(chartType, data, xKey, yKey);
 
     return {

--- a/src/adapters/recharts/index.ts
+++ b/src/adapters/recharts/index.ts
@@ -8,14 +8,15 @@
  * @packageDocumentation
  */
 
-export { convertRechartsToMaidr } from './converters';
+export { convertRechartsToMaidr, normalizeRechartsSubplotGrid } from './converters';
 export { MaidrRecharts } from './MaidrRecharts';
-export { getRechartsSelector } from './selectors';
+export { getPanelClassName, getRechartsSelector } from './selectors';
 export type {
   HistogramBinConfig,
   MaidrRechartsProps,
   RechartsAdapterConfig,
   RechartsChartType,
   RechartsLayerConfig,
+  RechartsSubplotConfig,
 } from './types';
 export { useRechartsAdapter } from './useRechartsAdapter';

--- a/src/adapters/recharts/selectors.ts
+++ b/src/adapters/recharts/selectors.ts
@@ -48,6 +48,22 @@ import type { RechartsChartType } from './types';
 import { cssEscape } from '@adapters/shared/selectorUtil';
 
 /**
+ * Returns the CSS class name of the generated wrapper div for one panel of
+ * a multi-panel (subplot mode) figure. `<MaidrRecharts>` stamps this class
+ * on each panel wrapper it renders.
+ */
+export function getPanelClassName(row: number, col: number): string {
+  return `maidr-panel-${row}-${col}`;
+}
+
+/**
+ * Returns the CSS selector matching one panel's generated wrapper div.
+ */
+export function getPanelClassSelector(row: number, col: number): string {
+  return `.${getPanelClassName(row, col)}`;
+}
+
+/**
  * Returns the CSS selector string for individual data point elements
  * of the given Recharts chart type.
  *
@@ -62,16 +78,24 @@ import { cssEscape } from '@adapters/shared/selectorUtil';
  * to scope every selector to that chart's own `#maidr-article-<id>` wrapper so
  * the charts cannot highlight one another's elements.
  *
+ * For multi-panel figures every panel lives inside the SAME article wrapper,
+ * so `chartId` alone is not enough: pass `panelScope` (a selector matching
+ * only that panel's container, e.g. `.maidr-panel-0-1`) to keep each panel's
+ * selectors from matching sibling panels' marks.
+ *
  * @param chartType - The Recharts chart type
  * @param seriesIndex - When set, indicates a multi-series chart — returns undefined
  * @param chartId - When set, scopes the selector to the chart's `<Maidr>`
  *                  article (`#maidr-article-<id>`) to avoid cross-chart matches
+ * @param panelScope - When set, additionally scopes the selector to one
+ *                     panel's container within the article (subplot mode)
  * @returns CSS selector string, or undefined for multi-series targeting
  */
 export function getRechartsSelector(
   chartType: RechartsChartType,
   seriesIndex?: number,
   chartId?: string,
+  panelScope?: string,
 ): string | undefined {
   // Multi-series positional targeting is unreliable with CSS alone.
   // Return undefined to gracefully disable highlighting.
@@ -80,12 +104,23 @@ export function getRechartsSelector(
   }
 
   const base = baseRechartsSelector(chartType);
-  if (base === undefined || chartId === undefined) {
+  if (base === undefined) {
     return base;
   }
   // Scope to the chart's own `<Maidr>` article so multiple Recharts charts on
-  // one page cannot cross-highlight under page-global selector resolution.
-  return `#maidr-article-${cssEscape(chartId)} ${base}`;
+  // one page cannot cross-highlight under page-global selector resolution,
+  // then to the panel's own container so sibling panels cannot either.
+  const scopes: string[] = [];
+  if (chartId !== undefined) {
+    scopes.push(`#maidr-article-${cssEscape(chartId)}`);
+  }
+  if (panelScope !== undefined) {
+    scopes.push(panelScope);
+  }
+  if (scopes.length === 0) {
+    return base;
+  }
+  return `${scopes.join(' ')} ${base}`;
 }
 
 /**

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -57,12 +57,72 @@ export interface HistogramBinConfig {
 }
 
 /**
+ * Per-panel configuration for multi-panel (faceted) charts.
+ *
+ * Each panel is one Recharts chart in a grid of small multiples. Panel
+ * fields mirror the corresponding {@link RechartsAdapterConfig} fields;
+ * any field left out falls back to the top-level config value, so shared
+ * settings (`data`, `xKey`, axis labels, ...) only need to be declared once.
+ *
+ * Every panel must define its own `chartType` + `yKeys` (simple mode) or
+ * `layers` (composed mode) — these are the only fields without a top-level
+ * default, because `subplots` is mutually exclusive with the top-level
+ * `chartType`/`layers`.
+ */
+export interface RechartsSubplotConfig {
+  /**
+   * Panel display name (e.g. the facet value, "Region: East").
+   * Announced when navigating between subplots.
+   */
+  title?: string;
+  /** Panel data array. Falls back to the top-level `data`. */
+  data?: Record<string, unknown>[];
+  /** Chart type for this panel (simple mode). Mutually exclusive with `layers`. */
+  chartType?: RechartsChartType;
+  /** Key in data objects for x-axis values. Falls back to the top-level `xKey`. */
+  xKey?: string;
+  /** Keys in data objects for y-axis values (simple mode). Falls back to the top-level `yKeys`. */
+  yKeys?: string[];
+  /** Layer configurations for a composed panel (composed mode). */
+  layers?: RechartsLayerConfig[];
+  /** X-axis label. Falls back to the top-level `xLabel`. */
+  xLabel?: string;
+  /** Y-axis label. Falls back to the top-level `yLabel`. */
+  yLabel?: string;
+  /** Bar chart orientation. Falls back to the top-level `orientation`. */
+  orientation?: Orientation;
+  /** Series display names. Falls back to the top-level `fillKeys`. */
+  fillKeys?: string[];
+  /** Histogram bin range configuration. Falls back to the top-level `binConfig`. */
+  binConfig?: HistogramBinConfig;
+  /**
+   * Custom CSS selector override for this panel's highlight elements.
+   * Unlike other fields, this does NOT fall back to the top-level
+   * `selectorOverride` (a single override cannot distinguish panels).
+   * Provide an already panel-scoped selector when using this.
+   */
+  selectorOverride?: string;
+  /**
+   * Custom CSS selector for this panel's container element — the escape
+   * hatch when you render the panel DOM yourself (e.g. via the
+   * `useRechartsAdapter` hook) instead of letting `<MaidrRecharts>`
+   * generate `.maidr-panel-<row>-<col>` wrapper divs.
+   *
+   * Used both to scope this panel's highlight selectors and as the
+   * subplot container selector, so it must match ONLY this panel.
+   */
+  panelSelector?: string;
+}
+
+/**
  * Configuration for the Recharts-to-MAIDR adapter.
  *
- * Supports two configuration modes:
+ * Supports three configuration modes:
  * 1. **Simple mode** — Set `chartType` and `yKeys` for a single chart type
  *    with one or more data series.
  * 2. **Composed mode** — Set `layers` for mixed chart types (e.g., bar + line).
+ * 3. **Subplot mode** — Set `subplots` for multi-panel (faceted) figures
+ *    made of a grid of Recharts charts.
  *
  * @example Simple bar chart
  * ```typescript
@@ -123,6 +183,22 @@ export interface HistogramBinConfig {
  *   yLabel: 'Value',
  * };
  * ```
+ *
+ * @example Multi-panel (faceted) figure — 1x2 grid of bar charts
+ * ```typescript
+ * const config: RechartsAdapterConfig = {
+ *   id: 'sales-by-region',
+ *   title: 'Sales by Region',
+ *   xKey: 'quarter',           // top-level fields are defaults for every panel
+ *   yKeys: ['revenue'],
+ *   xLabel: 'Quarter',
+ *   yLabel: 'Revenue ($)',
+ *   subplots: [[
+ *     { title: 'East', chartType: 'bar', data: eastData },
+ *     { title: 'West', chartType: 'bar', data: westData },
+ *   ]],
+ * };
+ * ```
  */
 export interface RechartsAdapterConfig {
   /** Unique identifier for the chart (used for DOM IDs). */
@@ -137,8 +213,13 @@ export interface RechartsAdapterConfig {
   /** Chart caption. */
   caption?: string;
 
-  /** Recharts data array. Each item is one data point with named fields. */
-  data: Record<string, unknown>[];
+  /**
+   * Recharts data array. Each item is one data point with named fields.
+   * Required in simple/composed mode. In subplot mode it acts as the
+   * default data for panels that do not provide their own `data`, and may
+   * be omitted when every panel does.
+   */
+  data?: Record<string, unknown>[];
 
   /**
    * Chart type for simple mode (single chart type with one or more series).
@@ -162,6 +243,29 @@ export interface RechartsAdapterConfig {
    * Mutually exclusive with `chartType`/`yKeys`.
    */
   layers?: RechartsLayerConfig[];
+
+  /**
+   * Panel configurations for multi-panel (faceted) figures (subplot mode).
+   * Mutually exclusive with the top-level `chartType` and `layers`.
+   *
+   * A 2D array describes the panel grid directly in row-major visual
+   * reading order (`subplots[0][0]` is the top-left panel). A flat array
+   * is chunked into rows of {@link columns} panels (one single row when
+   * `columns` is omitted). Rows may be ragged but never empty.
+   *
+   * When rendering through `<MaidrRecharts>`, pass one Recharts chart per
+   * panel as children in the same row-major order — each child is wrapped
+   * in a generated `.maidr-panel-<row>-<col>` div used for per-panel
+   * highlight scoping. See {@link RechartsSubplotConfig.panelSelector} for
+   * the custom-DOM escape hatch.
+   */
+  subplots?: RechartsSubplotConfig[] | RechartsSubplotConfig[][];
+
+  /**
+   * Number of panels per row when `subplots` is a flat array.
+   * Ignored when `subplots` is already a 2D grid.
+   */
+  columns?: number;
 
   /** X-axis label. */
   xLabel?: string;

--- a/src/adapters/recharts/useRechartsAdapter.ts
+++ b/src/adapters/recharts/useRechartsAdapter.ts
@@ -48,9 +48,15 @@ import { convertRechartsToMaidr } from './converters';
  * fields change. You do **not** need to stabilize the config object
  * reference itself — the hook destructures it and tracks each field
  * independently. However, fields that are arrays or objects (`data`,
- * `yKeys`, `layers`, `fillKeys`, `binConfig`) are compared by
- * reference. Define them outside the component or wrap them in
+ * `yKeys`, `layers`, `subplots`, `fillKeys`, `binConfig`) are compared
+ * by reference. Define them outside the component or wrap them in
  * `useMemo` to avoid unnecessary recomputation on every render.
+ *
+ * In subplot mode (`subplots` set), the hook — unlike `<MaidrRecharts>` —
+ * does NOT wrap your charts in panel container divs. You must render each
+ * panel's chart inside a container matching the generated panel scope
+ * (`<div className="maidr-panel-<row>-<col>">`, row-major grid positions)
+ * or set `panelSelector` on each panel config to your own unique selector.
  *
  * @param config - Recharts adapter configuration
  * @returns MaidrData ready to pass to `<Maidr data={...}>`
@@ -66,6 +72,8 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
     xKey,
     yKeys,
     layers,
+    subplots,
+    columns,
     xLabel,
     yLabel,
     orientation,
@@ -85,6 +93,8 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
       xKey,
       yKeys,
       layers,
+      subplots,
+      columns,
       xLabel,
       yLabel,
       orientation,
@@ -92,6 +102,6 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
       binConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, xLabel, yLabel, orientation, fillKeys, binConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, selectorOverride],
   );
 }

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -1093,6 +1093,13 @@ function buildConcatMaidr(
   let globalLayerIndex = 0;
 
   const subplotEntries: MaidrSubplot[] = specs.map((childSpec, i) => {
+    // Each concat child compiles to a per-cell Vega scope group
+    // (`concat_<i>_group`) wrapping the panel's background path. Pointing
+    // the subplot selector at that background gives MAIDR core a real
+    // per-panel element to measure, which is what lets it compute the
+    // visual panel order (and vertical arrow direction) for multi-row
+    // vconcat / wrapped-concat grids — Vega SVGs carry no `axes_*` ids.
+    const selector = `g.mark-group.role-scope.concat_${i}_group > g > path.background`;
     if (childSpec.layer) {
       const layers = childSpec.layer.map((layerSpec, j) => {
         // Vega names this child's mark groups `concat_<i>_layer_<j>_marks`
@@ -1115,7 +1122,7 @@ function buildConcatMaidr(
         globalLayerIndex++;
         return layer;
       }).filter(Boolean) as MaidrLayer[];
-      return { layers };
+      return { layers, selector };
     }
     // A single-view concat child renders under `concat_<i>_marks` (or the
     // sugar-expanded `concat_<i>_layer_0_marks`).
@@ -1131,8 +1138,16 @@ function buildConcatMaidr(
     if (layer)
       layer.id = `${i}_0`;
     globalLayerIndex++;
-    return { layers: layer ? [layer] : [] };
+    return { layers: layer ? [layer] : [], selector };
   });
+
+  // A subplot with zero layers inside a grid crashes MAIDR core's Subplot
+  // model on focus; collapse to the same single empty figure other
+  // unsupported specs produce (bindVegaLite skips mounting that shape).
+  if (subplotEntries.some(entry => entry.layers.length === 0)) {
+    console.warn('[maidr/vegalite] Concat spec contains a child with an unsupported mark type.');
+    return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
+  }
 
   // vconcat produces one subplot per row (column layout).
   // hconcat produces all subplots in a single row.
@@ -1315,6 +1330,14 @@ function buildFacetMaidr(
         const cellRows = layerRows[j].filter(row =>
           cell.filters.every(([field, key]) => String(row[field]) === key),
         );
+        // Skip layers whose rows don't cover this facet value (e.g. an
+        // annotation layer with its own dataset covering only some cells).
+        // convertLayerSpec would happily emit a layer with `data: []`,
+        // and a zero-point trace crashes MAIDR core's state getters the
+        // moment the user PageUp/PageDown's onto it.
+        if (cellRows.length === 0) {
+          return null;
+        }
         return convertLayerSpec(
           layerSpec,
           j,
@@ -1367,9 +1390,12 @@ function buildFacetMaidr(
  * `{repeat: ...}` field references substituted for that cell's fields.
  *
  * Unlike facets, repeat cells compile to per-cell Vega child views whose
- * mark classes are already unique (`child__row_<rf>column_<cf>_marks`
- * etc.), so selectors are class-scoped and no bind-time stamping is
- * needed.
+ * mark classes are already unique *within one chart*
+ * (`child__row_<rf>column_<cf>_marks` etc.), so selectors are class-scoped
+ * and no bind-time stamping is needed. Cross-chart uniqueness (two charts
+ * built from the same repeated fields compile to identical class names) is
+ * handled at bind time, where `bindVegaLite` prefixes every selector with
+ * the chart container's id.
  */
 function buildRepeatMaidr(
   id: string,

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -1257,7 +1257,10 @@ function buildFacetMaidr(
     }
     return rows;
   });
-  const allRows = layerRows.find(rows => rows.length > 0) ?? [];
+  // Union across ALL layers: a sparse layer declared first (e.g. an
+  // annotation layer covering a subset of facet values) must not hide
+  // panels that a fuller layer's data would produce.
+  const allRows = layerRows.flat();
 
   // Build the grid of cell definitions in visual reading order.
   const grid: FacetCellDef[][] = [];
@@ -1280,18 +1283,22 @@ function buildFacetMaidr(
       : [null];
 
     // Cross facets are sparse: Vega only renders cells for (row, column)
-    // combinations present in the data.
+    // combinations present in the data. The combo key is joined with NUL
+    // (which cannot appear in field values) - a bare space would make
+    // row="East Coast"/col="City" collide with row="East"/col="Coast City".
+    const comboKey = (rowValue: unknown, colValue: unknown): string =>
+      `${String(rowValue)}\u0000${String(colValue)}`;
     const combos = new Set<string>();
     if (rowField && colField) {
       for (const row of allRows) {
-        combos.add(`${String(row[rowField])} ${String(row[colField])}`);
+        combos.add(comboKey(row[rowField], row[colField]));
       }
     }
 
     for (const rowKey of rowKeys) {
       const cellsInRow: FacetCellDef[] = [];
       for (const colKey of colKeys) {
-        if (rowField && colField && !combos.has(`${rowKey} ${colKey}`)) {
+        if (rowField && colField && !combos.has(comboKey(rowKey, colKey))) {
           continue;
         }
         const filters: FacetCellDef['filters'] = [];

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -5,11 +5,15 @@
  * The converter handles:
  *   - Single-view specs (`mark` + `encoding`)
  *   - Layered specs (`layer`)
- *   - Composite specs (`hconcat`, `vconcat`, `concat`)
+ *   - Composite specs (`hconcat`, `vconcat`, `concat` + `columns`)
+ *   - Faceted specs (`facet` operator, `encoding.row` / `encoding.column`
+ *     shorthand, and wrapped facets via `facet.field` + `columns`)
+ *   - Repeated specs (`repeat` row/column arrays or wrapped `repeat: [...]`)
  *
- * Faceted (`facet`) and repeated (`repeat`) specs are not yet supported;
- * the converter logs a warning and returns an empty MAIDR schema in
- * those cases.
+ * Multi-panel specs produce a `Maidr.subplots` grid (one subplot per
+ * panel, in visual reading order); MAIDR core then starts in SUBPLOT
+ * navigation scope where arrow keys move between panels and Enter drills
+ * into one.
  */
 
 import type {
@@ -24,6 +28,7 @@ import type {
   ScatterPoint,
   SegmentedPoint,
 } from '@type/grammar';
+import type { FacetDescriptor, RepeatCellMapping, RepeatDescriptor } from './facets';
 import type {
   VegaLiteChannelDef,
   VegaLiteEncoding,
@@ -32,6 +37,17 @@ import type {
   VegaView,
 } from './types';
 import { Orientation, TraceType } from '@type/grammar';
+import {
+  chunkIntoRows,
+  describeFacet,
+  describeRepeat,
+  facetCellAttrValue,
+  facetCellScope,
+  repeatChildName,
+  resolveDomainKeys,
+  scopeSelector,
+  substituteRepeatFields,
+} from './facets';
 import { buildLineSelectors, buildSelector } from './selectors';
 
 // ---------------------------------------------------------------------------
@@ -67,20 +83,26 @@ export function vegaLiteToMaidr(
     return buildConcatMaidr(id, title, subtitle, caption, spec.vconcat, 'vertical', view, domOrder);
   }
   if (spec.concat) {
-    return buildConcatMaidr(id, title, subtitle, caption, spec.concat, 'wrap', view, domOrder);
+    return buildConcatMaidr(id, title, subtitle, caption, spec.concat, 'wrap', view, domOrder, spec.columns);
   }
 
-  // Unsupported composite spec types — warn and return an empty chart.
-  if (spec.facet) {
-    console.warn('[maidr/vegalite] Faceted specs are not yet supported.');
-    return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
+  // Faceted specs — the `facet` operator (row/column or wrapped) and the
+  // `encoding.row` / `encoding.column` shorthand both normalise to the
+  // same descriptor.
+  const facetDescriptor = describeFacet(spec);
+  if (facetDescriptor) {
+    return buildFacetMaidr(id, title, subtitle, caption, spec, facetDescriptor, view, domOrder);
   }
-  if (spec.repeat) {
-    console.warn('[maidr/vegalite] Repeat specs are not yet supported.');
-    return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
+
+  // Repeated specs.
+  const repeatDescriptor = describeRepeat(spec);
+  if (repeatDescriptor) {
+    return buildRepeatMaidr(id, title, subtitle, caption, spec, repeatDescriptor, view, domOrder);
   }
-  if (spec.spec && !spec.mark && !spec.layer) {
-    console.warn('[maidr/vegalite] Wrapped "spec" compositions are not yet supported.');
+
+  // Unsupported composite spec shapes — warn and return an empty chart.
+  if (spec.facet || spec.repeat || (spec.spec && !spec.mark && !spec.layer)) {
+    console.warn('[maidr/vegalite] Unsupported composition shape (facet/repeat without a child "spec", or a bare wrapped "spec").');
     return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
   }
 
@@ -316,6 +338,33 @@ function getAxisConfig(channel?: VegaLiteChannelDef): { label: string } {
 }
 
 /**
+ * True for compiled-Vega dataset names that hold layout / legend / header
+ * internals rather than chart data. Facet compilations register
+ * `row_domain` / `column_domain` / `facet_domain*`, header / footer group
+ * datasets, and the `cell` scenegraph dataset; repeat compilations
+ * register one `<childName>_group` dataset per cell.
+ */
+function isInternalDatasetName(name: string): boolean {
+  return name === 'root'
+    || name === 'cell'
+    || name.endsWith('_domain')
+    || name.includes('_domain_')
+    || name.endsWith('_group')
+    || name.endsWith('_header')
+    || name.endsWith('_footer')
+    || name.includes('-title');
+}
+
+/**
+ * True when a dataset row is a Vega scenegraph item (group mark instance)
+ * rather than a plain data record. Scenegraph items carry `mark` /
+ * `bounds` bookkeeping fields that no user dataset would have together.
+ */
+function isSceneGraphRow(row: Record<string, unknown>): boolean {
+  return 'mark' in row && 'bounds' in row && 'items' in row;
+}
+
+/**
  * Resolve the data array for a layer.
  *
  * Tries the compiled Vega view first (more accurate since it includes
@@ -384,8 +433,17 @@ function resolveData(
             // Skip the names we already tried above.
             if (datasetNames.includes(name))
               continue;
+            // Faceted / repeated compilations register layout-internal
+            // datasets (facet/row/column domains, headers, footers, and
+            // per-group scenegraph items like `cell` or `child__*_group`)
+            // that hold no chart data. Skip them by name pattern, and skip
+            // any dataset whose rows are scenegraph items rather than
+            // data records.
+            if (isInternalDatasetName(name))
+              continue;
             if (Array.isArray(rows) && rows.length > 0
-              && typeof rows[0] === 'object' && rows[0] !== null) {
+              && typeof rows[0] === 'object' && rows[0] !== null
+              && !isSceneGraphRow(rows[0] as Record<string, unknown>)) {
               return rows as Record<string, unknown>[];
             }
           }
@@ -855,7 +913,8 @@ function convertLayerSpec(
   parentEncoding?: VegaLiteEncoding,
   isLayered?: boolean,
   domOrderOverride?: 'series-major' | 'subject-major',
-  selectorOverride?: { layerIndex: number; markGroupPrefix: string },
+  selectorOverride?: { layerIndex: number; markGroupPrefix: string; cellScope?: string },
+  rowsOverride?: Record<string, unknown>[],
 ): MaidrLayer | null {
   const mark = getMarkType(spec);
   if (!mark)
@@ -872,7 +931,9 @@ function convertLayerSpec(
   if (!traceType)
     return null;
 
-  const rows = resolveData(spec, index, view);
+  // Faceted callers pre-filter the resolved dataset down to one panel's
+  // rows and pass them here, bypassing dataset-name resolution.
+  const rows = rowsOverride ?? resolveData(spec, index, view);
 
   const axes: MaidrLayer['axes'] = {
     x: getAxisConfig(encoding.x),
@@ -980,6 +1041,19 @@ function convertLayerSpec(
       return null;
   }
 
+  // Scope selectors to one facet cell. All facet cells share identical
+  // mark-group classes (`child_marks` / `child_layer_<j>_marks`), so the
+  // only way to address one panel's marks is via the `data-maidr-cell`
+  // attribute stamped on the cell's item <g> at bind time.
+  const cellScope = selectorOverride?.cellScope;
+  if (cellScope) {
+    if (typeof selectors === 'string') {
+      selectors = scopeSelector(selectors, cellScope);
+    } else if (Array.isArray(selectors)) {
+      selectors = (selectors as string[]).map(sel => scopeSelector(sel, cellScope));
+    }
+  }
+
   const layer: MaidrLayer = {
     id: String(index),
     type: traceType,
@@ -1011,6 +1085,7 @@ function buildConcatMaidr(
   direction: 'horizontal' | 'vertical' | 'wrap',
   view?: VegaView,
   domOrder?: 'series-major' | 'subject-major',
+  columns?: number,
 ): Maidr {
   // Track a global layer counter so that each concat child resolves
   // dataset names independently (Vega names datasets sequentially
@@ -1060,12 +1135,338 @@ function buildConcatMaidr(
   });
 
   // vconcat produces one subplot per row (column layout).
-  // hconcat / concat produce all subplots in a single row.
+  // hconcat produces all subplots in a single row.
+  // General `concat` wraps into rows of `columns` panels (Vega-Lite's
+  // default when `columns` is omitted is a single unbounded row).
   let subplots: MaidrSubplot[][];
   if (direction === 'vertical') {
     subplots = subplotEntries.map(s => [s]);
+  } else if (direction === 'wrap') {
+    subplots = chunkIntoRows(subplotEntries, columns);
   } else {
     subplots = [subplotEntries];
+  }
+
+  return buildMaidr(id, title, subtitle, caption, subplots);
+}
+
+// ---------------------------------------------------------------------------
+// Faceted views (facet operator / encoding shorthand / wrapped facet)
+// ---------------------------------------------------------------------------
+
+/** One facet panel: dataset row filters plus the announced panel title. */
+interface FacetCellDef {
+  filters: Array<[field: string, key: string]>;
+  title: string;
+}
+
+/**
+ * Resolve the raw source dataset (pre-transform rows carrying the facet
+ * fields). Used when the layer's own dataset resolution lands on a table
+ * that lost the facet fields.
+ */
+function resolveSourceRows(
+  spec: VegaLiteSpec,
+  view?: VegaView,
+): Record<string, unknown>[] {
+  if (view) {
+    try {
+      const rows = view.data('source_0');
+      if (Array.isArray(rows) && rows.length > 0)
+        return rows;
+    } catch {
+      // No source dataset — fall through to inline data.
+    }
+  }
+  const data = spec.data as { values?: Record<string, unknown>[] } | undefined;
+  if (data && typeof data === 'object' && Array.isArray(data.values))
+    return data.values;
+  return [];
+}
+
+/**
+ * Build a multi-subplot Maidr for a faceted spec.
+ *
+ * Grid construction: row facet values become grid rows and column facet
+ * values become grid columns, in Vega's layout order (the compiled
+ * `row_domain` / `column_domain` / `facet_domain` datasets when a view is
+ * available, ascending value order otherwise). Wrapped facets chunk the
+ * single facet field's values into rows of `columns` panels. Cross facets
+ * are sparse: Vega only renders a cell for (row, column) combinations
+ * present in the data, so the grid emits exactly those combinations
+ * (rows may be ragged), keeping the subplot order aligned with the
+ * rendered cell order.
+ *
+ * Every panel's layers are converted from the shared child spec with the
+ * resolved dataset pre-filtered down to that panel's facet value(s), and
+ * the panel's first layer title carries the facet value (e.g. `site: A`)
+ * — MAIDR core uses that as the panel display name in subplot summaries.
+ *
+ * Selectors are scoped per panel with a `data-maidr-cell` attribute that
+ * `stampFacetCells` (see `facets.ts`) writes onto each rendered cell at
+ * bind time, because all facet cells share identical Vega mark classes.
+ */
+function buildFacetMaidr(
+  id: string,
+  title: string,
+  subtitle: string | undefined,
+  caption: string | undefined,
+  spec: VegaLiteSpec,
+  descriptor: FacetDescriptor,
+  view?: VegaView,
+  domOrder?: 'series-major' | 'subject-major',
+): Maidr {
+  const childSpec = descriptor.childSpec;
+  const isLayered = childSpec.layer != null && childSpec.layer.length > 0;
+  const layerSpecs = isLayered ? childSpec.layer! : [childSpec];
+  const facetFields = [
+    descriptor.rowChannel?.field,
+    descriptor.columnChannel?.field,
+    descriptor.wrapChannel?.field,
+  ].filter((field): field is string => field != null);
+
+  // Resolve each layer's full dataset once; cells filter it below. When a
+  // layer's dataset resolution lands on a table without the facet fields
+  // (they are always groupby keys, so this signals a wrong dataset), fall
+  // back to the raw source rows.
+  const layerRows = layerSpecs.map((layerSpec, j) => {
+    const specForData: VegaLiteSpec = layerSpec.data != null
+      ? layerSpec
+      : { ...layerSpec, data: childSpec.data ?? spec.data };
+    let rows = resolveData(specForData, j, view);
+    if (rows.length > 0 && !facetFields.every(field => field in rows[0])) {
+      const source = resolveSourceRows(spec, view);
+      if (source.length > 0 && facetFields.every(field => field in source[0])) {
+        rows = source;
+      }
+    }
+    return rows;
+  });
+  const allRows = layerRows.find(rows => rows.length > 0) ?? [];
+
+  // Build the grid of cell definitions in visual reading order.
+  const grid: FacetCellDef[][] = [];
+  if (descriptor.wrapChannel?.field) {
+    const field = descriptor.wrapChannel.field;
+    const keys = resolveDomainKeys(field, allRows, view, 'facet_domain');
+    const cells = keys.map(key => ({
+      filters: [[field, key]] as FacetCellDef['filters'],
+      title: `${field}: ${key}`,
+    }));
+    grid.push(...chunkIntoRows(cells, descriptor.columns));
+  } else {
+    const rowField = descriptor.rowChannel?.field;
+    const colField = descriptor.columnChannel?.field;
+    const rowKeys: (string | null)[] = rowField
+      ? resolveDomainKeys(rowField, allRows, view, 'row_domain')
+      : [null];
+    const colKeys: (string | null)[] = colField
+      ? resolveDomainKeys(colField, allRows, view, 'column_domain')
+      : [null];
+
+    // Cross facets are sparse: Vega only renders cells for (row, column)
+    // combinations present in the data.
+    const combos = new Set<string>();
+    if (rowField && colField) {
+      for (const row of allRows) {
+        combos.add(`${String(row[rowField])} ${String(row[colField])}`);
+      }
+    }
+
+    for (const rowKey of rowKeys) {
+      const cellsInRow: FacetCellDef[] = [];
+      for (const colKey of colKeys) {
+        if (rowField && colField && !combos.has(`${rowKey} ${colKey}`)) {
+          continue;
+        }
+        const filters: FacetCellDef['filters'] = [];
+        const titleParts: string[] = [];
+        if (rowField && rowKey !== null) {
+          filters.push([rowField, rowKey]);
+          titleParts.push(`${rowField}: ${rowKey}`);
+        }
+        if (colField && colKey !== null) {
+          filters.push([colField, colKey]);
+          titleParts.push(`${colField}: ${colKey}`);
+        }
+        cellsInRow.push({ filters, title: titleParts.join(', ') });
+      }
+      if (cellsInRow.length > 0) {
+        grid.push(cellsInRow);
+      }
+    }
+  }
+
+  if (grid.length === 0) {
+    console.warn('[maidr/vegalite] Faceted spec produced no panels (empty data?).');
+    return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
+  }
+
+  const parentEncoding = isLayered ? childSpec.encoding : undefined;
+  const subplots: MaidrSubplot[][] = [];
+  let flatIndex = 0;
+  let hasEmptyPanel = false;
+  for (let r = 0; r < grid.length; r++) {
+    const subplotRow: MaidrSubplot[] = [];
+    for (let c = 0; c < grid[r].length; c++) {
+      const cell = grid[r][c];
+      const scope = facetCellScope(facetCellAttrValue(id, r, c));
+      const rawLayers = layerSpecs.map((layerSpec, j) => {
+        const cellRows = layerRows[j].filter(row =>
+          cell.filters.every(([field, key]) => String(row[field]) === key),
+        );
+        return convertLayerSpec(
+          layerSpec,
+          j,
+          view,
+          parentEncoding,
+          isLayered,
+          domOrder,
+          { layerIndex: j, markGroupPrefix: 'child_', cellScope: scope },
+          cellRows,
+        );
+      }).filter(Boolean) as MaidrLayer[];
+      const layers = coalesceSiblingLineLayers(rawLayers);
+      layers.forEach((layer, j) => {
+        layer.id = `${flatIndex}_${j}`;
+      });
+      if (layers.length === 0) {
+        hasEmptyPanel = true;
+      } else {
+        // The FIRST layer's title is the panel display name in MAIDR's
+        // subplot summaries — announce the facet value(s) there.
+        layers[0].title = cell.title;
+      }
+      subplotRow.push({ layers, selector: `${scope} > path.background` });
+      flatIndex++;
+    }
+    subplots.push(subplotRow);
+  }
+
+  // A panel with zero layers crashes MAIDR core's Subplot model; fall back
+  // to the same single empty figure other unsupported specs produce.
+  if (hasEmptyPanel) {
+    console.warn('[maidr/vegalite] Faceted spec uses an unsupported mark type.');
+    return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
+  }
+
+  return buildMaidr(id, title, subtitle, caption, subplots);
+}
+
+// ---------------------------------------------------------------------------
+// Repeated views (repeat operator)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a multi-subplot Maidr for a `repeat` spec.
+ *
+ * The grid comes straight from the repeat definition: `repeat.row` fields
+ * become grid rows and `repeat.column` fields become grid columns
+ * (row-major); the wrapped array form (`repeat: [...]` + `columns`) is
+ * chunked into rows. Each cell converts the shared child spec with its
+ * `{repeat: ...}` field references substituted for that cell's fields.
+ *
+ * Unlike facets, repeat cells compile to per-cell Vega child views whose
+ * mark classes are already unique (`child__row_<rf>column_<cf>_marks`
+ * etc.), so selectors are class-scoped and no bind-time stamping is
+ * needed.
+ */
+function buildRepeatMaidr(
+  id: string,
+  title: string,
+  subtitle: string | undefined,
+  caption: string | undefined,
+  spec: VegaLiteSpec,
+  descriptor: RepeatDescriptor,
+  view?: VegaView,
+  domOrder?: 'series-major' | 'subject-major',
+): Maidr {
+  const childSpec = descriptor.childSpec;
+
+  // Grid of per-cell field mappings in reading order.
+  interface RepeatCellDef { mapping: RepeatCellMapping; title: string }
+  let grid: RepeatCellDef[][];
+  if (descriptor.wrapFields) {
+    const cells = descriptor.wrapFields.map(field => ({
+      mapping: { repeat: field },
+      title: field,
+    }));
+    grid = chunkIntoRows(cells, descriptor.columns);
+  } else {
+    const rowFields: (string | undefined)[] = descriptor.rowFields ?? [undefined];
+    const colFields: (string | undefined)[] = descriptor.columnFields ?? [undefined];
+    grid = rowFields.map(rowField => colFields.map((colField) => {
+      const mapping: RepeatCellMapping = {};
+      if (rowField !== undefined) {
+        mapping.row = rowField;
+      }
+      if (colField !== undefined) {
+        mapping.column = colField;
+      }
+      const cellTitle = rowField !== undefined && colField !== undefined
+        ? `${rowField} vs ${colField}`
+        : rowField ?? colField ?? '';
+      return { mapping, title: cellTitle };
+    }));
+  }
+
+  if (grid.length === 0) {
+    console.warn('[maidr/vegalite] Repeat spec produced no panels.');
+    return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
+  }
+
+  // Track a global layer counter for dataset-name guessing, mirroring
+  // buildConcatMaidr: Vega numbers `data_<k>` datasets sequentially across
+  // the whole compiled spec, not per repeated child.
+  let globalLayerIndex = 0;
+  let flatIndex = 0;
+  let hasEmptyPanel = false;
+
+  const subplots: MaidrSubplot[][] = grid.map(rowCells => rowCells.map((cell) => {
+    const cellSpec = substituteRepeatFields(childSpec, cell.mapping);
+    if (cellSpec.data == null) {
+      cellSpec.data = spec.data;
+    }
+    const childName = repeatChildName(cell.mapping);
+    const isLayered = cellSpec.layer != null && cellSpec.layer.length > 0;
+    const layerSpecs = isLayered ? cellSpec.layer! : [cellSpec];
+    const parentEncoding = isLayered ? cellSpec.encoding : undefined;
+
+    const rawLayers = layerSpecs.map((layerSpec, j) => {
+      const specForData: VegaLiteSpec = layerSpec.data != null
+        ? layerSpec
+        : { ...layerSpec, data: cellSpec.data };
+      const layer = convertLayerSpec(
+        specForData,
+        globalLayerIndex,
+        view,
+        parentEncoding,
+        isLayered,
+        domOrder,
+        { layerIndex: j, markGroupPrefix: `${childName}_` },
+      );
+      globalLayerIndex++;
+      return layer;
+    }).filter(Boolean) as MaidrLayer[];
+    const layers = coalesceSiblingLineLayers(rawLayers);
+    layers.forEach((layer, j) => {
+      layer.id = `${flatIndex}_${j}`;
+    });
+    if (layers.length === 0) {
+      hasEmptyPanel = true;
+    } else {
+      layers[0].title = cell.title;
+    }
+    flatIndex++;
+    return {
+      layers,
+      selector: `g.mark-group.role-scope.${childName}_group > g > path.background`,
+    };
+  }));
+
+  if (hasEmptyPanel) {
+    console.warn('[maidr/vegalite] Repeat spec uses an unsupported mark type.');
+    return buildMaidr(id, title, subtitle, caption, [[{ layers: [] }]]);
   }
 
   return buildMaidr(id, title, subtitle, caption, subplots);

--- a/src/adapters/vegalite/facets.ts
+++ b/src/adapters/vegalite/facets.ts
@@ -25,8 +25,10 @@
  *     <childName>_group">` per cell, and the marks inside carry the
  *     already-unique class `<childName>_marks`, where `<childName>` is
  *     `child__row_<rf>column_<cf>` / `child__row_<rf>` /
- *     `child__column_<cf>` / `child__<f>` (non-word characters in field
- *     names replaced with `_`). No stamping is needed for repeats.
+ *     `child__column_<cf>` / `child__<f>` (field names sanitised with
+ *     Vega-Lite's `varName`: non-word characters become `_`, and a
+ *     leading digit gains a `_` prefix). No stamping is needed for
+ *     repeats.
  */
 
 import type { Maidr, MaidrLayer } from '@type/grammar';
@@ -186,10 +188,12 @@ export function substituteRepeatFields(
  * per-cell unique without any stamping.
  *
  * Mirrors Vega-Lite's `varName` sanitisation: every non-word character in
- * a field name becomes `_`.
+ * a field name becomes `_`, and a field name starting with a digit gains a
+ * leading `_` (e.g. field `2020` → `child___2020`).
  */
 export function repeatChildName(cell: RepeatCellMapping): string {
-  const sanitize = (field: string): string => field.replace(/\W/g, '_');
+  const sanitize = (field: string): string =>
+    (field.match(/^\d/) ? '_' : '') + field.replace(/\W/g, '_');
   if (cell.row !== undefined && cell.column !== undefined) {
     return `child__row_${sanitize(cell.row)}column_${sanitize(cell.column)}`;
   }
@@ -463,11 +467,11 @@ function crossCheckHeaders(svg: SVGSVGElement, maidr: Maidr): void {
  * Build the per-layer cell scope map used by the bind-time fixup passes
  * that need a per-panel DOM root (`buildBoxPlotSelectorsFromDom`,
  * `sortLinesByVisualOrder`). Works for both facet subplots (after
- * {@link stampFacetCells} has run) and repeat subplots (whose selectors
- * are class-scoped and need no stamping).
+ * {@link stampFacetCells} has run) and repeat / concat subplots (whose
+ * selectors are class-scoped and need no stamping).
  *
- * Returns an empty map for single-panel and concat charts, whose
- * subplots carry no selector.
+ * Returns an empty map for single-panel charts, whose subplots carry no
+ * selector.
  */
 export function buildCellDomMap(
   svg: SVGSVGElement,
@@ -481,9 +485,9 @@ export function buildCellDomMap(
         continue;
       // Subplot selectors point at the cell's background path
       // (`<scope> > path.background` for facets,
-      //  `<scope> > g > path.background` for repeats); the first segment
-      // is the cell scope and the background's parent <g> is the cell's
-      // content root in both shapes.
+      //  `<scope> > g > path.background` for repeats and concat); the
+      // first segment is the cell scope and the background's parent <g>
+      // is the cell's content root in both shapes.
       const scope = selector.split(' > ')[0];
       const background = svg.querySelector(selector);
       const root = background?.parentElement;

--- a/src/adapters/vegalite/facets.ts
+++ b/src/adapters/vegalite/facets.ts
@@ -1,0 +1,498 @@
+/**
+ * Facet / repeat helpers for the Vega-Lite adapter.
+ *
+ * Vega-Lite has three multi-panel mechanisms beyond concat:
+ *   1. The `facet` operator (`facet: {row?, column?}` or `facet: {field}` +
+ *      `columns`) with the panel template under `spec`.
+ *   2. The facet *shorthand*: `row` / `column` channels inside a unit or
+ *      layered spec's `encoding`.
+ *   3. The `repeat` operator (`repeat: {row?, column?}` arrays or
+ *      `repeat: [...]` + `columns`), whose child spec uses
+ *      `{repeat: 'row'|'column'|'repeat'}` field references.
+ *
+ * This module holds the pure descriptor / grid / selector helpers plus the
+ * bind-time DOM pass that stamps each rendered facet cell with a
+ * `data-maidr-cell` attribute. The actual Maidr assembly lives in
+ * `converters.ts` (`buildFacetMaidr` / `buildRepeatMaidr`).
+ *
+ * Rendered DOM reference (Vega-Lite v5, SVG renderer):
+ *   - Facets compile to ONE `<g class="mark-group role-scope cell">` group
+ *     whose direct `<g>` children are the per-cell items (reading order).
+ *     Inside each item, marks render as `g.mark-*.role-mark.child_marks`
+ *     (unit child) or `child_layer_<j>_marks` (layered child). All cells
+ *     share those classes, so per-cell scoping requires stamping the item.
+ *   - Repeats compile to one `<g class="mark-group role-scope
+ *     <childName>_group">` per cell, and the marks inside carry the
+ *     already-unique class `<childName>_marks`, where `<childName>` is
+ *     `child__row_<rf>column_<cf>` / `child__row_<rf>` /
+ *     `child__column_<cf>` / `child__<f>` (non-word characters in field
+ *     names replaced with `_`). No stamping is needed for repeats.
+ */
+
+import type { Maidr, MaidrLayer } from '@type/grammar';
+import type {
+  VegaLiteChannelDef,
+  VegaLiteSpec,
+  VegaView,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Descriptors
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalised facet description. Exactly one of the following holds:
+ *   - `rowChannel` and/or `columnChannel` set (row/column faceting), or
+ *   - `wrapChannel` set (wrapped faceting; `columns` bounds the row width).
+ */
+export interface FacetDescriptor {
+  rowChannel?: VegaLiteChannelDef;
+  columnChannel?: VegaLiteChannelDef;
+  wrapChannel?: VegaLiteChannelDef;
+  columns?: number;
+  /** The per-panel template spec (facet channels already stripped). */
+  childSpec: VegaLiteSpec;
+}
+
+/** Normalised repeat description. */
+export interface RepeatDescriptor {
+  rowFields?: string[];
+  columnFields?: string[];
+  wrapFields?: string[];
+  columns?: number;
+  childSpec: VegaLiteSpec;
+}
+
+/**
+ * Detect a faceted spec — either the top-level `facet` operator or the
+ * `encoding.row` / `encoding.column` shorthand on a unit / layered spec —
+ * and normalise it into a {@link FacetDescriptor}.
+ *
+ * Returns `null` when the spec is not faceted (or is malformed, e.g.
+ * `facet` without `spec`).
+ */
+export function describeFacet(spec: VegaLiteSpec): FacetDescriptor | null {
+  // Top-level facet operator.
+  if (spec.facet && spec.spec) {
+    const facet = spec.facet;
+    if (facet.field) {
+      return {
+        wrapChannel: facet,
+        columns: spec.columns,
+        childSpec: spec.spec,
+      };
+    }
+    if (facet.row?.field || facet.column?.field) {
+      return {
+        rowChannel: facet.row?.field ? facet.row : undefined,
+        columnChannel: facet.column?.field ? facet.column : undefined,
+        childSpec: spec.spec,
+      };
+    }
+    return null;
+  }
+
+  // Encoding shorthand on a unit or layered spec.
+  const hasView = spec.mark != null || (spec.layer != null && spec.layer.length > 0);
+  const rowChannel = spec.encoding?.row;
+  const columnChannel = spec.encoding?.column;
+  if (hasView && (rowChannel?.field || columnChannel?.field)) {
+    const { row: _row, column: _column, ...childEncoding } = spec.encoding!;
+    const childSpec: VegaLiteSpec = { ...spec, encoding: childEncoding };
+    return {
+      rowChannel: rowChannel?.field ? rowChannel : undefined,
+      columnChannel: columnChannel?.field ? columnChannel : undefined,
+      childSpec,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Detect a `repeat` spec and normalise it into a {@link RepeatDescriptor}.
+ * Returns `null` when the spec is not a (well-formed) repeat.
+ */
+export function describeRepeat(spec: VegaLiteSpec): RepeatDescriptor | null {
+  if (!spec.repeat || !spec.spec)
+    return null;
+  if (Array.isArray(spec.repeat)) {
+    if (spec.repeat.length === 0)
+      return null;
+    return {
+      wrapFields: spec.repeat,
+      columns: spec.columns,
+      childSpec: spec.spec,
+    };
+  }
+  const rowFields = spec.repeat.row;
+  const columnFields = spec.repeat.column;
+  if ((rowFields?.length ?? 0) === 0 && (columnFields?.length ?? 0) === 0)
+    return null;
+  return {
+    rowFields: rowFields && rowFields.length > 0 ? rowFields : undefined,
+    columnFields: columnFields && columnFields.length > 0 ? columnFields : undefined,
+    childSpec: spec.spec,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Repeat helpers
+// ---------------------------------------------------------------------------
+
+/** One repeated cell's field assignment. */
+export interface RepeatCellMapping {
+  row?: string;
+  column?: string;
+  repeat?: string;
+}
+
+/**
+ * Replace `{repeat: 'row'|'column'|'repeat'}` field references anywhere in
+ * a child spec with the concrete field names for one repeated cell.
+ * Deep-clones the spec so cells never share mutable state.
+ */
+export function substituteRepeatFields(
+  spec: VegaLiteSpec,
+  mapping: RepeatCellMapping,
+): VegaLiteSpec {
+  const walk = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      return value.map(walk);
+    }
+    if (value !== null && typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      const repeatRef = record.repeat;
+      if (typeof repeatRef === 'string' && Object.keys(record).length === 1) {
+        const substituted = mapping[repeatRef as keyof RepeatCellMapping];
+        if (substituted !== undefined)
+          return substituted;
+      }
+      const out: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(record)) {
+        out[key] = walk(val);
+      }
+      return out;
+    }
+    return value;
+  };
+  return walk(spec) as VegaLiteSpec;
+}
+
+/**
+ * Compute the Vega child-view name for one repeated cell. The rendered SVG
+ * uses this name in the cell group class (`<name>_group`) and the mark
+ * group class (`<name>_marks`), which is what makes repeat selectors
+ * per-cell unique without any stamping.
+ *
+ * Mirrors Vega-Lite's `varName` sanitisation: every non-word character in
+ * a field name becomes `_`.
+ */
+export function repeatChildName(cell: RepeatCellMapping): string {
+  const sanitize = (field: string): string => field.replace(/\W/g, '_');
+  if (cell.row !== undefined && cell.column !== undefined) {
+    return `child__row_${sanitize(cell.row)}column_${sanitize(cell.column)}`;
+  }
+  if (cell.row !== undefined) {
+    return `child__row_${sanitize(cell.row)}`;
+  }
+  if (cell.column !== undefined) {
+    return `child__column_${sanitize(cell.column)}`;
+  }
+  return `child__${sanitize(cell.repeat ?? '')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Grid helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Chunk a flat list of cells into grid rows of at most `columns` items
+ * (row-major). `columns` omitted or non-positive means "unbounded" —
+ * Vega-Lite's default wrap layout is a single row.
+ */
+export function chunkIntoRows<T>(items: T[], columns?: number): T[][] {
+  if (!columns || columns <= 0 || columns >= items.length) {
+    return items.length > 0 ? [items] : [];
+  }
+  const rows: T[][] = [];
+  for (let i = 0; i < items.length; i += columns) {
+    rows.push(items.slice(i, i + columns));
+  }
+  return rows;
+}
+
+/**
+ * Resolve a facet field's domain keys in Vega's layout order.
+ *
+ * Prefers the compiled view's domain dataset (`row_domain`,
+ * `column_domain`, or `facet_domain`), which reflects the exact order Vega
+ * lays cells out in — including custom facet sorts. Falls back to the
+ * distinct values found in `fallbackRows`, sorted ascending (Vega-Lite's
+ * default facet sort).
+ *
+ * Keys are `String()`-ified so they compare consistently with the
+ * per-cell row filtering, which stringifies the same dataset values.
+ */
+export function resolveDomainKeys(
+  field: string,
+  fallbackRows: Record<string, unknown>[],
+  view?: VegaView,
+  datasetName?: string,
+): string[] {
+  if (view && datasetName) {
+    try {
+      const rows = view.data(datasetName);
+      if (Array.isArray(rows) && rows.length > 0 && field in rows[0]) {
+        return rows.map(row => String(row[field]));
+      }
+    } catch {
+      // Dataset missing (e.g. no view or non-facet compilation) — fall back.
+    }
+  }
+
+  const seen = new Set<string>();
+  const distinct: unknown[] = [];
+  for (const row of fallbackRows) {
+    const key = String(row[field]);
+    if (!seen.has(key)) {
+      seen.add(key);
+      distinct.push(row[field]);
+    }
+  }
+  const allNumbers = distinct.every(v => typeof v === 'number');
+  distinct.sort((a, b) => {
+    if (allNumbers)
+      return (a as number) - (b as number);
+    return String(a).localeCompare(String(b));
+  });
+  return distinct.map(v => String(v));
+}
+
+// ---------------------------------------------------------------------------
+// Cell-scoped selectors
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the `data-maidr-cell` attribute value for a facet cell. Includes
+ * the chart id so several faceted charts on one page never share a value
+ * (MAIDR resolves all selectors document-globally).
+ */
+export function facetCellAttrValue(chartId: string, row: number, col: number): string {
+  const safeId = chartId.replace(/[^\w-]/g, '_');
+  return `${safeId}-${row}-${col}`;
+}
+
+/** CSS selector matching the stamped facet cell item for `attrValue`. */
+export function facetCellScope(attrValue: string): string {
+  return `g[data-maidr-cell="${attrValue}"]`;
+}
+
+/**
+ * Prefix every alternative in a (possibly comma-separated) selector with a
+ * cell scope, so `a, b` becomes `<scope> a, <scope> b`. The adapter never
+ * emits selectors containing commas inside a single alternative, so a
+ * plain split is safe.
+ */
+export function scopeSelector(selector: string, scope: string): string {
+  return selector
+    .split(',')
+    .map(part => `${scope} ${part.trim()}`)
+    .join(', ');
+}
+
+// ---------------------------------------------------------------------------
+// Bind-time DOM stamping (facet cells)
+// ---------------------------------------------------------------------------
+
+/** Per-layer DOM scope info used by the bind-time fixup passes. */
+export interface CellDomInfo {
+  /** The cell's item `<g>` — ancestor of exactly that cell's marks. */
+  root: Element;
+  /** Selector prefix that scopes a bare mark selector to this cell. */
+  scope: string;
+}
+
+const FACET_CELL_GROUP_SELECTOR = 'g.mark-group.role-scope.cell';
+
+/** Extract the `data-maidr-cell` value referenced by a subplot selector. */
+function parseCellAttr(selector: string | undefined): string | null {
+  if (!selector)
+    return null;
+  const match = selector.match(/\[data-maidr-cell="([^"]+)"\]/);
+  return match ? match[1] : null;
+}
+
+/** True when the element has a non-zero layout box (rendered pages). */
+function hasLayout(el: Element | undefined): boolean {
+  if (!el)
+    return false;
+  const rect = el.getBoundingClientRect();
+  return rect.width > 0 || rect.height > 0;
+}
+
+/**
+ * Stamp each rendered facet cell item with the `data-maidr-cell` value its
+ * subplot's selectors were emitted against. MUST run before any fixup pass
+ * (or trace construction) resolves the cell-scoped selectors.
+ *
+ * Cells are matched to grid slots in visual reading order (top-to-bottom,
+ * left-to-right, clustered by row) when the SVG is laid out, falling back
+ * to DOM order otherwise — Vega emits facet cell items in exactly that
+ * reading order (the facet partition is sorted by [row, column] domain).
+ *
+ * As a cross-check, the facet header texts (`role-row-header` /
+ * `role-column-header` titles) are compared against the panel titles the
+ * converter wrote into each cell's first layer; mismatches log a warning
+ * but do not abort (navigation and audio still work; only highlighting
+ * placement could be off).
+ */
+export function stampFacetCells(svg: SVGSVGElement, maidr: Maidr): void {
+  const cellGroup = svg.querySelector(FACET_CELL_GROUP_SELECTOR);
+  if (!cellGroup)
+    return;
+
+  // Collect the expected attribute values in grid reading order.
+  const expected: { attr: string; title?: string }[] = [];
+  for (const row of maidr.subplots) {
+    for (const subplot of row) {
+      const attr = parseCellAttr(subplot.selector);
+      if (!attr)
+        return; // Not a facet-scoped maidr (e.g. concat) — nothing to stamp.
+      expected.push({ attr, title: subplot.layers[0]?.title });
+    }
+  }
+  if (expected.length === 0)
+    return;
+
+  // One direct <g> child per rendered cell. Cross facets (row x column)
+  // compile with `cross: true`, so Vega renders a cell for EVERY (row,
+  // column) combination — including combinations with no data, which get
+  // no `role-mark` group inside. The converter deliberately emits no
+  // subplot for those (an empty-data panel would crash MAIDR core), so
+  // skip mark-less cells here to keep the pairing aligned.
+  const items = Array.from(cellGroup.children)
+    .filter((el): el is SVGGElement =>
+      el.tagName.toLowerCase() === 'g' && el.querySelector('g.role-mark') !== null,
+    );
+  if (items.length !== expected.length) {
+    console.warn(
+      `[maidr/vegalite] Facet cell count mismatch: SVG has ${items.length} `
+      + `cells but the schema expects ${expected.length}. Highlighting will `
+      + `be disabled for this chart; navigation still works.`,
+    );
+    return;
+  }
+
+  // Order cells visually (row clusters by top, then left-to-right) when the
+  // page is laid out; otherwise trust DOM order, which Vega emits in the
+  // same reading order.
+  let ordered = items;
+  if (hasLayout(items[0])) {
+    const infos = items.map((el) => {
+      const rect = el.getBoundingClientRect();
+      return { el, top: rect.top, left: rect.left, height: rect.height };
+    });
+    infos.sort((a, b) => a.top - b.top);
+    const tolerance = Math.max((infos[0]?.height ?? 0) / 2, 1);
+    const clusters: (typeof infos)[] = [];
+    for (const info of infos) {
+      const last = clusters[clusters.length - 1];
+      if (last && Math.abs(last[0].top - info.top) < tolerance) {
+        last.push(info);
+      } else {
+        clusters.push([info]);
+      }
+    }
+    for (const cluster of clusters) {
+      cluster.sort((a, b) => a.left - b.left);
+    }
+    ordered = clusters.flat().map(info => info.el);
+  }
+
+  ordered.forEach((el, i) => {
+    el.setAttribute('data-maidr-cell', expected[i].attr);
+  });
+
+  crossCheckHeaders(svg, maidr);
+}
+
+/**
+ * Best-effort verification that the facet header labels rendered by Vega
+ * match the panel titles the converter derived from the data. A mismatch
+ * means the grid order assumed at conversion time differs from the actual
+ * layout (e.g. an unsupported custom facet sort without a compiled view).
+ */
+function crossCheckHeaders(svg: SVGSVGElement, maidr: Maidr): void {
+  const headerTexts = (role: string): string[] =>
+    Array.from(svg.querySelectorAll(
+      `g.mark-group.${role} g.mark-text.role-title-text text`,
+    )).map(text => (text.textContent ?? '').trim());
+
+  const columnHeaders = headerTexts('role-column-header');
+  const firstRow = maidr.subplots[0] ?? [];
+  if (columnHeaders.length === firstRow.length && columnHeaders.length > 0) {
+    columnHeaders.forEach((header, c) => {
+      const title = firstRow[c]?.layers[0]?.title ?? '';
+      if (header && !title.includes(header)) {
+        console.warn(
+          `[maidr/vegalite] Facet column header "${header}" does not match `
+          + `panel title "${title}". Panel order may be misaligned `
+          + `(custom facet sort?).`,
+        );
+      }
+    });
+  }
+
+  const rowHeaders = headerTexts('role-row-header');
+  if (rowHeaders.length === maidr.subplots.length && rowHeaders.length > 0) {
+    rowHeaders.forEach((header, r) => {
+      const title = maidr.subplots[r]?.[0]?.layers[0]?.title ?? '';
+      if (header && !title.includes(header)) {
+        console.warn(
+          `[maidr/vegalite] Facet row header "${header}" does not match `
+          + `panel title "${title}". Panel order may be misaligned `
+          + `(custom facet sort?).`,
+        );
+      }
+    });
+  }
+}
+
+/**
+ * Build the per-layer cell scope map used by the bind-time fixup passes
+ * that need a per-panel DOM root (`buildBoxPlotSelectorsFromDom`,
+ * `sortLinesByVisualOrder`). Works for both facet subplots (after
+ * {@link stampFacetCells} has run) and repeat subplots (whose selectors
+ * are class-scoped and need no stamping).
+ *
+ * Returns an empty map for single-panel and concat charts, whose
+ * subplots carry no selector.
+ */
+export function buildCellDomMap(
+  svg: SVGSVGElement,
+  maidr: Maidr,
+): Map<MaidrLayer, CellDomInfo> {
+  const map = new Map<MaidrLayer, CellDomInfo>();
+  for (const row of maidr.subplots) {
+    for (const subplot of row) {
+      const selector = subplot.selector;
+      if (!selector)
+        continue;
+      // Subplot selectors point at the cell's background path
+      // (`<scope> > path.background` for facets,
+      //  `<scope> > g > path.background` for repeats); the first segment
+      // is the cell scope and the background's parent <g> is the cell's
+      // content root in both shapes.
+      const scope = selector.split(' > ')[0];
+      const background = svg.querySelector(selector);
+      const root = background?.parentElement;
+      if (!root)
+        continue;
+      for (const layer of subplot.layers) {
+        map.set(layer, { root, scope });
+      }
+    }
+  }
+  return map;
+}

--- a/src/adapters/vegalite/types.ts
+++ b/src/adapters/vegalite/types.ts
@@ -37,11 +37,35 @@ export interface VegaView {
 }
 
 /**
+ * Top-level `facet` operator definition.
+ *
+ * Two shapes exist in Vega-Lite:
+ *   - Row/column faceting: `{ row?: {field}, column?: {field} }`.
+ *   - Wrapped faceting: a single field definition (`{ field, type }`)
+ *     combined with the top-level `columns` property.
+ */
+export interface VegaLiteFacetDef {
+  row?: VegaLiteChannelDef;
+  column?: VegaLiteChannelDef;
+  field?: string;
+  type?: string;
+  title?: string;
+}
+
+/**
+ * Top-level `repeat` operator definition.
+ *
+ * Either a plain field array (wrapped layout, combined with `columns`)
+ * or `{ row?: string[], column?: string[] }` for a repeat grid.
+ */
+export type VegaLiteRepeatDef = string[] | { row?: string[]; column?: string[] };
+
+/**
  * Minimal Vega-Lite top-level specification shape.
  *
- * Covers single-view, layered (`layer`), and composite (`hconcat` / `vconcat`
- * / `concat`) specs. Faceted (`facet`) and repeated (`repeat`) specs are
- * recognised but not yet supported by the adapter.
+ * Covers single-view, layered (`layer`), composite (`hconcat` / `vconcat`
+ * / `concat`), faceted (`facet` operator or `encoding.row` /
+ * `encoding.column` shorthand), and repeated (`repeat`) specs.
  */
 export interface VegaLiteSpec {
   $schema?: string;
@@ -54,9 +78,15 @@ export interface VegaLiteSpec {
   hconcat?: VegaLiteSpec[];
   vconcat?: VegaLiteSpec[];
   concat?: VegaLiteSpec[];
-  facet?: unknown;
+  facet?: VegaLiteFacetDef;
   spec?: VegaLiteSpec;
-  repeat?: unknown;
+  repeat?: VegaLiteRepeatDef;
+  /**
+   * Wrap column count for `concat`, wrapped `facet` (single-field form),
+   * and wrapped `repeat` (array form). Vega-Lite's default when omitted
+   * is an unbounded number of columns (a single row).
+   */
+  columns?: number;
 }
 
 /**
@@ -83,6 +113,12 @@ export interface VegaLiteEncoding {
 
 /**
  * Subset of a Vega-Lite channel definition fields read by the adapter.
+ *
+ * Note on `field`: inside a `repeat` spec's child, Vega-Lite allows a
+ * repeat reference object (`{ repeat: 'row' | 'column' | 'repeat' }`)
+ * instead of a field name. The adapter substitutes those references with
+ * concrete field names (per repeated cell) *before* any conversion runs,
+ * so every code path past `substituteRepeatFields` only ever sees strings.
  */
 export interface VegaLiteChannelDef {
   field?: string;

--- a/src/adapters/victory/MaidrVictory.tsx
+++ b/src/adapters/victory/MaidrVictory.tsx
@@ -18,6 +18,11 @@ import { useVictoryAdapter } from './useVictoryAdapter';
  * - `VictoryBoxPlot` → box plot
  * - `VictoryCandlestick` → candlestick chart
  *
+ * Multi-panel figures: nest two or more `<VictoryChart>` components — each
+ * chart becomes one navigable MAIDR subplot. Give each chart a `title` prop
+ * to name its panel, and use the `layout` prop for row-major grid chunking
+ * (default is a single row in children order).
+ *
  * @example
  * ```tsx
  * import { MaidrVictory } from 'maidr/victory';
@@ -47,9 +52,10 @@ export function MaidrVictory({
   subtitle,
   caption,
   children,
+  layout,
 }: MaidrVictoryProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
-  const maidrData = useVictoryAdapter({ id, title, subtitle, caption, children }, containerRef);
+  const maidrData = useVictoryAdapter({ id, title, subtitle, caption, children, layout }, containerRef);
 
   return (
     <Maidr data={maidrData}>

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -577,10 +577,12 @@ export function extractVictoryLayers(children: ReactNode): VictoryLayerInfo[] {
  *
  * With two or more top-level `<VictoryChart>` children, each chart becomes
  * one panel carrying its own layers (ids `'{panelIdx}_{layerIdx}'`, unique
- * across the whole figure), its own axis labels, and its `title` prop as the
- * panel display name. Charts without supported data components produce an
- * entry with empty `layers` so panel indices stay aligned with the rendered
- * SVGs; callers must drop those entries before emitting the MAIDR grid.
+ * across the whole figure), its own axis labels, its `title` prop as the
+ * panel display name, and the `svgIndex` ordinal of its rendered svg among
+ * all top-level Victory components. Charts without supported data components
+ * produce an entry with empty `layers` so panel indices stay aligned with the
+ * rendered SVGs; callers must drop those entries before emitting the MAIDR
+ * grid.
  *
  * With fewer than two charts the extraction falls back to the original
  * single-panel behavior (all supported data components flattened into one
@@ -591,14 +593,24 @@ export function extractVictoryLayers(children: ReactNode): VictoryLayerInfo[] {
  * to a panel SVG.
  */
 export function extractVictorySubplots(children: ReactNode): VictorySubplotInfo[] {
-  const charts: ReactElement[] = [];
+  const charts: { element: ReactElement; svgIndex: number }[] = [];
   let hasStandaloneData = false;
+  let svgOrdinal = 0;
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child))
       return;
-    if (getVictoryDisplayName(child.type) === 'VictoryChart') {
-      charts.push(child);
+    const name = getVictoryDisplayName(child.type);
+    if (!name)
+      return;
+    // Every top-level Victory component — chart, standalone data component,
+    // legend, or unsupported component — renders its own standalone
+    // VictoryContainer `<svg role="img">`, so each one occupies one svg slot
+    // in the container. Tracking the ordinal keeps panels bound to their own
+    // svg even when a non-chart Victory sibling precedes them in the DOM.
+    const svgIndex = svgOrdinal++;
+    if (name === 'VictoryChart') {
+      charts.push({ element: child, svgIndex });
     } else if (collectDataLayers(child, {}, String).length > 0) {
       hasStandaloneData = true;
     }
@@ -616,12 +628,13 @@ export function extractVictorySubplots(children: ReactNode): VictorySubplotInfo[
     );
   }
 
-  return charts.map((chart, panelIndex) => {
-    const chartProps = chart.props as { children?: ReactNode; title?: string };
+  return charts.map(({ element, svgIndex }, panelIndex) => {
+    const chartProps = element.props as { children?: ReactNode; title?: string };
     const axisLabels = extractAxisLabels(chartProps.children);
     return {
       layers: collectDataLayers(chartProps.children, axisLabels, n => `${panelIndex}_${n}`),
       title: typeof chartProps.title === 'string' ? chartProps.title : undefined,
+      svgIndex,
     };
   });
 }

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -12,7 +12,13 @@ import type {
   SegmentedPoint,
 } from '@type/grammar';
 import type { ReactElement, ReactNode } from 'react';
-import type { VictoryComponentType, VictoryLayerData, VictoryLayerInfo } from './types';
+import type {
+  VictoryComponentType,
+  VictoryLayerData,
+  VictoryLayerInfo,
+  VictoryPanelLayout,
+  VictorySubplotInfo,
+} from './types';
 import { TraceType } from '@type/grammar';
 import { Children, isValidElement } from 'react';
 
@@ -384,7 +390,7 @@ function binByEdges(values: number[], rawEdges: unknown[]): HistogramBin[] | nul
  */
 function extractLayerFromElement(
   element: ReactElement,
-  layerId: number,
+  layerId: string,
   axisLabels: { x?: string; y?: string },
 ): VictoryLayerInfo | null {
   const name = getVictoryDisplayName(element.type);
@@ -420,7 +426,7 @@ function extractLayerFromElement(
     return null;
 
   return {
-    id: String(layerId),
+    id: layerId,
     victoryType: name,
     data: extracted.data,
     xAxisLabel: axisLabels.x,
@@ -442,7 +448,7 @@ function extractLayerFromElement(
 function extractSegmentedLayer(
   containerElement: ReactElement,
   containerType: 'VictoryStack',
-  layerId: number,
+  layerId: string,
   axisLabels: { x?: string; y?: string },
 ): VictoryLayerInfo | null {
   const containerProps = containerElement.props as { children?: ReactNode };
@@ -483,7 +489,7 @@ function extractSegmentedLayer(
   const traceType: VictoryComponentType = containerType;
 
   return {
-    id: String(layerId),
+    id: layerId,
     victoryType: traceType,
     data: { kind: 'segmented', points: series },
     xAxisLabel: axisLabels.x,
@@ -498,7 +504,47 @@ function extractSegmentedLayer(
 // ---------------------------------------------------------------------------
 
 /**
- * Walks the React element tree to extract Victory data layers.
+ * Collects the supported Victory data layers among `childNodes`.
+ *
+ * Handles individual data components (e.g. `<VictoryScatter>`) and
+ * `<VictoryStack>` for stacked bar charts. Layer ids are produced by
+ * `makeId`, called with the layer's local index among the collected layers.
+ */
+function collectDataLayers(
+  childNodes: ReactNode,
+  axisLabels: { x?: string; y?: string },
+  makeId: (localIndex: number) => string,
+): VictoryLayerInfo[] {
+  const layers: VictoryLayerInfo[] = [];
+
+  Children.forEach(childNodes, (child) => {
+    if (!isValidElement(child))
+      return;
+
+    const name = getVictoryDisplayName(child.type);
+    if (!name)
+      return;
+
+    // VictoryStack → stacked bar
+    if (name === 'VictoryStack') {
+      const segmented = extractSegmentedLayer(child, name, makeId(layers.length), axisLabels);
+      if (segmented)
+        layers.push(segmented);
+      return;
+    }
+
+    // Individual data components
+    const layer = extractLayerFromElement(child, makeId(layers.length), axisLabels);
+    if (layer)
+      layers.push(layer);
+  });
+
+  return layers;
+}
+
+/**
+ * Walks the React element tree to extract Victory data layers into one flat
+ * list (single-panel view).
  *
  * Handles:
  * - `<VictoryChart>` wrappers (processes children)
@@ -507,35 +553,6 @@ function extractSegmentedLayer(
  */
 export function extractVictoryLayers(children: ReactNode): VictoryLayerInfo[] {
   const layers: VictoryLayerInfo[] = [];
-  let layerId = 0;
-
-  function processChildren(childNodes: ReactNode, axisLabels: { x?: string; y?: string }): void {
-    Children.forEach(childNodes, (child) => {
-      if (!isValidElement(child))
-        return;
-
-      const name = getVictoryDisplayName(child.type);
-      if (!name)
-        return;
-
-      // VictoryStack → stacked bar
-      if (name === 'VictoryStack') {
-        const segmented = extractSegmentedLayer(child, name, layerId, axisLabels);
-        if (segmented) {
-          layers.push(segmented);
-          layerId++;
-        }
-        return;
-      }
-
-      // Individual data components
-      const layer = extractLayerFromElement(child, layerId, axisLabels);
-      if (layer) {
-        layers.push(layer);
-        layerId++;
-      }
-    });
-  }
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child))
@@ -546,13 +563,94 @@ export function extractVictoryLayers(children: ReactNode): VictoryLayerInfo[] {
     if (name === 'VictoryChart') {
       const chartProps = child.props as { children?: ReactNode };
       const axisLabels = extractAxisLabels(chartProps.children);
-      processChildren(chartProps.children, axisLabels);
+      layers.push(...collectDataLayers(chartProps.children, axisLabels, n => String(layers.length + n)));
     } else {
-      processChildren(child, {});
+      layers.push(...collectDataLayers(child, {}, n => String(layers.length + n)));
     }
   });
 
   return layers;
+}
+
+/**
+ * Groups Victory children into subplot panels.
+ *
+ * With two or more top-level `<VictoryChart>` children, each chart becomes
+ * one panel carrying its own layers (ids `'{panelIdx}_{layerIdx}'`, unique
+ * across the whole figure), its own axis labels, and its `title` prop as the
+ * panel display name. Charts without supported data components produce an
+ * entry with empty `layers` so panel indices stay aligned with the rendered
+ * SVGs; callers must drop those entries before emitting the MAIDR grid.
+ *
+ * With fewer than two charts the extraction falls back to the original
+ * single-panel behavior (all supported data components flattened into one
+ * subplot with monotonic ids), so existing single-chart output is unchanged.
+ *
+ * In multi-panel mode, standalone data components outside any VictoryChart
+ * are ignored (with a console warning) because they cannot be reliably bound
+ * to a panel SVG.
+ */
+export function extractVictorySubplots(children: ReactNode): VictorySubplotInfo[] {
+  const charts: ReactElement[] = [];
+  let hasStandaloneData = false;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child))
+      return;
+    if (getVictoryDisplayName(child.type) === 'VictoryChart') {
+      charts.push(child);
+    } else if (collectDataLayers(child, {}, String).length > 0) {
+      hasStandaloneData = true;
+    }
+  });
+
+  if (charts.length < 2) {
+    // Single-panel: preserve the original flat extraction exactly.
+    return [{ layers: extractVictoryLayers(children) }];
+  }
+
+  if (hasStandaloneData) {
+    console.warn(
+      'MAIDR: standalone Victory data components outside a <VictoryChart> are '
+      + 'ignored when multiple <VictoryChart> panels are present.',
+    );
+  }
+
+  return charts.map((chart, panelIndex) => {
+    const chartProps = chart.props as { children?: ReactNode; title?: string };
+    const axisLabels = extractAxisLabels(chartProps.children);
+    return {
+      layers: collectDataLayers(chartProps.children, axisLabels, n => `${panelIndex}_${n}`),
+      title: typeof chartProps.title === 'string' ? chartProps.title : undefined,
+    };
+  });
+}
+
+/**
+ * Chunks subplot panels into a row-major 2D grid.
+ *
+ * Defaults to a single row in children order. An explicit `layout` chunks the
+ * panels row-major: `columns` fixes the panels per row; otherwise `rows`
+ * derives the column count. Never produces empty rows (the MAIDR core cannot
+ * represent them); the last row may be shorter (ragged rows are supported).
+ */
+export function computeSubplotGrid<T>(panels: T[], layout?: VictoryPanelLayout): T[][] {
+  if (panels.length === 0)
+    return [];
+
+  const requestedColumns = Math.floor(layout?.columns ?? 0);
+  const requestedRows = Math.floor(layout?.rows ?? 0);
+
+  let columns = requestedColumns > 0 ? requestedColumns : 0;
+  if (columns === 0 && requestedRows > 0)
+    columns = Math.ceil(panels.length / requestedRows);
+  if (columns === 0)
+    columns = panels.length;
+
+  const grid: T[][] = [];
+  for (let i = 0; i < panels.length; i += columns)
+    grid.push(panels.slice(i, i + columns));
+  return grid;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/victory/index.ts
+++ b/src/adapters/victory/index.ts
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 
-export { extractVictoryLayers, toMaidrLayer } from './converters';
+export { computeSubplotGrid, extractVictoryLayers, extractVictorySubplots, toMaidrLayer } from './converters';
 export { MaidrVictory } from './MaidrVictory';
 export type {
   MaidrVictoryProps,
@@ -17,5 +17,7 @@ export type {
   VictoryComponentType,
   VictoryLayerData,
   VictoryLayerInfo,
+  VictoryPanelLayout,
+  VictorySubplotInfo,
 } from './types';
 export { useVictoryAdapter } from './useVictoryAdapter';

--- a/src/adapters/victory/selectors.ts
+++ b/src/adapters/victory/selectors.ts
@@ -15,23 +15,36 @@ const ATTR_PREFIX = 'data-maidr-victory';
  */
 export const PANEL_ATTR = `${ATTR_PREFIX}-panel`;
 
-/** Upper bound on enumerated layer tags per panel. */
-const MAX_TAGGED_LAYERS = 10;
-
-/** Upper bound on enumerated panels per figure. */
-const MAX_TAGGED_PANELS = 10;
+/**
+ * True when an element is (or lives inside) a MAIDR-created hidden clone.
+ *
+ * MAIDR's `Svg` helpers stamp every highlight clone with `data-maidr-owned`
+ * and insert it next to the original while a figure is focused. `cloneNode`
+ * preserves `role` and every `data-maidr-victory-*` attribute, so clones are
+ * otherwise indistinguishable from live Victory nodes — every DOM discovery
+ * in this module must skip them (`closest` matches the element itself).
+ */
+function isMaidrOwned(el: Element): boolean {
+  return el.closest('[data-maidr-owned]') !== null;
+}
 
 /**
- * CSS selector matching every layer tag: the flat single-panel names
- * (`data-maidr-victory-<layer>`) and the panel-scoped multi-panel names
- * (`data-maidr-victory-<panel>-<layer>`). Supports up to 10 layers per panel
- * and 10 panels per figure, well beyond any realistic Victory figure.
+ * Scans the container once for every element carrying a layer-tag attribute:
+ * the flat single-panel names (`data-maidr-victory-<layer>`), the panel-scoped
+ * multi-panel names (`data-maidr-victory-<panel>-<layer>`), and the named
+ * box/candlestick part attributes. CSS attribute selectors cannot express
+ * name-prefix matching, so an attribute-name scan (rather than an enumerated
+ * selector list) keeps discovery unbounded in panel and layer count.
+ *
+ * The panel stamp ({@link PANEL_ATTR}) shares the prefix but is index-stable
+ * and must never be treated as a layer tag, so it is excluded here.
  */
-const TAGGED_QUERY = [
-  ...Array.from({ length: MAX_TAGGED_LAYERS }, (_, layer) => `[${ATTR_PREFIX}-${layer}]`),
-  ...Array.from({ length: MAX_TAGGED_PANELS }, (_, panel) =>
-    Array.from({ length: MAX_TAGGED_LAYERS }, (_, layer) => `[${ATTR_PREFIX}-${panel}-${layer}]`).join(', ')),
-].join(', ');
+function findTaggedElements(container: HTMLElement): Element[] {
+  return Array.from(container.querySelectorAll('*')).filter(el =>
+    !isMaidrOwned(el)
+    && Array.from(el.attributes).some(attr =>
+      attr.name !== PANEL_ATTR && attr.name.startsWith(ATTR_PREFIX)));
+}
 
 /**
  * Builds a tag attribute name. In multi-panel mode the panel index is folded
@@ -54,9 +67,15 @@ function victoryAttr(panelIndex: number | null, suffix: string): string {
  * filter skips decorative user svgs (icons, etc.). If the filter yields fewer
  * svgs than expected (e.g. a Victory version drops the role), all svgs are
  * used as a fallback.
+ *
+ * MAIDR-owned hidden clones are excluded up front: while the figure is
+ * focused, the core inserts a `data-maidr-owned` clone right after each
+ * panel svg (with `role="img"` preserved), and counting those would bind
+ * every panel after the first to the previous panel's clone during a
+ * focused re-tag pass.
  */
 export function resolvePanelSvgs(container: HTMLElement, expectedCount: number): SVGElement[] {
-  const all = Array.from(container.querySelectorAll('svg'));
+  const all = Array.from(container.querySelectorAll('svg')).filter(svg => !isMaidrOwned(svg));
   const victorySvgs = all.filter(svg => svg.getAttribute('role') === 'img');
   return victorySvgs.length >= expectedCount ? victorySvgs : all;
 }
@@ -70,7 +89,7 @@ export function resolvePanelSvgs(container: HTMLElement, expectedCount: number):
  * live nodes.
  */
 export function getTaggedElements(container: HTMLElement): Element[] {
-  return Array.from(container.querySelectorAll(TAGGED_QUERY));
+  return findTaggedElements(container);
 }
 
 /**
@@ -80,11 +99,10 @@ export function getTaggedElements(container: HTMLElement): Element[] {
  * on the svg roots themselves are left intact — they are index-stable.
  */
 export function clearTaggedElements(container: HTMLElement): void {
-  const tagged = container.querySelectorAll(TAGGED_QUERY);
-  for (const el of tagged) {
+  for (const el of findTaggedElements(container)) {
     const attrs = Array.from(el.attributes);
     for (const attr of attrs) {
-      if (attr.name.startsWith(ATTR_PREFIX)) {
+      if (attr.name !== PANEL_ATTR && attr.name.startsWith(ATTR_PREFIX)) {
         el.removeAttribute(attr.name);
       }
     }
@@ -182,7 +200,7 @@ function tagDiscreteElements(
 ): string | undefined {
   const candidates = Array.from(
     svg.querySelectorAll('path[role="presentation"]'),
-  ).filter(el => !claimed.has(el));
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el));
 
   // Victory renders exactly one element per data point.
   // Take the first `dataCount` unclaimed elements.
@@ -242,7 +260,7 @@ function tagLineElements(
 ): string | undefined {
   const candidates = Array.from(
     svg.querySelectorAll('path[role="presentation"]'),
-  ).filter(el => !claimed.has(el));
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el));
 
   if (candidates.length === 0)
     return undefined;
@@ -293,7 +311,7 @@ function tagCandlestickElements(
 
   const bodies = Array.from(
     svg.querySelectorAll('rect[role="presentation"]'),
-  ).filter(el => !claimed.has(el));
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el));
 
   if (bodies.length === 0) {
     return undefined;
@@ -307,6 +325,7 @@ function tagCandlestickElements(
       continue;
     }
     const wicks = Array.from(group.querySelectorAll('line[role="presentation"]'))
+      .filter(line => !isMaidrOwned(line))
       .map(line => ({ line, y: lineMidY(line) }))
       .filter((w): w is { line: Element; y: number } => w.y !== null)
       .sort((a, b) => a.y - b.y);
@@ -360,7 +379,7 @@ function tagBoxElements(
 
   const rects = Array.from(
     svg.querySelectorAll('rect[role="presentation"]'),
-  ).filter(el => !claimed.has(el)) as SVGElement[];
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el)) as SVGElement[];
 
   // Each box is two rects (q1/q3 halves); bail if the shape is unexpected.
   if (rects.length === 0 || rects.length % 2 !== 0) {
@@ -387,7 +406,7 @@ function tagBoxElements(
   const boxCenters = Array.from(byX.keys()).sort((a, b) => a - b);
   const horizontalLines = Array.from(
     svg.querySelectorAll('line[role="presentation"]'),
-  ).filter(el => !claimed.has(el) && isHorizontalLine(el));
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el) && isHorizontalLine(el));
 
   const selectors: BoxSelector[] = [];
 

--- a/src/adapters/victory/selectors.ts
+++ b/src/adapters/victory/selectors.ts
@@ -8,36 +8,79 @@ import type { VictoryLayerInfo } from './types';
 const ATTR_PREFIX = 'data-maidr-victory';
 
 /**
- * CSS selector matching every `data-maidr-victory-<n>` tag (supports up to 10
- * layers per subplot, which is well beyond any realistic Victory chart).
+ * Attribute stamped on each panel's root `<svg>` in multi-panel mode; its
+ * value is the panel index. Emitted selectors use it as an ancestor segment
+ * so one panel's selectors can never match another panel's marks, and
+ * `MaidrSubplot.selector` targets it for subplot-level highlighting.
  */
-const TAGGED_QUERY = Array.from({ length: 10 }, (_, i) => `[${ATTR_PREFIX}-${i}]`).join(', ');
+export const PANEL_ATTR = `${ATTR_PREFIX}-panel`;
+
+/** Upper bound on enumerated layer tags per panel. */
+const MAX_TAGGED_LAYERS = 10;
+
+/** Upper bound on enumerated panels per figure. */
+const MAX_TAGGED_PANELS = 10;
 
 /**
- * Returns all currently-tagged elements inside the container's SVG.
+ * CSS selector matching every layer tag: the flat single-panel names
+ * (`data-maidr-victory-<layer>`) and the panel-scoped multi-panel names
+ * (`data-maidr-victory-<panel>-<layer>`). Supports up to 10 layers per panel
+ * and 10 panels per figure, well beyond any realistic Victory figure.
+ */
+const TAGGED_QUERY = [
+  ...Array.from({ length: MAX_TAGGED_LAYERS }, (_, layer) => `[${ATTR_PREFIX}-${layer}]`),
+  ...Array.from({ length: MAX_TAGGED_PANELS }, (_, panel) =>
+    Array.from({ length: MAX_TAGGED_LAYERS }, (_, layer) => `[${ATTR_PREFIX}-${panel}-${layer}]`).join(', ')),
+].join(', ');
+
+/**
+ * Builds a tag attribute name. In multi-panel mode the panel index is folded
+ * into the name (`data-maidr-victory-<panel>-<suffix>`) so names stay unique
+ * per panel; single-panel names keep the original flat form
+ * (`data-maidr-victory-<suffix>`) for backward compatibility.
+ */
+function victoryAttr(panelIndex: number | null, suffix: string): string {
+  return panelIndex === null
+    ? `${ATTR_PREFIX}-${suffix}`
+    : `${ATTR_PREFIX}-${panelIndex}-${suffix}`;
+}
+
+/**
+ * Resolves the per-panel `<svg>` roots inside the container, in document
+ * order (which matches the top-level `<VictoryChart>` children order, since
+ * each standalone VictoryChart renders exactly one svg).
+ *
+ * Victory's `VictoryContainer` renders its svg with `role="img"`, so the
+ * filter skips decorative user svgs (icons, etc.). If the filter yields fewer
+ * svgs than expected (e.g. a Victory version drops the role), all svgs are
+ * used as a fallback.
+ */
+export function resolvePanelSvgs(container: HTMLElement, expectedCount: number): SVGElement[] {
+  const all = Array.from(container.querySelectorAll('svg'));
+  const victorySvgs = all.filter(svg => svg.getAttribute('role') === 'img');
+  return victorySvgs.length >= expectedCount ? victorySvgs : all;
+}
+
+/**
+ * Returns all currently-tagged elements inside the container (across every
+ * panel svg).
  *
  * Used by the adapter to detect when Victory has detached a tagged node (it
  * re-renders some marks after mount), so the tags can be re-applied to the
  * live nodes.
  */
 export function getTaggedElements(container: HTMLElement): Element[] {
-  const svg = container.querySelector('svg');
-  if (!svg)
-    return [];
-  return Array.from(svg.querySelectorAll(TAGGED_QUERY));
+  return Array.from(container.querySelectorAll(TAGGED_QUERY));
 }
 
 /**
- * Removes all `data-maidr-victory-*` attributes from elements inside the
- * container. Must be called before re-tagging to prevent stale attributes
- * from accumulating across re-renders.
+ * Removes all `data-maidr-victory-*` attributes from tagged elements inside
+ * the container (across every panel svg). Must be called before re-tagging to
+ * prevent stale attributes from accumulating across re-renders. Panel stamps
+ * on the svg roots themselves are left intact — they are index-stable.
  */
 export function clearTaggedElements(container: HTMLElement): void {
-  const svg = container.querySelector('svg');
-  if (!svg)
-    return;
-
-  const tagged = svg.querySelectorAll(TAGGED_QUERY);
+  const tagged = container.querySelectorAll(TAGGED_QUERY);
   for (const el of tagged) {
     const attrs = Array.from(el.attributes);
     for (const attr of attrs) {
@@ -70,33 +113,35 @@ export function clearTaggedElements(container: HTMLElement): void {
  * degrade and highlighting will stop working (audio/text/braille are
  * unaffected).
  *
- * The emitted selectors are prefixed with `scope` (e.g. `#<containerId> `) so
+ * The emitted selectors are prefixed with `scope` (e.g. `#<containerId> `, or
+ * `#<containerId> [data-maidr-victory-panel="i"] ` in multi-panel mode) so
  * that MAIDR — which resolves selectors via page-global `document.querySelector`
- * — cannot match another Victory chart's identically-indexed tags. The
- * per-element `data-maidr-victory-<layerIndex>` attributes only need to be
- * unique within their own container, which `scope` guarantees.
+ * — cannot match another Victory chart's (or panel's) identically-indexed
+ * tags. The per-element tag attributes only need to be unique within their
+ * own container, which `scope` plus the panel-folded names guarantee.
  *
- * @param container  - The DOM node wrapping the Victory chart
+ * @param svg        - The panel's root svg element
  * @param layer      - The extracted layer info
  * @param layerIndex - Numeric index for generating unique attribute names
- * @param claimed    - Set of elements already claimed by prior layers
- * @param scope      - Per-chart CSS scope prefix (e.g. `#<containerId> `) that
- *                     disambiguates this chart's selectors page-wide
+ * @param claimed    - Set of elements already claimed by prior layers of the
+ *                     same panel (must not be shared across panels)
+ * @param scope      - Per-chart (and, in multi-panel mode, per-panel) CSS
+ *                     scope prefix that disambiguates this panel's selectors
+ *                     page-wide
+ * @param panelIndex - Panel index in multi-panel mode; `null` keeps the
+ *                     original single-panel attribute naming
  * @returns A CSS selector string, or `undefined` if elements could not be
  *          matched (highlighting will gracefully degrade).
  */
 export function tagLayerElements(
-  container: HTMLElement,
+  svg: SVGElement,
   layer: VictoryLayerInfo,
   layerIndex: number,
   claimed: Set<Element>,
   scope: string,
+  panelIndex: number | null = null,
 ): string | BoxSelector[] | CandlestickSelector | undefined {
-  const svg = container.querySelector('svg');
-  if (!svg)
-    return undefined;
-
-  const attrName = `${ATTR_PREFIX}-${layerIndex}`;
+  const attrName = victoryAttr(panelIndex, String(layerIndex));
   const { victoryType } = layer;
 
   // Line charts: single <path> representing the full series.
@@ -107,14 +152,14 @@ export function tagLayerElements(
   // Candlestick: each candle is a <g> with one body <rect> and two wick
   // <line>s — tag them as a structured CandlestickSelector.
   if (victoryType === 'VictoryCandlestick') {
-    return tagCandlestickElements(svg, attrName, claimed, scope);
+    return tagCandlestickElements(svg, attrName, claimed, scope, panelIndex);
   }
 
   // Box plot: component-grouped rects (q1/q3 halves), median lines, and
   // whisker line-pairs with no semantic classes — classify by geometry and
   // tag as a per-box BoxSelector[].
   if (victoryType === 'VictoryBoxPlot') {
-    return tagBoxElements(svg, attrName, claimed, scope);
+    return tagBoxElements(svg, attrName, claimed, scope, panelIndex);
   }
 
   // Discrete-element charts: one <path role="presentation"> per data point.
@@ -225,11 +270,6 @@ function tagLineElements(
 // Candlestick
 // ---------------------------------------------------------------------------
 
-/** Part attributes used to target candlestick sections. */
-const CANDLE_BODY = `${ATTR_PREFIX}-cbody`;
-const CANDLE_HIGH = `${ATTR_PREFIX}-chigh`;
-const CANDLE_LOW = `${ATTR_PREFIX}-clow`;
-
 /**
  * Tags the elements of a VictoryCandlestick layer.
  *
@@ -245,7 +285,12 @@ function tagCandlestickElements(
   attrName: string,
   claimed: Set<Element>,
   scope: string,
+  panelIndex: number | null,
 ): CandlestickSelector | undefined {
+  const bodyAttr = victoryAttr(panelIndex, 'cbody');
+  const highAttr = victoryAttr(panelIndex, 'chigh');
+  const lowAttr = victoryAttr(panelIndex, 'clow');
+
   const bodies = Array.from(
     svg.querySelectorAll('rect[role="presentation"]'),
   ).filter(el => !claimed.has(el));
@@ -255,7 +300,7 @@ function tagCandlestickElements(
   }
 
   for (const body of bodies) {
-    tag(body, attrName, CANDLE_BODY, claimed);
+    tag(body, attrName, bodyAttr, claimed);
 
     const group = body.parentElement;
     if (!group) {
@@ -268,27 +313,23 @@ function tagCandlestickElements(
 
     // Smaller mid-y = high (upper) wick; larger = low (lower) wick.
     if (wicks.length >= 1) {
-      tag(wicks[0].line, attrName, CANDLE_HIGH, claimed);
+      tag(wicks[0].line, attrName, highAttr, claimed);
     }
     if (wicks.length >= 2) {
-      tag(wicks[wicks.length - 1].line, attrName, CANDLE_LOW, claimed);
+      tag(wicks[wicks.length - 1].line, attrName, lowAttr, claimed);
     }
   }
 
   return {
-    body: `${scope}[${CANDLE_BODY}]`,
-    wickHigh: `${scope}[${CANDLE_HIGH}]`,
-    wickLow: `${scope}[${CANDLE_LOW}]`,
+    body: `${scope}[${bodyAttr}]`,
+    wickHigh: `${scope}[${highAttr}]`,
+    wickLow: `${scope}[${lowAttr}]`,
   };
 }
 
 // ---------------------------------------------------------------------------
 // Box plot
 // ---------------------------------------------------------------------------
-
-/** Part attributes used to target box-plot sections per box. */
-const BOX_INDEX = `${ATTR_PREFIX}-bidx`;
-const BOX_PART = `${ATTR_PREFIX}-bpart`;
 
 /**
  * Tags the elements of a VictoryBoxPlot layer.
@@ -312,7 +353,11 @@ function tagBoxElements(
   attrName: string,
   claimed: Set<Element>,
   scope: string,
+  panelIndex: number | null,
 ): BoxSelector[] | undefined {
+  const boxIndexAttr = victoryAttr(panelIndex, 'bidx');
+  const boxPartAttr = victoryAttr(panelIndex, 'bpart');
+
   const rects = Array.from(
     svg.querySelectorAll('rect[role="presentation"]'),
   ).filter(el => !claimed.has(el)) as SVGElement[];
@@ -360,8 +405,8 @@ function tagBoxElements(
     const xMin = num(q1Rect.getAttribute('x'))!;
     const xMax = xMin + num(q1Rect.getAttribute('width'))!;
 
-    tagBoxPart(q1Rect, attrName, i, 'q1', claimed);
-    tagBoxPart(q3Rect, attrName, i, 'q3', claimed);
+    tagBoxPart(q1Rect, attrName, boxIndexAttr, boxPartAttr, i, 'q1', claimed);
+    tagBoxPart(q3Rect, attrName, boxIndexAttr, boxPartAttr, i, 'q3', claimed);
 
     for (const line of horizontalLines) {
       const geom = horizontalLineGeom(line);
@@ -369,15 +414,15 @@ function tagBoxElements(
         continue;
       }
       if (geom.y >= boxTop - 1 && geom.y <= boxBottom + 1) {
-        tagBoxPart(line, attrName, i, 'q2', claimed); // median, inside the box
+        tagBoxPart(line, attrName, boxIndexAttr, boxPartAttr, i, 'q2', claimed); // median, inside the box
       } else if (geom.y < boxTop) {
-        tagBoxPart(line, attrName, i, 'max', claimed); // cap above the box
+        tagBoxPart(line, attrName, boxIndexAttr, boxPartAttr, i, 'max', claimed); // cap above the box
       } else if (geom.y > boxBottom) {
-        tagBoxPart(line, attrName, i, 'min', claimed); // cap below the box
+        tagBoxPart(line, attrName, boxIndexAttr, boxPartAttr, i, 'min', claimed); // cap below the box
       }
     }
 
-    const sel = (part: string): string => `${scope}[${BOX_INDEX}="${i}"][${BOX_PART}="${part}"]`;
+    const sel = (part: string): string => `${scope}[${boxIndexAttr}="${i}"][${boxPartAttr}="${part}"]`;
     selectors.push({
       lowerOutliers: [],
       upperOutliers: [],
@@ -414,10 +459,18 @@ function tag(el: Element, attrName: string, partAttr: string, claimed: Set<Eleme
 }
 
 /** Stamps a box element with its box index and section part. */
-function tagBoxPart(el: Element, attrName: string, boxIndex: number, part: string, claimed: Set<Element>): void {
+function tagBoxPart(
+  el: Element,
+  attrName: string,
+  boxIndexAttr: string,
+  boxPartAttr: string,
+  boxIndex: number,
+  part: string,
+  claimed: Set<Element>,
+): void {
   el.setAttribute(attrName, '');
-  el.setAttribute(BOX_INDEX, String(boxIndex));
-  el.setAttribute(BOX_PART, part);
+  el.setAttribute(boxIndexAttr, String(boxIndex));
+  el.setAttribute(boxPartAttr, part);
   claimed.add(el);
 }
 

--- a/src/adapters/victory/selectors.ts
+++ b/src/adapters/victory/selectors.ts
@@ -76,8 +76,21 @@ function victoryAttr(panelIndex: number | null, suffix: string): string {
  */
 export function resolvePanelSvgs(container: HTMLElement, expectedCount: number): SVGElement[] {
   const all = Array.from(container.querySelectorAll('svg')).filter(svg => !isMaidrOwned(svg));
-  const victorySvgs = all.filter(svg => svg.getAttribute('role') === 'img');
-  return victorySvgs.length >= expectedCount ? victorySvgs : all;
+
+  // Victory renders each chart svg inside a `div.VictoryContainer` wrapper —
+  // the most precise signal, immune to user-supplied `role="img"` svgs
+  // (icons, illustrations) sitting between panels.
+  const containerSvgs = all.filter(
+    svg => svg.parentElement?.classList.contains('VictoryContainer') ?? false,
+  );
+  if (containerSvgs.length === expectedCount)
+    return containerSvgs;
+
+  const roleImgSvgs = all.filter(svg => svg.getAttribute('role') === 'img');
+  if (roleImgSvgs.length === expectedCount)
+    return roleImgSvgs;
+
+  return roleImgSvgs.length >= expectedCount ? roleImgSvgs : all;
 }
 
 /**

--- a/src/adapters/victory/types.ts
+++ b/src/adapters/victory/types.ts
@@ -10,6 +10,21 @@ import type {
 import type { ReactNode } from 'react';
 
 /**
+ * Row-major grid layout for multi-panel figures (two or more top-level
+ * `<VictoryChart>` children). When omitted, panels form a single row in
+ * children order.
+ */
+export interface VictoryPanelLayout {
+  /**
+   * Number of grid rows. Used to derive the panels-per-row count when
+   * `columns` is omitted.
+   */
+  rows?: number;
+  /** Number of panels per row. Takes precedence over `rows`. */
+  columns?: number;
+}
+
+/**
  * Configuration accepted by both the {@link MaidrVictory} wrapper component
  * and the `useVictoryAdapter` hook.
  */
@@ -24,6 +39,12 @@ export interface VictoryAdapterConfig {
   caption?: string;
   /** Victory chart components to make accessible. */
   children: ReactNode;
+  /**
+   * Grid layout for multi-panel figures. Only consulted when `children`
+   * contains two or more top-level `<VictoryChart>` components; single-chart
+   * figures are unaffected.
+   */
+  layout?: VictoryPanelLayout;
 }
 
 /**
@@ -81,4 +102,20 @@ export interface VictoryLayerInfo {
   dataCount: number;
   /** Legend labels for multi-series segmented charts. */
   legend?: string[];
+}
+
+/**
+ * Intermediate representation of one subplot panel (one top-level
+ * `<VictoryChart>` in multi-panel mode) before conversion to the MAIDR
+ * schema.
+ */
+export interface VictorySubplotInfo {
+  /** Extracted data layers belonging to this panel. */
+  layers: VictoryLayerInfo[];
+  /**
+   * Panel display name, read from the `<VictoryChart title="...">` prop.
+   * Emitted as the first layer's title, which MAIDR uses as the panel name
+   * in subplot summaries.
+   */
+  title?: string;
 }

--- a/src/adapters/victory/types.ts
+++ b/src/adapters/victory/types.ts
@@ -118,4 +118,12 @@ export interface VictorySubplotInfo {
    * in subplot summaries.
    */
   title?: string;
+  /**
+   * Ordinal of this chart's `<svg>` among ALL top-level Victory components
+   * (each renders its own standalone `<svg role="img">`, including standalone
+   * data components, legends, and unsupported components). Used to bind the
+   * panel to the correct rendered svg even when non-chart Victory siblings
+   * precede it. Absent in single-panel mode.
+   */
+  svgIndex?: number;
 }

--- a/src/adapters/victory/useVictoryAdapter.ts
+++ b/src/adapters/victory/useVictoryAdapter.ts
@@ -6,6 +6,12 @@
  * rendered SVG elements (via a container ref) inside a `useLayoutEffect`. It
  * returns the MaidrData ready to pass to the `<Maidr>` component's `data` prop.
  *
+ * Multi-panel figures: when `children` contains two or more top-level
+ * `<VictoryChart>` components, each chart becomes one MAIDR subplot (arrow
+ * keys navigate panels; Enter drills into a panel). By default the panels
+ * form a single row in children order; pass `layout: { rows, columns }` for
+ * row-major grid chunking.
+ *
  * @example
  * ```tsx
  * import { useRef } from 'react';
@@ -31,13 +37,13 @@
  * ```
  */
 
-import type { Maidr as MaidrData, MaidrLayer } from '@type/grammar';
+import type { Maidr as MaidrData, MaidrSubplot } from '@type/grammar';
 import type { RefObject } from 'react';
-import type { VictoryAdapterConfig, VictoryLayerInfo } from './types';
+import type { VictoryAdapterConfig, VictoryLayerInfo, VictoryPanelLayout, VictorySubplotInfo } from './types';
 import { cssEscape, ensureContainerId } from '@adapters/shared/selectorUtil';
 import { useLayoutEffect, useRef, useState } from 'react';
-import { extractVictoryLayers, toMaidrLayer } from './converters';
-import { clearTaggedElements, getTaggedElements, tagLayerElements } from './selectors';
+import { computeSubplotGrid, extractVictorySubplots, toMaidrLayer } from './converters';
+import { clearTaggedElements, getTaggedElements, PANEL_ATTR, resolvePanelSvgs, tagLayerElements } from './selectors';
 
 /**
  * Collects all legend labels across layers that define them.
@@ -52,34 +58,115 @@ function collectLegend(layers: VictoryLayerInfo[]): string[] | undefined {
 }
 
 /**
- * Produces a stable, serialisable fingerprint from extracted Victory layers.
+ * Produces a stable, serialisable fingerprint from the extracted Victory
+ * subplot structure.
  *
  * React `children` creates a new object reference on every render, which
  * makes it an unstable dependency for hooks. Instead we compare the
- * JSON-serialisable layer data: if the actual chart data hasn't changed
- * the effect can skip DOM re-tagging.
+ * JSON-serialisable panel/layer data (plus the grid layout): if the actual
+ * chart structure hasn't changed the effect can skip DOM re-tagging.
  */
-function layerFingerprint(layers: VictoryLayerInfo[]): string {
-  return JSON.stringify(layers.map(l => ({
-    t: l.victoryType,
-    d: l.data,
-    n: l.dataCount,
-  })));
+function subplotFingerprint(subplots: VictorySubplotInfo[], layout?: VictoryPanelLayout): string {
+  return JSON.stringify({
+    r: layout?.rows ?? null,
+    c: layout?.columns ?? null,
+    p: subplots.map(s => ({
+      title: s.title ?? null,
+      layers: s.layers.map(l => ({
+        t: l.victoryType,
+        d: l.data,
+        n: l.dataCount,
+      })),
+    })),
+  });
+}
+
+/**
+ * Tags the rendered Victory SVG(s) inside `container` and builds the MAIDR
+ * subplot grid.
+ *
+ * Single-panel figures keep the original flat tagging
+ * (`data-maidr-victory-<n>` attributes on the container's first svg) and the
+ * original `[[{ layers, legend }]]` shape, byte-identical to previous output.
+ *
+ * Multi-panel figures resolve one svg per panel (index-aligned with the
+ * VictoryChart children in document order), stamp each panel svg with
+ * `data-maidr-victory-panel="<i>"`, and emit panel-scoped attribute names and
+ * selectors so panels can never cross-highlight. Each panel gets its own
+ * `claimed` element set so tagging never leaks across panels. Panels whose
+ * charts contain no supported data are dropped (the core model cannot
+ * represent an empty subplot inside a grid), while panel indices stay aligned
+ * with the rendered svgs.
+ */
+export function buildVictorySubplots(
+  container: HTMLElement,
+  victorySubplots: VictorySubplotInfo[],
+  scope: string,
+  layout?: VictoryPanelLayout,
+): MaidrSubplot[][] {
+  if (victorySubplots.length === 1) {
+    const victoryLayers = victorySubplots[0].layers;
+    const svg = container.querySelector('svg');
+    const claimed = new Set<Element>();
+    const maidrLayers = victoryLayers.map((layer, index) =>
+      toMaidrLayer(layer, svg ? tagLayerElements(svg, layer, index, claimed, scope) : undefined));
+    return [[{ layers: maidrLayers, legend: collectLegend(victoryLayers) }]];
+  }
+
+  const panelSvgs = resolvePanelSvgs(container, victorySubplots.length);
+  const subplots: MaidrSubplot[] = [];
+
+  victorySubplots.forEach((info, panelIndex) => {
+    // Never emit an empty subplot inside a grid — the core model throws on it.
+    if (info.layers.length === 0)
+      return;
+
+    const svg: SVGElement | undefined = panelSvgs[panelIndex];
+    let panelSelector: string | undefined;
+    if (svg) {
+      svg.setAttribute(PANEL_ATTR, String(panelIndex));
+      panelSelector = `${scope}[${PANEL_ATTR}="${panelIndex}"]`;
+    }
+
+    const panelScope = panelSelector ? `${panelSelector} ` : undefined;
+    const claimed = new Set<Element>();
+    const maidrLayers = info.layers.map((layer, layerIndex) =>
+      toMaidrLayer(layer, svg && panelScope
+        ? tagLayerElements(svg, layer, layerIndex, claimed, panelScope, panelIndex)
+        : undefined));
+
+    // The first layer's title is the panel's display name in MAIDR's subplot
+    // summaries (there is no subplot-level title field in the grammar).
+    maidrLayers[0].title = info.title ?? `Panel ${panelIndex + 1}`;
+
+    subplots.push({
+      layers: maidrLayers,
+      legend: collectLegend(info.layers),
+      selector: panelSelector,
+    });
+  });
+
+  return computeSubplotGrid(subplots, layout);
 }
 
 /**
  * Converts Victory chart children into MAIDR data, tagging the rendered SVG
  * elements inside `containerRef` for highlight integration.
  *
- * @param config       - Chart metadata and the Victory children to introspect
- * @param containerRef - Ref to the DOM node wrapping the rendered Victory SVG
+ * @param config       - Chart metadata, optional multi-panel layout, and the
+ *                       Victory children to introspect
+ * @param containerRef - Ref to the DOM node wrapping the rendered Victory SVG(s)
  * @returns MaidrData ready to pass to `<Maidr data={...}>`
  */
 export function useVictoryAdapter(
   config: VictoryAdapterConfig,
   containerRef: RefObject<HTMLDivElement | null>,
 ): MaidrData {
-  const { id, title, subtitle, caption, children } = config;
+  const { id, title, subtitle, caption, children, layout } = config;
+  // Primitive layout deps: an inline `layout` object literal would re-run the
+  // effect on every render.
+  const layoutRows = layout?.rows;
+  const layoutColumns = layout?.columns;
   const prevFingerprintRef = useRef<string>('');
   // Elements tagged by the most recent full pass. Hoisted to a component-level
   // ref so it survives effect re-runs (an unrelated parent re-render recreates
@@ -113,6 +200,10 @@ export function useVictoryAdapter(
     // MaidrVictory charts on one page cannot cross-highlight (the model resolves
     // selectors via page-global document.querySelector). Idempotent per chart.
     const scope = `#${cssEscape(ensureContainerId(container, 'mv'))} `;
+    const panelLayout: VictoryPanelLayout | undefined
+      = layoutRows !== undefined || layoutColumns !== undefined
+        ? { rows: layoutRows, columns: layoutColumns }
+        : undefined;
 
     let frameId = 0;
 
@@ -121,8 +212,8 @@ export function useVictoryAdapter(
 
       // Extract data from Victory component props via React children
       // introspection (pure computation, does not require the DOM).
-      const victoryLayers = extractVictoryLayers(children);
-      const fp = layerFingerprint(victoryLayers);
+      const victorySubplots = extractVictorySubplots(children);
+      const fp = subplotFingerprint(victorySubplots, panelLayout);
 
       // Fast path: when the layer data is unchanged AND every previously-tagged
       // node is still connected, the existing data-maidr-victory-* attributes
@@ -139,9 +230,7 @@ export function useVictoryAdapter(
 
       // Full pass: (re)apply tags to the current Victory nodes.
       clearTaggedElements(container);
-      const claimed = new Set<Element>();
-      const maidrLayers: MaidrLayer[] = victoryLayers.map((layer, index) =>
-        toMaidrLayer(layer, tagLayerElements(container, layer, index, claimed, scope)));
+      const subplots = buildVictorySubplots(container, victorySubplots, scope, panelLayout);
       taggedElementsRef.current = getTaggedElements(container);
 
       // Selector strings are stable (`#<id> [data-maidr-victory-N]`), so update
@@ -152,16 +241,11 @@ export function useVictoryAdapter(
         return;
       prevFingerprintRef.current = fp;
 
-      setMaidrData(victoryLayers.length === 0
+      const hasLayers = subplots.some(row => row.some(subplot => subplot.layers.length > 0));
+      setMaidrData(hasLayers
+        ? { id, title, subtitle, caption, subplots }
         // Preserve metadata even when no supported Victory components are found.
-        ? { id, title, subtitle, caption, subplots: [[{ layers: [] }]] }
-        : {
-            id,
-            title,
-            subtitle,
-            caption,
-            subplots: [[{ layers: maidrLayers, legend: collectLegend(victoryLayers) }]],
-          });
+        : { id, title, subtitle, caption, subplots: [[{ layers: [] }]] });
     };
 
     // Initial synchronous tag pass.
@@ -186,7 +270,7 @@ export function useVictoryAdapter(
       if (frameId)
         cancelAnimationFrame(frameId);
     };
-  }, [children, id, title, subtitle, caption]);
+  }, [children, id, title, subtitle, caption, layoutRows, layoutColumns]);
 
   return maidrData;
 }

--- a/src/adapters/victory/useVictoryAdapter.ts
+++ b/src/adapters/victory/useVictoryAdapter.ts
@@ -89,14 +89,19 @@ function subplotFingerprint(subplots: VictorySubplotInfo[], layout?: VictoryPane
  * (`data-maidr-victory-<n>` attributes on the container's first svg) and the
  * original `[[{ layers, legend }]]` shape, byte-identical to previous output.
  *
- * Multi-panel figures resolve one svg per panel (index-aligned with the
- * VictoryChart children in document order), stamp each panel svg with
+ * Multi-panel figures resolve one svg per panel (bound via each panel's
+ * `svgIndex` ordinal among all top-level Victory components, so non-chart
+ * Victory siblings such as a standalone scatter or a shared legend cannot
+ * shift the binding), stamp each panel svg with
  * `data-maidr-victory-panel="<i>"`, and emit panel-scoped attribute names and
  * selectors so panels can never cross-highlight. Each panel gets its own
- * `claimed` element set so tagging never leaks across panels. Panels whose
- * charts contain no supported data are dropped (the core model cannot
- * represent an empty subplot inside a grid), while panel indices stay aligned
- * with the rendered svgs.
+ * `claimed` element set so tagging never leaks across panels.
+ *
+ * Panels whose charts contain no supported data are dropped (the core model
+ * cannot represent an empty subplot inside a grid), but only AFTER grid
+ * chunking: every remaining panel keeps the grid cell of the visual CSS
+ * arrangement, and only rows left entirely empty are removed (the core cannot
+ * represent empty rows; ragged rows navigate fine).
  */
 export function buildVictorySubplots(
   container: HTMLElement,
@@ -113,15 +118,27 @@ export function buildVictorySubplots(
     return [[{ layers: maidrLayers, legend: collectLegend(victoryLayers) }]];
   }
 
-  const panelSvgs = resolvePanelSvgs(container, victorySubplots.length);
-  const subplots: MaidrSubplot[] = [];
+  // Standalone Victory siblings render their own svgs too, so the expected
+  // svg count is driven by the highest svg ordinal, not the panel count.
+  const expectedSvgCount = victorySubplots.reduce(
+    (max, info, index) => Math.max(max, (info.svgIndex ?? index) + 1),
+    0,
+  );
+  const panelSvgs = resolvePanelSvgs(container, expectedSvgCount);
 
-  victorySubplots.forEach((info, panelIndex) => {
+  // `null` entries keep an empty panel's grid cell during chunking; they are
+  // dropped per row afterwards.
+  const entries: (MaidrSubplot | null)[] = victorySubplots.map((info, panelIndex) => {
     // Never emit an empty subplot inside a grid — the core model throws on it.
-    if (info.layers.length === 0)
-      return;
+    if (info.layers.length === 0) {
+      console.warn(
+        `MAIDR: Victory panel ${panelIndex + 1} contains no supported data `
+        + 'components and is omitted from subplot navigation.',
+      );
+      return null;
+    }
 
-    const svg: SVGElement | undefined = panelSvgs[panelIndex];
+    const svg: SVGElement | undefined = panelSvgs[info.svgIndex ?? panelIndex];
     let panelSelector: string | undefined;
     if (svg) {
       svg.setAttribute(PANEL_ATTR, String(panelIndex));
@@ -139,14 +156,16 @@ export function buildVictorySubplots(
     // summaries (there is no subplot-level title field in the grammar).
     maidrLayers[0].title = info.title ?? `Panel ${panelIndex + 1}`;
 
-    subplots.push({
+    return {
       layers: maidrLayers,
       legend: collectLegend(info.layers),
       selector: panelSelector,
-    });
+    };
   });
 
-  return computeSubplotGrid(subplots, layout);
+  return computeSubplotGrid(entries, layout)
+    .map(row => row.filter((subplot): subplot is MaidrSubplot => subplot !== null))
+    .filter(row => row.length > 0);
 }
 
 /**

--- a/src/anychart-entry.ts
+++ b/src/anychart-entry.ts
@@ -1,8 +1,9 @@
 /**
  * Public API for the MAIDR AnyChart adapter.
  *
- * Provides {@link bindAnyChart} and {@link anyChartToMaidr} for integrating
- * AnyChart charts with MAIDR's accessible visualisation features.
+ * Provides {@link bindAnyChart} / {@link anyChartToMaidr} for single charts
+ * and {@link bindAnyCharts} / {@link anyChartsToMaidr} for grouping multiple
+ * charts into one multi-panel MAIDR figure.
  *
  * @remarks
  * AnyChart must be loaded separately – this module does not bundle the
@@ -11,23 +12,37 @@
  *
  * @example
  * ```ts
- * import { bindAnyChart } from 'maidr/anychart';
+ * import { bindAnyChart, bindAnyCharts } from 'maidr/anychart';
  *
  * const chart = anychart.bar([4, 2, 7, 1]);
  * chart.container('container').draw();
  *
  * // One-liner: extracts data, sets maidr-data attribute, fires event.
  * bindAnyChart(chart);
+ *
+ * // Multi-panel: group several charts into one accessible figure.
+ * bindAnyCharts([[chartA, chartB], [chartC, chartD]], { title: 'Dashboard' });
  * ```
  *
  * @packageDocumentation
  */
-export { anyChartToMaidr, bindAnyChart } from './adapters/anychart';
+export {
+  anyChartsToMaidr,
+  anyChartToMaidr,
+  bindAnyChart,
+  bindAnyCharts,
+} from './adapters/anychart';
 
 /**
  * Re-exported types for configuring the AnyChart adapter.
  */
-export type { AnyChartBinderOptions, AnyChartInstance } from './adapters/anychart';
+export type {
+  AnyChartBinderOptions,
+  AnyChartGridInput,
+  AnyChartInstance,
+  AnyChartsBinderOptions,
+  AnyChartsLayout,
+} from './adapters/anychart';
 
 /**
  * Re-exported core MAIDR types so consumers can type the output.

--- a/src/frappe-entry.ts
+++ b/src/frappe-entry.ts
@@ -7,11 +7,13 @@
  *
  * @packageDocumentation
  */
-import { createMaidrFromFrappeChart } from './adapters/frappe/converters';
+import { createMaidrFromFrappeChart, createMaidrFromFrappeCharts } from './adapters/frappe/converters';
 
 export {
   createMaidrFromFrappeChart,
+  createMaidrFromFrappeCharts,
   type FrappeChartAdapterOptions,
+  type FrappeChartsGridOptions,
 } from './adapters/frappe/converters';
 
 // Expose Frappe adapter globally for script-tag usage (UMD build).
@@ -20,6 +22,7 @@ declare global {
   interface Window {
     maidrFrappe?: {
       createMaidrFromFrappeChart: typeof createMaidrFromFrappeChart;
+      createMaidrFromFrappeCharts: typeof createMaidrFromFrappeCharts;
     };
   }
 }
@@ -27,6 +30,7 @@ declare global {
 if (typeof window !== 'undefined') {
   window.maidrFrappe = {
     createMaidrFromFrappeChart,
+    createMaidrFromFrappeCharts,
   };
 }
 
@@ -35,6 +39,7 @@ export type {
   FrappeChartType,
   FrappeData,
   FrappeDataset,
+  FrappePanel,
 } from './adapters/frappe/types';
 
 // Re-export core types that consumers may need alongside the adapter.

--- a/src/google-charts-entry.ts
+++ b/src/google-charts-entry.ts
@@ -47,6 +47,7 @@ export type {
   GoogleChartType,
   GoogleDataTable,
   GoogleEvents,
+  GoogleListenerHandle,
   GoogleSelectionItem,
 } from './adapters/google-charts/types';
 

--- a/src/google-charts-entry.ts
+++ b/src/google-charts-entry.ts
@@ -7,11 +7,19 @@
  *
  * @packageDocumentation
  */
-import { createMaidrFromGoogleChart } from './adapters/google-charts/converters';
+import {
+  createMaidrFromGoogleChart,
+  createMaidrFromGoogleCharts,
+  whenGoogleChartsReady,
+} from './adapters/google-charts/converters';
 
 export {
   createMaidrFromGoogleChart,
+  createMaidrFromGoogleCharts,
   type GoogleChartAdapterOptions,
+  type GoogleChartPanel,
+  type GoogleChartsGridOptions,
+  whenGoogleChartsReady,
 } from './adapters/google-charts/converters';
 
 // Expose Google Charts adapter globally for script-tag usage (UMD build)
@@ -20,6 +28,8 @@ declare global {
   interface Window {
     maidrGoogleCharts?: {
       createMaidrFromGoogleChart: typeof createMaidrFromGoogleChart;
+      createMaidrFromGoogleCharts: typeof createMaidrFromGoogleCharts;
+      whenGoogleChartsReady: typeof whenGoogleChartsReady;
     };
   }
 }
@@ -27,6 +37,8 @@ declare global {
 if (typeof window !== 'undefined') {
   window.maidrGoogleCharts = {
     createMaidrFromGoogleChart,
+    createMaidrFromGoogleCharts,
+    whenGoogleChartsReady,
   };
 }
 

--- a/src/recharts-entry.ts
+++ b/src/recharts-entry.ts
@@ -74,12 +74,51 @@
  * }
  * ```
  *
+ * @example Multi-panel (faceted) figure
+ * ```tsx
+ * import { MaidrRecharts } from 'maidr/recharts';
+ * import { Bar, BarChart, XAxis, YAxis } from 'recharts';
+ *
+ * const east = [{ quarter: 'Q1', revenue: 100 }, { quarter: 'Q2', revenue: 200 }];
+ * const west = [{ quarter: 'Q1', revenue: 80 }, { quarter: 'Q2', revenue: 140 }];
+ *
+ * function AccessibleFacetedChart() {
+ *   return (
+ *     <MaidrRecharts
+ *       id="sales-by-region"
+ *       title="Sales by Region"
+ *       xKey="quarter"
+ *       yKeys={['revenue']}
+ *       xLabel="Quarter"
+ *       yLabel="Revenue"
+ *       subplots={[[
+ *         { title: 'East', chartType: 'bar', data: east },
+ *         { title: 'West', chartType: 'bar', data: west },
+ *       ]]}
+ *     >
+ *       <BarChart width={300} height={250} data={east}>
+ *         <XAxis dataKey="quarter" />
+ *         <YAxis />
+ *         <Bar dataKey="revenue" />
+ *       </BarChart>
+ *       <BarChart width={300} height={250} data={west}>
+ *         <XAxis dataKey="quarter" />
+ *         <YAxis />
+ *         <Bar dataKey="revenue" />
+ *       </BarChart>
+ *     </MaidrRecharts>
+ *   );
+ * }
+ * ```
+ *
  * @packageDocumentation
  */
 export {
   convertRechartsToMaidr,
+  getPanelClassName,
   getRechartsSelector,
   MaidrRecharts,
+  normalizeRechartsSubplotGrid,
   useRechartsAdapter,
 } from './adapters/recharts';
 
@@ -89,6 +128,7 @@ export type {
   RechartsAdapterConfig,
   RechartsChartType,
   RechartsLayerConfig,
+  RechartsSubplotConfig,
 } from './adapters/recharts';
 
 // Re-export core types that consumers may need alongside the adapter

--- a/src/state/hook/useMaidrController.ts
+++ b/src/state/hook/useMaidrController.ts
@@ -56,9 +56,21 @@ export function useMaidrController(data: MaidrData, store: AppStore): UseMaidrCo
     if (!plotElement)
       return null;
 
+    // A subplot with zero layers crashes the model the moment Figure.state
+    // is read (Subplot.activeTrace is undefined), which happens inside the
+    // Controller constructor. Adapters emit such placeholder data before
+    // their chart introspection completes or when no supported components
+    // are found — treat it as "not ready" rather than constructing.
+    const maidrData = latestDataRef.current;
+    const hasLayers = maidrData.subplots?.some(
+      row => row.some(subplot => subplot.layers.length > 0),
+    );
+    if (!hasLayers)
+      return null;
+
     // Create a deep copy to prevent mutations on the original data object
     // (the model layer takes ownership of, and may mutate, the data arrays).
-    const ctrl = new Controller(cloneMaidrData(latestDataRef.current), plotElement, store);
+    const ctrl = new Controller(cloneMaidrData(maidrData), plotElement, store);
     return ctrl;
   }, [store]);
 

--- a/src/util/subplotLayout.ts
+++ b/src/util/subplotLayout.ts
@@ -72,8 +72,12 @@ interface AxesPosition {
  */
 export function resolveSubplotLayout(subplots: Subplot[][]): SubplotLayout {
   const axesElements = collectAxesElements(subplots);
-  const positions = collectAxesPositions(subplots, axesElements);
+  let positions = collectAxesPositions(subplots, axesElements);
   const totalAxesCount = document.querySelectorAll('g[id^="axes_"]').length;
+
+  if (positions.length === 0) {
+    positions = collectPanelPositions(subplots);
+  }
 
   if (positions.length === 0) {
     return buildFallbackLayout(subplots, totalAxesCount, axesElements);
@@ -206,6 +210,74 @@ function detectInversion(entries: AxesPosition[], numRows: number): boolean {
     return row0.y < row1.y;
   }
   return false;
+}
+
+/**
+ * Measures each subplot's own panel element when no `<g id="axes_*">` groups
+ * exist (charts not rendered by matplotlib — Vega-Lite cells, per-panel chart
+ * containers, etc.).
+ *
+ * The subplot's highlight element is preferred (it is a `visibility: hidden`
+ * clone inserted next to the panel container, so it still has real layout
+ * geometry); the first element matched by the first layer's selector is used
+ * as a fallback. Positions are only trusted when EVERY subplot resolves to an
+ * element with distinct, non-degenerate geometry — otherwise an empty array
+ * is returned and the caller falls back to data-array order. This keeps
+ * jsdom/test environments (all-zero rects) and partially-rendered charts on
+ * the conservative path.
+ */
+function collectPanelPositions(subplots: Subplot[][]): AxesPosition[] {
+  const positions: AxesPosition[] = [];
+
+  for (let r = 0; r < subplots.length; r++) {
+    for (let c = 0; c < subplots[r].length; c++) {
+      const el = resolvePanelElement(subplots[r][c]);
+      if (!el) {
+        return [];
+      }
+      const bbox = el.getBoundingClientRect();
+      positions.push({ row: r, col: c, y: bbox.top, x: bbox.left });
+    }
+  }
+
+  if (positions.length < 2) {
+    return [];
+  }
+
+  const distinct = new Set(positions.map(p => `${p.x},${p.y}`));
+  if (distinct.size !== positions.length) {
+    return [];
+  }
+
+  return positions;
+}
+
+/**
+ * Resolves the DOM element that best represents a subplot's panel geometry.
+ */
+function resolvePanelElement(subplot: Subplot): Element | null {
+  const highlight = subplot.getHighlightElement();
+  if (highlight && hasGeometry(highlight)) {
+    return highlight;
+  }
+
+  const selector = subplot.getLayerSelector();
+  if (selector) {
+    const el = document.querySelector(selector);
+    if (el && hasGeometry(el)) {
+      return el;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Whether an element reports any usable bounding-box geometry.
+ */
+function hasGeometry(el: Element): boolean {
+  const bbox = el.getBoundingClientRect();
+  return bbox.width > 0 || bbox.height > 0 || bbox.top !== 0 || bbox.left !== 0;
 }
 
 /**

--- a/src/vegalite-entry.ts
+++ b/src/vegalite-entry.ts
@@ -43,8 +43,9 @@ import type {
   VegaView,
 } from './adapters/vegalite/types';
 import type { BoxPoint, BoxSelector, HeatmapData, LinePoint, Maidr, MaidrLayer } from './type/grammar';
+import { cssEscape, ensureContainerId } from './adapters/shared/selectorUtil';
 import { vegaLiteToMaidr } from './adapters/vegalite/converters';
-import { buildCellDomMap, stampFacetCells } from './adapters/vegalite/facets';
+import { buildCellDomMap, scopeSelector, stampFacetCells } from './adapters/vegalite/facets';
 import { Orientation, TraceType } from './type/grammar';
 import { initMaidrOnElement } from './util/initMaidr';
 
@@ -1118,6 +1119,7 @@ function buildBoxPlotSelectorsFromDom(
   svg: SVGSVGElement,
   layers: MaidrLayer[],
   cellDomMap?: Map<MaidrLayer, CellDomInfo>,
+  containerScope?: string,
 ): void {
   for (const layer of layers) {
     if (layer.type !== TraceType.BOX) {
@@ -1139,10 +1141,16 @@ function buildBoxPlotSelectorsFromDom(
     // panel so sibling panels' boxes don't contaminate the pairing, and
     // prefix the attribute selectors built in step 9 with the panel scope
     // — every panel numbers its boxes from 0, so the bare attribute
-    // selector would match all panels at document level.
+    // selector would match all panels at document level. Single-panel
+    // layers fall back to the chart's container scope for the same
+    // reason: every CHART numbers its boxes from 0 too, so a bare
+    // attribute selector would match another chart's boxes when several
+    // box plots share the page.
     const cellInfo = cellDomMap?.get(layer);
     const root: Element = cellInfo?.root ?? svg;
-    const scopePrefix = cellInfo ? `${cellInfo.scope} ` : '';
+    const scopePrefix = cellInfo
+      ? `${cellInfo.scope} `
+      : (containerScope ? `${containerScope} ` : '');
 
     // 0. Discover sub-mark groups in the rendered DOM.
     //
@@ -1530,6 +1538,42 @@ function collectLayers(maidr: Maidr): MaidrLayer[] {
   return layers;
 }
 
+/**
+ * Prefix every selector in the schema with the chart container's scope
+ * (`#<containerId>`) so several charts on one page never resolve each
+ * other's DOM elements — MAIDR resolves all selectors document-globally.
+ *
+ * Applies to subplot selectors and to string / string[] layer selectors.
+ * BOX layers still carry their placeholder string selector at this point;
+ * the `BoxSelector[]` structures built later by
+ * {@link buildBoxPlotSelectorsFromDom} receive the same scope through its
+ * `containerScope` / cell-scope prefixes.
+ */
+function scopeSelectorsToContainer(
+  maidr: Maidr,
+  layers: MaidrLayer[],
+  containerScope: string,
+): void {
+  for (const row of maidr.subplots) {
+    for (const subplot of row) {
+      if (typeof subplot.selector === 'string') {
+        subplot.selector = scopeSelector(subplot.selector, containerScope);
+      }
+    }
+  }
+  for (const layer of layers) {
+    const selectors = layer.selectors;
+    if (typeof selectors === 'string') {
+      layer.selectors = scopeSelector(selectors, containerScope);
+    } else if (
+      Array.isArray(selectors)
+      && selectors.every(sel => typeof sel === 'string')
+    ) {
+      layer.selectors = (selectors as string[]).map(sel => scopeSelector(sel, containerScope));
+    }
+  }
+}
+
 export { vegaLiteToMaidr } from './adapters/vegalite/converters';
 
 export type {
@@ -1590,14 +1634,38 @@ export function bindVegaLite(
     return;
   }
 
-  // Derive an id from the options, the container, or a timestamp fallback.
-  // Use || for container.id since empty string is falsy but not nullish.
-  const id = options?.id
-    || container.id
-    || `vl-${Date.now()}`;
+  // Ensure the container carries an id: every selector emitted below is
+  // prefixed with `#<containerId>` because MAIDR resolves selectors
+  // against the whole document — without the prefix, two charts compiled
+  // from the same spec (identical Vega class names) would resolve each
+  // other's elements. The chart id defaults to the container id so the
+  // two stay aligned. (Use || since an empty options.id is falsy.)
+  const containerId = ensureContainerId(container, 'vl');
+  const id = options?.id || containerId;
 
   const maidr: Maidr = vegaLiteToMaidr(spec, view, { ...options, id });
   const layers = collectLayers(maidr);
+
+  // A schema with no usable layer at all is the converter's fallback for
+  // unsupported specs (a lone `{ layers: [] }` subplot). That shape
+  // crashes MAIDR core the moment the chart receives focus
+  // (`Subplot.activeTrace` on an empty traces array), so skip binding
+  // entirely — the chart still renders, it just isn't navigable.
+  if (layers.length === 0) {
+    console.warn(
+      '[maidr/vegalite] Spec produced no accessible layers; skipping MAIDR '
+      + 'binding. The chart renders normally but will not be keyboard-navigable.',
+    );
+    return;
+  }
+
+  // Prefix every selector with the container id (page-global uniqueness).
+  // Facet selectors already bake the chart id into their `data-maidr-cell`
+  // attribute values, where the prefix is harmless; it is essential for
+  // repeat / concat / single-view selectors, which are class-only and
+  // identical across charts built from the same spec.
+  const containerScope = `#${cssEscape(containerId)}`;
+  scopeSelectorsToContainer(maidr, layers, containerScope);
 
   // For faceted specs, stamp each rendered cell with the `data-maidr-cell`
   // attribute the converter baked into that panel's selectors. Must run
@@ -1658,7 +1726,7 @@ export function bindVegaLite(
   // doesn't appear at all" caused by `buildSelector` returning a
   // single string instead of the per-group structure
   // BoxTrace.mapToSvgElements expects.
-  buildBoxPlotSelectorsFromDom(svg as SVGSVGElement, layers, cellDomMap);
+  buildBoxPlotSelectorsFromDom(svg as SVGSVGElement, layers, cellDomMap, containerScope);
 
   // SVGSVGElement is not an HTMLElement, but initMaidrOnElement only
   // needs basic DOM node capabilities (parentNode, attributes).

--- a/src/vegalite-entry.ts
+++ b/src/vegalite-entry.ts
@@ -36,6 +36,7 @@
  * @packageDocumentation
  */
 
+import type { CellDomInfo } from './adapters/vegalite/facets';
 import type {
   VegaLiteSpec,
   VegaLiteToMaidrOptions,
@@ -43,6 +44,7 @@ import type {
 } from './adapters/vegalite/types';
 import type { BoxPoint, BoxSelector, HeatmapData, LinePoint, Maidr, MaidrLayer } from './type/grammar';
 import { vegaLiteToMaidr } from './adapters/vegalite/converters';
+import { buildCellDomMap, stampFacetCells } from './adapters/vegalite/facets';
 import { Orientation, TraceType } from './type/grammar';
 import { initMaidrOnElement } from './util/initMaidr';
 
@@ -892,9 +894,13 @@ function sortHeatmapCellsByVisualOrder(
  *
  * Used by {@link sortLinesByVisualOrder} to align line-chart data with
  * the visual order Vega-Lite renders for nominal/ordinal X scales.
+ *
+ * `root` is the element to search under — the whole SVG for single-panel
+ * charts, or one panel's cell group for multi-panel charts whose cells
+ * carry their own axes (repeat).
  */
-function readXAxisLabelsInVisualOrder(svg: SVGSVGElement): string[] {
-  const axisGroups = Array.from(svg.querySelectorAll<SVGGElement>('g.role-axis'));
+function readXAxisLabelsInVisualOrder(root: Element): string[] {
+  const axisGroups = Array.from(root.querySelectorAll<SVGGElement>('g.role-axis'));
   let bestLabels: string[] = [];
   let bestVariance = -1;
 
@@ -956,9 +962,19 @@ function readXAxisLabelsInVisualOrder(svg: SVGSVGElement): string[] {
  * array. Skipped for numeric/temporal axes (where natural ordering
  * matches insertion order) and for layers whose data labels can't be
  * matched against axis ticks.
+ *
+ * Multi-panel awareness: when `cellDomMap` provides a per-panel root for
+ * a layer, axis labels are read from that panel first (repeat cells have
+ * their own axes, possibly with different domains per cell) and only
+ * fall back to the whole SVG when the panel has no labelled axis of its
+ * own (facet cells share axes rendered in the header/footer groups).
  */
-function sortLinesByVisualOrder(svg: SVGSVGElement, layers: MaidrLayer[]): void {
-  let axisLabels: string[] | null = null;
+function sortLinesByVisualOrder(
+  svg: SVGSVGElement,
+  layers: MaidrLayer[],
+  cellDomMap?: Map<MaidrLayer, CellDomInfo>,
+): void {
+  let svgAxisLabels: string[] | null = null;
 
   for (const layer of layers) {
     if (layer.type !== TraceType.LINE)
@@ -981,9 +997,18 @@ function sortLinesByVisualOrder(svg: SVGSVGElement, layers: MaidrLayer[]): void 
     if (!hasStringX)
       continue;
 
-    // Lazily resolve axis labels once per call.
-    if (axisLabels === null) {
-      axisLabels = readXAxisLabelsInVisualOrder(svg);
+    // Resolve axis labels: the layer's own panel first, then the SVG-wide
+    // labels (lazily resolved once per call).
+    let axisLabels: string[] = [];
+    const cellRoot = cellDomMap?.get(layer)?.root;
+    if (cellRoot) {
+      axisLabels = readXAxisLabelsInVisualOrder(cellRoot);
+    }
+    if (axisLabels.length === 0) {
+      if (svgAxisLabels === null) {
+        svgAxisLabels = readXAxisLabelsInVisualOrder(svg);
+      }
+      axisLabels = svgAxisLabels;
     }
     if (axisLabels.length === 0) {
       debugLog(`line layer "${layer.id}": no X-axis labels found, skipping visual-order sort`);
@@ -1092,6 +1117,7 @@ function sortLinesByVisualOrder(svg: SVGSVGElement, layers: MaidrLayer[]): void 
 function buildBoxPlotSelectorsFromDom(
   svg: SVGSVGElement,
   layers: MaidrLayer[],
+  cellDomMap?: Map<MaidrLayer, CellDomInfo>,
 ): void {
   for (const layer of layers) {
     if (layer.type !== TraceType.BOX) {
@@ -1108,6 +1134,15 @@ function buildBoxPlotSelectorsFromDom(
     if (N === 0) {
       continue;
     }
+
+    // Multi-panel awareness: scope the group discovery to the layer's own
+    // panel so sibling panels' boxes don't contaminate the pairing, and
+    // prefix the attribute selectors built in step 9 with the panel scope
+    // — every panel numbers its boxes from 0, so the bare attribute
+    // selector would match all panels at document level.
+    const cellInfo = cellDomMap?.get(layer);
+    const root: Element = cellInfo?.root ?? svg;
+    const scopePrefix = cellInfo ? `${cellInfo.scope} ` : '';
 
     // 0. Discover sub-mark groups in the rendered DOM.
     //
@@ -1128,13 +1163,13 @@ function buildBoxPlotSelectorsFromDom(
     //    scanning the DOM and disambiguating IQ vs median (by aria-label
     //    presence) and lower vs upper whisker (by geometric position).
     const allRectGroups = Array.from(
-      svg.querySelectorAll<SVGGElement>('g.mark-rect.role-mark'),
+      root.querySelectorAll<SVGGElement>('g.mark-rect.role-mark'),
     );
     const allRuleGroups = Array.from(
-      svg.querySelectorAll<SVGGElement>('g.mark-rule.role-mark'),
+      root.querySelectorAll<SVGGElement>('g.mark-rule.role-mark'),
     );
     const allSymbolGroups = Array.from(
-      svg.querySelectorAll<SVGGElement>('g.mark-symbol.role-mark'),
+      root.querySelectorAll<SVGGElement>('g.mark-symbol.role-mark'),
     );
 
     // IQ rect group's first path has a non-empty aria-label; the
@@ -1459,17 +1494,17 @@ function buildBoxPlotSelectorsFromDom(
     const boxSelectors: BoxSelector[] = groups.map((g, i) => {
       const idxAttr = `[data-maidr-box-index="${i}"]`;
       const lowerSels = g.lowerOutliers.map((_, k) =>
-        `path${idxAttr}[data-maidr-box-part="lower-outlier"][data-maidr-outlier-index="${k}"]`,
+        `${scopePrefix}path${idxAttr}[data-maidr-box-part="lower-outlier"][data-maidr-outlier-index="${k}"]`,
       );
       const upperSels = g.upperOutliers.map((_, k) =>
-        `path${idxAttr}[data-maidr-box-part="upper-outlier"][data-maidr-outlier-index="${k}"]`,
+        `${scopePrefix}path${idxAttr}[data-maidr-box-part="upper-outlier"][data-maidr-outlier-index="${k}"]`,
       );
       return {
         lowerOutliers: lowerSels,
-        min: `line${idxAttr}[data-maidr-box-part="min"]`,
-        max: `line${idxAttr}[data-maidr-box-part="max"]`,
-        iq: `path${idxAttr}[data-maidr-box-part="iq"]`,
-        q2: `path${idxAttr}[data-maidr-box-part="q2"]`,
+        min: `${scopePrefix}line${idxAttr}[data-maidr-box-part="min"]`,
+        max: `${scopePrefix}line${idxAttr}[data-maidr-box-part="max"]`,
+        iq: `${scopePrefix}path${idxAttr}[data-maidr-box-part="iq"]`,
+        q2: `${scopePrefix}path${idxAttr}[data-maidr-box-part="q2"]`,
         upperOutliers: upperSels,
       };
     });
@@ -1564,6 +1599,17 @@ export function bindVegaLite(
   const maidr: Maidr = vegaLiteToMaidr(spec, view, { ...options, id });
   const layers = collectLayers(maidr);
 
+  // For faceted specs, stamp each rendered cell with the `data-maidr-cell`
+  // attribute the converter baked into that panel's selectors. Must run
+  // BEFORE any pass (or MAIDR trace construction) resolves those
+  // selectors — until the stamp exists they match nothing.
+  stampFacetCells(svg as SVGSVGElement, maidr);
+
+  // Per-layer cell roots for the passes that would otherwise query the
+  // whole SVG and cross-contaminate panels (box-plot selector rebuild,
+  // per-cell axis label reads). Empty for single-panel and concat charts.
+  const cellDomMap = buildCellDomMap(svg as SVGSVGElement, maidr);
+
   // Align the simple-bar SVG DOM order with the visual order so MAIDR's
   // index-based highlight lands on the right bar. Segmented layers are
   // handled by the dom-mapping step below instead of re-ordering the DOM.
@@ -1605,14 +1651,14 @@ export function bindVegaLite(
   // tick order. Fixes "highlight column != announced x-value" when
   // Vega-Lite renders nominal/ordinal X scales alphabetically while
   // the dataset is in insertion (e.g. calendar) order.
-  sortLinesByVisualOrder(svg as SVGSVGElement, layers);
+  sortLinesByVisualOrder(svg as SVGSVGElement, layers, cellDomMap);
 
   // For BOX layers, build the per-group BoxSelector[] from the
   // rendered DOM and populate outlier values. Fixes "highlight
   // doesn't appear at all" caused by `buildSelector` returning a
   // single string instead of the per-group structure
   // BoxTrace.mapToSvgElements expects.
-  buildBoxPlotSelectorsFromDom(svg as SVGSVGElement, layers);
+  buildBoxPlotSelectorsFromDom(svg as SVGSVGElement, layers, cellDomMap);
 
   // SVGSVGElement is not an HTMLElement, but initMaidrOnElement only
   // needs basic DOM node capabilities (parentNode, attributes).

--- a/src/victory-entry.ts
+++ b/src/victory-entry.ts
@@ -20,6 +20,11 @@
  * - `VictoryBoxPlot` → box plot
  * - `VictoryCandlestick` → candlestick chart
  *
+ * Multi-panel figures: nesting two or more `<VictoryChart>` components makes
+ * each chart one navigable MAIDR subplot (arrow keys move between panels,
+ * Enter drills in, Escape returns). Name panels via each chart's `title` prop
+ * and control the grid with the `layout` prop.
+ *
  * @example Using the wrapper component
  * ```tsx
  * import { MaidrVictory } from 'maidr/victory';
@@ -73,7 +78,9 @@
  */
 
 export {
+  computeSubplotGrid,
   extractVictoryLayers,
+  extractVictorySubplots,
   MaidrVictory,
   toMaidrLayer,
   useVictoryAdapter,
@@ -85,6 +92,8 @@ export type {
   VictoryComponentType,
   VictoryLayerData,
   VictoryLayerInfo,
+  VictoryPanelLayout,
+  VictorySubplotInfo,
 } from './adapters/victory';
 
 // Re-export core types that consumers may need alongside the adapter.

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -35,15 +35,21 @@ describe('findXYCharts', () => {
     expect(findXYCharts(root)).toEqual([panelA, panelB]);
   });
 
-  it('excludes XYChartScrollbar preview charts', () => {
-    const chart = fakeChart({ series: [fakeBarSeries('A', BAR_DATA)] });
-    const scrollbar = fakeChart({
-      className: 'XYChartScrollbar',
-      series: [fakeBarSeries('A', BAR_DATA)],
-    });
-    const root = fakeRoot([scrollbar, chart]);
+  it('excludes XYChartScrollbar preview charts (am5stock toolsContainer pattern)', () => {
+    // A real XYChartScrollbar is NOT chart-like itself (no series/xAxes/yAxes);
+    // its preview is a plain XYChart child holding a copy of the main data.
+    const previewChart = fakeChart({ series: [fakeBarSeries('A', BAR_DATA)] });
+    const scrollbar = fakeContainer([previewChart], 'XYChartScrollbar');
 
-    expect(findXYCharts(root)).toEqual([chart]);
+    const mainPanel = fakeChart({ series: [fakeBarSeries('A', BAR_DATA)] });
+    const panelsContainer = fakeContainer([mainPanel]);
+    const toolsContainer = fakeContainer([scrollbar]);
+    // stockChart.toolsContainer.children.push(scrollbar) re-parents the
+    // scrollbar OUTSIDE any panel, so only pruning keeps the preview out.
+    const stockChartLike = fakeContainer([toolsContainer, panelsContainer]);
+    const root = fakeRoot([stockChartLike]);
+
+    expect(findXYCharts(root)).toEqual([mainPanel]);
   });
 
   it('does not descend into a found chart (its scrollbar never becomes a panel)', () => {
@@ -129,7 +135,7 @@ describe('fromAmCharts (single chart)', () => {
 });
 
 describe('fromAmCharts (multi-panel)', () => {
-  it('arranges vertically stacked charts as one subplot per row', () => {
+  it('arranges vertically stacked charts as one subplot per row, bottom row first', () => {
     const top = fakeChart({
       series: [fakeBarSeries('Sales', BAR_DATA)],
       title: 'Top Panel',
@@ -152,16 +158,19 @@ describe('fromAmCharts (multi-panel)', () => {
     expect(result.subplots[0]).toHaveLength(1);
     expect(result.subplots[1]).toHaveLength(1);
 
+    // Rows are emitted BOTTOM-first: the core's MovableGrid maps UPWARD to
+    // row+1 and canvas charts get no DOM-based inversion, so data row 0 must
+    // be the visually lowest panel for ArrowUp to move visually up.
     const [firstLayer] = result.subplots[0][0].layers;
     const [secondLayer] = result.subplots[1][0].layers;
     // Panel display name lives on the FIRST layer's title.
-    expect(firstLayer.title).toBe('Top Panel');
-    expect(secondLayer.title).toBe('Bottom Panel');
-    expect(firstLayer.type).toBe(TraceType.BAR);
-    expect(secondLayer.type).toBe(TraceType.LINE);
+    expect(firstLayer.title).toBe('Bottom Panel');
+    expect(secondLayer.title).toBe('Top Panel');
+    expect(firstLayer.type).toBe(TraceType.LINE);
+    expect(secondLayer.type).toBe(TraceType.BAR);
     // Per-chart axis labels, not first-chart labels everywhere.
-    expect(firstLayer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Sales' } });
-    expect(secondLayer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Trend' } });
+    expect(firstLayer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Trend' } });
+    expect(secondLayer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Sales' } });
   });
 
   it('arranges side-by-side charts as one row, sorted left to right', () => {
@@ -184,7 +193,7 @@ describe('fromAmCharts (multi-panel)', () => {
     expect(result.subplots[0][1].layers[0].title).toBe('Right Panel');
   });
 
-  it('clusters a 2x2 grid layout in visual reading order', () => {
+  it('clusters a 2x2 grid layout bottom row first, left-to-right within rows', () => {
     const bounds = {
       a: { left: 0, top: 0, right: 280, bottom: 180 },
       b: { left: 320, top: 8, right: 600, bottom: 188 }, // slight offset, same row
@@ -204,7 +213,8 @@ describe('fromAmCharts (multi-panel)', () => {
     const titles = result.subplots.map(row =>
       row.map(subplot => subplot.layers[0].title),
     );
-    expect(titles).toEqual([['A', 'B'], ['C', 'D']]);
+    // Bottom row (C, D) is data row 0 (matplotlib convention: UPWARD = row+1).
+    expect(titles).toEqual([['C', 'D'], ['A', 'B']]);
   });
 
   it('falls back to a single row in insertion order without geometry', () => {
@@ -244,13 +254,19 @@ describe('fromAmCharts (multi-panel)', () => {
     }
   });
 
-  it('keeps the single-chart output shape when every chart is empty', () => {
+  it('throws a descriptive error when every chart is empty (never emits layers: [])', () => {
     const emptyA = fakeChart({ series: [] });
     const emptyB = fakeChart({ series: [] });
 
-    const result = fromAmCharts(fakeRoot([emptyA, emptyB]));
+    expect(() => fromAmCharts(fakeRoot([emptyA, emptyB])))
+      .toThrow(/no supported series with data/);
+  });
 
-    expect(result.subplots).toEqual([[{ layers: [] }]]);
+  it('throws a descriptive error when a single chart has no data (never emits layers: [])', () => {
+    const empty = fakeChart({ series: [] });
+
+    expect(() => fromAmCharts(fakeRoot([empty])))
+      .toThrow(/no supported series with data/);
   });
 
   it('keeps layer ids unique across all panels', () => {

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -1,0 +1,302 @@
+import type { BarPoint, MaidrLayer } from '@type/grammar';
+import { findXYCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
+import { TraceType } from '@type/grammar';
+import {
+  fakeBarSeries,
+  fakeChart,
+  fakeContainer,
+  fakeContainerEl,
+  fakeLineSeries,
+  fakeRoot,
+} from './helpers';
+
+const BAR_DATA = [
+  { categoryX: 'Sat', valueY: 87 },
+  { categoryX: 'Sun', valueY: 76 },
+];
+
+describe('findXYCharts', () => {
+  it('finds every XYChart at the top level of root.container', () => {
+    const chartA = fakeChart({ series: [fakeBarSeries('A', BAR_DATA)] });
+    const chartB = fakeChart({ series: [fakeBarSeries('B', BAR_DATA)] });
+    const root = fakeRoot([chartA, chartB]);
+
+    expect(findXYCharts(root)).toEqual([chartA, chartB]);
+  });
+
+  it('recurses into nested containers (am5stock StockPanel pattern)', () => {
+    const panelA = fakeChart({ series: [fakeBarSeries('A', BAR_DATA)] });
+    const panelB = fakeChart({ series: [fakeLineSeries('B', BAR_DATA)] });
+    // StockChart itself has no series/xAxes/yAxes; panels are nested deeper.
+    const panelsContainer = fakeContainer([panelA, panelB]);
+    const stockChartLike = fakeContainer([panelsContainer]);
+    const root = fakeRoot([stockChartLike]);
+
+    expect(findXYCharts(root)).toEqual([panelA, panelB]);
+  });
+
+  it('excludes XYChartScrollbar preview charts', () => {
+    const chart = fakeChart({ series: [fakeBarSeries('A', BAR_DATA)] });
+    const scrollbar = fakeChart({
+      className: 'XYChartScrollbar',
+      series: [fakeBarSeries('A', BAR_DATA)],
+    });
+    const root = fakeRoot([scrollbar, chart]);
+
+    expect(findXYCharts(root)).toEqual([chart]);
+  });
+
+  it('does not descend into a found chart (its scrollbar never becomes a panel)', () => {
+    const nestedScrollbar = fakeChart({ series: [fakeBarSeries('S', BAR_DATA)] });
+    const chart = fakeChart({ series: [fakeBarSeries('A', BAR_DATA)] });
+    // Stuff a chart-like child inside the found chart.
+    (chart as unknown as { children: { values: unknown[] } }).children = {
+      values: [nestedScrollbar],
+    };
+    const root = fakeRoot([chart]);
+
+    expect(findXYCharts(root)).toEqual([chart]);
+  });
+
+  it('returns an empty array when no chart exists', () => {
+    expect(findXYCharts(fakeRoot([fakeContainer([])]))).toEqual([]);
+  });
+});
+
+describe('fromAmCharts (single chart)', () => {
+  it('produces the original 1x1 grid with a bar layer', () => {
+    const chart = fakeChart({
+      series: [fakeBarSeries('Tips', BAR_DATA)],
+      title: 'Tips by Day',
+      xLabel: 'Day',
+      yLabel: 'Count',
+    });
+    const root = fakeRoot([chart], 'bar-chart');
+
+    const result = fromAmCharts(root);
+
+    expect(result.id).toBe('amcharts-bar-chart');
+    expect(result.title).toBe('Tips by Day');
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(1);
+
+    const layer = result.subplots[0][0].layers[0];
+    expect(layer.type).toBe(TraceType.BAR);
+    expect(layer.title).toBe('Tips');
+    expect(layer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Count' } });
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'Sat', y: 87 },
+      { x: 'Sun', y: 76 },
+    ]);
+  });
+
+  it('applies option overrides for title and axis labels', () => {
+    const chart = fakeChart({
+      series: [fakeBarSeries('Tips', BAR_DATA)],
+      title: 'Chart Title',
+      xLabel: 'Day',
+      yLabel: 'Count',
+    });
+    const root = fakeRoot([chart]);
+
+    const result = fromAmCharts(root, {
+      title: 'Override',
+      axisLabels: { x: 'X!', y: 'Y!' },
+    });
+
+    expect(result.title).toBe('Override');
+    const layer = result.subplots[0][0].layers[0];
+    expect(layer.axes).toEqual({ x: { label: 'X!' }, y: { label: 'Y!' } });
+  });
+
+  it('throws when the root contains no chart', () => {
+    expect(() => fromAmCharts(fakeRoot([]))).toThrow(/no XYChart found/);
+  });
+
+  it('fromXYChart matches the fromAmCharts single-chart output', () => {
+    const chart = fakeChart({
+      series: [fakeBarSeries('Tips', BAR_DATA)],
+      title: 'Tips by Day',
+    });
+
+    const result = fromXYChart(chart, fakeContainerEl('direct'));
+
+    expect(result.id).toBe('amcharts-direct');
+    expect(result.title).toBe('Tips by Day');
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+  });
+});
+
+describe('fromAmCharts (multi-panel)', () => {
+  it('arranges vertically stacked charts as one subplot per row', () => {
+    const top = fakeChart({
+      series: [fakeBarSeries('Sales', BAR_DATA)],
+      title: 'Top Panel',
+      xLabel: 'Day',
+      yLabel: 'Sales',
+      bounds: { left: 40, top: 0, right: 600, bottom: 180 },
+    });
+    const bottom = fakeChart({
+      series: [fakeLineSeries('Trend', BAR_DATA)],
+      title: 'Bottom Panel',
+      xLabel: 'Day',
+      yLabel: 'Trend',
+      bounds: { left: 40, top: 200, right: 600, bottom: 380 },
+    });
+    const root = fakeRoot([top, bottom]);
+
+    const result = fromAmCharts(root);
+
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(1);
+    expect(result.subplots[1]).toHaveLength(1);
+
+    const [firstLayer] = result.subplots[0][0].layers;
+    const [secondLayer] = result.subplots[1][0].layers;
+    // Panel display name lives on the FIRST layer's title.
+    expect(firstLayer.title).toBe('Top Panel');
+    expect(secondLayer.title).toBe('Bottom Panel');
+    expect(firstLayer.type).toBe(TraceType.BAR);
+    expect(secondLayer.type).toBe(TraceType.LINE);
+    // Per-chart axis labels, not first-chart labels everywhere.
+    expect(firstLayer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Sales' } });
+    expect(secondLayer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Trend' } });
+  });
+
+  it('arranges side-by-side charts as one row, sorted left to right', () => {
+    const right = fakeChart({
+      series: [fakeBarSeries('Right', BAR_DATA)],
+      title: 'Right Panel',
+      bounds: { left: 320, top: 0, right: 600, bottom: 300 },
+    });
+    const left = fakeChart({
+      series: [fakeBarSeries('Left', BAR_DATA)],
+      title: 'Left Panel',
+      bounds: { left: 0, top: 0, right: 280, bottom: 300 },
+    });
+    // Insertion order is right-first; visual order must win.
+    const result = fromAmCharts(fakeRoot([right, left]));
+
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[0][0].layers[0].title).toBe('Left Panel');
+    expect(result.subplots[0][1].layers[0].title).toBe('Right Panel');
+  });
+
+  it('clusters a 2x2 grid layout in visual reading order', () => {
+    const bounds = {
+      a: { left: 0, top: 0, right: 280, bottom: 180 },
+      b: { left: 320, top: 8, right: 600, bottom: 188 }, // slight offset, same row
+      c: { left: 0, top: 220, right: 280, bottom: 400 },
+      d: { left: 320, top: 220, right: 600, bottom: 400 },
+    };
+    const make = (name: string, b: typeof bounds.a): ReturnType<typeof fakeChart> =>
+      fakeChart({ series: [fakeBarSeries(name, BAR_DATA)], title: name, bounds: b });
+
+    const result = fromAmCharts(fakeRoot([
+      make('D', bounds.d),
+      make('B', bounds.b),
+      make('C', bounds.c),
+      make('A', bounds.a),
+    ]));
+
+    const titles = result.subplots.map(row =>
+      row.map(subplot => subplot.layers[0].title),
+    );
+    expect(titles).toEqual([['A', 'B'], ['C', 'D']]);
+  });
+
+  it('falls back to a single row in insertion order without geometry', () => {
+    const first = fakeChart({ series: [fakeBarSeries('First', BAR_DATA)], title: 'First' });
+    const second = fakeChart({ series: [fakeBarSeries('Second', BAR_DATA)], title: 'Second' });
+
+    const result = fromAmCharts(fakeRoot([first, second]));
+
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[0][0].layers[0].title).toBe('First');
+    expect(result.subplots[0][1].layers[0].title).toBe('Second');
+  });
+
+  it('drops charts with no supported layers (never emits empty subplots or rows)', () => {
+    const withData = fakeChart({
+      series: [fakeBarSeries('Data', BAR_DATA)],
+      title: 'Data',
+      bounds: { left: 0, top: 0, right: 600, bottom: 180 },
+    });
+    const empty = fakeChart({
+      series: [],
+      title: 'Empty',
+      bounds: { left: 0, top: 200, right: 600, bottom: 380 },
+    });
+
+    const result = fromAmCharts(fakeRoot([withData, empty]));
+
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(1);
+    expect(result.subplots[0][0].layers.length).toBeGreaterThan(0);
+    for (const row of result.subplots) {
+      expect(row.length).toBeGreaterThan(0);
+      for (const subplot of row) {
+        expect(subplot.layers.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('keeps the single-chart output shape when every chart is empty', () => {
+    const emptyA = fakeChart({ series: [] });
+    const emptyB = fakeChart({ series: [] });
+
+    const result = fromAmCharts(fakeRoot([emptyA, emptyB]));
+
+    expect(result.subplots).toEqual([[{ layers: [] }]]);
+  });
+
+  it('keeps layer ids unique across all panels', () => {
+    const chartA = fakeChart({
+      series: [fakeBarSeries('A', BAR_DATA), fakeLineSeries('LA', BAR_DATA)],
+      bounds: { left: 0, top: 0, right: 600, bottom: 180 },
+    });
+    const chartB = fakeChart({
+      series: [fakeBarSeries('B', BAR_DATA), fakeLineSeries('LB', BAR_DATA)],
+      bounds: { left: 0, top: 200, right: 600, bottom: 380 },
+    });
+
+    const result = fromAmCharts(fakeRoot([chartA, chartB]));
+
+    const ids = result.subplots
+      .flat()
+      .flatMap(subplot => subplot.layers.map((layer: MaidrLayer) => layer.id));
+    expect(ids).toHaveLength(4);
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it('applies figure-level axis label overrides to every panel', () => {
+    const chartA = fakeChart({
+      series: [fakeBarSeries('A', BAR_DATA)],
+      xLabel: 'ax',
+      yLabel: 'ay',
+      bounds: { left: 0, top: 0, right: 600, bottom: 180 },
+    });
+    const chartB = fakeChart({
+      series: [fakeBarSeries('B', BAR_DATA)],
+      xLabel: 'bx',
+      yLabel: 'by',
+      bounds: { left: 0, top: 200, right: 600, bottom: 380 },
+    });
+
+    const result = fromAmCharts(fakeRoot([chartA, chartB]), {
+      axisLabels: { x: 'Shared X', y: 'Shared Y' },
+    });
+
+    for (const row of result.subplots) {
+      for (const subplot of row) {
+        expect(subplot.layers[0].axes).toEqual({
+          x: { label: 'Shared X' },
+          y: { label: 'Shared Y' },
+        });
+      }
+    }
+  });
+});

--- a/test/adapters/amcharts/geometry.test.ts
+++ b/test/adapters/amcharts/geometry.test.ts
@@ -19,10 +19,24 @@ describe('computeChartGrid', () => {
     expect(computeChartGrid([chart])).toEqual([[chart]]);
   });
 
-  it('stacks vertically arranged charts into separate rows', () => {
+  it('stacks vertically arranged charts into separate rows, bottom row first', () => {
     const top = fakeChart({ bounds: { left: 0, top: 0, right: 600, bottom: 180 } });
     const bottom = fakeChart({ bounds: { left: 0, top: 200, right: 600, bottom: 380 } });
-    expect(computeChartGrid([bottom, top])).toEqual([[top], [bottom]]);
+    // Bottom-first (matplotlib convention): the core's MovableGrid maps UPWARD
+    // to row+1 and canvas charts get no DOM-based vertical inversion, so data
+    // row 0 must be the visually lowest panel for ArrowUp to move visually up.
+    expect(computeChartGrid([bottom, top])).toEqual([[bottom], [top]]);
+  });
+
+  it('orders a 2x2 grid bottom row first, left-to-right within rows', () => {
+    const topLeft = fakeChart({ bounds: { left: 0, top: 0, right: 280, bottom: 180 } });
+    const topRight = fakeChart({ bounds: { left: 320, top: 0, right: 600, bottom: 180 } });
+    const bottomLeft = fakeChart({ bounds: { left: 0, top: 220, right: 280, bottom: 400 } });
+    const bottomRight = fakeChart({ bounds: { left: 320, top: 220, right: 600, bottom: 400 } });
+    expect(computeChartGrid([topRight, bottomLeft, topLeft, bottomRight])).toEqual([
+      [bottomLeft, bottomRight],
+      [topLeft, topRight],
+    ]);
   });
 
   it('groups charts with nearly equal tops into one row, sorted by left', () => {

--- a/test/adapters/amcharts/geometry.test.ts
+++ b/test/adapters/amcharts/geometry.test.ts
@@ -1,0 +1,45 @@
+import { computeChartGrid, readPlotBounds } from '@adapters/amcharts/geometry';
+import { fakeChart } from './helpers';
+
+describe('readPlotBounds', () => {
+  it('reads globalBounds from the plot container', () => {
+    const chart = fakeChart({ bounds: { left: 10, top: 20, right: 300, bottom: 200 } });
+    expect(readPlotBounds(chart)).toEqual({ left: 10, top: 20, right: 300, bottom: 200 });
+  });
+
+  it('returns null without a plot container', () => {
+    expect(readPlotBounds(fakeChart())).toBeNull();
+  });
+});
+
+describe('computeChartGrid', () => {
+  it('returns a single row for zero or one chart', () => {
+    const chart = fakeChart();
+    expect(computeChartGrid([])).toEqual([[]]);
+    expect(computeChartGrid([chart])).toEqual([[chart]]);
+  });
+
+  it('stacks vertically arranged charts into separate rows', () => {
+    const top = fakeChart({ bounds: { left: 0, top: 0, right: 600, bottom: 180 } });
+    const bottom = fakeChart({ bounds: { left: 0, top: 200, right: 600, bottom: 380 } });
+    expect(computeChartGrid([bottom, top])).toEqual([[top], [bottom]]);
+  });
+
+  it('groups charts with nearly equal tops into one row, sorted by left', () => {
+    const left = fakeChart({ bounds: { left: 0, top: 0, right: 280, bottom: 300 } });
+    const right = fakeChart({ bounds: { left: 320, top: 12, right: 600, bottom: 312 } });
+    expect(computeChartGrid([right, left])).toEqual([[left, right]]);
+  });
+
+  it('falls back to one row in insertion order when geometry is missing', () => {
+    const withBounds = fakeChart({ bounds: { left: 0, top: 0, right: 600, bottom: 180 } });
+    const withoutBounds = fakeChart();
+    expect(computeChartGrid([withBounds, withoutBounds])).toEqual([[withBounds, withoutBounds]]);
+  });
+
+  it('falls back when a chart reports zero height (pre-layout)', () => {
+    const laidOut = fakeChart({ bounds: { left: 0, top: 0, right: 600, bottom: 180 } });
+    const collapsed = fakeChart({ bounds: { left: 0, top: 0, right: 600, bottom: 0 } });
+    expect(computeChartGrid([laidOut, collapsed])).toEqual([[laidOut, collapsed]]);
+  });
+});

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -1,0 +1,143 @@
+/**
+ * Duck-typed amCharts 5 fakes shared by the amCharts adapter tests.
+ *
+ * The adapter reads amCharts objects purely through structural typing
+ * (`get()`, `series.values`, `children.values`, ...), so plain objects are
+ * enough — no amCharts import and no DOM required.
+ */
+
+import type {
+  AmAxis,
+  AmBounds,
+  AmRoot,
+  AmXYChart,
+  AmXYSeries,
+} from '@adapters/amcharts/types';
+
+let nextUid = 1;
+
+export interface FakeSeriesConfig {
+  /** amCharts series class name. Defaults to `ColumnSeries`. */
+  className?: string;
+  /** Series name (used for layer titles / segmented fill). */
+  name?: string;
+  /** Extra series settings readable via `series.get(key)`. */
+  settings?: Record<string, unknown>;
+  /** Data-item records readable via `dataItem.get(key)`. */
+  data?: Array<Record<string, unknown>>;
+}
+
+export function fakeSeries(config: FakeSeriesConfig = {}): AmXYSeries {
+  const settings: Record<string, unknown> = {
+    ...(config.name != null ? { name: config.name } : {}),
+    ...config.settings,
+  };
+  return {
+    className: config.className ?? 'ColumnSeries',
+    uid: nextUid++,
+    get: (key: string) => settings[key],
+    dataItems: (config.data ?? []).map(record => ({
+      get: (key: string) => record[key],
+    })),
+  } as unknown as AmXYSeries;
+}
+
+/** A vertical column (bar) series with `categoryX`/`valueY` data items. */
+export function fakeBarSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number | null }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'ColumnSeries',
+    name,
+    settings: { categoryXField: 'category' },
+    data: points,
+  });
+}
+
+/** A line series with `categoryX`/`valueY` data items. */
+export function fakeLineSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'LineSeries',
+    name,
+    settings: { categoryXField: 'category' },
+    data: points,
+  });
+}
+
+function fakeAxis(label?: string): AmAxis {
+  const title = label != null
+    ? { get: (key: string) => (key === 'text' ? label : undefined) }
+    : undefined;
+  return {
+    get: (key: string) => (key === 'title' ? title : undefined),
+    dataItems: [],
+  } as unknown as AmAxis;
+}
+
+export interface FakeChartConfig {
+  series?: AmXYSeries[];
+  /** X axis title (readable via `axis.get('title').get('text')`). */
+  xLabel?: string;
+  /** Y axis title. */
+  yLabel?: string;
+  /** Chart title, exposed as a `Label` child like amCharts does. */
+  title?: string;
+  /** Plot-area bounds returned by `plotContainer.globalBounds()`. */
+  bounds?: AmBounds;
+  className?: string;
+}
+
+export function fakeChart(config: FakeChartConfig = {}): AmXYChart {
+  const chart: Record<string, unknown> = {
+    className: config.className ?? 'XYChart',
+    uid: nextUid++,
+    get: () => undefined,
+    series: { values: config.series ?? [] },
+    xAxes: { values: [fakeAxis(config.xLabel)] },
+    yAxes: { values: [fakeAxis(config.yLabel)] },
+  };
+  if (config.bounds) {
+    const bounds = config.bounds;
+    chart.plotContainer = { globalBounds: () => bounds };
+  }
+  if (config.title != null) {
+    const title = config.title;
+    chart.children = {
+      values: [{
+        className: 'Label',
+        get: (key: string) => (key === 'text' ? title : undefined),
+      }],
+    };
+  }
+  return chart as unknown as AmXYChart;
+}
+
+/** A container-like node (e.g. a StockChart or panels container). */
+export function fakeContainer(children: unknown[]): unknown {
+  return {
+    get: () => undefined,
+    children: { values: children },
+  };
+}
+
+/**
+ * A minimal `HTMLElement` stand-in for the chart container. The adapter only
+ * reads `id` and calls `querySelector` (selector probing), so no DOM needed.
+ */
+export function fakeContainerEl(id = 'chartdiv'): HTMLElement {
+  return {
+    id,
+    querySelector: () => null,
+  } as unknown as HTMLElement;
+}
+
+export function fakeRoot(children: unknown[], domId = 'chartdiv'): AmRoot {
+  return {
+    dom: fakeContainerEl(domId),
+    container: fakeContainer(children),
+  } as unknown as AmRoot;
+}

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -116,9 +116,14 @@ export function fakeChart(config: FakeChartConfig = {}): AmXYChart {
   return chart as unknown as AmXYChart;
 }
 
-/** A container-like node (e.g. a StockChart or panels container). */
-export function fakeContainer(children: unknown[]): unknown {
+/**
+ * A container-like node (e.g. a StockChart, a panels/tools container, or an
+ * `XYChartScrollbar` when given that `className` — a real scrollbar is a plain
+ * container, NOT chart-like, whose child is a preview `XYChart`).
+ */
+export function fakeContainer(children: unknown[], className?: string): unknown {
   return {
+    ...(className != null ? { className } : {}),
     get: () => undefined,
     children: { values: children },
   };

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -1,0 +1,116 @@
+import type { SeriesGroups } from '@adapters/amcharts/navmap';
+import type { AmXYChart, AmXYSeries } from '@adapters/amcharts/types';
+import type { MaidrLayer } from '@type/grammar';
+import { buildNavigationMap } from '@adapters/amcharts/navmap';
+import { TraceType } from '@type/grammar';
+import { fakeBarSeries, fakeChart, fakeLineSeries } from './helpers';
+
+function emptyGroups(): SeriesGroups {
+  return {
+    barSeriesList: [],
+    lineSeriesList: [],
+    histogramSeries: [],
+    heatmapSeries: [],
+  };
+}
+
+function barLayer(id: string): MaidrLayer {
+  return { id, type: TraceType.BAR, data: [] };
+}
+
+function lineLayer(id: string): MaidrLayer {
+  return { id, type: TraceType.LINE, data: [] };
+}
+
+interface Panel {
+  chart: AmXYChart;
+  layers: MaidrLayer[];
+  groups: SeriesGroups;
+}
+
+function barPanel(layerId: string, series: AmXYSeries): Panel {
+  const chart = fakeChart({ series: [series] });
+  return {
+    chart,
+    layers: [barLayer(layerId)],
+    groups: { ...emptyGroups(), barSeriesList: [series] },
+  };
+}
+
+describe('buildNavigationMap (multi-panel)', () => {
+  const seriesA = fakeBarSeries('A', [
+    { categoryX: 'Sat', valueY: 87 },
+    { categoryX: 'Sun', valueY: 76 },
+  ]);
+  const seriesB = fakeBarSeries('B', [
+    { categoryX: 'Sat', valueY: 10 },
+    { categoryX: 'Sun', valueY: 20 },
+  ]);
+  const panelA = barPanel('layer-a', seriesA);
+  const panelB = barPanel('layer-b', seriesB);
+  const navMap = buildNavigationMap([panelA, panelB]);
+
+  it('resolves each layer against its own panel series', () => {
+    const targetsA = navMap.resolve('layer-a', 0, 1);
+    expect(targetsA).toHaveLength(1);
+    expect(targetsA[0].series).toBe(seriesA);
+    expect(targetsA[0].dataItem.get('valueY')).toBe(76);
+    expect(targetsA[0].kind).toBe('column');
+
+    const targetsB = navMap.resolve('layer-b', 0, 0);
+    expect(targetsB).toHaveLength(1);
+    expect(targetsB[0].series).toBe(seriesB);
+    expect(targetsB[0].dataItem.get('valueY')).toBe(10);
+  });
+
+  it('records the owning chart per layer', () => {
+    expect(navMap.chartFor('layer-a')).toBe(panelA.chart);
+    expect(navMap.chartFor('layer-b')).toBe(panelB.chart);
+    expect(navMap.chartFor('unknown')).toBeUndefined();
+  });
+
+  it('returns no targets for unknown layers or out-of-range positions', () => {
+    expect(navMap.resolve('unknown', 0, 0)).toEqual([]);
+    expect(navMap.resolve('layer-a', 0, 99)).toEqual([]);
+  });
+});
+
+describe('buildNavigationMap (behavior preserved from single-panel)', () => {
+  it('skips null/gap records so col indices match extractor output', () => {
+    const series = fakeBarSeries('Gaps', [
+      { categoryX: 'A', valueY: 1 },
+      { categoryX: 'B', valueY: null },
+      { categoryX: 'C', valueY: 3 },
+    ]);
+    const navMap = buildNavigationMap([barPanel('bar', series)]);
+
+    const targets = navMap.resolve('bar', 0, 1);
+    expect(targets).toHaveLength(1);
+    // col 1 is the SECOND kept item, i.e. category C (the gap is skipped).
+    expect(targets[0].dataItem.get('categoryX')).toBe('C');
+  });
+
+  it('resolves line layers to point targets by [row, col]', () => {
+    const lineA = fakeLineSeries('L1', [
+      { categoryX: '2020', valueY: 100 },
+      { categoryX: '2021', valueY: 120 },
+    ]);
+    const lineB = fakeLineSeries('L2', [
+      { categoryX: '2020', valueY: 50 },
+      { categoryX: '2021', valueY: 60 },
+    ]);
+    const chart = fakeChart({ series: [lineA, lineB] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [lineLayer('lines')],
+      groups: { ...emptyGroups(), lineSeriesList: [lineA, lineB] },
+    }]);
+
+    const targets = navMap.resolve('lines', 1, 1);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].series).toBe(lineB);
+    expect(targets[0].dataItem.get('valueY')).toBe(60);
+    expect(targets[0].kind).toBe('point');
+    expect(navMap.chartFor('lines')).toBe(chart);
+  });
+});

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -50,6 +50,10 @@ describe('buildNavigationMap (multi-panel)', () => {
   const panelB = barPanel('layer-b', seriesB);
   const navMap = buildNavigationMap([panelA, panelB]);
 
+  it('reports the number of distinct panel charts', () => {
+    expect(navMap.chartCount).toBe(2);
+  });
+
   it('resolves each layer against its own panel series', () => {
     const targetsA = navMap.resolve('layer-a', 0, 1);
     expect(targetsA).toHaveLength(1);

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -1,0 +1,511 @@
+import type {
+  AnyChartAxis,
+  AnyChartInstance,
+  AnyChartIterator,
+  AnyChartSeries,
+} from '@adapters/anychart/types';
+import type { BarPoint, BoxSelector, MaidrLayer } from '@type/grammar';
+import {
+  anyChartsToMaidr,
+  anyChartToMaidr,
+  bindAnyCharts,
+} from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+// ---------------------------------------------------------------------------
+// DOM globals (jest runs in the node environment; the adapter resolves
+// containers and stamps SVGs via DOM globals at call time).
+// ---------------------------------------------------------------------------
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+// ---------------------------------------------------------------------------
+// AnyChart mocks
+// ---------------------------------------------------------------------------
+
+function createIterator(rows: Array<Record<string, unknown>>): AnyChartIterator {
+  let index = -1;
+  return {
+    advance: () => ++index < rows.length,
+    get: (field: string) => rows[index]?.[field],
+    getIndex: () => index,
+    getRowsCount: () => rows.length,
+    reset: () => {
+      index = -1;
+    },
+  };
+}
+
+function createSeries(
+  seriesType: string,
+  rows: Array<Record<string, unknown>>,
+): AnyChartSeries {
+  return {
+    id: () => 0,
+    name: () => seriesType,
+    seriesType: () => seriesType,
+    getIterator: () => createIterator(rows),
+    getPoint: () => ({ get: () => undefined, getIndex: () => 0, exists: () => false }),
+    getStat: () => undefined,
+  };
+}
+
+function createBarSeries(data: Array<[string, number]>): AnyChartSeries {
+  return createSeries('column', data.map(([x, value]) => ({ x, value })));
+}
+
+function createAxis(titleText: string): AnyChartAxis {
+  return {
+    title: () => ({ text: () => titleText }),
+    labels: () => ({ enabled: () => true }),
+  };
+}
+
+interface MockChartConfig {
+  title?: string;
+  container?: HTMLElement | string;
+  series?: AnyChartSeries[];
+  type?: string;
+  xTitle?: string;
+  yTitle?: string;
+  /** Chart-level data rows (heatmap-style single-dataset charts). */
+  heatRows?: Array<Record<string, unknown>>;
+}
+
+function createChart(config: MockChartConfig): AnyChartInstance {
+  const series = config.series ?? [];
+  const chartType = config.type;
+  const heatRows = config.heatRows;
+  const xTitle = config.xTitle;
+  const yTitle = config.yTitle;
+  return {
+    title: () => config.title ?? '',
+    container: () => config.container ?? '',
+    getSeriesCount: () => series.length,
+    getSeriesAt: (i: number) => series[i] ?? null,
+    ...(chartType ? { getType: () => chartType } : {}),
+    ...(heatRows
+      ? { data: () => ({ getIterator: () => createIterator(heatRows) }) }
+      : {}),
+    ...(xTitle ? { xAxis: () => createAxis(xTitle) } : {}),
+    ...(yTitle ? { yAxis: () => createAxis(yTitle) } : {}),
+  };
+}
+
+function createBarChart(
+  title: string,
+  data: Array<[string, number]> = [['A', 1], ['B', 2]],
+  extra: Omit<MockChartConfig, 'title' | 'series'> = {},
+): AnyChartInstance {
+  return createChart({ title, series: [createBarSeries(data)], ...extra });
+}
+
+/** Create a container div (attached to body) holding a rendered <svg>. */
+function createContainerWithSvg(id: string, parent?: HTMLElement): HTMLElement {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+  (parent ?? document.body).appendChild(container);
+  return container;
+}
+
+function stubRect(
+  el: HTMLElement,
+  rect: { top: number; left: number; width?: number; height?: number },
+): void {
+  const width = rect.width ?? 100;
+  const height = rect.height ?? 100;
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({
+      top: rect.top,
+      left: rect.left,
+      width,
+      height,
+      right: rect.left + width,
+      bottom: rect.top + height,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    }),
+  });
+}
+
+function firstLayer(maidr: NonNullable<ReturnType<typeof anyChartsToMaidr>>, r: number, c: number): MaidrLayer {
+  return maidr.subplots[r][c].layers[0];
+}
+
+// Silence the adapter's diagnostic warnings so test output stays readable.
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Single-panel behavior (must remain EXACTLY as before)
+// ---------------------------------------------------------------------------
+
+describe('anyChartToMaidr (single panel, unchanged)', () => {
+  it('emits a 1x1 grid with un-prefixed selectors and layer ids', () => {
+    const chart = createBarChart('Tips', [['Sat', 87], ['Sun', 76]], {
+      xTitle: 'Day',
+      yTitle: 'Count',
+    });
+
+    const result = anyChartToMaidr(chart);
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('anychart-maidr');
+    expect(result?.title).toBe('Tips');
+    expect(result?.subplots).toHaveLength(1);
+    expect(result?.subplots[0]).toHaveLength(1);
+
+    const subplot = result!.subplots[0][0];
+    // Single-panel subplots carry no panel selector.
+    expect(subplot.selector).toBeUndefined();
+
+    const layer = subplot.layers[0];
+    expect(layer.id).toBe('0');
+    expect(layer.type).toBe(TraceType.BAR);
+    // No panel-token scoping in single-panel mode.
+    expect(layer.selectors).toBe('[data-maidr-anychart-bar^="0-"]');
+    // Layer titles are not set in single-panel mode.
+    expect(layer.title).toBeUndefined();
+    expect(layer.axes?.x).toEqual({ label: 'Day' });
+    expect(layer.axes?.y).toEqual({ label: 'Count' });
+
+    const data = layer.data as BarPoint[];
+    expect(data).toEqual([{ x: 'Sat', y: 87 }, { x: 'Sun', y: 76 }]);
+  });
+
+  it('returns null for a chart with no convertible series', () => {
+    const chart = createChart({ series: [createSeries('pie', [{ x: 'A', value: 1 }])] });
+    expect(anyChartToMaidr(chart)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-panel conversion
+// ---------------------------------------------------------------------------
+
+describe('anyChartsToMaidr', () => {
+  it('maps an explicit 2D grid 1:1 onto subplots (ragged rows allowed)', () => {
+    const a = createBarChart('Panel A');
+    const b = createBarChart('Panel B');
+    const c = createBarChart('Panel C');
+
+    const result = anyChartsToMaidr([[a, b], [c]], { id: 'fig', title: 'Figure' });
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('fig');
+    expect(result?.title).toBe('Figure');
+    expect(result?.subplots).toHaveLength(2);
+    expect(result?.subplots[0]).toHaveLength(2);
+    expect(result?.subplots[1]).toHaveLength(1);
+
+    // First layer's title is the panel display name.
+    expect(firstLayer(result!, 0, 0).title).toBe('Panel A');
+    expect(firstLayer(result!, 0, 1).title).toBe('Panel B');
+    expect(firstLayer(result!, 1, 0).title).toBe('Panel C');
+
+    // Layer ids are unique across the whole figure.
+    const ids = result!.subplots.flat().flatMap(s => s.layers.map(l => l.id));
+    expect(ids).toEqual(['0_0_0', '0_1_0', '1_0_0']);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('scopes every selector to its own panel token', () => {
+    const a = createBarChart('A');
+    const b = createBarChart('B');
+
+    const result = anyChartsToMaidr([[a, b]], { id: 'fig' });
+
+    expect(result?.subplots[0][0].selector).toBe(
+      'svg[data-maidr-anychart-panel="fig-0-0"]',
+    );
+    expect(result?.subplots[0][1].selector).toBe(
+      'svg[data-maidr-anychart-panel="fig-0-1"]',
+    );
+    expect(firstLayer(result!, 0, 0).selectors).toBe(
+      '[data-maidr-anychart-panel="fig-0-0"] [data-maidr-anychart-bar^="fig-0-0:0-"]',
+    );
+    expect(firstLayer(result!, 0, 1).selectors).toBe(
+      '[data-maidr-anychart-panel="fig-0-1"] [data-maidr-anychart-bar^="fig-0-1:0-"]',
+    );
+  });
+
+  it('scopes BoxSelector entries and candlestick defaults to the panel', () => {
+    const box = createChart({
+      title: 'Box',
+      series: [
+        createSeries('box', [
+          { x: 'A', lowest: 1, q1: 2, median: 3, q3: 4, highest: 5 },
+        ]),
+      ],
+    });
+    const candle = createChart({
+      title: 'Candle',
+      series: [
+        createSeries('candlestick', [
+          { x: 'Mon', open: 1, high: 4, low: 0.5, close: 3 },
+        ]),
+      ],
+    });
+
+    const result = anyChartsToMaidr([[box, candle]], { id: 'fig' });
+
+    const boxSelectors = firstLayer(result!, 0, 0).selectors as BoxSelector[];
+    expect(boxSelectors).toHaveLength(1);
+    expect(boxSelectors[0].iq).toBe(
+      '[data-maidr-anychart-panel="fig-0-0"] '
+      + '[data-maidr-anychart-box="fig-0-0:0-0"][data-maidr-anychart-box-part="iq"]',
+    );
+    expect(boxSelectors[0].q2).toBe(
+      '[data-maidr-anychart-panel="fig-0-0"] '
+      + '[data-maidr-anychart-box="fig-0-0:0-0"][data-maidr-anychart-box-part="q2"]',
+    );
+
+    expect(firstLayer(result!, 0, 1).type).toBe(TraceType.CANDLESTICK);
+    expect(firstLayer(result!, 0, 1).selectors).toBe(
+      '[data-maidr-anychart-panel="fig-0-1"] '
+      + '[data-maidr-anychart-candlestick-cell^="fig-0-1:0-"]',
+    );
+  });
+
+  it('scopes heatmap panels to the panel token', () => {
+    const heat = createChart({
+      title: 'Heat',
+      type: 'heat-map',
+      heatRows: [
+        { x: 'X1', y: 'Y1', heat: 1 },
+        { x: 'X2', y: 'Y1', heat: 2 },
+      ],
+    });
+    const bar = createBarChart('Bar');
+
+    const result = anyChartsToMaidr([[heat, bar]], { id: 'fig' });
+
+    const heatLayer = firstLayer(result!, 0, 0);
+    expect(heatLayer.type).toBe(TraceType.HEATMAP);
+    expect(heatLayer.id).toBe('0_0_0');
+    expect(heatLayer.title).toBe('Heat');
+    expect(heatLayer.selectors).toBe(
+      '[data-maidr-anychart-panel="fig-0-0"] [data-maidr-anychart-heatmap-cell]',
+    );
+  });
+
+  it('applies figure-level axes overrides but keeps per-panel extraction otherwise', () => {
+    const a = createBarChart('A', [['x', 1]], { xTitle: 'AX', yTitle: 'AY' });
+    const b = createBarChart('B', [['x', 1]], { xTitle: 'BX', yTitle: 'BY' });
+
+    const extracted = anyChartsToMaidr([[a, b]], { id: 'fig' });
+    expect(firstLayer(extracted!, 0, 0).axes?.x).toEqual({ label: 'AX' });
+    expect(firstLayer(extracted!, 0, 1).axes?.x).toEqual({ label: 'BX' });
+
+    const overridden = anyChartsToMaidr([[a, b]], {
+      id: 'fig2',
+      axes: { x: 'Shared X', y: 'Shared Y' },
+    });
+    expect(firstLayer(overridden!, 0, 0).axes?.x).toEqual({ label: 'Shared X' });
+    expect(firstLayer(overridden!, 0, 1).axes?.y).toEqual({ label: 'Shared Y' });
+  });
+
+  it('sanitizes CSS-hostile figure ids in panel tokens but not in the figure id', () => {
+    const result = anyChartsToMaidr([[createBarChart('A')]], { id: 'my "fig" 1' });
+    expect(result?.id).toBe('my "fig" 1');
+    expect(result?.subplots[0][0].selector).toBe(
+      'svg[data-maidr-anychart-panel="my__fig__1-0-0"]',
+    );
+  });
+
+  it('drops panels with no convertible series, keeping original tokens', () => {
+    const bad = createChart({ series: [createSeries('pie', [{ x: 'A', value: 1 }])] });
+    const good = createBarChart('Good');
+
+    const result = anyChartsToMaidr([[bad, good]], { id: 'fig' });
+
+    expect(result?.subplots).toHaveLength(1);
+    expect(result?.subplots[0]).toHaveLength(1);
+    // Token still reflects the ORIGINAL grid position (0, 1).
+    expect(result?.subplots[0][0].selector).toBe(
+      'svg[data-maidr-anychart-panel="fig-0-1"]',
+    );
+  });
+
+  it('returns null when no panel is convertible', () => {
+    const bad = createChart({ series: [createSeries('pie', [{ x: 'A', value: 1 }])] });
+    expect(anyChartsToMaidr([[bad]], { id: 'fig' })).toBeNull();
+  });
+
+  describe('input validation', () => {
+    it('rejects an empty charts array', () => {
+      expect(anyChartsToMaidr([], { id: 'fig' })).toBeNull();
+    });
+
+    it('rejects grids containing an empty row', () => {
+      expect(anyChartsToMaidr([[createBarChart('A')], []], { id: 'fig' })).toBeNull();
+    });
+
+    it('rejects mixed flat/2D input', () => {
+      const a = createBarChart('A');
+      const b = createBarChart('B');
+      expect(
+        anyChartsToMaidr([a, [b]] as unknown as AnyChartInstance[][], { id: 'fig' }),
+      ).toBeNull();
+    });
+  });
+
+  describe('flat-array layouts', () => {
+    it('defaults to a single row when no layout is given', () => {
+      const charts = [createBarChart('A'), createBarChart('B'), createBarChart('C')];
+      const result = anyChartsToMaidr(charts, { id: 'fig' });
+      expect(result?.subplots).toHaveLength(1);
+      expect(result?.subplots[0]).toHaveLength(3);
+    });
+
+    it('chunks row-major by columns', () => {
+      const charts = [createBarChart('A'), createBarChart('B'), createBarChart('C')];
+      const result = anyChartsToMaidr(charts, { id: 'fig', layout: { columns: 2 } });
+      expect(result?.subplots).toHaveLength(2);
+      expect(result?.subplots[0]).toHaveLength(2);
+      expect(result?.subplots[1]).toHaveLength(1);
+      expect(firstLayer(result!, 0, 0).title).toBe('A');
+      expect(firstLayer(result!, 0, 1).title).toBe('B');
+      expect(firstLayer(result!, 1, 0).title).toBe('C');
+    });
+
+    it('derives columns from rows when only rows is given', () => {
+      const charts = [
+        createBarChart('A'),
+        createBarChart('B'),
+        createBarChart('C'),
+        createBarChart('D'),
+      ];
+      const result = anyChartsToMaidr(charts, { id: 'fig', layout: { rows: 2 } });
+      expect(result?.subplots).toHaveLength(2);
+      expect(result?.subplots[0]).toHaveLength(2);
+      expect(result?.subplots[1]).toHaveLength(2);
+    });
+
+    it('arranges layout "auto" by container position (rows by top, columns by left)', () => {
+      const wrapper = document.createElement('div');
+      document.body.appendChild(wrapper);
+      const topLeft = createContainerWithSvg('auto-tl', wrapper);
+      const topRight = createContainerWithSvg('auto-tr', wrapper);
+      const bottomLeft = createContainerWithSvg('auto-bl', wrapper);
+      stubRect(topLeft, { top: 0, left: 0 });
+      stubRect(topRight, { top: 3, left: 200 }); // within row tolerance of top: 0
+      stubRect(bottomLeft, { top: 300, left: 0 });
+
+      // Pass charts in shuffled order; 'auto' must sort them visually.
+      const charts = [
+        createBarChart('BottomLeft', [['x', 1]], { container: bottomLeft }),
+        createBarChart('TopRight', [['x', 1]], { container: topRight }),
+        createBarChart('TopLeft', [['x', 1]], { container: topLeft }),
+      ];
+
+      const result = anyChartsToMaidr(charts, { id: 'fig', layout: 'auto' });
+
+      expect(result?.subplots).toHaveLength(2);
+      expect(result?.subplots[0]).toHaveLength(2);
+      expect(result?.subplots[1]).toHaveLength(1);
+      expect(firstLayer(result!, 0, 0).title).toBe('TopLeft');
+      expect(firstLayer(result!, 0, 1).title).toBe('TopRight');
+      expect(firstLayer(result!, 1, 0).title).toBe('BottomLeft');
+      wrapper.remove();
+    });
+
+    it('fails layout "auto" when a chart has no resolvable container', () => {
+      const charts = [createBarChart('A'), createBarChart('B')];
+      expect(anyChartsToMaidr(charts, { id: 'fig', layout: 'auto' })).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bindAnyCharts (DOM integration)
+// ---------------------------------------------------------------------------
+
+describe('bindAnyCharts', () => {
+  it('stamps panel tokens, wraps the panels in one host, and binds once', () => {
+    const wrapper = document.createElement('div');
+    document.body.appendChild(wrapper);
+    const container1 = createContainerWithSvg('bind-p1', wrapper);
+    const container2 = createContainerWithSvg('bind-p2', wrapper);
+
+    const chartA = createBarChart('A', [['x', 1]], { container: container1 });
+    const chartB = createBarChart('B', [['x', 2]], { container: container2 });
+
+    const events: unknown[] = [];
+    const listener = (e: Event): void => {
+      events.push((e as CustomEvent).detail);
+    };
+    document.addEventListener('maidr:bindchart', listener);
+
+    const maidr = bindAnyCharts([[chartA, chartB]], { id: 'fig', title: 'Fig' });
+
+    expect(maidr).not.toBeNull();
+    expect(maidr?.subplots[0]).toHaveLength(2);
+
+    // Each panel's own SVG carries its token.
+    expect(container1.querySelector('svg')?.getAttribute('data-maidr-anychart-panel'))
+      .toBe('fig-0-0');
+    expect(container2.querySelector('svg')?.getAttribute('data-maidr-anychart-panel'))
+      .toBe('fig-0-1');
+
+    // One host wraps BOTH panel containers and carries the combined data.
+    const host = document.querySelector<HTMLElement>('[data-maidr-anychart-host]');
+    expect(host).not.toBeNull();
+    expect(host?.contains(container1)).toBe(true);
+    expect(host?.contains(container2)).toBe(true);
+    const parsed = JSON.parse(host?.getAttribute('maidr-data') ?? 'null');
+    expect(parsed?.id).toBe('fig');
+    expect(parsed?.subplots?.[0]).toHaveLength(2);
+
+    // Exactly one bind event for the whole figure.
+    expect(events).toHaveLength(1);
+
+    // Re-binding is a no-op that returns the data again.
+    const again = bindAnyCharts([[chartA, chartB]], { id: 'fig' });
+    expect(again).not.toBeNull();
+    expect(events).toHaveLength(1);
+
+    document.removeEventListener('maidr:bindchart', listener);
+    host?.remove();
+  });
+
+  it('refuses charts sharing one container (shared-Stage dashboards)', () => {
+    const container = createContainerWithSvg('bind-shared');
+    const chartA = createBarChart('A', [['x', 1]], { container });
+    const chartB = createBarChart('B', [['x', 2]], { container });
+
+    expect(bindAnyCharts([[chartA, chartB]], { id: 'fig' })).toBeNull();
+    container.remove();
+  });
+
+  it('fails when a chart has no container', () => {
+    const container = createContainerWithSvg('bind-solo');
+    const chartA = createBarChart('A', [['x', 1]], { container });
+    const chartB = createBarChart('B');
+
+    expect(bindAnyCharts([[chartA, chartB]], { id: 'fig' })).toBeNull();
+    container.remove();
+  });
+});

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -491,6 +491,110 @@ describe('bindAnyCharts', () => {
     host?.remove();
   });
 
+  it('resolves every emitted subplot selector to its own panel SVG (visual-layout contract)', () => {
+    // The MAIDR core computes visual panel order and vertical arrow
+    // direction (resolveSubplotLayout's panel-geometry pass) by measuring
+    // the element matched by each subplot's `selector`. This asserts the
+    // adapter's multi-ROW output satisfies that contract: every subplot
+    // carries a selector that resolves to that panel's own, distinct SVG.
+    const wrapper = document.createElement('div');
+    document.body.appendChild(wrapper);
+    const containers = [
+      createContainerWithSvg('layout-p00', wrapper),
+      createContainerWithSvg('layout-p01', wrapper),
+      createContainerWithSvg('layout-p10', wrapper),
+      createContainerWithSvg('layout-p11', wrapper),
+    ];
+    const charts = containers.map(
+      (container, i) => createBarChart(`P${i}`, [['x', i + 1]], { container }),
+    );
+
+    const maidr = bindAnyCharts(
+      [[charts[0], charts[1]], [charts[2], charts[3]]],
+      { id: 'layout-fig' },
+    );
+
+    expect(maidr).not.toBeNull();
+    expect(maidr?.subplots).toHaveLength(2);
+
+    const resolved: Element[] = [];
+    maidr!.subplots.forEach((row, r) => {
+      row.forEach((subplot, c) => {
+        expect(subplot.selector).toBe(
+          `svg[data-maidr-anychart-panel="layout-fig-${r}-${c}"]`,
+        );
+        const el = document.querySelector(subplot.selector!);
+        expect(el).toBe(containers[r * 2 + c].querySelector('svg'));
+        resolved.push(el!);
+        // The first layer's selector is scoped inside the same panel, so the
+        // core's layer-selector fallback also stays within the panel.
+        expect(subplot.layers[0].selectors).toBe(
+          `[data-maidr-anychart-panel="layout-fig-${r}-${c}"] `
+          + `[data-maidr-anychart-bar^="layout-fig-${r}-${c}:0-"]`,
+        );
+      });
+    });
+    // Four panels, four DISTINCT elements to measure.
+    expect(new Set(resolved).size).toBe(4);
+
+    document.querySelector('[data-maidr-anychart-host]')?.remove();
+  });
+
+  it('preserves page order when other content is interleaved between panels', () => {
+    const wrapper = document.createElement('div');
+    document.body.appendChild(wrapper);
+    const container1 = createContainerWithSvg('inter-p1', wrapper);
+    const heading = document.createElement('h3');
+    heading.textContent = 'Q2 sales';
+    wrapper.appendChild(heading);
+    const container2 = createContainerWithSvg('inter-p2', wrapper);
+
+    const chartA = createBarChart('A', [['x', 1]], { container: container1 });
+    const chartB = createBarChart('B', [['x', 2]], { container: container2 });
+
+    const maidr = bindAnyCharts([[chartA, chartB]], { id: 'inter-fig' });
+
+    expect(maidr).not.toBeNull();
+
+    // Non-contiguous same-parent panels must NOT be pulled together past the
+    // heading; the shared parent is wrapped in place instead.
+    expect(Array.from(wrapper.children)).toEqual([container1, heading, container2]);
+    const host = wrapper.parentElement;
+    expect(host?.hasAttribute('data-maidr-anychart-host')).toBe(true);
+    expect(host?.contains(container1)).toBe(true);
+    expect(host?.contains(container2)).toBe(true);
+    expect(host?.getAttribute('maidr-data')).toBeTruthy();
+
+    host?.remove();
+  });
+
+  it('returns the originally bound Maidr on re-bind without an explicit id', () => {
+    const wrapper = document.createElement('div');
+    document.body.appendChild(wrapper);
+    const container1 = createContainerWithSvg('rebind-p1', wrapper);
+    const container2 = createContainerWithSvg('rebind-p2', wrapper);
+
+    const chartA = createBarChart('A', [['x', 1]], { container: container1 });
+    const chartB = createBarChart('B', [['x', 2]], { container: container2 });
+
+    const first = bindAnyCharts([[chartA, chartB]]);
+    expect(first).not.toBeNull();
+
+    // Second call without options.id would mint a fresh generated id whose
+    // panel tokens were never stamped; the reuse path must return the
+    // Maidr the DOM was actually bound with.
+    const again = bindAnyCharts([[chartA, chartB]]);
+    expect(again).toBe(first);
+
+    // The returned object's selectors resolve against the stamped DOM.
+    expect(document.querySelector(again!.subplots[0][0].selector!))
+      .toBe(container1.querySelector('svg'));
+    expect(document.querySelector(again!.subplots[0][1].selector!))
+      .toBe(container2.querySelector('svg'));
+
+    document.querySelector('[data-maidr-anychart-host]')?.remove();
+  });
+
   it('refuses charts sharing one container (shared-Stage dashboards)', () => {
     const container = createContainerWithSvg('bind-shared');
     const chartA = createBarChart('A', [['x', 1]], { container });

--- a/test/adapters/chartjs/extractor.test.ts
+++ b/test/adapters/chartjs/extractor.test.ts
@@ -1,0 +1,359 @@
+import type { ChartJsChart, ChartJsData, ChartJsOptions, ChartJsRuntimeScale } from '@adapters/chartjs/types';
+import { extractChartData, extractMaidrData } from '@adapters/chartjs/extractor';
+import { TraceType } from '@type/grammar';
+
+interface MockChartConfig {
+  type: string;
+  data: ChartJsData;
+  options?: ChartJsOptions;
+  /** Runtime (laid-out) scales; omitted to simulate pre-layout charts. */
+  scales?: Record<string, ChartJsRuntimeScale>;
+}
+
+function createChart(config: MockChartConfig): ChartJsChart {
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data: config.data,
+    options: config.options ?? {},
+    config: { type: config.type },
+    ...(config.scales ? { scales: config.scales } : {}),
+    getDatasetMeta: () => ({ data: [], type: config.type }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+describe('chart.js extractor', () => {
+  describe('single-panel behavior (unchanged)', () => {
+    it('emits a 1x1 subplot grid for a plain bar chart', () => {
+      const chart = createChart({
+        type: 'bar',
+        data: {
+          labels: ['A', 'B', 'C'],
+          datasets: [{ label: 'Sales', data: [1, 2, 3] }],
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(1);
+      const layer = maidr.subplots[0][0].layers[0];
+      expect(layer.id).toBe('0');
+      expect(layer.type).toBe(TraceType.BAR);
+      expect(layerDatasetIndices.get('0')).toEqual([0]);
+    });
+
+    it('keeps a classic dual-axis chart (no stack option) as ONE subplot', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb'],
+          datasets: [
+            { label: 'Revenue', data: [10, 20] },
+            { label: 'Growth', data: [1, 2], yAxisID: 'y2' },
+          ],
+        },
+        options: {
+          scales: {
+            x: {},
+            y: { title: { text: 'USD' } },
+            y2: { title: { text: 'Percent' } },
+          },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(1);
+      expect(maidr.subplots[0][0].layers).toHaveLength(1);
+      expect(maidr.subplots[0][0].layers[0].id).toBe('0');
+    });
+
+    it('keeps overlapping same-kind runtime bands (dual axis) as ONE subplot', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb'],
+          datasets: [
+            { label: 'Revenue', data: [10, 20] },
+            { label: 'Growth', data: [1, 2], yAxisID: 'y2' },
+          ],
+        },
+        options: { scales: { x: {}, y: {}, y2: {} } },
+        scales: {
+          x: { axis: 'x', top: 400, bottom: 430, left: 40, right: 600 },
+          y: { axis: 'y', top: 0, bottom: 400, left: 0, right: 40 },
+          y2: { axis: 'y', top: 0, bottom: 400, left: 600, right: 640 },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(1);
+    });
+
+    it('falls back to a single subplot when all datasets share one stacked scale', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb'],
+          datasets: [{ label: 'Only', data: [1, 2] }],
+        },
+        options: {
+          scales: {
+            x: {},
+            y: { stack: 'demo' },
+            y2: { stack: 'demo' },
+          },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(1);
+      expect(maidr.subplots[0][0].layers[0].id).toBe('0');
+    });
+  });
+
+  describe('axis-stacked panels', () => {
+    const stackedLineChart = (scales?: Record<string, ChartJsRuntimeScale>): ChartJsChart =>
+      createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb', 'Mar'],
+          datasets: [
+            { label: 'Price', data: [10, 20, 30] },
+            { label: 'Volume', data: [1, 2, 3], yAxisID: 'y2' },
+          ],
+        },
+        options: {
+          scales: {
+            x: { title: { text: 'Month' } },
+            y: { stack: 'demo', stackWeight: 2, title: { text: 'Price ($)' } },
+            y2: { stack: 'demo', stackWeight: 1, title: { text: 'Volume' } },
+          },
+        },
+        scales,
+      });
+
+    it('splits y-stacked scales into an N rows x 1 col subplot grid', () => {
+      const { maidr } = extractChartData(stackedLineChart());
+
+      expect(maidr.subplots).toHaveLength(2);
+      expect(maidr.subplots[0]).toHaveLength(1);
+      expect(maidr.subplots[1]).toHaveLength(1);
+    });
+
+    it('gives every layer a figure-unique id and maps it to its datasets', () => {
+      const { maidr, layerDatasetIndices } = extractChartData(stackedLineChart());
+
+      const first = maidr.subplots[0][0].layers[0];
+      const second = maidr.subplots[1][0].layers[0];
+      expect(first.id).toBe('0_0');
+      expect(second.id).toBe('1_0');
+      expect(layerDatasetIndices.get('0_0')).toEqual([0]);
+      expect(layerDatasetIndices.get('1_0')).toEqual([1]);
+    });
+
+    it('labels each panel with its OWN scale title and shares the index axis', () => {
+      const { maidr } = extractChartData(stackedLineChart());
+
+      const first = maidr.subplots[0][0].layers[0];
+      const second = maidr.subplots[1][0].layers[0];
+      expect(first.axes?.y).toEqual({ label: 'Price ($)' });
+      expect(second.axes?.y).toEqual({ label: 'Volume' });
+      expect(first.axes?.x).toEqual({ label: 'Month' });
+      expect(second.axes?.x).toEqual({ label: 'Month' });
+      // Panel display name (first layer title) comes from the scale title.
+      expect(first.title).toBe('Price ($)');
+      expect(second.title).toBe('Volume');
+    });
+
+    it('orders panels by runtime band position (top-first), not declaration', () => {
+      // y2's band is laid out ABOVE y's, so y2 must come first.
+      const { maidr } = extractChartData(stackedLineChart({
+        x: { axis: 'x', top: 400, bottom: 430, left: 40, right: 600 },
+        y: { axis: 'y', top: 210, bottom: 400, left: 0, right: 40 },
+        y2: { axis: 'y', top: 0, bottom: 200, left: 0, right: 40 },
+      }));
+
+      expect(maidr.subplots[0][0].layers[0].title).toBe('Volume');
+      expect(maidr.subplots[1][0].layers[0].title).toBe('Price ($)');
+      // Ids stay contiguous in emission (visual) order.
+      expect(maidr.subplots[0][0].layers[0].id).toBe('0_0');
+      expect(maidr.subplots[1][0].layers[0].id).toBe('1_0');
+    });
+
+    it('detects stacked layout from disjoint runtime bands even without the stack option', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb'],
+          datasets: [
+            { label: 'Price', data: [10, 20] },
+            { label: 'Volume', data: [1, 2], yAxisID: 'y2' },
+          ],
+        },
+        options: { scales: { x: {}, y: {}, y2: {} } },
+        scales: {
+          x: { axis: 'x', top: 400, bottom: 430, left: 40, right: 600 },
+          y: { axis: 'y', top: 0, bottom: 200, left: 0, right: 40 },
+          y2: { axis: 'y', top: 210, bottom: 400, left: 0, right: 40 },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(2);
+      expect(maidr.subplots[0]).toHaveLength(1);
+    });
+
+    it('splits x-stacked scales into a 1 row x N cols subplot grid', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['a', 'b'],
+          datasets: [
+            { label: 'Left', data: [1, 2] },
+            { label: 'Right', data: [3, 4], xAxisID: 'x2' },
+          ],
+        },
+        options: {
+          scales: {
+            y: {},
+            x: { stack: 'cols', title: { text: 'Left Panel' } },
+            x2: { stack: 'cols', title: { text: 'Right Panel' } },
+          },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(2);
+      expect(maidr.subplots[0][0].layers[0].title).toBe('Left Panel');
+      expect(maidr.subplots[0][1].layers[0].title).toBe('Right Panel');
+    });
+
+    it('classifies stacked/dodged bars per panel from the panel\'s own scale', () => {
+      const chart = createChart({
+        type: 'bar',
+        data: {
+          labels: ['Q1', 'Q2'],
+          datasets: [
+            { label: 'East', data: [1, 2] },
+            { label: 'West', data: [3, 4] },
+            { label: 'North', data: [5, 6], yAxisID: 'y2' },
+            { label: 'South', data: [7, 8], yAxisID: 'y2' },
+          ],
+        },
+        options: {
+          scales: {
+            x: {},
+            y: { stack: 'demo', stacked: true },
+            y2: { stack: 'demo' },
+          },
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(2);
+      expect(maidr.subplots[0][0].layers[0].type).toBe(TraceType.STACKED);
+      expect(maidr.subplots[1][0].layers[0].type).toBe(TraceType.DODGED);
+      expect(layerDatasetIndices.get(maidr.subplots[0][0].layers[0].id)).toEqual([0, 1]);
+      expect(layerDatasetIndices.get(maidr.subplots[1][0].layers[0].id)).toEqual([2, 3]);
+    });
+
+    it('keeps per-dataset scatter layers within each panel, mapped to original datasets', () => {
+      const chart = createChart({
+        type: 'scatter',
+        data: {
+          datasets: [
+            { label: 'S1', data: [{ x: 1, y: 2 }] },
+            { label: 'S2', data: [{ x: 3, y: 4 }] },
+            { label: 'S3', data: [{ x: 5, y: 6 }], yAxisID: 'y2' },
+          ],
+        },
+        options: {
+          scales: {
+            x: {},
+            y: { stack: 'demo' },
+            y2: { stack: 'demo' },
+          },
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(2);
+      const panelOneIds = maidr.subplots[0][0].layers.map(l => l.id);
+      const panelTwoIds = maidr.subplots[1][0].layers.map(l => l.id);
+      expect(panelOneIds).toEqual(['0_0', '0_1']);
+      expect(panelTwoIds).toEqual(['1_0']);
+      expect(layerDatasetIndices.get('0_0')).toEqual([0]);
+      expect(layerDatasetIndices.get('0_1')).toEqual([1]);
+      expect(layerDatasetIndices.get('1_0')).toEqual([2]);
+    });
+
+    it('falls back to the first dataset label when a panel scale has no title', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan'],
+          datasets: [
+            { label: 'Price', data: [10] },
+            { label: 'Volume', data: [1], yAxisID: 'y2' },
+          ],
+        },
+        options: {
+          scales: { x: {}, y: { stack: 'demo' }, y2: { stack: 'demo' } },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots[0][0].layers[0].title).toBe('Price');
+      expect(maidr.subplots[1][0].layers[0].title).toBe('Volume');
+    });
+
+    it('still throws for unsupported chart types', () => {
+      const chart = createChart({
+        type: 'pie',
+        data: { datasets: [{ data: [1, 2] }] },
+        options: {
+          scales: { x: {}, y: { stack: 'demo' }, y2: { stack: 'demo' } },
+        },
+      });
+
+      expect(() => extractChartData(chart)).toThrow(/unsupported chart type/);
+    });
+  });
+
+  describe('extractMaidrData wrapper', () => {
+    it('returns the same schema shape as extractChartData().maidr', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan'],
+          datasets: [
+            { label: 'Price', data: [10] },
+            { label: 'Volume', data: [1], yAxisID: 'y2' },
+          ],
+        },
+        options: {
+          scales: { x: {}, y: { stack: 'demo' }, y2: { stack: 'demo' } },
+        },
+      });
+
+      const maidr = extractMaidrData(chart);
+
+      expect(maidr.subplots).toHaveLength(2);
+      expect(maidr.subplots[0][0].layers[0].id).toBe('0_0');
+    });
+  });
+});

--- a/test/adapters/chartjs/extractor.test.ts
+++ b/test/adapters/chartjs/extractor.test.ts
@@ -151,41 +151,54 @@ describe('chart.js extractor', () => {
     it('gives every layer a figure-unique id and maps it to its datasets', () => {
       const { maidr, layerDatasetIndices } = extractChartData(stackedLineChart());
 
+      // Rows are bottom-first: y2 (declared last = visually below) is row 0.
       const first = maidr.subplots[0][0].layers[0];
       const second = maidr.subplots[1][0].layers[0];
       expect(first.id).toBe('0_0');
       expect(second.id).toBe('1_0');
-      expect(layerDatasetIndices.get('0_0')).toEqual([0]);
-      expect(layerDatasetIndices.get('1_0')).toEqual([1]);
+      expect(layerDatasetIndices.get('0_0')).toEqual([1]);
+      expect(layerDatasetIndices.get('1_0')).toEqual([0]);
     });
 
     it('labels each panel with its OWN scale title and shares the index axis', () => {
       const { maidr } = extractChartData(stackedLineChart());
 
-      const first = maidr.subplots[0][0].layers[0];
-      const second = maidr.subplots[1][0].layers[0];
-      expect(first.axes?.y).toEqual({ label: 'Price ($)' });
-      expect(second.axes?.y).toEqual({ label: 'Volume' });
-      expect(first.axes?.x).toEqual({ label: 'Month' });
-      expect(second.axes?.x).toEqual({ label: 'Month' });
+      const bottom = maidr.subplots[0][0].layers[0];
+      const top = maidr.subplots[1][0].layers[0];
+      expect(bottom.axes?.y).toEqual({ label: 'Volume' });
+      expect(top.axes?.y).toEqual({ label: 'Price ($)' });
+      expect(bottom.axes?.x).toEqual({ label: 'Month' });
+      expect(top.axes?.x).toEqual({ label: 'Month' });
       // Panel display name (first layer title) comes from the scale title.
-      expect(first.title).toBe('Price ($)');
-      expect(second.title).toBe('Volume');
+      expect(bottom.title).toBe('Volume');
+      expect(top.title).toBe('Price ($)');
     });
 
-    it('orders panels by runtime band position (top-first), not declaration', () => {
-      // y2's band is laid out ABOVE y's, so y2 must come first.
+    it('orders y-stack rows bottom-first by runtime band position, not declaration', () => {
+      // y2's band is laid out ABOVE y's, so y (the bottom band) must be row 0:
+      // the core maps Up Arrow to row+1 (matplotlib convention) and canvas
+      // charts have no DOM geometry to auto-invert from, so bottom-first rows
+      // are what keep Up moving visually up.
       const { maidr } = extractChartData(stackedLineChart({
         x: { axis: 'x', top: 400, bottom: 430, left: 40, right: 600 },
         y: { axis: 'y', top: 210, bottom: 400, left: 0, right: 40 },
         y2: { axis: 'y', top: 0, bottom: 200, left: 0, right: 40 },
       }));
 
-      expect(maidr.subplots[0][0].layers[0].title).toBe('Volume');
-      expect(maidr.subplots[1][0].layers[0].title).toBe('Price ($)');
-      // Ids stay contiguous in emission (visual) order.
+      expect(maidr.subplots[0][0].layers[0].title).toBe('Price ($)');
+      expect(maidr.subplots[1][0].layers[0].title).toBe('Volume');
+      // Ids stay contiguous in emission (row) order.
       expect(maidr.subplots[0][0].layers[0].id).toBe('0_0');
       expect(maidr.subplots[1][0].layers[0].id).toBe('1_0');
+    });
+
+    it('emits the visually BOTTOM panel as row 0 in declaration-order fallback', () => {
+      // Without runtime layout, declaration order stands in for top-to-bottom
+      // on-canvas order, so the LAST declared y scale becomes row 0.
+      const { maidr } = extractChartData(stackedLineChart());
+
+      expect(maidr.subplots[0][0].layers[0].title).toBe('Volume');
+      expect(maidr.subplots[1][0].layers[0].title).toBe('Price ($)');
     });
 
     it('detects stacked layout from disjoint runtime bands even without the stack option', () => {
@@ -262,11 +275,12 @@ describe('chart.js extractor', () => {
 
       const { maidr, layerDatasetIndices } = extractChartData(chart);
 
+      // Bottom-first rows: y2 (declared last) is row 0, y is row 1.
       expect(maidr.subplots).toHaveLength(2);
-      expect(maidr.subplots[0][0].layers[0].type).toBe(TraceType.STACKED);
-      expect(maidr.subplots[1][0].layers[0].type).toBe(TraceType.DODGED);
-      expect(layerDatasetIndices.get(maidr.subplots[0][0].layers[0].id)).toEqual([0, 1]);
-      expect(layerDatasetIndices.get(maidr.subplots[1][0].layers[0].id)).toEqual([2, 3]);
+      expect(maidr.subplots[0][0].layers[0].type).toBe(TraceType.DODGED);
+      expect(maidr.subplots[1][0].layers[0].type).toBe(TraceType.STACKED);
+      expect(layerDatasetIndices.get(maidr.subplots[0][0].layers[0].id)).toEqual([2, 3]);
+      expect(layerDatasetIndices.get(maidr.subplots[1][0].layers[0].id)).toEqual([0, 1]);
     });
 
     it('keeps per-dataset scatter layers within each panel, mapped to original datasets', () => {
@@ -290,14 +304,15 @@ describe('chart.js extractor', () => {
 
       const { maidr, layerDatasetIndices } = extractChartData(chart);
 
+      // Bottom-first rows: the y2 panel (declared last) is row 0.
       expect(maidr.subplots).toHaveLength(2);
       const panelOneIds = maidr.subplots[0][0].layers.map(l => l.id);
       const panelTwoIds = maidr.subplots[1][0].layers.map(l => l.id);
-      expect(panelOneIds).toEqual(['0_0', '0_1']);
-      expect(panelTwoIds).toEqual(['1_0']);
-      expect(layerDatasetIndices.get('0_0')).toEqual([0]);
-      expect(layerDatasetIndices.get('0_1')).toEqual([1]);
-      expect(layerDatasetIndices.get('1_0')).toEqual([2]);
+      expect(panelOneIds).toEqual(['0_0']);
+      expect(panelTwoIds).toEqual(['1_0', '1_1']);
+      expect(layerDatasetIndices.get('0_0')).toEqual([2]);
+      expect(layerDatasetIndices.get('1_0')).toEqual([0]);
+      expect(layerDatasetIndices.get('1_1')).toEqual([1]);
     });
 
     it('falls back to the first dataset label when a panel scale has no title', () => {
@@ -317,8 +332,9 @@ describe('chart.js extractor', () => {
 
       const { maidr } = extractChartData(chart);
 
-      expect(maidr.subplots[0][0].layers[0].title).toBe('Price');
-      expect(maidr.subplots[1][0].layers[0].title).toBe('Volume');
+      // Bottom-first rows: the y2 panel (Volume) is row 0.
+      expect(maidr.subplots[0][0].layers[0].title).toBe('Volume');
+      expect(maidr.subplots[1][0].layers[0].title).toBe('Price');
     });
 
     it('still throws for unsupported chart types', () => {
@@ -331,6 +347,175 @@ describe('chart.js extractor', () => {
       });
 
       expect(() => extractChartData(chart)).toThrow(/unsupported chart type/);
+    });
+  });
+
+  describe('default-scale resolution (Chart.js firstIDs semantics)', () => {
+    it('folds datasets without a yAxisID into the FIRST declared y scale, not a phantom "y"', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb'],
+          datasets: [
+            // No yAxisID: Chart.js plots this on the first declared y scale
+            // ('price'), NOT on a scale literally named 'y'.
+            { label: 'Price', data: [10, 20] },
+            { label: 'Volume', data: [1, 2], yAxisID: 'volume' },
+          ],
+        },
+        options: {
+          scales: {
+            x: {},
+            price: { axis: 'y', stack: 's', title: { text: 'Price ($)' } },
+            volume: { axis: 'y', stack: 's', title: { text: 'Volume' } },
+          },
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      // Exactly two panels — no ghost 'y' subplot. Bottom-first rows put the
+      // volume panel (declared last) at row 0 and price at row 1.
+      expect(maidr.subplots).toHaveLength(2);
+      expect(maidr.subplots[0][0].layers[0].title).toBe('Volume');
+      const pricePanel = maidr.subplots[1][0].layers[0];
+      expect(pricePanel.title).toBe('Price ($)');
+      expect(pricePanel.axes?.y).toEqual({ label: 'Price ($)' });
+      expect(layerDatasetIndices.get(pricePanel.id)).toEqual([0]);
+    });
+
+    it('keeps a 2-band chart at 2 panels when another dataset targets the default scale explicitly', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb'],
+          datasets: [
+            { label: 'Bid', data: [10, 20] }, // defaults to 'price'
+            { label: 'Ask', data: [11, 21], yAxisID: 'price' },
+            { label: 'Volume', data: [1, 2], yAxisID: 'volume' },
+          ],
+        },
+        options: {
+          scales: {
+            x: {},
+            price: { axis: 'y', stack: 's', title: { text: 'Price ($)' } },
+            volume: { axis: 'y', stack: 's', title: { text: 'Volume' } },
+          },
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(2);
+      const pricePanel = maidr.subplots[1][0].layers[0];
+      expect(pricePanel.title).toBe('Price ($)');
+      expect(layerDatasetIndices.get(pricePanel.id)).toEqual([0, 1]);
+    });
+
+    it('resolves the default to the first DECLARED y scale even when a scale named "y" comes later', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['Jan', 'Feb'],
+          datasets: [
+            { label: 'Upper', data: [10, 20] }, // defaults to 'upper', not 'y'
+            { label: 'Lower', data: [1, 2], yAxisID: 'y' },
+          ],
+        },
+        options: {
+          scales: {
+            x: {},
+            upper: { axis: 'y', stack: 's', title: { text: 'Upper Panel' } },
+            y: { stack: 's', title: { text: 'Lower Panel' } },
+          },
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(2);
+      const upperPanel = maidr.subplots[1][0].layers[0];
+      expect(upperPanel.title).toBe('Upper Panel');
+      expect(layerDatasetIndices.get(upperPanel.id)).toEqual([0]);
+    });
+  });
+
+  describe('stack-group matching (position + stack name)', () => {
+    const dualAxisData: ChartJsData = {
+      labels: ['Jan', 'Feb'],
+      datasets: [
+        { label: 'Revenue', data: [10, 20] },
+        { label: 'Growth', data: [1, 2], yAxisID: 'y2' },
+      ],
+    };
+
+    it('keeps scales with DIFFERENT stack names as a single subplot', () => {
+      // Chart.js keys layout stacks by position + stack name, so 'a' and 'b'
+      // never band together — this renders as a classic dual-axis overlay.
+      const chart = createChart({
+        type: 'line',
+        data: dualAxisData,
+        options: {
+          scales: {
+            x: {},
+            y: { position: 'left', stack: 'a' },
+            y2: { position: 'right', stack: 'b' },
+          },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(1);
+    });
+
+    it('keeps the same stack name at different positions (left/right) as a single subplot', () => {
+      const chart = createChart({
+        type: 'line',
+        data: dualAxisData,
+        options: {
+          scales: {
+            x: {},
+            y: { position: 'left', stack: 'a' },
+            y2: { position: 'right', stack: 'a' },
+          },
+        },
+        scales: {
+          x: { axis: 'x', top: 400, bottom: 430, left: 40, right: 600 },
+          y: { axis: 'y', position: 'left', top: 0, bottom: 400, left: 0, right: 40 },
+          y2: { axis: 'y', position: 'right', top: 0, bottom: 400, left: 600, right: 640 },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(1);
+    });
+
+    it('falls back to the RUNTIME position when the scale options omit it', () => {
+      const chart = createChart({
+        type: 'line',
+        data: dualAxisData,
+        options: {
+          scales: {
+            x: {},
+            y: { stack: 'a' },
+            y2: { stack: 'a' },
+          },
+        },
+        scales: {
+          x: { axis: 'x', top: 400, bottom: 430, left: 40, right: 600 },
+          y: { axis: 'y', position: 'left', top: 0, bottom: 400, left: 0, right: 40 },
+          y2: { axis: 'y', position: 'right', top: 0, bottom: 400, left: 600, right: 640 },
+        },
+      });
+
+      const { maidr } = extractChartData(chart);
+
+      expect(maidr.subplots).toHaveLength(1);
+      expect(maidr.subplots[0]).toHaveLength(1);
     });
   });
 

--- a/test/adapters/chartjs/highlightTargets.test.ts
+++ b/test/adapters/chartjs/highlightTargets.test.ts
@@ -109,12 +109,13 @@ describe('chart.js highlight target resolution', () => {
 
       const { resolve } = setup(chart);
 
-      // Panel 2's single line: MAIDR row 0, but Chart.js dataset 1.
-      expect(resolve('1_0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
+      // Bottom-first rows: panel 0 is the y2 (Volume) band = Chart.js
+      // dataset 1; panel 1 is the y (Price) band = dataset 0.
+      expect(resolve('0_0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
       // Gap skipping still maps through to the original element index.
-      expect(resolve('1_0', 0, 1)).toEqual([{ datasetIndex: 1, index: 2 }]);
-      // Panel 1 stays on dataset 0.
-      expect(resolve('0_0', 0, 2)).toEqual([{ datasetIndex: 0, index: 2 }]);
+      expect(resolve('0_0', 0, 1)).toEqual([{ datasetIndex: 1, index: 2 }]);
+      // The Price panel stays on dataset 0.
+      expect(resolve('1_0', 0, 2)).toEqual([{ datasetIndex: 0, index: 2 }]);
     });
 
     it('routes scatter panel layers to the original dataset, not the panel-local one', () => {
@@ -128,10 +129,11 @@ describe('chart.js highlight target resolution', () => {
 
       const { resolve } = setup(chart);
 
-      expect(resolve('0_0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
-      expect(resolve('1_0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
-      // Second layer of panel 2 = dataset 2; its bucket has two shared-X points.
-      expect(resolve('1_1', 0, 0)).toEqual([
+      // Bottom-first rows: panel 0 is the y2 band (S2, S3), panel 1 is y (S1).
+      expect(resolve('0_0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
+      expect(resolve('1_0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+      // Second layer of the y2 panel = dataset 2; its bucket has two shared-X points.
+      expect(resolve('0_1', 0, 0)).toEqual([
         { datasetIndex: 2, index: 0 },
         { datasetIndex: 2, index: 1 },
       ]);
@@ -152,9 +154,11 @@ describe('chart.js highlight target resolution', () => {
 
       const panelTwoLayer = layers.find(layer => layer.id === '1_0');
       expect(panelTwoLayer).toBeDefined();
-      // Panel 2, MAIDR row 1 = its second dataset = original dataset 3.
-      expect(resolve('1_0', 1, 1)).toEqual([{ datasetIndex: 3, index: 1 }]);
-      expect(resolve('0_0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+      // Bottom-first rows: panel 0 is the y2 band (North/South). Its MAIDR
+      // row 1 = its second dataset = original dataset 3 (South).
+      expect(resolve('0_0', 1, 1)).toEqual([{ datasetIndex: 3, index: 1 }]);
+      // The y panel (East/West) row 0 = original dataset 0 (East).
+      expect(resolve('1_0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
     });
 
     it('returns no targets for unknown layer ids', () => {

--- a/test/adapters/chartjs/highlightTargets.test.ts
+++ b/test/adapters/chartjs/highlightTargets.test.ts
@@ -1,0 +1,174 @@
+import type { ChartJsChart, ChartJsData, ChartJsOptions } from '@adapters/chartjs/types';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+
+function createChart(type: string, data: ChartJsData, options?: ChartJsOptions): ChartJsChart {
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options: options ?? {},
+    config: { type },
+    getDatasetMeta: () => ({ data: [], type }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** Extract a chart and precompute everything the plugin's nav bridge uses. */
+function setup(chart: ChartJsChart): {
+  layers: ReturnType<typeof extractChartData>['maidr']['subplots'][number][number]['layers'];
+  resolve: (layerId: string, row: number, col: number) => { datasetIndex: number; index: number }[];
+} {
+  const { maidr, layerDatasetIndices } = extractChartData(chart);
+  const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+  const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+  return {
+    layers,
+    resolve: (layerId, row, col) =>
+      resolveActiveTargets(layers, maps, layerDatasetIndices, layerId, row, col),
+  };
+}
+
+const stackedScales: ChartJsOptions = {
+  scales: {
+    x: {},
+    y: { stack: 'demo' },
+    y2: { stack: 'demo' },
+  },
+};
+
+describe('chart.js highlight target resolution', () => {
+  describe('single-panel charts (legacy behavior preserved)', () => {
+    it('maps bar navigation to dataset 0, skipping gap markers', () => {
+      const chart = createChart('bar', {
+        labels: ['A', 'B', 'C'],
+        datasets: [{ label: 'Sales', data: [1, null, 3] }],
+      });
+
+      const { resolve } = setup(chart);
+
+      // col 1 is the second FINITE point, i.e. original element index 2.
+      expect(resolve('0', 0, 1)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    });
+
+    it('maps multi-line rows to their dataset indices', () => {
+      const chart = createChart('line', {
+        labels: ['A', 'B'],
+        datasets: [
+          { label: 'L1', data: [1, 2] },
+          { label: 'L2', data: [3, 4] },
+        ],
+      });
+
+      const { resolve } = setup(chart);
+
+      expect(resolve('0', 1, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
+    });
+
+    it('routes scatter layers to their own dataset (formerly parseInt(layer.id))', () => {
+      const chart = createChart('scatter', {
+        datasets: [
+          { label: 'S1', data: [{ x: 1, y: 1 }] },
+          { label: 'S2', data: [{ x: 2, y: 2 }, { x: 2, y: 3 }] },
+        ],
+      });
+
+      const { resolve } = setup(chart);
+
+      // Layer '1' is dataset 1; its col 0 X-bucket holds both x=2 points.
+      expect(resolve('1', 0, 0)).toEqual([
+        { datasetIndex: 1, index: 0 },
+        { datasetIndex: 1, index: 1 },
+      ]);
+    });
+
+    it('routes segmented bars by MAIDR row = dataset index', () => {
+      const chart = createChart('bar', {
+        labels: ['A', 'B'],
+        datasets: [
+          { label: 'G1', data: [1, 2] },
+          { label: 'G2', data: [3, 4] },
+        ],
+      });
+
+      const { resolve } = setup(chart);
+
+      expect(resolve('0', 1, 1)).toEqual([{ datasetIndex: 1, index: 1 }]);
+    });
+  });
+
+  describe('axis-stacked panel charts', () => {
+    it('routes each panel\'s line layer to the panel\'s original dataset', () => {
+      const chart = createChart('line', {
+        labels: ['A', 'B', 'C'],
+        datasets: [
+          { label: 'Price', data: [10, 20, 30] },
+          { label: 'Volume', data: [1, null, 3], yAxisID: 'y2' },
+        ],
+      }, stackedScales);
+
+      const { resolve } = setup(chart);
+
+      // Panel 2's single line: MAIDR row 0, but Chart.js dataset 1.
+      expect(resolve('1_0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
+      // Gap skipping still maps through to the original element index.
+      expect(resolve('1_0', 0, 1)).toEqual([{ datasetIndex: 1, index: 2 }]);
+      // Panel 1 stays on dataset 0.
+      expect(resolve('0_0', 0, 2)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    });
+
+    it('routes scatter panel layers to the original dataset, not the panel-local one', () => {
+      const chart = createChart('scatter', {
+        datasets: [
+          { label: 'S1', data: [{ x: 1, y: 1 }] },
+          { label: 'S2', data: [{ x: 2, y: 2 }], yAxisID: 'y2' },
+          { label: 'S3', data: [{ x: 3, y: 3 }, { x: 3, y: 4 }], yAxisID: 'y2' },
+        ],
+      }, stackedScales);
+
+      const { resolve } = setup(chart);
+
+      expect(resolve('0_0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+      expect(resolve('1_0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
+      // Second layer of panel 2 = dataset 2; its bucket has two shared-X points.
+      expect(resolve('1_1', 0, 0)).toEqual([
+        { datasetIndex: 2, index: 0 },
+        { datasetIndex: 2, index: 1 },
+      ]);
+    });
+
+    it('routes segmented panel rows through the partition to original datasets', () => {
+      const chart = createChart('bar', {
+        labels: ['Q1', 'Q2'],
+        datasets: [
+          { label: 'East', data: [1, 2] },
+          { label: 'West', data: [3, 4] },
+          { label: 'North', data: [5, 6], yAxisID: 'y2' },
+          { label: 'South', data: [7, 8], yAxisID: 'y2' },
+        ],
+      }, stackedScales);
+
+      const { layers, resolve } = setup(chart);
+
+      const panelTwoLayer = layers.find(layer => layer.id === '1_0');
+      expect(panelTwoLayer).toBeDefined();
+      // Panel 2, MAIDR row 1 = its second dataset = original dataset 3.
+      expect(resolve('1_0', 1, 1)).toEqual([{ datasetIndex: 3, index: 1 }]);
+      expect(resolve('0_0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+    });
+
+    it('returns no targets for unknown layer ids', () => {
+      const chart = createChart('line', {
+        labels: ['A'],
+        datasets: [
+          { label: 'P', data: [1] },
+          { label: 'V', data: [2], yAxisID: 'y2' },
+        ],
+      }, stackedScales);
+
+      const { resolve } = setup(chart);
+
+      expect(resolve('9_9', 0, 0)).toEqual([]);
+    });
+  });
+});

--- a/test/adapters/d3/subplots.test.ts
+++ b/test/adapters/d3/subplots.test.ts
@@ -99,9 +99,13 @@ describe('bindD3Facets', () => {
     expect(subplots[0][0].layers[0].selectors).toBe('#facet-svg [data-maidr-panel="0"] rect.bar');
     expect(subplots[0][1].layers[0].selectors).toBe('#facet-svg [data-maidr-panel="1"] rect.bar');
 
-    // Subplot selector points at the panel container itself.
-    expect(subplots[0][0].selector).toBe('#facet-svg [data-maidr-panel="0"]');
-    expect(subplots[0][1].selector).toBe('#facet-svg [data-maidr-panel="1"]');
+    // No subplot-level selector: the core would deep-clone whatever it
+    // matches into a hidden copy carrying the stamped axes_* id and outline
+    // the invisible clone. With it absent, axes lookup falls back to the
+    // first layer selector and resolves the ORIGINAL panel (the
+    // examples/facet_barplot.html convention).
+    expect(subplots[0][0].selector).toBeUndefined();
+    expect(subplots[0][1].selector).toBeUndefined();
 
     // Each panel's data is extracted from that panel only.
     expect(subplots[0][0].layers[0].data).toEqual([{ x: 'p', y: 1 }, { x: 'q', y: 2 }]);
@@ -129,6 +133,30 @@ describe('bindD3Facets', () => {
       chartType: 'bar',
       config: { selector: 'rect.bar', x: 'x', y: 'y' },
       panelTitle: (d: unknown) => `cyl = ${(d as [string, BarDatum[]])[0]}`,
+      layout: 'row',
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots[0][0].layers[0].title).toBe('cyl = 4');
+    expect(subplots[0][1].layers[0].title).toBe('cyl = 6');
+  });
+
+  test('invokes function panelTitle accessors even when panels have no bound datum', () => {
+    const { svg } = buildFacetSvg([
+      { key: '4', bars: [{ x: 'p', y: 1 }] },
+      { key: '6', bars: [{ x: 'p', y: 2 }] },
+    ]);
+    // Simulate panels appended without a data join (no `__data__`).
+    for (const panel of Array.from(svg.querySelectorAll('g.panel'))) {
+      setDatum(panel, undefined);
+    }
+
+    const keys = ['4', '6'];
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      panelTitle: (_d: unknown, i: number) => `cyl = ${keys[i]}`,
       layout: 'row',
     });
 
@@ -278,6 +306,48 @@ describe('bindD3Facets', () => {
     expect(secondSelectors).toEqual(firstSelectors);
   });
 
+  test('rebinding ignores MAIDR-owned hidden clones left by a live controller', () => {
+    const { svg, doc } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }] },
+      { key: 'B', bars: [{ x: 'p', y: 2 }] },
+    ]);
+    const facetsConfig = {
+      panelSelector: 'g.panel',
+      chartType: 'bar' as const,
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'row' as const,
+    };
+
+    const first = bindD3Facets(svg, facetsConfig);
+
+    // Simulate the clones the MAIDR core inserts while the chart is focused:
+    // a hidden copy of a mark inside an original panel (trace highlight) and
+    // a hidden copy of a whole panel as its sibling. cloneNode does not copy
+    // the JS `__data__` expando, exactly like the real core clones.
+    const firstPanel = svg.querySelector('g.panel')!;
+    const markClone = firstPanel.querySelector('rect.bar')!.cloneNode(true) as Element;
+    markClone.setAttribute('data-maidr-owned', 'true');
+    markClone.setAttribute('visibility', 'hidden');
+    firstPanel.querySelector('rect.bar')!.after(markClone);
+
+    const panelClone = firstPanel.cloneNode(true) as Element;
+    panelClone.setAttribute('data-maidr-owned', 'true');
+    panelClone.setAttribute('visibility', 'hidden');
+    firstPanel.after(panelClone);
+
+    // Sanity: without filtering, both clones would match the bind selectors.
+    expect(doc.querySelectorAll('g.panel')).toHaveLength(3);
+
+    const second = bindD3Facets(svg, facetsConfig);
+
+    const secondGrid = subplotGrid(second.maidr.subplots);
+    expect(secondGrid[0]).toHaveLength(2);
+    expect(secondGrid[0].map(subplot => subplot.layers[0].selectors))
+      .toEqual(subplotGrid(first.maidr.subplots)[0].map(subplot => subplot.layers[0].selectors));
+    expect(secondGrid[0][0].layers[0].data).toEqual([{ x: 'p', y: 1 }]);
+    expect(secondGrid[0][1].layers[0].data).toEqual([{ x: 'p', y: 2 }]);
+  });
+
   test('errors from a panel mention the panel index', () => {
     const { svg, doc } = buildFacetSvg([
       { key: 'A', bars: [{ x: 'p', y: 1 }] },
@@ -399,7 +469,8 @@ describe('bindD3Subplots', () => {
 
     expect(subplots[0][0].layers[0].selectors).toBe('#composed [data-maidr-panel="0"] rect.bar');
     expect(subplots[0][1].layers[0].selectors).toBe('#composed [data-maidr-panel="1"] circle.dot');
-    expect(subplots[0][0].selector).toBe('#composed [data-maidr-panel="0"]');
+    // No subplot-level selector (see the facets test for the rationale).
+    expect(subplots[0][0].selector).toBeUndefined();
 
     expect(subplots[0][0].layers[0].data).toEqual([{ x: 'Q1', y: 10 }, { x: 'Q2', y: 20 }]);
     expect(subplots[0][1].layers[0].data).toHaveLength(3);
@@ -439,6 +510,53 @@ describe('bindD3Subplots', () => {
     expect(() => bindD3Subplots(svg, {
       subplots: [[{ chartType: 'bar', root: 'g.missing', config: { selector: 'rect.bar' } }]],
     })).toThrow(/no element found for panel root selector/);
+  });
+
+  test('throws when two entries resolve to the same panel root', () => {
+    const { svg } = buildHeterogeneousSvg();
+
+    // Flat array + layout: both entries name the same root selector.
+    expect(() => bindD3Subplots(svg, {
+      subplots: [
+        { chartType: 'bar', root: 'g.revenue', config: { selector: 'rect.bar', x: 'x', y: 'y' } },
+        { chartType: 'bar', root: 'g.revenue', config: { selector: 'rect.bar', x: 'x', y: 'y' } },
+      ],
+      layout: 'row',
+    })).toThrow(/entries 0 and 1 resolve to the same panel root/);
+
+    // Explicit 2D grid: same Element passed twice.
+    const panel = svg.querySelector('g.spread')!;
+    expect(() => bindD3Subplots(svg, {
+      subplots: [[
+        { chartType: 'scatter', root: panel, config: { selector: 'circle.dot', x: 'x', y: 'y' } },
+        { chartType: 'scatter', root: panel, config: { selector: 'circle.dot', x: 'x', y: 'y' } },
+      ]],
+    })).toThrow(/resolve to the same panel root/);
+  });
+
+  test('root selectors skip MAIDR-owned hidden clones', () => {
+    const { svg } = buildHeterogeneousSvg();
+
+    // A hidden clone of the revenue panel, inserted BEFORE the original so a
+    // naive querySelector would resolve the clone (whose marks carry no
+    // `__data__`).
+    const original = svg.querySelector('g.revenue')!;
+    const clone = original.cloneNode(true) as Element;
+    clone.setAttribute('data-maidr-owned', 'true');
+    clone.setAttribute('visibility', 'hidden');
+    svg.insertBefore(clone, original);
+
+    const result = bindD3Subplots(svg, {
+      subplots: [[
+        { chartType: 'bar', root: 'g.revenue', config: { selector: 'rect.bar', title: 'Revenue', x: 'x', y: 'y' } },
+      ]],
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots[0][0].layers[0].data).toEqual([{ x: 'Q1', y: 10 }, { x: 'Q2', y: 20 }]);
+    // The stamp landed on the original, not the owned clone.
+    expect(original.getAttribute('data-maidr-panel')).toBe('0');
+    expect(clone.getAttribute('data-maidr-panel')).toBeNull();
   });
 
   test('composes panel scoping with box part-attribute stamping', () => {
@@ -515,6 +633,81 @@ describe('core-model integration', () => {
       if (!state.empty) {
         expect(state.size).toBe(2);
       }
+    } finally {
+      if (previousDocument === undefined) {
+        delete globals.document;
+      } else {
+        globals.document = previousDocument;
+      }
+    }
+  });
+});
+
+describe('core-layout integration (skipped axes stamping)', () => {
+  function mockRect(el: Element, rect: { top: number; left: number }): void {
+    Object.defineProperty(el, 'getBoundingClientRect', {
+      value: () => ({
+        top: rect.top,
+        left: rect.left,
+        width: 100,
+        height: 100,
+        right: rect.left + 100,
+        bottom: rect.top + 100,
+        x: rect.left,
+        y: rect.top,
+      }),
+      configurable: true,
+    });
+  }
+
+  test('vertical order and inversion resolve from panel geometry when stamping is skipped', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'top', bars: [{ x: 'p', y: 1 }], id: 'user-id-panel' },
+      { key: 'bottom', bars: [{ x: 'p', y: 2 }] },
+    ]);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'column', // two grid ROWS, emitted top-first
+    });
+
+    // The foreign user id disables axes_* stamping for the whole figure...
+    const panels = Array.from(svg.querySelectorAll('g.panel'));
+    expect(panels[0].id).toBe('user-id-panel');
+    expect(panels[1].id).toBe('');
+
+    // ...so the core falls back to measuring the first element matched by
+    // each subplot's first layer selector. Verify the emitted selectors hand
+    // it an original mark inside the RIGHT panel — the condition under which
+    // resolveSubplotLayout can fix ordering/inversion without axes groups.
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(2);
+    const doc = svg.ownerDocument;
+    subplots.forEach((row, rowIndex) => {
+      const selector = row[0].layers[0].selectors as string;
+      const firstMatch = doc.querySelector(selector);
+      expect(firstMatch).not.toBeNull();
+      expect(panels[rowIndex].contains(firstMatch)).toBe(true);
+    });
+
+    // Give the marks real geometry (top-first, as rendered) and run the core
+    // layout pass end-to-end: Up must map to the visually upper panel.
+    mockRect(panels[0].querySelector('rect.bar')!, { top: 0, left: 0 });
+    mockRect(panels[1].querySelector('rect.bar')!, { top: 200, left: 0 });
+
+    const globals = globalThis as { document?: Document };
+    const previousDocument = globals.document;
+    globals.document = doc;
+    try {
+      const figure = new Figure(result.maidr);
+      const layout = resolveSubplotLayout(figure.subplots);
+
+      expect(layout.invertVertical).toBe(true);
+      expect(layout.topLeftRow).toBe(0);
+      expect(layout.visualOrderMap.get('0,0')).toBe(1);
+      expect(layout.visualOrderMap.get('1,0')).toBe(2);
     } finally {
       if (previousDocument === undefined) {
         delete globals.document;

--- a/test/adapters/d3/subplots.test.ts
+++ b/test/adapters/d3/subplots.test.ts
@@ -1,0 +1,552 @@
+import type { BoxSelector, MaidrSubplot } from '@type/grammar';
+import { bindD3Bar } from '@adapters/d3/binders/bar';
+import { bindD3Facets, bindD3Subplots } from '@adapters/d3/binders/subplots';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface BarDatum {
+  x: string;
+  y: number;
+}
+
+interface FacetPanelSpec {
+  key: string;
+  bars: BarDatum[];
+  transform?: string;
+  id?: string;
+}
+
+function setDatum(el: Element, datum: unknown): void {
+  (el as unknown as { __data__: unknown }).__data__ = datum;
+}
+
+/** Builds one SVG containing a `<g class="panel">` per spec, each holding `rect.bar` marks. */
+function buildFacetSvg(panels: FacetPanelSpec[]): { svg: SVGElement; doc: Document } {
+  const dom = new JSDOM(`<!doctype html><body><svg xmlns="${SVG_NS}" id="facet-svg"></svg></body>`);
+  const doc = dom.window.document as Document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+  for (const panel of panels) {
+    const group = doc.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'panel');
+    if (panel.transform) {
+      group.setAttribute('transform', panel.transform);
+    }
+    if (panel.id) {
+      group.setAttribute('id', panel.id);
+    }
+    // d3.groups-style datum: [key, values]
+    setDatum(group, [panel.key, panel.bars]);
+    for (const bar of panel.bars) {
+      const rect = doc.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('class', 'bar');
+      setDatum(rect, bar);
+      group.appendChild(rect);
+    }
+    svg.appendChild(group);
+  }
+
+  return { svg, doc };
+}
+
+function subplotGrid(maidrSubplots: unknown): MaidrSubplot[][] {
+  return maidrSubplots as MaidrSubplot[][];
+}
+
+describe('bindD3Facets', () => {
+  test('emits one subplot per panel with panel-scoped selectors and stamps', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }, { x: 'q', y: 2 }] },
+      { key: 'B', bars: [{ x: 'p', y: 3 }, { x: 'q', y: 4 }] },
+    ]);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: {
+        selector: 'rect.bar',
+        title: 'Faceted Bars',
+        axes: { x: 'X', y: 'Y' },
+        x: 'x',
+        y: 'y',
+      },
+      layout: 'row',
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0]).toHaveLength(2);
+    expect(result.layers).toHaveLength(2);
+
+    // Figure-level title comes from the inner config; panel names go on layers.
+    expect(result.maidr.title).toBe('Faceted Bars');
+    expect(subplots[0][0].layers[0].title).toBe('A');
+    expect(subplots[0][1].layers[0].title).toBe('B');
+
+    // Panel elements are stamped in grid order.
+    const panels = Array.from(svg.querySelectorAll('g.panel'));
+    expect(panels[0].getAttribute('data-maidr-panel')).toBe('0');
+    expect(panels[1].getAttribute('data-maidr-panel')).toBe('1');
+
+    // Layer selectors are anchored to the SVG id AND narrowed per panel.
+    expect(subplots[0][0].layers[0].selectors).toBe('#facet-svg [data-maidr-panel="0"] rect.bar');
+    expect(subplots[0][1].layers[0].selectors).toBe('#facet-svg [data-maidr-panel="1"] rect.bar');
+
+    // Subplot selector points at the panel container itself.
+    expect(subplots[0][0].selector).toBe('#facet-svg [data-maidr-panel="0"]');
+    expect(subplots[0][1].selector).toBe('#facet-svg [data-maidr-panel="1"]');
+
+    // Each panel's data is extracted from that panel only.
+    expect(subplots[0][0].layers[0].data).toEqual([{ x: 'p', y: 1 }, { x: 'q', y: 2 }]);
+    expect(subplots[0][1].layers[0].data).toEqual([{ x: 'p', y: 3 }, { x: 'q', y: 4 }]);
+
+    // Layer ids are unique across the whole figure.
+    expect(result.layers[0].id).not.toBe(result.layers[1].id);
+
+    // Panel selectors actually resolve to only their own panel's marks.
+    const doc = svg.ownerDocument;
+    expect(doc.querySelectorAll(subplots[0][0].layers[0].selectors as string)).toHaveLength(2);
+
+    // autoApply defaults to true: the schema lands on the SVG.
+    expect(svg.getAttribute('maidr-data')).toBe(JSON.stringify(result.maidr));
+  });
+
+  test('resolves panel titles via the panelTitle accessor with index fallback', () => {
+    const { svg } = buildFacetSvg([
+      { key: '4', bars: [{ x: 'p', y: 1 }] },
+      { key: '6', bars: [{ x: 'p', y: 2 }] },
+    ]);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      panelTitle: (d: unknown) => `cyl = ${(d as [string, BarDatum[]])[0]}`,
+      layout: 'row',
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots[0][0].layers[0].title).toBe('cyl = 4');
+    expect(subplots[0][1].layers[0].title).toBe('cyl = 6');
+  });
+
+  test('falls back to "Panel <n>" when a panel has no usable datum', () => {
+    const { svg } = buildFacetSvg([{ key: 'A', bars: [{ x: 'p', y: 1 }] }]);
+    // Overwrite the group datum with something the auto-detection cannot use.
+    setDatum(svg.querySelector('g.panel')!, 42);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'row',
+    });
+
+    expect(subplotGrid(result.maidr.subplots)[0][0].layers[0].title).toBe('Panel 1');
+  });
+
+  test('infers a 2x2 grid from translate transforms in visual reading order', () => {
+    // Appended in shuffled DOM order to prove geometry sorting.
+    const { svg } = buildFacetSvg([
+      { key: 'bottom-right', bars: [{ x: 'p', y: 4 }], transform: 'translate(300, 200)' },
+      { key: 'top-left', bars: [{ x: 'p', y: 1 }], transform: 'translate(0, 0)' },
+      { key: 'top-right', bars: [{ x: 'p', y: 2 }], transform: 'translate(300, 0)' },
+      { key: 'bottom-left', bars: [{ x: 'p', y: 3 }], transform: 'translate(0, 200)' },
+    ]);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(2);
+    expect(subplots[0]).toHaveLength(2);
+    expect(subplots[1]).toHaveLength(2);
+    const titles = subplots.map(row => row.map(subplot => subplot.layers[0].title));
+    expect(titles).toEqual([
+      ['top-left', 'top-right'],
+      ['bottom-left', 'bottom-right'],
+    ]);
+  });
+
+  test('honors an explicit ragged { columns } layout over geometry', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }] },
+      { key: 'B', bars: [{ x: 'p', y: 2 }] },
+      { key: 'C', bars: [{ x: 'p', y: 3 }] },
+    ]);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: { columns: 2 },
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(2);
+    expect(subplots[0]).toHaveLength(2);
+    expect(subplots[1]).toHaveLength(1); // ragged last row, never empty
+  });
+
+  test('layout "column" stacks panels one per row', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }] },
+      { key: 'B', bars: [{ x: 'p', y: 2 }] },
+    ]);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'column',
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(2);
+    expect(subplots[0]).toHaveLength(1);
+    expect(subplots[1]).toHaveLength(1);
+  });
+
+  test('stamps axes_* ids on anonymous <g> panels for core panel outlines', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }] },
+      { key: 'B', bars: [{ x: 'p', y: 2 }] },
+    ]);
+
+    bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'row',
+    });
+
+    const panels = Array.from(svg.querySelectorAll('g.panel'));
+    expect(panels[0].id).toBe('axes_facet-svg_0');
+    expect(panels[1].id).toBe('axes_facet-svg_1');
+  });
+
+  test('never overwrites user-assigned panel ids', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }], id: 'my-panel' },
+      { key: 'B', bars: [{ x: 'p', y: 2 }] },
+    ]);
+
+    bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'row',
+    });
+
+    const panels = Array.from(svg.querySelectorAll('g.panel'));
+    expect(panels[0].id).toBe('my-panel');
+    // All-or-nothing: a user id anywhere disables axes stamping entirely.
+    expect(panels[1].id).toBe('');
+  });
+
+  test('rebinding is idempotent (stamps and selectors are stable)', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }] },
+      { key: 'B', bars: [{ x: 'p', y: 2 }] },
+    ]);
+    const facetsConfig = {
+      panelSelector: 'g.panel',
+      chartType: 'bar' as const,
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'row' as const,
+    };
+
+    const first = bindD3Facets(svg, facetsConfig);
+    const second = bindD3Facets(svg, facetsConfig);
+
+    const panels = Array.from(svg.querySelectorAll('g.panel'));
+    expect(panels.map(panel => panel.getAttribute('data-maidr-panel'))).toEqual(['0', '1']);
+    expect(panels.map(panel => panel.id)).toEqual(['axes_facet-svg_0', 'axes_facet-svg_1']);
+
+    const firstSelectors = subplotGrid(first.maidr.subplots)[0].map(subplot => subplot.layers[0].selectors);
+    const secondSelectors = subplotGrid(second.maidr.subplots)[0].map(subplot => subplot.layers[0].selectors);
+    expect(secondSelectors).toEqual(firstSelectors);
+  });
+
+  test('errors from a panel mention the panel index', () => {
+    const { svg, doc } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }] },
+    ]);
+    // Second panel exists but holds no marks.
+    const empty = doc.createElementNS(SVG_NS, 'g');
+    empty.setAttribute('class', 'panel');
+    svg.appendChild(empty);
+
+    expect(() => bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+      layout: 'row',
+    })).toThrow(/panel 1/);
+  });
+
+  test('throws an actionable error when the panel selector matches nothing', () => {
+    const { svg } = buildFacetSvg([{ key: 'A', bars: [{ x: 'p', y: 1 }] }]);
+
+    expect(() => bindD3Facets(svg, {
+      panelSelector: 'g.nope',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', x: 'x', y: 'y' },
+    })).toThrow(/no panel elements found/);
+  });
+
+  test('composes panel scoping with line-path index stamping', () => {
+    const dom = new JSDOM(`<!doctype html><body><svg xmlns="${SVG_NS}" id="line-facets"></svg></body>`);
+    const doc = dom.window.document as Document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+    for (const panelKey of ['A', 'B']) {
+      const group = doc.createElementNS(SVG_NS, 'g');
+      group.setAttribute('class', 'panel');
+      setDatum(group, [panelKey, []]);
+      for (const series of ['s1', 's2']) {
+        const path = doc.createElementNS(SVG_NS, 'path');
+        path.setAttribute('class', 'line');
+        setDatum(path, [
+          { x: 1, y: 10, fill: `${panelKey}-${series}` },
+          { x: 2, y: 20, fill: `${panelKey}-${series}` },
+        ]);
+        group.appendChild(path);
+      }
+      svg.appendChild(group);
+    }
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'line',
+      config: { selector: 'path.line' },
+      layout: 'row',
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots[0][0].layers[0].selectors).toEqual([
+      '#line-facets [data-maidr-panel="0"] path.line[data-maidr-line-index="0"]',
+      '#line-facets [data-maidr-panel="0"] path.line[data-maidr-line-index="1"]',
+    ]);
+    expect(subplots[0][1].layers[0].selectors).toEqual([
+      '#line-facets [data-maidr-panel="1"] path.line[data-maidr-line-index="0"]',
+      '#line-facets [data-maidr-panel="1"] path.line[data-maidr-line-index="1"]',
+    ]);
+    // Per-panel legends survive.
+    expect(subplots[0][0].legend).toEqual(['A-s1', 'A-s2']);
+  });
+});
+
+describe('bindD3Subplots', () => {
+  function buildHeterogeneousSvg(): { svg: SVGElement; doc: Document } {
+    const dom = new JSDOM(`<!doctype html><body><svg xmlns="${SVG_NS}" id="composed"></svg></body>`);
+    const doc = dom.window.document as Document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+    const barPanel = doc.createElementNS(SVG_NS, 'g');
+    barPanel.setAttribute('class', 'revenue');
+    for (const datum of [{ x: 'Q1', y: 10 }, { x: 'Q2', y: 20 }]) {
+      const rect = doc.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('class', 'bar');
+      setDatum(rect, datum);
+      barPanel.appendChild(rect);
+    }
+    svg.appendChild(barPanel);
+
+    const scatterPanel = doc.createElementNS(SVG_NS, 'g');
+    scatterPanel.setAttribute('class', 'spread');
+    for (const datum of [{ x: 1, y: 2 }, { x: 3, y: 4 }, { x: 5, y: 6 }]) {
+      const circle = doc.createElementNS(SVG_NS, 'circle');
+      circle.setAttribute('class', 'dot');
+      setDatum(circle, datum);
+      scatterPanel.appendChild(circle);
+    }
+    svg.appendChild(scatterPanel);
+
+    return { svg, doc };
+  }
+
+  test('composes different chart types into an explicit 2D grid', () => {
+    const { svg } = buildHeterogeneousSvg();
+
+    const result = bindD3Subplots(svg, {
+      title: 'Sales Overview',
+      subplots: [[
+        { chartType: 'bar', root: 'g.revenue', config: { selector: 'rect.bar', title: 'Revenue', x: 'x', y: 'y' } },
+        { chartType: 'scatter', root: 'g.spread', config: { selector: 'circle.dot', title: 'Spread', x: 'x', y: 'y' } },
+      ]],
+    });
+
+    expect(result.maidr.title).toBe('Sales Overview');
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0]).toHaveLength(2);
+
+    expect(subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+    expect(subplots[0][1].layers[0].type).toBe(TraceType.SCATTER);
+    expect(subplots[0][0].layers[0].title).toBe('Revenue');
+    expect(subplots[0][1].layers[0].title).toBe('Spread');
+
+    expect(subplots[0][0].layers[0].selectors).toBe('#composed [data-maidr-panel="0"] rect.bar');
+    expect(subplots[0][1].layers[0].selectors).toBe('#composed [data-maidr-panel="1"] circle.dot');
+    expect(subplots[0][0].selector).toBe('#composed [data-maidr-panel="0"]');
+
+    expect(subplots[0][0].layers[0].data).toEqual([{ x: 'Q1', y: 10 }, { x: 'Q2', y: 20 }]);
+    expect(subplots[0][1].layers[0].data).toHaveLength(3);
+
+    expect(result.layers.map(layer => layer.type)).toEqual([TraceType.BAR, TraceType.SCATTER]);
+    expect(svg.getAttribute('maidr-data')).toBe(JSON.stringify(result.maidr));
+  });
+
+  test('accepts Element roots and a flat array with layout "column"', () => {
+    const { svg } = buildHeterogeneousSvg();
+    const barPanel = svg.querySelector('g.revenue')!;
+    const scatterPanel = svg.querySelector('g.spread')!;
+
+    const result = bindD3Subplots(svg, {
+      subplots: [
+        { chartType: 'bar', root: barPanel, config: { selector: 'rect.bar', title: 'Revenue', x: 'x', y: 'y' } },
+        { chartType: 'scatter', root: scatterPanel, config: { selector: 'circle.dot', x: 'x', y: 'y' } },
+      ],
+      layout: 'column',
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(2);
+    expect(subplots[0]).toHaveLength(1);
+    expect(subplots[1]).toHaveLength(1);
+    // Untitled panels fall back to a positional display name.
+    expect(subplots[1][0].layers[0].title).toBe('Panel 2');
+  });
+
+  test('rejects empty rows and unresolvable roots', () => {
+    const { svg } = buildHeterogeneousSvg();
+
+    expect(() => bindD3Subplots(svg, {
+      subplots: [[]],
+    })).toThrow(/row 0 .* is empty/);
+
+    expect(() => bindD3Subplots(svg, {
+      subplots: [[{ chartType: 'bar', root: 'g.missing', config: { selector: 'rect.bar' } }]],
+    })).toThrow(/no element found for panel root selector/);
+  });
+
+  test('composes panel scoping with box part-attribute stamping', () => {
+    const dom = new JSDOM(`<!doctype html><body><svg xmlns="${SVG_NS}" id="box-grid"></svg></body>`);
+    const doc = dom.window.document as Document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+    const panel = doc.createElementNS(SVG_NS, 'g');
+    panel.setAttribute('class', 'left');
+    const boxGroup = doc.createElementNS(SVG_NS, 'g');
+    boxGroup.setAttribute('class', 'box');
+    setDatum(boxGroup, { fill: 'A', min: 1, q1: 2, q2: 3, q3: 4, max: 5 });
+
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', '50');
+    rect.setAttribute('y', '50');
+    rect.setAttribute('width', '20');
+    rect.setAttribute('height', '20');
+    boxGroup.appendChild(rect);
+    const median = doc.createElementNS(SVG_NS, 'line');
+    median.setAttribute('x1', '50');
+    median.setAttribute('y1', '60');
+    median.setAttribute('x2', '70');
+    median.setAttribute('y2', '60');
+    boxGroup.appendChild(median);
+    panel.appendChild(boxGroup);
+    svg.appendChild(panel);
+
+    const result = bindD3Subplots(svg, {
+      subplots: [[{ chartType: 'box', root: 'g.left', config: { selector: 'g.box', title: 'Left' } }]],
+    });
+
+    const selectors = subplotGrid(result.maidr.subplots)[0][0].layers[0].selectors as BoxSelector[];
+    expect(selectors).toHaveLength(1);
+    expect(selectors[0].iq).toBe(
+      '#box-grid [data-maidr-panel="0"] g.box[data-maidr-box-index="0"] [data-maidr-box-part="iq"]',
+    );
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted multi-panel Maidr constructs a navigable Figure', () => {
+    const { svg } = buildFacetSvg([
+      { key: 'A', bars: [{ x: 'p', y: 1 }, { x: 'q', y: 2 }] },
+      { key: 'B', bars: [{ x: 'p', y: 3 }, { x: 'q', y: 4 }] },
+    ]);
+
+    const result = bindD3Facets(svg, {
+      panelSelector: 'g.panel',
+      chartType: 'bar',
+      config: { selector: 'rect.bar', title: 'Faceted Bars', x: 'x', y: 'y' },
+      layout: 'row',
+    });
+
+    // The model resolves selectors via the page-global `document`; point it
+    // at this test's JSDOM document for the duration of the assertion.
+    const globals = globalThis as { document?: Document };
+    const previousDocument = globals.document;
+    globals.document = svg.ownerDocument;
+    try {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state).toMatchObject({ size: 2 });
+      const summaries = figure.getSubplotSummaries();
+      expect(summaries).toHaveLength(2);
+      expect(summaries.map(summary => summary.title)).toEqual(['A', 'B']);
+      expect(summaries.map(summary => summary.traceTypes)).toEqual([['bar'], ['bar']]);
+
+      // Reading the state exercises Subplot/Trace construction end-to-end
+      // (this is exactly what crashes on empty subplots or bad selectors).
+      const state = figure.state;
+      expect(state.empty).toBe(false);
+      if (!state.empty) {
+        expect(state.size).toBe(2);
+      }
+    } finally {
+      if (previousDocument === undefined) {
+        delete globals.document;
+      } else {
+        globals.document = previousDocument;
+      }
+    }
+  });
+});
+
+describe('single-panel regression', () => {
+  test('bindD3Bar still emits a 1x1 grid with an unpanelled selector', () => {
+    const dom = new JSDOM(`<!doctype html><body><svg xmlns="${SVG_NS}" id="solo"></svg></body>`);
+    const doc = dom.window.document as Document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+    for (const datum of [{ x: 'a', y: 1 }, { x: 'b', y: 2 }]) {
+      const rect = doc.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('class', 'bar');
+      setDatum(rect, datum);
+      svg.appendChild(rect);
+    }
+
+    const result = bindD3Bar(svg, { selector: 'rect.bar', title: 'Solo', x: 'x', y: 'y' });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0]).toHaveLength(1);
+    expect(subplots[0][0].layers).toEqual([result.layer]);
+    expect(subplots[0][0].selector).toBeUndefined();
+    expect(result.layer.selectors).toBe('#solo rect.bar');
+    expect(result.layer.title).toBe('Solo');
+    expect(result.maidr.title).toBe('Solo');
+    expect(svg.getAttribute('maidr-data')).toBe(JSON.stringify(result.maidr));
+  });
+});

--- a/test/adapters/frappe/converters.test.ts
+++ b/test/adapters/frappe/converters.test.ts
@@ -1,0 +1,284 @@
+import type { FrappeChart, FrappePanel } from '@adapters/frappe/types';
+import type { BarPoint, MaidrLayer } from '@type/grammar';
+import { createMaidrFromFrappeChart, createMaidrFromFrappeCharts } from '@adapters/frappe/converters';
+import { TraceType } from '@type/grammar';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Tests only use the public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+/** A minimal chart stub — the adapter only reads `chart.data`. */
+function makeChart(values: number[] = [10, 20, 30], name = 'Series'): FrappeChart {
+  return {
+    data: {
+      labels: ['A', 'B', 'C'].slice(0, values.length),
+      datasets: [{ name, values }],
+    },
+  };
+}
+
+/** Builds a wrapper element containing `count` panel containers. */
+function makeDom(count: number): { wrapper: HTMLElement; containers: HTMLElement[] } {
+  const dom = new JSDOM('<!doctype html><html><body><div id="wrapper"></div></body></html>');
+  const document = dom.window.document;
+  const wrapper = document.getElementById('wrapper') as HTMLElement;
+  const containers: HTMLElement[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const container = document.createElement('div');
+    wrapper.appendChild(container);
+    containers.push(container);
+  }
+  return { wrapper, containers };
+}
+
+function panel(container: HTMLElement, title?: string, values?: number[]): FrappePanel {
+  return {
+    chart: makeChart(values),
+    container,
+    chartType: 'bar',
+    ...(title ? { title } : {}),
+  };
+}
+
+describe('createMaidrFromFrappeChart (single chart)', () => {
+  it('produces an unchanged 1x1 figure without a subplot selector or layer title', () => {
+    const { containers } = makeDom(1);
+    const container = containers[0];
+    container.id = 'chart';
+
+    const maidr = createMaidrFromFrappeChart(makeChart(), container, {
+      chartType: 'bar',
+      title: 'My Chart',
+      axes: { x: 'Category', y: 'Value' },
+    });
+
+    expect(maidr.id).toBe('chart');
+    expect(maidr.title).toBe('My Chart');
+    expect(maidr.subplots).toHaveLength(1);
+    expect(maidr.subplots[0]).toHaveLength(1);
+
+    const subplot = maidr.subplots[0][0];
+    expect(subplot.selector).toBeUndefined();
+    expect(subplot.layers).toHaveLength(1);
+
+    const layer = subplot.layers[0];
+    expect(layer.type).toBe(TraceType.BAR);
+    expect(layer.title).toBeUndefined();
+    expect(layer.selectors).toBe('#chart svg.frappe-chart .dataset-units.dataset-bars.dataset-0 rect.bar');
+    expect(layer.axes).toEqual({ x: { label: 'Category' }, y: { label: 'Value' } });
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'A', y: 10 },
+      { x: 'B', y: 20 },
+      { x: 'C', y: 30 },
+    ]);
+  });
+
+  it('generates a container id when missing and uses it as the figure id', () => {
+    const { containers } = makeDom(1);
+    const container = containers[0];
+
+    const maidr = createMaidrFromFrappeChart(makeChart(), container, { chartType: 'bar' });
+
+    expect(container.id).not.toBe('');
+    expect(maidr.id).toBe(container.id);
+    expect(maidr.subplots[0][0].layers[0].selectors)
+      .toBe(`#${container.id} svg.frappe-chart .dataset-units.dataset-bars.dataset-0 rect.bar`);
+  });
+});
+
+describe('createMaidrFromFrappeCharts (multi-panel)', () => {
+  it('maps a 2D panel grid 1:1 to subplots, allowing ragged rows', () => {
+    const { wrapper, containers } = makeDom(3);
+
+    const maidr = createMaidrFromFrappeCharts(
+      [
+        [panel(containers[0], 'North'), panel(containers[1], 'South')],
+        [panel(containers[2], 'East')],
+      ],
+      wrapper,
+    );
+
+    expect(maidr.subplots).toHaveLength(2);
+    expect(maidr.subplots[0]).toHaveLength(2);
+    expect(maidr.subplots[1]).toHaveLength(1);
+  });
+
+  it('places a flat panel array in a single row when columns is omitted', () => {
+    const { wrapper, containers } = makeDom(3);
+
+    const maidr = createMaidrFromFrappeCharts(containers.map(c => panel(c)), wrapper);
+
+    expect(maidr.subplots).toHaveLength(1);
+    expect(maidr.subplots[0]).toHaveLength(3);
+  });
+
+  it('chunks a flat panel array into rows of `columns` panels (row-major)', () => {
+    const { wrapper, containers } = makeDom(3);
+
+    const maidr = createMaidrFromFrappeCharts(
+      [panel(containers[0], 'A'), panel(containers[1], 'B'), panel(containers[2], 'C')],
+      wrapper,
+      { columns: 2 },
+    );
+
+    expect(maidr.subplots).toHaveLength(2);
+    expect(maidr.subplots[0]).toHaveLength(2);
+    expect(maidr.subplots[1]).toHaveLength(1);
+    expect(maidr.subplots[0][0].layers[0].title).toBe('A');
+    expect(maidr.subplots[0][1].layers[0].title).toBe('B');
+    expect(maidr.subplots[1][0].layers[0].title).toBe('C');
+  });
+
+  it('scopes each panel\'s layer selectors and subplot selector to its own container id', () => {
+    const { wrapper, containers } = makeDom(2);
+
+    const maidr = createMaidrFromFrappeCharts(
+      [[panel(containers[0]), panel(containers[1])]],
+      wrapper,
+    );
+
+    const [first, second] = maidr.subplots[0];
+    const firstId = containers[0].id;
+    const secondId = containers[1].id;
+
+    expect(firstId).not.toBe('');
+    expect(secondId).not.toBe('');
+    expect(firstId).not.toBe(secondId);
+
+    expect(first.selector).toBe(`#${firstId} svg.frappe-chart`);
+    expect(second.selector).toBe(`#${secondId} svg.frappe-chart`);
+    expect(first.layers[0].selectors)
+      .toBe(`#${firstId} svg.frappe-chart .dataset-units.dataset-bars.dataset-0 rect.bar`);
+    expect(second.layers[0].selectors)
+      .toBe(`#${secondId} svg.frappe-chart .dataset-units.dataset-bars.dataset-0 rect.bar`);
+  });
+
+  it('puts the panel title on the first layer only', () => {
+    const { wrapper, containers } = makeDom(1);
+    const mixed: FrappePanel = {
+      chart: {
+        data: {
+          labels: ['A', 'B'],
+          datasets: [
+            { name: 'Sales', chartType: 'bar', values: [1, 2] },
+            { name: 'Trend', chartType: 'line', values: [3, 4] },
+          ],
+        },
+      },
+      container: containers[0],
+      chartType: 'axis-mixed',
+      title: 'Store One',
+    };
+
+    const maidr = createMaidrFromFrappeCharts([[mixed]], wrapper);
+    const layers = maidr.subplots[0][0].layers;
+
+    expect(layers).toHaveLength(2);
+    expect(layers[0].title).toBe('Store One');
+    expect(layers[1].title).toBe('Trend');
+  });
+
+  it('assigns figure-unique layer ids across all panels', () => {
+    const { wrapper, containers } = makeDom(4);
+
+    const maidr = createMaidrFromFrappeCharts(
+      [
+        [panel(containers[0]), panel(containers[1])],
+        [panel(containers[2]), panel(containers[3])],
+      ],
+      wrapper,
+    );
+
+    const ids = maidr.subplots
+      .flat()
+      .flatMap(subplot => subplot.layers.map((layer: MaidrLayer) => layer.id));
+    expect(ids).toHaveLength(4);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('uses the wrapper id as the figure id, generating one when missing', () => {
+    const { wrapper, containers } = makeDom(1);
+    wrapper.removeAttribute('id');
+
+    const maidr = createMaidrFromFrappeCharts([[panel(containers[0])]], wrapper);
+
+    expect(wrapper.id).not.toBe('');
+    expect(maidr.id).toBe(wrapper.id);
+  });
+
+  it('honors figure-level options', () => {
+    const { wrapper, containers } = makeDom(1);
+
+    const maidr = createMaidrFromFrappeCharts([[panel(containers[0])]], wrapper, {
+      id: 'dashboard',
+      title: 'Dashboard',
+      subtitle: 'Q1',
+      caption: 'Source: internal',
+    });
+
+    expect(maidr.id).toBe('dashboard');
+    expect(maidr.title).toBe('Dashboard');
+    expect(maidr.subtitle).toBe('Q1');
+    expect(maidr.caption).toBe('Source: internal');
+  });
+
+  it('emits a per-panel legend for multi-line panels', () => {
+    const { wrapper, containers } = makeDom(1);
+    const multiLine: FrappePanel = {
+      chart: {
+        data: {
+          labels: ['A', 'B'],
+          datasets: [
+            { name: 'One', values: [1, 2] },
+            { name: 'Two', values: [3, 4] },
+          ],
+        },
+      },
+      container: containers[0],
+      chartType: 'line',
+      title: 'Lines',
+    };
+
+    const maidr = createMaidrFromFrappeCharts([[multiLine]], wrapper);
+
+    expect(maidr.subplots[0][0].legend).toEqual(['One', 'Two']);
+  });
+
+  it('throws for an empty panel grid', () => {
+    const { wrapper } = makeDom(0);
+
+    expect(() => createMaidrFromFrappeCharts([], wrapper)).toThrow('at least one panel');
+  });
+
+  it('throws for an empty row in a 2D grid', () => {
+    const { wrapper, containers } = makeDom(1);
+
+    expect(() => createMaidrFromFrappeCharts([[panel(containers[0])], []], wrapper))
+      .toThrow('row 1 is empty');
+  });
+
+  it('throws for a non-positive or fractional columns value', () => {
+    const { wrapper, containers } = makeDom(1);
+
+    expect(() => createMaidrFromFrappeCharts([panel(containers[0])], wrapper, { columns: 0 }))
+      .toThrow('columns');
+    expect(() => createMaidrFromFrappeCharts([panel(containers[0])], wrapper, { columns: 1.5 }))
+      .toThrow('columns');
+  });
+
+  it('throws when a panel container is not a descendant of the wrapper', () => {
+    const { wrapper, containers } = makeDom(1);
+    const outside = wrapper.ownerDocument.createElement('div');
+    wrapper.ownerDocument.body.appendChild(outside);
+
+    expect(() =>
+      createMaidrFromFrappeCharts([[panel(containers[0]), panel(outside)]], wrapper),
+    ).toThrow('descendant of the wrapper');
+  });
+
+  it('throws when a panel container is the wrapper itself', () => {
+    const { wrapper } = makeDom(0);
+
+    expect(() => createMaidrFromFrappeCharts([[panel(wrapper)]], wrapper))
+      .toThrow('descendant of the wrapper');
+  });
+});

--- a/test/adapters/frappe/converters.test.ts
+++ b/test/adapters/frappe/converters.test.ts
@@ -128,7 +128,7 @@ describe('createMaidrFromFrappeCharts (multi-panel)', () => {
     expect(maidr.subplots[1][0].layers[0].title).toBe('C');
   });
 
-  it('scopes each panel\'s layer selectors and subplot selector to its own container id', () => {
+  it('scopes each panel\'s layer selectors to its own container id, without a subplot selector', () => {
     const { wrapper, containers } = makeDom(2);
 
     const maidr = createMaidrFromFrappeCharts(
@@ -144,8 +144,13 @@ describe('createMaidrFromFrappeCharts (multi-panel)', () => {
     expect(secondId).not.toBe('');
     expect(firstId).not.toBe(secondId);
 
-    expect(first.selector).toBe(`#${firstId} svg.frappe-chart`);
-    expect(second.selector).toBe(`#${secondId} svg.frappe-chart`);
+    // No subplot selector: the core would clone its match as a hidden
+    // sibling, and Frappe's only whole-panel element is the top-level
+    // `svg.frappe-chart` in HTML flow — its clone would double the panel's
+    // height on every focus. Panel geometry is resolved from the first layer
+    // selector instead (see multiPanelLayout.test.ts).
+    expect(first.selector).toBeUndefined();
+    expect(second.selector).toBeUndefined();
     expect(first.layers[0].selectors)
       .toBe(`#${firstId} svg.frappe-chart .dataset-units.dataset-bars.dataset-0 rect.bar`);
     expect(second.layers[0].selectors)

--- a/test/adapters/frappe/multiPanelLayout.test.ts
+++ b/test/adapters/frappe/multiPanelLayout.test.ts
@@ -1,0 +1,194 @@
+import type { FrappeChart, FrappePanel } from '@adapters/frappe/types';
+import type { Subplot } from '@model/plot';
+import type { MaidrSubplot } from '@type/grammar';
+import { createMaidrFromFrappeCharts } from '@adapters/frappe/converters';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+/**
+ * Contract test for the multi-panel visual-layout pipeline.
+ *
+ * `resolveSubplotLayout` (src/util/subplotLayout.ts) can only compute the
+ * visual ordering and vertical-inversion flag for a multi-row grid when every
+ * emitted subplot resolves to a real, measurable per-panel DOM element —
+ * either via `MaidrSubplot.selector` or via the first layer's first selector.
+ * The Frappe adapter documents rows in visual reading order (top row first),
+ * so without that geometry the core's data-order fallback would leave the
+ * Up/Down arrow keys inverted (MovableGrid maps UPWARD to row + 1).
+ *
+ * The Frappe adapter deliberately emits NO subplot selector (a hidden clone
+ * of the whole `svg.frappe-chart` would double each panel's height on focus),
+ * so these tests pin the fallback side of the contract: each panel's first
+ * layer selector must resolve to an element inside that panel, and feeding
+ * those elements through the core layout pass must yield
+ * `invertVertical: true` with reading-order subplot numbering.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const globals = globalThis as unknown as { document?: Document };
+let savedDocument: Document | undefined;
+let dom: JSDOM;
+
+beforeEach(() => {
+  savedDocument = globals.document;
+  dom = new JSDOM('<!doctype html><body><div id="dashboard"></div></body>');
+  globals.document = dom.window.document as Document;
+});
+
+afterEach(() => {
+  globals.document = savedDocument;
+});
+
+const VALUES = [10, 20, 30];
+
+function makeChart(values: number[] = VALUES, name = 'Series'): FrappeChart {
+  return {
+    data: {
+      labels: ['A', 'B', 'C'].slice(0, values.length),
+      datasets: [{ name, values }],
+    },
+  };
+}
+
+/**
+ * Builds one rendered panel inside `wrapper`, mimicking the Frappe v1.6.2 SVG
+ * structure the adapter's selectors target: `svg.frappe-chart` containing a
+ * `g.dataset-units.dataset-{bars|line}.dataset-0` group with one mark
+ * (`rect.bar` or `circle`) per data point.
+ */
+function makePanel(
+  wrapper: HTMLElement,
+  chartType: 'bar' | 'line',
+  title: string,
+): FrappePanel {
+  const doc = wrapper.ownerDocument;
+  const container = doc.createElement('div');
+  wrapper.appendChild(container);
+
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'frappe-chart chart');
+  container.appendChild(svg);
+
+  const group = doc.createElementNS(SVG_NS, 'g');
+  group.setAttribute(
+    'class',
+    chartType === 'bar'
+      ? 'dataset-units dataset-bars dataset-0'
+      : 'dataset-units dataset-line dataset-0',
+  );
+  svg.appendChild(group);
+
+  VALUES.forEach(() => {
+    const mark = chartType === 'bar'
+      ? doc.createElementNS(SVG_NS, 'rect')
+      : doc.createElementNS(SVG_NS, 'circle');
+    if (chartType === 'bar') {
+      mark.setAttribute('class', 'bar');
+    }
+    group.appendChild(mark);
+  });
+
+  return { chart: makeChart(), container, chartType, title };
+}
+
+/**
+ * Extracts the first layer's first selector string exactly as the core does
+ * (`Subplot` constructor, src/model/plot.ts) before handing it to
+ * `resolveSubplotLayout` as the panel-geometry fallback.
+ */
+function firstLayerSelector(subplot: MaidrSubplot): string {
+  const selectors = subplot.layers[0].selectors;
+  const first = typeof selectors === 'string'
+    ? selectors
+    : Array.isArray(selectors) && typeof selectors[0] === 'string'
+      ? selectors[0]
+      : null;
+  expect(first).not.toBeNull();
+  return first as string;
+}
+
+function mockRect(el: Element, rect: { top: number; left: number }): void {
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({
+      top: rect.top,
+      left: rect.left,
+      width: 20,
+      height: 20,
+      right: rect.left + 20,
+      bottom: rect.top + 20,
+      x: rect.left,
+      y: rect.top,
+    }),
+    configurable: true,
+  });
+}
+
+function make2x2Grid(wrapper: HTMLElement): FrappePanel[][] {
+  return [
+    [makePanel(wrapper, 'bar', 'top-left'), makePanel(wrapper, 'line', 'top-right')],
+    [makePanel(wrapper, 'line', 'bottom-left'), makePanel(wrapper, 'bar', 'bottom-right')],
+  ];
+}
+
+describe('createMaidrFromFrappeCharts × resolveSubplotLayout (vertical navigation)', () => {
+  it('resolves each panel\'s first layer selector to an element inside that panel', () => {
+    const wrapper = document.getElementById('dashboard') as HTMLElement;
+    const grid = make2x2Grid(wrapper);
+
+    const maidr = createMaidrFromFrappeCharts(grid, wrapper);
+
+    maidr.subplots.forEach((row, r) => row.forEach((subplot, c) => {
+      // No subplot selector — a hidden clone of the whole panel <svg> would
+      // corrupt the page layout (see converters.test.ts).
+      expect(subplot.selector).toBeUndefined();
+
+      // Fallback contract: the first layer's first selector resolves to a
+      // mark inside this panel's own container, giving the core layout pass
+      // real per-panel geometry.
+      const element = document.querySelector(firstLayerSelector(subplot));
+      expect(element).not.toBeNull();
+      expect(grid[r][c].container.contains(element)).toBe(true);
+    }));
+  });
+
+  it('drives the core layout pass to inverted vertical keys and reading-order numbering', () => {
+    const wrapper = document.getElementById('dashboard') as HTMLElement;
+    const grid = make2x2Grid(wrapper);
+
+    const maidr = createMaidrFromFrappeCharts(grid, wrapper);
+
+    // Give each panel's first mark the geometry of a 2x2 CSS grid (rows in
+    // visual reading order, matching the adapter's documented emission order).
+    const rects = [
+      [{ top: 40, left: 10 }, { top: 40, left: 310 }],
+      [{ top: 340, left: 10 }, { top: 340, left: 310 }],
+    ];
+    const subplots: Subplot[][] = maidr.subplots.map((row, r) => row.map((subplot, c) => {
+      const selector = firstLayerSelector(subplot);
+      const el = document.querySelector(selector) as SVGElement;
+      mockRect(el, rects[r][c]);
+      // Stand-in exposing the two accessors the layout utility consumes; the
+      // real Subplot emits no highlight element (no subplot selector) and
+      // caches the same first layer selector string.
+      return {
+        getHighlightElement: () => null,
+        getLayerSelector: () => selector,
+      } as unknown as Subplot;
+    }));
+
+    const layout = resolveSubplotLayout(subplots);
+
+    // With top-first rows, UPWARD (row + 1 in MovableGrid) must be inverted
+    // so the Up arrow moves visually up.
+    expect(layout.invertVertical).toBe(true);
+    expect(layout.topLeftRow).toBe(0);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('0,1')).toBe(2);
+    expect(layout.visualOrderMap.get('1,0')).toBe(3);
+    expect(layout.visualOrderMap.get('1,1')).toBe(4);
+  });
+});

--- a/test/adapters/google-charts/multiPanel.test.ts
+++ b/test/adapters/google-charts/multiPanel.test.ts
@@ -1,0 +1,418 @@
+import type {
+  GoogleChartPanel,
+  GoogleChartsGridOptions,
+} from '@adapters/google-charts/converters';
+import type {
+  GoogleBoundingBox,
+  GoogleChart,
+  GoogleDataTable,
+  GoogleEvents,
+} from '@adapters/google-charts/types';
+import type { BarPoint } from '@type/grammar';
+import {
+  createMaidrFromGoogleChart,
+  createMaidrFromGoogleCharts,
+  whenGoogleChartsReady,
+} from '@adapters/google-charts/converters';
+import { describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+type BarRow = [string, number];
+
+/** Minimal DataTable fake for a two-column (label, value) bar chart. */
+function makeBarDataTable(rows: BarRow[], labels: [string, string] = ['Day', 'Tips']): GoogleDataTable {
+  return {
+    getNumberOfRows: () => rows.length,
+    getNumberOfColumns: () => 2,
+    getValue: (r, c) => rows[r][c],
+    getFormattedValue: (r, c) => String(rows[r][c]),
+    getColumnLabel: c => labels[c],
+    getColumnType: c => (c === 0 ? 'string' : 'number'),
+  };
+}
+
+/**
+ * Builds one rendered bar-chart panel: a container div (appended to `parent`)
+ * holding an SVG with one rect per data row, plus a chart fake whose layout
+ * interface reports bounding boxes matching those rects.
+ */
+function makeBarPanel(
+  doc: Document,
+  parent: HTMLElement,
+  rows: BarRow[],
+  title?: string,
+  labels?: [string, string],
+): GoogleChartPanel {
+  const container = doc.createElement('div');
+  parent.appendChild(container);
+
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+  const group = doc.createElementNS(SVG_NS, 'g');
+  group.setAttribute('clip-path', 'url(#clip)');
+  svg.appendChild(group);
+
+  const bboxes = new Map<string, GoogleBoundingBox>();
+  rows.forEach(([, value], i) => {
+    const bbox: GoogleBoundingBox = { left: i * 30, top: 100 - value, width: 20, height: value };
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', String(bbox.left));
+    rect.setAttribute('y', String(bbox.top));
+    rect.setAttribute('width', String(bbox.width));
+    rect.setAttribute('height', String(bbox.height));
+    group.appendChild(rect);
+    bboxes.set(`bar#0#${i}`, bbox);
+  });
+
+  const chart: GoogleChart = {
+    getSelection: () => [],
+    setSelection: () => {},
+    getChartLayoutInterface: () => ({
+      getBoundingBox: id => bboxes.get(id) ?? null,
+      getXLocation: () => 0,
+      getYLocation: () => 0,
+    }),
+  };
+
+  return {
+    chart,
+    dataTable: makeBarDataTable(rows, labels),
+    container,
+    chartType: 'ColumnChart',
+    ...(title ? { title } : {}),
+  };
+}
+
+/** Creates a fresh document with a `root` wrapper for panel containers. */
+function makeRoot(): { doc: Document; root: HTMLElement } {
+  const dom = new JSDOM('<!doctype html><body><div id="grid"></div></body>');
+  const doc = dom.window.document as Document;
+  const root = doc.getElementById('grid') as HTMLElement;
+  return { doc, root };
+}
+
+/** Stubs `getBoundingClientRect` so geometry-based row clustering can run in jsdom. */
+function mockRect(el: HTMLElement, top: number, left: number): void {
+  el.getBoundingClientRect = () => ({
+    top,
+    left,
+    right: left + 100,
+    bottom: top + 100,
+    width: 100,
+    height: 100,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+const ROWS_A: BarRow[] = [['Sat', 40], ['Sun', 60]];
+const ROWS_B: BarRow[] = [['Sat', 10], ['Sun', 20], ['Mon', 30]];
+
+describe('createMaidrFromGoogleCharts', () => {
+  it('uses a 2D panel array directly as the subplot grid, allowing ragged rows', () => {
+    const { doc, root } = makeRoot();
+    const panels = [
+      [makeBarPanel(doc, root, ROWS_A), makeBarPanel(doc, root, ROWS_B)],
+      [makeBarPanel(doc, root, ROWS_A)],
+    ];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root });
+
+    expect(maidr.subplots).toHaveLength(2);
+    expect(maidr.subplots[0]).toHaveLength(2);
+    expect(maidr.subplots[1]).toHaveLength(1);
+    expect(maidr.subplots[0][0].layers).toHaveLength(1);
+    expect(maidr.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+  });
+
+  it('chunks a flat panel array row-major with layout.columns', () => {
+    const { doc, root } = makeRoot();
+    const panels = [
+      makeBarPanel(doc, root, ROWS_A, 'A'),
+      makeBarPanel(doc, root, ROWS_A, 'B'),
+      makeBarPanel(doc, root, ROWS_A, 'C'),
+    ];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root, layout: { columns: 2 } });
+
+    expect(maidr.subplots).toHaveLength(2);
+    expect(maidr.subplots[0]).toHaveLength(2);
+    expect(maidr.subplots[1]).toHaveLength(1);
+    expect(maidr.subplots[1][0].layers[0].title).toBe('C');
+  });
+
+  it('derives columns from layout.rows when columns is omitted', () => {
+    const { doc, root } = makeRoot();
+    const panels = [
+      makeBarPanel(doc, root, ROWS_A, 'A'),
+      makeBarPanel(doc, root, ROWS_A, 'B'),
+      makeBarPanel(doc, root, ROWS_A, 'C'),
+      makeBarPanel(doc, root, ROWS_A, 'D'),
+    ];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root, layout: { rows: 2 } });
+
+    expect(maidr.subplots).toHaveLength(2);
+    expect(maidr.subplots[0]).toHaveLength(2);
+    expect(maidr.subplots[1]).toHaveLength(2);
+    expect(maidr.subplots[1][0].layers[0].title).toBe('C');
+  });
+
+  it('infers the grid from container geometry when no layout is given', () => {
+    const { doc, root } = makeRoot();
+    // Provide panels out of reading order; geometry should reorder them.
+    const bottomRight = makeBarPanel(doc, root, ROWS_A, 'bottom-right');
+    const topRight = makeBarPanel(doc, root, ROWS_A, 'top-right');
+    const topLeft = makeBarPanel(doc, root, ROWS_A, 'top-left');
+    const bottomLeft = makeBarPanel(doc, root, ROWS_A, 'bottom-left');
+    mockRect(topLeft.container, 0, 0);
+    mockRect(topRight.container, 3, 200); // within row tolerance of topLeft
+    mockRect(bottomLeft.container, 300, 0);
+    mockRect(bottomRight.container, 300, 200);
+
+    const maidr = createMaidrFromGoogleCharts(
+      [bottomRight, topRight, topLeft, bottomLeft],
+      { root },
+    );
+
+    expect(maidr.subplots).toHaveLength(2);
+    const titles = maidr.subplots.map(row => row.map(subplot => subplot.layers[0].title));
+    expect(titles).toEqual([
+      ['top-left', 'top-right'],
+      ['bottom-left', 'bottom-right'],
+    ]);
+  });
+
+  it('scopes each panel to its own container: unique ids, layer selectors, and subplot selector', () => {
+    const { doc, root } = makeRoot();
+    const panelA = makeBarPanel(doc, root, ROWS_A);
+    const panelB = makeBarPanel(doc, root, ROWS_B);
+
+    const maidr = createMaidrFromGoogleCharts([[panelA, panelB]], { root });
+
+    const idA = panelA.container.id;
+    const idB = panelB.container.id;
+    expect(idA).toBeTruthy();
+    expect(idB).toBeTruthy();
+    expect(idA).not.toBe(idB);
+
+    expect(maidr.subplots[0][0].selector).toBe(`#${idA} svg`);
+    expect(maidr.subplots[0][1].selector).toBe(`#${idB} svg`);
+    expect(maidr.subplots[0][0].layers[0].selectors).toBe(`#${idA} svg rect[data-maidr-bar]`);
+    expect(maidr.subplots[0][1].layers[0].selectors).toBe(`#${idB} svg rect[data-maidr-bar]`);
+
+    // The marked rects must live only inside their own panel.
+    expect(panelA.container.querySelectorAll('rect[data-maidr-bar]')).toHaveLength(ROWS_A.length);
+    expect(panelB.container.querySelectorAll('rect[data-maidr-bar]')).toHaveLength(ROWS_B.length);
+  });
+
+  it('converts each panel from its own DataTable (data and axes labels)', () => {
+    const { doc, root } = makeRoot();
+    const panels = [[
+      makeBarPanel(doc, root, ROWS_A, 'East', ['Day', 'East Tips']),
+      makeBarPanel(doc, root, ROWS_B, 'West', ['Day', 'West Tips']),
+    ]];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root });
+
+    const [east, west] = maidr.subplots[0];
+    expect((east.layers[0].data as BarPoint[])).toEqual([{ x: 'Sat', y: 40 }, { x: 'Sun', y: 60 }]);
+    expect((west.layers[0].data as BarPoint[])).toHaveLength(3);
+    expect(east.layers[0].axes?.y?.label).toBe('East Tips');
+    expect(west.layers[0].axes?.y?.label).toBe('West Tips');
+  });
+
+  it('assigns figure-unique layer ids and puts panel titles on the first layer', () => {
+    const { doc, root } = makeRoot();
+    const panels = [
+      [makeBarPanel(doc, root, ROWS_A, 'cyl = 4'), makeBarPanel(doc, root, ROWS_A, 'cyl = 6')],
+      [makeBarPanel(doc, root, ROWS_A, 'cyl = 8')],
+    ];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root });
+
+    const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+    const ids = layers.map(layer => layer.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(layers.map(layer => layer.title)).toEqual(['cyl = 4', 'cyl = 6', 'cyl = 8']);
+  });
+
+  it('uses options.id / options.title and defaults id to the root id', () => {
+    const { doc, root } = makeRoot();
+    const panels = [[makeBarPanel(doc, root, ROWS_A)]];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root, title: 'Tips by Day' });
+    expect(maidr.id).toBe('grid');
+    expect(maidr.title).toBe('Tips by Day');
+
+    const explicit = createMaidrFromGoogleCharts(panels, { root, id: 'custom' });
+    expect(explicit.id).toBe('custom');
+    expect(explicit.title).toBeUndefined();
+  });
+
+  it('generates an id for a root without one', () => {
+    const { doc, root } = makeRoot();
+    const wrapper = doc.createElement('div');
+    root.appendChild(wrapper);
+    const panels = [[makeBarPanel(doc, wrapper, ROWS_A)]];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root: wrapper });
+
+    expect(wrapper.id).toBeTruthy();
+    expect(maidr.id).toBe(wrapper.id);
+  });
+
+  it('throws for an empty panel list or an empty grid row', () => {
+    const { root } = makeRoot();
+    expect(() => createMaidrFromGoogleCharts([], { root })).toThrow('at least one panel');
+
+    const { doc: doc2, root: root2 } = makeRoot();
+    const grid = [[makeBarPanel(doc2, root2, ROWS_A)], []];
+    expect(() => createMaidrFromGoogleCharts(grid, { root: root2 })).toThrow('row 1 is empty');
+  });
+
+  it('throws when options.root is missing', () => {
+    const { doc, root } = makeRoot();
+    const panels = [[makeBarPanel(doc, root, ROWS_A)]];
+    const options = {} as GoogleChartsGridOptions;
+    expect(() => createMaidrFromGoogleCharts(panels, options)).toThrow('options.root is required');
+  });
+
+  it('throws when a container is not a descendant of root', () => {
+    const { doc, root } = makeRoot();
+    const inside = makeBarPanel(doc, root, ROWS_A);
+    const outside = makeBarPanel(doc, doc.body as HTMLElement, ROWS_A);
+
+    expect(() => createMaidrFromGoogleCharts([[inside, outside]], { root }))
+      .toThrow('panel [0][1] container must be a descendant');
+  });
+
+  it('throws when two panels share a container', () => {
+    const { doc, root } = makeRoot();
+    const panel = makeBarPanel(doc, root, ROWS_A);
+    const twin: GoogleChartPanel = { ...panel, title: 'twin' };
+
+    expect(() => createMaidrFromGoogleCharts([[panel, twin]], { root }))
+      .toThrow('reuses a container');
+  });
+
+  it('throws for non-positive or fractional layout values', () => {
+    const { doc, root } = makeRoot();
+    const panels = [makeBarPanel(doc, root, ROWS_A)];
+
+    expect(() => createMaidrFromGoogleCharts(panels, { root, layout: { columns: 0 } }))
+      .toThrow('positive integer');
+    expect(() => createMaidrFromGoogleCharts(panels, { root, layout: { rows: 1.5 } }))
+      .toThrow('positive integer');
+  });
+});
+
+describe('createMaidrFromGoogleChart (single-panel API unchanged)', () => {
+  it('still returns a 1x1 grid without subplot selector or layer title', () => {
+    const { doc, root } = makeRoot();
+    const panel = makeBarPanel(doc, root, ROWS_A);
+
+    const maidr = createMaidrFromGoogleChart(panel.chart, panel.dataTable, panel.container, {
+      chartType: 'ColumnChart',
+      title: 'Tips by Day',
+    });
+
+    expect(maidr.subplots).toHaveLength(1);
+    expect(maidr.subplots[0]).toHaveLength(1);
+    expect(maidr.title).toBe('Tips by Day');
+    expect(maidr.id).toBe(panel.container.id);
+    expect(maidr.subplots[0][0].selector).toBeUndefined();
+    expect(maidr.subplots[0][0].layers[0].title).toBeUndefined();
+    expect(maidr.subplots[0][0].layers[0].selectors)
+      .toBe(`#${panel.container.id} svg rect[data-maidr-bar]`);
+  });
+});
+
+describe('whenGoogleChartsReady', () => {
+  /** Fake `google.visualization.events` capturing 'ready' handlers per chart. */
+  function makeEvents(): { events: GoogleEvents; fireReady: (chart: GoogleChart) => void } {
+    const handlers = new Map<GoogleChart, Set<(...args: unknown[]) => void>>();
+    const events: GoogleEvents = {
+      addListener: (chart, eventName, handler) => {
+        if (eventName === 'ready') {
+          const set = handlers.get(chart) ?? new Set();
+          set.add(handler);
+          handlers.set(chart, set);
+        }
+        return { remove: () => handlers.get(chart)?.delete(handler) };
+      },
+      removeAllListeners: (chart) => {
+        handlers.delete(chart);
+      },
+    };
+    const fireReady = (chart: GoogleChart): void => {
+      const set = handlers.get(chart);
+      if (set) {
+        [...set].forEach(handler => handler());
+      }
+    };
+    return { events, fireReady };
+  }
+
+  function makeChart(): GoogleChart {
+    return {
+      getSelection: () => [],
+      setSelection: () => {},
+      getChartLayoutInterface: () => ({
+        getBoundingBox: () => null,
+        getXLocation: () => 0,
+        getYLocation: () => 0,
+      }),
+    };
+  }
+
+  it('invokes the callback only after every chart fired ready', () => {
+    const { events, fireReady } = makeEvents();
+    const charts = [makeChart(), makeChart(), makeChart()];
+    const callback = jest.fn();
+
+    whenGoogleChartsReady(charts, events, callback);
+
+    fireReady(charts[0]);
+    fireReady(charts[1]);
+    expect(callback).not.toHaveBeenCalled();
+
+    fireReady(charts[2]);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts each chart once even if it fires ready again (redraw)', () => {
+    const { events, fireReady } = makeEvents();
+    const charts = [makeChart(), makeChart()];
+    const callback = jest.fn();
+
+    whenGoogleChartsReady(charts, events, callback);
+
+    fireReady(charts[0]);
+    fireReady(charts[0]); // redraw of the same chart
+    expect(callback).not.toHaveBeenCalled();
+
+    fireReady(charts[1]);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Listeners were removed; further redraws never re-invoke the callback.
+    fireReady(charts[0]);
+    fireReady(charts[1]);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes the callback immediately for an empty chart list', () => {
+    const { events } = makeEvents();
+    const callback = jest.fn();
+
+    whenGoogleChartsReady([], events, callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/adapters/google-charts/multiPanel.test.ts
+++ b/test/adapters/google-charts/multiPanel.test.ts
@@ -7,6 +7,7 @@ import type {
   GoogleChart,
   GoogleDataTable,
   GoogleEvents,
+  GoogleListenerHandle,
 } from '@adapters/google-charts/types';
 import type { BarPoint } from '@type/grammar';
 import {
@@ -302,6 +303,21 @@ describe('createMaidrFromGoogleCharts', () => {
       .toThrow('reuses a container');
   });
 
+  it('throws when one panel container is nested inside another panel container', () => {
+    // An outer wrapper (e.g. a card div) used as panel A's container that also
+    // contains panel B's chart div: A's id-scoped descendant selectors would
+    // match B's marked elements too, silently breaking A's highlighting.
+    const { doc, root } = makeRoot();
+    const outer = makeBarPanel(doc, root, ROWS_A, 'outer');
+    const inner = makeBarPanel(doc, outer.container, ROWS_B, 'inner');
+
+    expect(() => createMaidrFromGoogleCharts([[outer, inner]], { root }))
+      .toThrow('nested inside');
+    // Order-independent: the inner panel may be listed first.
+    expect(() => createMaidrFromGoogleCharts([[inner, outer]], { root }))
+      .toThrow('nested inside');
+  });
+
   it('throws for non-positive or fractional layout values', () => {
     const { doc, root } = makeRoot();
     const panels = [makeBarPanel(doc, root, ROWS_A)];
@@ -335,26 +351,62 @@ describe('createMaidrFromGoogleChart (single-panel API unchanged)', () => {
 });
 
 describe('whenGoogleChartsReady', () => {
-  /** Fake `google.visualization.events` capturing 'ready' handlers per chart. */
+  /**
+   * Fake `google.visualization.events` capturing 'ready' handlers per chart.
+   *
+   * Mirrors the REAL library shape: `addListener` returns an opaque handle
+   * exposing only `getKey()` (no `remove()` method!), detaching goes through
+   * `events.removeListener(handle)`, and `addOneTimeListener` self-detaches
+   * before invoking the handler — so a fake with extra convenience methods
+   * can never mask reliance on APIs the real library does not have.
+   */
   function makeEvents(): { events: GoogleEvents; fireReady: (chart: GoogleChart) => void } {
-    const handlers = new Map<GoogleChart, Set<(...args: unknown[]) => void>>();
-    const events: GoogleEvents = {
-      addListener: (chart, eventName, handler) => {
-        if (eventName === 'ready') {
-          const set = handlers.get(chart) ?? new Set();
-          set.add(handler);
-          handlers.set(chart, set);
+    const handlers = new Map<GoogleChart, Map<GoogleListenerHandle, (...args: unknown[]) => void>>();
+    let nextKey = 0;
+
+    const register = (
+      chart: GoogleChart,
+      eventName: string,
+      handler: (...args: unknown[]) => void,
+    ): GoogleListenerHandle => {
+      const key = nextKey++;
+      const handle: GoogleListenerHandle = { getKey: () => key };
+      if (eventName === 'ready') {
+        const map = handlers.get(chart) ?? new Map();
+        map.set(handle, handler);
+        handlers.set(chart, map);
+      }
+      return handle;
+    };
+
+    const removeListener = (handle: GoogleListenerHandle): boolean => {
+      for (const map of handlers.values()) {
+        if (map.delete(handle)) {
+          return true;
         }
-        return { remove: () => handlers.get(chart)?.delete(handler) };
+      }
+      return false;
+    };
+
+    const events: GoogleEvents = {
+      addListener: register,
+      addOneTimeListener: (chart, eventName, handler) => {
+        const handle = register(chart, eventName, (...args) => {
+          removeListener(handle);
+          handler(...args);
+        });
+        return handle;
       },
+      removeListener,
       removeAllListeners: (chart) => {
         handlers.delete(chart);
       },
     };
+
     const fireReady = (chart: GoogleChart): void => {
-      const set = handlers.get(chart);
-      if (set) {
-        [...set].forEach(handler => handler());
+      const map = handlers.get(chart);
+      if (map) {
+        [...map.values()].forEach(handler => handler());
       }
     };
     return { events, fireReady };

--- a/test/adapters/google-charts/multiPanelLayout.test.ts
+++ b/test/adapters/google-charts/multiPanelLayout.test.ts
@@ -1,0 +1,180 @@
+import type { GoogleChartPanel } from '@adapters/google-charts/converters';
+import type { GoogleBoundingBox, GoogleChart, GoogleDataTable } from '@adapters/google-charts/types';
+import type { Subplot } from '@model/plot';
+import { createMaidrFromGoogleCharts } from '@adapters/google-charts/converters';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+/**
+ * Contract test for the multi-panel visual-layout pipeline.
+ *
+ * `resolveSubplotLayout` (src/util/subplotLayout.ts) can only compute the
+ * visual ordering and vertical-inversion flag for a multi-row grid when every
+ * emitted subplot resolves to a real, measurable per-panel DOM element —
+ * either via `MaidrSubplot.selector` or via the first layer's first selector.
+ * The Google Charts adapter emits rows in visual reading order (top row
+ * first), so without that geometry the core's data-order fallback would leave
+ * the Up/Down arrow keys inverted (MovableGrid maps UPWARD to row + 1).
+ *
+ * These tests pin the adapter's side of the contract: the emitted selectors
+ * must resolve to distinct elements inside each panel, and feeding those
+ * elements through the core layout pass must yield `invertVertical: true`
+ * with reading-order subplot numbering.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const globals = globalThis as unknown as { document?: Document };
+let savedDocument: Document | undefined;
+
+beforeEach(() => {
+  savedDocument = globals.document;
+  const dom = new JSDOM('<!doctype html><body><div id="grid"></div></body>');
+  globals.document = dom.window.document as Document;
+});
+
+afterEach(() => {
+  globals.document = savedDocument;
+});
+
+type BarRow = [string, number];
+
+const ROWS: BarRow[] = [['Sat', 40], ['Sun', 60]];
+
+function makeBarDataTable(rows: BarRow[]): GoogleDataTable {
+  return {
+    getNumberOfRows: () => rows.length,
+    getNumberOfColumns: () => 2,
+    getValue: (r, c) => rows[r][c],
+    getFormattedValue: (r, c) => String(rows[r][c]),
+    getColumnLabel: c => (c === 0 ? 'Day' : 'Tips'),
+    getColumnType: c => (c === 0 ? 'string' : 'number'),
+  };
+}
+
+/** Builds one rendered bar-chart panel inside `parent` (see multiPanel.test.ts). */
+function makeBarPanel(parent: HTMLElement, title: string): GoogleChartPanel {
+  const doc = parent.ownerDocument;
+  const container = doc.createElement('div');
+  parent.appendChild(container);
+
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+  const group = doc.createElementNS(SVG_NS, 'g');
+  group.setAttribute('clip-path', 'url(#clip)');
+  svg.appendChild(group);
+
+  const bboxes = new Map<string, GoogleBoundingBox>();
+  ROWS.forEach(([, value], i) => {
+    const bbox: GoogleBoundingBox = { left: i * 30, top: 100 - value, width: 20, height: value };
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', String(bbox.left));
+    rect.setAttribute('y', String(bbox.top));
+    rect.setAttribute('width', String(bbox.width));
+    rect.setAttribute('height', String(bbox.height));
+    group.appendChild(rect);
+    bboxes.set(`bar#0#${i}`, bbox);
+  });
+
+  const chart: GoogleChart = {
+    getSelection: () => [],
+    setSelection: () => {},
+    getChartLayoutInterface: () => ({
+      getBoundingBox: id => bboxes.get(id) ?? null,
+      getXLocation: () => 0,
+      getYLocation: () => 0,
+    }),
+  };
+
+  return { chart, dataTable: makeBarDataTable(ROWS), container, chartType: 'ColumnChart', title };
+}
+
+function mockRect(el: Element, rect: { top: number; left: number }): void {
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({
+      top: rect.top,
+      left: rect.left,
+      width: 100,
+      height: 100,
+      right: rect.left + 100,
+      bottom: rect.top + 100,
+      x: rect.left,
+      y: rect.top,
+    }),
+    configurable: true,
+  });
+}
+
+describe('createMaidrFromGoogleCharts × resolveSubplotLayout (vertical navigation)', () => {
+  it('emits a subplot selector resolving to a real element inside each panel', () => {
+    const root = document.getElementById('grid') as HTMLElement;
+    const panels = [
+      makeBarPanel(root, 'top-left'),
+      makeBarPanel(root, 'top-right'),
+      makeBarPanel(root, 'bottom-left'),
+      makeBarPanel(root, 'bottom-right'),
+    ];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root, layout: { columns: 2 } });
+
+    const flatPanels = [panels[0], panels[1], panels[2], panels[3]];
+    maidr.subplots.flat().forEach((subplot, i) => {
+      // Subplot selector resolves to this panel's own <svg> — the element the
+      // core layout pass measures (via its hidden clone) for visual ordering.
+      expect(subplot.selector).toBeDefined();
+      const panelElement = document.querySelector(subplot.selector!);
+      expect(panelElement).toBe(flatPanels[i].container.querySelector('svg'));
+
+      // Fallback contract: the first layer's first selector also resolves to
+      // an element inside the same panel.
+      const layerSelector = subplot.layers[0].selectors as string;
+      const layerElement = document.querySelector(layerSelector);
+      expect(layerElement).not.toBeNull();
+      expect(flatPanels[i].container.contains(layerElement)).toBe(true);
+    });
+  });
+
+  it('drives the core layout pass to inverted vertical keys and reading-order numbering', () => {
+    const root = document.getElementById('grid') as HTMLElement;
+    const panels = [
+      makeBarPanel(root, 'top-left'),
+      makeBarPanel(root, 'top-right'),
+      makeBarPanel(root, 'bottom-left'),
+      makeBarPanel(root, 'bottom-right'),
+    ];
+
+    const maidr = createMaidrFromGoogleCharts(panels, { root, layout: { columns: 2 } });
+
+    // Give each panel's svg the geometry of a 2x2 CSS grid (rows in visual
+    // reading order, matching the adapter's documented emission order).
+    const rects = [
+      [{ top: 0, left: 0 }, { top: 0, left: 300 }],
+      [{ top: 300, left: 0 }, { top: 300, left: 300 }],
+    ];
+    const subplots: Subplot[][] = maidr.subplots.map((row, r) => row.map((subplot, c) => {
+      const el = document.querySelector(subplot.selector!) as SVGElement;
+      mockRect(el, rects[r][c]);
+      // Stand-in exposing the two accessors the layout utility consumes; the
+      // real Subplot resolves the same selector to a hidden clone with
+      // equivalent geometry.
+      return {
+        getHighlightElement: () => el,
+        getLayerSelector: () => subplot.layers[0].selectors as string,
+      } as unknown as Subplot;
+    }));
+
+    const layout = resolveSubplotLayout(subplots);
+
+    // With top-first rows, UPWARD (row + 1 in MovableGrid) must be inverted
+    // so the Up arrow moves visually up.
+    expect(layout.invertVertical).toBe(true);
+    expect(layout.topLeftRow).toBe(0);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('0,1')).toBe(2);
+    expect(layout.visualOrderMap.get('1,0')).toBe(3);
+    expect(layout.visualOrderMap.get('1,1')).toBe(4);
+  });
+});

--- a/test/adapters/highcharts/adapter.test.ts
+++ b/test/adapters/highcharts/adapter.test.ts
@@ -1,0 +1,404 @@
+import type { BarPoint, HeatmapData, LinePoint, SegmentedPoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { TraceType } from '@type/grammar';
+import { categoryPoints, fakeAxis, fakeChart, fakeSeries } from './helpers';
+
+describe('highchartsToMaidr', () => {
+  describe('single-pane charts (existing behavior)', () => {
+    it('converts a simple column chart into a 1x1 subplot grid', () => {
+      const chart = fakeChart({
+        title: 'Tips by Day',
+        type: 'column',
+        renderToId: 'bar-chart',
+        series: [fakeSeries({
+          index: 0,
+          name: 'Tips',
+          data: categoryPoints([20, 14, 23], ['Mon', 'Tue', 'Wed']),
+        })],
+      });
+
+      const result = highchartsToMaidr(chart, { id: 'test-bar' });
+
+      expect(result.id).toBe('test-bar');
+      expect(result.title).toBe('Tips by Day');
+      expect(result.subplots).toHaveLength(1);
+      expect(result.subplots[0]).toHaveLength(1);
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.id).toBe('0');
+      expect(layer.type).toBe(TraceType.BAR);
+      expect(layer.selectors).toBe(
+        '#bar-chart .highcharts-series-group .highcharts-series-0 .highcharts-point',
+      );
+
+      const data = layer.data as BarPoint[];
+      expect(data).toEqual([
+        { x: 'Mon', y: 20 },
+        { x: 'Tue', y: 14 },
+        { x: 'Wed', y: 23 },
+      ]);
+    });
+
+    it('keeps a dual-axis overlay (coinciding bands) as a single subplot', () => {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const yAxisLeft = fakeAxis({ top: 40, height: 300 });
+      const yAxisRight = fakeAxis({ top: 40, height: 300 });
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({ index: 0, type: 'line', xAxis, yAxis: yAxisLeft, data: categoryPoints([1, 2], ['a', 'b']) }),
+          fakeSeries({ index: 1, type: 'column', xAxis, yAxis: yAxisRight, data: categoryPoints([3, 4], ['a', 'b']) }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(1);
+      expect(result.subplots[0]).toHaveLength(1);
+      expect(result.subplots[0][0].layers).toHaveLength(2);
+    });
+
+    it('falls back to a single subplot when axis bands overlap ambiguously', () => {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({
+            index: 0,
+            type: 'line',
+            xAxis,
+            yAxis: fakeAxis({ top: 0, height: 300 }),
+            data: categoryPoints([1, 2], ['a', 'b']),
+          }),
+          fakeSeries({
+            index: 1,
+            type: 'line',
+            xAxis,
+            yAxis: fakeAxis({ top: 150, height: 300 }),
+            data: categoryPoints([3, 4], ['a', 'b']),
+          }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(1);
+      expect(result.subplots[0]).toHaveLength(1);
+    });
+
+    it('falls back to a single subplot when axis geometry is missing', () => {
+      const xAxis = fakeAxis();
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({ index: 0, type: 'line', xAxis, yAxis: fakeAxis(), data: categoryPoints([1], ['a']) }),
+          fakeSeries({ index: 1, type: 'line', xAxis, yAxis: fakeAxis(), data: categoryPoints([2], ['a']) }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(1);
+      expect(result.subplots[0]).toHaveLength(1);
+    });
+  });
+
+  describe('internal series exclusion', () => {
+    it('excludes navigator/internal series from conversion', () => {
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({
+            index: 0,
+            type: 'line',
+            name: 'Price',
+            data: categoryPoints([10, 12], ['a', 'b']),
+          }),
+          fakeSeries({
+            index: 1,
+            type: 'line',
+            name: 'Navigator',
+            options: { isInternal: true, className: 'highcharts-navigator-series' },
+            data: categoryPoints([10, 12], ['a', 'b']),
+          }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+      const layer = result.subplots[0][0].layers[0];
+
+      expect(result.subplots[0][0].layers).toHaveLength(1);
+      expect(layer.type).toBe(TraceType.LINE);
+      // Only the real series remains in the multi-line layer.
+      expect((layer.data as LinePoint[][])).toHaveLength(1);
+      expect(layer.title).toBe('Price');
+    });
+  });
+
+  describe('pane detection (stacked yAxis bands)', () => {
+    function stockStyleChart(): ReturnType<typeof fakeChart> {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const priceAxis = fakeAxis({ top: 40, height: 250, options: { title: { text: 'Price' } } });
+      const volumeAxis = fakeAxis({ top: 310, height: 100, options: { title: { text: 'Volume' } } });
+      return fakeChart({
+        title: 'AAPL',
+        type: 'line',
+        renderToId: 'stock-chart',
+        series: [
+          fakeSeries({
+            index: 0,
+            type: 'line',
+            name: 'AAPL Price',
+            xAxis,
+            yAxis: priceAxis,
+            data: categoryPoints([150, 152, 149], ['d1', 'd2', 'd3']),
+          }),
+          fakeSeries({
+            index: 1,
+            type: 'column',
+            name: 'AAPL Volume',
+            xAxis,
+            yAxis: volumeAxis,
+            data: categoryPoints([1000, 1400, 900], ['d1', 'd2', 'd3']),
+          }),
+        ],
+      });
+    }
+
+    it('emits one subplot per pane, top pane first', () => {
+      const result = highchartsToMaidr(stockStyleChart());
+
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0]).toHaveLength(1);
+      expect(result.subplots[1]).toHaveLength(1);
+
+      const topLayers = result.subplots[0][0].layers;
+      const bottomLayers = result.subplots[1][0].layers;
+      expect(topLayers).toHaveLength(1);
+      expect(topLayers[0].type).toBe(TraceType.LINE);
+      expect(bottomLayers).toHaveLength(1);
+      expect(bottomLayers[0].type).toBe(TraceType.BAR);
+    });
+
+    it('orders rows by visual position even when series come bottom-pane first', () => {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const topAxis = fakeAxis({ top: 40, height: 250 });
+      const bottomAxis = fakeAxis({ top: 310, height: 100 });
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({
+            index: 0,
+            type: 'column',
+            name: 'Bottom',
+            xAxis,
+            yAxis: bottomAxis,
+            data: categoryPoints([1, 2], ['a', 'b']),
+          }),
+          fakeSeries({
+            index: 1,
+            type: 'line',
+            name: 'Top',
+            xAxis,
+            yAxis: topAxis,
+            data: categoryPoints([3, 4], ['a', 'b']),
+          }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0][0].layers[0].title).toBe('Top');
+      expect(result.subplots[1][0].layers[0].title).toBe('Bottom');
+    });
+
+    it('keeps layer ids unique across panes and selectors series-scoped', () => {
+      const result = highchartsToMaidr(stockStyleChart());
+
+      const allLayers = result.subplots.flat().flatMap(subplot => subplot.layers);
+      const ids = allLayers.map(layer => layer.id);
+      expect(new Set(ids).size).toBe(ids.length);
+
+      // Each pane's selector targets only its own series index within the
+      // shared container.
+      expect(allLayers[0].selectors).toEqual([
+        '#stock-chart .highcharts-series-group .highcharts-series-0 path.highcharts-graph',
+      ]);
+      expect(allLayers[1].selectors).toBe(
+        '#stock-chart .highcharts-series-group .highcharts-series-1 .highcharts-point',
+      );
+    });
+
+    it('does not fuse bar series from different panes into one dodged layer', () => {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const chart = fakeChart({
+        type: 'column',
+        series: [
+          fakeSeries({
+            index: 0,
+            name: 'Pane A bars',
+            xAxis,
+            yAxis: fakeAxis({ top: 40, height: 200 }),
+            data: categoryPoints([1, 2], ['a', 'b']),
+          }),
+          fakeSeries({
+            index: 1,
+            name: 'Pane B bars',
+            xAxis,
+            yAxis: fakeAxis({ top: 260, height: 200 }),
+            data: categoryPoints([3, 4], ['a', 'b']),
+          }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+      expect(result.subplots[1][0].layers[0].type).toBe(TraceType.BAR);
+    });
+
+    it('still groups multiple bar series within the same pane as dodged', () => {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const topAxis = fakeAxis({ top: 40, height: 200 });
+      const bottomAxis = fakeAxis({ top: 260, height: 200 });
+      const chart = fakeChart({
+        type: 'column',
+        series: [
+          fakeSeries({ index: 0, name: 'A', xAxis, yAxis: topAxis, data: categoryPoints([1, 2], ['a', 'b']) }),
+          fakeSeries({ index: 1, name: 'B', xAxis, yAxis: topAxis, data: categoryPoints([3, 4], ['a', 'b']) }),
+          fakeSeries({ index: 2, name: 'C', xAxis, yAxis: bottomAxis, data: categoryPoints([5, 6], ['a', 'b']) }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(2);
+      const topLayer = result.subplots[0][0].layers[0];
+      expect(topLayer.type).toBe(TraceType.DODGED);
+      expect((topLayer.data as SegmentedPoint[][])).toHaveLength(2);
+      expect(result.subplots[1][0].layers[0].type).toBe(TraceType.BAR);
+    });
+
+    it('uses the pane yAxis title as panel name when the series is unnamed', () => {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({
+            index: 0,
+            type: 'line',
+            name: '',
+            xAxis,
+            yAxis: fakeAxis({ top: 40, height: 250, options: { title: { text: 'Price' } } }),
+            data: categoryPoints([1, 2], ['a', 'b']),
+          }),
+          fakeSeries({
+            index: 1,
+            type: 'column',
+            name: '',
+            xAxis,
+            yAxis: fakeAxis({ top: 310, height: 100, options: { title: { text: 'Volume' } } }),
+            data: categoryPoints([3, 4], ['a', 'b']),
+          }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots[0][0].layers[0].title).toBe('Price');
+      expect(result.subplots[1][0].layers[0].title).toBe('Volume');
+    });
+  });
+
+  describe('pane detection (side-by-side xAxis bands)', () => {
+    it('emits a 2x2 grid for two yAxis bands crossed with two xAxis bands', () => {
+      const leftX = fakeAxis({ left: 60, width: 280 });
+      const rightX = fakeAxis({ left: 380, width: 280 });
+      const topY = fakeAxis({ top: 40, height: 200 });
+      const bottomY = fakeAxis({ top: 260, height: 200 });
+      const chart = fakeChart({
+        type: 'column',
+        series: [
+          fakeSeries({ index: 0, name: 'TL', xAxis: leftX, yAxis: topY, data: categoryPoints([1], ['a']) }),
+          fakeSeries({ index: 1, name: 'TR', xAxis: rightX, yAxis: topY, data: categoryPoints([2], ['a']) }),
+          fakeSeries({ index: 2, name: 'BL', xAxis: leftX, yAxis: bottomY, data: categoryPoints([3], ['a']) }),
+          fakeSeries({ index: 3, name: 'BR', xAxis: rightX, yAxis: bottomY, data: categoryPoints([4], ['a']) }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0]).toHaveLength(2);
+      expect(result.subplots[1]).toHaveLength(2);
+      expect(result.subplots[0][0].layers[0].title).toBe('TL');
+      expect(result.subplots[0][1].layers[0].title).toBe('TR');
+      expect(result.subplots[1][0].layers[0].title).toBe('BL');
+      expect(result.subplots[1][1].layers[0].title).toBe('BR');
+    });
+
+    it('compacts ragged rows instead of emitting empty subplot cells', () => {
+      const leftX = fakeAxis({ left: 60, width: 280 });
+      const rightX = fakeAxis({ left: 380, width: 280 });
+      const topY = fakeAxis({ top: 40, height: 200 });
+      const bottomY = fakeAxis({ top: 260, height: 200 });
+      const chart = fakeChart({
+        type: 'column',
+        series: [
+          fakeSeries({ index: 0, name: 'TL', xAxis: leftX, yAxis: topY, data: categoryPoints([1], ['a']) }),
+          fakeSeries({ index: 1, name: 'TR', xAxis: rightX, yAxis: topY, data: categoryPoints([2], ['a']) }),
+          fakeSeries({ index: 2, name: 'BR', xAxis: rightX, yAxis: bottomY, data: categoryPoints([3], ['a']) }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0]).toHaveLength(2);
+      // Bottom row is ragged: only the occupied cell survives.
+      expect(result.subplots[1]).toHaveLength(1);
+      expect(result.subplots[1][0].layers[0].title).toBe('BR');
+      for (const row of result.subplots) {
+        for (const subplot of row) {
+          expect(subplot.layers.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe('heatmap axis resolution', () => {
+    it('reads categories from the series\' own axes, not chart.xAxis[0]', () => {
+      const seriesXAxis = fakeAxis({ categories: ['Mon', 'Tue'] });
+      const seriesYAxis = fakeAxis({ categories: ['AM', 'PM'] });
+      const heatmap = fakeSeries({
+        index: 0,
+        type: 'heatmap',
+        name: 'Activity',
+        xAxis: seriesXAxis,
+        yAxis: seriesYAxis,
+        data: [
+          { x: 0, y: 0, options: { value: 5 } },
+          { x: 1, y: 0, options: { value: 6 } },
+          { x: 0, y: 1, options: { value: 7 } },
+          { x: 1, y: 1, options: { value: 8 } },
+        ],
+      });
+      const chart = fakeChart({
+        type: 'heatmap',
+        series: [heatmap],
+        // A different primary axis pair on the chart itself: the wrong source.
+        xAxis: [fakeAxis({ categories: ['WRONG-X'] }), seriesXAxis],
+        yAxis: [fakeAxis({ categories: ['WRONG-Y'] }), seriesYAxis],
+      });
+
+      const result = highchartsToMaidr(chart);
+      const data = result.subplots[0][0].layers[0].data as HeatmapData;
+
+      expect(data.x).toEqual(['Mon', 'Tue']);
+      expect(data.y).toEqual(['AM', 'PM']);
+      expect(data.points).toEqual([[5, 6], [7, 8]]);
+    });
+  });
+});

--- a/test/adapters/highcharts/adapter.test.ts
+++ b/test/adapters/highcharts/adapter.test.ts
@@ -133,6 +133,28 @@ describe('highchartsToMaidr', () => {
       expect((layer.data as LinePoint[][])).toHaveLength(1);
       expect(layer.title).toBe('Price');
     });
+
+    it('converts a user series literally named "Navigator" in a plain chart', () => {
+      // Regression: the navigator filter must key off `isInternal` / the
+      // `highcharts-navigator-series` class, never the series name — a chart
+      // comparing SUV models legitimately has a series named "Navigator".
+      const chart = fakeChart({
+        type: 'column',
+        series: [
+          fakeSeries({ index: 0, name: 'Navigator', data: categoryPoints([1, 2], ['a', 'b']) }),
+          fakeSeries({ index: 1, name: 'Escalade', data: categoryPoints([3, 4], ['a', 'b']) }),
+        ],
+      });
+
+      const result = highchartsToMaidr(chart);
+      const layer = result.subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.DODGED);
+      const data = layer.data as SegmentedPoint[][];
+      expect(data).toHaveLength(2);
+      expect(data[0][0].z).toBe('Navigator');
+      expect(data[1][0].z).toBe('Escalade');
+    });
   });
 
   describe('pane detection (stacked yAxis bands)', () => {
@@ -228,6 +250,68 @@ describe('highchartsToMaidr', () => {
       expect(allLayers[1].selectors).toBe(
         '#stock-chart .highcharts-series-group .highcharts-series-1 .highcharts-point',
       );
+    });
+
+    it('emits a per-pane subplot selector for the layout pass to measure', () => {
+      // Highcharts SVG has no `g[id^="axes_"]` groups, so MAIDR's subplot
+      // layout pass measures `subplot.selector` (falling back to the first
+      // layer's first selector string) to compute visual order and the
+      // vertical arrow-key direction. Every pane must therefore point at a
+      // real per-pane element — its first series' rendered group.
+      const result = highchartsToMaidr(stockStyleChart());
+
+      expect(result.subplots[0][0].selector).toBe(
+        '#stock-chart .highcharts-series-group .highcharts-series-0',
+      );
+      expect(result.subplots[1][0].selector).toBe(
+        '#stock-chart .highcharts-series-group .highcharts-series-1',
+      );
+    });
+
+    it('emits a subplot selector even when the first layer has structured selectors', () => {
+      // Candlestick layers carry a CandlestickSelector object, from which the
+      // core cannot derive a measurable selector string — the subplot-level
+      // selector is the only geometry hook for such panes (the classic
+      // Highstock candlestick + volume layout).
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const xAxis = fakeAxis({ left: 60, width: 600 });
+        const chart = fakeChart({
+          type: 'candlestick',
+          renderToId: 'candle-pane-chart',
+          series: [
+            fakeSeries({
+              index: 0,
+              type: 'candlestick',
+              name: 'Price',
+              xAxis,
+              yAxis: fakeAxis({ top: 40, height: 250 }),
+              data: [{ x: 0, open: 1, close: 2, high: 3, low: 0.5 }],
+            }),
+            fakeSeries({
+              index: 1,
+              type: 'column',
+              name: 'Volume',
+              xAxis,
+              yAxis: fakeAxis({ top: 310, height: 100 }),
+              data: categoryPoints([1000], ['a']),
+            }),
+          ],
+        });
+
+        const result = highchartsToMaidr(chart);
+
+        expect(result.subplots).toHaveLength(2);
+        expect(result.subplots[0][0].layers[0].type).toBe(TraceType.CANDLESTICK);
+        expect(result.subplots[0][0].selector).toBe(
+          '#candle-pane-chart .highcharts-series-group .highcharts-series-0',
+        );
+        expect(result.subplots[1][0].selector).toBe(
+          '#candle-pane-chart .highcharts-series-group .highcharts-series-1',
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('does not fuse bar series from different panes into one dodged layer', () => {

--- a/test/adapters/highcharts/grid.test.ts
+++ b/test/adapters/highcharts/grid.test.ts
@@ -1,0 +1,142 @@
+import type { HighchartsChart } from '@adapters/highcharts/types';
+import type { LinePoint } from '@type/grammar';
+import { highchartsGridToMaidr } from '@adapters/highcharts/grid';
+import { TraceType } from '@type/grammar';
+import { categoryPoints, fakeChart, fakeSeries } from './helpers';
+
+function barChart(name: string, renderToId: string, title?: string): HighchartsChart {
+  return fakeChart({
+    title,
+    type: 'column',
+    renderToId,
+    series: [fakeSeries({
+      index: 0,
+      name,
+      data: categoryPoints([1, 2, 3], ['a', 'b', 'c']),
+    })],
+  });
+}
+
+describe('highchartsGridToMaidr', () => {
+  it('maps a flat chart list to a single subplot row by default', () => {
+    const result = highchartsGridToMaidr(
+      [barChart('East', 'grid-east', 'East'), barChart('West', 'grid-west', 'West')],
+      { id: 'grid-1', title: 'Sales by region' },
+    );
+
+    expect(result.id).toBe('grid-1');
+    expect(result.title).toBe('Sales by region');
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(2);
+  });
+
+  it('chunks a flat list into rows via options.layout.columns', () => {
+    const charts = [
+      barChart('A', 'grid-a'),
+      barChart('B', 'grid-b'),
+      barChart('C', 'grid-c'),
+    ];
+
+    const result = highchartsGridToMaidr(charts, { layout: { columns: 2 } });
+
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[1]).toHaveLength(1);
+  });
+
+  it('derives columns from options.layout.rows when columns is not set', () => {
+    const charts = [
+      barChart('A', 'grid-ra'),
+      barChart('B', 'grid-rb'),
+      barChart('C', 'grid-rc'),
+      barChart('D', 'grid-rd'),
+    ];
+
+    const result = highchartsGridToMaidr(charts, { layout: { rows: 2 } });
+
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[1]).toHaveLength(2);
+  });
+
+  it('maps 2D input 1:1 to the subplot grid, including ragged rows', () => {
+    const result = highchartsGridToMaidr([
+      [barChart('A', 'grid-2d-a'), barChart('B', 'grid-2d-b')],
+      [barChart('C', 'grid-2d-c')],
+    ]);
+
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[1]).toHaveLength(1);
+  });
+
+  it('uses each chart title as its panel display name (first layer title)', () => {
+    const result = highchartsGridToMaidr([
+      barChart('Sales', 'grid-t1', 'East region'),
+      barChart('Sales', 'grid-t2', 'West region'),
+    ]);
+
+    expect(result.subplots[0][0].layers[0].title).toBe('East region');
+    expect(result.subplots[0][1].layers[0].title).toBe('West region');
+  });
+
+  it('keeps layer ids unique across panels and selectors container-scoped', () => {
+    const result = highchartsGridToMaidr([
+      barChart('A', 'grid-u1'),
+      barChart('B', 'grid-u2'),
+    ]);
+
+    const layers = result.subplots.flat().flatMap(subplot => subplot.layers);
+    expect(layers.map(l => l.id)).toEqual(['0_0', '1_0']);
+    expect(layers[0].selectors).toBe(
+      '#grid-u1 .highcharts-series-group .highcharts-series-0 .highcharts-point',
+    );
+    expect(layers[1].selectors).toBe(
+      '#grid-u2 .highcharts-series-group .highcharts-series-0 .highcharts-point',
+    );
+  });
+
+  it('skips charts with no convertible series and compacts their rows', () => {
+    const empty = fakeChart({ type: 'column', renderToId: 'grid-empty', series: [] });
+
+    const result = highchartsGridToMaidr([
+      [barChart('A', 'grid-s1')],
+      [empty],
+      [barChart('B', 'grid-s2')],
+    ]);
+
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0][0].layers[0].title).toBe('A');
+    expect(result.subplots[1][0].layers[0].title).toBe('B');
+    for (const row of result.subplots) {
+      for (const subplot of row) {
+        expect(subplot.layers.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('supports mixed trace types across panels', () => {
+    const lineChart = fakeChart({
+      title: 'Trend',
+      type: 'line',
+      renderToId: 'grid-line',
+      series: [fakeSeries({
+        index: 0,
+        type: 'line',
+        name: 'Trend',
+        data: categoryPoints([5, 7, 6], ['a', 'b', 'c']),
+      })],
+    });
+
+    const result = highchartsGridToMaidr([barChart('Bars', 'grid-m1', 'Bars'), lineChart]);
+    const [barSubplot, lineSubplot] = result.subplots[0];
+
+    expect(barSubplot.layers[0].type).toBe(TraceType.BAR);
+    expect(lineSubplot.layers[0].type).toBe(TraceType.LINE);
+    expect((lineSubplot.layers[0].data as LinePoint[][])[0]).toHaveLength(3);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => highchartsGridToMaidr([])).toThrow(/at least one chart/);
+  });
+});

--- a/test/adapters/highcharts/grid.test.ts
+++ b/test/adapters/highcharts/grid.test.ts
@@ -2,7 +2,7 @@ import type { HighchartsChart } from '@adapters/highcharts/types';
 import type { LinePoint } from '@type/grammar';
 import { highchartsGridToMaidr } from '@adapters/highcharts/grid';
 import { TraceType } from '@type/grammar';
-import { categoryPoints, fakeChart, fakeSeries } from './helpers';
+import { categoryPoints, fakeAxis, fakeChart, fakeSeries } from './helpers';
 
 function barChart(name: string, renderToId: string, title?: string): HighchartsChart {
   return fakeChart({
@@ -136,7 +136,98 @@ describe('highchartsGridToMaidr', () => {
     expect((lineSubplot.layers[0].data as LinePoint[][])[0]).toHaveLength(3);
   });
 
+  it('emits a container-scoped subplot selector per panel', () => {
+    // Each panel's selector lets MAIDR's layout pass measure the chart's own
+    // geometry (visual ordering + vertical arrow-key direction for multi-row
+    // grids) — Highcharts SVG has no `g[id^="axes_"]` groups to measure.
+    const result = highchartsGridToMaidr([
+      barChart('A', 'grid-sel-a'),
+      barChart('B', 'grid-sel-b'),
+    ]);
+
+    expect(result.subplots[0][0].selector).toBe(
+      '#grid-sel-a .highcharts-series-group .highcharts-series-0',
+    );
+    expect(result.subplots[0][1].selector).toBe(
+      '#grid-sel-b .highcharts-series-group .highcharts-series-0',
+    );
+  });
+
+  it('expands a multi-pane member chart into adjacent cells instead of fusing panes', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const xAxis = fakeAxis({ left: 60, width: 600 });
+      const paneChart = fakeChart({
+        title: 'Metrics',
+        type: 'column',
+        renderToId: 'grid-panes',
+        series: [
+          fakeSeries({
+            index: 0,
+            name: 'Revenue',
+            xAxis,
+            yAxis: fakeAxis({ top: 40, height: 200 }),
+            data: categoryPoints([1, 2], ['a', 'b']),
+          }),
+          fakeSeries({
+            index: 1,
+            name: 'Headcount',
+            xAxis,
+            yAxis: fakeAxis({ top: 260, height: 200 }),
+            data: categoryPoints([3, 4], ['a', 'b']),
+          }),
+        ],
+      });
+
+      const result = highchartsGridToMaidr([barChart('A', 'grid-pane-a', 'A'), paneChart]);
+
+      // One row: plain chart cell + one cell per pane of the member chart.
+      expect(result.subplots).toHaveLength(1);
+      expect(result.subplots[0]).toHaveLength(3);
+
+      const [plainCell, topPane, bottomPane] = result.subplots[0];
+      expect(plainCell.layers[0].type).toBe(TraceType.BAR);
+      // Cross-pane bar series must stay separate BAR cells, never one DODGED
+      // layer mixing unrelated scales.
+      expect(topPane.layers[0].type).toBe(TraceType.BAR);
+      expect(bottomPane.layers[0].type).toBe(TraceType.BAR);
+
+      // Chart title names the first pane only; other panes keep their names.
+      expect(topPane.layers[0].title).toBe('Metrics');
+      expect(bottomPane.layers[0].title).toBe('Headcount');
+
+      // Layer ids stay unique across the whole figure.
+      const ids = result.subplots.flat().flatMap(subplot => subplot.layers).map(l => l.id);
+      expect(new Set(ids).size).toBe(ids.length);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('flattening them into adjacent cells'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('throws on empty input', () => {
     expect(() => highchartsGridToMaidr([])).toThrow(/at least one chart/);
+  });
+
+  it('throws when no chart in the grid produces any convertible series', () => {
+    // An all-skipped grid must fail loudly at conversion time — an
+    // empty-layers subplot would crash MAIDR's Context on first focus.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const noSeries = fakeChart({ type: 'column', renderToId: 'grid-none-1', series: [] });
+      const unsupported = fakeChart({
+        type: 'pie',
+        renderToId: 'grid-none-2',
+        series: [fakeSeries({ index: 0, type: 'pie', name: 'Share', data: categoryPoints([1], ['a']) })],
+      });
+
+      expect(() => highchartsGridToMaidr([noSeries, unsupported]))
+        .toThrow(/no chart in the grid produced any convertible series/);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/test/adapters/highcharts/helpers.ts
+++ b/test/adapters/highcharts/helpers.ts
@@ -1,0 +1,95 @@
+/**
+ * Fake Highcharts object builders for the adapter tests.
+ *
+ * The adapter reads only the minimal structural types in
+ * `@adapters/highcharts/types`, so tests construct plain objects matching
+ * that surface. `renderTo` needs a real element (the adapter stamps a
+ * container id on it), provided via jsdom since jest runs in a node env.
+ */
+
+import type {
+  HighchartsAxis,
+  HighchartsChart,
+  HighchartsPoint,
+  HighchartsSeries,
+} from '@adapters/highcharts/types';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Tests only use the public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><body></body>');
+const doc = dom.window.document as Document;
+
+let elementCounter = 0;
+
+export function fakeAxis(overrides: Partial<HighchartsAxis> = {}): HighchartsAxis {
+  return {
+    getExtremes: () => ({ min: 0, max: 100 }),
+    options: {},
+    ...overrides,
+  };
+}
+
+export interface FakeSeriesInput {
+  index: number;
+  data: Partial<HighchartsPoint>[];
+  type?: string;
+  name?: string;
+  xAxis?: HighchartsAxis;
+  yAxis?: HighchartsAxis;
+  visible?: boolean;
+  options?: HighchartsSeries['options'];
+}
+
+export function fakeSeries(input: FakeSeriesInput): HighchartsSeries {
+  const series = {
+    type: input.type ?? 'column',
+    name: input.name ?? `Series ${input.index}`,
+    index: input.index,
+    visible: input.visible ?? true,
+    xAxis: input.xAxis ?? fakeAxis(),
+    yAxis: input.yAxis ?? fakeAxis(),
+    options: input.options ?? {},
+    data: [] as HighchartsPoint[],
+  } as HighchartsSeries;
+
+  series.data = input.data.map((point, i) => ({
+    x: i,
+    y: null,
+    index: i,
+    series,
+    ...point,
+  } as HighchartsPoint));
+
+  return series;
+}
+
+export interface FakeChartInput {
+  series: HighchartsSeries[];
+  title?: string;
+  type?: string;
+  renderToId?: string;
+  xAxis?: HighchartsAxis[];
+  yAxis?: HighchartsAxis[];
+}
+
+export function fakeChart(input: FakeChartInput): HighchartsChart {
+  const renderTo = doc.createElement('div');
+  renderTo.id = input.renderToId ?? `fake-chart-${elementCounter++}`;
+  doc.body.appendChild(renderTo);
+
+  return {
+    series: input.series,
+    xAxis: input.xAxis ?? [...new Set(input.series.map(s => s.xAxis))],
+    yAxis: input.yAxis ?? [...new Set(input.series.map(s => s.yAxis))],
+    title: { textStr: input.title },
+    container: renderTo,
+    renderTo,
+    options: { chart: { type: input.type } },
+  } as HighchartsChart;
+}
+
+/** Points for a simple category bar/column series. */
+export function categoryPoints(values: number[], categories: string[]): Partial<HighchartsPoint>[] {
+  return values.map((y, i) => ({ x: i, y, category: categories[i] }));
+}

--- a/test/adapters/highcharts/paneLayout.test.ts
+++ b/test/adapters/highcharts/paneLayout.test.ts
@@ -1,0 +1,175 @@
+/**
+ * End-to-end regression tests for vertical navigation direction on multi-row
+ * Highcharts output (panes and chart grids).
+ *
+ * Highcharts SVG contains no `g[id^="axes_"]` groups, so the core's
+ * `resolveSubplotLayout` relies on each emitted subplot's `selector` (or the
+ * first layer's first selector string) to measure real panel geometry. These
+ * tests build a minimal rendered-DOM skeleton, run the adapter, resolve the
+ * emitted selectors exactly like `Subplot` does, and assert that the layout
+ * pass detects top-first row order (`invertVertical: true`) — i.e. that
+ * ArrowUp moves visually up. Without a measurable per-subplot element the
+ * core falls back to data order and vertical arrows are inverted.
+ */
+
+import type { Subplot } from '@model/plot';
+import type { MaidrSubplot } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { highchartsGridToMaidr } from '@adapters/highcharts/grid';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { categoryPoints, fakeAxis, fakeChart, fakeSeries } from './helpers';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const globals = globalThis as unknown as { document?: Document };
+let savedDocument: Document | undefined;
+
+function mockRect(el: Element, rect: { top: number; left: number }): void {
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({
+      top: rect.top,
+      left: rect.left,
+      width: 100,
+      height: 100,
+      right: rect.left + 100,
+      bottom: rect.top + 100,
+      x: rect.left,
+      y: rect.top,
+    }),
+    configurable: true,
+  });
+}
+
+/**
+ * Appends a Highcharts-like SVG skeleton (`svg > g.highcharts-series-group >
+ * g.highcharts-series.highcharts-series-N`) into a chart container and mocks
+ * each series group's on-screen position.
+ */
+function renderSeriesGroups(
+  container: HTMLElement,
+  seriesRects: { index: number; top: number; left: number }[],
+): void {
+  const doc = container.ownerDocument;
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  const seriesGroup = doc.createElementNS(SVG_NS, 'g');
+  seriesGroup.setAttribute('class', 'highcharts-series-group');
+  svg.appendChild(seriesGroup);
+  container.appendChild(svg);
+
+  for (const { index, top, left } of seriesRects) {
+    const g = doc.createElementNS(SVG_NS, 'g');
+    g.setAttribute('class', `highcharts-series highcharts-series-${index}`);
+    seriesGroup.appendChild(g);
+    mockRect(g, { top, left });
+  }
+}
+
+/**
+ * Builds a minimal `Subplot` stand-in from an emitted `MaidrSubplot`,
+ * resolving its selectors the same way the real Subplot constructor does
+ * (subplot selector first, first layer's first selector string as fallback).
+ */
+function stubFromEmitted(subplot: MaidrSubplot): Subplot {
+  const highlight = subplot.selector
+    ? (document.querySelector(subplot.selector) as SVGElement | null)
+    : null;
+  const firstSelectors = subplot.layers[0]?.selectors;
+  const layerSelector = typeof firstSelectors === 'string'
+    ? firstSelectors
+    : Array.isArray(firstSelectors) && typeof firstSelectors[0] === 'string'
+      ? firstSelectors[0]
+      : null;
+
+  return {
+    getHighlightElement: () => highlight,
+    getLayerSelector: () => layerSelector,
+  } as unknown as Subplot;
+}
+
+function stubGrid(subplots: MaidrSubplot[][]): Subplot[][] {
+  return subplots.map(row => row.map(stubFromEmitted));
+}
+
+describe('highcharts multi-row output drives the core layout pass', () => {
+  beforeEach(() => {
+    savedDocument = globals.document;
+  });
+
+  afterEach(() => {
+    globals.document = savedDocument;
+  });
+
+  it('pane charts (top pane = data row 0) resolve to invertVertical: true', () => {
+    const xAxis = fakeAxis({ left: 60, width: 600 });
+    const chart = fakeChart({
+      title: 'ACME',
+      type: 'line',
+      renderToId: 'pane-layout-chart',
+      series: [
+        fakeSeries({
+          index: 0,
+          type: 'line',
+          name: 'Price',
+          xAxis,
+          yAxis: fakeAxis({ top: 40, height: 250 }),
+          data: categoryPoints([150, 152], ['d1', 'd2']),
+        }),
+        fakeSeries({
+          index: 1,
+          type: 'column',
+          name: 'Volume',
+          xAxis,
+          yAxis: fakeAxis({ top: 310, height: 100 }),
+          data: categoryPoints([1000, 1400], ['d1', 'd2']),
+        }),
+      ],
+    });
+    // Price pane renders above the volume pane, as in the real chart.
+    renderSeriesGroups(chart.renderTo, [
+      { index: 0, top: 40, left: 60 },
+      { index: 1, top: 310, left: 60 },
+    ]);
+    globals.document = chart.renderTo.ownerDocument;
+
+    const result = highchartsToMaidr(chart);
+    expect(result.subplots).toHaveLength(2);
+
+    const layout = resolveSubplotLayout(stubGrid(result.subplots));
+
+    // Data row 0 (Price) is visually on top: ArrowUp must map to row - 1.
+    expect(layout.invertVertical).toBe(true);
+    expect(layout.topLeftRow).toBe(0);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('1,0')).toBe(2);
+  });
+
+  it('chart grids with multiple rows resolve to invertVertical: true', () => {
+    const makeChart = (renderToId: string, title: string): ReturnType<typeof fakeChart> =>
+      fakeChart({
+        title,
+        type: 'column',
+        renderToId,
+        series: [fakeSeries({
+          index: 0,
+          name: title,
+          data: categoryPoints([1, 2], ['a', 'b']),
+        })],
+      });
+
+    const north = makeChart('grid-layout-north', 'North');
+    const south = makeChart('grid-layout-south', 'South');
+    renderSeriesGroups(north.renderTo, [{ index: 0, top: 0, left: 0 }]);
+    renderSeriesGroups(south.renderTo, [{ index: 0, top: 400, left: 0 }]);
+    globals.document = north.renderTo.ownerDocument;
+
+    const result = highchartsGridToMaidr([north, south], { layout: { columns: 1 } });
+    expect(result.subplots).toHaveLength(2);
+
+    const layout = resolveSubplotLayout(stubGrid(result.subplots));
+
+    expect(layout.invertVertical).toBe(true);
+    expect(layout.topLeftRow).toBe(0);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('1,0')).toBe(2);
+  });
+});

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -145,7 +145,7 @@ describe('plotly extractor', () => {
       expect(names).toEqual([['A', 'B'], ['C', 'D']]);
     });
 
-    it('emits per-panel g[id="axes_…"] selectors prefixed with the chart id', () => {
+    it('emits per-panel g[id="axes_…"] selectors keyed by chart id and axis pair', () => {
       const gd = createGraphDiv({
         id: 'my-chart',
         traces: [
@@ -162,10 +162,37 @@ describe('plotly extractor', () => {
       const selectors = maidr!.subplots.flat().map(subplot => subplot.selector);
 
       expect(selectors).toEqual([
-        'g[id="axes_my-chart_1"]',
-        'g[id="axes_my-chart_2"]',
-        'g[id="axes_my-chart_3"]',
-        'g[id="axes_my-chart_4"]',
+        'g[id="axes_my-chart_xy"]',
+        'g[id="axes_my-chart_x2y2"]',
+        'g[id="axes_my-chart_x3y3"]',
+        'g[id="axes_my-chart_x4y4"]',
+      ]);
+    });
+
+    it('emits selectors even when the bglayer is empty (plotly default styling)', () => {
+      // With paper_bgcolor === plot_bgcolor (plotly.js default '#fff'),
+      // plotly renders NO per-panel background rects. Selectors must still
+      // be emitted so the normalizer can inject panel geometry — otherwise
+      // the core cannot detect visual ordering and Up/Down invert.
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+          scatterTrace({ name: 'C', xaxis: 'x3', yaxis: 'y3' }),
+          scatterTrace({ name: 'D', xaxis: 'x4', yaxis: 'y4' }),
+        ],
+        layout: twoByTwoLayout(),
+        bgRects: [],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const selectors = maidr!.subplots.flat().map(subplot => subplot.selector);
+
+      expect(selectors).toEqual([
+        'g[id="axes_chart_xy"]',
+        'g[id="axes_chart_x2y2"]',
+        'g[id="axes_chart_x3y3"]',
+        'g[id="axes_chart_x4y4"]',
       ]);
     });
 
@@ -188,10 +215,12 @@ describe('plotly extractor', () => {
       expect(ids).toEqual(['0', '1', '2', '3']);
     });
 
-    it('omits ALL subplot selectors when a dropped panel breaks rect alignment', () => {
+    it('keeps axis-pair-keyed selectors when a panel is dropped for unsupported traces', () => {
       // Panel x5y5 holds only an unsupported trace type, so it is dropped
       // from the schema — but its background rect is still rendered. The
-      // positional rect↔panel match would shift, so no selector is safe.
+      // axis-pair key in each selector id keeps the panel↔DOM association
+      // correct regardless (the normalizer no longer matches positionally
+      // when counts disagree).
       const gd = createGraphDiv({
         traces: [
           scatterTrace({ name: 'A' }),
@@ -210,7 +239,12 @@ describe('plotly extractor', () => {
       const maidr = extractPlotlyData(gd);
 
       const selectors = maidr!.subplots.flat().map(subplot => subplot.selector);
-      expect(selectors.every(selector => selector === undefined)).toBe(true);
+      expect(selectors).toEqual([
+        'g[id="axes_chart_xy"]',
+        'g[id="axes_chart_x2y2"]',
+        'g[id="axes_chart_x3y3"]',
+        'g[id="axes_chart_x4y4"]',
+      ]);
     });
 
     it('supports ragged grids (missing bottom-right panel)', () => {
@@ -337,6 +371,115 @@ describe('plotly extractor', () => {
       expect(titles).toEqual(['sex=Female', 'sex=Male']);
     });
 
+    it('uses plotly.py paper-ref annotations as facet column titles (px facet_col)', () => {
+      // Real Plotly Express output: _build_subplot_title_annotations
+      // hard-codes xref/yref 'paper' on every facet label.
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({}),
+          scatterTrace({ xaxis: 'x2', yaxis: 'y2' }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 0.48] },
+          xaxis2: { domain: [0.52, 1], matches: 'x' },
+          yaxis: { domain: [0, 1] },
+          yaxis2: { domain: [0, 1], matches: 'y' },
+          annotations: [
+            { text: 'sex=Female', x: 0.24, y: 1, xref: 'paper', yref: 'paper', showarrow: false },
+            { text: 'sex=Male', x: 0.76, y: 1, xref: 'paper', yref: 'paper', showarrow: false },
+          ],
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const titles = maidr!.subplots[0].map(s => s.layers[0].title);
+      expect(titles).toEqual(['sex=Female', 'sex=Male']);
+    });
+
+    it('combines paper-ref column and row titles for a facet_row + facet_col grid', () => {
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({}),
+          scatterTrace({ xaxis: 'x2', yaxis: 'y2' }),
+          scatterTrace({ xaxis: 'x3', yaxis: 'y3' }),
+          scatterTrace({ xaxis: 'x4', yaxis: 'y4' }),
+        ],
+        layout: twoByTwoLayout({
+          annotations: [
+            // Column titles sit above the top row…
+            { text: 'sex=Female', x: 0.225, y: 1, xref: 'paper', yref: 'paper', showarrow: false },
+            { text: 'sex=Male', x: 0.775, y: 1, xref: 'paper', yref: 'paper', showarrow: false },
+            // …row titles sit right of each row, rotated 90°.
+            { text: 'smoker=Yes', x: 1, y: 0.7875, xref: 'paper', yref: 'paper', showarrow: false, textangle: 90 },
+            { text: 'smoker=No', x: 1, y: 0.2125, xref: 'paper', yref: 'paper', showarrow: false, textangle: 90 },
+          ],
+        }),
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const titles = maidr!.subplots.map(row => row.map(s => s.layers[0].title));
+      expect(titles).toEqual([
+        ['sex=Female, smoker=Yes', 'sex=Male, smoker=Yes'],
+        ['sex=Female, smoker=No', 'sex=Male, smoker=No'],
+      ]);
+    });
+
+    it('keeps per-panel paper-ref titles per panel (px facet_col_wrap / subplot_titles)', () => {
+      // Every panel has its own title annotation just above its top edge,
+      // so top-row titles must NOT be promoted to whole-column titles.
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({}),
+          scatterTrace({ xaxis: 'x2', yaxis: 'y2' }),
+          scatterTrace({ xaxis: 'x3', yaxis: 'y3' }),
+          scatterTrace({ xaxis: 'x4', yaxis: 'y4' }),
+        ],
+        layout: twoByTwoLayout({
+          annotations: [
+            { text: 'day=Thur', x: 0.225, y: 1, xref: 'paper', yref: 'paper', showarrow: false },
+            { text: 'day=Fri', x: 0.775, y: 1, xref: 'paper', yref: 'paper', showarrow: false },
+            { text: 'day=Sat', x: 0.225, y: 0.425, xref: 'paper', yref: 'paper', showarrow: false },
+            { text: 'day=Sun', x: 0.775, y: 0.425, xref: 'paper', yref: 'paper', showarrow: false },
+          ],
+        }),
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const titles = maidr!.subplots.map(row => row.map(s => s.layers[0].title));
+      expect(titles).toEqual([
+        ['day=Thur', 'day=Fri'],
+        ['day=Sat', 'day=Sun'],
+      ]);
+    });
+
+    it('skips make_subplots global x_title/y_title annotations', () => {
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 0.48] },
+          xaxis2: { domain: [0.52, 1] },
+          yaxis: { domain: [0, 1] },
+          yaxis2: { domain: [0, 1] },
+          annotations: [
+            // Global axis titles: below the plot area / left of it (rotated).
+            { text: 'Total Bill', x: 0.5, y: -0.06, xref: 'paper', yref: 'paper', showarrow: false },
+            { text: 'Tip', x: -0.05, y: 0.5, xref: 'paper', yref: 'paper', showarrow: false, textangle: -90 },
+          ],
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const titles = maidr!.subplots[0].map(s => s.layers[0].title);
+      expect(titles).toEqual(['A', 'B']);
+    });
+
     it('ignores annotations that are not cleanly attributable to a panel', () => {
       const gd = createGraphDiv({
         traces: [
@@ -361,23 +504,11 @@ describe('plotly extractor', () => {
   });
 
   describe('core-model integration', () => {
-    it('the emitted multi-panel Maidr constructs a navigable Figure', () => {
-      const gd = createGraphDiv({
-        traces: [
-          { type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'A' },
-          { type: 'bar', x: ['a', 'b'], y: [3, 4], name: 'B', xaxis: 'x2', yaxis: 'y2' },
-          { type: 'bar', x: ['a', 'b'], y: [5, 6], name: 'C', xaxis: 'x3', yaxis: 'y3' },
-          { type: 'bar', x: ['a', 'b'], y: [7, 8], name: 'D', xaxis: 'x4', yaxis: 'y4' },
-        ],
-        layout: twoByTwoLayout(),
-        bgRects: TWO_BY_TWO_RECTS,
-      });
-
-      const maidr = extractPlotlyData(gd);
-      expect(maidr).not.toBeNull();
-
-      // The model and normalizer resolve elements via page globals; point
-      // them at this test's JSDOM window for the duration of the assertion.
+    /**
+     * The model and normalizer resolve elements via page globals; point
+     * them at the graph div's JSDOM window for the duration of `fn`.
+     */
+    function withDomGlobals(gd: PlotlyGraphDiv, fn: (doc: Document) => void): void {
       const doc = gd.ownerDocument;
       const win = doc.defaultView!;
       const testGlobals = globalThis as {
@@ -394,6 +525,38 @@ describe('plotly extractor', () => {
       testGlobals.MutationObserver = win.MutationObserver;
       testGlobals.requestAnimationFrame = () => 0;
       try {
+        fn(doc);
+      } finally {
+        for (const key of Object.keys(saved) as (keyof typeof saved)[]) {
+          if (saved[key] === undefined) {
+            delete testGlobals[key];
+          } else {
+            (testGlobals as Record<string, unknown>)[key] = saved[key];
+          }
+        }
+      }
+    }
+
+    function twoByTwoBarTraces(): PlotlyTrace[] {
+      return [
+        { type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'A' },
+        { type: 'bar', x: ['a', 'b'], y: [3, 4], name: 'B', xaxis: 'x2', yaxis: 'y2' },
+        { type: 'bar', x: ['a', 'b'], y: [5, 6], name: 'C', xaxis: 'x3', yaxis: 'y3' },
+        { type: 'bar', x: ['a', 'b'], y: [7, 8], name: 'D', xaxis: 'x4', yaxis: 'y4' },
+      ];
+    }
+
+    it('the emitted multi-panel Maidr constructs a navigable Figure', () => {
+      const gd = createGraphDiv({
+        traces: twoByTwoBarTraces(),
+        layout: twoByTwoLayout(),
+        bgRects: TWO_BY_TWO_RECTS,
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, (doc) => {
         const svg = gd.querySelector('svg.main-svg') as SVGSVGElement;
         normalizePlotlySvg(svg, maidr!);
 
@@ -421,15 +584,91 @@ describe('plotly extractor', () => {
         if (!state.empty) {
           expect(state.size).toBe(4);
         }
-      } finally {
-        for (const key of Object.keys(saved) as (keyof typeof saved)[]) {
-          if (saved[key] === undefined) {
-            delete testGlobals[key];
-          } else {
-            (testGlobals as Record<string, unknown>)[key] = saved[key];
-          }
-        }
+      });
+    });
+
+    it('injected panel geometry fixes vertical ordering when no bg rects exist', () => {
+      // plotly's DEFAULT styling (paper_bgcolor === plot_bgcolor) renders an
+      // EMPTY .bglayer. The normalizer must inject per-panel rects from the
+      // computed axis offsets so the core detects that data row 0 is
+      // visually on TOP and inverts vertical arrow keys accordingly.
+      const layout = twoByTwoLayout();
+      const pixelOffsets: Record<string, { _offset: number; _length: number }> = {
+        xaxis: { _offset: 80, _length: 300 },
+        xaxis2: { _offset: 480, _length: 300 },
+        xaxis3: { _offset: 80, _length: 300 },
+        xaxis4: { _offset: 480, _length: 300 },
+        yaxis: { _offset: 60, _length: 200 },
+        yaxis2: { _offset: 60, _length: 200 },
+        yaxis3: { _offset: 320, _length: 200 },
+        yaxis4: { _offset: 320, _length: 200 },
+      };
+      for (const [axisName, offsets] of Object.entries(pixelOffsets)) {
+        Object.assign(layout[axisName] as object, offsets);
       }
+
+      const gd = createGraphDiv({
+        traces: twoByTwoBarTraces(),
+        layout,
+        bgRects: [],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, (doc) => {
+        const svg = gd.querySelector('svg.main-svg') as SVGSVGElement;
+        normalizePlotlySvg(svg, maidr!);
+
+        // Injected transparent rects, wrapped in axis-pair-keyed groups.
+        const groups = Array.from(doc.querySelectorAll('g[id^="axes_"]'));
+        expect(groups.map(group => group.id)).toEqual([
+          'axes_chart_xy',
+          'axes_chart_x2y2',
+          'axes_chart_x3y3',
+          'axes_chart_x4y4',
+        ]);
+        const bottomLeft = doc.querySelector('g[id="axes_chart_x3y3"] > rect')!;
+        expect(bottomLeft.getAttribute('x')).toBe('80');
+        expect(bottomLeft.getAttribute('y')).toBe('320');
+        expect(bottomLeft.getAttribute('width')).toBe('300');
+        expect(bottomLeft.getAttribute('height')).toBe('200');
+        expect(bottomLeft.getAttribute('fill')).toBe('none');
+
+        const figure = new Figure(maidr!);
+
+        // jsdom reports zero geometry; stand in for the browser by deriving
+        // each axes group's bounding box from its rect attributes (covers
+        // the hidden clones the model created from the subplot selectors).
+        for (const group of Array.from(doc.querySelectorAll('g[id^="axes_"]'))) {
+          const rect = group.querySelector('rect')!;
+          const x = Number(rect.getAttribute('x'));
+          const y = Number(rect.getAttribute('y'));
+          const width = Number(rect.getAttribute('width'));
+          const height = Number(rect.getAttribute('height'));
+          Object.defineProperty(group, 'getBoundingClientRect', {
+            value: () => ({
+              top: y,
+              left: x,
+              width,
+              height,
+              right: x + width,
+              bottom: y + height,
+              x,
+              y,
+            }),
+            configurable: true,
+          });
+        }
+
+        const subplotLayout = resolveSubplotLayout(figure.subplots);
+        expect(subplotLayout.invertVertical).toBe(true);
+        expect(subplotLayout.topLeftRow).toBe(0);
+        expect(subplotLayout.visualOrderMap.get('0,0')).toBe(1);
+        expect(subplotLayout.visualOrderMap.get('0,1')).toBe(2);
+        expect(subplotLayout.visualOrderMap.get('1,0')).toBe(3);
+        expect(subplotLayout.visualOrderMap.get('1,1')).toBe(4);
+      });
     });
   });
 });

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,0 +1,435 @@
+import type { PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
+import { extractPlotlyData } from '@adapters/plotly/extractor';
+import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
+import { describe, expect, it } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface GraphDivOptions {
+  id?: string;
+  traces: PlotlyTrace[];
+  layout: PlotlyFullLayout;
+  /** Panel background rect positions rendered into the `.bglayer`. */
+  bgRects?: { x: number; y: number }[];
+}
+
+/** Builds a fake rendered Plotly graph div with `_fullData`/`_fullLayout`. */
+function createGraphDiv(options: GraphDivOptions): PlotlyGraphDiv {
+  const dom = new JSDOM('<!doctype html><body></body>');
+  const doc = dom.window.document as Document;
+
+  const div = doc.createElement('div');
+  div.id = options.id ?? 'chart';
+  div.className = 'js-plotly-plot';
+
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'main-svg');
+  const bglayer = doc.createElementNS(SVG_NS, 'g');
+  bglayer.setAttribute('class', 'bglayer');
+  for (const pos of options.bgRects ?? []) {
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', String(pos.x));
+    rect.setAttribute('y', String(pos.y));
+    bglayer.appendChild(rect);
+  }
+  svg.appendChild(bglayer);
+  div.appendChild(svg);
+  doc.body.appendChild(div);
+
+  const gd = div as PlotlyGraphDiv;
+  gd._fullData = options.traces;
+  gd._fullLayout = options.layout;
+  return gd;
+}
+
+function scatterTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+  return {
+    type: 'scatter',
+    mode: 'markers',
+    x: [1, 2, 3],
+    y: [4, 5, 6],
+    ...overrides,
+  };
+}
+
+/**
+ * Standard 2x2 make_subplots-style layout: subplot (1,1) is top-left.
+ * Panels: xy (top-left), x2y2 (top-right), x3y3 (bottom-left),
+ * x4y4 (bottom-right).
+ */
+function twoByTwoLayout(extra: Partial<PlotlyFullLayout> = {}): PlotlyFullLayout {
+  return {
+    xaxis: { domain: [0, 0.45] },
+    xaxis2: { domain: [0.55, 1] },
+    xaxis3: { domain: [0, 0.45] },
+    xaxis4: { domain: [0.55, 1] },
+    yaxis: { domain: [0.575, 1] },
+    yaxis2: { domain: [0.575, 1] },
+    yaxis3: { domain: [0, 0.425] },
+    yaxis4: { domain: [0, 0.425] },
+    ...extra,
+  };
+}
+
+const TWO_BY_TWO_RECTS = [
+  { x: 0, y: 0 },
+  { x: 400, y: 0 },
+  { x: 0, y: 300 },
+  { x: 400, y: 300 },
+];
+
+describe('plotly extractor', () => {
+  describe('single-panel behavior (unchanged)', () => {
+    it('emits a 1x1 grid without a subplot selector for a plain bar chart', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'Tips' }],
+        layout: {
+          title: { text: 'My Chart' },
+          xaxis: { title: { text: 'Day' }, domain: [0, 1] },
+          yaxis: { title: { text: 'Count' }, domain: [0, 1] },
+        },
+        bgRects: [{ x: 0, y: 0 }],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr).not.toBeNull();
+      expect(maidr!.id).toBe('chart');
+      expect(maidr!.title).toBe('My Chart');
+      expect(maidr!.subplots).toHaveLength(1);
+      expect(maidr!.subplots[0]).toHaveLength(1);
+
+      const subplot = maidr!.subplots[0][0];
+      expect(subplot.selector).toBeUndefined();
+      expect(subplot.layers).toHaveLength(1);
+
+      const layer = subplot.layers[0];
+      expect(layer.id).toBe('0');
+      expect(layer.type).toBe(TraceType.BAR);
+      expect(layer.title).toBe('Tips');
+      expect(layer.selectors).toBe('.subplot.xy .trace.bars .point > path');
+      expect(layer.axes?.x?.label).toBe('Day');
+      expect(layer.axes?.y?.label).toBe('Count');
+    });
+  });
+
+  describe('2x2 subplot grids', () => {
+    it('arranges panels row-major in visual order regardless of trace order', () => {
+      // Traces deliberately scrambled: bottom-right first, top-left second, …
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'D', xaxis: 'x4', yaxis: 'y4' }),
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'C', xaxis: 'x3', yaxis: 'y3' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+        ],
+        layout: twoByTwoLayout(),
+        bgRects: TWO_BY_TWO_RECTS,
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots).toHaveLength(2);
+      expect(maidr!.subplots[0]).toHaveLength(2);
+      expect(maidr!.subplots[1]).toHaveLength(2);
+
+      const names = maidr!.subplots.map(row =>
+        row.map(subplot => subplot.layers[0].title),
+      );
+      expect(names).toEqual([['A', 'B'], ['C', 'D']]);
+    });
+
+    it('emits per-panel g[id="axes_…"] selectors prefixed with the chart id', () => {
+      const gd = createGraphDiv({
+        id: 'my-chart',
+        traces: [
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+          scatterTrace({ name: 'C', xaxis: 'x3', yaxis: 'y3' }),
+          scatterTrace({ name: 'D', xaxis: 'x4', yaxis: 'y4' }),
+        ],
+        layout: twoByTwoLayout(),
+        bgRects: TWO_BY_TWO_RECTS,
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const selectors = maidr!.subplots.flat().map(subplot => subplot.selector);
+
+      expect(selectors).toEqual([
+        'g[id="axes_my-chart_1"]',
+        'g[id="axes_my-chart_2"]',
+        'g[id="axes_my-chart_3"]',
+        'g[id="axes_my-chart_4"]',
+      ]);
+    });
+
+    it('gives each layer a figure-unique id (the global trace index)', () => {
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+          scatterTrace({ name: 'C', xaxis: 'x3', yaxis: 'y3' }),
+          scatterTrace({ name: 'D', xaxis: 'x4', yaxis: 'y4' }),
+        ],
+        layout: twoByTwoLayout(),
+        bgRects: TWO_BY_TWO_RECTS,
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const ids = maidr!.subplots.flat().flatMap(s => s.layers.map(l => l.id));
+
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(ids).toEqual(['0', '1', '2', '3']);
+    });
+
+    it('omits ALL subplot selectors when a dropped panel breaks rect alignment', () => {
+      // Panel x5y5 holds only an unsupported trace type, so it is dropped
+      // from the schema — but its background rect is still rendered. The
+      // positional rect↔panel match would shift, so no selector is safe.
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+          scatterTrace({ name: 'C', xaxis: 'x3', yaxis: 'y3' }),
+          scatterTrace({ name: 'D', xaxis: 'x4', yaxis: 'y4' }),
+          { type: 'violin', y: [1, 2, 3], xaxis: 'x5', yaxis: 'y5' },
+        ],
+        layout: twoByTwoLayout({
+          xaxis5: { domain: [0, 0.45] },
+          yaxis5: { domain: [0, 0.425] },
+        }),
+        bgRects: [...TWO_BY_TWO_RECTS, { x: 800, y: 300 }],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const selectors = maidr!.subplots.flat().map(subplot => subplot.selector);
+      expect(selectors.every(selector => selector === undefined)).toBe(true);
+    });
+
+    it('supports ragged grids (missing bottom-right panel)', () => {
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+          scatterTrace({ name: 'C', xaxis: 'x3', yaxis: 'y3' }),
+        ],
+        layout: twoByTwoLayout(),
+        bgRects: [{ x: 0, y: 0 }, { x: 400, y: 0 }, { x: 0, y: 300 }],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots).toHaveLength(2);
+      expect(maidr!.subplots[0].map(s => s.layers[0].title)).toEqual(['A', 'B']);
+      expect(maidr!.subplots[1].map(s => s.layers[0].title)).toEqual(['C']);
+    });
+
+    it('falls back to a single row when layout.grid contradicts the domains', () => {
+      // Two vertically stacked panels but grid claims a single row.
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'Top' }),
+          scatterTrace({ name: 'Bottom', xaxis: 'x2', yaxis: 'y2' }),
+        ],
+        layout: {
+          grid: { rows: 1, columns: 2 },
+          xaxis: { domain: [0, 1] },
+          xaxis2: { domain: [0, 1] },
+          yaxis: { domain: [0.55, 1] },
+          yaxis2: { domain: [0, 0.45] },
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots).toHaveLength(1);
+      expect(maidr!.subplots[0]).toHaveLength(2);
+    });
+  });
+
+  describe('overlapping domains (not a grid)', () => {
+    it('keeps overlaid dual-axis panels as a single row without selectors', () => {
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'Revenue' }),
+          scatterTrace({ name: 'Growth', yaxis: 'y2' }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 1] },
+          yaxis: { domain: [0, 1] },
+          yaxis2: { domain: [0, 1], anchor: 'x' },
+        },
+        bgRects: [{ x: 0, y: 0 }],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots).toHaveLength(1);
+      expect(maidr!.subplots[0]).toHaveLength(2);
+      const names = maidr!.subplots[0].map(s => s.layers[0].title);
+      expect(names).toEqual(['Revenue', 'Growth']);
+      expect(maidr!.subplots[0].every(s => s.selector === undefined)).toBe(true);
+    });
+
+    it('keeps inset plots as a single row', () => {
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'Main' }),
+          scatterTrace({ name: 'Inset', xaxis: 'x2', yaxis: 'y2' }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 1] },
+          yaxis: { domain: [0, 1] },
+          xaxis2: { domain: [0.6, 0.9] },
+          yaxis2: { domain: [0.6, 0.9] },
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots).toHaveLength(1);
+      expect(maidr!.subplots[0]).toHaveLength(2);
+    });
+  });
+
+  describe('plotly-express style facets', () => {
+    function facetGraphDiv(): PlotlyGraphDiv {
+      return createGraphDiv({
+        traces: [
+          scatterTrace({}),
+          scatterTrace({ xaxis: 'x2', yaxis: 'y2' }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 0.48], title: { text: 'Total Bill' } },
+          xaxis2: { domain: [0.52, 1], matches: 'x' },
+          yaxis: { domain: [0, 1], title: { text: 'Tip' } },
+          yaxis2: { domain: [0, 1], matches: 'y' },
+          annotations: [
+            { text: 'sex=Female', xref: 'x domain', yref: 'y domain', showarrow: false },
+            { text: 'sex=Male', xref: 'x2 domain', yref: 'y2 domain', showarrow: false },
+          ],
+        },
+        bgRects: [{ x: 0, y: 0 }, { x: 400, y: 0 }],
+      });
+    }
+
+    it('resolves axis labels through matches: chains', () => {
+      const maidr = extractPlotlyData(facetGraphDiv());
+
+      const [left, right] = maidr!.subplots[0];
+      expect(left.layers[0].axes?.x?.label).toBe('Total Bill');
+      expect(right.layers[0].axes?.x?.label).toBe('Total Bill');
+      expect(right.layers[0].axes?.y?.label).toBe('Tip');
+    });
+
+    it('uses facet annotations as per-panel first-layer titles', () => {
+      const maidr = extractPlotlyData(facetGraphDiv());
+
+      expect(maidr!.subplots).toHaveLength(1);
+      const titles = maidr!.subplots[0].map(s => s.layers[0].title);
+      expect(titles).toEqual(['sex=Female', 'sex=Male']);
+    });
+
+    it('ignores annotations that are not cleanly attributable to a panel', () => {
+      const gd = createGraphDiv({
+        traces: [
+          scatterTrace({ name: 'A' }),
+          scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 0.48] },
+          xaxis2: { domain: [0.52, 1] },
+          yaxis: { domain: [0, 1] },
+          yaxis2: { domain: [0, 1] },
+          annotations: [
+            { text: 'Figure note', xref: 'paper', yref: 'paper', showarrow: false },
+          ],
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const titles = maidr!.subplots[0].map(s => s.layers[0].title);
+      expect(titles).toEqual(['A', 'B']);
+    });
+  });
+
+  describe('core-model integration', () => {
+    it('the emitted multi-panel Maidr constructs a navigable Figure', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'A' },
+          { type: 'bar', x: ['a', 'b'], y: [3, 4], name: 'B', xaxis: 'x2', yaxis: 'y2' },
+          { type: 'bar', x: ['a', 'b'], y: [5, 6], name: 'C', xaxis: 'x3', yaxis: 'y3' },
+          { type: 'bar', x: ['a', 'b'], y: [7, 8], name: 'D', xaxis: 'x4', yaxis: 'y4' },
+        ],
+        layout: twoByTwoLayout(),
+        bgRects: TWO_BY_TWO_RECTS,
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      // The model and normalizer resolve elements via page globals; point
+      // them at this test's JSDOM window for the duration of the assertion.
+      const doc = gd.ownerDocument;
+      const win = doc.defaultView!;
+      const testGlobals = globalThis as {
+        document?: Document;
+        MutationObserver?: typeof MutationObserver;
+        requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+      };
+      const saved = {
+        document: testGlobals.document,
+        MutationObserver: testGlobals.MutationObserver,
+        requestAnimationFrame: testGlobals.requestAnimationFrame,
+      };
+      testGlobals.document = doc;
+      testGlobals.MutationObserver = win.MutationObserver;
+      testGlobals.requestAnimationFrame = () => 0;
+      try {
+        const svg = gd.querySelector('svg.main-svg') as SVGSVGElement;
+        normalizePlotlySvg(svg, maidr!);
+
+        // The normalizer wrapped each bglayer rect in the panel's axes group.
+        expect(doc.querySelectorAll('g[id^="axes_"]')).toHaveLength(4);
+
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        expect(figure.state).toMatchObject({ size: 4 });
+        const summaries = figure.getSubplotSummaries();
+        expect(summaries).toHaveLength(4);
+        expect(summaries.map(summary => summary.title)).toEqual(['A', 'B', 'C', 'D']);
+        expect(summaries.map(summary => summary.traceTypes)).toEqual([
+          ['bar'],
+          ['bar'],
+          ['bar'],
+          ['bar'],
+        ]);
+
+        // Reading the state exercises Subplot/Trace construction end-to-end
+        // (this is exactly what crashes on empty subplots or bad selectors).
+        const state = figure.state;
+        expect(state.empty).toBe(false);
+        if (!state.empty) {
+          expect(state.size).toBe(4);
+        }
+      } finally {
+        for (const key of Object.keys(saved) as (keyof typeof saved)[]) {
+          if (saved[key] === undefined) {
+            delete testGlobals[key];
+          } else {
+            (testGlobals as Record<string, unknown>)[key] = saved[key];
+          }
+        }
+      }
+    });
+  });
+});

--- a/test/adapters/plotly/normalizer.test.ts
+++ b/test/adapters/plotly/normalizer.test.ts
@@ -1,3 +1,4 @@
+import type { PlotlyFullLayout, PlotlyGraphDiv } from '@adapters/plotly/types';
 import type { Maidr } from '@type/grammar';
 import { collectUniqueBgRects, normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
@@ -47,10 +48,16 @@ afterEach(() => {
 });
 
 /** Builds a plotly-shaped container with a `.bglayer` holding the given rects. */
-function createPlotlySvg(rects: { x: number; y: number }[]): SVGSVGElement {
+function createPlotlySvg(
+  rects: { x: number; y: number }[],
+  fullLayout?: PlotlyFullLayout,
+): SVGSVGElement {
   const doc = dom.window.document as Document;
   const div = doc.createElement('div');
   div.className = 'js-plotly-plot';
+  if (fullLayout) {
+    (div as unknown as PlotlyGraphDiv)._fullLayout = fullLayout;
+  }
   const svg = doc.createElementNS(SVG_NS, 'svg') as SVGSVGElement;
   svg.setAttribute('class', 'main-svg');
   const bglayer = doc.createElementNS(SVG_NS, 'g');
@@ -114,7 +121,7 @@ describe('plotly normalizer subplot background wrapping', () => {
     expect(positionOf('axes_chart_4')).toBe('400,300');
   });
 
-  it('skips wrapping entirely when rect and panel counts disagree', () => {
+  it('skips wrapping when counts disagree and no panel geometry is available', () => {
     const svg = createPlotlySvg([
       { x: 0, y: 0 },
       { x: 400, y: 0 },
@@ -127,6 +134,65 @@ describe('plotly normalizer subplot background wrapping', () => {
     normalizePlotlySvg(svg, schema);
 
     expect(svg.querySelectorAll('g[id^="axes_"]')).toHaveLength(0);
+  });
+
+  it('injects transparent panel rects when the bglayer is empty (plotly default styling)', () => {
+    const svg = createPlotlySvg([], {
+      xaxis: { domain: [0, 0.45], _offset: 80, _length: 300 },
+      xaxis2: { domain: [0.55, 1], _offset: 480, _length: 300 },
+      yaxis: { domain: [0, 1], _offset: 60, _length: 400 },
+      yaxis2: { domain: [0, 1], _offset: 60, _length: 400 },
+    });
+    const schema = createSchema([
+      ['g[id="axes_chart_xy"]', 'g[id="axes_chart_x2y2"]'],
+    ]);
+
+    normalizePlotlySvg(svg, schema);
+
+    const groups = Array.from(svg.querySelectorAll('g[id^="axes_"]'));
+    expect(groups.map(g => g.id)).toEqual(['axes_chart_xy', 'axes_chart_x2y2']);
+
+    const rect = svg.querySelector('g[id="axes_chart_x2y2"] > rect')!;
+    expect(rect.getAttribute('x')).toBe('480');
+    expect(rect.getAttribute('y')).toBe('60');
+    expect(rect.getAttribute('width')).toBe('300');
+    expect(rect.getAttribute('height')).toBe('400');
+    expect(rect.getAttribute('fill')).toBe('none');
+    expect(rect.getAttribute('pointer-events')).toBe('none');
+  });
+
+  it('injects panel rects keyed by axis pair when a dropped panel leaves an extra bg rect', () => {
+    // Three rendered rects but only two schema panels (one panel was
+    // dropped for unsupported trace types): positional matching is unsafe,
+    // so geometry comes from each panel's own axis offsets instead.
+    const svg = createPlotlySvg(
+      [
+        { x: 80, y: 60 },
+        { x: 480, y: 60 },
+        { x: 880, y: 60 },
+      ],
+      {
+        xaxis: { domain: [0, 0.3], _offset: 80, _length: 300 },
+        xaxis2: { domain: [0.35, 0.65], _offset: 480, _length: 300 },
+        yaxis: { domain: [0, 1], _offset: 60, _length: 400 },
+        yaxis2: { domain: [0, 1], _offset: 60, _length: 400 },
+      },
+    );
+    const schema = createSchema([
+      ['g[id="axes_chart_xy"]', 'g[id="axes_chart_x2y2"]'],
+    ]);
+
+    normalizePlotlySvg(svg, schema);
+
+    const groups = Array.from(svg.querySelectorAll('g[id^="axes_"]'));
+    expect(groups.map(g => g.id)).toEqual(['axes_chart_xy', 'axes_chart_x2y2']);
+    const wrapped = svg.querySelector('g[id="axes_chart_xy"] > rect')!;
+    expect(wrapped.getAttribute('x')).toBe('80');
+    expect(wrapped.getAttribute('y')).toBe('60');
+
+    // The original bg rects stay untouched (direct bglayer children).
+    const bglayer = svg.querySelector('.bglayer')!;
+    expect(bglayer.querySelectorAll(':scope > rect')).toHaveLength(3);
   });
 
   it('wraps nothing for single-panel schemas without selectors', () => {

--- a/test/adapters/plotly/normalizer.test.ts
+++ b/test/adapters/plotly/normalizer.test.ts
@@ -1,0 +1,158 @@
+import type { Maidr } from '@type/grammar';
+import { collectUniqueBgRects, normalizePlotlySvg } from '@adapters/plotly/normalizer';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface TestGlobals {
+  document?: Document;
+  MutationObserver?: typeof MutationObserver;
+  requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+}
+
+const globals = globalThis as TestGlobals;
+let savedGlobals: TestGlobals;
+let dom: JSDOM;
+
+/**
+ * `normalizePlotlySvg` uses page globals (document, MutationObserver,
+ * requestAnimationFrame); point them at this test's JSDOM window.
+ * requestAnimationFrame is a no-op stub so the layout observer's polling
+ * loop never spins during tests.
+ */
+beforeEach(() => {
+  dom = new JSDOM('<!doctype html><body></body>');
+  savedGlobals = {
+    document: globals.document,
+    MutationObserver: globals.MutationObserver,
+    requestAnimationFrame: globals.requestAnimationFrame,
+  };
+  globals.document = dom.window.document;
+  globals.MutationObserver = dom.window.MutationObserver;
+  globals.requestAnimationFrame = () => 0;
+});
+
+afterEach(() => {
+  for (const key of Object.keys(savedGlobals) as (keyof TestGlobals)[]) {
+    if (savedGlobals[key] === undefined) {
+      delete globals[key];
+    } else {
+      (globals as Record<string, unknown>)[key] = savedGlobals[key];
+    }
+  }
+});
+
+/** Builds a plotly-shaped container with a `.bglayer` holding the given rects. */
+function createPlotlySvg(rects: { x: number; y: number }[]): SVGSVGElement {
+  const doc = dom.window.document as Document;
+  const div = doc.createElement('div');
+  div.className = 'js-plotly-plot';
+  const svg = doc.createElementNS(SVG_NS, 'svg') as SVGSVGElement;
+  svg.setAttribute('class', 'main-svg');
+  const bglayer = doc.createElementNS(SVG_NS, 'g');
+  bglayer.setAttribute('class', 'bglayer');
+  for (const pos of rects) {
+    const rect = doc.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', String(pos.x));
+    rect.setAttribute('y', String(pos.y));
+    bglayer.appendChild(rect);
+  }
+  svg.appendChild(bglayer);
+  div.appendChild(svg);
+  doc.body.appendChild(div);
+  return svg;
+}
+
+function createSchema(selectors: (string | undefined)[][]): Maidr {
+  return {
+    id: 'chart',
+    subplots: selectors.map(row =>
+      row.map(selector => ({
+        ...(selector ? { selector } : {}),
+        layers: [{ id: '0', type: TraceType.BAR, data: [{ x: 'a', y: 1 }] }],
+      })),
+    ),
+  };
+}
+
+describe('plotly normalizer subplot background wrapping', () => {
+  it('wraps each bg rect in a g[id="axes_…"] group in row-major order', () => {
+    // Rects appended out of visual order; wrapping must sort them row-major.
+    const svg = createPlotlySvg([
+      { x: 400, y: 300 },
+      { x: 0, y: 0 },
+      { x: 0, y: 300 },
+      { x: 400, y: 0 },
+    ]);
+    const schema = createSchema([
+      ['g[id="axes_chart_1"]', 'g[id="axes_chart_2"]'],
+      ['g[id="axes_chart_3"]', 'g[id="axes_chart_4"]'],
+    ]);
+
+    normalizePlotlySvg(svg, schema);
+
+    const groups = Array.from(svg.querySelectorAll('g[id^="axes_"]'));
+    expect(groups.map(g => g.id).sort()).toEqual([
+      'axes_chart_1',
+      'axes_chart_2',
+      'axes_chart_3',
+      'axes_chart_4',
+    ]);
+    // Ids are assigned by visual position (row-major), not DOM order:
+    // axes_chart_1 wraps the top-left rect, axes_chart_4 the bottom-right.
+    const positionOf = (id: string): string => {
+      const rect = svg.querySelector(`g[id="${id}"] > rect`)!;
+      return `${rect.getAttribute('x')},${rect.getAttribute('y')}`;
+    };
+    expect(positionOf('axes_chart_1')).toBe('0,0');
+    expect(positionOf('axes_chart_2')).toBe('400,0');
+    expect(positionOf('axes_chart_3')).toBe('0,300');
+    expect(positionOf('axes_chart_4')).toBe('400,300');
+  });
+
+  it('skips wrapping entirely when rect and panel counts disagree', () => {
+    const svg = createPlotlySvg([
+      { x: 0, y: 0 },
+      { x: 400, y: 0 },
+      { x: 0, y: 300 },
+    ]);
+    const schema = createSchema([
+      ['g[id="axes_chart_1"]', 'g[id="axes_chart_2"]'],
+    ]);
+
+    normalizePlotlySvg(svg, schema);
+
+    expect(svg.querySelectorAll('g[id^="axes_"]')).toHaveLength(0);
+  });
+
+  it('wraps nothing for single-panel schemas without selectors', () => {
+    const svg = createPlotlySvg([{ x: 0, y: 0 }]);
+    const schema = createSchema([[undefined]]);
+
+    normalizePlotlySvg(svg, schema);
+
+    expect(svg.querySelectorAll('g[id^="axes_"]')).toHaveLength(0);
+  });
+});
+
+describe('collectUniqueBgRects', () => {
+  it('deduplicates rects sharing a position and sorts row-major', () => {
+    const svg = createPlotlySvg([
+      { x: 400, y: 0 },
+      { x: 0, y: 300 },
+      { x: 0, y: 0 },
+      { x: 0, y: 0 }, // duplicate
+    ]);
+    const bglayer = svg.querySelector('.bglayer')!;
+
+    const rects = collectUniqueBgRects(bglayer);
+
+    expect(rects).toHaveLength(3);
+    expect(rects.map(r => `${r.getAttribute('x')},${r.getAttribute('y')}`))
+      .toEqual(['0,0', '400,0', '0,300']);
+  });
+});

--- a/test/adapters/recharts/panelDom.test.ts
+++ b/test/adapters/recharts/panelDom.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Verifies the multi-panel DOM contract between the recharts adapter's emitted
+ * MAIDR schema and the DOM that `<MaidrRecharts>` actually renders.
+ *
+ * Since commit 1c14563 the core layout pass (`resolveSubplotLayout`) fixes
+ * vertical arrow-key inversion for multi-row grids WITHOUT matplotlib-style
+ * `g[id^="axes_"]` groups — but only when every subplot's `selector` (or its
+ * first layer's first selector) resolves to a real per-panel element whose
+ * geometry can be measured. These tests mount the real component (recharts
+ * charts included) in jsdom and assert that contract holds for every panel,
+ * so a regression in either the emitted selectors or the generated wrapper
+ * DOM re-introduces the inversion and fails here.
+ */
+
+import type { Maidr } from '@type/grammar';
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import { convertRechartsToMaidr } from '@adapters/recharts/converters';
+import { getPanelClassName } from '@adapters/recharts/selectors';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses the public JSDOM/Document surface.
+import { JSDOM } from 'jsdom';
+
+// MaidrApp only mounts after focus-in (contextValue starts null), so it never
+// renders in these tests — mock it away to keep its ESM-only dependencies
+// (react-markdown et al.) out of the ts-jest CJS transform.
+jest.mock('@ui/App', () => ({ MaidrApp: () => null }));
+
+const eastData = [
+  { quarter: 'Q1', revenue: 100 },
+  { quarter: 'Q2', revenue: 200 },
+];
+const westData = [
+  { quarter: 'Q1', revenue: 80 },
+  { quarter: 'Q2', revenue: 140 },
+];
+const northData = [
+  { quarter: 'Q1', revenue: 60 },
+  { quarter: 'Q2', revenue: 90 },
+];
+const southData = [
+  { quarter: 'Q1', revenue: 70 },
+  { quarter: 'Q2', revenue: 110 },
+];
+
+/** 2x2 grid matching examples/recharts/examples/FacetExample.tsx. */
+const facetConfig = {
+  id: 'facet-dom',
+  title: 'Sales by Region',
+  xKey: 'quarter',
+  yKeys: ['revenue'],
+  subplots: [
+    [
+      { title: 'East', chartType: 'bar' as const, data: eastData },
+      { title: 'West', chartType: 'bar' as const, data: westData },
+    ],
+    [
+      { title: 'North', chartType: 'bar' as const, data: northData },
+      { title: 'South', chartType: 'bar' as const, data: southData },
+    ],
+  ],
+};
+
+interface MutableGlobals {
+  window?: unknown;
+  document?: unknown;
+  navigator?: unknown;
+  ResizeObserver?: unknown;
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+}
+
+const globals = globalThis as unknown as MutableGlobals;
+const saved: MutableGlobals = {};
+let root: Root | null = null;
+let maidr: Maidr;
+
+function defineGlobal(key: keyof MutableGlobals, value: unknown): void {
+  Object.defineProperty(globals, key, { value, configurable: true, writable: true });
+}
+
+beforeAll(async () => {
+  saved.window = globals.window;
+  saved.document = globals.document;
+  saved.navigator = globals.navigator;
+  saved.ResizeObserver = globals.ResizeObserver;
+  saved.IS_REACT_ACT_ENVIRONMENT = globals.IS_REACT_ACT_ENVIRONMENT;
+
+  const dom = new JSDOM(
+    '<!doctype html><body><div id="root"></div></body>',
+    { pretendToBeVisual: true },
+  );
+  defineGlobal('window', dom.window);
+  defineGlobal('document', dom.window.document);
+  defineGlobal('navigator', dom.window.navigator);
+  defineGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  // Recharts v3 observes its wrapper for size changes; jsdom has no
+  // ResizeObserver, and explicit width/height props make a stub sufficient.
+  class ResizeObserverStub {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  defineGlobal('ResizeObserver', ResizeObserverStub);
+
+  // Import after the DOM globals exist so module-level environment checks in
+  // React/recharts/component code see a browser-like environment.
+  const { createElement } = await import('react');
+  const { act } = await import('react');
+  const { createRoot } = await import('react-dom/client');
+  const { Bar, BarChart, XAxis, YAxis } = await import('recharts');
+  const { MaidrRecharts } = await import('@adapters/recharts/MaidrRecharts');
+
+  function barChart(data: Record<string, number | string>[]): ReactElement {
+    return createElement(
+      BarChart,
+      { width: 320, height: 220, data },
+      createElement(XAxis, { dataKey: 'quarter' }),
+      createElement(YAxis, {}),
+      createElement(Bar, { dataKey: 'revenue', isAnimationActive: false }),
+    );
+  }
+
+  maidr = convertRechartsToMaidr(facetConfig);
+  root = createRoot(document.getElementById('root') as HTMLElement);
+  await act(async () => {
+    // createElement's typing requires `children` in the props object even
+    // when children are passed as rest arguments (which take precedence).
+    root?.render(createElement(
+      MaidrRecharts,
+      { ...facetConfig, children: null },
+      barChart(eastData),
+      barChart(westData),
+      barChart(northData),
+      barChart(southData),
+    ));
+  });
+});
+
+afterAll(async () => {
+  if (root) {
+    const { act } = await import('react');
+    await act(async () => root?.unmount());
+    root = null;
+  }
+  defineGlobal('window', saved.window);
+  defineGlobal('document', saved.document);
+  defineGlobal('navigator', saved.navigator);
+  defineGlobal('ResizeObserver', saved.ResizeObserver);
+  defineGlobal('IS_REACT_ACT_ENVIRONMENT', saved.IS_REACT_ACT_ENVIRONMENT);
+});
+
+describe('recharts multi-panel rendered DOM contract', () => {
+  it('resolves every emitted subplot selector to exactly one per-panel element', () => {
+    for (const [rowIndex, row] of maidr.subplots.entries()) {
+      for (const [colIndex, subplot] of row.entries()) {
+        expect(subplot.selector).toBeDefined();
+        const matches = document.querySelectorAll(subplot.selector as string);
+
+        // Exactly one match: the layout pass measures this element's
+        // geometry, and an ambiguous or empty match would silently push the
+        // figure back onto the uninverted data-order fallback.
+        expect(matches).toHaveLength(1);
+
+        const panel = document.querySelector(`.${getPanelClassName(rowIndex, colIndex)}`);
+        expect(panel).not.toBeNull();
+        expect(matches[0].matches('svg.recharts-surface')).toBe(true);
+        expect(panel?.contains(matches[0])).toBe(true);
+      }
+    }
+  });
+
+  it('resolves each subplot selector to a DISTINCT panel element', () => {
+    const resolved = maidr.subplots.flat().map(subplot =>
+      document.querySelector(subplot.selector as string),
+    );
+
+    expect(new Set(resolved).size).toBe(resolved.length);
+  });
+
+  it('places row 0 panels before row 1 panels in document order (top-first grid)', () => {
+    // `<MaidrRecharts>` renders grid rows top-to-bottom, so data row 0 is the
+    // visually TOP row. The core detects this from panel geometry and inverts
+    // vertical arrow keys; this test pins the emitted-grid/rendered-DOM
+    // agreement that the detection relies on.
+    const topPanel = document.querySelector(maidr.subplots[0][0].selector as string) as Element;
+    const bottomPanel = document.querySelector(maidr.subplots[1][0].selector as string) as Element;
+
+    expect(
+      topPanel.compareDocumentPosition(bottomPanel) & topPanel.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('scopes every layer selector to marks inside its own panel only', () => {
+    for (const [rowIndex, row] of maidr.subplots.entries()) {
+      for (const [colIndex, subplot] of row.entries()) {
+        const selector = subplot.layers[0].selectors;
+        expect(typeof selector).toBe('string');
+        const marks = document.querySelectorAll(selector as string);
+        const panel = document.querySelector(`.${getPanelClassName(rowIndex, colIndex)}`);
+
+        // One rectangle per data point, all inside this panel's wrapper.
+        expect(marks).toHaveLength(2);
+        for (const mark of marks) {
+          expect(panel?.contains(mark)).toBe(true);
+        }
+      }
+    }
+  });
+});

--- a/test/adapters/recharts/subplots.test.ts
+++ b/test/adapters/recharts/subplots.test.ts
@@ -1,0 +1,364 @@
+import type { RechartsAdapterConfig, RechartsSubplotConfig } from '@adapters/recharts/types';
+import type { BarPoint, LinePoint } from '@type/grammar';
+import { convertRechartsToMaidr, normalizeRechartsSubplotGrid } from '@adapters/recharts/converters';
+import { getPanelClassName, getRechartsSelector } from '@adapters/recharts/selectors';
+import { TraceType } from '@type/grammar';
+
+const eastData = [
+  { quarter: 'Q1', revenue: 100 },
+  { quarter: 'Q2', revenue: 200 },
+];
+const westData = [
+  { quarter: 'Q1', revenue: 80 },
+  { quarter: 'Q2', revenue: 140 },
+];
+
+describe('recharts subplot mode', () => {
+  describe('normalizeRechartsSubplotGrid', () => {
+    const panel = (title: string): RechartsSubplotConfig => ({ title, chartType: 'bar' });
+
+    it('returns a 2D grid unchanged, allowing ragged rows', () => {
+      const grid = [[panel('a'), panel('b')], [panel('c')]];
+      expect(normalizeRechartsSubplotGrid(grid)).toBe(grid);
+    });
+
+    it('chunks a flat array into rows of `columns` panels', () => {
+      const flat = [panel('a'), panel('b'), panel('c')];
+      const grid = normalizeRechartsSubplotGrid(flat, 2);
+
+      expect(grid).toHaveLength(2);
+      expect(grid[0]).toHaveLength(2);
+      expect(grid[1]).toHaveLength(1);
+      expect(grid[0][0].title).toBe('a');
+      expect(grid[1][0].title).toBe('c');
+    });
+
+    it('places a flat array in a single row when columns is omitted', () => {
+      const grid = normalizeRechartsSubplotGrid([panel('a'), panel('b'), panel('c')]);
+
+      expect(grid).toHaveLength(1);
+      expect(grid[0]).toHaveLength(3);
+    });
+
+    it('throws for an empty subplots array', () => {
+      expect(() => normalizeRechartsSubplotGrid([])).toThrow('at least one panel');
+    });
+
+    it('throws for an empty row in a 2D grid', () => {
+      expect(() => normalizeRechartsSubplotGrid([[panel('a')], []])).toThrow('row 1');
+    });
+
+    it('throws for a non-positive or fractional columns value', () => {
+      expect(() => normalizeRechartsSubplotGrid([panel('a')], 0)).toThrow('columns');
+      expect(() => normalizeRechartsSubplotGrid([panel('a')], 1.5)).toThrow('columns');
+    });
+  });
+
+  describe('convertRechartsToMaidr with subplots', () => {
+    it('builds one MaidrSubplot per panel in the same grid shape', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        title: 'Sales by Region',
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        subplots: [
+          [
+            { title: 'East', chartType: 'bar', data: eastData },
+            { title: 'West', chartType: 'bar', data: westData },
+          ],
+          [
+            { title: 'North', chartType: 'bar', data: eastData },
+          ],
+        ],
+      };
+
+      const result = convertRechartsToMaidr(config);
+
+      expect(result.id).toBe('facet');
+      expect(result.title).toBe('Sales by Region');
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0]).toHaveLength(2);
+      expect(result.subplots[1]).toHaveLength(1);
+    });
+
+    it('scopes each panel layer selector to the panel wrapper class', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        subplots: [[
+          { title: 'East', chartType: 'bar', data: eastData },
+          { title: 'West', chartType: 'bar', data: westData },
+        ]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+
+      expect(result.subplots[0][0].layers[0].selectors)
+        .toBe('#maidr-article-facet .maidr-panel-0-0 .recharts-bar-rectangle .recharts-rectangle');
+      expect(result.subplots[0][1].layers[0].selectors)
+        .toBe('#maidr-article-facet .maidr-panel-0-1 .recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('sets the subplot container selector to the panel SVG surface', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        subplots: [[{ title: 'East', chartType: 'bar', data: eastData }]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+
+      expect(result.subplots[0][0].selector)
+        .toBe('#maidr-article-facet .maidr-panel-0-0 svg.recharts-surface');
+    });
+
+    it('assigns figure-unique layer ids prefixed with the grid position', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        xKey: 'quarter',
+        subplots: [[
+          { title: 'East', chartType: 'bar', yKeys: ['revenue'], data: eastData },
+          {
+            title: 'West',
+            data: westData,
+            layers: [
+              { yKey: 'revenue', chartType: 'bar', name: 'Revenue' },
+              { yKey: 'revenue', chartType: 'line', name: 'Trend' },
+            ],
+          },
+        ]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+      const allIds = result.subplots.flat().flatMap(subplot => subplot.layers.map(layer => layer.id));
+
+      expect(result.subplots[0][0].layers[0].id).toBe('0_0_0');
+      expect(result.subplots[0][1].layers[0].id).toBe('0_1_0');
+      expect(result.subplots[0][1].layers[1].id).toBe('0_1_1');
+      expect(new Set(allIds).size).toBe(allIds.length);
+    });
+
+    it('puts the panel title on the first layer only', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        xKey: 'quarter',
+        subplots: [[{
+          title: 'East',
+          data: eastData,
+          layers: [
+            { yKey: 'revenue', chartType: 'bar', name: 'Revenue' },
+            { yKey: 'revenue', chartType: 'line', name: 'Trend' },
+          ],
+        }]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+      const layers = result.subplots[0][0].layers;
+
+      expect(layers[0].title).toBe('East');
+      expect(layers[1].title).toBe('Trend');
+    });
+
+    it('merges top-level defaults into each panel', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        data: eastData,
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        xLabel: 'Quarter',
+        yLabel: 'Revenue ($)',
+        subplots: [[
+          { title: 'Default data', chartType: 'bar' },
+          { title: 'Own data', chartType: 'bar', data: westData, yLabel: 'West Revenue' },
+        ]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+      const [first, second] = result.subplots[0];
+
+      expect(first.layers[0].axes?.x).toEqual({ label: 'Quarter' });
+      expect(first.layers[0].axes?.y).toEqual({ label: 'Revenue ($)' });
+      expect((first.layers[0].data as BarPoint[])[0]).toEqual({ x: 'Q1', y: 100 });
+
+      expect(second.layers[0].axes?.y).toEqual({ label: 'West Revenue' });
+      expect((second.layers[0].data as BarPoint[])[0]).toEqual({ x: 'Q1', y: 80 });
+    });
+
+    it('supports flat subplots with columns chunking', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        data: eastData,
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        columns: 2,
+        subplots: [
+          { title: 'A', chartType: 'bar' },
+          { title: 'B', chartType: 'bar' },
+          { title: 'C', chartType: 'bar' },
+        ],
+      };
+
+      const result = convertRechartsToMaidr(config);
+
+      expect(result.subplots).toHaveLength(2);
+      expect(result.subplots[0]).toHaveLength(2);
+      expect(result.subplots[1]).toHaveLength(1);
+      expect(result.subplots[1][0].layers[0].title).toBe('C');
+      expect(result.subplots[1][0].layers[0].selectors)
+        .toBe('#maidr-article-facet .maidr-panel-1-0 .recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('honors panelSelector as the panel scope escape hatch', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        data: eastData,
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        subplots: [[{ title: 'East', chartType: 'bar', panelSelector: '.my-east-panel' }]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+
+      expect(result.subplots[0][0].layers[0].selectors)
+        .toBe('#maidr-article-facet .my-east-panel .recharts-bar-rectangle .recharts-rectangle');
+      expect(result.subplots[0][0].selector)
+        .toBe('#maidr-article-facet .my-east-panel svg.recharts-surface');
+    });
+
+    it('uses the panel selectorOverride verbatim and does not inherit the top-level one', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        data: eastData,
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        selectorOverride: '.top-level-override',
+        subplots: [[
+          { title: 'Own override', chartType: 'bar', selectorOverride: '.east-bars .recharts-rectangle' },
+          { title: 'Generated', chartType: 'bar' },
+        ]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+
+      expect(result.subplots[0][0].layers[0].selectors).toBe('.east-bars .recharts-rectangle');
+      expect(result.subplots[0][1].layers[0].selectors)
+        .toBe('#maidr-article-facet .maidr-panel-0-1 .recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('converts mixed panel chart types', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        data: eastData,
+        xKey: 'quarter',
+        subplots: [[
+          { title: 'Bars', chartType: 'bar', yKeys: ['revenue'] },
+          { title: 'Lines', chartType: 'line', yKeys: ['revenue'] },
+        ]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+      const [bars, lines] = result.subplots[0];
+
+      expect(bars.layers[0].type).toBe(TraceType.BAR);
+      expect(lines.layers[0].type).toBe(TraceType.LINE);
+      // Line selectors are wrapped in an array (one per series) and panel-scoped.
+      expect(lines.layers[0].selectors)
+        .toEqual(['#maidr-article-facet .maidr-panel-0-1 .recharts-line-dots .recharts-line-dot']);
+      expect((lines.layers[0].data as LinePoint[][])[0][0]).toEqual({ x: 'Q1', y: 100 });
+    });
+
+    it('disables highlighting for multi-series panels (selectors undefined)', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'facet',
+        data: [{ quarter: 'Q1', a: 1, b: 2 }],
+        xKey: 'quarter',
+        subplots: [[{ title: 'Multi', chartType: 'bar', yKeys: ['a', 'b'] }]],
+      };
+
+      const result = convertRechartsToMaidr(config);
+      const layers = result.subplots[0][0].layers;
+
+      expect(layers).toHaveLength(2);
+      expect(layers[0].selectors).toBeUndefined();
+      expect(layers[1].selectors).toBeUndefined();
+    });
+
+    it('throws when subplots is combined with top-level chartType', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'bad',
+        data: eastData,
+        chartType: 'bar',
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        subplots: [[{ title: 'East', chartType: 'bar' }]],
+      };
+
+      expect(() => convertRechartsToMaidr(config)).toThrow('mutually exclusive');
+    });
+
+    it('throws when subplots is combined with top-level layers', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'bad',
+        data: eastData,
+        xKey: 'quarter',
+        layers: [{ yKey: 'revenue', chartType: 'bar' }],
+        subplots: [[{ title: 'East', chartType: 'bar', yKeys: ['revenue'] }]],
+      };
+
+      expect(() => convertRechartsToMaidr(config)).toThrow('mutually exclusive');
+    });
+
+    it('throws when a panel defines neither chartType nor layers', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'bad',
+        data: eastData,
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        subplots: [[{ title: 'East', chartType: 'bar' }], [{ title: 'Broken' }]],
+      };
+
+      expect(() => convertRechartsToMaidr(config)).toThrow('panel [1][0]');
+    });
+
+    it('throws when neither the panel nor the top level provides data', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'bad',
+        xKey: 'quarter',
+        yKeys: ['revenue'],
+        subplots: [[{ title: 'East', chartType: 'bar' }]],
+      };
+
+      expect(() => convertRechartsToMaidr(config)).toThrow('data is required');
+    });
+  });
+
+  describe('getRechartsSelector with panelScope', () => {
+    it('inserts the panel scope between the article scope and the leaf selector', () => {
+      expect(getRechartsSelector('bar', undefined, 'facet', '.maidr-panel-1-2'))
+        .toBe('#maidr-article-facet .maidr-panel-1-2 .recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('uses the panel scope alone when no chartId is given', () => {
+      expect(getRechartsSelector('scatter', undefined, undefined, '.maidr-panel-0-0'))
+        .toBe('.maidr-panel-0-0 .recharts-scatter-symbol .recharts-symbols');
+    });
+
+    it('still returns undefined for multi-series charts', () => {
+      expect(getRechartsSelector('bar', 1, 'facet', '.maidr-panel-0-0')).toBeUndefined();
+    });
+
+    it('keeps single-chart behavior unchanged when panelScope is omitted', () => {
+      expect(getRechartsSelector('bar', undefined, 'facet'))
+        .toBe('#maidr-article-facet .recharts-bar-rectangle .recharts-rectangle');
+    });
+  });
+
+  describe('getPanelClassName', () => {
+    it('generates the row/col wrapper class', () => {
+      expect(getPanelClassName(0, 0)).toBe('maidr-panel-0-0');
+      expect(getPanelClassName(2, 3)).toBe('maidr-panel-2-3');
+    });
+  });
+});

--- a/test/adapters/vegalite/entry.test.ts
+++ b/test/adapters/vegalite/entry.test.ts
@@ -1,0 +1,155 @@
+import type { VegaLiteSpec, VegaView } from '@adapters/vegalite/types';
+import type { Maidr } from '@type/grammar';
+import { initMaidrOnElement } from '@util/initMaidr';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Tests only use the public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+import { bindVegaLite } from '../../../src/vegalite-entry';
+
+// Mock the MAIDR mount so bindVegaLite never touches React / the real
+// controller; the tests below only verify what (and whether) it mounts.
+jest.mock('@util/initMaidr', () => ({
+  initMaidrOnElement: jest.fn(),
+}));
+
+const initMock = initMaidrOnElement as jest.Mock;
+
+/** Build a JSDOM chart container (with an <svg>) and a minimal Vega view. */
+function setupChart(withId = true): { container: HTMLElement; view: VegaView } {
+  const dom = new JSDOM(
+    `<!DOCTYPE html><body><div${withId ? ' id="chart"' : ''}><svg></svg></div></body>`,
+  );
+  const container = dom.window.document.querySelector('div') as HTMLElement;
+  const view = {
+    container: () => container,
+    data: (name: string) => {
+      throw new Error(`no dataset ${name}`);
+    },
+    runAsync: async (): Promise<unknown> => view,
+    scale: () => undefined,
+  } as unknown as VegaView;
+  return { container, view };
+}
+
+const barSpec: VegaLiteSpec = {
+  data: { values: [{ a: 'A', b: 1 }, { a: 'B', b: 2 }] },
+  mark: 'bar',
+  encoding: {
+    x: { field: 'a', type: 'nominal' },
+    y: { field: 'b', type: 'quantitative' },
+  },
+};
+
+describe('bindVegaLite', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    initMock.mockClear();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('skips binding when the spec produces no accessible layers', () => {
+    const { view } = setupChart();
+    const arcSpec: VegaLiteSpec = {
+      data: { values: [{ a: 'A', b: 1 }] },
+      mark: 'arc',
+      encoding: {
+        color: { field: 'a', type: 'nominal' },
+        y: { field: 'b', type: 'quantitative' },
+      },
+    };
+    bindVegaLite(view, arcSpec);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no accessible layers'),
+    );
+  });
+
+  it('skips binding for a faceted spec whose child mark is unsupported', () => {
+    // A faceted pie compiles every cell to zero layers; mounting the
+    // resulting `[[{ layers: [] }]]` fallback would crash MAIDR core on
+    // focus (Subplot.activeTrace on an empty traces array).
+    const { view } = setupChart();
+    const facetedArc: VegaLiteSpec = {
+      data: { values: [{ site: 'A', a: 'x', b: 1 }, { site: 'B', a: 'y', b: 2 }] },
+      facet: { column: { field: 'site', type: 'nominal' } },
+      spec: {
+        mark: 'arc',
+        encoding: {
+          color: { field: 'a', type: 'nominal' },
+          y: { field: 'b', type: 'quantitative' },
+        },
+      },
+    };
+    bindVegaLite(view, facetedArc);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no accessible layers'),
+    );
+  });
+
+  it('mounts supported specs with selectors prefixed by the container id', () => {
+    const { view } = setupChart();
+    bindVegaLite(view, barSpec);
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const maidr = initMock.mock.calls[0][0] as Maidr;
+    expect(maidr.id).toBe('chart');
+
+    const selector = maidr.subplots[0][0].layers[0].selectors as string;
+    expect(selector.startsWith('#chart ')).toBe(true);
+  });
+
+  it('generates a container id when missing and scopes repeat selectors', () => {
+    // Two identical repeat charts on one page compile to identical Vega
+    // class names; only the container-id prefix keeps their selectors
+    // from resolving each other's elements.
+    const { container, view } = setupChart(false);
+    const repeatSpec: VegaLiteSpec = {
+      data: { values: [{ a: 1, b: 2, c: 3 }, { a: 4, b: 5, c: 6 }] },
+      repeat: { row: ['b', 'c'] },
+      spec: {
+        mark: 'point',
+        encoding: {
+          x: { field: 'a', type: 'quantitative' },
+          y: { field: { repeat: 'row' } as unknown as string, type: 'quantitative' },
+        },
+      },
+    };
+    bindVegaLite(view, repeatSpec);
+
+    expect(container.id).toMatch(/^vl-/);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const maidr = initMock.mock.calls[0][0] as Maidr;
+    const scope = `#${container.id}`;
+
+    for (const row of maidr.subplots) {
+      for (const subplot of row) {
+        expect(subplot.selector!.startsWith(`${scope} g.mark-group.role-scope.child__row_`))
+          .toBe(true);
+        expect((subplot.layers[0].selectors as string).startsWith(`${scope} `))
+          .toBe(true);
+      }
+    }
+  });
+
+  it('scopes vconcat subplot background selectors with the container id', () => {
+    const { view } = setupChart();
+    const vconcatSpec: VegaLiteSpec = {
+      vconcat: [barSpec, barSpec],
+    };
+    bindVegaLite(view, vconcatSpec);
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const maidr = initMock.mock.calls[0][0] as Maidr;
+    expect(maidr.subplots).toHaveLength(2);
+    expect(maidr.subplots[0][0].selector)
+      .toBe('#chart g.mark-group.role-scope.concat_0_group > g > path.background');
+    expect(maidr.subplots[1][0].selector)
+      .toBe('#chart g.mark-group.role-scope.concat_1_group > g > path.background');
+  });
+});

--- a/test/adapters/vegalite/facets.test.ts
+++ b/test/adapters/vegalite/facets.test.ts
@@ -275,6 +275,73 @@ describe('vega-Lite faceted conversion', () => {
     }
   });
 
+  it('enumerates facet panels from all layers, not just the first non-empty one', () => {
+    // The sparse annotation layer is declared FIRST and covers only site A;
+    // panel keys must still come from the union of all layers' rows, so the
+    // bar layer's full dataset produces panels for B and C too.
+    const spec: VegaLiteSpec = {
+      data: { values: siteValues },
+      facet: { column: { field: 'site', type: 'nominal' } },
+      spec: {
+        layer: [
+          {
+            mark: 'point',
+            data: { values: [{ site: 'A', variety: 'v1', yield: 11 }] },
+            encoding: {
+              x: { field: 'variety', type: 'nominal' },
+              y: { field: 'yield', type: 'quantitative' },
+            },
+          },
+          {
+            mark: 'bar',
+            encoding: {
+              x: { field: 'variety', type: 'nominal' },
+              y: { field: 'yield', type: 'quantitative' },
+            },
+          },
+        ],
+      },
+    };
+    const result = vegaLiteToMaidr(spec);
+
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(3);
+    expect(result.subplots[0].map(s => s.layers[0].title)).toEqual([
+      'site: A',
+      'site: B',
+      'site: C',
+    ]);
+    expect(result.subplots[0][0].layers.map(l => l.type))
+      .toEqual([TraceType.SCATTER, TraceType.BAR]);
+    expect(result.subplots[0][1].layers.map(l => l.type)).toEqual([TraceType.BAR]);
+  });
+
+  it('does not confuse facet combos whose space-joined keys would collide', () => {
+    // With a bare-space combo delimiter, the phantom combo (r="X", c="Y W")
+    // would serialize identically to the real combo (r="X Y", c="W"),
+    // fabricating an empty panel that collapses the whole chart.
+    const values = [
+      { r: 'X', c: 'Q', variety: 'v1', yield: 1 },
+      { r: 'X Y', c: 'W', variety: 'v1', yield: 2 },
+      { r: 'Z', c: 'Y W', variety: 'v1', yield: 3 },
+    ];
+    const spec: VegaLiteSpec = {
+      data: { values },
+      facet: {
+        row: { field: 'r', type: 'nominal' },
+        column: { field: 'c', type: 'nominal' },
+      },
+      spec: barChild,
+    };
+    const result = vegaLiteToMaidr(spec);
+
+    expect(result.subplots.map(row => row.map(s => s.layers[0].title))).toEqual([
+      ['r: X, c: Q'],
+      ['r: X Y, c: W'],
+      ['r: Z, c: Y W'],
+    ]);
+  });
+
   it('converts the encoding.column shorthand like the facet operator', () => {
     const spec: VegaLiteSpec = {
       data: { values: siteValues },

--- a/test/adapters/vegalite/facets.test.ts
+++ b/test/adapters/vegalite/facets.test.ts
@@ -1,0 +1,596 @@
+import type { VegaLiteSpec, VegaView } from '@adapters/vegalite/types';
+import type { BarPoint, BoxPoint, ScatterPoint } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import {
+  buildCellDomMap,
+  chunkIntoRows,
+  describeFacet,
+  describeRepeat,
+  repeatChildName,
+  stampFacetCells,
+  substituteRepeatFields,
+} from '@adapters/vegalite/facets';
+import { TraceType } from '@type/grammar';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Tests only use the public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const siteValues = [
+  { site: 'A', variety: 'v1', yield: 10 },
+  { site: 'A', variety: 'v2', yield: 20 },
+  { site: 'B', variety: 'v1', yield: 15 },
+  { site: 'B', variety: 'v2', yield: 25 },
+  { site: 'C', variety: 'v1', yield: 12 },
+  { site: 'C', variety: 'v2', yield: 30 },
+];
+
+const barChild: VegaLiteSpec = {
+  mark: 'bar',
+  encoding: {
+    x: { field: 'variety', type: 'nominal' },
+    y: { field: 'yield', type: 'quantitative' },
+  },
+};
+
+describe('vega-Lite facet/repeat helpers', () => {
+  describe('describeFacet', () => {
+    it('detects the facet operator (row/column form)', () => {
+      const spec: VegaLiteSpec = {
+        data: { values: siteValues },
+        facet: { column: { field: 'site', type: 'nominal' } },
+        spec: barChild,
+      };
+      const descriptor = describeFacet(spec);
+      expect(descriptor).not.toBeNull();
+      expect(descriptor!.columnChannel?.field).toBe('site');
+      expect(descriptor!.rowChannel).toBeUndefined();
+      expect(descriptor!.childSpec).toBe(barChild);
+    });
+
+    it('detects the wrapped facet (field + columns form)', () => {
+      const spec: VegaLiteSpec = {
+        data: { values: siteValues },
+        facet: { field: 'site', type: 'nominal' },
+        columns: 2,
+        spec: barChild,
+      };
+      const descriptor = describeFacet(spec);
+      expect(descriptor!.wrapChannel?.field).toBe('site');
+      expect(descriptor!.columns).toBe(2);
+    });
+
+    it('detects the encoding.row/column shorthand and strips the channels', () => {
+      const spec: VegaLiteSpec = {
+        data: { values: siteValues },
+        mark: 'bar',
+        encoding: {
+          x: { field: 'variety', type: 'nominal' },
+          y: { field: 'yield', type: 'quantitative' },
+          column: { field: 'site', type: 'nominal' },
+        },
+      };
+      const descriptor = describeFacet(spec);
+      expect(descriptor).not.toBeNull();
+      expect(descriptor!.columnChannel?.field).toBe('site');
+      expect(descriptor!.childSpec.encoding?.column).toBeUndefined();
+      expect(descriptor!.childSpec.encoding?.x?.field).toBe('variety');
+    });
+
+    it('returns null for plain single-view and concat specs', () => {
+      expect(describeFacet({ ...barChild, data: { values: siteValues } })).toBeNull();
+      expect(describeFacet({ hconcat: [barChild] })).toBeNull();
+      // facet without a child spec is malformed — not a facet.
+      expect(describeFacet({ facet: { column: { field: 'site' } } })).toBeNull();
+    });
+  });
+
+  describe('describeRepeat', () => {
+    it('detects the row/column form', () => {
+      const descriptor = describeRepeat({
+        repeat: { row: ['a', 'b'] },
+        spec: barChild,
+      });
+      expect(descriptor!.rowFields).toEqual(['a', 'b']);
+      expect(descriptor!.columnFields).toBeUndefined();
+    });
+
+    it('detects the wrapped array form with columns', () => {
+      const descriptor = describeRepeat({
+        repeat: ['a', 'b', 'c'],
+        columns: 2,
+        spec: barChild,
+      });
+      expect(descriptor!.wrapFields).toEqual(['a', 'b', 'c']);
+      expect(descriptor!.columns).toBe(2);
+    });
+
+    it('returns null for empty or missing repeat definitions', () => {
+      expect(describeRepeat({ repeat: [], spec: barChild })).toBeNull();
+      expect(describeRepeat({ repeat: {}, spec: barChild })).toBeNull();
+      expect(describeRepeat({ repeat: ['a'] })).toBeNull();
+    });
+  });
+
+  describe('substituteRepeatFields', () => {
+    it('replaces {repeat: ...} references anywhere in the child spec', () => {
+      const child: VegaLiteSpec = {
+        mark: 'point',
+        encoding: {
+          x: { field: { repeat: 'column' } as unknown as string, type: 'quantitative' },
+          y: { field: { repeat: 'row' } as unknown as string, type: 'quantitative' },
+        },
+      };
+      const substituted = substituteRepeatFields(child, { row: 'hp', column: 'mpg' });
+      expect(substituted.encoding?.x?.field).toBe('mpg');
+      expect(substituted.encoding?.y?.field).toBe('hp');
+      // The original child spec is untouched (deep clone).
+      expect(child.encoding?.y?.field).toEqual({ repeat: 'row' });
+    });
+
+    it('leaves objects that merely contain a repeat key untouched', () => {
+      const child = {
+        mark: 'point',
+        encoding: { x: { field: 'a', repeat: 'not-a-ref' } },
+      } as unknown as VegaLiteSpec;
+      const substituted = substituteRepeatFields(child, { repeat: 'b' });
+      expect((substituted.encoding?.x as Record<string, unknown>).repeat).toBe('not-a-ref');
+    });
+  });
+
+  describe('repeatChildName', () => {
+    it('matches Vega-Lite child view naming', () => {
+      expect(repeatChildName({ repeat: 'yield' })).toBe('child__yield');
+      expect(repeatChildName({ row: 'yield' })).toBe('child__row_yield');
+      expect(repeatChildName({ column: 'year' })).toBe('child__column_year');
+      expect(repeatChildName({ row: 'yield', column: 'year' }))
+        .toBe('child__row_yieldcolumn_year');
+      // Non-word characters in field names become underscores.
+      expect(repeatChildName({ repeat: 'my field' })).toBe('child__my_field');
+    });
+  });
+
+  describe('chunkIntoRows', () => {
+    it('wraps into rows of the given width, ragged at the end', () => {
+      expect(chunkIntoRows(['a', 'b', 'c'], 2)).toEqual([['a', 'b'], ['c']]);
+      expect(chunkIntoRows(['a', 'b', 'c'], undefined)).toEqual([['a', 'b', 'c']]);
+      expect(chunkIntoRows([], 2)).toEqual([]);
+    });
+  });
+});
+
+describe('vega-Lite faceted conversion', () => {
+  it('converts a column facet into a 1xN subplot grid with per-cell data', () => {
+    const spec: VegaLiteSpec = {
+      title: 'Yield by Site',
+      data: { values: siteValues },
+      facet: { column: { field: 'site', type: 'nominal' } },
+      spec: barChild,
+    };
+    const result = vegaLiteToMaidr(spec);
+
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(3);
+
+    const [cellA, cellB, cellC] = result.subplots[0];
+    expect(cellA.layers[0].title).toBe('site: A');
+    expect(cellB.layers[0].title).toBe('site: B');
+    expect(cellC.layers[0].title).toBe('site: C');
+
+    // Per-cell data is filtered from the shared dataset.
+    const dataA = cellA.layers[0].data as BarPoint[];
+    expect(dataA).toEqual([{ x: 'v1', y: 10 }, { x: 'v2', y: 20 }]);
+    const dataC = cellC.layers[0].data as BarPoint[];
+    expect(dataC).toEqual([{ x: 'v1', y: 12 }, { x: 'v2', y: 30 }]);
+
+    // Selectors are cell-scoped via the stamped attribute and target the
+    // facet child mark classes.
+    const selectorA = cellA.layers[0].selectors as string;
+    expect(selectorA).toContain('g[data-maidr-cell="vl-chart-0-0"]');
+    expect(selectorA).toContain('child_marks');
+    const selectorC = cellC.layers[0].selectors as string;
+    expect(selectorC).toContain('g[data-maidr-cell="vl-chart-0-2"]');
+
+    // Subplot selector points at the cell's background path.
+    expect(cellA.selector).toBe('g[data-maidr-cell="vl-chart-0-0"] > path.background');
+
+    // Layer ids are unique across the whole figure.
+    const ids = result.subplots.flat().flatMap(s => s.layers.map(l => l.id));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('converts a row facet into an Nx1 subplot grid', () => {
+    const spec: VegaLiteSpec = {
+      data: { values: siteValues },
+      facet: { row: { field: 'site', type: 'nominal' } },
+      spec: barChild,
+    };
+    const result = vegaLiteToMaidr(spec);
+    expect(result.subplots).toHaveLength(3);
+    expect(result.subplots.every(row => row.length === 1)).toBe(true);
+    expect(result.subplots[1][0].layers[0].title).toBe('site: B');
+  });
+
+  it('converts the encoding.column shorthand like the facet operator', () => {
+    const spec: VegaLiteSpec = {
+      data: { values: siteValues },
+      mark: 'bar',
+      encoding: {
+        x: { field: 'variety', type: 'nominal' },
+        y: { field: 'yield', type: 'quantitative' },
+        column: { field: 'site', type: 'nominal' },
+      },
+    };
+    const result = vegaLiteToMaidr(spec);
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(3);
+    expect(result.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+    expect(result.subplots[0][0].layers[0].data).toEqual([
+      { x: 'v1', y: 10 },
+      { x: 'v2', y: 20 },
+    ]);
+  });
+
+  it('emits sparse row x column facets with ragged rows for missing combos', () => {
+    const values = [
+      { site: 'A', year: 1931, variety: 'v1', yield: 10 },
+      { site: 'B', year: 1931, variety: 'v1', yield: 15 },
+      { site: 'B', year: 1932, variety: 'v1', yield: 25 },
+      { site: 'C', year: 1932, variety: 'v1', yield: 12 },
+    ];
+    const spec: VegaLiteSpec = {
+      data: { values },
+      facet: {
+        row: { field: 'year', type: 'ordinal' },
+        column: { field: 'site', type: 'nominal' },
+      },
+      spec: barChild,
+    };
+    const result = vegaLiteToMaidr(spec);
+
+    // 1931 exists for sites A and B; 1932 for B and C.
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0].map(s => s.layers[0].title)).toEqual([
+      'year: 1931, site: A',
+      'year: 1931, site: B',
+    ]);
+    expect(result.subplots[1].map(s => s.layers[0].title)).toEqual([
+      'year: 1932, site: B',
+      'year: 1932, site: C',
+    ]);
+    const bTitles = result.subplots[1][0].layers[0].data as BarPoint[];
+    expect(bTitles).toEqual([{ x: 'v1', y: 25 }]);
+  });
+
+  it('wraps a single-field facet into rows of `columns` panels', () => {
+    const spec: VegaLiteSpec = {
+      data: { values: siteValues },
+      facet: { field: 'site', type: 'nominal' },
+      columns: 2,
+      spec: barChild,
+    };
+    const result = vegaLiteToMaidr(spec);
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[1]).toHaveLength(1);
+    expect(result.subplots[1][0].layers[0].title).toBe('site: C');
+  });
+
+  it('orders panels by the compiled view domain datasets when available', () => {
+    const view = {
+      data: (name: string) => {
+        if (name === 'column_domain') {
+          return [{ site: 'C' }, { site: 'A' }, { site: 'B' }];
+        }
+        throw new Error(`no dataset ${name}`);
+      },
+      container: () => null,
+      runAsync: () => Promise.resolve(view),
+      scale: () => undefined,
+    } as unknown as VegaView;
+
+    const spec: VegaLiteSpec = {
+      data: { values: siteValues },
+      facet: { column: { field: 'site', type: 'nominal' } },
+      spec: barChild,
+    };
+    const result = vegaLiteToMaidr(spec, view);
+    expect(result.subplots[0].map(s => s.layers[0].title)).toEqual([
+      'site: C',
+      'site: A',
+      'site: B',
+    ]);
+    expect(result.subplots[0][0].layers[0].data).toEqual([
+      { x: 'v1', y: 12 },
+      { x: 'v2', y: 30 },
+    ]);
+  });
+
+  it('supports boxplot children with per-cell grouping', () => {
+    const values = [
+      { site: 'A', variety: 'v1', yield: 10 },
+      { site: 'A', variety: 'v1', yield: 14 },
+      { site: 'A', variety: 'v2', yield: 20 },
+      { site: 'B', variety: 'v1', yield: 15 },
+    ];
+    const spec: VegaLiteSpec = {
+      data: { values },
+      facet: { column: { field: 'site', type: 'nominal' } },
+      spec: {
+        mark: 'boxplot',
+        encoding: {
+          x: { field: 'variety', type: 'nominal' },
+          y: { field: 'yield', type: 'quantitative' },
+        },
+      },
+    };
+    const result = vegaLiteToMaidr(spec);
+    const cellA = result.subplots[0][0].layers[0];
+    expect(cellA.type).toBe(TraceType.BOX);
+    expect((cellA.data as BoxPoint[]).map(b => b.z)).toEqual(['v1', 'v2']);
+    const cellB = result.subplots[0][1].layers[0];
+    expect((cellB.data as BoxPoint[]).map(b => b.z)).toEqual(['v1']);
+  });
+});
+
+describe('vega-Lite repeat conversion', () => {
+  const numericValues = [
+    { g: 'p', a: 1, b: 2, c: 3 },
+    { g: 'q', a: 4, b: 5, c: 6 },
+  ];
+
+  it('converts repeat.row into an Nx1 grid with substituted fields', () => {
+    const spec: VegaLiteSpec = {
+      data: { values: numericValues },
+      repeat: { row: ['b', 'c'] },
+      spec: {
+        mark: 'point',
+        encoding: {
+          x: { field: 'a', type: 'quantitative' },
+          y: { field: { repeat: 'row' } as unknown as string, type: 'quantitative' },
+        },
+      },
+    };
+    const result = vegaLiteToMaidr(spec);
+
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots.every(row => row.length === 1)).toBe(true);
+
+    const [top, bottom] = result.subplots.map(row => row[0].layers[0]);
+    expect(top.type).toBe(TraceType.SCATTER);
+    expect(top.title).toBe('b');
+    expect(top.axes?.y?.label).toBe('b');
+    expect(top.data as ScatterPoint[]).toEqual([{ x: 1, y: 2 }, { x: 4, y: 5 }]);
+    expect(bottom.axes?.y?.label).toBe('c');
+    expect(bottom.data as ScatterPoint[]).toEqual([{ x: 1, y: 3 }, { x: 4, y: 6 }]);
+
+    // Selectors use the per-cell child view class — unique without stamping.
+    expect(top.selectors as string).toContain('child__row_b_marks');
+    expect(bottom.selectors as string).toContain('child__row_c_marks');
+
+    // Subplot selector points at the repeat cell group's background path.
+    expect(result.subplots[0][0].selector)
+      .toBe('g.mark-group.role-scope.child__row_b_group > g > path.background');
+  });
+
+  it('converts repeat.row x repeat.column into a full grid', () => {
+    const spec: VegaLiteSpec = {
+      data: { values: numericValues },
+      repeat: { row: ['b', 'c'], column: ['a', 'b'] },
+      spec: {
+        mark: 'point',
+        encoding: {
+          x: { field: { repeat: 'column' } as unknown as string, type: 'quantitative' },
+          y: { field: { repeat: 'row' } as unknown as string, type: 'quantitative' },
+        },
+      },
+    };
+    const result = vegaLiteToMaidr(spec);
+
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[0][0].layers[0].title).toBe('b vs a');
+    expect(result.subplots[0][0].layers[0].selectors as string)
+      .toContain('child__row_bcolumn_a_marks');
+    expect(result.subplots[1][1].layers[0].axes?.x?.label).toBe('b');
+    expect(result.subplots[1][1].layers[0].axes?.y?.label).toBe('c');
+
+    const ids = result.subplots.flat().flatMap(s => s.layers.map(l => l.id));
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it('wraps repeat arrays into rows of `columns` panels', () => {
+    const spec: VegaLiteSpec = {
+      data: { values: numericValues },
+      repeat: ['a', 'b', 'c'],
+      columns: 2,
+      spec: {
+        mark: 'bar',
+        encoding: {
+          x: { field: 'g', type: 'nominal' },
+          y: { field: { repeat: 'repeat' } as unknown as string, type: 'quantitative' },
+        },
+      },
+    };
+    const result = vegaLiteToMaidr(spec);
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[1]).toHaveLength(1);
+    expect(result.subplots[1][0].layers[0].title).toBe('c');
+    expect(result.subplots[1][0].layers[0].selectors as string)
+      .toContain('child__c_marks');
+  });
+});
+
+describe('concat wrap columns', () => {
+  it('honours spec.columns for general concat', () => {
+    const child = (values: Record<string, unknown>[]): VegaLiteSpec => ({
+      data: { values },
+      mark: 'bar',
+      encoding: {
+        x: { field: 'x', type: 'nominal' },
+        y: { field: 'y', type: 'quantitative' },
+      },
+    });
+    const spec: VegaLiteSpec = {
+      concat: [
+        child([{ x: 'a', y: 1 }]),
+        child([{ x: 'b', y: 2 }]),
+        child([{ x: 'c', y: 3 }]),
+      ],
+      columns: 2,
+    };
+    const result = vegaLiteToMaidr(spec);
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0]).toHaveLength(2);
+    expect(result.subplots[1]).toHaveLength(1);
+  });
+
+  it('keeps a single row when columns is omitted', () => {
+    const spec: VegaLiteSpec = {
+      concat: [
+        { data: { values: [{ x: 'a', y: 1 }] }, mark: 'bar', encoding: { x: { field: 'x', type: 'nominal' }, y: { field: 'y', type: 'quantitative' } } },
+        { data: { values: [{ x: 'b', y: 2 }] }, mark: 'bar', encoding: { x: { field: 'x', type: 'nominal' }, y: { field: 'y', type: 'quantitative' } } },
+      ],
+    };
+    const result = vegaLiteToMaidr(spec);
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(2);
+  });
+});
+
+describe('stampFacetCells / buildCellDomMap (DOM)', () => {
+  /**
+   * Build a minimal jsdom SVG mimicking Vega-Lite's faceted output: one
+   * `g.mark-group.role-scope.cell` whose direct <g> children are the
+   * per-cell items (each with a background path and a child_marks group),
+   * plus column headers with the facet values.
+   */
+  function buildFacetDom(
+    cellCount: number,
+    headers: string[],
+    options?: { emptyCellAt?: number },
+  ): { svg: SVGSVGElement; dom: unknown } {
+    const header = (text: string): string =>
+      `<g><g><g class="mark-group role-title"><g><g>`
+      + `<g class="mark-text role-title-text"><text>${text}</text></g>`
+      + `</g></g></g></g></g>`;
+    const cell = (empty: boolean): string =>
+      `<g transform="translate(0,0)"><path class="background"></path><g>${
+        empty
+          ? ''
+          : `<g class="mark-rect role-mark child_marks"><path></path><path></path></g>`
+      }</g></g>`;
+    const cells = Array.from(
+      { length: cellCount },
+      (_, i) => cell(i === options?.emptyCellAt),
+    );
+    const html = `<!DOCTYPE html><body><svg>`
+      + `<g class="mark-group role-frame root"><g><g>`
+      + `<g class="mark-group role-column-header column_header">${headers.map(header).join('')}</g>`
+      + `<g class="mark-group role-scope cell">${cells.join('')}</g>`
+      + `</g></g></g>`
+      + `</svg></body>`;
+    const dom = new JSDOM(html);
+    const svg = dom.window.document.querySelector('svg') as SVGSVGElement;
+    return { svg, dom };
+  }
+
+  const facetSpec: VegaLiteSpec = {
+    data: { values: siteValues },
+    facet: { column: { field: 'site', type: 'nominal' } },
+    spec: barChild,
+  };
+
+  it('stamps cells in DOM order and makes cell-scoped selectors resolve', () => {
+    const maidr = vegaLiteToMaidr(facetSpec);
+    const { svg } = buildFacetDom(3, ['A', 'B', 'C']);
+
+    stampFacetCells(svg, maidr);
+
+    const cellGroup = svg.querySelector('g.mark-group.role-scope.cell')!;
+    const items = Array.from(cellGroup.children);
+    expect(items.map(el => el.getAttribute('data-maidr-cell'))).toEqual([
+      'vl-chart-0-0',
+      'vl-chart-0-1',
+      'vl-chart-0-2',
+    ]);
+
+    // Each panel's layer selector now matches exactly its own cell's marks.
+    for (let c = 0; c < 3; c++) {
+      const selector = maidr.subplots[0][c].layers[0].selectors as string;
+      const matched = svg.querySelectorAll(selector);
+      expect(matched).toHaveLength(2);
+      expect(items[c].contains(matched[0])).toBe(true);
+    }
+
+    // Subplot selectors resolve to each cell's background path.
+    const background = svg.querySelector(maidr.subplots[0][1].selector!);
+    expect(background).not.toBeNull();
+    expect(items[1].contains(background!)).toBe(true);
+  });
+
+  it('builds the per-layer cell root map after stamping', () => {
+    const maidr = vegaLiteToMaidr(facetSpec);
+    const { svg } = buildFacetDom(3, ['A', 'B', 'C']);
+    stampFacetCells(svg, maidr);
+
+    const map = buildCellDomMap(svg, maidr);
+    expect(map.size).toBe(3);
+
+    const cellGroup = svg.querySelector('g.mark-group.role-scope.cell')!;
+    const firstLayer = maidr.subplots[0][0].layers[0];
+    const info = map.get(firstLayer)!;
+    expect(info.root).toBe(cellGroup.children[0]);
+    expect(info.scope).toBe('g[data-maidr-cell="vl-chart-0-0"]');
+  });
+
+  it('skips mark-less cells rendered for empty cross-facet combinations', () => {
+    const maidr = vegaLiteToMaidr(facetSpec);
+    // Four rendered cells, one of them empty (no role-mark group inside) —
+    // Vega renders these for (row, column) combinations with no data.
+    const { svg } = buildFacetDom(4, ['A', 'B', 'C'], { emptyCellAt: 1 });
+
+    stampFacetCells(svg, maidr);
+
+    const cellGroup = svg.querySelector('g.mark-group.role-scope.cell')!;
+    const items = Array.from(cellGroup.children);
+    expect(items[0].getAttribute('data-maidr-cell')).toBe('vl-chart-0-0');
+    expect(items[1].hasAttribute('data-maidr-cell')).toBe(false);
+    expect(items[2].getAttribute('data-maidr-cell')).toBe('vl-chart-0-1');
+    expect(items[3].getAttribute('data-maidr-cell')).toBe('vl-chart-0-2');
+  });
+
+  it('warns and skips stamping on a cell count mismatch', () => {
+    const maidr = vegaLiteToMaidr(facetSpec);
+    const { svg } = buildFacetDom(2, ['A', 'B']); // one cell missing
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      stampFacetCells(svg, maidr);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cell count mismatch'));
+      const stamped = svg.querySelectorAll('[data-maidr-cell]');
+      expect(stamped).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns when header texts disagree with panel titles', () => {
+    const maidr = vegaLiteToMaidr(facetSpec);
+    const { svg } = buildFacetDom(3, ['X', 'Y', 'Z']); // wrong headers
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      stampFacetCells(svg, maidr);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('does not match'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does nothing for non-facet charts', () => {
+    const singleView = vegaLiteToMaidr({ ...barChild, data: { values: siteValues } });
+    const { svg } = buildFacetDom(3, ['A', 'B', 'C']);
+    stampFacetCells(svg, singleView);
+    expect(svg.querySelectorAll('[data-maidr-cell]')).toHaveLength(0);
+    expect(buildCellDomMap(svg, singleView).size).toBe(0);
+  });
+});

--- a/test/adapters/vegalite/facets.test.ts
+++ b/test/adapters/vegalite/facets.test.ts
@@ -147,6 +147,17 @@ describe('vega-Lite facet/repeat helpers', () => {
       // Non-word characters in field names become underscores.
       expect(repeatChildName({ repeat: 'my field' })).toBe('child__my_field');
     });
+
+    it('prefixes an underscore for digit-leading field names (varName rule)', () => {
+      // Vega-Lite's varName prepends `_` when the field starts with a
+      // digit, so the compiled classes are `child___2020_marks` /
+      // `child___2020_group`. Without the prefix every selector for a
+      // repeated year-column chart matches nothing.
+      expect(repeatChildName({ repeat: '2020' })).toBe('child___2020');
+      expect(repeatChildName({ row: '3rd quarter' })).toBe('child__row__3rd_quarter');
+      expect(repeatChildName({ column: '2019', row: 'yield' }))
+        .toBe('child__row_yieldcolumn__2019');
+    });
   });
 
   describe('chunkIntoRows', () => {
@@ -208,6 +219,60 @@ describe('vega-Lite faceted conversion', () => {
     expect(result.subplots).toHaveLength(3);
     expect(result.subplots.every(row => row.length === 1)).toBe(true);
     expect(result.subplots[1][0].layers[0].title).toBe('site: B');
+
+    // Every panel of a multi-ROW grid must carry a subplot selector that
+    // resolves to a real per-panel element — MAIDR core measures its
+    // geometry to compute the visual panel order and to keep Up/Down
+    // arrows matching screen direction (Vega SVGs have no axes_* ids).
+    result.subplots.forEach((row, r) => {
+      expect(row[0].selector)
+        .toBe(`g[data-maidr-cell="vl-chart-${r}-0"] > path.background`);
+    });
+  });
+
+  it('drops layers whose rows do not cover a facet cell (layered child)', () => {
+    // The point layer carries its own dataset covering only site A. Cell
+    // B must contain just the bar layer — an empty-data SCATTER layer
+    // would crash MAIDR core's trace state getters on PageDown.
+    const spec: VegaLiteSpec = {
+      data: { values: siteValues },
+      facet: { column: { field: 'site', type: 'nominal' } },
+      spec: {
+        layer: [
+          {
+            mark: 'bar',
+            encoding: {
+              x: { field: 'variety', type: 'nominal' },
+              y: { field: 'yield', type: 'quantitative' },
+            },
+          },
+          {
+            mark: 'point',
+            data: { values: [{ site: 'A', variety: 'v1', yield: 11 }] },
+            encoding: {
+              x: { field: 'variety', type: 'nominal' },
+              y: { field: 'yield', type: 'quantitative' },
+            },
+          },
+        ],
+      },
+    };
+    const result = vegaLiteToMaidr(spec);
+
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0]).toHaveLength(3);
+
+    const [cellA, cellB, cellC] = result.subplots[0];
+    expect(cellA.layers.map(l => l.type)).toEqual([TraceType.BAR, TraceType.SCATTER]);
+    expect(cellB.layers.map(l => l.type)).toEqual([TraceType.BAR]);
+    expect(cellC.layers.map(l => l.type)).toEqual([TraceType.BAR]);
+
+    // No emitted layer may carry an empty data array.
+    for (const subplot of result.subplots.flat()) {
+      for (const layer of subplot.layers) {
+        expect(Array.isArray(layer.data) && layer.data.length === 0).toBe(false);
+      }
+    }
   });
 
   it('converts the encoding.column shorthand like the facet operator', () => {
@@ -455,6 +520,57 @@ describe('concat wrap columns', () => {
     const result = vegaLiteToMaidr(spec);
     expect(result.subplots).toHaveLength(1);
     expect(result.subplots[0]).toHaveLength(2);
+  });
+
+  it('emits per-panel background selectors so core can measure panel geometry', () => {
+    // Multi-ROW vconcat grids rely on MAIDR core measuring each panel's
+    // own element to compute visual order / vertical arrow direction.
+    // The concat cell group selector is that element.
+    const bar = (values: Record<string, unknown>[]): VegaLiteSpec => ({
+      data: { values },
+      mark: 'bar',
+      encoding: {
+        x: { field: 'x', type: 'nominal' },
+        y: { field: 'y', type: 'quantitative' },
+      },
+    });
+    const spec: VegaLiteSpec = {
+      vconcat: [bar([{ x: 'a', y: 1 }]), bar([{ x: 'b', y: 2 }])],
+    };
+    const result = vegaLiteToMaidr(spec);
+    expect(result.subplots).toHaveLength(2);
+    expect(result.subplots[0][0].selector)
+      .toBe('g.mark-group.role-scope.concat_0_group > g > path.background');
+    expect(result.subplots[1][0].selector)
+      .toBe('g.mark-group.role-scope.concat_1_group > g > path.background');
+  });
+
+  it('collapses to the empty-figure fallback when a concat child is unsupported', () => {
+    // A `{ layers: [] }` subplot inside a grid crashes MAIDR core on
+    // focus; the converter must collapse the whole grid to the single
+    // empty fallback, which bindVegaLite refuses to mount.
+    const spec: VegaLiteSpec = {
+      hconcat: [
+        {
+          data: { values: [{ x: 'a', y: 1 }] },
+          mark: 'bar',
+          encoding: { x: { field: 'x', type: 'nominal' }, y: { field: 'y', type: 'quantitative' } },
+        },
+        {
+          data: { values: [{ x: 'a', y: 1 }] },
+          mark: 'arc',
+          encoding: { x: { field: 'x', type: 'nominal' }, y: { field: 'y', type: 'quantitative' } },
+        },
+      ],
+    };
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = vegaLiteToMaidr(spec);
+      expect(result.subplots).toEqual([[{ layers: [] }]]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unsupported mark type'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/test/adapters/victory/converters.test.ts
+++ b/test/adapters/victory/converters.test.ts
@@ -1,0 +1,301 @@
+import type { VictoryLayerInfo } from '@adapters/victory/types';
+import type { BarPoint, SegmentedPoint } from '@type/grammar';
+import type { ReactNode } from 'react';
+import {
+  computeSubplotGrid,
+  extractVictoryLayers,
+  extractVictorySubplots,
+  toMaidrLayer,
+} from '@adapters/victory/converters';
+import { describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { createElement } from 'react';
+
+// ---------------------------------------------------------------------------
+// Victory component stubs
+//
+// The extraction only reads `displayName` (must start with 'Victory') and the
+// element props, so lightweight stubs avoid pulling the real Victory renderer
+// into unit tests.
+// ---------------------------------------------------------------------------
+
+interface VictoryStub {
+  (props: Record<string, unknown>): null;
+  displayName: string;
+}
+
+function stub(displayName: string): VictoryStub {
+  const component = (): null => null;
+  component.displayName = displayName;
+  return component as VictoryStub;
+}
+
+const VictoryChart = stub('VictoryChart');
+const VictoryAxis = stub('VictoryAxis');
+const VictoryBar = stub('VictoryBar');
+const VictoryLine = stub('VictoryLine');
+const VictoryScatter = stub('VictoryScatter');
+const VictoryStack = stub('VictoryStack');
+
+const barData = [
+  { x: 'A', y: 1 },
+  { x: 'B', y: 2 },
+];
+const lineData = [
+  { x: 1, y: 10 },
+  { x: 2, y: 20 },
+];
+const scatterData = [
+  { x: 1, y: 2 },
+  { x: 3, y: 4 },
+];
+
+function chart(props: Record<string, unknown>, ...children: ReactNode[]): ReactNode {
+  return createElement(VictoryChart, props, ...children);
+}
+
+describe('extractVictoryLayers (single-panel, legacy)', () => {
+  it('flattens a single chart into monotonic layer ids', () => {
+    const children = chart(
+      {},
+      createElement(VictoryAxis, { label: 'Category' }),
+      createElement(VictoryAxis, { dependentAxis: true, label: 'Value' }),
+      createElement(VictoryBar, { data: barData }),
+      createElement(VictoryLine, { data: lineData }),
+    );
+
+    const layers = extractVictoryLayers(children);
+
+    expect(layers).toHaveLength(2);
+    expect(layers[0].id).toBe('0');
+    expect(layers[0].victoryType).toBe('VictoryBar');
+    expect(layers[0].xAxisLabel).toBe('Category');
+    expect(layers[0].yAxisLabel).toBe('Value');
+    expect(layers[1].id).toBe('1');
+    expect(layers[1].victoryType).toBe('VictoryLine');
+  });
+
+  it('keeps monotonic ids across multiple top-level charts (flat public API)', () => {
+    const children = [
+      chart({ key: 'a' }, createElement(VictoryBar, { data: barData })),
+      chart({ key: 'b' }, createElement(VictoryLine, { data: lineData })),
+      chart({ key: 'c' }, createElement(VictoryScatter, { data: scatterData })),
+    ];
+
+    const layers = extractVictoryLayers(children);
+
+    expect(layers.map(l => l.id)).toEqual(['0', '1', '2']);
+    expect(layers.map(l => l.victoryType)).toEqual(['VictoryBar', 'VictoryLine', 'VictoryScatter']);
+  });
+
+  it('extracts standalone data components outside any chart', () => {
+    const children = [
+      createElement(VictoryScatter, { key: 's1', data: scatterData }),
+      createElement(VictoryBar, { key: 'b1', data: barData }),
+    ];
+
+    const layers = extractVictoryLayers(children);
+
+    expect(layers.map(l => l.id)).toEqual(['0', '1']);
+    expect(layers.map(l => l.victoryType)).toEqual(['VictoryScatter', 'VictoryBar']);
+  });
+});
+
+describe('extractVictorySubplots', () => {
+  it('returns one legacy subplot for a single chart (ids unchanged)', () => {
+    const children = chart(
+      { title: 'Ignored in single-panel mode' },
+      createElement(VictoryBar, { data: barData }),
+      createElement(VictoryLine, { data: lineData }),
+    );
+
+    const subplots = extractVictorySubplots(children);
+
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0].title).toBeUndefined();
+    expect(subplots[0].layers.map(l => l.id)).toEqual(['0', '1']);
+  });
+
+  it('returns one legacy subplot for standalone-only content', () => {
+    const children = [
+      createElement(VictoryScatter, { key: 's1', data: scatterData }),
+      createElement(VictoryScatter, { key: 's2', data: scatterData }),
+    ];
+
+    const subplots = extractVictorySubplots(children);
+
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0].layers.map(l => l.id)).toEqual(['0', '1']);
+  });
+
+  it('flattens one chart plus standalone siblings into a single legacy subplot', () => {
+    const children = [
+      chart({ key: 'c' }, createElement(VictoryBar, { data: barData })),
+      createElement(VictoryScatter, { key: 's', data: scatterData }),
+    ];
+
+    const subplots = extractVictorySubplots(children);
+
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0].layers.map(l => l.id)).toEqual(['0', '1']);
+  });
+
+  it('creates one subplot per chart with panel-scoped ids and per-chart axes', () => {
+    const children = [
+      chart(
+        { key: 'a', title: 'Panel A' },
+        createElement(VictoryAxis, { label: 'Quarter' }),
+        createElement(VictoryAxis, { dependentAxis: true, label: 'Revenue' }),
+        createElement(VictoryBar, { data: barData }),
+        createElement(VictoryLine, { data: lineData }),
+      ),
+      chart(
+        { key: 'b', title: 'Panel B' },
+        createElement(VictoryAxis, { label: 'Month' }),
+        createElement(VictoryLine, { data: lineData }),
+      ),
+    ];
+
+    const subplots = extractVictorySubplots(children);
+
+    expect(subplots).toHaveLength(2);
+    expect(subplots[0].title).toBe('Panel A');
+    expect(subplots[0].layers.map(l => l.id)).toEqual(['0_0', '0_1']);
+    expect(subplots[0].layers[0].xAxisLabel).toBe('Quarter');
+    expect(subplots[0].layers[0].yAxisLabel).toBe('Revenue');
+    expect(subplots[1].title).toBe('Panel B');
+    expect(subplots[1].layers.map(l => l.id)).toEqual(['1_0']);
+    expect(subplots[1].layers[0].xAxisLabel).toBe('Month');
+    expect(subplots[1].layers[0].yAxisLabel).toBeUndefined();
+  });
+
+  it('keeps empty-chart entries so panel indices stay svg-aligned', () => {
+    const children = [
+      chart({ key: 'a' }, createElement(VictoryBar, { data: barData })),
+      chart({ key: 'b' }), // no supported data components
+      chart({ key: 'c' }, createElement(VictoryLine, { data: lineData })),
+    ];
+
+    const subplots = extractVictorySubplots(children);
+
+    expect(subplots).toHaveLength(3);
+    expect(subplots[0].layers.map(l => l.id)).toEqual(['0_0']);
+    expect(subplots[1].layers).toHaveLength(0);
+    expect(subplots[2].layers.map(l => l.id)).toEqual(['2_0']);
+  });
+
+  it('handles VictoryStack inside a panel', () => {
+    const children = [
+      chart({ key: 'a' }, createElement(VictoryBar, { data: barData })),
+      chart(
+        { key: 'b' },
+        createElement(
+          VictoryStack,
+          {},
+          createElement(VictoryBar, { name: 'S1', data: barData }),
+          createElement(VictoryBar, { name: 'S2', data: barData }),
+        ),
+      ),
+    ];
+
+    const subplots = extractVictorySubplots(children);
+
+    expect(subplots[1].layers).toHaveLength(1);
+    expect(subplots[1].layers[0].id).toBe('1_0');
+    expect(subplots[1].layers[0].victoryType).toBe('VictoryStack');
+    expect(subplots[1].layers[0].legend).toEqual(['S1', 'S2']);
+  });
+
+  it('ignores standalone data siblings in multi-panel mode with a warning', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const children = [
+        chart({ key: 'a' }, createElement(VictoryBar, { data: barData })),
+        createElement(VictoryScatter, { key: 's', data: scatterData }),
+        chart({ key: 'b' }, createElement(VictoryLine, { data: lineData })),
+      ];
+
+      const subplots = extractVictorySubplots(children);
+
+      expect(subplots).toHaveLength(2);
+      expect(subplots.flatMap(s => s.layers.map(l => l.victoryType)))
+        .toEqual(['VictoryBar', 'VictoryLine']);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('computeSubplotGrid', () => {
+  const panels = ['a', 'b', 'c', 'd', 'e'];
+
+  it('defaults to a single row in panel order', () => {
+    expect(computeSubplotGrid(panels)).toEqual([['a', 'b', 'c', 'd', 'e']]);
+  });
+
+  it('chunks row-major by columns', () => {
+    expect(computeSubplotGrid(['a', 'b', 'c', 'd'], { columns: 2 }))
+      .toEqual([['a', 'b'], ['c', 'd']]);
+  });
+
+  it('allows a ragged last row and never emits empty rows', () => {
+    expect(computeSubplotGrid(panels, { columns: 2 }))
+      .toEqual([['a', 'b'], ['c', 'd'], ['e']]);
+  });
+
+  it('derives columns from rows when columns is omitted', () => {
+    expect(computeSubplotGrid(panels, { rows: 2 }))
+      .toEqual([['a', 'b', 'c'], ['d', 'e']]);
+  });
+
+  it('prefers columns over rows when both are given', () => {
+    expect(computeSubplotGrid(['a', 'b', 'c', 'd'], { rows: 4, columns: 4 }))
+      .toEqual([['a', 'b', 'c', 'd']]);
+  });
+
+  it('ignores non-positive layout values', () => {
+    expect(computeSubplotGrid(['a', 'b'], { rows: 0, columns: -1 }))
+      .toEqual([['a', 'b']]);
+  });
+
+  it('returns an empty grid for no panels', () => {
+    expect(computeSubplotGrid([], { columns: 2 })).toEqual([]);
+  });
+});
+
+describe('toMaidrLayer', () => {
+  it('converts a bar layer preserving its id and axes', () => {
+    const info: VictoryLayerInfo = {
+      id: '1_0',
+      victoryType: 'VictoryBar',
+      data: { kind: 'bar', points: barData as BarPoint[] },
+      xAxisLabel: 'X',
+      yAxisLabel: 'Y',
+      dataCount: 2,
+    };
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-1-0]');
+
+    expect(layer.id).toBe('1_0');
+    expect(layer.type).toBe(TraceType.BAR);
+    expect(layer.selectors).toBe('#mv [data-maidr-victory-1-0]');
+    expect(layer.axes?.x).toEqual({ label: 'X' });
+  });
+
+  it('converts a segmented layer to stacked type', () => {
+    const points: SegmentedPoint[][] = [[{ x: 'A', y: 1, z: 'S1' }]];
+    const info: VictoryLayerInfo = {
+      id: '0_0',
+      victoryType: 'VictoryStack',
+      data: { kind: 'segmented', points },
+      dataCount: 1,
+      legend: ['S1'],
+    };
+
+    const layer = toMaidrLayer(info);
+
+    expect(layer.type).toBe(TraceType.STACKED);
+    expect(layer.selectors).toBeUndefined();
+  });
+});

--- a/test/adapters/victory/converters.test.ts
+++ b/test/adapters/victory/converters.test.ts
@@ -167,6 +167,7 @@ describe('extractVictorySubplots', () => {
     expect(subplots[1].layers.map(l => l.id)).toEqual(['1_0']);
     expect(subplots[1].layers[0].xAxisLabel).toBe('Month');
     expect(subplots[1].layers[0].yAxisLabel).toBeUndefined();
+    expect(subplots.map(s => s.svgIndex)).toEqual([0, 1]);
   });
 
   it('keeps empty-chart entries so panel indices stay svg-aligned', () => {
@@ -220,7 +221,31 @@ describe('extractVictorySubplots', () => {
       expect(subplots).toHaveLength(2);
       expect(subplots.flatMap(s => s.layers.map(l => l.victoryType)))
         .toEqual(['VictoryBar', 'VictoryLine']);
+      // The standalone sibling still renders its own svg, so the second
+      // chart's svg is the third one in the container.
+      expect(subplots.map(s => s.svgIndex)).toEqual([0, 2]);
       expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('advances the svg ordinal for every Victory component but not plain elements', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const VictoryLegend = stub('VictoryLegend');
+      const children = [
+        createElement('div', { key: 'd' }), // renders no Victory svg
+        createElement(VictoryLegend, { key: 'l' }), // renders its own svg, no data
+        chart({ key: 'a' }, createElement(VictoryBar, { data: barData })),
+        chart({ key: 'b' }, createElement(VictoryLine, { data: lineData })),
+      ];
+
+      const subplots = extractVictorySubplots(children);
+
+      expect(subplots.map(s => s.svgIndex)).toEqual([1, 2]);
+      // A legend carries no data layers, so no standalone-data warning fires.
+      expect(warnSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
     }

--- a/test/adapters/victory/selectors.test.ts
+++ b/test/adapters/victory/selectors.test.ts
@@ -1,0 +1,254 @@
+import type { VictoryLayerInfo } from '@adapters/victory/types';
+import type { BarPoint } from '@type/grammar';
+import {
+  clearTaggedElements,
+  getTaggedElements,
+  PANEL_ATTR,
+  resolvePanelSvgs,
+  tagLayerElements,
+} from '@adapters/victory/selectors';
+import { buildVictorySubplots } from '@adapters/victory/useVictoryAdapter';
+import { describe, expect, it } from '@jest/globals';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Tests only use the public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Builds a container holding one Victory-style panel per entry: a wrapper div
+ * with an `<svg role="img">` containing `barCount` `<path role="presentation">`
+ * marks (Victory's Bar primitive renders paths).
+ */
+function buildContainer(panelBarCounts: number[]): { container: HTMLElement; doc: Document } {
+  const dom = new JSDOM('<!doctype html><body><div id="mv-test"></div></body>');
+  const doc = dom.window.document as Document;
+  const container = doc.getElementById('mv-test') as HTMLElement;
+
+  for (const barCount of panelBarCounts) {
+    const wrapper = doc.createElement('div');
+    const svg = doc.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('role', 'img');
+    for (let i = 0; i < barCount; i++) {
+      const path = doc.createElementNS(SVG_NS, 'path');
+      path.setAttribute('role', 'presentation');
+      path.setAttribute('d', `M ${i * 10}, 100 L ${i * 10 + 5}, 50`);
+      svg.appendChild(path);
+    }
+    wrapper.appendChild(svg);
+    container.appendChild(wrapper);
+  }
+
+  return { container, doc };
+}
+
+function barLayer(id: string, count: number): VictoryLayerInfo {
+  const points: BarPoint[] = Array.from({ length: count }, (_, i) => ({ x: `c${i}`, y: i }));
+  return {
+    id,
+    victoryType: 'VictoryBar',
+    data: { kind: 'bar', points },
+    dataCount: count,
+  };
+}
+
+describe('resolvePanelSvgs', () => {
+  it('returns Victory container svgs in document order', () => {
+    const { container } = buildContainer([2, 3]);
+    const svgs = resolvePanelSvgs(container, 2);
+
+    expect(svgs).toHaveLength(2);
+    expect(svgs[0].querySelectorAll('path')).toHaveLength(2);
+    expect(svgs[1].querySelectorAll('path')).toHaveLength(3);
+  });
+
+  it('skips decorative svgs without role="img"', () => {
+    const { container, doc } = buildContainer([2, 3]);
+    const icon = doc.createElementNS(SVG_NS, 'svg');
+    container.insertBefore(icon, container.firstChild);
+
+    const svgs = resolvePanelSvgs(container, 2);
+
+    expect(svgs).toHaveLength(2);
+    expect(svgs[0].querySelectorAll('path')).toHaveLength(2);
+  });
+
+  it('falls back to all svgs when the role filter finds too few', () => {
+    const { container } = buildContainer([2, 3]);
+    for (const svg of Array.from(container.querySelectorAll('svg'))) {
+      svg.removeAttribute('role');
+    }
+
+    const svgs = resolvePanelSvgs(container, 2);
+
+    expect(svgs).toHaveLength(2);
+  });
+});
+
+describe('tagLayerElements', () => {
+  it('keeps the flat single-panel attribute naming when panelIndex is null', () => {
+    const { container } = buildContainer([2]);
+    const svg = container.querySelector('svg') as SVGElement;
+
+    const selector = tagLayerElements(svg, barLayer('0', 2), 0, new Set(), '#mv-test ');
+
+    expect(selector).toBe('#mv-test [data-maidr-victory-0]');
+    expect(svg.querySelectorAll('[data-maidr-victory-0]')).toHaveLength(2);
+  });
+
+  it('folds the panel index into attribute names and selectors', () => {
+    const { container } = buildContainer([2, 3]);
+    const svgs = resolvePanelSvgs(container, 2);
+    const scope = `#mv-test [${PANEL_ATTR}="1"] `;
+
+    const selector = tagLayerElements(svgs[1], barLayer('1_0', 3), 0, new Set(), scope, 1);
+
+    expect(selector).toBe(`#mv-test [${PANEL_ATTR}="1"] [data-maidr-victory-1-0]`);
+    expect(svgs[1].querySelectorAll('[data-maidr-victory-1-0]')).toHaveLength(3);
+    // No leakage into the other panel.
+    expect(svgs[0].querySelectorAll('[data-maidr-victory-1-0]')).toHaveLength(0);
+  });
+
+  it('reconciles counts per panel with per-panel claimed sets', () => {
+    const { container } = buildContainer([3, 3]);
+    const svgs = resolvePanelSvgs(container, 2);
+
+    // Same mark count in both panels: tagging panel 1 must not depend on
+    // panel 0's claims (the old single-svg logic broke exactly here).
+    const sel0 = tagLayerElements(svgs[0], barLayer('0_0', 3), 0, new Set(), 'a ', 0);
+    const sel1 = tagLayerElements(svgs[1], barLayer('1_0', 3), 0, new Set(), 'b ', 1);
+
+    expect(sel0).toBe('a [data-maidr-victory-0-0]');
+    expect(sel1).toBe('b [data-maidr-victory-1-0]');
+    expect(svgs[0].querySelectorAll('[data-maidr-victory-0-0]')).toHaveLength(3);
+    expect(svgs[1].querySelectorAll('[data-maidr-victory-1-0]')).toHaveLength(3);
+  });
+});
+
+describe('getTaggedElements / clearTaggedElements', () => {
+  it('finds and clears both flat and panel-scoped tags across all panels', () => {
+    const { container } = buildContainer([2, 3]);
+    const svgs = resolvePanelSvgs(container, 2);
+
+    tagLayerElements(svgs[0], barLayer('0_0', 2), 0, new Set(), 'a ', 0);
+    tagLayerElements(svgs[1], barLayer('1_0', 3), 0, new Set(), 'b ', 1);
+
+    expect(getTaggedElements(container)).toHaveLength(5);
+
+    clearTaggedElements(container);
+
+    expect(getTaggedElements(container)).toHaveLength(0);
+    expect(container.querySelectorAll('[data-maidr-victory-0-0]')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-maidr-victory-1-0]')).toHaveLength(0);
+  });
+
+  it('leaves the panel stamp on svg roots intact when clearing', () => {
+    const { container } = buildContainer([2]);
+    const svg = container.querySelector('svg') as SVGElement;
+    svg.setAttribute(PANEL_ATTR, '0');
+
+    tagLayerElements(svg, barLayer('0_0', 2), 0, new Set(), 'a ', 0);
+    clearTaggedElements(container);
+
+    expect(svg.getAttribute(PANEL_ATTR)).toBe('0');
+  });
+});
+
+describe('buildVictorySubplots', () => {
+  const scope = '#mv-test ';
+
+  it('emits the original single-subplot shape for one panel', () => {
+    const { container } = buildContainer([2]);
+    const subplots = buildVictorySubplots(container, [{ layers: [barLayer('0', 2)] }], scope);
+
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0]).toHaveLength(1);
+    const subplot = subplots[0][0];
+    expect(subplot.selector).toBeUndefined();
+    expect(subplot.layers).toHaveLength(1);
+    expect(subplot.layers[0].id).toBe('0');
+    expect(subplot.layers[0].title).toBeUndefined();
+    expect(subplot.layers[0].selectors).toBe('#mv-test [data-maidr-victory-0]');
+    // No panel stamps in single-panel mode.
+    expect(container.querySelectorAll(`[${PANEL_ATTR}]`)).toHaveLength(0);
+  });
+
+  it('emits one subplot per panel with panel-scoped selectors and stamps', () => {
+    const { container } = buildContainer([2, 3]);
+    const subplots = buildVictorySubplots(container, [
+      { layers: [barLayer('0_0', 2)], title: 'Panel A' },
+      { layers: [barLayer('1_0', 3)] },
+    ], scope);
+
+    expect(subplots).toEqual([[
+      expect.objectContaining({ selector: `#mv-test [${PANEL_ATTR}="0"]` }),
+      expect.objectContaining({ selector: `#mv-test [${PANEL_ATTR}="1"]` }),
+    ]]);
+
+    const [first, second] = subplots[0];
+    expect(first.layers[0].title).toBe('Panel A');
+    expect(first.layers[0].selectors)
+      .toBe(`#mv-test [${PANEL_ATTR}="0"] [data-maidr-victory-0-0]`);
+    expect(second.layers[0].title).toBe('Panel 2');
+    expect(second.layers[0].selectors)
+      .toBe(`#mv-test [${PANEL_ATTR}="1"] [data-maidr-victory-1-0]`);
+
+    const svgs = Array.from(container.querySelectorAll('svg'));
+    expect(svgs[0].getAttribute(PANEL_ATTR)).toBe('0');
+    expect(svgs[1].getAttribute(PANEL_ATTR)).toBe('1');
+
+    // Each panel-scoped selector resolves to exactly its own panel's marks.
+    const doc = container.ownerDocument;
+    expect(doc.querySelectorAll(first.layers[0].selectors as string)).toHaveLength(2);
+    expect(doc.querySelectorAll(second.layers[0].selectors as string)).toHaveLength(3);
+  });
+
+  it('drops empty panels but keeps svg index alignment', () => {
+    const { container } = buildContainer([2, 1, 3]);
+    const subplots = buildVictorySubplots(container, [
+      { layers: [barLayer('0_0', 2)] },
+      { layers: [] }, // chart without supported data
+      { layers: [barLayer('2_0', 3)] },
+    ], scope);
+
+    expect(subplots).toHaveLength(1);
+    expect(subplots[0]).toHaveLength(2);
+    // The third chart still binds to the third svg (panel index 2).
+    expect(subplots[0][1].selector).toBe(`#mv-test [${PANEL_ATTR}="2"]`);
+    expect(subplots[0][1].layers[0].selectors)
+      .toBe(`#mv-test [${PANEL_ATTR}="2"] [data-maidr-victory-2-0]`);
+
+    const svgs = Array.from(container.querySelectorAll('svg'));
+    expect(svgs[1].hasAttribute(PANEL_ATTR)).toBe(false);
+    expect(svgs[2].getAttribute(PANEL_ATTR)).toBe('2');
+  });
+
+  it('chunks panels row-major with an explicit layout', () => {
+    const { container } = buildContainer([1, 1, 1, 1]);
+    const subplots = buildVictorySubplots(container, [
+      { layers: [barLayer('0_0', 1)] },
+      { layers: [barLayer('1_0', 1)] },
+      { layers: [barLayer('2_0', 1)] },
+      { layers: [barLayer('3_0', 1)] },
+    ], scope, { columns: 2 });
+
+    expect(subplots).toHaveLength(2);
+    expect(subplots[0]).toHaveLength(2);
+    expect(subplots[1]).toHaveLength(2);
+    expect(subplots[1][0].layers[0].id).toBe('2_0');
+  });
+
+  it('emits undefined selectors when a panel svg is missing', () => {
+    const { container } = buildContainer([2]); // only one svg for two panels
+    const subplots = buildVictorySubplots(container, [
+      { layers: [barLayer('0_0', 2)] },
+      { layers: [barLayer('1_0', 3)] },
+    ], scope);
+
+    expect(subplots[0]).toHaveLength(2);
+    expect(subplots[0][0].layers[0].selectors)
+      .toBe(`#mv-test [${PANEL_ATTR}="0"] [data-maidr-victory-0-0]`);
+    expect(subplots[0][1].selector).toBeUndefined();
+    expect(subplots[0][1].layers[0].selectors).toBeUndefined();
+  });
+});

--- a/test/adapters/victory/selectors.test.ts
+++ b/test/adapters/victory/selectors.test.ts
@@ -8,7 +8,7 @@ import {
   tagLayerElements,
 } from '@adapters/victory/selectors';
 import { buildVictorySubplots } from '@adapters/victory/useVictoryAdapter';
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 // @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
 // no @types/jsdom installed. Tests only use the public Element/JSDOM surface.
 import { JSDOM } from 'jsdom';
@@ -83,6 +83,40 @@ describe('resolvePanelSvgs', () => {
 
     expect(svgs).toHaveLength(2);
   });
+
+  it('excludes MAIDR-owned hidden clone svgs from panel resolution', () => {
+    const { container } = buildContainer([2, 3]);
+    // Simulate the core's focus-in behavior: a hidden clone of each panel svg
+    // (role and marks preserved by cloneNode) inserted right after the
+    // original, marked only with data-maidr-owned.
+    for (const svg of Array.from(container.querySelectorAll('svg'))) {
+      const clone = svg.cloneNode(true) as SVGElement;
+      clone.setAttribute('data-maidr-owned', 'true');
+      svg.after(clone);
+    }
+
+    const svgs = resolvePanelSvgs(container, 2);
+
+    expect(svgs).toHaveLength(2);
+    expect(svgs[0].querySelectorAll('path')).toHaveLength(2);
+    expect(svgs[1].querySelectorAll('path')).toHaveLength(3);
+    expect(svgs.every(svg => !svg.hasAttribute('data-maidr-owned'))).toBe(true);
+  });
+
+  it('excludes MAIDR-owned clones in the all-svgs fallback too', () => {
+    const { container } = buildContainer([2, 3]);
+    for (const svg of Array.from(container.querySelectorAll('svg'))) {
+      svg.removeAttribute('role');
+      const clone = svg.cloneNode(true) as SVGElement;
+      clone.setAttribute('data-maidr-owned', 'true');
+      svg.after(clone);
+    }
+
+    const svgs = resolvePanelSvgs(container, 2);
+
+    expect(svgs).toHaveLength(2);
+    expect(svgs.every(svg => !svg.hasAttribute('data-maidr-owned'))).toBe(true);
+  });
 });
 
 describe('tagLayerElements', () => {
@@ -123,6 +157,25 @@ describe('tagLayerElements', () => {
     expect(svgs[0].querySelectorAll('[data-maidr-victory-0-0]')).toHaveLength(3);
     expect(svgs[1].querySelectorAll('[data-maidr-victory-1-0]')).toHaveLength(3);
   });
+
+  it('never tags marks inside MAIDR-owned clones', () => {
+    const { container } = buildContainer([2]);
+    const svg = container.querySelector('svg') as SVGElement;
+    // Simulate the core's per-mark highlight clones inserted next to the
+    // originals inside the same svg during a focused re-tag pass.
+    for (const path of Array.from(svg.querySelectorAll('path'))) {
+      const clone = path.cloneNode(true) as Element;
+      clone.setAttribute('data-maidr-owned', 'true');
+      path.after(clone);
+    }
+
+    const selector = tagLayerElements(svg, barLayer('0', 2), 0, new Set(), '#mv-test ');
+
+    expect(selector).toBe('#mv-test [data-maidr-victory-0]');
+    const tagged = Array.from(svg.querySelectorAll('[data-maidr-victory-0]'));
+    expect(tagged).toHaveLength(2);
+    expect(tagged.every(el => !el.hasAttribute('data-maidr-owned'))).toBe(true);
+  });
 });
 
 describe('getTaggedElements / clearTaggedElements', () => {
@@ -151,6 +204,40 @@ describe('getTaggedElements / clearTaggedElements', () => {
     clearTaggedElements(container);
 
     expect(svg.getAttribute(PANEL_ATTR)).toBe('0');
+  });
+
+  it('finds and clears tags for panel indices of 10 and above', () => {
+    const { container } = buildContainer([2]);
+    const svg = container.querySelector('svg') as SVGElement;
+
+    const selector = tagLayerElements(svg, barLayer('11_0', 2), 0, new Set(), 'a ', 11);
+
+    expect(selector).toBe('a [data-maidr-victory-11-0]');
+    expect(getTaggedElements(container)).toHaveLength(2);
+
+    clearTaggedElements(container);
+
+    expect(getTaggedElements(container)).toHaveLength(0);
+    expect(container.querySelectorAll('[data-maidr-victory-11-0]')).toHaveLength(0);
+  });
+
+  it('ignores tag attributes inside MAIDR-owned clones when finding and clearing', () => {
+    const { container } = buildContainer([2]);
+    const svg = container.querySelector('svg') as SVGElement;
+    tagLayerElements(svg, barLayer('0', 2), 0, new Set(), 'a ');
+    // Clone the tagged svg the way the core does on focus-in — cloneNode
+    // preserves the tag attributes on the clone's marks.
+    const clone = svg.cloneNode(true) as SVGElement;
+    clone.setAttribute('data-maidr-owned', 'true');
+    svg.after(clone);
+
+    expect(getTaggedElements(container)).toHaveLength(2);
+
+    clearTaggedElements(container);
+
+    expect(getTaggedElements(container)).toHaveLength(0);
+    // Owned clones are left untouched — the core disposes them itself.
+    expect(clone.querySelectorAll('[data-maidr-victory-0]')).toHaveLength(2);
   });
 });
 
@@ -223,6 +310,38 @@ describe('buildVictorySubplots', () => {
     expect(svgs[2].getAttribute(PANEL_ATTR)).toBe('2');
   });
 
+  it('binds panels to their own svgs when a standalone Victory sibling precedes them', () => {
+    const { container, doc } = buildContainer([2, 3]);
+    // Simulate a standalone VictoryScatter sibling: its svg is document-first,
+    // also role="img", and its markers are path[role="presentation"] like bars.
+    const wrapper = doc.createElement('div');
+    const standalone = doc.createElementNS(SVG_NS, 'svg');
+    standalone.setAttribute('role', 'img');
+    for (let i = 0; i < 2; i++) {
+      const path = doc.createElementNS(SVG_NS, 'path');
+      path.setAttribute('role', 'presentation');
+      standalone.appendChild(path);
+    }
+    wrapper.appendChild(standalone);
+    container.insertBefore(wrapper, container.firstChild);
+
+    const subplots = buildVictorySubplots(container, [
+      { layers: [barLayer('0_0', 2)], svgIndex: 1 },
+      { layers: [barLayer('1_0', 3)], svgIndex: 2 },
+    ], scope);
+
+    const svgs = Array.from(container.querySelectorAll('svg'));
+    expect(svgs[0].hasAttribute(PANEL_ATTR)).toBe(false);
+    expect(svgs[1].getAttribute(PANEL_ATTR)).toBe('0');
+    expect(svgs[2].getAttribute(PANEL_ATTR)).toBe('1');
+
+    const ownerDoc = container.ownerDocument;
+    expect(ownerDoc.querySelectorAll(subplots[0][0].layers[0].selectors as string)).toHaveLength(2);
+    expect(ownerDoc.querySelectorAll(subplots[0][1].layers[0].selectors as string)).toHaveLength(3);
+    // The standalone component's marks stay untagged.
+    expect(standalone.querySelectorAll('[data-maidr-victory-0-0]')).toHaveLength(0);
+  });
+
   it('chunks panels row-major with an explicit layout', () => {
     const { container } = buildContainer([1, 1, 1, 1]);
     const subplots = buildVictorySubplots(container, [
@@ -236,6 +355,78 @@ describe('buildVictorySubplots', () => {
     expect(subplots[0]).toHaveLength(2);
     expect(subplots[1]).toHaveLength(2);
     expect(subplots[1][0].layers[0].id).toBe('2_0');
+  });
+
+  it('gives every cell of a multi-row grid a selector resolving to its own panel svg', () => {
+    // The core's resolveSubplotLayout measures each panel's rendered geometry
+    // through subplot.selector (via its hidden-clone highlight element) to
+    // compute visual ordering and vertical arrow direction for multi-row
+    // grids — so every emitted subplot must carry a selector matching exactly
+    // its own panel element.
+    const { container } = buildContainer([1, 1, 1, 1]);
+    const subplots = buildVictorySubplots(container, [
+      { layers: [barLayer('0_0', 1)] },
+      { layers: [barLayer('1_0', 1)] },
+      { layers: [barLayer('2_0', 1)] },
+      { layers: [barLayer('3_0', 1)] },
+    ], scope, { columns: 2 });
+
+    const svgs = Array.from(container.querySelectorAll('svg'));
+    const ownerDoc = container.ownerDocument;
+    let panel = 0;
+    for (const row of subplots) {
+      for (const subplot of row) {
+        expect(subplot.selector).toBe(`#mv-test [${PANEL_ATTR}="${panel}"]`);
+        const matched = ownerDoc.querySelectorAll(subplot.selector as string);
+        expect(matched).toHaveLength(1);
+        expect(matched[0]).toBe(svgs[panel]);
+        panel++;
+      }
+    }
+    expect(panel).toBe(4);
+  });
+
+  it('keeps grid cells aligned with the layout when a panel is empty', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { container } = buildContainer([1, 1, 1, 1]);
+      const subplots = buildVictorySubplots(container, [
+        { layers: [barLayer('0_0', 1)] },
+        { layers: [] }, // chart without supported data
+        { layers: [barLayer('2_0', 1)] },
+        { layers: [barLayer('3_0', 1)] },
+      ], scope, { columns: 2 });
+
+      // The empty panel's cell is dropped from its own row only — the
+      // remaining panels keep the rows/columns of the visual arrangement.
+      expect(subplots).toHaveLength(2);
+      expect(subplots[0].map(s => s.layers[0].id)).toEqual(['0_0']);
+      expect(subplots[1].map(s => s.layers[0].id)).toEqual(['2_0', '3_0']);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('removes rows left entirely empty after dropping empty panels', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { container } = buildContainer([1, 1, 1, 1]);
+      const subplots = buildVictorySubplots(container, [
+        { layers: [barLayer('0_0', 1)] },
+        { layers: [barLayer('1_0', 1)] },
+        { layers: [] },
+        { layers: [] },
+      ], scope, { columns: 2 });
+
+      expect(subplots).toEqual([[
+        expect.objectContaining({ selector: `#mv-test [${PANEL_ATTR}="0"]` }),
+        expect.objectContaining({ selector: `#mv-test [${PANEL_ATTR}="1"]` }),
+      ]]);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('emits undefined selectors when a panel svg is missing', () => {

--- a/test/adapters/victory/selectors.test.ts
+++ b/test/adapters/victory/selectors.test.ts
@@ -103,6 +103,25 @@ describe('resolvePanelSvgs', () => {
     expect(svgs.every(svg => !svg.hasAttribute('data-maidr-owned'))).toBe(true);
   });
 
+  it('ignores a user role="img" svg between panels when VictoryContainer wrappers are present', () => {
+    const { container, doc } = buildContainer([2, 3]);
+    // Real Victory stamps its wrapper divs with the VictoryContainer class.
+    for (const wrapper of Array.from(container.children)) {
+      wrapper.classList.add('VictoryContainer');
+    }
+    // A user-supplied accessible illustration between the two panels: passes
+    // the role="img" filter but is not a Victory chart svg.
+    const interloper = doc.createElementNS(SVG_NS, 'svg');
+    interloper.setAttribute('role', 'img');
+    container.insertBefore(interloper, container.children[1]);
+
+    const svgs = resolvePanelSvgs(container, 2);
+
+    expect(svgs).toHaveLength(2);
+    expect(svgs[0].querySelectorAll('path')).toHaveLength(2);
+    expect(svgs[1].querySelectorAll('path')).toHaveLength(3);
+  });
+
   it('excludes MAIDR-owned clones in the all-svgs fallback too', () => {
     const { container } = buildContainer([2, 3]);
     for (const svg of Array.from(container.querySelectorAll('svg'))) {

--- a/test/util/subplotLayout.test.ts
+++ b/test/util/subplotLayout.test.ts
@@ -1,0 +1,197 @@
+import type { Subplot } from '@model/plot';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Test only uses public Element/JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const globals = globalThis as unknown as { document?: Document };
+let savedDocument: Document | undefined;
+
+beforeEach(() => {
+  savedDocument = globals.document;
+  const dom = new JSDOM('<!doctype html><body></body>');
+  globals.document = dom.window.document as Document;
+});
+
+interface StubPanel {
+  rect?: { top: number; left: number; width?: number; height?: number };
+  layerSelector?: string;
+}
+
+function mockRect(
+  el: Element,
+  rect: { top: number; left: number; width?: number; height?: number },
+): void {
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({
+      top: rect.top,
+      left: rect.left,
+      width: rect.width ?? 100,
+      height: rect.height ?? 100,
+      right: rect.left + (rect.width ?? 100),
+      bottom: rect.top + (rect.height ?? 100),
+      x: rect.left,
+      y: rect.top,
+    }),
+    configurable: true,
+  });
+}
+
+/**
+ * Builds a minimal Subplot stand-in exposing only the accessors the layout
+ * utility consumes: getHighlightElement() and getLayerSelector().
+ */
+function stubSubplot(panel: StubPanel): Subplot {
+  let highlight: SVGElement | null = null;
+  if (panel.rect) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    document.body.appendChild(el);
+    mockRect(el, panel.rect);
+    highlight = el;
+  }
+  return {
+    getHighlightElement: () => highlight,
+    getLayerSelector: () => panel.layerSelector ?? null,
+  } as unknown as Subplot;
+}
+
+function grid(panels: StubPanel[][]): Subplot[][] {
+  return panels.map(row => row.map(stubSubplot));
+}
+
+afterEach(() => {
+  globals.document = savedDocument;
+});
+
+describe('resolveSubplotLayout panel-geometry fallback (no axes_* groups)', () => {
+  it('detects inversion for rows emitted top-first', () => {
+    const layout = resolveSubplotLayout(grid([
+      [{ rect: { top: 0, left: 0 } }],
+      [{ rect: { top: 100, left: 0 } }],
+      [{ rect: { top: 200, left: 0 } }],
+    ]));
+
+    expect(layout.invertVertical).toBe(true);
+    expect(layout.topLeftRow).toBe(0);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('1,0')).toBe(2);
+    expect(layout.visualOrderMap.get('2,0')).toBe(3);
+  });
+
+  it('keeps native direction for rows emitted bottom-first (matplotlib convention)', () => {
+    const layout = resolveSubplotLayout(grid([
+      [{ rect: { top: 200, left: 0 } }],
+      [{ rect: { top: 100, left: 0 } }],
+      [{ rect: { top: 0, left: 0 } }],
+    ]));
+
+    expect(layout.invertVertical).toBe(false);
+    expect(layout.topLeftRow).toBe(2);
+    expect(layout.visualOrderMap.get('2,0')).toBe(1);
+    expect(layout.visualOrderMap.get('0,0')).toBe(3);
+  });
+
+  it('numbers a 2x2 grid in visual reading order', () => {
+    const layout = resolveSubplotLayout(grid([
+      [{ rect: { top: 0, left: 0 } }, { rect: { top: 0, left: 300 } }],
+      [{ rect: { top: 300, left: 0 } }, { rect: { top: 300, left: 300 } }],
+    ]));
+
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('0,1')).toBe(2);
+    expect(layout.visualOrderMap.get('1,0')).toBe(3);
+    expect(layout.visualOrderMap.get('1,1')).toBe(4);
+    expect(layout.invertVertical).toBe(true);
+  });
+
+  it('falls back to data order when rects are degenerate (jsdom default)', () => {
+    // No mocked rects: real jsdom elements report all-zero geometry.
+    const subplots = grid([[{}], [{}]]);
+    subplots.forEach(row => row.forEach((s) => {
+      (s.getHighlightElement as unknown) = () => null;
+    }));
+
+    const layout = resolveSubplotLayout(subplots);
+
+    expect(layout.invertVertical).toBe(false);
+    expect(layout.topLeftRow).toBe(0);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('1,0')).toBe(2);
+  });
+
+  it('falls back to data order when any panel is missing geometry', () => {
+    const layout = resolveSubplotLayout(grid([
+      [{ rect: { top: 0, left: 0 } }],
+      [{}],
+    ]));
+
+    expect(layout.invertVertical).toBe(false);
+    expect(layout.topLeftRow).toBe(0);
+  });
+
+  it('falls back to data order when panels overlap exactly', () => {
+    const layout = resolveSubplotLayout(grid([
+      [{ rect: { top: 50, left: 50 } }],
+      [{ rect: { top: 50, left: 50 } }],
+    ]));
+
+    expect(layout.invertVertical).toBe(false);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+  });
+
+  it('measures the first layer-selector element when no highlight element exists', () => {
+    const mark = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    mark.setAttribute('class', 'panel-a-mark');
+    document.body.appendChild(mark);
+    mockRect(mark, { top: 200, left: 0 });
+
+    const mark2 = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    mark2.setAttribute('class', 'panel-b-mark');
+    document.body.appendChild(mark2);
+    mockRect(mark2, { top: 0, left: 0 });
+
+    const layout = resolveSubplotLayout(grid([
+      [{ layerSelector: '.panel-a-mark' }],
+      [{ layerSelector: '.panel-b-mark' }],
+    ]));
+
+    expect(layout.invertVertical).toBe(false);
+    expect(layout.topLeftRow).toBe(1);
+    expect(layout.visualOrderMap.get('1,0')).toBe(1);
+    expect(layout.visualOrderMap.get('0,0')).toBe(2);
+  });
+});
+
+describe('resolveSubplotLayout axes-group path precedence', () => {
+  it('uses axes_* group geometry when available, ignoring panel fallback', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    document.body.appendChild(svg);
+
+    const panels = [
+      { axesTop: 0, panelTop: 999 },
+      { axesTop: 100, panelTop: 998 },
+    ].map(({ axesTop, panelTop }, i) => {
+      const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      g.setAttribute('id', `axes_${i + 1}`);
+      svg.appendChild(g);
+      mockRect(g, { top: axesTop, left: 0 });
+
+      const inner = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      g.appendChild(inner);
+      mockRect(inner, { top: panelTop, left: 0 });
+
+      return {
+        getHighlightElement: () => inner,
+        getLayerSelector: () => null,
+      } as unknown as Subplot;
+    });
+
+    const layout = resolveSubplotLayout([[panels[0]], [panels[1]]]);
+
+    // Axes groups (top 0 / 100) decide order — not the inner rects (999/998).
+    expect(layout.invertVertical).toBe(true);
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.totalAxesCount).toBe(2);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #623: every chart-library adapter now detects (or accepts) multi-panel / faceted / small-multiple charts and emits a proper `subplots[][]` grid, instead of flattening to a single panel, dropping panels, or crashing. Users get MAIDR's existing subplot navigation (arrows between panels, Enter/Esc to drill in/out) on faceted charts from all eleven supported libraries.

Originally stacked on #623; now that #623 has merged, this branch is rebased directly onto `main` and contains only the 23 multi-panel commits.

## Related Issues

Follow-up to #623.

## Changes Made

**Core (one small change):** `resolveSubplotLayout` now measures each subplot's own panel element geometry when the SVG has no matplotlib-style `g[id^="axes_"]` groups (`src/util/subplotLayout.ts`). Previously every multi-row grid from a non-matplotlib source fell back to data-array order with no vertical inversion, making Up/Down arrows visually backwards — including for pre-existing Vega-Lite `vconcat`. Fully unit-tested; matplotlib and single-panel paths untouched.

**Native multi-panel detection** (the library has a facet/grid concept):
- **Vega-Lite**: `facet` operator, `encoding.row`/`encoding.column` shorthand, wrapped facet (`columns:N`), `repeat` (row/column and wrapped), and `concat` now honors `columns`. Per-cell data filtering, facet values as panel names, cell-scoped selectors via `data-maidr-cell` stamping, and per-chart container scoping so two charts on one page can't cross-highlight.
- **Plotly**: `make_subplots` / `layout.grid` / Plotly Express facet grids via axis-domain clustering into a 2D (possibly ragged) grid; per-panel `g[id="axes_…"]` selectors emitted even without background rects; facet annotation titles; inset plots safely fall back to single-row.
- **Chart.js**: axis-stacked panel charts (multiple same-kind scales with `stack` options) partition datasets into one subplot per panel, with per-panel axis labels and Chart.js-faithful default-scale resolution. Dual-axis overlays stay single-panel.
- **Highcharts**: multi-pane charts (stock-style stacked axes) split series into per-pane subplots (navigator/scrollbar series excluded), plus `highchartsGridToMaidr` for grids of separate chart instances.
- **amCharts 5**: multiple XYCharts in one Root become a geometry-clustered subplot grid, and `am5stock` StockPanels now work (they previously threw); highlighting clips against the owning panel.
- **Victory**: multiple `<VictoryChart>` children of one `MaidrVictory` become subplots (default single row, optional `layout` chunking) with panel-scoped SVG binding and tagging.

**Explicit grouping APIs** (the library has no native facet concept; separate chart instances are the idiom):
- **D3**: `bindD3Facets` (homogeneous small multiples via a panel selector) and `bindD3Subplots` (heterogeneous 2D composition) over all nine existing binders.
- **Recharts**: declarative `subplots` config (2D grid or flat + `columns`) with generated per-panel wrapper scoping.
- **AnyChart**: `anyChartsToMaidr` / `bindAnyCharts` (2D grid, flat + layout, or geometry auto-layout).
- **Google Charts**: `createMaidrFromGoogleCharts` plus a `whenGoogleChartsReady` gate for the library's per-chart `ready` events.
- **Frappe Charts**: `createMaidrFromFrappeCharts` with wrapper-element attachment and per-panel selector scoping.

**Review hardening:** the full diff was adversarially reviewed (38 findings, 36 confirmed after independent verification, 2 rejected) and every confirmed finding is fixed: crash-prone `[[{layers: []}]]` fallbacks no longer reach Figure construction, canvas adapters emit bottom-first rows so arrow keys are correct, selector scoping holes (repeat cells, whole-`<svg>` panel clones, cross-chart collisions) are closed, Chart.js default-axis and stack-group semantics match the library, the Google Charts ready-listener uses the real API, and more.

**Tests/examples/docs:** 321 new Jest tests (373 → 694) across `test/adapters/*` and `test/util/subplotLayout.test.ts`; new example pages for every adapter (`examples/vegalite-facet-bar.html`, `plotly-subplots.html`, `chartjs/line-stacked-panels.html`, `d3-bindfacets.html`, `d3-bindsubplots.html`, `highcharts-panes.html`, `highcharts-grid.html`, `frappe-multipanel.html`, `anychart/multipanel.html`, Recharts/Victory example apps, amCharts and Google Charts example sections); multi-panel sections added to each adapter's doc in `docs/`.

## Screenshots (if applicable)

Not applicable (non-visual feature).

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verification at the end of every phase (re-verified after the rebase onto `main`): 694/694 Jest tests, clean `tsc --noEmit`, clean ESLint, all 12 production entry-point builds passing. A headless-Chromium smoke run of the built `dist/vegalite.js` bundle against `examples/vegalite-facet-bar.html` (real Vega-Lite 5 rendering) confirmed the full flow end-to-end: focus announces the multi-subplot figure, arrow keys move between facet panels ("Subplot 1 of 3" → "Subplot 2 of 3"), Enter drills into a panel and arrows announce its data points, Escape returns to panel navigation — with zero console errors.

Known follow-ups (intentionally out of scope): a multi-canvas grouping API for Chart.js (multiple `Chart` instances → one figure); AnyStock multi-plot detection; amCharts multi-Root grouping and stacked-yAxes pane splitting (ambiguous with dual-scale overlays); Vega-Lite `repeat` with layered children relies on unverified compiled class naming for highlighting (navigation/data are correct); canvas adapters (Chart.js, amCharts) announce panel numbering bottom-up because the core layout pass has no DOM geometry to measure — a core-side ordering hint would fix this generically; subplot outline highlighting still requires `axes_*` groups, so Vega-family charts get no visual panel outline (navigation, text, and audio all work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YV3qoWXDK3TjzNjYGByiQk