### PR TITLE
fix(chat): keep KaTeX's MathML through markdown sanitisation

### DIFF
--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import { useViewModelState } from '@state/hook/useViewModel';
 import { containsLatex, ensureKatexStylesheet } from '@util/katex';
+import { createChatSanitizeSchema } from '@util/markdownSanitize';
 import React, { memo, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
@@ -14,6 +15,9 @@ type RehypePlugins = NonNullable<
 
 /** Stable empty list, so a message without maths never re-renders on identity. */
 const NO_MATH_PLUGINS: RehypePlugins = [];
+
+/** Built once: the allowlist is the same for every message on the page. */
+const SANITIZE_SCHEMA = createChatSanitizeSchema();
 
 interface TypingEffectProps {
   text: string;
@@ -142,39 +146,9 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
         <ReactMarkdown
           rehypePlugins={[
             // Before rehypeSanitize, so KaTeX's own markup goes through the
-            // allowlist below rather than around it.
+            // allowlist rather than around it.
             ...mathPlugins,
-            [rehypeSanitize, {
-              attributes: {
-                '*': ['className', 'aria-label', 'aria-hidden', 'role', 'aria-busy', 'aria-live', 'aria-atomic'],
-                'a': ['href', 'target'],
-                'img': ['src', 'alt'],
-                'math': ['display'],
-                'span': ['style'],
-                'svg': ['aria-hidden', 'role', 'xmlns', 'width', 'height', 'viewBox'],
-                'path': ['d'],
-              },
-              tagNames: [
-                'p',
-                'br',
-                'b',
-                'i',
-                'em',
-                'strong',
-                'a',
-                'pre',
-                'code',
-                'ul',
-                'ol',
-                'li',
-                'blockquote',
-                'img',
-                'math',
-                'span',
-                'svg',
-                'path',
-              ],
-            }],
+            [rehypeSanitize, SANITIZE_SCHEMA],
           ]}
           remarkPlugins={[remarkGfm, remarkMath]}
           components={{

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -4,10 +4,12 @@ import type { Options as SanitizeSchema } from 'rehype-sanitize';
  * The sanitisation allowlist for Markdown rendered in AI chat responses.
  *
  * Lives here rather than beside its one caller in `TypingEffect.tsx` because
- * that module imports `react-markdown`, which is ESM-only and cannot be loaded
- * by the Jest suite. Keeping the schema in a module with no runtime imports is
- * what lets `test/util/markdownSanitize.test.ts` check it against the MathML
- * KaTeX actually emits.
+ * that module imports `react-markdown`, which is ESM-only and so is not
+ * loadable by the Jest suite as it is configured — CommonJS, with `allowJs`
+ * off, so nothing under `node_modules` is transformed. Keeping the schema in a
+ * module with no runtime imports is what lets
+ * `test/util/markdownSanitize.test.ts` check it against the MathML KaTeX
+ * actually emits.
  *
  * `rehype-sanitize` *replaces* its default schema with the one it is given
  * rather than merging into it, so everything the chat is allowed to render has
@@ -167,7 +169,7 @@ export function createChatSanitizeSchema(): SanitizeSchema {
       // load-bearing for stretchy delimiters and arrows, which KaTeX draws at
       // `width="400em"` over a `viewBox` 400000 units wide and expects
       // `xMaxYMin slice` to crop rather than scale.
-      'svg': ['ariaHidden', 'xmlns', 'width', 'height', 'viewBox', 'preserveAspectRatio', 'style'],
+      'svg': ['xmlns', 'width', 'height', 'viewBox', 'preserveAspectRatio', 'style'],
       'path': ['d'],
       // `\cancel` and `\not` draw their strike as an SVG line.
       'line': ['x1', 'x2', 'y1', 'y2', 'strokeWidth'],

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -160,12 +160,25 @@ export function createChatSanitizeSchema(): SanitizeSchema {
   return {
     attributes: {
       '*': [...GLOBAL_ATTRIBUTES],
-      'a': ['href', 'target'],
+      // No `target`. Markdown has no syntax for it, raw HTML is escaped to
+      // text, and nothing in the plugin chain adds one, so it was allowing an
+      // attribute that could not arrive — and a `target="_blank"` without
+      // `rel="noopener"` is reverse tabnabbing waiting for the day one could.
+      // Same reasoning as the ARIA entries dropped from GLOBAL_ATTRIBUTES.
+      'a': ['href'],
       'img': ['src', 'alt'],
+      // `style` here and on `svg` below carries KaTeX's computed layout —
+      // `height:1em;vertical-align:-0.25em`, `top:-4em`, `width:0.471em`. The
+      // values are generated, never passed through: `\htmlStyle` and
+      // `\htmlClass` are disabled by the untrusted defaults KaTeX renders with,
+      // and a raw `<span style>` in a response is escaped to text. So a
+      // response cannot reach a `url()` and turn a rendered equation into a
+      // tracking beacon.
       'span': ['style'],
       // KaTeX's visual layer. It sits inside an `aria-hidden` wrapper, so what
       // is lost here is rendering rather than announcement — but it is lost the
-      // same way the MathML was, by not being named. `preserveAspectRatio` is
+      // same way the MathML was, by not being named. `style` is what `\vec`,
+      // `\hat` and `\dot` size their accent with. `preserveAspectRatio` is
       // load-bearing for stretchy delimiters and arrows, which KaTeX draws at
       // `width="400em"` over a `viewBox` 400000 units wide and expects
       // `xMaxYMin slice` to crop rather than scale.

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -114,20 +114,22 @@ export const MATHML_ATTRIBUTES: readonly string[] = [
 /**
  * Attributes allowed on every element, spelled as hast property names.
  *
- * `ariaHidden` is the one that carries weight today: KaTeX marks its visual
- * layer with it so assistive technology reads the MathML instead of the glyph
- * spans beside it. The rest are allowed for markup that may carry them; no
- * plugin in the chain emits them at present, and raw HTML in a response never
- * reaches this tree because the pipeline runs without `rehype-raw`.
+ * Both entries are load-bearing. KaTeX puts `class` on every span it builds,
+ * and marks its visual layer `aria-hidden` so assistive technology reads the
+ * MathML instead of the glyph spans beside it.
+ *
+ * The list used to also carry `role`, `ariaLabel`, `ariaBusy`, `ariaLive` and
+ * `ariaAtomic`. Nothing in the pipeline emits any of them — the `role` and
+ * `aria-label` that `TypingEffect` puts on `<pre>` and `<a>` are React props,
+ * applied to the tree after it has been sanitised — and while they were
+ * misspelled they were inert. Correcting the spelling would have made them
+ * live for the first time, so they are dropped instead: a response body cannot
+ * reach an attribute today (the pipeline runs without `rehype-raw`, so raw HTML
+ * is escaped to text), and this way it still could not were that to change.
  */
 const GLOBAL_ATTRIBUTES: readonly string[] = [
   'className',
-  'ariaLabel',
   'ariaHidden',
-  'role',
-  'ariaBusy',
-  'ariaLive',
-  'ariaAtomic',
 ];
 
 /** Every MathML element, mapped to the presentation attributes it may keep. */
@@ -141,6 +143,15 @@ function mathmlAttributes(): Record<string, string[]> {
  * The schema `TypingEffect` hands to `rehype-sanitize`.
  *
  * Built fresh on each call so a caller cannot mutate the shared allowlists.
+ *
+ * Deliberately declares only `tagNames` and `attributes`. `hast-util-sanitize`
+ * resolves its configuration as `{...defaultSchema, ...options}` — a shallow
+ * merge, one level deep — so every key left out here keeps its default. That is
+ * what still strips `javascript:` from a link or an image without `protocols`
+ * appearing anywhere below: the default map covers `href`, `src`, `cite` and
+ * `longDesc`. Adding a partial `protocols` key would replace that map outright
+ * rather than extend it, which is why the test asserts this schema declares no
+ * key beyond the two it means to override.
  * @returns The allowlist of tags and attributes an AI chat response may render.
  */
 export function createChatSanitizeSchema(): SanitizeSchema {
@@ -150,8 +161,16 @@ export function createChatSanitizeSchema(): SanitizeSchema {
       'a': ['href', 'target'],
       'img': ['src', 'alt'],
       'span': ['style'],
-      'svg': ['ariaHidden', 'role', 'xmlns', 'width', 'height', 'viewBox'],
+      // KaTeX's visual layer. It sits inside an `aria-hidden` wrapper, so what
+      // is lost here is rendering rather than announcement — but it is lost the
+      // same way the MathML was, by not being named. `preserveAspectRatio` is
+      // load-bearing for stretchy delimiters and arrows, which KaTeX draws at
+      // `width="400em"` over a `viewBox` 400000 units wide and expects
+      // `xMaxYMin slice` to crop rather than scale.
+      'svg': ['ariaHidden', 'xmlns', 'width', 'height', 'viewBox', 'preserveAspectRatio', 'style'],
       'path': ['d'],
+      // `\cancel` and `\not` draw their strike as an SVG line.
+      'line': ['x1', 'x2', 'y1', 'y2', 'strokeWidth'],
       ...mathmlAttributes(),
     },
     tagNames: [
@@ -172,6 +191,7 @@ export function createChatSanitizeSchema(): SanitizeSchema {
       'span',
       'svg',
       'path',
+      'line',
       ...MATHML_TAG_NAMES,
     ],
   };

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -1,0 +1,178 @@
+import type { Options as SanitizeSchema } from 'rehype-sanitize';
+
+/**
+ * The sanitisation allowlist for Markdown rendered in AI chat responses.
+ *
+ * Lives here rather than beside its one caller in `TypingEffect.tsx` because
+ * that module imports `react-markdown`, which is ESM-only and cannot be loaded
+ * by the Jest suite. Keeping the schema in a module with no runtime imports is
+ * what lets `test/util/markdownSanitize.test.ts` check it against the MathML
+ * KaTeX actually emits.
+ *
+ * `rehype-sanitize` *replaces* its default schema with the one it is given
+ * rather than merging into it, so everything the chat is allowed to render has
+ * to be named here. Two things follow from that, and both were wrong before
+ * this module existed:
+ *
+ * 1. Allowing `math` allows the `<math>` wrapper and nothing inside it. The
+ *    utility drops a disallowed element but keeps its text, so KaTeX's
+ *    `<math><semantics><mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>
+ *    <annotation>\frac{a}{b}</annotation></semantics></math>` collapsed to
+ *    `<math>ab\frac{a}{b}</math>` — the fraction gone, the raw TeX left behind,
+ *    and a screen reader announcing "ab backslash frac a b". Every element in
+ *    {@link MATHML_TAG_NAMES} has to be named for the equation to survive.
+ * 2. Attributes are matched by **hast property name**, not HTML attribute name.
+ *    `aria-hidden` never matches anything; the property is `ariaHidden`. The
+ *    hyphenated spelling silently stripped `aria-hidden="true"` from KaTeX's
+ *    visual layer, so screen readers read the glyph spans *as well as* the
+ *    MathML. `test/util/markdownSanitize.test.ts` pins the rule.
+ */
+
+/**
+ * MathML elements KaTeX emits inside `<span class="katex-mathml">`.
+ *
+ * Derived from KaTeX's own output rather than from the MathML specification:
+ * anything KaTeX cannot produce is left out, so the allowlist stays as narrow
+ * as the markup it exists to admit. The test walks a corpus through the pinned
+ * KaTeX version and fails when an upgrade starts emitting something new.
+ */
+export const MATHML_TAG_NAMES: readonly string[] = [
+  'annotation',
+  'math',
+  'menclose',
+  'mfrac',
+  'mi',
+  'mn',
+  'mo',
+  'mover',
+  'mpadded',
+  'mphantom',
+  'mroot',
+  'mrow',
+  'mspace',
+  'msqrt',
+  'mstyle',
+  'msub',
+  'msubsup',
+  'msup',
+  'mtable',
+  'mtd',
+  'mtext',
+  'mtr',
+  'munder',
+  'munderover',
+  'semantics',
+];
+
+/**
+ * MathML presentation attributes allowed on {@link MATHML_TAG_NAMES}.
+ *
+ * Presentation only. `href` is deliberately absent — MathML carries it on any
+ * element, the value reaches the page from an LLM response, and none of it is
+ * needed for the accessible tree. `src` and `alt` are absent for the same
+ * reason: they belong to `mglyph`, which only `\includegraphics` produces and
+ * which KaTeX disables unless `trust` is set, and MAIDR renders with KaTeX's
+ * untrusted defaults.
+ *
+ * `class` is not listed either — the shared `className` entry already covers
+ * it, under the hast spelling.
+ */
+export const MATHML_ATTRIBUTES: readonly string[] = [
+  'accent',
+  'accentunder',
+  'columnalign',
+  'columnlines',
+  'columnspacing',
+  'depth',
+  'display',
+  'displaystyle',
+  'encoding',
+  'fence',
+  'height',
+  'largeop',
+  'linebreak',
+  'linethickness',
+  'lspace',
+  'mathbackground',
+  'mathcolor',
+  'mathsize',
+  'mathvariant',
+  'maxsize',
+  'minsize',
+  'notation',
+  'rowlines',
+  'rowspacing',
+  'rspace',
+  'scriptlevel',
+  'separator',
+  'stretchy',
+  'voffset',
+  'width',
+  'xmlns',
+];
+
+/**
+ * Attributes allowed on every element, spelled as hast property names.
+ *
+ * `ariaHidden` is the one that carries weight today: KaTeX marks its visual
+ * layer with it so assistive technology reads the MathML instead of the glyph
+ * spans beside it. The rest are allowed for markup that may carry them; no
+ * plugin in the chain emits them at present, and raw HTML in a response never
+ * reaches this tree because the pipeline runs without `rehype-raw`.
+ */
+const GLOBAL_ATTRIBUTES: readonly string[] = [
+  'className',
+  'ariaLabel',
+  'ariaHidden',
+  'role',
+  'ariaBusy',
+  'ariaLive',
+  'ariaAtomic',
+];
+
+/** Every MathML element, mapped to the presentation attributes it may keep. */
+function mathmlAttributes(): Record<string, string[]> {
+  return Object.fromEntries(
+    MATHML_TAG_NAMES.map(tagName => [tagName, [...MATHML_ATTRIBUTES]]),
+  );
+}
+
+/**
+ * The schema `TypingEffect` hands to `rehype-sanitize`.
+ *
+ * Built fresh on each call so a caller cannot mutate the shared allowlists.
+ * @returns The allowlist of tags and attributes an AI chat response may render.
+ */
+export function createChatSanitizeSchema(): SanitizeSchema {
+  return {
+    attributes: {
+      '*': [...GLOBAL_ATTRIBUTES],
+      'a': ['href', 'target'],
+      'img': ['src', 'alt'],
+      'span': ['style'],
+      'svg': ['ariaHidden', 'role', 'xmlns', 'width', 'height', 'viewBox'],
+      'path': ['d'],
+      ...mathmlAttributes(),
+    },
+    tagNames: [
+      'p',
+      'br',
+      'b',
+      'i',
+      'em',
+      'strong',
+      'a',
+      'pre',
+      'code',
+      'ul',
+      'ol',
+      'li',
+      'blockquote',
+      'img',
+      'span',
+      'svg',
+      'path',
+      ...MATHML_TAG_NAMES,
+    ],
+  };
+}

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -145,6 +145,10 @@ function mathmlAttributes(): Record<string, string[]> {
  * The schema `TypingEffect` hands to `rehype-sanitize`.
  *
  * Built fresh on each call so a caller cannot mutate the shared allowlists.
+ * `TypingEffect` calls it once and hoists the result to module scope — the
+ * chat animation re-renders every 10 ms, and the allowlist is the same for
+ * every message — so the freshness matters to this function's own contract
+ * rather than to anything visible at that call site.
  *
  * Deliberately declares only `tagNames` and `attributes`. `hast-util-sanitize`
  * resolves its configuration as `{...defaultSchema, ...options}` — a shallow

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -315,11 +315,34 @@ describe('createChatSanitizeSchema', () => {
     expect(Object.keys(schema).sort()).toEqual(['attributes', 'tagNames']);
   });
 
-  it('should return a fresh schema each call', () => {
+  it('should return a fresh schema each call, nested arrays included', () => {
     const first = createChatSanitizeSchema();
     const second = createChatSanitizeSchema();
 
     expect(first).not.toBe(second);
     expect(first.tagNames).not.toBe(second.tagNames);
+    expect(first.attributes).not.toBe(second.attributes);
+    // The per-element lists too — a shared array one level down would leave the
+    // allowlists just as mutable, while the two assertions above still passed.
+    expect(first.attributes?.['*']).not.toBe(second.attributes?.['*']);
+    expect(first.attributes?.math).not.toBe(second.attributes?.math);
+  });
+
+  it('should not let a mutated schema reach the next caller', () => {
+    const first = createChatSanitizeSchema();
+
+    first.tagNames?.push('script');
+    first.attributes?.['*']?.push('onclick');
+    first.attributes?.math?.push('href');
+
+    // The property the doc comment actually promises, stated as the failure it
+    // exists to prevent: one caller widening its own copy must not widen
+    // anyone else's, nor the module's exported lists.
+    const second = createChatSanitizeSchema();
+    expect(second.tagNames).not.toContain('script');
+    expect(second.attributes?.['*']).not.toContain('onclick');
+    expect(second.attributes?.math).not.toContain('href');
+    expect(MATHML_TAG_NAMES).not.toContain('script');
+    expect(MATHML_ATTRIBUTES).not.toContain('href');
   });
 });

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -9,14 +9,20 @@
  * emitting `<mmultiscripts>` fails here instead of silently losing the markup
  * at runtime.
  *
- * `rehype-sanitize` cannot be exercised directly — it is ESM-only and the Jest
- * suite is CommonJS — so these tests cover the schema's *contents*. Its two
- * matching rules are relied on rather than re-verified:
+ * These tests cover the schema's *contents*, not `rehype-sanitize` running on
+ * it: the package is ESM-only and this suite is CommonJS, so it cannot be
+ * imported here. That is a property of the current Jest configuration rather
+ * than a hard limit — a second Jest project with `extensionsToTreatAsEsm` and
+ * `--experimental-vm-modules` loads it fine — but wiring one up is test
+ * infrastructure, not part of this fix.
+ *
+ * So two of the utility's rules are relied on rather than re-verified here:
  *
  * - a disallowed element is dropped but its text is kept, so a missing MathML
  *   element leaves the leaf characters behind as prose;
  * - attributes match on hast property names (`ariaHidden`), not HTML attribute
- *   names (`aria-hidden`).
+ *   names (`aria-hidden`), and an entry under `'*'` is additive to the
+ *   element's own list rather than replaced by it.
  */
 
 import { describe, expect, it } from '@jest/globals';

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -75,18 +75,55 @@ const CORPUS: readonly string[] = [
 ];
 
 /**
- * Anything in KaTeX's MathML branch. `m[a-z]+` covers `math` and every `m*`
- * element; `semantics` and `annotation` are the two that do not start with `m`.
+ * Anything in KaTeX's MathML branch.
+ *
+ * `m[a-z-]+` covers `math` and every `m*` element; `semantics` and
+ * `annotation` are the two that do not start with `m`. The hyphens are what
+ * make `annotation-xml` match: KaTeX does not emit it under the untrusted
+ * defaults MAIDR renders with, but a pattern that could not match it would
+ * quietly drop the element from the survey instead of failing, and a survey
+ * that cannot see an element cannot report it as unnamed.
  */
-const MATHML_ELEMENT = /^(?:semantics|annotation|m[a-z]+)$/;
+const MATHML_ELEMENT = /^(?:semantics|annotation[a-z-]*|m[a-z-]+)$/;
 
-interface MathmlUsage {
+/** One attribute, and the element KaTeX put it on. */
+interface AttributeUsage {
+  readonly tagName: string;
+  readonly attribute: string;
+}
+
+/** What a corpus render produced, kept separate so bare elements still count. */
+interface Usage {
+  /** Every element name seen, including the many that carry no attributes. */
   readonly tagNames: Set<string>;
-  readonly attributes: Set<string>;
+  /** Every element/attribute pair seen. */
+  readonly attributes: AttributeUsage[];
 }
 
 /**
- * Renders the corpus and collects the MathML KaTeX puts in the accessible tree.
+ * The hast property name for an HTML or MathML attribute.
+ *
+ * Only the two rules that apply to KaTeX's output, written out rather than
+ * pulled from `property-information` — that package is ESM-only, and the point
+ * of the assertion is to state the rule the schema has to follow rather than to
+ * agree with another implementation of it.
+ * @param attribute - The attribute name as it appears in the markup.
+ * @returns The name `rehype-sanitize` matches the attribute under.
+ */
+function hastPropertyName(attribute: string): string {
+  if (attribute === 'class') {
+    return 'className';
+  }
+  return attribute.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+/**
+ * Renders the corpus and collects everything KaTeX puts in the tree.
+ *
+ * Covers both of KaTeX's layers, not just the MathML: the visual layer carries
+ * the `aria-hidden` that keeps it from being announced twice, and the SVG that
+ * draws stretchy delimiters. An allowlist checked against one layer alone lets
+ * the other rot.
  *
  * Both display modes are rendered because they take different paths — a sum's
  * limits become `msubsup` inline and `munderover` in display mode, so covering
@@ -94,37 +131,50 @@ interface MathmlUsage {
  * defaults to match how `rehype-katex` is configured in `TypingEffect`; that is
  * what keeps `\href` and `\includegraphics` (and so `href`, `src` and `mglyph`)
  * out of the output.
- * @returns The element and attribute names found under `.katex-mathml`.
+ * @returns The elements seen, and the element/attribute pairs seen.
  */
-function collectMathmlUsage(): MathmlUsage {
+function collectUsage(): Usage {
   const tagNames = new Set<string>();
-  const attributes = new Set<string>();
+  // Keyed so a pair seen in fifty renders is reported once.
+  const attributes = new Map<string, AttributeUsage>();
 
   for (const displayMode of [false, true]) {
     for (const tex of CORPUS) {
       const html = katex.renderToString(tex, { throwOnError: false, displayMode });
       const { document } = new JSDOM(`<div>${html}</div>`).window;
-      const mathml = document.querySelector('.katex-mathml');
-      if (mathml === null) {
+      const root = document.querySelector('.katex');
+      if (root === null) {
         // `\begin{align}` is display-only in LaTeX too, so KaTeX renders the
-        // inline pass as an error span with no MathML. Every other combination
-        // has to produce some, or the corpus is checking nothing.
+        // inline pass as an error span. Every other combination has to render,
+        // or the corpus is checking nothing.
         expect(document.querySelector('.katex-error')).not.toBeNull();
         continue;
       }
 
-      for (const element of mathml.querySelectorAll('*')) {
+      for (const element of root.querySelectorAll('*')) {
         const tagName = element.tagName.toLowerCase();
-        if (!MATHML_ELEMENT.test(tagName)) {
-          continue;
-        }
+        // Recorded before the attributes, because most of the elements that
+        // carry an equation's structure — `mrow`, `msqrt`, `msub` — have none.
         tagNames.add(tagName);
         for (const attribute of element.getAttributeNames()) {
-          attributes.add(attribute);
+          attributes.set(`${tagName}\0${attribute}`, { tagName, attribute });
         }
       }
     }
   }
+
+  return { tagNames, attributes: [...attributes.values()] };
+}
+
+/** The MathML subset of {@link collectUsage}. */
+function collectMathmlUsage(): { tagNames: Set<string>; attributes: Set<string> } {
+  const usage = collectUsage();
+  const tagNames = new Set([...usage.tagNames].filter(tag => MATHML_ELEMENT.test(tag)));
+  const attributes = new Set(
+    usage.attributes
+      .filter(({ tagName }) => MATHML_ELEMENT.test(tagName))
+      .map(({ attribute }) => attribute),
+  );
 
   return { tagNames, attributes };
 }
@@ -206,6 +256,47 @@ describe('createChatSanitizeSchema', () => {
     const schema = createChatSanitizeSchema();
 
     expect(schema.attributes?.['*']).toContain('ariaHidden');
+  });
+
+  it('should name every element KaTeX emits, in both of its layers', () => {
+    const schema = createChatSanitizeSchema();
+
+    const stripped = [...collectUsage().tagNames]
+      .filter(tagName => !schema.tagNames?.includes(tagName))
+      .sort();
+
+    // `line` — which `\cancel` and `\not` draw their strike with — was missing
+    // until this case existed, and an unnamed element is removed outright.
+    expect(stripped).toEqual([]);
+  });
+
+  it('should allow every attribute KaTeX puts on any element, under its hast name', () => {
+    const schema = createChatSanitizeSchema();
+    const shared = schema.attributes?.['*'] ?? [];
+
+    const stripped = collectUsage().attributes.filter(({ tagName, attribute }) => {
+      const property = hastPropertyName(attribute);
+      const allowed = [...shared, ...(schema.attributes?.[tagName] ?? [])];
+      return !allowed.some(entry => (typeof entry === 'string' ? entry : entry[0]) === property);
+    }).map(({ tagName, attribute }) => `${tagName}[${attribute}]`).sort();
+
+    // Covers both layers. `span[aria-hidden]` is the one that broke the
+    // accessible tree; `svg[preserveAspectRatio]` is the one that broke the
+    // rendering of stretchy delimiters, and went unnoticed because the first
+    // version of this suite only surveyed the MathML.
+    expect(stripped).toEqual([]);
+  });
+
+  it('should override no schema key other than tagNames and attributes', () => {
+    const schema = createChatSanitizeSchema();
+
+    // `hast-util-sanitize` resolves its config as `{...defaultSchema,
+    // ...options}` — one level deep. Every key absent here keeps its default,
+    // which is what still strips `javascript:` from a link without `protocols`
+    // being named. Declaring a partial `protocols` would replace that map
+    // rather than extend it, and drop the protocol filtering the default
+    // provides for the keys it left out.
+    expect(Object.keys(schema).sort()).toEqual(['attributes', 'tagNames']);
   });
 
   it('should return a fresh schema each call', () => {

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for src/util/markdownSanitize.ts.
+ *
+ * The allowlist is checked against KaTeX itself rather than against a fixed
+ * string of expected markup. KaTeX is the only thing that decides which MathML
+ * a response can contain, so rendering a corpus through the pinned version and
+ * comparing what comes out to what the schema admits is the assertion that
+ * keeps meaning something after an upgrade: a KaTeX release that starts
+ * emitting `<mmultiscripts>` fails here instead of silently losing the markup
+ * at runtime.
+ *
+ * `rehype-sanitize` cannot be exercised directly — it is ESM-only and the Jest
+ * suite is CommonJS — so these tests cover the schema's *contents*. Its two
+ * matching rules are relied on rather than re-verified:
+ *
+ * - a disallowed element is dropped but its text is kept, so a missing MathML
+ *   element leaves the leaf characters behind as prose;
+ * - attributes match on hast property names (`ariaHidden`), not HTML attribute
+ *   names (`aria-hidden`).
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import {
+  createChatSanitizeSchema,
+  MATHML_ATTRIBUTES,
+  MATHML_TAG_NAMES,
+} from '@util/markdownSanitize';
+import { JSDOM } from 'jsdom';
+import katex from 'katex';
+
+/**
+ * TeX exercising the output paths KaTeX has: fractions, radicals, scripts,
+ * over/under-braces, tables, spacing, phantoms, enclosures and text runs.
+ */
+const CORPUS: readonly string[] = [
+  '\\frac{a}{b}',
+  '\\sum_{i=1}^{n} x_i',
+  '\\prod_k k',
+  '\\sqrt{x}',
+  '\\sqrt[3]{x}',
+  'x^2_j',
+  '\\int_0^\\infty e^{-x}dx',
+  '\\lim_{x\\to0}\\frac{\\sin x}{x}',
+  '\\begin{matrix}a&b\\\\c&d\\end{matrix}',
+  '\\begin{cases}1&x>0\\\\0&x\\le0\\end{cases}',
+  '\\begin{align}a&=b\\\\c&=d\\end{align}',
+  '\\begin{array}{c|c}a&b\\\\\\hline c&d\\end{array}',
+  '\\overline{AB}',
+  '\\underline{x}',
+  '\\underbrace{x+y}_{z}',
+  '\\overbrace{x}^{y}',
+  '\\overset{a}{b}',
+  '\\underset{a}{b}',
+  '\\text{hello world}',
+  '\\mathbb{R}\\mathcal{L}\\mathfrak{g}',
+  '\\mathrm{d}x',
+  '\\vec{v}\\hat{n}\\dot{x}',
+  '\\left(\\frac12\\right)',
+  '\\binom{n}{k}',
+  '\\boxed{x=1}',
+  '\\cancel{x}',
+  'a\\ne b\\le c\\ge d',
+  '\\phantom{xy}',
+  '\\smash{x}',
+  '\\color{red}{x}',
+  '\\textcolor{blue}{z}',
+  '\\hspace{1em}',
+  '\\rule{1em}{1em}',
+  '\\raisebox{1em}{x}',
+  '\\substack{a\\\\b}',
+  '\\operatorname{foo}',
+  '\\xrightarrow{f}',
+  '\\bmod 5',
+  '\\not=',
+];
+
+/**
+ * Anything in KaTeX's MathML branch. `m[a-z]+` covers `math` and every `m*`
+ * element; `semantics` and `annotation` are the two that do not start with `m`.
+ */
+const MATHML_ELEMENT = /^(?:semantics|annotation|m[a-z]+)$/;
+
+interface MathmlUsage {
+  readonly tagNames: Set<string>;
+  readonly attributes: Set<string>;
+}
+
+/**
+ * Renders the corpus and collects the MathML KaTeX puts in the accessible tree.
+ *
+ * Both display modes are rendered because they take different paths — a sum's
+ * limits become `msubsup` inline and `munderover` in display mode, so covering
+ * one alone would leave half the allowlist unchecked. Options are left at their
+ * defaults to match how `rehype-katex` is configured in `TypingEffect`; that is
+ * what keeps `\href` and `\includegraphics` (and so `href`, `src` and `mglyph`)
+ * out of the output.
+ * @returns The element and attribute names found under `.katex-mathml`.
+ */
+function collectMathmlUsage(): MathmlUsage {
+  const tagNames = new Set<string>();
+  const attributes = new Set<string>();
+
+  for (const displayMode of [false, true]) {
+    for (const tex of CORPUS) {
+      const html = katex.renderToString(tex, { throwOnError: false, displayMode });
+      const { document } = new JSDOM(`<div>${html}</div>`).window;
+      const mathml = document.querySelector('.katex-mathml');
+      if (mathml === null) {
+        // `\begin{align}` is display-only in LaTeX too, so KaTeX renders the
+        // inline pass as an error span with no MathML. Every other combination
+        // has to produce some, or the corpus is checking nothing.
+        expect(document.querySelector('.katex-error')).not.toBeNull();
+        continue;
+      }
+
+      for (const element of mathml.querySelectorAll('*')) {
+        const tagName = element.tagName.toLowerCase();
+        if (!MATHML_ELEMENT.test(tagName)) {
+          continue;
+        }
+        tagNames.add(tagName);
+        for (const attribute of element.getAttributeNames()) {
+          attributes.add(attribute);
+        }
+      }
+    }
+  }
+
+  return { tagNames, attributes };
+}
+
+describe('mathML allowlist', () => {
+  it('should name every MathML element KaTeX emits', () => {
+    const { tagNames } = collectMathmlUsage();
+
+    const missing = [...tagNames].filter(tag => !MATHML_TAG_NAMES.includes(tag)).sort();
+
+    // A missing element is not a rendering nicety: rehype-sanitize keeps the
+    // text of an element it drops, so the equation degrades into its own leaf
+    // characters run together — "ab" for a fraction — rather than disappearing.
+    expect(missing).toEqual([]);
+  });
+
+  it('should name every MathML attribute KaTeX emits', () => {
+    const { attributes } = collectMathmlUsage();
+
+    const missing = [...attributes]
+      // `class` is covered by the shared `className` entry, under the hast
+      // spelling that entry has to use.
+      .filter(attribute => attribute !== 'class')
+      .filter(attribute => !MATHML_ATTRIBUTES.includes(attribute))
+      .sort();
+
+    expect(missing).toEqual([]);
+  });
+
+  it('should cover the elements that carry the structure of an equation', () => {
+    // Belt and braces for the corpus: were it ever trimmed to the point of
+    // exercising no fractions or scripts, the two tests above would still pass
+    // while allowing the allowlist to lose them.
+    expect(MATHML_TAG_NAMES).toEqual(
+      expect.arrayContaining(['math', 'semantics', 'mrow', 'mfrac', 'msqrt', 'msub', 'msup', 'mi', 'mo', 'mn']),
+    );
+  });
+
+  it('should not allow href or src on MathML elements', () => {
+    // MathML accepts `href` on any element and the value arrives from an LLM
+    // response. Nothing in the accessible tree needs either one.
+    expect(MATHML_ATTRIBUTES).not.toContain('href');
+    expect(MATHML_ATTRIBUTES).not.toContain('src');
+  });
+});
+
+describe('createChatSanitizeSchema', () => {
+  it('should allow every MathML element as a tag name', () => {
+    const schema = createChatSanitizeSchema();
+
+    expect(schema.tagNames).toEqual(expect.arrayContaining([...MATHML_TAG_NAMES]));
+  });
+
+  it('should give each MathML element its presentation attributes', () => {
+    const schema = createChatSanitizeSchema();
+
+    for (const tagName of MATHML_TAG_NAMES) {
+      expect(schema.attributes?.[tagName]).toEqual([...MATHML_ATTRIBUTES]);
+    }
+  });
+
+  it('should spell attributes as hast property names, never as HTML attribute names', () => {
+    const schema = createChatSanitizeSchema();
+
+    const hyphenated = Object.values(schema.attributes ?? {})
+      .flat()
+      .map(entry => (typeof entry === 'string' ? entry : entry[0]))
+      .filter(name => name.includes('-'))
+      .sort();
+
+    // `aria-hidden` matches no property and so stripped KaTeX's own
+    // `aria-hidden="true"`, leaving the visual glyph spans exposed to a screen
+    // reader alongside the MathML. The property is `ariaHidden`. No attribute
+    // this schema needs is spelled with a hyphen.
+    expect(hyphenated).toEqual([]);
+  });
+
+  it('should keep aria-hidden available so KaTeX can hide its visual layer', () => {
+    const schema = createChatSanitizeSchema();
+
+    expect(schema.attributes?.['*']).toContain('ariaHidden');
+  });
+
+  it('should return a fresh schema each call', () => {
+    const first = createChatSanitizeSchema();
+    const second = createChatSanitizeSchema();
+
+    expect(first).not.toBe(second);
+    expect(first.tagNames).not.toBe(second.tagNames);
+  });
+});

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -293,6 +293,16 @@ describe('createChatSanitizeSchema', () => {
     expect(stripped).toEqual([]);
   });
 
+  it('should allow a link its href and nothing else', () => {
+    const schema = createChatSanitizeSchema();
+
+    // `target` was allowed and unreachable — markdown has no syntax for it and
+    // raw HTML is escaped to text — so it only stood to admit a
+    // `target="_blank"` with no `rel="noopener"` the day something could set
+    // one. `href` keeps the default `protocols` filtering; see the test below.
+    expect(schema.attributes?.a).toEqual(['href']);
+  });
+
   it('should override no schema key other than tagNames and attributes', () => {
     const schema = createChatSanitizeSchema();
 


### PR DESCRIPTION
# Pull Request

## Description

Maths in AI chat responses reached the page with its structure destroyed. Evaluating #671 — should MAIDR move from KaTeX to MathJax's browser components for their a11y extensions — meant first measuring what KaTeX actually delivers today. It delivers nothing: MAIDR's own sanitisation allowlist was stripping it.

Chromium's accessibility tree for `$x = \frac{-b \pm \sqrt{b^2-4ac}}{2a}$`, rendered through the exact plugin chain in `TypingEffect`:

| | before | after |
|---|---|---|
| MathML structural roles | **0** | **21** |
| distinct roles | *(none)* | `MathMLFraction`, `MathMLSquareRoot`, `MathMLSup`, `MathMLRow`, `MathMLIdentifier`, `MathMLOperator`, `MathMLNumber` |

Before the fix the `<math>` element held only flat `StaticText` in *visual* order — `x`, `=`, `2`, `a`, `−`, `b`, `±` … — with no fraction, radical or exponent anywhere in the tree. The markup behind it:

```html
<math>x=−b±b2−4ac2ax = \frac{-b \pm \sqrt{b^2-4ac}}{2a}</math>
```

Three causes, all in the allowlist:

1. **`math` was allowed; nothing inside it was.** `rehype-sanitize` drops a disallowed element but keeps its text, so the expression collapsed into its own leaf characters. The fraction, radical and exponents were gone before the markup rendered.

2. **ARIA attributes were spelled as HTML attribute names.** `rehype-sanitize` matches on hast property names, so `aria-hidden` matched nothing. KaTeX marks its visual layer `aria-hidden="true"` precisely so assistive technology reads the MathML instead of the glyph spans; that attribute was stripped and both layers were exposed:

   ```
   before  "The root is x=−b±b2−4ac2ax = \frac{…}{2a}x=2a−b±b2−4ac."   ← visual layer too
   after   "The root is x=−b±b2−4ac2ax = \frac{…}{2a}."
   ```

3. **KaTeX's visual layer had the same disease** (found while acting on review feedback). `<line>` was not named at all, so `\cancel` and `\not` lost their strike entirely; `preserveAspectRatio` was stripped from `<svg>`, which stretchy delimiters and arrows rely on to crop rather than scale. Rendering defects rather than announcement ones — both sit inside the `aria-hidden` wrapper — but lost for exactly the reason the MathML was.

## Related Issues

Refs #671. The evaluation that issue asks for is [posted there](https://github.com/xability/maidr/issues/671#issuecomment-5135932595) — measurements for all four of its open questions, and the reasoning for staying on KaTeX. This PR is the defect that evaluation surfaced; it does not close the issue.

Two follow-ups were opened from review on this PR:

- **#677** — the same allowlist drops GFM tables, `h1`–`h6`, strikethrough and task-list checkboxes. Larger user impact than the maths bug: a table of chart values renders as `BarValueJan45.2Feb51.8`. Kept separate because `input`, `id` and `data-*` need their own security review.
- **#678** — an ESM-aware Jest project, so the pipeline can be tested end to end rather than only the schema's contents.

## Changes Made

- **`src/util/markdownSanitize.ts`** (new) — the chat allowlist, naming every element and attribute KaTeX emits across both of its layers, with ARIA entries under their hast spellings.

  It lives in `util/` rather than beside its caller because `TypingEffect.tsx` imports `react-markdown`, which is ESM-only and so is not loadable by the Jest suite as currently configured — CommonJS, with `allowJs` off, so nothing under `node_modules` is transformed. A module with no runtime imports can be tested. (That configuration is changeable; see #678.)

- **`src/ui/components/TypingEffect.tsx`** — uses the shared schema; the inline literal is gone. Built once at module scope rather than per render, which matters here because the typing animation re-renders every 10 ms.

- **`test/util/markdownSanitize.test.ts`** (new) — renders a 39-case TeX corpus through the pinned KaTeX in both display modes and fails when the output carries an element or attribute the allowlist does not name, in either layer. So a KaTeX upgrade that starts emitting something new fails here rather than silently losing the markup.

### Security

`href` and `src` are excluded from the MathML attribute list. MathML accepts `href` on any element, the value arrives from an LLM response, and the accessible tree needs neither. `src`/`alt` belong to `mglyph`, which only `\includegraphics` produces and which KaTeX disables under its untrusted defaults — the defaults MAIDR renders with.

`target` is dropped from links. Markdown has no syntax for it and raw HTML is escaped to text, so it admitted an attribute that could not arrive — while standing to allow a `target="_blank"` without `rel="noopener"` the day one could.

The shared attribute list is narrowed to `className` and `ariaHidden`. `role`, `ariaLabel`, `ariaBusy`, `ariaLive` and `ariaAtomic` were present but misspelled, and so inert; correcting the spelling would have made them live for the first time. Nothing in the pipeline emits them — the `role` and `aria-label` on `<pre>` and `<a>` are React props applied after sanitisation — so they are dropped rather than fixed.

`style` stays on `span` and `svg` because KaTeX needs it (`\vec`, `\hat` and `\dot` size their accent SVG with `width:`). It is not a passthrough: `\htmlStyle` and `\htmlClass` are disabled under KaTeX's untrusted defaults and raw HTML is escaped, so a response cannot reach a `url()`.

The schema deliberately declares no key beyond `tagNames` and `attributes`. `hast-util-sanitize` resolves its config as `{...defaultSchema, ...options}` (`lib/index.js:235`) — shallow, one level deep — so the default `protocols` map is what still strips `javascript:` from a link. A partial `protocols` key would replace that map rather than extend it, and a test pins that none is added.

Verified against the compiled module: `javascript:`, `vbscript:` and `data:` URLs in links and images, `\href{javascript:…}` inside maths, `\includegraphics`, raw HTML with an inline handler, and an `aria-live` injection attempt all remain stripped; ordinary `https:` links survive.

## Screenshots (if applicable)

Not applicable — the accessibility-tree change is shown in the table above. The equation looked correct throughout, which is why this went unnoticed.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass — 1291 tests across 101 suites, `markdownSanitize.ts` at 100% coverage. CI is green on `c35b75a`, all 13 checks.

## Additional Notes

**Not verified here:** how NVDA, JAWS and VoiceOver each render the restored MathML. Chromium's accessibility tree is what screen readers consume through the platform APIs, so the table above is meaningfully closer than a DOM assertion — but it is not a screen reader, and confirmation with real assistive technology is worth having before #671 is closed.

An earlier revision of this description claimed the raw TeX annotation was being read aloud. That was overstated: the TeX reaches the DOM text but not the accessibility tree, in either version. The defect is the lost structure, not a spoken annotation.

`<annotation encoding="application/x-tex">` is kept. MathML Core renders only the first child of `<semantics>`, Chromium's AX tree confirms it is excluded, and keeping it preserves copy-as-TeX.