### PR TITLE
build: parallelized the vite library build to speed up by 3x

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -119,7 +119,9 @@ function defaultJobs() {
  * report success having built nothing.
  */
 function parseJobs(raw, source) {
-  const jobs = Number.parseInt(raw, 10);
+  // Number(), not parseInt(): parseInt stops at the first non-digit, so a
+  // value like "4x" would silently parse as 4 instead of being rejected.
+  const jobs = Number(raw);
   if (!Number.isInteger(jobs) || jobs < 1) {
     console.error(`Invalid ${source} value: "${raw}" — expected a positive integer.`);
     process.exit(1);
@@ -534,7 +536,7 @@ async function main() {
     : builds;
 
   // Resolve the job cap early: before the sequential-path branch (a cap of 1
-  // routes there) and before touching dist, so a malformed
+  // routes there) and before emptying dist, so a malformed
   // --jobs/MAIDR_BUILD_JOBS aborts without wiping previous build output.
   const jobs = jobsArg
     ? parseJobs(jobsArg.slice('--jobs='.length), '--jobs')

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -90,6 +90,9 @@ function defaultJobs() {
   // reports the host's cores (Node >= 18.14; fall back for older runtimes).
   const cores = os.availableParallelism?.() ?? os.cpus().length;
   const cpuCap = Math.round(cores * 2 / 3);
+  // Unlike availableParallelism, totalmem() is NOT cgroup-aware: it reports
+  // the host's physical RAM, so a memory-limited container can still
+  // over-provision. Set MAIDR_BUILD_JOBS/--jobs explicitly in that case.
   const memGb = os.totalmem() / 1024 ** 3;
   const memCap = Math.floor((memGb - 1.5) / 1.75);
   return Math.max(1, Math.min(8, cpuCap, memCap));
@@ -358,8 +361,10 @@ async function runParallel(selected, jobs, outDir) {
   const scriptPath = fileURLToPath(import.meta.url);
   const total = selected.length;
   let started = 0;
-  let done = 0;
   const activeChildren = new Set();
+  // Filenames merged into dist this run, keyed to the bundle that emitted
+  // them — lets us detect two bundles emitting the same name (see below).
+  const mergedBy = new Map();
 
   const runWorker = config => new Promise((resolve, reject) => {
     const step = `[${++started}/${total}]`;
@@ -391,14 +396,27 @@ async function runParallel(selected, jobs, outDir) {
       }
       try {
         // Merge this bundle's artifacts into dist. Filenames are unique per
-        // bundle, so concurrent merges never collide; if two bundles ever
-        // emit a same-named entry the rename fails loudly instead of output
-        // being silently dropped.
+        // bundle today, but fs.rename silently replaces an existing file, so
+        // that alone can't be trusted to surface a collision. Track what each
+        // bundle emitted this run and fail loudly if two bundles ever produce
+        // the same name, instead of one silently overwriting the other.
         const entries = await fs.readdir(workerOut, { withFileTypes: true });
-        await Promise.all(entries.map(e =>
-          fs.rename(path.join(workerOut, e.name), path.join(outDir, e.name))));
+        for (const e of entries) {
+          const emitter = mergedBy.get(e.name);
+          if (emitter !== undefined)
+            throw new Error(`Merge collision: "${config.name}" and "${emitter}" both emitted "${e.name}"`);
+          mergedBy.set(e.name, config.name);
+        }
+        await Promise.all(entries.map(async (e) => {
+          const dest = path.join(outDir, e.name);
+          // Stale copies from an earlier build are expected in selective
+          // builds (dist isn't emptied); clear them first so a directory
+          // rename can't fail with ENOTEMPTY.
+          await fs.rm(dest, { recursive: true, force: true });
+          await fs.rename(path.join(workerOut, e.name), dest);
+        }));
         await fs.rm(workerOut, { recursive: true, force: true });
-        console.log(`[${++done}/${total}] Done ${config.name} (${((Date.now() - t) / 1000).toFixed(1)}s)`);
+        console.log(`${step} Done ${config.name} (${((Date.now() - t) / 1000).toFixed(1)}s)`);
         resolve();
       } catch (err) {
         reject(err);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -71,6 +71,17 @@ async function emptyDir(dir) {
 }
 
 /**
+ * Byte-compare two files (cheap size check first, then contents).
+ */
+async function filesEqual(a, b) {
+  const [statA, statB] = await Promise.all([fs.stat(a), fs.stat(b)]);
+  if (statA.size !== statB.size)
+    return false;
+  const [bufA, bufB] = await Promise.all([fs.readFile(a), fs.readFile(b)]);
+  return bufA.equals(bufB);
+}
+
+/**
  * Pick a default worker count that works across a wide range of dev machines.
  *
  * The build is bottlenecked by ~7 heavy React + vite-plugin-dts bundles, each
@@ -306,7 +317,7 @@ function createViteConfig(config) {
   // Workers build into an isolated outDir (passed via env) so parallel
   // vite-plugin-dts runs never clobber each other's intermediate .d.ts files
   // in the shared dist directory. vite-plugin-dts follows build.outDir.
-  const outDir = process.env.MAIDR_BUILD_OUTDIR || config.outDir || 'dist';
+  const outDir = process.env.MAIDR_BUILD_OUTDIR || 'dist';
 
   return {
     configFile: false,
@@ -365,6 +376,38 @@ async function runParallel(selected, jobs, outDir) {
   // Filenames merged into dist this run, keyed to the bundle that emitted
   // them — lets us detect two bundles emitting the same name (see below).
   const mergedBy = new Map();
+  // Merges are serialized through this promise chain: they're just a few
+  // renames (milliseconds next to the builds they follow), and running them
+  // one at a time keeps the duplicate/collision bookkeeping race-free.
+  let mergeLock = Promise.resolve();
+
+  const mergeOutput = async (config, workerOut) => {
+    const entries = await fs.readdir(workerOut, { withFileTypes: true });
+    for (const e of entries) {
+      const src = path.join(workerOut, e.name);
+      const dest = path.join(outDir, e.name);
+      const emitter = mergedBy.get(e.name);
+      if (emitter !== undefined) {
+        // Some outputs are legitimately emitted by several bundles: every
+        // React-based bundle writes an identical shared maidr.css. Keep the
+        // first copy when contents are byte-identical, and fail only on a
+        // genuine conflict — fs.rename would otherwise silently replace the
+        // existing file and corrupt another bundle's artifact.
+        if (e.isFile() && await filesEqual(src, dest))
+          continue;
+        throw new Error(
+          `Merge collision: "${config.name}" and "${emitter}" emitted different contents for "${e.name}"`,
+        );
+      }
+      mergedBy.set(e.name, config.name);
+      // Stale copies from an earlier build are expected in selective builds
+      // (dist isn't emptied); clear them first so a directory rename can't
+      // fail with ENOTEMPTY.
+      await fs.rm(dest, { recursive: true, force: true });
+      await fs.rename(src, dest);
+    }
+    await fs.rm(workerOut, { recursive: true, force: true });
+  };
 
   const runWorker = config => new Promise((resolve, reject) => {
     const step = `[${++started}/${total}]`;
@@ -395,27 +438,9 @@ async function runParallel(selected, jobs, outDir) {
         return;
       }
       try {
-        // Merge this bundle's artifacts into dist. Filenames are unique per
-        // bundle today, but fs.rename silently replaces an existing file, so
-        // that alone can't be trusted to surface a collision. Track what each
-        // bundle emitted this run and fail loudly if two bundles ever produce
-        // the same name, instead of one silently overwriting the other.
-        const entries = await fs.readdir(workerOut, { withFileTypes: true });
-        for (const e of entries) {
-          const emitter = mergedBy.get(e.name);
-          if (emitter !== undefined)
-            throw new Error(`Merge collision: "${config.name}" and "${emitter}" both emitted "${e.name}"`);
-          mergedBy.set(e.name, config.name);
-        }
-        await Promise.all(entries.map(async (e) => {
-          const dest = path.join(outDir, e.name);
-          // Stale copies from an earlier build are expected in selective
-          // builds (dist isn't emptied); clear them first so a directory
-          // rename can't fail with ENOTEMPTY.
-          await fs.rm(dest, { recursive: true, force: true });
-          await fs.rename(path.join(workerOut, e.name), dest);
-        }));
-        await fs.rm(workerOut, { recursive: true, force: true });
+        const merge = mergeLock.then(() => mergeOutput(config, workerOut));
+        mergeLock = merge.catch(() => {});
+        await merge;
         console.log(`${step} Done ${config.name} (${((Date.now() - t) / 1000).toFixed(1)}s)`);
         resolve();
       } catch (err) {
@@ -440,7 +465,22 @@ async function runParallel(selected, jobs, outDir) {
       }
     }
   });
-  await Promise.all(workers);
+  // Defense-in-depth for Ctrl+C / kill: shells usually signal the whole
+  // foreground process group, but that isn't guaranteed everywhere (notably
+  // Windows), so make sure an interrupted build doesn't leave workers running.
+  const onSignal = (signal) => {
+    for (const child of activeChildren)
+      child.kill('SIGTERM');
+    process.exit(signal === 'SIGINT' ? 130 : 143);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+  try {
+    await Promise.all(workers);
+  } finally {
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+  }
   if (firstError)
     throw firstError;
 }
@@ -471,6 +511,13 @@ async function main() {
   }
 
   const isWorker = process.env.MAIDR_BUILD_WORKER === '1';
+
+  // Sweep stale worker temp output on every non-worker invocation — a
+  // crashed or interrupted parallel build can leave dist/.tmp behind, and
+  // `files: ["dist"]` would ship it via npm pack. Workers must NOT do this:
+  // they run concurrently, and dist/.tmp holds their siblings' output.
+  if (!isWorker)
+    await fs.rm(path.resolve(rootDir, 'dist', '.tmp'), { recursive: true, force: true });
 
   const selected = requested.length > 0
     ? builds
@@ -503,8 +550,7 @@ async function main() {
   const shouldEmpty = selected.some(b => b.emptyOutDir);
   if (shouldEmpty)
     await emptyDir(outDir);
-  // Ensure a clean dist (and no stale .tmp) exists for merges to land into.
-  await fs.rm(path.join(outDir, '.tmp'), { recursive: true, force: true });
+  // Ensure dist exists for merges to land into (.tmp was swept above).
   await fs.mkdir(outDir, { recursive: true });
   const workerBuilds = selected.map(b => ({ ...b, emptyOutDir: false }));
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,15 +2,28 @@
  * Programmatic build runner for MAIDR library.
  *
  * Consolidates all Vite build configurations into a single file.
- * Builds run sequentially due to vite-plugin-dts limitations.
  *
- * Usage: node scripts/build.js [name ...]
+ * The bundles are fully independent, so by default the orchestrator builds
+ * them in parallel across several child processes. Running each build in its
+ * own process sidesteps the vite-plugin-dts shared-state limitation that used
+ * to force serial builds (its temp/rollup state is per-process), while making
+ * use of all available CPU cores.
+ *
+ * Usage: node scripts/build.js [name ...] [--sequential] [--jobs=N]
  *
  * With no arguments, all bundles are built. Passing bundle names (e.g.
  * `node scripts/build.js core react`) builds only those bundles; selective
  * builds never empty the output directory.
+ *
+ * Flags:
+ *   --sequential   Build one bundle at a time, in-process (legacy behaviour).
+ *   --jobs=N       Cap the number of concurrent build processes (default:
+ *                  based on CPU count). Also settable via MAIDR_BUILD_JOBS.
  */
 
+import { fork } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -37,6 +50,46 @@ const adapterAliases = {
   ...baseAliases,
   '@adapters': path.resolve(rootDir, 'src/adapters'),
 };
+
+/**
+ * Empty a directory's contents without removing the directory itself. Removing
+ * the dir outright can EPERM on Windows (OneDrive sync, AV scanners, or a
+ * lingering handle on the folder), so we clear children instead — this mirrors
+ * Vite's own emptyOutDir behaviour.
+ */
+async function emptyDir(dir) {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT')
+      return;
+    throw err;
+  }
+  await Promise.all(entries.map(e =>
+    fs.rm(path.join(dir, e.name), { recursive: true, force: true })));
+}
+
+/**
+ * Pick a default worker count that works across a wide range of dev machines.
+ *
+ * The build is bottlenecked by ~7 heavy React + vite-plugin-dts bundles, each
+ * of which holds ~1.75 GB during the api-extractor type rollup. So we cap by
+ * three things and take the smallest:
+ *   - CPU: ~2/3 of logical cores keeps them busy without oversubscribing the
+ *     dts/esbuild work (which slows every build via contention past that).
+ *   - RAM: ~1.75 GB per concurrent build with ~1.5 GB held in reserve — this is
+ *     what keeps low-memory laptops (e.g. 8 GB) from OOM-ing.
+ *   - A hard ceiling of 8: there are only ~7-8 heavy bundles, so more workers
+ *     than that never shortens the wall clock on any machine.
+ * Override with --jobs=N or MAIDR_BUILD_JOBS when you know your hardware.
+ */
+function defaultJobs() {
+  const cpuCap = Math.round(os.cpus().length * 2 / 3);
+  const memGb = os.totalmem() / 1024 ** 3;
+  const memCap = Math.floor((memGb - 1.5) / 1.75);
+  return Math.max(2, Math.min(8, cpuCap, memCap));
+}
 
 function onWarn(warning, warn) {
   if (warning.code === 'MODULE_LEVEL_DIRECTIVE' || warning.code === 'SOURCEMAP_ERROR') {
@@ -228,6 +281,11 @@ function createViteConfig(config) {
     }));
   }
 
+  // Workers build into an isolated outDir (passed via env) so parallel
+  // vite-plugin-dts runs never clobber each other's intermediate .d.ts files
+  // in the shared dist directory. vite-plugin-dts follows build.outDir.
+  const outDir = process.env.MAIDR_BUILD_OUTDIR || config.outDir || 'dist';
+
   return {
     configFile: false,
     root: rootDir,
@@ -240,7 +298,7 @@ function createViteConfig(config) {
         fileName: config.fileName,
       },
       sourcemap: true,
-      outDir: 'dist',
+      outDir,
       emptyOutDir: config.emptyOutDir,
       rollupOptions: { external: config.external, onwarn: onWarn },
     },
@@ -249,16 +307,105 @@ function createViteConfig(config) {
   };
 }
 
+/**
+ * Build a single bundle in-process. Used both by the legacy sequential path
+ * and by each forked worker process.
+ */
+async function buildOne(config) {
+  await build(createViteConfig(config));
+}
+
+/**
+ * Run the selected builds one at a time in this process (legacy behaviour).
+ */
+async function runSequential(selected) {
+  for (let i = 0; i < selected.length; i++) {
+    const config = selected[i];
+    const step = `[${i + 1}/${selected.length}]`;
+    console.log(`${step} Building ${config.name}...`);
+
+    const t = Date.now();
+    await buildOne(config);
+    console.log(`${step} Done (${((Date.now() - t) / 1000).toFixed(1)}s)\n`);
+  }
+}
+
+/**
+ * Fork one worker per bundle and run up to `jobs` at a time. Each worker
+ * builds a single bundle in its own process, so vite-plugin-dts state never
+ * collides across builds.
+ */
+async function runParallel(selected, jobs, outDir) {
+  const scriptPath = fileURLToPath(import.meta.url);
+  const total = selected.length;
+  let started = 0;
+  let done = 0;
+
+  const runWorker = config => new Promise((resolve, reject) => {
+    const step = `[${++started}/${total}]`;
+    console.log(`${step} Building ${config.name}...`);
+    const t = Date.now();
+
+    // Each worker gets an isolated outDir so parallel dts rollups don't
+    // collide; the final artifacts are merged into dist below.
+    const workerOut = path.join(outDir, '.tmp', config.name);
+
+    const child = fork(scriptPath, [config.name], {
+      // MAIDR_BUILD_WORKER makes the child build in-process instead of
+      // re-orchestrating. MAIDR_BUILD_OUTDIR isolates its output directory.
+      env: { ...process.env, MAIDR_BUILD_WORKER: '1', MAIDR_BUILD_OUTDIR: workerOut },
+      stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+    });
+
+    child.on('error', reject);
+    child.on('exit', async (code) => {
+      if (code !== 0) {
+        reject(new Error(`Build "${config.name}" failed (exit code ${code})`));
+        return;
+      }
+      try {
+        // Merge this bundle's flat artifacts into dist (filenames are unique
+        // per bundle, so concurrent merges never collide).
+        const entries = await fs.readdir(workerOut, { withFileTypes: true });
+        await Promise.all(entries
+          .filter(e => e.isFile())
+          .map(e => fs.rename(path.join(workerOut, e.name), path.join(outDir, e.name))));
+        await fs.rm(workerOut, { recursive: true, force: true });
+        console.log(`[${++done}/${total}] Done ${config.name} (${((Date.now() - t) / 1000).toFixed(1)}s)`);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+
+  // Simple concurrency pool: keep `jobs` workers in flight.
+  const queue = [...selected];
+  const workers = Array.from({ length: Math.min(jobs, queue.length) }, async () => {
+    while (queue.length > 0) {
+      await runWorker(queue.shift());
+    }
+  });
+  await Promise.all(workers);
+}
+
 async function main() {
   const startTime = Date.now();
 
-  const requested = process.argv.slice(2);
+  const argv = process.argv.slice(2);
+  const sequential = argv.includes('--sequential');
+  const jobsArg = argv.find(a => a.startsWith('--jobs='));
+  const requested = argv.filter(a => !a.startsWith('--'));
+
   const unknown = requested.filter(name => !builds.some(b => b.name === name));
   if (unknown.length > 0) {
     console.error(`Unknown bundle name(s): ${unknown.join(', ')}`);
     console.error(`Available: ${builds.map(b => b.name).join(', ')}`);
     process.exit(1);
   }
+
+  const isWorker = process.env.MAIDR_BUILD_WORKER === '1';
+
   const selected = requested.length > 0
     ? builds
         .filter(b => requested.includes(b.name))
@@ -266,19 +413,39 @@ async function main() {
         .map(b => ({ ...b, emptyOutDir: false }))
     : builds;
 
-  console.log('Building MAIDR library...\n');
-
-  for (let i = 0; i < selected.length; i++) {
-    const config = selected[i];
-    const step = `[${i + 1}/${selected.length}]`;
-    console.log(`${step} Building ${config.name}...`);
-
-    const t = Date.now();
-    await build(createViteConfig(config));
-    console.log(`${step} Done (${((Date.now() - t) / 1000).toFixed(1)}s)\n`);
+  // Worker processes (and single-bundle requests) just build in-process.
+  if (isWorker || sequential || selected.length === 1) {
+    if (!isWorker)
+      console.log('Building MAIDR library...\n');
+    await runSequential(selected);
+    if (!isWorker)
+      console.log(`All builds complete in ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
+    return;
   }
 
-  console.log(`All builds complete in ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
+  // Parent orchestrator: empty dist once up front, then fork workers. Children
+  // build into isolated temp dirs and the parent merges results into dist.
+  const outDir = path.resolve(rootDir, 'dist');
+  const shouldEmpty = selected.some(b => b.emptyOutDir);
+  if (shouldEmpty)
+    await emptyDir(outDir);
+  // Ensure a clean dist (and no stale .tmp) exists for merges to land into.
+  await fs.rm(path.join(outDir, '.tmp'), { recursive: true, force: true });
+  await fs.mkdir(outDir, { recursive: true });
+  const workerBuilds = selected.map(b => ({ ...b, emptyOutDir: false }));
+
+  const explicitJobs = jobsArg
+    ? Number.parseInt(jobsArg.split('=')[1], 10)
+    : process.env.MAIDR_BUILD_JOBS
+      ? Number.parseInt(process.env.MAIDR_BUILD_JOBS, 10)
+      : null;
+  const jobs = Math.max(1, explicitJobs ?? defaultJobs());
+
+  console.log(`Building MAIDR library (${workerBuilds.length} bundles, up to ${jobs} in parallel)...\n`);
+  await runParallel(workerBuilds, jobs, outDir);
+  await fs.rm(path.join(outDir, '.tmp'), { recursive: true, force: true });
+
+  console.log(`\nAll builds complete in ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
 }
 
 main().catch((err) => {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -76,19 +76,38 @@ async function emptyDir(dir) {
  * The build is bottlenecked by ~7 heavy React + vite-plugin-dts bundles, each
  * of which holds ~1.75 GB during the api-extractor type rollup. So we cap by
  * three things and take the smallest:
- *   - CPU: ~2/3 of logical cores keeps them busy without oversubscribing the
+ *   - CPU: ~2/3 of available cores keeps them busy without oversubscribing the
  *     dts/esbuild work (which slows every build via contention past that).
  *   - RAM: ~1.75 GB per concurrent build with ~1.5 GB held in reserve — this is
- *     what keeps low-memory laptops (e.g. 8 GB) from OOM-ing.
+ *     what keeps low-memory laptops (e.g. 8 GB) from OOM-ing. On very tight
+ *     machines the cap can drop all the way to a single worker.
  *   - A hard ceiling of 8: there are only ~7-8 heavy bundles, so more workers
  *     than that never shortens the wall clock on any machine.
  * Override with --jobs=N or MAIDR_BUILD_JOBS when you know your hardware.
  */
 function defaultJobs() {
-  const cpuCap = Math.round(os.cpus().length * 2 / 3);
+  // availableParallelism honours container/cgroup CPU limits where cpus()
+  // reports the host's cores (Node >= 18.14; fall back for older runtimes).
+  const cores = os.availableParallelism?.() ?? os.cpus().length;
+  const cpuCap = Math.round(cores * 2 / 3);
   const memGb = os.totalmem() / 1024 ** 3;
   const memCap = Math.floor((memGb - 1.5) / 1.75);
-  return Math.max(2, Math.min(8, cpuCap, memCap));
+  return Math.max(1, Math.min(8, cpuCap, memCap));
+}
+
+/**
+ * Parse a user-supplied job count. A malformed value must abort the build:
+ * left unchecked it flows as NaN into the worker pool, where
+ * `Array.from({ length: NaN })` yields an empty array and the script would
+ * report success having built nothing.
+ */
+function parseJobs(raw, source) {
+  const jobs = Number.parseInt(raw, 10);
+  if (!Number.isInteger(jobs) || jobs < 1) {
+    console.error(`Invalid ${source} value: "${raw}" — expected a positive integer.`);
+    process.exit(1);
+  }
+  return jobs;
 }
 
 function onWarn(warning, warn) {
@@ -340,6 +359,7 @@ async function runParallel(selected, jobs, outDir) {
   const total = selected.length;
   let started = 0;
   let done = 0;
+  const activeChildren = new Set();
 
   const runWorker = config => new Promise((resolve, reject) => {
     const step = `[${++started}/${total}]`;
@@ -356,20 +376,27 @@ async function runParallel(selected, jobs, outDir) {
       env: { ...process.env, MAIDR_BUILD_WORKER: '1', MAIDR_BUILD_OUTDIR: workerOut },
       stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
     });
+    activeChildren.add(child);
 
-    child.on('error', reject);
-    child.on('exit', async (code) => {
+    child.on('error', (err) => {
+      activeChildren.delete(child);
+      reject(err);
+    });
+    child.on('exit', async (code, signal) => {
+      activeChildren.delete(child);
       if (code !== 0) {
-        reject(new Error(`Build "${config.name}" failed (exit code ${code})`));
+        const cause = signal ? `terminated by ${signal}` : `exit code ${code}`;
+        reject(new Error(`Build "${config.name}" failed (${cause})`));
         return;
       }
       try {
-        // Merge this bundle's flat artifacts into dist (filenames are unique
-        // per bundle, so concurrent merges never collide).
+        // Merge this bundle's artifacts into dist. Filenames are unique per
+        // bundle, so concurrent merges never collide; if two bundles ever
+        // emit a same-named entry the rename fails loudly instead of output
+        // being silently dropped.
         const entries = await fs.readdir(workerOut, { withFileTypes: true });
-        await Promise.all(entries
-          .filter(e => e.isFile())
-          .map(e => fs.rename(path.join(workerOut, e.name), path.join(outDir, e.name))));
+        await Promise.all(entries.map(e =>
+          fs.rename(path.join(workerOut, e.name), path.join(outDir, e.name))));
         await fs.rm(workerOut, { recursive: true, force: true });
         console.log(`[${++done}/${total}] Done ${config.name} (${((Date.now() - t) / 1000).toFixed(1)}s)`);
         resolve();
@@ -379,14 +406,25 @@ async function runParallel(selected, jobs, outDir) {
     });
   });
 
-  // Simple concurrency pool: keep `jobs` workers in flight.
+  // Simple concurrency pool: keep `jobs` workers in flight. On the first
+  // failure stop dequeuing and kill in-flight siblings, so a broken build
+  // doesn't leave orphaned processes chewing CPU/RAM after the parent exits.
   const queue = [...selected];
+  let firstError = null;
   const workers = Array.from({ length: Math.min(jobs, queue.length) }, async () => {
-    while (queue.length > 0) {
-      await runWorker(queue.shift());
+    while (queue.length > 0 && firstError === null) {
+      try {
+        await runWorker(queue.shift());
+      } catch (err) {
+        firstError ??= err;
+        for (const child of activeChildren)
+          child.kill('SIGTERM');
+      }
     }
   });
   await Promise.all(workers);
+  if (firstError)
+    throw firstError;
 }
 
 async function main() {
@@ -396,6 +434,16 @@ async function main() {
   const sequential = argv.includes('--sequential');
   const jobsArg = argv.find(a => a.startsWith('--jobs='));
   const requested = argv.filter(a => !a.startsWith('--'));
+
+  // A mistyped flag must not silently fall through to the default behaviour
+  // (e.g. `--sequental` quietly running a full parallel build).
+  const unknownFlags = argv.filter(a =>
+    a.startsWith('--') && a !== '--sequential' && !a.startsWith('--jobs='));
+  if (unknownFlags.length > 0) {
+    console.error(`Unknown flag(s): ${unknownFlags.join(', ')}`);
+    console.error('Supported flags: --sequential, --jobs=N');
+    process.exit(1);
+  }
 
   const unknown = requested.filter(name => !builds.some(b => b.name === name));
   if (unknown.length > 0) {
@@ -423,6 +471,14 @@ async function main() {
     return;
   }
 
+  // Resolve the job cap before touching dist, so a malformed
+  // --jobs/MAIDR_BUILD_JOBS aborts without wiping previous build output.
+  const jobs = jobsArg
+    ? parseJobs(jobsArg.slice('--jobs='.length), '--jobs')
+    : process.env.MAIDR_BUILD_JOBS
+      ? parseJobs(process.env.MAIDR_BUILD_JOBS, 'MAIDR_BUILD_JOBS')
+      : defaultJobs();
+
   // Parent orchestrator: empty dist once up front, then fork workers. Children
   // build into isolated temp dirs and the parent merges results into dist.
   const outDir = path.resolve(rootDir, 'dist');
@@ -434,16 +490,16 @@ async function main() {
   await fs.mkdir(outDir, { recursive: true });
   const workerBuilds = selected.map(b => ({ ...b, emptyOutDir: false }));
 
-  const explicitJobs = jobsArg
-    ? Number.parseInt(jobsArg.split('=')[1], 10)
-    : process.env.MAIDR_BUILD_JOBS
-      ? Number.parseInt(process.env.MAIDR_BUILD_JOBS, 10)
-      : null;
-  const jobs = Math.max(1, explicitJobs ?? defaultJobs());
-
   console.log(`Building MAIDR library (${workerBuilds.length} bundles, up to ${jobs} in parallel)...\n`);
-  await runParallel(workerBuilds, jobs, outDir);
-  await fs.rm(path.join(outDir, '.tmp'), { recursive: true, force: true });
+  try {
+    await runParallel(workerBuilds, jobs, outDir);
+  } finally {
+    // Clean up .tmp on success AND failure — `files: ["dist"]` in package.json
+    // means anything left under dist/ would end up in the published package.
+    // Best-effort so a cleanup error can't mask a real build failure.
+    await fs.rm(path.join(outDir, '.tmp'), { recursive: true, force: true })
+      .catch(() => {});
+  }
 
   console.log(`\nAll builds complete in ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -321,7 +321,9 @@ function createViteConfig(config) {
 
   // Workers build into an isolated outDir (passed via env) so parallel
   // vite-plugin-dts runs never clobber each other's intermediate .d.ts files
-  // in the shared dist directory. vite-plugin-dts follows build.outDir.
+  // in the shared dist directory. vite-plugin-dts follows build.outDir —
+  // that assumption is load-bearing for the parallel build, so re-verify it
+  // (default output byte-identical to --sequential) when bumping the plugin.
   const outDir = process.env.MAIDR_BUILD_OUTDIR || 'dist';
 
   return {
@@ -502,6 +504,10 @@ async function main() {
   const jobsArg = argv.find(a => a.startsWith('--jobs='));
   const requested = argv.filter(a => !a.startsWith('--'));
 
+  if (argv.includes('--jobs')) {
+    console.error('--jobs requires a value, e.g. --jobs=4');
+    process.exit(1);
+  }
   // A mistyped flag must not silently fall through to the default behaviour
   // (e.g. `--sequental` quietly running a full parallel build).
   const unknownFlags = argv.filter(a =>
@@ -525,6 +531,9 @@ async function main() {
   // crashed or interrupted parallel build can leave dist/.tmp behind, and
   // `files: ["dist"]` would ship it via npm pack. Workers must NOT do this:
   // they run concurrently, and dist/.tmp holds their siblings' output.
+  // As with the old serial build, concurrent invocations of this script
+  // against the same checkout are unsupported — this sweep (and the dist
+  // merges later) would race with the other run's in-flight output.
   if (!isWorker)
     await fs.rm(path.resolve(rootDir, 'dist', '.tmp'), { recursive: true, force: true });
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -95,6 +95,9 @@ async function filesEqual(a, b) {
  *   - A hard ceiling of 8: there are only ~7-8 heavy bundles, so more workers
  *     than that never shortens the wall clock on any machine.
  * Override with --jobs=N or MAIDR_BUILD_JOBS when you know your hardware.
+ *
+ * The 2/3, 1.75 GB and 1.5 GB constants were tuned empirically against the
+ * current bundle set — retune them if bundles get heavier or more numerous.
  */
 function defaultJobs() {
   // availableParallelism honours container/cgroup CPU limits where cpus()
@@ -392,7 +395,9 @@ async function runParallel(selected, jobs, outDir) {
         // React-based bundle writes an identical shared maidr.css. Keep the
         // first copy when contents are byte-identical, and fail only on a
         // genuine conflict — fs.rename would otherwise silently replace the
-        // existing file and corrupt another bundle's artifact.
+        // existing file and corrupt another bundle's artifact. Deliberately
+        // conservative: same-named directories always conflict, since no
+        // bundle emits them today and deep-comparing them is untested.
         if (e.isFile() && await filesEqual(src, dest))
           continue;
         throw new Error(
@@ -468,6 +473,8 @@ async function runParallel(selected, jobs, outDir) {
   // Defense-in-depth for Ctrl+C / kill: shells usually signal the whole
   // foreground process group, but that isn't guaranteed everywhere (notably
   // Windows), so make sure an interrupted build doesn't leave workers running.
+  // Best-effort by design: exit() neither waits for the children to die nor
+  // runs main()'s finally cleanup — the next non-worker run sweeps dist/.tmp.
   const onSignal = (signal) => {
     for (const child of activeChildren)
       child.kill('SIGTERM');
@@ -526,8 +533,19 @@ async function main() {
         .map(b => ({ ...b, emptyOutDir: false }))
     : builds;
 
-  // Worker processes (and single-bundle requests) just build in-process.
-  if (isWorker || sequential || selected.length === 1) {
+  // Resolve the job cap early: before the sequential-path branch (a cap of 1
+  // routes there) and before touching dist, so a malformed
+  // --jobs/MAIDR_BUILD_JOBS aborts without wiping previous build output.
+  const jobs = jobsArg
+    ? parseJobs(jobsArg.slice('--jobs='.length), '--jobs')
+    : process.env.MAIDR_BUILD_JOBS
+      ? parseJobs(process.env.MAIDR_BUILD_JOBS, 'MAIDR_BUILD_JOBS')
+      : defaultJobs();
+
+  // Worker processes (and single-bundle requests) just build in-process. A
+  // job cap of 1 gains nothing from forking, so it goes in-process too
+  // instead of paying per-bundle child startup.
+  if (isWorker || sequential || jobs === 1 || selected.length === 1) {
     if (!isWorker)
       console.log('Building MAIDR library...\n');
     await runSequential(selected);
@@ -535,14 +553,6 @@ async function main() {
       console.log(`All builds complete in ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
     return;
   }
-
-  // Resolve the job cap before touching dist, so a malformed
-  // --jobs/MAIDR_BUILD_JOBS aborts without wiping previous build output.
-  const jobs = jobsArg
-    ? parseJobs(jobsArg.slice('--jobs='.length), '--jobs')
-    : process.env.MAIDR_BUILD_JOBS
-      ? parseJobs(process.env.MAIDR_BUILD_JOBS, 'MAIDR_BUILD_JOBS')
-      : defaultJobs();
 
   // Parent orchestrator: empty dist once up front, then fork workers. Children
   // build into isolated temp dirs and the parent merges results into dist.


### PR DESCRIPTION
# Pull Request

## Parallelize the library build

Reduced build time from nearly 5 min to 100 sec by running build steps in parallel. 

### Problem
`npm run build` produces 12 independent bundles, but ran them one at a time. On a 12-core machine that meant 11 cores sat idle for the entire ~4.5 minute build. The 7 React-based bundles (chartjs, vegalite, amcharts, recharts, react, core, victory) were the bulk of the cost at ~217s combined.

The build comment blamed a `vite-plugin-dts` limitation for the serial approach. The actual cause was narrower: every bundle writes intermediate TypeScript declaration (`.d.ts`) files into the **shared `dist/` folder**, so two builds running at once would clobber each other's files. It's a shared-directory conflict, not something inherent to building in parallel.

This was all done on Windows, but should be safe for Mac/Linux, and probably will work even better. 

### Fix
The build orchestrator (`scripts/build.js`) now runs bundles concurrently:

- One child process per bundle, several at a time. Each worker builds into its own isolated temp dir (`dist/.tmp/<name>`), then the parent moves the finished files into `dist`. Because each bundle's output filenames are unique, the merges never collide, and the `.d.ts` conflict disappears entirely.
- Memory-aware default concurrency: My machine has 12 cores, but what if we have a dev with an old clunky laptop? We don't want an OOM error. So we do `min(⅔ of CPU cores, a RAM-based cap, 8)`. Each heavy build holds ~1.75GB during type rollup, so the RAM cap keeps low-memory laptops (e.g. 8GB) from running out of memory. Override with `--jobs=N` or `MAIDR_BUILD_JOBS`.
- Windows-safe `dist` cleanup: empties the folder's *contents* instead of deleting the folder, avoiding an `EPERM` error on Windows.
- Escape hatches preserved: `--sequential` restores the old behavior, and single-bundle builds (`node scripts/build.js d3`) stay in-process and don't wipe `dist`.

### Results

| Config | Time |
|---|---|
| Before (serial) | 282s |
| After (default, 8 jobs on an 12 core machine) | **~106s** (2.6× faster) |

The default scales per machine: e.g. ~3 jobs on an 8GB laptop, up to the cap of 8 on beefier hardware. After 8 simultaneous jobs it started to get slower, but we could theoretically test with a really beefy machine and see if running all 12 at once is better at the high end. 

### Verification
- Parallel `dist` output is byte-identical to the serial build (all 52 artifacts, spot-checked `maidr.js`, `chartjs.mjs`, `react.d.mts`, etc.).
- Temp dirs cleaned up after build; single-bundle build and lint pass.

### Not included
Each React bundle still re-bundles React + MUI + emotion + the full MAIDR UI independently. Deduplicating that shared code is a larger, riskier restructure left for a follow-up.