### PR TITLE
feat(settings): report maidr.js version, bundle source and browser in the settings dialog

### DIFF
--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -52,11 +52,24 @@ import {
   selectBraillePreset,
   SINGLE_LINE_BRAILLE_PRESETS,
 } from '@util/braillePreset';
+import { copyToClipboard } from '@util/clipboard';
+import {
+  collectDiagnostics,
+  describeMaidrSource,
+  formatDiagnostics,
+} from '@util/diagnostics';
 import { resolveVersionOptions } from '@util/llm';
-import { MAIDR_VERSION } from '@util/version';
-import React, { useCallback, useEffect, useId, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+const COPY_STATUS_MESSAGE: Record<CopyStatus, string> = {
+  idle: '',
+  copied: 'Copied to clipboard',
+  failed: 'Could not copy — select the values above and copy them manually',
+};
 
 // Letter portion of the dialog accelerator keys. Shared between the
 // keydown handler and the aria-keyshortcuts attributes so the two
@@ -407,6 +420,22 @@ const Settings: React.FC = () => {
   // arrives in a coherent shape and does not need to re-normalize here.
   const [generalSettings, setGeneralSettings] = useState<GeneralSettings>(general);
   const [llmSettings, setLlmSettings] = useState<LlmSettings>(llm);
+
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+  const copyStatusId = `${id}-copy-status`;
+  // The bundle source and the browser cannot change while the dialog is open,
+  // so the DOM scan behind this runs once per mount rather than per render.
+  const diagnostics = useMemo(() => collectDiagnostics(), []);
+
+  const handleCopyDiagnostics = useCallback(async (): Promise<void> => {
+    try {
+      await copyToClipboard(formatDiagnostics(diagnostics));
+      setCopyStatus('copied');
+    } catch (error) {
+      console.error('[Settings] Failed to copy diagnostics', error);
+      setCopyStatus('failed');
+    }
+  }, [diagnostics]);
 
   useEffect(() => {
     viewModel.load();
@@ -1171,7 +1200,85 @@ const Settings: React.FC = () => {
             <SettingRow
               label="maidr.js Version"
               input={(
-                <Typography variant="body2">{MAIDR_VERSION}</Typography>
+                <Typography variant="body2">{diagnostics.version}</Typography>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="Loaded From"
+              alignLabel={diagnostics.source.url ? 'flex-start' : 'center'}
+              input={(
+                <>
+                  <Typography variant="body2">
+                    {describeMaidrSource(diagnostics.source)}
+                  </Typography>
+                  {diagnostics.source.url && (
+                    <Typography
+                      variant="caption"
+                      sx={{ color: 'text.secondary', wordBreak: 'break-all' }}
+                    >
+                      {diagnostics.source.url}
+                    </Typography>
+                  )}
+                </>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="Browser"
+              input={(
+                <Typography variant="body2">{diagnostics.browser}</Typography>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="Operating System"
+              input={(
+                <Typography variant="body2">
+                  {diagnostics.operatingSystem}
+                </Typography>
+              )}
+            />
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="Diagnostics"
+              input={(
+                <Grid container spacing={1} alignItems="center">
+                  <Grid size="auto">
+                    <Button
+                      variant="outlined"
+                      color="inherit"
+                      size="small"
+                      onClick={handleCopyDiagnostics}
+                      aria-label="Copy diagnostics to clipboard"
+                      aria-describedby={copyStatusId}
+                    >
+                      Copy diagnostics
+                    </Button>
+                  </Grid>
+                  <Grid size="auto">
+                    {/* Rendered even while empty: a live region has to be in
+                        the DOM before its text changes for the update to be
+                        announced. */}
+                    <Typography
+                      id={copyStatusId}
+                      variant="caption"
+                      role="status"
+                      aria-live="polite"
+                      sx={{
+                        color: copyStatus === 'failed'
+                          ? 'error.main'
+                          : 'text.secondary',
+                      }}
+                    >
+                      {COPY_STATUS_MESSAGE[copyStatus]}
+                    </Typography>
+                  </Grid>
+                </Grid>
               )}
             />
           </Grid>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -53,6 +53,7 @@ import {
   SINGLE_LINE_BRAILLE_PRESETS,
 } from '@util/braillePreset';
 import { resolveVersionOptions } from '@util/llm';
+import { MAIDR_VERSION } from '@util/version';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
 const MIN_CUSTOM_INSTRUCTION_LENGTH = 10;
@@ -1148,6 +1149,32 @@ const Settings: React.FC = () => {
               </Grid>
             </Grid>
           )}
+        </Grid>
+
+        <Grid size={12}>
+          <Divider className="settings-divider" />
+        </Grid>
+
+        {/* About */}
+        <Grid container spacing={0.5} className="settings-section">
+          <Grid size={12}>
+            <Typography
+              variant="h6"
+              fontWeight="bold"
+              gutterBottom
+              className="settings-section-title"
+            >
+              About
+            </Typography>
+          </Grid>
+          <Grid size={12}>
+            <SettingRow
+              label="maidr.js Version"
+              input={(
+                <Typography variant="body2">{MAIDR_VERSION}</Typography>
+              )}
+            />
+          </Grid>
         </Grid>
 
         <Grid size={12}>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -57,6 +57,7 @@ import {
   collectDiagnostics,
   describeMaidrSource,
   formatDiagnostics,
+  redactScriptUrl,
 } from '@util/diagnostics';
 import { resolveVersionOptions } from '@util/llm';
 import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
@@ -426,6 +427,13 @@ const Settings: React.FC = () => {
   // The bundle source and the browser cannot change while the dialog is open,
   // so the DOM scan behind this runs once per mount rather than per render.
   const diagnostics = useMemo(() => collectDiagnostics(), []);
+  // Displayed with the same redaction the copied block uses: a screenshot of
+  // this dialog is handed to a maintainer just as readily as the pasted text,
+  // so both have to drop the OS username and any signed-URL token.
+  const sourceUrl = useMemo(
+    () => (diagnostics.source.url ? redactScriptUrl(diagnostics.source.url) : null),
+    [diagnostics],
+  );
 
   const handleCopyDiagnostics = useCallback(async (): Promise<void> => {
     try {
@@ -1207,18 +1215,18 @@ const Settings: React.FC = () => {
           <Grid size={12}>
             <SettingRow
               label="Loaded From"
-              alignLabel={diagnostics.source.url ? 'flex-start' : 'center'}
+              alignLabel={sourceUrl ? 'flex-start' : 'center'}
               input={(
                 <>
                   <Typography variant="body2">
                     {describeMaidrSource(diagnostics.source)}
                   </Typography>
-                  {diagnostics.source.url && (
+                  {sourceUrl && (
                     <Typography
                       variant="caption"
                       sx={{ color: 'text.secondary', wordBreak: 'break-all' }}
                     >
-                      {diagnostics.source.url}
+                      {sourceUrl}
                     </Typography>
                   )}
                 </>

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -72,6 +72,17 @@ const COPY_STATUS_MESSAGE: Record<CopyStatus, string> = {
   failed: 'Could not copy — select the values above and copy them manually',
 };
 
+interface CopyState {
+  readonly status: CopyStatus;
+  /**
+   * Counts attempts so a repeat copy still reaches the user. Setting the same
+   * status twice changes no text, and unchanged text is no DOM mutation — a
+   * live region announces on the mutation, not on the state update, so without
+   * this a second successful copy would be silent to a screen reader.
+   */
+  readonly attempt: number;
+}
+
 // Letter portion of the dialog accelerator keys. Shared between the
 // keydown handler and the aria-keyshortcuts attributes so the two
 // cannot drift apart and announce a shortcut that no longer fires.
@@ -422,7 +433,7 @@ const Settings: React.FC = () => {
   const [generalSettings, setGeneralSettings] = useState<GeneralSettings>(general);
   const [llmSettings, setLlmSettings] = useState<LlmSettings>(llm);
 
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+  const [copyState, setCopyState] = useState<CopyState>({ status: 'idle', attempt: 0 });
   const copyStatusId = `${id}-copy-status`;
   // The bundle source and the browser cannot change while the dialog is open,
   // so the DOM scan behind this runs once per mount rather than per render.
@@ -436,13 +447,16 @@ const Settings: React.FC = () => {
   );
 
   const handleCopyDiagnostics = useCallback(async (): Promise<void> => {
+    let status: CopyStatus;
     try {
       await copyToClipboard(formatDiagnostics(diagnostics));
-      setCopyStatus('copied');
+      status = 'copied';
     } catch (error) {
       console.error('[Settings] Failed to copy diagnostics', error);
-      setCopyStatus('failed');
+      status = 'failed';
     }
+    // Always a fresh object, so an unchanged status still re-renders.
+    setCopyState(prev => ({ status, attempt: prev.attempt + 1 }));
   }, [diagnostics]);
 
   useEffect(() => {
@@ -1278,12 +1292,18 @@ const Settings: React.FC = () => {
                       role="status"
                       aria-live="polite"
                       sx={{
-                        color: copyStatus === 'failed'
+                        color: copyState.status === 'failed'
                           ? 'error.main'
                           : 'text.secondary',
                       }}
                     >
-                      {COPY_STATUS_MESSAGE[copyStatus]}
+                      {/* Keyed by attempt so React swaps the node on every
+                          copy. Re-rendering the same text would leave the
+                          region untouched, and an untouched live region is
+                          never announced. */}
+                      <span key={copyState.attempt}>
+                        {COPY_STATUS_MESSAGE[copyState.status]}
+                      </span>
                     </Typography>
                   </Grid>
                 </Grid>

--- a/src/util/clipboard.ts
+++ b/src/util/clipboard.ts
@@ -45,9 +45,13 @@ function copyWithExecCommand(text: string): void {
   const textarea = document.createElement('textarea');
   textarea.value = text;
   textarea.setAttribute('readonly', '');
-  // Hidden, but not via `display`/`visibility`/`hidden` — those make the
-  // selection empty and turn the copy into a silent no-op.
-  textarea.setAttribute('aria-hidden', 'true');
+  // Kept off-screen rather than hidden: `display`, `visibility` and the
+  // `hidden` attribute all empty the selection and turn the copy into a silent
+  // no-op. `aria-hidden` is deliberately NOT set either — `select()` below puts
+  // focus on this element, and WAI-ARIA forbids `aria-hidden` on focused
+  // content, which leaves assistive technology with undefined behaviour at the
+  // exact moment the user asked for something to happen. Off-screen and
+  // short-lived is the honest trade.
   textarea.style.position = 'fixed';
   textarea.style.top = '-1000px';
   textarea.style.opacity = '0';

--- a/src/util/clipboard.ts
+++ b/src/util/clipboard.ts
@@ -1,0 +1,65 @@
+/**
+ * Writes text to the system clipboard.
+ *
+ * `navigator.clipboard` is unavailable on insecure origins and on `file://`
+ * pages — both of which MAIDR runs on routinely, since py-maidr and r-maidr
+ * write charts to standalone HTML files — so a `execCommand` fallback covers
+ * the cases the async API refuses.
+ * @param text - The text to place on the clipboard.
+ * @throws Error if neither the async API nor the fallback can copy.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch (error) {
+      // Not fatal: the async API also rejects when the document is not
+      // focused or the permission was denied, and the fallback still works
+      // in both cases. Logged rather than swallowed so a genuine failure of
+      // both paths can be traced.
+      console.warn('[clipboard] navigator.clipboard.writeText failed, falling back', error);
+    }
+  }
+  copyWithExecCommand(text);
+}
+
+/**
+ * Copies via a throwaway textarea and the deprecated `execCommand('copy')`.
+ *
+ * Selecting the textarea steals focus, so the previously focused element is
+ * restored afterwards — without that, a keyboard or screen reader user is
+ * dropped back to the document body and loses their place in the dialog.
+ * @param text - The text to place on the clipboard.
+ * @throws Error if the document rejects the copy command.
+ */
+function copyWithExecCommand(text: string): void {
+  if (typeof document === 'undefined') {
+    throw new TypeError('Clipboard is unavailable outside a document');
+  }
+
+  const previouslyFocused = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  // Hidden, but not via `display`/`visibility`/`hidden` — those make the
+  // selection empty and turn the copy into a silent no-op.
+  textarea.setAttribute('aria-hidden', 'true');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-1000px';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.select();
+    if (!document.execCommand('copy')) {
+      throw new Error('document.execCommand("copy") was rejected');
+    }
+  } finally {
+    textarea.remove();
+    previouslyFocused?.focus();
+  }
+}

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -34,7 +34,15 @@ export interface Diagnostics {
  * run, so it is snapshotted here instead of read on demand. Classic scripts —
  * including the ones py-maidr and r-maidr inject, whether they point at the CDN
  * or at a bundled copy — report the tag that loaded maidr.js. Module scripts
- * report `null`, which the DOM scan in `findMaidrScript` covers.
+ * report `null`, which the DOM scan in {@link findMaidrScriptUrl} covers.
+ *
+ * This carries a load-order assumption worth stating: it holds only while this
+ * module is evaluated as part of the bundle's initial synchronous execution,
+ * which is true of every build target today because none of them code-split.
+ * Should one ever dynamic-import the code that reaches this module, the
+ * snapshot would be `null` on a classic-script load too and every such page
+ * would quietly fall back to the DOM scan — still correct, but a weaker signal
+ * than reading the tag that actually loaded the bundle.
  */
 const loadingScript: HTMLScriptElement | null
   = typeof document !== 'undefined' && document.currentScript instanceof HTMLScriptElement

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -256,15 +256,20 @@ export function collectDiagnostics(): Diagnostics {
  * Reduces a script URL to what a bug report needs, dropping what it does not.
  *
  * A `file://` bundle sits wherever the reporter saved it, so its path carries
- * their OS username — and the copied block is headed for a public issue, so
- * only the protocol and filename survive. Everywhere else the origin and path
- * are the whole point of the field (they are what shows a jsDelivr `@latest`
- * against a pinned local copy), so those are kept and only the query and
- * fragment are dropped, since a signed asset URL can carry a token there.
+ * their OS username; only the protocol and filename survive. Everywhere else
+ * the origin and path are the whole point of the field (they are what shows a
+ * jsDelivr `@latest` against a pinned local copy), so those are kept and only
+ * the query and fragment are dropped, since a signed asset URL can carry a
+ * token there.
+ *
+ * This applies to what the dialog displays as well as to what it copies. The
+ * two cannot diverge: the whole point of the section is to be handed to a
+ * maintainer, and a screenshot of the dialog travels just as far as the pasted
+ * block — so a value unsafe to paste is unsafe to show.
  * @param url - The script URL to reduce.
  * @returns The redacted URL, or `null` if it cannot be parsed.
  */
-function redactScriptUrl(url: string): string | null {
+export function redactScriptUrl(url: string): string | null {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -288,8 +293,7 @@ function redactScriptUrl(url: string): string | null {
  * The page URL is deliberately left out: it is the field most likely to carry
  * private paths or credentials in a query string, and it tells a maintainer
  * nothing they cannot get from the report itself. The script URL is kept, but
- * redacted on the same reasoning — see {@link redactScriptUrl}. The dialog
- * still shows it in full, since that stays on the reporter's own screen.
+ * redacted on the same reasoning — see {@link redactScriptUrl}.
  * @param diagnostics - The snapshot to format.
  * @returns A newline-separated `key: value` block.
  */

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -253,19 +253,51 @@ export function collectDiagnostics(): Diagnostics {
 }
 
 /**
+ * Reduces a script URL to what a bug report needs, dropping what it does not.
+ *
+ * A `file://` bundle sits wherever the reporter saved it, so its path carries
+ * their OS username — and the copied block is headed for a public issue, so
+ * only the protocol and filename survive. Everywhere else the origin and path
+ * are the whole point of the field (they are what shows a jsDelivr `@latest`
+ * against a pinned local copy), so those are kept and only the query and
+ * fragment are dropped, since a signed asset URL can carry a token there.
+ * @param url - The script URL to reduce.
+ * @returns The redacted URL, or `null` if it cannot be parsed.
+ */
+function redactScriptUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Unreachable via `script.src`, which the DOM always resolves to an
+    // absolute URL. Dropping it beats pasting an unparsed string.
+    return null;
+  }
+
+  if (parsed.protocol === 'file:') {
+    const filename = parsed.pathname.split('/').pop();
+    return filename ? `file:///.../${filename}` : null;
+  }
+  return `${parsed.origin}${parsed.pathname}`;
+}
+
+/**
  * Formats a diagnostics snapshot as the plain-text block copied to the
  * clipboard, ready to paste into a bug report.
  *
- * The page URL is deliberately left out: it is the one field here that can
- * carry private paths or credentials in a query string, and it tells a
- * maintainer nothing they cannot get from the report itself.
+ * The page URL is deliberately left out: it is the field most likely to carry
+ * private paths or credentials in a query string, and it tells a maintainer
+ * nothing they cannot get from the report itself. The script URL is kept, but
+ * redacted on the same reasoning — see {@link redactScriptUrl}. The dialog
+ * still shows it in full, since that stays on the reporter's own screen.
  * @param diagnostics - The snapshot to format.
  * @returns A newline-separated `key: value` block.
  */
 export function formatDiagnostics(diagnostics: Diagnostics): string {
   const { version, browser, operatingSystem, source, userAgent } = diagnostics;
-  const loadedFrom = source.url
-    ? `${describeMaidrSource(source)} (${source.url})`
+  const redactedUrl = source.url ? redactScriptUrl(source.url) : null;
+  const loadedFrom = redactedUrl
+    ? `${describeMaidrSource(source)} (${redactedUrl})`
     : describeMaidrSource(source);
 
   return [

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -42,11 +42,20 @@ const loadingScript: HTMLScriptElement | null
     : null;
 
 /**
- * Matches the filenames the library is published under — `maidr.js` plus the
- * per-adapter bundles (`recharts.mjs`, `vegalite.js`, …) when they are loaded
- * from a path that names maidr.
+ * Matches the paths the library is published under.
+ *
+ * Two alternatives, both deliberately narrow so an unrelated script whose name
+ * merely starts with "maidr" is not mistaken for the bundle:
+ * - A maidr package directory, which is what catches the per-adapter bundles
+ *   (`recharts.mjs`, `vegalite.js`, …) under `/npm/maidr@3.74.0/dist/`. A `@`
+ *   may be followed by any npm version spec, but a `-` has to be followed by a
+ *   digit, so `/maidr-3.74.0/` matches while `/maidr-analytics/` does not.
+ * - The bundle's own filename, where anything after "maidr" must start at a
+ *   separator — otherwise `maidrical.js` would match. The separator class and
+ *   the segment class are kept disjoint (`\w` excludes `.` and `-`) so the
+ *   repetition cannot reach itself and backtrack super-linearly.
  */
-const MAIDR_SCRIPT_PATTERN = /\/maidr[\w.@-]*\/|(?:^|\/)maidr[\w.-]*\.m?js(?:$|[?#])/i;
+const MAIDR_SCRIPT_PATTERN = /\/maidr(?:@[\w.-]+|-\d[\w.-]*)?\/|(?:^|\/)maidr(?:[.-]\w+)*\.m?js(?:$|[?#])/i;
 
 // Order matters: Edge, Opera and Samsung Internet all keep "Chrome" in their
 // user agent, so each has to be matched before Chrome itself.
@@ -143,6 +152,15 @@ export function classifyScriptOrigin(scriptUrl: string, pageUrl: string): MaidrS
 }
 
 /**
+ * Reports whether a script URL looks like a maidr bundle.
+ * @param url - The script URL to test.
+ * @returns True when the URL names a maidr package directory or bundle file.
+ */
+export function isMaidrScriptUrl(url: string): boolean {
+  return MAIDR_SCRIPT_PATTERN.test(url);
+}
+
+/**
  * Finds the URL of the script that loaded maidr.js, falling back to a scan of
  * the document when the bundle was loaded as an ES module (module scripts do
  * not set `document.currentScript`).
@@ -154,7 +172,7 @@ function findMaidrScriptUrl(): string | null {
   }
   const scripts = document.querySelectorAll<HTMLScriptElement>('script[src]');
   for (const script of scripts) {
-    if (MAIDR_SCRIPT_PATTERN.test(script.src)) {
+    if (isMaidrScriptUrl(script.src)) {
       return script.src;
     }
   }
@@ -171,8 +189,13 @@ export function detectMaidrSource(): MaidrSource {
     return { kind: 'unknown', url: null };
   }
 
-  // A `<script>` with no `src` carries the bundle in its own body — that is
-  // how a notebook cell or a self-contained HTML export ships maidr.js.
+  // A `<script>` with no `src` carries the bundle in its own body — that is how
+  // a notebook cell or a self-contained HTML export ships maidr.js. Known gap:
+  // this only recognises an inlined *classic* script, because per spec
+  // `document.currentScript` is null while a module script evaluates. An
+  // inlined `<script type="module">` therefore reports `unknown` rather than
+  // `inline` — deliberately, since nothing distinguishes it at that point from
+  // a bundle rolled into a host application's own chunk.
   const url = loadingScript ? loadingScript.src || null : findMaidrScriptUrl();
   if (!url) {
     return { kind: loadingScript ? 'inline' : 'unknown', url: null };

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -42,20 +42,33 @@ const loadingScript: HTMLScriptElement | null
     : null;
 
 /**
- * Matches the paths the library is published under.
+ * Matches a maidr *package directory*, which is what catches the per-adapter
+ * bundles (`recharts.mjs`, `vegalite.js`, …) whose own filenames say nothing
+ * about maidr.
  *
- * Two alternatives, both deliberately narrow so an unrelated script whose name
- * merely starts with "maidr" is not mistaken for the bundle:
- * - A maidr package directory, which is what catches the per-adapter bundles
- *   (`recharts.mjs`, `vegalite.js`, …) under `/npm/maidr@3.74.0/dist/`. A `@`
- *   may be followed by any npm version spec, but a `-` has to be followed by a
- *   digit, so `/maidr-3.74.0/` matches while `/maidr-analytics/` does not.
- * - The bundle's own filename, where anything after "maidr" must start at a
- *   separator — otherwise `maidrical.js` would match. The separator class and
- *   the segment class are kept disjoint (`\w` excludes `.` and `-`) so the
- *   repetition cannot reach itself and backtrack super-linearly.
+ * Deliberately narrow in both alternatives. A bare `/maidr/` segment counts
+ * only directly under `/npm/` or `/node_modules/`: the project's own docs and
+ * examples are served from `xability.github.io/maidr/`, where *every* asset URL
+ * contains that segment, and `findMaidrScriptUrl` takes the first match in
+ * document order — so accepting it outright would let an unrelated docs bundle
+ * shadow the real one. Anywhere else the version has to be present, where a `@`
+ * takes any npm spec but a `-` must be followed by a digit, so `/maidr-3.74.0/`
+ * matches while `/maidr-analytics/` does not.
+ *
+ * The cost is a miss on an unversioned `unpkg.com/maidr/dist/recharts.mjs`,
+ * which reports `unknown`. That is the right way to be wrong here: this field
+ * exists to be trusted in a bug report, so declining to answer beats answering
+ * with the wrong script.
  */
-const MAIDR_SCRIPT_PATTERN = /\/maidr(?:@[\w.-]+|-\d[\w.-]*)?\/|(?:^|\/)maidr(?:[.-]\w+)*\.m?js(?:$|[?#])/i;
+const MAIDR_PACKAGE_DIR_PATTERN = /\/(?:npm|node_modules)\/maidr(?:@[\w.-]+)?\/|\/maidr(?:@[\w.-]+|-\d[\w.-]*)\//i;
+
+/**
+ * Matches the bundle's own filename. Anything after "maidr" has to start at a
+ * separator — otherwise `maidrical.js` would match. The separator class and the
+ * segment class are kept disjoint (`\w` excludes `.` and `-`) so the repetition
+ * cannot reach itself and backtrack super-linearly.
+ */
+const MAIDR_FILENAME_PATTERN = /(?:^|\/)maidr(?:[.-]\w+)*\.m?js(?:$|[?#])/i;
 
 // Order matters: Edge, Opera and Samsung Internet all keep "Chrome" in their
 // user agent, so each has to be matched before Chrome itself.
@@ -90,7 +103,9 @@ export function describeBrowser(userAgent: string): string {
  *
  * Only what the user agent can actually support is reported: Windows 10 and 11
  * are indistinguishable there, and Safari/Chrome freeze the macOS version at
- * 10.15.7, so neither is given a version it cannot back up.
+ * 10.15.7, so neither is given a version it cannot back up. For the same
+ * reason iPadOS Safari reads as `macOS` — its default user agent claims
+ * `Macintosh; Intel Mac OS X` and carries no iPad token at all.
  * @param userAgent - The `navigator.userAgent` value to read.
  * @returns A label such as `macOS` or `Android 14`, or `Unknown`.
  */
@@ -157,7 +172,7 @@ export function classifyScriptOrigin(scriptUrl: string, pageUrl: string): MaidrS
  * @returns True when the URL names a maidr package directory or bundle file.
  */
 export function isMaidrScriptUrl(url: string): boolean {
-  return MAIDR_SCRIPT_PATTERN.test(url);
+  return MAIDR_FILENAME_PATTERN.test(url) || MAIDR_PACKAGE_DIR_PATTERN.test(url);
 }
 
 /**

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -114,8 +114,10 @@ export function describeOperatingSystem(userAgent: string): string {
   if (windows) {
     return windows[1] === '10.0' ? 'Windows 10 or 11' : `Windows (NT ${windows[1]})`;
   }
-  // ChromeOS and Android both carry "Linux" in their user agent, so they have
-  // to be matched before the bare Linux check below.
+  // Android is the one that carries "Linux" in its user agent, so it has to be
+  // matched before the bare Linux fallback below. ChromeOS carries neither
+  // token — it identifies as "X11; CrOS" — so its place in this order is
+  // grouping with the Linux-adjacent platforms, not a dependency.
   if (userAgent.includes('CrOS')) {
     return 'ChromeOS';
   }

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -74,7 +74,10 @@ const MAIDR_FILENAME_PATTERN = /(?:^|\/)maidr(?:[.-]\w+)*\.m?js(?:$|[?#])/i;
 // user agent, so each has to be matched before Chrome itself.
 const BROWSER_PATTERNS: readonly { readonly name: string; readonly pattern: RegExp }[] = [
   { name: 'Microsoft Edge', pattern: /Edg(?:e|A|iOS)?\/(\d+)/ },
-  { name: 'Opera', pattern: /OPR\/(\d+)/ },
+  // Opera ships a different token per platform: OPR on desktop and Android,
+  // OPiOS on iOS, OPT for Opera Touch. Only the first is the well-known one,
+  // and missing the others silently reports Opera users as Chrome or Safari.
+  { name: 'Opera', pattern: /(?:OPR|OPiOS|OPT)\/(\d+)/ },
   { name: 'Samsung Internet', pattern: /SamsungBrowser\/(\d+)/ },
   { name: 'Firefox', pattern: /(?:Firefox|FxiOS)\/(\d+)/ },
   { name: 'Chrome', pattern: /(?:Chrome|CriOS)\/(\d+)/ },

--- a/src/util/diagnostics.ts
+++ b/src/util/diagnostics.ts
@@ -1,0 +1,241 @@
+import { MAIDR_VERSION } from './version';
+
+/**
+ * Where the running maidr.js bundle was loaded from.
+ *
+ * - `cdn` — served by an origin other than the page's (jsDelivr, unpkg, or any
+ *   other asset host).
+ * - `local` — served by the page's own origin, or read off the filesystem
+ *   alongside a `file://` page.
+ * - `inline` — embedded directly in the page rather than fetched.
+ * - `unknown` — no script tag could be attributed to maidr.js, which is what
+ *   happens when the bundle is rolled into a host application's own chunk.
+ */
+export type MaidrSourceKind = 'cdn' | 'local' | 'inline' | 'unknown';
+
+export interface MaidrSource {
+  readonly kind: MaidrSourceKind;
+  /** Absolute URL of the script that loaded maidr.js, when one is known. */
+  readonly url: string | null;
+}
+
+export interface Diagnostics {
+  readonly version: string;
+  readonly browser: string;
+  readonly operatingSystem: string;
+  readonly source: MaidrSource;
+  readonly userAgent: string;
+}
+
+/**
+ * The `<script>` element that was executing while this module was evaluated.
+ *
+ * `document.currentScript` is only meaningful during that first synchronous
+ * run, so it is snapshotted here instead of read on demand. Classic scripts —
+ * including the ones py-maidr and r-maidr inject, whether they point at the CDN
+ * or at a bundled copy — report the tag that loaded maidr.js. Module scripts
+ * report `null`, which the DOM scan in `findMaidrScript` covers.
+ */
+const loadingScript: HTMLScriptElement | null
+  = typeof document !== 'undefined' && document.currentScript instanceof HTMLScriptElement
+    ? document.currentScript
+    : null;
+
+/**
+ * Matches the filenames the library is published under — `maidr.js` plus the
+ * per-adapter bundles (`recharts.mjs`, `vegalite.js`, …) when they are loaded
+ * from a path that names maidr.
+ */
+const MAIDR_SCRIPT_PATTERN = /\/maidr[\w.@-]*\/|(?:^|\/)maidr[\w.-]*\.m?js(?:$|[?#])/i;
+
+// Order matters: Edge, Opera and Samsung Internet all keep "Chrome" in their
+// user agent, so each has to be matched before Chrome itself.
+const BROWSER_PATTERNS: readonly { readonly name: string; readonly pattern: RegExp }[] = [
+  { name: 'Microsoft Edge', pattern: /Edg(?:e|A|iOS)?\/(\d+)/ },
+  { name: 'Opera', pattern: /OPR\/(\d+)/ },
+  { name: 'Samsung Internet', pattern: /SamsungBrowser\/(\d+)/ },
+  { name: 'Firefox', pattern: /(?:Firefox|FxiOS)\/(\d+)/ },
+  { name: 'Chrome', pattern: /(?:Chrome|CriOS)\/(\d+)/ },
+  // Safari puts the WebKit build number in `Safari/` and its own release in
+  // `Version/`, so the latter is the one worth reporting.
+  { name: 'Safari', pattern: /Version\/(\d+)(?:\.\d+)*\s+(?:Mobile\/\S+\s+)?Safari\// },
+];
+
+/**
+ * Names the browser behind a user agent string, with its major version.
+ * @param userAgent - The `navigator.userAgent` value to read.
+ * @returns A label such as `Chrome 141`, or `Unknown` when nothing matches.
+ */
+export function describeBrowser(userAgent: string): string {
+  for (const { name, pattern } of BROWSER_PATTERNS) {
+    const match = pattern.exec(userAgent);
+    if (match) {
+      return `${name} ${match[1]}`;
+    }
+  }
+  return 'Unknown';
+}
+
+/**
+ * Names the operating system behind a user agent string.
+ *
+ * Only what the user agent can actually support is reported: Windows 10 and 11
+ * are indistinguishable there, and Safari/Chrome freeze the macOS version at
+ * 10.15.7, so neither is given a version it cannot back up.
+ * @param userAgent - The `navigator.userAgent` value to read.
+ * @returns A label such as `macOS` or `Android 14`, or `Unknown`.
+ */
+export function describeOperatingSystem(userAgent: string): string {
+  const windows = /Windows NT ([\d.]+)/.exec(userAgent);
+  if (windows) {
+    return windows[1] === '10.0' ? 'Windows 10 or 11' : `Windows (NT ${windows[1]})`;
+  }
+  // ChromeOS and Android both carry "Linux" in their user agent, so they have
+  // to be matched before the bare Linux check below.
+  if (userAgent.includes('CrOS')) {
+    return 'ChromeOS';
+  }
+  const android = /Android ([\d.]+)/.exec(userAgent);
+  if (android) {
+    return `Android ${android[1]}`;
+  }
+  if (userAgent.includes('Android')) {
+    return 'Android';
+  }
+  if (/iPhone|iPad|iPod/.test(userAgent)) {
+    const ios = /OS ([\d_]+) like Mac OS X/.exec(userAgent);
+    return ios ? `iOS ${ios[1].replace(/_/g, '.')}` : 'iOS';
+  }
+  if (userAgent.includes('Mac OS X')) {
+    return 'macOS';
+  }
+  if (userAgent.includes('Linux')) {
+    return 'Linux';
+  }
+  return 'Unknown';
+}
+
+/**
+ * Decides whether a script URL is served by the page's own origin or by a
+ * separate host.
+ * @param scriptUrl - Absolute URL of the script that loaded maidr.js.
+ * @param pageUrl - Absolute URL of the page hosting the chart.
+ * @returns `local`, `cdn`, or `unknown` when either URL cannot be parsed.
+ */
+export function classifyScriptOrigin(scriptUrl: string, pageUrl: string): MaidrSourceKind {
+  let script: URL;
+  let page: URL;
+  try {
+    script = new URL(scriptUrl);
+    page = new URL(pageUrl);
+  } catch {
+    return 'unknown';
+  }
+
+  // Every `file://` URL reports its origin as the opaque string "null", so
+  // comparing origins would call any pair of them same-origin. Compare the
+  // protocol instead: a bundle read off the filesystem next to a `file://`
+  // page — how py-maidr's saved HTML and the static examples load — is local.
+  if (script.protocol === 'file:' || page.protocol === 'file:') {
+    return script.protocol === page.protocol ? 'local' : 'cdn';
+  }
+  return script.origin === page.origin ? 'local' : 'cdn';
+}
+
+/**
+ * Finds the URL of the script that loaded maidr.js, falling back to a scan of
+ * the document when the bundle was loaded as an ES module (module scripts do
+ * not set `document.currentScript`).
+ * @returns The script's absolute URL, or `null` if none can be attributed.
+ */
+function findMaidrScriptUrl(): string | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const scripts = document.querySelectorAll<HTMLScriptElement>('script[src]');
+  for (const script of scripts) {
+    if (MAIDR_SCRIPT_PATTERN.test(script.src)) {
+      return script.src;
+    }
+  }
+  return null;
+}
+
+/**
+ * Reports where the running bundle came from.
+ * @returns The source kind and, when known, the script URL behind it.
+ */
+export function detectMaidrSource(): MaidrSource {
+  const pageUrl = typeof window === 'undefined' ? null : window.location.href;
+  if (!pageUrl) {
+    return { kind: 'unknown', url: null };
+  }
+
+  // A `<script>` with no `src` carries the bundle in its own body — that is
+  // how a notebook cell or a self-contained HTML export ships maidr.js.
+  const url = loadingScript ? loadingScript.src || null : findMaidrScriptUrl();
+  if (!url) {
+    return { kind: loadingScript ? 'inline' : 'unknown', url: null };
+  }
+  return { kind: classifyScriptOrigin(url, pageUrl), url };
+}
+
+/**
+ * Renders a source as a short label for the settings dialog.
+ * @param source - The detected bundle source.
+ * @returns A label such as `CDN` or `Local assets`.
+ */
+export function describeMaidrSource(source: MaidrSource): string {
+  switch (source.kind) {
+    case 'cdn':
+      return 'CDN';
+    case 'local':
+      return 'Local assets';
+    case 'inline':
+      return 'Embedded in the page';
+    case 'unknown':
+      return 'Unknown';
+  }
+}
+
+/**
+ * Collects everything the settings dialog reports about the running bundle and
+ * the browser it is running in.
+ * @returns The current diagnostics snapshot.
+ */
+export function collectDiagnostics(): Diagnostics {
+  const userAgent = typeof navigator === 'undefined' ? '' : navigator.userAgent;
+  return {
+    version: MAIDR_VERSION,
+    browser: describeBrowser(userAgent),
+    operatingSystem: describeOperatingSystem(userAgent),
+    source: detectMaidrSource(),
+    userAgent,
+  };
+}
+
+/**
+ * Formats a diagnostics snapshot as the plain-text block copied to the
+ * clipboard, ready to paste into a bug report.
+ *
+ * The page URL is deliberately left out: it is the one field here that can
+ * carry private paths or credentials in a query string, and it tells a
+ * maintainer nothing they cannot get from the report itself.
+ * @param diagnostics - The snapshot to format.
+ * @returns A newline-separated `key: value` block.
+ */
+export function formatDiagnostics(diagnostics: Diagnostics): string {
+  const { version, browser, operatingSystem, source, userAgent } = diagnostics;
+  const loadedFrom = source.url
+    ? `${describeMaidrSource(source)} (${source.url})`
+    : describeMaidrSource(source);
+
+  return [
+    'MAIDR diagnostics',
+    `maidr.js version: ${version}`,
+    `Loaded from: ${loadedFrom}`,
+    `Browser: ${browser}`,
+    `Operating system: ${operatingSystem}`,
+    `User agent: ${userAgent}`,
+  ].join('\n');
+}

--- a/src/util/version.ts
+++ b/src/util/version.ts
@@ -1,0 +1,10 @@
+import { version } from '../../package.json';
+
+/**
+ * Version of the maidr.js bundle that is currently running.
+ *
+ * Read from `package.json`, which semantic-release owns, so the value always
+ * matches the published release without a second source of truth to keep in
+ * sync. Bundlers inline the field at build time, so nothing is read at runtime.
+ */
+export const MAIDR_VERSION: string = version;

--- a/test/util/clipboard.test.ts
+++ b/test/util/clipboard.test.ts
@@ -131,7 +131,7 @@ describe('copyToClipboard', () => {
     expect(appended[0].value).toBe(REPORT);
   });
 
-  it('hides the textarea without display, visibility or the hidden attribute', async () => {
+  it('keeps the textarea off-screen without display, visibility or the hidden attribute', async () => {
     // Any of those would empty the selection and turn the copy into a no-op.
     await copyToClipboard(REPORT);
 
@@ -139,7 +139,17 @@ describe('copyToClipboard', () => {
     expect(textarea.style.display).toBeUndefined();
     expect(textarea.style.visibility).toBeUndefined();
     expect(textarea.getAttribute('hidden')).toBeNull();
-    expect(textarea.getAttribute('aria-hidden')).toBe('true');
+    expect(textarea.style.position).toBe('fixed');
+    expect(textarea.style.opacity).toBe('0');
+  });
+
+  it('does not mark the textarea aria-hidden, since select() focuses it', async () => {
+    // WAI-ARIA forbids aria-hidden on focused content: assistive technology
+    // behaviour is undefined for it, and this runs at the exact moment the
+    // user asked for a copy.
+    await copyToClipboard(REPORT);
+
+    expect(created[0].getAttribute('aria-hidden')).toBeNull();
   });
 
   it('removes the textarea and restores focus after a successful copy', async () => {

--- a/test/util/clipboard.test.ts
+++ b/test/util/clipboard.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { copyToClipboard } from '@util/clipboard';
+
+/**
+ * Minimal stand-in for the handful of DOM surfaces `copyToClipboard` touches.
+ *
+ * The suite runs on the `node` test environment (see jest.config.ts), so there
+ * is no document to lean on. Stubbing just these members keeps the branch under
+ * test — async API vs. execCommand fallback, and the focus restore — honest
+ * without pulling in a jsdom dependency for one file.
+ */
+class FakeElement {
+  public readonly style: Record<string, string> = {};
+  public value = '';
+  public focusCount = 0;
+  public removed = false;
+  public selected = false;
+  private readonly attributes = new Map<string, string>();
+
+  public setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  public getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  public select(): void {
+    this.selected = true;
+  }
+
+  public remove(): void {
+    this.removed = true;
+  }
+
+  public focus(): void {
+    this.focusCount += 1;
+  }
+}
+
+interface FakeDocument {
+  activeElement: FakeElement | null;
+  createElement: () => FakeElement;
+  body: { appendChild: (element: FakeElement) => void };
+  execCommand: (command: string) => boolean;
+}
+
+const REPORT = 'MAIDR diagnostics\nmaidr.js version: 3.74.0';
+
+let created: FakeElement[];
+let appended: FakeElement[];
+let previouslyFocused: FakeElement;
+let execCommandResult: boolean;
+let fakeDocument: FakeDocument;
+
+function define(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+
+function remove(name: string): void {
+  Reflect.deleteProperty(globalThis, name);
+}
+
+/** Installs the async clipboard API, or removes it to force the fallback. */
+function setClipboard(writeText: ((text: string) => Promise<void>) | null): void {
+  define('navigator', writeText ? { clipboard: { writeText } } : {});
+}
+
+beforeEach(() => {
+  created = [];
+  appended = [];
+  execCommandResult = true;
+  previouslyFocused = new FakeElement();
+
+  fakeDocument = {
+    activeElement: previouslyFocused,
+    createElement: () => {
+      const element = new FakeElement();
+      created.push(element);
+      return element;
+    },
+    body: { appendChild: element => appended.push(element) },
+    execCommand: () => execCommandResult,
+  };
+
+  define('document', fakeDocument);
+  // `copyWithExecCommand` narrows activeElement with `instanceof HTMLElement`
+  // before restoring focus, so the fake has to satisfy that check.
+  define('HTMLElement', FakeElement);
+  setClipboard(null);
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  remove('document');
+  remove('HTMLElement');
+  remove('navigator');
+  jest.restoreAllMocks();
+});
+
+describe('copyToClipboard', () => {
+  it('uses the async clipboard API when it is available', async () => {
+    const writeText = jest.fn(async () => {});
+    setClipboard(writeText);
+
+    await copyToClipboard(REPORT);
+
+    expect(writeText).toHaveBeenCalledWith(REPORT);
+    // The fallback must not also run — it would steal focus for no reason.
+    expect(created).toHaveLength(0);
+  });
+
+  it('falls back to execCommand when the async API rejects', async () => {
+    const writeText = jest.fn(async () => {
+      throw new Error('Document is not focused');
+    });
+    setClipboard(writeText);
+
+    await copyToClipboard(REPORT);
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(created).toHaveLength(1);
+    expect(created[0].value).toBe(REPORT);
+    expect(created[0].selected).toBe(true);
+  });
+
+  it('falls back to execCommand when the async API is missing', async () => {
+    await copyToClipboard(REPORT);
+
+    expect(appended).toHaveLength(1);
+    expect(appended[0].value).toBe(REPORT);
+  });
+
+  it('hides the textarea without display, visibility or the hidden attribute', async () => {
+    // Any of those would empty the selection and turn the copy into a no-op.
+    await copyToClipboard(REPORT);
+
+    const textarea = created[0];
+    expect(textarea.style.display).toBeUndefined();
+    expect(textarea.style.visibility).toBeUndefined();
+    expect(textarea.getAttribute('hidden')).toBeNull();
+    expect(textarea.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('removes the textarea and restores focus after a successful copy', async () => {
+    await copyToClipboard(REPORT);
+
+    expect(created[0].removed).toBe(true);
+    expect(previouslyFocused.focusCount).toBe(1);
+  });
+
+  it('rejects when execCommand refuses the copy', async () => {
+    execCommandResult = false;
+
+    await expect(copyToClipboard(REPORT)).rejects.toThrow(/execCommand/);
+  });
+
+  it('still removes the textarea and restores focus when the copy fails', async () => {
+    // The finally block owns this: a failed copy must not strand the user on
+    // the document body with a stray textarea left in the DOM.
+    execCommandResult = false;
+
+    await expect(copyToClipboard(REPORT)).rejects.toThrow();
+
+    expect(created[0].removed).toBe(true);
+    expect(previouslyFocused.focusCount).toBe(1);
+  });
+
+  it('copes with nothing being focused beforehand', async () => {
+    fakeDocument.activeElement = null;
+
+    await expect(copyToClipboard(REPORT)).resolves.toBeUndefined();
+    expect(created[0].removed).toBe(true);
+  });
+
+  it('rejects outside a document', async () => {
+    remove('document');
+
+    await expect(copyToClipboard(REPORT)).rejects.toThrow(TypeError);
+  });
+});

--- a/test/util/diagnostics.test.ts
+++ b/test/util/diagnostics.test.ts
@@ -315,4 +315,33 @@ describe('formatDiagnostics', () => {
   it('leaves the page URL out, which can carry private paths or tokens', () => {
     expect(formatDiagnostics(diagnostics)).not.toContain('report.html');
   });
+
+  it('keeps the origin and path of a hosted bundle, which is the diagnostic part', () => {
+    // A jsDelivr @latest against a pinned local copy is exactly the mismatch
+    // this field exists to expose, so the path has to survive.
+    expect(formatDiagnostics(diagnostics)).toContain(
+      'Loaded from: CDN (https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js)',
+    );
+  });
+
+  it('strips the query and fragment, which can carry signed-URL tokens', () => {
+    const report = formatDiagnostics({
+      ...diagnostics,
+      source: { kind: 'cdn', url: 'https://cdn.example/maidr.js?token=s3cret#frag' },
+    });
+    expect(report).toContain('Loaded from: CDN (https://cdn.example/maidr.js)');
+    expect(report).not.toContain('s3cret');
+    expect(report).not.toContain('frag');
+  });
+
+  it('redacts the directory of a file:// bundle, which carries the OS username', () => {
+    const report = formatDiagnostics({
+      ...diagnostics,
+      source: { kind: 'local', url: 'file:///Users/jane.doe/reports/dist/maidr.js' },
+    });
+    expect(report).toContain('Loaded from: Local assets (file:///.../maidr.js)');
+    // The filename still says which bundle; the home directory does not travel.
+    expect(report).not.toContain('jane.doe');
+    expect(report).not.toContain('reports');
+  });
 });

--- a/test/util/diagnostics.test.ts
+++ b/test/util/diagnostics.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 import {
   classifyScriptOrigin,
   describeBrowser,
   describeMaidrSource,
   describeOperatingSystem,
+  detectMaidrSource,
   formatDiagnostics,
   isMaidrScriptUrl,
 } from '@util/diagnostics';
@@ -80,6 +81,17 @@ describe('describeOperatingSystem', () => {
     expect(describeOperatingSystem(SAFARI_IOS)).toBe('iOS 17.4');
   });
 
+  it('reads iPadOS Safari as macOS, which its user agent cannot distinguish', () => {
+    // Known limitation, pinned so it is a documented answer rather than a
+    // surprise: iPadOS Safari's default agent claims Macintosh and carries no
+    // iPad token at all.
+    expect(
+      describeOperatingSystem(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15',
+      ),
+    ).toBe('macOS');
+  });
+
   it('falls back to Unknown for an unrecognised agent', () => {
     expect(describeOperatingSystem('some-crawler/1.0')).toBe('Unknown');
   });
@@ -112,6 +124,95 @@ describe('isMaidrScriptUrl', () => {
     expect(isMaidrScriptUrl('https://example.com/maidr-analytics/tracker.js')).toBe(false);
     expect(isMaidrScriptUrl('https://example.com/maidrify.js')).toBe(false);
     expect(isMaidrScriptUrl('https://example.com/vendor/analytics.js')).toBe(false);
+  });
+
+  it('does not match unrelated assets served under a bare /maidr/ path', () => {
+    // The project's own docs and examples live at xability.github.io/maidr/,
+    // so every asset there carries a /maidr/ segment.
+    expect(
+      isMaidrScriptUrl('https://xability.github.io/maidr/assets/javascripts/bundle.8f2a91c4.min.js'),
+    ).toBe(false);
+    // ...while the real bundle on that same host still matches, by filename.
+    expect(isMaidrScriptUrl('https://xability.github.io/maidr/dist/maidr.js')).toBe(true);
+  });
+
+  it('accepts a bare maidr package directory only under npm or node_modules', () => {
+    expect(isMaidrScriptUrl('https://cdn.jsdelivr.net/npm/maidr/dist/recharts.mjs')).toBe(true);
+    expect(isMaidrScriptUrl('/node_modules/maidr/dist/chartjs.js')).toBe(true);
+    // Known, deliberate miss: an unversioned unpkg path has neither marker, so
+    // it reports unknown rather than risking the wrong script.
+    expect(isMaidrScriptUrl('https://unpkg.com/maidr/dist/recharts.mjs')).toBe(false);
+  });
+});
+
+describe('detectMaidrSource', () => {
+  /**
+   * `document.currentScript` is null under the node test environment, which is
+   * exactly the module-script path where the URL is recovered by scanning the
+   * document — so these stubs exercise the real fallback rather than a mock of
+   * it.
+   */
+  function stubPage(scriptUrls: readonly string[], pageUrl: string): void {
+    Object.defineProperty(globalThis, 'window', {
+      value: { location: { href: pageUrl } },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      value: { querySelectorAll: () => scriptUrls.map(src => ({ src })) },
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window');
+    Reflect.deleteProperty(globalThis, 'document');
+  });
+
+  it('is not shadowed by an unrelated script that loads first', () => {
+    // Regression guard: on the project's own GitHub Pages host every asset URL
+    // contains /maidr/, and the docs bundle is emitted before the chart script.
+    stubPage(
+      [
+        'https://xability.github.io/maidr/assets/javascripts/bundle.8f2a91c4.min.js',
+        'https://xability.github.io/maidr/dist/maidr.js',
+      ],
+      'https://xability.github.io/maidr/examples/barplot.html',
+    );
+
+    expect(detectMaidrSource()).toEqual({
+      kind: 'local',
+      url: 'https://xability.github.io/maidr/dist/maidr.js',
+    });
+  });
+
+  it('takes the first genuine match in document order', () => {
+    stubPage(
+      [
+        'https://cdn.jsdelivr.net/npm/maidr@3.74.0/dist/maidr.js',
+        'https://example.com/dist/maidr.js',
+      ],
+      'https://example.com/report.html',
+    );
+
+    expect(detectMaidrSource()).toEqual({
+      kind: 'cdn',
+      url: 'https://cdn.jsdelivr.net/npm/maidr@3.74.0/dist/maidr.js',
+    });
+  });
+
+  it('reports unknown when no script can be attributed', () => {
+    stubPage(
+      ['https://example.com/vendor/analytics.js'],
+      'https://example.com/report.html',
+    );
+
+    expect(detectMaidrSource()).toEqual({ kind: 'unknown', url: null });
+  });
+
+  it('reports unknown outside a browser', () => {
+    expect(detectMaidrSource()).toEqual({ kind: 'unknown', url: null });
   });
 });
 

--- a/test/util/diagnostics.test.ts
+++ b/test/util/diagnostics.test.ts
@@ -13,6 +13,8 @@ import {
 const CHROME = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
 const EDGE = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.3485.14';
 const OPERA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 OPR/124.0.0.0';
+const OPERA_IOS = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) OPiOS/16.0.7.121091 Mobile/15E148 Safari/9537.53';
+const OPERA_TOUCH = 'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36 OPT/2.6';
 const SAMSUNG = 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/27.0 Chrome/125.0.0.0 Mobile Safari/537.36';
 const FIREFOX = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0';
 const SAFARI = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15';
@@ -39,6 +41,13 @@ describe('describeBrowser', () => {
 
   it('prefers Opera over the Chrome token it also carries', () => {
     expect(describeBrowser(OPERA)).toBe('Opera 124');
+  });
+
+  it('recognises Opera under each of its per-platform tokens', () => {
+    // OPR is the desktop/Android token; iOS sends OPiOS and Opera Touch sends
+    // OPT, and both would otherwise fall through to Safari or Chrome.
+    expect(describeBrowser(OPERA_IOS)).toBe('Opera 16');
+    expect(describeBrowser(OPERA_TOUCH)).toBe('Opera 2');
   });
 
   it('prefers Samsung Internet over the Chrome token it also carries', () => {

--- a/test/util/diagnostics.test.ts
+++ b/test/util/diagnostics.test.ts
@@ -5,6 +5,7 @@ import {
   describeMaidrSource,
   describeOperatingSystem,
   formatDiagnostics,
+  isMaidrScriptUrl,
 } from '@util/diagnostics';
 
 const CHROME = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
@@ -81,6 +82,36 @@ describe('describeOperatingSystem', () => {
 
   it('falls back to Unknown for an unrecognised agent', () => {
     expect(describeOperatingSystem('some-crawler/1.0')).toBe('Unknown');
+  });
+});
+
+describe('isMaidrScriptUrl', () => {
+  it('matches the bundle filename, versioned or not', () => {
+    expect(isMaidrScriptUrl('https://example.com/dist/maidr.js')).toBe(true);
+    expect(isMaidrScriptUrl('https://example.com/maidr.mjs')).toBe(true);
+    expect(isMaidrScriptUrl('https://example.com/maidr.min.js')).toBe(true);
+    expect(isMaidrScriptUrl('https://example.com/lib/maidr-3.74.0.js')).toBe(true);
+    expect(isMaidrScriptUrl('https://example.com/maidr.js?v=3')).toBe(true);
+  });
+
+  it('matches per-adapter bundles under a maidr package directory', () => {
+    expect(
+      isMaidrScriptUrl('https://cdn.jsdelivr.net/npm/maidr@latest/dist/recharts.mjs'),
+    ).toBe(true);
+    expect(
+      isMaidrScriptUrl('https://cdn.jsdelivr.net/npm/maidr@3.74.0/dist/vegalite.js'),
+    ).toBe(true);
+    expect(isMaidrScriptUrl('/lib/maidr-3.74.0/maidr.js')).toBe(true);
+    expect(isMaidrScriptUrl('/node_modules/maidr/dist/chartjs.js')).toBe(true);
+  });
+
+  it('does not match unrelated scripts whose name merely starts with maidr', () => {
+    // The scan returns the first match in document order, so a false positive
+    // here would shadow the real bundle.
+    expect(isMaidrScriptUrl('https://example.com/maidrical.js')).toBe(false);
+    expect(isMaidrScriptUrl('https://example.com/maidr-analytics/tracker.js')).toBe(false);
+    expect(isMaidrScriptUrl('https://example.com/maidrify.js')).toBe(false);
+    expect(isMaidrScriptUrl('https://example.com/vendor/analytics.js')).toBe(false);
   });
 });
 

--- a/test/util/diagnostics.test.ts
+++ b/test/util/diagnostics.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  classifyScriptOrigin,
+  describeBrowser,
+  describeMaidrSource,
+  describeOperatingSystem,
+  formatDiagnostics,
+} from '@util/diagnostics';
+
+const CHROME = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
+const EDGE = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.3485.14';
+const OPERA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 OPR/124.0.0.0';
+const SAMSUNG = 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/27.0 Chrome/125.0.0.0 Mobile Safari/537.36';
+const FIREFOX = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0';
+const SAFARI = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15';
+const SAFARI_IOS = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+const CHROMEOS = 'Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+describe('describeBrowser', () => {
+  it('names Chrome with its major version', () => {
+    expect(describeBrowser(CHROME)).toBe('Chrome 141');
+  });
+
+  it('names Firefox with its major version', () => {
+    expect(describeBrowser(FIREFOX)).toBe('Firefox 133');
+  });
+
+  it('reads Safari from Version/, not the WebKit build in Safari/', () => {
+    expect(describeBrowser(SAFARI)).toBe('Safari 18');
+    expect(describeBrowser(SAFARI_IOS)).toBe('Safari 17');
+  });
+
+  it('prefers Edge over the Chrome token it also carries', () => {
+    expect(describeBrowser(EDGE)).toBe('Microsoft Edge 140');
+  });
+
+  it('prefers Opera over the Chrome token it also carries', () => {
+    expect(describeBrowser(OPERA)).toBe('Opera 124');
+  });
+
+  it('prefers Samsung Internet over the Chrome token it also carries', () => {
+    expect(describeBrowser(SAMSUNG)).toBe('Samsung Internet 27');
+  });
+
+  it('falls back to Unknown for an unrecognised agent', () => {
+    expect(describeBrowser('some-crawler/1.0')).toBe('Unknown');
+    expect(describeBrowser('')).toBe('Unknown');
+  });
+});
+
+describe('describeOperatingSystem', () => {
+  it('reports Windows 10 and 11 together, since the agent cannot tell them apart', () => {
+    expect(describeOperatingSystem(EDGE)).toBe('Windows 10 or 11');
+  });
+
+  it('reports older Windows releases by their NT version', () => {
+    expect(describeOperatingSystem('Mozilla/5.0 (Windows NT 6.1; Win64; x64)')).toBe(
+      'Windows (NT 6.1)',
+    );
+  });
+
+  it('names macOS without a version, which the agent freezes', () => {
+    expect(describeOperatingSystem(SAFARI)).toBe('macOS');
+  });
+
+  it('names Linux', () => {
+    expect(describeOperatingSystem(CHROME)).toBe('Linux');
+  });
+
+  it('prefers ChromeOS over the Linux token it also carries', () => {
+    expect(describeOperatingSystem(CHROMEOS)).toBe('ChromeOS');
+  });
+
+  it('prefers Android over the Linux token it also carries', () => {
+    expect(describeOperatingSystem(SAMSUNG)).toBe('Android 14');
+  });
+
+  it('names iOS with its version', () => {
+    expect(describeOperatingSystem(SAFARI_IOS)).toBe('iOS 17.4');
+  });
+
+  it('falls back to Unknown for an unrecognised agent', () => {
+    expect(describeOperatingSystem('some-crawler/1.0')).toBe('Unknown');
+  });
+});
+
+describe('classifyScriptOrigin', () => {
+  it('treats a script from the page origin as local', () => {
+    expect(
+      classifyScriptOrigin(
+        'https://example.com/lib/maidr-3.74.0/maidr.js',
+        'https://example.com/report.html',
+      ),
+    ).toBe('local');
+  });
+
+  it('treats a script from another origin as CDN', () => {
+    expect(
+      classifyScriptOrigin(
+        'https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js',
+        'https://example.com/report.html',
+      ),
+    ).toBe('cdn');
+  });
+
+  it('distinguishes ports and schemes on the same host', () => {
+    expect(
+      classifyScriptOrigin('http://localhost:8080/maidr.js', 'http://localhost:3000/index.html'),
+    ).toBe('cdn');
+    expect(
+      classifyScriptOrigin('http://example.com/maidr.js', 'https://example.com/index.html'),
+    ).toBe('cdn');
+  });
+
+  it('treats a bundle sitting next to a file:// page as local', () => {
+    // Both file:// URLs report an opaque "null" origin, so this can only be
+    // decided on the protocol.
+    expect(
+      classifyScriptOrigin('file:///home/user/dist/maidr.js', 'file:///home/user/chart.html'),
+    ).toBe('local');
+  });
+
+  it('treats a remote bundle on a file:// page as CDN', () => {
+    expect(
+      classifyScriptOrigin(
+        'https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js',
+        'file:///home/user/chart.html',
+      ),
+    ).toBe('cdn');
+  });
+
+  it('returns unknown when a URL cannot be parsed', () => {
+    expect(classifyScriptOrigin('not a url', 'https://example.com')).toBe('unknown');
+    expect(classifyScriptOrigin('https://example.com/maidr.js', 'not a url')).toBe('unknown');
+  });
+});
+
+describe('describeMaidrSource', () => {
+  it('labels every source kind', () => {
+    expect(describeMaidrSource({ kind: 'cdn', url: 'https://cdn.example/maidr.js' })).toBe('CDN');
+    expect(describeMaidrSource({ kind: 'local', url: '/maidr.js' })).toBe('Local assets');
+    expect(describeMaidrSource({ kind: 'inline', url: null })).toBe('Embedded in the page');
+    expect(describeMaidrSource({ kind: 'unknown', url: null })).toBe('Unknown');
+  });
+});
+
+describe('formatDiagnostics', () => {
+  const diagnostics = {
+    version: '3.74.0',
+    browser: 'Chrome 141',
+    operatingSystem: 'Linux',
+    source: {
+      kind: 'cdn' as const,
+      url: 'https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js',
+    },
+    userAgent: CHROME,
+  };
+
+  it('reports every field on its own line', () => {
+    expect(formatDiagnostics(diagnostics)).toBe(
+      [
+        'MAIDR diagnostics',
+        'maidr.js version: 3.74.0',
+        'Loaded from: CDN (https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js)',
+        'Browser: Chrome 141',
+        'Operating system: Linux',
+        `User agent: ${CHROME}`,
+      ].join('\n'),
+    );
+  });
+
+  it('omits the URL when the source has none', () => {
+    const report = formatDiagnostics({
+      ...diagnostics,
+      source: { kind: 'inline', url: null },
+    });
+    const loadedFrom = report
+      .split('\n')
+      .find(line => line.startsWith('Loaded from:'));
+    expect(loadedFrom).toBe('Loaded from: Embedded in the page');
+  });
+
+  it('leaves the page URL out, which can carry private paths or tokens', () => {
+    expect(formatDiagnostics(diagnostics)).not.toContain('report.html');
+  });
+});

--- a/test/util/diagnostics.test.ts
+++ b/test/util/diagnostics.test.ts
@@ -7,6 +7,7 @@ import {
   detectMaidrSource,
   formatDiagnostics,
   isMaidrScriptUrl,
+  redactScriptUrl,
 } from '@util/diagnostics';
 
 const CHROME = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
@@ -273,6 +274,32 @@ describe('describeMaidrSource', () => {
     expect(describeMaidrSource({ kind: 'local', url: '/maidr.js' })).toBe('Local assets');
     expect(describeMaidrSource({ kind: 'inline', url: null })).toBe('Embedded in the page');
     expect(describeMaidrSource({ kind: 'unknown', url: null })).toBe('Unknown');
+  });
+});
+
+describe('redactScriptUrl', () => {
+  it('keeps the origin and path of a hosted bundle', () => {
+    expect(
+      redactScriptUrl('https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js'),
+    ).toBe('https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js');
+  });
+
+  it('drops the query and fragment, where a signed URL carries its token', () => {
+    expect(redactScriptUrl('https://cdn.example/maidr.js?token=s3cret#frag')).toBe(
+      'https://cdn.example/maidr.js',
+    );
+  });
+
+  it('reduces a file:// bundle to its protocol and filename', () => {
+    // The directory is the reporter's home directory, so it carries their OS
+    // username — and this value is both displayed and copied.
+    expect(redactScriptUrl('file:///Users/jane.doe/reports/dist/maidr.js')).toBe(
+      'file:///.../maidr.js',
+    );
+  });
+
+  it('returns null for a URL it cannot parse', () => {
+    expect(redactScriptUrl('not a url')).toBeNull();
   });
 });
 

--- a/test/util/diagnostics.test.ts
+++ b/test/util/diagnostics.test.ts
@@ -301,6 +301,13 @@ describe('redactScriptUrl', () => {
   it('returns null for a URL it cannot parse', () => {
     expect(redactScriptUrl('not a url')).toBeNull();
   });
+
+  it('returns null for a file:// URL with no filename to keep', () => {
+    // Degrades to the bare "Local assets" label rather than inventing a path.
+    // Unreachable from a script that actually executed, but the redaction has
+    // to fail closed rather than fall through to the unredacted URL.
+    expect(redactScriptUrl('file:///Users/jane.doe/dist/')).toBeNull();
+  });
 });
 
 describe('formatDiagnostics', () => {

--- a/test/util/version.test.ts
+++ b/test/util/version.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { MAIDR_VERSION } from '@util/version';
 import { version as packageVersion } from '../../package.json';
 
-describe('mAIDR_VERSION', () => {
+describe('maidr version constant', () => {
   it('reports the version declared in package.json', () => {
     expect(MAIDR_VERSION).toBe(packageVersion);
   });

--- a/test/util/version.test.ts
+++ b/test/util/version.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+import { MAIDR_VERSION } from '@util/version';
+import { version as packageVersion } from '../../package.json';
+
+describe('mAIDR_VERSION', () => {
+  it('reports the version declared in package.json', () => {
+    expect(MAIDR_VERSION).toBe(packageVersion);
+  });
+
+  it('is a non-empty semantic version string', () => {
+    expect(typeof MAIDR_VERSION).toBe('string');
+    expect(MAIDR_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Description

The settings dialog (`Ctrl` + `,` / `Cmd` + `,`) now ends with an **About** section reporting everything a maintainer needs to reproduce a bug, plus a button that copies it as a plain-text block:

| Row | Example |
| --- | --- |
| maidr.js Version | `3.74.0` |
| Loaded From | `CDN` — `https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js` |
| Browser | `Chrome 141` |
| Operating System | `Linux` |
| Diagnostics | **Copy diagnostics** |

"Loaded From" is the field that is hardest to get any other way and the one most likely to explain a mismatch: py-maidr and r-maidr can load maidr.js either from jsDelivr at `@latest` or from the copy they ship, so the running bundle is not always the version the binding expects.

## Related Issues

> [!IMPORTANT]
> **Read before merging — #655 makes half of this feature's accessibility work inert on arrival.**
>
> Every MAIDR dialog is currently hidden from the accessibility tree while open: MUI's `ModalManager` marks the MAIDR wrapper `aria-hidden="true"`, and because the dialogs use `disablePortal` they sit inside that wrapper, so each one hides itself.
>
> The consequence for *this* PR: the copy-status live region **will not be announced to a screen reader user today**. The button works, the clipboard write works, the visible text updates — the confirmation is silent.
>
> This is pre-existing and repo-wide, not introduced here. The Volume slider, Reset, Close and Save & Close are equally unreachable today, so merging this does not regress anything, and holding it does not help anyone. But the live region, `aria-describedby` wiring and WCAG 2.5.3 label-in-name work in this PR are unobservable in practice until #655 lands, so the two are best landed close together.

Also filed while working on this: #656 (<kbd>Esc</kbd> does not close the settings dialog) and #657 (no component-test harness — jest is node-only and skips `.tsx`).

## Changes Made

**`src/util/version.ts` (new)** — exports `MAIDR_VERSION`, read from the `version` field of `package.json`. semantic-release already owns that field, so there is no second source of truth to keep in sync, and bundlers inline the value at build time.

**`src/util/diagnostics.ts` (new)** — browser and OS names parsed from the user agent, plus bundle-source detection:

- `document.currentScript` is snapshotted at module evaluation. For a classic script that is the tag which loaded the bundle — the path both bindings use, CDN or bundled copy alike. A `<script>` with no `src` means the bundle is embedded in the page.
- Module scripts leave `currentScript` null, so a scan of maidr-shaped `script[src]` URLs backs it up. That scan takes the first match in document order, so the patterns are deliberately narrow: a bare `/maidr/` segment counts only directly under `/npm/` or `/node_modules/`, because the project's own docs are served from `xability.github.io/maidr/` where every asset URL contains it.
- Anything still unattributed is reported as `Unknown` rather than guessed at. An unversioned `unpkg.com/maidr/dist/…` falls in here — declining to answer beats naming the wrong script in a field that exists to be trusted.
- CDN vs local is decided by comparing origins, with a protocol check first because every `file://` URL reports its origin as the opaque string `"null"` — without that, any two `file://` URLs would compare as same-origin.

Only what the user agent can actually support is reported: Windows 10 and 11 are indistinguishable there, Safari/Chrome freeze the macOS version at 10.15.7, and iPadOS Safari claims `Macintosh` with no iPad token. Edge, Opera and Samsung Internet are matched before Chrome, whose token they all carry, and Opera is matched under all three of its per-platform tokens (`OPR`, `OPiOS`, `OPT`).

**`src/util/clipboard.ts` (new)** — `navigator.clipboard` where available, falling back to `execCommand` otherwise, since the async API is unavailable on the `file://` pages py-maidr and r-maidr write charts to. The fallback restores focus to the copy button afterwards, and deliberately does not mark the throwaway textarea `aria-hidden`, since `select()` focuses it and WAI-ARIA forbids that combination.

**`src/ui/component/Settings.tsx`** — the About section, built from the existing `SettingRow` layout. The copy status is a `role="status" aria-live="polite"` region rendered while empty, keyed by an attempt counter so a repeat copy still mutates the DOM — identical text alone produces no mutation, and a live region announces on the mutation, not on the state update.

**Tests (new)** — `version.test.ts`, `diagnostics.test.ts`, `clipboard.test.ts`, 44 cases over the pure logic: browser and OS families including the ones that shadow another's token, script-URL matching including the false positives that would shadow the real bundle, `detectMaidrSource`'s document scan, origin classification, URL redaction, the clipboard fallback chain, and the focus restore.

### Privacy

The copied block is written to be pasted into a public issue, so two things are held back — and the dialog applies the same rule to what it displays, since a screenshot travels just as far as pasted text:

- **The page URL is omitted entirely.** It is the field most likely to carry private paths or credentials in a query string.
- **The script URL is redacted.** A `file://` bundle sits wherever the reporter saved it, so its path carries their OS username; only the protocol and filename survive. Hosted URLs keep origin and path — that is what exposes a jsDelivr `@latest` against a pinned local copy — and lose only the query and fragment, where a signed asset URL would carry a token.

## Screenshots (if applicable)

Bottom of the dialog, from `examples/barplot.html` after clicking **Copy diagnostics**:

```
About

maidr.js Version     3.74.0
Loaded From          Local assets
                     file:///.../maidr.js
Browser              Chrome 141
Operating System     Linux
Diagnostics          [ COPY DIAGNOSTICS ]  Copied to clipboard
```

The clipboard block, read back after the copy:

```
MAIDR diagnostics
maidr.js version: 3.74.0
Loaded from: CDN (http://127.0.0.1:8002/maidr.js)
Browser: Chrome 141
Operating system: Linux
User agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/141.0.0.0 Safari/537.36
```

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Verification

- `npm run type-check` — clean
- `npm run lint` over `src` and `test` — clean
- `npm test` — 94 suites, 1195 tests, all passing
- `npm run build` — all 12 bundle targets built

**Bundle content**, checked across every artifact rather than one: 11 artifacts across the 7 React-bundling targets embed `"3.74.0"`; **zero** artifacts contain `devDependencies` or `"semantic-release"`, including `chartjs.js` and `amcharts.js` with their differing externals. So the tree-shaking holds across the differing plugin configs, not just the core bundle.

**Manual browser pass** against the built bundle, since the React glue has no automated coverage — 19 checks, all passing: the four rows render with real values, the live region exists and is empty before the first click, three clicks produce three DOM mutations, the button is keyboard-focusable and activates on <kbd>Enter</kbd>, the clipboard payload is complete and carries no home directory or page URL, and on the `execCommand` fallback the copy succeeds, focus returns to the button, and no textarea is left behind.

### Known gaps

No component-level test for the `Settings.tsx` wiring and no e2e assertion for the new rows. jest here runs `testEnvironment: 'node'` with `testMatch: ['**/test/**/*.test.ts']`, so a component test needs `jest-environment-jsdom` + `@testing-library/react` and an environment switch — repo-wide infrastructure, tracked as #657. The e2e page object is shared across all 12 specs, which is wider than this change needs.

Docs are unchanged: `docs/CONTROLS.md` lists the shortcut but does not describe the dialog's contents.