### PR TITLE
ci: skip commitlint for bot dependency bump commits

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,15 +1,13 @@
 import type { UserConfig } from '@commitlint/types';
 import conventional from '@commitlint/config-conventional';
+import { isBotDependencyBump } from './commitlint.ignores';
 
 const config: UserConfig = {
   extends: ['@commitlint/config-conventional'],
   rules: conventional.rules,
-  // Bot dependency bumps (Dependabot, Renovate) list every bumped package in
-  // the commit body, which routinely exceeds `body-max-line-length`. Failing
-  // commitlint on those skips every job that declares `needs: [commitlint]`,
-  // so security updates would ship untested. Skip linting for those commits
-  // only; the rules stay fully enforced for human-authored commits.
-  ignores: [message => /^(?:build|chore)\(deps(?:-dev)?\)/.test(message)],
+  // Let bot dependency bumps through; the rules stay fully enforced for
+  // human-authored commits. See commitlint.ignores.ts for why.
+  ignores: [isBotDependencyBump],
   helpUrl: 'https://github.com/conventional-changelog/commitlint/#what-is-commitlint',
 };
 

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -4,6 +4,12 @@ import conventional from '@commitlint/config-conventional';
 const config: UserConfig = {
   extends: ['@commitlint/config-conventional'],
   rules: conventional.rules,
+  // Bot dependency bumps (Dependabot, Renovate) list every bumped package in
+  // the commit body, which routinely exceeds `body-max-line-length`. Failing
+  // commitlint on those skips every job that declares `needs: [commitlint]`,
+  // so security updates would ship untested. Skip linting for those commits
+  // only; the rules stay fully enforced for human-authored commits.
+  ignores: [message => /^(?:build|chore)\(deps(?:-dev)?\)/.test(message)],
   helpUrl: 'https://github.com/conventional-changelog/commitlint/#what-is-commitlint',
 };
 

--- a/commitlint.ignores.ts
+++ b/commitlint.ignores.ts
@@ -1,0 +1,21 @@
+/**
+ * Matches dependency-bump commits authored by bots (Dependabot, Renovate).
+ *
+ * Those commits list every bumped package in the body, which routinely
+ * exceeds `body-max-line-length`. A failing commitlint job skips every job
+ * declaring `needs: [commitlint, lint]` in ci.yml -- build, unit-test,
+ * type-check, e2e-smoke and docs-build -- so dependency updates would merge
+ * without ever being built or tested.
+ *
+ * Anchored on the subject so a `build(deps)` mention inside the body of an
+ * ordinary commit does not silently bypass linting.
+ *
+ * Kept free of imports so it can be unit tested; commitlint's own config
+ * packages are ESM and cannot be loaded by this repo's CommonJS Jest setup.
+ *
+ * @param message - The raw commit message, subject line first.
+ * @returns Whether commitlint should skip this commit.
+ */
+export function isBotDependencyBump(message: string): boolean {
+  return /^(?:build|chore)\(deps(?:-dev)?\)/.test(message);
+}

