### PR TITLE
fix(rotor): re-announce compare-mode boundary messages to screen readers

### DIFF
--- a/src/service/rotor.ts
+++ b/src/service/rotor.ts
@@ -573,9 +573,9 @@ export class RotorNavigationService {
    * screen readers to re-announce on every keystroke. Without this, repeated
    * identical messages dispatched only to the rotor area announce once and
    * then stay silent. Used by the intersection, compare-mode, and filter-unit
-   * boundary paths. Returns the message unchanged so callers can chain. Empty strings
-   * (text-off mode) are passed through; NotificationService already no-ops on
-   * empty input.
+   * boundary paths. Returns the message unchanged so callers can chain. Empty
+   * strings (text-off mode) are passed through; NotificationService already
+   * no-ops on empty input.
    * @param message The text to announce; returned unchanged.
    */
   private announceRotorMessage(message: string): string {

--- a/src/service/rotor.ts
+++ b/src/service/rotor.ts
@@ -50,11 +50,12 @@ export class RotorNavigationService {
    * Creates a new RotorNavigationService instance.
    * @param context - The context providing access to the active trace
    * @param text - Provides terse/verbose/off mode for message formatting
-   * @param notification - Used to push intersection-mode messages through the
-   *   text alert region. The alert region re-mounts on every dispatch (keyed
-   *   by a revision counter), which is what causes screen readers to
-   *   re-announce on repeat key presses. Without this, identical messages
-   *   dispatched only to the rotor area do not re-announce.
+   * @param notification - Used to push rotor boundary messages (intersection
+   *   and compare mode) through the text alert region. The alert region
+   *   re-mounts on every dispatch (keyed by a revision counter), which is what
+   *   causes screen readers to re-announce on repeat key presses. Without
+   *   this, identical messages dispatched only to the rotor area do not
+   *   re-announce.
    */
   public constructor(context: Context, text: TextService, notification: NotificationService) {
     this.context = context;
@@ -135,7 +136,7 @@ export class RotorNavigationService {
         if (!moved) {
           const msg = this.getMessage(this.getCompareNoun(compareType), direction);
           console.warn(msg);
-          return msg;
+          return this.announceRotorMessage(msg);
         }
       } else {
         console.error('Unable to retrieve the current X value.');
@@ -181,7 +182,7 @@ export class RotorNavigationService {
         if (!moved) {
           const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'above');
           console.warn(msg);
-          return msg;
+          return this.announceRotorMessage(msg);
         }
       }
     } catch {
@@ -219,7 +220,7 @@ export class RotorNavigationService {
         if (!moved) {
           const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'below');
           console.warn(msg);
-          return msg;
+          return this.announceRotorMessage(msg);
         }
       }
     } catch {
@@ -255,7 +256,7 @@ export class RotorNavigationService {
         if (!moved) {
           const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'left');
           console.warn(msg);
-          return msg;
+          return this.announceRotorMessage(msg);
         }
       }
     } catch {
@@ -291,7 +292,7 @@ export class RotorNavigationService {
         if (!moved) {
           const msg = this.getMessage(this.getCompareNoun(this.getCompareType()), 'right');
           console.warn(msg);
-          return msg;
+          return this.announceRotorMessage(msg);
         }
       }
     } catch {
@@ -571,8 +572,8 @@ export class RotorNavigationService {
    * alert region re-mounts (it is keyed by a revision counter), forcing
    * screen readers to re-announce on every keystroke. Without this, repeated
    * identical messages dispatched only to the rotor area announce once and
-   * then stay silent. Used by the intersection and filter-unit boundary
-   * paths. Returns the message unchanged so callers can chain. Empty strings
+   * then stay silent. Used by the intersection, compare-mode, and filter-unit
+   * boundary paths. Returns the message unchanged so callers can chain. Empty strings
    * (text-off mode) are passed through; NotificationService already no-ops on
    * empty input.
    * @param message The text to announce; returned unchanged.

--- a/src/state/viewModel/textViewModel.ts
+++ b/src/state/viewModel/textViewModel.ts
@@ -16,8 +16,11 @@ export interface TextState {
   announce: boolean;
   value: string;
   /**
-   * Monotonic counter that increments on every update (including same-text updates).
-   *  Used by the View to detect re-announcement requests without invisible characters.
+   * Monotonic counter that increments on every text update AND every
+   * notification (including same-text/same-message dispatches). The View keys
+   * the screen-reader alert region on it, so bumping it here is what forces a
+   * re-announcement (via re-mount) even when the text/message is unchanged —
+   * without relying on invisible Unicode characters.
    */
   revision: number;
   message: string | null;
@@ -47,6 +50,11 @@ const textSlice = createSlice({
     },
     notify(state, action: PayloadAction<string>): void {
       state.message = action.payload;
+      // Bump revision so the alert region re-mounts and screen readers
+      // re-announce even when the same message is dispatched repeatedly (e.g.
+      // holding a direction key at a rotor boundary). Without this, an
+      // identical repeat notify() produces no DOM change and stays silent.
+      state.revision += 1;
     },
     clearMessage(state): void {
       state.message = null;

--- a/test/service/rotor.test.ts
+++ b/test/service/rotor.test.ts
@@ -272,3 +272,64 @@ describe('RotorNavigationService intersection dispatch', () => {
     expect(seen.has(Constant.INTERSECTION_MODE)).toBe(false);
   });
 });
+
+describe('RotorNavigationService compare-mode boundary re-announcement', () => {
+  /**
+   * Single ascending line so that, sitting on the maximum, HIGHER_VALUE_MODE
+   * has no further higher value to the right — a reliable compare boundary.
+   * @returns A single-line LineTrace with values [1, 2, 3]
+   */
+  function createAscendingLine(): LineTrace {
+    return new LineTrace(createLineLayer([
+      [
+        { x: 0, y: 1 },
+        { x: 1, y: 2 },
+        { x: 2, y: 3 },
+      ],
+    ]));
+  }
+
+  test('compare-mode boundary routes through notification.notify and re-announces each press', () => {
+    // Regression: the intersection path already re-announces on repeat presses
+    // by routing through notification.notify (the alert region is keyed by a
+    // revision counter). The compare-mode boundary path historically returned
+    // the message to the rotor area only, so repeated identical hits went
+    // silent for screen readers. This asserts compare mode now re-announces
+    // the same way.
+    const trace = createAscendingLine();
+    trace.col = 2; // sit on the maximum (value 3)
+    const notification = createMockNotificationService();
+    const service = new RotorNavigationService(
+      createMockContext(trace),
+      createMockTextService(),
+      notification,
+    );
+    cycleTo(service, Constant.HIGHER_VALUE_MODE);
+
+    const result = service.moveRight();
+    expect(result).not.toBeNull();
+    expect(notification.notify).toHaveBeenCalledWith(
+      expect.stringMatching(/higher value/i),
+    );
+    expect(trace.col).toBe(2); // did not move
+
+    // Each repeat hit must call notify so the alert region re-mounts.
+    const callsBefore = (notification.notify as jest.Mock).mock.calls.length;
+    service.moveRight();
+    service.moveRight();
+    expect((notification.notify as jest.Mock).mock.calls.length).toBe(callsBefore + 2);
+  });
+
+  test('text-off mode still suppresses the compare boundary message', () => {
+    const trace = createAscendingLine();
+    trace.col = 2;
+    const service = new RotorNavigationService(
+      createMockContext(trace),
+      createMockTextService({ off: true }),
+      createMockNotificationService(),
+    );
+    cycleTo(service, Constant.HIGHER_VALUE_MODE);
+
+    expect(service.moveRight()).toBe('');
+  });
+});

--- a/test/service/rotor.test.ts
+++ b/test/service/rotor.test.ts
@@ -1,8 +1,9 @@
 import type { Context } from '@model/context';
 import type { NotificationService } from '@service/notification';
 import type { TextService } from '@service/text';
-import type { MaidrLayer } from '@type/grammar';
+import type { HeatmapData, MaidrLayer } from '@type/grammar';
 import { describe, expect, jest, test } from '@jest/globals';
+import { Heatmap } from '@model/heatmap';
 import { LineTrace } from '@model/line';
 import { RotorNavigationService } from '@service/rotor';
 import { TraceType } from '@type/grammar';
@@ -317,6 +318,72 @@ describe('RotorNavigationService compare-mode boundary re-announcement', () => {
     const callsBefore = (notification.notify as jest.Mock).mock.calls.length;
     service.moveRight();
     service.moveRight();
+    expect((notification.notify as jest.Mock).mock.calls.length).toBe(callsBefore + 2);
+  });
+
+  test('the left/lower fallback path also re-announces the boundary', () => {
+    // moveLeft in LOWER_VALUE_MODE exercises a different message branch than
+    // the moveRight/higher case above: LineTrace does not override
+    // moveLeftRotor, so moveLeft throws and falls back to
+    // callMoveToNextCompareMethod('left'), which is the fifth wrapped site.
+    const trace = createAscendingLine();
+    trace.col = 0; // leftmost — no lower value further left
+    const notification = createMockNotificationService();
+    const service = new RotorNavigationService(
+      createMockContext(trace),
+      createMockTextService(),
+      notification,
+    );
+    cycleTo(service, Constant.LOWER_VALUE_MODE);
+
+    const result = service.moveLeft();
+    expect(result).not.toBeNull();
+    expect(notification.notify).toHaveBeenCalledWith(
+      expect.stringMatching(/lower value/i),
+    );
+    expect(trace.col).toBe(0);
+
+    const callsBefore = (notification.notify as jest.Mock).mock.calls.length;
+    service.moveLeft();
+    service.moveLeft();
+    expect((notification.notify as jest.Mock).mock.calls.length).toBe(callsBefore + 2);
+  });
+
+  test('the inline vertical compare branch (heatmap moveUp) re-announces too', () => {
+    // Heatmap overrides moveUpRotor to delegate to a compare search that can
+    // return false, so its boundary flows through the INLINE moveUp branch
+    // rather than the callMoveToNextCompareMethod fallback the line cases hit.
+    // No selectors → no DOM needed (highlightValues stays null).
+    const data: HeatmapData = { x: ['a', 'b'], y: ['p', 'q'], points: [[1, 2], [3, 4]] };
+    const layer: MaidrLayer = {
+      id: 'hm',
+      type: TraceType.HEATMAP,
+      title: 'rotor heatmap',
+      axes: { x: { label: 'X' }, y: { label: 'Y' } },
+      data,
+    };
+    const trace = new Heatmap(layer);
+    // The model reverses rows, so trace row 0 = points row 1 = [3, 4]; sitting
+    // on col 0 (value 3) there is no higher value further up its column.
+    trace.row = 0;
+    trace.col = 0;
+    const notification = createMockNotificationService();
+    const service = new RotorNavigationService(
+      createMockContext(trace),
+      createMockTextService(),
+      notification,
+    );
+    cycleTo(service, Constant.HIGHER_VALUE_MODE);
+
+    const result = service.moveUp();
+    expect(result).not.toBeNull();
+    expect(notification.notify).toHaveBeenCalledWith(
+      expect.stringMatching(/higher value/i),
+    );
+
+    const callsBefore = (notification.notify as jest.Mock).mock.calls.length;
+    service.moveUp();
+    service.moveUp();
     expect((notification.notify as jest.Mock).mock.calls.length).toBe(callsBefore + 2);
   });
 

--- a/test/state/viewModel/textViewModel.test.ts
+++ b/test/state/viewModel/textViewModel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from '@jest/globals';
+import textReducer from '@state/viewModel/textViewModel';
+
+/**
+ * These reducer-level tests lock in the re-announcement mechanism the rotor
+ * boundary messages depend on: the screen-reader alert region in Text.tsx is
+ * keyed by `revision`, so `revision` must change on every dispatch that should
+ * re-announce — including repeated identical `notify` messages (e.g. holding a
+ * direction key at a rotor boundary). Redux Toolkit exposes reducers by the
+ * `${slice}/${reducer}` action type, so the actions are dispatched by type
+ * here (the slice does not export them individually).
+ */
+describe('text slice revision counter', () => {
+  test('notify bumps revision even when the message is identical', () => {
+    const initial = textReducer(undefined, { type: '@@INIT' });
+    expect(initial.revision).toBe(0);
+
+    const first = textReducer(initial, { type: 'text/notify', payload: 'No higher value found' });
+    expect(first.message).toBe('No higher value found');
+    expect(first.revision).toBe(1);
+
+    // Repeating the SAME message must still advance revision so the alert
+    // region re-mounts and re-announces.
+    const second = textReducer(first, { type: 'text/notify', payload: 'No higher value found' });
+    expect(second.message).toBe('No higher value found');
+    expect(second.revision).toBe(2);
+
+    const third = textReducer(second, { type: 'text/notify', payload: 'No higher value found' });
+    expect(third.revision).toBe(3);
+  });
+
+  test('update continues to bump revision (unchanged behavior)', () => {
+    const initial = textReducer(undefined, { type: '@@INIT' });
+    const updated = textReducer(initial, { type: 'text/update', payload: 'Bar 1 of 5' });
+    expect(updated.value).toBe('Bar 1 of 5');
+    expect(updated.revision).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description

Fixes a screen-reader accessibility gap in rotor **compare mode** (lower/higher value navigation): boundary messages ("No higher value found…") were dispatched only to the rotor `aria-live` area, which does **not** re-announce identical content on repeat key presses. So a screen-reader user holding/repeating a direction at a compare boundary heard it once, then silence.

Fixing this surfaced a deeper root cause (see Changes Made #2): the `notify` reducer never bumped the `revision` counter that the alert region is keyed on, so routing a message through `notification.notify()` did **not** reliably force a re-announcement on its own. Compare mode happened to still re-announce because each boundary also emits a model *warning* state that flows through the `update` reducer (which does bump `revision`) — but paths that `notify()` without a warning (e.g. intersection mode's *vertical-unavailable* message) would go silent on repeat. This PR fixes both the routing and the underlying reducer, so re-announcement is robust and self-contained for **all** rotor boundary paths.

Split out of #628 (candlestick rotor trend units) because it affects **all** trace types with compare navigation (bar, line, heatmap, candlestick, box…), not just candlesticks.

## Related Issues

Follow-up to #628 — surfaced during that PR's review. Deferred rotor items tracked in #630.

## Changes Made

1. **`src/service/rotor.ts`** — Route the five compare-mode boundary returns (`moveUp`, `moveDown`, `moveLeft`, `moveRight`, and the shared `callMoveToNextCompareMethod`) through the notification helper so they re-announce. Generalized the helper name `announceIntersectionMessage → announceRotorMessage` now that it serves the intersection, compare, and filter-unit paths; updated the related doc comments.
2. **`src/state/viewModel/textViewModel.ts`** — Root-cause fix: the `notify` reducer now bumps `revision` (previously only `update` did). The `role="alert"` region in `Text.tsx` is keyed by `revision`, so this is what actually forces a re-mount / re-announcement on repeat presses. Makes the "route through `notify()` to re-announce" contract true for **every** `notify()` caller, and closes the intersection *vertical-unavailable* repeat gap.
3. **Tests** — `test/service/rotor.test.ts`: three structurally distinct wrapped call sites (the `callMoveToNextCompareMethod` fallback via `moveRight`/higher, the left/lower fallback, and a heatmap `moveUp` **inline** compare branch) plus text-off suppression. `test/state/viewModel/textViewModel.test.ts`: reducer-level test asserting `notify` advances `revision` on identical repeats (and that `update` still does).

## Screenshots (if applicable)

N/A — screen-reader announcement behavior.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass (61 suites / 793 tests green; production build passes).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- Behavior is now consistent across all rotor boundary paths (compare / intersection / filter): every repeat press at a boundary re-announces, and text-off mode suppresses the message.
- **Known pre-existing trade-off (not changed here):** rotor boundary messages are written to two live regions (`rotor_value` and the `role="alert"` region), so the *first* hit may announce twice. This predates #628/#629 (it already applied to intersection mode). Consolidating onto a single announcement path is tracked as item 3 in #630, gated on a screen-reader pass.
- #628 (now merged) performed the same `announceIntersectionMessage → announceRotorMessage` rename; this branch has been rebased onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENgT6oNeYux73K1A699ky6