### PR TITLE
ci: make the scheduled e2e workflows runnable and add a PR smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,20 +86,24 @@ jobs:
         run: node scripts/build.js core
 
       - name: Run smoke specs
+        id: smoke
         run: npx playwright test --config=e2e_tests/config/test-config.ts --project=chromium liveData.spec.ts
         env:
           CI: true
 
       # The smoke specs are kept green, so a failure here is a real
       # regression — ship the report and screenshots with the PR run.
+      # Scoped to the test step so an earlier failure (npm ci, browser
+      # install) doesn't trigger an upload with nothing to upload.
       - name: Upload Playwright report on failure
-        if: failure()
+        if: failure() && steps.smoke.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-smoke-report
           path: |
             playwright-report/
             test-results/
+          if-no-files-found: ignore
 
   build:
     name: Build Project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,32 +53,42 @@ jobs:
       - name: Run linter
         run: npm run lint
 
-  # test:
-  #   name: Run Unit Tests
-  #   runs-on: ubuntu-latest
-  #   needs: [commitlint, lint]
+  # Fast Playwright smoke on every PR: chromium only, core bundle only, and
+  # only the live-data spec (kept deliberately green). The full 3-browser
+  # suite stays on the scheduled e2e workflows; extend the spec list here as
+  # more specs are verified healthy.
+  e2e-smoke:
+    name: E2E Smoke (chromium)
+    runs-on: ubuntu-latest
+    needs: [commitlint, lint]
+    timeout-minutes: 15
 
-  #   permissions:
-  #     contents: read
+    permissions:
+      contents: read
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Set up Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 'lts/*'
-  #         cache: npm
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
 
-  #     - name: Install dependencies
-  #       run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-  #     - name: Install Playwright browsers
-  #       run: npm run e2e:install
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
 
-  #     - name: Run unit tests
-  #       run: npm run e2e
+      - name: Build core bundle
+        run: node scripts/build.js core
+
+      - name: Run smoke specs
+        run: npx playwright test --config=e2e_tests/config/test-config.ts --project=chromium liveData.spec.ts
+        env:
+          CI: true
 
   build:
     name: Build Project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
         env:
           CI: true
 
+      # The smoke specs are kept green, so a failure here is a real
+      # regression — ship the report and screenshots with the PR run.
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-report
+          path: |
+            playwright-report/
+            test-results/
+
   build:
     name: Build Project
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install Playwright browsers
         run: npm run e2e:install
 
+      # The specs drive the example pages against the built bundles via
+      # file://, and dist/ is gitignored — without this step every test
+      # fails on a fresh checkout.
+      - name: Build library
+        run: npm run build
+
       - name: Run Playwright tests
         run: npm run e2e
         env:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -88,8 +88,10 @@ jobs:
               `[View Workflow Run](${run_url})`
             ].join('\n');
 
-            // Determine issue title and labels based on test status
-            const isFailure = process.env.TEST_STATUS === 'failure';
+            // Determine issue title and labels based on test status. Anything
+            // other than success (failure, cancelled — e.g. the job timeout
+            // interrupting a hung run) must be filed as a failure.
+            const isFailure = process.env.TEST_STATUS !== 'success';
             const title = isFailure
               ? `test: Some e2e tests failed - ${new Date().toISOString()}`
               : `Test Report - ${new Date().toISOString()}`;

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -105,9 +105,12 @@ jobs:
               state: 'open'
             });
 