--- a/test/config/commitlint.test.ts
+++ b/test/config/commitlint.test.ts
@@ -1,0 +1,47 @@
+import { isBotDependencyBump } from '../../commitlint.ignores';
+
+/**
+ * Guards the `ignores` predicate that lets bot dependency bumps bypass
+ * commitlint. Without it, Dependabot's package-listing body trips
+ * `body-max-line-length`, the commitlint job fails, and every job declaring
+ * `needs: [commitlint, lint]` in ci.yml is skipped -- so dependency updates
+ * would merge without ever being built or tested.
+ */
+describe('commitlint config ignores', () => {
+  const isIgnored = isBotDependencyBump;
+
+  // Verbatim subject from PR #650, the Dependabot security update that
+  // exposed the problem.
+  const dependabotSubject
+    = 'build(deps): bump the npm_and_yarn group across 1 directory with 15 updates';
+
+  const overLongBody
+    = 'Body line that is comfortably longer than the one hundred character limit enforced by commitlint.';
+
+  it.each([
+    dependabotSubject,
+    'build(deps): bump vite from 6.4.2 to 8.1.5',
+    'build(deps-dev): bump eslint from 9.0.0 to 9.1.0',
+    'chore(deps): bump axios from 1.15.0 to 1.18.1',
+    'chore(deps-dev): bump jest from 29.0.0 to 30.0.0',
+  ])('ignores bot dependency bump %#', (subject) => {
+    expect(isIgnored(`${subject}\n\n${overLongBody}`)).toBe(true);
+  });
+
+  it.each([
+    'fix(audio): correct frequency mapping for empty bar segments',
+    'feat(position): announce the group name for multiline plots',
+    'ci: skip commitlint for bot dependency bump commits',
+    // Only build/chore bypass -- a feat touching dependency code still lints.
+    'feat(deps): add a dependency resolution helper',
+    // Scope must be exactly deps/deps-dev, not merely start with it.
+    'chore(depsomething): unrelated change',
+  ])('lints human-authored commit %#', (subject) => {
+    expect(isIgnored(`${subject}\n\n${overLongBody}`)).toBe(false);
+  });
+
+  it('anchors on the subject, not anywhere in the body', () => {
+    const message = `fix: something unrelated\n\nSee build(deps): ${overLongBody}`;
+    expect(isIgnored(message)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Dependabot security-update PRs currently never get built or tested.

Dependabot lists every bumped package in the commit body, and those lines routinely exceed commitlint's `body-max-line-length: 100`. The `commitlint` job therefore fails on every Dependabot PR — and because `.github/workflows/ci.yml` declares `needs: [commitlint, lint]` on **`build`, `unit-test`, `type-check`, `e2e-smoke`, and `docs-build`**, all five are SKIPPED. Dependency updates, including security fixes, ship completely untested.

This PR unblocks those five jobs by making commitlint skip bot dependency-bump commits, while leaving the rules fully enforced for human-authored commits.

## Related Issues

Observed on #650, where the commitlint job failed with:

```
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 problems, 0 warnings
```

Note: the separate vite/esbuild `ERESOLVE` failure on #650 is tracked independently and is **not** addressed here.

## Changes Made

**`commitlint.ignores.ts`** (new) — the predicate, deliberately import-free:

```ts
export function isBotDependencyBump(message: string): boolean {
  return /^(?:build|chore)\(deps(?:-dev)?\)/.test(message);
}
```

**`commitlint.config.ts`** — wires it in as `ignores: [isBotDependencyBump]`.

**`test/config/commitlint.test.ts`** (new) — 11 unit tests covering the predicate.

`ignores` was preferred over relaxing `body-max-line-length` globally, because it keeps the rule active for humans. The anchored regex matches only the commit *subject*, so it targets Dependabot/Renovate subjects (`build(deps):`, `build(deps-dev):`, `chore(deps):`, `chore(deps-dev):`) and nothing else.

`.husky/commit-msg` uses the same config, so local commits inherit this behavior.

### Why the predicate lives in its own file

So it can be unit tested. Importing `commitlint.config.ts` from Jest fails with `SyntaxError: Cannot use import statement outside a module`, because `@commitlint/config-conventional` is ESM while this repo's Jest setup is CommonJS. The alternatives were modifying the shared `jest.config.ts` `transformIgnorePatterns` (invasive for a CI-config fix, and it would add transform cost to all 88 suites) or re-declaring the regex in the test — which is worse than no test, since editing the config wouldn't fail it.

## Verification

Verified locally with `@commitlint/cli` 19.8 against the **real** commit message from #650, using the exact CI invocation (`npm run commitlint`, i.e. `commitlint --from=HEAD~1 --to=HEAD`) as well as the husky `--edit` path. Re-run after the predicate was extracted, since that could have broken commitlint's TypeScript config loading — it didn't.

| # | Case | Path | Result |
|---|------|------|--------|
| 0 | Dependabot message, **before** the fix | `--from/--to` | ❌ fails with `body-max-line-length` (reproduces #650) |
| 1 | Dependabot message, **after** the fix | `--from/--to` | ✅ passes |
| 2 | Human `fix(audio):` with a >100-char body line | `--from/--to` | ❌ still fails — rule not globally disabled |
| 3 | Dependabot message | `--edit` (husky) | ✅ passes |
| 4 | Human over-long body | `--edit` (husky) | ❌ still fails |
| 5 | `chore(deps-dev):` / `chore(deps):` with over-long body | stdin | ✅ ignored |
| 6 | `feat(deps):` with over-long body | stdin | ❌ still linted — only `build`/`chore` bypass |
| 7 | `build(deps)` appearing only in the **body** of a `fix:` commit | stdin | ❌ still linted — `^` anchor holds |

Full suite green: **88 suites / 1059 tests**, plus `npx eslint` and `npx tsc --noEmit` on the changed files.

**Most importantly:** the five jobs this PR unblocks are demonstrably running on this very PR — Unit Tests, Type Check, Build Project, E2E Smoke and Docs Build all executed rather than being skipped.

## Screenshots (if applicable)

N/A — CI configuration change.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Manually authored dependency bumps that use a `build(deps):` / `chore(deps):` subject will also bypass commitlint. That is inherent to matching on the subject — commit content cannot distinguish bot from human — and it is intentional here, matching the semantic-release configuration, which already treats `build`/`chore` as non-releasing types. Bot-only enforcement would require a CI-level actor check (`github.actor == 'dependabot[bot]'`), which would not cover the local husky hook; happy to add that as a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpUcHHmMhRLPWdmZPiHhs2