### PR TITLE
test(e2e): restore the e2e suite to green and run all of chromium on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
   # chromium suite is green, so it all runs here — a subset let the specs rot
   # for two months while PRs stayed green (see issue #626). The other two
   # browsers stay on the scheduled e2e workflows.
-  e2e-smoke:
+  e2e-chromium:
     name: E2E (chromium)
     runs-on: ubuntu-latest
     needs: [commitlint, lint]
@@ -109,7 +109,7 @@ jobs:
         run: node scripts/build.js core
 
       - name: Run e2e specs
-        id: smoke
+        id: e2e
         run: npx playwright test --config=e2e_tests/config/test-config.ts --project=chromium
         env:
           CI: true
@@ -119,10 +119,10 @@ jobs:
       # Scoped to the test step so an earlier failure (npm ci, browser
       # install) doesn't trigger an upload with nothing to upload.
       - name: Upload Playwright report on failure
-        if: failure() && steps.smoke.outcome == 'failure'
+        if: failure() && steps.e2e.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-smoke-report
+          name: e2e-chromium-report
           path: |
             playwright-report/
             test-results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,15 @@ jobs:
       - name: Run linter
         run: npm run lint
 
-  # Fast Playwright smoke on every PR: chromium only, core bundle only, and
-  # only the specs kept deliberately green. The full 3-browser suite stays on
-  # the scheduled e2e workflows; extend the spec list here as more specs are
-  # verified healthy.
+  # Playwright on every PR: chromium only, core bundle only. The whole
+  # chromium suite is green, so it all runs here — a subset let the specs rot
+  # for two months while PRs stayed green (see issue #626). The other two
+  # browsers stay on the scheduled e2e workflows.
   e2e-smoke:
-    name: E2E Smoke (chromium)
+    name: E2E (chromium)
     runs-on: ubuntu-latest
     needs: [commitlint, lint]
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     permissions:
       contents: read
@@ -108,13 +108,13 @@ jobs:
       - name: Build core bundle
         run: node scripts/build.js core
 
-      - name: Run smoke specs
+      - name: Run e2e specs
         id: smoke
-        run: npx playwright test --config=e2e_tests/config/test-config.ts --project=chromium liveData.spec.ts dialogAccessibility.spec.ts
+        run: npx playwright test --config=e2e_tests/config/test-config.ts --project=chromium
         env:
           CI: true
 
-      # The smoke specs are kept green, so a failure here is a real
+      # The chromium suite is kept green, so a failure here is a real
       # regression — ship the report and screenshots with the PR run.
       # Scoped to the test step so an earlier failure (npm ci, browser
       # install) doesn't trigger an upload with nothing to upload.

--- a/e2e_tests/page-objects/plots/multiLayer-page.ts
+++ b/e2e_tests/page-objects/plots/multiLayer-page.ts
@@ -38,7 +38,7 @@ export class MultiLayerPlotPage extends BasePage {
    */
   public async navigateToMultiLayerPlot(): Promise<void> {
     try {
-      await super.navigateTo('examples/multiLayer_plot.html');
+      await super.navigateTo('examples/multilayer_plot.html');
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {
       throw new MultiLayerPlotError('Failed to navigate to Multi Layer Plot');

--- a/e2e_tests/specs/barplot.spec.ts
+++ b/e2e_tests/specs/barplot.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { BarPlotPage } from '../page-objects/plots/barplot-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a Bar Plot page
@@ -82,26 +83,7 @@ test.describe('Bar Plot', () => {
       await barPlotPage.navigateToBarPlot();
       await page.waitForSelector(`svg#${TestConstants.BAR_ID}`, { timeout: 10000 });
 
-      maidrData = await page.evaluate((plotId) => {
-        const svgElement = document.querySelector(`svg#${plotId}`);
-
-        if (!svgElement) {
-          throw new Error(`SVG element with ID ${plotId} not found`);
-        }
-
-        const maidrDataAttr = svgElement.getAttribute('maidr-data');
-
-        if (!maidrDataAttr) {
-          throw new Error('maidr-data attribute not found on SVG element');
-        }
-
-        try {
-          return JSON.parse(maidrDataAttr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-        }
-      }, TestConstants.BAR_ID);
+      maidrData = await extractMaidrData(page);
 
       barLayer = maidrData.subplots[0][0].layers[0];
       dataLength = getBarPlotDataLength(barLayer);

--- a/e2e_tests/specs/boxplotHorizontal.spec.ts
+++ b/e2e_tests/specs/boxplotHorizontal.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { BoxplotHorizontalPage } from '../page-objects/plots/boxplotHorizontal-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a boxplot horizontal page
@@ -19,34 +20,6 @@ async function setupBoxplotHorizontalPage(
     await boxplotHorizontalPage.activateMaidr();
   }
   return boxplotHorizontalPage;
-}
-
-/**
- * Helper function to extract MAIDR data from the page
- * @param page - The Playwright page
- * @param plotId - The ID of the plot to extract data from
- * @returns The extracted MAIDR data
- * @throws Error if data extraction fails
- */
-async function extractMaidrData(page: Page, plotId: string): Promise<Maidr> {
-  return await page.evaluate((id) => {
-    const svgElement = document.querySelector(`svg`);
-    if (!svgElement) {
-      throw new Error(`SVG element with ID ${id} not found`);
-    }
-
-    const maidrDataAttr = svgElement.getAttribute('maidr-data');
-    if (!maidrDataAttr) {
-      throw new Error('maidr-data attribute not found on SVG element');
-    }
-
-    try {
-      return JSON.parse(maidrDataAttr);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-    }
-  }, plotId);
 }
 
 /**
@@ -112,7 +85,7 @@ test.describe('Boxplot Horizontal', () => {
       await boxplotHorizontalPage.navigateToBoxplotHorizontal();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await extractMaidrData(page, TestConstants.BOXPLOT_HORIZONTAL_ID);
+      maidrData = await extractMaidrData(page);
       boxplotHorizontalLayer = maidrData.subplots[0][0].layers[0];
       dataLength = getBoxplotHorizontalDataLength(boxplotHorizontalLayer);
     } catch (error) {

--- a/e2e_tests/specs/boxplotHorizontal.spec.ts
+++ b/e2e_tests/specs/boxplotHorizontal.spec.ts
@@ -44,13 +44,13 @@ function getBoxplotHorizontalDisplayValue(layer: MaidrLayer | undefined, index: 
 
   const boxPoint = layer.data[index];
 
-  if (!boxPoint || !('fill' in boxPoint)) {
+  if (!boxPoint || !('z' in boxPoint)) {
     throw new Error(`Data point at index ${index} has invalid format`);
   }
 
-  // For boxplot, the 'fill' property represents the category label (e.g., 'Africa', 'Americas')
-  // This is what appears in the UI text during navigation
-  return String(boxPoint.fill);
+  // `BoxPoint.z` carries the category label (e.g. 'Group 1'), which is what
+  // MAIDR announces during navigation.
+  return String(boxPoint.z);
 }
 
 /**

--- a/e2e_tests/specs/boxplotVertical.spec.ts
+++ b/e2e_tests/specs/boxplotVertical.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { BoxplotVerticalPage } from '../page-objects/plots/boxplotVertical-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a boxplot vertical page
@@ -19,34 +20,6 @@ async function setupBoxplotVerticalPage(
     await boxplotVerticalPage.activateMaidr();
   }
   return boxplotVerticalPage;
-}
-
-/**
- * Helper function to extract MAIDR data from the page
- * @param page - The Playwright page
- * @param plotId - The ID of the plot to extract data from
- * @returns The extracted MAIDR data
- * @throws Error if data extraction fails
- */
-async function extractMaidrData(page: Page, plotId: string): Promise<Maidr> {
-  return await page.evaluate((id) => {
-    const svgElement = document.querySelector(`svg`);
-    if (!svgElement) {
-      throw new Error(`SVG element with ID ${id} not found`);
-    }
-
-    const maidrDataAttr = svgElement.getAttribute('maidr-data');
-    if (!maidrDataAttr) {
-      throw new Error('maidr-data attribute not found on SVG element');
-    }
-
-    try {
-      return JSON.parse(maidrDataAttr);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-    }
-  }, plotId);
 }
 
 /**
@@ -111,7 +84,7 @@ test.describe('Boxplot Vertical', () => {
       await boxplotVerticalPage.navigateToBoxplotVertical();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await extractMaidrData(page, TestConstants.BOXPLOT_VERTICAL_ID);
+      maidrData = await extractMaidrData(page);
       boxplotVerticalLayer = maidrData.subplots[0][0].layers[0];
       dataLength = getBoxplotVerticalDataLength(boxplotVerticalLayer);
     } catch (error) {

--- a/e2e_tests/specs/boxplotVertical.spec.ts
+++ b/e2e_tests/specs/boxplotVertical.spec.ts
@@ -44,12 +44,13 @@ function getBoxplotVerticalDisplayValue(layer: MaidrLayer | undefined, index: nu
 
   const boxPoint = layer.data[index];
 
-  if (!boxPoint || !('fill' in boxPoint)) {
+  if (!boxPoint || !('z' in boxPoint)) {
     throw new Error(`Data point at index ${index} has invalid format`);
   }
 
-  // For boxplot, the 'fill' property represents the category label (like '2seater', 'compact', etc.)
-  return String(boxPoint.fill);
+  // `BoxPoint.z` carries the category label (e.g. 'Group 1'), which is what
+  // MAIDR announces during navigation.
+  return String(boxPoint.z);
 }
 
 /**

--- a/e2e_tests/specs/dodgedBarplot.spec.ts
+++ b/e2e_tests/specs/dodgedBarplot.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { DodgedBarplotPage } from '../page-objects/plots/dodgedBarplot-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 interface DodgedBarDataPoint {
   x: string;
@@ -130,26 +131,7 @@ test.describe('Dodged Barplot', () => {
       await dodgedBarplotPage.navigateToDodgedBarplot();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await page.evaluate((plotId) => {
-        const svgElement = document.querySelector(`svg`);
-
-        if (!svgElement) {
-          throw new Error(`SVG element with ID ${plotId} not found`);
-        }
-
-        const maidrDataAttr = svgElement.getAttribute('maidr-data');
-
-        if (!maidrDataAttr) {
-          throw new Error('maidr-data attribute not found on SVG element');
-        }
-
-        try {
-          return JSON.parse(maidrDataAttr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-        }
-      }, TestConstants.DODGED_BARPLOT_ID);
+      maidrData = await extractMaidrData(page);
 
       dodgedBarplotLayer = maidrData.subplots[0][0].layers[0];
       dataLength = getDodgedBarplotDataLength(dodgedBarplotLayer);

--- a/e2e_tests/specs/heatmap.spec.ts
+++ b/e2e_tests/specs/heatmap.spec.ts
@@ -3,6 +3,7 @@ import type { HeatmapData, Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { HeatmapPage } from '../page-objects/plots/heatmap-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a heatmap page
@@ -21,34 +22,6 @@ async function setupHeatmapPage(
   return heatmapPage;
 }
 
-/**
- * Helper function to extract MAIDR data from the page
- * @param page - The Playwright page
- * @param plotId - The ID of the plot to extract data from
- * @returns The extracted MAIDR data
- * @throws Error if data extraction fails
- */
-async function extractMaidrData(page: Page, plotId: string): Promise<Maidr> {
-  return await page.evaluate((id) => {
-    const svgElement = document.querySelector(`svg`);
-    if (!svgElement) {
-      throw new Error(`SVG element with ID ${id} not found`);
-    }
-
-    const maidrDataAttr = svgElement.getAttribute('maidr-data');
-    if (!maidrDataAttr) {
-      throw new Error('maidr-data attribute not found on SVG element');
-    }
-
-    try {
-      return JSON.parse(maidrDataAttr);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-    }
-  }, plotId);
-}
-
 test.describe('Heatmap', () => {
   let maidrData: Maidr;
   let heatmapLayer: MaidrLayer;
@@ -63,7 +36,7 @@ test.describe('Heatmap', () => {
       await heatmapPage.navigateToHeatmap();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await extractMaidrData(page, TestConstants.HEATMAP_ID);
+      maidrData = await extractMaidrData(page);
       heatmapLayer = maidrData.subplots[0][0].layers[0];
       heatmapData = heatmapLayer.data as HeatmapData;
     } catch (error) {

--- a/e2e_tests/specs/histogram.spec.ts
+++ b/e2e_tests/specs/histogram.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { HistogramPage } from '../page-objects/plots/histogram-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a histogram page
@@ -66,26 +67,7 @@ test.describe('Histogram', () => {
       await histogramPage.navigateToHistogram();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await page.evaluate((plotId) => {
-        const svgElement = document.querySelector(`svg`);
-
-        if (!svgElement) {
-          throw new Error(`SVG element with ID ${plotId} not found`);
-        }
-
-        const maidrDataAttr = svgElement.getAttribute('maidr-data');
-
-        if (!maidrDataAttr) {
-          throw new Error('maidr-data attribute not found on SVG element');
-        }
-
-        try {
-          return JSON.parse(maidrDataAttr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-        }
-      }, TestConstants.HISTOGRAM_ID);
+      maidrData = await extractMaidrData(page);
 
       histogramLayer = maidrData.subplots[0][0].layers[0];
       dataLength = (histogramLayer.data as { x: string; y: number }[]).length;

--- a/e2e_tests/specs/lineplot.spec.ts
+++ b/e2e_tests/specs/lineplot.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { LinePlotPage } from '../page-objects/plots/lineplot-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a lineplot page
@@ -93,26 +94,7 @@ test.describe('Line Plot', () => {
       await linePlotPage.navigateToLinePlot();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await page.evaluate((plotId) => {
-        const svgElement = document.querySelector(`svg`);
-
-        if (!svgElement) {
-          throw new Error(`SVG element with ID ${plotId} not found`);
-        }
-
-        const maidrDataAttr = svgElement.getAttribute('maidr-data');
-
-        if (!maidrDataAttr) {
-          throw new Error('maidr-data attribute not found on SVG element');
-        }
-
-        try {
-          return JSON.parse(maidrDataAttr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-        }
-      }, TestConstants.LINEPLOT_ID);
+      maidrData = await extractMaidrData(page);
 
       linePlotLayer = maidrData.subplots[0][0].layers[0];
       dataLength = getLinePlotDataLength(linePlotLayer);

--- a/e2e_tests/specs/multiLayer.spec.ts
+++ b/e2e_tests/specs/multiLayer.spec.ts
@@ -104,7 +104,10 @@ test.describe('Multi Layer Plot', () => {
       });
       test('should switch to first layer', async ({ page }) => {
         const multiLayerPlotPage = await setupMultiLayerPlotPage(page);
+        // Leave layer 1 before returning to it, so the assertion proves the
+        // switch happened rather than that nothing moved.
         await multiLayerPlotPage.switchToUpperLayer();
+        await multiLayerPlotPage.switchToLowerLayer();
         const currentLayer = await multiLayerPlotPage.getCurrentLayerInfo();
         expect(currentLayer).toContain(TestConstants.MULTI_LAYER_FIRST_LAYER);
       });
@@ -333,7 +336,10 @@ test.describe('Multi Layer Plot', () => {
   test.describe('Layer Switching', () => {
     test('should switch to first layer', async ({ page }) => {
       const multiLayerPlotPage = await setupMultiLayerPlotPage(page);
+      // Leave layer 1 before returning to it, so the assertion proves the
+      // switch happened rather than that nothing moved.
       await multiLayerPlotPage.switchToUpperLayer();
+      await multiLayerPlotPage.switchToLowerLayer();
       const currentLayer = await multiLayerPlotPage.getCurrentLayerInfo();
       expect(currentLayer).toContain(TestConstants.MULTI_LAYER_FIRST_LAYER);
     });
@@ -347,7 +353,8 @@ test.describe('Multi Layer Plot', () => {
      */
     async function setupSecondLayerTest(page: Page): Promise<MultiLayerPlotPage> {
       const multiLayerPlotPage = await setupMultiLayerPlotPage(page);
-      await multiLayerPlotPage.switchToUpperLayer();
+      // The plot opens on layer 1, so a single Page Up reaches layer 2. A
+      // second press is already at the top and reports "No additional layer".
       await multiLayerPlotPage.switchToUpperLayer();
       const currentLayer = await multiLayerPlotPage.getCurrentLayerInfo();
       expect(currentLayer).toContain(TestConstants.MULTI_LAYER_SECOND_LAYER);
@@ -373,9 +380,8 @@ test.describe('Multi Layer Plot', () => {
 
       test('should switch to bottom layer', async ({ page }) => {
         const multiLayerPlotPage = await setupMultiLayerPlotPage(page);
-        await multiLayerPlotPage.switchToUpperLayer(); // switching to first layer
-        await multiLayerPlotPage.switchToUpperLayer(); // switching to second layer
-        await multiLayerPlotPage.switchToLowerLayer(); // switch to first layer
+        await multiLayerPlotPage.switchToUpperLayer(); // layer 1 -> layer 2
+        await multiLayerPlotPage.switchToLowerLayer(); // layer 2 -> layer 1
         const currentLayer = await multiLayerPlotPage.getCurrentLayerInfo();
         expect(currentLayer).toContain(TestConstants.MULTI_LAYER_FIRST_LAYER);
       });

--- a/e2e_tests/specs/multiLayer.spec.ts
+++ b/e2e_tests/specs/multiLayer.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { MultiLayerPlotPage } from '../page-objects/plots/multiLayer-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a Multi Layer plot page
@@ -66,26 +67,7 @@ test.describe('Multi Layer Plot', () => {
       await multiLayerPlotPage.navigateToMultiLayerPlot();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await page.evaluate((plotId) => {
-        const svgElement = document.querySelector(`svg`);
-
-        if (!svgElement) {
-          throw new Error(`SVG element with ID ${plotId} not found`);
-        }
-
-        const maidrDataAttr = svgElement.getAttribute('maidr-data');
-
-        if (!maidrDataAttr) {
-          throw new Error('maidr-data attribute not found on SVG element');
-        }
-
-        try {
-          return JSON.parse(maidrDataAttr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-        }
-      }, TestConstants.MULTI_LAYER_PLOT_ID);
+      maidrData = await extractMaidrData(page);
 
       multiLayerPlotLayer = maidrData.subplots[0][0].layers[0];
       dataLength = (multiLayerPlotLayer.data as { x: string; y: number }[]).length;

--- a/e2e_tests/specs/multiLineplot.spec.ts
+++ b/e2e_tests/specs/multiLineplot.spec.ts
@@ -395,8 +395,11 @@ test.describe('Multi Lineplot', () => {
       expect(targetCount).toBeGreaterThanOrEqual(2);
 
       // Check for intersection targets - they should contain "Intersection with"
+      // buildTargetDisplayLabel prefixes the kind, so labels read
+      // "Point intersection with …" / "Slope intersection with …" — match
+      // case-insensitively rather than on a leading capital.
       const allTargetTexts = await targets.allTextContents();
-      const intersectionTargets = allTargetTexts.filter(text => text.includes('Intersection'));
+      const intersectionTargets = allTargetTexts.filter(text => /intersection/i.test(text));
 
       // The multi-lineplot example has 3 lines that should have intersections
       // At least some intersections should be found
@@ -415,7 +418,7 @@ test.describe('Multi Lineplot', () => {
 
       // Find an intersection target
       const intersectionTarget = dialog.locator('[role="option"]').filter({
-        hasText: /Intersection/,
+        hasText: /intersection/i,
       }).first();
 
       // Ensure intersection targets exist in the test data
@@ -461,7 +464,7 @@ test.describe('Multi Lineplot', () => {
 
       // Get intersection targets
       const intersectionTargets = dialog.locator('[role="option"]').filter({
-        hasText: /Intersection/,
+        hasText: /intersection/i,
       });
 
       // All intersection targets should mention other lines (not just current)
@@ -502,27 +505,33 @@ test.describe('Multi Lineplot', () => {
       await setupMultiLineplotPage(page);
 
       await cycleRotorTo(page, 'INTERSECTING POINT NAVIGATION');
-      const rotorArea = page.locator('#maidr-rotor-area');
+      // Bound and unavailable messages are announced through the text alert
+      // region. The rotor area only carries the mode name and is cleared on
+      // each move, so asserting on it here never sees the message.
+      const textContainer = page.locator('#maidr-text-container');
 
-      // The example data has no point intersections, so arrow keys must route
-      // through intersection mode and land on the boundary message — proving
-      // the key was handled by the rotor service (not a no-op / crash).
-      await page.keyboard.press('ArrowRight');
-      await expect(rotorArea).toContainText(/No intersection.*right/i, { timeout: 2000 });
-
+      // The example's only point intersection is where all three series meet
+      // at (x=8, y=8), so Left from the starting column has nothing to land on
+      // — proving the key was handled by the rotor service (not a no-op).
       await page.keyboard.press('ArrowLeft');
-      await expect(rotorArea).toContainText(/No intersection.*left/i, { timeout: 2000 });
+      await expect(textContainer).toContainText(/No intersection.*left/i, { timeout: 2000 });
+
+      // Right reaches that intersection; a second Right runs out of them.
+      await page.keyboard.press('ArrowRight');
+      await page.keyboard.press('ArrowRight');
+      await expect(textContainer).toContainText(/No intersection.*right/i, { timeout: 2000 });
 
       // Up/Down in intersection mode should announce the vertical-unavailable
-      // message, not a directional bound.
+      // message, not a directional bound. The terse and verbose wordings differ
+      // by one word ("intersection mode" vs "intersection point mode").
       await page.keyboard.press('ArrowUp');
-      await expect(rotorArea).toContainText(/intersection mode/i, { timeout: 2000 });
+      await expect(textContainer).toContainText(/intersection (point )?mode/i, { timeout: 2000 });
     });
 
     test('should navigate to a real point intersection with ArrowRight', async ({ page }) => {
-      // Use a fixture that contains actual point intersections — all three
-      // lines in multiline_plot_intersection.html share the sampled point
-      // (x="3", y=4), so ArrowRight in intersection mode from col 0 lands
+      // Use a fixture that contains actual point intersections — Series 1 and
+      // Series 2 in multiline_plot_intersection.html share the sampled point
+      // (x="3", y=5), so ArrowRight in intersection mode from col 0 lands
       // there rather than hitting a boundary.
       //
       // Path note: the Playwright baseURL (e2e_tests/config/test-config.ts)
@@ -537,23 +546,22 @@ test.describe('Multi Lineplot', () => {
       // ArrowRight should actually move to the (3, 4) point intersection and
       // the text-output area should announce both coordinates. A regex that
       // binds the digits to their axis labels avoids false positives from
-      // incidental "3"s and "4"s in other parts of the description.
+      // incidental "3"s and "5"s in other parts of the description.
       const textContainer = page.locator('#maidr-text-container');
-      const rotorArea = page.locator('#maidr-rotor-area');
       await page.keyboard.press('ArrowRight');
       await expect(textContainer).toContainText(/x\D*3/i, { timeout: 2000 });
-      await expect(textContainer).toContainText(/y\D*4/i, { timeout: 2000 });
+      await expect(textContainer).toContainText(/y\D*5/i, { timeout: 2000 });
 
-      // Rotor area should not be announcing a bound message — movement succeeded.
-      await expect(rotorArea).not.toContainText(/No intersection/i);
+      // No bound message — movement succeeded.
+      await expect(textContainer).not.toContainText(/No intersection/i);
 
       // Vertical navigation must still announce the "unavailable" message even
       // when the fixture contains real intersections — confirms Up/Down don't
       // accidentally traverse between lines in intersection mode.
       await page.keyboard.press('ArrowUp');
-      await expect(rotorArea).toContainText(/intersection mode/i, { timeout: 2000 });
+      await expect(textContainer).toContainText(/intersection (point )?mode/i, { timeout: 2000 });
       await page.keyboard.press('ArrowDown');
-      await expect(rotorArea).toContainText(/intersection mode/i, { timeout: 2000 });
+      await expect(textContainer).toContainText(/intersection (point )?mode/i, { timeout: 2000 });
     });
   });
 });

--- a/e2e_tests/specs/multiLineplot.spec.ts
+++ b/e2e_tests/specs/multiLineplot.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { MultiLineplotPage } from '../page-objects/plots/multiLineplot-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a Multi Lineplot page
@@ -93,26 +94,7 @@ test.describe('Multi Lineplot', () => {
       await multiLineplotPage.navigateToLinePlot();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await page.evaluate((plotId) => {
-        const svgElement = document.querySelector(`svg`);
-
-        if (!svgElement) {
-          throw new Error(`SVG element with ID ${plotId} not found`);
-        }
-
-        const maidrDataAttr = svgElement.getAttribute('maidr-data');
-
-        if (!maidrDataAttr) {
-          throw new Error('maidr-data attribute not found on SVG element');
-        }
-
-        try {
-          return JSON.parse(maidrDataAttr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-        }
-      }, TestConstants.MULTI_LINEPLOT_ID);
+      maidrData = await extractMaidrData(page);
 
       multiLineplotLayer = maidrData.subplots[0][0].layers[0];
       dataLength = getLinePlotDataLength(multiLineplotLayer);

--- a/e2e_tests/specs/stackedBarplot.spec.ts
+++ b/e2e_tests/specs/stackedBarplot.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { StackedBarplotPage } from '../page-objects/plots/stackedBarplot-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a Stacked Barplot page
@@ -102,26 +103,7 @@ test.describe('Stacked Barplot', () => {
       await stackedBarplotPage.navigateToStackedBarplot();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await page.evaluate((plotId) => {
-        const svgElement = document.querySelector(`svg`);
-
-        if (!svgElement) {
-          throw new Error(`SVG element with ID ${plotId} not found`);
-        }
-
-        const maidrDataAttr = svgElement.getAttribute('maidr-data');
-
-        if (!maidrDataAttr) {
-          throw new Error('maidr-data attribute not found on SVG element');
-        }
-
-        try {
-          return JSON.parse(maidrDataAttr);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-        }
-      }, TestConstants.STACKED_BARPLOT_ID);
+      maidrData = await extractMaidrData(page);
 
       stackedBarplotLayer = maidrData.subplots[0][0].layers[0];
       dataLength = getStackedBarplotDataLength(stackedBarplotLayer);

--- a/e2e_tests/specs/violinPlot.spec.ts
+++ b/e2e_tests/specs/violinPlot.spec.ts
@@ -3,6 +3,7 @@ import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
 import { ViolinPlotPage } from '../page-objects/plots/violinPlot-page';
 import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
 
 /**
  * Helper function to create and initialize a violin plot page
@@ -21,34 +22,6 @@ async function setupViolinPlotPage(
   return violinPlotPage;
 }
 
-/**
- * Helper function to extract MAIDR data from the page
- * @param page - The Playwright page
- * @param plotId - The ID of the plot to extract data from
- * @returns The extracted MAIDR data
- * @throws Error if data extraction fails
- */
-async function extractMaidrData(page: Page, plotId: string): Promise<Maidr> {
-  return await page.evaluate((id) => {
-    const svgElement = document.querySelector(`svg`);
-    if (!svgElement) {
-      throw new Error(`SVG element with ID ${id} not found`);
-    }
-
-    const maidrDataAttr = svgElement.getAttribute('maidr-data');
-    if (!maidrDataAttr) {
-      throw new Error('maidr-data attribute not found on SVG element');
-    }
-
-    try {
-      return JSON.parse(maidrDataAttr);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to parse maidr-data JSON: ${errorMessage}`);
-    }
-  }, plotId);
-}
-
 test.describe('Violin Plot', () => {
   let maidrData: Maidr;
   // Layer references for potential future test expansion
@@ -64,7 +37,7 @@ test.describe('Violin Plot', () => {
       await violinPlotPage.navigateToViolinPlot();
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
-      maidrData = await extractMaidrData(page, TestConstants.VIOLIN_PLOT_ID);
+      maidrData = await extractMaidrData(page);
       // Violin plots have two layers: SMOOTH (KDE) and BOX
       const layers = maidrData.subplots[0][0].layers;
       _violinKdeLayer = layers.find(l => l.type === 'smooth') || layers[0];

--- a/e2e_tests/specs/violinPlot.spec.ts
+++ b/e2e_tests/specs/violinPlot.spec.ts
@@ -38,10 +38,10 @@ test.describe('Violin Plot', () => {
       await page.waitForSelector(`svg`, { timeout: 10000 });
 
       maidrData = await extractMaidrData(page);
-      // Violin plots have two layers: SMOOTH (KDE) and BOX
+      // Violin plots have two layers, each with its own trace type
       const layers = maidrData.subplots[0][0].layers;
-      _violinKdeLayer = layers.find(l => l.type === 'smooth') || layers[0];
-      _violinBoxLayer = layers.find(l => l.type === 'box') || layers[1];
+      _violinKdeLayer = layers.find(l => l.type === 'violin_kde') || layers[0];
+      _violinBoxLayer = layers.find(l => l.type === 'violin_box') || layers[1];
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('Failed to extract MAIDR data:', errorMessage);
@@ -77,8 +77,8 @@ test.describe('Violin Plot', () => {
     test('should have two layers (KDE and BOX)', async () => {
       const layers = maidrData.subplots[0][0].layers;
       expect(layers.length).toBe(2);
-      expect(layers.some(l => l.type === 'smooth')).toBe(true);
-      expect(layers.some(l => l.type === 'box')).toBe(true);
+      expect(layers.some(l => l.type === 'violin_kde')).toBe(true);
+      expect(layers.some(l => l.type === 'violin_box')).toBe(true);
     });
   });
 
@@ -137,7 +137,11 @@ test.describe('Violin Plot', () => {
     });
 
     test('should navigate along KDE curve with up/down arrows', async () => {
-      // Get initial position
+      // The first Up press steps off the instruction banner onto the lowest
+      // point. Round-tripping is a property of data points, so take that step
+      // before recording the starting position — otherwise the Down press
+      // walks off the bottom and reports out of bounds.
+      await violinPlotPage.moveUpKdeCurve();
       const initialInfo = await violinPlotPage.getCurrentDataPointInfo();
 
       // Move up along the curve

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -113,11 +113,15 @@ export abstract class TestConstants {
   static readonly LINEPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: single line. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  static readonly BOXPLOT_VERTICAL_INSTRUCTION_TEXT = 'This is a maidr plot of type: box. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  static readonly BOXPLOT_HORIZONTAL_INSTRUCTION_TEXT = 'This is a maidr plot of type: box. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // `formatPlotType` in src/model/context.ts prefixes the box type with its
+  // orientation, so a screen reader user hears which axis the boxes run along.
+  static readonly BOXPLOT_VERTICAL_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical box. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly BOXPLOT_HORIZONTAL_INSTRUCTION_TEXT = 'This is a maidr plot of type: horizontal box. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly MULTI_LINEPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: multiline with 3 groups. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly MULTI_LAYER_PLOT_INSTRUCTION_TEXT = 'This is a maidr plot containing 2 layers, and this is layer 1 of 2: bar plot. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  static readonly VIOLIN_PLOT_INSTRUCTION_TEXT = 'This is a maidr plot containing 2 layers, and this is layer 1 of 2: smooth plot. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // Violin layers are their own trace types (violin_kde / violin_box), not the
+  // smooth + box pair they used to be modelled as.
+  static readonly VIOLIN_PLOT_INSTRUCTION_TEXT = 'This is a maidr plot containing 2 layers, and this is layer 1 of 2: vertical violin_box plot. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
 
   /**
    * Text Modes

--- a/e2e_tests/utils/maidr-data.ts
+++ b/e2e_tests/utils/maidr-data.ts
@@ -1,0 +1,65 @@
+import type { Page } from '@playwright/test';
+import type { Maidr } from '../../src/type/grammar';
+
+/**
+ * The three ways an example page can hand MAIDR its schema, in the same
+ * precedence order `main()` in `src/index.tsx` resolves them.
+ *
+ * Keep this list in sync with the entry point: a spec that reads only one of
+ * them passes or fails on which mechanism its example happens to use, not on
+ * whether the product works.
+ */
+const SCHEMA_SOURCES = [
+  'the [maidr^="{"] attribute',
+  'the [maidr-data] attribute',
+  'the window.maidr global',
+] as const;
+
+/**
+ * Reads the MAIDR schema out of a loaded example page.
+ *
+ * Resolution mirrors `main()` in `src/index.tsx`: a JSON-shaped `maidr`
+ * attribute first, then a `maidr-data` attribute, then the `window.maidr`
+ * global. All three are supported inputs, and the examples are split across
+ * all three, so a spec must accept whichever one its page uses.
+ * @param page - The Playwright page, already navigated to the example
+ * @returns The parsed MAIDR schema
+ * @throws Error if no source carries a schema, or if the schema is not valid JSON
+ */
+export async function extractMaidrData(page: Page): Promise<Maidr> {
+  const result = await page.evaluate(() => {
+    // Mirrors Constant.MAIDR_JSON_SELECTOR — chart exports also stamp
+    // non-JSON `maidr="<uuid>"` attributes, which are not schemas.
+    const jsonAttrPlot = document.querySelector('[maidr^="{"]');
+    const jsonAttr = jsonAttrPlot?.getAttribute('maidr');
+    if (jsonAttr) {
+      return { json: jsonAttr, source: 'the [maidr^="{"] attribute' };
+    }
+
+    const dataAttrPlot = document.querySelector('[maidr-data]');
+    const dataAttr = dataAttrPlot?.getAttribute('maidr-data');
+    if (dataAttr) {
+      return { json: dataAttr, source: 'the [maidr-data] attribute' };
+    }
+
+    const globalMaidr = (window as Window & { maidr?: unknown }).maidr;
+    if (globalMaidr) {
+      return { json: JSON.stringify(globalMaidr), source: 'the window.maidr global' };
+    }
+
+    return null;
+  });
+
+  if (!result) {
+    throw new Error(
+      `No MAIDR schema found on the page. Looked for ${SCHEMA_SOURCES.join(', ')}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(result.json) as Maidr;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse the MAIDR schema from ${result.source}: ${errorMessage}`);
+  }
+}

--- a/e2e_tests/utils/maidr-data.ts
+++ b/e2e_tests/utils/maidr-data.ts
@@ -9,11 +9,11 @@ import type { Maidr } from '../../src/type/grammar';
  * them passes or fails on which mechanism its example happens to use, not on
  * whether the product works.
  */
-const SCHEMA_SOURCES = [
-  'the [maidr^="{"] attribute',
-  'the [maidr-data] attribute',
-  'the window.maidr global',
-] as const;
+const SCHEMA_SOURCES = {
+  jsonAttribute: 'the [maidr^="{"] attribute',
+  dataAttribute: 'the [maidr-data] attribute',
+  windowGlobal: 'the window.maidr global',
+} as const;
 
 /**
  * Reads the MAIDR schema out of a loaded example page.
@@ -27,32 +27,34 @@ const SCHEMA_SOURCES = [
  * @throws Error if no source carries a schema, or if the schema is not valid JSON
  */
 export async function extractMaidrData(page: Page): Promise<Maidr> {
-  const result = await page.evaluate(() => {
+  // The callback runs in the browser and cannot close over module bindings,
+  // so the labels are passed in rather than repeated on both sides.
+  const result = await page.evaluate((sources) => {
     // Mirrors Constant.MAIDR_JSON_SELECTOR — chart exports also stamp
     // non-JSON `maidr="<uuid>"` attributes, which are not schemas.
     const jsonAttrPlot = document.querySelector('[maidr^="{"]');
     const jsonAttr = jsonAttrPlot?.getAttribute('maidr');
     if (jsonAttr) {
-      return { json: jsonAttr, source: 'the [maidr^="{"] attribute' };
+      return { json: jsonAttr, source: sources.jsonAttribute };
     }
 
     const dataAttrPlot = document.querySelector('[maidr-data]');
     const dataAttr = dataAttrPlot?.getAttribute('maidr-data');
     if (dataAttr) {
-      return { json: dataAttr, source: 'the [maidr-data] attribute' };
+      return { json: dataAttr, source: sources.dataAttribute };
     }
 
     const globalMaidr = (window as Window & { maidr?: unknown }).maidr;
     if (globalMaidr) {
-      return { json: JSON.stringify(globalMaidr), source: 'the window.maidr global' };
+      return { json: JSON.stringify(globalMaidr), source: sources.windowGlobal };
     }
 
     return null;
-  });
+  }, SCHEMA_SOURCES);
 
   if (!result) {
     throw new Error(
-      `No MAIDR schema found on the page. Looked for ${SCHEMA_SOURCES.join(', ')}.`,
+      `No MAIDR schema found on the page. Looked for ${Object.values(SCHEMA_SOURCES).join(', ')}.`,
     );
   }
 


### PR DESCRIPTION
# Pull Request

## Description

Seven specs were failing in `beforeAll`. Because Playwright skips an entire `describe` block behind a failed hook, that also took out 185 more tests — **about 62% of the e2e suite was not executing**, and the failure count badly understated the loss. barplot, both boxplots, heatmap, multiLayer, multiLineplot and violin had no effective e2e coverage at all.

Baseline on `main`, chromium:

```
106 passed, 7 failed, 185 did not run   (298 total)
```

After this PR, chromium **and** firefox:

```
298 passed (0 failed, 0 skipped)
```

None of it was a product regression. Every failure was stale test code.

## Related Issues

Fixes #626

## Changes Made

Three commits, one root cause each.

### 1. `fix(e2e)` — resolve the maidr schema the way the library does

`extractMaidrData()` read only the `maidr-data` attribute. But `main()` in `src/index.tsx` accepts **three** inputs, in this order:

1. a JSON-shaped `maidr` attribute (`Constant.MAIDR_JSON_SELECTOR` = `[maidr^="{"]`)
2. a `maidr-data` attribute
3. the `window.maidr` global

The examples are split across all three, so a spec that read one of them passed or failed on which mechanism its example happened to use:

| example | mechanism | before |
|---|---|---|
| `dodged-barplot`, `stacked-barplot`, `lineplot`, `histogram`, `multilayer_plot` | `maidr-data="{…}"` | ✅ |
| `barplot`, `boxplot-horizontal`, `boxplot-vertical`, `heatmap` | `var maidr = {…}` global | ❌ |
| `violin`, `multi-lineplot` | `maidr="{…}"` | ❌ |

Since all three are supported product inputs, the test helper was the stale side. The eleven near-identical copies are replaced with one in `e2e_tests/utils/maidr-data.ts` that mirrors the entry point's resolution order (−257/+88 lines).

Separately, `multiLayer-page.ts` navigated to `examples/multiLayer_plot.html` while the file on disk is `multilayer_plot.html`. That resolves on a case-insensitive filesystem (macOS) and 404s on the Linux CI runner — which is why it reproduced on CI and not necessarily on a maintainer's laptop.

### 2. `test(e2e)` — update expectations that drifted while the specs were skipped

Unblocking the hooks surfaced 50 failures inside the previously-skipped blocks. Each was verified against the running product before being changed:

- **Boxplot category labels** come from `BoxPoint.z`. The helpers read `fill`, which `BoxPoint` has no such property for.
- **Boxplot instruction text** — `formatPlotType` in `src/model/context.ts` prefixes the orientation, so it reads `horizontal box` / `vertical box`. That is better for a screen reader user; the constants were stale.
- **Violin layers** are their own trace types (`violin_kde`, `violin_box`), no longer `smooth` + `box`.
- **Violin up/down round trip** started from the instruction banner rather than a data point, so the Down press correctly walked off the bottom and reported out of bounds. It now steps onto a point first, which is the property the test name claims.
- **Multi-layer switching** — the plot opens on layer 1, so `setupSecondLayerTest`'s second Page Up was already at the top and announced `No additional layer`. Likewise "switch to first layer" pressed Up and expected layer 1; returning to layer 1 means Up then Down.
- **Go To intersection targets** are labelled `Point intersection …` / `Slope intersection …`, so filtering on a capitalised `Intersection` matched nothing (Playwright's `hasText` regex is case-sensitive). The dialog was listing 11 targets the whole time.
- **Rotor bound messages** are announced through `#maidr-text-container`, not `#maidr-rotor-area` — the rotor area only carries the mode name and is cleared on each move. Also, `multi-lineplot.html` *does* contain a point intersection (all three series meet at `x=8, y=8`), and in `multiline_plot_intersection.html` it is Series 1 and Series 2 meeting at `(3, 5)`, not `(3, 4)`.

### 3. `ci` — run the whole chromium suite on pull requests

`ci.yml` ran only `liveData.spec.ts` and `dialogAccessibility.spec.ts` on PRs. Neither touches the broken specs, so PRs went green while the scheduled 3-browser workflow stayed red continuously for about two months. The job's own comment invited extending the list "as more specs are verified healthy" — they are now, so it runs the full chromium project, with the timeout raised 15 → 25 minutes. Firefox and WebKit stay on the scheduled workflows.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no user-facing behaviour changed.
- [ ] I have added appropriate unit tests, if applicable. — the change *is* test code; the new helper's coverage is the suite it unblocks.

## Additional Notes

Verification run on this branch:

| check | result |
|---|---|
| `npm run lint` | clean |
| `npm run type-check` | clean |
| `npm test` (jest) | 1240 passed, 98 suites |
| `npm run build` | succeeds |
| e2e — chromium | **298 passed, 0 failed** |
| e2e — firefox | **298 passed, 0 failed** |
| e2e — webkit | **not verified** |

WebKit could not be exercised here: its Playwright build needs system libraries (`libwoff2dec`, `libenchant-2`, `libGLESv2`, `libx264`, …) that are not installable in this container. The scheduled workflow will be the first real signal for it. Everything changed is browser-agnostic assertion logic, so I would not expect WebKit-specific failures, but I have not proven it.

Each commit was checked to stand on its own — commit 1 alone type-checks and moves the suite to 248 passed / 0 skipped, with the 50 stale expectations still red; commit 2 clears them.

One thing left deliberately alone: the page objects wrap navigation in `catch (error) { throw new SomePlotError('…') }`, which discards the original error. That is why `multiLayer` reported only `Failed to navigate to Multi Layer Plot` instead of a 404, and it is a good part of why this sat undiagnosed. Attaching `{ cause: error }` would mean touching all eleven error classes, so it felt like a separate change — happy to send it as a follow-up if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz)_