### PR TITLE
fix: address audiocontext suspension on menu tones

### DIFF
--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -824,8 +824,36 @@ export class AudioService implements Observer<PlotState>, Disposable {
     if (this.volume <= 0) {
       return;
     }
-    // A suspended context reports currentTime === 0; scheduling start(0)/stop()
-    // now would fire an unexpected beep the instant the context resumes.
+
+    // A suspended context (before the first user gesture reaches the audio
+    // graph) reports currentTime === 0; scheduling start(0)/stop() against it
+    // would collapse the whole arpeggio to the instant it later resumes. Resume
+    // it first and play the notes once it is actually running, so the first cue
+    // after focus is heard rather than dropped.
+    if (this.audioContext.state !== 'running') {
+      void this.audioContext.resume()
+        .then(() => this.scheduleMenuTone(frequencies))
+        .catch(() => {
+          // resume() rejects on a closed context (dispose raced the resume) or
+          // when the browser still blocks playback; nothing to schedule then.
+        });
+      return;
+    }
+
+    this.scheduleMenuTone(frequencies);
+  }
+
+  /**
+   * Schedules a menu arpeggio's beeps back-to-back from the current time.
+   * Re-checks mode/volume/context because it can run after an async
+   * {@link AudioContext.resume}, by which point the user may have turned sound
+   * off or to zero, or the context may have been closed on disposal.
+   * @param frequencies - Beep frequencies in play order.
+   */
+  private scheduleMenuTone(frequencies: number[]): void {
+    if (this.mode === AudioMode.OFF || this.volume <= 0) {
+      return;
+    }
     if (this.audioContext.state !== 'running') {
       return;
     }

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -765,6 +765,12 @@ export class AudioService implements Observer<PlotState>, Disposable {
    * instead of collapsing to a stray beep when the context later resumes.
    */
   public playWarningTone(): void {
+    // At volume 0 the beeps are skipped anyway (see playOneWarningBeep); bail
+    // early so a silent cue neither triggers resume() nor claims the deferred
+    // cue slot (mirroring playMenuTone's outer guard).
+    if (this.volume <= 0) {
+      return;
+    }
     this.scheduleWhenRunning(() => this.scheduleWarningTone());
   }
 
@@ -795,6 +801,10 @@ export class AudioService implements Observer<PlotState>, Disposable {
    */
   public playWarningToneIfEnabled(): void {
     if (this.mode === AudioMode.OFF) {
+      return;
+    }
+    // See playWarningTone: a silent cue must not resume() or claim the slot.
+    if (this.volume <= 0) {
       return;
     }
     this.scheduleWhenRunning(() => {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -847,17 +847,21 @@ export class AudioService implements Observer<PlotState>, Disposable {
       // The already in-flight resume() below will pick up this newer cue.
       return;
     }
-    void this.audioContext.resume()
-      .then(() => {
+    // Two-argument then(): the rejection handler must cover only resume()
+    // itself. A bug thrown by the cue callback should surface as an unhandled
+    // rejection, not be silently absorbed as if resume() had failed.
+    void this.audioContext.resume().then(
+      () => {
         const pending = this.pendingCue;
         this.pendingCue = null;
         pending?.();
-      })
-      .catch(() => {
+      },
+      () => {
         // resume() rejects on a closed context (dispose raced the resume) or
         // when the browser still blocks playback; nothing to schedule then.
         this.pendingCue = null;
-      });
+      },
+    );
   }
 
   /**

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -772,7 +772,10 @@ export class AudioService implements Observer<PlotState>, Disposable {
    * Schedules the two descending warning beeps from the current time.
    * Re-checks the context state because it can run after an async
    * {@link AudioContext.resume}, by which point disposal may have closed the
-   * context. The volume is re-checked by playOneWarningBeep itself.
+   * context. The volume is re-checked by playOneWarningBeep itself. The mode
+   * is deliberately NOT re-checked here: playWarningTone is the unconditional
+   * variant (its callers want the alert even when sound is OFF), and
+   * playWarningToneIfEnabled layers its own mode re-check on top.
    */
   private scheduleWarningTone(): void {
     if (this.audioContext.state !== 'running') {
@@ -785,13 +788,21 @@ export class AudioService implements Observer<PlotState>, Disposable {
 
   /**
    * Plays a warning tone only if audio mode is enabled.
-   * Use this for conditional warnings that should respect user's audio preferences.
+   * Use this for conditional warnings that should respect user's audio
+   * preferences. The mode is re-checked when a cue deferred behind
+   * {@link AudioContext.resume} finally schedules, so a warning queued while
+   * suspended stays suppressed if the user turns sound OFF in the meantime.
    */
   public playWarningToneIfEnabled(): void {
     if (this.mode === AudioMode.OFF) {
       return;
     }
-    this.playWarningTone();
+    this.scheduleWhenRunning(() => {
+      if (this.mode === AudioMode.OFF) {
+        return;
+      }
+      this.scheduleWarningTone();
+    });
   }
 
   /**

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -103,6 +103,7 @@ export class AudioService implements Observer<PlotState>, Disposable {
   private readonly audioContext: AudioContext;
   private readonly compressor: DynamicsCompressorNode;
   private nextPointerGuidanceBeepAt: number;
+  private pendingCue: (() => void) | null;
 
   /**
    * Creates an instance of AudioService.
@@ -140,6 +141,7 @@ export class AudioService implements Observer<PlotState>, Disposable {
     this.audioContext = new AudioContext();
     this.compressor = this.initCompressor();
     this.nextPointerGuidanceBeepAt = 0;
+    this.pendingCue = null;
   }
 
   /**
@@ -148,6 +150,9 @@ export class AudioService implements Observer<PlotState>, Disposable {
    * the compressor, and closes the AudioContext.
    */
   public dispose(): void {
+    // Drop any cue still waiting on AudioContext.resume(); its then-callback
+    // must not schedule audio against the closing context.
+    this.pendingCue = null;
     this.stopAll();
     this.audioPalette.dispose();
 
@@ -755,12 +760,27 @@ export class AudioService implements Observer<PlotState>, Disposable {
   /**
    * Plays a warning tone to indicate navigation boundary or invalid state.
    * Consists of two descending beeps (half-step down) to clearly signal a warning.
+   * Like the menu cues, a warning on a suspended context is deferred behind
+   * {@link AudioContext.resume} so the first warning after focus is heard
+   * instead of collapsing to a stray beep when the context later resumes.
    */
   public playWarningTone(): void {
+    this.scheduleWhenRunning(() => this.scheduleWarningTone());
+  }
+
+  /**
+   * Schedules the two descending warning beeps from the current time.
+   * Re-checks the context state because it can run after an async
+   * {@link AudioContext.resume}, by which point disposal may have closed the
+   * context. The volume is re-checked by playOneWarningBeep itself.
+   */
+  private scheduleWarningTone(): void {
+    if (this.audioContext.state !== 'running') {
+      return;
+    }
     const now = this.audioContext.currentTime;
     this.playOneWarningBeep(WARNING_FREQUENCY, now);
     this.playOneWarningBeep(WARNING_FREQUENCY / 2 ** (1 / 12), now + WARNING_SPACE); // half step down
-    // setTimeout(() => this.audioContext.close(), (WARNING_SPACE + WARNING_DURATION + 0.1) * 1000);
   }
 
   /**
@@ -772,6 +792,49 @@ export class AudioService implements Observer<PlotState>, Disposable {
       return;
     }
     this.playWarningTone();
+  }
+
+  /**
+   * Runs a cue's scheduling callback once the AudioContext is running.
+   *
+   * A suspended context (before the first user gesture reaches the audio
+   * graph) reports currentTime === 0, so scheduling against it would collapse
+   * the cue to the instant the context later resumes. When not running, resume
+   * the context first and schedule once it settles, so the first cue after
+   * focus is heard rather than dropped.
+   *
+   * Only the most recent deferred cue is kept (last one wins): replaying every
+   * cue queued while suspended would stack them into one garbled chord on
+   * resume, and the latest cue is the one that reflects the current UI state.
+   *
+   * @param scheduleCue - Schedules the cue; it must re-check any mode/volume/
+   * context preconditions itself, because it can run after an async gap.
+   */
+  private scheduleWhenRunning(scheduleCue: () => void): void {
+    if (this.audioContext.state === 'running') {
+      // A cue still waiting on resume() is superseded by this newer one.
+      this.pendingCue = null;
+      scheduleCue();
+      return;
+    }
+
+    const resumePending = this.pendingCue !== null;
+    this.pendingCue = scheduleCue;
+    if (resumePending) {
+      // The already in-flight resume() below will pick up this newer cue.
+      return;
+    }
+    void this.audioContext.resume()
+      .then(() => {
+        const pending = this.pendingCue;
+        this.pendingCue = null;
+        pending?.();
+      })
+      .catch(() => {
+        // resume() rejects on a closed context (dispose raced the resume) or
+        // when the browser still blocks playback; nothing to schedule then.
+        this.pendingCue = null;
+      });
   }
 
   /**
@@ -825,22 +888,7 @@ export class AudioService implements Observer<PlotState>, Disposable {
       return;
     }
 
-    // A suspended context (before the first user gesture reaches the audio
-    // graph) reports currentTime === 0; scheduling start(0)/stop() against it
-    // would collapse the whole arpeggio to the instant it later resumes. Resume
-    // it first and play the notes once it is actually running, so the first cue
-    // after focus is heard rather than dropped.
-    if (this.audioContext.state !== 'running') {
-      void this.audioContext.resume()
-        .then(() => this.scheduleMenuTone(frequencies))
-        .catch(() => {
-          // resume() rejects on a closed context (dispose raced the resume) or
-          // when the browser still blocks playback; nothing to schedule then.
-        });
-      return;
-    }
-
-    this.scheduleMenuTone(frequencies);
+    this.scheduleWhenRunning(() => this.scheduleMenuTone(frequencies));
   }
 
   /**

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -803,9 +803,11 @@ export class AudioService implements Observer<PlotState>, Disposable {
    * the context first and schedule once it settles, so the first cue after
    * focus is heard rather than dropped.
    *
-   * Only the most recent deferred cue is kept (last one wins): replaying every
-   * cue queued while suspended would stack them into one garbled chord on
-   * resume, and the latest cue is the one that reflects the current UI state.
+   * Only the most recent deferred cue is kept (last one wins), and the slot is
+   * deliberately shared across cue types (menu, subplot, and warning cues
+   * alike): replaying every cue queued while suspended would stack them into
+   * one garbled chord on resume, and the latest cue — whatever its type — is
+   * the one that reflects the current UI state.
    *
    * @param scheduleCue - Schedules the cue; it must re-check any mode/volume/
    * context preconditions itself, because it can run after an async gap.

--- a/test/service/audio.menuTone.test.ts
+++ b/test/service/audio.menuTone.test.ts
@@ -31,6 +31,7 @@ interface MockAudioContext {
   createGain: () => unknown;
   createStereoPanner: () => unknown;
   createDynamicsCompressor: () => unknown;
+  resume: () => Promise<void>;
   close: () => void;
 }
 
@@ -89,6 +90,10 @@ function installAudioContextMock(state: string = 'running'): MockAudioContext {
     createGain: makeGain,
     createStereoPanner: makePanner,
     createDynamicsCompressor: makeCompressor,
+    resume() {
+      this.state = 'running';
+      return Promise.resolve();
+    },
     close: jest.fn(),
   };
   const audioGlobal = globalThis as unknown as { AudioContext: new () => MockAudioContext };
@@ -162,7 +167,7 @@ describe('AudioService menu open/close cues', () => {
     service.dispose();
   });
 
-  it('plays no cue while the AudioContext is suspended (avoids a beep on resume)', async () => {
+  it('resumes a suspended AudioContext, then plays the cue (no drop on first use)', async () => {
     const ctx = installAudioContextMock('suspended');
     const { AudioService } = await import('@service/audio');
     const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
@@ -170,7 +175,15 @@ describe('AudioService menu open/close cues', () => {
     const before = ctx.oscillators.length;
     service.playMenuOpenTone();
 
+    // Nothing synchronously: scheduling start(0)/stop() against a still-suspended
+    // context (currentTime === 0) would collapse the arpeggio to a single instant.
     expect(ctx.oscillators.length).toBe(before);
+
+    // Flush the resume() microtask; the two arpeggio notes schedule once the
+    // context is actually running.
+    await Promise.resolve();
+    expect(ctx.state).toBe('running');
+    expect(ctx.oscillators.length).toBe(before + 2);
     service.dispose();
   });
 

--- a/test/service/audio.menuTone.test.ts
+++ b/test/service/audio.menuTone.test.ts
@@ -1,8 +1,11 @@
 /**
  * Tests for AudioService.playMenuOpenTone / playMenuCloseTone — the Go-To modal
  * open/close cues. Each cue is a short two-note arpeggio, so a successful cue
- * creates exactly two oscillators. The cue must be silent when audio is OFF,
- * when the volume is 0, or when the AudioContext is still suspended.
+ * creates exactly two oscillators. The cue must be silent when audio is OFF or
+ * when the volume is 0. On a suspended AudioContext the cue is deferred behind
+ * resume() and only the most recent deferred cue plays (last one wins); it is
+ * dropped entirely if the service is disposed, audio is turned OFF, or the
+ * context still is not running once resume() settles.
  *
  * AudioContext doesn't exist in the node test environment, so we install a
  * minimal global mock that records createOscillator calls (the visible side
@@ -184,6 +187,76 @@ describe('AudioService menu open/close cues', () => {
     await Promise.resolve();
     expect(ctx.state).toBe('running');
     expect(ctx.oscillators.length).toBe(before + 2);
+    service.dispose();
+  });
+
+  it('plays only the latest cue queued while suspended (no stacked arpeggios)', async () => {
+    const ctx = installAudioContextMock('suspended');
+    // Like a real browser, flip the state only when resume() settles, so both
+    // cues below are requested while the context is still suspended.
+    ctx.resume = () => Promise.resolve().then(() => {
+      ctx.state = 'running';
+    });
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+    service.playMenuCloseTone();
+    expect(ctx.oscillators.length).toBe(before);
+
+    // After resume() settles (two microtask hops: the state flip, then the
+    // deferred scheduling), only the close cue (falling 990 -> 660) plays;
+    // replaying the superseded open cue too would stack both arpeggios into
+    // one garbled chord at the same start time.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ctx.oscillators.slice(before).map(osc => osc.frequency.value)).toEqual([990, 660]);
+    service.dispose();
+  });
+
+  it('drops a cue still waiting on resume() when the service is disposed', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+    service.dispose();
+
+    // The mock's close() does not flip the state, so only the dispose-time
+    // cancellation of the pending cue prevents audio after disposal.
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+  });
+
+  it('drops a cue still waiting on resume() when audio is toggled OFF', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+    service.toggle(); // SEPARATE -> OFF during the async resume() gap
+
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
+  });
+
+  it('plays no cue when resume() settles but the context still is not running', async () => {
+    const ctx = installAudioContextMock('suspended');
+    // Autoplay policy edge: resume() can settle without the context actually
+    // reaching the running state; the deferred path must re-check.
+    ctx.resume = () => Promise.resolve();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
     service.dispose();
   });
 

--- a/test/service/audio.menuTone.test.ts
+++ b/test/service/audio.menuTone.test.ts
@@ -194,9 +194,13 @@ describe('AudioService menu open/close cues', () => {
     const ctx = installAudioContextMock('suspended');
     // Like a real browser, flip the state only when resume() settles, so both
     // cues below are requested while the context is still suspended.
-    ctx.resume = () => Promise.resolve().then(() => {
-      ctx.state = 'running';
-    });
+    let resumeCalls = 0;
+    ctx.resume = () => {
+      resumeCalls += 1;
+      return Promise.resolve().then(() => {
+        ctx.state = 'running';
+      });
+    };
     const { AudioService } = await import('@service/audio');
     const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
 
@@ -208,10 +212,36 @@ describe('AudioService menu open/close cues', () => {
     // After resume() settles (two microtask hops: the state flip, then the
     // deferred scheduling), only the close cue (falling 990 -> 660) plays;
     // replaying the superseded open cue too would stack both arpeggios into
-    // one garbled chord at the same start time.
+    // one garbled chord at the same start time. The second call only replaces
+    // the pending cue — it must not kick off a second resume().
     await Promise.resolve();
     await Promise.resolve();
+    expect(resumeCalls).toBe(1);
     expect(ctx.oscillators.slice(before).map(osc => osc.frequency.value)).toEqual([990, 660]);
+    service.dispose();
+  });
+
+  it('swallows a rejected resume() and recovers on the next cue', async () => {
+    const ctx = installAudioContextMock('suspended');
+    // Autoplay policy edge: resume() can reject outright while the browser
+    // still blocks playback (distinct from resolving without running).
+    ctx.resume = () => Promise.reject(new Error('blocked by autoplay policy'));
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+
+    // Two microtask hops: the rejection propagates, then the catch runs. The
+    // suite fails on any unhandled rejection, so this also pins the swallow.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+
+    // Once the context is running (e.g. a later user gesture), cues play again.
+    ctx.state = 'running';
+    service.playMenuOpenTone();
+    expect(ctx.oscillators.length).toBe(before + 2);
     service.dispose();
   });
 

--- a/test/service/audio.menuTone.test.ts
+++ b/test/service/audio.menuTone.test.ts
@@ -93,6 +93,9 @@ function installAudioContextMock(state: string = 'running'): MockAudioContext {
     createGain: makeGain,
     createStereoPanner: makePanner,
     createDynamicsCompressor: makeCompressor,
+    // Simplification: state flips synchronously, though a real AudioContext
+    // only transitions once the promise settles. Tests where that ordering
+    // matters must override resume() with a deferred flip.
     resume() {
       this.state = 'running';
       return Promise.resolve();
@@ -258,6 +261,38 @@ describe('AudioService menu open/close cues', () => {
     // cancellation of the pending cue prevents audio after disposal.
     await Promise.resolve();
     expect(ctx.oscillators.length).toBe(before);
+  });
+
+  it('drops a cue still waiting on resume() when volume is set to 0', async () => {
+    const ctx = installAudioContextMock('suspended');
+    // Extend the settings stub so the test can fire a live volume change into
+    // the listener AudioService registers in its constructor.
+    interface MockSettingsEvent {
+      affectsSetting: (key: string) => boolean;
+      get: <T>(key: string) => T;
+    }
+    let onSettingsChange: ((event: MockSettingsEvent) => void) | undefined;
+    const settings = {
+      get: <T>(_key: string) => 100 as unknown as T,
+      onChange: (listener: (event: MockSettingsEvent) => void) => {
+        onSettingsChange = listener;
+      },
+    } as unknown as SettingsService;
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), settings, INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+    // Volume drops to 0 during the async resume() gap; the deferred path's
+    // volume re-check must silence the cue.
+    onSettingsChange?.({
+      affectsSetting: (key: string) => key === 'general.volume',
+      get: <T>(_key: string) => 0 as unknown as T,
+    });
+
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
   });
 
   it('drops a cue still waiting on resume() when audio is toggled OFF', async () => {

--- a/test/service/audio.subplotCue.test.ts
+++ b/test/service/audio.subplotCue.test.ts
@@ -35,6 +35,7 @@ interface MockAudioContext {
   createGain: () => unknown;
   createStereoPanner: () => unknown;
   createDynamicsCompressor: () => unknown;
+  resume: () => Promise<void>;
   close: () => void;
 }
 
@@ -85,6 +86,10 @@ function installAudioContextMock(state: string = 'running'): MockAudioContext {
       connect: jest.fn(),
       disconnect: jest.fn(),
     }),
+    resume() {
+      this.state = 'running';
+      return Promise.resolve();
+    },
     close: jest.fn(),
   };
   const audioGlobal = globalThis as unknown as { AudioContext: new () => MockAudioContext };

--- a/test/service/audio.subplotCue.test.ts
+++ b/test/service/audio.subplotCue.test.ts
@@ -137,6 +137,26 @@ describe('AudioService subplot enter/exit cues', () => {
     service.dispose();
   });
 
+  it('resumes a suspended AudioContext, then plays the subplot cue', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playSubplotEnterTone();
+
+    // Nothing synchronously: the cue defers behind resume() while suspended.
+    expect(ctx.oscillators.length).toBe(before);
+
+    // Flush the resume() microtask; the three arpeggio notes schedule once the
+    // context is actually running (same path as the menu cues, pinned here so
+    // the subplot entry point's coverage is explicit).
+    await Promise.resolve();
+    expect(ctx.state).toBe('running');
+    expect(ctx.oscillators.length).toBe(before + 3);
+    service.dispose();
+  });
+
   it('plays no cue when audio mode is OFF', async () => {
     const ctx = installAudioContextMock();
     const { AudioService } = await import('@service/audio');

--- a/test/service/audio.subplotCue.test.ts
+++ b/test/service/audio.subplotCue.test.ts
@@ -86,6 +86,9 @@ function installAudioContextMock(state: string = 'running'): MockAudioContext {
       connect: jest.fn(),
       disconnect: jest.fn(),
     }),
+    // Simplification: state flips synchronously, though a real AudioContext
+    // only transitions once the promise settles. Tests where that ordering
+    // matters must override resume() with a deferred flip.
     resume() {
       this.state = 'running';
       return Promise.resolve();

--- a/test/service/audio.warningTone.test.ts
+++ b/test/service/audio.warningTone.test.ts
@@ -177,6 +177,35 @@ describe('AudioService warning cue', () => {
     service.dispose();
   });
 
+  it('a warning queued while suspended supersedes a pending menu cue', async () => {
+    const ctx = installAudioContextMock('suspended');
+    // Like a real browser, flip the state only when resume() settles, so both
+    // cues below are requested while the context is still suspended.
+    ctx.resume = () => Promise.resolve().then(() => {
+      ctx.state = 'running';
+    });
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+    service.playWarningTone();
+    expect(ctx.oscillators.length).toBe(before);
+
+    // The deferred slot is deliberately shared across cue types (last one
+    // wins): after resume() settles (two microtask hops: the state flip, then
+    // the deferred scheduling), only the newest cue — the warning's descending
+    // 180 Hz pair — plays; the stale menu cue would otherwise stack on top of
+    // it at the same start time.
+    await Promise.resolve();
+    await Promise.resolve();
+    const frequencies = ctx.oscillators.slice(before).map(osc => osc.frequency.value);
+    expect(frequencies).toHaveLength(2);
+    expect(frequencies[0]).toBe(180);
+    expect(frequencies[1]).toBeCloseTo(180 / 2 ** (1 / 12), 10);
+    service.dispose();
+  });
+
   it('drops a warning still waiting on resume() when the service is disposed', async () => {
     const ctx = installAudioContextMock('suspended');
     const { AudioService } = await import('@service/audio');

--- a/test/service/audio.warningTone.test.ts
+++ b/test/service/audio.warningTone.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for AudioService.playWarningTone / playWarningToneIfEnabled — the
+ * boundary/invalid-state cue. A warning is two descending beeps, so a
+ * successful cue creates exactly two oscillators. On a suspended AudioContext
+ * (issue #641: before the first user gesture reaches the audio graph) the
+ * warning is deferred behind resume() and plays once the context is running,
+ * instead of being scheduled against currentTime === 0 and collapsing to a
+ * stray beep when the context later resumes.
+ *
+ * AudioContext doesn't exist in the node test environment, so we install a
+ * minimal global mock that records createOscillator calls (the visible side
+ * effect), mirroring test/service/audio.menuTone.test.ts.
+ */
+import type { NotificationService } from '@service/notification';
+import type { SettingsService } from '@service/settings';
+import type { PlotState } from '@type/state';
+import { describe, expect, it, jest } from '@jest/globals';
+
+interface MockOscillator {
+  type: string;
+  frequency: { value: number };
+  connect: jest.Mock;
+  start: jest.Mock;
+  stop: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+interface MockAudioContext {
+  currentTime: number;
+  state: string;
+  destination: object;
+  oscillators: MockOscillator[];
+  createOscillator: () => MockOscillator;
+  createGain: () => unknown;
+  createStereoPanner: () => unknown;
+  createDynamicsCompressor: () => unknown;
+  resume: () => Promise<void>;
+  close: () => void;
+}
+
+function makeOscillator(): MockOscillator {
+  return {
+    type: '',
+    frequency: { value: 0 },
+    connect: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makeGain(): unknown {
+  return {
+    gain: {
+      value: 0,
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+      linearRampToValueAtTime: jest.fn(),
+      setValueCurveAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makePanner(): unknown {
+  return { pan: { value: 0 }, connect: jest.fn(), disconnect: jest.fn() };
+}
+
+function makeCompressor(): unknown {
+  return {
+    threshold: { value: 0 },
+    knee: { value: 0 },
+    ratio: { value: 0 },
+    attack: { value: 0 },
+    release: { value: 0 },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function installAudioContextMock(state: string = 'running'): MockAudioContext {
+  const ctx: MockAudioContext = {
+    currentTime: 0,
+    state,
+    destination: {},
+    oscillators: [],
+    createOscillator() {
+      const osc = makeOscillator();
+      this.oscillators.push(osc);
+      return osc;
+    },
+    createGain: makeGain,
+    createStereoPanner: makePanner,
+    createDynamicsCompressor: makeCompressor,
+    resume() {
+      this.state = 'running';
+      return Promise.resolve();
+    },
+    close: jest.fn(),
+  };
+  const audioGlobal = globalThis as unknown as { AudioContext: new () => MockAudioContext };
+  audioGlobal.AudioContext = function () {
+    return ctx;
+  } as unknown as new () => MockAudioContext;
+  return ctx;
+}
+
+function createSettings(volume: number = 100): SettingsService {
+  return {
+    get: <T>(key: string) => (key === 'general.volume' ? volume : 100) as unknown as T,
+    onChange: () => {},
+  } as unknown as SettingsService;
+}
+
+function createNotification(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+const INITIAL_STATE: PlotState = { empty: true, type: 'figure' };
+
+describe('AudioService warning cue', () => {
+  it('playWarningTone creates two oscillators (a descending two-beep warning)', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playWarningTone();
+
+    expect(ctx.oscillators.length).toBe(before + 2);
+    service.dispose();
+  });
+
+  it('resumes a suspended AudioContext, then plays the warning (no stray beep)', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playWarningTone();
+
+    // Nothing synchronously: scheduling start(0)/stop() against a still-suspended
+    // context (currentTime === 0) would fire at an arbitrary later instant.
+    expect(ctx.oscillators.length).toBe(before);
+
+    // Flush the resume() microtask; the two beeps schedule once the context is
+    // actually running.
+    await Promise.resolve();
+    expect(ctx.state).toBe('running');
+    expect(ctx.oscillators.length).toBe(before + 2);
+    service.dispose();
+  });
+
+  it('plays no warning when volume is 0', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(0), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playWarningTone();
+
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
+  });
+
+  it('playWarningToneIfEnabled plays nothing when audio mode is OFF', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+    service.toggle(); // SEPARATE -> OFF
+
+    const before = ctx.oscillators.length;
+    service.playWarningToneIfEnabled();
+
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
+  });
+
+  it('drops a warning still waiting on resume() when the service is disposed', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playWarningTone();
+    service.dispose();
+
+    // The mock's close() does not flip the state, so only the dispose-time
+    // cancellation of the pending cue prevents audio after disposal.
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+  });
+});

--- a/test/service/audio.warningTone.test.ts
+++ b/test/service/audio.warningTone.test.ts
@@ -93,6 +93,9 @@ function installAudioContextMock(state: string = 'running'): MockAudioContext {
     createGain: makeGain,
     createStereoPanner: makePanner,
     createDynamicsCompressor: makeCompressor,
+    // Simplification: state flips synchronously, though a real AudioContext
+    // only transitions once the promise settles. Tests where that ordering
+    // matters must override resume() with a deferred flip.
     resume() {
       this.state = 'running';
       return Promise.resolve();

--- a/test/service/audio.warningTone.test.ts
+++ b/test/service/audio.warningTone.test.ts
@@ -177,6 +177,38 @@ describe('AudioService warning cue', () => {
     service.dispose();
   });
 
+  it('playWarningToneIfEnabled drops a deferred warning when audio is toggled OFF', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playWarningToneIfEnabled();
+    service.toggle(); // SEPARATE -> OFF during the async resume() gap
+
+    // The "IfEnabled" contract must hold across the gap: no beep after resume.
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
+  });
+
+  it('playWarningTone still plays a deferred warning after audio is toggled OFF', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playWarningTone();
+    service.toggle(); // SEPARATE -> OFF during the async resume() gap
+
+    // playWarningTone is the deliberately unconditional variant (used by e.g.
+    // ToggleBrailleCommand): it alerts even when sound is OFF, so the deferred
+    // path must not silently grow a mode check.
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before + 2);
+    service.dispose();
+  });
+
   it('a warning queued while suspended supersedes a pending menu cue', async () => {
     const ctx = installAudioContextMock('suspended');
     // Like a real browser, flip the state only when resume() settles, so both

--- a/test/service/audio.warningTone.test.ts
+++ b/test/service/audio.warningTone.test.ts
@@ -164,6 +164,29 @@ describe('AudioService warning cue', () => {
     service.dispose();
   });
 
+  it('does not resume a suspended context for a silent (volume 0) warning', async () => {
+    const ctx = installAudioContextMock('suspended');
+    let resumeCalls = 0;
+    ctx.resume = () => {
+      resumeCalls += 1;
+      ctx.state = 'running';
+      return Promise.resolve();
+    };
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(0), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playWarningTone();
+    service.playWarningToneIfEnabled();
+
+    // A cue that would play nothing must neither trigger resume() nor claim
+    // the deferred cue slot (mirrors playMenuTone's outer volume guard).
+    await Promise.resolve();
+    expect(resumeCalls).toBe(0);
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
+  });
+
   it('playWarningToneIfEnabled plays nothing when audio mode is OFF', async () => {
     const ctx = installAudioContextMock();
     const { AudioService } = await import('@service/audio');


### PR DESCRIPTION
# Pull Request

## Description

Fixed playMenuTone so it no longer drops a cue when AudioContext is suspended (calls resume() via promise once context is actually running). Should fix all affected menu tones: subplot enter/exit arpeggios, mode toggle confirmations, and warning ticks. 

## Related Issues

Fixes #641 

## Changes Made

audio.ts: 
 - Rewired playMenuTone to call resume() then schedule via .then() once call back is in running state and currentTime is advancing normally.
 - moved scheduling into scheduleMenuTone helper
 - deffered path rechecks mode / vol / state because the async gap means user could theoretically toggle sound off or dispose and kill context before it resolves. Reject on a closed context. 
 - test: resume() added, flipping state to running and resolving
 - test: minor rewrite of the menu tone suspended test

## Additional notes

Major reliance on claude for unit test and general testing as this issue couldn't be verified manually. 
