### PR TITLE
fix(text): announce arrow navigation for single-panel plots

### DIFF
--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -582,6 +582,26 @@ export class TextService implements Observer<PlotState>, Disposable {
       return;
     }
 
+    // Enable screen-reader announcements on the user's first navigation, at
+    // whatever plot level that navigation happens.
+    //
+    // The initial instruction is shown visually with announcements suppressed
+    // (Controller.showInitialInstructionInText -> setAnnounce(false)); the
+    // first model-driven update that reaches this point is the user's first
+    // arrow-key navigation, after which nav text must be announced.
+    //
+    // This previously only fired for figure-type states ("first navigation in
+    // multi-panel plots"). But single-subplot plots start navigation at the
+    // trace level and never emit a figure-type state, so `announce` stayed
+    // false forever and their terse/verbose nav text was silently gated out
+    // of the alert region — while rotor/notification messages (which ignore
+    // `announce`) still spoke. Firing on the first non-empty update of ANY
+    // level fixes single-panel plots and keeps multi-panel behavior identical.
+    if (!this.hasHadFirstNavigation && !state.empty) {
+      this.hasHadFirstNavigation = true;
+      this.onNavigationEmitter.fire({ type: 'first_navigation' });
+    }
+
     // Use the type guard and formatter for layer switches
     if (state.type === 'trace' && isLayerSwitchTraceState(state)) {
       const announcement = this.formatLayerSwitchAnnouncement(state);
@@ -595,12 +615,6 @@ export class TextService implements Observer<PlotState>, Disposable {
         this.notification.notify(text);
       }
       return;
-    }
-
-    // Handle figure-level navigation - this is the first navigation in multi-panel plots
-    if (state.type === 'figure' && !state.empty && !this.hasHadFirstNavigation) {
-      this.hasHadFirstNavigation = true;
-      this.onNavigationEmitter.fire({ type: 'first_navigation' });
     }
 
     const text = this.format(state);

