### PR TITLE
fix(rotor): orientation-independent candlestick compare + grid-mode re-announce (#630 items 1–2)

### DIFF
--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -1010,30 +1010,25 @@ export class Candlestick extends AbstractTrace {
       this.handleInitialEntry();
     }
 
-    const currentGroup = this.row;
-    if (currentGroup < 0 || currentGroup >= this.candles.length) {
+    // Drive off currentPointIndex, which is the candle index in BOTH
+    // orientations. Reading this.col directly is only correct in the vertical
+    // layout — in the horizontal layout this.col holds the segment position
+    // and this.row holds the candle index (see updateVisualPointPosition).
+    // updateVisualPointPosition() maps currentPointIndex back to row/col.
+    const currentIndex = this.currentPointIndex;
+    if (currentIndex < 0 || currentIndex >= this.candles.length) {
       return false;
     }
     const currentSegment = this.currentSegmentType ?? 'open';
 
-    const segmentValues = this.candles.map((c, index) => ({
-      value: c[currentSegment],
-      index,
-      xValue: c.value,
-    }));
-
-    const currentIndex = this.col;
     const step = direction === 'right' ? 1 : -1;
-    let i = currentIndex + step;
-    while (i >= 0 && i < segmentValues.length) {
-      if (this.compare(segmentValues[i].value, segmentValues[currentIndex].value, type)) {
-        this.col = i;
+    for (let i = currentIndex + step; i >= 0 && i < this.candles.length; i += step) {
+      if (this.compare(this.candles[i][currentSegment], this.candles[currentIndex][currentSegment], type)) {
         this.currentPointIndex = i;
         this.updateVisualPointPosition();
         this.notifyStateUpdate();
         return true;
       }
-      i += step;
     }
     this.notifyRotorBounds();
     return false;

--- a/src/service/rotor.ts
+++ b/src/service/rotor.ts
@@ -638,7 +638,12 @@ export class RotorNavigationService {
   private moveGrid(direction: 'up' | 'down' | 'left' | 'right'): string | null {
     const activeTrace = this.context.active;
     if (!isGridNavigable(activeTrace) || !activeTrace.supportsGridMode()) {
-      return this.getMessage('grid value', direction);
+      // Route through announceRotorMessage so this boundary re-announces on
+      // repeat presses like every other rotor boundary path. Defensive only:
+      // GRID_MODE is offered by getAvailableModes() only when supportsGridMode()
+      // is true, so this branch is not reachable through the normal getMode()
+      // dispatch — hence there is no black-box test for it.
+      return this.announceRotorMessage(this.getMessage('grid value', direction));
     }
 
     // Grid move methods call notifyOutOfBounds() on boundary, which handles audio/text

--- a/test/model/candlestickCompareOrientation.test.ts
+++ b/test/model/candlestickCompareOrientation.test.ts
@@ -50,7 +50,7 @@ function makeLayer(orientation: Orientation): MaidrLayer {
  * @param trace - The trace to inspect
  * @returns The current candle's x label
  */
-function currentDate(trace: Candlestick): string | number | undefined {
+function currentDate(trace: Candlestick): string | number | number[] | undefined {
   const state = trace.state;
   return state.empty ? undefined : state.text.main.value;
 }

--- a/test/model/candlestickCompareOrientation.test.ts
+++ b/test/model/candlestickCompareOrientation.test.ts
@@ -81,6 +81,21 @@ describe('candlestick compare navigation is orientation-independent', () => {
     expect(trace.row).toBe(1);
   });
 
+  test('horizontal: compare works after navigating in, not only from entry', () => {
+    // Exercises the currentPointIndex path from a moved position (this.col
+    // holds the segment index here, this.row the candle index), so it guards
+    // the fix independently of the initial-entry code path.
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
+    trace.moveOnce('FORWARD'); // initial entry -> d0
+    trace.moveOnce('FORWARD'); // d0 -> d1
+    expect(currentDate(trace)).toBe('d1');
+
+    // From d1 (close 8) the next higher close to the right is d2 (12).
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
+    expect(currentDate(trace)).toBe('d2');
+    expect(trace.row).toBe(2);
+  });
+
   test('horizontal: boundary returns false and stays on the current candle', () => {
     const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
     // From d0 there is nothing further left.

--- a/test/model/candlestickCompareOrientation.test.ts
+++ b/test/model/candlestickCompareOrientation.test.ts
@@ -1,0 +1,90 @@
+import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { Candlestick } from '@model/candlestick';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Builds a candle with a chosen close. open === close (neutral) keeps the
+ * default entry segment ('close') the comparison target; the model recomputes
+ * trend/volatility, so the placeholders here are ignored.
+ * @param value - The x label (date)
+ * @param close - The closing price used by the compare search
+ * @returns A candlestick point
+ */
+function candle(value: string, close: number): CandlestickPoint {
+  return {
+    value,
+    open: close,
+    high: close + 2,
+    low: close - 2,
+    close,
+    volume: 100,
+    trend: 'Neutral',
+    volatility: 4,
+  };
+}
+
+// Close values across d0..d4. From d0 (10): the next HIGHER close is d2 (12,
+// skipping d1's 8); the next LOWER close is d1 (8).
+const CLOSES = [10, 8, 12, 9, 14];
+
+/**
+ * Creates a candlestick layer in the given orientation.
+ * @param orientation - Vertical or horizontal layout
+ * @returns A candlestick layer definition
+ */
+function makeLayer(orientation: Orientation): MaidrLayer {
+  return {
+    id: 'candle',
+    type: TraceType.CANDLESTICK,
+    orientation,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: CLOSES.map((c, i) => candle(`d${i}`, c)),
+  };
+}
+
+/**
+ * Reads the x label of the candle the cursor currently sits on, via the
+ * public trace state (orientation-independent — main.value is the candle's
+ * value in both layouts).
+ * @param trace - The trace to inspect
+ * @returns The current candle's x label
+ */
+function currentDate(trace: Candlestick): string | number | undefined {
+  const state = trace.state;
+  return state.empty ? undefined : state.text.main.value;
+}
+
+describe('candlestick compare navigation is orientation-independent', () => {
+  test('vertical: moveRight/higher lands on the next higher-close candle', () => {
+    const trace = new Candlestick(makeLayer(Orientation.VERTICAL));
+    // Default entry segment is 'close'; start at d0 (close 10).
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
+    expect(currentDate(trace)).toBe('d2'); // close 12, skipping d1 (8)
+    expect(trace.col).toBe(2); // candle index lives in col when vertical
+  });
+
+  test('horizontal: moveRight/higher lands on the same candle as vertical', () => {
+    // Regression guard for the orientation bug: before the fix this read
+    // this.col (the segment position in horizontal layout) as the candle
+    // index and jumped to the wrong candle.
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
+    expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
+    expect(currentDate(trace)).toBe('d2');
+    expect(trace.row).toBe(2); // candle index lives in row when horizontal
+  });
+
+  test('horizontal: moveRight/lower finds the next lower-close candle', () => {
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
+    expect(trace.moveToNextCompareValue('right', 'lower')).toBe(true);
+    expect(currentDate(trace)).toBe('d1'); // close 8 < 10
+    expect(trace.row).toBe(1);
+  });
+
+  test('horizontal: boundary returns false and stays on the current candle', () => {
+    const trace = new Candlestick(makeLayer(Orientation.HORIZONTAL));
+    // From d0 there is nothing further left.
+    expect(trace.moveToNextCompareValue('left', 'higher')).toBe(false);
+    expect(currentDate(trace)).toBe('d0');
+  });
+});


### PR DESCRIPTION
## Description

Addresses **items 1 and 2 of #630**. Item 3 (consolidating the dual live-region announcement) is intentionally left open — it's gated on a real screen-reader pass.

### Item 2 — candlestick compare navigation was not orientation-independent (bug)

`Candlestick.moveToNextCompareValue` derived the current candle index from `this.col` and bounds-checked `this.row` against `candles.length`. That's only correct in the **vertical** layout. In the **horizontal** layout, `updateVisualPointPosition()` puts the candle index in `this.row` and the value-sorted **segment** position in `this.col` — so lower/higher-value compare (rotor) navigation started the search from the wrong index and jumped to the wrong candle on horizontal candlestick charts.

**Fix:** drive the search off `this.currentPointIndex` — the candle index in *both* orientations — and let `updateVisualPointPosition()` map it back to row/col. This mirrors the already-correct `moveToRotorFilter()`. As a side benefit, it also removes a latent fragility in the old `this.row`-based bounds check (which could spuriously return false on charts with fewer than 5 candles, since `this.row` in vertical is the 0–4 segment index).

### Item 1 — grid-mode unsupported-boundary message didn't re-announce (defensive consistency)

`moveGrid()`'s unsupported-grid branch returned its message raw instead of routing through `announceRotorMessage()`, so it wouldn't re-announce on repeat presses like every other rotor boundary path. Now wrapped for consistency.

This branch is **unreachable through the public rotor API** — `GRID_MODE` only enters the mode cycle when `supportsGridMode()` is true, which makes the guard false, and the dispatch reads the same `context.active` synchronously — so there is no black-box test for it (documented in a comment).

## Related Issues

Addresses items 1–2 of #630 (item 3 remains open).

## Changes Made

- **`src/model/candlestick.ts`** — `moveToNextCompareValue` now uses `currentPointIndex` and `updateVisualPointPosition()`; removed the orientation-specific `this.col`/`this.row` reads and the redundant `this.col = i` write.
- **`src/service/rotor.ts`** — `moveGrid` unsupported branch routes through `announceRotorMessage()`, with a comment noting the branch is unreachable/defensive.
- **`test/model/candlestickCompareOrientation.test.ts`** — new: vertical (non-regression guard), horizontal higher/lower, a post-navigation horizontal case, and a boundary case. The horizontal cases fail against the old `this.col`-based logic (verified: old code lands on `d4` instead of `d2`).

## Screenshots (if applicable)

N/A — non-visual navigation behavior.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass (62 suites / 798 tests green; production build passes).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- **#630 item 3** (rotor boundary messages are written to two live regions — `rotor_value` and the `role="alert"` region — so the first hit may announce twice) is **not** addressed here; it's a UX decision gated on a screen-reader pass, so the issue stays open for it.
- The orientation fix was cross-checked with an adversarial review pass (correctness in both layouts, that the new tests genuinely catch the bug, `moveGrid` reachability, and regressions) — no defects found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENgT6oNeYux73K1A699ky6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENgT6oNeYux73K1A699ky6)_