### PR TITLE
fix: accept SVG targets in the maidr:bindchart listener

### DIFF
--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -2453,12 +2453,12 @@ export function bindAnyChart(
     }
   }
 
-  // MAIDR's `maidr:bindchart` listener in `src/index.tsx` filters its target
-  // with `instanceof HTMLElement`, which excludes `SVGElement`. Wrap the SVG
-  // in a host `<div>` so the listener accepts it. The host carries explicit
-  // pixel dimensions captured from the original container so the SVG keeps
-  // its size once MAIDR re-parents it into the focusable
+  // Wrap the SVG in a host `<div>` carrying explicit pixel dimensions captured
+  // from the original container, so the SVG keeps its size once MAIDR
+  // re-parents it into the focusable
   // `<div tabIndex=0 role="img" style="width: fit-content">` wrapper.
+  // (The wrapper is purely about sizing — `maidr:bindchart` accepts any
+  // `Element`, so an `<svg>` target would bind fine on its own.)
   //
   // The bindchart dispatch below is unconditional: line-marker stamping is
   // best-effort, but the chart must always become focusable so audio /

--- a/src/adapters/plotly/normalizer.ts
+++ b/src/adapters/plotly/normalizer.ts
@@ -7,7 +7,7 @@ import type { PlotlyAxis, PlotlyFullLayout, PlotlyGraphDiv } from './types';
  * @param plot - The DOM element that carries the `maidr` attribute.
  * @returns `true` when the element is (or is inside) a Plotly-rendered chart.
  */
