### PR TITLE
perf(css): ship only woff2 for inlined KaTeX fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react-markdown": "^10.1.0",
         "react-redux": "^9.2.0",
         "rehype-katex": "^7.0.1",
-        "rehype-mathjax": "^5.0.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0"
@@ -5254,6 +5253,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -5773,12 +5773,6 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/mathjax": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@types/mathjax/-/mathjax-0.0.37.tgz",
-      "integrity": "sha512-y0WSZBtBNQwcYipTU/BhgeFu1EZNlFvUNCmkMXV9kBQZq7/o5z82dNVyH3yy2Xv5zzeNeQoHSL4Xm06+EQiH+g==",
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -6574,15 +6568,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6602,6 +6587,7 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
@@ -6668,6 +6654,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -6905,6 +6892,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/axios": {
@@ -7309,6 +7297,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7716,6 +7705,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8123,6 +8113,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
       "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rrweb-cssom": "^0.6.0"
@@ -8603,6 +8594,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
       "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abab": "^2.0.6",
@@ -8641,6 +8633,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -8736,6 +8729,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8828,6 +8822,7 @@
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "webidl-conversions": "^7.0.0"
@@ -8853,6 +8848,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -9145,6 +9141,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9170,6 +9167,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -9182,6 +9180,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10224,15 +10223,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -10670,6 +10660,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -10792,6 +10783,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10826,6 +10818,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -11025,6 +11018,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11093,6 +11087,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11105,6 +11100,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -11392,6 +11388,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
@@ -11436,6 +11433,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
@@ -11511,6 +11509,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -11550,6 +11549,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -11913,6 +11913,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -13393,6 +13394,7 @@
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
       "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abab": "^2.0.6",
@@ -14112,21 +14114,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mathjax-full": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.1.tgz",
-      "integrity": "sha512-aUz9o16MGZdeiIBwZjAfUBTiJb7LRqzZEl1YOZ8zQMGYIyh1/nxRebxKxjDe9L+xcZCr2OHdzoFBMcd6VnLv9Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esm": "^3.2.25",
-        "mhchemparser": "^4.1.0",
-        "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^4.0.6"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -14488,12 +14479,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mhchemparser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
-      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -15138,6 +15123,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15147,6 +15133,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -15200,12 +15187,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
-      "license": "Apache-2.0"
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -17953,6 +17934,7 @@
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -18968,6 +18950,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -18980,6 +18963,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19049,6 +19033,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rc": {
@@ -19478,26 +19463,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-mathjax": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-mathjax/-/rehype-mathjax-5.0.0.tgz",
-      "integrity": "sha512-IRPgpSpwOq4JNn3efeTrbYDMmzjOKCTJtu1Wyo/+6nenyqwqIvlojYDczRILOeHa1HyCMYmqpdvfOovOVzDIGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mathjax": "^0.0.37",
-        "hast-util-from-dom": "^5.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "jsdom": "^22.0.0",
-        "mathjax-full": "^3.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/rehype-sanitize": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
@@ -19618,6 +19583,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/reselect": {
@@ -19746,6 +19712,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rw": {
@@ -19776,12 +19743,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -20507,29 +20476,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/speech-rule-engine": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.3.tgz",
-      "integrity": "sha512-SBMgkuJYvP4F62daRfBNwYC2nXTEhNXAfsBZ/BB7Ly85/KnbnjmKM7/45ZrFbH6jIMiAliDUDPSZFUuXDvcg6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@xmldom/xmldom": "0.9.9",
-        "commander": "13.1.0",
-        "wicked-good-xpath": "1.3.0"
-      },
-      "bin": {
-        "sre": "bin/sre"
-      }
-    },
-    "node_modules/speech-rule-engine/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
@@ -20849,6 +20795,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -21261,6 +21208,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.33",
@@ -21276,6 +21224,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -21285,6 +21234,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
       "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.0"
@@ -21858,6 +21808,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -22682,6 +22633,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^4.0.0"
@@ -22755,6 +22707,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -22848,6 +22801,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -22860,6 +22814,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -22869,6 +22824,7 @@
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
       "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^4.1.1",
@@ -22893,12 +22849,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wicked-good-xpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
-      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -22976,6 +22926,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -22997,6 +22948,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
@@ -23006,6 +22958,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "react-markdown": "^10.1.0",
     "react-redux": "^9.2.0",
     "rehype-katex": "^7.0.1",
-    "rehype-mathjax": "^5.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,6 +30,7 @@ import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
 import { build } from 'vite';
 import dts from 'vite-plugin-dts';
+import { woff2OnlyFonts } from './vite-plugin-woff2-only.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -318,6 +319,10 @@ function createViteConfig(config) {
       insertTypesEntry: false,
     }));
   }
+  // Registered for every bundle, unconditionally: the React-based bundles all
+  // emit the same maidr.css, and runParallel's merge step fails with a "Merge
+  // collision" if their contents differ. Keep this out of any `if`.
+  plugins.push(woff2OnlyFonts());
 
   // Workers build into an isolated outDir (passed via env) so parallel
   // vite-plugin-dts runs never clobber each other's intermediate .d.ts files

--- a/scripts/vite-plugin-woff2-only.d.ts
+++ b/scripts/vite-plugin-woff2-only.d.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite';
+
+/**
+ * Hand-written declarations for `vite-plugin-woff2-only.js`.
+ *
+ * The plugin is plain JS so `scripts/build.js` (run directly by node) can
+ * import it; `tsconfig.json` sets `allowJs: false`, so `vite.config.ts` needs
+ * these types to import it too. Keep both files in sync.
+ */
+
+/**
+ * Strip non-woff2 `@font-face` sources from a stylesheet. Faces that offer no
+ * woff2 alternative are left untouched and counted in `skipped`.
+ */
+export declare function stripNonWoff2FontSources(css: string): {
+  css: string;
+  rewritten: number;
+  skipped: number;
+};
+
+/** Vite plugin that applies the above to every emitted CSS asset. */
+export declare function woff2OnlyFonts(): Plugin;

