### PR TITLE
feat(candlestick): rework delta layer with Ctrl+L toggle, OHLC nav, and directional sonification

### DIFF
--- a/src/command/candlestickDelta.ts
+++ b/src/command/candlestickDelta.ts
@@ -3,7 +3,7 @@ import type { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDelt
 import type { Command } from './command';
 
 /**
- * Command bound to Ctrl+L: toggles the virtual candlestick delta layer on or
+ * Command bound to Alt+L: toggles the virtual candlestick delta layer on or
  * off using the remembered reference line. With no reference chosen yet it
  * warns and opens the reference picker.
  */

--- a/src/command/candlestickDelta.ts
+++ b/src/command/candlestickDelta.ts
@@ -3,25 +3,87 @@ import type { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDelt
 import type { Command } from './command';
 
 /**
- * Command bound to F7: opens (or closes) the candlestick reference
- * comparison dialog where the user picks a reference line and OHLC field.
+ * Command bound to Ctrl+L: toggles the virtual candlestick delta layer on or
+ * off using the remembered reference line. With no reference chosen yet it
+ * warns and opens the reference picker.
  */
-export class ToggleCandlestickDeltaCommand implements Command {
+export class ToggleCandlestickDeltaLayerCommand implements Command {
   private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
 
-  /**
-   * Creates an instance of ToggleCandlestickDeltaCommand.
-   * @param {CandlestickDeltaViewModel} candlestickDeltaViewModel - The candlestick delta view model.
-   */
   public constructor(candlestickDeltaViewModel: CandlestickDeltaViewModel) {
     this.candlestickDeltaViewModel = candlestickDeltaViewModel;
   }
 
-  /**
-   * Toggles the candlestick delta settings dialog.
-   */
   public execute(): void {
-    this.candlestickDeltaViewModel.toggle();
+    this.candlestickDeltaViewModel.toggleLayer();
+  }
+}
+
+/**
+ * Command bound to Ctrl+Shift+L: opens the reference picker so the user can
+ * choose (or change) the moving-average line to compare against.
+ */
+export class SelectCandlestickDeltaReferenceCommand implements Command {
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
+
+  public constructor(candlestickDeltaViewModel: CandlestickDeltaViewModel) {
+    this.candlestickDeltaViewModel = candlestickDeltaViewModel;
+  }
+
+  public execute(): void {
+    this.candlestickDeltaViewModel.openReferencePicker();
+  }
+}
+
+/** Moves the reference-picker selection up one option. */
+export class CandlestickDeltaRefMoveUpCommand implements Command {
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
+
+  public constructor(candlestickDeltaViewModel: CandlestickDeltaViewModel) {
+    this.candlestickDeltaViewModel = candlestickDeltaViewModel;
+  }
+
+  public execute(): void {
+    this.candlestickDeltaViewModel.moveSelectionUp();
+  }
+}
+
+/** Moves the reference-picker selection down one option. */
+export class CandlestickDeltaRefMoveDownCommand implements Command {
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
+
+  public constructor(candlestickDeltaViewModel: CandlestickDeltaViewModel) {
+    this.candlestickDeltaViewModel = candlestickDeltaViewModel;
+  }
+
+  public execute(): void {
+    this.candlestickDeltaViewModel.moveSelectionDown();
+  }
+}
+
+/** Confirms the highlighted reference line and activates the comparison. */
+export class CandlestickDeltaRefSelectCommand implements Command {
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
+
+  public constructor(candlestickDeltaViewModel: CandlestickDeltaViewModel) {
+    this.candlestickDeltaViewModel = candlestickDeltaViewModel;
+  }
+
+  public execute(): void {
+    this.candlestickDeltaViewModel.confirmSelection();
+  }
+}
+
+/** Closes the reference picker without changing the remembered reference. */
+export class CandlestickDeltaRefCloseCommand implements Command {
+  private readonly candlestickDeltaViewModel: CandlestickDeltaViewModel;
+
+  public constructor(candlestickDeltaViewModel: CandlestickDeltaViewModel) {
+    this.candlestickDeltaViewModel = candlestickDeltaViewModel;
+  }
+
+  public execute(): void {
+    this.candlestickDeltaViewModel.cancel();
   }
 }
 
@@ -32,17 +94,10 @@ export class ToggleCandlestickDeltaCommand implements Command {
 export class ExitCandlestickDeltaCommand implements Command {
   private readonly candlestickDeltaService: CandlestickDeltaService;
 
-  /**
-   * Creates an instance of ExitCandlestickDeltaCommand.
-   * @param {CandlestickDeltaService} candlestickDeltaService - The candlestick delta service.
-   */
   public constructor(candlestickDeltaService: CandlestickDeltaService) {
     this.candlestickDeltaService = candlestickDeltaService;
   }
 
-  /**
-   * Deactivates the virtual delta layer.
-   */
   public execute(): void {
     this.candlestickDeltaService.deactivate();
   }

--- a/src/command/factory.ts
+++ b/src/command/factory.ts
@@ -35,8 +35,13 @@ import {
   StopAutoplayCommand,
 } from './autoplay';
 import {
+  CandlestickDeltaRefCloseCommand,
+  CandlestickDeltaRefMoveDownCommand,
+  CandlestickDeltaRefMoveUpCommand,
+  CandlestickDeltaRefSelectCommand,
   ExitCandlestickDeltaCommand,
-  ToggleCandlestickDeltaCommand,
+  SelectCandlestickDeltaReferenceCommand,
+  ToggleCandlestickDeltaLayerCommand,
 } from './candlestickDelta';
 import {
   AnnounceCaptionCommand,
@@ -248,8 +253,18 @@ export class CommandFactory {
         return new ToggleDescriptionCommand(this.descriptionViewModel);
       case 'TOGGLE_SETTINGS':
         return new ToggleSettingsCommand(this.settingsViewModel);
-      case 'TOGGLE_CANDLESTICK_DELTA':
-        return new ToggleCandlestickDeltaCommand(this.candlestickDeltaViewModel);
+      case 'TOGGLE_CANDLESTICK_DELTA_LAYER':
+        return new ToggleCandlestickDeltaLayerCommand(this.candlestickDeltaViewModel);
+      case 'SELECT_CANDLESTICK_DELTA_REFERENCE':
+        return new SelectCandlestickDeltaReferenceCommand(this.candlestickDeltaViewModel);
+      case 'CANDLESTICK_DELTA_REF_MOVE_UP':
+        return new CandlestickDeltaRefMoveUpCommand(this.candlestickDeltaViewModel);
+      case 'CANDLESTICK_DELTA_REF_MOVE_DOWN':
+        return new CandlestickDeltaRefMoveDownCommand(this.candlestickDeltaViewModel);
+      case 'CANDLESTICK_DELTA_REF_SELECT':
+        return new CandlestickDeltaRefSelectCommand(this.candlestickDeltaViewModel);
+      case 'CANDLESTICK_DELTA_REF_CLOSE':
+        return new CandlestickDeltaRefCloseCommand(this.candlestickDeltaViewModel);
       case 'EXIT_CANDLESTICK_DELTA':
         return new ExitCandlestickDeltaCommand(this.candlestickDeltaService);
 

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -162,9 +162,10 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   private readonly deltaGrid: number[][];
   /** Largest |delta| across every field — audio's shared pitch ceiling. */
   private readonly maxAbsDelta: number;
-  /** True when any field of any candle lands exactly on the line. */
-  private readonly hasOnLinePoint: boolean;
-  private readonly onLineUnits: readonly RotorFilterUnit[];
+  /** Cached on-line rotor unit, exposed only for fields that have a zero. */
+  private readonly onLineUnits: readonly RotorFilterUnit[] = [
+    { key: ON_LINE_KEY, label: ON_LINE_MODE, noun: 'point on the line' },
+  ];
 
   private currentPointIndex = 0;
   private currentField: CandlestickDeltaField;
@@ -215,13 +216,6 @@ export class CandlestickDeltaTrace extends AbstractTrace {
       (max, field) => Math.max(max, this.brailleMaxByField[field][0]),
       0,
     );
-    this.hasOnLinePoint = CANDLESTICK_DELTA_FIELDS.some(field =>
-      this.deltaByField[field].includes(0),
-    );
-    this.onLineUnits = this.hasOnLinePoint
-      ? [{ key: ON_LINE_KEY, label: ON_LINE_MODE, noun: 'point on the line' }]
-      : [];
-
     this.sortedFieldsByPoint = this.candles.map((candle) => {
       // Sort by the candle's price so up/down matches the candle geometry
       // (low at the bottom, high at the top); a stable tiebreak keeps the
@@ -407,14 +401,15 @@ export class CandlestickDeltaTrace extends AbstractTrace {
       this.notifyOutOfBounds();
       return false;
     }
-    const navOrder = this.sortedFieldsByPoint[col];
-    if (row < 0 || row >= navOrder.length) {
-      this.notifyOutOfBounds();
-      return false;
-    }
+    // Braille flattens the four OHLC fields into a single row for the current
+    // field (see the braille getter — always row 0), so an incoming `row`
+    // carries no field information. This is the layer's only index-navigation
+    // source (it has no SVG geometry to hover), so preserve the compared field
+    // and move along the candle axis only — matching how Left/Right (moveOnce)
+    // behaves, rather than silently snapping to the candle's lowest field.
+    void row;
     this.isInitialEntry = false;
     this.currentPointIndex = col;
-    this.currentField = navOrder[row];
     this.updateVisualPosition();
     this.notifyStateUpdate();
     return true;
@@ -658,14 +653,19 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   }
 
   /**
-   * Exposes the "on line" rotor filter unit when at least one point lands
-   * exactly on the reference line. Appended after the above/below compare
-   * units so cycling the rotor offers: delta point (default), below line,
-   * above line, and — when present — on line.
-   * @returns The on-line filter unit, or an empty list
+   * Exposes the "on line" rotor filter unit when the CURRENT field has a
+   * point exactly on the reference line. Gating on the current field (rather
+   * than any field) keeps availability aligned with navigation, which only
+   * ever searches the current field — so the unit is never a dead end. The
+   * rotor service re-queries this every keystroke, so the unit appears and
+   * disappears as the user moves between fields. Appended after the
+   * above/below compare units in the rotor cycle.
+   * @returns The on-line filter unit when reachable, or an empty list
    */
   public override getRotorFilterUnits(): readonly RotorFilterUnit[] {
-    return this.onLineUnits;
+    return this.deltaByField[this.currentField].includes(0)
+      ? this.onLineUnits
+      : [];
   }
 
   /**

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -162,7 +162,7 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   private readonly deltaGrid: number[][];
   /** Largest |delta| across every field — audio's shared pitch ceiling. */
   private readonly maxAbsDelta: number;
-  /** Cached on-line rotor unit, exposed only for fields that have a zero. */
+  /** Cached on-line rotor unit; always offered (see getRotorFilterUnits). */
   private readonly onLineUnits: readonly RotorFilterUnit[] = [
     { key: ON_LINE_KEY, label: ON_LINE_MODE, noun: 'point on the line' },
   ];
@@ -660,19 +660,19 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   }
 
   /**
-   * Exposes the "on line" rotor filter unit when the CURRENT field has a
-   * point exactly on the reference line. Gating on the current field (rather
-   * than any field) keeps availability aligned with navigation, which only
-   * ever searches the current field — so the unit is never a dead end. The
-   * rotor service re-queries this every keystroke, so the unit appears and
-   * disappears as the user moves between fields. Appended after the
-   * above/below compare units in the rotor cycle.
-   * @returns The on-line filter unit when reachable, or an empty list
+   * Always exposes the "on line" rotor filter unit, completing the fixed
+   * above-line / on-line / below-line trichotomy alongside the two compare
+   * units. It is intentionally NOT gated on a zero being present: gating on
+   * the current field made the unit flicker in and out as the user moved
+   * between OHLC fields, and gating on any field would silently hide the
+   * category for the (common) real-world case where no candle sits exactly on
+   * a moving average. A present-but-empty unit announces "no point on the
+   * line", which is the honest, predictable result — mirroring how the
+   * above/below compare units are always offered even when empty.
+   * @returns The on-line filter unit
    */
   public override getRotorFilterUnits(): readonly RotorFilterUnit[] {
-    return this.deltaByField[this.currentField].includes(0)
-      ? this.onLineUnits
-      : [];
+    return this.onLineUnits;
   }
 
   /**

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -631,6 +631,13 @@ export class CandlestickDeltaTrace extends AbstractTrace {
       return false;
     }
 
+    // Establish the entry position on the first move so a compare jump made as
+    // the very first action starts from a settled cursor, mirroring
+    // Candlestick.moveToRotorFilter / moveOnce / moveToExtreme.
+    if (this.isInitialEntry) {
+      this.handleInitialEntry();
+    }
+
     const deltas = this.deltaByField[this.currentField];
     const step = direction === 'right' ? 1 : -1;
     for (
@@ -684,6 +691,12 @@ export class CandlestickDeltaTrace extends AbstractTrace {
     if (key !== ON_LINE_KEY) {
       this.notifyRotorBounds();
       return false;
+    }
+
+    // Settle the cursor if this filter jump is the user's first action, so the
+    // search starts from the entry candle (mirrors Candlestick.moveToRotorFilter).
+    if (this.isInitialEntry) {
+      this.handleInitialEntry();
     }
 
     const deltas = this.deltaByField[this.currentField];

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -1,14 +1,15 @@
 import type { ExtremaTarget } from '@type/extrema';
 import type { CandlestickTrend, MaidrLayer } from '@type/grammar';
-import type { Movable } from '@type/movable';
+import type { Movable, MovableDirection } from '@type/movable';
 import type { XValue } from '@type/navigation';
 import type {
   AudioState,
   BrailleState,
   DescriptionState,
   TextState,
+  TraceState,
 } from '@type/state';
-import type { CompareModeInfo, Dimension, NearestPoint } from './abstract';
+import type { CompareModeInfo, Dimension, NearestPoint, RotorFilterUnit } from './abstract';
 import { AbstractTrace } from './abstract';
 import { MovableGrid } from './movable';
 
@@ -26,35 +27,41 @@ export const CANDLESTICK_DELTA_FIELDS: readonly CandlestickDeltaField[] = [
 export const ABOVE_LINE_MODE = 'ABOVE LINE NAVIGATION';
 /** Rotor unit for browsing only the points below the reference line. */
 export const BELOW_LINE_MODE = 'BELOW LINE NAVIGATION';
+/** Rotor unit for jumping between points exactly on the reference line. */
+export const ON_LINE_MODE = 'ON LINE NAVIGATION';
 /** Default rotor unit for the delta layer. */
 export const DELTA_POINT_MODE = 'DELTA POINT NAVIGATION';
+
+/** Stable {@link RotorFilterUnit.key} for the on-line filter. */
+const ON_LINE_KEY = 'onLine';
 
 const ABOVE_LINE = 'above line';
 const BELOW_LINE = 'below line';
 const ON_LINE = 'on line';
 
 /**
- * One point of the virtual delta layer: a candlestick OHLC value matched by
- * x value against a reference line point, with their signed difference.
+ * One matched candle of the virtual delta layer: the shared x value, the
+ * reference line value at x, and the candle's four OHLC values. Signed deltas
+ * (`fieldValue - reference`) are derived per field inside the trace so the
+ * user can navigate open/high/low/close and have the delta recomputed.
  */
-export interface CandlestickDeltaPoint {
+export interface CandlestickDeltaCandle {
   /** Shared x value (e.g., date) present in both the candles and the line. */
   x: string;
-  /** The chosen OHLC value at x. */
-  fieldValue: number;
   /** The reference line value at x. */
   reference: number;
-  /** fieldValue - reference, rounded to suppress float noise. */
-  delta: number;
-  /** 'Bull' above the line, 'Bear' below, 'Neutral' exactly on it. */
-  trend: CandlestickTrend;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
 }
 
-/** Configuration captured when the user confirms the F7 dialog. */
+/** Configuration captured when the delta layer is activated. */
 export interface CandlestickDeltaConfig {
-  points: CandlestickDeltaPoint[];
-  field: CandlestickDeltaField;
+  candles: CandlestickDeltaCandle[];
   referenceLabel: string;
+  /** OHLC field the cursor lands on when the layer activates (default close). */
+  initialField?: CandlestickDeltaField;
 }
 
 /**
@@ -100,18 +107,32 @@ export function deltaTrend(delta: number): CandlestickTrend {
 }
 
 /**
- * Virtual (invisible) trace comparing one OHLC field of a candlestick chart
- * against a reference line (e.g. a moving average) from the same subplot.
+ * Signed delta between a candle's field value and the reference at the same x,
+ * with float noise suppressed relative to the operand magnitude.
+ */
+function fieldDelta(fieldValue: number, reference: number): number {
+  return roundDelta(
+    fieldValue - reference,
+    Math.max(Math.abs(fieldValue), Math.abs(reference)),
+  );
+}
+
+/**
+ * Virtual (invisible) trace comparing a candlestick chart against a reference
+ * line (e.g. a moving average) from the same subplot.
  *
- * Each point is `field value - reference value` at a shared x value, exposed
- * through the standard BTS pipeline:
- * - Audio: pitch encodes |delta|, stereo pan encodes x, and the bull/bear
- *   candlestick timbres encode direction; an exact zero plays a click.
- * - Braille: candlestick-style height encoding of |delta| where below-line
- *   points carry the bearish dot-8 marker.
+ * Like a real candlestick, the user navigates left/right between candles and
+ * up/down between the four OHLC fields (value-sorted per candle, matching the
+ * candle's visual geometry). Each point exposes the signed delta
+ * `fieldValue - reference` through the standard BTS pipeline:
+ * - Audio: pitch encodes |delta|; the tone glides up for above-line points and
+ *   down for below-line points; an exact zero plays a percussive click.
+ * - Braille: candlestick-style height encoding of |delta| for the current
+ *   field where below-line points carry the bearish dot-8 marker.
  * - Text: "above line" / "below line" / "on line" with the delta magnitude.
  *
- * The layer has no SVG geometry of its own, so it never highlights.
+ * The layer has no SVG geometry of its own, so it never highlights, and it
+ * deliberately omits the volatility section a real candlestick exposes.
  */
 export class CandlestickDeltaTrace extends AbstractTrace {
   protected readonly supportsExtrema = true;
@@ -119,61 +140,122 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   protected readonly highlightValues: (SVGElement[] | SVGElement)[][] | null
     = null;
 
-  private readonly deltaPoints: CandlestickDeltaPoint[];
-  /** Signed deltas; single row (the layer is a 1 x N series). */
-  private readonly deltaValues: number[][];
-  /** |delta| per point — the braille height source, cached for stable identity. */
-  private readonly absDeltaValues: number[][];
-  private readonly trends: CandlestickTrend[];
-  private readonly brailleMin: number[];
-  private readonly brailleMax: number[];
-  private readonly maxAbsDelta: number;
-
-  private readonly field: CandlestickDeltaField;
+  private readonly candles: CandlestickDeltaCandle[];
   private readonly referenceLabel: string;
+  private readonly initialField: CandlestickDeltaField;
+
+  /** Signed deltas per field, indexed [field][candle]. */
+  private readonly deltaByField: Record<CandlestickDeltaField, number[]>;
+  /** |delta| per field — the braille height source, cached for stable identity. */
+  private readonly absDeltaByField: Record<CandlestickDeltaField, number[]>;
+  /** Braille `values` wrappers ([absDelta row]) per field, cached for identity. */
+  private readonly brailleValuesByField: Record<CandlestickDeltaField, number[][]>;
+  /** Per-field trend arrays — the braille dot-8 source, cached for identity. */
+  private readonly trendByField: Record<CandlestickDeltaField, CandlestickTrend[]>;
+  /** Per-field braille max ([maxAbs]) arrays, cached for identity. */
+  private readonly brailleMaxByField: Record<CandlestickDeltaField, number[]>;
+  private readonly brailleMin: number[] = [0];
+
+  /** OHLC fields sorted ascending by value for each candle (low..high). */
+  private readonly sortedFieldsByPoint: CandlestickDeltaField[][];
+  /** Static-order signed delta grid (fields x candles); backs the movable. */
+  private readonly deltaGrid: number[][];
+  /** Largest |delta| across every field — audio's shared pitch ceiling. */
+  private readonly maxAbsDelta: number;
+  /** True when any field of any candle lands exactly on the line. */
+  private readonly hasOnLinePoint: boolean;
+  private readonly onLineUnits: readonly RotorFilterUnit[];
+
+  private currentPointIndex = 0;
+  private currentField: CandlestickDeltaField;
 
   public constructor(layer: MaidrLayer, config: CandlestickDeltaConfig) {
     super(layer);
 
-    this.deltaPoints = config.points;
-    this.field = config.field;
+    this.candles = config.candles;
     this.referenceLabel = config.referenceLabel;
+    this.initialField = config.initialField ?? 'close';
+    this.currentField = this.initialField;
 
-    this.deltaValues = [this.deltaPoints.map(point => point.delta)];
-    this.absDeltaValues = [
-      this.deltaPoints.map(point => Math.abs(point.delta)),
-    ];
-    this.trends = this.deltaPoints.map(point => point.trend);
+    const byField = (
+      build: (field: CandlestickDeltaField) => number[],
+    ): Record<CandlestickDeltaField, number[]> => ({
+      open: build('open'),
+      high: build('high'),
+      low: build('low'),
+      close: build('close'),
+    });
 
-    this.maxAbsDelta = this.absDeltaValues[0].reduce(
-      (max, value) => Math.max(max, value),
+    this.deltaByField = byField(field =>
+      this.candles.map(candle => fieldDelta(candle[field], candle.reference)),
+    );
+    this.absDeltaByField = byField(field =>
+      this.deltaByField[field].map(Math.abs),
+    );
+    this.brailleValuesByField = {
+      open: [this.absDeltaByField.open],
+      high: [this.absDeltaByField.high],
+      low: [this.absDeltaByField.low],
+      close: [this.absDeltaByField.close],
+    };
+    this.trendByField = {
+      open: this.deltaByField.open.map(deltaTrend),
+      high: this.deltaByField.high.map(deltaTrend),
+      low: this.deltaByField.low.map(deltaTrend),
+      close: this.deltaByField.close.map(deltaTrend),
+    };
+    this.brailleMaxByField = {
+      open: [maxOf(this.absDeltaByField.open)],
+      high: [maxOf(this.absDeltaByField.high)],
+      low: [maxOf(this.absDeltaByField.low)],
+      close: [maxOf(this.absDeltaByField.close)],
+    };
+
+    this.maxAbsDelta = CANDLESTICK_DELTA_FIELDS.reduce(
+      (max, field) => Math.max(max, this.brailleMaxByField[field][0]),
       0,
     );
-    this.brailleMin = [0];
-    this.brailleMax = [this.maxAbsDelta];
+    this.hasOnLinePoint = CANDLESTICK_DELTA_FIELDS.some(field =>
+      this.deltaByField[field].includes(0),
+    );
+    this.onLineUnits = this.hasOnLinePoint
+      ? [{ key: ON_LINE_KEY, label: ON_LINE_MODE, noun: 'point on the line' }]
+      : [];
 
-    this.movable = new MovableGrid<number>(this.deltaValues);
+    this.sortedFieldsByPoint = this.candles.map((candle) => {
+      // Sort by the candle's price so up/down matches the candle geometry
+      // (low at the bottom, high at the top); a stable tiebreak keeps the
+      // order deterministic when two OHLC values coincide.
+      return [...CANDLESTICK_DELTA_FIELDS].sort((a, b) => {
+        const diff = candle[a] - candle[b];
+        return diff !== 0
+          ? diff
+          : CANDLESTICK_DELTA_FIELDS.indexOf(a) - CANDLESTICK_DELTA_FIELDS.indexOf(b);
+      });
+    });
+
+    this.deltaGrid = CANDLESTICK_DELTA_FIELDS.map(field =>
+      this.deltaByField[field],
+    );
+    this.movable = new MovableGrid<number>(this.deltaGrid);
   }
 
   public dispose(): void {
-    this.deltaPoints.length = 0;
-    this.deltaValues.length = 0;
-    this.absDeltaValues.length = 0;
-    this.trends.length = 0;
+    this.candles.length = 0;
     super.dispose();
   }
 
   protected get values(): number[][] {
-    return this.deltaValues;
+    return this.deltaGrid;
   }
 
   protected get dimension(): Dimension {
-    return { rows: 1, cols: this.deltaPoints.length };
+    return { rows: CANDLESTICK_DELTA_FIELDS.length, cols: this.candles.length };
   }
 
-  /** The OHLC field this layer compares against the reference line. */
+  /** The OHLC field the cursor is currently comparing. */
   public get comparedField(): CandlestickDeltaField {
-    return this.field;
+    return this.currentField;
   }
 
   /** Human-readable name of the reference line this layer compares against. */
@@ -183,74 +265,232 @@ export class CandlestickDeltaTrace extends AbstractTrace {
 
   /** Number of matched (candle, reference) points in this layer. */
   public get size(): number {
-    return this.deltaPoints.length;
+    return this.candles.length;
+  }
+
+  /** Signed delta of the current field at the current candle. */
+  private get currentDelta(): number {
+    return this.deltaByField[this.currentField][this.currentPointIndex] ?? 0;
   }
 
   /**
-   * Moves the cursor to a point index without notifying observers. Used on
-   * activation to align the delta layer with the candle the user was on.
-   * @param index - The point index to position the cursor at
+   * Syncs the movable's row/col to the current field/candle. Row is the
+   * field's value-sorted position (0 = lowest .. 3 = highest), matching the
+   * candlestick's segment layout; col is the candle index.
+   */
+  private updateVisualPosition(): void {
+    const navOrder = this.sortedFieldsByPoint[this.currentPointIndex];
+    this.row = Math.max(0, navOrder.indexOf(this.currentField));
+    this.col = this.currentPointIndex;
+  }
+
+  private handleInitialEntry(): void {
+    this.isInitialEntry = false;
+    this.currentPointIndex = Math.max(
+      0,
+      Math.min(this.currentPointIndex, this.candles.length - 1),
+    );
+    this.currentField = this.initialField;
+    this.updateVisualPosition();
+  }
+
+  /**
+   * Moves the cursor to a candle index without notifying observers. Used on
+   * activation to align the delta layer with the candle the user was on while
+   * preserving the x position across on/off toggles.
+   * @param index - The candle index to position the cursor at
    */
   public setInitialPosition(index: number): void {
-    if (index < 0 || index >= this.deltaPoints.length) {
+    if (index < 0 || index >= this.candles.length) {
       return;
     }
     this.isInitialEntry = false;
-    this.row = 0;
-    this.col = index;
+    this.currentPointIndex = index;
+    this.currentField = this.initialField;
+    this.updateVisualPosition();
+  }
+
+  public override moveOnce(direction: MovableDirection): boolean {
+    if (this.isInitialEntry) {
+      this.handleInitialEntry();
+      this.notifyStateUpdate();
+      return true;
+    }
+
+    switch (direction) {
+      case 'UPWARD':
+      case 'DOWNWARD': {
+        const navOrder = this.sortedFieldsByPoint[this.currentPointIndex];
+        const pos = navOrder.indexOf(this.currentField);
+        const newPos = direction === 'UPWARD' ? pos + 1 : pos - 1;
+        if (newPos < 0 || newPos >= navOrder.length) {
+          this.notifyOutOfBounds();
+          return false;
+        }
+        this.currentField = navOrder[newPos];
+        this.updateVisualPosition();
+        break;
+      }
+      case 'FORWARD':
+      case 'BACKWARD': {
+        const newIndex
+          = direction === 'FORWARD'
+            ? this.currentPointIndex + 1
+            : this.currentPointIndex - 1;
+        if (newIndex < 0 || newIndex >= this.candles.length) {
+          this.notifyOutOfBounds();
+          return false;
+        }
+        this.currentPointIndex = newIndex;
+        this.updateVisualPosition();
+        break;
+      }
+    }
+
+    this.notifyStateUpdate();
+    return true;
+  }
+
+  public override moveToExtreme(direction: MovableDirection): boolean {
+    if (this.isInitialEntry) {
+      this.handleInitialEntry();
+    }
+
+    const navOrder = this.sortedFieldsByPoint[this.currentPointIndex];
+    switch (direction) {
+      case 'UPWARD':
+        this.currentField = navOrder[navOrder.length - 1];
+        break;
+      case 'DOWNWARD':
+        this.currentField = navOrder[0];
+        break;
+      case 'FORWARD':
+        this.currentPointIndex = this.candles.length - 1;
+        break;
+      case 'BACKWARD':
+        this.currentPointIndex = 0;
+        break;
+    }
+    this.updateVisualPosition();
+    this.notifyStateUpdate();
+    return true;
+  }
+
+  public override isMovable(target: [number, number] | MovableDirection): boolean {
+    if (Array.isArray(target)) {
+      return super.isMovable(target);
+    }
+    if (this.isInitialEntry) {
+      return true;
+    }
+    switch (target) {
+      case 'UPWARD':
+      case 'DOWNWARD': {
+        const navOrder = this.sortedFieldsByPoint[this.currentPointIndex];
+        const pos = navOrder.indexOf(this.currentField);
+        const newPos = target === 'UPWARD' ? pos + 1 : pos - 1;
+        return newPos >= 0 && newPos < navOrder.length;
+      }
+      case 'FORWARD':
+      case 'BACKWARD': {
+        const newIndex
+          = target === 'FORWARD'
+            ? this.currentPointIndex + 1
+            : this.currentPointIndex - 1;
+        return newIndex >= 0 && newIndex < this.candles.length;
+      }
+    }
+  }
+
+  public override moveToIndex(row: number, col: number): boolean {
+    if (col < 0 || col >= this.candles.length) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+    const navOrder = this.sortedFieldsByPoint[col];
+    if (row < 0 || row >= navOrder.length) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+    this.isInitialEntry = false;
+    this.currentPointIndex = col;
+    this.currentField = navOrder[row];
+    this.updateVisualPosition();
+    this.notifyStateUpdate();
+    return true;
+  }
+
+  public override getStateAt(row: number, col: number): TraceState {
+    const previous = {
+      pointIndex: this.currentPointIndex,
+      field: this.currentField,
+    };
+    this.isComputingStateAt = true;
+    try {
+      const safeCol = col >= 0 && col < this.candles.length ? col : 0;
+      const navOrder = this.sortedFieldsByPoint[safeCol];
+      const safeRow = row >= 0 && row < navOrder.length ? row : 0;
+      this.currentPointIndex = safeCol;
+      this.currentField = navOrder[safeRow];
+      return super.getStateAt(row, col);
+    } finally {
+      this.isComputingStateAt = false;
+      this.currentPointIndex = previous.pointIndex;
+      this.currentField = previous.field;
+    }
   }
 
   protected get audio(): AudioState {
-    const { col } = this.getSafeIndices();
-    const point = this.deltaPoints[col];
-
-    return {
-      freq: {
-        min: 0,
-        // Guard the all-zero-deltas case: raw is then always 0 and takes the
-        // click path, but interpolate() must never see min === max.
-        max: this.maxAbsDelta > 0 ? this.maxAbsDelta : 1,
-        raw: Math.abs(point.delta),
-      },
-      panning: {
-        x: col,
-        y: 0,
-        rows: 1,
-        cols: this.deltaPoints.length,
-      },
-      trend: point.trend,
-      zeroClick: true,
+    const delta = this.currentDelta;
+    const panning = {
+      x: this.currentPointIndex,
+      y: this.row,
+      rows: CANDLESTICK_DELTA_FIELDS.length,
+      cols: this.candles.length,
     };
+    const freq = {
+      min: 0,
+      // Guard the all-zero-deltas case: raw is then always 0 and takes the
+      // click path, but interpolate() must never see min === max.
+      max: this.maxAbsDelta > 0 ? this.maxAbsDelta : 1,
+      raw: Math.abs(delta),
+    };
+
+    if (delta === 0) {
+      return { freq, panning, zeroClick: true };
+    }
+    // Above the line rises, below the line falls; pitch still encodes |delta|.
+    return { freq, panning, glide: delta > 0 ? 'up' : 'down' };
   }
 
   protected get braille(): BrailleState {
-    // Height encodes |delta| over [0, max |delta|]; the custom trends add the
-    // bearish dot-8 marker for below-line points (see CandlestickBrailleEncoder).
-    // Must stay side-effect free and return stable array references — the
-    // braille cache compares `values` by identity.
+    // Height encodes |delta| over [0, max |delta| for this field]; the custom
+    // trends add the bearish dot-8 marker for below-line points (see
+    // CandlestickBrailleEncoder). Must stay side-effect free and return stable
+    // array references — the braille cache compares `values` by identity.
     return {
       empty: false,
       id: this.id,
-      values: this.absDeltaValues,
+      values: this.brailleValuesByField[this.currentField],
       min: this.brailleMin,
-      max: this.brailleMax,
+      max: this.brailleMaxByField[this.currentField],
       row: 0,
-      col: this.getSafeIndices().col,
-      custom: this.trends,
+      col: this.currentPointIndex,
+      custom: this.trendByField[this.currentField],
     };
   }
 
   protected get text(): TextState {
-    const point = this.deltaPoints[this.getSafeIndices().col];
+    const delta = this.currentDelta;
     const position
-      = point.delta > 0 ? ABOVE_LINE : point.delta < 0 ? BELOW_LINE : ON_LINE;
+      = delta > 0 ? ABOVE_LINE : delta < 0 ? BELOW_LINE : ON_LINE;
 
     // Verbose: "Date is 2019-11-05, close delta is 1.25, position is above line"
     // Terse:   "2019-11-05, close 1.25, above line"
     return {
-      main: { label: this.xAxis, value: point.x },
-      cross: { label: 'delta', value: Math.abs(point.delta) },
-      section: this.field,
+      main: { label: this.xAxis, value: this.candles[this.currentPointIndex].x },
+      cross: { label: 'delta', value: Math.abs(delta) },
+      section: this.currentField,
       z: { label: 'position', value: position },
       mainAxis: 'x',
       crossAxis: 'y',
@@ -258,17 +498,18 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   }
 
   public get description(): DescriptionState {
-    const aboveCount = this.deltaPoints.filter(p => p.delta > 0).length;
-    const belowCount = this.deltaPoints.filter(p => p.delta < 0).length;
-    const onLineCount = this.deltaPoints.length - aboveCount - belowCount;
-    const signedDeltas = this.deltaValues[0];
-    const maxDelta = signedDeltas.reduce((a, b) => Math.max(a, b), Number.NEGATIVE_INFINITY);
-    const minDelta = signedDeltas.reduce((a, b) => Math.min(a, b), Number.POSITIVE_INFINITY);
+    const field = this.currentField;
+    const deltas = this.deltaByField[field];
+    const aboveCount = deltas.filter(d => d > 0).length;
+    const belowCount = deltas.filter(d => d < 0).length;
+    const onLineCount = deltas.length - aboveCount - belowCount;
+    const maxDelta = deltas.reduce((a, b) => Math.max(a, b), Number.NEGATIVE_INFINITY);
+    const minDelta = deltas.reduce((a, b) => Math.min(a, b), Number.POSITIVE_INFINITY);
 
     const stats: DescriptionState['stats'] = [
       { label: 'Reference line', value: this.referenceLabel },
-      { label: 'Compared value', value: this.field },
-      { label: 'Number of points', value: this.deltaPoints.length },
+      { label: 'Compared value', value: field },
+      { label: 'Number of points', value: this.candles.length },
       { label: 'Points above line', value: aboveCount },
       { label: 'Points below line', value: belowCount },
       { label: 'Points on line', value: onLineCount },
@@ -277,17 +518,17 @@ export class CandlestickDeltaTrace extends AbstractTrace {
 
     const headers = [
       this.xAxis,
-      this.field,
+      field,
       this.referenceLabel,
       'Delta',
       'Position',
     ];
-    const rows: (string | number)[][] = this.deltaPoints.map(point => [
-      point.x,
-      point.fieldValue,
-      point.reference,
-      point.delta,
-      point.delta > 0 ? ABOVE_LINE : point.delta < 0 ? BELOW_LINE : ON_LINE,
+    const rows: (string | number)[][] = this.candles.map((candle, index) => [
+      candle.x,
+      candle[field],
+      candle.reference,
+      deltas[index],
+      deltas[index] > 0 ? ABOVE_LINE : deltas[index] < 0 ? BELOW_LINE : ON_LINE,
     ]);
 
     return {
@@ -300,41 +541,46 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   }
 
   public override getCurrentXValue(): XValue | null {
-    return this.deltaPoints[this.col]?.x ?? null;
+    return this.candles[this.currentPointIndex]?.x ?? null;
   }
 
   public override moveToXValue(xValue: XValue): boolean {
-    const index = this.deltaPoints.findIndex(point => point.x === xValue);
+    const index = this.candles.findIndex(candle => candle.x === xValue);
     if (index === -1) {
       return false;
     }
-    return this.moveToIndex(0, index);
+    this.isInitialEntry = false;
+    this.currentPointIndex = index;
+    this.updateVisualPosition();
+    this.notifyStateUpdate();
+    return true;
   }
 
   /**
    * Gets available X values for the Go To search combobox.
-   * @returns Array of X values in point order
+   * @returns Array of X values in candle order
    */
   public getAvailableXValues(): XValue[] {
-    return this.deltaPoints.map(point => point.x);
+    return this.candles.map(candle => candle.x);
   }
 
   public override getExtremaTargets(): ExtremaTarget[] {
-    if (this.deltaPoints.length === 0) {
+    if (this.candles.length === 0) {
       return [];
     }
 
-    const signedDeltas = this.deltaValues[0];
-    const maxDelta = signedDeltas.reduce((a, b) => Math.max(a, b));
-    const minDelta = signedDeltas.reduce((a, b) => Math.min(a, b));
+    const field = this.currentField;
+    const deltas = this.deltaByField[field];
+    const maxDelta = deltas.reduce((a, b) => Math.max(a, b));
+    const minDelta = deltas.reduce((a, b) => Math.min(a, b));
 
     const targets: ExtremaTarget[] = [];
-    signedDeltas.forEach((delta, index) => {
+    deltas.forEach((delta, index) => {
       if (delta === maxDelta) {
         targets.push(this.buildExtremaTarget('max', index));
       }
     });
-    signedDeltas.forEach((delta, index) => {
+    deltas.forEach((delta, index) => {
       if (delta === minDelta) {
         targets.push(this.buildExtremaTarget('min', index));
       }
@@ -343,25 +589,29 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   }
 
   private buildExtremaTarget(type: 'max' | 'min', index: number): ExtremaTarget {
-    const point = this.deltaPoints[index];
+    const candle = this.candles[index];
     return {
-      label: `${type === 'max' ? 'Max' : 'Min'} Delta at ${point.x}`,
-      value: point.delta,
+      label: `${type === 'max' ? 'Max' : 'Min'} Delta at ${candle.x}`,
+      value: this.deltaByField[this.currentField][index],
       pointIndex: index,
-      segment: this.field,
+      segment: this.currentField,
       type,
       navigationType: 'point',
-      xValue: point.x,
+      xValue: candle.x,
     };
   }
 
   public override navigateToExtrema(target: ExtremaTarget): void {
-    if (target.pointIndex < 0 || target.pointIndex >= this.deltaPoints.length) {
+    if (target.pointIndex < 0 || target.pointIndex >= this.candles.length) {
       return;
     }
-    this.row = 0;
-    this.col = target.pointIndex;
-    this.finalizeNavigation();
+    this.isInitialEntry = false;
+    this.currentPointIndex = target.pointIndex;
+    if (CANDLESTICK_DELTA_FIELDS.includes(target.segment as CandlestickDeltaField)) {
+      this.currentField = target.segment as CandlestickDeltaField;
+    }
+    this.updateVisualPosition();
+    this.notifyStateUpdate();
   }
 
   public override dataModeName(): string {
@@ -386,17 +636,67 @@ export class CandlestickDeltaTrace extends AbstractTrace {
       return false;
     }
 
+    const deltas = this.deltaByField[this.currentField];
     const step = direction === 'right' ? 1 : -1;
     for (
-      let i = this.col + step;
-      i >= 0 && i < this.deltaPoints.length;
+      let i = this.currentPointIndex + step;
+      i >= 0 && i < this.candles.length;
       i += step
     ) {
-      const delta = this.deltaPoints[i].delta;
+      const delta = deltas[i];
       if (type === 'higher' ? delta > 0 : delta < 0) {
         this.isInitialEntry = false;
-        this.row = 0;
-        this.col = i;
+        this.currentPointIndex = i;
+        this.updateVisualPosition();
+        this.notifyStateUpdate();
+        return true;
+      }
+    }
+
+    this.notifyRotorBounds();
+    return false;
+  }
+
+  /**
+   * Exposes the "on line" rotor filter unit when at least one point lands
+   * exactly on the reference line. Appended after the above/below compare
+   * units so cycling the rotor offers: delta point (default), below line,
+   * above line, and — when present — on line.
+   * @returns The on-line filter unit, or an empty list
+   */
+  public override getRotorFilterUnits(): readonly RotorFilterUnit[] {
+    return this.onLineUnits;
+  }
+
+  /**
+   * Jumps to the previous/next candle whose current-field delta is exactly
+   * zero (on the reference line), preserving the current field. On-line
+   * filtering runs along the candle axis; the rotor service handles up/down
+   * (announcing them as unavailable) and dispatches only left/right here.
+   * @param key - The active filter unit key
+   * @param direction - The direction to search
+   * @returns True if a matching candle was found and moved to
+   */
+  public override moveToRotorFilter(
+    key: string,
+    direction: 'left' | 'right',
+  ): boolean {
+    if (key !== ON_LINE_KEY) {
+      this.notifyRotorBounds();
+      return false;
+    }
+
+    const deltas = this.deltaByField[this.currentField];
+    const step = direction === 'right' ? 1 : -1;
+    for (
+      let i = this.currentPointIndex + step;
+      i >= 0 && i < this.candles.length;
+      i += step
+    ) {
+      if (deltas[i] === 0) {
+        this.isInitialEntry = false;
+        this.currentPointIndex = i;
+        this.updateVisualPosition();
         this.notifyStateUpdate();
         return true;
       }
@@ -410,4 +710,12 @@ export class CandlestickDeltaTrace extends AbstractTrace {
     // Virtual layer: no SVG geometry to hover.
     return null;
   }
+}
+
+/**
+ * Max of a numeric array without the spread-argument RangeError that
+ * `Math.max(...arr)` hits on very large arrays; returns 0 for an empty array.
+ */
+function maxOf(values: number[]): number {
+  return values.reduce((max, value) => Math.max(max, value), 0);
 }

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -660,6 +660,31 @@ export class CandlestickDeltaTrace extends AbstractTrace {
   }
 
   /**
+   * Switches to the next OHLC field upward while the rotor is in a compare
+   * (above-line / below-line) mode. Without this override the rotor would fall
+   * back to the base class's throwing implementation and silently mirror a
+   * right move, jumping candles instead of changing field. Mirrors
+   * Candlestick.moveUpRotor: delegate to moveOnce, which handles its own
+   * boundary tone, and always report success so the rotor adds no competing
+   * message.
+   * @returns Always true (boundary handled by moveOnce)
+   */
+  public override moveUpRotor(): boolean {
+    this.moveOnce('UPWARD');
+    return true;
+  }
+
+  /**
+   * Switches to the next OHLC field downward in a compare mode. See
+   * {@link moveUpRotor}.
+   * @returns Always true (boundary handled by moveOnce)
+   */
+  public override moveDownRotor(): boolean {
+    this.moveOnce('DOWNWARD');
+    return true;
+  }
+
+  /**
    * Always exposes the "on line" rotor filter unit, completing the fixed
    * above-line / on-line / below-line trichotomy alongside the two compare
    * units. It is intentionally NOT gated on a zero being present: gating on

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -305,10 +305,108 @@ export class AudioService implements Observer<PlotState>, Disposable {
         } else {
           this.playZeroTone(audio.panning);
         }
+      } else if (audio.glide) {
+        this.playGlideTone(audio.freq, audio.panning, audio.glide);
       } else {
         this.playTone(audio.freq, audio.panning, paletteEntry);
       }
     }
+  }
+
+  /**
+   * Plays a pitched tone that glides its frequency over the note duration to
+   * convey a direction: `'up'` rises (a "whoosh"), `'down'` falls (a drop).
+   *
+   * The base pitch — mapped from the data value in `freq` exactly like
+   * {@link playTone} — is where the glide starts, so pitch still encodes the
+   * value (e.g. |delta|) while the sweep direction carries an independent
+   * meaning (e.g. above vs below the reference line). The sweep spans a
+   * perfect fifth (frequency ratio 1.5), large enough to be unmistakably
+   * directional yet musical, and is stereo-panned by x like every data tone.
+   *
+   * @param freq - Frequency mapping for the base pitch
+   * @param panning - Position information for stereo placement
+   * @param direction - Sweep direction: 'up' rises, 'down' falls
+   * @returns AudioId for the played tone
+   */
+  private playGlideTone(
+    freq: Frequency,
+    panning: Panning,
+    direction: 'up' | 'down',
+  ): AudioId {
+    // Silent at volume 0; return a harmless self-clearing id (see playEmptyTone).
+    if (this.volume <= 0) {
+      const audioId = setTimeout(() => this.activeAudioIds.delete(audioId), 0);
+      this.activeAudioIds.set(audioId, []);
+      return audioId;
+    }
+
+    const ctx = this.audioContext;
+    const startTime = ctx.currentTime;
+    const duration = DEFAULT_DURATION;
+
+    const baseFrequency = MathUtil.interpolate(
+      freq.raw as number,
+      freq.min,
+      freq.max,
+      this.minFrequency,
+      this.maxFrequency,
+    );
+    // Perfect fifth sweep: unmistakably directional but still musical.
+    const SWEEP_RATIO = 1.5;
+    const targetFrequency = direction === 'up'
+      ? baseFrequency * SWEEP_RATIO
+      : baseFrequency / SWEEP_RATIO;
+
+    const oscillator = ctx.createOscillator();
+    // Triangle rising, sine falling: the softer sine reinforces the "drop".
+    oscillator.type = direction === 'up' ? 'triangle' : 'sine';
+    oscillator.frequency.setValueAtTime(baseFrequency, startTime);
+    // Exponential glide reads as a smooth, natural pitch slide (linear-in-Hz
+    // sounds like it decelerates). Both endpoints are > 0, so it is safe.
+    oscillator.frequency.exponentialRampToValueAtTime(
+      targetFrequency,
+      startTime + duration,
+    );
+
+    const gainNode = ctx.createGain();
+    gainNode.gain.setValueAtTime(1e-4 * this.volume, startTime);
+    gainNode.gain.linearRampToValueAtTime(this.volume, startTime + duration * 0.15);
+    gainNode.gain.linearRampToValueAtTime(1e-4 * this.volume, startTime + duration);
+
+    const xPos = MathUtil.clamp(
+      MathUtil.interpolate(panning.x, 0, panning.cols - 1, -1, 1),
+      -1,
+      1,
+    );
+    // createStereoPanner is unavailable on Safari < 14.5; degrade to mono.
+    const stereoPanner = typeof ctx.createStereoPanner === 'function'
+      ? ctx.createStereoPanner()
+      : null;
+    if (stereoPanner) {
+      stereoPanner.pan.value = xPos;
+    }
+
+    oscillator.connect(gainNode);
+    if (stereoPanner) {
+      gainNode.connect(stereoPanner);
+      stereoPanner.connect(this.compressor);
+    } else {
+      gainNode.connect(this.compressor);
+    }
+
+    oscillator.start(startTime);
+    oscillator.stop(startTime + duration);
+
+    const nodes: AudioNode[] = stereoPanner
+      ? [oscillator, gainNode, stereoPanner]
+      : [oscillator, gainNode];
+    const audioId = setTimeout(() => {
+      nodes.forEach(node => node.disconnect());
+      this.activeAudioIds.delete(audioId);
+    }, duration * 1e3 * 2);
+    this.activeAudioIds.set(audioId, [oscillator]);
+    return audioId;
   }
 
   private playTone(freq: Frequency, panning: Panning, paletteEntry?: AudioPaletteEntry): AudioId {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -357,15 +357,21 @@ export class AudioService implements Observer<PlotState>, Disposable {
     const targetFrequency = direction === 'up'
       ? baseFrequency * SWEEP_RATIO
       : baseFrequency / SWEEP_RATIO;
+    // exponentialRampToValueAtTime rejects non-positive targets. A misconfigured
+    // (negative) Min Frequency setting can push baseFrequency <= 0, so floor
+    // both endpoints just above zero — otherwise the throw would propagate out
+    // of update() and abort the remaining observer updates for this keypress.
+    const safeBase = Math.max(baseFrequency, 1e-3);
+    const safeTarget = Math.max(targetFrequency, 1e-3);
 
     const oscillator = ctx.createOscillator();
     // Triangle rising, sine falling: the softer sine reinforces the "drop".
     oscillator.type = direction === 'up' ? 'triangle' : 'sine';
-    oscillator.frequency.setValueAtTime(baseFrequency, startTime);
+    oscillator.frequency.setValueAtTime(safeBase, startTime);
     // Exponential glide reads as a smooth, natural pitch slide (linear-in-Hz
-    // sounds like it decelerates). Both endpoints are > 0, so it is safe.
+    // sounds like it decelerates).
     oscillator.frequency.exponentialRampToValueAtTime(
-      targetFrequency,
+      safeTarget,
       startTime + duration,
     );
 

--- a/src/service/candlestickDelta.ts
+++ b/src/service/candlestickDelta.ts
@@ -171,13 +171,6 @@ export class CandlestickDeltaService implements Disposable {
       );
       return false;
     }
-    // The reference is a usable line (it overlaps the candles somewhere), so
-    // remember it now — even if we cannot virtualize at the current candle —
-    // so a later Alt L from a covered candle can re-enable the comparison. A
-    // reference with no overlap at all is rejected above and never reaches
-    // here, so it can't clobber a previously working selection.
-    this.selectedReferenceId = referenceId;
-
     const wasActive = this.isActive;
 
     // The delta layer stays x-synced with the candlestick, so it must land on
@@ -191,12 +184,23 @@ export class CandlestickDeltaService implements Disposable {
       : candles.findIndex(candle => candle.x === currentX);
 
     // A moving average is shorter than the candlestick, so the current candle
-    // may have no reference value — and therefore no delta — at its x. On a
-    // fresh activation, refuse and alert instead of silently jumping to the
-    // far-left first delta point: the layer only ever virtualizes where a
-    // delta actually exists. (An in-place reconfiguration keeps its own cursor
-    // and is not gated here.)
-    if (!wasActive && startIndex < 0) {
+    // may have no reference value — and therefore no delta — at its x. Never
+    // teleport to some other candle to hide that: keep the layer x-synced.
+    if (startIndex < 0) {
+      if (wasActive) {
+        // Reconfiguring (Ctrl+Shift+L) to a reference that does not cover the
+        // candle the user is on: keep the current comparison and position
+        // rather than silently jumping to the new reference's first candle.
+        // The previous reference stays remembered.
+        this.notification.notify(
+          `Keeping the current comparison: ${reference.label} does not reach `
+          + `${currentX}. Move to a candle it covers, then choose it again.`,
+        );
+        return false;
+      }
+      // Fresh activation: remember the usable reference so a later Alt L from a
+      // covered candle re-enables it, then alert that there is nothing here.
+      this.selectedReferenceId = referenceId;
       this.notification.notify(
         `No reference comparison at ${currentX}: ${reference.label} does not `
         + 'reach this candle. Move to a candle the moving average covers, then '
@@ -204,6 +208,9 @@ export class CandlestickDeltaService implements Disposable {
       );
       return false;
     }
+
+    // The current candle has a delta: virtualize it. The reference is
+    // committed as remembered only once the swap below succeeds.
 
     // Preserve the field being compared across an in-place reconfiguration.
     const initialField: CandlestickDeltaField
@@ -215,9 +222,7 @@ export class CandlestickDeltaService implements Disposable {
       candles,
       initialField,
     );
-    if (startIndex >= 0) {
-      trace.setInitialPosition(startIndex);
-    }
+    trace.setInitialPosition(startIndex);
     const previous = this.context.swapActiveTrace(trace);
     if (!previous) {
       trace.dispose();
@@ -232,6 +237,7 @@ export class CandlestickDeltaService implements Disposable {
       this.anchor = previous;
     }
     this.deltaTrace = trace;
+    this.selectedReferenceId = referenceId;
 
     this.rotor.resetToDataMode();
     if (!wasActive) {

--- a/src/service/candlestickDelta.ts
+++ b/src/service/candlestickDelta.ts
@@ -33,8 +33,8 @@ export interface CandlestickDeltaReference {
  * Interaction model:
  * - Ctrl+Shift+L opens the reference picker; confirming a line remembers it as
  *   the reference and activates the comparison.
- * - Ctrl+L toggles the comparison on/off using the remembered reference. The
- *   very first Ctrl+L with no reference chosen yet warns and opens the picker.
+ * - Alt+L toggles the comparison on/off using the remembered reference. The
+ *   very first Alt+L with no reference chosen yet warns and opens the picker.
  */
 export class CandlestickDeltaService implements Disposable {
   private readonly context: Context;
@@ -226,7 +226,7 @@ export class CandlestickDeltaService implements Disposable {
       + `${candles.length} points, starting on ${initialField}. `
       + 'Positive values are above the line, negative below. '
       + 'Use Left and Right arrows to move between candles, Up and Down to '
-      + 'switch between open, high, low and close. Press Control L to turn the '
+      + 'switch between open, high, low and close. Press Alt L to turn the '
       + 'comparison off, G for extrema, and the rotor to browse above-line, '
       + 'below-line, or on-line points. Press Escape to return to the chart.',
     );
@@ -235,7 +235,7 @@ export class CandlestickDeltaService implements Disposable {
 
   /**
    * Deactivates the virtual delta layer and restores the real chart layer.
-   * The remembered reference is kept so a later Ctrl+L can re-enable it.
+   * The remembered reference is kept so a later Alt+L can re-enable it.
    *
    * @param options - Deactivation options
    * @param options.silent - Skip announcements and position sync (used when
@@ -282,7 +282,7 @@ export class CandlestickDeltaService implements Disposable {
       }
       this.notification.notify(
         'Reference comparison closed. Returned to the chart layer. '
-        + 'Press Control L to compare again.',
+        + 'Press Alt L to compare again.',
       );
     }
     return true;

--- a/src/service/candlestickDelta.ts
+++ b/src/service/candlestickDelta.ts
@@ -171,8 +171,40 @@ export class CandlestickDeltaService implements Disposable {
       );
       return false;
     }
+    // The reference is a usable line (it overlaps the candles somewhere), so
+    // remember it now — even if we cannot virtualize at the current candle —
+    // so a later Alt L from a covered candle can re-enable the comparison. A
+    // reference with no overlap at all is rejected above and never reaches
+    // here, so it can't clobber a previously working selection.
+    this.selectedReferenceId = referenceId;
 
     const wasActive = this.isActive;
+
+    // The delta layer stays x-synced with the candlestick, so it must land on
+    // the candle the user is currently on: the delta layer's own position when
+    // reconfiguring, otherwise the candle in the underlying chart.
+    const currentX = wasActive && this.deltaTrace
+      ? this.deltaTrace.getCurrentXValue()
+      : candlestick.getCurrentXValue();
+    const startIndex = currentX === null
+      ? -1
+      : candles.findIndex(candle => candle.x === currentX);
+
+    // A moving average is shorter than the candlestick, so the current candle
+    // may have no reference value — and therefore no delta — at its x. On a
+    // fresh activation, refuse and alert instead of silently jumping to the
+    // far-left first delta point: the layer only ever virtualizes where a
+    // delta actually exists. (An in-place reconfiguration keeps its own cursor
+    // and is not gated here.)
+    if (!wasActive && startIndex < 0) {
+      this.notification.notify(
+        `No reference comparison at ${currentX}: ${reference.label} does not `
+        + 'reach this candle. Move to a candle the moving average covers, then '
+        + 'press Alt L.',
+      );
+      return false;
+    }
+
     // Preserve the field being compared across an in-place reconfiguration.
     const initialField: CandlestickDeltaField
       = wasActive && this.deltaTrace ? this.deltaTrace.comparedField : 'close';
@@ -183,16 +215,6 @@ export class CandlestickDeltaService implements Disposable {
       candles,
       initialField,
     );
-
-    // Land on the x the user is currently on: the delta layer's own position
-    // when reconfiguring, otherwise the candle the user was on. This keeps the
-    // candle position fixed as the virtual layer is toggled on and off.
-    const currentX = wasActive && this.deltaTrace
-      ? this.deltaTrace.getCurrentXValue()
-      : candlestick.getCurrentXValue();
-    const startIndex = currentX === null
-      ? -1
-      : candles.findIndex(candle => candle.x === currentX);
     if (startIndex >= 0) {
       trace.setInitialPosition(startIndex);
     }
@@ -210,7 +232,6 @@ export class CandlestickDeltaService implements Disposable {
       this.anchor = previous;
     }
     this.deltaTrace = trace;
-    this.selectedReferenceId = referenceId;
 
     this.rotor.resetToDataMode();
     if (!wasActive) {

--- a/src/service/candlestickDelta.ts
+++ b/src/service/candlestickDelta.ts
@@ -1,6 +1,6 @@
 import type {
+  CandlestickDeltaCandle,
   CandlestickDeltaField,
-  CandlestickDeltaPoint,
 } from '@model/candlestickDelta';
 import type { Context } from '@model/context';
 import type { Trace } from '@model/plot';
@@ -11,11 +11,7 @@ import type { DisplayService } from './display';
 import type { NotificationService } from './notification';
 import type { RotorNavigationService } from './rotor';
 import { Candlestick } from '@model/candlestick';
-import {
-  CandlestickDeltaTrace,
-  deltaTrend,
-  roundDelta,
-} from '@model/candlestickDelta';
+import { CandlestickDeltaTrace } from '@model/candlestickDelta';
 import { LineTrace } from '@model/line';
 import { Scope } from '@type/event';
 import { TraceType } from '@type/grammar';
@@ -28,17 +24,17 @@ export interface CandlestickDeltaReference {
   label: string;
 }
 
-/** The configuration of the currently active delta layer, if any. */
-export interface CandlestickDeltaSelection {
-  referenceId: string;
-  field: CandlestickDeltaField;
-}
-
 /**
  * Manages the virtual candlestick delta layer: discovers reference lines in
- * the active subplot, builds the {@link CandlestickDeltaTrace} from the
- * user's F7 dialog selection, swaps it in/out of the navigation context, and
- * announces activation and exit.
+ * the active subplot, remembers the user's chosen reference line, builds the
+ * {@link CandlestickDeltaTrace} on demand, swaps it in/out of the navigation
+ * context, and announces activation and exit.
+ *
+ * Interaction model:
+ * - Ctrl+Shift+L opens the reference picker; confirming a line remembers it as
+ *   the reference and activates the comparison.
+ * - Ctrl+L toggles the comparison on/off using the remembered reference. The
+ *   very first Ctrl+L with no reference chosen yet warns and opens the picker.
  */
 export class CandlestickDeltaService implements Disposable {
   private readonly context: Context;
@@ -52,7 +48,8 @@ export class CandlestickDeltaService implements Disposable {
   private deltaTrace: CandlestickDeltaTrace | null = null;
   /** The real trace the delta layer replaced; restored on exit. */
   private anchor: Trace | null = null;
-  private selection: CandlestickDeltaSelection | null = null;
+  /** The reference line remembered across on/off toggles. */
+  private selectedReferenceId: string | null = null;
 
   public constructor(
     context: Context,
@@ -70,7 +67,7 @@ export class CandlestickDeltaService implements Disposable {
     this.deltaTrace?.dispose();
     this.deltaTrace = null;
     this.anchor = null;
-    this.selection = null;
+    this.selectedReferenceId = null;
     this.wireTrace = null;
   }
 
@@ -89,9 +86,9 @@ export class CandlestickDeltaService implements Disposable {
     return this.deltaTrace !== null && this.context.active === this.deltaTrace;
   }
 
-  /** The active layer's configuration, used to preselect the F7 dialog. */
-  public get activeSelection(): CandlestickDeltaSelection | null {
-    return this.isActive ? this.selection : null;
+  /** The remembered reference line id, or null when none has been chosen. */
+  public get selectedReference(): string | null {
+    return this.selectedReferenceId;
   }
 
   /**
@@ -120,26 +117,39 @@ export class CandlestickDeltaService implements Disposable {
     return references.length > 0 ? references : null;
   }
 
-  /** Moves keyboard focus into the F7 settings dialog scope. */
+  /** Moves keyboard focus into the reference picker dialog scope. */
   public openSettings(): void {
     this.display.toggleFocus(Scope.CANDLESTICK_DELTA_SETTINGS);
   }
 
-  /** Closes the F7 settings dialog scope, returning to the previous scope. */
+  /** Closes the reference picker dialog scope, returning to the previous scope. */
   public closeSettings(): void {
     this.display.toggleFocus(Scope.CANDLESTICK_DELTA_SETTINGS);
   }
 
   /**
-   * Builds and activates the virtual delta layer for the given reference
-   * series and OHLC field. Replaces an already-active delta layer in place
-   * when the user reconfigures via F7.
-   *
+   * Remembers a reference line as the active comparison target. Persists
+   * across on/off toggles until the user picks a different one.
    * @param referenceId - Id of the reference series (from getReferences)
-   * @param field - The OHLC field to compare
+   */
+  public setSelectedReference(referenceId: string): void {
+    this.selectedReferenceId = referenceId;
+  }
+
+  /**
+   * Builds and activates the virtual delta layer for the remembered (or
+   * given) reference line, comparing every OHLC field. Replaces an
+   * already-active delta layer in place when the user reconfigures via the
+   * reference picker.
+   *
+   * @param referenceId - Reference series id; defaults to the remembered one
    * @returns True when the layer was activated
    */
-  public activate(referenceId: string, field: CandlestickDeltaField): boolean {
+  public activate(referenceId: string | null = this.selectedReferenceId): boolean {
+    if (referenceId === null) {
+      return false;
+    }
+
     const candlestick = this.resolveCandlestick();
     if (!candlestick) {
       this.notification.notify(
@@ -154,25 +164,35 @@ export class CandlestickDeltaService implements Disposable {
       return false;
     }
 
-    const points = this.buildDeltaPoints(candlestick, reference.points, field);
-    if (points.length === 0) {
+    const candles = this.buildDeltaCandles(candlestick, reference.points);
+    if (candles.length === 0) {
       this.notification.notify(
         `No matching x values between the candlestick chart and ${reference.label}.`,
       );
       return false;
     }
 
-    const trace = this.buildTrace(candlestick, reference.label, field, points);
-
     const wasActive = this.isActive;
+    // Preserve the field being compared across an in-place reconfiguration.
+    const initialField: CandlestickDeltaField
+      = wasActive && this.deltaTrace ? this.deltaTrace.comparedField : 'close';
+
+    const trace = this.buildTrace(
+      candlestick,
+      reference.label,
+      candles,
+      initialField,
+    );
 
     // Land on the x the user is currently on: the delta layer's own position
-    // when reconfiguring via F7, otherwise the candle the user was on.
+    // when reconfiguring, otherwise the candle the user was on. This keeps the
+    // candle position fixed as the virtual layer is toggled on and off.
     const currentX = wasActive && this.deltaTrace
       ? this.deltaTrace.getCurrentXValue()
       : candlestick.getCurrentXValue();
-    const startIndex
-      = currentX === null ? -1 : points.findIndex(point => point.x === currentX);
+    const startIndex = currentX === null
+      ? -1
+      : candles.findIndex(candle => candle.x === currentX);
     if (startIndex >= 0) {
       trace.setInitialPosition(startIndex);
     }
@@ -190,7 +210,7 @@ export class CandlestickDeltaService implements Disposable {
       this.anchor = previous;
     }
     this.deltaTrace = trace;
-    this.selection = { referenceId, field };
+    this.selectedReferenceId = referenceId;
 
     this.rotor.resetToDataMode();
     if (!wasActive) {
@@ -202,17 +222,20 @@ export class CandlestickDeltaService implements Disposable {
     // update would wipe these instructions before screen readers read them.
     trace.notifyStateUpdate();
     this.notification.notify(
-      `Reference comparison on: ${field} price minus ${reference.label}, `
-      + `${points.length} points. Positive values are above the line, negative below. `
-      + 'Use Left and Right arrows to explore, G for extrema, '
-      + 'and the rotor to browse only above-line or below-line points. '
-      + 'Press Escape to return to the chart.',
+      `Reference comparison on: OHLC price minus ${reference.label}, `
+      + `${candles.length} points, starting on ${initialField}. `
+      + 'Positive values are above the line, negative below. '
+      + 'Use Left and Right arrows to move between candles, Up and Down to '
+      + 'switch between open, high, low and close. Press Control L to turn the '
+      + 'comparison off, G for extrema, and the rotor to browse above-line, '
+      + 'below-line, or on-line points. Press Escape to return to the chart.',
     );
     return true;
   }
 
   /**
    * Deactivates the virtual delta layer and restores the real chart layer.
+   * The remembered reference is kept so a later Ctrl+L can re-enable it.
    *
    * @param options - Deactivation options
    * @param options.silent - Skip announcements and position sync (used when
@@ -237,7 +260,6 @@ export class CandlestickDeltaService implements Disposable {
     const anchor = this.anchor;
     this.deltaTrace = null;
     this.anchor = null;
-    this.selection = null;
     trace.dispose();
     this.rotor.resetToDataMode();
 
@@ -259,7 +281,8 @@ export class CandlestickDeltaService implements Disposable {
         anchor.moveToXValue(lastX);
       }
       this.notification.notify(
-        'Reference comparison closed. Returned to the chart layer.',
+        'Reference comparison closed. Returned to the chart layer. '
+        + 'Press Control L to compare again.',
       );
     }
     return true;
@@ -278,7 +301,6 @@ export class CandlestickDeltaService implements Disposable {
       this.deltaTrace.dispose();
       this.deltaTrace = null;
       this.anchor = null;
-      this.selection = null;
     }
   }
 
@@ -298,7 +320,6 @@ export class CandlestickDeltaService implements Disposable {
     const trace = this.deltaTrace;
     this.deltaTrace = null;
     this.anchor = null;
-    this.selection = null;
     trace.dispose();
     this.rotor.resetToDataMode();
   }
@@ -340,15 +361,16 @@ export class CandlestickDeltaService implements Disposable {
   }
 
   /**
-   * Matches candles to reference points by x value and computes the signed
-   * deltas. Candles without a reference value at the same x (e.g. the head
-   * of a moving average window) are skipped.
+   * Matches candles to reference points by x value, capturing every OHLC
+   * value alongside the reference so the delta layer can recompute deltas as
+   * the user navigates open/high/low/close. Candles without a reference value
+   * at the same x (e.g. the head of a moving average window) or with any
+   * non-finite OHLC value are skipped.
    */
-  private buildDeltaPoints(
+  private buildDeltaCandles(
     candlestick: Candlestick,
     referencePoints: readonly LinePoint[],
-    field: CandlestickDeltaField,
-  ): CandlestickDeltaPoint[] {
+  ): CandlestickDeltaCandle[] {
     const referenceByX = new Map<string, number>();
     for (const point of referencePoints) {
       const y = Number(point.y);
@@ -357,36 +379,37 @@ export class CandlestickDeltaService implements Disposable {
       }
     }
 
-    const points: CandlestickDeltaPoint[] = [];
+    const candles: CandlestickDeltaCandle[] = [];
     for (const candle of candlestick.getCandles()) {
       const reference = referenceByX.get(String(candle.value));
       if (reference === undefined) {
         continue;
       }
-      const fieldValue = candle[field];
-      if (!Number.isFinite(fieldValue)) {
+      if (
+        !Number.isFinite(candle.open)
+        || !Number.isFinite(candle.high)
+        || !Number.isFinite(candle.low)
+        || !Number.isFinite(candle.close)
+      ) {
         continue;
       }
-      const delta = roundDelta(
-        fieldValue - reference,
-        Math.max(Math.abs(fieldValue), Math.abs(reference)),
-      );
-      points.push({
+      candles.push({
         x: candle.value,
-        fieldValue,
         reference,
-        delta,
-        trend: deltaTrend(delta),
+        open: candle.open,
+        high: candle.high,
+        low: candle.low,
+        close: candle.close,
       });
     }
-    return points;
+    return candles;
   }
 
   private buildTrace(
     candlestick: Candlestick,
     referenceLabel: string,
-    field: CandlestickDeltaField,
-    points: CandlestickDeltaPoint[],
+    candles: CandlestickDeltaCandle[],
+    initialField: CandlestickDeltaField,
   ): CandlestickDeltaTrace {
     const candleState = candlestick.state;
     const xAxis = candleState.empty ? 'X' : candleState.xAxis;
@@ -397,7 +420,7 @@ export class CandlestickDeltaService implements Disposable {
       // currency) apply to the delta layer's x values and magnitudes too.
       id: candlestick.getId(),
       type: TraceType.CANDLESTICK_DELTA,
-      title: `${field} price vs ${referenceLabel}`,
+      title: `OHLC price vs ${referenceLabel}`,
       axes: {
         x: { label: xAxis },
         y: { label: `${yAxis} delta` },
@@ -406,9 +429,9 @@ export class CandlestickDeltaService implements Disposable {
     };
 
     const trace = new CandlestickDeltaTrace(layer, {
-      points,
-      field,
+      candles,
       referenceLabel,
+      initialField,
     });
     this.wireTrace?.(trace);
     return trace;

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -141,7 +141,7 @@ const CANDLESTICK_DELTA_KEYMAP = {
 } as const;
 
 /**
- * Keymap configuration for the candlestick delta settings dialog (F7).
+ * Keymap configuration for the candlestick delta reference picker (Ctrl+Shift+L).
  */
 const CANDLESTICK_DELTA_SETTINGS_KEYMAP = {
   // Reference picker listbox navigation (standard UI, not shown in help)

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -87,7 +87,8 @@ const BRAILLE_KEYMAP = {
  */
 const CANDLESTICK_DELTA_KEYMAP = {
   EXIT_CANDLESTICK_DELTA: key(`esc`, 'Exit Comparison and Return to Chart'),
-  TOGGLE_CANDLESTICK_DELTA: key(`f7`, 'Change Reference Comparison', { helpKey: 'F7' }),
+  TOGGLE_CANDLESTICK_DELTA_LAYER: key(`${Platform.ctrl}+l`, 'Turn Off Reference Comparison', { helpKey: `${Platform.ctrl} + L` }),
+  SELECT_CANDLESTICK_DELTA_REFERENCE: key(`${Platform.ctrl}+shift+l`, 'Change Reference Line', { helpKey: `${Platform.ctrl} + shift + L` }),
 
   // Label scope ('l') is intentionally NOT bound here: TRACE_LABEL's Escape
   // (DEACTIVATE_TRACE_LABEL_SCOPE) hard-returns to Scope.TRACE, which would
@@ -143,8 +144,11 @@ const CANDLESTICK_DELTA_KEYMAP = {
  * Keymap configuration for the candlestick delta settings dialog (F7).
  */
 const CANDLESTICK_DELTA_SETTINGS_KEYMAP = {
-  // Misc
-  TOGGLE_CANDLESTICK_DELTA: key(`esc`, 'Close Reference Comparison Dialog', { showInHelp: false }),
+  // Reference picker listbox navigation (standard UI, not shown in help)
+  CANDLESTICK_DELTA_REF_MOVE_UP: key(`up`, 'Previous Reference Line', { showInHelp: false }),
+  CANDLESTICK_DELTA_REF_MOVE_DOWN: key(`down`, 'Next Reference Line', { showInHelp: false }),
+  CANDLESTICK_DELTA_REF_SELECT: key(`enter`, 'Select Reference Line', { showInHelp: false }),
+  CANDLESTICK_DELTA_REF_CLOSE: key(`esc`, 'Close Reference Picker', { showInHelp: false }),
 } as const;
 
 /**
@@ -310,7 +314,8 @@ const TRACE_KEYMAP = {
   TOGGLE_DESCRIPTION: key(`d`, 'Open Chart Description'),
 
   // Candlestick reference comparison (virtual delta layer)
-  TOGGLE_CANDLESTICK_DELTA: key(`f7`, 'Compare Candlestick to Reference Line', { helpKey: 'F7' }),
+  TOGGLE_CANDLESTICK_DELTA_LAYER: key(`${Platform.ctrl}+l`, 'Toggle Candlestick Reference Comparison', { helpKey: `${Platform.ctrl} + L` }),
+  SELECT_CANDLESTICK_DELTA_REFERENCE: key(`${Platform.ctrl}+shift+l`, 'Choose Candlestick Reference Line', { helpKey: `${Platform.ctrl} + shift + L` }),
 
   // rotor functionality
   ROTOR_NEXT_NAV: key(`${Platform.alt}+shift+up`, 'Next Navigation Mode (Rotor)', { helpKey: `${Platform.alt} + shift + up` }),

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -87,7 +87,7 @@ const BRAILLE_KEYMAP = {
  */
 const CANDLESTICK_DELTA_KEYMAP = {
   EXIT_CANDLESTICK_DELTA: key(`esc`, 'Exit Comparison and Return to Chart'),
-  TOGGLE_CANDLESTICK_DELTA_LAYER: key(`${Platform.ctrl}+l`, 'Turn Off Reference Comparison', { helpKey: `${Platform.ctrl} + L` }),
+  TOGGLE_CANDLESTICK_DELTA_LAYER: key(`${Platform.alt}+l`, 'Turn Off Reference Comparison', { helpKey: `${Platform.alt} + L` }),
   SELECT_CANDLESTICK_DELTA_REFERENCE: key(`${Platform.ctrl}+shift+l`, 'Change Reference Line', { helpKey: `${Platform.ctrl} + shift + L` }),
 
   // Label scope ('l') is intentionally NOT bound here: TRACE_LABEL's Escape
@@ -314,7 +314,7 @@ const TRACE_KEYMAP = {
   TOGGLE_DESCRIPTION: key(`d`, 'Open Chart Description'),
 
   // Candlestick reference comparison (virtual delta layer)
-  TOGGLE_CANDLESTICK_DELTA_LAYER: key(`${Platform.ctrl}+l`, 'Toggle Candlestick Reference Comparison', { helpKey: `${Platform.ctrl} + L` }),
+  TOGGLE_CANDLESTICK_DELTA_LAYER: key(`${Platform.alt}+l`, 'Toggle Candlestick Reference Comparison', { helpKey: `${Platform.alt} + L` }),
   SELECT_CANDLESTICK_DELTA_REFERENCE: key(`${Platform.ctrl}+shift+l`, 'Choose Candlestick Reference Line', { helpKey: `${Platform.ctrl} + shift + L` }),
 
   // rotor functionality

--- a/src/state/viewModel/candlestickDeltaViewModel.ts
+++ b/src/state/viewModel/candlestickDeltaViewModel.ts
@@ -178,9 +178,10 @@ export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDelt
     }
     this.store.dispatch(hide());
     this.deltaService.closeSettings();
-    // activate() commits the reference as the remembered one only on success,
-    // so a reference that no longer overlaps the candles fails cleanly without
-    // clobbering the previously working selection.
+    // activate() remembers the reference as soon as it is a usable line (it
+    // overlaps the candles), even if it can't virtualize at the current candle
+    // — so the user can move to a covered candle and press Alt L. A reference
+    // with no overlap at all fails cleanly without clobbering the previous one.
     this.deltaService.activate(reference.id);
   }
 

--- a/src/state/viewModel/candlestickDeltaViewModel.ts
+++ b/src/state/viewModel/candlestickDeltaViewModel.ts
@@ -1,4 +1,3 @@
-import type { CandlestickDeltaField } from '@model/candlestickDelta';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type {
   CandlestickDeltaReference,
@@ -6,33 +5,28 @@ import type {
 } from '@service/candlestickDelta';
 import type { NotificationService } from '@service/notification';
 import type { AppStore } from '@state/store';
-import { CANDLESTICK_DELTA_FIELDS } from '@model/candlestickDelta';
 import { createSlice } from '@reduxjs/toolkit';
 import { AbstractViewModel } from '@state/viewModel/viewModel';
 
 /**
- * State for the candlestick delta settings dialog (F7).
+ * State for the candlestick delta reference picker (Ctrl+Shift+L): a listbox
+ * of the moving-average / reference lines available in the current subplot.
  */
 export interface CandlestickDeltaState {
   visible: boolean;
   references: CandlestickDeltaReference[];
-  fields: CandlestickDeltaField[];
-  initialReferenceId: string;
-  initialField: CandlestickDeltaField;
+  selectedIndex: number;
 }
 
 const initialState: CandlestickDeltaState = {
   visible: false,
   references: [],
-  fields: [...CANDLESTICK_DELTA_FIELDS],
-  initialReferenceId: '',
-  initialField: 'close',
+  selectedIndex: 0,
 };
 
 interface ShowPayload {
   references: CandlestickDeltaReference[];
-  initialReferenceId: string;
-  initialField: CandlestickDeltaField;
+  selectedIndex: number;
 }
 
 const candlestickDeltaSlice = createSlice({
@@ -43,10 +37,14 @@ const candlestickDeltaSlice = createSlice({
       return {
         visible: true,
         references: action.payload.references,
-        fields: [...CANDLESTICK_DELTA_FIELDS],
-        initialReferenceId: action.payload.initialReferenceId,
-        initialField: action.payload.initialField,
+        selectedIndex: action.payload.selectedIndex,
       };
+    },
+    setSelectedIndex(
+      state,
+      action: PayloadAction<number>,
+    ): CandlestickDeltaState {
+      return { ...state, selectedIndex: action.payload };
     },
     hide(): CandlestickDeltaState {
       return initialState;
@@ -54,10 +52,11 @@ const candlestickDeltaSlice = createSlice({
   },
 });
 
-const { show, hide } = candlestickDeltaSlice.actions;
+const { show, setSelectedIndex, hide } = candlestickDeltaSlice.actions;
 
 /**
- * ViewModel bridging the candlestick delta service and the F7 dialog UI.
+ * ViewModel bridging the candlestick delta service and the reference picker.
+ * Owns the Ctrl+L toggle logic and the Ctrl+Shift+L reference listbox.
  */
 export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDeltaState> {
   private readonly deltaService: CandlestickDeltaService;
@@ -83,13 +82,41 @@ export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDelt
   }
 
   /**
-   * Opens the settings dialog when the feature applies here, or closes it if
-   * it is already open (ESC path). Announces why when unavailable.
+   * Ctrl+L: toggles the comparison layer on or off using the remembered
+   * reference line. When no reference has been chosen yet, warns the user and
+   * opens the reference picker so they can pick one.
    */
-  public toggle(): void {
+  public toggleLayer(): void {
+    if (this.deltaService.isActive) {
+      this.deltaService.deactivate();
+      return;
+    }
+
+    if (this.deltaService.selectedReference !== null) {
+      this.deltaService.activate();
+      return;
+    }
+
+    // First use with nothing chosen: guide the user to the picker.
+    if (!this.openReferencePicker()) {
+      return;
+    }
+    this.notification.notify(
+      'No reference line chosen yet. Use the list to pick a moving average '
+      + 'line and press Enter to compare. Press Escape to cancel.',
+    );
+  }
+
+  /**
+   * Ctrl+Shift+L: opens the reference picker so the user can choose (or
+   * change) the reference line. Returns false and announces why when the
+   * feature does not apply in the current context.
+   * @returns True when the picker was opened
+   */
+  public openReferencePicker(): boolean {
     if (this.state.visible) {
       this.cancel();
-      return;
+      return false;
     }
 
     const references = this.deltaService.getReferences();
@@ -97,37 +124,69 @@ export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDelt
       this.notification.notify(
         'Reference comparison is only available on candlestick charts with a line layer.',
       );
-      return;
+      return false;
     }
 
-    const activeSelection = this.deltaService.activeSelection;
-    const initialReferenceId
-      = activeSelection && references.some(ref => ref.id === activeSelection.referenceId)
-        ? activeSelection.referenceId
-        : references[0].id;
+    const remembered = this.deltaService.selectedReference;
+    const rememberedIndex = remembered
+      ? references.findIndex(ref => ref.id === remembered)
+      : -1;
 
     this.store.dispatch(
       show({
         references,
-        initialReferenceId,
-        initialField: activeSelection?.field ?? 'close',
+        selectedIndex: rememberedIndex >= 0 ? rememberedIndex : 0,
       }),
     );
     this.deltaService.openSettings();
+    return true;
+  }
+
+  /** Moves the listbox selection up one option, clamped at the top. */
+  public moveSelectionUp(): void {
+    const nextIndex = Math.max(0, this.state.selectedIndex - 1);
+    this.store.dispatch(setSelectedIndex(nextIndex));
+  }
+
+  /** Moves the listbox selection down one option, clamped at the bottom. */
+  public moveSelectionDown(): void {
+    const nextIndex = Math.min(
+      this.state.references.length - 1,
+      this.state.selectedIndex + 1,
+    );
+    this.store.dispatch(setSelectedIndex(nextIndex));
+  }
+
+  /** Sets the listbox selection directly (mouse click on an option). */
+  public setSelectedIndex(index: number): void {
+    if (index < 0 || index >= this.state.references.length) {
+      return;
+    }
+    this.store.dispatch(setSelectedIndex(index));
   }
 
   /**
-   * Confirms the dialog: closes it and activates the virtual delta layer
-   * with the chosen reference series and OHLC field.
+   * Confirms the highlighted reference line: remembers it and activates the
+   * comparison. Reselecting while active reconfigures the layer in place.
    */
-  public confirm(referenceId: string, field: CandlestickDeltaField): void {
+  public confirmSelection(): void {
+    const { references, selectedIndex } = this.state;
+    const reference = references[selectedIndex];
+    if (!reference) {
+      this.cancel();
+      return;
+    }
     this.store.dispatch(hide());
     this.deltaService.closeSettings();
-    this.deltaService.activate(referenceId, field);
+    this.deltaService.setSelectedReference(reference.id);
+    this.deltaService.activate(reference.id);
   }
 
-  /** Cancels the dialog without changing the active layer. */
+  /** Closes the picker without changing the remembered reference. */
   public cancel(): void {
+    if (!this.state.visible) {
+      return;
+    }
     this.store.dispatch(hide());
     this.deltaService.closeSettings();
   }

--- a/src/state/viewModel/candlestickDeltaViewModel.ts
+++ b/src/state/viewModel/candlestickDeltaViewModel.ts
@@ -178,7 +178,9 @@ export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDelt
     }
     this.store.dispatch(hide());
     this.deltaService.closeSettings();
-    this.deltaService.setSelectedReference(reference.id);
+    // activate() commits the reference as the remembered one only on success,
+    // so a reference that no longer overlaps the candles fails cleanly without
+    // clobbering the previously working selection.
     this.deltaService.activate(reference.id);
   }
 

--- a/src/state/viewModel/candlestickDeltaViewModel.ts
+++ b/src/state/viewModel/candlestickDeltaViewModel.ts
@@ -56,7 +56,7 @@ const { show, setSelectedIndex, hide } = candlestickDeltaSlice.actions;
 
 /**
  * ViewModel bridging the candlestick delta service and the reference picker.
- * Owns the Ctrl+L toggle logic and the Ctrl+Shift+L reference listbox.
+ * Owns the Alt+L toggle logic and the Ctrl+Shift+L reference listbox.
  */
 export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDeltaState> {
   private readonly deltaService: CandlestickDeltaService;
@@ -82,7 +82,7 @@ export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDelt
   }
 
   /**
-   * Ctrl+L: toggles the comparison layer on or off using the remembered
+   * Alt+L: toggles the comparison layer on or off using the remembered
    * reference line. When no reference has been chosen yet, warns the user and
    * opens the reference picker so they can pick one.
    */

--- a/src/type/event.ts
+++ b/src/type/event.ts
@@ -45,7 +45,7 @@ export enum Scope {
   BRAILLE = 'BRAILLE',
   /** Navigating the virtual candlestick-vs-reference-line delta layer. */
   CANDLESTICK_DELTA = 'CANDLESTICK_DELTA',
-  /** The F7 dialog for configuring the candlestick delta layer. */
+  /** The reference-line picker (Ctrl+Shift+L) for the candlestick delta layer. */
   CANDLESTICK_DELTA_SETTINGS = 'CANDLESTICK_DELTA_SETTINGS',
   CHAT = 'CHAT',
   COMMAND_PALETTE = 'COMMAND_PALETTE',

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -492,9 +492,10 @@ export enum TraceType {
   BOX = 'box',
   CANDLESTICK = 'candlestick',
   /**
-   * Virtual layer comparing one candlestick OHLC field against a reference
+   * Virtual layer comparing candlestick OHLC fields against a reference
    * line (e.g. a moving average). Never declared in MAIDR JSON — created at
-   * runtime by the candlestick delta feature (F7).
+   * runtime by the candlestick delta feature (Alt+L to toggle, Ctrl+Shift+L
+   * to pick the reference line).
    */
   CANDLESTICK_DELTA = 'candlestick_delta',
   DODGED = 'dodged_bar',

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -173,6 +173,16 @@ export interface AudioState {
    */
   zeroClick?: boolean;
   /**
+   * Pitch-glide direction for the tone. When set, the tone glides its pitch
+   * over the note duration to convey a direction while `freq.raw` still sets
+   * the base pitch: `'up'` sweeps upward (a rising "whoosh"), `'down'` sweeps
+   * downward (a falling drop). Used by the candlestick delta layer so
+   * above-line points rise and below-line points fall, independent of the
+   * base pitch that still encodes the delta magnitude. Ignored for the zero
+   * (`zeroClick`) path.
+   */
+  glide?: 'up' | 'down';
+  /**
    * Volume multiplier for dynamic volume control.
    * Used to scale audio volume based on data characteristics (e.g., violin plot width).
    * If undefined, defaults to 1.0 (no volume scaling).

--- a/src/ui/component/CandlestickDeltaSettings.tsx
+++ b/src/ui/component/CandlestickDeltaSettings.tsx
@@ -1,132 +1,182 @@
-import type { CandlestickDeltaField } from '@model/candlestickDelta';
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  FormControl,
-  MenuItem,
-  Select,
-  Typography,
-} from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { Box, IconButton, Typography } from '@mui/material';
 import { useViewModel, useViewModelState } from '@state/hook/useViewModel';
-import React, { useId, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 /**
- * The F7 dialog for the candlestick reference comparison: the user picks a
- * reference line (e.g. a moving average series) and the OHLC value to
- * compare, then OK activates the virtual delta layer. ESC/Cancel closes the
- * dialog without changing anything (ESC is handled by the
- * CANDLESTICK_DELTA_SETTINGS keybinding scope).
+ * The Ctrl+Shift+L reference picker for the candlestick delta layer: a listbox
+ * of the moving-average / reference lines in the current subplot. The user
+ * moves the highlight with Up/Down (handled by the CANDLESTICK_DELTA_SETTINGS
+ * keybinding scope) and presses Enter to remember that line and activate the
+ * comparison; Escape closes without changing anything.
+ *
+ * Keyboard handling lives in the scope keybindings (which drive the view
+ * model), so this component only renders state and manages focus and
+ * screen-reader announcements — mirroring the GoToExtrema modal.
  */
 const CandlestickDeltaSettings: React.FC = () => {
   const viewModel = useViewModel('candlestickDelta');
   const state = useViewModelState('candlestickDelta');
 
-  const titleId = useId();
-  const descriptionId = useId();
-  const referenceLabelId = useId();
-  const fieldLabelId = useId();
+  const modalRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLDivElement>(null);
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const liveRegionRef = useRef<HTMLDivElement>(null);
 
-  const [referenceId, setReferenceId] = useState(state.initialReferenceId);
-  const [field, setField] = useState<CandlestickDeltaField>(state.initialField);
+  const visible = state.visible && state.references.length > 0;
 
-  if (!state.visible || state.references.length === 0) {
+  // Focus the modal on open so the scope keybindings have a non-input focus
+  // target (hotkeys-js ignores editable elements) and screen readers land here.
+  useEffect(() => {
+    if (visible && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [visible]);
+
+  // Keep the highlighted option focused and in view, and announce it.
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    const item = selectedItemRef.current;
+    if (item) {
+      item.focus();
+      item.scrollIntoView({ block: 'nearest' });
+    }
+    const reference = state.references[state.selectedIndex];
+    if (liveRegionRef.current && reference) {
+      liveRegionRef.current.textContent = `Selected: ${reference.label}`;
+    }
+  }, [visible, state.selectedIndex, state.references]);
+
+  if (!visible) {
     return null;
   }
 
-  const handleOk = (): void => {
-    viewModel.confirm(referenceId, field);
-  };
-
-  const handleCancel = (): void => {
+  const handleClose = (): void => {
     viewModel.cancel();
   };
 
+  const handleSelect = (index: number): void => {
+    viewModel.setSelectedIndex(index);
+    viewModel.confirmSelection();
+  };
+
   return (
-    <Dialog
-      role="dialog"
-      aria-labelledby={titleId}
-      aria-describedby={descriptionId}
-      open={true}
-      maxWidth="xs"
-      fullWidth
-      disablePortal
-      disableEnforceFocus
-      onClick={e => e.stopPropagation()}
-      // Focus sits inside the dialog (autoFocus on the first Select), so MUI
-      // swallows the Escape keydown before the scope keybinding can see it.
-      // Route MUI's own escape/backdrop-close through the cancel path instead.
-      onClose={handleCancel}
-    >
-      <DialogContent>
-        <Typography id={titleId} variant="h6" component="h2" fontWeight="bold" gutterBottom>
-          Compare to Reference Line
-        </Typography>
-        <Typography id={descriptionId} variant="body2" color="text.secondary" gutterBottom>
-          Explore how far each candle sits above or below a reference line.
-          Pick the reference and the price value to compare, then press OK.
-        </Typography>
+    <>
+      <Box
+        sx={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          bgcolor: 'rgba(0, 0, 0, 0.5)',
+          zIndex: 9999,
+        }}
+        onClick={handleClose}
+        aria-hidden="true"
+      />
 
-        <Typography id={referenceLabelId} variant="body2" sx={{ mt: 2, mb: 0.5 }}>
-          Reference data
-        </Typography>
-        <FormControl fullWidth>
-          <Select
-            value={referenceId}
-            onChange={e => setReferenceId(e.target.value)}
-            MenuProps={{ disablePortal: true }}
-            inputProps={{ 'aria-labelledby': referenceLabelId }}
-            autoFocus
-            size="small"
-          >
-            {state.references.map(reference => (
-              <MenuItem key={reference.id} value={reference.id}>
-                {reference.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
-        <Typography id={fieldLabelId} variant="body2" sx={{ mt: 2, mb: 0.5 }}>
-          Value to compare
-        </Typography>
-        <FormControl fullWidth>
-          <Select
-            value={field}
-            onChange={e => setField(e.target.value as CandlestickDeltaField)}
-            MenuProps={{ disablePortal: true }}
-            inputProps={{ 'aria-labelledby': fieldLabelId }}
-            size="small"
-          >
-            {state.fields.map(fieldOption => (
-              <MenuItem key={fieldOption} value={fieldOption}>
-                {fieldOption}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </DialogContent>
-
-      <DialogActions>
-        <Button
-          variant="outlined"
-          color="inherit"
-          onClick={handleCancel}
-          aria-label="Cancel and close without comparing"
+      <Box
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="candlestick-delta-title"
+        aria-describedby="candlestick-delta-description"
+        tabIndex={0}
+        sx={{
+          position: 'fixed',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          bgcolor: 'background.paper',
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 2,
+          p: 3,
+          boxShadow: 3,
+          zIndex: 10000,
+          minWidth: 320,
+          maxWidth: 420,
+          maxHeight: '80vh',
+          outline: 'none',
+        }}
+      >
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}
         >
-          Cancel
-        </Button>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleOk}
-          aria-label="Activate the reference comparison layer"
+          <Typography
+            id="candlestick-delta-title"
+            variant="h6"
+            component="h2"
+            sx={{ m: 0, fontWeight: 600 }}
+          >
+            Compare to Reference Line
+          </Typography>
+          <IconButton onClick={handleClose} aria-label="Close reference picker" size="small">
+            <Close />
+          </IconButton>
+        </Box>
+
+        <Typography
+          id="candlestick-delta-description"
+          variant="body2"
+          color="text.secondary"
+          sx={{ mb: 2 }}
         >
-          Okay
-        </Button>
-      </DialogActions>
-    </Dialog>
+          Choose a reference line to compare each candle against. Use the Up and
+          Down arrows to move, then press Enter. Once chosen, press Control L to
+          turn the comparison on or off.
+        </Typography>
+
+        <Box
+          ref={listContainerRef}
+          role="listbox"
+          aria-label="Reference lines"
+          aria-activedescendant={`candlestick-delta-option-${state.selectedIndex}`}
+          sx={{ maxHeight: 320, overflowY: 'auto', border: 1, borderColor: 'divider', borderRadius: 1, p: 1 }}
+        >
+          {state.references.map((reference, index) => {
+            const isSelected = index === state.selectedIndex;
+            return (
+              <Box
+                key={reference.id}
+                ref={isSelected ? selectedItemRef : null}
+                id={`candlestick-delta-option-${index}`}
+                role="option"
+                aria-selected={isSelected}
+                aria-label={reference.label}
+                tabIndex={isSelected ? 0 : -1}
+                onClick={() => handleSelect(index)}
+                sx={{
+                  'p': 1.5,
+                  'mb': 0.5,
+                  'border': isSelected ? 2 : 1,
+                  'borderColor': isSelected ? 'primary.main' : 'divider',
+                  'borderRadius': 1,
+                  'cursor': 'pointer',
+                  'bgcolor': isSelected ? 'action.selected' : 'transparent',
+                  'outline': 'none',
+                  '&:hover': { bgcolor: 'action.hover' },
+                }}
+              >
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  {reference.label}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+
+        <div
+          ref={liveRegionRef}
+          aria-live="assertive"
+          aria-atomic="true"
+          style={{ position: 'absolute', left: '-10000px', width: '1px', height: '1px', overflow: 'hidden' }}
+        />
+      </Box>
+    </>
   );
 };
 

--- a/src/ui/component/CandlestickDeltaSettings.tsx
+++ b/src/ui/component/CandlestickDeltaSettings.tsx
@@ -16,6 +16,11 @@ import React, { useEffect, useRef } from 'react';
  * mirroring the Command Palette (Ctrl+Shift+P). An extra aria-live region here
  * would double-announce the selection ("… 3 of 3, Selected: …"), so there
  * intentionally isn't one.
+ *
+ * The modal is hand-rolled (not MUI's Modal) to keep Escape and the arrow
+ * keys flowing to the hotkeys-js scope, so it also lacks MUI's built-in focus
+ * containment. A small Tab trap (onKeyDown below) keeps keyboard focus inside
+ * the picker instead of letting it escape behind the backdrop into the page.
  */
 const CandlestickDeltaSettings: React.FC = () => {
   const viewModel = useViewModel('candlestickDelta');
@@ -24,6 +29,7 @@ const CandlestickDeltaSettings: React.FC = () => {
   const modalRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
   const listContainerRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const visible = state.visible && state.references.length > 0;
 
@@ -62,6 +68,27 @@ const CandlestickDeltaSettings: React.FC = () => {
     viewModel.confirmSelection();
   };
 
+  // Trap Tab within the picker. Without browser-level focus containment a Tab
+  // would move focus behind the backdrop into the still-interactive page, so
+  // cycle between the two focusable controls (close button and highlighted
+  // option). Only Tab is intercepted — arrows, Enter and Escape fall through
+  // to the hotkeys-js scope untouched.
+  const handleModalKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key !== 'Tab') {
+      return;
+    }
+    const focusables = [closeButtonRef.current, selectedItemRef.current]
+      .filter(Boolean) as HTMLElement[];
+    if (focusables.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    const activeIndex = focusables.indexOf(document.activeElement as HTMLElement);
+    const step = event.shiftKey ? -1 : 1;
+    const nextIndex = (activeIndex + step + focusables.length) % focusables.length;
+    focusables[nextIndex].focus();
+  };
+
   return (
     <>
       <Box
@@ -85,6 +112,7 @@ const CandlestickDeltaSettings: React.FC = () => {
         aria-labelledby="candlestick-delta-title"
         aria-describedby="candlestick-delta-description"
         tabIndex={0}
+        onKeyDown={handleModalKeyDown}
         sx={{
           position: 'fixed',
           top: '50%',
@@ -114,7 +142,7 @@ const CandlestickDeltaSettings: React.FC = () => {
           >
             Compare to Reference Line
           </Typography>
-          <IconButton onClick={handleClose} aria-label="Close reference picker" size="small">
+          <IconButton ref={closeButtonRef} onClick={handleClose} aria-label="Close reference picker" size="small">
             <Close />
           </IconButton>
         </Box>

--- a/src/ui/component/CandlestickDeltaSettings.tsx
+++ b/src/ui/component/CandlestickDeltaSettings.tsx
@@ -126,15 +126,20 @@ const CandlestickDeltaSettings: React.FC = () => {
           sx={{ mb: 2 }}
         >
           Choose a reference line to compare each candle against. Use the Up and
-          Down arrows to move, then press Enter. Once chosen, press Control L to
+          Down arrows to move, then press Enter. Once chosen, press Alt L to
           turn the comparison on or off.
         </Typography>
 
+        {/*
+          Roving tabindex: real DOM focus is moved onto the highlighted option
+          (see the selection effect above), so the container deliberately does
+          NOT also carry aria-activedescendant — combining both focus patterns
+          can double-announce on some screen reader/browser combinations.
+        */}
         <Box
           ref={listContainerRef}
           role="listbox"
           aria-label="Reference lines"
-          aria-activedescendant={`candlestick-delta-option-${state.selectedIndex}`}
           sx={{ maxHeight: 320, overflowY: 'auto', border: 1, borderColor: 'divider', borderRadius: 1, p: 1 }}
         >
           {state.references.map((reference, index) => {

--- a/src/ui/component/CandlestickDeltaSettings.tsx
+++ b/src/ui/component/CandlestickDeltaSettings.tsx
@@ -11,8 +11,11 @@ import React, { useEffect, useRef } from 'react';
  * comparison; Escape closes without changing anything.
  *
  * Keyboard handling lives in the scope keybindings (which drive the view
- * model), so this component only renders state and manages focus and
- * screen-reader announcements — mirroring the GoToExtrema modal.
+ * model), so this component only renders state and moves DOM focus onto the
+ * highlighted option. That focus move is the sole announcement mechanism —
+ * mirroring the Command Palette (Ctrl+Shift+P). An extra aria-live region here
+ * would double-announce the selection ("… 3 of 3, Selected: …"), so there
+ * intentionally isn't one.
  */
 const CandlestickDeltaSettings: React.FC = () => {
   const viewModel = useViewModel('candlestickDelta');
@@ -21,7 +24,6 @@ const CandlestickDeltaSettings: React.FC = () => {
   const modalRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
   const listContainerRef = useRef<HTMLDivElement>(null);
-  const liveRegionRef = useRef<HTMLDivElement>(null);
 
   const visible = state.visible && state.references.length > 0;
 
@@ -33,7 +35,9 @@ const CandlestickDeltaSettings: React.FC = () => {
     }
   }, [visible]);
 
-  // Keep the highlighted option focused and in view, and announce it.
+  // Move focus onto the highlighted option and keep it in view. The focus move
+  // is what the screen reader announces (the option's label plus its position),
+  // so no separate live region is used — that would announce a second time.
   useEffect(() => {
     if (!visible) {
       return;
@@ -42,10 +46,6 @@ const CandlestickDeltaSettings: React.FC = () => {
     if (item) {
       item.focus();
       item.scrollIntoView({ block: 'nearest' });
-    }
-    const reference = state.references[state.selectedIndex];
-    if (liveRegionRef.current && reference) {
-      liveRegionRef.current.textContent = `Selected: ${reference.label}`;
     }
   }, [visible, state.selectedIndex, state.references]);
 
@@ -173,13 +173,6 @@ const CandlestickDeltaSettings: React.FC = () => {
             );
           })}
         </Box>
-
-        <div
-          ref={liveRegionRef}
-          aria-live="assertive"
-          aria-atomic="true"
-          style={{ position: 'absolute', left: '-10000px', width: '1px', height: '1px', overflow: 'hidden' }}
-        />
       </Box>
     </>
   );

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -898,6 +898,7 @@ const Settings: React.FC = () => {
                       input: {
                         inputProps: {
                           'aria-label': 'Minimum Frequency',
+                          'min': 0,
                         },
                       },
                     }}
@@ -925,6 +926,7 @@ const Settings: React.FC = () => {
                       input: {
                         inputProps: {
                           'aria-label': 'Maximum Frequency',
+                          'min': 0,
                         },
                       },
                     }}

--- a/test/model/candlestickDelta.test.ts
+++ b/test/model/candlestickDelta.test.ts
@@ -362,18 +362,37 @@ describe('candlestickDelta rotor', () => {
     expect(info.lower.label).toBe(BELOW_LINE_MODE);
   });
 
-  test('exposes the on-line filter unit only for fields that have a zero', () => {
+  test('always offers the on-line filter unit, regardless of the current field', () => {
     const trace = createTrace();
-    // close has an on-line point (2026-01-03), so the unit is offered.
     const closeUnits = trace.getRotorFilterUnits();
     expect(closeUnits).toHaveLength(1);
     expect(closeUnits[0].label).toBe(ON_LINE_MODE);
 
-    // high never touches the line (deltas +3, +1, +0.5, +1), so no unit —
-    // gating on the current field avoids advertising a dead-end mode.
+    // high never touches the line (deltas +3, +1, +0.5, +1), but the unit
+    // stays offered so the above/on/below trichotomy is stable as the user
+    // moves between fields; moving simply reports no point on the line.
     enter(trace);
     trace.moveOnce('UPWARD'); // high field
-    expect(trace.getRotorFilterUnits()).toHaveLength(0);
+    expect(trace.getRotorFilterUnits()).toHaveLength(1);
+    expect(trace.moveToRotorFilter('onLine', 'right')).toBe(false);
+    expect(trace.moveToRotorFilter('onLine', 'left')).toBe(false);
+  });
+
+  test('offers the on-line unit even when no candle sits exactly on the line', () => {
+    // Every field of every candle is strictly above or below the reference,
+    // as real moving-average data usually is.
+    const trace = new CandlestickDeltaTrace(createLayer(), {
+      candles: [
+        { x: 'a', reference: 10, open: 11, high: 12, low: 10.5, close: 11.5 },
+        { x: 'b', reference: 10, open: 9, high: 9.5, low: 8, close: 8.8 },
+      ],
+      referenceLabel: 'Moving Average 3 days',
+      initialField: 'close',
+    });
+
+    expect(trace.getRotorFilterUnits()).toHaveLength(1);
+    enter(trace);
+    expect(trace.moveToRotorFilter('onLine', 'right')).toBe(false);
   });
 
   test('above-line unit skips to the next point above the reference', () => {

--- a/test/model/candlestickDelta.test.ts
+++ b/test/model/candlestickDelta.test.ts
@@ -1,4 +1,4 @@
-import type { CandlestickDeltaPoint } from '@model/candlestickDelta';
+import type { CandlestickDeltaCandle } from '@model/candlestickDelta';
 import type { MaidrLayer } from '@type/grammar';
 import { describe, expect, jest, test } from '@jest/globals';
 import {
@@ -7,21 +7,10 @@ import {
   CandlestickDeltaTrace,
   DELTA_POINT_MODE,
   deltaTrend,
+  ON_LINE_MODE,
   roundDelta,
 } from '@model/candlestickDelta';
 import { TraceType } from '@type/grammar';
-
-/**
- * Builds a delta point with the trend derived from the delta sign.
- * @param x - The shared x value
- * @param fieldValue - The OHLC value at x
- * @param reference - The reference line value at x
- * @returns A delta point
- */
-function point(x: string, fieldValue: number, reference: number): CandlestickDeltaPoint {
-  const delta = roundDelta(fieldValue - reference);
-  return { x, fieldValue, reference, delta, trend: deltaTrend(delta) };
-}
 
 /**
  * Creates a synthetic layer definition for the virtual delta trace.
@@ -31,26 +20,33 @@ function createLayer(): MaidrLayer {
   return {
     id: 'candle-layer',
     type: TraceType.CANDLESTICK_DELTA,
-    title: 'close price vs MA 3',
+    title: 'OHLC price vs MA 3',
     axes: { x: { label: 'Date' }, y: { label: 'Price delta' } },
     data: [],
   };
 }
 
 /**
- * Creates a delta trace with deltas +2, -1.5, 0, +0.5 over four dates.
+ * Four candles over a flat reference line of 10. Close deltas are
+ * +2, -1.5, 0, +0.5 (above, below, on line, above); the largest |delta|
+ * across every field is the high of 2026-01-01 (+3).
+ */
+const CANDLES: CandlestickDeltaCandle[] = [
+  { x: '2026-01-01', reference: 10, open: 11, high: 13, low: 9, close: 12 },
+  { x: '2026-01-02', reference: 10, open: 9, high: 11, low: 8, close: 8.5 },
+  { x: '2026-01-03', reference: 10, open: 10, high: 10.5, low: 9.5, close: 10 },
+  { x: '2026-01-04', reference: 10, open: 10.2, high: 11, low: 10, close: 10.5 },
+];
+
+/**
+ * Creates a delta trace over {@link CANDLES}, starting on the close field.
  * @returns The trace under test
  */
 function createTrace(): CandlestickDeltaTrace {
   return new CandlestickDeltaTrace(createLayer(), {
-    points: [
-      point('2026-01-01', 12, 10), // +2 (above)
-      point('2026-01-02', 8.5, 10), // -1.5 (below)
-      point('2026-01-03', 10, 10), // 0 (on line)
-      point('2026-01-04', 10.5, 10), // +0.5 (above)
-    ],
-    field: 'close',
+    candles: CANDLES.map(candle => ({ ...candle })),
     referenceLabel: 'Moving Average 3 days',
+    initialField: 'close',
   });
 }
 
@@ -70,18 +66,12 @@ describe('roundDelta and deltaTrend', () => {
   });
 
   test('scales the zero tolerance to operand magnitude for large prices', () => {
-    // A ~2e-3 residual on a ~1.6e9 instrument is averaging noise: on line.
-    // The old fixed 1e-9 grid both overflowed here and reported it as nonzero.
     expect(roundDelta(2e-3, 1.6e9)).toBe(0);
-    // The same residual on a ~10 instrument is a real, meaningful delta.
     expect(roundDelta(2e-3, 10)).toBe(0.002);
-    // A genuinely large delta on a large instrument survives (no overflow).
     expect(roundDelta(1500, 1.6e9)).toBe(1500);
   });
 
   test('preserves precision at large magnitude instead of overflowing', () => {
-    // Math.round(1.6e9 * 1e9) overflows MAX_SAFE_INTEGER and returns garbage;
-    // the magnitude-aware version returns the delta faithfully.
     expect(roundDelta(12.5, 1.6e9)).toBe(12.5);
   });
 
@@ -92,11 +82,13 @@ describe('roundDelta and deltaTrend', () => {
   });
 });
 
-describe('candlestickDelta navigation', () => {
-  test('moves left and right through the delta points', () => {
+describe('candlestickDelta candle navigation', () => {
+  test('moves left and right through the candles, starting on close', () => {
     const trace = createTrace();
     enter(trace);
     expect(trace.col).toBe(0);
+    expect(trace.comparedField).toBe('close');
+    expect(trace.getCurrentXValue()).toBe('2026-01-01');
 
     expect(trace.moveOnce('FORWARD')).toBe(true);
     expect(trace.col).toBe(1);
@@ -104,20 +96,13 @@ describe('candlestickDelta navigation', () => {
     expect(trace.col).toBe(0);
   });
 
-  test('reports out of bounds for vertical movement (single-row layer)', () => {
-    const trace = createTrace();
-    enter(trace);
-
-    expect(trace.moveOnce('UPWARD')).toBe(false);
-    expect(trace.moveOnce('DOWNWARD')).toBe(false);
-  });
-
-  test('setInitialPosition places the cursor without entering initial entry', () => {
+  test('setInitialPosition places the cursor on a candle without initial entry', () => {
     const trace = createTrace();
     trace.setInitialPosition(2);
 
     expect(trace.isInitialEntry).toBe(false);
     expect(trace.col).toBe(2);
+    expect(trace.comparedField).toBe('close');
     expect(trace.getCurrentXValue()).toBe('2026-01-03');
   });
 
@@ -132,8 +117,42 @@ describe('candlestickDelta navigation', () => {
   });
 });
 
+describe('candlestickDelta field navigation', () => {
+  test('up and down move through the OHLC fields value-sorted per candle', () => {
+    const trace = createTrace();
+    enter(trace); // 2026-01-01, close (sorted: low, open, close, high)
+
+    // Up from close reaches high (the top field).
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+    expect(trace.comparedField).toBe('high');
+    // Already at the top: another up is out of bounds.
+    expect(trace.moveOnce('UPWARD')).toBe(false);
+    expect(trace.comparedField).toBe('high');
+
+    // Down walks high -> close -> open -> low, then bottoms out.
+    expect(trace.moveOnce('DOWNWARD')).toBe(true);
+    expect(trace.comparedField).toBe('close');
+    expect(trace.moveOnce('DOWNWARD')).toBe(true);
+    expect(trace.comparedField).toBe('open');
+    expect(trace.moveOnce('DOWNWARD')).toBe(true);
+    expect(trace.comparedField).toBe('low');
+    expect(trace.moveOnce('DOWNWARD')).toBe(false);
+    expect(trace.comparedField).toBe('low');
+  });
+
+  test('the compared field is preserved when moving between candles', () => {
+    const trace = createTrace();
+    enter(trace);
+    trace.moveOnce('UPWARD'); // high on 2026-01-01
+    trace.moveOnce('FORWARD'); // still high, now 2026-01-02
+
+    expect(trace.comparedField).toBe('high');
+    expect(trace.getCurrentXValue()).toBe('2026-01-02');
+  });
+});
+
 describe('candlestickDelta state', () => {
-  test('text describes direction and magnitude', () => {
+  test('text describes the field, magnitude and position', () => {
     const trace = createTrace();
     enter(trace);
     const state = trace.state;
@@ -160,23 +179,40 @@ describe('candlestickDelta state', () => {
     expect(!onLine.empty && onLine.text.cross.value).toBe(0);
   });
 
-  test('audio encodes |delta| as pitch, trend as timbre, and opts into the zero click', () => {
+  test('audio encodes |delta| as pitch and glides up for above-line points', () => {
     const trace = createTrace();
-    trace.setInitialPosition(1);
+    enter(trace); // 2026-01-01 close: +2 (above)
     const state = trace.state;
 
     expect(state.empty).toBe(false);
     if (!state.empty) {
-      expect(state.audio.freq.raw).toBe(1.5);
+      expect(state.audio.freq.raw).toBe(2);
       expect(state.audio.freq.min).toBe(0);
-      expect(state.audio.freq.max).toBe(2);
-      expect(state.audio.trend).toBe('Bear');
-      expect(state.audio.zeroClick).toBe(true);
-      expect(state.audio.panning).toEqual({ x: 1, y: 0, rows: 1, cols: 4 });
+      expect(state.audio.freq.max).toBe(3); // global max |delta| (high +3)
+      expect(state.audio.glide).toBe('up');
+      expect(state.audio.zeroClick).toBeUndefined();
+      expect(state.audio.panning).toEqual({ x: 0, y: 2, rows: 4, cols: 4 });
     }
   });
 
-  test('braille exposes |delta| heights with bearish markers for below-line points', () => {
+  test('audio glides down for below-line points', () => {
+    const trace = createTrace();
+    trace.setInitialPosition(1); // close -1.5 (below)
+    const state = trace.state;
+    expect(!state.empty && state.audio.freq.raw).toBe(1.5);
+    expect(!state.empty && state.audio.glide).toBe('down');
+  });
+
+  test('audio opts into the zero click on the line with no glide', () => {
+    const trace = createTrace();
+    trace.setInitialPosition(2); // close 0 (on line)
+    const state = trace.state;
+    expect(!state.empty && state.audio.freq.raw).toBe(0);
+    expect(!state.empty && state.audio.zeroClick).toBe(true);
+    expect(!state.empty && state.audio.glide).toBeUndefined();
+  });
+
+  test('braille exposes |delta| heights for the current field with bearish markers', () => {
     const trace = createTrace();
     enter(trace);
     const state = trace.state;
@@ -189,10 +225,26 @@ describe('candlestickDelta state', () => {
       expect(state.braille.custom).toEqual(['Bull', 'Bear', 'Neutral', 'Bull']);
       expect(state.braille.row).toBe(0);
       expect(state.braille.col).toBe(0);
+      expect((state.braille as { max: number[] }).max).toEqual([2]);
     }
   });
 
-  test('braille returns stable array references across navigation', () => {
+  test('braille reflects the field after moving up to high', () => {
+    const trace = createTrace();
+    enter(trace);
+    trace.moveOnce('UPWARD'); // high field
+    const state = trace.state;
+
+    if (!state.empty && !state.braille.empty) {
+      // high deltas: +3, +1, +0.5, +1 (all above the line -> all Bull)
+      expect((state.braille as { values: number[][] }).values).toEqual([
+        [3, 1, 0.5, 1],
+      ]);
+      expect(state.braille.custom).toEqual(['Bull', 'Bull', 'Bull', 'Bull']);
+    }
+  });
+
+  test('braille returns stable array references across candle navigation', () => {
     const trace = createTrace();
     enter(trace);
     const first = trace.state;
@@ -205,13 +257,15 @@ describe('candlestickDelta state', () => {
     }
   });
 
-  test('autoplay spans the point count in horizontal directions', () => {
+  test('autoplay spans candles horizontally and fields vertically', () => {
     const trace = createTrace();
     enter(trace);
     const state = trace.state;
 
     expect(!state.empty && state.autoplay.FORWARD).toBe(4);
     expect(!state.empty && state.autoplay.BACKWARD).toBe(4);
+    expect(!state.empty && state.autoplay.UPWARD).toBe(4);
+    expect(!state.empty && state.autoplay.DOWNWARD).toBe(4);
   });
 
   test('never highlights (virtual layer)', () => {
@@ -222,7 +276,7 @@ describe('candlestickDelta state', () => {
     expect(!state.empty && state.highlight.empty).toBe(true);
   });
 
-  test('description summarizes reference, counts, and data table', () => {
+  test('description summarizes the current field, counts, and data table', () => {
     const trace = createTrace();
     const description = trace.description;
 
@@ -231,6 +285,7 @@ describe('candlestickDelta state', () => {
       label: 'Reference line',
       value: 'Moving Average 3 days',
     });
+    expect(description.stats).toContainEqual({ label: 'Compared value', value: 'close' });
     expect(description.stats).toContainEqual({ label: 'Points above line', value: 2 });
     expect(description.stats).toContainEqual({ label: 'Points below line', value: 1 });
     expect(description.stats).toContainEqual({ label: 'Points on line', value: 1 });
@@ -246,7 +301,7 @@ describe('candlestickDelta state', () => {
 });
 
 describe('candlestickDelta extrema', () => {
-  test('exposes max and min signed delta targets', () => {
+  test('exposes max and min signed delta targets for the current field', () => {
     const trace = createTrace();
     const targets = trace.getExtremaTargets();
 
@@ -294,14 +349,20 @@ describe('candlestickDelta rotor', () => {
     expect(info.lower.label).toBe(BELOW_LINE_MODE);
   });
 
+  test('exposes the on-line filter unit when a point sits on the line', () => {
+    const trace = createTrace();
+    const units = trace.getRotorFilterUnits();
+    expect(units).toHaveLength(1);
+    expect(units[0].label).toBe(ON_LINE_MODE);
+  });
+
   test('above-line unit skips to the next point above the reference', () => {
     const trace = createTrace();
     enter(trace); // col 0 (+2)
 
     expect(trace.moveToNextCompareValue('right', 'higher')).toBe(true);
-    expect(trace.col).toBe(3); // skips -1.5 and 0
+    expect(trace.col).toBe(3); // skips -1.5 and 0 to reach +0.5
 
-    // No further above-line point to the right.
     expect(trace.moveToNextCompareValue('right', 'higher')).toBe(false);
     expect(trace.col).toBe(3);
   });
@@ -313,6 +374,16 @@ describe('candlestickDelta rotor', () => {
     expect(trace.moveToNextCompareValue('left', 'lower')).toBe(true);
     expect(trace.col).toBe(1);
     expect(trace.moveToNextCompareValue('left', 'lower')).toBe(false);
+  });
+
+  test('on-line filter jumps between points exactly on the reference line', () => {
+    const trace = createTrace();
+    enter(trace); // col 0
+
+    expect(trace.moveToRotorFilter('onLine', 'right')).toBe(true);
+    expect(trace.col).toBe(2); // 2026-01-03 close is exactly on the line
+    expect(trace.moveToRotorFilter('onLine', 'right')).toBe(false);
+    expect(trace.col).toBe(2);
   });
 
   test('vertical compare navigation is out of bounds', () => {

--- a/test/model/candlestickDelta.test.ts
+++ b/test/model/candlestickDelta.test.ts
@@ -149,6 +149,19 @@ describe('candlestickDelta field navigation', () => {
     expect(trace.comparedField).toBe('high');
     expect(trace.getCurrentXValue()).toBe('2026-01-02');
   });
+
+  test('moveToIndex (braille cursor) preserves the compared field', () => {
+    const trace = createTrace();
+    enter(trace);
+    trace.moveOnce('UPWARD'); // high field
+    expect(trace.comparedField).toBe('high');
+
+    // Braille collapses fields to a single row (row 0); moving the cursor must
+    // not snap the field back to the candle's lowest value.
+    expect(trace.moveToIndex(0, 3)).toBe(true);
+    expect(trace.col).toBe(3);
+    expect(trace.comparedField).toBe('high');
+  });
 });
 
 describe('candlestickDelta state', () => {
@@ -349,11 +362,18 @@ describe('candlestickDelta rotor', () => {
     expect(info.lower.label).toBe(BELOW_LINE_MODE);
   });
 
-  test('exposes the on-line filter unit when a point sits on the line', () => {
+  test('exposes the on-line filter unit only for fields that have a zero', () => {
     const trace = createTrace();
-    const units = trace.getRotorFilterUnits();
-    expect(units).toHaveLength(1);
-    expect(units[0].label).toBe(ON_LINE_MODE);
+    // close has an on-line point (2026-01-03), so the unit is offered.
+    const closeUnits = trace.getRotorFilterUnits();
+    expect(closeUnits).toHaveLength(1);
+    expect(closeUnits[0].label).toBe(ON_LINE_MODE);
+
+    // high never touches the line (deltas +3, +1, +0.5, +1), so no unit —
+    // gating on the current field avoids advertising a dead-end mode.
+    enter(trace);
+    trace.moveOnce('UPWARD'); // high field
+    expect(trace.getRotorFilterUnits()).toHaveLength(0);
   });
 
   test('above-line unit skips to the next point above the reference', () => {

--- a/test/service/audio.glide.test.ts
+++ b/test/service/audio.glide.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for AudioService's directional pitch glide (the candlestick delta
+ * layer's above/below-line sonification).
+ *
+ * AudioContext doesn't exist in the node test environment, so we install a
+ * minimal global mock. Critically, the oscillator's `frequency` mock mirrors
+ * the Web Audio spec: `exponentialRampToValueAtTime` THROWS on a non-positive
+ * target. That makes this a real regression guard for the `safeBase`/
+ * `safeTarget` clamps — remove them and the negative-Min-Frequency test throws
+ * exactly like the browser would.
+ */
+import type { NotificationService } from '@service/notification';
+import type { SettingsService } from '@service/settings';
+import type { PlotState } from '@type/state';
+import { describe, expect, it, jest } from '@jest/globals';
+
+interface MockParam {
+  value: number;
+  setValueAtTime: jest.Mock;
+  exponentialRampToValueAtTime: jest.Mock;
+  linearRampToValueAtTime: jest.Mock;
+  setValueCurveAtTime: jest.Mock;
+}
+
+function makeParam(spec = false): MockParam {
+  return {
+    value: 0,
+    setValueAtTime: jest.fn(),
+    // Spec-faithful only for oscillator frequency: the real API throws when
+    // the ramp target is <= 0. Other params (gain) are lenient.
+    exponentialRampToValueAtTime: jest.fn((target: number) => {
+      if (spec && !(target > 0)) {
+        throw new RangeError('exponentialRampToValueAtTime: target must be > 0');
+      }
+    }) as jest.Mock,
+    linearRampToValueAtTime: jest.fn(),
+    setValueCurveAtTime: jest.fn(),
+  };
+}
+
+interface MockOscillator {
+  type: string;
+  frequency: MockParam;
+  connect: jest.Mock;
+  start: jest.Mock;
+  stop: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+function makeOscillator(): MockOscillator {
+  return {
+    type: '',
+    frequency: makeParam(true),
+    connect: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makeGain(): { gain: MockParam; connect: jest.Mock; disconnect: jest.Mock } {
+  return { gain: makeParam(false), connect: jest.fn(), disconnect: jest.fn() };
+}
+
+function makePanner(): { pan: { value: number }; connect: jest.Mock; disconnect: jest.Mock } {
+  return { pan: { value: 0 }, connect: jest.fn(), disconnect: jest.fn() };
+}
+
+function makeCompressor(): Record<string, unknown> {
+  return {
+    threshold: { value: 0 },
+    knee: { value: 0 },
+    ratio: { value: 0 },
+    attack: { value: 0 },
+    release: { value: 0 },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+interface MockAudioContext {
+  currentTime: number;
+  state: string;
+  destination: object;
+  sampleRate: number;
+  oscillators: MockOscillator[];
+  createOscillator: () => MockOscillator;
+  createGain: () => ReturnType<typeof makeGain>;
+  createStereoPanner: () => ReturnType<typeof makePanner>;
+  createDynamicsCompressor: () => Record<string, unknown>;
+  close: jest.Mock;
+}
+
+function installAudioContextMock(): MockAudioContext {
+  const ctx: MockAudioContext = {
+    currentTime: 0,
+    state: 'running',
+    destination: {},
+    sampleRate: 44100,
+    oscillators: [],
+    createOscillator() {
+      const osc = makeOscillator();
+      this.oscillators.push(osc);
+      return osc;
+    },
+    createGain: makeGain,
+    createStereoPanner: makePanner,
+    createDynamicsCompressor: makeCompressor,
+    close: jest.fn(),
+  };
+  const audioGlobal = globalThis as unknown as { AudioContext: new () => MockAudioContext };
+  audioGlobal.AudioContext = function () {
+    return ctx;
+  } as unknown as new () => MockAudioContext;
+  return ctx;
+}
+
+/** Settings stub returning fixed volume / min / max frequency. */
+function createSettings(min: number, max: number, volume = 100): SettingsService {
+  return {
+    get: <T>(key: string): T => {
+      const value
+        = key === 'general.volume'
+          ? volume
+          : key === 'general.minFrequency'
+            ? min
+            : key === 'general.maxFrequency'
+              ? max
+              : 0;
+      return value as unknown as T;
+    },
+    onChange: () => {},
+  } as unknown as SettingsService;
+}
+
+function createNotification(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+/** A trace audio state that routes through the glide path in update(). */
+function glideState(glide: 'up' | 'down', raw: number): PlotState {
+  return {
+    empty: false,
+    type: 'trace',
+    traceType: 'candlestick_delta',
+    hasMultiPoints: false,
+    audio: {
+      freq: { min: 0, max: 3, raw },
+      panning: { x: 0, y: 0, rows: 4, cols: 4 },
+      glide,
+    },
+  } as unknown as PlotState;
+}
+
+const INITIAL_STATE = { empty: true, type: 'figure' } as unknown as PlotState;
+
+describe('AudioService directional glide', () => {
+  it('rises for above-line and falls for below-line points', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(200, 1000), INITIAL_STATE);
+
+    service.update(glideState('up', 1.5)); // base 600 -> up
+    let osc = ctx.oscillators[ctx.oscillators.length - 1];
+    let base = osc.frequency.setValueAtTime.mock.calls[0][0] as number;
+    let target = osc.frequency.exponentialRampToValueAtTime.mock.calls[0][0] as number;
+    expect(osc.type).toBe('triangle');
+    expect(target).toBeGreaterThan(base);
+
+    service.update(glideState('down', 1.5)); // base 600 -> down
+    osc = ctx.oscillators[ctx.oscillators.length - 1];
+    base = osc.frequency.setValueAtTime.mock.calls[0][0] as number;
+    target = osc.frequency.exponentialRampToValueAtTime.mock.calls[0][0] as number;
+    expect(osc.type).toBe('sine');
+    expect(target).toBeLessThan(base);
+
+    service.dispose();
+  });
+
+  it('does not throw when a negative Min Frequency setting pushes the base pitch below zero', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    // A negative Min Frequency + a small |delta| interpolates to a negative
+    // base pitch; without the clamp the frequency ramp would throw (as the
+    // spec-faithful mock does) and abort update() mid-observer-chain.
+    const service = new AudioService(createNotification(), createSettings(-100, 1000), INITIAL_STATE);
+
+    expect(() => service.update(glideState('down', 0.001))).not.toThrow();
+
+    const osc = ctx.oscillators[ctx.oscillators.length - 1];
+    const target = osc.frequency.exponentialRampToValueAtTime.mock.calls[0][0] as number;
+    const base = osc.frequency.setValueAtTime.mock.calls[0][0] as number;
+    expect(target).toBeGreaterThan(0); // clamped to a positive value
+    expect(base).toBeGreaterThan(0);
+
+    service.dispose();
+  });
+});

--- a/test/service/candlestickDelta.test.ts
+++ b/test/service/candlestickDelta.test.ts
@@ -111,6 +111,12 @@ function createHarness(): Harness {
   const toggleFocus = jest.fn();
   const display = { toggleFocus } as unknown as DisplayService;
   const service = new CandlestickDeltaService(context, notification, display, rotor);
+  // The moving averages start one day after the candles (2026-01-01 is
+  // uncovered), and the delta layer only activates where the current candle
+  // has a delta. Park the candlestick on the first covered candle so the
+  // activation tests exercise the success path; the refusal tests move back to
+  // 2026-01-01 explicitly.
+  (context.active as Trace).moveToXValue('2026-01-02');
   return { context, service, rotor, notify, toggleFocus };
 }
 
@@ -177,6 +183,35 @@ describe('candlestickDeltaService activation', () => {
     // An unresolvable reference must not clobber the working selection.
     expect(service.activate('ma-layer:9')).toBe(false);
     expect(service.selectedReference).toBe('ma-layer:0');
+  });
+
+  test('refuses and alerts when the current candle has no reference value', () => {
+    const { context, service, notify, toggleFocus } = createHarness();
+    // 2026-01-01 is before the moving average starts — no delta there.
+    (context.active as Trace).moveToXValue('2026-01-01');
+
+    expect(service.activate('ma-layer:0')).toBe(false);
+    expect(service.isActive).toBe(false);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining('does not reach this candle'),
+    );
+    // The virtual layer must not have been swapped in.
+    expect(context.active.constructor.name).toBe('Candlestick');
+    expect(toggleFocus).not.toHaveBeenCalledWith(Scope.CANDLESTICK_DELTA);
+    // The reference is still remembered so a later Alt L can use it.
+    expect(service.selectedReference).toBe('ma-layer:0');
+  });
+
+  test('activates from a covered candle after a refusal on an uncovered one', () => {
+    const { context, service } = createHarness();
+    (context.active as Trace).moveToXValue('2026-01-01');
+    expect(service.activate('ma-layer:0')).toBe(false);
+
+    // Move onto a covered candle and toggle on via the remembered reference.
+    (context.active as Trace).moveToXValue('2026-01-03');
+    expect(service.activate()).toBe(true);
+    expect(service.isActive).toBe(true);
+    expect((context.active as CandlestickDeltaTrace).getCurrentXValue()).toBe('2026-01-03');
   });
 
   test('starts on the candle the user was on when it exists in the delta domain', () => {

--- a/test/service/candlestickDelta.test.ts
+++ b/test/service/candlestickDelta.test.ts
@@ -169,6 +169,16 @@ describe('candlestickDeltaService activation', () => {
     expect(service.isActive).toBe(false);
   });
 
+  test('a failed activation leaves the remembered reference untouched', () => {
+    const { service } = createHarness();
+    service.activate('ma-layer:0');
+    expect(service.selectedReference).toBe('ma-layer:0');
+
+    // An unresolvable reference must not clobber the working selection.
+    expect(service.activate('ma-layer:9')).toBe(false);
+    expect(service.selectedReference).toBe('ma-layer:0');
+  });
+
   test('starts on the candle the user was on when it exists in the delta domain', () => {
     const { context, service } = createHarness();
     (context.active as Trace).moveToXValue('2026-01-03');

--- a/test/service/candlestickDelta.test.ts
+++ b/test/service/candlestickDelta.test.ts
@@ -258,6 +258,47 @@ describe('candlestickDeltaService activation', () => {
     expect(context.active.constructor.name).toBe('Candlestick');
   });
 
+  test('reconfiguring to a reference that misses the current candle keeps the current comparison', () => {
+    // A third moving average that only covers the last two candles.
+    const maidr = createMaidr();
+    const lineLayer = maidr.subplots[0][0].layers[1];
+    (lineLayer.data as LinePoint[][]).push([
+      { x: '2026-01-03', y: 10, z: 'Moving Average 9 days' },
+      { x: '2026-01-04', y: 11, z: 'Moving Average 9 days' },
+    ]);
+    const context = new Context(new Figure(maidr));
+    const notification = new NotificationService();
+    const notify = jest.fn();
+    notification.onChange(event => notify(event.value));
+    const text = new TextService(notification);
+    const rotor = new RotorNavigationService(context, text, notification);
+    const service = new CandlestickDeltaService(
+      context,
+      notification,
+      { toggleFocus: jest.fn() } as unknown as DisplayService,
+      rotor,
+    );
+
+    // On 2026-01-02, activate MA3 (which covers it).
+    (context.active as Trace).moveToXValue('2026-01-02');
+    expect(service.activate('ma-layer:0')).toBe(true);
+    expect((context.active as CandlestickDeltaTrace).getCurrentXValue()).toBe('2026-01-02');
+    notify.mockClear();
+
+    // Reconfigure to MA9 (ma-layer:2), which does NOT reach 2026-01-02.
+    expect(service.activate('ma-layer:2')).toBe(false);
+
+    // The old MA3 comparison stays active on the same candle; the remembered
+    // reference is unchanged.
+    expect(service.isActive).toBe(true);
+    expect((context.active as CandlestickDeltaTrace).reference).toBe('Moving Average 3 days');
+    expect((context.active as CandlestickDeltaTrace).getCurrentXValue()).toBe('2026-01-02');
+    expect(service.selectedReference).toBe('ma-layer:0');
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining('Keeping the current comparison'),
+    );
+  });
+
   test('reconfiguring preserves the current delta-layer x, not the pre-activation candle', () => {
     const { context, service } = createHarness();
     service.activate('ma-layer:0');

--- a/test/service/candlestickDelta.test.ts
+++ b/test/service/candlestickDelta.test.ts
@@ -354,6 +354,29 @@ describe('candlestickDelta rotor integration', () => {
     expect(trace.getCurrentXValue()).toBe('2026-01-03');
   });
 
+  test('up/down in above-line mode switches OHLC fields, not candles', () => {
+    const { context, service, rotor } = createHarness();
+    service.activate('ma-layer:0');
+    const trace = context.active as CandlestickDeltaTrace;
+    trace.setInitialPosition(0); // 2026-01-02, close (sorted: low, open, close, high)
+    expect(trace.comparedField).toBe('close');
+
+    rotor.moveToNextRotorUnit(); // below line
+    rotor.moveToNextRotorUnit(); // above line
+    expect(rotor.getMode()).toBe(ABOVE_LINE_MODE);
+
+    // Up must move to the field above close (high) on the SAME candle, not fall
+    // through to a right/candle jump (the pre-fix behaviour).
+    rotor.moveUp();
+    expect(trace.getCurrentXValue()).toBe('2026-01-02');
+    expect(trace.comparedField).toBe('high');
+
+    // Down returns to close, still on the same candle.
+    rotor.moveDown();
+    expect(trace.getCurrentXValue()).toBe('2026-01-02');
+    expect(trace.comparedField).toBe('close');
+  });
+
   test('activation and deactivation reset the rotor to the data unit', () => {
     const { context, service, rotor } = createHarness();
     service.activate('ma-layer:0');

--- a/test/service/candlestickDelta.test.ts
+++ b/test/service/candlestickDelta.test.ts
@@ -7,6 +7,7 @@ import {
   BELOW_LINE_MODE,
   CandlestickDeltaTrace,
   DELTA_POINT_MODE,
+  ON_LINE_MODE,
 } from '@model/candlestickDelta';
 import { Context } from '@model/context';
 import { Figure } from '@model/plot';
@@ -135,7 +136,7 @@ describe('candlestickDeltaService activation', () => {
   test('activates a virtual delta layer matched by x value', () => {
     const { context, service, notify, toggleFocus } = createHarness();
 
-    expect(service.activate('ma-layer:0', 'close')).toBe(true);
+    expect(service.activate('ma-layer:0')).toBe(true);
 
     const active = context.active;
     expect(active).toBeInstanceOf(CandlestickDeltaTrace);
@@ -148,48 +149,62 @@ describe('candlestickDeltaService activation', () => {
       '2026-01-04',
     ]);
     expect(toggleFocus).toHaveBeenCalledWith(Scope.CANDLESTICK_DELTA);
-    expect(notify).toHaveBeenCalledWith(expect.stringContaining('close price minus Moving Average 3 days'));
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('OHLC price minus Moving Average 3 days'));
     expect(notify).toHaveBeenCalledWith(expect.stringContaining('Escape'));
     expect(service.isActive).toBe(true);
+    expect(service.selectedReference).toBe('ma-layer:0');
+  });
+
+  test('activate with no argument uses the remembered reference', () => {
+    const { context, service } = createHarness();
+    service.setSelectedReference('ma-layer:1');
+
+    expect(service.activate()).toBe(true);
+    expect((context.active as CandlestickDeltaTrace).reference).toBe('Moving Average 6 days');
+  });
+
+  test('activate with no reference chosen is a no-op', () => {
+    const { service } = createHarness();
+    expect(service.activate()).toBe(false);
+    expect(service.isActive).toBe(false);
   });
 
   test('starts on the candle the user was on when it exists in the delta domain', () => {
     const { context, service } = createHarness();
     (context.active as Trace).moveToXValue('2026-01-03');
 
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
 
     expect((context.active as CandlestickDeltaTrace).getCurrentXValue()).toBe('2026-01-03');
   });
 
-  test('computes signed deltas including exact zeros', () => {
+  test('computes signed deltas including exact zeros on the close field', () => {
     const { context, service } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
     const trace = context.active as CandlestickDeltaTrace;
 
-    // close - MA3: 12-11=+1, 9-10=-1, 11-11=0
+    // close - MA3: 12-11=+1 (above), 9-10=-1 (below), 11-11=0 (on line)
     trace.moveToXValue('2026-01-02');
     let state = trace.state;
     expect(!state.empty && state.audio.freq.raw).toBe(1);
-    expect(!state.empty && state.audio.trend).toBe('Bull');
+    expect(!state.empty && state.audio.glide).toBe('up');
 
     trace.moveToXValue('2026-01-03');
     state = trace.state;
-    expect(!state.empty && state.audio.trend).toBe('Bear');
+    expect(!state.empty && state.audio.glide).toBe('down');
 
     trace.moveToXValue('2026-01-04');
     state = trace.state;
     expect(!state.empty && state.audio.freq.raw).toBe(0);
-    expect(!state.empty && state.audio.trend).toBe('Neutral');
     expect(!state.empty && state.audio.zeroClick).toBe(true);
   });
 
   test('reconfiguring while active replaces the layer and keeps the anchor', () => {
     const { context, service } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
     const firstTrace = context.active;
 
-    expect(service.activate('ma-layer:1', 'open')).toBe(true);
+    expect(service.activate('ma-layer:1')).toBe(true);
     expect(context.active).not.toBe(firstTrace);
     expect((context.active as CandlestickDeltaTrace).reference).toBe('Moving Average 6 days');
 
@@ -200,13 +215,10 @@ describe('candlestickDeltaService activation', () => {
 
   test('reconfiguring preserves the current delta-layer x, not the pre-activation candle', () => {
     const { context, service } = createHarness();
-    // User was on the first candle before activating.
-    service.activate('ma-layer:0', 'close');
-    // Navigate deep inside the delta layer.
+    service.activate('ma-layer:0');
     (context.active as CandlestickDeltaTrace).moveToXValue('2026-01-04');
 
-    // Reconfigure to a different reference that still covers that x.
-    service.activate('ma-layer:1', 'close');
+    service.activate('ma-layer:1');
 
     expect((context.active as CandlestickDeltaTrace).getCurrentXValue()).toBe('2026-01-04');
   });
@@ -224,7 +236,7 @@ describe('candlestickDeltaService activation', () => {
     const display = { toggleFocus: jest.fn() } as unknown as DisplayService;
     const service = new CandlestickDeltaService(context, notification, display, rotor);
 
-    expect(service.activate('ma-layer:0', 'close')).toBe(false);
+    expect(service.activate('ma-layer:0')).toBe(false);
     expect(service.isActive).toBe(false);
     expect(notify).toHaveBeenCalledWith(expect.stringContaining('No matching x values'));
   });
@@ -233,7 +245,7 @@ describe('candlestickDeltaService activation', () => {
 describe('candlestickDeltaService deactivation', () => {
   test('restores the candlestick layer and syncs its position to the delta x', () => {
     const { context, service, toggleFocus } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
     (context.active as CandlestickDeltaTrace).moveToXValue('2026-01-03');
     toggleFocus.mockClear();
 
@@ -245,6 +257,16 @@ describe('candlestickDeltaService deactivation', () => {
     expect(service.isActive).toBe(false);
   });
 
+  test('keeps the remembered reference after deactivation for re-toggling', () => {
+    const { service } = createHarness();
+    service.activate('ma-layer:0');
+    service.deactivate();
+
+    expect(service.selectedReference).toBe('ma-layer:0');
+    // A bare activate() re-enables the same comparison.
+    expect(service.activate()).toBe(true);
+  });
+
   test('deactivate is a no-op when nothing is active', () => {
     const { service } = createHarness();
     expect(service.deactivate()).toBe(false);
@@ -252,7 +274,7 @@ describe('candlestickDeltaService deactivation', () => {
 
   test('deactivateIfActive silently restores the anchor before layer switching', () => {
     const { context, service, notify } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
     notify.mockClear();
 
     service.deactivateIfActive();
@@ -263,7 +285,7 @@ describe('candlestickDeltaService deactivation', () => {
 
   test('discardActiveLayer tears down state and resets the rotor without touching focus or the stack', () => {
     const { context, service, rotor, toggleFocus, notify } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
     const deltaTrace = context.active;
     rotor.moveToNextRotorUnit(); // leave data mode
     expect(context.isRotorEnabled()).toBe(true);
@@ -272,11 +294,9 @@ describe('candlestickDeltaService deactivation', () => {
 
     service.discardActiveLayer();
 
-    // Internal state is cleared and the rotor is reset...
     expect(service.isActive).toBe(false);
     expect(context.isRotorEnabled()).toBe(false);
     expect(rotor.getCurrentUnit()).toBe(0);
-    // ...but the caller owns the stack and focus, so neither is touched here.
     expect(context.active).toBe(deltaTrace);
     expect(toggleFocus).not.toHaveBeenCalled();
     expect(notify).not.toHaveBeenCalled();
@@ -289,35 +309,36 @@ describe('candlestickDeltaService deactivation', () => {
 });
 
 describe('candlestickDelta rotor integration', () => {
-  test('cycles delta point, below line, and above line units', () => {
+  test('cycles delta point, below line, above line, and on line units', () => {
     const { service, rotor } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
 
     expect(rotor.getMode()).toBe(DELTA_POINT_MODE);
     expect(rotor.moveToNextRotorUnit()).toBe(BELOW_LINE_MODE);
     expect(rotor.getCompareType()).toBe('lower');
     expect(rotor.moveToNextRotorUnit()).toBe(ABOVE_LINE_MODE);
     expect(rotor.getCompareType()).toBe('higher');
+    expect(rotor.moveToNextRotorUnit()).toBe(ON_LINE_MODE);
     expect(rotor.moveToNextRotorUnit()).toBe(DELTA_POINT_MODE);
   });
 
   test('right arrow in above-line mode jumps to the next above-line point', () => {
     const { context, service, rotor } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
     const trace = context.active as CandlestickDeltaTrace;
-    trace.setInitialPosition(0); // 2026-01-02, delta +1
+    trace.setInitialPosition(0); // 2026-01-02, close delta +1
 
     rotor.moveToNextRotorUnit(); // below line
     rotor.moveToNextRotorUnit(); // above line
 
-    // Only point 0 is above the line, so moving right reports a boundary.
+    // Only point 0 is above the line on close, so moving right hits a boundary.
     const message = rotor.moveRight();
     expect(message).toContain('point above the line');
     expect(trace.getCurrentXValue()).toBe('2026-01-02');
 
     // From the right edge, moving left in below-line mode lands on -1.
     trace.setInitialPosition(2);
-    rotor.moveToNextRotorUnit(); // wraps to delta point
+    rotor.resetToDataMode();
     rotor.moveToNextRotorUnit(); // below line
     expect(rotor.moveLeft()).toBeNull();
     expect(trace.getCurrentXValue()).toBe('2026-01-03');
@@ -325,7 +346,7 @@ describe('candlestickDelta rotor integration', () => {
 
   test('activation and deactivation reset the rotor to the data unit', () => {
     const { context, service, rotor } = createHarness();
-    service.activate('ma-layer:0', 'close');
+    service.activate('ma-layer:0');
     rotor.moveToNextRotorUnit(); // below line
     expect(context.isRotorEnabled()).toBe(true);
 

--- a/test/state/viewModel/candlestickDeltaViewModel.test.ts
+++ b/test/state/viewModel/candlestickDeltaViewModel.test.ts
@@ -1,0 +1,197 @@
+import type {
+  CandlestickDeltaReference,
+  CandlestickDeltaService,
+} from '@service/candlestickDelta';
+import type { NotificationService } from '@service/notification';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { createMaidrStore } from '@state/store';
+import { CandlestickDeltaViewModel } from '@state/viewModel/candlestickDeltaViewModel';
+
+const REFERENCES: CandlestickDeltaReference[] = [
+  { id: 'ma-layer:0', label: 'Moving Average 3 days' },
+  { id: 'ma-layer:1', label: 'Moving Average 6 days' },
+];
+
+/**
+ * A mutable stub of CandlestickDeltaService. isActive/selectedReference are
+ * plain properties the tests flip; the rest are jest mocks.
+ */
+interface ServiceStub {
+  isActive: boolean;
+  selectedReference: string | null;
+  getReferences: jest.Mock;
+  activate: jest.Mock;
+  deactivate: jest.Mock;
+  openSettings: jest.Mock;
+  closeSettings: jest.Mock;
+  setSelectedReference: jest.Mock;
+}
+
+interface Harness {
+  vm: CandlestickDeltaViewModel;
+  service: ServiceStub;
+  notify: jest.Mock;
+}
+
+function setup(): Harness {
+  const store = createMaidrStore();
+  const service: ServiceStub = {
+    isActive: false,
+    selectedReference: null,
+    getReferences: jest.fn(() => REFERENCES),
+    activate: jest.fn(() => true),
+    deactivate: jest.fn(() => true),
+    openSettings: jest.fn(),
+    closeSettings: jest.fn(),
+    setSelectedReference: jest.fn(),
+  };
+  const notify = jest.fn();
+  const notification = { notify } as unknown as NotificationService;
+  const vm = new CandlestickDeltaViewModel(
+    store,
+    service as unknown as CandlestickDeltaService,
+    notification,
+  );
+  return { vm, service, notify };
+}
+
+describe('CandlestickDeltaViewModel.toggleLayer', () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = setup();
+  });
+
+  test('deactivates when the layer is already active', () => {
+    h.service.isActive = true;
+
+    h.vm.toggleLayer();
+
+    expect(h.service.deactivate).toHaveBeenCalledTimes(1);
+    expect(h.service.activate).not.toHaveBeenCalled();
+    expect(h.vm.state.visible).toBe(false);
+  });
+
+  test('re-activates the remembered reference without opening the picker', () => {
+    h.service.isActive = false;
+    h.service.selectedReference = 'ma-layer:0';
+
+    h.vm.toggleLayer();
+
+    expect(h.service.activate).toHaveBeenCalledTimes(1);
+    expect(h.service.getReferences).not.toHaveBeenCalled();
+    expect(h.vm.state.visible).toBe(false);
+  });
+
+  test('first use with no reference warns and opens the picker', () => {
+    h.service.isActive = false;
+    h.service.selectedReference = null;
+
+    h.vm.toggleLayer();
+
+    expect(h.vm.state.visible).toBe(true);
+    expect(h.vm.state.references).toEqual(REFERENCES);
+    expect(h.service.openSettings).toHaveBeenCalledTimes(1);
+    expect(h.service.activate).not.toHaveBeenCalled();
+    expect(h.notify).toHaveBeenCalledWith(
+      expect.stringContaining('No reference line chosen yet'),
+    );
+  });
+
+  test('first use on an unsupported chart announces and does not open the picker', () => {
+    h.service.isActive = false;
+    h.service.selectedReference = null;
+    h.service.getReferences.mockReturnValue(null);
+
+    h.vm.toggleLayer();
+
+    expect(h.vm.state.visible).toBe(false);
+    expect(h.service.openSettings).not.toHaveBeenCalled();
+    expect(h.notify).toHaveBeenCalledWith(
+      expect.stringContaining('only available on candlestick charts'),
+    );
+  });
+});
+
+describe('CandlestickDeltaViewModel reference picker', () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = setup();
+  });
+
+  test('opens preselecting the remembered reference', () => {
+    h.service.selectedReference = 'ma-layer:1';
+
+    expect(h.vm.openReferencePicker()).toBe(true);
+    expect(h.vm.state.visible).toBe(true);
+    expect(h.vm.state.selectedIndex).toBe(1);
+    expect(h.service.openSettings).toHaveBeenCalledTimes(1);
+  });
+
+  test('opening while already open cancels (toggle behavior)', () => {
+    h.vm.openReferencePicker();
+    expect(h.vm.state.visible).toBe(true);
+
+    expect(h.vm.openReferencePicker()).toBe(false);
+    expect(h.vm.state.visible).toBe(false);
+    expect(h.service.closeSettings).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not open on an unsupported chart', () => {
+    h.service.getReferences.mockReturnValue(null);
+
+    expect(h.vm.openReferencePicker()).toBe(false);
+    expect(h.vm.state.visible).toBe(false);
+    expect(h.notify).toHaveBeenCalledWith(
+      expect.stringContaining('only available on candlestick charts'),
+    );
+  });
+
+  test('move selection clamps at both ends', () => {
+    h.vm.openReferencePicker(); // selectedIndex 0, two references
+    h.vm.moveSelectionUp();
+    expect(h.vm.state.selectedIndex).toBe(0);
+
+    h.vm.moveSelectionDown();
+    expect(h.vm.state.selectedIndex).toBe(1);
+    h.vm.moveSelectionDown();
+    expect(h.vm.state.selectedIndex).toBe(1);
+
+    h.vm.moveSelectionUp();
+    expect(h.vm.state.selectedIndex).toBe(0);
+  });
+
+  test('setSelectedIndex ignores out-of-range indices', () => {
+    h.vm.openReferencePicker();
+    h.vm.setSelectedIndex(1);
+    expect(h.vm.state.selectedIndex).toBe(1);
+
+    h.vm.setSelectedIndex(5);
+    expect(h.vm.state.selectedIndex).toBe(1);
+    h.vm.setSelectedIndex(-1);
+    expect(h.vm.state.selectedIndex).toBe(1);
+  });
+
+  test('confirm activates the highlighted reference and closes the picker', () => {
+    h.vm.openReferencePicker();
+    h.vm.setSelectedIndex(1);
+
+    h.vm.confirmSelection();
+
+    expect(h.vm.state.visible).toBe(false);
+    expect(h.service.closeSettings).toHaveBeenCalled();
+    expect(h.service.activate).toHaveBeenCalledWith('ma-layer:1');
+  });
+
+  test('confirm with nothing to select cancels without activating', () => {
+    // Picker never opened: no references, not visible.
+    h.vm.confirmSelection();
+
+    expect(h.service.activate).not.toHaveBeenCalled();
+    expect(h.vm.state.visible).toBe(false);
+  });
+
+  test('cancel while closed is a no-op', () => {
+    h.vm.cancel();
+    expect(h.service.closeSettings).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Replace the F7 reference-comparison dialog with a two-key model:
- Ctrl+Shift+L opens an accessible listbox of the reference (moving-average)
  lines in the candlestick subplot; Enter remembers the chosen line and
  activates the comparison.
- Ctrl+L toggles the invisible delta layer on/off using the remembered
  reference, preserving the candle x position. The first Ctrl+L with no
  reference chosen warns and auto-opens the picker; the reference persists
  across toggles until re-selected via Ctrl+Shift+L.

Make the virtual delta layer navigable like a real candlestick: left/right
between candles and up/down between OHLC fields (value-sorted per candle),
recomputing the signed delta per field. Volatility is omitted.

Add an "on line" rotor unit that jumps to points sitting exactly on the
reference line, alongside the existing above/below-line units.

Sonify direction: below-line points play a falling pitch glide and
above-line points a rising glide (a new AudioState `glide` field), while
pitch still encodes the delta magnitude; on-line points keep the click.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BoRu6Lav5mD8mjsJbWCsw7