### PR TITLE
fix(rotor): single-announce rotor boundary messages (#630 item 3)

### DIFF
--- a/src/state/viewModel/rotorNavigationViewModel.ts
+++ b/src/state/viewModel/rotorNavigationViewModel.ts
@@ -85,31 +85,51 @@ export class RotorNavigationViewModel extends AbstractViewModel<RotorState> {
   }
 
   /**
+   * Runs a rotor move and clears the rotor announcement area.
+   *
+   * Boundary / unavailable messages returned by the service have already been
+   * announced through the notification service (the revision-keyed
+   * `role="alert"` region, which re-announces on every repeat press) and are
+   * shown visually in the text container. Writing them into `rotor_value` too
+   * would push the identical text into a SECOND aria-live region
+   * (`ROTOR_AREA`), so a screen reader announces the same boundary message
+   * twice on the first hit (#630 item 3). `rotor_value` is therefore reserved
+   * for the rotor mode name (set by the cycle methods); moves clear it, which
+   * matches the pre-existing behaviour on a successful move.
+   * @param move - The rotor service move to run; its return value is ignored
+   *   here because announcement is handled inside the service.
+   */
+  private runMove(move: () => string | null): void {
+    move();
+    this.store.dispatch(setValue(null));
+  }
+
+  /**
    * Moves up within the current rotor navigation unit.
    */
   public moveUp(): void {
-    this.store.dispatch(setValue(this.rotorService.moveUp()));
+    this.runMove(() => this.rotorService.moveUp());
   }
 
   /**
    * Moves left within the current rotor navigation unit.
    */
   public moveLeft(): void {
-    this.store.dispatch(setValue(this.rotorService.moveLeft()));
+    this.runMove(() => this.rotorService.moveLeft());
   }
 
   /**
    * Moves down within the current rotor navigation unit.
    */
   public moveDown(): void {
-    this.store.dispatch(setValue(this.rotorService.moveDown()));
+    this.runMove(() => this.rotorService.moveDown());
   }
 
   /**
    * Moves right within the current rotor navigation unit.
    */
   public moveRight(): void {
-    this.store.dispatch(setValue(this.rotorService.moveRight()));
+    this.runMove(() => this.rotorService.moveRight());
   }
 }
 

--- a/test/state/viewModel/rotorNavigationViewModel.test.ts
+++ b/test/state/viewModel/rotorNavigationViewModel.test.ts
@@ -23,6 +23,11 @@ function createMockService(
   } as unknown as RotorNavigationService;
 }
 
