### PR TITLE
fix(ui): name the settings dialog with a rendered title

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -104,5 +104,6 @@ When a change surfaces a bug that belongs to a different fix, pin it with
 `it.failing` and the issue number rather than skipping it or leaving a comment.
 The case keeps running, the suite stays green while the bug stands, and the day
 the fix lands the case turns red — which is the reminder to delete it and
-anything written to work around the bug. `test/ui/settings.copyDiagnostics.test.tsx`
-does this for #663.
+anything written to work around the bug. Replace it then with a case that
+asserts the fixed behaviour, rather than dropping the marker and leaving the
+weaker assertion the pin was written to tolerate.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -103,5 +103,6 @@ When a change surfaces a bug that belongs to a different fix, pin it with
 `it.failing` and the issue number rather than skipping it or leaving a comment.
 The case keeps running, the suite stays green while the bug stands, and the day
 the fix lands the case turns red — which is the reminder to delete it and
-anything written to work around the bug. `test/ui/settings.copyDiagnostics.test.tsx`
-does this for #663.
+anything written to work around the bug. Replace it then with a case that
+asserts the fixed behaviour, rather than dropping the marker and leaving the
+weaker assertion the pin was written to tolerate.

--- a/e2e_tests/specs/dialogAccessibility.spec.ts
+++ b/e2e_tests/specs/dialogAccessibility.spec.ts
@@ -96,10 +96,13 @@ test.describe('dialog accessibility tree', () => {
     const barPlotPage = await setupBarPlotPage(page);
     await barPlotPage.openSettingsMenu();
 
-    await expect(page.getByRole('dialog')).toBeVisible();
+    // By name, not by role alone (#663): the dialog used to resolve here with
+    // no accessible name, indistinguishable from the four other dialogs.
+    await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
     expect(await hiddenAncestorsOf(page, '.settings-dialog')).toEqual([]);
     expect(await wrapperAriaHidden(page)).toBeNull();
 
+    await expect(page.getByRole('heading', { name: 'Settings', level: 2 })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Reset Settings' })).toBeVisible();
     await expect(
       page.getByRole('button', { name: 'Close Settings with no changes' }),

--- a/src/ui/component/Settings.tsx
+++ b/src/ui/component/Settings.tsx
@@ -18,6 +18,7 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
+  DialogTitle,
   Divider,
   FormControl,
   FormControlLabel,
@@ -441,6 +442,7 @@ const Settings: React.FC = () => {
   const [llmSettings, setLlmSettings] = useState<LlmSettings>(llm);
 
   const [copyState, setCopyState] = useState<CopyState>({ status: 'idle', attempt: 0 });
+  const titleId = `${id}-title`;
   const copyStatusId = `${id}-copy-status`;
   // The bundle source and the browser cannot change while the dialog is open,
   // so the DOM scan behind this runs once per mount rather than per render.
@@ -631,7 +633,14 @@ const Settings: React.FC = () => {
     <Dialog
       id={id}
       role="dialog"
-      aria-label="Settings"
+      // Names the dialog. `aria-label` cannot do it here: MUI applies
+      // `role` and `aria-labelledby` to the paper — the `role="dialog"`
+      // element — but spreads everything else, `aria-label` included, onto
+      // the modal root, which is `role="presentation"` and names nothing.
+      // Passing the id also settles the reference MUI derives from it for
+      // `DialogContext`; left to generate its own, it points the paper at a
+      // `DialogTitle` that need not exist.
+      aria-labelledby={titleId}
       open={true}
       onClose={handleDialogClose}
       maxWidth="sm"
@@ -644,9 +653,16 @@ const Settings: React.FC = () => {
       onKeyDown={handleDialogKeyDown}
       className="settings-dialog"
     >
+      {/* Renders as an `h2`, so the dialog also gains the top-level heading
+          it lacked — the section headings below were the only ones in it,
+          leaving nothing to land on when navigating by heading. */}
+      <DialogTitle id={titleId} className="settings-dialog-title">
+        Settings
+      </DialogTitle>
+
       <DialogContent className="settings-dialog-content">
         <Grid size="grow">
-          <Typography variant="h6" fontWeight="bold" gutterBottom>
+          <Typography variant="h6" component="h3" fontWeight="bold" gutterBottom>
             General Settings
           </Typography>
         </Grid>
@@ -1114,6 +1130,7 @@ const Settings: React.FC = () => {
           <Grid size={12}>
             <Typography
               variant="h6"
+              component="h3"
               fontWeight="bold"
               gutterBottom
               className="settings-section-title"
@@ -1237,6 +1254,7 @@ const Settings: React.FC = () => {
           <Grid size={12}>
             <Typography
               variant="h6"
+              component="h3"
               fontWeight="bold"
               gutterBottom
               className="settings-section-title"

--- a/test/ui/settings.copyDiagnostics.test.tsx
+++ b/test/ui/settings.copyDiagnostics.test.tsx
@@ -256,28 +256,41 @@ describe('settings About section: copy diagnostics', () => {
   });
 
   /**
-   * Pins the accessible name gap that #659 uncovered: the settings dialog has
-   * none. `aria-label="Settings"` is passed to `<Dialog>`, which spreads it
-   * onto the modal root — a `role="presentation"` element, where it names
-   * nothing — while the `role="dialog"` paper carries the `aria-labelledby`
-   * MUI generates for a `DialogTitle` this dialog never renders, so the
-   * reference dangles. A screen reader announces the dialog with no name.
+   * Guards #663: the dialog was exposed with no accessible name at all.
+   * `aria-label="Settings"` was passed to `<Dialog>`, which spreads it onto
+   * the modal root — a `role="presentation"` element, where it names nothing
+   * — while the `role="dialog"` paper carried the `aria-labelledby` MUI
+   * generates for a `DialogTitle` the dialog never rendered, so the reference
+   * dangled and a screen reader announced "dialog" and nothing else.
    *
-   * Invisible until now because the whole dialog sat outside the accessibility
-   * tree. Marked `failing` rather than skipped so it stays executed: naming the
-   * dialog turns this red, which is the signal to drop the marker.
+   * Invisible until #659, which put the dialog back in the accessibility tree
+   * and left this as what remained.
    */
-  it.failing('should give the dialog an accessible name (#663)', () => {
+  it('should name the dialog after the title it renders', () => {
     renderSettings();
 
-    // Any non-empty name, not the literal "Settings": the contract is that the
-    // dialog is named at all, and pinning the exact string would keep this red
-    // — indistinguishably from still-unnamed — if the fix lands on wording
-    // this test did not predict.
-    //
-    // `queryByRole`, not `getByRole`: the getter's not-found error renders the
-    // whole dialog into the failure message, and this case is expected to miss
-    // on every run until the dialog is named.
-    expect(screen.queryByRole('dialog', { name: /\S/ })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument();
+  });
+
+  /**
+   * The name has to come from a reference that resolves. MUI puts an
+   * `aria-labelledby` on the paper whether or not a `DialogTitle` is rendered,
+   * and a dangling one is a defect in its own right — it also outranks
+   * `aria-label` in the name computation, so a label cannot sit beside it and
+   * win. Resolved through the DOM the way assistive technology resolves it,
+   * rather than by asserting on the markup that happens to produce it.
+   */
+  it('should point the dialog at a heading that exists', () => {
+    renderSettings();
+
+    const id = screen.getByRole('dialog').getAttribute('aria-labelledby');
+    expect(id).toBeTruthy();
+
+    const title = document.getElementById(id as string);
+    expect(title).not.toBeNull();
+    // A heading, not just any labelled node: it is the dialog's only
+    // top-level one, so heading navigation has nothing to land on without it.
+    expect(title).toHaveTextContent('Settings');
+    expect(screen.getByRole('heading', { name: 'Settings', level: 2 })).toBe(title);
   });
 });


### PR DESCRIPTION
Closes #663.

## Root cause

Confirmed against `@mui/material` v7 source rather than inferred:

- `Dialog/Dialog.js:346-352` applies `role`, `aria-labelledby`, `aria-describedby` and `aria-modal` to the **paper** — the `role="dialog"` element — and spreads `...other`, where `aria-label` lands, onto the **root**, which is `role="presentation"` and names nothing.
- `Dialog/Dialog.js:264`, `useId(ariaLabelledbyProp)`, generates an id when none is passed and puts it on the paper unconditionally, whether or not a `DialogTitle` is ever rendered.

`Settings.tsx` passed `aria-label` and rendered no `DialogTitle`, so its name resolved through a reference to an element that did not exist. It was the only dialog with that shape. Invisible until #659 put the dialog back in the accessibility tree.

## The fix

Render a `DialogTitle` and point `aria-labelledby` at it, the way `Description.tsx` does.

- `aria-label="Settings"` → `aria-labelledby={titleId}`.
- Added `<DialogTitle id={titleId}>Settings</DialogTitle>`. Passing the id explicitly also settles the reference MUI would otherwise generate, which answers the "worth checking with the fix" item on the issue: nothing dangles.
- Section headings (General Settings, LLM Settings, About) move from `h6` to `h3`. `DialogTitle` renders as `h2`, and adding it above bare `h6`s would have introduced a level skip in a dialog whose new heading is meant to help heading navigation.

The id sits on the `DialogTitle` itself rather than on a nested `Typography`. `DialogTitle.js:57` resolves `id: idProp ?? titleId`, so the wrapper picks up the context id regardless — the nested-`Typography` pattern gives two elements the same id.

## Verification

- `npm run type-check`, `eslint`, `npm run build` — clean.
- `npm test` — 96 suites, 1209 tests, all pass.
- The `it.failing` pin from #660 becomes two real cases: one asserting the name, one resolving `aria-labelledby` through the DOM so a dangling reference fails there rather than passing against a name that happens to compute.
- `dialogAccessibility.spec.ts` now asserts the settings dialog by name rather than by role alone; all 7 tests pass in chromium.
- Reproduced the issue's exact repro steps in a real browser: 1 `role="dialog"`, `aria-labelledby` resolving to an existing `H2` "Settings", exactly one element carrying that id, root no longer carrying the stray `aria-label`, outline reading H2 → H3/H3/H3, and Playwright's accessible-name computation resolving `getByRole('dialog', { name: 'Settings' })`.

## Two things to flag

**Firefox and WebKit are unverified, and this PR's CI will not cover them either.** The `e2e-smoke` job in `ci.yml` runs `dialogAccessibility.spec.ts` on every PR but is chromium-only by design; the full three-browser suite lives in the scheduled workflows (`e2e.yml`, every 2 days). So the first firefox/webkit run against this change is the next scheduled one, after merge. Locally I could only run chromium as well — the box has chromium rev 1194 against a `^1.52` pin with a 1.59 CLI, so the other two projects fail on a missing browser. The fix is a static markup change with no browser-specific API, so the risk is low, but it is untested there and worth saying plainly.

Separately: root `playwright.config.ts` is broken on `main` (`__dirname` in an ESM package, `testDir` pointing at a nonexistent `test/e2e/specs`). Nothing uses it — every workflow passes `--config=e2e_tests/config/test-config.ts` — but `npx playwright test` with no `--config` fails at load. Predates this branch; not touched here.

**A pre-existing duplicate-id bug in `Description.tsx`,** not touched here. Lines 136-142 pass `aria-labelledby={`${id}-title`}` to `Dialog` and render `<Grid component={DialogTitle}>` with an inner `<Typography id={`${id}-title`}>` — so both the `DialogTitle` wrapper (via `idProp ?? titleId`) and the `Typography` carry that id. The dialog is still announced correctly, so this is cosmetic rather than a naming failure, but it is worth a follow-up.

## Out-of-scope edit worth a look

`.claude/rules/testing.md` cited this test file as the live `it.failing` example for #663. Fixing the bug makes that citation stale, so I replaced it with generic guidance and regenerated the `.github/` mirror via `npm run sync:copilot`. No `it.failing` pins remain in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH49ExPkrEGyEWZJj1EFmm