### PR TITLE
feat(candlestick): add virtual reference-line delta layer with F7 dialog

### DIFF
--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -557,17 +557,50 @@ export class BasePage {
   }
 
   /**
-   * Verifies if the SVG element is focused
-   * @throws Error if SVG is not focused
+   * Verifies that MAIDR's plot is the active (focused) element.
+   *
+   * MAIDR wraps the chart's SVG in a focusable `<div role="img"/"application"
+   * tabindex="0">` inside `#maidr-figure-*`; Tab/click activation focuses that
+   * wrapper, not the raw `<svg>`. Some SVG-native adapters instead focus the
+   * `<svg>` directly. Accept either so the check reflects "MAIDR is active"
+   * rather than an outdated assumption about which node holds focus.
+   * @throws Error if neither the SVG nor MAIDR's focusable wrapper is focused
    */
   protected async verifySvgFocused(): Promise<void> {
-    const activeElementInfo = await this.getActiveElementInfo();
-    if (activeElementInfo.tagName !== 'svg') {
+    const isPlotFocused = await this.isMaidrPlotFocused();
+    if (!isPlotFocused) {
+      const activeElementInfo = await this.getActiveElementInfo();
       throw new Error(
-        `Expected SVG element to be focused, `
+        `Expected MAIDR plot to be focused, `
         + `but found ${activeElementInfo.tagName}`,
       );
     }
+  }
+
+  /**
+   * Returns whether MAIDR's plot is currently focused — either the raw SVG or
+   * the focusable wrapper MAIDR renders around it.
+   * @returns Promise resolving to true when the plot (or its wrapper) is focused
+   */
+  protected async isMaidrPlotFocused(): Promise<boolean> {
+    return this.page.evaluate(() => {
+      const active = document.activeElement;
+      if (!active) {
+        return false;
+      }
+      if (active.tagName?.toLowerCase() === 'svg') {
+        return true;
+      }
+      // MAIDR's focusable wrapper: a tabbable node that wraps the plot SVG
+      // inside the maidr figure. Role flips img -> application on activation.
+      const role = active.getAttribute('role');
+      return (
+        active.getAttribute('tabindex') === '0'
+        && (role === 'img' || role === 'application')
+        && active.querySelector('svg') !== null
+        && active.closest('[id^="maidr-figure"]') !== null
+      );
+    });
   }
 
   /**

--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -126,20 +126,6 @@ export class BarPlotPage extends BasePage {
   }
 
   /**
-   * Verifies that the SVG element is focused
-   * @throws Error if SVG element is not focused
-   */
-  protected async verifySvgFocused(): Promise<void> {
-    const activeElementInfo = await this.getActiveElementInfo();
-    if (activeElementInfo.tagName !== 'svg') {
-      throw new Error(
-        `Expected SVG element to be focused, `
-        + `but found ${activeElementInfo.tagName} instead"`,
-      );
-    }
-  }
-
-  /**
    * Activates MAIDR by focusing the plot
    * @returns Promise resolving when MAIDR is activated
    * @throws BarPlotError if MAIDR cannot be activated

--- a/e2e_tests/specs/barplot.spec.ts
+++ b/e2e_tests/specs/barplot.spec.ts
@@ -201,7 +201,7 @@ test.describe('Bar Plot', () => {
       await barPlotPage.toggleXAxisTitle();
 
       const xAxisTitle = await barPlotPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(barLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(barLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -209,7 +209,7 @@ test.describe('Bar Plot', () => {
       await barPlotPage.toggleYAxisTitle();
 
       const yAxisTitle = await barPlotPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(barLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(barLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/boxplotHorizontal.spec.ts
+++ b/e2e_tests/specs/boxplotHorizontal.spec.ts
@@ -213,7 +213,7 @@ test.describe('Boxplot Horizontal', () => {
       await boxplotHorizontalPage.toggleXAxisTitle();
 
       const xAxisTitle = await boxplotHorizontalPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(boxplotHorizontalLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(boxplotHorizontalLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -221,7 +221,7 @@ test.describe('Boxplot Horizontal', () => {
       await boxplotHorizontalPage.toggleYAxisTitle();
 
       const yAxisTitle = await boxplotHorizontalPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(boxplotHorizontalLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(boxplotHorizontalLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/boxplotVertical.spec.ts
+++ b/e2e_tests/specs/boxplotVertical.spec.ts
@@ -211,7 +211,7 @@ test.describe('Boxplot Vertical', () => {
       await boxplotVerticalPage.toggleXAxisTitle();
 
       const xAxisTitle = await boxplotVerticalPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(boxplotVerticalLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(boxplotVerticalLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -219,7 +219,7 @@ test.describe('Boxplot Vertical', () => {
       await boxplotVerticalPage.toggleYAxisTitle();
 
       const yAxisTitle = await boxplotVerticalPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(boxplotVerticalLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(boxplotVerticalLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/dodgedBarplot.spec.ts
+++ b/e2e_tests/specs/dodgedBarplot.spec.ts
@@ -251,7 +251,7 @@ test.describe('Dodged Barplot', () => {
       await dodgedBarplotPage.toggleXAxisTitle();
 
       const xAxisTitle = await dodgedBarplotPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(dodgedBarplotLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(dodgedBarplotLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -259,7 +259,7 @@ test.describe('Dodged Barplot', () => {
       await dodgedBarplotPage.toggleYAxisTitle();
 
       const yAxisTitle = await dodgedBarplotPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(dodgedBarplotLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(dodgedBarplotLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/heatmap.spec.ts
+++ b/e2e_tests/specs/heatmap.spec.ts
@@ -164,7 +164,7 @@ test.describe('Heatmap', () => {
 
       await heatmapPage.toggleXAxisTitle();
       const xAxisTitle = await heatmapPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(heatmapLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(heatmapLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -172,7 +172,7 @@ test.describe('Heatmap', () => {
 
       await heatmapPage.toggleYAxisTitle();
       const yAxisTitle = await heatmapPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(heatmapLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(heatmapLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/histogram.spec.ts
+++ b/e2e_tests/specs/histogram.spec.ts
@@ -185,7 +185,7 @@ test.describe('Histogram', () => {
       await histogramPage.toggleXAxisTitle();
 
       const xAxisTitle = await histogramPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(histogramLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(histogramLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -193,7 +193,7 @@ test.describe('Histogram', () => {
       await histogramPage.toggleYAxisTitle();
 
       const yAxisTitle = await histogramPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(histogramLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(histogramLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/lineplot.spec.ts
+++ b/e2e_tests/specs/lineplot.spec.ts
@@ -198,14 +198,14 @@ test.describe('Line Plot', () => {
       const linePlotPage = await setupLinePlotPage(page);
       await linePlotPage.toggleXAxisTitle();
       const xAxisTitle = await linePlotPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(linePlotLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(linePlotLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
       const linePlotPage = await setupLinePlotPage(page);
       await linePlotPage.toggleYAxisTitle();
       const yAxisTitle = await linePlotPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(linePlotLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(linePlotLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/multiLayer.spec.ts
+++ b/e2e_tests/specs/multiLayer.spec.ts
@@ -193,14 +193,14 @@ test.describe('Multi Layer Plot', () => {
         const multiLayerPlotPage = await setupMultiLayerPlotPage(page);
         await multiLayerPlotPage.toggleXAxisTitle();
         const xAxisTitle = await multiLayerPlotPage.getXAxisTitle();
-        expect(xAxisTitle).toContain(multiLayerPlotLayer?.axes?.x ?? '');
+        expect(xAxisTitle).toContain(multiLayerPlotLayer?.axes?.x?.label ?? '');
       });
 
       test('should display Y-Axis Title', async ({ page }) => {
         const multiLayerPlotPage = await setupMultiLayerPlotPage(page);
         await multiLayerPlotPage.toggleYAxisTitle();
         const yAxisTitle = await multiLayerPlotPage.getYAxisTitle();
-        expect(yAxisTitle).toContain(multiLayerPlotLayer?.axes?.y ?? '');
+        expect(yAxisTitle).toContain(multiLayerPlotLayer?.axes?.y?.label ?? '');
       });
     });
 
@@ -464,7 +464,7 @@ test.describe('Multi Layer Plot', () => {
         const multiLayerPlotPage = await setupSecondLayerTest(page);
         await multiLayerPlotPage.toggleXAxisTitle();
         const xAxisTitle = await multiLayerPlotPage.getXAxisTitle();
-        expect(xAxisTitle).toContain(multiLayerPlotLayer?.axes?.x ?? '');
+        expect(xAxisTitle).toContain(multiLayerPlotLayer?.axes?.x?.label ?? '');
       });
 
       test('should display Y-axis Title', async ({ page }) => {
@@ -472,7 +472,7 @@ test.describe('Multi Layer Plot', () => {
         const secondLayer = maidrData.subplots[0][0].layers[1];
         await multiLayerPlotPage.toggleYAxisTitle();
         const yAxisTitle = await multiLayerPlotPage.getYAxisTitle();
-        expect(yAxisTitle).toContain(secondLayer?.axes?.y ?? '');
+        expect(yAxisTitle).toContain(secondLayer?.axes?.y?.label ?? '');
       });
     });
 

--- a/e2e_tests/specs/multiLineplot.spec.ts
+++ b/e2e_tests/specs/multiLineplot.spec.ts
@@ -214,7 +214,7 @@ test.describe('Multi Lineplot', () => {
       await multiLineplotPage.toggleXAxisTitle();
 
       const xAxisTitle = await multiLineplotPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(multiLineplotLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(multiLineplotLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -222,7 +222,7 @@ test.describe('Multi Lineplot', () => {
       await multiLineplotPage.toggleYAxisTitle();
 
       const yAxisTitle = await multiLineplotPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(multiLineplotLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(multiLineplotLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/specs/stackedBarplot.spec.ts
+++ b/e2e_tests/specs/stackedBarplot.spec.ts
@@ -223,7 +223,7 @@ test.describe('Stacked Barplot', () => {
       await stackedBarplotPage.toggleXAxisTitle();
 
       const xAxisTitle = await stackedBarplotPage.getXAxisTitle();
-      expect(xAxisTitle).toContain(stackedBarplotLayer?.axes?.x ?? '');
+      expect(xAxisTitle).toContain(stackedBarplotLayer?.axes?.x?.label ?? '');
     });
 
     test('should display Y-Axis Title', async ({ page }) => {
@@ -231,7 +231,7 @@ test.describe('Stacked Barplot', () => {
       await stackedBarplotPage.toggleYAxisTitle();
 
       const yAxisTitle = await stackedBarplotPage.getYAxisTitle();
-      expect(yAxisTitle).toContain(stackedBarplotLayer?.axes?.y ?? '');
+      expect(yAxisTitle).toContain(stackedBarplotLayer?.axes?.y?.label ?? '');
     });
   });
 

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -4,6 +4,8 @@
  * Contains selectors, element IDs, keyboard keys, instruction text,
  * and other constants needed for testing MAIDR functionality
  */
+import process from 'node:process';
+
 export abstract class TestConstants {
   /**
    * HTML element selectors
@@ -69,7 +71,15 @@ export abstract class TestConstants {
   static readonly PERIOD_KEY = '.';
   static readonly COMMA_KEY = ',';
   static readonly SLASH_KEY = '/';
-  static readonly META_KEY = 'Meta';
+  /**
+   * Modifier for MAIDR's "control/command" shortcuts (extreme navigation,
+   * autoplay, help, settings). MAIDR binds Cmd on macOS and Ctrl elsewhere
+   * (see src/util/platform.ts `Platform.ctrl`), so the e2e modifier must
+   * track the OS running the browser. On the Linux CI runner sending 'Meta'
+   * (the Super key) is a no-op, which silently breaks every Ctrl-combination
+   * test. Mirror the app's own platform logic here.
+   */
+  static readonly META_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
   static readonly SHIFT_KEY = 'Shift';
   static readonly HOME_KEY = 'Home';
   static readonly END_KEY = 'End';
@@ -80,7 +90,10 @@ export abstract class TestConstants {
   static readonly LABEL_KEY = 'l';
   static readonly X_AXIS_TITLE = 'x';
   static readonly Y_AXIS_TITLE = 'y';
-  static readonly COMMAND_KEY = 'Meta';
+  // Same control/command modifier as META_KEY (see its note): MAIDR binds Cmd
+  // on macOS and Ctrl elsewhere, so help/settings shortcuts need the OS-correct
+  // modifier or they silently no-op on the Linux CI runner.
+  static readonly COMMAND_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
   static readonly ESCAPE_KEY = 'Escape';
   static readonly PAGE_UP_KEY = 'PageUp';
   static readonly PAGE_DOWN_KEY = 'PageDown';

--- a/src/command/candlestickDelta.ts
+++ b/src/command/candlestickDelta.ts
@@ -1,0 +1,49 @@
+import type { CandlestickDeltaService } from '@service/candlestickDelta';
+import type { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDeltaViewModel';
+import type { Command } from './command';
+
+/**
+ * Command bound to F7: opens (or closes) the candlestick reference
+ * comparison dialog where the user picks a reference line and OHLC field.
+ */
+export class ToggleCandlestickDeltaCommand implements Command {
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
+
+  /**
+   * Creates an instance of ToggleCandlestickDeltaCommand.
+   * @param {CandlestickDeltaViewModel} candlestickDeltaViewModel - The candlestick delta view model.
+   */
+  public constructor(candlestickDeltaViewModel: CandlestickDeltaViewModel) {
+    this.candlestickDeltaViewModel = candlestickDeltaViewModel;
+  }
+
+  /**
+   * Toggles the candlestick delta settings dialog.
+   */
+  public execute(): void {
+    this.candlestickDeltaViewModel.toggle();
+  }
+}
+
+/**
+ * Command bound to ESC in the virtual delta layer: deactivates the layer and
+ * returns the user to the real chart layer.
+ */
+export class ExitCandlestickDeltaCommand implements Command {
+  private readonly candlestickDeltaService: CandlestickDeltaService;
+
+  /**
+   * Creates an instance of ExitCandlestickDeltaCommand.
+   * @param {CandlestickDeltaService} candlestickDeltaService - The candlestick delta service.
+   */
+  public constructor(candlestickDeltaService: CandlestickDeltaService) {
+    this.candlestickDeltaService = candlestickDeltaService;
+  }
+
+  /**
+   * Deactivates the virtual delta layer.
+   */
+  public execute(): void {
+    this.candlestickDeltaService.deactivate();
+  }
+}

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -2,6 +2,7 @@ import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
 import type { AutoplayService } from '@service/autoplay';
 import type { BrailleService } from '@service/braille';
+import type { CandlestickDeltaService } from '@service/candlestickDelta';
 import type { DisplayService } from '@service/display';
 import type { HighContrastService } from '@service/highContrast';
 import type { HighlightService } from '@service/highlight';
@@ -11,6 +12,7 @@ import type { RotorNavigationService } from '@service/rotor';
 import type { SettingsService } from '@service/settings';
 import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
+import type { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDeltaViewModel';
 import type { ChatViewModel } from '@state/viewModel/chatViewModel';
 import type { CommandPaletteViewModel } from '@state/viewModel/commandPaletteViewModel';
 import type { DescriptionViewModel } from '@state/viewModel/descriptionViewModel';
@@ -45,6 +47,8 @@ export interface CommandContext {
   autoplayService: AutoplayService;
   /** Braille service for managing braille display. */
   brailleService: BrailleService;
+  /** Candlestick delta service for the virtual reference-comparison layer. */
+  candlestickDeltaService: CandlestickDeltaService;
   /** Display service for managing display state. */
   displayService: DisplayService;
   /** High contrast service for accessibility. */
@@ -63,6 +67,8 @@ export interface CommandContext {
 
   /** Braille view model for braille display. */
   brailleViewModel: BrailleViewModel;
+  /** Candlestick delta view model for the reference-comparison dialog. */
+  candlestickDeltaViewModel: CandlestickDeltaViewModel;
   /** Chat view model for chat interface. */
   chatViewModel: ChatViewModel;
   /** Command palette view model for command selection. */

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -2,6 +2,7 @@ import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
 import type { AutoplayService } from '@service/autoplay';
 import type { BrailleService } from '@service/braille';
+import type { CandlestickDeltaService } from '@service/candlestickDelta';
 import type { DisplayService } from '@service/display';
 import type { HighContrastService } from '@service/highContrast';
 import type { HighlightService } from '@service/highlight';
@@ -10,6 +11,7 @@ import type { NotificationService } from '@service/notification';
 import type { RotorNavigationService } from '@service/rotor';
 import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
+import type { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDeltaViewModel';
 import type { ChatViewModel } from '@state/viewModel/chatViewModel';
 import type { CommandPaletteViewModel } from '@state/viewModel/commandPaletteViewModel';
 import type { DescriptionViewModel } from '@state/viewModel/descriptionViewModel';
@@ -32,6 +34,10 @@ import {
   SpeedUpAutoplayCommand,
   StopAutoplayCommand,
 } from './autoplay';
+import {
+  ExitCandlestickDeltaCommand,
+  ToggleCandlestickDeltaCommand,
+} from './candlestickDelta';
 import {
   AnnounceCaptionCommand,
   AnnouncePointCommand,
@@ -111,6 +117,7 @@ export class CommandFactory {
   private readonly audioService: AudioService;
   private readonly autoplayService: AutoplayService;
   private readonly brailleService: BrailleService;
+  private readonly candlestickDeltaService: CandlestickDeltaService;
   private readonly displayService: DisplayService;
   private readonly highContrastService: HighContrastService;
   private readonly highlightService: HighlightService;
@@ -120,6 +127,7 @@ export class CommandFactory {
   private readonly textService: TextService;
 
   private readonly brailleViewModel: BrailleViewModel;
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
   private readonly chatViewModel: ChatViewModel;
   private readonly commandPaletteViewModel: CommandPaletteViewModel;
   private readonly descriptionViewModel: DescriptionViewModel;
@@ -140,6 +148,7 @@ export class CommandFactory {
     this.audioService = commandContext.audioService;
     this.autoplayService = commandContext.autoplayService;
     this.brailleService = commandContext.brailleService;
+    this.candlestickDeltaService = commandContext.candlestickDeltaService;
     this.displayService = commandContext.displayService;
     this.highContrastService = commandContext.highContrastService;
     this.highlightService = commandContext.highlightService;
@@ -149,6 +158,7 @@ export class CommandFactory {
     this.textService = commandContext.textService;
 
     this.brailleViewModel = commandContext.brailleViewModel;
+    this.candlestickDeltaViewModel = commandContext.candlestickDeltaViewModel;
     this.chatViewModel = commandContext.chatViewModel;
     this.commandPaletteViewModel = commandContext.commandPaletteViewModel;
     this.descriptionViewModel = commandContext.descriptionViewModel;
@@ -209,11 +219,11 @@ export class CommandFactory {
       case 'MOVE_TO_SUBPLOT_CONTEXT':
         return new MoveToSubplotContextCommand(this.context, this.displayService);
       case 'EXIT_BRAILLE_AND_SUBPLOT':
-        return new ExitBrailleAndSubplotCommand(this.context, this.displayService, this.brailleViewModel);
+        return new ExitBrailleAndSubplotCommand(this.context, this.displayService, this.brailleViewModel, this.candlestickDeltaService);
       case 'MOVE_TO_NEXT_TRACE':
-        return new MoveToNextTraceCommand(this.context);
+        return new MoveToNextTraceCommand(this.context, this.candlestickDeltaService);
       case 'MOVE_TO_PREV_TRACE':
-        return new MoveToPrevTraceCommand(this.context);
+        return new MoveToPrevTraceCommand(this.context, this.candlestickDeltaService);
 
       case 'TOGGLE_AUDIO':
         return new ToggleAudioCommand(this.audioService);
@@ -238,6 +248,10 @@ export class CommandFactory {
         return new ToggleDescriptionCommand(this.descriptionViewModel);
       case 'TOGGLE_SETTINGS':
         return new ToggleSettingsCommand(this.settingsViewModel);
+      case 'TOGGLE_CANDLESTICK_DELTA':
+        return new ToggleCandlestickDeltaCommand(this.candlestickDeltaViewModel);
+      case 'EXIT_CANDLESTICK_DELTA':
+        return new ExitCandlestickDeltaCommand(this.candlestickDeltaService);
 
       case 'GO_TO_EXTREMA_MOVE_UP':
         return new GoToExtremaMoveUpCommand(this.goToExtremaViewModel);

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -1,5 +1,6 @@
 import type { Context } from '@model/context';
 import type { BrailleService } from '@service/braille';
+import type { CandlestickDeltaService } from '@service/candlestickDelta';
 import type { DisplayService } from '@service/display';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { Command } from './command';
@@ -289,21 +290,25 @@ export class ExitBrailleAndSubplotCommand implements Command {
   private readonly context: Context;
   private readonly displayService: DisplayService;
   private readonly brailleViewModel: BrailleViewModel;
+  private readonly candlestickDeltaService: CandlestickDeltaService;
 
   /**
    * Creates an instance of ExitBrailleAndSubplotCommand.
    * @param {Context} context - The navigation context.
    * @param {DisplayService} displayService - The display service for focus management.
    * @param {BrailleViewModel} brailleViewModel - The braille view model for the single-panel fallback.
+   * @param {CandlestickDeltaService} candlestickDeltaService - Releases the virtual delta layer on the multi-panel exit path.
    */
   public constructor(
     context: Context,
     displayService: DisplayService,
     brailleViewModel: BrailleViewModel,
+    candlestickDeltaService: CandlestickDeltaService,
   ) {
     this.context = context;
     this.displayService = displayService;
     this.brailleViewModel = brailleViewModel;
+    this.candlestickDeltaService = candlestickDeltaService;
   }
 
   /**
@@ -312,6 +317,12 @@ export class ExitBrailleAndSubplotCommand implements Command {
    */
   public execute(): void {
     if (this.context.isMultiPanel) {
+      // The multi-panel exit pops the active trace off the stack via
+      // exitSubplot(). If that trace is the virtual delta layer, tear down
+      // the delta service's own state (and reset the rotor sign-filter)
+      // first, so it does not survive on the real chart layer. This command
+      // manages the stack and focus itself, so discardActiveLayer() must not.
+      this.candlestickDeltaService.discardActiveLayer();
       this.displayService.dismissModalScope(Scope.SUBPLOT);
       this.context.exitSubplot();
       this.displayService.notifyFocusChange(Scope.SUBPLOT);
@@ -330,19 +341,25 @@ export class ExitBrailleAndSubplotCommand implements Command {
  */
 export class MoveToNextTraceCommand implements Command {
   private readonly context: Context;
+  private readonly candlestickDeltaService: CandlestickDeltaService;
 
   /**
    * Creates an instance of MoveToNextTraceCommand.
    * @param {Context} context - The context in which the move operation is performed.
+   * @param {CandlestickDeltaService} candlestickDeltaService - Deactivates the virtual delta layer before switching.
    */
-  public constructor(context: Context) {
+  public constructor(context: Context, candlestickDeltaService: CandlestickDeltaService) {
     this.context = context;
+    this.candlestickDeltaService = candlestickDeltaService;
   }
 
   /**
    * Executes the move operation to step to the next trace upward.
+   * The virtual delta layer is not a subplot layer, so it must be released
+   * first (reachable from braille mode, where PageUp stays bound).
    */
   public execute(): void {
+    this.candlestickDeltaService.deactivateIfActive();
     this.context.stepTrace('UPWARD');
   }
 }
@@ -352,19 +369,25 @@ export class MoveToNextTraceCommand implements Command {
  */
 export class MoveToPrevTraceCommand implements Command {
   private readonly context: Context;
+  private readonly candlestickDeltaService: CandlestickDeltaService;
 
   /**
    * Creates an instance of MoveToPrevTraceCommand.
    * @param {Context} context - The context in which the move operation is performed.
+   * @param {CandlestickDeltaService} candlestickDeltaService - Deactivates the virtual delta layer before switching.
    */
-  public constructor(context: Context) {
+  public constructor(context: Context, candlestickDeltaService: CandlestickDeltaService) {
     this.context = context;
+    this.candlestickDeltaService = candlestickDeltaService;
   }
 
   /**
    * Executes the move operation to step to the previous trace downward.
+   * The virtual delta layer is not a subplot layer, so it must be released
+   * first (reachable from braille mode, where PageDown stays bound).
    */
   public execute(): void {
+    this.candlestickDeltaService.deactivateIfActive();
     this.context.stepTrace('DOWNWARD');
   }
 }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -9,6 +9,7 @@ import { Figure } from '@model/plot';
 import { AudioService } from '@service/audio';
 import { AutoplayService } from '@service/autoplay';
 import { BrailleService } from '@service/braille';
+import { CandlestickDeltaService } from '@service/candlestickDelta';
 import { ChatService } from '@service/chat';
 import { CommandExecutor } from '@service/commandExecutor';
 import { CommandPaletteService } from '@service/commandPalette';
@@ -29,6 +30,7 @@ import { SettingsService } from '@service/settings';
 import { LocalStorageService } from '@service/storage';
 import { TextService } from '@service/text';
 import { BrailleViewModel } from '@state/viewModel/brailleViewModel';
+import { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDeltaViewModel';
 import { ChatViewModel } from '@state/viewModel/chatViewModel';
 import { CommandPaletteViewModel } from '@state/viewModel/commandPaletteViewModel';
 import { DescriptionViewModel } from '@state/viewModel/descriptionViewModel';
@@ -57,6 +59,7 @@ export class Controller implements Disposable {
 
   private readonly audioService: AudioService;
   private readonly brailleService: BrailleService;
+  private readonly candlestickDeltaService: CandlestickDeltaService;
   private readonly goToExtremaService: GoToExtremaService;
   private readonly textService: TextService;
   private readonly reviewService: ReviewService;
@@ -72,6 +75,7 @@ export class Controller implements Disposable {
 
   private readonly textViewModel: TextViewModel;
   private readonly brailleViewModel: BrailleViewModel;
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
   private readonly goToExtremaViewModel: GoToExtremaViewModel;
   private readonly reviewViewModel: ReviewViewModel;
   private readonly descriptionViewModel: DescriptionViewModel;
@@ -177,6 +181,26 @@ export class Controller implements Disposable {
       store,
       this.rotorNavigationService,
     );
+    this.candlestickDeltaService = new CandlestickDeltaService(
+      this.context,
+      this.notificationService,
+      this.displayService,
+      this.rotorNavigationService,
+    );
+    // Runtime-created virtual traces are not covered by registerObservers(),
+    // so the delta service wires the same observer set itself on creation.
+    this.candlestickDeltaService.setObserverWirer((trace) => {
+      trace.addObserver(this.audioService);
+      trace.addObserver(this.brailleService);
+      trace.addObserver(this.textService);
+      trace.addObserver(this.reviewService);
+      trace.addObserver(this.highlightService);
+    });
+    this.candlestickDeltaViewModel = new CandlestickDeltaViewModel(
+      store,
+      this.candlestickDeltaService,
+      this.notificationService,
+    );
     this.chatViewModel = new ChatViewModel(
       store,
       this.chatService,
@@ -198,6 +222,7 @@ export class Controller implements Disposable {
       audioService: this.audioService,
       autoplayService: this.autoplayService,
       brailleService: this.brailleService,
+      candlestickDeltaService: this.candlestickDeltaService,
       displayService: this.displayService,
       highContrastService: this.highContrastService,
       highlightService: this.highlightService,
@@ -208,6 +233,7 @@ export class Controller implements Disposable {
       textService: this.textService,
 
       brailleViewModel: this.brailleViewModel,
+      candlestickDeltaViewModel: this.candlestickDeltaViewModel,
       chatViewModel: this.chatViewModel,
       commandPaletteViewModel: this.commandPaletteViewModel,
       descriptionViewModel: this.descriptionViewModel,
@@ -225,6 +251,7 @@ export class Controller implements Disposable {
         audioService: this.audioService,
         autoplayService: this.autoplayService,
         brailleService: this.brailleService,
+        candlestickDeltaService: this.candlestickDeltaService,
         displayService: this.displayService,
         highContrastService: this.highContrastService,
         highlightService: this.highlightService,
@@ -235,6 +262,7 @@ export class Controller implements Disposable {
         textService: this.textService,
 
         brailleViewModel: this.brailleViewModel,
+        candlestickDeltaViewModel: this.candlestickDeltaViewModel,
         chatViewModel: this.chatViewModel,
         commandPaletteViewModel: this.commandPaletteViewModel,
         descriptionViewModel: this.descriptionViewModel,
@@ -256,6 +284,7 @@ export class Controller implements Disposable {
         audioService: this.audioService,
         autoplayService: this.autoplayService,
         brailleService: this.brailleService,
+        candlestickDeltaService: this.candlestickDeltaService,
         displayService: this.displayService,
         highContrastService: this.highContrastService,
         highlightService: this.highlightService,
@@ -266,6 +295,7 @@ export class Controller implements Disposable {
         textService: this.textService,
 
         brailleViewModel: this.brailleViewModel,
+        candlestickDeltaViewModel: this.candlestickDeltaViewModel,
         chatViewModel: this.chatViewModel,
         commandPaletteViewModel: this.commandPaletteViewModel,
         descriptionViewModel: this.descriptionViewModel,
@@ -334,6 +364,14 @@ export class Controller implements Disposable {
    * @param appended - Location of the newly appended point, for appendData updates
    */
   public updateData(maidr: Maidr, appended?: AppendedPointInfo): void {
+    // The virtual delta layer is derived from the current model; a data
+    // update rebuilds the figure underneath it, so close it first to keep
+    // the navigation stack and keyboard scope consistent.
+    if (this.candlestickDeltaService.isActive) {
+      this.candlestickDeltaService.deactivate({ silent: true });
+      this.notificationService.notify('Reference comparison closed by a data update.');
+    }
+
     // Ordering is load-bearing: the sliding-window shift must be resolved
     // against the OLD figure (the user's current position) before the swap,
     // while announceAppendedPoint below runs against the NEW figure.
@@ -432,6 +470,7 @@ export class Controller implements Disposable {
     this.displayViewModel.dispose();
     this.goToExtremaViewModel.dispose();
     this.reviewViewModel.dispose();
+    this.candlestickDeltaViewModel.dispose();
     this.brailleViewModel.dispose();
     this.textViewModel.dispose();
     this.commandPaletteViewModel.dispose();
@@ -443,6 +482,7 @@ export class Controller implements Disposable {
     this.monitorService.dispose();
 
     this.chatService.dispose();
+    this.candlestickDeltaService.dispose();
     this.textService.dispose();
     this.reviewService.dispose();
     this.brailleService.dispose();
@@ -473,6 +513,7 @@ export class Controller implements Disposable {
   private registerViewModels(): void {
     this.viewModelRegistry.register('text', this.textViewModel);
     this.viewModelRegistry.register('braille', this.brailleViewModel);
+    this.viewModelRegistry.register('candlestickDelta', this.candlestickDeltaViewModel);
     this.viewModelRegistry.register('goToExtrema', this.goToExtremaViewModel);
     this.viewModelRegistry.register('review', this.reviewViewModel);
     this.viewModelRegistry.register('description', this.descriptionViewModel);

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -34,6 +34,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.BAR]: 'Bar Chart',
   [TraceType.BOX]: 'Box Plot',
   [TraceType.CANDLESTICK]: 'Candlestick Chart',
+  [TraceType.CANDLESTICK_DELTA]: 'Candlestick Reference Delta',
   [TraceType.DODGED]: 'Dodged Bar Chart',
   [TraceType.HEATMAP]: 'Heatmap',
   [TraceType.HISTOGRAM]: 'Histogram',
@@ -49,6 +50,16 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
 export interface Dimension {
   rows: number;
   cols: number;
+}
+
+/**
+ * Display metadata for the rotor's two compare modes. `label` is the rotor
+ * unit name announced when cycling modes; `noun` is the phrase used in
+ * "No {noun} found ..." boundary messages.
+ */
+export interface CompareModeInfo {
+  lower: { label: string; noun: string };
+  higher: { label: string; noun: string };
 }
 
 export interface NearestPoint {
@@ -292,6 +303,18 @@ export abstract class AbstractPlot<State> implements Movable, Observable<State>,
    */
   public dataModeName(): string {
     return Constant.DATA_MODE;
+  }
+
+  /**
+   * Returns the rotor's compare-mode labels and boundary-message nouns.
+   * Override to rename the two compare units for a trace-specific semantic
+   * (e.g., the candlestick delta layer uses "above line" / "below line").
+   */
+  public compareModeInfo(): CompareModeInfo {
+    return {
+      lower: { label: Constant.LOWER_VALUE_MODE, noun: 'lower value' },
+      higher: { label: Constant.HIGHER_VALUE_MODE, noun: 'higher value' },
+    };
   }
 
   /**

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -793,6 +793,15 @@ export class Candlestick extends AbstractTrace {
   }
 
   /**
+   * Gets the candle data points. Used by the candlestick delta feature to
+   * derive a virtual comparison layer against a reference line.
+   * @returns The candle points in x order
+   */
+  public getCandles(): readonly CandlestickPoint[] {
+    return this.candles;
+  }
+
+  /**
    * Gets the current X value from the candlestick trace
    * @returns The current X value or null if not available
    */

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -1,0 +1,413 @@
+import type { ExtremaTarget } from '@type/extrema';
+import type { CandlestickTrend, MaidrLayer } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type { XValue } from '@type/navigation';
+import type {
+  AudioState,
+  BrailleState,
+  DescriptionState,
+  TextState,
+} from '@type/state';
+import type { CompareModeInfo, Dimension, NearestPoint } from './abstract';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/** OHLC fields a user can compare against a reference line. */
+export type CandlestickDeltaField = 'open' | 'high' | 'low' | 'close';
+
+export const CANDLESTICK_DELTA_FIELDS: readonly CandlestickDeltaField[] = [
+  'open',
+  'high',
+  'low',
+  'close',
+];
+
+/** Rotor unit for browsing only the points above the reference line. */
+export const ABOVE_LINE_MODE = 'ABOVE LINE NAVIGATION';
+/** Rotor unit for browsing only the points below the reference line. */
+export const BELOW_LINE_MODE = 'BELOW LINE NAVIGATION';
+/** Default rotor unit for the delta layer. */
+export const DELTA_POINT_MODE = 'DELTA POINT NAVIGATION';
+
+const ABOVE_LINE = 'above line';
+const BELOW_LINE = 'below line';
+const ON_LINE = 'on line';
+
+/**
+ * One point of the virtual delta layer: a candlestick OHLC value matched by
+ * x value against a reference line point, with their signed difference.
+ */
+export interface CandlestickDeltaPoint {
+  /** Shared x value (e.g., date) present in both the candles and the line. */
+  x: string;
+  /** The chosen OHLC value at x. */
+  fieldValue: number;
+  /** The reference line value at x. */
+  reference: number;
+  /** fieldValue - reference, rounded to suppress float noise. */
+  delta: number;
+  /** 'Bull' above the line, 'Bear' below, 'Neutral' exactly on it. */
+  trend: CandlestickTrend;
+}
+
+/** Configuration captured when the user confirms the F7 dialog. */
+export interface CandlestickDeltaConfig {
+  points: CandlestickDeltaPoint[];
+  field: CandlestickDeltaField;
+  referenceLabel: string;
+}
+
+/**
+ * Rounds a delta to suppress binary floating-point noise (e.g.
+ * 0.30000000000000004) so exactly-on-the-line points compare equal to zero.
+ *
+ * Float noise scales with operand magnitude, so a fixed absolute grid is
+ * wrong at both extremes: a fixed `raw * 1e9` round overflows
+ * Number.MAX_SAFE_INTEGER for large-priced instruments (e.g. crypto quoted
+ * above ~9e6, where the round loses all precision), and a 1e-9 absolute grid
+ * over-suppresses genuine tiny deltas on small-priced ones. Instead, snap to
+ * zero with a tolerance relative to the operand magnitude — values that agree
+ * to ~9 significant figures (typical financial display precision) are treated
+ * as "on the line" — then round survivors to 9 significant figures.
+ *
+ * @param raw - The raw difference between the OHLC value and the reference
+ * @param magnitude - The larger operand magnitude, used to scale the tolerance
+ *   (defaults to 0, which floors the tolerance at an absolute 1e-9)
+ * @returns The cleaned delta
+ */
+export function roundDelta(raw: number, magnitude: number = 0): number {
+  const tolerance = Math.max(Math.abs(magnitude), 1) * 1e-9;
+  if (Math.abs(raw) <= tolerance) {
+    return 0;
+  }
+  return Number(raw.toPrecision(9));
+}
+
+/**
+ * Derives the trend for a signed delta: above the line is bullish, below is
+ * bearish, exactly on the line is neutral.
+ * @param delta - The signed delta value
+ * @returns The corresponding candlestick trend
+ */
+export function deltaTrend(delta: number): CandlestickTrend {
+  if (delta > 0) {
+    return 'Bull';
+  }
+  if (delta < 0) {
+    return 'Bear';
+  }
+  return 'Neutral';
+}
+
+/**
+ * Virtual (invisible) trace comparing one OHLC field of a candlestick chart
+ * against a reference line (e.g. a moving average) from the same subplot.
+ *
+ * Each point is `field value - reference value` at a shared x value, exposed
+ * through the standard BTS pipeline:
+ * - Audio: pitch encodes |delta|, stereo pan encodes x, and the bull/bear
+ *   candlestick timbres encode direction; an exact zero plays a click.
+ * - Braille: candlestick-style height encoding of |delta| where below-line
+ *   points carry the bearish dot-8 marker.
+ * - Text: "above line" / "below line" / "on line" with the delta magnitude.
+ *
+ * The layer has no SVG geometry of its own, so it never highlights.
+ */
+export class CandlestickDeltaTrace extends AbstractTrace {
+  protected readonly supportsExtrema = true;
+  protected readonly movable: Movable;
+  protected readonly highlightValues: (SVGElement[] | SVGElement)[][] | null
+    = null;
+
+  private readonly deltaPoints: CandlestickDeltaPoint[];
+  /** Signed deltas; single row (the layer is a 1 x N series). */
+  private readonly deltaValues: number[][];
+  /** |delta| per point — the braille height source, cached for stable identity. */
+  private readonly absDeltaValues: number[][];
+  private readonly trends: CandlestickTrend[];
+  private readonly brailleMin: number[];
+  private readonly brailleMax: number[];
+  private readonly maxAbsDelta: number;
+
+  private readonly field: CandlestickDeltaField;
+  private readonly referenceLabel: string;
+
+  public constructor(layer: MaidrLayer, config: CandlestickDeltaConfig) {
+    super(layer);
+
+    this.deltaPoints = config.points;
+    this.field = config.field;
+    this.referenceLabel = config.referenceLabel;
+
+    this.deltaValues = [this.deltaPoints.map(point => point.delta)];
+    this.absDeltaValues = [
+      this.deltaPoints.map(point => Math.abs(point.delta)),
+    ];
+    this.trends = this.deltaPoints.map(point => point.trend);
+
+    this.maxAbsDelta = this.absDeltaValues[0].reduce(
+      (max, value) => Math.max(max, value),
+      0,
+    );
+    this.brailleMin = [0];
+    this.brailleMax = [this.maxAbsDelta];
+
+    this.movable = new MovableGrid<number>(this.deltaValues);
+  }
+
+  public dispose(): void {
+    this.deltaPoints.length = 0;
+    this.deltaValues.length = 0;
+    this.absDeltaValues.length = 0;
+    this.trends.length = 0;
+    super.dispose();
+  }
+
+  protected get values(): number[][] {
+    return this.deltaValues;
+  }
+
+  protected get dimension(): Dimension {
+    return { rows: 1, cols: this.deltaPoints.length };
+  }
+
+  /** The OHLC field this layer compares against the reference line. */
+  public get comparedField(): CandlestickDeltaField {
+    return this.field;
+  }
+
+  /** Human-readable name of the reference line this layer compares against. */
+  public get reference(): string {
+    return this.referenceLabel;
+  }
+
+  /** Number of matched (candle, reference) points in this layer. */
+  public get size(): number {
+    return this.deltaPoints.length;
+  }
+
+  /**
+   * Moves the cursor to a point index without notifying observers. Used on
+   * activation to align the delta layer with the candle the user was on.
+   * @param index - The point index to position the cursor at
+   */
+  public setInitialPosition(index: number): void {
+    if (index < 0 || index >= this.deltaPoints.length) {
+      return;
+    }
+    this.isInitialEntry = false;
+    this.row = 0;
+    this.col = index;
+  }
+
+  protected get audio(): AudioState {
+    const { col } = this.getSafeIndices();
+    const point = this.deltaPoints[col];
+
+    return {
+      freq: {
+        min: 0,
+        // Guard the all-zero-deltas case: raw is then always 0 and takes the
+        // click path, but interpolate() must never see min === max.
+        max: this.maxAbsDelta > 0 ? this.maxAbsDelta : 1,
+        raw: Math.abs(point.delta),
+      },
+      panning: {
+        x: col,
+        y: 0,
+        rows: 1,
+        cols: this.deltaPoints.length,
+      },
+      trend: point.trend,
+      zeroClick: true,
+    };
+  }
+
+  protected get braille(): BrailleState {
+    // Height encodes |delta| over [0, max |delta|]; the custom trends add the
+    // bearish dot-8 marker for below-line points (see CandlestickBrailleEncoder).
+    // Must stay side-effect free and return stable array references — the
+    // braille cache compares `values` by identity.
+    return {
+      empty: false,
+      id: this.id,
+      values: this.absDeltaValues,
+      min: this.brailleMin,
+      max: this.brailleMax,
+      row: 0,
+      col: this.getSafeIndices().col,
+      custom: this.trends,
+    };
+  }
+
+  protected get text(): TextState {
+    const point = this.deltaPoints[this.getSafeIndices().col];
+    const position
+      = point.delta > 0 ? ABOVE_LINE : point.delta < 0 ? BELOW_LINE : ON_LINE;
+
+    // Verbose: "Date is 2019-11-05, close delta is 1.25, position is above line"
+    // Terse:   "2019-11-05, close 1.25, above line"
+    return {
+      main: { label: this.xAxis, value: point.x },
+      cross: { label: 'delta', value: Math.abs(point.delta) },
+      section: this.field,
+      z: { label: 'position', value: position },
+      mainAxis: 'x',
+      crossAxis: 'y',
+    };
+  }
+
+  public get description(): DescriptionState {
+    const aboveCount = this.deltaPoints.filter(p => p.delta > 0).length;
+    const belowCount = this.deltaPoints.filter(p => p.delta < 0).length;
+    const onLineCount = this.deltaPoints.length - aboveCount - belowCount;
+    const signedDeltas = this.deltaValues[0];
+    const maxDelta = signedDeltas.reduce((a, b) => Math.max(a, b), Number.NEGATIVE_INFINITY);
+    const minDelta = signedDeltas.reduce((a, b) => Math.min(a, b), Number.POSITIVE_INFINITY);
+
+    const stats: DescriptionState['stats'] = [
+      { label: 'Reference line', value: this.referenceLabel },
+      { label: 'Compared value', value: this.field },
+      { label: 'Number of points', value: this.deltaPoints.length },
+      { label: 'Points above line', value: aboveCount },
+      { label: 'Points below line', value: belowCount },
+      { label: 'Points on line', value: onLineCount },
+      { label: 'Delta range', value: `${minDelta} to ${maxDelta}` },
+    ];
+
+    const headers = [
+      this.xAxis,
+      this.field,
+      this.referenceLabel,
+      'Delta',
+      'Position',
+    ];
+    const rows: (string | number)[][] = this.deltaPoints.map(point => [
+      point.x,
+      point.fieldValue,
+      point.reference,
+      point.delta,
+      point.delta > 0 ? ABOVE_LINE : point.delta < 0 ? BELOW_LINE : ON_LINE,
+    ]);
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  public override getCurrentXValue(): XValue | null {
+    return this.deltaPoints[this.col]?.x ?? null;
+  }
+
+  public override moveToXValue(xValue: XValue): boolean {
+    const index = this.deltaPoints.findIndex(point => point.x === xValue);
+    if (index === -1) {
+      return false;
+    }
+    return this.moveToIndex(0, index);
+  }
+
+  /**
+   * Gets available X values for the Go To search combobox.
+   * @returns Array of X values in point order
+   */
+  public getAvailableXValues(): XValue[] {
+    return this.deltaPoints.map(point => point.x);
+  }
+
+  public override getExtremaTargets(): ExtremaTarget[] {
+    if (this.deltaPoints.length === 0) {
+      return [];
+    }
+
+    const signedDeltas = this.deltaValues[0];
+    const maxDelta = signedDeltas.reduce((a, b) => Math.max(a, b));
+    const minDelta = signedDeltas.reduce((a, b) => Math.min(a, b));
+
+    const targets: ExtremaTarget[] = [];
+    signedDeltas.forEach((delta, index) => {
+      if (delta === maxDelta) {
+        targets.push(this.buildExtremaTarget('max', index));
+      }
+    });
+    signedDeltas.forEach((delta, index) => {
+      if (delta === minDelta) {
+        targets.push(this.buildExtremaTarget('min', index));
+      }
+    });
+    return targets;
+  }
+
+  private buildExtremaTarget(type: 'max' | 'min', index: number): ExtremaTarget {
+    const point = this.deltaPoints[index];
+    return {
+      label: `${type === 'max' ? 'Max' : 'Min'} Delta at ${point.x}`,
+      value: point.delta,
+      pointIndex: index,
+      segment: this.field,
+      type,
+      navigationType: 'point',
+      xValue: point.x,
+    };
+  }
+
+  public override navigateToExtrema(target: ExtremaTarget): void {
+    if (target.pointIndex < 0 || target.pointIndex >= this.deltaPoints.length) {
+      return;
+    }
+    this.row = 0;
+    this.col = target.pointIndex;
+    this.finalizeNavigation();
+  }
+
+  public override dataModeName(): string {
+    return DELTA_POINT_MODE;
+  }
+
+  public override compareModeInfo(): CompareModeInfo {
+    // The rotor's two compare units become sign filters for this layer:
+    // 'higher' walks points above the reference line, 'lower' below it.
+    return {
+      lower: { label: BELOW_LINE_MODE, noun: 'point below the line' },
+      higher: { label: ABOVE_LINE_MODE, noun: 'point above the line' },
+    };
+  }
+
+  public override moveToNextCompareValue(
+    direction: 'left' | 'right' | 'up' | 'down',
+    type: 'lower' | 'higher',
+  ): boolean {
+    if (direction !== 'left' && direction !== 'right') {
+      this.notifyRotorBounds();
+      return false;
+    }
+
+    const step = direction === 'right' ? 1 : -1;
+    for (
+      let i = this.col + step;
+      i >= 0 && i < this.deltaPoints.length;
+      i += step
+    ) {
+      const delta = this.deltaPoints[i].delta;
+      if (type === 'higher' ? delta > 0 : delta < 0) {
+        this.isInitialEntry = false;
+        this.row = 0;
+        this.col = i;
+        this.notifyStateUpdate();
+        return true;
+      }
+    }
+
+    this.notifyRotorBounds();
+    return false;
+  }
+
+  protected findNearestPoint(_x: number, _y: number): NearestPoint | null {
+    // Virtual layer: no SVG geometry to hover.
+    return null;
+  }
+}

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -431,6 +431,35 @@ export class Context implements Disposable {
     return this.active.moveToPointAndGetPointerGuidance(x, y);
   }
 
+  /**
+   * Replaces the active trace at the top of the plot context with another
+   * trace, leaving the rest of the stack (and its depth) untouched. Used by
+   * the candlestick delta feature to activate its virtual layer and to
+   * restore the real layer on exit.
+   *
+   * @param trace - The trace to make active
+   * @returns The trace that was active before the swap, or null when the
+   *   current context is not at trace level (nothing is swapped then)
+   */
+  public swapActiveTrace(trace: Trace): Trace | null {
+    const current = this.plotContext.peek();
+    if (!current || current.state.type !== 'trace') {
+      return null;
+    }
+    this.plotContext.pop();
+    this.plotContext.push(trace);
+    return current as Trace;
+  }
+
+  /**
+   * Returns the traces of the subplot the user is currently in, flattened in
+   * layer order. Used to discover sibling layers (e.g., reference lines for
+   * the candlestick delta feature).
+   */
+  public getActiveSubplotTraces(): Trace[] {
+    return this.figure.activeSubplot.traces.flat();
+  }
+
   public stepTrace(direction: MovableDirection): void {
     if (this.plotContext.size() > 1) {
       const previousTrace = this.active as Trace;

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -110,6 +110,21 @@ export class LineTrace extends AbstractTrace {
   }
 
   /**
+   * Gets the line series with human-readable labels. Used by the candlestick
+   * delta feature to list reference-line candidates (e.g., moving averages).
+   * @returns One entry per series with its label and points
+   */
+  public getSeries(): { label: string; points: readonly LinePoint[] }[] {
+    return this.points.map((line, index) => ({
+      label: String(
+        line[0]?.z
+        ?? (this.points.length > 1 ? `Line ${index + 1}` : this.title),
+      ),
+      points: line,
+    }));
+  }
+
+  /**
    * Gets the description state for the line trace.
    * @returns The description state containing chart metadata and data table
    */

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -298,7 +298,13 @@ export class AudioService implements Observer<PlotState>, Disposable {
     } else {
       const value = audio.freq.raw as number;
       if (value === 0) {
-        this.playZeroTone(audio.panning);
+        // A trace can opt into a percussive click for exact zeros (e.g. the
+        // candlestick delta layer, where zero means "on the reference line").
+        if (audio.zeroClick) {
+          this.playClickTone(audio.panning);
+        } else {
+          this.playZeroTone(audio.panning);
+        }
       } else {
         this.playTone(audio.freq, audio.panning, paletteEntry);
       }
@@ -764,6 +770,83 @@ export class AudioService implements Observer<PlotState>, Disposable {
     }, POINTER_GUIDANCE_BEEP_DURATION * 1000 * 2);
     this.activeAudioIds.set(audioId, nodes);
     return true;
+  }
+
+  /**
+   * Plays a short percussive click, spatialized by x-position. Used for
+   * zero-delta points in the candlestick delta layer, where "exactly on the
+   * reference line" needs a sound clearly distinct from both the pitched
+   * data tones and the low "null value" tone.
+   *
+   * The click is a ~40 ms band-passed noise burst with a quadratic decay —
+   * a tick rather than a tone, so it cannot be confused with a pitch.
+   *
+   * @param panning - Position information for stereo placement
+   * @returns AudioId for the played click
+   */
+  private playClickTone(panning: Panning): AudioId {
+    // Silent at volume 0; return a harmless self-clearing id (see playEmptyTone).
+    if (this.volume <= 0) {
+      const audioId = setTimeout(() => this.activeAudioIds.delete(audioId), 0);
+      this.activeAudioIds.set(audioId, []);
+      return audioId;
+    }
+
+    const ctx = this.audioContext;
+    const now = ctx.currentTime;
+    const duration = 0.04;
+
+    const frameCount = Math.max(1, Math.floor(ctx.sampleRate * duration));
+    const buffer = ctx.createBuffer(1, frameCount, ctx.sampleRate);
+    const channel = buffer.getChannelData(0);
+    for (let i = 0; i < frameCount; i++) {
+      channel[i] = (Math.random() * 2 - 1) * (1 - i / frameCount) ** 2;
+    }
+
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+
+    const bandpass = ctx.createBiquadFilter();
+    bandpass.type = 'bandpass';
+    bandpass.frequency.value = 2500;
+    bandpass.Q.value = 1;
+
+    const gain = ctx.createGain();
+    gain.gain.value = this.volume;
+
+    const xPos = MathUtil.clamp(
+      MathUtil.interpolate(panning.x, 0, panning.cols - 1, -1, 1),
+      -1,
+      1,
+    );
+    // createStereoPanner is unavailable on Safari < 14.5; degrade to mono.
+    const stereoPanner = typeof ctx.createStereoPanner === 'function'
+      ? ctx.createStereoPanner()
+      : null;
+    if (stereoPanner) {
+      stereoPanner.pan.value = xPos;
+    }
+
+    source.connect(bandpass);
+    bandpass.connect(gain);
+    if (stereoPanner) {
+      gain.connect(stereoPanner);
+      stereoPanner.connect(this.compressor);
+    } else {
+      gain.connect(this.compressor);
+    }
+
+    source.start(now);
+
+    const nodes: AudioNode[] = stereoPanner
+      ? [source, bandpass, gain, stereoPanner]
+      : [source, bandpass, gain];
+    const audioId = setTimeout(() => {
+      nodes.forEach(node => node.disconnect());
+      this.activeAudioIds.delete(audioId);
+    }, duration * 1e3 * 2);
+    this.activeAudioIds.set(audioId, [source]);
+    return audioId;
   }
 
   private playZeroTone(panning: Panning): AudioId {

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1094,6 +1094,9 @@ implements Observer<SubplotState | TraceState>, Disposable {
       [TraceType.BAR, asGeneric(new BarBrailleEncoder())],
       [TraceType.BOX, asGeneric(new BoxBrailleEncoder())],
       [TraceType.CANDLESTICK, asGeneric(new CandlestickBrailleEncoder())],
+      // The virtual delta layer reuses the candlestick encoding: height maps
+      // |delta| and the 'Bear' trend adds dot 8 for below-line points.
+      [TraceType.CANDLESTICK_DELTA, asGeneric(new CandlestickBrailleEncoder())],
       [TraceType.DODGED, asGeneric(new BarBrailleEncoder())],
       [TraceType.HEATMAP, asGeneric(new HeatmapBrailleEncoder())],
       [TraceType.HISTOGRAM, asGeneric(new BarBrailleEncoder())],

--- a/src/service/candlestickDelta.ts
+++ b/src/service/candlestickDelta.ts
@@ -1,0 +1,416 @@
+import type {
+  CandlestickDeltaField,
+  CandlestickDeltaPoint,
+} from '@model/candlestickDelta';
+import type { Context } from '@model/context';
+import type { Trace } from '@model/plot';
+import type { Disposable } from '@type/disposable';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { XValue } from '@type/navigation';
+import type { DisplayService } from './display';
+import type { NotificationService } from './notification';
+import type { RotorNavigationService } from './rotor';
+import { Candlestick } from '@model/candlestick';
+import {
+  CandlestickDeltaTrace,
+  deltaTrend,
+  roundDelta,
+} from '@model/candlestickDelta';
+import { LineTrace } from '@model/line';
+import { Scope } from '@type/event';
+import { TraceType } from '@type/grammar';
+
+/** A selectable reference series (one line of a line layer) for comparison. */
+export interface CandlestickDeltaReference {
+  /** Stable option id: `{layer id}:{series index}`. */
+  id: string;
+  /** Human-readable series name (e.g., "Moving Average 3 days"). */
+  label: string;
+}
+
+/** The configuration of the currently active delta layer, if any. */
+export interface CandlestickDeltaSelection {
+  referenceId: string;
+  field: CandlestickDeltaField;
+}
+
+/**
+ * Manages the virtual candlestick delta layer: discovers reference lines in
+ * the active subplot, builds the {@link CandlestickDeltaTrace} from the
+ * user's F7 dialog selection, swaps it in/out of the navigation context, and
+ * announces activation and exit.
+ */
+export class CandlestickDeltaService implements Disposable {
+  private readonly context: Context;
+  private readonly notification: NotificationService;
+  private readonly display: DisplayService;
+  private readonly rotor: RotorNavigationService;
+
+  /** Wires the standard trace observers onto a runtime-created trace. */
+  private wireTrace: ((trace: Trace) => void) | null = null;
+
+  private deltaTrace: CandlestickDeltaTrace | null = null;
+  /** The real trace the delta layer replaced; restored on exit. */
+  private anchor: Trace | null = null;
+  private selection: CandlestickDeltaSelection | null = null;
+
+  public constructor(
+    context: Context,
+    notification: NotificationService,
+    display: DisplayService,
+    rotor: RotorNavigationService,
+  ) {
+    this.context = context;
+    this.notification = notification;
+    this.display = display;
+    this.rotor = rotor;
+  }
+
+  public dispose(): void {
+    this.deltaTrace?.dispose();
+    this.deltaTrace = null;
+    this.anchor = null;
+    this.selection = null;
+    this.wireTrace = null;
+  }
+
+  /**
+   * Injects the observer wiring used for runtime-created traces. The
+   * Controller owns the services that must observe a trace (audio, braille,
+   * text, review, highlight), so it supplies this hook after construction.
+   * @param wireTrace - Callback registering all trace observers
+   */
+  public setObserverWirer(wireTrace: (trace: Trace) => void): void {
+    this.wireTrace = wireTrace;
+  }
+
+  /** Whether the virtual delta layer is the active navigation target. */
+  public get isActive(): boolean {
+    return this.deltaTrace !== null && this.context.active === this.deltaTrace;
+  }
+
+  /** The active layer's configuration, used to preselect the F7 dialog. */
+  public get activeSelection(): CandlestickDeltaSelection | null {
+    return this.isActive ? this.selection : null;
+  }
+
+  /**
+   * Lists the reference series available for comparison in the current
+   * subplot, or null when the feature does not apply here (the active trace
+   * is not a candlestick, or no line layer exists alongside it).
+   * @returns The selectable references, or null when unavailable
+   */
+  public getReferences(): CandlestickDeltaReference[] | null {
+    if (!this.resolveCandlestick()) {
+      return null;
+    }
+
+    const references: CandlestickDeltaReference[] = [];
+    for (const trace of this.context.getActiveSubplotTraces()) {
+      if (!(trace instanceof LineTrace)) {
+        continue;
+      }
+      trace.getSeries().forEach((series, index) => {
+        references.push({
+          id: `${trace.getId()}:${index}`,
+          label: series.label,
+        });
+      });
+    }
+    return references.length > 0 ? references : null;
+  }
+
+  /** Moves keyboard focus into the F7 settings dialog scope. */
+  public openSettings(): void {
+    this.display.toggleFocus(Scope.CANDLESTICK_DELTA_SETTINGS);
+  }
+
+  /** Closes the F7 settings dialog scope, returning to the previous scope. */
+  public closeSettings(): void {
+    this.display.toggleFocus(Scope.CANDLESTICK_DELTA_SETTINGS);
+  }
+
+  /**
+   * Builds and activates the virtual delta layer for the given reference
+   * series and OHLC field. Replaces an already-active delta layer in place
+   * when the user reconfigures via F7.
+   *
+   * @param referenceId - Id of the reference series (from getReferences)
+   * @param field - The OHLC field to compare
+   * @returns True when the layer was activated
+   */
+  public activate(referenceId: string, field: CandlestickDeltaField): boolean {
+    const candlestick = this.resolveCandlestick();
+    if (!candlestick) {
+      this.notification.notify(
+        'Reference comparison is only available on candlestick charts.',
+      );
+      return false;
+    }
+
+    const reference = this.resolveReference(referenceId);
+    if (!reference) {
+      this.notification.notify('The selected reference line is unavailable.');
+      return false;
+    }
+
+    const points = this.buildDeltaPoints(candlestick, reference.points, field);
+    if (points.length === 0) {
+      this.notification.notify(
+        `No matching x values between the candlestick chart and ${reference.label}.`,
+      );
+      return false;
+    }
+
+    const trace = this.buildTrace(candlestick, reference.label, field, points);
+
+    const wasActive = this.isActive;
+
+    // Land on the x the user is currently on: the delta layer's own position
+    // when reconfiguring via F7, otherwise the candle the user was on.
+    const currentX = wasActive && this.deltaTrace
+      ? this.deltaTrace.getCurrentXValue()
+      : candlestick.getCurrentXValue();
+    const startIndex
+      = currentX === null ? -1 : points.findIndex(point => point.x === currentX);
+    if (startIndex >= 0) {
+      trace.setInitialPosition(startIndex);
+    }
+    const previous = this.context.swapActiveTrace(trace);
+    if (!previous) {
+      trace.dispose();
+      this.notification.notify('Reference comparison could not be activated here.');
+      return false;
+    }
+
+    if (wasActive && this.deltaTrace && previous === this.deltaTrace) {
+      // Reconfiguration: the old virtual layer is replaced; the anchor stays.
+      this.deltaTrace.dispose();
+    } else {
+      this.anchor = previous;
+    }
+    this.deltaTrace = trace;
+    this.selection = { referenceId, field };
+
+    this.rotor.resetToDataMode();
+    if (!wasActive) {
+      this.display.toggleFocus(Scope.CANDLESTICK_DELTA);
+    }
+
+    // State first, notification second: TextViewModel clears the alert
+    // message on every navigation update, so announcing before the state
+    // update would wipe these instructions before screen readers read them.
+    trace.notifyStateUpdate();
+    this.notification.notify(
+      `Reference comparison on: ${field} price minus ${reference.label}, `
+      + `${points.length} points. Positive values are above the line, negative below. `
+      + 'Use Left and Right arrows to explore, G for extrema, '
+      + 'and the rotor to browse only above-line or below-line points. '
+      + 'Press Escape to return to the chart.',
+    );
+    return true;
+  }
+
+  /**
+   * Deactivates the virtual delta layer and restores the real chart layer.
+   *
+   * @param options - Deactivation options
+   * @param options.silent - Skip announcements and position sync (used when
+   *   another navigation action is about to announce anyway)
+   * @returns True when an active layer was deactivated
+   */
+  public deactivate(options: { silent?: boolean } = {}): boolean {
+    const trace = this.deltaTrace;
+    if (!trace) {
+      return false;
+    }
+
+    const active = this.context.active === trace;
+    let lastX: XValue | null = null;
+    if (active) {
+      lastX = trace.getCurrentXValue();
+      if (this.anchor) {
+        this.context.swapActiveTrace(this.anchor);
+      }
+    }
+
+    const anchor = this.anchor;
+    this.deltaTrace = null;
+    this.anchor = null;
+    this.selection = null;
+    trace.dispose();
+    this.rotor.resetToDataMode();
+
+    if (!active) {
+      return false;
+    }
+
+    // Remove the delta scope from the focus stack (wherever it sits — the
+    // user may be in braille or another nested mode) and re-assert the scope
+    // now on top.
+    this.display.toggleFocus(Scope.CANDLESTICK_DELTA);
+
+    if (!options.silent) {
+      // Sync the chart to the delta layer's x position first (plays the
+      // regular tone + description), then announce the closure —
+      // TextViewModel clears the alert message on every navigation update,
+      // so the reverse order would wipe the announcement.
+      if (anchor && lastX !== null) {
+        anchor.moveToXValue(lastX);
+      }
+      this.notification.notify(
+        'Reference comparison closed. Returned to the chart layer.',
+      );
+    }
+    return true;
+  }
+
+  /**
+   * Deactivates without announcements if the delta layer is active. Used by
+   * layer-switching commands so PageUp/PageDown from a nested mode cannot
+   * strand the virtual trace on the navigation stack.
+   */
+  public deactivateIfActive(): void {
+    if (this.isActive) {
+      this.deactivate({ silent: true });
+    } else if (this.deltaTrace) {
+      // Stale virtual trace (e.g. the stack was rebuilt around it): drop it.
+      this.deltaTrace.dispose();
+      this.deltaTrace = null;
+      this.anchor = null;
+      this.selection = null;
+    }
+  }
+
+  /**
+   * Discards the virtual layer's internal state and resets the rotor WITHOUT
+   * touching the plot context stack or display focus. Used by callers that
+   * manage the navigation stack and keyboard scope themselves while tearing
+   * the delta layer down — e.g. the braille-Escape command on a multi-panel
+   * figure, which pops the delta trace via `exitSubplot()` and re-focuses the
+   * plot on its own. Using {@link deactivate} there would double-manage the
+   * stack and fire a competing focus change.
+   */
+  public discardActiveLayer(): void {
+    if (!this.deltaTrace) {
+      return;
+    }
+    const trace = this.deltaTrace;
+    this.deltaTrace = null;
+    this.anchor = null;
+    this.selection = null;
+    trace.dispose();
+    this.rotor.resetToDataMode();
+  }
+
+  /**
+   * Finds the candlestick trace the comparison anchors to: the active trace,
+   * or the stored anchor when the delta layer itself is active.
+   */
+  private resolveCandlestick(): Candlestick | null {
+    const active = this.context.active;
+    if (active instanceof Candlestick) {
+      return active;
+    }
+    if (
+      this.deltaTrace !== null
+      && active === this.deltaTrace
+      && this.anchor instanceof Candlestick
+    ) {
+      return this.anchor;
+    }
+    return null;
+  }
+
+  private resolveReference(
+    referenceId: string,
+  ): { label: string; points: readonly LinePoint[] } | null {
+    for (const trace of this.context.getActiveSubplotTraces()) {
+      if (!(trace instanceof LineTrace)) {
+        continue;
+      }
+      const series = trace.getSeries();
+      for (let index = 0; index < series.length; index++) {
+        if (`${trace.getId()}:${index}` === referenceId) {
+          return series[index];
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Matches candles to reference points by x value and computes the signed
+   * deltas. Candles without a reference value at the same x (e.g. the head
+   * of a moving average window) are skipped.
+   */
+  private buildDeltaPoints(
+    candlestick: Candlestick,
+    referencePoints: readonly LinePoint[],
+    field: CandlestickDeltaField,
+  ): CandlestickDeltaPoint[] {
+    const referenceByX = new Map<string, number>();
+    for (const point of referencePoints) {
+      const y = Number(point.y);
+      if (Number.isFinite(y)) {
+        referenceByX.set(String(point.x), y);
+      }
+    }
+
+    const points: CandlestickDeltaPoint[] = [];
+    for (const candle of candlestick.getCandles()) {
+      const reference = referenceByX.get(String(candle.value));
+      if (reference === undefined) {
+        continue;
+      }
+      const fieldValue = candle[field];
+      if (!Number.isFinite(fieldValue)) {
+        continue;
+      }
+      const delta = roundDelta(
+        fieldValue - reference,
+        Math.max(Math.abs(fieldValue), Math.abs(reference)),
+      );
+      points.push({
+        x: candle.value,
+        fieldValue,
+        reference,
+        delta,
+        trend: deltaTrend(delta),
+      });
+    }
+    return points;
+  }
+
+  private buildTrace(
+    candlestick: Candlestick,
+    referenceLabel: string,
+    field: CandlestickDeltaField,
+    points: CandlestickDeltaPoint[],
+  ): CandlestickDeltaTrace {
+    const candleState = candlestick.state;
+    const xAxis = candleState.empty ? 'X' : candleState.xAxis;
+    const yAxis = candleState.empty ? 'Y' : candleState.yAxis;
+
+    const layer: MaidrLayer = {
+      // Reuse the candlestick layer id so per-layer value formatters (dates,
+      // currency) apply to the delta layer's x values and magnitudes too.
+      id: candlestick.getId(),
+      type: TraceType.CANDLESTICK_DELTA,
+      title: `${field} price vs ${referenceLabel}`,
+      axes: {
+        x: { label: xAxis },
+        y: { label: `${yAxis} delta` },
+      },
+      data: [],
+    };
+
+    const trace = new CandlestickDeltaTrace(layer, {
+      points,
+      field,
+      referenceLabel,
+    });
+    this.wireTrace?.(trace);
+    return trace;
+  }
+}

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -205,7 +205,8 @@ export class DisplayService implements Disposable {
         || focus === 'DESCRIPTION'
         || focus === 'SETTINGS'
         || focus === 'CHAT'
-        || focus === 'HELP';
+        || focus === 'HELP'
+        || focus === 'CANDLESTICK_DELTA_SETTINGS';
 
     // Clear any existing instruction label when entering a modal
     if (this.isReturningFromModeToggle) {
@@ -283,7 +284,9 @@ export class DisplayService implements Disposable {
    * @param {Focus} newScope - The new focus scope
    */
   private updateFocus(newScope: Focus): void {
-    if (newScope === 'TRACE' || newScope === 'SUBPLOT') {
+    // CANDLESTICK_DELTA is plot navigation (like TRACE), so the plot element
+    // must (re)take DOM focus when the virtual delta layer becomes active.
+    if (newScope === 'TRACE' || newScope === 'SUBPLOT' || newScope === 'CANDLESTICK_DELTA') {
       this.plot.tabIndex = 0;
       setTimeout((): void => {
         // Only run first-entry init when NOT returning from a modal

--- a/src/service/help.ts
+++ b/src/service/help.ts
@@ -134,6 +134,7 @@ export class HelpService {
     // Auto-generate help menus from keymaps including nested scopes
     const traceHelpMenu = generateCompleteHelpMenu(Scope.TRACE);
     const subplotHelpMenu = generateCompleteHelpMenu(Scope.SUBPLOT);
+    const candlestickDeltaHelpMenu = generateCompleteHelpMenu(Scope.CANDLESTICK_DELTA);
 
     this.scopedMenuItems = {
       [Scope.TRACE]: traceHelpMenu,
@@ -141,6 +142,7 @@ export class HelpService {
       [Scope.BRAILLE]: traceHelpMenu,
       [Scope.SUBPLOT]: subplotHelpMenu,
       [Scope.FIGURE_LABEL]: subplotHelpMenu,
+      [Scope.CANDLESTICK_DELTA]: candlestickDeltaHelpMenu,
     };
   }
 

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -81,6 +81,73 @@ const BRAILLE_KEYMAP = {
 } as const;
 
 /**
+ * Keymap configuration for the virtual candlestick delta layer. Mirrors the
+ * trace scope minus layer switching (the delta layer is not a subplot layer)
+ * and with ESC bound to exiting back to the real chart layer.
+ */
+const CANDLESTICK_DELTA_KEYMAP = {
+  EXIT_CANDLESTICK_DELTA: key(`esc`, 'Exit Comparison and Return to Chart'),
+  TOGGLE_CANDLESTICK_DELTA: key(`f7`, 'Change Reference Comparison', { helpKey: 'F7' }),
+
+  // Label scope ('l') is intentionally NOT bound here: TRACE_LABEL's Escape
+  // (DEACTIVATE_TRACE_LABEL_SCOPE) hard-returns to Scope.TRACE, which would
+  // desync the keyboard scope from the still-active virtual delta layer. The
+  // delta layer's own announcements already spell out the axes, so the
+  // separate label mode is redundant here.
+
+  // Autoplay
+  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpKey: `${Platform.ctrl} + shift + right` }),
+  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpKey: `${Platform.ctrl} + shift + left` }),
+
+  STOP_AUTOPLAY: key(`${Platform.ctrl}, up, down, left, right`, 'Stop Autoplay', { helpKey: `${Platform.ctrl}` }),
+  SPEED_UP_AUTOPLAY: key(`.`, 'Speed Up Autoplay', { helpKey: '. (period)' }),
+  SPEED_DOWN_AUTOPLAY: key(`,`, 'Speed Down Autoplay', { helpKey: ', (comma)' }),
+  RESET_AUTOPLAY_SPEED: key(`/`, 'Reset Autoplay Speed', { helpKey: '/ (slash)' }),
+
+  // Navigation
+  MOVE_UP: key(`up`, 'Navigate Up'),
+  MOVE_DOWN: key(`down`, 'Navigate Down'),
+  MOVE_RIGHT: key(`right`, 'Navigate Right'),
+  MOVE_LEFT: key(`left`, 'Navigate Left'),
+
+  MOVE_TO_LEFT_EXTREME: key(`${Platform.ctrl}+left`, 'Go to Left Extreme', { helpKey: `${Platform.ctrl} + left` }),
+  MOVE_TO_RIGHT_EXTREME: key(`${Platform.ctrl}+right`, 'Go to Right Extreme', { helpKey: `${Platform.ctrl} + right` }),
+
+  // Modes
+  TOGGLE_BRAILLE: key(`b`, 'Toggle Braille Mode'),
+  TOGGLE_TEXT: key(`t`, 'Toggle Text Mode'),
+  TOGGLE_AUDIO: key(`s`, 'Toggle Sonification Mode'),
+  TOGGLE_REVIEW: key(`r`, 'Toggle Review Mode'),
+
+  // Misc
+  TOGGLE_HELP: key(`${Platform.ctrl}+/`, 'Open/Close Help', { helpKey: `${Platform.ctrl} + /` }),
+  TOGGLE_CHAT: key(`shift+/`, 'Open Chat', { helpKey: '?' }),
+  TOGGLE_SETTINGS: key(`${Platform.ctrl}+,`, 'Open Settings', { helpKey: `${Platform.ctrl} + ,` }),
+
+  // Description
+  ANNOUNCE_POINT: key(`space`, 'Replay Current Point'),
+  ANNOUNCE_POSITION: key(`p`, 'Announce Position'),
+
+  // Go To functionality
+  GO_TO_EXTREMA_TOGGLE: key(`g`, 'Go To Extrema'),
+
+  // Chart description
+  TOGGLE_DESCRIPTION: key(`d`, 'Open Chart Description'),
+
+  // rotor functionality
+  ROTOR_NEXT_NAV: key(`${Platform.alt}+shift+up`, 'Next Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + up` }),
+  ROTOR_PREV_NAV: key(`${Platform.alt}+shift+down`, 'Previous Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + down` }),
+} as const;
+
+/**
+ * Keymap configuration for the candlestick delta settings dialog (F7).
+ */
+const CANDLESTICK_DELTA_SETTINGS_KEYMAP = {
+  // Misc
+  TOGGLE_CANDLESTICK_DELTA: key(`esc`, 'Close Reference Comparison Dialog', { showInHelp: false }),
+} as const;
+
+/**
  * Keymap configuration for chat interface interactions.
  */
 const CHAT_KEYMAP = {
@@ -242,6 +309,9 @@ const TRACE_KEYMAP = {
   // Chart description
   TOGGLE_DESCRIPTION: key(`d`, 'Open Chart Description'),
 
+  // Candlestick reference comparison (virtual delta layer)
+  TOGGLE_CANDLESTICK_DELTA: key(`f7`, 'Compare Candlestick to Reference Line', { helpKey: 'F7' }),
+
   // rotor functionality
   ROTOR_NEXT_NAV: key(`${Platform.alt}+shift+up`, 'Next Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + up` }),
   ROTOR_PREV_NAV: key(`${Platform.alt}+shift+down`, 'Previous Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + down` }),
@@ -295,6 +365,8 @@ const GRID_CELL_KEYMAP = {
  */
 export const SCOPED_KEYMAP = {
   [Scope.BRAILLE]: BRAILLE_KEYMAP,
+  [Scope.CANDLESTICK_DELTA]: CANDLESTICK_DELTA_KEYMAP,
+  [Scope.CANDLESTICK_DELTA_SETTINGS]: CANDLESTICK_DELTA_SETTINGS_KEYMAP,
   [Scope.CHAT]: CHAT_KEYMAP,
   [Scope.COMMAND_PALETTE]: COMMAND_PALETTE_KEYMAP,
   [Scope.DESCRIPTION]: DESCRIPTION_KEYMAP,

--- a/src/service/rotor.ts
+++ b/src/service/rotor.ts
@@ -1,3 +1,4 @@
+import type { CompareModeInfo } from '@model/abstract';
 import type { Context } from '@model/context';
 import type { NotificationService } from './notification';
 import type { TextService } from './text';
@@ -132,7 +133,7 @@ export class RotorNavigationService {
       if (xValue !== null) {
         const moved = activeTrace.moveToNextCompareValue(direction, compareType);
         if (!moved) {
-          const msg = this.getMessage(compareType, direction);
+          const msg = this.getMessage(this.getCompareNoun(compareType), direction);
           console.warn(msg);
           return msg;
         }
@@ -173,7 +174,7 @@ export class RotorNavigationService {
       if (activeTrace instanceof AbstractTrace) {
         const moved = activeTrace.moveUpRotor(this.getCompareType());
         if (!moved) {
-          const msg = this.getMessage(this.getCompareType(), 'above');
+          const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'above');
           console.warn(msg);
           return msg;
         }
@@ -206,7 +207,7 @@ export class RotorNavigationService {
       if (activeTrace instanceof AbstractTrace) {
         const moved = activeTrace.moveDownRotor(this.getCompareType());
         if (!moved) {
-          const msg = this.getMessage(this.getCompareType(), 'below');
+          const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'below');
           console.warn(msg);
           return msg;
         }
@@ -237,7 +238,7 @@ export class RotorNavigationService {
       if (activeTrace instanceof AbstractTrace) {
         const moved = activeTrace.moveLeftRotor(this.getCompareType());
         if (!moved) {
-          const msg = this.getMessage(this.getCompareType(), 'left');
+          const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'left');
           console.warn(msg);
           return msg;
         }
@@ -268,7 +269,7 @@ export class RotorNavigationService {
       if (activeTrace instanceof AbstractTrace) {
         const moved = activeTrace.moveRightRotor(this.getCompareType());
         if (!moved) {
-          const msg = this.getMessage(this.getCompareType(), 'right');
+          const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'right');
           console.warn(msg);
           return msg;
         }
@@ -314,26 +315,54 @@ export class RotorNavigationService {
   }
 
   /**
+   * Gets the compare-mode labels and message nouns for the active trace.
+   * Traces can rename the two compare units (e.g., the candlestick delta
+   * layer exposes them as "above line" / "below line"); everything else
+   * falls back to the classic lower/higher value modes.
+   */
+  private getCompareInfo(): CompareModeInfo {
+    const activeTrace = this.context.active;
+    if (activeTrace instanceof AbstractTrace) {
+      return activeTrace.compareModeInfo();
+    }
+    return {
+      lower: { label: Constant.LOWER_VALUE_MODE, noun: 'lower value' },
+      higher: { label: Constant.HIGHER_VALUE_MODE, noun: 'higher value' },
+    };
+  }
+
+  /**
    * Gets the comparison type for the current rotor mode.
    * @returns 'lower' or 'higher' based on the current mode
    */
   public getCompareType(): 'lower' | 'higher' {
+    const info = this.getCompareInfo();
     const currMode = this.getMode();
-    if (currMode === Constant.HIGHER_VALUE_MODE) {
+    if (currMode === info.higher.label) {
       return 'higher';
-    } else if (currMode === Constant.LOWER_VALUE_MODE) {
+    } else if (currMode === info.lower.label) {
       return 'lower';
     }
     return 'lower'; // fallback
   }
 
-  public getMessage(navType: string, direction: string): string {
+  /**
+   * Gets the noun used in boundary messages for a compare type, honoring
+   * trace-specific renames (e.g., "point above the line").
+   * @param type - The compare type to describe
+   * @returns The noun for "No {noun} found ..." messages
+   */
+  private getCompareNoun(type: 'lower' | 'higher'): string {
+    return this.getCompareInfo()[type].noun;
+  }
+
+  public getMessage(noun: string, direction: string): string {
     const isVertical = direction === 'above' || direction === 'below';
     const preposition = isVertical ? '' : 'on the ';
     const position = isVertical ? `${direction} ` : `to the ${direction} of `;
     return this.buildMessage(
-      `No ${navType} value found ${preposition}${direction}`,
-      `No ${navType} value found ${position}the current value.`,
+      `No ${noun} found ${preposition}${direction}`,
+      `No ${noun} found ${position}the current value.`,
     );
   }
 
@@ -357,8 +386,9 @@ export class RotorNavigationService {
       modes.push(activeTrace.dataModeName());
 
       if (activeTrace.supportsCompareMode()) {
-        modes.push(Constant.LOWER_VALUE_MODE);
-        modes.push(Constant.HIGHER_VALUE_MODE);
+        const compareInfo = activeTrace.compareModeInfo();
+        modes.push(compareInfo.lower.label);
+        modes.push(compareInfo.higher.label);
       }
 
       if (isGridNavigable(activeTrace) && activeTrace.supportsGridMode()) {
@@ -376,10 +406,27 @@ export class RotorNavigationService {
   }
 
   /**
-   * Checks if the given mode name is a data mode (either DATA_MODE or ROW_COL_MODE).
+   * Checks if the given mode name is a data mode. Besides the two classic
+   * names, the active trace's own dataModeName() counts — traces like the
+   * candlestick delta layer rename their default unit.
    */
   private isDataMode(mode: string): boolean {
-    return mode === Constant.DATA_MODE || mode === Constant.ROW_COL_MODE;
+    if (mode === Constant.DATA_MODE || mode === Constant.ROW_COL_MODE) {
+      return true;
+    }
+    const activeTrace = this.context.active;
+    return activeTrace instanceof AbstractTrace && mode === activeTrace.dataModeName();
+  }
+
+  /**
+   * Resets the rotor to the default data mode. Called when the navigation
+   * target changes wholesale (e.g., the candlestick delta layer activates or
+   * deactivates) so a compare mode from the previous trace cannot silently
+   * map onto a different unit of the new one.
+   */
+  public resetToDataMode(): void {
+    this.rotorIndex = 0;
+    this.setMode();
   }
 
   /**
@@ -492,7 +539,7 @@ export class RotorNavigationService {
   private moveGrid(direction: 'up' | 'down' | 'left' | 'right'): string | null {
     const activeTrace = this.context.active;
     if (!isGridNavigable(activeTrace) || !activeTrace.supportsGridMode()) {
-      return this.getMessage('grid', direction);
+      return this.getMessage('grid value', direction);
     }
 
     // Grid move methods call notifyOutOfBounds() on boundary, which handles audio/text

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import brailleReducer from './viewModel/brailleViewModel';
+import candlestickDeltaReducer from './viewModel/candlestickDeltaViewModel';
 import chatReducer from './viewModel/chatViewModel';
 import commandPaletteReducer from './viewModel/commandPaletteViewModel';
 import descriptionReducer from './viewModel/descriptionViewModel';
@@ -13,6 +14,7 @@ import textReducer from './viewModel/textViewModel';
 
 const reducers = {
   braille: brailleReducer,
+  candlestickDelta: candlestickDeltaReducer,
   chat: chatReducer,
   commandPalette: commandPaletteReducer,
   description: descriptionReducer,

--- a/src/state/viewModel/candlestickDeltaViewModel.ts
+++ b/src/state/viewModel/candlestickDeltaViewModel.ts
@@ -1,0 +1,136 @@
+import type { CandlestickDeltaField } from '@model/candlestickDelta';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type {
+  CandlestickDeltaReference,
+  CandlestickDeltaService,
+} from '@service/candlestickDelta';
+import type { NotificationService } from '@service/notification';
+import type { AppStore } from '@state/store';
+import { CANDLESTICK_DELTA_FIELDS } from '@model/candlestickDelta';
+import { createSlice } from '@reduxjs/toolkit';
+import { AbstractViewModel } from '@state/viewModel/viewModel';
+
+/**
+ * State for the candlestick delta settings dialog (F7).
+ */
+export interface CandlestickDeltaState {
+  visible: boolean;
+  references: CandlestickDeltaReference[];
+  fields: CandlestickDeltaField[];
+  initialReferenceId: string;
+  initialField: CandlestickDeltaField;
+}
+
+const initialState: CandlestickDeltaState = {
+  visible: false,
+  references: [],
+  fields: [...CANDLESTICK_DELTA_FIELDS],
+  initialReferenceId: '',
+  initialField: 'close',
+};
+
+interface ShowPayload {
+  references: CandlestickDeltaReference[];
+  initialReferenceId: string;
+  initialField: CandlestickDeltaField;
+}
+
+const candlestickDeltaSlice = createSlice({
+  name: 'candlestickDelta',
+  initialState,
+  reducers: {
+    show(_state, action: PayloadAction<ShowPayload>): CandlestickDeltaState {
+      return {
+        visible: true,
+        references: action.payload.references,
+        fields: [...CANDLESTICK_DELTA_FIELDS],
+        initialReferenceId: action.payload.initialReferenceId,
+        initialField: action.payload.initialField,
+      };
+    },
+    hide(): CandlestickDeltaState {
+      return initialState;
+    },
+  },
+});
+
+const { show, hide } = candlestickDeltaSlice.actions;
+
+/**
+ * ViewModel bridging the candlestick delta service and the F7 dialog UI.
+ */
+export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDeltaState> {
+  private readonly deltaService: CandlestickDeltaService;
+  private readonly notification: NotificationService;
+
+  public constructor(
+    store: AppStore,
+    deltaService: CandlestickDeltaService,
+    notification: NotificationService,
+  ) {
+    super(store);
+    this.deltaService = deltaService;
+    this.notification = notification;
+  }
+
+  public dispose(): void {
+    super.dispose();
+    this.store.dispatch(hide());
+  }
+
+  public get state(): CandlestickDeltaState {
+    return this.store.getState().candlestickDelta;
+  }
+
+  /**
+   * Opens the settings dialog when the feature applies here, or closes it if
+   * it is already open (ESC path). Announces why when unavailable.
+   */
+  public toggle(): void {
+    if (this.state.visible) {
+      this.cancel();
+      return;
+    }
+
+    const references = this.deltaService.getReferences();
+    if (!references) {
+      this.notification.notify(
+        'Reference comparison is only available on candlestick charts with a line layer.',
+      );
+      return;
+    }
+
+    const activeSelection = this.deltaService.activeSelection;
+    const initialReferenceId
+      = activeSelection && references.some(ref => ref.id === activeSelection.referenceId)
+        ? activeSelection.referenceId
+        : references[0].id;
+
+    this.store.dispatch(
+      show({
+        references,
+        initialReferenceId,
+        initialField: activeSelection?.field ?? 'close',
+      }),
+    );
+    this.deltaService.openSettings();
+  }
+
+  /**
+   * Confirms the dialog: closes it and activates the virtual delta layer
+   * with the chosen reference series and OHLC field.
+   */
+  public confirm(referenceId: string, field: CandlestickDeltaField): void {
+    this.store.dispatch(hide());
+    this.deltaService.closeSettings();
+    this.deltaService.activate(referenceId, field);
+  }
+
+  /** Cancels the dialog without changing the active layer. */
+  public cancel(): void {
+    this.store.dispatch(hide());
+    this.deltaService.closeSettings();
+  }
+}
+
+export default candlestickDeltaSlice.reducer;

--- a/src/state/viewModel/registry.ts
+++ b/src/state/viewModel/registry.ts
@@ -1,5 +1,6 @@
 import type { CommandExecutor } from '@service/commandExecutor';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
+import type { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDeltaViewModel';
 import type { ChatViewModel } from '@state/viewModel/chatViewModel';
 import type { CommandPaletteViewModel } from '@state/viewModel/commandPaletteViewModel';
 import type { DescriptionViewModel } from '@state/viewModel/descriptionViewModel';
@@ -17,6 +18,7 @@ import type { TextViewModel } from './textViewModel';
  */
 export interface ViewModelMap {
   braille: BrailleViewModel;
+  candlestickDelta: CandlestickDeltaViewModel;
   chat: ChatViewModel;
   commandExecutor: CommandExecutor;
   commandPalette: CommandPaletteViewModel;

--- a/src/type/event.ts
+++ b/src/type/event.ts
@@ -43,6 +43,10 @@ export type Status
  */
 export enum Scope {
   BRAILLE = 'BRAILLE',
+  /** Navigating the virtual candlestick-vs-reference-line delta layer. */
+  CANDLESTICK_DELTA = 'CANDLESTICK_DELTA',
+  /** The F7 dialog for configuring the candlestick delta layer. */
+  CANDLESTICK_DELTA_SETTINGS = 'CANDLESTICK_DELTA_SETTINGS',
   CHAT = 'CHAT',
   COMMAND_PALETTE = 'COMMAND_PALETTE',
   DESCRIPTION = 'DESCRIPTION',

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -491,6 +491,12 @@ export enum TraceType {
   BAR = 'bar',
   BOX = 'box',
   CANDLESTICK = 'candlestick',
+  /**
+   * Virtual layer comparing one candlestick OHLC field against a reference
+   * line (e.g. a moving average). Never declared in MAIDR JSON — created at
+   * runtime by the candlestick delta feature (F7).
+   */
+  CANDLESTICK_DELTA = 'candlestick_delta',
   DODGED = 'dodged_bar',
   HEATMAP = 'heat',
   HISTOGRAM = 'hist',

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -166,6 +166,13 @@ export interface AudioState {
    */
   trend?: CandlestickTrend;
   /**
+   * When true, a raw value of exactly 0 plays a percussive click instead of
+   * the default low "null" tone. Used by the candlestick delta layer, where
+   * zero means "exactly on the reference line" — a meaningful data point,
+   * not missing data.
+   */
+  zeroClick?: boolean;
+  /**
    * Volume multiplier for dynamic volume control.
    * Used to scale audio volume based on data characteristics (e.g., violin plot width).
    * If undefined, defaults to 1.0 (no volume scaling).

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,6 +6,7 @@ import { MaidrContext } from '@state/context';
 import { useViewModelState } from '@state/hook/useViewModel';
 import { Provider } from 'react-redux';
 import Braille from './component/Braille';
+import CandlestickDeltaSettings from './component/CandlestickDeltaSettings';
 import Chat from './component/Chat';
 import CommandPalette from './component/CommandPalette';
 import Description from './component/Description';
@@ -27,6 +28,9 @@ const App: FC<AppProps> = ({ plot }) => {
     switch (focused) {
       case 'BRAILLE':
         return <Braille />;
+
+      case 'CANDLESTICK_DELTA_SETTINGS':
+        return <CandlestickDeltaSettings />;
 
       case 'CHAT':
         return <Chat />;

--- a/src/ui/component/CandlestickDeltaSettings.tsx
+++ b/src/ui/component/CandlestickDeltaSettings.tsx
@@ -1,0 +1,133 @@
+import type { CandlestickDeltaField } from '@model/candlestickDelta';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  FormControl,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
+import { useViewModel, useViewModelState } from '@state/hook/useViewModel';
+import React, { useId, useState } from 'react';
+
+/**
+ * The F7 dialog for the candlestick reference comparison: the user picks a
+ * reference line (e.g. a moving average series) and the OHLC value to
+ * compare, then OK activates the virtual delta layer. ESC/Cancel closes the
+ * dialog without changing anything (ESC is handled by the
+ * CANDLESTICK_DELTA_SETTINGS keybinding scope).
+ */
+const CandlestickDeltaSettings: React.FC = () => {
+  const viewModel = useViewModel('candlestickDelta');
+  const state = useViewModelState('candlestickDelta');
+
+  const titleId = useId();
+  const descriptionId = useId();
+  const referenceLabelId = useId();
+  const fieldLabelId = useId();
+
+  const [referenceId, setReferenceId] = useState(state.initialReferenceId);
+  const [field, setField] = useState<CandlestickDeltaField>(state.initialField);
+
+  if (!state.visible || state.references.length === 0) {
+    return null;
+  }
+
+  const handleOk = (): void => {
+    viewModel.confirm(referenceId, field);
+  };
+
+  const handleCancel = (): void => {
+    viewModel.cancel();
+  };
+
+  return (
+    <Dialog
+      role="dialog"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      open={true}
+      maxWidth="xs"
+      fullWidth
+      disablePortal
+      disableEnforceFocus
+      onClick={e => e.stopPropagation()}
+      // Focus sits inside the dialog (autoFocus on the first Select), so MUI
+      // swallows the Escape keydown before the scope keybinding can see it.
+      // Route MUI's own escape/backdrop-close through the cancel path instead.
+      onClose={handleCancel}
+    >
+      <DialogContent>
+        <Typography id={titleId} variant="h6" component="h2" fontWeight="bold" gutterBottom>
+          Compare to Reference Line
+        </Typography>
+        <Typography id={descriptionId} variant="body2" color="text.secondary" gutterBottom>
+          Explore how far each candle sits above or below a reference line.
+          Pick the reference and the price value to compare, then press OK.
+        </Typography>
+
+        <Typography id={referenceLabelId} variant="body2" sx={{ mt: 2, mb: 0.5 }}>
+          Reference data
+        </Typography>
+        <FormControl fullWidth>
+          <Select
+            value={referenceId}
+            onChange={e => setReferenceId(e.target.value)}
+            MenuProps={{ disablePortal: true }}
+            inputProps={{ 'aria-labelledby': referenceLabelId }}
+            autoFocus
+            size="small"
+          >
+            {state.references.map(reference => (
+              <MenuItem key={reference.id} value={reference.id}>
+                {reference.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Typography id={fieldLabelId} variant="body2" sx={{ mt: 2, mb: 0.5 }}>
+          Value to compare
+        </Typography>
+        <FormControl fullWidth>
+          <Select
+            value={field}
+            onChange={e => setField(e.target.value as CandlestickDeltaField)}
+            MenuProps={{ disablePortal: true }}
+            inputProps={{ 'aria-labelledby': fieldLabelId }}
+            size="small"
+          >
+            {state.fields.map(fieldOption => (
+              <MenuItem key={fieldOption} value={fieldOption}>
+                {fieldOption}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </DialogContent>
+
+      <DialogActions>
+        <Button
+          variant="outlined"
+          color="inherit"
+          onClick={handleCancel}
+          aria-label="Cancel and close without comparing"
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleOk}
+          aria-label="Activate the reference comparison layer"
+        >
+          Okay
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CandlestickDeltaSettings;

--- a/test/command/braille-escape.test.ts
+++ b/test/command/braille-escape.test.ts
@@ -1,10 +1,23 @@
 import type { Context } from '@model/context';
 import type { BrailleService } from '@service/braille';
+import type { CandlestickDeltaService } from '@service/candlestickDelta';
 import type { DisplayService } from '@service/display';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import { ExitBrailleAndSubplotCommand, MoveToTraceContextCommand } from '@command/move';
 import { describe, expect, jest, test } from '@jest/globals';
 import { Scope } from '@type/event';
+
+/**
+ * Creates a mock CandlestickDeltaService with a discardActiveLayer stub.
+ * @param overrides - Optional property overrides
+ * @returns A mock service
+ */
+function createMockCandlestickDeltaService(overrides: Record<string, unknown> = {}): CandlestickDeltaService {
+  return {
+    discardActiveLayer: jest.fn(),
+    ...overrides,
+  } as unknown as CandlestickDeltaService;
+}
 
 /**
  * Creates a mock Context with enterSubplot and exitSubplot stubs.
@@ -75,7 +88,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       });
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel);
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService());
       command.execute();
 
       expect(callOrder).toEqual([
@@ -90,7 +103,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel);
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService());
       command.execute();
 
       expect(displayService.dismissModalScope).toHaveBeenCalledWith(Scope.SUBPLOT);
@@ -101,7 +114,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel);
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService());
       command.execute();
 
       expect(displayService.notifyFocusChange).toHaveBeenCalledWith(Scope.SUBPLOT);
@@ -112,7 +125,7 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel);
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService());
       command.execute();
 
       expect(context.exitSubplot).toHaveBeenCalled();
@@ -123,10 +136,34 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel);
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService());
       command.execute();
 
       expect(brailleViewModel.toggle).not.toHaveBeenCalled();
+    });
+
+    test('discards the virtual delta layer before exiting the subplot', () => {
+      const callOrder: string[] = [];
+      const context = createMockContext({
+        isMultiPanel: true,
+        exitSubplot: jest.fn<() => void>().mockImplementation(() => {
+          callOrder.push('exitSubplot');
+        }),
+      });
+      const displayService = createMockDisplayService();
+      const brailleViewModel = createMockBrailleViewModel();
+      const candlestickDeltaService = createMockCandlestickDeltaService({
+        discardActiveLayer: jest.fn<() => void>().mockImplementation(() => {
+          callOrder.push('discardActiveLayer');
+        }),
+      });
+
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, candlestickDeltaService);
+      command.execute();
+
+      expect(candlestickDeltaService.discardActiveLayer).toHaveBeenCalled();
+      // The delta layer must be torn down before exitSubplot pops it.
+      expect(callOrder.indexOf('discardActiveLayer')).toBeLessThan(callOrder.indexOf('exitSubplot'));
     });
   });
 
@@ -137,13 +174,25 @@ describe('ExitBrailleAndSubplotCommand', () => {
       const displayService = createMockDisplayService();
       const brailleViewModel = createMockBrailleViewModel();
 
-      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel);
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, createMockCandlestickDeltaService());
       command.execute();
 
       expect(brailleViewModel.toggle).toHaveBeenCalledWith(traceState);
       expect(context.exitSubplot).not.toHaveBeenCalled();
       expect(displayService.dismissModalScope).not.toHaveBeenCalled();
       expect(displayService.notifyFocusChange).not.toHaveBeenCalled();
+    });
+
+    test('leaves the virtual delta layer untouched (user stays in it)', () => {
+      const context = createMockContext({ isMultiPanel: false });
+      const displayService = createMockDisplayService();
+      const brailleViewModel = createMockBrailleViewModel();
+      const candlestickDeltaService = createMockCandlestickDeltaService();
+
+      const command = new ExitBrailleAndSubplotCommand(context, displayService, brailleViewModel, candlestickDeltaService);
+      command.execute();
+
+      expect(candlestickDeltaService.discardActiveLayer).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/model/candlestickDelta.test.ts
+++ b/test/model/candlestickDelta.test.ts
@@ -1,0 +1,325 @@
+import type { CandlestickDeltaPoint } from '@model/candlestickDelta';
+import type { MaidrLayer } from '@type/grammar';
+import { describe, expect, jest, test } from '@jest/globals';
+import {
+  ABOVE_LINE_MODE,
+  BELOW_LINE_MODE,
+  CandlestickDeltaTrace,
+  DELTA_POINT_MODE,
+  deltaTrend,
+  roundDelta,
+} from '@model/candlestickDelta';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Builds a delta point with the trend derived from the delta sign.
+ * @param x - The shared x value
+ * @param fieldValue - The OHLC value at x
+ * @param reference - The reference line value at x
+ * @returns A delta point
+ */
+function point(x: string, fieldValue: number, reference: number): CandlestickDeltaPoint {
+  const delta = roundDelta(fieldValue - reference);
+  return { x, fieldValue, reference, delta, trend: deltaTrend(delta) };
+}
+
+/**
+ * Creates a synthetic layer definition for the virtual delta trace.
+ * @returns A candlestick-delta layer definition
+ */
+function createLayer(): MaidrLayer {
+  return {
+    id: 'candle-layer',
+    type: TraceType.CANDLESTICK_DELTA,
+    title: 'close price vs MA 3',
+    axes: { x: { label: 'Date' }, y: { label: 'Price delta' } },
+    data: [],
+  };
+}
+
+/**
+ * Creates a delta trace with deltas +2, -1.5, 0, +0.5 over four dates.
+ * @returns The trace under test
+ */
+function createTrace(): CandlestickDeltaTrace {
+  return new CandlestickDeltaTrace(createLayer(), {
+    points: [
+      point('2026-01-01', 12, 10), // +2 (above)
+      point('2026-01-02', 8.5, 10), // -1.5 (below)
+      point('2026-01-03', 10, 10), // 0 (on line)
+      point('2026-01-04', 10.5, 10), // +0.5 (above)
+    ],
+    field: 'close',
+    referenceLabel: 'Moving Average 3 days',
+  });
+}
+
+/**
+ * Enters the trace (consumes the initial-entry move) so subsequent moves
+ * actually navigate.
+ * @param trace - The trace to enter
+ */
+function enter(trace: CandlestickDeltaTrace): void {
+  trace.moveOnce('FORWARD');
+}
+
+describe('roundDelta and deltaTrend', () => {
+  test('suppresses binary float noise so on-line points compare to zero', () => {
+    expect(roundDelta(0.1 + 0.2 - 0.3)).toBe(0);
+    expect(roundDelta(10.75 - 10.5)).toBe(0.25);
+  });
+
+  test('scales the zero tolerance to operand magnitude for large prices', () => {
+    // A ~2e-3 residual on a ~1.6e9 instrument is averaging noise: on line.
+    // The old fixed 1e-9 grid both overflowed here and reported it as nonzero.
+    expect(roundDelta(2e-3, 1.6e9)).toBe(0);
+    // The same residual on a ~10 instrument is a real, meaningful delta.
+    expect(roundDelta(2e-3, 10)).toBe(0.002);
+    // A genuinely large delta on a large instrument survives (no overflow).
+    expect(roundDelta(1500, 1.6e9)).toBe(1500);
+  });
+
+  test('preserves precision at large magnitude instead of overflowing', () => {
+    // Math.round(1.6e9 * 1e9) overflows MAX_SAFE_INTEGER and returns garbage;
+    // the magnitude-aware version returns the delta faithfully.
+    expect(roundDelta(12.5, 1.6e9)).toBe(12.5);
+  });
+
+  test('maps delta sign to bull, bear, and neutral trends', () => {
+    expect(deltaTrend(0.01)).toBe('Bull');
+    expect(deltaTrend(-0.01)).toBe('Bear');
+    expect(deltaTrend(0)).toBe('Neutral');
+  });
+});
+
+describe('candlestickDelta navigation', () => {
+  test('moves left and right through the delta points', () => {
+    const trace = createTrace();
+    enter(trace);
+    expect(trace.col).toBe(0);
+
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.col).toBe(1);
+    expect(trace.moveOnce('BACKWARD')).toBe(true);
+    expect(trace.col).toBe(0);
+  });
+
+  test('reports out of bounds for vertical movement (single-row layer)', () => {
+    const trace = createTrace();
+    enter(trace);
+
+    expect(trace.moveOnce('UPWARD')).toBe(false);
+    expect(trace.moveOnce('DOWNWARD')).toBe(false);
+  });
+
+  test('setInitialPosition places the cursor without entering initial entry', () => {
+    const trace = createTrace();
+    trace.setInitialPosition(2);
+
+    expect(trace.isInitialEntry).toBe(false);
+    expect(trace.col).toBe(2);
+    expect(trace.getCurrentXValue()).toBe('2026-01-03');
+  });
+
+  test('moveToXValue jumps to the matching date and rejects unknown dates', () => {
+    const trace = createTrace();
+    enter(trace);
+
+    expect(trace.moveToXValue('2026-01-04')).toBe(true);
+    expect(trace.col).toBe(3);
+    expect(trace.moveToXValue('1999-01-01')).toBe(false);
+    expect(trace.col).toBe(3);
+  });
+});
+
+describe('candlestickDelta state', () => {
+  test('text describes direction and magnitude', () => {
+    const trace = createTrace();
+    enter(trace);
+    const state = trace.state;
+
+    expect(state.empty).toBe(false);
+    if (!state.empty) {
+      expect(state.text.main.value).toBe('2026-01-01');
+      expect(state.text.cross.value).toBe(2);
+      expect(state.text.section).toBe('close');
+      expect(state.text.z?.value).toBe('above line');
+    }
+  });
+
+  test('text reports below line and on line positions', () => {
+    const trace = createTrace();
+    trace.setInitialPosition(1);
+    const below = trace.state;
+    expect(!below.empty && below.text.z?.value).toBe('below line');
+    expect(!below.empty && below.text.cross.value).toBe(1.5);
+
+    trace.setInitialPosition(2);
+    const onLine = trace.state;
+    expect(!onLine.empty && onLine.text.z?.value).toBe('on line');
+    expect(!onLine.empty && onLine.text.cross.value).toBe(0);
+  });
+
+  test('audio encodes |delta| as pitch, trend as timbre, and opts into the zero click', () => {
+    const trace = createTrace();
+    trace.setInitialPosition(1);
+    const state = trace.state;
+
+    expect(state.empty).toBe(false);
+    if (!state.empty) {
+      expect(state.audio.freq.raw).toBe(1.5);
+      expect(state.audio.freq.min).toBe(0);
+      expect(state.audio.freq.max).toBe(2);
+      expect(state.audio.trend).toBe('Bear');
+      expect(state.audio.zeroClick).toBe(true);
+      expect(state.audio.panning).toEqual({ x: 1, y: 0, rows: 1, cols: 4 });
+    }
+  });
+
+  test('braille exposes |delta| heights with bearish markers for below-line points', () => {
+    const trace = createTrace();
+    enter(trace);
+    const state = trace.state;
+
+    expect(state.empty).toBe(false);
+    if (!state.empty && !state.braille.empty) {
+      expect((state.braille as { values: number[][] }).values).toEqual([
+        [2, 1.5, 0, 0.5],
+      ]);
+      expect(state.braille.custom).toEqual(['Bull', 'Bear', 'Neutral', 'Bull']);
+      expect(state.braille.row).toBe(0);
+      expect(state.braille.col).toBe(0);
+    }
+  });
+
+  test('braille returns stable array references across navigation', () => {
+    const trace = createTrace();
+    enter(trace);
+    const first = trace.state;
+    trace.moveOnce('FORWARD');
+    const second = trace.state;
+
+    if (!first.empty && !second.empty && !first.braille.empty && !second.braille.empty) {
+      expect((second.braille as { values: number[][] }).values)
+        .toBe((first.braille as { values: number[][] }).values);
+    }
+  });
+
+  test('autoplay spans the point count in horizontal directions', () => {
+    const trace = createTrace();
+    enter(trace);
+    const state = trace.state;
+
+    expect(!state.empty && state.autoplay.FORWARD).toBe(4);
+    expect(!state.empty && state.autoplay.BACKWARD).toBe(4);
+  });
+
+  test('never highlights (virtual layer)', () => {
+    const trace = createTrace();
+    enter(trace);
+    const state = trace.state;
+
+    expect(!state.empty && state.highlight.empty).toBe(true);
+  });
+
+  test('description summarizes reference, counts, and data table', () => {
+    const trace = createTrace();
+    const description = trace.description;
+
+    expect(description.chartType).toBe('Candlestick Reference Delta');
+    expect(description.stats).toContainEqual({
+      label: 'Reference line',
+      value: 'Moving Average 3 days',
+    });
+    expect(description.stats).toContainEqual({ label: 'Points above line', value: 2 });
+    expect(description.stats).toContainEqual({ label: 'Points below line', value: 1 });
+    expect(description.stats).toContainEqual({ label: 'Points on line', value: 1 });
+    expect(description.dataTable.rows).toHaveLength(4);
+    expect(description.dataTable.rows[1]).toEqual([
+      '2026-01-02',
+      8.5,
+      10,
+      -1.5,
+      'below line',
+    ]);
+  });
+});
+
+describe('candlestickDelta extrema', () => {
+  test('exposes max and min signed delta targets', () => {
+    const trace = createTrace();
+    const targets = trace.getExtremaTargets();
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({
+      label: 'Max Delta at 2026-01-01',
+      value: 2,
+      pointIndex: 0,
+      type: 'max',
+      xValue: '2026-01-01',
+    });
+    expect(targets[1]).toMatchObject({
+      label: 'Min Delta at 2026-01-02',
+      value: -1.5,
+      pointIndex: 1,
+      type: 'min',
+    });
+  });
+
+  test('navigateToExtrema moves the cursor and notifies observers', () => {
+    const trace = createTrace();
+    enter(trace);
+    const observer = { update: jest.fn() };
+    trace.addObserver(observer);
+
+    trace.navigateToExtrema(trace.getExtremaTargets()[1]);
+
+    expect(trace.col).toBe(1);
+    expect(observer.update).toHaveBeenCalled();
+  });
+
+  test('supports extrema navigation (G key gate)', () => {
+    const trace = createTrace();
+    expect(trace.supportsExtremaNavigation()).toBe(true);
+  });
+});
+
+describe('candlestickDelta rotor', () => {
+  test('renames the default unit and the compare units', () => {
+    const trace = createTrace();
+
+    expect(trace.dataModeName()).toBe(DELTA_POINT_MODE);
+    const info = trace.compareModeInfo();
+    expect(info.higher.label).toBe(ABOVE_LINE_MODE);
+    expect(info.lower.label).toBe(BELOW_LINE_MODE);
+  });
+
+  test('above-line unit skips to the next point above the reference', () => {
+    const trace = createTrace();
+    enter(trace); // col 0 (+2)
+
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
+    expect(trace.col).toBe(3); // skips -1.5 and 0
+
+    // No further above-line point to the right.
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(false);
+    expect(trace.col).toBe(3);
+  });
+
+  test('below-line unit finds the bearish point in either direction', () => {
+    const trace = createTrace();
+    trace.setInitialPosition(3);
+
+    expect(trace.moveToNextCompareValue('left', 'lower')).toBe(true);
+    expect(trace.col).toBe(1);
+    expect(trace.moveToNextCompareValue('left', 'lower')).toBe(false);
+  });
+
+  test('vertical compare navigation is out of bounds', () => {
+    const trace = createTrace();
+    enter(trace);
+
+    expect(trace.moveToNextCompareValue('up', 'higher')).toBe(false);
+    expect(trace.moveToNextCompareValue('down', 'lower')).toBe(false);
+  });
+});

--- a/test/service/candlestickDelta.test.ts
+++ b/test/service/candlestickDelta.test.ts
@@ -1,0 +1,337 @@
+import type { Trace } from '@model/plot';
+import type { DisplayService } from '@service/display';
+import type { CandlestickPoint, LinePoint, Maidr } from '@type/grammar';
+import { describe, expect, jest, test } from '@jest/globals';
+import {
+  ABOVE_LINE_MODE,
+  BELOW_LINE_MODE,
+  CandlestickDeltaTrace,
+  DELTA_POINT_MODE,
+} from '@model/candlestickDelta';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { CandlestickDeltaService } from '@service/candlestickDelta';
+import { NotificationService } from '@service/notification';
+import { RotorNavigationService } from '@service/rotor';
+import { TextService } from '@service/text';
+import { Scope } from '@type/event';
+import { TraceType } from '@type/grammar';
+
+jest.mock('hotkeys-js', () => ({
+  __esModule: true,
+  default: { setScope: jest.fn() },
+}));
+
+/**
+ * Builds a candle whose close price is the given value.
+ * @param value - The date string
+ * @param close - The close price
+ * @returns A candlestick point
+ */
+function candle(value: string, close: number): CandlestickPoint {
+  return {
+    value,
+    open: close - 1,
+    high: close + 2,
+    low: close - 2,
+    close,
+    volume: 100,
+    trend: 'Bull',
+    volatility: 4,
+  };
+}
+
+/**
+ * Creates a single-subplot Maidr config with a candlestick layer and a line
+ * layer holding two moving-average series. The averages intentionally start
+ * one day later than the candles, like real moving averages do.
+ * @returns A Maidr config
+ */
+function createMaidr(): Maidr {
+  const candles: CandlestickPoint[] = [
+    candle('2026-01-01', 10),
+    candle('2026-01-02', 12),
+    candle('2026-01-03', 9),
+    candle('2026-01-04', 11),
+  ];
+  const ma3: LinePoint[] = [
+    { x: '2026-01-02', y: 11, z: 'Moving Average 3 days' },
+    { x: '2026-01-03', y: 10, z: 'Moving Average 3 days' },
+    { x: '2026-01-04', y: 11, z: 'Moving Average 3 days' },
+  ];
+  const ma6: LinePoint[] = [
+    { x: '2026-01-02', y: 12, z: 'Moving Average 6 days' },
+    { x: '2026-01-03', y: 11, z: 'Moving Average 6 days' },
+    { x: '2026-01-04', y: 10, z: 'Moving Average 6 days' },
+  ];
+  return {
+    id: 'delta-test',
+    subplots: [[
+      {
+        layers: [
+          {
+            id: 'candle-layer',
+            type: TraceType.CANDLESTICK,
+            axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+            data: candles,
+          },
+          {
+            id: 'ma-layer',
+            type: TraceType.LINE,
+            axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+            data: [ma3, ma6],
+          },
+        ],
+      },
+    ]],
+  };
+}
+
+interface Harness {
+  context: Context;
+  service: CandlestickDeltaService;
+  rotor: RotorNavigationService;
+  notify: jest.Mock;
+  toggleFocus: jest.Mock;
+}
+
+/**
+ * Builds a context over the candlestick+MA fixture with the delta service
+ * wired against stubbed display focus handling.
+ * @returns The test harness
+ */
+function createHarness(): Harness {
+  const context = new Context(new Figure(createMaidr()));
+  const notification = new NotificationService();
+  const notify = jest.fn();
+  notification.onChange(event => notify(event.value));
+  const text = new TextService(notification);
+  const rotor = new RotorNavigationService(context, text, notification);
+  const toggleFocus = jest.fn();
+  const display = { toggleFocus } as unknown as DisplayService;
+  const service = new CandlestickDeltaService(context, notification, display, rotor);
+  return { context, service, rotor, notify, toggleFocus };
+}
+
+describe('candlestickDeltaService references', () => {
+  test('lists every series of every line layer in the subplot', () => {
+    const { service } = createHarness();
+
+    expect(service.getReferences()).toEqual([
+      { id: 'ma-layer:0', label: 'Moving Average 3 days' },
+      { id: 'ma-layer:1', label: 'Moving Average 6 days' },
+    ]);
+  });
+
+  test('is unavailable when the active trace is not a candlestick', () => {
+    const { context, service } = createHarness();
+    context.stepTrace('UPWARD'); // switch to the line layer
+
+    expect(service.getReferences()).toBeNull();
+  });
+});
+
+describe('candlestickDeltaService activation', () => {
+  test('activates a virtual delta layer matched by x value', () => {
+    const { context, service, notify, toggleFocus } = createHarness();
+
+    expect(service.activate('ma-layer:0', 'close')).toBe(true);
+
+    const active = context.active;
+    expect(active).toBeInstanceOf(CandlestickDeltaTrace);
+    const trace = active as CandlestickDeltaTrace;
+    // 2026-01-01 has no MA value and must be skipped.
+    expect(trace.size).toBe(3);
+    expect(trace.getAvailableXValues()).toEqual([
+      '2026-01-02',
+      '2026-01-03',
+      '2026-01-04',
+    ]);
+    expect(toggleFocus).toHaveBeenCalledWith(Scope.CANDLESTICK_DELTA);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('close price minus Moving Average 3 days'));
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Escape'));
+    expect(service.isActive).toBe(true);
+  });
+
+  test('starts on the candle the user was on when it exists in the delta domain', () => {
+    const { context, service } = createHarness();
+    (context.active as Trace).moveToXValue('2026-01-03');
+
+    service.activate('ma-layer:0', 'close');
+
+    expect((context.active as CandlestickDeltaTrace).getCurrentXValue()).toBe('2026-01-03');
+  });
+
+  test('computes signed deltas including exact zeros', () => {
+    const { context, service } = createHarness();
+    service.activate('ma-layer:0', 'close');
+    const trace = context.active as CandlestickDeltaTrace;
+
+    // close - MA3: 12-11=+1, 9-10=-1, 11-11=0
+    trace.moveToXValue('2026-01-02');
+    let state = trace.state;
+    expect(!state.empty && state.audio.freq.raw).toBe(1);
+    expect(!state.empty && state.audio.trend).toBe('Bull');
+
+    trace.moveToXValue('2026-01-03');
+    state = trace.state;
+    expect(!state.empty && state.audio.trend).toBe('Bear');
+
+    trace.moveToXValue('2026-01-04');
+    state = trace.state;
+    expect(!state.empty && state.audio.freq.raw).toBe(0);
+    expect(!state.empty && state.audio.trend).toBe('Neutral');
+    expect(!state.empty && state.audio.zeroClick).toBe(true);
+  });
+
+  test('reconfiguring while active replaces the layer and keeps the anchor', () => {
+    const { context, service } = createHarness();
+    service.activate('ma-layer:0', 'close');
+    const firstTrace = context.active;
+
+    expect(service.activate('ma-layer:1', 'open')).toBe(true);
+    expect(context.active).not.toBe(firstTrace);
+    expect((context.active as CandlestickDeltaTrace).reference).toBe('Moving Average 6 days');
+
+    // Deactivation must still restore the original candlestick anchor.
+    service.deactivate();
+    expect(context.active.constructor.name).toBe('Candlestick');
+  });
+
+  test('reconfiguring preserves the current delta-layer x, not the pre-activation candle', () => {
+    const { context, service } = createHarness();
+    // User was on the first candle before activating.
+    service.activate('ma-layer:0', 'close');
+    // Navigate deep inside the delta layer.
+    (context.active as CandlestickDeltaTrace).moveToXValue('2026-01-04');
+
+    // Reconfigure to a different reference that still covers that x.
+    service.activate('ma-layer:1', 'close');
+
+    expect((context.active as CandlestickDeltaTrace).getCurrentXValue()).toBe('2026-01-04');
+  });
+
+  test('refuses to activate when no x values match', () => {
+    const maidr = createMaidr();
+    const lineLayer = maidr.subplots[0][0].layers[1];
+    lineLayer.data = [[{ x: '1999-01-01', y: 1, z: 'MA' }]];
+    const context = new Context(new Figure(maidr));
+    const notification = new NotificationService();
+    const notify = jest.fn();
+    notification.onChange(event => notify(event.value));
+    const text = new TextService(notification);
+    const rotor = new RotorNavigationService(context, text, notification);
+    const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
+    const service = new CandlestickDeltaService(context, notification, display, rotor);
+
+    expect(service.activate('ma-layer:0', 'close')).toBe(false);
+    expect(service.isActive).toBe(false);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('No matching x values'));
+  });
+});
+
+describe('candlestickDeltaService deactivation', () => {
+  test('restores the candlestick layer and syncs its position to the delta x', () => {
+    const { context, service, toggleFocus } = createHarness();
+    service.activate('ma-layer:0', 'close');
+    (context.active as CandlestickDeltaTrace).moveToXValue('2026-01-03');
+    toggleFocus.mockClear();
+
+    expect(service.deactivate()).toBe(true);
+
+    expect(context.active.constructor.name).toBe('Candlestick');
+    expect((context.active as Trace).getCurrentXValue()).toBe('2026-01-03');
+    expect(toggleFocus).toHaveBeenCalledWith(Scope.CANDLESTICK_DELTA);
+    expect(service.isActive).toBe(false);
+  });
+
+  test('deactivate is a no-op when nothing is active', () => {
+    const { service } = createHarness();
+    expect(service.deactivate()).toBe(false);
+  });
+
+  test('deactivateIfActive silently restores the anchor before layer switching', () => {
+    const { context, service, notify } = createHarness();
+    service.activate('ma-layer:0', 'close');
+    notify.mockClear();
+
+    service.deactivateIfActive();
+
+    expect(context.active.constructor.name).toBe('Candlestick');
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test('discardActiveLayer tears down state and resets the rotor without touching focus or the stack', () => {
+    const { context, service, rotor, toggleFocus, notify } = createHarness();
+    service.activate('ma-layer:0', 'close');
+    const deltaTrace = context.active;
+    rotor.moveToNextRotorUnit(); // leave data mode
+    expect(context.isRotorEnabled()).toBe(true);
+    toggleFocus.mockClear();
+    notify.mockClear();
+
+    service.discardActiveLayer();
+
+    // Internal state is cleared and the rotor is reset...
+    expect(service.isActive).toBe(false);
+    expect(context.isRotorEnabled()).toBe(false);
+    expect(rotor.getCurrentUnit()).toBe(0);
+    // ...but the caller owns the stack and focus, so neither is touched here.
+    expect(context.active).toBe(deltaTrace);
+    expect(toggleFocus).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test('discardActiveLayer is a no-op when nothing is active', () => {
+    const { service } = createHarness();
+    expect(() => service.discardActiveLayer()).not.toThrow();
+  });
+});
+
+describe('candlestickDelta rotor integration', () => {
+  test('cycles delta point, below line, and above line units', () => {
+    const { service, rotor } = createHarness();
+    service.activate('ma-layer:0', 'close');
+
+    expect(rotor.getMode()).toBe(DELTA_POINT_MODE);
+    expect(rotor.moveToNextRotorUnit()).toBe(BELOW_LINE_MODE);
+    expect(rotor.getCompareType()).toBe('lower');
+    expect(rotor.moveToNextRotorUnit()).toBe(ABOVE_LINE_MODE);
+    expect(rotor.getCompareType()).toBe('higher');
+    expect(rotor.moveToNextRotorUnit()).toBe(DELTA_POINT_MODE);
+  });
+
+  test('right arrow in above-line mode jumps to the next above-line point', () => {
+    const { context, service, rotor } = createHarness();
+    service.activate('ma-layer:0', 'close');
+    const trace = context.active as CandlestickDeltaTrace;
+    trace.setInitialPosition(0); // 2026-01-02, delta +1
+
+    rotor.moveToNextRotorUnit(); // below line
+    rotor.moveToNextRotorUnit(); // above line
+
+    // Only point 0 is above the line, so moving right reports a boundary.
+    const message = rotor.moveRight();
+    expect(message).toContain('point above the line');
+    expect(trace.getCurrentXValue()).toBe('2026-01-02');
+
+    // From the right edge, moving left in below-line mode lands on -1.
+    trace.setInitialPosition(2);
+    rotor.moveToNextRotorUnit(); // wraps to delta point
+    rotor.moveToNextRotorUnit(); // below line
+    expect(rotor.moveLeft()).toBeNull();
+    expect(trace.getCurrentXValue()).toBe('2026-01-03');
+  });
+
+  test('activation and deactivation reset the rotor to the data unit', () => {
+    const { context, service, rotor } = createHarness();
+    service.activate('ma-layer:0', 'close');
+    rotor.moveToNextRotorUnit(); // below line
+    expect(context.isRotorEnabled()).toBe(true);
+
+    service.deactivate();
+
+    expect(context.isRotorEnabled()).toBe(false);
+    expect(rotor.getCurrentUnit()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Blind users exploring a candlestick chart that also carries moving-average line layers (e.g. the [candlestick example](https://py.maidr.ai/examples.html#candlestick-chart)) had no way to tell whether the current OHLC value sits **above or below** a reference line, nor **by how much**.

This PR adds a **virtual reference-comparison ("delta") layer** for candlestick charts. Pressing **F7** opens an accessible dialog where the user picks a reference series (any line-layer series in the same subplot, such as "Moving Average 3 days") and one OHLC field. Pressing **Okay** activates an invisible virtual layer where each point is `field value − reference value`, matched by x value. The user then knows:

1. **Direction** — positive means above the line, negative means below.
2. **Magnitude** — the absolute delta between the OHLC value and the line.

**Escape** deactivates the layer and returns to the chart, with the candlestick position synced to where the user left off.

## Related Issues

- Also repairs the bulk of the scheduled e2e-suite failures reported in #626 (see the second commit).

## Changes Made

**Model**
- New `CandlestickDeltaTrace` (`src/model/candlestickDelta.ts`) and `TraceType.CANDLESTICK_DELTA`: a 1×N virtual trace of signed deltas with full BTS state, Go-To extrema (max/min delta with ties), x-value search, and sign-filtered rotor navigation. It has no SVG geometry, so it never highlights.
- `Context.swapActiveTrace()` / `Context.getActiveSubplotTraces()` to swap the virtual layer in/out of the navigation stack at the same depth as a real layer.
- Public read accessors: `Candlestick.getCandles()`, `LineTrace.getSeries()`.

**Sonification**
- Pitch encodes |delta| over `[0, max |delta|]`, stereo pan encodes x, and the existing candlestick **bull/bear timbres** encode direction (above/below the line).
- New percussive **click tone** (`AudioService.playClickTone`, opted into via `AudioState.zeroClick`) for exact zeros — "on the line" is a meaningful data point, so it must sound distinct from both pitched tones and the low null tone.

**Braille**
- Reuses the candlestick encoder for the new trace type: character height encodes |delta|; below-line points carry the bearish **dot-8** marker, above-line points read like bullish candles.

**Text**
- Verbose: `Date is Nov 5, close delta is $1.353, position is above line`; terse: `Nov 5, close $1.353, above line`. Per-layer axis formatters (dates, currency) are inherited from the candlestick layer.

**Rotor**
- The delta layer renames its rotor units to **delta point** (default) / **above line** / **below line**; the compare units filter left/right navigation by sign, following the heatmap's compare-mode implementation.
- `RotorNavigationService` gained a `compareModeInfo()` trace hook (labels + boundary-message nouns), data-mode detection that honors `dataModeName()`, and `resetToDataMode()` so a stale compare unit can never silently map onto a different unit when the layer activates/deactivates. Legacy traces keep their exact wording.

**UI / ViewModel / Wiring**
- `CandlestickDeltaSettings` MUI dialog (two labelled dropdowns + Okay/Cancel, focus moves into the dialog, ESC/backdrop cancel), new `CANDLESTICK_DELTA` and `CANDLESTICK_DELTA_SETTINGS` keyboard scopes with their own keymaps (arrows, autoplay, B/T/S/R toggles, space, P, G, D, rotor keys, help/chat/settings, F7 to reconfigure, ESC to exit).
- `CandlestickDeltaService` orchestrates activation/deactivation, announces activation (with exit instructions) and exit through the `role="alert"` live region, resets the rotor, wires the standard observers onto the runtime-created trace, and closes the layer safely on live-data updates and PageUp/PageDown layer switches.
- Redux slice + view model + registry + `CommandContext`/`CommandFactory`/`Controller` wiring; help menu auto-generated for the new scope.

## Screenshots (if applicable)

The layer is intentionally invisible (no SVG highlight); all output is auditory, braille, and textual. Sample text output while navigating the delta layer of `examples/candlestick_multilayer.html`:

```
Date is Nov 5, close delta is $1.353, position is above line
Date is Nov 6, close delta is $0.223, position is above line
```

Braille (dot-8 marks below-line points): `⠤⠤⠔⠒⢢⠤⠤⠤⠜⠑⢢⢔⢒⠢⠜⠉⠑⢢`

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- Unit tests (`test/model/candlestickDelta.test.ts`, `test/service/candlestickDelta.test.ts`, plus updates to `test/command/braille-escape.test.ts`) cover delta computation and x-matching, magnitude-aware zero snapping, navigation, extrema, sign-filtered rotor movement, BTS state shapes, activation/deactivation/reconfiguration with position preservation, `discardActiveLayer` teardown, and rotor-unit integration. Full suite: **746 passed**.
- An adversarial multi-agent review of the initial commit surfaced (and this PR fixes) four issues: F7 reconfiguration now preserves the current delta-layer position instead of jumping to the pre-activation candle; the multi-panel braille-Escape path now tears down the virtual layer instead of stranding stale rotor state; the `l` label binding was removed from the delta scope to avoid a scope desync on its Escape; and `roundDelta` is now magnitude-relative so it neither overflows nor misclassifies on-line points on large- or small-priced instruments.
- Verified end-to-end in a real browser (Playwright + `examples/candlestick_multilayer.html`): F7 dialog focus management and keyboard-only operation, activation announcement with ESC instructions, delta navigation with inherited currency formatting, rotor unit cycling and sign-filtered movement, Go-To max/min delta, braille rendering with dot-8 markers, ESC exit with candlestick position sync, and F7 reconfiguration.
- Candles without a reference value at the same x (e.g. the head of a moving-average window) are skipped; activation refuses (with an announcement) when no x values match.

### E2E suite repair (#626)

The scheduled e2e workflow re-enabled in #625 failed en masse (~291 tests, nearly all "Failed to activate MAIDR"): the suite had drifted from the app while it was disabled. The second commit fixes the systemic root causes:

- **Activation** — MAIDR now wraps the chart SVG in a focusable `<div role="img"/"application" tabindex=0>` and focuses that wrapper on Tab/click, but `verifySvgFocused()` still required the active element to be literally `<svg>`, so every test failed at setup. It now accepts the SVG or MAIDR's focusable wrapper (and the duplicated stale copy in `barplot-page` is removed).
- **Platform modifier** — `META_KEY`/`COMMAND_KEY` were hard-coded to `'Meta'`, but MAIDR binds Ctrl on Linux/Windows (`Platform.ctrl`); on the Linux CI runner `'Meta'` is the Super key, so every Ctrl-combination test (extreme navigation, autoplay, help, settings) silently no-opped. Both constants now track the OS like the app.
- **Axis titles** — axis config migrated to `{ label }` objects; the axis-title assertions still compared against the raw `axes.x`/`axes.y` object. Updated to read `.label` across all specs.

Verified on chromium (stacked bar: **0 → 22 passing**). The remaining `PLOT_EXTREME_VERIFICATION` boundary assertions reflect an intentional app change — boundaries now preserve the last valid point instead of announcing "No plot info to display" — and their per-spec helpers/selectors need individual updates with full cross-browser validation; those are tracked as a focused follow-up rather than bundled here under chromium-only validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxNjc1H1QAsQLJG9hGewSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxNjc1H1QAsQLJG9hGewSL)_