--- a/scripts/vite-plugin-woff2-only.js
+++ b/scripts/vite-plugin-woff2-only.js
@@ -47,13 +47,31 @@ const LEGACY_SOURCE_RE = new RegExp([
 ].join('|'), 'i');
 
 /**
- * Split `value` on occurrences of `separator` that sit outside parentheses.
+ * Blank out `/* ... *\/` comments so their contents cannot be mistaken for
+ * markup. Used only for inspecting CSS, never for producing it — the original
+ * text, comments included, is what gets emitted.
+ *
+ * @param {string} value
+ * @returns {string} `value` with every closed comment removed
+ */
+function stripComments(value) {
+  return value.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Split `value` on occurrences of `separator` that sit outside parentheses and
+ * outside comments.
  *
  * Naive splitting is wrong here: a `src` list is comma-separated, but every
  * inlined `url(data:font/woff2;base64,...)` contains both a comma and a
  * semicolon. Font `src` values never nest parentheses outside a `url()` or
  * `format()`, and base64 has no parentheses of its own, so tracking depth is
  * enough.
+ *
+ * Comments are skipped wholesale for the same reason. Minified CSS carries
+ * none today, but a change in minifier settings could reintroduce them, and a
+ * `;` or `:` inside one would otherwise split a declaration in the wrong place.
+ * An unterminated comment runs to the end of the value, as CSS parsers do.
  *
  * @param {string} value
  * @param {string} separator single character
@@ -65,7 +83,10 @@ function splitTopLevel(value, separator) {
   let start = 0;
   for (let i = 0; i < value.length; i++) {
     const char = value[i];
-    if (char === '(') {
+    if (char === '/' && value[i + 1] === '*') {
+      const end = value.indexOf('*/', i + 2);
+      i = end === -1 ? value.length : end + 1;
+    } else if (char === '(') {
       depth++;
     } else if (char === ')') {
       depth = Math.max(0, depth - 1);
@@ -79,15 +100,17 @@ function splitTopLevel(value, separator) {
 }
 
 /**
- * Classify one alternative of a `src` list.
+ * Classify one alternative of a `src` list. Comments are ignored, so a
+ * commented-out `format("woff2")` cannot make a legacy source look current.
  *
  * @param {string} source
  * @returns {'woff2' | 'legacy' | 'other'} `legacy` marks the ones safe to drop
  */
 function classifySource(source) {
-  if (WOFF2_FORMAT_RE.test(source) || WOFF2_URL_RE.test(source))
+  const bare = stripComments(source);
+  if (WOFF2_FORMAT_RE.test(bare) || WOFF2_URL_RE.test(bare))
     return 'woff2';
-  if (LEGACY_SOURCE_RE.test(source))
+  if (LEGACY_SOURCE_RE.test(bare))
     return 'legacy';
   return 'other';
 }
@@ -111,13 +134,16 @@ function rewriteFontFaceBody(body) {
 
   const declarations = splitTopLevel(body, ';').map((declaration) => {
     const colon = splitTopLevel(declaration, ':');
-    if (colon.length < 2 || colon[0].trim().toLowerCase() !== 'src')
+    if (colon.length < 2 || stripComments(colon[0]).trim().toLowerCase() !== 'src')
       return declaration;
 
     const property = colon[0];
     const value = colon.slice(1).join(':');
+    // A segment that is nothing but a comment is not an alternative; carrying
+    // it through would leave a dangling comma, which invalidates the whole
+    // `src` descriptor once the browser strips the comment.
     const sources = splitTopLevel(value, ',')
-      .filter(s => s.trim() !== '')
+      .filter(s => stripComments(s).trim() !== '')
       .map(s => ({ source: s, kind: classifySource(s) }));
     if (sources.length === 0)
       return declaration;

--- a/scripts/vite-plugin-woff2-only.js
+++ b/scripts/vite-plugin-woff2-only.js
@@ -1,0 +1,210 @@
+/**
+ * Vite plugin: drop every non-woff2 `@font-face` source from emitted CSS.
+ *
+ * `src/ui/components/TypingEffect.tsx` imports `katex/dist/katex.min.css` to
+ * render LaTeX in AI chat responses. Vite's library mode inlines the fonts that
+ * stylesheet references as base64 data URIs, and KaTeX ships each of its 20
+ * faces three times over — woff2, woff and ttf:
+ *
+ *   src:url(...woff2) format("woff2"),url(...woff) format("woff"),
+ *       url(...ttf) format("truetype")
+ *
+ * A browser downloads exactly one of those, so the other two are dead weight in
+ * `dist/maidr.css` — 1,402 KB of the file's 1,425 KB was font data, and two
+ * thirds of that was never going to be used. woff2 has been baseline since
+ * Chrome 36, Safari 12, Firefox 39 and Edge 14, so the legacy alternatives are
+ * pure duplication.
+ *
+ * This is written as a build-time transform rather than a vendored copy of
+ * KaTeX's stylesheet so it keeps working across KaTeX upgrades.
+ *
+ * NOTE: several bundles emit a byte-identical `maidr.css`, and the parallel
+ * build in `scripts/build.js` fails with "Merge collision" if they diverge.
+ * Register this plugin for every bundle that emits CSS (it lives in the shared
+ * `createViteConfig` factory for exactly that reason), never for a subset.
+ */
+
+import { Buffer } from 'node:buffer';
+
+const FONT_FACE_RE = /(@font-face\s*\{)([^}]*)(\})/gi;
+
+/** Matches a `format("woff2")` hint. */
+const WOFF2_FORMAT_RE = /format\(\s*['"]?woff2['"]?\s*\)/i;
+
+/** Matches a `url(...)` pointing at woff2, by file extension or data-URI mime. */
+const WOFF2_URL_RE = /url\([^)]*\.woff2\b|url\(\s*['"]?data:[^;,)]*\/woff2[;,]/i;
+
+/**
+ * Matches a `url(...)` source that is recognisably a font in a pre-woff2
+ * format, either via its `format()` hint or via its extension / data-URI mime.
+ * Anything not matched here is left alone, so an unrecognised source (or a
+ * `local(...)` alternative, which costs no bytes) is never discarded.
+ */
+const LEGACY_SOURCE_RE = new RegExp([
+  String.raw`format\(\s*['"]?(?:woff|truetype|opentype|embedded-opentype|svg)['"]?\s*\)`,
+  String.raw`url\([^)]*\.(?:woff|ttf|otf|eot)\b`,
+  String.raw`url\(\s*['"]?data:[^;,)]*\/(?:woff|ttf|truetype|otf|opentype|vnd\.ms-fontobject)[;,]`,
+].join('|'), 'i');
+
+/**
+ * Split `value` on occurrences of `separator` that sit outside parentheses.
+ *
+ * Naive splitting is wrong here: a `src` list is comma-separated, but every
+ * inlined `url(data:font/woff2;base64,...)` contains both a comma and a
+ * semicolon. Font `src` values never nest parentheses outside a `url()` or
+ * `format()`, and base64 has no parentheses of its own, so tracking depth is
+ * enough.
+ *
+ * @param {string} value
+ * @param {string} separator single character
+ * @returns {string[]} the segments, with the separators removed
+ */
+function splitTopLevel(value, separator) {
+  const parts = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth = Math.max(0, depth - 1);
+    } else if (char === separator && depth === 0) {
+      parts.push(value.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(value.slice(start));
+  return parts;
+}
+
+/**
+ * Classify one alternative of a `src` list.
+ *
+ * @param {string} source
+ * @returns {'woff2' | 'legacy' | 'other'} `legacy` marks the ones safe to drop
+ */
+function classifySource(source) {
+  if (WOFF2_FORMAT_RE.test(source) || WOFF2_URL_RE.test(source))
+    return 'woff2';
+  if (LEGACY_SOURCE_RE.test(source))
+    return 'legacy';
+  return 'other';
+}
+
+/**
+ * Rewrite a single `@font-face` body, keeping only woff2 sources.
+ *
+ * A face is only rewritten when it actually offers a woff2 alternative; a face
+ * without one is returned untouched, so this can never leave a face with
+ * nothing to load. That is deliberately conservative — a KaTeX upgrade that
+ * drops woff2 from some face would grow the bundle back rather than break
+ * rendering, and the caller reports the skip.
+ *
+ * @param {string} body declarations between the braces
+ * @returns {{ body: string, rewritten: boolean, skipped: boolean }} the new
+ * body, plus whether it was trimmed and whether it lacked a woff2 alternative
+ */
+function rewriteFontFaceBody(body) {
+  let rewritten = false;
+  let skipped = false;
+
+  const declarations = splitTopLevel(body, ';').map((declaration) => {
+    const colon = splitTopLevel(declaration, ':');
+    if (colon.length < 2 || colon[0].trim().toLowerCase() !== 'src')
+      return declaration;
+
+    const property = colon[0];
+    const value = colon.slice(1).join(':');
+    const sources = splitTopLevel(value, ',')
+      .filter(s => s.trim() !== '')
+      .map(s => ({ source: s, kind: classifySource(s) }));
+    if (sources.length === 0)
+      return declaration;
+
+    if (!sources.some(s => s.kind === 'woff2')) {
+      skipped = true;
+      return declaration;
+    }
+
+    const kept = sources.filter(s => s.kind !== 'legacy');
+    // Guaranteed by the woff2 check above, but assert rather than assume:
+    // emitting an empty `src` would silently break maths rendering.
+    if (kept.length === 0) {
+      throw new Error(
+        `refusing to empty the src of an @font-face: ${body.slice(0, 120)}`,
+      );
+    }
+    if (kept.length === sources.length)
+      return declaration;
+
+    rewritten = true;
+    return `${property}:${kept.map(s => s.source).join(',')}`;
+  });
+
+  return { body: declarations.join(';'), rewritten, skipped };
+}
+
+/**
+ * Strip non-woff2 `@font-face` sources from a stylesheet.
+ *
+ * @param {string} css
+ * @returns {{ css: string, rewritten: number, skipped: number }} `rewritten` is
+ * the number of faces trimmed, `skipped` the number left alone for lack of a
+ * woff2 alternative.
+ */
+export function stripNonWoff2FontSources(css) {
+  let rewritten = 0;
+  let skipped = 0;
+
+  const out = css.replace(FONT_FACE_RE, (_match, open, body, close) => {
+    const result = rewriteFontFaceBody(body);
+    if (result.rewritten)
+      rewritten++;
+    if (result.skipped)
+      skipped++;
+    return `${open}${result.body}${close}`;
+  });
+
+  return { css: out, rewritten, skipped };
+}
+
+/**
+ * @returns {import('vite').Plugin} a plugin that applies the above to every
+ * CSS asset in the bundle
+ */
+export function woff2OnlyFonts() {
+  return {
+    name: 'maidr:woff2-only-fonts',
+    // Run after vite:css-post has assembled and emitted the CSS asset.
+    enforce: 'post',
+    apply: 'build',
+
+    generateBundle(_options, bundle) {
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type !== 'asset' || !fileName.endsWith('.css'))
+          continue;
+
+        const before = typeof output.source === 'string'
+          ? output.source
+          : Buffer.from(output.source).toString('utf8');
+        const { css, rewritten, skipped } = stripNonWoff2FontSources(before);
+        if (skipped > 0) {
+          this.warn(
+            `${fileName}: ${skipped} @font-face rule(s) offer no woff2 source; `
+            + 'their legacy formats were kept so text still renders.',
+          );
+        }
+        if (rewritten === 0)
+          continue;
+
+        output.source = css;
+        const saved = Buffer.byteLength(before) - Buffer.byteLength(css);
+        this.info(
+          `${fileName}: dropped non-woff2 sources from ${rewritten} @font-face `
+          + `rule(s), saving ${(saved / 1024).toFixed(1)} kB`,
+        );
+      }
+    },
+  };
+}

--- a/test/scripts/woff2OnlyFonts.test.ts
+++ b/test/scripts/woff2OnlyFonts.test.ts
@@ -1,0 +1,137 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Tests for scripts/vite-plugin-woff2-only.js.
+ *
+ * The plugin trims `@font-face` src lists down to their woff2 alternative,
+ * which cuts ~1 MB of duplicated KaTeX font data out of dist/maidr.css. The
+ * cases here pin the two things a naive implementation gets wrong — inlined
+ * `url(data:font/woff2;base64,...)` values contain both a comma and a
+ * semicolon, so splitting a src list needs to be paren-aware — plus the
+ * safety rule that a face without a woff2 alternative is left alone rather
+ * than emptied.
+ *
+ * The plugin is plain ESM JS (scripts/build.js imports it directly from node)
+ * and `tsconfig.json` sets `allowJs: false`, so it is exercised through a node
+ * subprocess rather than imported, mirroring test/scripts/syncCopilotInstructions.
+ */
+
+const MODULE = pathToFileURL(
+  resolve(__dirname, '../../scripts/vite-plugin-woff2-only.js'),
+).href;
+
+const RUNNER = `
+import { stripNonWoff2FontSources } from ${JSON.stringify(MODULE)};
+try {
+  const result = stripNonWoff2FontSources(process.env.FIXTURE_CSS);
+  process.stdout.write(JSON.stringify(result));
+} catch (error) {
+  process.stdout.write(JSON.stringify({ error: error.message }));
+}
+`;
+
+interface Result {
+  css?: string;
+  rewritten?: number;
+  skipped?: number;
+  error?: string;
+}
+
+/** Runs the transform on `css` in a child node process. */
+function strip(css: string): Result {
+  const stdout = execFileSync('node', ['--input-type=module', '-e', RUNNER], {
+    env: { ...process.env, FIXTURE_CSS: css },
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return JSON.parse(stdout) as Result;
+}
+
+/** A base64 payload, so fixtures exercise the `;base64,` comma/semicolon. */
+const DATA = 'd09GMgABAAAAAA';
+
+/** A face in the exact shape KaTeX ships: woff2, then woff, then ttf. */
+function katexFace(family: string): string {
+  return `@font-face{font-display:block;font-family:${family};font-style:normal;font-weight:400;`
+    + `src:url(data:font/woff2;base64,${DATA}) format("woff2"),`
+    + `url(data:font/woff;base64,${DATA}) format("woff"),`
+    + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+}
+
+describe('stripNonWoff2FontSources', () => {
+  it('keeps only the woff2 alternative of an inlined KaTeX face', () => {
+    const result = strip(katexFace('KaTeX_AMS'));
+
+    expect(result.error).toBeUndefined();
+    expect(result.rewritten).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.css).toBe(
+      '@font-face{font-display:block;font-family:KaTeX_AMS;font-style:normal;font-weight:400;'
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2")}`,
+    );
+  });
+
+  it('rewrites every face in a multi-face stylesheet', () => {
+    const css = `${katexFace('KaTeX_AMS')}${katexFace('KaTeX_Main')}${katexFace('KaTeX_Math')}`;
+    const result = strip(css);
+
+    expect(result.rewritten).toBe(3);
+    expect(result.css).not.toContain('font/woff;');
+    expect(result.css).not.toContain('font/ttf');
+    expect((result.css!.match(/font\/woff2/g) ?? []).length).toBe(3);
+  });
+
+  it('leaves declarations other than src untouched', () => {
+    const result = strip(katexFace('KaTeX_AMS'));
+
+    expect(result.css).toContain('font-display:block');
+    expect(result.css).toContain('font-family:KaTeX_AMS');
+    expect(result.css).toContain('font-weight:400');
+  });
+
+  it('leaves a face with no woff2 alternative alone rather than emptying it', () => {
+    const css = '@font-face{font-family:Legacy;'
+      + `src:url(data:font/woff;base64,${DATA}) format("woff"),`
+      + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.error).toBeUndefined();
+    expect(result.rewritten).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.css).toBe(css);
+  });
+
+  it('strips legacy sources referenced by file url as well as data uri', () => {
+    const css = '@font-face{font-family:Rel;'
+      + 'src:url(fonts/Rel.woff2) format("woff2"),'
+      + 'url(fonts/Rel.woff) format("woff"),'
+      + 'url(fonts/Rel.ttf) format("truetype")}';
+    const result = strip(css);
+
+    expect(result.rewritten).toBe(1);
+    expect(result.css).toBe('@font-face{font-family:Rel;src:url(fonts/Rel.woff2) format("woff2")}');
+  });
+
+  it('keeps local() alternatives, which cost no bytes', () => {
+    const css = '@font-face{font-family:Mixed;'
+      + 'src:local("Mixed Regular"),'
+      + `url(data:font/woff2;base64,${DATA}) format("woff2"),`
+      + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.rewritten).toBe(1);
+    expect(result.css).toContain('local("Mixed Regular")');
+    expect(result.css).not.toContain('font/ttf');
+  });
+
+  it('does not touch css without @font-face rules', () => {
+    const css = '.maidr{color:red}.maidr-braille{font-family:monospace}';
+    const result = strip(css);
+
+    expect(result.rewritten).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.css).toBe(css);
+  });
+});

--- a/test/scripts/woff2OnlyFonts.test.ts
+++ b/test/scripts/woff2OnlyFonts.test.ts
@@ -135,3 +135,102 @@ describe('stripNonWoff2FontSources', () => {
     expect(result.css).toBe(css);
   });
 });
+
+/**
+ * Minified CSS carries no comments today, so these guard a future change in
+ * minifier settings: a `;` or `:` inside a comment must not split a
+ * declaration in the wrong place, and the emitted rule must stay parseable.
+ */
+describe('stripNonWoff2FontSources with comments', () => {
+  /** Fails if the transform emits an empty, doubled or dangling src list. */
+  function expectWellFormed(css: string): void {
+    // Comments are what the browser drops first; check the result after that.
+    const bare = css.replace(/\/\*[\s\S]*?\*\//g, '');
+    for (const [, body] of bare.matchAll(/@font-face\s*\{([^}]*)\}/g)) {
+      const src = /(?:^|;)\s*src\s*:([^;]*(?:;base64,[^;]*)*)/.exec(body);
+      expect(src).not.toBeNull();
+      const value = src![1].trim();
+      expect(value).not.toBe('');
+      expect(value.startsWith(',')).toBe(false);
+      expect(value.endsWith(',')).toBe(false);
+      expect(value).not.toContain(',,');
+    }
+  }
+
+  it('ignores a semicolon inside a comment in the body', () => {
+    const css = '@font-face{font-family:X;/* a; b; c */'
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2"),`
+      + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.error).toBeUndefined();
+    expect(result.rewritten).toBe(1);
+    expect(result.css).toContain('/* a; b; c */');
+    expect(result.css).toContain('font-family:X');
+    expect(result.css).not.toContain('font/ttf');
+    expect((result.css!.match(/font\/woff2/g) ?? []).length).toBe(1);
+    expectWellFormed(result.css!);
+  });
+
+  it('ignores a colon inside a comment in the body', () => {
+    const css = '@font-face{/* src: see below */font-family:X;'
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2"),`
+      + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.error).toBeUndefined();
+    expect(result.rewritten).toBe(1);
+    expect(result.css).toContain('/* src: see below */');
+    expect(result.css).not.toContain('font/ttf');
+    expectWellFormed(result.css!);
+  });
+
+  it('ignores a comment sitting between sources in a src list', () => {
+    const css = '@font-face{font-family:X;'
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2")/* keep; me: here */,`
+      + `url(data:font/woff;base64,${DATA}) format("woff"),`
+      + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.error).toBeUndefined();
+    expect(result.rewritten).toBe(1);
+    expect(result.css).toBe(
+      '@font-face{font-family:X;'
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2")/* keep; me: here */}`,
+    );
+    expectWellFormed(result.css!);
+  });
+
+  it('does not let a commented-out format hint rescue a legacy source', () => {
+    const css = '@font-face{font-family:X;'
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2"),`
+      + `url(data:font/ttf;base64,${DATA})/* format("woff2") */ format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.rewritten).toBe(1);
+    expect(result.css).not.toContain('font/ttf');
+    expectWellFormed(result.css!);
+  });
+
+  it('leaves the rule alone when a comment hides the closing brace', () => {
+    // `}` inside a comment truncates the @font-face match. The transform must
+    // degrade to "no change" rather than emit half a rule.
+    const css = '@font-face{font-family:X;/* } */'
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2"),`
+      + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.error).toBeUndefined();
+    expect(result.css).toBe(css);
+  });
+
+  it('leaves an unterminated comment alone rather than guessing', () => {
+    const css = '@font-face{font-family:X;/* never closed '
+      + `src:url(data:font/woff2;base64,${DATA}) format("woff2"),`
+      + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+    const result = strip(css);
+
+    expect(result.error).toBeUndefined();
+    expect(result.css).toBe(css);
+  });
+});