+            // Match on the stable title prefix only: the body always embeds
+            // the CURRENT run's URL, so matching on it could never find an
+            // issue from a previous run — each scheduled failure would file
+            // a brand-new issue instead of updating the rolling one.
             const existingIssue = issues.data.find(issue =>
-              issue.title.includes(isFailure ? 'test: Some e2e tests failed' : 'Test Report') &&
-              issue.body.includes(run_url)
+              issue.title.includes(isFailure ? 'test: Some e2e tests failed' : 'Test Report')
             );
 
             if (existingIssue) {

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 2 */2 * *'
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: read
+  issues: write # the report step files/updates a test-report issue
+
 jobs:
   test:
     name: Run Playwright Tests
@@ -27,20 +31,46 @@ jobs:
       - name: Install Playwright browsers
         run: npm run e2e:install
 
+      # The specs drive the example pages against the built bundles via
+      # file://, and dist/ is gitignored — without this step every test
+      # fails on a fresh checkout.
+      - name: Build library
+        run: npm run build
+
+      # continue-on-error so the report step below always gets the output;
+      # the final step re-raises the failure. tee captures the list-reporter
+      # output into the file the report step reads — outside playwright-report/,
+      # which the html reporter wipes when it writes.
       - name: Run Playwright tests
-        run: npm run e2e
+        id: e2e
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          npm run e2e 2>&1 | tee test-results.txt
         env:
           CI: true
 
       - name: Create or update test report issue
         if: always()
         uses: actions/github-script@v7
+        env:
+          TEST_STATUS: ${{ steps.e2e.outcome }}
         with:
           script: |
             const fs = require('fs');
             const { repo, owner } = context.repo;
             const run_id = context.runId;
             const run_url = `https://github.com/${owner}/${repo}/actions/runs/${run_id}`;
+
+            // The summary is at the end of the reporter output; keep the tail
+            // so the report always fits the issue-body size limit.
+            const resultsPath = 'test-results.txt';
+            const rawResults = fs.existsSync(resultsPath)
+              ? fs.readFileSync(resultsPath, 'utf8')
+              : 'No test output was captured (the test step did not run).';
+            const results = rawResults.length > 60000
+              ? `… (truncated, full output in the workflow run)\n${rawResults.slice(-60000)}`
+              : rawResults;
 
             // Generate report content
             const reportContent = [
@@ -52,7 +82,7 @@ jobs:
               '',
               '### Test Results',
               '```',
-              fs.readFileSync('playwright-report/test-results.txt', 'utf8'),
+              results,
               '```',
               '',
               `[View Workflow Run](${run_url})`
@@ -97,3 +127,9 @@ jobs:
                 labels
               });
             }
+
+      # The test step ran with continue-on-error so the report above always
+      # publishes; surface the real outcome as the workflow conclusion.
+      - name: Propagate test outcome
+        if: steps.e2e.outcome != 'success'
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ out
 
 # Playwright
 test-results/
+test-results.txt
 playwright-report/
 
 # VSCode


### PR DESCRIPTION
## Summary

Follow-up to #622, closing the remaining half of a review finding there: the Playwright e2e coverage could not execute automatically anywhere. #622 fixed the ESM `__dirname` config-loading crash; this PR fixes the workflows themselves, which could never pass on a fresh checkout, and adds a fast PR-CI smoke job so live-data regressions surface before merge instead of on the two-day cron.

## What was broken

**Both scheduled workflows (`e2e.yml`, `e2e_tests.yml`) never built the library.** The specs drive example pages that load the gitignored `dist/` bundles via `file://`, so on a clean CI checkout every test fails at page load. Added a `npm run build` step to both.

**The report step in `e2e_tests.yml` read `playwright-report/test-results.txt`, which nothing ever wrote** — the July 3 scheduled run shows it dying with `ENOENT` (and the html reporter wipes `playwright-report/` when it writes, so even a file teed there would vanish; verified locally). The test step now tees the list-reporter output to a root-level `test-results.txt` (gitignored), and the report script guards the read with a fallback and truncates to fit the issue-body limit.

**`TEST_STATUS` was referenced but never set**, so failed runs would have been filed under the `test-report` label instead of `test-failure`. The test step now runs with `continue-on-error` and an id, its outcome is passed to the report step as `TEST_STATUS`, and a final step re-raises the failure so the workflow conclusion stays honest. Also granted `issues: write`, which the issue-filing step needs.

**PR CI had no e2e at all** (only a commented-out, mislabeled job in `ci.yml`). Replaced it with a working `e2e-smoke` job: chromium only, core bundle only (`node scripts/build.js core`, ~30s), and only `liveData.spec.ts` — the spec added in #622 and kept deliberately green. Extend the spec list as more specs are verified healthy.

## What to expect from the first scheduled run

With the infrastructure fixed, the scheduled workflows will finally reveal the true state of the legacy suite. Running the full chromium project locally on current `main`: **7 passed, 97 failed, 185 did not run** — the legacy page objects fail at page load with `maidr-data attribute not found on SVG element` (they predate the current binding architecture), which cascades through each spec file. The first cron run will therefore file a `test-failure` issue listing these — that is the workflow doing its job and surfacing bit-rot that was previously invisible, not a regression from this PR. Repairing the legacy specs is a separate, larger effort. The new `liveData.spec.ts` passes 4/4.

## Verification

- All three workflow files pass YAML validation.
- The tee-capture test step was simulated locally end-to-end (including catching the html-reporter folder-wipe pitfall).
- The exact smoke-job command (`npx playwright test --config=e2e_tests/config/test-config.ts --project=chromium liveData.spec.ts`) passes locally in ~8s after a core-only build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuiTyhDAEWtQX9oTKGatzN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuiTyhDAEWtQX9oTKGatzN)_