### PR TITLE
feat(description): support 'd' shortcut at multi-panel figure level

### DIFF
--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -1,6 +1,6 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
-import type { DescriptionState } from '@type/state';
+import type { DescriptionStat, DescriptionState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
 import { Scope } from '@type/event';
 
@@ -41,7 +41,52 @@ export class DescriptionService {
         ...(subplots.length > 0 && { subplots }),
       };
     }
+
+    // Multi-panel lobby: the active element is the Figure itself (the user has
+    // not entered a subplot yet), so there is no trace to introspect.
+    // Summarize the whole figure instead so 'd' works at the figure level.
+    const state = active.state;
+    if (state.type === 'figure' && !state.empty) {
+      return this.getFigureDescription(state.size);
+    }
+
     return null;
+  }
+
+  /**
+   * Builds a figure-level description for a multi-panel figure's lobby view.
+   * Surfaces the authored figure title, subplot count, and any authored
+   * subtitle/caption, plus the per-subplot summaries so the user sees what
+   * is available before navigating in. Axes and a data table are omitted
+   * because those are trace-level concepts with no figure-level equivalent.
+   *
+   * @param size - The number of subplots in the figure.
+   * @returns The figure-level description state.
+   */
+  private getFigureDescription(size: number): DescriptionState {
+    const figureTitle = this.context.figureTitle;
+    const title = this.context.isAuthoredTitle(figureTitle) ? figureTitle : '';
+
+    const stats: DescriptionStat[] = [
+      { label: 'Subplots', value: size },
+    ];
+    const subtitle = this.context.figureSubtitle;
+    if (this.context.isAuthoredSubtitle(subtitle)) {
+      stats.push({ label: 'Subtitle', value: subtitle });
+    }
+    const caption = this.context.figureCaption;
+    if (this.context.isAuthoredCaption(caption)) {
+      stats.push({ label: 'Caption', value: caption });
+    }
+
+    return {
+      chartType: 'Multi-panel figure',
+      title,
+      axes: {},
+      stats,
+      dataTable: { headers: [], rows: [] },
+      subplots: this.context.getSubplotSummaries(),
+    };
   }
 
   /**

--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -45,6 +45,11 @@ export class DescriptionService {
     // Multi-panel lobby: the active element is the Figure itself (the user has
     // not entered a subplot yet), so there is no trace to introspect.
     // Summarize the whole figure instead so 'd' works at the figure level.
+    //
+    // Only 'figure' is handled here, not 'subplot': the Context stack pushes a
+    // bare Figure exactly when it is at figure level (Context.isFigureLevel),
+    // and a Subplot is always paired with a Trace on top (see enterSubplot), so
+    // a Subplot is never the active element on its own.
     const state = active.state;
     if (state.type === 'figure' && !state.empty) {
       return this.getFigureDescription(state.size);
@@ -57,8 +62,10 @@ export class DescriptionService {
    * Builds a figure-level description for a multi-panel figure's lobby view.
    * Surfaces the authored figure title, subplot count, and any authored
    * subtitle/caption, plus the per-subplot summaries so the user sees what
-   * is available before navigating in. Axes and a data table are omitted
-   * because those are trace-level concepts with no figure-level equivalent.
+   * is available before navigating in. Axes and the data table are left
+   * blank (empty object / no rows) because those are trace-level concepts
+   * with no figure-level equivalent; the description modal hides those
+   * empty sections.
    *
    * @param size - The number of subplots in the figure.
    * @returns The figure-level description state.
@@ -79,13 +86,17 @@ export class DescriptionService {
       stats.push({ label: 'Caption', value: caption });
     }
 
+    // Mirror the trace-level branch: only surface `subplots` when there is at
+    // least one summary, matching the DescriptionState contract that the field
+    // is present only for genuine multi-panel figures.
+    const subplots = this.context.getSubplotSummaries();
     return {
       chartType: 'Multi-panel figure',
       title,
       axes: {},
       stats,
       dataTable: { headers: [], rows: [] },
-      subplots: this.context.getSubplotSummaries(),
+      ...(subplots.length > 0 && { subplots }),
     };
   }
 

--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -50,6 +50,13 @@ export class DescriptionService {
     // bare Figure exactly when it is at figure level (Context.isFigureLevel),
     // and a Subplot is always paired with a Trace on top (see enterSubplot), so
     // a Subplot is never the active element on its own.
+    //
+    // The `!state.empty` check is required to narrow to the populated
+    // FigureState variant (which carries `size`); `Figure.state` never returns
+    // the empty variant in practice (that only comes from `outOfBoundsState`,
+    // which is delivered straight to observers, not via this getter). The final
+    // `return null` is therefore defensive against the declared PlotState type
+    // rather than a reachable runtime path.
     const state = active.state;
     if (state.type === 'figure' && !state.empty) {
       return this.getFigureDescription(state.size);

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -193,6 +193,9 @@ const SUBPLOT_KEYMAP = {
   ANNOUNCE_POINT: key(`space`, 'Announce Current Subplot'),
   ANNOUNCE_POSITION: key(`p`, 'Announce Position'),
 
+  // Chart description
+  TOGGLE_DESCRIPTION: key(`d`, 'Open Chart Description'),
+
   // Navigation
   MOVE_UP: key(`up`, 'Move Up'),
   MOVE_DOWN: key(`down`, 'Move Down'),

--- a/src/state/viewModel/descriptionViewModel.ts
+++ b/src/state/viewModel/descriptionViewModel.ts
@@ -49,6 +49,12 @@ export class DescriptionViewModel extends AbstractViewModel<DescriptionMenuState
     const isCurrentlyOpen = this.store.getState().description.data !== null;
     if (!isCurrentlyOpen) {
       const data = this.descriptionService.getDescription();
+      // Nothing to describe: don't enter the DESCRIPTION scope, which would
+      // otherwise trap the user in an invisible modal (Description renders
+      // nothing for null data) recoverable only via Escape.
+      if (data === null) {
+        return;
+      }
       this.store.dispatch(setDescription(data));
     } else {
       this.store.dispatch(setDescription(null));

--- a/test/service/description.test.ts
+++ b/test/service/description.test.ts
@@ -106,6 +106,9 @@ describe('descriptionService figure-level description', () => {
     expect(description!.stats).toEqual([{ label: 'Subplots', value: 4 }]);
   });
 
+  // Documents the defensive null contract that DescriptionViewModel's guard
+  // relies on. Figure.state never actually yields an empty variant at runtime
+  // (see getDescription's comment), so this fabricates one via the mock.
   test('returns null for an empty figure state', () => {
     const context = createMockContext({
       state: { empty: true, type: 'figure' } as unknown as PlotState,

--- a/test/service/description.test.ts
+++ b/test/service/description.test.ts
@@ -1,0 +1,116 @@
+import type { Context } from '@model/context';
+import type { DisplayService } from '@service/display';
+import type { PlotState, SubplotSummary } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { DescriptionService } from '@service/description';
+
+/**
+ * Mock configuration for the figure-level surface used by DescriptionService.
+ */
+interface ContextOverrides {
+  state: PlotState;
+  figureTitle?: string;
+  figureSubtitle?: string;
+  figureCaption?: string;
+  authored?: string[];
+  subplotSummaries?: SubplotSummary[];
+}
+
+/**
+ * Creates a mock Context exposing only the surface DescriptionService touches
+ * for the figure-level (multi-panel lobby) branch. `active` is a plain object
+ * so it is never an AbstractTrace instance, forcing the figure branch.
+ */
+function createMockContext(overrides: ContextOverrides): Context {
+  const authored = new Set(overrides.authored ?? []);
+  return {
+    active: { state: overrides.state },
+    figureTitle: overrides.figureTitle ?? 'unavailable',
+    figureSubtitle: overrides.figureSubtitle ?? 'unavailable',
+    figureCaption: overrides.figureCaption ?? 'unavailable',
+    isAuthoredTitle: (value: string) => authored.has(value),
+    isAuthoredSubtitle: (value: string) => authored.has(value),
+    isAuthoredCaption: (value: string) => authored.has(value),
+    getSubplotSummaries: () => overrides.subplotSummaries ?? [],
+  } as unknown as Context;
+}
+
+function createMockDisplayService(): DisplayService {
+  return {
+    toggleFocus: jest.fn(),
+  } as unknown as DisplayService;
+}
+
+function figureState(size: number): PlotState {
+  return { empty: false, type: 'figure', size } as unknown as PlotState;
+}
+
+describe('descriptionService figure-level description', () => {
+  test('summarizes a multi-panel figure when the active element is the figure', () => {
+    const subplots: SubplotSummary[] = [
+      { index: 1, title: 'Left', traceTypes: ['bar'], isActive: true },
+      { index: 2, title: 'Right', traceTypes: ['line'], isActive: false },
+    ];
+    const context = createMockContext({
+      state: figureState(2),
+      figureTitle: 'My Figure',
+      authored: ['My Figure'],
+      subplotSummaries: subplots,
+    });
+
+    const service = new DescriptionService(context, createMockDisplayService());
+    const description = service.getDescription();
+
+    expect(description).not.toBeNull();
+    expect(description!.chartType).toBe('Multi-panel figure');
+    expect(description!.title).toBe('My Figure');
+    expect(description!.axes).toEqual({});
+    expect(description!.dataTable).toEqual({ headers: [], rows: [] });
+    expect(description!.subplots).toEqual(subplots);
+    expect(description!.stats).toEqual([{ label: 'Subplots', value: 2 }]);
+  });
+
+  test('includes authored subtitle and caption as stats', () => {
+    const context = createMockContext({
+      state: figureState(3),
+      figureSubtitle: 'A subtitle',
+      figureCaption: 'A caption',
+      authored: ['A subtitle', 'A caption'],
+    });
+
+    const service = new DescriptionService(context, createMockDisplayService());
+    const description = service.getDescription();
+
+    expect(description!.stats).toEqual([
+      { label: 'Subplots', value: 3 },
+      { label: 'Subtitle', value: 'A subtitle' },
+      { label: 'Caption', value: 'A caption' },
+    ]);
+  });
+
+  test('omits unauthored title, subtitle, and caption', () => {
+    const context = createMockContext({
+      state: figureState(4),
+      figureTitle: 'MAIDR Plot',
+      figureSubtitle: 'unavailable',
+      figureCaption: 'unavailable',
+      authored: [],
+    });
+
+    const service = new DescriptionService(context, createMockDisplayService());
+    const description = service.getDescription();
+
+    expect(description!.title).toBe('');
+    expect(description!.stats).toEqual([{ label: 'Subplots', value: 4 }]);
+  });
+
+  test('returns null for an empty figure state', () => {
+    const context = createMockContext({
+      state: { empty: true, type: 'figure' } as unknown as PlotState,
+    });
+
+    const service = new DescriptionService(context, createMockDisplayService());
+
+    expect(service.getDescription()).toBeNull();
+  });
+});

