### PR TITLE
test(e2e): synchronise assertions with MAIDR's announcements

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -32,7 +32,7 @@ You are a testing specialist for the MAIDR accessibility library.
 - Test config: `e2e_tests/config/test-config.ts`
 - Utils: `e2e_tests/utils/constants.ts`, `e2e_tests/utils/errors.ts`
 - Tests run against `file://` protocol (no server needed)
-- 30s timeout, retries: 2
+- 30s timeout, no retries (a flake is a real failure; see e2e_tests/utils/announcements.ts)
 
 ### Existing E2E spec files
 - `barplot.spec.ts` — Bar plot navigation and sonification

--- a/e2e_tests/config/test-config.ts
+++ b/e2e_tests/config/test-config.ts
@@ -6,7 +6,6 @@
  */
 import type { PlaywrightTestConfig } from '@playwright/test';
 import path from 'node:path';
-import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 // The package is ESM ("type": "module"), so CommonJS `__dirname` does not
@@ -41,18 +40,6 @@ const config: PlaywrightTestConfig = {
   expect: {
     timeout: 5000,
   },
-
-  // The page objects read MAIDR's live regions immediately after dispatching a
-  // key. Under parallel load WebKit — the slowest of the three — occasionally
-  // reads before the announcement lands, and a different test flakes each run.
-  // Retries absorb that without hiding it: Playwright still marks a test that
-  // needed one as "flaky" in the report. A test that fails every attempt is a
-  // real failure and still fails the run.
-  //
-  // This is a mitigation, not the cure. The cure is for those getters to wait
-  // for the region to update rather than snapshotting it once — see
-  // `isModeActive` in base-page.ts for the shape that fix takes.
-  retries: process.env.CI ? 2 : 0,
 
   // Test reporters
   reporter: [

--- a/e2e_tests/config/test-config.ts
+++ b/e2e_tests/config/test-config.ts
@@ -55,8 +55,13 @@ const config: PlaywrightTestConfig = {
     // Browser settings
     viewport: null,
 
-    // Capture traces and screenshots on failure
-    trace: 'on-first-retry',
+    // Capture traces and screenshots on failure.
+    //
+    // `retain-on-failure`, not `on-first-retry`: there are no retries any more,
+    // so a trace keyed to a retry attempt would never be written and a real
+    // failure would leave only a screenshot. A failure is now always the first
+    // and only attempt, which is exactly when the trace is worth having.
+    trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
   },
 

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -1048,9 +1048,10 @@ export class BasePage {
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);
 
+      // Only the two modifiers are still held: `pressKey` above is a full
+      // press, so the arrow key was already released.
       await this.page.keyboard.up(modifier);
       await this.page.keyboard.up(TestConstants.SHIFT_KEY);
-      await this.page.keyboard.up(arrowKey);
 
       if (expectedContent) {
         await this.waitForElementContent(

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -699,8 +699,28 @@ export class BasePage {
    * @throws KeypressError if operation fails
    */
   protected async toggleAxisTitle(axisKey: string, axisName: string): Promise<void> {
+    // Wait on the displayed text, not on an announcement. The axis title only
+    // reaches the alert once the cursor is on a data point, and these specs
+    // assert it straight after activation — so an announcement wait finds
+    // nothing and spends its whole timeout, which passes only because the
+    // delay works as a sleep. The assertion reads this container, so a change
+    // here is the event it actually depends on.
+    //
+    // This also settles the two-keypress sequence: entering label scope warns
+    // when text mode is off, and that announcement lands inside this wait
+    // rather than leaking into the next action's.
+    const container = this.page.locator(
+      `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER}`,
+    );
+    const before = normalizeText((await container.textContent()) ?? '');
+
     await this.pressKey(TestConstants.LABEL_KEY, 'label scope');
-    await this.pressKeyAwaitingAnnouncement(axisKey, axisName);
+    await this.pressKey(axisKey, axisName);
+
+    await expect(container)
+      .not
+      .toHaveText(before, { timeout: TestConstants.ANNOUNCEMENT_TIMEOUT })
+      .catch(() => { /* the caller's assertion decides */ });
   }
 
   /**

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -23,14 +23,13 @@ export class BasePage {
    * region's current text, so a later announcement replacing theirs — or an
    * earlier one arriving late — cannot turn a real pass into a failure.
    *
-   * The contract is positional and not enforced by the types: `isModeActive`
-   * assumes the action it is checking was the last one to set this. Every
-   * caller follows `toggleXMode()` with `isXModeActive()`, which holds it. A
-   * check that is NOT preceded by an awaited action reads the window since
-   * some unrelated earlier action instead, so widen this to an explicit
-   * handle rather than adding such a caller.
+   * Null until an awaited action sets it, and reset to null once a check has
+   * consumed it. That makes the positional contract self-limiting: a check
+   * with no awaited action before it takes the region fallback instead of
+   * matching against an unrelated earlier announcement, which would be a
+   * silent false positive rather than a visible failure.
    */
-  private actionAnnouncementMark = 0;
+  private actionAnnouncementMark: number | null = null;
 
   /**
    * Common selectors used across different pages
@@ -858,13 +857,20 @@ export class BasePage {
     // been replaced — an announcement from an earlier, un-awaited action
     // arriving late is enough — and sampling the current text would then report
     // a mode that did toggle as inactive.
-    const announced = await announcementsSince(this.page, this.actionAnnouncementMark);
-    if (announced.length > 0) {
-      return announced.some(text => normalizeText(text) === normalizeText(expected));
+    const mark = this.actionAnnouncementMark;
+    this.actionAnnouncementMark = null;
+    if (mark !== null) {
+      const announced = await announcementsSince(this.page, mark);
+      if (announced.length > 0) {
+        return announced.some(text => normalizeText(text) === normalizeText(expected));
+      }
     }
 
-    // No announcements recorded, so this was not reached through an awaited
-    // action. Fall back to waiting on the region. A timeout here is
+    // Nothing recorded for this action, so fall back to the region. Note this
+    // path reads `#maidr-text-container`, which is the displayed text and not
+    // the `role="alert"` node a screen reader hears — the two agree for every
+    // `notify()`-driven message, which is all of these, but the fallback does
+    // not carry the same guarantee as the recorded path above. A timeout here is
     // deliberately not fatal: the read below is the authoritative check and
     // answers either way, so rethrowing would only turn a "mode never
     // announced" expectation into a page-object error. Callers assert on the

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -1,7 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import {
-  announcementCount,
   announcementsSince,
   installAnnouncementRecorder,
   waitForAnnouncementAfter,
@@ -234,8 +233,9 @@ export class BasePage {
    * @param act - The key action to run
    */
   private async awaitingAnnouncement(act: () => Promise<void>): Promise<void> {
-    await installAnnouncementRecorder(this.page);
-    this.actionAnnouncementMark = await announcementCount(this.page);
+    // Install and mark in one page call: this path now runs on nearly every
+    // interaction in the suite, so a second round trip per action is not free.
+    this.actionAnnouncementMark = await installAnnouncementRecorder(this.page);
     await act();
     await waitForAnnouncementAfter(this.page, this.actionAnnouncementMark);
   }

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -1,5 +1,11 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
+import {
+  announcementCount,
+  announcementsSince,
+  installAnnouncementRecorder,
+  waitForAnnouncementAfter,
+} from '../utils/announcements';
 import { TestConstants } from '../utils/constants';
 import { AssertionError, KeypressError } from '../utils/errors';
 import { modifierKey } from '../utils/platform';
@@ -11,6 +17,14 @@ import { normalizeText } from '../utils/text';
  */
 export class BasePage {
   protected readonly page: Page;
+
+  /**
+   * Announcement count captured immediately before the most recent action that
+   * waited for one. Assertions read the window after this mark rather than the
+   * region's current text, so a later announcement replacing theirs — or an
+   * earlier one arriving late — cannot turn a real pass into a failure.
+   */
+  private actionAnnouncementMark = 0;
 
   /**
    * Common selectors used across different pages
@@ -190,6 +204,27 @@ export class BasePage {
   }
 
   /**
+   * Presses a key and waits for MAIDR to announce the result.
+   *
+   * This is the synchronisation point the assertions depend on. Reading the
+   * live region straight after a keypress races the announcement, and waiting
+   * afterwards cannot recover one that has already been replaced — so the wait
+   * has to start before the key is pressed.
+   *
+   * Silent keypresses are fine: the wait resolves false and the caller's own
+   * assertion still decides.
+   * @param key - The key to press
+   * @param context - Context description for error reporting
+   * @throws KeypressError if the key press itself fails
+   */
+  protected async pressKeyAwaitingAnnouncement(key: string, context: string): Promise<void> {
+    await installAnnouncementRecorder(this.page);
+    this.actionAnnouncementMark = await announcementCount(this.page);
+    await this.pressKey(key, context);
+    await waitForAnnouncementAfter(this.page, this.actionAnnouncementMark);
+  }
+
+  /**
    * Presses a key combination (e.g., Command + key)
    *
    * Named `modifier` rather than `modifierKey` so it does not shadow the
@@ -279,7 +314,7 @@ export class BasePage {
    * @throws KeypressError if toggling fails
    */
   protected async toggleMode(key: string, modeName: string): Promise<void> {
-    await this.pressKey(key, modeName);
+    await this.pressKeyAwaitingAnnouncement(key, modeName);
   }
 
   /**
@@ -496,7 +531,7 @@ export class BasePage {
    * @throws KeypressError if operation fails
    */
   protected async changeSpeed(key: string, action: string): Promise<void> {
-    await this.pressKey(key, action);
+    await this.pressKeyAwaitingAnnouncement(key, action);
   }
 
   /**
@@ -545,9 +580,12 @@ export class BasePage {
     useMetaKey = false,
   ): Promise<void> {
     if (useMetaKey) {
+      await installAnnouncementRecorder(this.page);
+      this.actionAnnouncementMark = await announcementCount(this.page);
       await this.pressKeyCombination(await this.resolveModifier(action), key, action);
+      await waitForAnnouncementAfter(this.page, this.actionAnnouncementMark);
     } else {
-      await this.pressKey(key, action);
+      await this.pressKeyAwaitingAnnouncement(key, action);
     }
   }
 
@@ -647,7 +685,7 @@ export class BasePage {
    */
   protected async toggleAxisTitle(axisKey: string, axisName: string): Promise<void> {
     await this.pressKey(TestConstants.LABEL_KEY, 'label scope');
-    await this.pressKey(axisKey, axisName);
+    await this.pressKeyAwaitingAnnouncement(axisKey, axisName);
   }
 
   /**
@@ -799,13 +837,22 @@ export class BasePage {
   ): Promise<boolean> {
     const expected = modeMessages[mode];
 
-    // The announcement lands asynchronously after the keypress, so reading the
-    // region once races the update — fast enough to pass in Chromium and
-    // Firefox, and a flake in WebKit under full-suite load. Wait for the
-    // expected text first. A timeout here is deliberately not fatal: the read
-    // below is the authoritative check and answers either way, so rethrowing
-    // would only turn a "mode never announced" expectation into a page-object
-    // error. Callers assert on the boolean.
+    // Prefer what the action actually announced. The region holds one message
+    // at a time, so by the time this runs the mode message may already have
+    // been replaced — an announcement from an earlier, un-awaited action
+    // arriving late is enough — and sampling the current text would then report
+    // a mode that did toggle as inactive.
+    const announced = await announcementsSince(this.page, this.actionAnnouncementMark);
+    if (announced.length > 0) {
+      return announced.some(text => normalizeText(text) === normalizeText(expected));
+    }
+
+    // No announcements recorded, so this was not reached through an awaited
+    // action. Fall back to waiting on the region. A timeout here is
+    // deliberately not fatal: the read below is the authoritative check and
+    // answers either way, so rethrowing would only turn a "mode never
+    // announced" expectation into a page-object error. Callers assert on the
+    // boolean.
     // The catch is broad on purpose but not lossy: a structural problem such as
     // a strict-mode violation from a selector matching several elements is
     // raised again by `getElementText` below and surfaces as "Failed to check

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -901,9 +901,13 @@ export class BasePage {
    * @throws Error if mode status cannot be checked
    *
    * Note: on the recorded path a false result is immediate — the window is
-   * already known, so a mismatch costs nothing. Only the fallback below pays
-   * the full wait timeout, and it is reached only when no awaited action
-   * preceded the check.
+   * already known, so a mismatch costs nothing. The fallback below is what
+   * pays the full wait timeout, and it is reached in three cases: no awaited
+   * action preceded the check, the action announced nothing, or this is the
+   * second check after a single action, since the first read consumes the
+   * mark. All three still answer correctly, just from the region rather than
+   * from what was announced — so a check that wants the stronger guarantee
+   * should follow its own awaited action.
    */
   protected async isModeActive(
     notificationSelector: string,

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -251,9 +251,16 @@ export class BasePage {
     // interaction in the suite, so a second round trip per action is not free.
     const mark = await installAnnouncementRecorder(this.page);
 
-    // Publish only once the action has actually run. `act()` presses keys and
-    // `pressKey` clears the mark, so holding it in a local until then is what
-    // lets that clearing be unconditional. It also means a throwing action
+    // Clear here rather than leaving it to `pressKey`. `act()` is sometimes
+    // `pressKeyCombination`, which holds the modifier down before it reaches
+    // `pressKey` — so an action that throws on `keyboard.down` would never
+    // reach the clearing site and would leave an earlier action's mark in
+    // place. Nothing swallows a KeypressError today, so that stale mark has no
+    // route to a later check; this makes the invalidation independent of that
+    // staying true.
+    this.actionAnnouncementMark = null;
+
+    // Publish only once the action has actually run, so a throwing action
     // leaves the mark cleared: a caller that swallowed the failure and carried
     // on cannot be handed a window belonging to an action that never happened.
     await act();
@@ -945,7 +952,7 @@ export class BasePage {
     // <mode> status" with the violation as its cause. Only a genuine
     // "never announced" reaches the boolean. Verified, not assumed.
     await expect(this.page.locator(notificationSelector))
-      .toHaveText(expected, { timeout: 5000 })
+      .toHaveText(expected, { timeout: TestConstants.REGION_FALLBACK_TIMEOUT })
       .catch(() => { /* the read below decides */ });
 
     try {

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -23,6 +23,13 @@ export class BasePage {
    * waited for one. Assertions read the window after this mark rather than the
    * region's current text, so a later announcement replacing theirs — or an
    * earlier one arriving late — cannot turn a real pass into a failure.
+   *
+   * The contract is positional and not enforced by the types: `isModeActive`
+   * assumes the action it is checking was the last one to set this. Every
+   * caller follows `toggleXMode()` with `isXModeActive()`, which holds it. A
+   * check that is NOT preceded by an awaited action reads the window since
+   * some unrelated earlier action instead, so widen this to an explicit
+   * handle rather than adding such a caller.
    */
   private actionAnnouncementMark = 0;
 
@@ -218,9 +225,18 @@ export class BasePage {
    * @throws KeypressError if the key press itself fails
    */
   protected async pressKeyAwaitingAnnouncement(key: string, context: string): Promise<void> {
+    await this.awaitingAnnouncement(() => this.pressKey(key, context));
+  }
+
+  /**
+   * Runs a key action and waits for the announcement it causes, recording
+   * where the action started so assertions can read only its announcements.
+   * @param act - The key action to run
+   */
+  private async awaitingAnnouncement(act: () => Promise<void>): Promise<void> {
     await installAnnouncementRecorder(this.page);
     this.actionAnnouncementMark = await announcementCount(this.page);
-    await this.pressKey(key, context);
+    await act();
     await waitForAnnouncementAfter(this.page, this.actionAnnouncementMark);
   }
 
@@ -580,10 +596,10 @@ export class BasePage {
     useMetaKey = false,
   ): Promise<void> {
     if (useMetaKey) {
-      await installAnnouncementRecorder(this.page);
-      this.actionAnnouncementMark = await announcementCount(this.page);
-      await this.pressKeyCombination(await this.resolveModifier(action), key, action);
-      await waitForAnnouncementAfter(this.page, this.actionAnnouncementMark);
+      const modifier = await this.resolveModifier(action);
+      await this.awaitingAnnouncement(
+        () => this.pressKeyCombination(modifier, key, action),
+      );
     } else {
       await this.pressKeyAwaitingAnnouncement(key, action);
     }

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -728,16 +728,35 @@ export class BasePage {
     await this.pressKey(TestConstants.LABEL_KEY, 'label scope');
     await this.pressKey(axisKey, axisName);
 
-    // Bare catch, and unlike `isModeActive` there is no re-read after it to
-    // resurface a structural problem. There does not need to be: the
-    // `textContent()` above exercises this same locator with nothing catching
-    // it, and locator calls enforce strict mode — a selector matching several
-    // elements raises there, before this wait is reached. Only the timeout
-    // gets here, and the caller's assertion decides on that.
-    await expect(container)
-      .not
-      .toHaveText(before, { timeout: TestConstants.ANNOUNCEMENT_TIMEOUT })
-      .catch(() => { /* the caller's assertion decides */ });
+    // Written with `waitForFunction` rather than `expect(...).not.toHaveText()`
+    // so this can swallow the same narrow thing `waitForAnnouncementAfter`
+    // does: only a timeout means "the display never changed", and anything
+    // else is a broken run that must not pass for one. `expect` rejects with a
+    // plain `Error` — an `ExpectError`, whose `name` is "Error" — so there is
+    // nothing to narrow on, while `waitForFunction` rejects with a named
+    // `TimeoutError`.
+    //
+    // The strict-mode check is not lost: the `textContent()` above exercises
+    // this same locator with nothing catching it, so a selector matching
+    // several elements raises there, before this wait is reached.
+    //
+    // The normalisation is repeated inline because this predicate runs in the
+    // page, where `normalizeText` does not exist.
+    try {
+      await this.page.waitForFunction(
+        ({ containerId, previous }) => {
+          const element = document.getElementById(containerId);
+          return (element?.textContent ?? '').replace(/\s+/g, ' ').trim() !== previous;
+        },
+        { containerId: TestConstants.MAIDR_NOTIFICATION_CONTAINER, previous: before },
+        { timeout: TestConstants.ANNOUNCEMENT_TIMEOUT, polling: 16 },
+      );
+    } catch (error) {
+      if (!(error instanceof Error && error.name === 'TimeoutError')) {
+        throw error;
+      }
+      // The display never changed. The caller's assertion decides.
+    }
   }
 
   /**

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -184,6 +184,10 @@ export class BasePage {
     this.actionAnnouncementMark = null;
 
     try {
+      // The one sanctioned keyboard.press in the page objects: everything else
+      // goes through here so the mark above is always cleared. See the rule's
+      // note in eslint.config.ts.
+      // eslint-disable-next-line no-restricted-syntax
       await this.page.keyboard.press(key);
     } catch (error) {
       throw new KeypressError(
@@ -849,7 +853,7 @@ export class BasePage {
   protected async activateMaidr(svgSelector: string, _plotId: string): Promise<void> {
     try {
       await this.verifyPlotLoaded(svgSelector);
-      await this.page.keyboard.press(TestConstants.TAB_KEY);
+      await this.pressKey(TestConstants.TAB_KEY, 'activate maidr');
       await this.verifySvgFocused();
     } catch (error) {
       throw new Error('Failed to activate MAIDR', { cause: error });

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -574,14 +574,6 @@ export class BasePage {
   }
 
   /**
-   * Replays the current data point
-   * @throws KeypressError if operation fails
-   */
-  public async replayCurrentPoint(): Promise<void> {
-    await this.pressKey(TestConstants.SPACE_KEY, 'replay current point');
-  }
-
-  /**
    * Moves to a specific data point using a key combination
    * @param key - The key to press
    * @param action - Description of the movement action
@@ -860,10 +852,10 @@ export class BasePage {
    * @returns Promise resolving to true if mode is active, false otherwise
    * @throws Error if mode status cannot be checked
    *
-   * Note: a false result costs the full wait timeout, because the wait can only
-   * end early on a match. Every caller today asserts the mode IS active, so
-   * that path is not hit; a future "assert mode X is NOT active" test would pay
-   * ~5s per call and should take a shorter timeout rather than live with it.
+   * Note: on the recorded path a false result is immediate — the window is
+   * already known, so a mismatch costs nothing. Only the fallback below pays
+   * the full wait timeout, and it is reached only when no awaited action
+   * preceded the check.
    */
   protected async isModeActive(
     notificationSelector: string,

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -933,6 +933,16 @@ export class BasePage {
     if (mark !== null) {
       const announced = await announcementsSince(this.page, mark);
       if (announced.length > 0) {
+        // `some`, not "the last one": an action can announce more than once,
+        // and the mode message is not necessarily last. Entering label scope
+        // warns when text mode is off before announcing the label, and that is
+        // the same shape. Matching only the last entry would report those as
+        // inactive.
+        //
+        // Safe because the window holds this action's announcements and no one
+        // else's: the mark is taken immediately before the action and any
+        // unwrapped keypress invalidates it. An earlier action's message
+        // cannot be sitting in here to match by accident.
         return announced.some(text => normalizeText(text) === normalizeText(expected));
       }
     }

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -235,7 +235,17 @@ export class BasePage {
     // Install and mark in one page call: this path now runs on nearly every
     // interaction in the suite, so a second round trip per action is not free.
     this.actionAnnouncementMark = await installAnnouncementRecorder(this.page);
-    await act();
+
+    try {
+      await act();
+    } catch (error) {
+      // Clear the mark rather than leave a stale one behind. A caller that
+      // swallowed this failure and carried on would otherwise hand the next
+      // check a window belonging to an action that never happened.
+      this.actionAnnouncementMark = null;
+      throw error;
+    }
+
     await waitForAnnouncementAfter(this.page, this.actionAnnouncementMark);
   }
 
@@ -709,6 +719,12 @@ export class BasePage {
     await this.pressKey(TestConstants.LABEL_KEY, 'label scope');
     await this.pressKey(axisKey, axisName);
 
+    // Bare catch, and unlike `isModeActive` there is no re-read after it to
+    // resurface a structural problem. There does not need to be: the
+    // `textContent()` above exercises this same locator with nothing catching
+    // it, and locator calls enforce strict mode — a selector matching several
+    // elements raises there, before this wait is reached. Only the timeout
+    // gets here, and the caller's assertion decides on that.
     await expect(container)
       .not
       .toHaveText(before, { timeout: TestConstants.ANNOUNCEMENT_TIMEOUT })

--- a/e2e_tests/page-objects/base-page.ts
+++ b/e2e_tests/page-objects/base-page.ts
@@ -172,6 +172,17 @@ export class BasePage {
    * @throws KeypressError if key press fails
    */
   public async pressKey(key: string, context: string): Promise<void> {
+    // Any key pressed outside `awaitingAnnouncement` invalidates the recorded
+    // window: whatever lands after the mark no longer belongs solely to the
+    // action the mark was taken for, so a later check reading it could match an
+    // older action's message. `toggleAxisTitle` is the live case — it presses
+    // two keys and waits on the display instead. Clearing here rather than at
+    // each call site means a new unwrapped keypress cannot reintroduce the bug.
+    //
+    // `awaitingAnnouncement` publishes its own mark after the action runs, so
+    // this does not interfere with the wrapped path.
+    this.actionAnnouncementMark = null;
+
     try {
       await this.page.keyboard.press(key);
     } catch (error) {
@@ -234,19 +245,17 @@ export class BasePage {
   private async awaitingAnnouncement(act: () => Promise<void>): Promise<void> {
     // Install and mark in one page call: this path now runs on nearly every
     // interaction in the suite, so a second round trip per action is not free.
-    this.actionAnnouncementMark = await installAnnouncementRecorder(this.page);
+    const mark = await installAnnouncementRecorder(this.page);
 
-    try {
-      await act();
-    } catch (error) {
-      // Clear the mark rather than leave a stale one behind. A caller that
-      // swallowed this failure and carried on would otherwise hand the next
-      // check a window belonging to an action that never happened.
-      this.actionAnnouncementMark = null;
-      throw error;
-    }
+    // Publish only once the action has actually run. `act()` presses keys and
+    // `pressKey` clears the mark, so holding it in a local until then is what
+    // lets that clearing be unconditional. It also means a throwing action
+    // leaves the mark cleared: a caller that swallowed the failure and carried
+    // on cannot be handed a window belonging to an action that never happened.
+    await act();
+    this.actionAnnouncementMark = mark;
 
-    await waitForAnnouncementAfter(this.page, this.actionAnnouncementMark);
+    await waitForAnnouncementAfter(this.page, mark);
   }
 
   /**

--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -369,9 +369,10 @@ export class BarPlotPage extends BasePage {
       await this.page.keyboard.down(TestConstants.SHIFT_KEY);
       await this.pressKey(arrowKey, `start ${directionName} autoplay`);
 
+      // Only the two modifiers are still held: `pressKey` above is a full
+      // press, so the arrow key was already released.
       await this.page.keyboard.up(modifier);
       await this.page.keyboard.up(TestConstants.SHIFT_KEY);
-      await this.page.keyboard.up(arrowKey);
 
       if (expectedContent) {
         await this.waitForElementContent(

--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -135,7 +135,7 @@ export class BarPlotPage extends BasePage {
   public async activateMaidr(): Promise<void> {
     try {
       await this.verifyPlotLoaded();
-      await this.page.keyboard.press(TestConstants.TAB_KEY);
+      await this.pressKey(TestConstants.TAB_KEY, 'activate maidr');
       await this.verifySvgFocused();
     } catch (error) {
       throw new BarPlotError('Failed to activate MAIDR', { cause: error });

--- a/e2e_tests/page-objects/plots/boxplotVertical-page.ts
+++ b/e2e_tests/page-objects/plots/boxplotVertical-page.ts
@@ -341,9 +341,12 @@ export class BoxplotVerticalPage extends BasePage {
    */
   public async moveToTop(): Promise<void> {
     try {
-      await this.pressKeyCombination(await this.resolveModifier('Move to top'), TestConstants.UP_ARROW_KEY, 'Move to top');
+      // Via `moveToDataPoint` rather than `pressKeyCombination` directly: this
+      // announces, and an un-awaited announcement can land inside the next
+      // action's window and satisfy its wait early.
+      await this.moveToDataPoint(TestConstants.UP_ARROW_KEY, 'Move to top', true);
     } catch (error) {
-      throw new BoxplotVerticalError('Failed to move to last box', { cause: error });
+      throw new BoxplotVerticalError('Failed to move to top', { cause: error });
     }
   }
 }

--- a/e2e_tests/page-objects/plots/boxplotVertical-page.ts
+++ b/e2e_tests/page-objects/plots/boxplotVertical-page.ts
@@ -317,7 +317,7 @@ export class BoxplotVerticalPage extends BasePage {
    */
   public async moveToDataPointBelow(): Promise<void> {
     try {
-      await this.page.keyboard.press('ArrowDown');
+      await this.pressKeyAwaitingAnnouncement('ArrowDown', 'move to data point below');
     } catch (error) {
       throw new BoxplotVerticalError('Failed to move to data point below', { cause: error });
     }
@@ -329,7 +329,7 @@ export class BoxplotVerticalPage extends BasePage {
    */
   public async moveToLastBox(): Promise<void> {
     try {
-      await this.page.keyboard.press('End');
+      await this.pressKeyAwaitingAnnouncement('End', 'move to last box');
     } catch (error) {
       throw new BoxplotVerticalError('Failed to move to last box', { cause: error });
     }

--- a/e2e_tests/page-objects/plots/multiLayer-page.ts
+++ b/e2e_tests/page-objects/plots/multiLayer-page.ts
@@ -279,7 +279,7 @@ export class MultiLayerPlotPage extends BasePage {
    */
   public async switchToUpperLayer(): Promise<void> {
     try {
-      await this.pressKey(TestConstants.PAGE_UP_KEY, 'switch to upper layer');
+      await this.pressKeyAwaitingAnnouncement(TestConstants.PAGE_UP_KEY, 'switch to upper layer');
     } catch (error) {
       throw new MultiLayerPlotError('Failed to switch to upper layer', { cause: error });
     }
@@ -291,7 +291,7 @@ export class MultiLayerPlotPage extends BasePage {
    */
   public async switchToLowerLayer(): Promise<void> {
     try {
-      await this.pressKey(TestConstants.PAGE_DOWN_KEY, 'switch to lower layer');
+      await this.pressKeyAwaitingAnnouncement(TestConstants.PAGE_DOWN_KEY, 'switch to lower layer');
     } catch (error) {
       throw new MultiLayerPlotError('Failed to switch to lower layer', { cause: error });
     }

--- a/e2e_tests/page-objects/plots/violinPlot-page.ts
+++ b/e2e_tests/page-objects/plots/violinPlot-page.ts
@@ -184,7 +184,7 @@ export class ViolinPlotPage extends BasePage {
    */
   public async moveToNextViolin(): Promise<void> {
     try {
-      await this.page.keyboard.press('ArrowRight');
+      await this.pressKeyAwaitingAnnouncement('ArrowRight', 'move to next violin');
     } catch (error) {
       throw new ViolinPlotError('Failed to move to next violin', { cause: error });
     }
@@ -196,7 +196,7 @@ export class ViolinPlotPage extends BasePage {
    */
   public async moveToPreviousViolin(): Promise<void> {
     try {
-      await this.page.keyboard.press('ArrowLeft');
+      await this.pressKeyAwaitingAnnouncement('ArrowLeft', 'move to previous violin');
     } catch (error) {
       throw new ViolinPlotError('Failed to move to previous violin', { cause: error });
     }
@@ -208,7 +208,7 @@ export class ViolinPlotPage extends BasePage {
    */
   public async moveUpKdeCurve(): Promise<void> {
     try {
-      await this.page.keyboard.press('ArrowUp');
+      await this.pressKeyAwaitingAnnouncement('ArrowUp', 'move up KDE curve');
     } catch (error) {
       throw new ViolinPlotError('Failed to move up KDE curve', { cause: error });
     }
@@ -220,7 +220,7 @@ export class ViolinPlotPage extends BasePage {
    */
   public async moveDownKdeCurve(): Promise<void> {
     try {
-      await this.page.keyboard.press('ArrowDown');
+      await this.pressKeyAwaitingAnnouncement('ArrowDown', 'move down KDE curve');
     } catch (error) {
       throw new ViolinPlotError('Failed to move down KDE curve', { cause: error });
     }
@@ -232,7 +232,7 @@ export class ViolinPlotPage extends BasePage {
    */
   public async switchToNextLayer(): Promise<void> {
     try {
-      await this.page.keyboard.press('PageDown');
+      await this.pressKeyAwaitingAnnouncement('PageDown', 'switch to next layer');
     } catch (error) {
       throw new ViolinPlotError('Failed to switch to next layer', { cause: error });
     }
@@ -244,7 +244,7 @@ export class ViolinPlotPage extends BasePage {
    */
   public async switchToPreviousLayer(): Promise<void> {
     try {
-      await this.page.keyboard.press('PageUp');
+      await this.pressKeyAwaitingAnnouncement('PageUp', 'switch to previous layer');
     } catch (error) {
       throw new ViolinPlotError('Failed to switch to previous layer', { cause: error });
     }

--- a/e2e_tests/specs/announcements.spec.ts
+++ b/e2e_tests/specs/announcements.spec.ts
@@ -106,6 +106,26 @@ test.describe('Announcement recorder', () => {
     expect(await histogramPage.isTextModeActive(TestConstants.TEXT_MODE_TERSE)).toBe(true);
   });
 
+  test('does not answer from a window an unwrapped keypress has invalidated', async ({ page }) => {
+    const histogramPage = new HistogramPage(page);
+    await histogramPage.navigateToHistogram();
+    await installAnnouncementRecorder(page);
+    await histogramPage.activateMaidr();
+
+    // Awaited, so it leaves a mark behind: "Text mode is terse".
+    await histogramPage.toggleTextMode();
+
+    // Now change the mode again without going through the awaited path, the
+    // way `toggleAxisTitle` presses its two keys. Text mode is off after this.
+    await histogramPage.pressKey(TestConstants.TEXT_KEY, 'unwrapped text mode toggle');
+
+    // If the earlier mark survived, the recorded window would still hold
+    // "Text mode is terse" and this would report a mode that is no longer
+    // active. An unwrapped keypress has to invalidate the window, so the check
+    // falls back to the region and reads the state as it now is.
+    expect(await histogramPage.isTextModeActive(TestConstants.TEXT_MODE_TERSE)).toBe(false);
+  });
+
   test('ignores display updates that were never announced', async ({ page }) => {
     const histogramPage = new HistogramPage(page);
     await histogramPage.navigateToHistogram();

--- a/e2e_tests/specs/announcements.spec.ts
+++ b/e2e_tests/specs/announcements.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { DEFAULT_SETTINGS } from '../../src/type/settings';
 import { HistogramPage } from '../page-objects/plots/histogram-page';
 import { installAnnouncementRecorder, recordedAnnouncements } from '../utils/announcements';
 import { TestConstants } from '../utils/constants';
@@ -68,8 +69,13 @@ test.describe('Announcement recorder', () => {
 
     // Autoplay turns the `announce` flag off, so no alert node renders while
     // it runs even though the display text advances on every step.
+    //
+    // Sample at half the autoplay duration, derived rather than hard-coded:
+    // reaching the last point flips `announce` back on and does announce, so a
+    // fixed wait would silently start failing for an unrelated reason if the
+    // default were ever tuned down.
     await histogramPage.startForwardAutoplay();
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(DEFAULT_SETTINGS.general.autoplayDuration / 2);
 
     // The display really did move — otherwise this test proves nothing.
     expect(await container.textContent()).not.toBe(textBefore);

--- a/e2e_tests/specs/announcements.spec.ts
+++ b/e2e_tests/specs/announcements.spec.ts
@@ -88,6 +88,24 @@ test.describe('Announcement recorder', () => {
       .toEqual(['First batched message', 'Second batched message']);
   });
 
+  test('falls back to the region when no action preceded the check', async ({ page }) => {
+    const histogramPage = new HistogramPage(page);
+    await histogramPage.navigateToHistogram();
+    await installAnnouncementRecorder(page);
+    await histogramPage.activateMaidr();
+
+    await histogramPage.toggleTextMode();
+
+    // The first check reads the recorded window and consumes the mark.
+    expect(await histogramPage.isTextModeActive(TestConstants.TEXT_MODE_TERSE)).toBe(true);
+
+    // The second has no action before it and no mark left, so it has to answer
+    // from the region instead. Pinning this because the alternative — treating
+    // a missing mark as "not active" — would be a silent false negative, and
+    // because the contract is positional and not enforced by the types.
+    expect(await histogramPage.isTextModeActive(TestConstants.TEXT_MODE_TERSE)).toBe(true);
+  });
+
   test('ignores display updates that were never announced', async ({ page }) => {
     const histogramPage = new HistogramPage(page);
     await histogramPage.navigateToHistogram();

--- a/e2e_tests/specs/announcements.spec.ts
+++ b/e2e_tests/specs/announcements.spec.ts
@@ -56,6 +56,38 @@ test.describe('Announcement recorder', () => {
     ]);
   });
 
+  test('records both announcements when two land in one flush', async ({ page }) => {
+    const histogramPage = new HistogramPage(page);
+    await histogramPage.navigateToHistogram();
+    await installAnnouncementRecorder(page);
+    await histogramPage.activateMaidr();
+
+    const before = (await recordedAnnouncements(page)).length;
+
+    // Insert two alerts in one synchronous block so the observer sees both in
+    // a single callback. Driving this through MAIDR would depend on two
+    // notifies landing before one flush, which is not something a test can
+    // force; the observer's own batching behaviour is what is under test, and
+    // it is the reason this walks MutationRecords rather than sampling the
+    // live node once per callback.
+    await page.evaluate((containerId) => {
+      const parent = document.getElementById(containerId)?.parentElement;
+      if (!parent) {
+        throw new Error(`No parent for #${containerId}`);
+      }
+      for (const text of ['First batched message', 'Second batched message']) {
+        const alert = document.createElement('div');
+        alert.setAttribute('role', 'alert');
+        alert.textContent = text;
+        parent.appendChild(alert);
+      }
+    }, TestConstants.MAIDR_NOTIFICATION_CONTAINER);
+
+    await expect
+      .poll(async () => (await recordedAnnouncements(page)).slice(before))
+      .toEqual(['First batched message', 'Second batched message']);
+  });
+
   test('ignores display updates that were never announced', async ({ page }) => {
     const histogramPage = new HistogramPage(page);
     await histogramPage.navigateToHistogram();

--- a/e2e_tests/specs/announcements.spec.ts
+++ b/e2e_tests/specs/announcements.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+import { HistogramPage } from '../page-objects/plots/histogram-page';
+import { installAnnouncementRecorder, recordedAnnouncements } from '../utils/announcements';
+import { TestConstants } from '../utils/constants';
+
+/**
+ * The announcement recorder is what every mode assertion now depends on, so
+ * its contract is pinned here rather than left to the specs that consume it.
+ *
+ * It reads the `role="alert"` node — the live region a screen reader hears —
+ * and not `#maidr-text-container`, which renders a different string that is
+ * not gated by the `announce` flag. The last test is the one that tells those
+ * two apart.
+ */
+test.describe('Announcement recorder', () => {
+  test('records one entry per announcement, in order', async ({ page }) => {
+    const histogramPage = new HistogramPage(page);
+    await histogramPage.navigateToHistogram();
+    await installAnnouncementRecorder(page);
+    await histogramPage.activateMaidr();
+
+    const before = (await recordedAnnouncements(page)).length;
+    await histogramPage.toggleTextMode();
+    await histogramPage.toggleTextMode();
+    await histogramPage.toggleTextMode();
+
+    const recorded = (await recordedAnnouncements(page)).slice(before);
+    expect(recorded).toEqual([
+      TestConstants.TEXT_MODE_TERSE_MESSAGE,
+      TestConstants.TEXT_MODE_OFF_MESSAGE,
+      TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+    ]);
+  });
+
+  test('records a repeated identical message every time', async ({ page }) => {
+    const histogramPage = new HistogramPage(page);
+    await histogramPage.navigateToHistogram();
+    await installAnnouncementRecorder(page);
+    await histogramPage.activateMaidr();
+    await histogramPage.moveToFirstDataPoint();
+
+    // Walking off the same edge repeatedly announces the same string each
+    // time. MAIDR re-mounts the alert so a screen reader re-reads it, and the
+    // recorder has to see each one — comparing text alone would collapse them.
+    const before = (await recordedAnnouncements(page)).length;
+    await histogramPage.moveToPreviousDataPoint();
+    await histogramPage.moveToPreviousDataPoint();
+    await histogramPage.moveToPreviousDataPoint();
+
+    const recorded = (await recordedAnnouncements(page)).slice(before);
+    expect(recorded).toEqual([
+      TestConstants.PLOT_EXTREME_VERIFICATION,
+      TestConstants.PLOT_EXTREME_VERIFICATION,
+      TestConstants.PLOT_EXTREME_VERIFICATION,
+    ]);
+  });
+
+  test('ignores display updates that were never announced', async ({ page }) => {
+    const histogramPage = new HistogramPage(page);
+    await histogramPage.navigateToHistogram();
+    await installAnnouncementRecorder(page);
+    await histogramPage.activateMaidr();
+    await histogramPage.moveToFirstDataPoint();
+
+    const container = page.locator(`#${TestConstants.MAIDR_NOTIFICATION_CONTAINER}`);
+    const textBefore = await container.textContent();
+    const before = (await recordedAnnouncements(page)).length;
+
+    // Autoplay turns the `announce` flag off, so no alert node renders while
+    // it runs even though the display text advances on every step.
+    await histogramPage.startForwardAutoplay();
+    await page.waitForTimeout(2000);
+
+    // The display really did move — otherwise this test proves nothing.
+    expect(await container.textContent()).not.toBe(textBefore);
+
+    // ...and none of it counted as an announcement.
+    expect((await recordedAnnouncements(page)).length).toBe(before);
+  });
+});

--- a/e2e_tests/specs/announcements.spec.ts
+++ b/e2e_tests/specs/announcements.spec.ts
@@ -88,6 +88,37 @@ test.describe('Announcement recorder', () => {
       .toEqual(['First batched message', 'Second batched message']);
   });
 
+  test('records both announcements when one insertion carries two', async ({ page }) => {
+    const histogramPage = new HistogramPage(page);
+    await histogramPage.navigateToHistogram();
+    await installAnnouncementRecorder(page);
+    await histogramPage.activateMaidr();
+
+    const before = (await recordedAnnouncements(page)).length;
+
+    // The same collapse as the test above, one level down. A MutationRecord
+    // lists only the root of an inserted subtree, so taking the first match
+    // inside that root would count one announcement where there are two.
+    await page.evaluate((containerId) => {
+      const parent = document.getElementById(containerId)?.parentElement;
+      if (!parent) {
+        throw new Error(`No parent for #${containerId}`);
+      }
+      const wrapper = document.createElement('div');
+      for (const text of ['First nested message', 'Second nested message']) {
+        const alert = document.createElement('div');
+        alert.setAttribute('role', 'alert');
+        alert.textContent = text;
+        wrapper.appendChild(alert);
+      }
+      parent.appendChild(wrapper);
+    }, TestConstants.MAIDR_NOTIFICATION_CONTAINER);
+
+    await expect
+      .poll(async () => (await recordedAnnouncements(page)).slice(before))
+      .toEqual(['First nested message', 'Second nested message']);
+  });
+
   test('falls back to the region when no action preceded the check', async ({ page }) => {
     const histogramPage = new HistogramPage(page);
     await histogramPage.navigateToHistogram();

--- a/e2e_tests/utils/announcements.ts
+++ b/e2e_tests/utils/announcements.ts
@@ -97,10 +97,15 @@ export async function installAnnouncementRecorder(page: Page): Promise<number> {
  * announces — an out-of-bounds move in some modes is silent — and a caller
  * that waited in vain should carry on and let its own assertion decide, the
  * same way `isModeActive` does.
+ *
+ * Only a timeout means that. Anything else — a destroyed execution context
+ * from an unexpected navigation, say — is a broken run rather than a silent
+ * key, and is rethrown so it cannot pass for an expected no-op.
  * @param page - The Playwright page
  * @param since - Count captured before the action
  * @param timeout - How long to wait, in milliseconds
  * @returns True if an announcement arrived, false if the wait timed out
+ * @throws The original error if the wait failed for any reason but a timeout
  */
 export async function waitForAnnouncementAfter(
   page: Page,
@@ -114,8 +119,11 @@ export async function waitForAnnouncementAfter(
       { timeout, polling: 16 },
     );
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'TimeoutError') {
+      return false;
+    }
+    throw error;
   }
 }
 

--- a/e2e_tests/utils/announcements.ts
+++ b/e2e_tests/utils/announcements.ts
@@ -1,0 +1,128 @@
+import type { Page } from '@playwright/test';
+import { TestConstants } from './constants';
+
+/** Shape the recorder installs on `window`. */
+interface AnnouncementWindow extends Window {
+  __maidrAnnouncements?: string[];
+}
+
+/**
+ * Records every update to MAIDR's text alert region.
+ *
+ * The page objects used to read that region straight after dispatching a key,
+ * which races the announcement: fast enough to pass in Chromium and Firefox,
+ * and a flake in WebKit under load. Waiting only after the fact does not fix
+ * it either, because an announcement the test arrived too late for is already
+ * gone — waiting cannot bring it back.
+ *
+ * Observing instead means the count advances the moment MAIDR announces, so an
+ * action can wait for its own announcement before the assertion reads anything.
+ * The region is keyed by a revision counter and re-mounts on every notify (see
+ * the note on `announceRotorMessage` in src/service/rotor.ts), so a repeated
+ * identical message still registers.
+ *
+ * Idempotent: installing twice on the same page is a no-op, and the recorder
+ * survives for the life of the page. Observation is rooted at `document.body`
+ * rather than the container, because MAIDR creates the container on activation
+ * and it is replaced wholesale on each announcement.
+ * @param page - The Playwright page, already navigated to the example
+ */
+export async function installAnnouncementRecorder(page: Page): Promise<void> {
+  await page.evaluate((containerId) => {
+    const w = window as AnnouncementWindow;
+    if (w.__maidrAnnouncements) {
+      return;
+    }
+    w.__maidrAnnouncements = [];
+
+    // One entry per observer callback, not per MutationRecord: a single
+    // announcement replaces several nodes and would otherwise count as many.
+    new MutationObserver(() => {
+      const text = (document.getElementById(containerId)?.textContent ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (text) {
+        w.__maidrAnnouncements?.push(text);
+      }
+    }).observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }, TestConstants.MAIDR_NOTIFICATION_CONTAINER);
+}
+
+/**
+ * Number of announcements recorded so far. Callers capture this before an
+ * action and pass it to {@link waitForAnnouncementAfter}.
+ * @param page - The Playwright page
+ * @returns The count, or 0 when the recorder is not installed
+ */
+export async function announcementCount(page: Page): Promise<number> {
+  return await page.evaluate(
+    () => (window as AnnouncementWindow).__maidrAnnouncements?.length ?? 0,
+  );
+}
+
+/**
+ * Waits until a new announcement lands after the given count.
+ *
+ * Resolves `false` on timeout rather than throwing. Not every keypress
+ * announces — an out-of-bounds move in some modes is silent — and a caller
+ * that waited in vain should carry on and let its own assertion decide, the
+ * same way `isModeActive` does.
+ * @param page - The Playwright page
+ * @param since - Count captured before the action
+ * @param timeout - How long to wait, in milliseconds
+ * @returns True if an announcement arrived, false if the wait timed out
+ */
+export async function waitForAnnouncementAfter(
+  page: Page,
+  since: number,
+  timeout = 2000,
+): Promise<boolean> {
+  try {
+    await page.waitForFunction(
+      count => ((window as AnnouncementWindow).__maidrAnnouncements?.length ?? 0) > count,
+      since,
+      { timeout, polling: 16 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Announcements recorded after the given count, oldest first.
+ *
+ * Assertions use this rather than the region's current text. An action's
+ * announcement can be replaced by a later one before the assertion reads —
+ * and an announcement from an earlier, un-awaited action can arrive in the
+ * middle — so "was this announced by this action?" is a question about the
+ * recorded window, not about whatever happens to be on screen now.
+ * @param page - The Playwright page
+ * @param since - Count captured before the action
+ * @returns The announcements recorded since that point
+ */
+export async function announcementsSince(page: Page, since: number): Promise<string[]> {
+  return await page.evaluate(
+    count => ((window as AnnouncementWindow).__maidrAnnouncements ?? []).slice(count),
+    since,
+  );
+}
+
+/**
+ * Every announcement recorded so far, oldest first.
+ *
+ * Use this to assert a sequence of transient announcements — the shape
+ * `.claude/rules/testing.md` prescribes for live regions — rather than
+ * sampling the region once per step and hoping each sample lands in time.
+ * @param page - The Playwright page
+ * @returns The recorded announcements
+ */
+export async function recordedAnnouncements(page: Page): Promise<string[]> {
+  return await page.evaluate(
+    () => [...((window as AnnouncementWindow).__maidrAnnouncements ?? [])],
+  );
+}

--- a/e2e_tests/utils/announcements.ts
+++ b/e2e_tests/utils/announcements.ts
@@ -69,15 +69,22 @@ export async function installAnnouncementRecorder(page: Page): Promise<number> {
           if (!(node instanceof Element)) {
             continue;
           }
-          const alert = node.matches('[role="alert"]')
-            ? node
-            : node.querySelector('[role="alert"]');
-          if (!alert || !inMaidrRegion(alert)) {
-            continue;
-          }
-          const text = (alert.textContent ?? '').replace(/\s+/g, ' ').trim();
-          if (text) {
-            w.__maidrAnnouncements?.push(text);
+          // `querySelectorAll`, not `querySelector`, for the same reason this
+          // walks the records rather than sampling: taking the first match
+          // collapses two announcements into one. A record only lists the root
+          // of an inserted subtree, so a commit that mounted two alerts under
+          // one new node would otherwise register a single entry.
+          const alerts = node.matches('[role="alert"]')
+            ? [node]
+            : node.querySelectorAll('[role="alert"]');
+          for (const alert of alerts) {
+            if (!inMaidrRegion(alert)) {
+              continue;
+            }
+            const text = (alert.textContent ?? '').replace(/\s+/g, ' ').trim();
+            if (text) {
+              w.__maidrAnnouncements?.push(text);
+            }
           }
         }
       }

--- a/e2e_tests/utils/announcements.ts
+++ b/e2e_tests/utils/announcements.ts
@@ -21,10 +21,15 @@ interface AnnouncementWindow extends Window {
  * the note on `announceRotorMessage` in src/service/rotor.ts), so a repeated
  * identical message still registers.
  *
+ * What counts as an announcement is the `role="alert"` node, not the visible
+ * text container: only the alert is gated by the `announce` flag, so the
+ * container can advance — during autoplay, for instance — while a screen
+ * reader hears nothing.
+ *
  * Idempotent: installing twice on the same page is a no-op, and the recorder
  * survives for the life of the page. Observation is rooted at `document.body`
- * rather than the container, because MAIDR creates the container on activation
- * and it is replaced wholesale on each announcement.
+ * because MAIDR builds its UI on activation and re-mounts the alert on every
+ * announcement, so there is no stable node to attach to.
  * @param page - The Playwright page, already navigated to the example
  */
 export async function installAnnouncementRecorder(page: Page): Promise<void> {
@@ -35,12 +40,31 @@ export async function installAnnouncementRecorder(page: Page): Promise<void> {
     }
     w.__maidrAnnouncements = [];
 
-    // One entry per observer callback, not per MutationRecord: a single
-    // announcement replaces several nodes and would otherwise count as many.
+    // Read the role="alert" node, NOT #maidr-text-container. They can differ:
+    // src/ui/component/Text.tsx renders `visual` into the container and
+    // `current` into the alert, and only `current` is gated by the `announce`
+    // flag. During autoplay `announce` is false, so the container keeps
+    // updating per step while nothing is announced — watching the container
+    // would record announcements a screen reader never heard.
+    //
+    // Scoped through the container's parent so MUI's own role="alert" inside
+    // the settings dialog cannot be mistaken for MAIDR's live region.
+    const findAlert = (): Element | null =>
+      document.getElementById(containerId)?.parentElement?.querySelector('[role="alert"]') ?? null;
+
+    // The alert is keyed by a revision counter and re-mounts on every update,
+    // so a new announcement is a new node. Comparing node identity gives one
+    // entry per announcement — including a repeat of identical text — and
+    // ignores mutations elsewhere that leave the alert untouched.
+    let lastAlert: Element | null = null;
+
     new MutationObserver(() => {
-      const text = (document.getElementById(containerId)?.textContent ?? '')
-        .replace(/\s+/g, ' ')
-        .trim();
+      const alert = findAlert();
+      if (!alert || alert === lastAlert) {
+        return;
+      }
+      lastAlert = alert;
+      const text = (alert.textContent ?? '').replace(/\s+/g, ' ').trim();
       if (text) {
         w.__maidrAnnouncements?.push(text);
       }
@@ -79,7 +103,7 @@ export async function announcementCount(page: Page): Promise<number> {
 export async function waitForAnnouncementAfter(
   page: Page,
   since: number,
-  timeout = 2000,
+  timeout = TestConstants.ANNOUNCEMENT_TIMEOUT,
 ): Promise<boolean> {
   try {
     await page.waitForFunction(

--- a/e2e_tests/utils/announcements.ts
+++ b/e2e_tests/utils/announcements.ts
@@ -53,31 +53,37 @@ export async function installAnnouncementRecorder(page: Page): Promise<number> {
     // updating per step while nothing is announced — watching the container
     // would record announcements a screen reader never heard.
     //
-    // Scoped through the container's parent so MUI's own role="alert" inside
-    // the settings dialog cannot be mistaken for MAIDR's live region.
-    const findAlert = (): Element | null =>
-      document.getElementById(containerId)?.parentElement?.querySelector('[role="alert"]') ?? null;
+    // Scoped to MAIDR's own region so MUI's role="alert" inside the settings
+    // dialog cannot be mistaken for it.
+    const inMaidrRegion = (node: Element): boolean =>
+      document.getElementById(containerId)?.parentElement?.contains(node) ?? false;
 
     // The alert is keyed by a revision counter and re-mounts on every update,
-    // so a new announcement is a new node. Comparing node identity gives one
-    // entry per announcement — including a repeat of identical text — and
-    // ignores mutations elsewhere that leave the alert untouched.
-    let lastAlert: Element | null = null;
-
-    new MutationObserver(() => {
-      const alert = findAlert();
-      if (!alert || alert === lastAlert) {
-        return;
-      }
-      lastAlert = alert;
-      const text = (alert.textContent ?? '').replace(/\s+/g, ' ').trim();
-      if (text) {
-        w.__maidrAnnouncements?.push(text);
+    // so each announcement is a fresh node insertion. Walk the mutation
+    // records rather than sampling whatever is live when the callback runs:
+    // a callback batches every record since the last flush, so two alerts
+    // inserted before one flush would otherwise collapse into one entry.
+    new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (!(node instanceof Element)) {
+            continue;
+          }
+          const alert = node.matches('[role="alert"]')
+            ? node
+            : node.querySelector('[role="alert"]');
+          if (!alert || !inMaidrRegion(alert)) {
+            continue;
+          }
+          const text = (alert.textContent ?? '').replace(/\s+/g, ' ').trim();
+          if (text) {
+            w.__maidrAnnouncements?.push(text);
+          }
+        }
       }
     }).observe(document.body, {
       childList: true,
       subtree: true,
-      characterData: true,
     });
 
     return w.__maidrAnnouncements.length;

--- a/e2e_tests/utils/announcements.ts
+++ b/e2e_tests/utils/announcements.ts
@@ -30,13 +30,19 @@ interface AnnouncementWindow extends Window {
  * survives for the life of the page. Observation is rooted at `document.body`
  * because MAIDR builds its UI on activation and re-mounts the alert on every
  * announcement, so there is no stable node to attach to.
+ *
+ * Returns the count so an action can install and mark in a single page call.
+ * Installing lazily rather than once at activation is deliberate: a navigation
+ * replaces `window` and takes the recorder with it, so pinning installation to
+ * one earlier moment would go quietly blind afterwards.
  * @param page - The Playwright page, already navigated to the example
+ * @returns The number of announcements already recorded
  */
-export async function installAnnouncementRecorder(page: Page): Promise<void> {
-  await page.evaluate((containerId) => {
+export async function installAnnouncementRecorder(page: Page): Promise<number> {
+  return await page.evaluate((containerId) => {
     const w = window as AnnouncementWindow;
     if (w.__maidrAnnouncements) {
-      return;
+      return w.__maidrAnnouncements.length;
     }
     w.__maidrAnnouncements = [];
 
@@ -73,19 +79,9 @@ export async function installAnnouncementRecorder(page: Page): Promise<void> {
       subtree: true,
       characterData: true,
     });
-  }, TestConstants.MAIDR_NOTIFICATION_CONTAINER);
-}
 
-/**
- * Number of announcements recorded so far. Callers capture this before an
- * action and pass it to {@link waitForAnnouncementAfter}.
- * @param page - The Playwright page
- * @returns The count, or 0 when the recorder is not installed
- */
-export async function announcementCount(page: Page): Promise<number> {
-  return await page.evaluate(
-    () => (window as AnnouncementWindow).__maidrAnnouncements?.length ?? 0,
-  );
+    return w.__maidrAnnouncements.length;
+  }, TestConstants.MAIDR_NOTIFICATION_CONTAINER);
 }
 
 /**

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -42,6 +42,12 @@ export abstract class TestConstants {
    */
   static readonly PLOT_EXTREME_VERIFICATION = 'No more data to display';
   /**
+   * How long an action waits for the announcement it triggered. Generous
+   * next to the millisecond the announcement normally takes, and only ever
+   * spent in full on a keypress that announces nothing.
+   */
+  static readonly ANNOUNCEMENT_TIMEOUT = 2000;
+  /**
    * MAIDR component identifiers
    */
   static readonly MAIDR_NOTIFICATION_CONTAINER = 'maidr-text-container';

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -48,6 +48,14 @@ export abstract class TestConstants {
    */
   static readonly ANNOUNCEMENT_TIMEOUT = 2000;
   /**
+   * How long a mode check polls the displayed region when the recorded window
+   * came back empty. Deliberately longer than `ANNOUNCEMENT_TIMEOUT` rather
+   * than the same value: this is the slower path, reached only once the
+   * recorded one has already found nothing, so it is where a real-but-late
+   * message still has to be caught.
+   */
+  static readonly REGION_FALLBACK_TIMEOUT = 5000;
+  /**
    * MAIDR component identifiers
    */
   static readonly MAIDR_NOTIFICATION_CONTAINER = 'maidr-text-container';

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -48,10 +48,15 @@ const config: ReturnType<typeof antfu> = antfu({
   // satisfy that action's wait early — the assertion then reads the region
   // before its own announcement arrives. Layer switches are the usual case.
   //
-  // `base-page.ts` is deliberately out of scope: it is where the wrapping
-  // lives. Use `pressKey` for a keypress that announces nothing, and
+  // Use `pressKey` for a keypress that announces nothing, and
   // `pressKeyAwaitingAnnouncement` for one that does.
-  files: ['e2e_tests/page-objects/plots/**/*.ts'],
+  //
+  // `base-page.ts` is in scope too, with a single inline disable on the one
+  // sanctioned call site inside `pressKey`. Excluding the whole file would
+  // leave the invariant resting on discipline exactly where a new helper is
+  // most likely to be added; an explicit exception at the one line that is
+  // allowed to press a key says the same thing and stays enforceable.
+  files: ['e2e_tests/page-objects/**/*.ts'],
   rules: {
     'no-restricted-syntax': ['error', {
       selector: 'CallExpression[callee.property.name=\'press\'][callee.object.property.name=\'keyboard\']',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -60,7 +60,30 @@ const config: ReturnType<typeof antfu> = antfu({
   rules: {
     'no-restricted-syntax': ['error', {
       selector: 'CallExpression[callee.property.name=\'press\'][callee.object.property.name=\'keyboard\']',
-      message: 'Do not press keys directly in a plot page object. Use this.pressKey() for a silent key, or this.pressKeyAwaitingAnnouncement() when MAIDR announces the result.',
+      message: 'Do not press keys directly in a page object. Use this.pressKey() for a silent key, or this.pressKeyAwaitingAnnouncement() when MAIDR announces the result.',
+    }],
+  },
+}, {
+  // The same bypass one level up. `pressKeyCombination` routes through
+  // `pressKey`, so the mark is cleared and nothing goes unwrapped — but it
+  // does not *wait*, and a modified data-point move announces. `moveToTop` in
+  // boxplotVertical-page.ts was the live case.
+  //
+  // Scoped to `plots/**` rather than all of `page-objects/**`: base-page's own
+  // direct callers are the menu and dialog openers, which are asserted on
+  // visibility rather than on an announcement, and `moveToDataPoint` is where
+  // the wrapped combination lives.
+  // Both selectors are repeated here on purpose: flat config replaces a rule's
+  // options rather than merging them, so listing only the new one would switch
+  // the keypress ban off for exactly the directory it was written for.
+  files: ['e2e_tests/page-objects/plots/**/*.ts'],
+  rules: {
+    'no-restricted-syntax': ['error', {
+      selector: 'CallExpression[callee.property.name=\'press\'][callee.object.property.name=\'keyboard\']',
+      message: 'Do not press keys directly in a page object. Use this.pressKey() for a silent key, or this.pressKeyAwaitingAnnouncement() when MAIDR announces the result.',
+    }, {
+      selector: 'CallExpression[callee.property.name=\'pressKeyCombination\']',
+      message: 'Do not call pressKeyCombination() from a plot page object: it presses the key but does not wait for the announcement. Use this.moveToDataPoint(key, action, true) for a modified move.',
     }],
   },
 });

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -43,11 +43,10 @@ const config: ReturnType<typeof antfu> = antfu({
     markdown: 'prettier',
   },
 }).append({
-  // Five review rounds on #684 each turned up one more page object dispatching
-  // a key straight at the keyboard, bypassing the synchronisation in
-  // BasePage — including layer switches whose late announcement then leaked
-  // into the next action's wait. Make that a lint error rather than something
-  // the next reviewer has to remember to grep for.
+  // A key dispatched straight at the keyboard skips BasePage's
+  // synchronisation, so its announcement can land during the NEXT action and
+  // satisfy that action's wait early — the assertion then reads the region
+  // before its own announcement arrives. Layer switches are the usual case.
   //
   // `base-page.ts` is deliberately out of scope: it is where the wrapping
   // lives. Use `pressKey` for a keypress that announces nothing, and

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -42,6 +42,23 @@ const config: ReturnType<typeof antfu> = antfu({
     html: true,
     markdown: 'prettier',
   },
+}).append({
+  // Five review rounds on #684 each turned up one more page object dispatching
+  // a key straight at the keyboard, bypassing the synchronisation in
+  // BasePage — including layer switches whose late announcement then leaked
+  // into the next action's wait. Make that a lint error rather than something
+  // the next reviewer has to remember to grep for.
+  //
+  // `base-page.ts` is deliberately out of scope: it is where the wrapping
+  // lives. Use `pressKey` for a keypress that announces nothing, and
+  // `pressKeyAwaitingAnnouncement` for one that does.
+  files: ['e2e_tests/page-objects/plots/**/*.ts'],
+  rules: {
+    'no-restricted-syntax': ['error', {
+      selector: 'CallExpression[callee.property.name=\'press\'][callee.object.property.name=\'keyboard\']',
+      message: 'Do not press keys directly in a plot page object. Use this.pressKey() for a silent key, or this.pressKeyAwaitingAnnouncement() when MAIDR announces the result.',
+    }],
+  },
 });
 
 export default config;


### PR DESCRIPTION
# Pull Request

## Description

#679 left the WebKit suite green only because it added `retries: process.env.CI ? 2 : 0`, and said so plainly. #680 wrote down the acceptance test for removing them: **a full three-browser run is clean without retries.**

This PR meets it.

## Related Issues

Closes #680. Follows #679, #676, #674. Spun off #685.

## Changes Made

### The race, and why waiting was not enough

The page objects read the live region straight after dispatching a key. #679 taught `isModeActive` to wait for the expected text, which fixes reading **too early** — but not arriving **too late**. The region holds one message at a time, so an announcement already replaced cannot be waited for. That is why mode toggles kept flaking after #679.

The fix is to stop sampling and start observing, and to move the wait to *before* the keypress.

### 1. Record the announcements

`e2e_tests/utils/announcements.ts` observes `document.body` and counts inserted `role="alert"` nodes.

Three things here are deliberate, and all three were wrong in earlier revisions of this PR:

- **The alert node, not `#maidr-text-container`.** `Text.tsx` renders `current` (gated by the `announce` flag) into the alert and `visual` (ungated) into the container. During autoplay the container advances every step while nothing is announced — measured: container changed `true`, announcements recorded `0`.
- **Walk the `MutationRecord`s, don't sample the live node.** A callback batches every record since the last flush, so two announcements landing before one flush would collapse into a single entry.
- **`querySelectorAll`, not `querySelector`.** A record lists only the *root* of an inserted subtree, so two alerts mounted under one new node collapse the same way, one level down.

### 2. Wait for the announcement the action causes

`pressKeyAwaitingAnnouncement` marks the count, presses, then waits for it to advance — mode toggles, speed changes, data-point moves, layer switches. A silent keypress resolves `false` and the caller's assertion still decides.

### 3. Assert against what was announced, not what is on screen

Waiting for *any* new announcement is not sufficient. The layer switches did not await, so their message could land during the **next** action and satisfy its wait early:

```
announcements since mark: ["Layer 2 of 2: single line plot at X values is 0, …",
                           "Sound is off"]
```

That made the multiLayer sound toggle fail on the third acceptance run. `isModeActive` now asks what the action announced. The mark is **consumed** after each check, so a check with no preceding awaited action falls back to the region rather than matching stale history — a silent false positive otherwise.

### 4. Axis titles wait on the display, not on an announcement

The axis title only reaches the alert once the cursor is on a data point, and those specs assert straight after activation:

```
without prior navigation:  2082 ms, announcements []
after navigation:            59 ms, announcements ["X label is Petal Length (cm)"]
```

An announcement wait there finds nothing and spends its whole budget — so those tests passed because a 2 s timeout acted as a sleep, which is the anti-pattern this branch exists to remove. They now wait for the container the assertion reads: **2082 ms → 78 ms**.

### 5. Drop the retries

`retries` is gone, so a flake is a real failure again. `trace` becomes `retain-on-failure`, because `on-first-retry` can no longer fire and a genuine failure would otherwise leave only a screenshot.

### 6. Make the invariant enforceable, not remembered

Five review rounds each found one more page object dispatching a key straight at the keyboard, so the invariant is now lint-enforced rather than left to inspection:

- `keyboard.press` is banned across `page-objects/**`, with one inline disable on the sanctioned call site in `pressKey`. Widening it from `plots/**` to the whole directory immediately caught a bypass no re-read had: **`activateMaidr` pressed Tab directly**, so activation neither wrapped its failure nor cleared the mark.
- `pressKeyCombination` is banned in `plots/**`. It routes through `pressKey`, so nothing goes unwrapped — but it does not *wait*, and a modified data-point move announces. `moveToTop` on the vertical boxplot was the live case.
- The mark is invalidated by any unwrapped keypress, and cleared in `awaitingAnnouncement` itself rather than relying on `pressKey` being reached — `pressKeyCombination` holds the modifier down first, so a throw on `keyboard.down` would never reach the clearing site.

Each of these is pinned by a test in `announcements.spec.ts` and verified to fail without its fix, with one exception stated plainly: the `keyboard.down` case has no test, because nothing swallows a `KeypressError` today and the stale mark has no route to a check. The change removes the dependency on that staying true.

The rules deliberately stop at `page-objects/**`. Three specs do press keys directly (`multiLineplot` 20, `liveData` 13, `dialogAccessibility` 3), but each keypress is followed by a *waiting* assertion on text that persists rather than a sample of the transient alert — polling something that persists cannot arrive too late, which is exactly the property `role="alert"` lacks.

### Waits swallow a timeout and nothing else

Both waits distinguish "nothing happened" from "the run is broken", rather than folding every rejection into a no-op:

```
TOHAVETEXT       name= "Error"        ctor= ExpectError
WAITFORFUNCTION  name= "TimeoutError" ctor= TimeoutError
```

`expect().not.toHaveText()` offers nothing to narrow on, which is why the axis-title wait is written with `page.waitForFunction` — the consistency is in behaviour, not just in comments.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no user-facing behaviour changed. `.claude/agents/test-runner.md` corrected, since it described the retry config this PR removes.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| check | result |
|---|---|
| `npm run lint` | clean |
| `npm run type-check` | clean |
| `npm test` (jest) | 1291 passed, 101 suites |
| e2e — webkit | 308 passed (3.8m) |
| e2e — chromium | 308 passed (3.5m) |
| e2e — firefox | 308 passed (4.1m) |

Run one project at a time at `338acba`, clean tree verified before and after, exit 0 on all three. No retries, so every one is a hard-failure run.

This PR's own CI job runs chromium only — firefox and WebKit live in the scheduled workflows — so the three-browser criterion from #680 is met locally and re-run on every push rather than read off this PR's checks.

**Cost.** An earlier revision of this description claimed "~2% slower". That was true but was measuring dead time: 22 axis toggles per project each burning a 2 s timeout. With change 4 that is gone — WebKit went 4.1 min → 3.6 min. The remaining synchronisation resolves as soon as the announcement lands.

**What this does not claim.** Consecutive clean runs are good evidence, not proof. If something flakes again, the recorded announcements are available to the test, so the diagnosis starts from what MAIDR actually announced rather than from one sampled string.

**Scope.** No `src/` product code is touched. The investigation on #679 established that MAIDR announces reliably — five for five on WebKit — so this was always a test-synchronisation defect, not an accessibility one.