### PR TITLE
fix(build): stop emitting a core ES bundle that UMD overwrites

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -144,7 +144,10 @@ const builds = [
     name: 'core',
     entry: 'src/index.tsx',
     libName: 'maidr',
-    formats: ['es', 'umd'],
+    // UMD only: src/index.tsx is a pure side-effect entry with no exports, so
+    // an ES build has no consumer value. Adding 'es' back here would also make
+    // both formats resolve to the same fileName and silently overwrite.
+    formats: ['umd'],
     fileName: () => 'maidr.js',
     emptyOutDir: true,
     external: [],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -138,8 +138,11 @@ function onWarn(warning, warn) {
 
 /**
  * Build configurations
+ *
+ * Exported so the build-config test can assert against the real array rather
+ * than a fixture that could drift away from it.
  */
-const builds = [
+export const builds = [
   {
     name: 'core',
     entry: 'src/index.tsx',
@@ -499,8 +502,71 @@ async function runParallel(selected, jobs, outDir) {
     throw firstError;
 }
 
+/**
+ * Reject any entry whose formats would fight over one output filename.
+ *
+ * Vite resolves `build.lib.fileName` once per format and writes the outputs in
+ * order, overwriting silently when two formats resolve to the same name: the
+ * earlier format's work is simply lost, and the only hint is the same filename
+ * appearing twice in the build log. That is exactly how the core bundle spent
+ * every build producing an ES output that the UMD output immediately replaced,
+ * so catch the whole class here instead of shipping half a build again.
+ *
+ * `fileName` is invoked the way Vite invokes it — `(format, entryName)` — so an
+ * implementation that ignores its `format` argument (and therefore collides) is
+ * caught behaving exactly as it would at build time.
+ *
+ * @param {typeof builds} configs Entries to check.
+ * @throws {Error} If any entry maps two formats onto the same filename.
+ */
+export function assertUniqueOutputFilenames(configs) {
+  for (const config of configs) {
+    // Vite's lib-mode default when `name` is set. Every entry declares
+    // `formats` today; defaulting keeps an omission from skipping the check.
+    const formats = config.formats ?? ['es', 'umd'];
+    // A string `fileName` cannot collide — Vite appends a per-format extension.
+    if (typeof config.fileName !== 'function')
+      continue;
+    // Vite derives the entry name from the entry file's base name.
+    const entryName = path.basename(config.entry, path.extname(config.entry));
+
+    /** @type {Map<string, string>} filename -> the format that claimed it */
+    const claimedBy = new Map();
+    for (const format of formats) {
+      let fileName;
+      try {
+        fileName = config.fileName(format, entryName);
+      } catch (cause) {
+        throw new Error(
+          `Build config error: bundle "${config.name}" threw while resolving its `
+          + `fileName for the "${format}" format: ${cause.message}`,
+          { cause },
+        );
+      }
+
+      const previous = claimedBy.get(fileName);
+      if (previous !== undefined) {
+        throw new Error(
+          `Build config error: bundle "${config.name}" emits "${fileName}" for both the `
+          + `"${previous}" and "${format}" formats. Vite writes them in order, so `
+          + `"${format}" would silently overwrite "${previous}" and that output would be `
+          + `lost. Give each format its own filename — the adapter entries use `
+          + `\`fileName: format => format === 'es' ? '<name>.mjs' : '<name>.js'\` — or drop `
+          + `the redundant format.`,
+        );
+      }
+      claimedBy.set(fileName, format);
+    }
+  }
+}
+
 async function main() {
   const startTime = Date.now();
+
+  // Fail fast, before emptying dist or forking anything. Checked across every
+  // entry rather than just the selected ones: a collision in a bundle nobody
+  // asked for today is still a latent bug, and the check costs nothing.
+  assertUniqueOutputFilenames(builds);
 
   const argv = process.argv.slice(2);
   const sequential = argv.includes('--sequential');
@@ -592,7 +658,14 @@ async function main() {
   console.log(`\nAll builds complete in ${((Date.now() - startTime) / 1000).toFixed(1)}s`);
 }
 
-main().catch((err) => {
-  console.error('Build failed:', err);
-  process.exit(1);
-});
+// Orchestrate only when this file is the process entry point — which includes
+// each forked worker, whose argv[1] is this same path. Importing the module,
+// as the build-config test does to reach the real `builds` array, must never
+// kick off a build.
+const invokedAs = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedAs === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('Build failed:', err);
+    process.exit(1);
+  });
+}

--- a/test/scripts/buildOutputFilenames.test.ts
+++ b/test/scripts/buildOutputFilenames.test.ts
@@ -1,0 +1,211 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Guards the build config against two formats resolving to the same output
+ * filename.
+ *
+ * Vite writes lib outputs one format at a time and overwrites silently, so a
+ * `fileName` callback that ignores its `format` argument costs a whole format's
+ * build with nothing but a repeated filename in the log to show for it. That is
+ * how the core bundle came to emit an ES output that the UMD output replaced on
+ * every build. `assertUniqueOutputFilenames` turns that into a hard failure;
+ * these tests keep the guard honest and keep this repo's own `builds` array
+ * continuously checked.
+ *
+ * `scripts/build.js` is plain ESM JavaScript and `allowJs` is false, so it
+ * cannot be imported from a ts-jest test directly. Each case runs in a real
+ * node subprocess with `--input-type=module` instead, which also exercises the
+ * module exactly as the build does.
+ */
+
+const ROOT = resolve(__dirname, '../..');
+const BUILD_SCRIPT = pathToFileURL(resolve(ROOT, 'scripts/build.js')).href;
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run ESM source in a node subprocess, capturing output either way. */
+function runModule(source: string): RunResult {
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      ['--input-type=module', '-e', source],
+      { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' },
+    );
+    return { status: 0, stdout, stderr: '' };
+  } catch (error) {
+    const err = error as { status?: number; stdout?: string; stderr?: string };
+    return {
+      status: err.status ?? 1,
+      stdout: String(err.stdout ?? ''),
+      stderr: String(err.stderr ?? ''),
+    };
+  }
+}
+
+/**
+ * Check one inline entry and report the outcome on stdout, so a genuine crash
+ * (non-zero exit, empty stdout) stays distinguishable from a rejection.
+ */
+function checkEntry(entryLiteral: string): RunResult {
+  return runModule(`
+    import { assertUniqueOutputFilenames } from '${BUILD_SCRIPT}';
+    try {
+      assertUniqueOutputFilenames([${entryLiteral}]);
+      console.log('ACCEPTED');
+    } catch (error) {
+      console.log('REJECTED:' + error.message);
+    }
+  `);
+}
+
+describe('importing the build script', () => {
+  // The guard that makes every other case here possible: main() is wired to
+  // run only when build.js is the entry point, so importing it for its exports
+  // must not start a multi-minute build.
+  it('should not start a build', () => {
+    const result = runModule(`
+      import { builds } from '${BUILD_SCRIPT}';
+      console.log('IMPORTED:' + builds.length);
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/IMPORTED:\d+/);
+    expect(result.stdout).not.toContain('Building MAIDR library');
+    expect(result.stdout).not.toContain('vite');
+  });
+});
+
+describe('the real builds array', () => {
+  it('should map every format to a distinct filename', () => {
+    const result = runModule(`
+      import { assertUniqueOutputFilenames, builds } from '${BUILD_SCRIPT}';
+      assertUniqueOutputFilenames(builds);
+      console.log('OK:' + builds.length);
+    `);
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('OK:');
+  });
+
+  it('should actually have entries to check', () => {
+    const result = runModule(`
+      import { builds } from '${BUILD_SCRIPT}';
+      console.log('COUNT:' + builds.length);
+    `);
+    const count = Number(result.stdout.match(/COUNT:(\d+)/)?.[1]);
+
+    // Guards against the previous case passing vacuously on an empty array.
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('should declare a fileName callback for every multi-format entry', () => {
+    const result = runModule(`
+      import { builds } from '${BUILD_SCRIPT}';
+      const bad = builds
+        .filter(b => (b.formats ?? []).length > 1 && typeof b.fileName !== 'function')
+        .map(b => b.name);
+      console.log('BAD:' + JSON.stringify(bad));
+    `);
+
+    expect(result.stdout).toContain('BAD:[]');
+  });
+});
+
+describe('assertUniqueOutputFilenames', () => {
+  it('should reject a fileName that ignores its format argument', () => {
+    const result = checkEntry(`{
+      name: 'core',
+      entry: 'src/index.tsx',
+      formats: ['es', 'umd'],
+      fileName: () => 'maidr.js',
+    }`);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('REJECTED:');
+    // The message has to name the bundle and the filename, or the next person
+    // hitting this learns nothing from it.
+    expect(result.stdout).toContain('"core"');
+    expect(result.stdout).toContain('"maidr.js"');
+    expect(result.stdout).toContain('"es"');
+    expect(result.stdout).toContain('"umd"');
+  });
+
+  it('should accept the per-format naming the adapters use', () => {
+    const result = checkEntry(`{
+      name: 'anychart',
+      entry: 'src/anychart-entry.ts',
+      formats: ['es', 'umd'],
+      fileName: format => format === 'es' ? 'anychart.mjs' : 'anychart.js',
+    }`);
+
+    expect(result.stdout).toContain('ACCEPTED');
+  });
+
+  it('should accept a single-format entry whose fileName ignores its argument', () => {
+    const result = checkEntry(`{
+      name: 'react',
+      entry: 'src/react-entry.ts',
+      formats: ['es'],
+      fileName: () => 'react.mjs',
+    }`);
+
+    expect(result.stdout).toContain('ACCEPTED');
+  });
+
+  it('should catch a collision among three formats', () => {
+    const result = checkEntry(`{
+      name: 'triple',
+      entry: 'src/index.tsx',
+      formats: ['es', 'cjs', 'umd'],
+      fileName: format => format === 'es' ? 'triple.mjs' : 'triple.js',
+    }`);
+
+    expect(result.stdout).toContain('REJECTED:');
+    expect(result.stdout).toContain('"triple"');
+    expect(result.stdout).toContain('"triple.js"');
+  });
+
+  it('should surface a throwing fileName instead of swallowing it', () => {
+    const result = checkEntry(`{
+      name: 'explosive',
+      entry: 'src/index.tsx',
+      formats: ['es', 'umd'],
+      fileName: () => { throw new Error('kaboom'); },
+    }`);
+
+    expect(result.stdout).toContain('REJECTED:');
+    expect(result.stdout).toContain('"explosive"');
+    expect(result.stdout).toContain('kaboom');
+  });
+
+  it('should check an entry that omits formats against vite\'s default', () => {
+    // Vite defaults lib builds to ['es', 'umd'] when a name is set, so an
+    // omitted `formats` must not become a hole in the check.
+    const result = checkEntry(`{
+      name: 'defaulted',
+      entry: 'src/index.tsx',
+      fileName: () => 'defaulted.js',
+    }`);
+
+    expect(result.stdout).toContain('REJECTED:');
+    expect(result.stdout).toContain('"defaulted"');
+  });
+
+  it('should ignore a string fileName, which vite disambiguates by extension', () => {
+    const result = checkEntry(`{
+      name: 'stringly',
+      entry: 'src/index.tsx',
+      formats: ['es', 'umd'],
+      fileName: 'stringly',
+    }`);
+
+    expect(result.stdout).toContain('ACCEPTED');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.tsx'),
       name: 'maidr',
-      formats: ['es', 'umd'],
+      // UMD only: src/index.tsx is a pure side-effect entry with no exports, so
+      // an ES build has no consumer value. Adding 'es' back here would also make
+      // both formats resolve to the same fileName and silently overwrite.
+      formats: ['umd'],
       fileName: () => `maidr.js`,
     },
     sourcemap: true,


### PR DESCRIPTION
## Problem

The `core` bundle was declared with two output formats that collided on one filename. In `scripts/build.js`:

```js
{
  name: 'core',
  entry: 'src/index.tsx',
  libName: 'maidr',
  formats: ['es', 'umd'],
  fileName: () => 'maidr.js',   // ignores its `format` argument
  ...
}
```

The `fileName` callback ignores its `format` argument and returns `'maidr.js'` for **both** formats. Vite wrote the ES output first and the UMD output then silently overwrote it, so roughly half of the core build's work was discarded on every build.

Evidence from the build log on `main` — two `dist/maidr.js` lines with different sizes, but only one file surviving in `dist/`:

```
dist/maidr.css  1,458.77 kB │ gzip: 945.07 kB
dist/maidr.js   3,224.37 kB │ gzip: 757.80 kB │ map: 9,020.07 kB   <- ES, written first
dist/maidr.css  1,458.77 kB │ gzip: 945.07 kB
dist/maidr.js   1,890.62 kB │ gzip: 553.21 kB │ map: 8,684.68 kB   <- UMD, overwrites it
✓ built in 52.40s
```

The single surviving `dist/maidr.js` begins with a UMD wrapper, confirming the ES output lost the race:

```
(function(Xu){typeof define=="function"&&define.amd?define(Xu):Xu()})(...
```

The root `vite.config.ts` declared the same `formats: ['es', 'umd']` + `fileName: () => 'maidr.js'` combination and had the same problem.

## Fix

Stop building the `es` format for `core` rather than emitting a second file.

`src/index.tsx` contains **no `export` statements at all** (verified — the only `export` match in the file is the word inside a comment). It is a pure side-effect entry point: it assigns `window.maidrLive` and `window.disconnectMaidrObservers`, registers DOM listeners, and auto-initialises charts on `DOMContentLoaded`. An ES-module build of an entry with no exports has no consumer value, and its output never survived anyway.

So `formats` becomes `['umd']` in both `scripts/build.js` (the `core` entry) and `vite.config.ts`. `fileName` is left as-is — it is now correct, and matches how the other single-format entries are written.

### Scope

- **Only the `core` entry changed.** Every other entry in the `builds` array already handled this correctly and is untouched: multi-format adapters use `fileName: format => format === 'es' ? 'x.mjs' : 'x.js'`. The full build confirms this still holds — e.g. `anychart` emits both `anychart.mjs` (39.57 kB) and `anychart.js` (28.62 kB).
- **`package.json` needed no change**, confirmed rather than assumed:
  - `main` is `dist/maidr.js`
  - `exports["."]` is `{"default": "./dist/maidr.js"}` — a single condition, with no `import` key
  - there is no `module`, `types`, or `browser` field at the root

  Both already pointed at the UMD file that is actually produced, so they stay correct. Nothing in the repo referenced a core ES build; the only `maidr.mjs` string outside `dist/` is in `test/util/diagnostics.test.ts`, exercising the permissive `isMaidrScriptUrl()` URL matcher, which does not depend on the build emitting that file.
- `dist/` is gitignored and untouched.

## Verification

**1. Core build now prints one `dist/maidr.js` line instead of two**

```
[1/1] Building core...
dist/maidr.css  1,458.77 kB │ gzip: 945.07 kB
dist/maidr.js   1,890.62 kB │ gzip: 553.21 kB │ map: 8,684.83 kB
✓ built in 37.31s
[1/1] Done (37.4s)
```

Line count of `dist/…maidr.js ` in the log: **2 before → 1 after**.

Core bundle build time: **52.5s → 37.4s** (~29% faster, 15.1s saved).

**2. The surviving artifact is unchanged** — `dist/maidr.js` is 1,890,618 bytes (~1.88 MB), byte-for-byte the same size as the UMD output produced before this change, and still starts with `(function(Xu){typeof define=="function"&&define.amd?define(Xu):Xu()})(`.

**3. No stray outputs** — no `dist/maidr.mjs`. The core build emits exactly `maidr.css`, `maidr.js`, `maidr.js.map`.

**4. Runtime smoke test (real browser, via Playwright)** — served a page loading the built `dist/maidr.js` plus an inline SVG bar chart carrying a `maidr` attribute with a valid spec (4 bars: Sat/87, Sun/76, Thur/62, Fri/19). Results:
- `window.maidrLive` is present, so the UMD side effects ran
- `<figure id="maidr-figure-testbar">` mounted, with a focusable `div[tabindex="0"][role="application"]`
- arrow-key navigation works and announces data points: first `ArrowRight` → **"Day is Sat, Count is 87"**, second `ArrowRight` → **"Day is Sun, Count is 76"**, matching the spec
- `HighlightService` created a `data-maidr-owned="true"` highlight rect on the navigated bar
- no console errors other than an unrelated `favicon.ico` 404

**5. Full build** — `node scripts/build.js` succeeds (all 12 bundles, 284.8s, exit 0) with **no "Merge collision" error** and no build errors. `dist/.tmp` is swept.

**6. Type-check and tests**
- `npm run type-check` — clean, no errors
- `npx jest --coverage=false` — **96 suites passed / 96 total, 1209 tests passed / 1209 total, 0 failures**
- The anticipated pre-existing `test/adapters/recharts/panelDom.test.ts` failure (`Cannot find module 'recharts'`) did **not** occur here, because `npm ci` installed the `recharts` devDependency in this tree; that suite passes (4/4).

**7. Lint** — `npx eslint scripts/build.js vite.config.ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