--- a/test/service/description.test.ts
+++ b/test/service/description.test.ts
@@ -81,6 +81,7 @@ describe('descriptionService figure-level description', () => {
     const service = new DescriptionService(context, createMockDisplayService());
     const description = service.getDescription();
 
+    expect(description).not.toBeNull();
     expect(description!.stats).toEqual([
       { label: 'Subplots', value: 3 },
       { label: 'Subtitle', value: 'A subtitle' },
@@ -100,6 +101,7 @@ describe('descriptionService figure-level description', () => {
     const service = new DescriptionService(context, createMockDisplayService());
     const description = service.getDescription();
 
+    expect(description).not.toBeNull();
     expect(description!.title).toBe('');
     expect(description!.stats).toEqual([{ label: 'Subplots', value: 4 }]);
   });

--- a/test/state/viewModel/descriptionViewModel.test.ts
+++ b/test/state/viewModel/descriptionViewModel.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for DescriptionViewModel.toggle() covering the open/close dispatch
+ * flow and, in particular, the guard that avoids entering the DESCRIPTION
+ * scope (via descriptionService.toggle()) when there is nothing to describe
+ * — otherwise the user would be trapped in a modal that renders nothing.
+ */
+import type { DescriptionService } from '@service/description';
+import type { DescriptionState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { createMaidrStore } from '@state/store';
+import { DescriptionViewModel } from '@state/viewModel/descriptionViewModel';
+
+function createServiceStub(
+  description: DescriptionState | null,
+): DescriptionService {
+  return {
+    getDescription: jest.fn(() => description),
+    toggle: jest.fn(),
+  } as unknown as DescriptionService;
+}
+
+const FIGURE_DESCRIPTION: DescriptionState = {
+  chartType: 'Multi-panel figure',
+  title: 'My Figure',
+  axes: {},
+  stats: [{ label: 'Subplots', value: 2 }],
+  dataTable: { headers: [], rows: [] },
+};
+
+describe('descriptionViewModel.toggle', () => {
+  test('opens the modal and switches scope when there is a description', () => {
+    const store = createMaidrStore();
+    const service = createServiceStub(FIGURE_DESCRIPTION);
+    const vm = new DescriptionViewModel(store, service);
+
+    vm.toggle();
+
+    expect(store.getState().description.data).toEqual(FIGURE_DESCRIPTION);
+    expect(service.toggle).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not dispatch or switch scope when there is nothing to describe', () => {
+    const store = createMaidrStore();
+    const service = createServiceStub(null);
+    const vm = new DescriptionViewModel(store, service);
+
+    vm.toggle();
+
+    // No data was stored, so the modal stays closed...
+    expect(store.getState().description.data).toBeNull();
+    // ...and the scope was never switched into the empty DESCRIPTION modal.
+    expect(service.toggle).not.toHaveBeenCalled();
+  });
+
+  test('closing an open modal clears the data and switches scope back', () => {
+    const store = createMaidrStore();
+    const service = createServiceStub(FIGURE_DESCRIPTION);
+    const vm = new DescriptionViewModel(store, service);
+
+    vm.toggle(); // open
+    vm.toggle(); // close
+
+    expect(store.getState().description.data).toBeNull();
+    // Once to enter the modal scope, once to leave it.
+    expect(service.toggle).toHaveBeenCalledTimes(2);
+    // getDescription is only consulted when opening, not when closing.
+    expect(service.getDescription).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The **Open Chart Description** shortcut (`d`) previously did nothing in the multi-panel figure "lobby" — the area you land in before entering a subplot. It only worked once you navigated into a subplot. This PR makes `d` open a meaningful chart description at the figure level as well.

## Related Issues

<!-- None specified. -->

## Changes Made

Two root causes were addressed:

1. **`d` was not bound at the lobby scope.** `TOGGLE_DESCRIPTION` was registered in the trace, braille, and candlestick-delta keymaps but not in `SUBPLOT_KEYMAP` (the multi-panel figure lobby, `Scope.SUBPLOT`). Added the binding there so the key fires the command at the figure level.

2. **The description came back empty at the figure level.** `DescriptionService.getDescription()` returned `null` whenever the active element was not an `AbstractTrace`. At the lobby the active element is the `Figure`, so even if `d` had fired, the modal would have rendered nothing. Added a figure-level branch (`getFigureDescription`) that summarizes the whole figure:
   - Chart type: `Multi-panel figure`
   - Authored figure title (falls back to empty when only a placeholder default exists)
   - Stats: subplot count, plus authored subtitle / caption when present
   - The per-subplot summaries already produced by `context.getSubplotSummaries()`, so the user sees what's available before navigating in
   - Axes and the data table are omitted, since those are trace-level concepts with no figure-level equivalent

Existing trace-level behavior, single-panel figures, and modal open/close scope restoration (`SUBPLOT → DESCRIPTION → SUBPLOT`) are unchanged.

## Screenshots (if applicable)

<!-- N/A -->

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- New unit tests in `test/service/description.test.ts` cover the figure-level branch: multi-panel summary, authored subtitle/caption stats, placeholder omission, and the empty-figure `null` case.
- Verified with `npm run type-check`, `npm run lint`, `npm run build`, and the relevant Jest suites (all green).
- The help menu will now list "Open Chart Description" at subplot scope, consistent with `d` being available there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013zeAqRDqTFkhxPyjY1YbHm)_