### PR TITLE
test(e2e): make the WebKit project pass

### DIFF
--- a/e2e_tests/config/test-config.ts
+++ b/e2e_tests/config/test-config.ts
@@ -6,6 +6,7 @@
  */
 import type { PlaywrightTestConfig } from '@playwright/test';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 // The package is ESM ("type": "module"), so CommonJS `__dirname` does not
@@ -40,6 +41,18 @@ const config: PlaywrightTestConfig = {
   expect: {
     timeout: 5000,
   },
+
+  // The page objects read MAIDR's live regions immediately after dispatching a
+  // key. Under parallel load WebKit — the slowest of the three — occasionally
+  // reads before the announcement lands, and a different test flakes each run.
+  // Retries absorb that without hiding it: Playwright still marks a test that
+  // needed one as "flaky" in the report. A test that fails every attempt is a
+  // real failure and still fails the run.
+  //
+  // This is a mitigation, not the cure. The cure is for those getters to wait
+  // for the region to update rather than snapshotting it once — see
+  // `isModeActive` in base-page.ts for the shape that fix takes.
+  retries: process.env.CI ? 2 : 0,
 
   // Test reporters
   reporter: [

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -762,6 +762,16 @@ export class BasePage {
     mode: string,
     modeMessages: Record<string, string>,
   ): Promise<boolean> {
+    // The announcement lands asynchronously after the keypress, so reading the
+    // region once races the update — fast enough to pass in Chromium and
+    // Firefox, and a flake in WebKit under full-suite load. Wait for the
+    // expected text instead, and report absence as false rather than throwing:
+    // callers assert on the boolean, and "the mode never announced" is a
+    // failed expectation, not a broken page object.
+    await expect(this.page.locator(notificationSelector))
+      .toHaveText(modeMessages[mode], { timeout: 5000 })
+      .catch(() => { /* fall through to the re-read below */ });
+
     try {
       const notificationText = await this.getElementText(notificationSelector);
       return notificationText === modeMessages[mode];

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -317,7 +317,7 @@ export class BasePage {
   public async showHelpMenu(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await this.resolveModifier('key combination'),
+        await this.resolveModifier('show help menu'),
         TestConstants.SLASH_KEY,
         'show help menu',
       );
@@ -341,7 +341,7 @@ export class BasePage {
   public async showSettingsMenu(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await this.resolveModifier('key combination'),
+        await this.resolveModifier('show settings menu'),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -369,7 +369,7 @@ export class BasePage {
    */
   public async openHelpMenu(): Promise<void> {
     await this.pressKeyCombination(
-      await this.resolveModifier('key combination'),
+      await this.resolveModifier('open help menu'),
       TestConstants.SLASH_KEY,
       'open help menu',
     );
@@ -382,7 +382,7 @@ export class BasePage {
    */
   public async openSettingsMenu(): Promise<void> {
     await this.pressKeyCombination(
-      await this.resolveModifier('key combination'),
+      await this.resolveModifier('open settings menu'),
       TestConstants.COMMA_KEY,
       'open settings menu',
       100,
@@ -396,7 +396,7 @@ export class BasePage {
   public async closeSettingsMenuWithEscape(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await this.resolveModifier('key combination'),
+        await this.resolveModifier('show settings menu'),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -428,7 +428,7 @@ export class BasePage {
   public async verifySettingsMenuIgnoresBackdropClick(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await this.resolveModifier('key combination'),
+        await this.resolveModifier('show settings menu'),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -541,7 +541,7 @@ export class BasePage {
     useMetaKey = false,
   ): Promise<void> {
     if (useMetaKey) {
-      await this.pressKeyCombination(await this.resolveModifier('key combination'), key, action);
+      await this.pressKeyCombination(await this.resolveModifier(action), key, action);
     } else {
       await this.pressKey(key, action);
     }

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -176,26 +176,29 @@ export class BasePage {
 
   /**
    * Presses a key combination (e.g., Command + key)
-   * @param modifierKey - The modifier key (e.g., Command, Shift)
+   *
+   * Named `modifier` rather than `modifierKey` so it does not shadow the
+   * imported `modifierKey()` helper, which callers pass the result of.
+   * @param modifier - The already-resolved modifier key (e.g., Meta, Shift)
    * @param key - The key to press
    * @param context - Context description for error reporting
    * @param delay - Optional delay between key presses
    * @throws KeypressError if key combination fails
    */
   protected async pressKeyCombination(
-    modifierKey: string,
+    modifier: string,
     key: string,
     context: string,
     delay = 50,
   ): Promise<void> {
     try {
-      await this.page.keyboard.down(modifierKey);
+      await this.page.keyboard.down(modifier);
       await this.page.waitForTimeout(delay);
       await this.pressKey(key, context);
-      await this.page.keyboard.up(modifierKey);
+      await this.page.keyboard.up(modifier);
     } catch (error) {
       throw new KeypressError(
-        `${modifierKey}+${key}`,
+        `${modifier}+${key}`,
         context,
         error instanceof Error ? error : undefined,
       );
@@ -517,7 +520,8 @@ export class BasePage {
    * Moves to a specific data point using a key combination
    * @param key - The key to press
    * @param action - Description of the movement action
-   * @param useMetaKey - Whether to use the Meta key
+   * @param useMetaKey - Whether to hold the control/command modifier, which
+   * resolves to Meta or Control depending on what the browser reports
    * @throws KeypressError if operation fails
    */
   protected async moveToDataPoint(
@@ -767,6 +771,11 @@ export class BasePage {
    * @param modeMessages - Map of mode values to expected messages
    * @returns Promise resolving to true if mode is active, false otherwise
    * @throws Error if mode status cannot be checked
+   *
+   * Note: a false result costs the full wait timeout, because the wait can only
+   * end early on a match. Every caller today asserts the mode IS active, so
+   * that path is not hit; a future "assert mode X is NOT active" test would pay
+   * ~5s per call and should take a shorter timeout rather than live with it.
    */
   protected async isModeActive(
     notificationSelector: string,

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { TestConstants } from '../utils/constants';
 import { AssertionError, KeypressError } from '../utils/errors';
+import { modifierKey } from '../utils/platform';
 
 /**
  * Base page object that all other page objects extend
@@ -291,7 +292,7 @@ export class BasePage {
   public async showHelpMenu(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        TestConstants.COMMAND_KEY,
+        await modifierKey(this.page),
         TestConstants.SLASH_KEY,
         'show help menu',
       );
@@ -315,7 +316,7 @@ export class BasePage {
   public async showSettingsMenu(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        TestConstants.COMMAND_KEY,
+        await modifierKey(this.page),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -343,7 +344,7 @@ export class BasePage {
    */
   public async openHelpMenu(): Promise<void> {
     await this.pressKeyCombination(
-      TestConstants.COMMAND_KEY,
+      await modifierKey(this.page),
       TestConstants.SLASH_KEY,
       'open help menu',
     );
@@ -356,7 +357,7 @@ export class BasePage {
    */
   public async openSettingsMenu(): Promise<void> {
     await this.pressKeyCombination(
-      TestConstants.COMMAND_KEY,
+      await modifierKey(this.page),
       TestConstants.COMMA_KEY,
       'open settings menu',
       100,
@@ -370,7 +371,7 @@ export class BasePage {
   public async closeSettingsMenuWithEscape(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        TestConstants.COMMAND_KEY,
+        await modifierKey(this.page),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -402,7 +403,7 @@ export class BasePage {
   public async verifySettingsMenuIgnoresBackdropClick(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        TestConstants.COMMAND_KEY,
+        await modifierKey(this.page),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -514,7 +515,7 @@ export class BasePage {
     useMetaKey = false,
   ): Promise<void> {
     if (useMetaKey) {
-      await this.pressKeyCombination(TestConstants.META_KEY, key, action);
+      await this.pressKeyCombination(await modifierKey(this.page), key, action);
     } else {
       await this.pressKey(key, action);
     }
@@ -833,11 +834,11 @@ export class BasePage {
     const directionName = direction === 'forward' ? 'forward' : direction === 'reverse' ? 'reverse' : direction === 'downward' ? 'downward' : 'upward';
 
     try {
-      await this.page.keyboard.down(TestConstants.META_KEY);
+      await this.page.keyboard.down(await modifierKey(this.page));
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);
 
-      await this.page.keyboard.up(TestConstants.META_KEY);
+      await this.page.keyboard.up(await modifierKey(this.page));
       await this.page.keyboard.up(TestConstants.SHIFT_KEY);
       await this.page.keyboard.up(arrowKey);
 

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -177,8 +177,12 @@ export class BasePage {
     try {
       return await modifierKey(this.page);
     } catch (error) {
+      // "Meta/Control" rather than "modifier": KeypressError renders this as
+      // `Failed to press key "..." during <context>`, and naming the two
+      // candidates says what could not be decided. The keypress genuinely did
+      // not happen, so the type is right even though the cause is a page read.
       throw new KeypressError(
-        'modifier',
+        'Meta/Control',
         context,
         error instanceof Error ? error : undefined,
       );

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -806,6 +806,11 @@ export class BasePage {
     // below is the authoritative check and answers either way, so rethrowing
     // would only turn a "mode never announced" expectation into a page-object
     // error. Callers assert on the boolean.
+    // The catch is broad on purpose but not lossy: a structural problem such as
+    // a strict-mode violation from a selector matching several elements is
+    // raised again by `getElementText` below and surfaces as "Failed to check
+    // <mode> status" with the violation as its cause. Only a genuine
+    // "never announced" reaches the boolean. Verified, not assumed.
     await expect(this.page.locator(notificationSelector))
       .toHaveText(expected, { timeout: 5000 })
       .catch(() => { /* the read below decides */ });

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -3,17 +3,7 @@ import { expect } from '@playwright/test';
 import { TestConstants } from '../utils/constants';
 import { AssertionError, KeypressError } from '../utils/errors';
 import { modifierKey } from '../utils/platform';
-
-/**
- * Collapses whitespace runs and trims, the way `expect(...).toHaveText()` does
- * before comparing. MAIDR's announcement markup wraps its text across lines, so
- * comparisons against a single-line expected string have to normalise first.
- * @param text - Raw text content read from the page
- * @returns The text with whitespace runs collapsed to single spaces, trimmed
- */
-function normalizeText(text: string): string {
-  return text.replace(/\s+/g, ' ').trim();
-}
+import { normalizeText } from '../utils/text';
 
 /**
  * Base page object that all other page objects extend
@@ -175,6 +165,27 @@ export class BasePage {
   }
 
   /**
+   * Resolves the control/command modifier, wrapping a failure the way the key
+   * helpers do. Callers pass the result straight into `pressKeyCombination`,
+   * which evaluates its arguments before its own try block — so without this
+   * a page-evaluate failure would escape unwrapped.
+   * @param context - Context description for error reporting
+   * @returns The modifier key name for this browser
+   * @throws KeypressError if the modifier cannot be resolved
+   */
+  protected async resolveModifier(context: string): Promise<string> {
+    try {
+      return await modifierKey(this.page);
+    } catch (error) {
+      throw new KeypressError(
+        'modifier',
+        context,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  /**
    * Presses a key combination (e.g., Command + key)
    *
    * Named `modifier` rather than `modifierKey` so it does not shadow the
@@ -306,7 +317,7 @@ export class BasePage {
   public async showHelpMenu(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await modifierKey(this.page),
+        await this.resolveModifier('key combination'),
         TestConstants.SLASH_KEY,
         'show help menu',
       );
@@ -330,7 +341,7 @@ export class BasePage {
   public async showSettingsMenu(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await modifierKey(this.page),
+        await this.resolveModifier('key combination'),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -358,7 +369,7 @@ export class BasePage {
    */
   public async openHelpMenu(): Promise<void> {
     await this.pressKeyCombination(
-      await modifierKey(this.page),
+      await this.resolveModifier('key combination'),
       TestConstants.SLASH_KEY,
       'open help menu',
     );
@@ -371,7 +382,7 @@ export class BasePage {
    */
   public async openSettingsMenu(): Promise<void> {
     await this.pressKeyCombination(
-      await modifierKey(this.page),
+      await this.resolveModifier('key combination'),
       TestConstants.COMMA_KEY,
       'open settings menu',
       100,
@@ -385,7 +396,7 @@ export class BasePage {
   public async closeSettingsMenuWithEscape(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await modifierKey(this.page),
+        await this.resolveModifier('key combination'),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -417,7 +428,7 @@ export class BasePage {
   public async verifySettingsMenuIgnoresBackdropClick(): Promise<void> {
     try {
       await this.pressKeyCombination(
-        await modifierKey(this.page),
+        await this.resolveModifier('key combination'),
         TestConstants.COMMA_KEY,
         'show settings menu',
         100,
@@ -530,7 +541,7 @@ export class BasePage {
     useMetaKey = false,
   ): Promise<void> {
     if (useMetaKey) {
-      await this.pressKeyCombination(await modifierKey(this.page), key, action);
+      await this.pressKeyCombination(await this.resolveModifier('key combination'), key, action);
     } else {
       await this.pressKey(key, action);
     }
@@ -758,7 +769,7 @@ export class BasePage {
   protected async getInstructionText(notificationSelector: string): Promise<string> {
     try {
       const text = await this.getElementText(notificationSelector);
-      return text.replace(/\s+/g, ' ').trim();
+      return normalizeText(text);
     } catch (error) {
       throw new Error('Failed to get instruction text', { cause: error });
     }
@@ -869,10 +880,11 @@ export class BasePage {
     const arrowKey = direction === 'forward' ? TestConstants.RIGHT_ARROW_KEY : direction === 'reverse' ? TestConstants.LEFT_ARROW_KEY : direction === 'downward' ? TestConstants.DOWN_ARROW_KEY : TestConstants.UP_ARROW_KEY;
     const directionName = direction === 'forward' ? 'forward' : direction === 'reverse' ? 'reverse' : direction === 'downward' ? 'downward' : 'upward';
 
-    // Resolve once: it costs a page round-trip and cannot change mid-test.
-    const modifier = await modifierKey(this.page);
-
     try {
+      // Resolve once: it costs a page round-trip and cannot change mid-test.
+      // Inside the try so a failure is wrapped like every other step here.
+      const modifier = await this.resolveModifier(`start ${directionName} autoplay`);
+
       await this.page.keyboard.down(modifier);
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -5,6 +5,17 @@ import { AssertionError, KeypressError } from '../utils/errors';
 import { modifierKey } from '../utils/platform';
 
 /**
+ * Collapses whitespace runs and trims, the way `expect(...).toHaveText()` does
+ * before comparing. MAIDR's announcement markup wraps its text across lines, so
+ * comparisons against a single-line expected string have to normalise first.
+ * @param text - Raw text content read from the page
+ * @returns The text with whitespace runs collapsed to single spaces, trimmed
+ */
+function normalizeText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Base page object that all other page objects extend
  * Provides common functionality for all pages
  */
@@ -762,19 +773,25 @@ export class BasePage {
     mode: string,
     modeMessages: Record<string, string>,
   ): Promise<boolean> {
+    const expected = modeMessages[mode];
+
     // The announcement lands asynchronously after the keypress, so reading the
     // region once races the update — fast enough to pass in Chromium and
     // Firefox, and a flake in WebKit under full-suite load. Wait for the
-    // expected text instead, and report absence as false rather than throwing:
-    // callers assert on the boolean, and "the mode never announced" is a
-    // failed expectation, not a broken page object.
+    // expected text first. A timeout here is deliberately not fatal: the read
+    // below is the authoritative check and answers either way, so rethrowing
+    // would only turn a "mode never announced" expectation into a page-object
+    // error. Callers assert on the boolean.
     await expect(this.page.locator(notificationSelector))
-      .toHaveText(modeMessages[mode], { timeout: 5000 })
-      .catch(() => { /* fall through to the re-read below */ });
+      .toHaveText(expected, { timeout: 5000 })
+      .catch(() => { /* the read below decides */ });
 
     try {
       const notificationText = await this.getElementText(notificationSelector);
-      return notificationText === modeMessages[mode];
+      // Normalise both sides. `toHaveText` collapses whitespace, so a raw
+      // strict compare could contradict the wait that just succeeded, and the
+      // announcement markup wraps its text across lines.
+      return normalizeText(notificationText) === normalizeText(expected);
     } catch (error) {
       throw new Error(`Failed to check ${mode} status`, { cause: error });
     }
@@ -843,12 +860,15 @@ export class BasePage {
     const arrowKey = direction === 'forward' ? TestConstants.RIGHT_ARROW_KEY : direction === 'reverse' ? TestConstants.LEFT_ARROW_KEY : direction === 'downward' ? TestConstants.DOWN_ARROW_KEY : TestConstants.UP_ARROW_KEY;
     const directionName = direction === 'forward' ? 'forward' : direction === 'reverse' ? 'reverse' : direction === 'downward' ? 'downward' : 'upward';
 
+    // Resolve once: it costs a page round-trip and cannot change mid-test.
+    const modifier = await modifierKey(this.page);
+
     try {
-      await this.page.keyboard.down(await modifierKey(this.page));
+      await this.page.keyboard.down(modifier);
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);
 
-      await this.page.keyboard.up(await modifierKey(this.page));
+      await this.page.keyboard.up(modifier);
       await this.page.keyboard.up(TestConstants.SHIFT_KEY);
       await this.page.keyboard.up(arrowKey);
 

--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -190,8 +190,13 @@ export class BarPlotPage extends BasePage {
    */
   protected async isModeActive(mode: string, expectedMessage: string): Promise<boolean> {
     try {
-      const notificationText = await this.getNotificationText();
-      return notificationText === expectedMessage;
+      // Delegate rather than read the notification directly: the base
+      // implementation waits for the announcement before comparing, and a
+      // second snapshot-reading copy here would keep the barplot toggles
+      // exposed to the live-region race the base class exists to avoid.
+      return await super.isModeActive(this.selectors.notification, mode, {
+        [mode]: expectedMessage,
+      });
     } catch (error) {
       throw new BarPlotError(`Failed to check ${mode} status`, { cause: error });
     }
@@ -349,12 +354,15 @@ export class BarPlotPage extends BasePage {
     const arrowKey = direction === 'forward' ? TestConstants.RIGHT_ARROW_KEY : TestConstants.LEFT_ARROW_KEY;
     const directionName = direction === 'forward' ? 'forward' : 'reverse';
 
+    // Resolve once: it costs a page round-trip and cannot change mid-test.
+    const modifier = await modifierKey(this.page);
+
     try {
-      await this.page.keyboard.down(await modifierKey(this.page));
+      await this.page.keyboard.down(modifier);
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);
 
-      await this.page.keyboard.up(await modifierKey(this.page));
+      await this.page.keyboard.up(modifier);
       await this.page.keyboard.up(TestConstants.SHIFT_KEY);
       await this.page.keyboard.up(arrowKey);
 

--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -183,12 +183,18 @@ export class BarPlotPage extends BasePage {
 
   /**
    * Checks if a specific mode is active based on expected message
+   *
+   * Deliberately NOT named `isModeActive`: that would override the base
+   * method with an incompatible parameter list, which is how the barplot
+   * toggles previously ended up bypassing the base class's wait entirely.
+   * A different name means a future change to the base signature cannot
+   * silently miss this one.
    * @param mode - The mode to check
    * @param expectedMessage - The expected message for the mode
    * @returns Promise resolving to true if mode is active, false otherwise
    * @throws BarPlotError if mode status cannot be checked
    */
-  protected async isModeActive(mode: string, expectedMessage: string): Promise<boolean> {
+  protected async isModeMessageActive(mode: string, expectedMessage: string): Promise<boolean> {
     try {
       // Delegate rather than read the notification directly: the base
       // implementation waits for the announcement before comparing, and a
@@ -217,7 +223,7 @@ export class BarPlotPage extends BasePage {
       throw new BarPlotError('Invalid text mode specified');
     }
 
-    return this.isModeActive('text', modeMessages[textMode]);
+    return this.isModeMessageActive('text', modeMessages[textMode]);
   }
 
   /**
@@ -234,7 +240,7 @@ export class BarPlotPage extends BasePage {
       throw new BarPlotError('Invalid braille mode specified');
     }
 
-    return this.isModeActive('braille', modeMessages[brailleMode]);
+    return this.isModeMessageActive('braille', modeMessages[brailleMode]);
   }
 
   /**
@@ -251,7 +257,7 @@ export class BarPlotPage extends BasePage {
       throw new BarPlotError('Invalid sonification mode specified');
     }
 
-    return this.isModeActive('sonification', modeMessages[sonificationMode]);
+    return this.isModeMessageActive('sonification', modeMessages[sonificationMode]);
   }
 
   /**
@@ -268,7 +274,7 @@ export class BarPlotPage extends BasePage {
       throw new BarPlotError('Invalid review mode specified');
     }
 
-    return this.isModeActive('review', modeMessages[reviewMode]);
+    return this.isModeMessageActive('review', modeMessages[reviewMode]);
   }
 
   /**

--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { TestConstants } from '../../utils/constants';
 import { BarPlotError } from '../../utils/errors';
-import { modifierKey } from '../../utils/platform';
+import { normalizeText } from '../../utils/text';
 import { BasePage } from '../base-page';
 
 /**
@@ -166,7 +166,7 @@ export class BarPlotPage extends BasePage {
   private async getNotificationText(): Promise<string> {
     try {
       const text = await this.getElementText(this.selectors.notification);
-      return text.replace(/\s+/g, ' ').trim();
+      return normalizeText(text);
     } catch (error) {
       throw new BarPlotError('Failed to get notification text', { cause: error });
     }
@@ -354,10 +354,11 @@ export class BarPlotPage extends BasePage {
     const arrowKey = direction === 'forward' ? TestConstants.RIGHT_ARROW_KEY : TestConstants.LEFT_ARROW_KEY;
     const directionName = direction === 'forward' ? 'forward' : 'reverse';
 
-    // Resolve once: it costs a page round-trip and cannot change mid-test.
-    const modifier = await modifierKey(this.page);
-
     try {
+      // Resolve once: it costs a page round-trip and cannot change mid-test.
+      // Inside the try so a failure is wrapped like every other step here.
+      const modifier = await this.resolveModifier(`start ${directionName} autoplay`);
+
       await this.page.keyboard.down(modifier);
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);

--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { TestConstants } from '../../utils/constants';
 import { BarPlotError } from '../../utils/errors';
+import { modifierKey } from '../../utils/platform';
 import { BasePage } from '../base-page';
 
 /**
@@ -349,11 +350,11 @@ export class BarPlotPage extends BasePage {
     const directionName = direction === 'forward' ? 'forward' : 'reverse';
 
     try {
-      await this.page.keyboard.down(TestConstants.META_KEY);
+      await this.page.keyboard.down(await modifierKey(this.page));
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);
 
-      await this.page.keyboard.up(TestConstants.META_KEY);
+      await this.page.keyboard.up(await modifierKey(this.page));
       await this.page.keyboard.up(TestConstants.SHIFT_KEY);
       await this.page.keyboard.up(arrowKey);
 

--- a/e2e_tests/page-objects/plots/boxplotVertical-page.ts
+++ b/e2e_tests/page-objects/plots/boxplotVertical-page.ts
@@ -1,7 +1,6 @@
 import type { Page } from '@playwright/test';
 import { TestConstants } from '../../utils/constants';
 import { BoxplotVerticalError } from '../../utils/errors';
-import { modifierKey } from '../../utils/platform';
 import { BasePage } from '../base-page';
 
 /**
@@ -342,7 +341,7 @@ export class BoxplotVerticalPage extends BasePage {
    */
   public async moveToTop(): Promise<void> {
     try {
-      await this.pressKeyCombination(await modifierKey(this.page), TestConstants.UP_ARROW_KEY, 'Move to top');
+      await this.pressKeyCombination(await this.resolveModifier('Move to top'), TestConstants.UP_ARROW_KEY, 'Move to top');
     } catch (error) {
       throw new BoxplotVerticalError('Failed to move to last box', { cause: error });
     }

--- a/e2e_tests/page-objects/plots/boxplotVertical-page.ts
+++ b/e2e_tests/page-objects/plots/boxplotVertical-page.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test';
 import { TestConstants } from '../../utils/constants';
 import { BoxplotVerticalError } from '../../utils/errors';
+import { modifierKey } from '../../utils/platform';
 import { BasePage } from '../base-page';
 
 /**
@@ -341,7 +342,7 @@ export class BoxplotVerticalPage extends BasePage {
    */
   public async moveToTop(): Promise<void> {
     try {
-      await this.pressKeyCombination(TestConstants.META_KEY, TestConstants.UP_ARROW_KEY, 'Move to top');
+      await this.pressKeyCombination(await modifierKey(this.page), TestConstants.UP_ARROW_KEY, 'Move to top');
     } catch (error) {
       throw new BoxplotVerticalError('Failed to move to last box', { cause: error });
     }

--- a/e2e_tests/specs/dialogAccessibility.spec.ts
+++ b/e2e_tests/specs/dialogAccessibility.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
 import { BarPlotPage } from '../page-objects/plots/barplot-page';
 import { TestConstants } from '../utils/constants';
+import { modifierKey } from '../utils/platform';
 
 /**
  * Every MAIDR dialog is rendered with `disablePortal`, so it lives inside the
@@ -142,7 +143,7 @@ test.describe('dialog accessibility tree', () => {
   test('command palette resolves by role', async ({ page }) => {
     await setupBarPlotPage(page);
     // The binding is `Platform.ctrl + shift + p`, which is Command on macOS.
-    await page.keyboard.press(`${TestConstants.COMMAND_KEY}+Shift+P`);
+    await page.keyboard.press(`${await modifierKey(page)}+Shift+P`);
 
     await expect(page.getByRole('dialog')).toBeVisible();
     expect(await hiddenAncestorsOf(page, '.MuiDialog-root')).toEqual([]);

--- a/e2e_tests/specs/errorCause.spec.ts
+++ b/e2e_tests/specs/errorCause.spec.ts
@@ -34,6 +34,12 @@ test.describe('Error cause propagation', () => {
     // intercepts file:// navigations in Chromium, so the routed version passed
     // there and let the navigation succeed in Firefox and WebKit. A closed
     // page rejects `page.goto` identically in all three.
+    //
+    // Closing the fixture's own page is deliberate, and it is why every
+    // assertion below reads the rejected error rather than the page: once it
+    // is closed Playwright can capture no screenshot, trace or video for this
+    // test. Anything added after this line that touches the page would fail
+    // with no artefact to debug from — open a second page for that instead.
     const plotPage = new MultiLayerPlotPage(page);
     await page.close();
 

--- a/e2e_tests/specs/errorCause.spec.ts
+++ b/e2e_tests/specs/errorCause.spec.ts
@@ -28,11 +28,15 @@ import {
 test.describe('Error cause propagation', () => {
   test('a failed navigation reports the browser error through both wrappers', async ({ page }) => {
     // Fail the navigation itself rather than relying on a bad path, so the
-    // test keeps working once the example filename is corrected. Playwright
-    // routing does apply to file:// URLs.
-    await page.route(/\.html$/, route => route.abort());
-
+    // test keeps working now that the example filename is corrected.
+    //
+    // Closing the page rather than aborting via `page.route`: routing only
+    // intercepts file:// navigations in Chromium, so the routed version passed
+    // there and let the navigation succeed in Firefox and WebKit. A closed
+    // page rejects `page.goto` identically in all three.
     const plotPage = new MultiLayerPlotPage(page);
+    await page.close();
+
     const error = await plotPage
       .navigateToMultiLayerPlot()
       .then(() => null, (thrown: unknown) => thrown as MultiLayerPlotError);

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -4,8 +4,6 @@
  * Contains selectors, element IDs, keyboard keys, instruction text,
  * and other constants needed for testing MAIDR functionality
  */
-import process from 'node:process';
-
 export abstract class TestConstants {
   /**
    * HTML element selectors
@@ -72,15 +70,9 @@ export abstract class TestConstants {
   static readonly PERIOD_KEY = '.';
   static readonly COMMA_KEY = ',';
   static readonly SLASH_KEY = '/';
-  /**
-   * Modifier for MAIDR's "control/command" shortcuts (extreme navigation,
-   * autoplay, help, settings). MAIDR binds Cmd on macOS and Ctrl elsewhere
-   * (see src/util/platform.ts `Platform.ctrl`), so the e2e modifier must
-   * track the OS running the browser. On the Linux CI runner sending 'Meta'
-   * (the Super key) is a no-op, which silently breaks every Ctrl-combination
-   * test. Mirror the app's own platform logic here.
-   */
-  static readonly META_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
+  // The control/command modifier is NOT a constant: it depends on what the
+  // browser reports, not on the host OS. Use `modifierKey(page)` from
+  // e2e_tests/utils/platform.ts — see the note there on WebKit.
   static readonly SHIFT_KEY = 'Shift';
   static readonly HOME_KEY = 'Home';
   static readonly END_KEY = 'End';
@@ -91,10 +83,6 @@ export abstract class TestConstants {
   static readonly LABEL_KEY = 'l';
   static readonly X_AXIS_TITLE = 'x';
   static readonly Y_AXIS_TITLE = 'y';
-  // Same control/command modifier as META_KEY (see its note): MAIDR binds Cmd
-  // on macOS and Ctrl elsewhere, so help/settings shortcuts need the OS-correct
-  // modifier or they silently no-op on the Linux CI runner.
-  static readonly COMMAND_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
   static readonly ESCAPE_KEY = 'Escape';
   static readonly PAGE_UP_KEY = 'PageUp';
   static readonly PAGE_DOWN_KEY = 'PageDown';

--- a/e2e_tests/utils/platform.ts
+++ b/e2e_tests/utils/platform.ts
@@ -1,0 +1,27 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Resolves the control/command modifier for MAIDR's shortcuts by asking the
+ * browser, exactly the way `Platform.IS_MAC` in src/util/platform.ts does.
+ *
+ * This cannot be decided from `process.platform`. Playwright's WebKit build on
+ * Linux is a Mac-flavoured WebKit that reports `navigator.platform` as
+ * "MacIntel", so MAIDR binds Command there while the host OS is Linux. A
+ * modifier chosen from the host sends Control, which WebKit ignores, and every
+ * Ctrl-combination shortcut — help, settings, extreme navigation, autoplay —
+ * silently no-ops.
+ * @param page - The Playwright page, already navigated to a document
+ * @returns 'Meta' when the browser reports macOS, otherwise 'Control'
+ */
+export async function modifierKey(page: Page): Promise<'Meta' | 'Control'> {
+  const isMac = await page.evaluate(() => {
+    const navigatorWithUaData = navigator as Navigator & {
+      userAgentData?: { platform?: string };
+    };
+    const platform
+      = navigatorWithUaData.userAgentData?.platform ?? navigator.platform;
+    return platform.toLowerCase().includes('mac');
+  });
+
+  return isMac ? 'Meta' : 'Control';
+}

--- a/e2e_tests/utils/text.ts
+++ b/e2e_tests/utils/text.ts
@@ -1,0 +1,13 @@
+/**
+ * Collapses whitespace runs and trims, the way `expect(...).toHaveText()` does
+ * before comparing.
+ *
+ * MAIDR's announcement markup wraps its text across lines, so any comparison
+ * against a single-line expected string has to normalise first — otherwise a
+ * wait that matched and a strict equality check that followed it can disagree.
+ * @param text - Raw text content read from the page
+ * @returns The text with whitespace runs collapsed to single spaces, trimmed
+ */
+export function normalizeText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
# Pull Request

## Description

WebKit had never actually been verified. #674 and #676 both shipped with "webkit — not verified" in their notes, because its Playwright build needs system libraries the sandbox lacked. I installed them (`npx playwright install-deps webkit`) and ran it.

It was badly broken, for a reason that had nothing to do with WebKit rendering:

```
before   22 failed,  49 passed    (three barplot specs only)
after     0 failed,  71 passed
```

Full three-browser suite, `CI=true`, on this branch:

```
903 passed (chromium 301, firefox 301, webkit 301)   0 failed
```

## Related Issues

Follows #674 (restored the e2e suite) and #676 (error causes). Closes the WebKit gap both left open.

## Changes Made

### 1. The control modifier was read from the wrong machine

Playwright's WebKit on Linux is a **Mac-flavoured WebKit** — it reports `navigator.platform` as `MacIntel`. Measured across the three projects:

| project | `navigator.platform` | app binds | test sent |
|---|---|---|---|
| chromium | `Linux x86_64` | Control | Control ✅ |
| firefox | `Linux x86_64` | Control | Control ✅ |
| **webkit** | **`MacIntel`** | **Command** | Control ❌ |

`src/util/platform.ts` reads `navigator.platform`, so MAIDR was right to bind Command. The test constants read `process.platform` — the *host* OS — which is `linux` on the runner:

```ts
static readonly META_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
```

Host and browser happen to agree for Chromium and Firefox, which is why nobody noticed. On WebKit they disagree, every Ctrl-combination shortcut silently no-ops, and help, settings, extreme navigation and autoplay all fail.

Replaced with `modifierKey(page)` in a new `e2e_tests/utils/platform.ts`, which asks the browser the same way the app does. Both constants are deleted rather than left in place, so the next caller can't pick the broken one.

### 2. A cross-browser defect I introduced in #676

`errorCause.spec.ts` blocked its navigation with `page.route(/\.html$/, route => route.abort())`. **Playwright only intercepts `file://` navigations in Chromium** — which is the only browser I verified it on. In Firefox and WebKit the navigation just succeeded and the test failed its own guard.

This was already on `main` and would have failed the scheduled workflow. Closing the page instead makes `page.goto` reject identically everywhere; the asserted chain is unchanged.

### 3. A racy assertion

`isModeActive` snapshotted the live region immediately after the keypress, racing MAIDR's announcement. It now waits for the expected text first, then re-reads and compares as before.

### 4. Retries on CI — a mitigation, stated as one

Several other getters read live regions the same snapshot way. Under parallel load WebKit occasionally reads first, and **a different test failed on each full run**:

| run | WebKit failure |
|---|---|
| 1 | multiLayer → toggle sound mode |
| 2 | multiLineplot → toggle braille mode |
| 3 | multiLayer → display Y-axis Title |
| 4 | boxplotVertical → Y-axis Title, dodgedBarplot → bottom level |

Every one passed 3/3 in isolation. That is load-induced flakiness, not four bugs.

`retries: process.env.CI ? 2 : 0` absorbs it without hiding it — Playwright still marks a retried test **flaky** in the report, and a test that fails every attempt still fails the run. Local runs keep 0 retries so a real failure stays immediate.

**This is not a cure.** The cure is for those getters to wait for the region to update rather than snapshotting it, the way `isModeActive` now does. The config comment says exactly that and points at the example. I did not do it here because it means touching every reader and risks masking genuine "never announced" bugs — which are accessibility bugs, and the ones this suite exists to catch.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no user-facing behaviour changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| check | result |
|---|---|
| `npm run lint` | clean |
| `npm run type-check` | clean |
| `npm test` (jest) | 1277 passed, 100 suites |
| e2e — chromium | 301 passed |
| e2e — firefox | 301 passed |
| e2e — **webkit** | **301 passed** |
| e2e — all three, `CI=true` | **903 passed, 0 failed** |

No `src/` product code is touched. The product was correct throughout — on a browser reporting itself as a Mac it binds Command, which is right. Only the tests were wrong.

Two things worth flagging beyond this diff:

- **`e2e.yml` and `e2e_tests.yml` are near-duplicates** — same `0 2 */2 * *` cron, both running the full three-browser suite, so every scheduled window does the work twice. Only `e2e_tests.yml` files the report issue. Left alone as unrelated, but worth collapsing.
- **The PR job still runs chromium only.** Now that WebKit and Firefox pass, adding them is defensible, but it roughly triples that job's runtime (~3m40s → ~9m). I'd rather the maintainer make that call than spend it by default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz)_