### PR TITLE
fix(text): restore edge boundary alert for single-panel navigation

### DIFF
--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -42,7 +42,7 @@ export abstract class TestConstants {
   /**
    * MAIDR plot identifiers
    */
-  static readonly PLOT_EXTREME_VERIFICATION = 'No plot info to display';
+  static readonly PLOT_EXTREME_VERIFICATION = 'No more data to display';
   /**
    * MAIDR component identifiers
    */

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -556,20 +556,17 @@ export class TextService implements Observer<PlotState>, Disposable {
    * @param state - The new plot state to process
    */
   public update(state: PlotState): void {
-    // Pure out-of-bounds events (empty trace state with no `warning` field) are
-    // fired by AbstractTrace.notifyOutOfBounds() when navigation hits a boundary
-    // (far left/right/top/bottom of a trace). The user stays located at the last
-    // valid data point, so we must NOT overwrite `currentState` (used by the AI
-    // chat) below — hence the early return before that bookkeeping.
+    // Out-of-bounds events (empty trace state, no `warning`) are fired by
+    // AbstractTrace.notifyOutOfBounds() when navigation hits a boundary. The
+    // user stays at the last valid data point, so we must NOT overwrite
+    // `currentState` (used by the AI chat) — hence the early return before that
+    // bookkeeping below.
     //
-    // We DO, however, announce a boundary alert so reaching an edge is not
-    // silent. Respect the text mode: OFF stays silent, while TERSE ("No info")
-    // and VERBOSE ("No plot info to display") get mode-appropriate wording from
+    // We still announce a boundary alert so reaching an edge is not silent,
+    // respecting text mode: OFF stays silent, while TERSE ("No info") and
+    // VERBOSE ("No plot info to display") get mode-appropriate wording from
     // format(). Returning early also avoids firing `first_navigation` for an
     // empty state, keeping announce-gating intact.
-    //
-    // (A regression from #557 turned this into a bare `return`, silencing the
-    // edge alert entirely — this restores it without clobbering `currentState`.)
     if (
       state
       && state.empty

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -557,13 +557,14 @@ export class TextService implements Observer<PlotState>, Disposable {
     // bookkeeping below.
     //
     // We still announce a boundary alert so reaching an edge is not silent,
-    // respecting text mode: OFF stays silent, TERSE gets a short "No info" cue,
-    // and VERBOSE reuses format()'s full "No plot info to display". The wording
-    // split is kept LOCAL to this branch so it applies only to edge navigation
-    // — the warning/rotor-bounds path (excluded by `!state.warning`) still flows
-    // through format() and keeps its original, mode-independent wording.
-    // Returning early also avoids firing `first_navigation` for an empty state,
-    // keeping announce-gating intact.
+    // respecting text mode: OFF stays silent, TERSE gets the short "No more
+    // data" cue, and VERBOSE gets "No more data to display". These literals are
+    // LOCAL to this edge branch (not from format()) so the wording applies only
+    // to edge navigation — the warning/rotor-bounds path (excluded by
+    // `!state.warning`) still flows through format() and keeps its original,
+    // mode-independent "No plot info to display" wording. Returning early also
+    // avoids firing `first_navigation` for an empty state, keeping
+    // announce-gating intact.
     if (
       state
       && state.empty
@@ -571,7 +572,7 @@ export class TextService implements Observer<PlotState>, Disposable {
       && !state.warning
     ) {
       if (this.mode !== TextMode.OFF) {
-        const text = this.mode === TextMode.TERSE ? 'No info' : this.format(state);
+        const text = this.mode === TextMode.TERSE ? 'No more data' : 'No more data to display';
         this.onChangeEmitter.fire({ value: text });
       }
       return;

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -226,7 +226,13 @@ export class TextService implements Observer<PlotState>, Disposable {
       if (state.type === 'subplot') {
         return 'No additional layer';
       }
-      return `No ${state.type === 'trace' ? 'plot' : state.type} info to display`;
+      if (state.type === 'trace') {
+        // Boundary / out-of-bounds cue shown when navigation hits a trace edge.
+        // Terse trims the phrasing the same way terse navigation text trims its
+        // scaffolding; verbose keeps the full sentence.
+        return this.mode === TextMode.TERSE ? 'No info' : 'No plot info to display';
+      }
+      return `No ${state.type} info to display`;
     } else if (state.type === 'figure') {
       return this.formatFigureText(state.index, state.size, state.traceTypes);
     } else if (state.type === 'subplot') {
@@ -556,11 +562,11 @@ export class TextService implements Observer<PlotState>, Disposable {
     // valid data point, so we must NOT overwrite `currentState` (used by the AI
     // chat) below — hence the early return before that bookkeeping.
     //
-    // We DO, however, announce a boundary alert ("No plot info to display") so
-    // reaching an edge is not silent. Respect the text mode: OFF stays silent;
-    // TERSE and VERBOSE both surface the placeholder (format() yields the same
-    // string for empty states). Returning early also avoids firing
-    // `first_navigation` for an empty state, keeping announce-gating intact.
+    // We DO, however, announce a boundary alert so reaching an edge is not
+    // silent. Respect the text mode: OFF stays silent, while TERSE ("No info")
+    // and VERBOSE ("No plot info to display") get mode-appropriate wording from
+    // format(). Returning early also avoids firing `first_navigation` for an
+    // empty state, keeping announce-gating intact.
     //
     // (A regression from #557 turned this into a bare `return`, silencing the
     // edge alert entirely — this restores it without clobbering `currentState`.)

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -226,13 +226,7 @@ export class TextService implements Observer<PlotState>, Disposable {
       if (state.type === 'subplot') {
         return 'No additional layer';
       }
-      if (state.type === 'trace') {
-        // Boundary / out-of-bounds cue shown when navigation hits a trace edge.
-        // Terse trims the phrasing the same way terse navigation text trims its
-        // scaffolding; verbose keeps the full sentence.
-        return this.mode === TextMode.TERSE ? 'No info' : 'No plot info to display';
-      }
-      return `No ${state.type} info to display`;
+      return `No ${state.type === 'trace' ? 'plot' : state.type} info to display`;
     } else if (state.type === 'figure') {
       return this.formatFigureText(state.index, state.size, state.traceTypes);
     } else if (state.type === 'subplot') {
@@ -563,10 +557,13 @@ export class TextService implements Observer<PlotState>, Disposable {
     // bookkeeping below.
     //
     // We still announce a boundary alert so reaching an edge is not silent,
-    // respecting text mode: OFF stays silent, while TERSE ("No info") and
-    // VERBOSE ("No plot info to display") get mode-appropriate wording from
-    // format(). Returning early also avoids firing `first_navigation` for an
-    // empty state, keeping announce-gating intact.
+    // respecting text mode: OFF stays silent, TERSE gets a short "No info" cue,
+    // and VERBOSE reuses format()'s full "No plot info to display". The wording
+    // split is kept LOCAL to this branch so it applies only to edge navigation
+    // — the warning/rotor-bounds path (excluded by `!state.warning`) still flows
+    // through format() and keeps its original, mode-independent wording.
+    // Returning early also avoids firing `first_navigation` for an empty state,
+    // keeping announce-gating intact.
     if (
       state
       && state.empty
@@ -574,10 +571,8 @@ export class TextService implements Observer<PlotState>, Disposable {
       && !state.warning
     ) {
       if (this.mode !== TextMode.OFF) {
-        const text = this.format(state);
-        if (text) {
-          this.onChangeEmitter.fire({ value: text });
-        }
+        const text = this.mode === TextMode.TERSE ? 'No info' : this.format(state);
+        this.onChangeEmitter.fire({ value: text });
       }
       return;
     }

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -551,16 +551,31 @@ export class TextService implements Observer<PlotState>, Disposable {
    */
   public update(state: PlotState): void {
     // Pure out-of-bounds events (empty trace state with no `warning` field) are
-    // fired by AbstractTrace.notifyOutOfBounds() when navigation hits a boundary.
-    // These should NOT overwrite the previously-shown valid text or emit a
-    // "No plot info to display" placeholder, since the user is still located at
-    // the last valid data point. Preserve last valid text by returning early.
+    // fired by AbstractTrace.notifyOutOfBounds() when navigation hits a boundary
+    // (far left/right/top/bottom of a trace). The user stays located at the last
+    // valid data point, so we must NOT overwrite `currentState` (used by the AI
+    // chat) below — hence the early return before that bookkeeping.
+    //
+    // We DO, however, announce a boundary alert ("No plot info to display") so
+    // reaching an edge is not silent. Respect the text mode: OFF stays silent;
+    // TERSE and VERBOSE both surface the placeholder (format() yields the same
+    // string for empty states). Returning early also avoids firing
+    // `first_navigation` for an empty state, keeping announce-gating intact.
+    //
+    // (A regression from #557 turned this into a bare `return`, silencing the
+    // edge alert entirely — this restores it without clobbering `currentState`.)
     if (
       state
       && state.empty
       && state.type === 'trace'
       && !state.warning
     ) {
+      if (this.mode !== TextMode.OFF) {
+        const text = this.format(state);
+        if (text) {
+          this.onChangeEmitter.fire({ value: text });
+        }
+      }
       return;
     }
 

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -74,6 +74,23 @@ function createOutOfBoundsState(): TraceState {
   };
 }
 
+/**
+ * Builds the warning/rotor-bounds trace state that AbstractTrace.notifyRotorBounds()
+ * pushes at a rotor/section boundary: an empty trace state WITH `warning: true`.
+ * Distinct from a pure out-of-bounds edge event, and deliberately excluded from
+ * the edge-alert branch's terse/verbose wording split.
+ * @returns A warning trace-type PlotState.
+ */
+function createWarningState(): TraceState {
+  return {
+    empty: true,
+    type: 'trace',
+    traceType: TraceType.BAR,
+    audio: { y: 0, x: 0, rows: 0, cols: 0 },
+    warning: true,
+  };
+}
+
 describe('textService first-navigation announcement gate', () => {
   test('fires first_navigation on the first trace-level navigation', () => {
     const text = new TextService(createMockNotificationService());
@@ -129,14 +146,7 @@ describe('textService first-navigation announcement gate', () => {
 
     // Warning empties bypass the top-of-method out-of-bounds early return, so
     // the `!state.empty` guard is what keeps them from un-gating announcements.
-    const warningState: TraceState = {
-      empty: true,
-      type: 'trace',
-      traceType: TraceType.BAR,
-      audio: { y: 0, x: 0, rows: 0, cols: 0 },
-      warning: true,
-    };
-    text.update(warningState);
+    text.update(createWarningState());
 
     expect(listener).not.toHaveBeenCalled();
   });
@@ -236,6 +246,23 @@ describe('textService out-of-bounds edge alert', () => {
     // Terse gets its own shorter wording, distinct from verbose.
     expect(changeListener).toHaveBeenCalledTimes(1);
     expect(changeListener).toHaveBeenCalledWith({ value: 'No info' });
+  });
+
+  test('keeps the warning/rotor-bounds wording mode-independent in terse mode', () => {
+    // The terse "No info" split is scoped to the pure out-of-bounds edge path.
+    // Warning states (rotor/section bounds) are excluded by `!state.warning` and
+    // flow through format() unchanged, so they must NOT become "No info" in
+    // terse mode — that feature is out of this fix's scope.
+    const text = new TextService(createMockNotificationService());
+    text.toggle(); // VERBOSE -> TERSE
+    expect(text.isTerse()).toBe(true);
+
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(createWarningState());
+
+    expect(changeListener).toHaveBeenCalledWith({ value: 'No plot info to display' });
   });
 
   test('stays silent on out-of-bounds while text mode is off', () => {

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -215,12 +215,12 @@ describe('textService first-navigation announcement gate', () => {
  * Regression coverage for the "no text alert at plot edges" bug. A guard added
  * in #557 turned the out-of-bounds branch of TextService.update() into a bare
  * `return`, silently swallowing the boundary alert. These tests lock in that
- * the alert is emitted again with mode-appropriate wording (verbose: "No plot
- * info to display"; terse: "No info"; off: silent) while `currentState` (used
- * by the AI chat) is still preserved.
+ * the alert is emitted again with mode-appropriate wording (verbose: "No more
+ * data to display"; terse: "No more data"; off: silent) while `currentState`
+ * (used by the AI chat) is still preserved.
  */
 describe('textService out-of-bounds edge alert', () => {
-  test('emits "No plot info to display" on out-of-bounds in verbose mode', () => {
+  test('emits "No more data to display" on out-of-bounds in verbose mode', () => {
     const text = new TextService(createMockNotificationService());
     expect(text.isVerbose()).toBe(true); // default mode
 
@@ -230,10 +230,10 @@ describe('textService out-of-bounds edge alert', () => {
     text.update(createOutOfBoundsState());
 
     expect(changeListener).toHaveBeenCalledTimes(1);
-    expect(changeListener).toHaveBeenCalledWith({ value: 'No plot info to display' });
+    expect(changeListener).toHaveBeenCalledWith({ value: 'No more data to display' });
   });
 
-  test('emits the terser "No info" on out-of-bounds in terse mode', () => {
+  test('emits the terser "No more data" on out-of-bounds in terse mode', () => {
     const text = new TextService(createMockNotificationService());
     text.toggle(); // VERBOSE -> TERSE
     expect(text.isTerse()).toBe(true);
@@ -245,14 +245,15 @@ describe('textService out-of-bounds edge alert', () => {
 
     // Terse gets its own shorter wording, distinct from verbose.
     expect(changeListener).toHaveBeenCalledTimes(1);
-    expect(changeListener).toHaveBeenCalledWith({ value: 'No info' });
+    expect(changeListener).toHaveBeenCalledWith({ value: 'No more data' });
   });
 
   test('keeps the warning/rotor-bounds wording mode-independent in terse mode', () => {
-    // The terse "No info" split is scoped to the pure out-of-bounds edge path.
-    // Warning states (rotor/section bounds) are excluded by `!state.warning` and
-    // flow through format() unchanged, so they must NOT become "No info" in
-    // terse mode — that feature is out of this fix's scope.
+    // The terse/verbose edge wording ("No more data" / "No more data to
+    // display") is scoped to the pure out-of-bounds edge path. Warning states
+    // (rotor/section bounds) are excluded by `!state.warning` and flow through
+    // format() unchanged, so they must keep the original "No plot info to
+    // display" in both modes — that path is out of this fix's scope.
     const text = new TextService(createMockNotificationService());
     text.toggle(); // VERBOSE -> TERSE
     expect(text.isTerse()).toBe(true);
@@ -290,8 +291,8 @@ describe('textService out-of-bounds edge alert', () => {
     text.update(createOutOfBoundsState());
 
     expect(changeListener).toHaveBeenCalledTimes(2);
-    expect(changeListener).toHaveBeenNthCalledWith(1, { value: 'No plot info to display' });
-    expect(changeListener).toHaveBeenNthCalledWith(2, { value: 'No plot info to display' });
+    expect(changeListener).toHaveBeenNthCalledWith(1, { value: 'No more data to display' });
+    expect(changeListener).toHaveBeenNthCalledWith(2, { value: 'No more data to display' });
   });
 
   test('preserves the last valid currentState (AI chat position) on out-of-bounds', () => {

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -157,6 +157,26 @@ describe('textService first-navigation announcement gate', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  test('flips the gate on the first key press even in a boundary direction', () => {
+    // Refutes the "first interaction is out-of-bounds -> silent" concern: the
+    // model's initial-entry guard (MovableGrid/MovableGraph/LineTrace moveOnce)
+    // makes the FIRST move succeed with a non-empty state regardless of
+    // direction, so first_navigation fires and announcements un-gate. A genuine
+    // boundary (empty) event can therefore only occur after >=1 successful move,
+    // by which point `announce` is already true.
+    const trace = new BarTrace(createBarLayer()); // single row of bars
+    const text = new TextService(createMockNotificationService());
+    const listener = jest.fn();
+    text.onNavigation(listener);
+    trace.addObserver(text);
+
+    // UPWARD is a boundary direction for a single-row bar plot, yet the very
+    // first press lands on a valid point via handleInitialEntry (non-empty).
+    trace.moveOnce('UPWARD');
+
+    expect(listener).toHaveBeenCalledWith({ type: 'first_navigation' });
+  });
+
   test('still fires first_navigation for a figure-type first navigation', () => {
     const text = new TextService(createMockNotificationService());
     const listener = jest.fn();

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -59,6 +59,21 @@ function createTraceState(): TraceState {
   return state;
 }
 
+/**
+ * Builds the pure out-of-bounds trace state that AbstractTrace.notifyOutOfBounds()
+ * pushes when arrow navigation hits an edge (far left/right/top/bottom): an empty
+ * trace state with no `warning` field.
+ * @returns An out-of-bounds trace-type PlotState.
+ */
+function createOutOfBoundsState(): TraceState {
+  return {
+    empty: true,
+    type: 'trace',
+    traceType: TraceType.BAR,
+    audio: { y: 0, x: 0, rows: 0, cols: 0 },
+  };
+}
+
 describe('textService first-navigation announcement gate', () => {
   test('fires first_navigation on the first trace-level navigation', () => {
     const text = new TextService(createMockNotificationService());
@@ -102,13 +117,7 @@ describe('textService first-navigation announcement gate', () => {
     text.onNavigation(listener);
 
     // Pure out-of-bounds events are empty trace states with no `warning`.
-    const emptyState: TraceState = {
-      empty: true,
-      type: 'trace',
-      traceType: TraceType.BAR,
-      audio: { y: 0, x: 0, rows: 0, cols: 0 },
-    };
-    text.update(emptyState);
+    text.update(createOutOfBoundsState());
 
     expect(listener).not.toHaveBeenCalled();
   });
@@ -169,5 +178,86 @@ describe('textService first-navigation announcement gate', () => {
 
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith({ type: 'first_navigation' });
+  });
+});
+
+/**
+ * Regression coverage for the "no text alert at plot edges" bug. A guard added
+ * in #557 turned the out-of-bounds branch of TextService.update() into a bare
+ * `return`, silently swallowing the "No plot info to display" boundary alert.
+ * These tests lock in that the alert is emitted again (respecting text mode)
+ * while `currentState` (used by the AI chat) is still preserved.
+ */
+describe('textService out-of-bounds edge alert', () => {
+  test('emits "No plot info to display" on out-of-bounds in verbose mode', () => {
+    const text = new TextService(createMockNotificationService());
+    expect(text.isVerbose()).toBe(true); // default mode
+
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(createOutOfBoundsState());
+
+    expect(changeListener).toHaveBeenCalledTimes(1);
+    expect(changeListener).toHaveBeenCalledWith({ value: 'No plot info to display' });
+  });
+
+  test('emits "No plot info to display" on out-of-bounds in terse mode', () => {
+    const text = new TextService(createMockNotificationService());
+    text.toggle(); // VERBOSE -> TERSE
+    expect(text.isTerse()).toBe(true);
+
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(createOutOfBoundsState());
+
+    // Terse and verbose share the same placeholder for empty states.
+    expect(changeListener).toHaveBeenCalledTimes(1);
+    expect(changeListener).toHaveBeenCalledWith({ value: 'No plot info to display' });
+  });
+
+  test('stays silent on out-of-bounds while text mode is off', () => {
+    const text = new TextService(createMockNotificationService());
+    text.toggle(); // VERBOSE -> TERSE
+    text.toggle(); // TERSE -> OFF
+    expect(text.isOff()).toBe(true);
+
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(createOutOfBoundsState());
+
+    expect(changeListener).not.toHaveBeenCalled();
+  });
+
+  test('re-emits the boundary alert on repeated edge presses', () => {
+    const text = new TextService(createMockNotificationService());
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    // Holding a direction key against an edge fires the out-of-bounds state
+    // repeatedly; each must re-emit so the alert region re-announces.
+    text.update(createOutOfBoundsState());
+    text.update(createOutOfBoundsState());
+
+    expect(changeListener).toHaveBeenCalledTimes(2);
+    expect(changeListener).toHaveBeenNthCalledWith(1, { value: 'No plot info to display' });
+    expect(changeListener).toHaveBeenNthCalledWith(2, { value: 'No plot info to display' });
+  });
+
+  test('preserves the last valid currentState (AI chat position) on out-of-bounds', () => {
+    const text = new TextService(createMockNotificationService());
+
+    // Navigate to a real point, then hit an edge.
+    text.update(createTraceState());
+    const coordinateAtPoint = text.getCoordinateText();
+    expect(coordinateAtPoint).not.toBeNull();
+
+    text.update(createOutOfBoundsState());
+
+    // The out-of-bounds event must NOT overwrite currentState, so the AI chat
+    // still reports the user's last valid coordinate rather than null.
+    expect(text.getCoordinateText()).toBe(coordinateAtPoint);
   });
 });

--- a/test/service/textFirstNavigation.test.ts
+++ b/test/service/textFirstNavigation.test.ts
@@ -184,9 +184,10 @@ describe('textService first-navigation announcement gate', () => {
 /**
  * Regression coverage for the "no text alert at plot edges" bug. A guard added
  * in #557 turned the out-of-bounds branch of TextService.update() into a bare
- * `return`, silently swallowing the "No plot info to display" boundary alert.
- * These tests lock in that the alert is emitted again (respecting text mode)
- * while `currentState` (used by the AI chat) is still preserved.
+ * `return`, silently swallowing the boundary alert. These tests lock in that
+ * the alert is emitted again with mode-appropriate wording (verbose: "No plot
+ * info to display"; terse: "No info"; off: silent) while `currentState` (used
+ * by the AI chat) is still preserved.
  */
 describe('textService out-of-bounds edge alert', () => {
   test('emits "No plot info to display" on out-of-bounds in verbose mode', () => {
@@ -202,7 +203,7 @@ describe('textService out-of-bounds edge alert', () => {
     expect(changeListener).toHaveBeenCalledWith({ value: 'No plot info to display' });
   });
 
-  test('emits "No plot info to display" on out-of-bounds in terse mode', () => {
+  test('emits the terser "No info" on out-of-bounds in terse mode', () => {
     const text = new TextService(createMockNotificationService());
     text.toggle(); // VERBOSE -> TERSE
     expect(text.isTerse()).toBe(true);
@@ -212,9 +213,9 @@ describe('textService out-of-bounds edge alert', () => {
 
     text.update(createOutOfBoundsState());
 
-    // Terse and verbose share the same placeholder for empty states.
+    // Terse gets its own shorter wording, distinct from verbose.
     expect(changeListener).toHaveBeenCalledTimes(1);
-    expect(changeListener).toHaveBeenCalledWith({ value: 'No plot info to display' });
+    expect(changeListener).toHaveBeenCalledWith({ value: 'No info' });
   });
 
   test('stays silent on out-of-bounds while text mode is off', () => {


### PR DESCRIPTION
## Description

Navigating to a trace **edge** (far left / far right / far top / far bottom) within a MAIDR single panel produced **no text alert**. It previously announced something like _"No plot info to display"_ — this was a silent regression.

**Root cause.** When a move fails at a boundary, `AbstractTrace.notifyOutOfBounds()` (`src/model/abstract.ts`) pushes an out-of-bounds trace state: `{ empty: true, type: 'trace', … }` with **no `warning` field**. A guard added to `TextService.update()` in #557 (the AnyChart adapter PR) turned that branch into a bare `return`, short-circuiting **before** `format()` / `onChangeEmitter.fire()`. So the boundary alert never reached the info/alert region. This is most visible in single-panel plots, whose navigation is entirely trace-level (subplot- and figure-level edges were never affected, since the guard is scoped to `type === 'trace'`).

**Fix.** Restore the alert while keeping the guard's intent, with **mode-appropriate wording** (the maintainer asked for terse ≠ verbose):

| Text mode | Behavior at edge |
|-----------|------------------|
| OFF       | silent (no announcement) |
| TERSE     | **"No more data"** |
| VERBOSE   | **"No more data to display"** |

Both modes use data-oriented phrasing and signal the boundary ("no more …") explicitly. The terse/verbose strings are kept **local to the out-of-bounds branch**, so they apply only to edge navigation — the rotor/section-bounds path (`warning: true`, excluded by `!state.warning`) keeps its original mode-independent `"No plot info to display"` via `format()`.

The out-of-bounds branch still `return`s **before** the `currentState` bookkeeping (so the AI chat keeps the user's last valid position) and **before** the `first_navigation` gate (so screen-reader announce-gating is unaffected).

This is a deliberate **hybrid, not a pure revert**: pre-#557 also overwrote `currentState` with the empty state; we intentionally preserve it, which is strictly better for the AI chat's "current position".

## Related Issues

Regression introduced in #557 (the out-of-bounds edge alert was silently swallowed).

## Changes Made

- **`src/service/text.ts`**
  - In the out-of-bounds guard of `update()`, emit the boundary alert via `onChangeEmitter` when text mode is not OFF, before returning. The terse/verbose strings (`"No more data"` / `"No more data to display"`) are literals **local to this branch**, so the wording is scoped to edge navigation only.
  - `format()` is left unchanged, so the rotor/section-bounds message (a `warning: true` empty trace state routed through the same `format()` call) keeps its original `"No plot info to display"` in both modes.
  - No model or ViewModel changes needed — every trace type funnels through the same out-of-bounds state shape, so the alert is restored uniformly (bar, line, scatter, heatmap, histogram, boxplot, candlestick, violin, segmented, …).
- **`e2e_tests/utils/constants.ts`** — updated `PLOT_EXTREME_VERIFICATION` to `"No more data to display"` (asserted in the default/verbose mode across the plot specs, which all reference the constant).
- **`test/service/textFirstNavigation.test.ts`** — regression coverage: out-of-bounds emission in VERBOSE (`"No more data to display"`) and TERSE (`"No more data"`), silence in OFF, re-announcement on repeated edge presses, `currentState` preservation, a model-level proof that the first key press un-gates announcements even in a boundary direction, and a scoping test that the rotor-bounds/warning path stays `"No plot info to display"` in both modes.

## Screenshots (if applicable)

N/A — screen-reader / text-alert behavior; verified via unit tests and the e2e extreme-navigation specs.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass (`npm run type-check`, targeted Jest suites, `npm run build`, ESLint — all green).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable (no doc changes needed).
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- **Verification:** `npm run type-check` clean; `test/service` + `test/state` → 198 passed; `npm run build` succeeds; ESLint clean.
- **Wording:** terse `"No more data"` / verbose `"No more data to display"` per maintainer preference; both use data-oriented phrasing.
- **Announce-gating (deliberate):** the boundary alert follows the same `announce` gating as normal navigation text — always shown visually, announced to screen readers only when `announce` is `true`. It's unreachable as a *first* interaction (the initial-entry guard makes the first move succeed, un-gating announcements; covered by a test), and during autoplay the boundary text stays visually present but unannounced, consistent with per-point nav text under `announce: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6gyjDvAqC2TUpvrds69dU