### PR TITLE
fix(audio): defer empty-state tones behind AudioContext.resume()

### DIFF
--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -666,17 +666,37 @@ export class AudioService implements Observer<PlotState>, Disposable {
    * The panning position from the Panning object provides directional spatial cues,
    * helping users infer where the empty state occurs within the overall layout.
    *
+   * Like the menu and warning cues, an empty tone on a suspended context is
+   * deferred behind {@link AudioContext.resume} instead of being scheduled at
+   * currentTime === 0, where it would fire at an arbitrary later instant once
+   * the context resumes, detached from the interaction that caused it.
+   *
    * @param panning - Position information for spatial audio placement
-   * @returns AudioId for the played tone
    */
-  private playEmptyTone(panning: Panning): AudioId {
+  private playEmptyTone(panning: Panning): void {
     // At volume 0 every exponential ramp target below collapses to 0, which
     // the Web Audio spec rejects with a RangeError. The tone would be silent
-    // anyway, so skip scheduling and return a harmless, self-clearing id.
+    // anyway, so it must neither trigger resume() nor claim the deferred cue
+    // slot (mirroring playMenuTone's outer guard).
     if (this.volume <= 0) {
-      const audioId = setTimeout(() => this.activeAudioIds.delete(audioId), 0);
-      this.activeAudioIds.set(audioId, []);
-      return audioId;
+      return;
+    }
+    this.scheduleWhenRunning(() => this.scheduleEmptyTone(panning));
+  }
+
+  /**
+   * Schedules the empty-state harmonics from the current time.
+   * Re-checks mode/volume/context because it can run after an async
+   * {@link AudioContext.resume}, by which point the user may have turned sound
+   * off or to zero, or the context may have been closed on disposal.
+   * @param panning - Position information for spatial audio placement
+   */
+  private scheduleEmptyTone(panning: Panning): void {
+    if (this.mode === AudioMode.OFF || this.volume <= 0) {
+      return;
+    }
+    if (this.audioContext.state !== 'running') {
+      return;
     }
 
     const xPos = MathUtil.interpolate(panning.x, 0, panning.cols - 1, -1, 1);
@@ -730,7 +750,6 @@ export class AudioService implements Observer<PlotState>, Disposable {
 
     const audioId = setTimeout(() => cleanUp(audioId), duration * 1e3 * 2);
     this.activeAudioIds.set(audioId, oscillators);
-    return audioId;
   }
 
   private playOneWarningBeep(freq: number, startTime: number): void {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -844,10 +844,10 @@ export class AudioService implements Observer<PlotState>, Disposable {
    * focus is heard rather than dropped.
    *
    * Only the most recent deferred cue is kept (last one wins), and the slot is
-   * deliberately shared across cue types (menu, subplot, and warning cues
-   * alike): replaying every cue queued while suspended would stack them into
-   * one garbled chord on resume, and the latest cue — whatever its type — is
-   * the one that reflects the current UI state.
+   * deliberately shared across cue types (menu, subplot, warning, and
+   * empty-state cues alike): replaying every cue queued while suspended would
+   * stack them into one garbled chord on resume, and the latest cue — whatever
+   * its type — is the one that reflects the current UI state.
    *
    * @param scheduleCue - Schedules the cue; it must re-check any mode/volume/
    * context preconditions itself, because it can run after an async gap.

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -355,7 +355,9 @@ export class AudioService implements Observer<PlotState>, Disposable {
     panning: Panning,
     direction: 'up' | 'down',
   ): AudioId {
-    // Silent at volume 0; return a harmless self-clearing id (see playEmptyTone).
+    // Silent at volume 0 (an exponential ramp target of 0 would throw a
+    // RangeError anyway); return a harmless self-clearing id so the caller
+    // still gets an AudioId to track.
     if (this.volume <= 0) {
       const audioId = setTimeout(() => this.activeAudioIds.delete(audioId), 0);
       this.activeAudioIds.set(audioId, []);
@@ -677,7 +679,9 @@ export class AudioService implements Observer<PlotState>, Disposable {
     // At volume 0 every exponential ramp target below collapses to 0, which
     // the Web Audio spec rejects with a RangeError. The tone would be silent
     // anyway, so it must neither trigger resume() nor claim the deferred cue
-    // slot (mirroring playMenuTone's outer guard).
+    // slot (mirroring playMenuTone's outer guard). Unlike playMenuTone, no
+    // mode check here: update(), the only caller, already gates on
+    // AudioMode.OFF, and scheduleEmptyTone re-checks it after the async gap.
     if (this.volume <= 0) {
       return;
     }
@@ -1128,7 +1132,9 @@ export class AudioService implements Observer<PlotState>, Disposable {
    * @returns AudioId for the played click
    */
   private playClickTone(panning: Panning): AudioId {
-    // Silent at volume 0; return a harmless self-clearing id (see playEmptyTone).
+    // Silent at volume 0 (an exponential ramp target of 0 would throw a
+    // RangeError anyway); return a harmless self-clearing id so the caller
+    // still gets an AudioId to track.
     if (this.volume <= 0) {
       const audioId = setTimeout(() => this.activeAudioIds.delete(audioId), 0);
       this.activeAudioIds.set(audioId, []);

--- a/test/service/audio.emptyTone.test.ts
+++ b/test/service/audio.emptyTone.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the AudioService empty-state tone — the spatialized "null" sound
+ * played from update() for empty/out-of-bounds navigation states. A successful
+ * tone creates exactly five oscillators (one per harmonic). On a suspended
+ * AudioContext (issue #644: before the first user gesture reaches the audio
+ * graph) the tone is deferred behind resume() and plays once the context is
+ * running, instead of being scheduled at currentTime === 0 and firing at an
+ * arbitrary later instant, detached from the interaction that caused it.
+ *
+ * AudioContext doesn't exist in the node test environment, so we install a
+ * minimal global mock that records createOscillator calls (the visible side
+ * effect), mirroring test/service/audio.menuTone.test.ts.
+ */
+import type { NotificationService } from '@service/notification';
+import type { SettingsService } from '@service/settings';
+import type { PlotState } from '@type/state';
+import { describe, expect, it, jest } from '@jest/globals';
+
+const EMPTY_TONE_OSCILLATORS = 5; // one per harmonic frequency
+
+interface MockOscillator {
+  type: string;
+  frequency: { value: number };
+  connect: jest.Mock;
+  start: jest.Mock;
+  stop: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+interface MockAudioContext {
+  currentTime: number;
+  state: string;
+  destination: object;
+  oscillators: MockOscillator[];
+  createOscillator: () => MockOscillator;
+  createGain: () => unknown;
+  createStereoPanner: () => unknown;
+  createDynamicsCompressor: () => unknown;
+  resume: () => Promise<void>;
+  close: () => void;
+}
+
+function makeOscillator(): MockOscillator {
+  return {
+    type: '',
+    frequency: { value: 0 },
+    connect: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makeGain(): unknown {
+  return {
+    gain: {
+      value: 0,
+      setValueAtTime: jest.fn(),
+      exponentialRampToValueAtTime: jest.fn(),
+      linearRampToValueAtTime: jest.fn(),
+      setValueCurveAtTime: jest.fn(),
+    },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function makePanner(): unknown {
+  return { pan: { value: 0 }, connect: jest.fn(), disconnect: jest.fn() };
+}
+
+function makeCompressor(): unknown {
+  return {
+    threshold: { value: 0 },
+    knee: { value: 0 },
+    ratio: { value: 0 },
+    attack: { value: 0 },
+    release: { value: 0 },
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+function installAudioContextMock(state: string = 'running'): MockAudioContext {
+  const ctx: MockAudioContext = {
+    currentTime: 0,
+    state,
+    destination: {},
+    oscillators: [],
+    createOscillator() {
+      const osc = makeOscillator();
+      this.oscillators.push(osc);
+      return osc;
+    },
+    createGain: makeGain,
+    createStereoPanner: makePanner,
+    createDynamicsCompressor: makeCompressor,
+    // Simplification: state flips synchronously, though a real AudioContext
+    // only transitions once the promise settles. Tests where that ordering
+    // matters must override resume() with a deferred flip.
+    resume() {
+      this.state = 'running';
+      return Promise.resolve();
+    },
+    close: jest.fn(),
+  };
+  const audioGlobal = globalThis as unknown as { AudioContext: new () => MockAudioContext };
+  audioGlobal.AudioContext = function () {
+    return ctx;
+  } as unknown as new () => MockAudioContext;
+  return ctx;
+}
+
+function createSettings(volume: number = 100): SettingsService {
+  return {
+    get: <T>(key: string) => (key === 'general.volume' ? volume : 100) as unknown as T,
+    onChange: () => {},
+  } as unknown as SettingsService;
+}
+
+function createNotification(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+const INITIAL_STATE: PlotState = { empty: true, type: 'figure' };
+// An empty subplot state routes update() to the default-panning empty tone.
+const EMPTY_SUBPLOT_STATE = { empty: true, type: 'subplot' } as unknown as PlotState;
+
+describe('AudioService empty-state tone', () => {
+  it('update() with an empty state plays the five-oscillator empty tone', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.update(EMPTY_SUBPLOT_STATE);
+
+    expect(ctx.oscillators.length).toBe(before + EMPTY_TONE_OSCILLATORS);
+    service.dispose();
+  });
+
+  it('resumes a suspended AudioContext, then plays the empty tone (no stray late tone)', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.update(EMPTY_SUBPLOT_STATE);
+
+    // Nothing synchronously: scheduling start(0)/stop() against a still-suspended
+    // context (currentTime === 0) would fire at an arbitrary instant on resume.
+    expect(ctx.oscillators.length).toBe(before);
+
+    // Flush the resume() microtask; the harmonics schedule once the context is
+    // actually running.
+    await Promise.resolve();
+    expect(ctx.state).toBe('running');
+    expect(ctx.oscillators.length).toBe(before + EMPTY_TONE_OSCILLATORS);
+    service.dispose();
+  });
+
+  it('does not resume a suspended context for a silent (volume 0) empty tone', async () => {
+    const ctx = installAudioContextMock('suspended');
+    let resumeCalls = 0;
+    ctx.resume = () => {
+      resumeCalls += 1;
+      ctx.state = 'running';
+      return Promise.resolve();
+    };
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(0), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.update(EMPTY_SUBPLOT_STATE);
+
+    await Promise.resolve();
+    expect(resumeCalls).toBe(0);
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
+  });
+
+  it('drops an empty tone still waiting on resume() when audio is toggled OFF', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.update(EMPTY_SUBPLOT_STATE);
+    service.toggle(); // SEPARATE -> OFF during the async resume() gap
+
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+    service.dispose();
+  });
+
+  it('drops an empty tone still waiting on resume() when the service is disposed', async () => {
+    const ctx = installAudioContextMock('suspended');
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.update(EMPTY_SUBPLOT_STATE);
+    service.dispose();
+
+    // The mock's close() does not flip the state, so only the dispose-time
+    // cancellation of the pending cue prevents audio after disposal.
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before);
+  });
+
+  it('an empty tone queued while suspended supersedes a pending menu cue', async () => {
+    const ctx = installAudioContextMock('suspended');
+    // Like a real browser, flip the state only when resume() settles, so both
+    // cues below are requested while the context is still suspended.
+    ctx.resume = () => Promise.resolve().then(() => {
+      ctx.state = 'running';
+    });
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.playMenuOpenTone();
+    service.update(EMPTY_SUBPLOT_STATE);
+    expect(ctx.oscillators.length).toBe(before);
+
+    // The deferred slot is deliberately shared across cue types (last one
+    // wins): after resume() settles (two microtask hops: the state flip, then
+    // the deferred scheduling), only the newest cue — the five-harmonic empty
+    // tone — plays; the stale menu cue is superseded.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ctx.oscillators.length).toBe(before + EMPTY_TONE_OSCILLATORS);
+    service.dispose();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #643. `playEmptyTone` — the spatialized "null" sound played from `update()` for empty/out-of-bounds navigation states — had no suspended-state guard at all: on a suspended `AudioContext` (before the first user gesture reaches the audio graph) it scheduled its harmonics at `currentTime === 0`, so the tone fired at an arbitrary later instant once the context resumed, detached from the interaction that caused it. It now routes through the `scheduleWhenRunning` deferral idiom introduced in #643, so the tone plays once the context is actually running.

## Related Issues

Fixes #644

## Changes Made

- `src/service/audio.ts`:
  - Split `playEmptyTone` into a deferring wrapper and a `scheduleEmptyTone` core. The wrapper keeps the outer `volume <= 0` guard (a silent tone must neither trigger `resume()` nor claim the shared deferred-cue slot); the core re-checks mode/volume/context state because it can run after the async `resume()` gap, matching the discipline of `scheduleMenuTone`/`scheduleWarningTone`.
  - `playEmptyTone` now returns `void`: its `AudioId` was unused by both `update()` call sites, and the volume-0 placeholder-id existed only to satisfy that contract.
  - Data-tone paths (`playOscillator`) are deliberately unchanged: their `AudioId` returns are consumed by chaining/stop logic, and #641 explicitly scoped them out.
- `test/service/audio.emptyTone.test.ts` (new): running-context happy path, suspended → resume → plays, volume-0 skips `resume()` entirely, mode toggled OFF during the gap, disposal during the gap, and cross-cue supersession of a pending menu cue (the shared last-one-wins slot now includes the empty tone).

## Screenshots (if applicable)

Not applicable — audio-only change.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

The suspended-context window cannot be verified manually in a reliable way (same situation as #643), hence the unchecked manual-testing box; behavior is pinned by the six new unit tests. Full suite: 970 tests, type-check, lint, and the production build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dr1Qb5MLPo5TP2jPU24RBd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr1Qb5MLPo5TP2jPU24RBd)_