-export function isPlotlyPlot(plot: HTMLElement): boolean {
+export function isPlotlyPlot(plot: Element): boolean {
   return (
     plot.classList.contains('main-svg')
     || plot.closest('.js-plotly-plot') !== null

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,7 +75,10 @@ if (document.readyState === 'loading') {
 document.addEventListener('maidr:bindchart', ((event: CustomEvent<Maidr>) => {
   const target = event.target;
 
-  if (!(target instanceof HTMLElement))
+  // `Element`, not `HTMLElement`: adapters bind the element their charting
+  // library rendered, which is usually an `<svg>` — an `SVGElement`. Narrowing
+  // to `HTMLElement` here silently dropped every SVG-rooted chart.
+  if (!(target instanceof Element))
     return;
 
   const json = target.getAttribute(Constant.MAIDR_DATA);
@@ -85,7 +88,7 @@ document.addEventListener('maidr:bindchart', ((event: CustomEvent<Maidr>) => {
 }) as EventListener);
 
 function parseAndInit(
-  plot: HTMLElement,
+  plot: Element,
   json: string,
   source: 'maidr' | 'maidr-data',
 ): void {
@@ -201,7 +204,7 @@ function initPlotlyChart(gd: HTMLElement): void {
 
   gd.setAttribute('data-maidr-auto', '1');
   normalizePlotlySvg(svg, maidrData);
-  initMaidrOnElement(maidrData, svg as unknown as HTMLElement);
+  initMaidrOnElement(maidrData, svg);
 }
 
 /**

--- a/src/util/initMaidr.tsx
+++ b/src/util/initMaidr.tsx
@@ -19,14 +19,14 @@ import { Constant } from './constant';
  * re-initialisation (e.g. a live [maidr] attribute change) can tear down the
  * previous root instead of nesting a second root inside it.
  */
-const rootRegistry = new WeakMap<HTMLElement, { root: Root; container: HTMLElement }>();
+const rootRegistry = new WeakMap<Element, { root: Root; container: HTMLElement }>();
 
 /**
  * Adopts an existing DOM node into React's tree via a ref callback.
  * Used by script-tag and adapter entry points to render a pre-existing plot
  * element as children of the {@link MaidrComponent}.
  */
-export function DomNodeAdapter({ node }: { node: HTMLElement }): JSX.Element {
+export function DomNodeAdapter({ node }: { node: Element }): JSX.Element {
   const ref = useCallback(
     (container: HTMLDivElement | null) => {
       if (container) {
@@ -64,7 +64,7 @@ export function SizedDomNodeAdapter({
   width,
   height,
 }: {
-  node: HTMLElement;
+  node: Element;
   width: number;
   height: number;
 }): JSX.Element {
@@ -106,8 +106,13 @@ export function SizedDomNodeAdapter({
  * restored to its original DOM position before a fresh root is created. Without
  * this teardown a second init would nest a new React root inside the still-
  * mounted old one, duplicating controllers/hotkeys and leaking the old root.
+ *
+ * `plot` is typed as `Element`, not `HTMLElement`: charting libraries render
+ * into `<svg>`, which is an `SVGElement`. Only basic node capabilities
+ * (parentNode, attributes) are needed here, and both branches of the DOM tree
+ * provide them.
  */
-export function initMaidrOnElement(maidr: Maidr, plot: HTMLElement): void {
+export function initMaidrOnElement(maidr: Maidr, plot: Element): void {
   // Re-init path: tear down the previous root first. Order matters — unmounting
   // runs DomNodeAdapter's ref cleanup, which detaches `plot`; we then restore
   // `plot` where the old container was so the standard init path below can run.
@@ -128,8 +133,10 @@ export function initMaidrOnElement(maidr: Maidr, plot: HTMLElement): void {
   plot.parentNode.replaceChild(container, plot);
 
   // Opt-in path for adapters whose bound element has no intrinsic size.
-  const hostWidth = plot.dataset.maidrHostWidth;
-  const hostHeight = plot.dataset.maidrHostHeight;
+  // Read via getAttribute rather than `dataset`: `dataset` lives on
+  // HTMLOrSVGElement, which `Element` does not narrow to.
+  const hostWidth = plot.getAttribute('data-maidr-host-width');
+  const hostHeight = plot.getAttribute('data-maidr-host-height');
   const adopt
     = hostWidth && hostHeight
       ? (

--- a/src/vegalite-entry.ts
+++ b/src/vegalite-entry.ts
@@ -1728,10 +1728,7 @@ export function bindVegaLite(
   // BoxTrace.mapToSvgElements expects.
   buildBoxPlotSelectorsFromDom(svg as SVGSVGElement, layers, cellDomMap, containerScope);
 
-  // SVGSVGElement is not an HTMLElement, but initMaidrOnElement only
-  // needs basic DOM node capabilities (parentNode, attributes).
-  // Widen through Element which both SVG and HTML elements extend.
-  initMaidrOnElement(maidr, svg as Element as HTMLElement);
+  initMaidrOnElement(maidr, svg);
 }
 
 /**

--- a/test/entry/bindChart.test.ts
+++ b/test/entry/bindChart.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the `maidr:bindchart` listener registered by the script-tag entry
+ * point (`src/index.tsx`).
+ *
+ * Adapters bind a chart by stamping `maidr-data` on the rendered element and
+ * dispatching `maidr:bindchart` on it. Charting libraries render into `<svg>`,
+ * which is an `SVGElement` and *not* an `HTMLElement`, so the listener has to
+ * accept any `Element` — otherwise SVG-rooted charts are dropped silently.
+ */
+
+// @ts-expect-error - jsdom is available transitively (rehype-mathjax → jsdom@22),
+// no @types/jsdom installed. Tests only use the public JSDOM surface.
+import { JSDOM } from 'jsdom';
+
+const mockInitMaidrOnElement = jest.fn();
+
+jest.mock('@util/initMaidr', () => ({
+  initMaidrOnElement: mockInitMaidrOnElement,
+}));
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const SPEC = {
+  id: 'chart',
+  title: 'Revenue by Quarter',
+  subplots: [[{
+    layers: [{
+      id: '0',
+      type: 'bar',
+      selectors: 'rect.bar',
+      axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+      data: [{ x: 'Q1', y: 120 }, { x: 'Q2', y: 185 }],
+    }],
+  }]],
+};
+
+/** Dispatches the adapter binding event the way real adapters do. */
+function bindChart(element: Element): void {
+  element.setAttribute('maidr-data', JSON.stringify(SPEC));
+  element.dispatchEvent(
+    new CustomEvent('maidr:bindchart', { bubbles: true, detail: SPEC }),
+  );
+}
+
+describe('maidr:bindchart listener', () => {
+  beforeAll(async () => {
+    // `instanceof` checks inside the entry point resolve against these globals,
+    // so every element the tests create must come from this same window.
+    const { window } = new JSDOM('<!DOCTYPE html><body></body>');
+    Object.assign(globalThis, {
+      window,
+      document: window.document,
+      Element: window.Element,
+      HTMLElement: window.HTMLElement,
+      SVGElement: window.SVGElement,
+      Node: window.Node,
+      Event: window.Event,
+      CustomEvent: window.CustomEvent,
+      MutationObserver: window.MutationObserver,
+    });
+    // Imported after the DOM exists: the listener registers at module scope.
+    await import('../../src/index');
+  });
+
+  beforeEach(() => {
+    mockInitMaidrOnElement.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it('initialises MAIDR when the bound element is an <svg>', () => {
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    document.body.appendChild(svg);
+
+    bindChart(svg);
+
+    expect(mockInitMaidrOnElement).toHaveBeenCalledTimes(1);
+    expect(mockInitMaidrOnElement.mock.calls[0][1]).toBe(svg);
+  });
+
+  it('initialises MAIDR when the bound element is an HTML host div', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    bindChart(host);
+
+    expect(mockInitMaidrOnElement).toHaveBeenCalledTimes(1);
+    expect(mockInitMaidrOnElement.mock.calls[0][1]).toBe(host);
+  });
+
+  it('ignores the event when the bound element carries no maidr-data', () => {
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    document.body.appendChild(svg);
+
+    svg.dispatchEvent(
+      new CustomEvent('maidr:bindchart', { bubbles: true, detail: SPEC }),
+    );
+
+    expect(mockInitMaidrOnElement).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

The `maidr:bindchart` listener in [`src/index.tsx`](https://github.com/xability/maidr/blob/main/src/index.tsx) narrowed its event target with `instanceof HTMLElement`:

```ts
document.addEventListener('maidr:bindchart', ((event: CustomEvent<Maidr>) => {
  const target = event.target;
  if (!(target instanceof HTMLElement))
    return;                                  // ← <svg> lands here
```

Charting libraries render into `<svg>`, which is an **`SVGElement`, not an `HTMLElement`**. So any chart bound through the documented adapter contract — stamp `maidr-data`, dispatch `maidr:bindchart` — was dropped when the bound element was the SVG itself. Silently: no error, no warning, nothing to debug from.

The codebase already carried three scars from this:

| Site | Workaround |
|---|---|
| [`vegalite-entry.ts:1734`](https://github.com/xability/maidr/blob/main/src/vegalite-entry.ts#L1734) | `initMaidrOnElement(maidr, svg as Element as HTMLElement)` |
| [`index.tsx:204`](https://github.com/xability/maidr/blob/main/src/index.tsx#L204) | `initMaidrOnElement(maidrData, svg as unknown as HTMLElement)` |
| [`anychart/converters.ts:2456`](https://github.com/xability/maidr/blob/main/src/adapters/anychart/converters.ts#L2456) | wraps the SVG in a host `<div>`, comment explicitly cites the guard |

The Vega-Lite comment already stated the conclusion: *"initMaidrOnElement only needs basic DOM node capabilities (parentNode, attributes)."* The `HTMLElement` typing was the artificial constraint, not a real requirement.

## How this surfaced

While checking whether MAIDR can run inside a claude.ai Artifact sandbox. Loading `maidr.js` from a CDN and binding a generated `<svg>` via `maidr-data` + `maidr:bindchart` produced no error and no chart. Setting the `maidr` attribute instead worked — that path goes through the MutationObserver, which casts rather than checks. Two binding paths, two different answers for the same element.

## Fix

Widen the guard to `Element`, and let the signatures follow:

- `initMaidrOnElement(maidr, plot: Element)`
- `DomNodeAdapter` / `SizedDomNodeAdapter` `node: Element`
- `isPlotlyPlot(plot: Element)`
- `rootRegistry: WeakMap<Element, …>`
- host-size lookup moves from `plot.dataset.*` to `plot.getAttribute('data-maidr-host-*')`, since `dataset` lives on `HTMLOrSVGElement` and `Element` does not narrow to it

Both casts are removed. The AnyChart host `<div>` **stays** — it also carries the explicit pixel dimensions the SVG needs to remain sized inside the `width: fit-content` focusable wrapper. Only its now-stale comment is corrected.

## Tests

New `test/entry/bindChart.test.ts` covers the listener against a JSDOM document (following the existing `test/adapters/vegalite/entry.test.ts` pattern of mocking `@util/initMaidr`):

- binds when the target is an `<svg>` — **fails on `main`, passes here**
- binds when the target is an HTML host `<div>` — regression guard, passes on `main` too
- ignores the event when no `maidr-data` is present

Written test-first; the SVG case was confirmed failing (`Received number of calls: 0`) before the fix, while the other two passed — so the harness itself is not producing a false negative.

## Verification

- `npx jest` → **1047 passing**. The 4 failures in `test/adapters/recharts/panelDom.test.ts` are `Cannot find module 'recharts'` and reproduce identically on `main` in the same tree — environmental, unrelated to this change.
- `npm run type-check` → clean apart from that same missing-`recharts` resolution error.
- `npx eslint` on all touched files → clean.
- **Browser, locally built bundle:** an `<svg>` bound purely via `maidr-data` + `maidr:bindchart` now mounts the focusable wrapper (`role="img"` + instructions `aria-label`), announces `"Quarter is Q1, Revenue (USD, millions) is 120"` on arrow-key navigation, creates 5 highlight elements, and logs zero console errors. Before the fix this exact page produced nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