--- a/src/state/viewModel/textViewModel.ts
+++ b/src/state/viewModel/textViewModel.ts
@@ -74,6 +74,16 @@ export class TextViewModel extends AbstractViewModel<TextState> {
   private readonly textService: TextService;
 
   /**
+   * Whether autoplay is currently running. Autoplay deliberately suppresses
+   * per-point screen-reader announcements (it toggles `announce` off on start
+   * and back on when it stops). The `first_navigation` event also enables
+   * announcements, and it can fire mid-playback when autoplay is the user's
+   * very first navigation — so this flag lets that handler defer to autoplay's
+   * suppression instead of re-enabling announcements underneath it.
+   */
+  private autoplayActive = false;
+
+  /**
    * Creates a new TextViewModel instance and registers event listeners.
    * @param store - The Redux store for state management
    * @param text - Service for managing text formatting and updates
@@ -113,7 +123,10 @@ export class TextViewModel extends AbstractViewModel<TextState> {
     }));
 
     this.disposables.push(this.textService.onNavigation((e) => {
-      if (e.type === 'first_navigation') {
+      // Enable announcements on the first navigation, unless autoplay is
+      // running — autoplay owns the announce flag while active and re-enables
+      // it on stop, so overriding here would defeat its per-point suppression.
+      if (e.type === 'first_navigation' && !this.autoplayActive) {
         this.setAnnounce(true);
       }
     }));
@@ -125,9 +138,11 @@ export class TextViewModel extends AbstractViewModel<TextState> {
     this.disposables.push(autoplay.onChange((e) => {
       switch (e.type) {
         case 'start':
+          this.autoplayActive = true;
           this.setAnnounce(false);
           break;
         case 'stop':
+          this.autoplayActive = false;
           this.setAnnounce(true);
           break;
       }

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -1,0 +1,115 @@
+import type { NotificationService } from '@service/notification';
+import type { MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Regression coverage for the "arrow navigation is silent to screen readers"
+ * bug. TextService only announces terse/verbose navigation text through the
+ * revision-keyed role="alert" region when Redux `text.announce` is true. That
+ * flag starts false (the initial instruction is shown without announcing) and
+ * is flipped to true by the `first_navigation` event.
+ *
+ * The event used to fire ONLY for figure-type states, so single-subplot plots
+ * — which start navigation at the trace level and never emit a figure state —
+ * left `announce` false forever and their navigation text was never spoken.
+ * These tests lock in that the event now fires on the first navigation at any
+ * level.
+ */
+
+/**
+ * Builds a single-layer bar layer for trace-level navigation tests.
+ * @returns A bar layer definition with three points.
+ */
+function createBarLayer(): MaidrLayer {
+  return {
+    id: 'bar-layer',
+    type: TraceType.BAR,
+    axes: { x: { label: 'Category' }, y: { label: 'Value' } },
+    data: [
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 },
+      { x: 'C', y: 3 },
+    ],
+  };
+}
+
+/**
+ * Minimal NotificationService stub whose notify is a jest mock.
+ * @returns A NotificationService-shaped object sufficient for these tests.
+ */
+function createMockNotificationService(): NotificationService {
+  return {
+    notify: jest.fn(),
+  } as unknown as NotificationService;
+}
+
+/**
+ * Produces a real, non-empty trace state for a single-layer bar plot, as a
+ * trace emits when the user navigates to a data point.
+ * @returns A non-empty trace-type PlotState.
+ */
+function createTraceState(): TraceState {
+  const trace = new BarTrace(createBarLayer());
+  const state = trace.getStateAt(0, 1);
+  expect(state.empty).toBe(false);
+  return state;
+}
+
+describe('textService first-navigation announcement gate', () => {
+  test('fires first_navigation on the first trace-level navigation', () => {
+    const text = new TextService(createMockNotificationService());
+    const listener = jest.fn();
+    text.onNavigation(listener);
+
+    text.update(createTraceState());
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ type: 'first_navigation' });
+  });
+
+  test('still emits the formatted navigation text on that first update', () => {
+    const text = new TextService(createMockNotificationService());
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(createTraceState());
+
+    expect(changeListener).toHaveBeenCalledTimes(1);
+    const arg = changeListener.mock.calls[0][0] as { value: string };
+    expect(typeof arg.value).toBe('string');
+    expect(arg.value.length).toBeGreaterThan(0);
+  });
+
+  test('fires first_navigation only once across repeated navigation', () => {
+    const text = new TextService(createMockNotificationService());
+    const listener = jest.fn();
+    text.onNavigation(listener);
+
+    text.update(createTraceState());
+    text.update(createTraceState());
+    text.update(createTraceState());
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fire first_navigation for an out-of-bounds empty trace state', () => {
+    const text = new TextService(createMockNotificationService());
+    const listener = jest.fn();
+    text.onNavigation(listener);
+
+    // Pure out-of-bounds events are empty trace states with no `warning`.
+    const emptyState: TraceState = {
+      empty: true,
+      type: 'trace',
+      traceType: TraceType.BAR,
+      audio: { y: 0, x: 0, rows: 0, cols: 0 },
+    };
+    text.update(emptyState);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -1,6 +1,6 @@
 import type { NotificationService } from '@service/notification';
 import type { MaidrLayer } from '@type/grammar';
-import type { TraceState } from '@type/state';
+import type { PlotState, TraceState } from '@type/state';
 import { describe, expect, jest, test } from '@jest/globals';
 import { BarTrace } from '@model/bar';
 import { TextService } from '@service/text';
@@ -111,5 +111,63 @@ describe('textService first-navigation announcement gate', () => {
     text.update(emptyState);
 
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('does not fire first_navigation for a warning empty trace state', () => {
+    const text = new TextService(createMockNotificationService());
+    const listener = jest.fn();
+    text.onNavigation(listener);
+
+    // Warning empties bypass the top-of-method out-of-bounds early return, so
+    // the `!state.empty` guard is what keeps them from un-gating announcements.
+    const warningState: TraceState = {
+      empty: true,
+      type: 'trace',
+      traceType: TraceType.BAR,
+      audio: { y: 0, x: 0, rows: 0, cols: 0 },
+      warning: true,
+    };
+    text.update(warningState);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('does not fire first_navigation while text mode is off', () => {
+    const text = new TextService(createMockNotificationService());
+    const listener = jest.fn();
+    text.onNavigation(listener);
+
+    // VERBOSE -> TERSE -> OFF. Navigating while off must not un-gate; the flag
+    // stays armed for when the user turns text back on and navigates.
+    text.toggle();
+    text.toggle();
+    expect(text.isOff()).toBe(true);
+
+    text.update(createTraceState());
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('still fires first_navigation for a figure-type first navigation', () => {
+    const text = new TextService(createMockNotificationService());
+    const listener = jest.fn();
+    text.onNavigation(listener);
+
+    // Multi-panel plots start at figure level; removing the old figure-only
+    // block must not regress their first-navigation announcement.
+    const figureState = {
+      empty: false,
+      type: 'figure',
+      title: '',
+      subtitle: '',
+      caption: '',
+      size: 2,
+      index: 1,
+      traceTypes: ['bar'],
+    } as unknown as PlotState;
+    text.update(figureState);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ type: 'first_navigation' });
   });
 });

--- a/test/state/viewModel/textViewModelAnnounce.test.ts
+++ b/test/state/viewModel/textViewModelAnnounce.test.ts
@@ -1,0 +1,75 @@
+import type { AudioService } from '@service/audio';
+import type { AutoplayService } from '@service/autoplay';
+import type { NotificationService } from '@service/notification';
+import type { TextService } from '@service/text';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { createMaidrStore } from '@state/store';
+import { TextViewModel } from '@state/viewModel/textViewModel';
+import { Emitter } from '@type/event';
+
+/**
+ * Behavioral tests for how TextViewModel wires the `first_navigation` and
+ * autoplay events onto the Redux `text.announce` flag. `announce` gates
+ * terse/verbose navigation text out of the screen-reader alert region until
+ * the user's first navigation; autoplay separately suppresses per-point
+ * announcements while it runs.
+ */
+describe('textViewModel announce coordination', () => {
+  let onChange: Emitter<{ value: string }>;
+  let onNavigation: Emitter<{ type: 'first_navigation' }>;
+  let notificationChange: Emitter<{ value: string }>;
+  let autoplayChange: Emitter<{ type: 'start' | 'stop' }>;
+  let store: ReturnType<typeof createMaidrStore>;
+  let viewModel: TextViewModel;
+
+  beforeEach(() => {
+    onChange = new Emitter();
+    onNavigation = new Emitter();
+    notificationChange = new Emitter();
+    autoplayChange = new Emitter();
+
+    const text = {
+      onChange: onChange.event,
+      onNavigation: onNavigation.event,
+      format: (value: string) => value,
+    } as unknown as TextService;
+    const notification = {
+      onChange: notificationChange.event,
+    } as unknown as NotificationService;
+    const autoplay = {
+      onChange: autoplayChange.event,
+    } as unknown as AutoplayService;
+    const audio = {} as unknown as AudioService;
+
+    store = createMaidrStore();
+    viewModel = new TextViewModel(store, text, notification, autoplay, audio);
+  });
+
+  afterEach(() => {
+    viewModel.dispose();
+  });
+
+  test('first_navigation enables announcements', () => {
+    // Mirrors focus-in: the initial instruction is shown with announcements off.
+    viewModel.setAnnounce(false);
+    expect(store.getState().text.announce).toBe(false);
+
+    onNavigation.fire({ type: 'first_navigation' });
+
+    expect(store.getState().text.announce).toBe(true);
+  });
+
+  test('first_navigation during autoplay does not re-enable announcements', () => {
+    // Autoplay-as-first-action: autoplay suppresses announcements, and the
+    // first navigation it drives must not override that suppression.
+    autoplayChange.fire({ type: 'start' });
+    expect(store.getState().text.announce).toBe(false);
+
+    onNavigation.fire({ type: 'first_navigation' });
+    expect(store.getState().text.announce).toBe(false);
+
+    // When autoplay stops, announcements resume as usual.
+    autoplayChange.fire({ type: 'stop' });
+    expect(store.getState().text.announce).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

When moving between data points with the arrow keys, terse/verbose navigation text was **not spoken by screen readers** on single-panel plots. Rotor boundary/warning messages, by contrast, were announced correctly — which is the asymmetry that made this so noticeable.

Root cause: the screen-reader alert region in `Text.tsx` only exposes **navigation** text when the Redux `text.announce` flag is `true`. That flag starts `false` (the initial instruction is shown visually without announcing) and is meant to flip to `true` on the user's first navigation, via the `first_navigation` event. But `TextService.update()` only fired that event for **figure-type** states ("first navigation in multi-panel plots"). Single-subplot plots start navigation at the **trace** level (`Context.initializePlotContext` pushes only the trace) and never emit a figure-type state, so `announce` stayed `false` forever and their navigation text was silently gated out of the alert region. Notification/rotor messages take the `message` path, which ignores `announce`, so they kept speaking — hence the divergence.

This is a long-standing gate (present since the alert-region rewrite), but it became conspicuous recently because rotor boundary messages were changed to re-announce on every keypress (a `revision` bump on `notify`), sharpening the contrast against navigation text that never announced at all.

## Related Issues

Fixes the reported regression: "when moving around data points with arrows, terse/verbose text mode doesn't speak to screen reader, but rotor warning text is spoken correctly."

## Changes Made

- **`src/service/text.ts`** — Fire `first_navigation` on the first non-empty navigation update at **any** plot level (figure, subplot, or trace), guarded by `!hasHadFirstNavigation && !state.empty`, placed after the OFF-mode early return and before the layer-switch/subplot branches. Removed the redundant figure-only block. This un-gates announcements on the user's first arrow keypress for single-panel plots; multi-panel behavior is unchanged (its first navigation is still a figure state).
- **`src/state/viewModel/textViewModel.ts`** — Autoplay deliberately suppresses per-point announcements while running. Because autoplay can be the user's very first navigation on a single-panel plot, the view model now tracks whether autoplay is active and lets it keep ownership of the `announce` flag, so `first_navigation` doesn't re-enable announcements underneath a running autoplay. This companion change is load-bearing: without it, the fix would make autoplay-as-first-action flood the screen reader.
- **Tests** — Added `test/service/textFirstNavigation.test.ts` (first navigation fires at trace level, still emits nav text, fires only once, and does **not** fire for out-of-bounds/warning-empty states, in OFF mode, and **does** still fire for a figure-type first navigation) and `test/state/viewModel/textViewModelAnnounce.test.ts` (first navigation enables announcements; is ignored while autoplay is active; resumes on autoplay stop).

## Screenshots (if applicable)

N/A — the change affects screen-reader output, not visual rendering.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verification: full suite green (`npm test` — 65 suites / 810 tests), `tsc --noEmit` clean, and `eslint` clean on all changed files. The `announce` flag is now driven by three coordinated sources — initial-instruction suppression, `first_navigation`, and autoplay — all reconciled in `TextViewModel`; future features touching `announce` should route through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYfo9ibDfc4T9hwKpSHh5R

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYfo9ibDfc4T9hwKpSHh5R)_