--- a/test/scripts/woff2OnlyFonts.test.ts
+++ b/test/scripts/woff2OnlyFonts.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -232,5 +233,245 @@ describe('stripNonWoff2FontSources with comments', () => {
 
     expect(result.error).toBeUndefined();
     expect(result.css).toBe(css);
+  });
+});
+
+/**
+ * Tests for the plugin object itself — the part `scripts/build.js` actually
+ * loads. The suite above covers the transform; these cover the `generateBundle`
+ * hook wrapped around it: which bundle entries it selects, how it reads a
+ * source that Rollup handed over as bytes rather than a string, and when it
+ * reassigns `output.source` or reports through the plugin context.
+ *
+ * Every scenario runs in one child process, not one per case: the transform
+ * suite above pays a spawn per assertion, and there is no reason to multiply
+ * that here. `beforeAll` collects the results and each `it` reads its own.
+ */
+
+/** One bundle entry as handed to the child. */
+interface BundleEntrySpec {
+  type: 'asset' | 'chunk';
+  source: string;
+  /** `bytes` makes the child hand the plugin a Uint8Array, as Rollup may. */
+  encoding?: 'string' | 'bytes';
+}
+
+/** What the child reports back for one entry after the hook ran. */
+interface BundleEntryResult {
+  type: string;
+  /** Whether the hook assigned to `output.source` at all. */
+  assigned: boolean;
+  isString: boolean;
+  text: string;
+}
+
+interface ScenarioResult {
+  outputs: Record<string, BundleEntryResult>;
+  warns: string[];
+  infos: string[];
+  error: string | null;
+  meta: { name: string; enforce?: string; apply?: string };
+}
+
+const PLUGIN_RUNNER = `
+import { Buffer } from 'node:buffer';
+import { woff2OnlyFonts } from ${JSON.stringify(MODULE)};
+
+const scenarios = JSON.parse(process.env.FIXTURE_SCENARIOS);
+const results = {};
+
+for (const scenario of scenarios) {
+  const bundle = {};
+  const assigned = {};
+
+  for (const [fileName, spec] of Object.entries(scenario.bundle)) {
+    const output = { type: spec.type };
+    if (spec.type === 'asset') {
+      // Intercept the setter so "did the hook reassign source?" is observable
+      // rather than inferred from the resulting text.
+      let current = spec.encoding === 'bytes'
+        ? new Uint8Array(Buffer.from(spec.source, 'utf8'))
+        : spec.source;
+      assigned[fileName] = false;
+      Object.defineProperty(output, 'source', {
+        get: () => current,
+        set: (value) => { current = value; assigned[fileName] = true; },
+        configurable: true,
+        enumerable: true,
+      });
+    } else {
+      // A chunk has no \`source\` at all, so reading one would throw — which is
+      // what makes the type guard, not the extension guard, testable.
+      output.code = spec.source;
+    }
+    bundle[fileName] = output;
+  }
+
+  const warns = [];
+  const infos = [];
+  const plugin = woff2OnlyFonts();
+  let error = null;
+  try {
+    plugin.generateBundle.call(
+      { warn: m => warns.push(String(m)), info: m => infos.push(String(m)) },
+      {},
+      bundle,
+    );
+  } catch (e) {
+    error = e.message;
+  }
+
+  const outputs = {};
+  for (const [fileName, output] of Object.entries(bundle)) {
+    const source = output.type === 'asset' ? output.source : output.code;
+    outputs[fileName] = {
+      type: output.type,
+      assigned: assigned[fileName] ?? false,
+      isString: typeof source === 'string',
+      text: typeof source === 'string' ? source : Buffer.from(source).toString('utf8'),
+    };
+  }
+
+  results[scenario.name] = {
+    outputs,
+    warns,
+    infos,
+    error,
+    meta: { name: plugin.name, enforce: plugin.enforce, apply: plugin.apply },
+  };
+}
+
+process.stdout.write(JSON.stringify(results));
+`;
+
+/** A face offering only pre-woff2 formats, so the skip-and-warn path runs. */
+const LEGACY_ONLY_FACE = '@font-face{font-family:Legacy;'
+  + `src:url(data:font/woff;base64,${DATA}) format("woff"),`
+  + `url(data:font/ttf;base64,${DATA}) format("truetype")}`;
+
+/** Already woff2-only, so there is nothing for the hook to rewrite. */
+const ALREADY_TRIMMED = '@font-face{font-family:Trim;'
+  + `src:url(data:font/woff2;base64,${DATA}) format("woff2")}`;
+
+const SCENARIOS: { name: string; bundle: Record<string, BundleEntrySpec> }[] = [
+  {
+    name: 'string-source',
+    bundle: { 'maidr.css': { type: 'asset', source: katexFace('KaTeX_Main') } },
+  },
+  {
+    name: 'bytes-source',
+    bundle: {
+      'maidr.css': { type: 'asset', source: katexFace('KaTeX_Main'), encoding: 'bytes' },
+    },
+  },
+  {
+    name: 'mixed-bundle',
+    bundle: {
+      'maidr.css': { type: 'asset', source: katexFace('KaTeX_Main') },
+      'logo.svg': { type: 'asset', source: '<svg role="img"></svg>' },
+      'maidr.js': { type: 'chunk', source: 'export const a = 1;' },
+      // Named .css but emitted as a chunk: only the `type` check saves it.
+      'inlined.css': { type: 'chunk', source: 'export const css = 1;' },
+    },
+  },
+  {
+    name: 'no-woff2',
+    bundle: { 'maidr.css': { type: 'asset', source: LEGACY_ONLY_FACE } },
+  },
+  {
+    name: 'nothing-to-rewrite',
+    bundle: { 'maidr.css': { type: 'asset', source: ALREADY_TRIMMED } },
+  },
+];
+
+describe('woff2OnlyFonts generateBundle', () => {
+  let results: Record<string, ScenarioResult>;
+
+  beforeAll(() => {
+    const stdout = execFileSync('node', ['--input-type=module', '-e', PLUGIN_RUNNER], {
+      env: { ...process.env, FIXTURE_SCENARIOS: JSON.stringify(SCENARIOS) },
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    results = JSON.parse(stdout) as Record<string, ScenarioResult>;
+  });
+
+  it('runs after vite:css-post, on build only', () => {
+    // enforce:'post' is load-bearing — the CSS asset does not exist in the
+    // bundle until vite:css-post has assembled it.
+    expect(results['string-source'].meta).toEqual({
+      name: 'maidr:woff2-only-fonts',
+      enforce: 'post',
+      apply: 'build',
+    });
+  });
+
+  it('rewrites a css asset whose source is a string', () => {
+    const { outputs, warns, error } = results['string-source'];
+    const css = outputs['maidr.css'];
+
+    expect(error).toBeNull();
+    expect(warns).toEqual([]);
+    expect(css.assigned).toBe(true);
+    expect(css.isString).toBe(true);
+    expect(css.text).toContain('font/woff2');
+    expect(css.text).not.toContain('font/ttf');
+    expect(css.text).not.toContain('font/woff;');
+  });
+
+  it('decodes and rewrites a css asset whose source is bytes', () => {
+    const { outputs, error } = results['bytes-source'];
+    const css = outputs['maidr.css'];
+
+    expect(error).toBeNull();
+    expect(css.assigned).toBe(true);
+    expect(css.text).toBe(results['string-source'].outputs['maidr.css'].text);
+    // Rollup accepts either, and the hook writes back the transformed string.
+    expect(css.isString).toBe(true);
+  });
+
+  it('leaves non-css assets and chunks alone', () => {
+    const { outputs, error } = results['mixed-bundle'];
+
+    expect(error).toBeNull();
+    expect(outputs['maidr.css'].assigned).toBe(true);
+    expect(outputs['logo.svg'].assigned).toBe(false);
+    expect(outputs['logo.svg'].text).toBe('<svg role="img"></svg>');
+    expect(outputs['maidr.js'].text).toBe('export const a = 1;');
+    expect(outputs['inlined.css'].text).toBe('export const css = 1;');
+  });
+
+  it('warns and leaves the source intact when no face offers woff2', () => {
+    const { outputs, warns, infos, error } = results['no-woff2'];
+
+    expect(error).toBeNull();
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('maidr.css');
+    expect(warns[0]).toContain('no woff2 source');
+    expect(outputs['maidr.css'].assigned).toBe(false);
+    expect(outputs['maidr.css'].text).toBe(LEGACY_ONLY_FACE);
+    expect(infos).toEqual([]);
+  });
+
+  it('does not touch the asset when there is nothing to rewrite', () => {
+    const { outputs, warns, infos, error } = results['nothing-to-rewrite'];
+
+    expect(error).toBeNull();
+    expect(outputs['maidr.css'].assigned).toBe(false);
+    expect(outputs['maidr.css'].text).toBe(ALREADY_TRIMMED);
+    expect(infos).toEqual([]);
+    expect(warns).toEqual([]);
+  });
+
+  it('reports a saving that matches the actual byte delta', () => {
+    const { infos } = results['string-source'];
+    const before = Buffer.byteLength(katexFace('KaTeX_Main'));
+    const after = Buffer.byteLength(results['string-source'].outputs['maidr.css'].text);
+
+    expect(infos).toHaveLength(1);
+    expect(infos[0]).toContain('maidr.css');
+    expect(infos[0]).toContain('1 @font-face');
+    expect(after).toBeLessThan(before);
+    expect(infos[0]).toContain(`saving ${((before - after) / 1024).toFixed(1)} kB`);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,13 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { woff2OnlyFonts } from './scripts/vite-plugin-woff2-only.js';
 
 export default defineConfig({
-  plugins: [react()],
+  // woff2OnlyFonts must stay in step with scripts/build.js, which is what
+  // `npm run build` runs — otherwise a build driven from this config emits a
+  // maidr.css that differs from the published one.
+  plugins: [react(), woff2OnlyFonts()],
   build: {
     lib: {
       entry: path.resolve(__dirname, 'src/index.tsx'),


### PR DESCRIPTION
Two related bundle-size fixes.

## 1. `dist/maidr.css`: 1,425 KB → 359 KB

`src/ui/components/TypingEffect.tsx` imports `katex/dist/katex.min.css` so LaTeX in AI chat responses renders, and Vite's library mode inlines the fonts that stylesheet references as base64 data URIs. KaTeX declares each of its 20 faces with three alternatives:

```css
src:url(fonts/KaTeX_AMS-Regular.woff2) format("woff2"),
    url(fonts/KaTeX_AMS-Regular.woff)  format("woff"),
    url(fonts/KaTeX_AMS-Regular.ttf)   format("truetype")
```

So every glyph set shipped three times. 1,402 KB of the 1,425 KB file was font data — MAIDR's own styling is only ~23 KB of it:

| inlined format | before |
|---|---|
| `font/ttf` | 669 KB |
| `font/woff` | 395 KB |
| `font/woff2` | 338 KB |

A browser picks exactly one alternative per face, and woff2 has been baseline since Chrome 36, Safari 12, Firefox 39 and Edge 14 — so the woff and ttf copies were pure duplication.

**Result:** `dist/maidr.css` goes from **1,458,693 B (1424.5 KiB)** to **367,893 B (359.3 KiB)** — a 74.8% reduction, 1,065 KiB off every page that loads MAIDR's stylesheet. Gzipped: 264 KB.

### How

`scripts/vite-plugin-woff2-only.js` — a `generateBundle` transform over emitted CSS assets, not a vendored copy of KaTeX's stylesheet, so it stays correct across KaTeX upgrades.

Three things a naive implementation gets wrong, all pinned by tests:

- **Splitting a `src` list needs to be paren-aware.** An inlined `url(data:font/woff2;base64,...)` contains both a comma and a semicolon, so `value.split(',')` shreds it.
- **It needs to be comment-aware too.** A `;` or `:` inside a `/* ... */` would otherwise split a declaration in the wrong place. Minified output carries no comments today, so this was latent rather than live, but a change in minifier settings would surface it silently. `splitTopLevel` now steps over comments wholesale, and classification runs against a comment-stripped copy so a commented-out `format("woff2")` cannot make a legacy source look current. Comments are only ignored for *inspection* — the original text, comments included, is what gets emitted.
- **A face must never end up without a source.** The transform only trims a face that actually offers a woff2 alternative; a face without one is left untouched (and reported via `this.warn`) rather than emptied. It also throws outright rather than emit an empty `src`. A future KaTeX that drops woff2 from some face would grow the bundle back rather than break maths rendering.

`local(...)` alternatives, and any source the transform does not positively recognise as a pre-woff2 font, are preserved. A comment hiding a closing brace, or an unterminated comment, degrades to "no change" rather than emitting half a rule.

Deliberately **not** switching to postcss — pulling in a parser is a much larger change than this PR should carry.

The plugin is registered in the shared `createViteConfig` factory in `scripts/build.js`, unconditionally — 11 of the 12 bundles emit a byte-identical `maidr.css`, and `runParallel`'s merge step fails with `Merge collision` if they diverge. It is mirrored in `vite.config.ts` so a build driven from either config agrees.

## 2. Dead `rehype-mathjax` dependency removed

`rehype-mathjax` was the original renderer for chat LaTeX (`import rehypeMathjax from 'rehype-mathjax/svg'`), replaced by `rehype-katex` in #433. The dependency was never cleaned up — it is imported nowhere in `src/`, `examples/`, `scripts/` or any config file (re-verified by grep across the repo; the only hit was the `package.json` line itself).

KaTeX is also the more accessible of the two: the removed SVG mode emitted `<svg role="img" focusable="false">` with no MathML and no accessible name, where KaTeX emits real hidden MathML alongside the visual output. So KaTeX stays.

Removing it prunes 10 packages from the install tree (`mathjax-full`, `speech-rule-engine`, `mj-context-menu`, `mhchemparser`, `@types/mathjax`, …). `rehype-katex`, `remark-math`, `rehype-sanitize` and `remark-gfm` are untouched.

`package-lock.json` is updated to match. **Correcting an earlier claim in this PR description and in the review: this repo *does* track a lockfile, and the release workflow does not regenerate it** — its `rm -f package-lock.json` only deletes the file on the CI runner before `npm install`, and nothing commits one back. Leaving `package.json` and the lockfile disagreeing would have meant (a) the next `npm install` dragging an unrelated lockfile diff into someone else's commit and (b) `npm audit`/Dependabot continuing to scan `mathjax-full`, `speech-rule-engine` and friends for a dependency the project no longer has. Local `npm audit` goes from 32 findings to 30.

The lockfile diff was kept to exactly the intended change, verified programmatically — **0 packages added, 0 version changes, 0 dependency ranges touched**:

- **10 entries removed:** `rehype-mathjax@5.0.0`, `mathjax-full@3.2.1`, `speech-rule-engine@4.1.3` (+ its pinned `commander@13.1.0`), `mj-context-menu@0.6.1`, `mhchemparser@4.2.1`, `esm@3.2.25`, `@xmldom/xmldom@0.9.9`, `wicked-good-xpath@1.3.0`, `@types/mathjax@0.0.37`.
- **51 packages reclassified `dev: true`.** `rehype-mathjax` depended on `jsdom@^22`, so jsdom and its tree (`tough-cookie`, `whatwg-url`, `ws`, `saxes`, …) were reachable from a *production* dependency; they are now reachable only through the jest devDependencies. That is the point of the change, not churn.
- **Two npm-11.7.0 artifacts reverted**, since both reproduce when regenerating from an unmodified `main` and so are unrelated to this PR: bumping the lock's own `version` 3.74.0 → 3.75.0 (it trails because the release workflow deletes the file), and dropping the `libc` field from 21 optional linux binaries.

`npm ci` reinstalls cleanly from the committed result and leaves the file byte-identical.

## Explicitly out of scope

**Splitting KaTeX out of the default stylesheet, or loading it lazily, is intentionally left to a follow-up PR.** This change only removes redundancy from what already ships — the remaining 359 KB is the single woff2 copy of each face, still eagerly loaded.

## Verification

- `node scripts/build.js core` — succeeds.
- `node scripts/build.js` (all 12 bundles) — succeeds in 235 s, **zero** `Merge collision`, all emissions of `maidr.css` identical at 367.89 kB, zero plugin warnings.
- Programmatic assertions on the rebuilt `dist/maidr.css`: 367,893 B; 20 `@font-face` blocks; exactly **one** `src` source per face, all 20 `format("woff2")` with a `data:font/woff2` URI; **0** `font/ttf`, **0** `font/woff`, 0 other font data URIs, 0 unresolved font urls.
- Browser check (Playwright/Chromium, page linking the rebuilt CSS with a rendered KaTeX fraction): the browser parses 20 `CSSFontFaceRule`s, and for all 20 exact `(family, style, weight)` triples `await document.fonts.load(...)` resolves to one face and `document.fonts.check(...)` is `true`. Zero failures; the only console error is a favicon 404.
- `npm run type-check` — clean.
- `npx jest --coverage=false` — **97 suites / 1222 tests, all passing**, including 13 new cases for the transform. (`test/adapters/recharts/panelDom.test.ts` passes; the `recharts` devDependency is installed.)
- `npm ci` — reinstalls cleanly from the committed lockfile and leaves it byte-identical.
- `npx eslint` on all changed files — clean, also with `CI=true` (which enables the rules antfu's config relaxes in-editor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
