### PR TITLE
ci: close the rolling test-failure issue when the suite goes green

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -122,10 +122,16 @@ jobs:
             // Determine issue title and labels based on test status. Anything
             // other than success (failure, cancelled — e.g. the job timeout
             // interrupting a hung run) must be filed as a failure.
+            //
+            // The prefixes are named once: they identify this workflow's own
+            // issues in three places below, and two literals that must agree
+            // are two literals that can drift apart.
+            const FAILURE_PREFIX = 'test: Some e2e tests failed';
+            const REPORT_PREFIX = 'Test Report';
             const isFailure = process.env.TEST_STATUS !== 'success';
             const title = isFailure
-              ? `test: Some e2e tests failed - ${new Date().toISOString()}`
-              : `Test Report - ${new Date().toISOString()}`;
+              ? `${FAILURE_PREFIX} - ${new Date().toISOString()}`
+              : `${REPORT_PREFIX} - ${new Date().toISOString()}`;
             const labels = isFailure ? ['test-failure'] : ['test-report'];
 
             // Search for existing issue
@@ -144,7 +150,7 @@ jobs:
             // issue from a previous run — each scheduled failure would file
             // a brand-new issue instead of updating the rolling one.
             const existingIssue = issues.find(issue =>
-              issue.title.includes(isFailure ? 'test: Some e2e tests failed' : 'Test Report')
+              issue.title.includes(isFailure ? FAILURE_PREFIX : REPORT_PREFIX)
             );
 
             if (existingIssue) {
@@ -188,8 +194,20 @@ jobs:
                 state: 'open'
               });
 
-              // listForRepo returns pull requests too; they are not reports.
-              for (const issue of stale.filter(i => !i.pull_request)) {
+              // Only this workflow's own reports. The label alone is not
+              // proof of authorship: a maintainer tracking a flaky spec could
+              // reasonably reach for `test-failure`, and closing their issue
+              // with "fixed by the run that passed" would be a lie the
+              // automation has no way to know it told. The title prefix is
+              // something only this step writes.
+              //
+              // Pull requests are excluded as well — listForRepo returns them
+              // and they are not reports either.
+              const mine = stale.filter(i =>
+                !i.pull_request && i.title.includes(FAILURE_PREFIX)
+              );
+
+              for (const issue of mine) {
                 await github.rest.issues.createComment({
                   owner,
                   repo,

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -149,8 +149,14 @@ jobs:
             // the CURRENT run's URL, so matching on it could never find an
             // issue from a previous run — each scheduled failure would file
             // a brand-new issue instead of updating the rolling one.
+            //
+            // Pull requests are excluded for the same reason the retire loop
+            // below excludes them: listForRepo returns them, and one carrying
+            // this label and title would otherwise be adopted as the rolling
+            // issue and have its title and body overwritten.
             const existingIssue = issues.find(issue =>
-              issue.title.includes(isFailure ? FAILURE_PREFIX : REPORT_PREFIX)
+              !issue.pull_request
+              && issue.title.startsWith(isFailure ? FAILURE_PREFIX : REPORT_PREFIX)
             );
 
             if (existingIssue) {
@@ -204,7 +210,7 @@ jobs:
               // Pull requests are excluded as well — listForRepo returns them
               // and they are not reports either.
               const mine = stale.filter(i =>
-                !i.pull_request && i.title.includes(FAILURE_PREFIX)
+                !i.pull_request && i.title.startsWith(FAILURE_PREFIX)
               );
 
               // Per issue, so one failure does not strand the rest. An
@@ -213,8 +219,22 @@ jobs:
               // kind of lie about the suite's state that this step exists to
               // stop telling. Retrying is left to the next run: the issue is
               // still open and still matches, so it gets picked up again.
+              // Close first, comment second. If the close fails the issue is
+              // still open and still matches, so the next green run retries
+              // it — and because no comment was posted, that retry does not
+              // stack a second "green again" note. The reverse order leaves
+              // the stale report standing while adding a comment per cycle,
+              // which is the wrong half to have succeeded.
               for (const issue of mine) {
                 try {
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    state: 'closed',
+                    state_reason: 'completed'
+                  });
+
                   await github.rest.issues.createComment({
                     owner,
                     repo,
@@ -229,14 +249,6 @@ jobs:
                       'tests fail again a fresh issue is filed rather than this',
                       'one reopened, so the history stays per-incident.'
                     ].join('\n')
-                  });
-
-                  await github.rest.issues.update({
-                    owner,
-                    repo,
-                    issue_number: issue.number,
-                    state: 'closed',
-                    state_reason: 'completed'
                   });
                 } catch (error) {
                   core.warning(`Could not retire #${issue.number}: ${error.message}`);

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -12,7 +12,9 @@ on:
 
 permissions:
   contents: read
-  issues: write # the report step files/updates a test-report issue
+  # The report step files and updates the rolling report issue, and on a green
+  # run also closes and comments on the failure issues it had filed.
+  issues: write
 
 jobs:
   test:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -217,14 +217,24 @@ jobs:
               // uncaught throw here would fail this step and report the whole
               // scheduled run as red even though the suite passed — the same
               // kind of lie about the suite's state that this step exists to
-              // stop telling. Retrying is left to the next run: the issue is
-              // still open and still matches, so it gets picked up again.
+              // stop telling.
+              //
               // Close first, comment second. If the close fails the issue is
               // still open and still matches, so the next green run retries
               // it — and because no comment was posted, that retry does not
               // stack a second "green again" note. The reverse order leaves
               // the stale report standing while adding a comment per cycle,
               // which is the wrong half to have succeeded.
+              //
+              // The two are caught separately because they are not the same
+              // event and only one of them is retried. A failed close leaves
+              // the issue open for the next run. A failed comment does not:
+              // the issue is already closed, so the `state: 'open'` filter
+              // above means no later run will ever look at it again and the
+              // note is gone for good. One shared handler saying "could not
+              // retire" would report the second as the first — claiming the
+              // issue is still open and will be picked up later, when it is
+              // closed and will not be.
               for (const issue of mine) {
                 try {
                   await github.rest.issues.update({
@@ -234,7 +244,15 @@ jobs:
                     state: 'closed',
                     state_reason: 'completed'
                   });
+                } catch (error) {
+                  core.warning(
+                    `Could not close #${issue.number}, leaving it for the next `
+                    + `green run: ${error.message}`
+                  );
+                  continue;
+                }
 
+                try {
                   await github.rest.issues.createComment({
                     owner,
                     repo,
@@ -251,7 +269,10 @@ jobs:
                     ].join('\n')
                   });
                 } catch (error) {
-                  core.warning(`Could not retire #${issue.number}: ${error.message}`);
+                  core.warning(
+                    `Closed #${issue.number} but could not comment on it; the `
+                    + `run that fixed it is in this log only: ${error.message}`
+                  );
                 }
               }
             }

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -164,6 +164,51 @@ jobs:
               });
             }
 
