### PR TITLE
fix(chat): keep tables, headings and task lists through sanitisation

### DIFF
--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -155,8 +155,14 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
             pre: ({ node, ...props }) => (
               <pre {...props} role="text" aria-label="Code block" />
             ),
+            // Fall back rather than overwrite, the way the `img` override
+            // below already does. A prop after a spread wins unconditionally,
+            // so this used to discard any `aria-label` the pipeline had set —
+            // and the one case that has one is the footnote backref, whose
+            // visible text is a bare return arrow. It announced as "Link: ↩"
+            // in place of "Back to reference 1".
             a: ({ node, ...props }) => (
-              <a {...props} aria-label={`Link: ${props.children}`} />
+              <a {...props} aria-label={props['aria-label'] ?? `Link: ${props.children}`} />
             ),
             img: ({ node, ...props }) => (
               <img {...props} alt={props.alt || 'Image in message'} />

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -179,13 +179,18 @@ export function createChatSanitizeSchema(): SanitizeSchema {
       // every dataset key a future plugin invents.
       'a': [
         'href',
+        // `[text](url "title")`. Text only — no protocol, nothing to filter.
+        'title',
         'id',
         'ariaLabel',
         'ariaDescribedBy',
         'dataFootnoteRef',
         'dataFootnoteBackref',
       ],
-      'img': ['src', 'alt'],
+      'img': ['src', 'alt', 'title'],
+      // `start` only appears when a numbered list does not begin at 1, so
+      // without it a list written "2." "3." silently renumbers from 1.
+      'ol': ['start'],
       // The footnotes block and the anchors its links resolve against.
       'section': ['dataFootnotes'],
       'h2': ['id'],

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -202,7 +202,13 @@ export function createChatSanitizeSchema(): SanitizeSchema {
       // and `value` are deliberately absent: none is emitted, and together
       // they are what would turn a rendered response into a submittable
       // control.
-      'input': ['type', 'checked', 'disabled'],
+      //
+      // `type` is pinned to the one value rather than merely allowed. The
+      // tuple form replaces a disallowed value instead of dropping it, which
+      // is the safer failure here: a dropped `type` leaves an `input` that
+      // defaults to a text box, where a replaced one stays the inert checkbox
+      // this entry exists to admit.
+      'input': [['type', 'checkbox'], 'checked', 'disabled'],
       // Column alignment from `:--` / `--:`. Carries no meaning for a screen
       // reader but is the difference between a table that reads as a table
       // visually and one that does not.

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -121,13 +121,19 @@ export const MATHML_ATTRIBUTES: readonly string[] = [
  * MathML instead of the glyph spans beside it.
  *
  * The list used to also carry `role`, `ariaLabel`, `ariaBusy`, `ariaLive` and
- * `ariaAtomic`. Nothing in the pipeline emits any of them — the `role` and
- * `aria-label` that `TypingEffect` puts on `<pre>` and `<a>` are React props,
- * applied to the tree after it has been sanitised — and while they were
+ * `ariaAtomic`, on the reasoning that nothing in the pipeline emitted any of
+ * them — the `role` and `aria-label` `TypingEffect` puts on `<pre>` and `<a>`
+ * are React props, applied after sanitisation — and that while they were
  * misspelled they were inert. Correcting the spelling would have made them
- * live for the first time, so they are dropped instead: a response body cannot
- * reach an attribute today (the pipeline runs without `rehype-raw`, so raw HTML
- * is escaped to text), and this way it still could not were that to change.
+ * live for the first time, so they were dropped instead.
+ *
+ * That reasoning held only while footnotes were being dropped too. remark-gfm
+ * emits `ariaLabel` and `ariaDescribedBy` on the reference and backref links,
+ * so both are admitted now — on `a` alone rather than here. Which is the point
+ * this comment is really making: the narrow grant is what keeps an attribute
+ * from being available on every element that never needed it, and a response
+ * body still cannot reach one, since the pipeline runs without `rehype-raw`
+ * and raw HTML is escaped to text.
  */
 const GLOBAL_ATTRIBUTES: readonly string[] = [
   'className',

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -169,8 +169,40 @@ export function createChatSanitizeSchema(): SanitizeSchema {
       // attribute that could not arrive — and a `target="_blank"` without
       // `rel="noopener"` is reverse tabnabbing waiting for the day one could.
       // Same reasoning as the ARIA entries dropped from GLOBAL_ATTRIBUTES.
-      'a': ['href'],
+      // `id` and the two ARIA entries are the footnote wiring remark-gfm
+      // emits: the reference anchor is described by the footnotes heading, and
+      // the backref carries "Back to reference 1" as its only text. Without
+      // them the backref is an unlabelled link.
+      //
+      // The `data-footnote-*` pair is named rather than admitted by a `data-*`
+      // wildcard, so this allows the two attributes footnotes need and not
+      // every dataset key a future plugin invents.
+      'a': [
+        'href',
+        'id',
+        'ariaLabel',
+        'ariaDescribedBy',
+        'dataFootnoteRef',
+        'dataFootnoteBackref',
+      ],
       'img': ['src', 'alt'],
+      // The footnotes block and the anchors its links resolve against.
+      'section': ['dataFootnotes'],
+      'h2': ['id'],
+      'li': ['id'],
+      // GFM's task list. A form control in a chat transcript is admitted only
+      // as the disabled checkbox remark-gfm produces — `checked` is the whole
+      // point, since checked and unchecked are otherwise indistinguishable,
+      // and `disabled` is what keeps it from being operable. `form`, `name`
+      // and `value` are deliberately absent: none is emitted, and together
+      // they are what would turn a rendered response into a submittable
+      // control.
+      'input': ['type', 'checked', 'disabled'],
+      // Column alignment from `:--` / `--:`. Carries no meaning for a screen
+      // reader but is the difference between a table that reads as a table
+      // visually and one that does not.
+      'th': ['align'],
+      'td': ['align'],
       // `style` here and on `svg` below carries KaTeX's computed layout —
       // `height:1em;vertical-align:-0.25em`, `top:-4em`, `width:0.471em`. The
       // values are generated, never passed through: `\htmlStyle` and
@@ -208,6 +240,34 @@ export function createChatSanitizeSchema(): SanitizeSchema {
       'blockquote',
       'img',
       'span',
+      // Heading levels. `rehype-sanitize` keeps the text of an element it
+      // drops, so a missing heading did not vanish — it flattened into the
+      // paragraph flow, taking heading navigation with it.
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      // `del` and `input` change what a sentence means rather than how it
+      // looks: a retraction read as an assertion, and a done task
+      // indistinguishable from an outstanding one.
+      'del',
+      'input',
+      'hr',
+      // Footnotes: `sup` on the reference, `section` on the block.
+      'sup',
+      'section',
+      // The table family. An LLM describing a chart reaches for a table first,
+      // and losing it leaves the numbers as a run of digits with nothing
+      // binding them to a label — no headers, no row or cell boundaries, and
+      // none of the table navigation assistive technology provides.
+      'table',
+      'thead',
+      'tbody',
+      'tr',
+      'th',
+      'td',
       'svg',
       'path',
       'line',

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -239,6 +239,11 @@ describe('mathML allowlist', () => {
  *
  * #678 wires up the ESM Jest project that closes that gap; this list is what
  * the survey should reproduce when it does.
+ *
+ * A transcript is also only as good as the corpus behind it. `ol[start]`,
+ * `a[title]` and `img[title]` are absent from a corpus whose lists all begin
+ * at 1 and whose links carry no title, and were missed on the first pass for
+ * exactly that reason.
  */
 const GFM_ELEMENTS: readonly string[] = [
   'a',
@@ -279,13 +284,17 @@ const GFM_PROPERTIES: readonly (readonly [string, string])[] = [
   ['a', 'dataFootnoteRef'],
   ['a', 'href'],
   ['a', 'id'],
+  ['a', 'title'],
   ['h2', 'id'],
   ['img', 'alt'],
   ['img', 'src'],
+  ['img', 'title'],
   ['input', 'checked'],
   ['input', 'disabled'],
   ['input', 'type'],
   ['li', 'id'],
+  // Emitted only when a numbered list does not begin at 1.
+  ['ol', 'start'],
   ['section', 'dataFootnotes'],
   ['td', 'align'],
   ['th', 'align'],
@@ -327,6 +336,15 @@ describe('GFM allowlist', () => {
     );
     expect(schema.attributes?.th).toContain('align');
     expect(schema.attributes?.td).toContain('align');
+  });
+
+  it('should keep a numbered list starting anywhere but 1', () => {
+    const schema = createChatSanitizeSchema();
+
+    // `start` is emitted only for a list that does not begin at 1, so losing
+    // it renumbers the list from 1 without dropping anything visible — the
+    // reader is given different numbers from the ones that were written.
+    expect(schema.attributes?.ol).toContain('start');
   });
 
   it('should admit a task-list checkbox only as a disabled checkbox', () => {
@@ -437,6 +455,7 @@ describe('createChatSanitizeSchema', () => {
     // default `protocols` filtering; see the test below.
     expect(schema.attributes?.a).toEqual([
       'href',
+      'title',
       'id',
       'ariaLabel',
       'ariaDescribedBy',

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -227,6 +227,142 @@ describe('mathML allowlist', () => {
   });
 });
 
+/**
+ * Every element the GFM and CommonMark side of the pipeline produces.
+ *
+ * Collected by running a markdown corpus through `remark-parse` →
+ * `remark-gfm` → `remark-rehype` and walking the resulting hast tree. That run
+ * cannot happen here — the whole chain is ESM and this suite is CommonJS — so
+ * unlike {@link MATHML_TAG_NAMES}, which the KaTeX cases above check against
+ * KaTeX itself, this list is a transcript rather than a live survey. It will
+ * not notice a plugin upgrade that starts emitting something new.
+ *
+ * #678 wires up the ESM Jest project that closes that gap; this list is what
+ * the survey should reproduce when it does.
+ */
+const GFM_ELEMENTS: readonly string[] = [
+  'a',
+  'blockquote',
+  'code',
+  'del',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'img',
+  'input',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'section',
+  'strong',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'th',
+  'thead',
+  'tr',
+  'ul',
+];
+
+/** Element/property pairs from the same run, minus the ones `'*'` covers. */
+const GFM_PROPERTIES: readonly (readonly [string, string])[] = [
+  ['a', 'ariaDescribedBy'],
+  ['a', 'ariaLabel'],
+  ['a', 'dataFootnoteBackref'],
+  ['a', 'dataFootnoteRef'],
+  ['a', 'href'],
+  ['a', 'id'],
+  ['h2', 'id'],
+  ['img', 'alt'],
+  ['img', 'src'],
+  ['input', 'checked'],
+  ['input', 'disabled'],
+  ['input', 'type'],
+  ['li', 'id'],
+  ['section', 'dataFootnotes'],
+  ['td', 'align'],
+  ['th', 'align'],
+];
+
+describe('gFM allowlist', () => {
+  it('should name every element the markdown pipeline emits', () => {
+    const schema = createChatSanitizeSchema();
+
+    const stripped = GFM_ELEMENTS.filter(tag => !schema.tagNames?.includes(tag)).sort();
+
+    // Dropping an element keeps its text, so the failure is silent: a table
+    // becomes "BarValueJan45.2", a heading becomes a sentence, and `~~gone~~`
+    // reads as an assertion rather than a retraction.
+    expect(stripped).toEqual([]);
+  });
+
+  it('should allow every attribute the markdown pipeline emits', () => {
+    const schema = createChatSanitizeSchema();
+    const shared = schema.attributes?.['*'] ?? [];
+
+    const stripped = GFM_PROPERTIES.filter(([tagName, property]) => {
+      const allowed = [...shared, ...(schema.attributes?.[tagName] ?? [])];
+      return !allowed.some(entry => (typeof entry === 'string' ? entry : entry[0]) === property);
+    }).map(([tagName, property]) => `${tagName}[${property}]`).sort();
+
+    expect(stripped).toEqual([]);
+  });
+
+  it('should give a table its structure and its column alignment', () => {
+    const schema = createChatSanitizeSchema();
+
+    // Named separately from the survey because this is the case the issue was
+    // filed for: a table of chart values is the most likely thing an LLM emits
+    // when describing a plot, and losing it leaves a screen reader user with a
+    // run of digits and nothing binding them to a label.
+    expect(schema.tagNames).toEqual(
+      expect.arrayContaining(['table', 'thead', 'tbody', 'tr', 'th', 'td']),
+    );
+    expect(schema.attributes?.th).toContain('align');
+    expect(schema.attributes?.td).toContain('align');
+  });
+
+  it('should admit a task-list checkbox only as a disabled checkbox', () => {
+    const schema = createChatSanitizeSchema();
+
+    // `checked` is the whole point — without it a done task and an outstanding
+    // one are indistinguishable — and `disabled` is what keeps it inert.
+    expect(schema.attributes?.input).toEqual(['type', 'checked', 'disabled']);
+  });
+
+  it('should never let a rendered response become a submittable control', () => {
+    const schema = createChatSanitizeSchema();
+
+    // The attributes that would turn `input` from a rendering of markdown into
+    // a form. None is emitted by the pipeline, so allowing any of them could
+    // only ever admit something a response invented.
+    for (const attribute of ['form', 'name', 'value', 'formAction', 'onClick']) {
+      expect(schema.attributes?.input).not.toContain(attribute);
+    }
+  });
+
+  it('should name the footnote data attributes rather than a data wildcard', () => {
+    const schema = createChatSanitizeSchema();
+
+    expect(schema.attributes?.a).toContain('dataFootnoteRef');
+    expect(schema.attributes?.a).toContain('dataFootnoteBackref');
+    // A `data*` wildcard would admit every dataset key any future plugin
+    // invents, which is a wider grant than footnotes need.
+    const wildcards = Object.values(schema.attributes ?? {})
+      .flat()
+      .map(entry => (typeof entry === 'string' ? entry : entry[0]))
+      .filter(name => name.includes('*'));
+    expect(wildcards).toEqual([]);
+  });
+});
+
 describe('createChatSanitizeSchema', () => {
   it('should allow every MathML element as a tag name', () => {
     const schema = createChatSanitizeSchema();
@@ -293,14 +429,31 @@ describe('createChatSanitizeSchema', () => {
     expect(stripped).toEqual([]);
   });
 
-  it('should allow a link its href and nothing else', () => {
+  it('should allow a link only what the pipeline puts on one', () => {
     const schema = createChatSanitizeSchema();
 
-    // `target` was allowed and unreachable — markdown has no syntax for it and
-    // raw HTML is escaped to text — so it only stood to admit a
-    // `target="_blank"` with no `rel="noopener"` the day something could set
-    // one. `href` keeps the default `protocols` filtering; see the test below.
-    expect(schema.attributes?.a).toEqual(['href']);
+    // Was `['href']` until footnotes were admitted; the rest is the wiring
+    // remark-gfm emits on a reference and its backref. `href` keeps the
+    // default `protocols` filtering; see the test below.
+    expect(schema.attributes?.a).toEqual([
+      'href',
+      'id',
+      'ariaLabel',
+      'ariaDescribedBy',
+      'dataFootnoteRef',
+      'dataFootnoteBackref',
+    ]);
+  });
+
+  it('should never allow target on a link', () => {
+    const schema = createChatSanitizeSchema();
+
+    // Markdown has no syntax for it and raw HTML is escaped to text, so it
+    // could only ever admit a `target="_blank"` with no `rel="noopener"` the
+    // day something could set one. Stated on its own rather than implied by
+    // the exact list above, which now grows whenever the pipeline does.
+    expect(schema.attributes?.a).not.toContain('target');
+    expect(schema.attributes?.['*']).not.toContain('target');
   });
 
   it('should override no schema key other than tagNames and attributes', () => {

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -248,6 +248,10 @@ describe('mathML allowlist', () => {
 const GFM_ELEMENTS: readonly string[] = [
   'a',
   'blockquote',
+  // From a hard line break — two trailing spaces, or a trailing backslash.
+  // Already allowed before this change, so its absence here cost nothing at
+  // the time; a transcript with a hole in it is what costs something later.
+  'br',
   'code',
   'del',
   'em',

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -291,7 +291,7 @@ const GFM_PROPERTIES: readonly (readonly [string, string])[] = [
   ['th', 'align'],
 ];
 
-describe('gFM allowlist', () => {
+describe('GFM allowlist', () => {
   it('should name every element the markdown pipeline emits', () => {
     const schema = createChatSanitizeSchema();
 

--- a/test/util/markdownSanitize.test.ts
+++ b/test/util/markdownSanitize.test.ts
@@ -356,7 +356,22 @@ describe('GFM allowlist', () => {
 
     // `checked` is the whole point — without it a done task and an outstanding
     // one are indistinguishable — and `disabled` is what keeps it inert.
-    expect(schema.attributes?.input).toEqual(['type', 'checked', 'disabled']);
+    // `type` is pinned to the value, not just the name.
+    expect(schema.attributes?.input).toEqual([['type', 'checkbox'], 'checked', 'disabled']);
+  });
+
+  it('should pin the checkbox type rather than trusting the pipeline', () => {
+    const schema = createChatSanitizeSchema();
+
+    // The tuple form replaces a disallowed value rather than dropping it,
+    // which is what makes this worth pinning: a dropped `type` leaves an
+    // `input` that renders as a text box, so allowing the bare name would
+    // fail open on any value that ever reached it.
+    const type = schema.attributes?.input?.find(
+      entry => typeof entry !== 'string' && entry[0] === 'type',
+    );
+
+    expect(type).toEqual(['type', 'checkbox']);
   });
 
   it('should never let a rendered response become a submittable control', () => {


### PR DESCRIPTION
# Pull Request

## Description

The chat allowlist names what KaTeX emits — that side was surveyed in #675 — but the GFM and CommonMark side never was. `rehype-sanitize` drops a disallowed element **while keeping its text**, so none of this failed visibly. It flattened.

A table of chart values, the single most likely thing an LLM emits when describing a plot:

```markdown
| Bar | Value |
| --- | ----: |
| Jan | 45.2 |
| Feb | 51.8 |
```

reached the user as:

```
BarValueJan45.2Feb51.8
```

No headers, no row or cell boundaries, and none of the table navigation assistive technology provides — a run of digits with nothing binding them to a label. In a library whose purpose is making data readable non-visually, that is the worst thing on the list.

The rest of the same survey:

| Markdown | Rendered as | Lost |
|---|---|---|
| `## Summary` | `Summary` | `h1`–`h6`, and heading navigation with them |
| `~~gone~~` | `gone` | `del` — **meaning inverted**, a retraction reads as an assertion |
| `- [x] done` | `done` | `input` — checked and unchecked indistinguishable |
| `2.` `3.` | renumbered from 1 | `ol[start]` — the reader gets different numbers than were written |
| `text[^1]` | partial | `sup`, `section` |
| `---` | *(nothing)* | `hr` |

## Related Issues

Refs #677. Follows #675, which fixed the same class of defect for maths.

Filed from this PR: #696 (footnote anchors), #697 (`.sr-only` is not styled), #698 (`Link: [object Object]`). Blocked-on: #678.

## Changes Made

Adds the elements and attributes a survey of the **real pipeline** reports — `remark-parse` → `remark-gfm` → `remark-rehype`, walking the resulting hast tree rather than reasoning from the GFM spec.

Two things the issue did not list turned up in that survey:

- **`a[ariaLabel]` and `a[ariaDescribedBy]` are genuinely emitted.** #675 removed both from the global list on the reasoning that *"nothing in the pipeline emits any of them"*. That holds for maths and stops holding the moment footnotes are admitted: the backref's only text is its `aria-label` (`"Back to reference 1"`), so without it the link is unlabelled.
- **`h2[id]` and `section[dataFootnotes]`**, for the footnotes block.

Three security decisions, as the issue asked:

- **`input`** is admitted only as the disabled checkbox remark-gfm emits, with `type` **pinned to its value** rather than merely named. The tuple form matters: it replaces a disallowed value instead of dropping it, and an `input` whose `type` is dropped renders as a **text box**, so the bare name failed open in both directions.

  ```
  [['type','checkbox'], …]   type=hidden  ->  type="checkbox"
  ['type', …]                type=hidden  ->  type="hidden"
  ```

  `form`, `name` and `value` stay out: none is emitted, so allowing them could only ever admit something a response invented.
- **The footnote data attributes are named individually**, not admitted by a `data-*` wildcard. A test asserts no wildcard appears anywhere in the schema.
- **`id` relies on the default `clobberPrefix`**, which still applies because the schema declares only `tagNames` and `attributes` — the existing test pinning that is what keeps it true, and it is now load-bearing for three elements where it guarded none before.

Also fixes one defect a layer up: `TypingEffect`'s `a` override set `aria-label` unconditionally after the spread, so it discarded the one the pipeline had just been permitted to carry. The footnote backref announced as *"Link: ↩"* rather than *"Back to reference 1"* — the exact information admitting `ariaLabel` was meant to preserve. It falls back now, matching the `img` override beside it.

`MessageBubble.tsx` was checked as the issue suggested: it delegates to `TypingEffect`, so this one allowlist covers both.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no documented behaviour changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Verified end to end, not just against the schema

Checking the allowlist against itself would pass while the rendering stayed broken, so every claim here was run through the real pipeline with `hast-util-sanitize`:

```html
<table><thead><tr><th align="left">Bar</th><th align="right">Value</th></tr></thead>
<tbody><tr><td align="left">Jan</td><td align="right">45.2</td></tr></tbody></table>

<li class="task-list-item"><input type="checkbox" checked disabled> done</li>

ol  {"start":2}
a   {"href":"https://e.com","title":"the title"}
```

And the footnote references, resolved against the ids actually present after sanitisation:

```
aria-describedby  user-content-footnote-label   RESOLVES
href              user-content-fn-1             DANGLING
href              user-content-fnref-1          DANGLING
```

### Known limitation: footnote anchors dangle

The issue said the `id` decision was *"worth confirming rather than assuming"*. Confirmed, and it is a real trap: `mdast-util-to-hast` prefixes the ids **derived from user text** with `user-content-` and leaves its own literal `footnote-label` bare, then `hast-util-sanitize` prefixes everything in `clobber` again. So `href="#user-content-fn-1"` points at a target that became `user-content-user-content-fn-1`.

`aria-describedby` survives because it is in `clobber` alongside `id`, so both sides of that pair move together. `href` is not, so it cannot follow its target — that, rather than the double-prefixing itself, is the bug.

Not fixed here, and **#696 now records why the obvious fix does not work**: a per-message `clobberPrefix` leaves `footnote-label` colliding, because the library hardcodes that id and documents that it always does. Full de-duplication needs a post-processing pass, which is a different change from this one.

Leaving `id` out entirely would be worse, not better: `aria-describedby` would then point at nothing, and the anchors would be dead either way.

### On the tests

Each new case was verified to fail against the defect it names — removing `table`, `del`, `input`, `ol[start]` or `br` from the allowlist, adding `name`/`value` to the checkbox, or loosening the `type` pin each turns the relevant case red.

The corpus in the test file is a **transcript** of the pipeline survey rather than a live one: the whole remark/rehype chain is ESM and this Jest suite is CommonJS, so it cannot run here. Review proved the sharp edge of that — `ol[start]`, `a[title]`, `img[title]` and `br` were all missed on the first pass, every one of them because the corpus behind the transcript was too narrow to emit them. That limitation is now recorded next to the transcript, and #678 has a ranked list of what its live survey should pin first.

| check | result |
|---|---|
| `npm test` | 1326 passed, 103 suites |
| `npm run build` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npx eslint . --fix` | exit 0 |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz