### PR TITLE
ci: add per-PR Cloudflare Pages preview of the example gallery

### DIFF
--- a/.github/PR_PREVIEW.md
+++ b/.github/PR_PREVIEW.md
@@ -1,0 +1,76 @@
+# PR example previews
+
+Every pull request gets a **live, browsable preview of the example gallery**,
+deployed to Cloudflare Pages. Reviewers (including screen-reader users) can open
+a URL instead of pulling the branch and running `npm run build` locally.
+
+- **Stable per-PR URL:** `https://pr-<number>.maidr-preview.pages.dev`
+- A bot posts (and keeps updating) a comment on the PR with the link.
+- The preview refreshes automatically on every new commit to the PR.
+- **Nothing is committed to the PR branch.** The built site lives only in a CI
+  artifact and on Cloudflare Pages, so the PR's git history stays clean.
+
+## How it works
+
+Two workflows implement GitHub's recommended secure pattern for previewing
+pull requests — including PRs from forks — without exposing secrets to
+untrusted code:
+
+| Workflow | Trigger | Context | Secrets? | Job |
+| --- | --- | --- | --- | --- |
+| [`pr-preview-build.yml`](workflows/pr-preview-build.yml) | `pull_request` | untrusted (PR code) | **no** | `npm run build:preview` → uploads `_site` + PR number as artifacts |
+| [`pr-preview-deploy.yml`](workflows/pr-preview-deploy.yml) | `workflow_run` | trusted (base repo) | **yes** | downloads the artifacts, deploys to Cloudflare Pages, comments the URL |
+
+The build job never sees the Cloudflare secrets, and the deploy job never checks
+out or runs the PR's code — it only publishes the pre-built files. The PR number
+is passed between them via an artifact (the `workflow_run` event doesn't carry it
+for fork PRs) and validated as strictly numeric before use.
+
+`npm run build:preview` produces `_site/` — all `dist` bundles (core + every
+adapter), the recharts/victory/react single-file examples, and the example
+gallery. It is the same pipeline as the published docs site minus TypeDoc, so
+the `/api` link in the preview's navbar is the only intentionally dead link.
+
+You can run the exact same build locally:
+
+```bash
+npm run build:preview
+npx http-server _site -o     # then open /examples.html
+```
+
+## One-time setup
+
+The workflows are safe to merge before this is done — the deploy job just logs a
+warning and skips until the two secrets exist.
+
+1. **Create a Cloudflare API token** (Cloudflare dashboard → **Manage Account →
+   API Tokens → Create Token → Custom token**). Give it exactly one permission:
+   **Account → Cloudflare Pages → Edit**.
+2. **Find your Account ID** (Cloudflare dashboard → account **Overview**, right-hand
+   **API** panel).
+3. **Add both as repository secrets** (GitHub → repo **Settings → Secrets and
+   variables → Actions → New repository secret**):
+   - `CLOUDFLARE_API_TOKEN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+4. *(Optional)* **Pre-create the Pages project** so its production branch is
+   pinned to `main` from the start. The deploy workflow also attempts this
+   automatically, but you can do it once by hand:
+   ```bash
+   npx wrangler pages project create maidr-preview --production-branch=main
+   ```
+
+That's it. Open a PR and the preview comment appears once the build + deploy
+finish.
+
+## Notes
+
+- The Cloudflare **project name** is `maidr-preview` (referenced in
+  `pr-preview-deploy.yml`). Change it there and in step 4 if you prefer a
+  different name.
+- This is entirely separate from the production docs site at
+  [maidr.ai](https://maidr.ai), which is still deployed by
+  [`docs.yml`](workflows/docs.yml) via GitHub Pages. PR previews don't touch it.
+- Preview deployments count against the Cloudflare Pages free tier (500
+  builds/month at the time of writing) — generous for typical PR volume.
+- To disable previews, delete the two `pr-preview-*.yml` workflows (or remove the
+  secrets to leave them dormant).

--- a/.github/PR_PREVIEW.md
+++ b/.github/PR_PREVIEW.md
@@ -62,6 +62,30 @@ warning and skips until the two secrets exist.
 That's it. Open a PR and the preview comment appears once the build + deploy
 finish.
 
+> **Activation caveat:** `workflow_run` workflows only run the copy that lives on
+> the repository's **default branch**. So the deploy half starts working only
+> after these files are merged to `main` — the PR that *introduces* this feature
+> will build a preview but won't post a comment. Validate end-to-end with a
+> follow-up test PR (ideally one same-repo and one from a fork) after merging.
+
+## Security model
+
+Because a preview is built from untrusted PR code (fork PRs included), the design
+keeps that code away from anything privileged:
+
+- The **build** job (`pull_request`) has no secrets and a read-only token. The
+  **deploy** job (`workflow_run`) holds the secrets but never checks out or runs
+  PR code — it only publishes the pre-built files.
+- The PR number is passed via artifact but **verified** in the deploy job: it
+  must match an open PR whose head commit and repo equal the triggering run's,
+  so a forged number can't redirect the deploy or comment at another PR.
+- The deploy strips `_worker.js`, `functions/`, `_headers`, and `_redirects`
+  from the site so a malicious build can't run server-side code or set response
+  headers on the preview origin.
+- **Never add environment variables, secrets, or bindings to the `maidr-preview`
+  Pages project** — it serves untrusted, PR-built content, and a preview
+  `_worker.js` could otherwise read them.
+
 ## Notes
 
 - The Cloudflare **project name** is `maidr-preview` (referenced in

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,0 +1,81 @@
+# Builds a self-contained preview of the MAIDR example gallery for every pull
+# request and uploads it as an artifact. Screen-reader reviewers can then open a
+# live URL instead of pulling the branch and running `npm run build` locally.
+#
+# This workflow runs in the UNTRUSTED `pull_request` context (fork PRs included),
+# so it has NO access to secrets and only a read-only token — it never deploys.
+# Its companion, `pr-preview-deploy.yml`, runs on `workflow_run` in the trusted
+# base-repo context (where the Cloudflare secrets live), downloads this artifact,
+# and publishes the preview + comments the URL on the PR.
+#
+# Nothing here is committed to the PR branch — the built site exists only as a
+# CI artifact and, after deploy, on Cloudflare Pages. The PR's git history is
+# untouched.
+#
+# One-time Cloudflare setup is documented in .github/PR_PREVIEW.md.
+name: PR Preview Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel superseded builds for the same PR so only the latest commit is previewed.
+concurrency:
+  group: pr-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build example preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          # Untrusted PR code is checked out only to be BUILT; don't leave the
+          # job token in .git/config where a build script could read it.
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Builds all dist bundles (core + every adapter), the recharts/victory/
+      # react single-file examples, and assembles _site/ (dist + examples +
+      # gallery). Skips typedoc — the /api docs aren't needed to test examples.
+      - name: Build preview site
+        run: npm run build:preview
+
+      - name: Upload preview site
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-site
+          path: _site
+          retention-days: 5
+          if-no-files-found: error
+
+      # The PR number is written to a SEPARATE artifact (never into _site, which
+      # is served publicly) so the trusted deploy workflow knows which PR to
+      # comment on — github.event.workflow_run.pull_requests is empty for fork
+      # PRs. The number is a GitHub-controlled integer, safe to inline here.
+      - name: Save PR metadata
+        run: |
+          mkdir -p pr-meta
+          echo "${{ github.event.pull_request.number }}" > pr-meta/pr-number
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-meta
+          path: pr-meta
+          retention-days: 5
+          if-no-files-found: error

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -27,7 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
   actions: read # download the triggering run's artifacts (cross-run)
   pull-requests: write # create/update the sticky preview comment
 
@@ -75,19 +74,51 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
-      # The artifact came from an untrusted PR build, so treat its contents as
-      # attacker-controlled: enforce a strictly numeric PR number before it is
-      # used in any privileged API call or the deploy branch label.
-      - name: Read and validate PR number
+      # The pr-meta artifact came from an UNTRUSTED PR build — and a fork PR can
+      # even rewrite pr-preview-build.yml, because `pull_request` runs the
+      # workflow from the PR head. So the PR number it claims is only a
+      # candidate: validate it is strictly numeric AND verify it belongs to the
+      # commit/repo that produced this run, so a forged number can't redirect
+      # the deploy or the sticky comment at a different (victim) PR.
+      - name: Resolve and verify PR number
         if: success() && steps.cfg.outputs.ready == 'true'
         id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const raw = fs.readFileSync('pr-meta/pr-number', 'utf8').trim();
+            if (!/^[0-9]+$/.test(raw)) {
+              throw new Error(`Non-numeric PR number in artifact: ${JSON.stringify(raw)}`);
+            }
+            const prNumber = Number(raw);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              throw new Error(`Invalid PR number: ${raw}`);
+            }
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            // head_sha is set by GitHub for the triggering run and cannot be
+            // forged to match an unrelated PR's head commit.
+            if (pr.head.sha !== run.head_sha) {
+              throw new Error(`PR #${prNumber} head (${pr.head.sha}) does not match the run head (${run.head_sha}); refusing to deploy.`);
+            }
+            const claimedRepo = pr.head.repo && pr.head.repo.full_name;
+            const runRepo = run.head_repository && run.head_repository.full_name;
+            if (claimedRepo && runRepo && claimedRepo !== runRepo) {
+              throw new Error(`PR #${prNumber} head repo (${claimedRepo}) does not match the run head repo (${runRepo}); refusing to deploy.`);
+            }
+            core.setOutput('number', String(prNumber));
+
+      # Previews must be purely static. The built _site is untrusted (a fork PR
+      # produced it), so strip the files Cloudflare Pages treats specially —
+      # otherwise a malicious build could run server-side code (_worker.js /
+      # functions/) or set arbitrary response headers (_headers / _redirects)
+      # on the preview origin.
+      - name: Enforce static-only preview
+        if: success() && steps.cfg.outputs.ready == 'true'
         run: |