+            // A green run has to retire the failure issue as well as file its
+            // own report. Success only ever touched the `test-report` issue,
+            // so the rolling `test-failure` one outlived the fix: #683 stayed
+            // open listing WebKit failures that #679 and #684 had already
+            // fixed, and no number of green runs would have closed it.
+            //
+            // Every open one, not just the newest: the title carries a
+            // timestamp, and a run that failed before this step existed could
+            // have left more than one behind.
+            if (!isFailure) {
+              const stale = await github.rest.issues.listForRepo({
+                owner,
+                repo,
+                labels: ['test-failure'],
+                state: 'open'
+              });
+
+              // listForRepo returns pull requests too; they are not reports.
+              for (const issue of stale.data.filter(i => !i.pull_request)) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: [
+                    'The scheduled suite is green again.',
+                    '',
+                    `Commit: ${context.sha}`,
+                    `[View Workflow Run](${run_url})`,
+                    '',
+                    'Closed automatically by the run that passed. If these',
+                    'tests fail again a fresh issue is filed rather than this',
+                    'one reopened, so the history stays per-incident.'
+                  ].join('\n')
+                });
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed'
+                });
+              }
+            }
+
       # The test step ran with continue-on-error so the report above always
       # publishes; surface the real outcome as the workflow conclusion.
       - name: Propagate test outcome

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -150,6 +150,23 @@ jobs:
               : `${REPORT_PREFIX} - ${new Date().toISOString()}`;
             const labels = isFailure ? ['test-failure'] : ['test-report'];
 
+            // "One this workflow filed, under `prefix`." Both lookups below
+            // ask it, and they used to ask it in their own words — the same
+            // two conditions written twice, which is two places to remember
+            // when either one changes. They already drifted once: the retire
+            // loop excluded pull requests for a round while the lookup above
+            // it did not.
+            //
+            // The label is not enough on its own. A maintainer tracking a
+            // flaky spec could reasonably reach for `test-failure`, and
+            // closing their issue with "fixed by the run that passed" is a
+            // claim this step has no way to know is false. The title prefix
+            // is something only this step writes. It has to be startsWith
+            // rather than includes: a human title can mention the prefix
+            // partway through and mean something else entirely.
+            const isOwn = (issue, prefix) =>
+              !issue.pull_request && issue.title.startsWith(prefix);
+
             // Search for existing issue
             // Paginated: listForRepo caps at 30 per page by default, and a
             // report older than one page would be invisible here — which
@@ -166,13 +183,10 @@ jobs:
             // issue from a previous run — each scheduled failure would file
             // a brand-new issue instead of updating the rolling one.
             //
-            // Pull requests are excluded for the same reason the retire loop
-            // below excludes them: listForRepo returns them, and one carrying
-            // this label and title would otherwise be adopted as the rolling
-            // issue and have its title and body overwritten.
+            // What this one does with a match is rewrite its title and body,
+            // so adopting a pull request by mistake overwrites it.
             const existingIssue = issues.find(issue =>
-              !issue.pull_request
-              && issue.title.startsWith(isFailure ? FAILURE_PREFIX : REPORT_PREFIX)
+              isOwn(issue, isFailure ? FAILURE_PREFIX : REPORT_PREFIX)
             );
 
             if (existingIssue) {
@@ -216,18 +230,12 @@ jobs:
                 state: 'open'
               });
 
-              // Only this workflow's own reports. The label alone is not
-              // proof of authorship: a maintainer tracking a flaky spec could
-              // reasonably reach for `test-failure`, and closing their issue
-              // with "fixed by the run that passed" would be a lie the
-              // automation has no way to know it told. The title prefix is
-              // something only this step writes.
-              //
-              // Pull requests are excluded as well — listForRepo returns them
-              // and they are not reports either.
-              const mine = stale.filter(i =>
-                !i.pull_request && i.title.startsWith(FAILURE_PREFIX)
-              );
+              // Only this workflow's own reports — see isOwn above for why
+              // the label by itself is not proof of authorship. Always the
+              // failure prefix here, never the report one: this branch only
+              // runs on success, when the issues being retired are the
+              // failures a previous run filed.
+              const mine = stale.filter(issue => isOwn(issue, FAILURE_PREFIX));
 
               // Per issue, so one failure does not strand the rest. An
               // uncaught throw here would fail this step and report the whole

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -129,7 +129,10 @@ jobs:
             const labels = isFailure ? ['test-failure'] : ['test-report'];
 
             // Search for existing issue
