### PR TITLE
test(e2e): let the barplot page inherit the shared autoplay helper

### DIFF
--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -341,53 +341,6 @@ export class BarPlotPage extends BasePage {
   }
 
   /**
-   * Starts autoplay in a specific direction
-   * @param direction - The direction to autoplay ('forward' or 'reverse')
-   * @param infoSelector - The selector for the info element
-   * @param expectedContent - Expected content to wait for upon completion
-   * @param options - Optional timeout configuration
-   * @param options.timeout - Maximum time to wait in milliseconds (default: 10000)
-   * @param options.pollInterval - Time between checks in milliseconds (default: 100)
-   * @returns Promise resolving when autoplay completes and expected content is displayed
-   * @throws BarPlotError if autoplay fails or times out
-   */
-  protected async startAutoplay(
-    direction: 'forward' | 'reverse',
-    infoSelector: string,
-    expectedContent?: string,
-    options: { timeout?: number; pollInterval?: number } = {},
-  ): Promise<void> {
-    const arrowKey = direction === 'forward' ? TestConstants.RIGHT_ARROW_KEY : TestConstants.LEFT_ARROW_KEY;
-    const directionName = direction === 'forward' ? 'forward' : 'reverse';
-
-    try {
-      // Resolve once: it costs a page round-trip and cannot change mid-test.
-      // Inside the try so a failure is wrapped like every other step here.
-      const modifier = await this.resolveModifier(`start ${directionName} autoplay`);
-
-      await this.page.keyboard.down(modifier);
-      await this.page.keyboard.down(TestConstants.SHIFT_KEY);
-      await this.pressKey(arrowKey, `start ${directionName} autoplay`);
-
-      // Only the two modifiers are still held: `pressKey` above is a full
-      // press, so the arrow key was already released.
-      await this.page.keyboard.up(modifier);
-      await this.page.keyboard.up(TestConstants.SHIFT_KEY);
-
-      if (expectedContent) {
-        await this.waitForElementContent(
-          infoSelector,
-          expectedContent,
-          options,
-        );
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new BarPlotError(`Failed to complete ${directionName} autoplay: ${errorMessage}`, { cause: error });
-    }
-  }
-
-  /**
    * Starts forward autoplay and waits for completion
    * @param expectedContent - Expected content to wait for upon completion
    * @param options - Optional timeout configuration
@@ -400,7 +353,11 @@ export class BarPlotPage extends BasePage {
     expectedContent?: string,
     options: { timeout?: number; pollInterval?: number } = {},
   ): Promise<void> {
-    await this.startAutoplay('forward', this.selectors.info, expectedContent, options);
+    try {
+      await super.startAutoplay('forward', this.selectors.info, expectedContent, options);
+    } catch (error) {
+      throw new BarPlotError('Failed to start forward autoplay', { cause: error });
+    }
   }
 
   /**
@@ -416,6 +373,10 @@ export class BarPlotPage extends BasePage {
     expectedContent?: string,
     options: { timeout?: number; pollInterval?: number } = {},
   ): Promise<void> {
-    await this.startAutoplay('reverse', this.selectors.info, expectedContent, options);
+    try {
+      await super.startAutoplay('reverse', this.selectors.info, expectedContent, options);
+    } catch (error) {
+      throw new BarPlotError('Failed to start reverse autoplay', { cause: error });
+    }
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

`BasePage.startAutoplay` and `BarPlotPage.startAutoplay` were near-identical copies, maintained independently, and they had already drifted. During #684's review the dead `keyboard.up(arrowKey)` was removed from the barplot copy and missed in the base one — which is the copy `histogram`, `lineplot`, `heatmap`, both boxplot orientations, `multiLineplot`, `multiLayer`, `stackedBarplot` and `dodgedBarplot` all inherit. The fix landed in the less-used copy first.

## Related Issues

Closes #685. Follows #684, #688.

## Changes Made

### Does the override need to exist?

That is the question the issue asks first, so I diffed the two rather than assuming. They are identical except for two things:

| | `BasePage` | `BarPlotPage` |
|---|---|---|
| `direction` | `'forward' \| 'reverse' \| 'downward' \| 'upward'` | `'forward' \| 'reverse'` |
| error thrown | `Error` | `BarPlotError` |

The narrowing buys nothing — barplot only ever calls it with `forward` and `reverse`, and the wider base type accepts both. It is also the same silently-narrowing override shape that #679 had to untangle on `isModeActive`, which `barplot-page.ts` now carries a comment about.

So the only real difference is the error class. And barplot is the odd one out in how it gets there:

```ts
// every other plot page — three lines in the public wrapper
public async startForwardAutoplay(…) {
  try {
    await super.startAutoplay('forward', this.selectors.info, …);
  } catch (error) {
    throw new HistogramError('Failed to start forward autoplay', { cause: error });
  }
}

// barplot — duplicated the whole 47-line helper to throw from inside it
public async startForwardAutoplay(…) {
  await this.startAutoplay('forward', this.selectors.info, …);
}
```

### The fix

Delete the override; give the two public wrappers the same `try`/`catch` every sibling already has. Net **−48 / +9**.

`BarPlotError` still reaches callers, and the message now matches the other nine plots (`Failed to start forward autoplay`) instead of interpolating the inner message into a string that also carried it as `cause`.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no documented behaviour changed; the `@throws BarPlotError` on both wrappers is still accurate.
- [ ] I have added appropriate unit tests, if applicable. — no new behaviour; the existing autoplay specs cover it, and the error contract was verified directly (below).

## Additional Notes

The error path is the only thing this could plausibly have broken, so I drove a real failure through it rather than reasoning about it — a `startForwardAutoplay` waiting for content that never appears:

```
CLASS= BarPlotError | MSG= Failed to start forward autoplay | HAS_CAUSE= true
CHAIN= BarPlotError -> Error -> BarPlotError -> TimeoutError
```

Same top-level class as before, root cause still reachable.

**One honest difference:** the chain is one link deeper than it was. Before, barplot's private copy caught directly; now the shared base helper wraps in a plain `Error` on the way through. That is the price of using the shared helper instead of a private copy, which is the point of the change. Removing it would mean teaching the base not to wrap — altering the shape for all ten plot pages to spare barplot one link.

(The second `BarPlotError` in that chain is pre-existing and unrelated: barplot overrides `waitForElementContent` where the other nine do not. Out of scope here, but it is the next instance of the same duplication pattern.)

| check | result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| e2e — chromium | 308 passed (4.2m) |
| e2e — firefox | 308 passed (5.3m) |
| e2e — webkit | 308 passed (4.9m) |

Run one project at a time at `577d2ef`, clean tree verified before and after, exit 0 on all three, no retries.

**Why `BarPlotError` from the wrapper rather than a hook on the base.** An overridable error-wrapping hook would let every plot keep its own type without a `try`/`catch` each, but it would have exactly one caller today and the repo's guidance is not to add an abstraction before the second one exists. The base method throwing plain `Error` and subclasses wrapping at their own boundary is the convention already in place across the other nine pages; this makes barplot follow it rather than inventing a tenth way.