-          PR="$(cat pr-meta/pr-number)"
-          if ! printf '%s' "$PR" | grep -Eq '^[0-9]+$'; then
-            echo "::error::Invalid PR number from artifact: '$PR'"
-            exit 1
-          fi
-          echo "number=$PR" >> "$GITHUB_OUTPUT"
+          rm -rf _site/_worker.js _site/_worker.js.map _site/functions _site/_headers _site/_redirects
 
       # Idempotent: pins production-branch=main so every pr-* deploy is a preview.
       # No-ops (errors) once the project exists, hence continue-on-error.

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,194 @@
+# Deploys the example preview built by "PR Preview Build" to Cloudflare Pages and
+# posts (or updates) a sticky comment on the PR with a browsable URL.
+#
+# This runs on `workflow_run` — i.e. in the TRUSTED context of the base repo's
+# default branch — which is the only context where fork-PR previews can safely
+# use secrets. It deploys the PRE-BUILT artifact bytes and NEVER checks out or
+# runs the PR's code.
+#
+# Requires two repository secrets (one-time setup — see .github/PR_PREVIEW.md):
+#   CLOUDFLARE_API_TOKEN    scope: Account > Cloudflare Pages > Edit
+#   CLOUDFLARE_ACCOUNT_ID
+# Until they are set, the job logs a warning and exits without deploying, so it
+# is safe to merge before the secrets exist.
+#
+# The preview is served at a stable per-PR alias:
+#   https://pr-<number>.maidr-preview.pages.dev
+name: PR Preview Deploy
+
+on:
+  workflow_run:
+    workflows: ["PR Preview Build"]
+    types: [completed]
+
+# One in-flight deploy per source branch; newer commits supersede older deploys.
+concurrency:
+  group: pr-preview-deploy-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read # download the triggering run's artifacts (cross-run)
+  pull-requests: write # create/update the sticky preview comment
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only act on preview builds that actually succeeded.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      # Detect whether the Cloudflare secrets are configured. Secrets can't be
+      # used directly in `if:`, so we surface a boolean output instead. When
+      # unset (e.g. before first-time setup) every later step no-ops.
+      - name: Check Cloudflare configuration
+        id: cfg
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "$CF_API_TOKEN" ] && [ -n "$CF_ACCOUNT_ID" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Cloudflare secrets (CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID) are not set — skipping PR preview deploy. See .github/PR_PREVIEW.md for setup."
+          fi
+
+      - name: Download preview site
+        if: success() && steps.cfg.outputs.ready == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-site
+          path: _site
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Download PR metadata
+        if: success() && steps.cfg.outputs.ready == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-meta
+          path: pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # The artifact came from an untrusted PR build, so treat its contents as
+      # attacker-controlled: enforce a strictly numeric PR number before it is
+      # used in any privileged API call or the deploy branch label.
+      - name: Read and validate PR number
+        if: success() && steps.cfg.outputs.ready == 'true'
+        id: pr
+        run: |
+          PR="$(cat pr-meta/pr-number)"
+          if ! printf '%s' "$PR" | grep -Eq '^[0-9]+$'; then
+            echo "::error::Invalid PR number from artifact: '$PR'"
+            exit 1
+          fi
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      # Idempotent: pins production-branch=main so every pr-* deploy is a preview.
+      # No-ops (errors) once the project exists, hence continue-on-error.
+      - name: Ensure Cloudflare Pages project exists
+        if: success() && steps.cfg.outputs.ready == 'true'
+        continue-on-error: true
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create maidr-preview --production-branch=main
+
+      - name: Deploy to Cloudflare Pages
+        if: success() && steps.cfg.outputs.ready == 'true'
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy _site --project-name=maidr-preview --branch=pr-${{ steps.pr.outputs.number }} --commit-dirty=true
+
+      - name: Post preview URL to the PR
+        if: success() && steps.cfg.outputs.ready == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              throw new Error(`Invalid PR number: ${process.env.PR_NUMBER}`);
+            }
+            // Prefer the stable per-PR alias; fall back to the immutable deploy URL.
+            const url = (process.env.ALIAS_URL || process.env.DEPLOY_URL || '').trim();
+            if (!url) {
+              throw new Error('No deployment URL was returned by wrangler-action');
+            }
+            const sha = (process.env.HEAD_SHA || '').slice(0, 7);
+            const marker = '<!-- maidr-pr-preview -->';
+            const body = [
+              marker,
+              '### 🔎 MAIDR example preview is ready',
+              '',
+              `**Open the preview:** ${url}`,
+              '',
+              `- Example gallery: ${url}/examples.html`,
+              `- Or open any example directly, e.g. ${url}/examples/heatmap.html`,
+              '',
+              `Built from \`${sha}\`. This preview URL is stable and updates automatically on every new commit to the PR.`,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }
+
+      # Best-effort: if the deploy failed after we knew the PR number, flip the
+      # sticky comment to a failure notice so reviewers aren't left waiting.
+      - name: Note preview failure on the PR
+        if: failure() && steps.pr.outputs.number != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              return;
+            }
+            const marker = '<!-- maidr-pr-preview -->';
+            const body = [
+              marker,
+              '### ⚠️ MAIDR example preview failed to deploy',
+              '',
+              `The preview build succeeded but publishing to Cloudflare Pages failed. See the [workflow logs](${process.env.RUN_URL}) for details.`,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   ],
   "scripts": {
     "build": "node scripts/build.js",
+    "build:preview": "npm run build && npm run build:recharts-example && npm run build:victory-example && node scripts/build-site.js",
     "prepublishOnly": "npm run build",
     "prepare": "husky",
     "commitlint": "commitlint --from=HEAD~1 --to=HEAD",


### PR DESCRIPTION
Reviewers (screen-reader users included) can open a live URL for a PR's
example gallery instead of pulling the branch and running the build locally.

Implements GitHub's secure two-workflow preview pattern so it is safe for
fork PRs and never exposes secrets to untrusted code, and never commits build
output to the PR branch:

- pr-preview-build.yml (pull_request, no secrets): runs `npm run build:preview`
  and uploads the assembled _site plus the PR number as artifacts.
- pr-preview-deploy.yml (workflow_run, trusted): downloads the artifacts,
  deploys to Cloudflare Pages at a stable https://pr-<n>.maidr-preview.pages.dev
  alias, and posts/updates a sticky comment with the URL. The PR number is
  validated as strictly numeric and the deploy job never checks out PR code.

Adds a `build:preview` npm script (build + recharts/victory examples +
build-site.js, minus typedoc) usable locally too, and .github/PR_PREVIEW.md
with the one-time Cloudflare secret setup. Until the secrets exist the deploy
job logs a warning and no-ops, so this is safe to merge as-is.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WxjxUMHXzV7jMZUKbLnXiG