### PR TITLE
build: enable noImplicitOverride

### DIFF
--- a/e2e_tests/page-objects/plots/barplot-page.ts
+++ b/e2e_tests/page-objects/plots/barplot-page.ts
@@ -18,7 +18,7 @@ export class BarPlotPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors: {
+  protected override readonly selectors: {
     notification: string;
     info: string;
     speedIndicator: string;
@@ -75,7 +75,7 @@ export class BarPlotPage extends BasePage {
    * @returns Promise resolving when the condition is met
    * @throws BarPlotError if timeout is reached before the condition is met
    */
-  public async waitForElementContent(
+  public override async waitForElementContent(
     selector: string,
     expectedContent: string,
     options: { timeout?: number; pollInterval?: number } = {},
@@ -116,7 +116,7 @@ export class BarPlotPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws BarPlotError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await this.page.waitForLoadState('domcontentloaded');
       await expect(this.page.locator(this.selectors.svg)).toBeVisible({
@@ -132,7 +132,7 @@ export class BarPlotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws BarPlotError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await this.verifyPlotLoaded();
       await this.pressKey(TestConstants.TAB_KEY, 'activate maidr');
@@ -147,7 +147,7 @@ export class BarPlotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws BarPlotError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await this.verifyPlotLoaded();
       await this.page.click(this.selectors.svg);
@@ -177,7 +177,7 @@ export class BarPlotPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws BarPlotError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     return this.getNotificationText();
   }
 
@@ -313,7 +313,7 @@ export class BarPlotPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws BarPlotError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       const speedText = await this.getElementText(this.selectors.speedIndicator);
       return Number.parseFloat(speedText);
@@ -336,7 +336,7 @@ export class BarPlotPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws BarPlotError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     return this.getInfoText();
   }
 

--- a/e2e_tests/page-objects/plots/boxplotHorizontal-page.ts
+++ b/e2e_tests/page-objects/plots/boxplotHorizontal-page.ts
@@ -11,7 +11,7 @@ export class BoxplotHorizontalPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.BOXPLOT_HORIZONTAL_ID}`,
@@ -50,7 +50,7 @@ export class BoxplotHorizontalPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws BoxplotHorizontalError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, TestConstants.BOXPLOT_HORIZONTAL_ID);
     } catch (error) {
@@ -63,7 +63,7 @@ export class BoxplotHorizontalPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws BoxplotHorizontalError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, TestConstants.BOXPLOT_HORIZONTAL_ID);
     } catch (error) {
@@ -76,7 +76,7 @@ export class BoxplotHorizontalPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws BoxplotHorizontalError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -188,7 +188,7 @@ export class BoxplotHorizontalPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws BoxplotHorizontalError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -201,7 +201,7 @@ export class BoxplotHorizontalPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws BoxplotHorizontalError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -304,7 +304,7 @@ export class BoxplotHorizontalPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws BoxplotHorizontalError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/e2e_tests/page-objects/plots/boxplotVertical-page.ts
+++ b/e2e_tests/page-objects/plots/boxplotVertical-page.ts
@@ -11,7 +11,7 @@ export class BoxplotVerticalPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.BOXPLOT_VERTICAL_ID}`,
@@ -50,7 +50,7 @@ export class BoxplotVerticalPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws BoxplotVerticalError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, TestConstants.BOXPLOT_VERTICAL_ID);
     } catch (error) {
@@ -63,7 +63,7 @@ export class BoxplotVerticalPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws BoxplotVerticalError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, TestConstants.BOXPLOT_VERTICAL_ID);
     } catch (error) {
@@ -76,7 +76,7 @@ export class BoxplotVerticalPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws BoxplotVerticalError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -188,7 +188,7 @@ export class BoxplotVerticalPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws BoxplotVerticalError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -201,7 +201,7 @@ export class BoxplotVerticalPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws BoxplotVerticalError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -303,7 +303,7 @@ export class BoxplotVerticalPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws BoxplotVerticalError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {
@@ -315,7 +315,7 @@ export class BoxplotVerticalPage extends BasePage {
    * Moves to the data point below the current position
    * @throws BoxplotVerticalError if movement fails
    */
-  public async moveToDataPointBelow(): Promise<void> {
+  public override async moveToDataPointBelow(): Promise<void> {
     try {
       await this.pressKeyAwaitingAnnouncement('ArrowDown', 'move to data point below');
     } catch (error) {
@@ -327,7 +327,7 @@ export class BoxplotVerticalPage extends BasePage {
    * Moves to the last box in the plot
    * @throws BoxplotVerticalError if movement fails
    */
-  public async moveToLastBox(): Promise<void> {
+  public override async moveToLastBox(): Promise<void> {
     try {
       await this.pressKeyAwaitingAnnouncement('End', 'move to last box');
     } catch (error) {

--- a/e2e_tests/page-objects/plots/dodgedBarplot-page.ts
+++ b/e2e_tests/page-objects/plots/dodgedBarplot-page.ts
@@ -11,7 +11,7 @@ export class DodgedBarplotPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.DODGED_BARPLOT_ID}`,
@@ -50,7 +50,7 @@ export class DodgedBarplotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws DodgedBarplotError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, TestConstants.DODGED_BARPLOT_ID);
     } catch (error) {
@@ -63,7 +63,7 @@ export class DodgedBarplotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws DodgedBarplotError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, TestConstants.DODGED_BARPLOT_ID);
     } catch (error) {
@@ -76,7 +76,7 @@ export class DodgedBarplotPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws DodgedBarplotError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -188,7 +188,7 @@ export class DodgedBarplotPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws DodgedBarplotError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -201,7 +201,7 @@ export class DodgedBarplotPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws DodgedBarplotError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -265,7 +265,7 @@ export class DodgedBarplotPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws DodgedBarplotError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/e2e_tests/page-objects/plots/heatmap-page.ts
+++ b/e2e_tests/page-objects/plots/heatmap-page.ts
@@ -11,7 +11,7 @@ export class HeatmapPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.HEATMAP_ID}`,
@@ -55,7 +55,7 @@ export class HeatmapPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws HeatmapError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, this.plotId);
     } catch (error) {
@@ -68,7 +68,7 @@ export class HeatmapPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws HeatmapError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, this.plotId);
     } catch (error) {
@@ -81,7 +81,7 @@ export class HeatmapPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws HeatmapError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -209,7 +209,7 @@ export class HeatmapPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws HeatmapError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -222,7 +222,7 @@ export class HeatmapPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws HeatmapError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -286,7 +286,7 @@ export class HeatmapPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws HeatmapError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/e2e_tests/page-objects/plots/histogram-page.ts
+++ b/e2e_tests/page-objects/plots/histogram-page.ts
@@ -11,7 +11,7 @@ export class HistogramPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.HISTOGRAM_ID}`,
@@ -55,7 +55,7 @@ export class HistogramPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws HistogramError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, this.plotId);
     } catch (error) {
@@ -68,7 +68,7 @@ export class HistogramPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws HistogramError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, this.plotId);
     } catch (error) {
@@ -81,7 +81,7 @@ export class HistogramPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws HistogramError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -209,7 +209,7 @@ export class HistogramPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws HistogramError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -222,7 +222,7 @@ export class HistogramPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws HistogramError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -286,7 +286,7 @@ export class HistogramPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws HistogramError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/e2e_tests/page-objects/plots/lineplot-page.ts
+++ b/e2e_tests/page-objects/plots/lineplot-page.ts
@@ -12,7 +12,7 @@ export class LinePlotPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.LINEPLOT_ID}`,
@@ -54,7 +54,7 @@ export class LinePlotPage extends BasePage {
    * Activates MAIDR on the line plot
    * @throws LinePlotError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, this.plotId);
     } catch (error) {
@@ -66,7 +66,7 @@ export class LinePlotPage extends BasePage {
    * Activates MAIDR by clicking on the line plot
    * @throws LinePlotError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, this.plotId);
     } catch (error) {
@@ -79,7 +79,7 @@ export class LinePlotPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws LinePlotError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -207,7 +207,7 @@ export class LinePlotPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws LinePlotError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -220,7 +220,7 @@ export class LinePlotPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws LinePlotError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -271,7 +271,7 @@ export class LinePlotPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws LinePlotError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await this.page.waitForLoadState('domcontentloaded');
       await expect(this.page.locator(this.selectors.svg)).toBeVisible({

--- a/e2e_tests/page-objects/plots/multiLayer-page.ts
+++ b/e2e_tests/page-objects/plots/multiLayer-page.ts
@@ -11,7 +11,7 @@ export class MultiLayerPlotPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.MULTI_LAYER_PLOT_ID}`,
@@ -50,7 +50,7 @@ export class MultiLayerPlotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws MultiLayerPlotError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, TestConstants.MULTI_LAYER_PLOT_ID);
     } catch (error) {
@@ -63,7 +63,7 @@ export class MultiLayerPlotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws MultiLayerPlotError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, TestConstants.MULTI_LAYER_PLOT_ID);
     } catch (error) {
@@ -76,7 +76,7 @@ export class MultiLayerPlotPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws MultiLayerPlotError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -188,7 +188,7 @@ export class MultiLayerPlotPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws MultiLayerPlotError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -214,7 +214,7 @@ export class MultiLayerPlotPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws MultiLayerPlotError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -265,7 +265,7 @@ export class MultiLayerPlotPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws MultiLayerPlotError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/e2e_tests/page-objects/plots/multiLineplot-page.ts
+++ b/e2e_tests/page-objects/plots/multiLineplot-page.ts
@@ -11,7 +11,7 @@ export class MultiLineplotPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.MULTI_LINEPLOT_ID}`,
@@ -50,7 +50,7 @@ export class MultiLineplotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws MultiLineplotError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, TestConstants.MULTI_LINEPLOT_ID);
     } catch (error) {
@@ -63,7 +63,7 @@ export class MultiLineplotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws MultiLineplotError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, TestConstants.MULTI_LINEPLOT_ID);
     } catch (error) {
@@ -76,7 +76,7 @@ export class MultiLineplotPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws MultiLineplotError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -188,7 +188,7 @@ export class MultiLineplotPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws MultiLineplotError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -201,7 +201,7 @@ export class MultiLineplotPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws MultiLineplotError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -265,7 +265,7 @@ export class MultiLineplotPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws MultiLineplotError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/e2e_tests/page-objects/plots/stackedBarplot-page.ts
+++ b/e2e_tests/page-objects/plots/stackedBarplot-page.ts
@@ -11,7 +11,7 @@ export class StackedBarplotPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.STACKED_BARPLOT_ID}`,
@@ -50,7 +50,7 @@ export class StackedBarplotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws StackedBarplotError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, TestConstants.STACKED_BARPLOT_ID);
     } catch (error) {
@@ -63,7 +63,7 @@ export class StackedBarplotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws StackedBarplotError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, TestConstants.STACKED_BARPLOT_ID);
     } catch (error) {
@@ -76,7 +76,7 @@ export class StackedBarplotPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws StackedBarplotError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -188,7 +188,7 @@ export class StackedBarplotPage extends BasePage {
    * @returns Promise resolving to the current speed value
    * @throws StackedBarplotError if speed cannot be retrieved
    */
-  public async getPlaybackSpeed(): Promise<number> {
+  public override async getPlaybackSpeed(): Promise<number> {
     try {
       return await super.getPlaybackSpeed(this.selectors.speedIndicator);
     } catch (error) {
@@ -201,7 +201,7 @@ export class StackedBarplotPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws StackedBarplotError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -265,7 +265,7 @@ export class StackedBarplotPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws StackedBarplotError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/e2e_tests/page-objects/plots/violinPlot-page.ts
+++ b/e2e_tests/page-objects/plots/violinPlot-page.ts
@@ -11,7 +11,7 @@ export class ViolinPlotPage extends BasePage {
   /**
    * Selectors for various UI elements
    */
-  protected readonly selectors = {
+  protected override readonly selectors = {
     notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
     info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
     speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.VIOLIN_PLOT_ID}`,
@@ -50,7 +50,7 @@ export class ViolinPlotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated
    * @throws ViolinPlotError if MAIDR cannot be activated
    */
-  public async activateMaidr(): Promise<void> {
+  public override async activateMaidr(): Promise<void> {
     try {
       await super.activateMaidr(this.selectors.svg, TestConstants.VIOLIN_PLOT_ID);
     } catch (error) {
@@ -63,7 +63,7 @@ export class ViolinPlotPage extends BasePage {
    * @returns Promise resolving when MAIDR is activated via click
    * @throws ViolinPlotError if MAIDR cannot be activated by clicking
    */
-  public async activateMaidrOnClick(): Promise<void> {
+  public override async activateMaidrOnClick(): Promise<void> {
     try {
       await super.activateMaidrOnClick(this.selectors.svg, TestConstants.VIOLIN_PLOT_ID);
     } catch (error) {
@@ -76,7 +76,7 @@ export class ViolinPlotPage extends BasePage {
    * @returns Promise resolving to the instruction text
    * @throws ViolinPlotError if instruction text cannot be retrieved
    */
-  public async getInstructionText(): Promise<string> {
+  public override async getInstructionText(): Promise<string> {
     try {
       return await super.getInstructionText(this.selectors.notification);
     } catch (error) {
@@ -144,7 +144,7 @@ export class ViolinPlotPage extends BasePage {
    * @returns Promise resolving to the current data point information
    * @throws ViolinPlotError if data point information cannot be retrieved
    */
-  public async getCurrentDataPointInfo(): Promise<string> {
+  public override async getCurrentDataPointInfo(): Promise<string> {
     try {
       return await super.getCurrentDataPointInfo(this.selectors.info);
     } catch (error) {
@@ -170,7 +170,7 @@ export class ViolinPlotPage extends BasePage {
    * @returns Promise resolving when verification is complete
    * @throws ViolinPlotError if plot is not loaded correctly
    */
-  public async verifyPlotLoaded(): Promise<void> {
+  public override async verifyPlotLoaded(): Promise<void> {
     try {
       await super.verifyPlotLoaded(this.selectors.svg);
     } catch (error) {

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -388,7 +388,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
    * heatmap cells, line dots) merely drop their references so the visible
    * chart geometry survives focusout and live-data rebuilds.
    */
-  public dispose(): void {
+  public override dispose(): void {
     if (this.highlightValues) {
       this.highlightValues.forEach(row =>
         row.forEach((el) => {
@@ -628,7 +628,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     };
   }
 
-  protected abstract get dimension(): Dimension;
+  protected abstract override get dimension(): Dimension;
 
   protected abstract get highlightValues():
     | (SVGElement[] | SVGElement)[][]

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -43,7 +43,7 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
   /**
    * Cleans up bar plot resources including points and min/max arrays.
    */
-  public dispose(): void {
+  public override dispose(): void {
     this.points.length = 0;
 
     this.min.length = 0;
@@ -321,7 +321,7 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
    * @param element.col - The column position of the element
    * @returns True if coordinates are within bounds, false otherwise
    */
-  public isPointInBounds(
+  public override isPointInBounds(
     x: number,
     y: number,
     { element, row: _row, col: _col }: { element: SVGElement; row: number; col: number },
@@ -439,7 +439,7 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
   /**
    * Updates the visual position of the current point ensuring it's within bounds.
    */
-  protected updateVisualPointPosition(): void {
+  protected override updateVisualPointPosition(): void {
     // Ensure we're within bounds
     const { row: safeRow, col: safeCol } = this.getSafeIndices();
     this.row = safeRow;

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -155,7 +155,7 @@ export class BoxTrace extends AbstractTrace {
     };
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     this.points.length = 0;
     this.sections.length = 0;
     super.dispose();
@@ -374,7 +374,7 @@ export class BoxTrace extends AbstractTrace {
   /**
    * Moves to the next boxplot section that matches the comparison criteria.
    */
-  public moveToNextCompareValue(direction: 'left' | 'right' | 'up' | 'down', type: 'lower' | 'higher'): boolean {
+  public override moveToNextCompareValue(direction: 'left' | 'right' | 'up' | 'down', type: 'lower' | 'higher'): boolean {
     const currentGroup = this.row;
     if (currentGroup < 0 || currentGroup >= this.boxValues.length) {
       return false;
@@ -429,7 +429,7 @@ export class BoxTrace extends AbstractTrace {
     }
   }
 
-  public moveUpRotor(mode: 'lower' | 'higher'): boolean {
+  public override moveUpRotor(mode: 'lower' | 'higher'): boolean {
     if (this.orientation === Orientation.VERTICAL) {
       this.moveOnce('UPWARD');
       return true;
@@ -437,7 +437,7 @@ export class BoxTrace extends AbstractTrace {
     return this.moveToNextCompareValue('up', mode);
   }
 
-  public moveDownRotor(mode: 'lower' | 'higher'): boolean {
+  public override moveDownRotor(mode: 'lower' | 'higher'): boolean {
     if (this.orientation === Orientation.VERTICAL) {
       this.moveOnce('DOWNWARD');
       return true;
@@ -445,7 +445,7 @@ export class BoxTrace extends AbstractTrace {
     return this.moveToNextCompareValue('down', mode);
   }
 
-  public moveLeftRotor(mode: 'lower' | 'higher'): boolean {
+  public override moveLeftRotor(mode: 'lower' | 'higher'): boolean {
     if (this.orientation === Orientation.HORIZONTAL) {
       this.moveOnce('BACKWARD');
       return true;
@@ -453,7 +453,7 @@ export class BoxTrace extends AbstractTrace {
     return this.moveToNextCompareValue('left', mode);
   }
 
-  public moveRightRotor(mode: 'lower' | 'higher'): boolean {
+  public override moveRightRotor(mode: 'lower' | 'higher'): boolean {
     if (this.orientation === Orientation.HORIZONTAL) {
       this.moveOnce('FORWARD');
       return true;

--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -100,7 +100,7 @@ export class Candlestick extends AbstractTrace {
     | null;
 
   // Service dependency for navigation logic
-  protected readonly navigationService: NavigationService;
+  protected override readonly navigationService: NavigationService;
 
   /**
    * Creates a new Candlestick instance from a MAIDR layer
@@ -256,7 +256,7 @@ export class Candlestick extends AbstractTrace {
   /**
    * Updates visual position for point highlighting and segment position
    */
-  protected updateVisualPointPosition(): void {
+  protected override updateVisualPointPosition(): void {
     if (this.orientation === Orientation.HORIZONTAL) {
       this.row = this.currentPointIndex;
     } else {
@@ -285,7 +285,7 @@ export class Candlestick extends AbstractTrace {
    * Moves navigation position one step in the specified direction
    * @param direction - Direction to move (UPWARD, DOWNWARD, FORWARD, BACKWARD)
    */
-  public moveOnce(direction: MovableDirection): boolean {
+  public override moveOnce(direction: MovableDirection): boolean {
     if (this.isInitialEntry) {
       this.handleInitialEntry();
       this.notifyStateUpdate();
@@ -429,7 +429,7 @@ export class Candlestick extends AbstractTrace {
     }
   }
 
-  public moveToIndex(row: number, col: number): boolean {
+  public override moveToIndex(row: number, col: number): boolean {
     // Delegate navigation logic to service and only handle data state updates
     if (this.isInitialEntry) {
       this.handleInitialEntry();
@@ -461,7 +461,7 @@ export class Candlestick extends AbstractTrace {
    * @param target - Target position array or movement direction
    * @returns True if movement is possible, false otherwise
    */
-  public isMovable(target: [number, number] | MovableDirection): boolean {
+  public override isMovable(target: [number, number] | MovableDirection): boolean {
     if (Array.isArray(target)) {
       // For direct position targeting, use parent logic
       return super.isMovable(target);
@@ -536,7 +536,7 @@ export class Candlestick extends AbstractTrace {
   /**
    * Cleans up resources and disposes of the candlestick instance
    */
-  public dispose(): void {
+  public override dispose(): void {
     this.navigationService.dispose();
     this.candles.length = 0;
     super.dispose();
@@ -834,7 +834,7 @@ export class Candlestick extends AbstractTrace {
    * Gets the current X value from the candlestick trace
    * @returns The current X value or null if not available
    */
-  public getCurrentXValue(): XValue | null {
+  public override getCurrentXValue(): XValue | null {
     if (
       this.currentPointIndex >= 0
       && this.currentPointIndex < this.candles.length
@@ -849,7 +849,7 @@ export class Candlestick extends AbstractTrace {
    * @param xValue - The X value to move to
    * @returns True if the position was found and set, false otherwise
    */
-  public moveToXValue(xValue: XValue): boolean {
+  public override moveToXValue(xValue: XValue): boolean {
     const targetIndex = this.candles.findIndex(
       candle => candle.value === xValue,
     );
@@ -876,7 +876,7 @@ export class Candlestick extends AbstractTrace {
    * Gets extrema targets for the current candlestick trace with labels and descriptions
    * @returns Array of extrema targets for navigation
    */
-  public getExtremaTargets(): ExtremaTarget[] {
+  public override getExtremaTargets(): ExtremaTarget[] {
     const targets: ExtremaTarget[] = [];
     const currentSegment = this.currentSegmentType ?? 'open';
 
@@ -985,7 +985,7 @@ export class Candlestick extends AbstractTrace {
    * Navigates to a specific extrema target
    * @param target - The extrema target to navigate to
    */
-  public navigateToExtrema(target: ExtremaTarget): void {
+  public override navigateToExtrema(target: ExtremaTarget): void {
     // Update the current point index
     this.currentPointIndex = target.pointIndex;
 
@@ -1002,7 +1002,7 @@ export class Candlestick extends AbstractTrace {
    * @param type - Comparison type (lower or higher)
    * @returns True if a matching value was found and moved to
    */
-  public moveToNextCompareValue(direction: 'left' | 'right', type: 'lower' | 'higher'): boolean {
+  public override moveToNextCompareValue(direction: 'left' | 'right', type: 'lower' | 'higher'): boolean {
     // Establish the entry position on the first move so the compare jump
     // highlights and a subsequent ordinary keypress isn't swallowed by the
     // initial-entry branch of moveOnce (mirrors moveOnce/moveToExtreme).
@@ -1038,7 +1038,7 @@ export class Candlestick extends AbstractTrace {
    * Moves upward between segments within a candle in rotor mode
    * @returns True if the move was successful
    */
-  public moveUpRotor(): boolean {
+  public override moveUpRotor(): boolean {
     this.moveOnce('UPWARD');
     return true;
   }
@@ -1047,7 +1047,7 @@ export class Candlestick extends AbstractTrace {
    * Moves downward between segments within a candle in rotor mode
    * @returns True if the move was successful
    */
-  public moveDownRotor(): boolean {
+  public override moveDownRotor(): boolean {
     this.moveOnce('DOWNWARD');
     return true;
   }

--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -234,7 +234,7 @@ export class CandlestickDeltaTrace extends AbstractTrace {
     this.movable = new MovableGrid<number>(this.deltaGrid);
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     this.candles.length = 0;
     super.dispose();
   }

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -51,7 +51,7 @@ export class Heatmap extends AbstractTrace {
   /**
    * Cleans up resources and disposes of the heatmap instance
    */
-  public dispose(): void {
+  public override dispose(): void {
     this.heatmapValues.length = 0;
 
     this.x.length = 0;
@@ -280,7 +280,7 @@ export class Heatmap extends AbstractTrace {
   /**
    * Updates the visual position of the current point to safe bounds
    */
-  protected updateVisualPointPosition(): void {
+  protected override updateVisualPointPosition(): void {
     // Ensure we're within bounds
     const { row: safeRow, col: safeCol } = this.getSafeIndices();
     this.row = safeRow;

--- a/src/model/histogram.ts
+++ b/src/model/histogram.ts
@@ -51,7 +51,7 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
     };
   }
 
-  protected get text(): TextState {
+  protected override get text(): TextState {
     const isVertical = this.orientation === Orientation.VERTICAL;
     const point = this.points[this.row][this.col];
 

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -207,7 +207,7 @@ export class LineTrace extends AbstractTrace {
     };
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     if (typeof window !== 'undefined') {
       window.removeEventListener('scroll', this.invalidateHighlightCenters, true);
       window.removeEventListener('resize', this.invalidateHighlightCenters);
@@ -360,7 +360,7 @@ export class LineTrace extends AbstractTrace {
     };
   }
 
-  public moveOnce(direction: MovableDirection): boolean {
+  public override moveOnce(direction: MovableDirection): boolean {
     if (this.isInitialEntry) {
       this.movable.handleInitialEntry();
       this.previousRow = null;
@@ -494,7 +494,7 @@ export class LineTrace extends AbstractTrace {
     return intersections;
   }
 
-  public isMovable(target: [number, number] | MovableDirection): boolean {
+  public override isMovable(target: [number, number] | MovableDirection): boolean {
     if (Array.isArray(target)) {
       const [row, col] = target;
       return (
@@ -803,7 +803,7 @@ export class LineTrace extends AbstractTrace {
     }
   }
 
-  public get state(): TraceState {
+  public override get state(): TraceState {
     const baseState = super.state;
     if (baseState.empty)
       return baseState;
@@ -1404,7 +1404,7 @@ export class LineTrace extends AbstractTrace {
    * Update the visual position of the current point
    * This method should be called when navigation changes
    */
-  protected updateVisualPointPosition(): void {
+  protected override updateVisualPointPosition(): void {
     // Ensure we're within bounds
     const { row: safeRow, col: safeCol } = this.getSafeIndices();
     this.row = safeRow;
@@ -1424,7 +1424,7 @@ export class LineTrace extends AbstractTrace {
    * @param xValue The X value to move to
    * @returns true if the position was found and set, false otherwise
    */
-  public moveToXValue(xValue: XValue): boolean {
+  public override moveToXValue(xValue: XValue): boolean {
     // Handle initial entry properly
     if (this.isInitialEntry) {
       this.movable.handleInitialEntry();
@@ -1432,7 +1432,7 @@ export class LineTrace extends AbstractTrace {
     return super.moveToXValue(xValue);
   }
 
-  public moveToNextCompareValue(direction: string, type: 'lower' | 'higher'): boolean {
+  public override moveToNextCompareValue(direction: string, type: 'lower' | 'higher'): boolean {
     const currentGroup = this.row;
     if (currentGroup < 0 || currentGroup >= this.lineValues.length) {
       return false;
@@ -1460,12 +1460,12 @@ export class LineTrace extends AbstractTrace {
     return false;
   }
 
-  public moveUpRotor(_mode?: 'lower' | 'higher'): boolean {
+  public override moveUpRotor(_mode?: 'lower' | 'higher'): boolean {
     this.moveOnce('UPWARD');
     return true;
   }
 
-  public moveDownRotor(_mode?: 'lower' | 'higher'): boolean {
+  public override moveDownRotor(_mode?: 'lower' | 'higher'): boolean {
     this.moveOnce('DOWNWARD');
     return true;
   }

--- a/src/model/movable.ts
+++ b/src/model/movable.ts
@@ -103,7 +103,7 @@ export class MovableGrid<Element> extends AbstractMovable {
     return true;
   }
 
-  public moveToIndex(row: number, col: number): boolean {
+  public override moveToIndex(row: number, col: number): boolean {
     if (!this.isMovable([row, col])) {
       return false;
     }

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -223,7 +223,7 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
   /**
    * Cleans up all subplots and releases resources
    */
-  public dispose(): void {
+  public override dispose(): void {
     this.subplots.forEach(row => row.forEach(subplot => subplot.dispose()));
     this.subplots.length = 0;
     super.dispose();
@@ -414,7 +414,7 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
     this.movable = new MovableGrid<Trace>(this.traces);
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     this.traces.forEach(row => row.forEach(trace => trace.dispose()));
     this.traces.length = 0;
     // Remove the cloned highlight element to avoid stale DOM nodes

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -168,7 +168,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
   /**
    * Cleans up resources and removes all highlight elements from the DOM.
    */
-  public dispose(): void {
+  public override dispose(): void {
     if (typeof window !== 'undefined') {
       window.removeEventListener('scroll', this.invalidateHighlightCenters, true);
       window.removeEventListener('resize', this.invalidateHighlightCenters);
@@ -205,7 +205,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
    * Returns an empty object to avoid grouping scatter points by audio tone.
    * @returns Empty object without groupIndex to maintain consistent audio feedback
    */
-  protected getAudioGroupIndex(): { groupIndex?: number } {
+  protected override getAudioGroupIndex(): { groupIndex?: number } {
     // Rationale for returning empty object instead of groupIndex:
     //
     // Scatterplots fundamentally differ from other plot types in their grouping semantics:
@@ -427,7 +427,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
     };
   }
 
-  protected get highlight(): HighlightState {
+  protected override get highlight(): HighlightState {
     if (this.isInGridMode && this.gridCells) {
       const cell = this.gridCells[this.gridRow][this.gridCol];
 
@@ -470,7 +470,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
     };
   }
 
-  protected get hasMultiPoints(): boolean {
+  protected override get hasMultiPoints(): boolean {
     return true;
   }
 
@@ -478,7 +478,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
    * Returns out-of-bounds state with correct position for grid mode panning.
    * In grid mode, uses gridCol/gridRow for correct left/right audio panning.
    */
-  protected get outOfBoundsState(): TraceState {
+  protected override get outOfBoundsState(): TraceState {
     // Use grid position when in grid mode for correct panning
     if (this.isInGridMode && this.gridCells) {
       return {
@@ -546,7 +546,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
     }
   }
 
-  public moveOnce(direction: MovableDirection): boolean {
+  public override moveOnce(direction: MovableDirection): boolean {
     if (this.isInitialEntry) {
       this.handleInitialEntry();
       this.notifyStateUpdate();
@@ -622,7 +622,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
     return moved;
   }
 
-  public moveToExtreme(direction: MovableDirection): boolean {
+  public override moveToExtreme(direction: MovableDirection): boolean {
     if (this.isInitialEntry) {
       this.handleInitialEntry();
     }
@@ -666,7 +666,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
     return true;
   }
 
-  public moveToIndex(row: number, col: number): boolean {
+  public override moveToIndex(row: number, col: number): boolean {
     // Grid semantics: `col` is the x index (COL mode) and `row` is the y index
     // (ROW mode). NavigationService.moveToXValueInValues preserves X across
     // layer switches by calling moveToIndex(0, xIndex), so COL mode must read
@@ -701,7 +701,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
    * @param target - Direction or coordinate to check
    * @returns True if movement is possible, false otherwise
    */
-  public isMovable(target: [number, number] | MovableDirection): boolean {
+  public override isMovable(target: [number, number] | MovableDirection): boolean {
     if (Array.isArray(target)) {
       // Array targets are raw cursor coordinates, used by
       // Context.restoreTracePosition to keep the user's position across

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -184,7 +184,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
    * Update the visual position of the current point
    * This method should be called when navigation changes
    */
-  protected updateVisualPointPosition(): void {
+  protected override updateVisualPointPosition(): void {
     // Ensure we're within bounds
     const { row: safeRow, col: safeCol } = this.getSafeIndices();
     this.row = safeRow;
@@ -236,7 +236,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     };
   }
 
-  protected get text(): TextState {
+  protected override get text(): TextState {
     return {
       ...super.text,
       z: {
@@ -246,7 +246,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     };
   }
 
-  protected get highlight(): HighlightState {
+  protected override get highlight(): HighlightState {
     if (this.highlightValues === null || this.row === this.barValues.length - 1) {
       return this.outOfBoundsState as HighlightState;
     }
@@ -263,7 +263,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     };
   }
 
-  protected mapToSvgElements(selector?: string): SVGElement[][] | null {
+  protected override mapToSvgElements(selector?: string): SVGElement[][] | null {
     if (!selector) {
       return null;
     }

--- a/src/model/smooth.ts
+++ b/src/model/smooth.ts
@@ -20,7 +20,7 @@ export class SmoothTrace extends LineTrace {
    * in instruction text and layer announcements.
    * @returns The trace state with plotType set to 'smooth'
    */
-  public get state(): TraceState {
+  public override get state(): TraceState {
     const baseState = super.state;
     if (baseState.empty)
       return baseState;
@@ -38,7 +38,7 @@ export class SmoothTrace extends LineTrace {
    * @returns The description state containing chart metadata and data table
    */
 
-  protected get audio(): AudioState {
+  protected override get audio(): AudioState {
     const rowYValues = this.lineValues[this.row];
     const getY = (i: number): number => {
       return rowYValues[Math.max(0, Math.min(i, rowYValues.length - 1))];

--- a/src/model/smoothSvgXY.ts
+++ b/src/model/smoothSvgXY.ts
@@ -19,7 +19,7 @@ export class SmoothTraceSvgXY extends SmoothTrace {
    * @param selectors - Optional array of CSS selectors for line elements
    * @returns Array of SVG element arrays for each line, or null if selectors are invalid or all mappings failed
    */
-  protected mapToSvgElements(selectors?: string[]): SVGElement[][] | null {
+  protected override mapToSvgElements(selectors?: string[]): SVGElement[][] | null {
     if (!selectors || selectors.length !== this.lineValues.length) {
       return null;
     }

--- a/src/model/violin.ts
+++ b/src/model/violin.ts
@@ -148,7 +148,7 @@ export class ViolinKdeTrace extends AbstractTrace {
     };
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     this.points.length = 0;
     this.densityValues.length = 0;
     this.yValues.length = 0;
@@ -474,14 +474,14 @@ export class ViolinKdeTrace extends AbstractTrace {
   /**
    * Returns the violin index (row) for layer switching.
    */
-  public getCurrentXValue(): XValue | null {
+  public override getCurrentXValue(): XValue | null {
     return this.row >= 0 && this.row < this.points.length ? this.row : null;
   }
 
   /**
    * Moves to the specified violin, resetting to bottom of curve.
    */
-  public moveToXValue(xValue: XValue): boolean {
+  public override moveToXValue(xValue: XValue): boolean {
     if (this.isInitialEntry) {
       this.handleInitialEntry();
     }
@@ -687,7 +687,7 @@ export class ViolinKdeTrace extends AbstractTrace {
     };
   }
 
-  protected updateVisualPointPosition(): void {
+  protected override updateVisualPointPosition(): void {
     const { row: safeRow, col: safeCol } = this.getSafeIndices();
     this.row = safeRow;
     this.col = safeCol;

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -186,7 +186,7 @@ export class ViolinBoxTrace extends AbstractTrace {
     };
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     this.points.length = 0;
     this.sections.length = 0;
     super.dispose();
@@ -336,7 +336,7 @@ export class ViolinBoxTrace extends AbstractTrace {
   /**
    * Returns the violin index for layer switching.
    */
-  public getCurrentXValue(): XValue | null {
+  public override getCurrentXValue(): XValue | null {
     if (this.orientation === Orientation.VERTICAL) {
       return this.col >= 0 ? this.col : null;
     }
@@ -346,7 +346,7 @@ export class ViolinBoxTrace extends AbstractTrace {
   /**
    * Moves to a violin index, resetting to MIN section.
    */
-  public moveToXValue(xValue: XValue): boolean {
+  public override moveToXValue(xValue: XValue): boolean {
     if (this.isInitialEntry) {
       this.handleInitialEntry();
     }
@@ -707,7 +707,7 @@ export class ViolinBoxTrace extends AbstractTrace {
     // Disabled for violin box plots
   }
 
-  protected updateVisualPointPosition(): void {
+  protected override updateVisualPointPosition(): void {
     const { row: safeRow, col: safeCol } = this.getSafeIndices();
     this.row = safeRow;
     this.col = safeCol;

--- a/src/service/chat.ts
+++ b/src/service/chat.ts
@@ -611,7 +611,7 @@ class Claude extends AbstractLlmModel<ClaudeResponse> {
    * @param {LlmRequest} request - The request containing authentication details
    * @returns {Record<string, string>} The HTTP headers
    */
-  protected getHeaders(request: LlmRequest): Record<string, string> {
+  protected override getHeaders(request: LlmRequest): Record<string, string> {
     if (request.clientToken) {
       const headers = super.getHeaders(request);
       headers['anthropic-version'] = ANTHROPIC_API_VERSION;
@@ -759,7 +759,7 @@ class Gemini extends AbstractLlmModel<GeminiResponse> {
    * @param {LlmRequest} request - The request containing authentication details
    * @returns {Record<string, string>} The HTTP headers
    */
-  protected getHeaders(request: LlmRequest): Record<string, string> {
+  protected override getHeaders(request: LlmRequest): Record<string, string> {
     const headers = super.getHeaders(request);
     // Gemini uses API key in URL, so we don't need to add it to headers
     delete headers.Authorization;
@@ -893,7 +893,7 @@ class Ollama extends AbstractLlmModel<OllamaResponse> {
    * @param {LlmRequest} _request - The request containing connection details (unused)
    * @returns {Record<string, string>} The HTTP headers
    */
-  protected getHeaders(_request: LlmRequest): Record<string, string> {
+  protected override getHeaders(_request: LlmRequest): Record<string, string> {
     return {
       'Content-Type': 'application/json',
     };

--- a/src/state/viewModel/brailleViewModel.ts
+++ b/src/state/viewModel/brailleViewModel.ts
@@ -57,7 +57,7 @@ export class BrailleViewModel extends AbstractViewModel<BrailleState> {
   /**
    * Disposes the view model and resets braille state to initial values.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/src/state/viewModel/candlestickDeltaViewModel.ts
+++ b/src/state/viewModel/candlestickDeltaViewModel.ts
@@ -72,7 +72,7 @@ export class CandlestickDeltaViewModel extends AbstractViewModel<CandlestickDelt
     this.notification = notification;
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(hide());
   }

--- a/src/state/viewModel/chatViewModel.ts
+++ b/src/state/viewModel/chatViewModel.ts
@@ -119,7 +119,7 @@ export class ChatViewModel extends AbstractViewModel<ChatState> {
   /**
    * Disposes the view model and resets chat state to initial values.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/src/state/viewModel/commandPaletteViewModel.ts
+++ b/src/state/viewModel/commandPaletteViewModel.ts
@@ -114,7 +114,7 @@ export class CommandPaletteViewModel extends AbstractViewModel<CommandPaletteSta
   /**
    * Disposes the view model and hides the command palette.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(hide());
   }

--- a/src/state/viewModel/descriptionViewModel.ts
+++ b/src/state/viewModel/descriptionViewModel.ts
@@ -62,7 +62,7 @@ export class DescriptionViewModel extends AbstractViewModel<DescriptionMenuState
     this.descriptionService.toggle();
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/src/state/viewModel/displayViewModel.ts
+++ b/src/state/viewModel/displayViewModel.ts
@@ -73,7 +73,7 @@ export class DisplayViewModel extends AbstractViewModel<DisplayState> {
   /**
    * Disposes the view model, clears focus, and restores instruction tooltip.
    */
-  public dispose(): void {
+  public override dispose(): void {
     // Clear only focus to avoid wiping other display UI state
     this.store.dispatch(clearFocus());
     this.store.dispatch(showTooltip(this.displayService.getInstruction()));

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -92,7 +92,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     this.formatter = formatter;
   }
 
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(hide());
   }

--- a/src/state/viewModel/helpViewModel.ts
+++ b/src/state/viewModel/helpViewModel.ts
@@ -58,7 +58,7 @@ export class HelpViewModel extends AbstractViewModel<HelpMenuState> {
   /**
    * Disposes the view model and resets help menu state.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/src/state/viewModel/reviewViewModel.ts
+++ b/src/state/viewModel/reviewViewModel.ts
@@ -50,7 +50,7 @@ export class ReviewViewModel extends AbstractViewModel<ReviewState> {
   /**
    * Disposes the view model and resets review state.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/src/state/viewModel/rotorNavigationViewModel.ts
+++ b/src/state/viewModel/rotorNavigationViewModel.ts
@@ -55,7 +55,7 @@ export class RotorNavigationViewModel extends AbstractViewModel<RotorState> {
    * Prevents a stale rotor value from surviving controller disposal and being
    * re-announced in the live region on the next focus-in.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/src/state/viewModel/settingsViewModel.ts
+++ b/src/state/viewModel/settingsViewModel.ts
@@ -47,7 +47,7 @@ export class SettingsViewModel extends AbstractViewModel<SettingsState> {
   /**
    * Disposes the view model and resets settings state.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/src/state/viewModel/textViewModel.ts
+++ b/src/state/viewModel/textViewModel.ts
@@ -107,7 +107,7 @@ export class TextViewModel extends AbstractViewModel<TextState> {
   /**
    * Disposes the view model and resets text state.
    */
-  public dispose(): void {
+  public override dispose(): void {
     super.dispose();
     this.store.dispatch(reset());
   }

--- a/test/model/moveToNearestOverride.test.ts
+++ b/test/model/moveToNearestOverride.test.ts
@@ -103,16 +103,16 @@ class TestTrace extends AbstractTrace {
     return this.nearest;
   }
 
-  public isPointInBounds(_x: number, _y: number, _nearest: NearestPoint): boolean {
+  public override isPointInBounds(_x: number, _y: number, _nearest: NearestPoint): boolean {
     return this.inBounds;
   }
 
-  public moveToIndex(row: number, col: number): boolean {
+  public override moveToIndex(row: number, col: number): boolean {
     this.moveToIndexCalls++;
     return super.moveToIndex(row, col);
   }
 
-  public getExtremaTargets(): ExtremaTarget[] {
+  public override getExtremaTargets(): ExtremaTarget[] {
     return [];
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "resolveJsonModule": true,
     "allowJs": false,
     "strict": true,
+    "noImplicitOverride": true,
 
     "noEmit": true,
     "sourceMap": true,


### PR DESCRIPTION
# Pull Request

## Description

`tsconfig.json` has `strict: true` but not `noImplicitOverride`, so a method that overrides a base member looks identical to one that does not.

#679 lost time to exactly that. A subclass kept a snapshot-reading `isModeActive` while the base class was taught to wait, so every barplot mode toggle quietly resolved to the un-fixed copy — invisible at the call sites *and* at the base method, and caught only by a reviewer reading the diff.

## Related Issues

Closes #682. Follows #679, #684.

> **Merge order — resolved.** #689 has merged and this branch is rebased onto it (`35001a4`). The one predicted conflict, the `override` on the `startAutoplay` that #689 deletes, is resolved in `main`'s favour. Every number below was re-measured after the rebase.

## Changes Made

One flag, and the 161 members that now need the keyword:

| area | members |
|---|---|
| `e2e_tests/page-objects` | 79 |
| `src/model` | 64 |
| `src/state/viewModel` | 12 |
| `src/service` | 3 |
| `test/model` | 3 |

**Nothing else changes.** Two checks rather than an assurance:

- **Every one of the 161 changed lines differs from its original by exactly the inserted `override `.** Compared line by line, not by eye — 161 added, 161 removed, 161 matching after removing the keyword.
- **The emitted bundle is unchanged.** Built this branch and `main` and hashed the output: all **34** js/css files match byte for byte. `override` is erased at compile time, so that is the expected result — and now a verified one rather than an assumption.

### The issue undersold the flag

#682 said the value is "disclosure, not prevention", on the grounds that bivariant parameters mean the keyword would not have rejected #679's incompatible signature. That part is right, but it is not the whole story, and I checked rather than assumed:

```
$ # rename AbstractPlot.dispose, then type-check
src/model/abstract.ts(391,19): error TS4113: This member cannot have an 'override'
  modifier because it is not declared in the base class 'AbstractPlot<TraceState>'
src/model/plot.ts(226,19): error TS4113: …
src/model/plot.ts(417,19): error TS4113: …
```

Renaming a base member turns its now-orphaned overrides into compile errors. Without the flag they silently become new methods nothing calls. That is prevention, of a real failure mode. The issue body has been corrected.

### How it was applied

Mechanically, from the compiler's own diagnostics — 161 hand edits would be 161 chances to fumble one.

Worth recording one trap, because the obvious implementation is wrong: the reported column points at the *member name*, which sits after `async`, `readonly`, `get` and `set`. TypeScript wants `override` before those, so inserting at the column produces `public async override activateMaidr()`, which does not parse. The script backs up over them:

```python
while True:
    head = text[:at].rstrip(' ')
    for word in ('async', 'readonly', 'get', 'set'):
        if head.endswith(word) and not head[-len(word) - 1].isalnum():
            at = len(head) - len(word)
            break
    else:
        break
```

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas. — no new code; the change is a keyword.
- [ ] I have updated the documentation, if applicable. — no documented behaviour changed. `.claude/rules/typescript.md` describes conventions, not compiler flags.
- [ ] I have added appropriate unit tests, if applicable. — the compiler is the test; `npm run type-check` fails without the keywords.

## Additional Notes

All measured on the rebased head `34cad8a`, against `main` at `35001a4`:

| check | result |
|---|---|
| `npm run type-check` | clean |
| `npm run lint:fix` | clean, no reformatting |
| `npm run build` | exit 0 |
| bundle vs `main` | **34/34 files byte-identical** |
| `npm test` | 1300 passed, 102 suites |
| e2e — chromium | 308 passed (3.6m) |
| e2e — firefox | 308 passed (4.3m) |
| e2e — webkit | 308 passed (3.8m) |

Run one project at a time, clean tree verified before and after, exit 0 on all three, no retries.

**This is the first PR in this thread to touch `src/`.** #674, #676, #679, #684, #686, #688 and #689 all leaned on "no product code touched" when reviewers assessed risk, so that property is gone here and worth saying plainly rather than leaving a reviewer to notice. What replaces it is the bundle comparison above: the risk is not that this changes behaviour — it provably does not — but that a mechanical sweep across 41 files is tedious to review. The line-by-line check is there so it does not have to be read that way.

**Why it could not be split.** `noImplicitOverride` is a single `tsconfig` flag. Turning it on requires all 161 keywords at once; there is no "e2e first, `src/` later" version of this change.