-            const issues = await github.rest.issues.listForRepo({
+            // Paginated: listForRepo caps at 30 per page by default, and a
+            // report older than one page would be invisible here — which
+            // reads as "no rolling issue exists" and files a duplicate.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
               labels,
@@ -140,7 +143,7 @@ jobs:
             // the CURRENT run's URL, so matching on it could never find an
             // issue from a previous run — each scheduled failure would file
             // a brand-new issue instead of updating the rolling one.
-            const existingIssue = issues.data.find(issue =>
+            const existingIssue = issues.find(issue =>
               issue.title.includes(isFailure ? 'test: Some e2e tests failed' : 'Test Report')
             );
 
@@ -174,7 +177,11 @@ jobs:
             // timestamp, and a run that failed before this step existed could
             // have left more than one behind.
             if (!isFailure) {
-              const stale = await github.rest.issues.listForRepo({
+              // Paginated for the same reason "every open one" is the rule
+              // here: listForRepo returns 30 per page by default, so anything
+              // past the first page would silently stay open — which is the
+              // exact failure this step exists to stop.
+              const stale = await github.paginate(github.rest.issues.listForRepo, {
                 owner,
                 repo,
                 labels: ['test-failure'],
@@ -182,7 +189,7 @@ jobs:
               });
 
               // listForRepo returns pull requests too; they are not reports.
-              for (const issue of stale.data.filter(i => !i.pull_request)) {
+              for (const issue of stale.filter(i => !i.pull_request)) {
                 await github.rest.issues.createComment({
                   owner,
                   repo,

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -207,30 +207,40 @@ jobs:
                 !i.pull_request && i.title.includes(FAILURE_PREFIX)
               );
 
+              // Per issue, so one failure does not strand the rest. An
+              // uncaught throw here would fail this step and report the whole
+              // scheduled run as red even though the suite passed — the same
+              // kind of lie about the suite's state that this step exists to
+              // stop telling. Retrying is left to the next run: the issue is
+              // still open and still matches, so it gets picked up again.
               for (const issue of mine) {
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number: issue.number,
-                  body: [
-                    'The scheduled suite is green again.',
-                    '',
-                    `Commit: ${context.sha}`,
-                    `[View Workflow Run](${run_url})`,
-                    '',
-                    'Closed automatically by the run that passed. If these',
-                    'tests fail again a fresh issue is filed rather than this',
-                    'one reopened, so the history stays per-incident.'
-                  ].join('\n')
-                });
+                try {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: [
+                      'The scheduled suite is green again.',
+                      '',
+                      `Commit: ${context.sha}`,
+                      `[View Workflow Run](${run_url})`,
+                      '',
+                      'Closed automatically by the run that passed. If these',
+                      'tests fail again a fresh issue is filed rather than this',
+                      'one reopened, so the history stays per-incident.'
+                    ].join('\n')
+                  });
 
-                await github.rest.issues.update({
-                  owner,
-                  repo,
-                  issue_number: issue.number,
-                  state: 'closed',
-                  state_reason: 'completed'
-                });
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    state: 'closed',
+                    state_reason: 'completed'
+                  });
+                } catch (error) {
+                  core.warning(`Could not retire #${issue.number}: ${error.message}`);
+                }
               }
             }
 

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -10,6 +10,20 @@ on:
     - cron: '37 2 */2 * *'
   workflow_dispatch: # Allow manual triggering
 
+# One run at a time. Two overlapping runs — a manual dispatch started while a
+# scheduled run is still going — both read the open failure issues, and both
+# then close and comment on the same ones, because each fetched its list
+# before the other had closed anything. The result is duplicate "green again"
+# comments on an issue that only went green once.
+#
+# cancel-in-progress must stay false. Cancelling the running suite would be
+# worse than the race: the report step treats a cancelled run as a failure,
+# so a manual dispatch would file a failure issue about the run it just
+# interrupted. Queuing costs at most one delayed run.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   # The report step files and updates the rolling report issue, and on a green
@@ -221,22 +235,29 @@ jobs:
               // kind of lie about the suite's state that this step exists to
               // stop telling.
               //
-              // Close first, comment second. If the close fails the issue is
-              // still open and still matches, so the next green run retries
-              // it — and because no comment was posted, that retry does not
-              // stack a second "green again" note. The reverse order leaves
-              // the stale report standing while adding a comment per cycle,
-              // which is the wrong half to have succeeded.
+              // Close first, comment second. A close that fails usually
+              // leaves the issue open and still matching, so the next green
+              // run picks it up — and because no comment was posted, that
+              // retry does not stack a second "green again" note. The reverse
+              // order leaves the stale report standing while adding a comment
+              // per cycle, which is the wrong half to have succeeded.
+              //
+              // "Usually", because a lost response is indistinguishable from
+              // a rejected request: the close may have landed and only the
+              // reply gone missing, in which case the issue is closed, the
+              // `state: 'open'` filter never surfaces it again, and it keeps
+              // its report body without ever getting the comment. Rare, and
+              // the wrong half to lose is the note rather than the close, so
+              // it is left alone — but the retry below is best-effort, not a
+              // guarantee, and the warning is the only trace either way.
               //
               // The two are caught separately because they are not the same
-              // event and only one of them is retried. A failed close leaves
-              // the issue open for the next run. A failed comment does not:
-              // the issue is already closed, so the `state: 'open'` filter
-              // above means no later run will ever look at it again and the
-              // note is gone for good. One shared handler saying "could not
-              // retire" would report the second as the first — claiming the
-              // issue is still open and will be picked up later, when it is
-              // closed and will not be.
+              // event and only one of them is even eligible for a retry. A
+              // failed comment never is: the issue is already closed by then,
+              // so no later run will look at it. One shared handler saying
+              // "could not retire" would report that as the other — claiming
+              // the issue is still open and will be picked up later, when it
+              // is closed and will not be.
               for (const issue of mine) {
                 try {
                   await github.rest.issues.update({

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -150,20 +150,16 @@ jobs:
               : `${REPORT_PREFIX} - ${new Date().toISOString()}`;
             const labels = isFailure ? ['test-failure'] : ['test-report'];
 
-            // "One this workflow filed, under `prefix`." Both lookups below
-            // ask it, and they used to ask it in their own words — the same
-            // two conditions written twice, which is two places to remember
-            // when either one changes. They already drifted once: the retire
-            // loop excluded pull requests for a round while the lookup above
-            // it did not.
+            // "One this workflow filed, under `prefix`" — asked by both
+            // lookups below, so they cannot drift apart.
             //
-            // The label is not enough on its own. A maintainer tracking a
-            // flaky spec could reasonably reach for `test-failure`, and
-            // closing their issue with "fixed by the run that passed" is a
-            // claim this step has no way to know is false. The title prefix
-            // is something only this step writes. It has to be startsWith
-            // rather than includes: a human title can mention the prefix
-            // partway through and mean something else entirely.
+            // The label alone is not proof of authorship: a maintainer
+            // tracking a flaky spec could reasonably reach for `test-failure`,
+            // and closing it with "fixed by the run that passed" is a claim
+            // this step cannot know is false. Only this step writes the title
+            // prefix. `startsWith`, not `includes` — a human title can mention
+            // the prefix partway through and mean something else. And
+            // listForRepo returns pull requests, which are neither.
             const isOwn = (issue, prefix) =>
               !issue.pull_request && issue.title.startsWith(prefix);
 
@@ -209,20 +205,16 @@ jobs:
               });
             }
 
-            // A green run has to retire the failure issue as well as file its
-            // own report. Success only ever touched the `test-report` issue,
-            // so the rolling `test-failure` one outlived the fix: #683 stayed
-            // open listing WebKit failures that #679 and #684 had already
-            // fixed, and no number of green runs would have closed it.
+            // A green run retires the failure issue as well as filing its own
+            // report. Without this, success only ever touched `test-report`
+            // and a failure report outlived its fix, with no number of green
+            // runs able to close it.
             //
-            // Every open one, not just the newest: the title carries a
-            // timestamp, and a run that failed before this step existed could
-            // have left more than one behind.
+            // Every open one, not just the newest: the titles carry
+            // timestamps, so a failing period can leave several behind.
             if (!isFailure) {
-              // Paginated for the same reason "every open one" is the rule
-              // here: listForRepo returns 30 per page by default, so anything
-              // past the first page would silently stay open — which is the
-              // exact failure this step exists to stop.
+              // Paginated: listForRepo caps at 30 per page, and anything past
+              // the first page would silently stay open.
               const stale = await github.paginate(github.rest.issues.listForRepo, {
                 owner,
                 repo,
@@ -230,47 +222,29 @@ jobs:
                 state: 'open'
               });
 
-              // Only this workflow's own reports — see isOwn above for why
-              // the label by itself is not proof of authorship. Always the
-              // failure prefix here, never the report one: this branch only
-              // runs on success, when the issues being retired are the
-              // failures a previous run filed.
+              // Always the failure prefix: this branch only runs on success,
+              // so the issues to retire are the failures a previous run filed.
               const mine = stale.filter(issue => isOwn(issue, FAILURE_PREFIX));
 
-              // Per issue, so one failure does not strand the rest. An
-              // uncaught throw here would fail this step and report the whole
-              // scheduled run as red even though the suite passed — the same
-              // kind of lie about the suite's state that this step exists to
-              // stop telling.
-              //
-              // Close first, comment second. A close that fails usually
-              // leaves the issue open and still matching, so the next green
-              // run picks it up — and because no comment was posted, that
-              // retry does not stack a second "green again" note. The reverse
-              // order leaves the stale report standing while adding a comment
-              // per cycle, which is the wrong half to have succeeded.
-              //
-              // "Usually", because a lost response is indistinguishable from
-              // a rejected request: the close may have landed and only the
-              // reply gone missing, in which case the issue is closed, the
-              // `state: 'open'` filter never surfaces it again, and it keeps
-              // its report body without ever getting the comment. Rare, and
-              // the wrong half to lose is the note rather than the close, so
-              // it is left alone — but the retry below is best-effort, not a
-              // guarantee, and the warning is the only trace either way.
-              //
-              // The two are caught separately because they are not the same
-              // event and only one of them is even eligible for a retry. A
-              // failed comment never is: the issue is already closed by then,
-              // so no later run will look at it. One shared handler saying
-              // "could not retire" would report that as the other — claiming
-              // the issue is still open and will be picked up later, when it
-              // is closed and will not be.
-              // Anything can be thrown, and `.message` on a non-Error is
-              // undefined — which would leave the warning as the only record
-              // of the failure and strip the one useful part out of it.
+              // `.message` on a non-Error is undefined, and these warnings are
+              // the only record either failure below leaves.
               const reason = error =>
                 error instanceof Error ? error.message : String(error);
+
+              // Caught per issue: an uncaught throw would fail the step and
+              // report a green suite as a red run.
+              //
+              // Close before comment. A failed close usually leaves the issue
+              // open and matching, so the next green run retries it with no
+              // comment already posted to duplicate. The reverse order leaves
+              // the stale report standing and adds a note every cycle.
+              // "Usually" because a lost response looks the same as a refused
+              // one — the close may have landed — so the retry is best-effort.
+              //
+              // Caught separately because only the close is ever retried. By
+              // the time the comment runs the issue is closed, and the
+              // `state: 'open'` filter means no later run will see it, so one
+              // shared handler would report a closed issue as still pending.
 
               for (const issue of mine) {
                 try {

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -258,6 +258,12 @@ jobs:
               // "could not retire" would report that as the other — claiming
               // the issue is still open and will be picked up later, when it
               // is closed and will not be.
+              // Anything can be thrown, and `.message` on a non-Error is
+              // undefined — which would leave the warning as the only record
+              // of the failure and strip the one useful part out of it.
+              const reason = error =>
+                error instanceof Error ? error.message : String(error);
+
               for (const issue of mine) {
                 try {
                   await github.rest.issues.update({
@@ -270,7 +276,7 @@ jobs:
                 } catch (error) {
                   core.warning(
                     `Could not close #${issue.number}, leaving it for the next `
-                    + `green run: ${error.message}`
+                    + `green run: ${reason(error)}`
                   );
                   continue;
                 }
@@ -294,7 +300,7 @@ jobs:
                 } catch (error) {
                   core.warning(
                     `Closed #${issue.number} but could not comment on it; the `
-                    + `run that fixed it is in this log only: ${error.message}`
+                    + `run that fixed it is in this log only: ${reason(error)}`
                   );
                 }
               }

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -45,8 +45,8 @@ interface RunResult {
   adopted: number[];
 }
 
-/** Issue numbers whose `issues.update` should reject, to test the catch. */
-type FailingUpdates = ReadonlySet<number>;
+/** Issue numbers whose API calls should reject, to test the catch blocks. */
+type Failing = ReadonlySet<number>;
 
 const ROOT = resolve(__dirname, '../..');
 const WORKFLOW = join(ROOT, '.github/workflows/e2e_tests.yml');
@@ -83,7 +83,8 @@ function reportScript(): string {
 async function runScript(
   status: string,
   issues: StubIssue[],
-  failingUpdates: FailingUpdates = new Set(),
+  failingUpdates: Failing = new Set(),
+  failingComments: Failing = new Set(),
 ): Promise<RunResult> {
   const result: RunResult = {
     closed: [],
@@ -117,6 +118,9 @@ async function runScript(
           result.created.push(params.labels);
         },
         createComment: async (params: { issue_number: number }) => {
+          if (failingComments.has(params.issue_number)) {
+            throw new Error('simulated API failure');
+          }
           result.commented.push(params.issue_number);
         },
         update: async (params: { issue_number: number; state?: string }) => {
@@ -244,7 +248,7 @@ describe('the scheduled e2e report step', () => {
       // The other two still close, and the step does not throw.
       expect(result.closed).toEqual([683, 685]);
       expect(result.warnings).toEqual([
-        expect.stringContaining('#684') as unknown as string,
+        expect.stringContaining('Could not close #684') as unknown as string,
       ]);
     });
 
@@ -259,6 +263,26 @@ describe('the scheduled e2e report step', () => {
       );
 
       expect(result.commented).toEqual([683]);
+    });
+
+    // The close and the comment are caught separately, and this is the case
+    // that tells them apart: the close worked, so the issue must stay closed
+    // rather than being reopened or retried. It also must not be reported as
+    // "could not retire" — it was retired; only the note was lost, and since
+    // the issue is closed no later run will look at it again.
+    it('should stay closed when only the comment fails', async () => {
+      const result = await runScript(
+        'success',
+        [botIssue(683), botIssue(684)],
+        new Set(),
+        new Set([684]),
+      );
+
+      expect(result.closed).toEqual([683, 684]);
+      expect(result.commented).toEqual([683]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining('Closed #684') as unknown as string,
+      ]);
     });
 
     // `includes` would match this; only `startsWith` does not. The bot's own

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -52,19 +52,38 @@ const ROOT = resolve(__dirname, '../..');
 const WORKFLOW = join(ROOT, '.github/workflows/e2e_tests.yml');
 
 /**
+ * Matches the header of a `script:` block scalar.
+ *
+ * Deliberately wider than the one form this file uses today. YAML also spells
+ * it `|-`, `|+` and `|2`, and a reformat that reached for any of those would
+ * otherwise report "no script block" — which reads like the step was deleted
+ * rather than like the header moved. Matching them means the failure names
+ * the real cause instead.
+ */
+const SCRIPT_HEADER = /^\s*script: \|[-+]?\d*\s*$/;
+
+/**
  * The github-script body from the report step, as it will run in CI.
  *
- * Takes everything indented past the `script: |` line, then removes that
- * indentation — which is what the YAML block scalar means.
+ * Takes everything indented past the `script:` line and removes that
+ * indentation, which is what a YAML block scalar means.
+ *
+ * The indentation is measured from the block's first line rather than assumed
+ * to be the header's plus two. That assumption holds for this file today, but
+ * it describes how the file happens to be formatted, not what YAML requires.
+ * Indenting the block deeper survived it — the extra spaces just rode along
+ * as harmless leading whitespace — but dedenting it sliced into the code and
+ * failed with "does not look like the report script", which points at the
+ * wrong thing. Measuring costs one line and neither case arises.
  */
 function reportScript(): string {
   const lines = readFileSync(WORKFLOW, 'utf8').split('\n');
   const starts = lines.reduce<number[]>(
-    (found, line, i) => (/^\s*script: \|\s*$/.test(line) ? [...found, i] : found),
+    (found, line, i) => (SCRIPT_HEADER.test(line) ? [...found, i] : found),
     [],
   );
   if (starts.length === 0) {
-    throw new Error(`No "script: |" block in ${WORKFLOW}`);
+    throw new Error(`No "script:" block scalar in ${WORKFLOW}`);
   }
   // Taking the first block is only unambiguous while there is one. A second
   // github-script step added above this one would otherwise be extracted
@@ -72,16 +91,22 @@ function reportScript(): string {
   // script. Fail loudly and make whoever adds it say which block they mean.
   if (starts.length > 1) {
     throw new Error(
-      `${WORKFLOW} has ${starts.length} "script: |" blocks; this test assumes `
+      `${WORKFLOW} has ${starts.length} "script:" blocks; this test assumes `
       + 'one and would silently extract the first. Select the report step '
       + 'explicitly before adding another.',
     );
   }
   const [start] = starts;
 
-  const indent = (lines[start].match(/^\s*/) ?? [''])[0].length + 2;
+  const rest = lines.slice(start + 1);
+  const first = rest.find(line => line.trim());
+  if (first === undefined) {
+    throw new Error(`The "script:" block in ${WORKFLOW} is empty`);
+  }
+  const indent = (first.match(/^\s*/) ?? [''])[0].length;
+
   const body: string[] = [];
-  for (const line of lines.slice(start + 1)) {
+  for (const line of rest) {
     if (line.trim() && !line.startsWith(' '.repeat(indent))) {
       break;
     }

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -25,6 +25,8 @@ interface StubIssue {
   number: number;
   title: string;
   labels: string[];
+  /** Defaults to open; a closed one must never be picked up. */
+  state?: 'open' | 'closed';
   pull_request?: object;
 }
 
@@ -37,7 +39,12 @@ interface RunResult {
   created: string[][];
   /** True if any lookup bypassed `paginate`. */
   usedUnpaginatedList: boolean;
+  /** Warnings the script emitted instead of throwing. */
+  warnings: string[];
 }
+
+/** Issue numbers whose `issues.update` should reject, to test the catch. */
+type FailingUpdates = ReadonlySet<number>;
 
 const ROOT = resolve(__dirname, '../..');
 const WORKFLOW = join(ROOT, '.github/workflows/e2e_tests.yml');
@@ -71,25 +78,37 @@ function reportScript(): string {
 }
 
 /** Runs the script against stubs and records what it asked GitHub to do. */
-async function runScript(status: string, open: StubIssue[]): Promise<RunResult> {
+async function runScript(
+  status: string,
+  issues: StubIssue[],
+  failingUpdates: FailingUpdates = new Set(),
+): Promise<RunResult> {
   const result: RunResult = {
     closed: [],
     commented: [],
     created: [],
     usedUnpaginatedList: false,
+    warnings: [],
   };
 
-  const matching = (labels: string[]): StubIssue[] =>
-    open.filter(issue => issue.labels.includes(labels[0]));
+  // Honours `state` as well as `labels`, so a query that dropped
+  // `state: 'open'` would start seeing closed issues and fail a test rather
+  // than passing because every fixture happened to be open.
+  const matching = (params: { labels: string[]; state?: string }): StubIssue[] =>
+    issues.filter(issue =>
+      issue.labels.includes(params.labels[0])
+      && (params.state === 'all' || (issue.state ?? 'open') === (params.state ?? 'open')),
+    );
 
   const github = {
-    paginate: async (_fn: unknown, params: { labels: string[] }) => matching(params.labels),
+    paginate: async (_fn: unknown, params: { labels: string[]; state?: string }) =>
+      matching(params),
     rest: {
       issues: {
         // The real API pages at 30; a caller that skips `paginate` sees no more.
-        listForRepo: async (params: { labels: string[] }) => {
+        listForRepo: async (params: { labels: string[]; state?: string }) => {
           result.usedUnpaginatedList = true;
-          return { data: matching(params.labels).slice(0, 30) };
+          return { data: matching(params).slice(0, 30) };
         },
         create: async (params: { labels: string[] }) => {
           result.created.push(params.labels);
@@ -98,12 +117,19 @@ async function runScript(status: string, open: StubIssue[]): Promise<RunResult> 
           result.commented.push(params.issue_number);
         },
         update: async (params: { issue_number: number; state?: string }) => {
+          if (failingUpdates.has(params.issue_number)) {
+            throw new Error('simulated API failure');
+          }
           if (params.state === 'closed') {
             result.closed.push(params.issue_number);
           }
         },
       },
     },
+  };
+
+  const core = {
+    warning: (message: string) => result.warnings.push(message),
   };
 
   const context = {
@@ -121,6 +147,7 @@ async function runScript(status: string, open: StubIssue[]): Promise<RunResult> 
   const sandbox = {
     github,
     context,
+    core,
     require,
     process: { env: { TEST_STATUS: status } },
     Date,
@@ -188,6 +215,32 @@ describe('the scheduled e2e report step', () => {
 
       expect(result.created).toEqual([['test-report']]);
       expect(result.closed).toEqual([]);
+    });
+
+    // The lookups pass `state: 'open'`. Without this every fixture is open,
+    // so dropping that filter would change nothing here and the argument
+    // would be decorative rather than covered.
+    it('should ignore a failure issue that is already closed', async () => {
+      const alreadyClosed: StubIssue = { ...botIssue(600), state: 'closed' };
+
+      const result = await runScript('success', [alreadyClosed, botIssue(683)]);
+
+      expect(result.closed).toEqual([683]);
+      expect(result.commented).toEqual([683]);
+    });
+
+    it('should keep going when one issue cannot be retired', async () => {
+      const result = await runScript(
+        'success',
+        [botIssue(683), botIssue(684), botIssue(685)],
+        new Set([684]),
+      );
+
+      // The other two still close, and the step does not throw.
+      expect(result.closed).toEqual([683, 685]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining('#684') as unknown as string,
+      ]);
     });
   });
 

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -59,10 +59,25 @@ const WORKFLOW = join(ROOT, '.github/workflows/e2e_tests.yml');
  */
 function reportScript(): string {
   const lines = readFileSync(WORKFLOW, 'utf8').split('\n');
-  const start = lines.findIndex(line => /^\s*script: \|\s*$/.test(line));
-  if (start === -1) {
+  const starts = lines.reduce<number[]>(
+    (found, line, i) => (/^\s*script: \|\s*$/.test(line) ? [...found, i] : found),
+    [],
+  );
+  if (starts.length === 0) {
     throw new Error(`No "script: |" block in ${WORKFLOW}`);
   }
+  // Taking the first block is only unambiguous while there is one. A second
+  // github-script step added above this one would otherwise be extracted
+  // instead, and every case below would still pass — against the wrong
+  // script. Fail loudly and make whoever adds it say which block they mean.
+  if (starts.length > 1) {
+    throw new Error(
+      `${WORKFLOW} has ${starts.length} "script: |" blocks; this test assumes `
+      + 'one and would silently extract the first. Select the report step '
+      + 'explicitly before adding another.',
+    );
+  }
+  const [start] = starts;
 
   const indent = (lines[start].match(/^\s*/) ?? [''])[0].length + 2;
   const body: string[] = [];
@@ -316,6 +331,24 @@ describe('the scheduled e2e report step', () => {
 
       expect(result.adopted).toEqual([]);
       expect(result.created).toEqual([['test-report']]);
+    });
+
+    // The same guard, reached through the other branch of the prefix ternary.
+    // One line serves both paths today, so this is cheap insurance rather
+    // than new coverage — but the failure path is the one that runs when
+    // something is already wrong, and it had no PR case at all.
+    it('should not adopt a pull request on the failure path either', async () => {
+      const pr: StubIssue = {
+        number: 998,
+        title: 'test: Some e2e tests failed - a pull request',
+        labels: ['test-failure'],
+        pull_request: {},
+      };
+
+      const result = await runScript('failure', [pr]);
+
+      expect(result.adopted).toEqual([]);
+      expect(result.created).toEqual([['test-failure']]);
     });
   });
 

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -41,6 +41,8 @@ interface RunResult {
   usedUnpaginatedList: boolean;
   /** Warnings the script emitted instead of throwing. */
   warnings: string[];
+  /** Issue numbers whose title/body were rewritten as the rolling report. */
+  adopted: number[];
 }
 
 /** Issue numbers whose `issues.update` should reject, to test the catch. */
@@ -89,6 +91,7 @@ async function runScript(
     created: [],
     usedUnpaginatedList: false,
     warnings: [],
+    adopted: [],
   };
 
   // Honours `state` as well as `labels`, so a query that dropped
@@ -122,6 +125,8 @@ async function runScript(
           }
           if (params.state === 'closed') {
             result.closed.push(params.issue_number);
+          } else {
+            result.adopted.push(params.issue_number);
           }
         },
       },
@@ -241,6 +246,52 @@ describe('the scheduled e2e report step', () => {
       expect(result.warnings).toEqual([
         expect.stringContaining('#684') as unknown as string,
       ]);
+    });
+
+    // Closing comes before commenting, so a close that fails leaves no note
+    // behind. Otherwise the issue stays open, matches again next run, and
+    // collects a fresh "green again" comment every cycle.
+    it('should not comment on an issue it failed to close', async () => {
+      const result = await runScript(
+        'success',
+        [botIssue(683), botIssue(684)],
+        new Set([684]),
+      );
+
+      expect(result.commented).toEqual([683]);
+    });
+
+    // `includes` would match this; only `startsWith` does not. The bot's own
+    // titles always begin with the prefix, so nothing is lost by requiring it.
+    it('should leave a human issue that merely mentions the prefix', async () => {
+      const humanFiled: StubIssue = {
+        number: 501,
+        title: 'Investigate: test: Some e2e tests failed intermittently on Safari',
+        labels: ['test-failure'],
+      };
+
+      const result = await runScript('success', [humanFiled, botIssue(683)]);
+
+      expect(result.closed).toEqual([683]);
+      expect(result.commented).toEqual([683]);
+    });
+  });
+
+  describe('when it looks for the rolling issue', () => {
+    // The lookup rewrites the title and body of whatever it adopts, so a pull
+    // request adopted by mistake would be silently overwritten.
+    it('should not adopt a pull request as the rolling report', async () => {
+      const pr: StubIssue = {
+        number: 999,
+        title: 'Test Report - a pull request',
+        labels: ['test-report'],
+        pull_request: {},
+      };
+
+      const result = await runScript('success', [pr]);
+
+      expect(result.adopted).toEqual([]);
+      expect(result.created).toEqual([['test-report']]);
     });
   });
 

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -17,8 +17,16 @@ import { runInNewContext } from 'node:vm';
  * what makes the pagination case fail if the fix is ever reverted.
  *
  * The block is extracted textually rather than with a YAML parser: `js-yaml`
- * is only present transitively here, and a test that reaches for an
- * undeclared dependency breaks the day something upstream stops pulling it.
+ * and `yaml` are both present, but only transitively — neither is declared,
+ * and a test that reaches for an undeclared dependency breaks the day
+ * something upstream stops pulling it in.
+ *
+ * That is the whole of the argument, so it expires the moment either becomes
+ * a direct devDependency for some other reason. Parse the workflow then and
+ * delete the extraction below: block-scalar spellings and indentation are a
+ * class of fragility a parser does not have, and this file has already spent
+ * three commits on that class. Adding the dependency solely to delete this
+ * is the trade that is not worth it.
  */
 
 interface StubIssue {
@@ -358,6 +366,24 @@ describe('the scheduled e2e report step', () => {
       };
 
       const result = await runScript('success', [pr]);
+
+      expect(result.adopted).toEqual([]);
+      expect(result.created).toEqual([['test-report']]);
+    });
+
+    // The retire loop's `state: 'open'` is pinned by the already-closed
+    // failure case above; this is the same filter on the other lookup, which
+    // had no closed fixture. Reopening a finished report to write a new run
+    // into it would resurrect an issue someone deliberately closed.
+    it('should file a fresh report rather than reopen a closed one', async () => {
+      const closedReport: StubIssue = {
+        number: 601,
+        title: 'Test Report - 2026-07-29T03:20:11.879Z',
+        labels: ['test-report'],
+        state: 'closed',
+      };
+
+      const result = await runScript('success', [closedReport]);
 
       expect(result.adopted).toEqual([]);
       expect(result.created).toEqual([['test-report']]);

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -5,28 +5,19 @@ import { runInNewContext } from 'node:vm';
 /**
  * Exercises the `github-script` body in the scheduled e2e workflow.
  *
- * That script cannot be run from a pull request — it only fires on
- * `schedule` — so until now it was verified by hand each time it changed.
- * A real bug got through that way: the first version of the close-on-green
- * step called `listForRepo` unpaginated, so "close every open failure issue"
- * silently meant "the first thirty".
+ * That script only fires on `schedule`, so no pull request can run it. The
+ * body is read out of the YAML rather than copied here, so what is tested is
+ * what runs. Octokit is stubbed, and the stub caps an unpaginated
+ * `listForRepo` at 30 the way the real API does — without that the pagination
+ * cases would pass against either version.
  *
- * The script is read out of the YAML rather than duplicated here, so the
- * thing under test is the thing that runs. Octokit is stubbed, and the stub
- * caps an unpaginated `listForRepo` at 30 the way the real API does — that is
- * what makes the pagination case fail if the fix is ever reverted.
- *
- * The block is extracted textually rather than with a YAML parser: `js-yaml`
- * and `yaml` are both present, but only transitively — neither is declared,
- * and a test that reaches for an undeclared dependency breaks the day
- * something upstream stops pulling it in.
- *
- * That is the whole of the argument, so it expires the moment either becomes
- * a direct devDependency for some other reason. Parse the workflow then and
- * delete the extraction below: block-scalar spellings and indentation are a
- * class of fragility a parser does not have, and this file has already spent
- * three commits on that class. Adding the dependency solely to delete this
- * is the trade that is not worth it.
+ * Extracted textually rather than parsed: `js-yaml` and `yaml` are present
+ * but only transitively, and a test resting on an undeclared dependency
+ * breaks when something upstream stops pulling it in. That argument expires
+ * if either becomes a direct devDependency for another reason — parse the
+ * workflow then and delete `reportScript`, since block-scalar spelling and
+ * indentation are a class of bug a parser does not have. Adding the
+ * dependency solely to delete this is the trade that is not worth it.
  */
 
 interface StubIssue {
@@ -62,16 +53,12 @@ const WORKFLOW = join(ROOT, '.github/workflows/e2e_tests.yml');
 /**
  * Matches the header of a `script:` block scalar.
  *
- * Deliberately wider than the one form this file uses today. YAML also spells
- * it `|-`, `|+`, `|2`, and the indentation and chomping indicators may come
- * in either order — `|2-` as readily as `|-2`. A reformat reaching for any of
- * those would otherwise report "no script block", which reads like the step
- * was deleted rather than like the header changed spelling.
+ * Wider than the form used today, since YAML also spells it `|-`, `|+`, `|2`,
+ * and takes the two indicators in either order. Missing one of those would
+ * report "no script block", which reads as though the step were deleted.
  *
- * The character class is looser than the grammar: it also admits nonsense
- * like `|--`. That is the right trade here, because this recognises a header
- * so the error can name the real cause — it is not validating YAML, and
- * actionlint already rejects anything malformed.
+ * Looser than the grammar too — it admits `|--`. This recognises a header so
+ * the error can name the real cause; validating YAML is actionlint's job.
  */
 const SCRIPT_HEADER = /^\s*script: \|[-+\d]*\s*$/;
 
@@ -79,15 +66,10 @@ const SCRIPT_HEADER = /^\s*script: \|[-+\d]*\s*$/;
  * The github-script body from the report step, as it will run in CI.
  *
  * Takes everything indented past the `script:` line and removes that
- * indentation, which is what a YAML block scalar means.
- *
- * The indentation is measured from the block's first line rather than assumed
- * to be the header's plus two. That assumption holds for this file today, but
- * it describes how the file happens to be formatted, not what YAML requires.
- * Indenting the block deeper survived it — the extra spaces just rode along
- * as harmless leading whitespace — but dedenting it sliced into the code and
- * failed with "does not look like the report script", which points at the
- * wrong thing. Measuring costs one line and neither case arises.
+ * indentation, which is what a YAML block scalar means. The indentation is
+ * measured from the block's first line rather than assumed to be the header's
+ * plus two — that assumption describes this file's current formatting, not
+ * anything YAML requires, and dedenting the block would slice into the code.
  */
 function reportScript(): string {
   const lines = readFileSync(WORKFLOW, 'utf8').split('\n');
@@ -206,6 +188,13 @@ async function runScript(
   // allowed to see explicit. The script reads the reporter output through
   // `fs`; an absent file is a case it already handles, which keeps this from
   // needing a fixture.
+  // `Error` is shared rather than left to the sandbox's own. github-script
+  // runs the script and octokit in one realm, so a thrown error is an
+  // instance of the same constructor the script tests against. A fresh
+  // context gets its own, and `error instanceof Error` on an error the stubs
+  // built out here would be false — sending the script down its non-Error
+  // path on every failure case, and testing the branch production never
+  // takes. Passing it in makes the sandbox model production's single realm.
   const sandbox = {
     github,
     context,
@@ -213,6 +202,7 @@ async function runScript(
     require,
     process: { env: { TEST_STATUS: status } },
     Date,
+    Error,
   };
 
   await runInNewContext(`(async () => {\n${reportScript()}\n})()`, sandbox);
@@ -303,6 +293,11 @@ describe('the scheduled e2e report step', () => {
       expect(result.warnings).toEqual([
         expect.stringContaining('Could not close #684') as unknown as string,
       ]);
+      // The bare message, not `String(error)` — which would read
+      // "Error: simulated API failure". Asserting only the surrounding
+      // template text leaves both branches of `reason()` passing.
+      expect(result.warnings[0]).toContain(': simulated API failure');
+      expect(result.warnings[0]).not.toContain('Error: simulated');
     });
 
     // Closing comes before commenting, so a close that fails leaves no note

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -55,12 +55,17 @@ const WORKFLOW = join(ROOT, '.github/workflows/e2e_tests.yml');
  * Matches the header of a `script:` block scalar.
  *
  * Deliberately wider than the one form this file uses today. YAML also spells
- * it `|-`, `|+` and `|2`, and a reformat that reached for any of those would
- * otherwise report "no script block" — which reads like the step was deleted
- * rather than like the header moved. Matching them means the failure names
- * the real cause instead.
+ * it `|-`, `|+`, `|2`, and the indentation and chomping indicators may come
+ * in either order — `|2-` as readily as `|-2`. A reformat reaching for any of
+ * those would otherwise report "no script block", which reads like the step
+ * was deleted rather than like the header changed spelling.
+ *
+ * The character class is looser than the grammar: it also admits nonsense
+ * like `|--`. That is the right trade here, because this recognises a header
+ * so the error can name the real cause — it is not validating YAML, and
+ * actionlint already rejects anything malformed.
  */
-const SCRIPT_HEADER = /^\s*script: \|[-+]?\d*\s*$/;
+const SCRIPT_HEADER = /^\s*script: \|[-+\d]*\s*$/;
 
 /**
  * The github-script body from the report step, as it will run in CI.

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -1,0 +1,211 @@
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+/**
+ * Exercises the `github-script` body in the scheduled e2e workflow.
+ *
+ * That script cannot be run from a pull request — it only fires on
+ * `schedule` — so until now it was verified by hand each time it changed.
+ * A real bug got through that way: the first version of the close-on-green
+ * step called `listForRepo` unpaginated, so "close every open failure issue"
+ * silently meant "the first thirty".
+ *
+ * The script is read out of the YAML rather than duplicated here, so the
+ * thing under test is the thing that runs. Octokit is stubbed, and the stub
+ * caps an unpaginated `listForRepo` at 30 the way the real API does — that is
+ * what makes the pagination case fail if the fix is ever reverted.
+ *
+ * The block is extracted textually rather than with a YAML parser: `js-yaml`
+ * is only present transitively here, and a test that reaches for an
+ * undeclared dependency breaks the day something upstream stops pulling it.
+ */
+
+interface StubIssue {
+  number: number;
+  title: string;
+  labels: string[];
+  pull_request?: object;
+}
+
+interface RunResult {
+  /** Issue numbers closed by this run. */
+  closed: number[];
+  /** Issue numbers commented on. */
+  commented: number[];
+  /** Labels passed to `issues.create`, if it filed a new report. */
+  created: string[][];
+  /** True if any lookup bypassed `paginate`. */
+  usedUnpaginatedList: boolean;
+}
+
+const ROOT = resolve(__dirname, '../..');
+const WORKFLOW = join(ROOT, '.github/workflows/e2e_tests.yml');
+
+/**
+ * The github-script body from the report step, as it will run in CI.
+ *
+ * Takes everything indented past the `script: |` line, then removes that
+ * indentation — which is what the YAML block scalar means.
+ */
+function reportScript(): string {
+  const lines = readFileSync(WORKFLOW, 'utf8').split('\n');
+  const start = lines.findIndex(line => /^\s*script: \|\s*$/.test(line));
+  if (start === -1) {
+    throw new Error(`No "script: |" block in ${WORKFLOW}`);
+  }
+
+  const indent = (lines[start].match(/^\s*/) ?? [''])[0].length + 2;
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() && !line.startsWith(' '.repeat(indent))) {
+      break;
+    }
+    body.push(line.slice(indent));
+  }
+
+  if (!body.some(line => line.includes('github.rest.issues'))) {
+    throw new Error('Extracted block does not look like the report script');
+  }
+  return body.join('\n');
+}
+
+/** Runs the script against stubs and records what it asked GitHub to do. */
+async function runScript(status: string, open: StubIssue[]): Promise<RunResult> {
+  const result: RunResult = {
+    closed: [],
+    commented: [],
+    created: [],
+    usedUnpaginatedList: false,
+  };
+
+  const matching = (labels: string[]): StubIssue[] =>
+    open.filter(issue => issue.labels.includes(labels[0]));
+
+  const github = {
+    paginate: async (_fn: unknown, params: { labels: string[] }) => matching(params.labels),
+    rest: {
+      issues: {
+        // The real API pages at 30; a caller that skips `paginate` sees no more.
+        listForRepo: async (params: { labels: string[] }) => {
+          result.usedUnpaginatedList = true;
+          return { data: matching(params.labels).slice(0, 30) };
+        },
+        create: async (params: { labels: string[] }) => {
+          result.created.push(params.labels);
+        },
+        createComment: async (params: { issue_number: number }) => {
+          result.commented.push(params.issue_number);
+        },
+        update: async (params: { issue_number: number; state?: string }) => {
+          if (params.state === 'closed') {
+            result.closed.push(params.issue_number);
+          }
+        },
+      },
+    },
+  };
+
+  const context = {
+    repo: { owner: 'xability', repo: 'maidr' },
+    runId: 1,
+    sha: 'abc123',
+    ref: 'refs/heads/main',
+  };
+
+  // `runInNewContext` rather than `new Function`: the same execution, without
+  // tripping `no-new-func`, and the sandbox makes the globals the script is
+  // allowed to see explicit. The script reads the reporter output through
+  // `fs`; an absent file is a case it already handles, which keeps this from
+  // needing a fixture.
+  const sandbox = {
+    github,
+    context,
+    require,
+    process: { env: { TEST_STATUS: status } },
+    Date,
+  };
+
+  await runInNewContext(`(async () => {\n${reportScript()}\n})()`, sandbox);
+  return result;
+}
+
+/** A report as this workflow files it. */
+function botIssue(number: number): StubIssue {
+  return {
+    number,
+    title: 'test: Some e2e tests failed - 2026-07-31T03:20:11.879Z',
+    labels: ['test-failure'],
+  };
+}
+
+describe('the scheduled e2e report step', () => {
+  describe('when the suite passes', () => {
+    it('should close the failure issue it had filed', async () => {
+      const result = await runScript('success', [botIssue(683)]);
+
+      expect(result.commented).toEqual([683]);
+      expect(result.closed).toEqual([683]);
+    });
+
+    it('should close every open failure issue, not one page of them', async () => {
+      const many = Array.from({ length: 35 }, (_, i) => botIssue(700 + i));
+
+      const result = await runScript('success', many);
+
+      expect(result.closed).toHaveLength(35);
+      expect(result.usedUnpaginatedList).toBe(false);
+    });
+
+    it('should leave an issue a human labelled test-failure alone', async () => {
+      const humanFiled: StubIssue = {
+        number: 500,
+        title: 'fix: heatmap autoplay skips the last row',
+        labels: ['test-failure'],
+      };
+
+      const result = await runScript('success', [humanFiled, botIssue(683)]);
+
+      expect(result.closed).toEqual([683]);
+      expect(result.commented).toEqual([683]);
+    });
+
+    it('should skip a pull request carrying the label', async () => {
+      const pr: StubIssue = {
+        number: 999,
+        title: 'test: Some e2e tests failed - fixing it',
+        labels: ['test-failure'],
+        pull_request: {},
+      };
+
+      const result = await runScript('success', [pr, botIssue(683)]);
+
+      expect(result.closed).toEqual([683]);
+    });
+
+    it('should file its own report', async () => {
+      const result = await runScript('success', []);
+
+      expect(result.created).toEqual([['test-report']]);
+      expect(result.closed).toEqual([]);
+    });
+  });
+
+  describe('when the suite fails', () => {
+    it('should close nothing', async () => {
+      const result = await runScript('failure', [botIssue(683)]);
+
+      expect(result.closed).toEqual([]);
+      expect(result.commented).toEqual([]);
+    });
+
+    // A cancelled run — the 60-minute timeout interrupting a hung suite — is
+    // not a pass, and must be reported as a failure rather than silently
+    // retiring the issue that is still true.
+    it('should treat a cancelled run as a failure', async () => {
+      const result = await runScript('cancelled', [botIssue(683)]);
+
+      expect(result.closed).toEqual([]);
+    });
+  });
+});

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -126,7 +126,7 @@ function reportScript(): string {
 
 /** Runs the script against stubs and records what it asked GitHub to do. */
 async function runScript(
-  status: string,
+  status: string | undefined,
   issues: StubIssue[],
   failingUpdates: Failing = new Set(),
   failingComments: Failing = new Set(),
@@ -397,6 +397,27 @@ describe('the scheduled e2e report step', () => {
       const result = await runScript('cancelled', [botIssue(683)]);
 
       expect(result.closed).toEqual([]);
+    });
+
+    // What the workflow actually passes when the test step never ran: the
+    // env is `${{ steps.e2e.outcome }}`, and an unreached step's outcome is
+    // the empty string, not an absent variable. `!== 'success'` covers both,
+    // but only by accident of how it is written — an equality check against
+    // a failure list would not, and nothing here would have noticed.
+    // No fixtures: with an open failure issue present the script updates it
+    // instead of filing one, and `created` would be empty on both the success
+    // and failure paths — which is the same answer for the two cases this is
+    // meant to tell apart.
+    it('should treat an empty status as a failure', async () => {
+      const result = await runScript('', []);
+
+      expect(result.created).toEqual([['test-failure']]);
+    });
+
+    it('should treat an absent status as a failure', async () => {
+      const result = await runScript(undefined, []);
+
+      expect(result.created).toEqual([['test-failure']]);
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

A passing scheduled run files its own `test-report` issue and leaves the `test-failure` one untouched. So a failure report outlives the fix, and no number of green runs ever closes it.

**#683 is the live example.** It was filed at `79bde6d` — after #674 and #676, but before #679 and #684 — and reports **80 failed / 823 passed**. Every parsed failure is WebKit:

| spec | failures |
|---|---|
| `multiLayer.spec.ts` | 10 |
| `multiLineplot.spec.ts` | 7 |
| `stackedBarplot.spec.ts` | 7 |
| `lineplot.spec.ts` | 6 |
| `violinPlot.spec.ts` | 2 |

Those are precisely what #679 (cross-browser modifier key) and #684 (announcement synchronisation) fixed. WebKit has since run 308/308 locally on every branch in that series. The suite is green; the issue saying otherwise simply had no way to close.

## Related Issues

Refs #683 — which I am closing separately, since this fix cannot retroactively close it. Follows #626, #679, #684, #686.

## Changes Made

On a green run, comment on every open `test-failure` issue and close it as `completed`.

Three deliberate details:

- **Every open one, not just the newest.** The title carries a timestamp, so a period of failures before this existed could have left more than one behind.
- **Pull requests filtered out.** `issues.listForRepo` returns PRs as well, and a PR that happened to carry the label is not a report.
- **Failure behaviour untouched.** A red run still updates the rolling issue in place and closes nothing.

The comment says a future failure files a fresh issue rather than reopening this one, so the history stays per-incident rather than one issue accumulating unrelated runs.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass. — see the harness below; a scheduled workflow cannot be exercised from a PR.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no documented behaviour changed.
- [ ] I have added appropriate unit tests, if applicable. — not applicable to workflow config; the harness is the evidence.

## Additional Notes

Syntax checks pass, but syntax passing is not the logic being right — so I extracted the `github-script` body and ran it against stubbed octokit calls:

```
SUCCESS + open #683      : listForRepo(test-report), create(test-report),
                           listForRepo(test-failure), comment(#683),
                           update(#683 -> closed/completed)
SUCCESS + #683 and a PR  : … only #683 touched, PR #999 skipped
FAILURE + open #683      : listForRepo(test-failure), update(#683 body)   ← closes nothing
SUCCESS + nothing open   : listForRepo(test-failure)                      ← no spurious calls
```

All four branches behave as intended, including the two that matter most for not making things worse: a red run closes nothing, and a green run with nothing open does nothing.

| check | result |
|---|---|
| `actionlint` on `e2e_tests.yml` | clean |
| `actionlint` on all of `.github/workflows/` | clean |
| YAML parses, 9 steps in order | confirmed |
| embedded script `node --check` | OK |
| stubbed-run harness | 4/4 branches correct |

**What is not verified here.** The same limit as #686: nothing in this repository can trigger a `schedule` workflow, so the real proof is the next scheduled run on 2026-08-02. If it is green it should close #683 — except I am closing that by hand now, so the first genuine exercise will be whenever a failure is filed and later fixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz)_