+// This suite verifies the view-model half of the fix (rotor_value is not
+// written with the boundary message). The complementary half — that the
+// boundary message is still announced exactly once via notification.notify
+// inside the service, re-announcing on each repeat press — is covered in
+// test/service/rotor.test.ts.
 describe('RotorNavigationViewModel boundary announcement (#630 item 3)', () => {
   test('a boundary move runs the service but does NOT write the message to rotor_value', () => {
     const store = createMaidrStore();

--- a/test/state/viewModel/rotorNavigationViewModel.test.ts
+++ b/test/state/viewModel/rotorNavigationViewModel.test.ts
@@ -1,0 +1,64 @@
+import type { RotorNavigationService } from '@service/rotor';
+import { describe, expect, jest, test } from '@jest/globals';
+import { createMaidrStore } from '@state/store';
+import { RotorNavigationViewModel } from '@state/viewModel/rotorNavigationViewModel';
+
+/**
+ * Builds a RotorNavigationService stub exposing only the methods the view
+ * model calls. Move methods default to a successful (null) result; override
+ * to simulate a boundary by returning a message string.
+ * @param overrides - Per-method return-value overrides
+ * @returns A service-shaped stub with jest mocks
+ */
+function createMockService(
+  overrides: Partial<Record<'moveUp' | 'moveDown' | 'moveLeft' | 'moveRight', string | null>> = {},
+): RotorNavigationService {
+  return {
+    moveUp: jest.fn(() => overrides.moveUp ?? null),
+    moveDown: jest.fn(() => overrides.moveDown ?? null),
+    moveLeft: jest.fn(() => overrides.moveLeft ?? null),
+    moveRight: jest.fn(() => overrides.moveRight ?? null),
+    moveToNextRotorUnit: jest.fn(() => 'HIGHER VALUE NAVIGATION'),
+    moveToPrevRotorUnit: jest.fn(() => 'LOWER VALUE NAVIGATION'),
+  } as unknown as RotorNavigationService;
+}
+
+describe('RotorNavigationViewModel boundary announcement (#630 item 3)', () => {
+  test('a boundary move runs the service but does NOT write the message to rotor_value', () => {
+    const store = createMaidrStore();
+    const service = createMockService({ moveRight: 'No higher value found to the right' });
+    const vm = new RotorNavigationViewModel(store, service);
+
+    vm.moveRight();
+
+    // The service still runs — its notification path announces the boundary
+    // through the revision-keyed alert region.
+    expect(service.moveRight).toHaveBeenCalledTimes(1);
+    // rotor_value must NOT carry the boundary text, otherwise the ROTOR_AREA
+    // aria-live region announces the same message a second time on first hit.
+    expect(store.getState().rotor.rotor_value).toBeNull();
+  });
+
+  test('a successful move clears rotor_value (unchanged behaviour)', () => {
+    const store = createMaidrStore();
+    const service = createMockService();
+    const vm = new RotorNavigationViewModel(store, service);
+
+    vm.moveUp();
+
+    expect(service.moveUp).toHaveBeenCalledTimes(1);
+    expect(store.getState().rotor.rotor_value).toBeNull();
+  });
+
+  test('cycling navigation units still announces the mode name via rotor_value', () => {
+    const store = createMaidrStore();
+    const service = createMockService();
+    const vm = new RotorNavigationViewModel(store, service);
+
+    vm.moveToNextNavUnit();
+    expect(store.getState().rotor.rotor_value).toBe('HIGHER VALUE NAVIGATION');
+
+    vm.moveToPrevNavUnit();
+    expect(store.getState().rotor.rotor_value).toBe('LOWER VALUE NAVIGATION');
+  });
+});


### PR DESCRIPTION
## Description

Addresses the final item of #630 (**item 3**): rotor boundary/unavailable messages were announced to a screen reader **twice** on the first hit.

The messages were written into **two** aria-live regions at once:
1. `rotor_value` → the visible `#ROTOR_AREA` `aria-live` div (via `RotorNavigationViewModel` dispatching the service's return value), **and**
2. `notification.notify()` → the revision-keyed hidden `role="alert"` region (inside the service).

Since #629 made `notify()` reliably re-announce on every repeat press (the `revision` bump), the `rotor_value` copy is now redundant and only causes the first-press double-announce.

**Fix:** the four directional move methods now run the service move (announcement handled inside via `notify()`) and clear `rotor_value` instead of writing the boundary message into it. `rotor_value` stays reserved for the rotor **mode name** set by the cycle methods, and boundary messages remain visible via the text container (`notify()` also sets `text.message`, which renders in `#TEXT_CONTAINER`). Implemented with a small `runMove()` helper.

> ⚠️ **Screen-reader smoke test recommended before merge.** #630 flagged this as gated on a real NVDA/VoiceOver pass — the double-announce is only audible with a live screen reader. The change is verified by reasoning + unit tests, but a manual pass is the intended merge gate.

## Related Issues

Closes the remaining item (item 3) of #630. Items 1–2 are in #631.

## Changes Made

- **`src/state/viewModel/rotorNavigationViewModel.ts`** — `moveUp/moveDown/moveLeft/moveRight` route through a new `runMove()` helper that runs the service move and dispatches `setValue(null)` (instead of `setValue(<returned message>)`). Cycle methods are unchanged.
- **`test/state/viewModel/rotorNavigationViewModel.test.ts`** — new: a boundary move does not populate `rotor_value` (fails against the old code), a successful move clears it (unchanged behavior), and cycling still announces the mode name. Cross-references the service-side announcement coverage in `test/service/rotor.test.ts`.

## Screenshots (if applicable)

N/A — screen-reader announcement behavior.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass (62 suites / 796 tests green; type-check + production build pass).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- **No reachable announcement is lost.** An adversarial review pass confirmed that every *reachable* rotor boundary/unavailable message (compare, intersection, filter units, and normal grid boundaries via `notifyOutOfBounds`) already routes through `notify()`, so removing the `rotor_value` copy loses nothing. The one exception — `moveGrid`'s unsupported-grid branch — is provably **unreachable** through the public rotor API, and it's separately wrapped in `announceRotorMessage()` by **#631** (item 1), so once both land that defensive branch is fully consistent. Not touched here to avoid a conflict with #631.
- Independent of #631 (different files); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENgT6oNeYux73K1A699ky6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENgT6oNeYux73K1A699ky6)_