### PR TITLE
fix(chat): hide the live region that was rendering every message twice

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -86,6 +86,32 @@ const config: ReturnType<typeof antfu> = antfu({
       message: 'Do not call pressKeyCombination() from a plot page object: it presses the key but does not wait for the announcement. Use this.moveToDataPoint(key, action, true) for a modified move.',
     }],
   },
+}, {
+  // `sr-only` hides nothing here. MAIDR ships no stylesheet — `dist/maidr.css`
+  // is a placeholder and the UI is styled at runtime by emotion — so an element
+  // given that class is an ordinary visible one. `TypingEffect`'s live region
+  // carried it and rendered every finished chat message a second time, in full.
+  //
+  // Matched on the AST rather than by scanning source text. This started as a
+  // regex over `className=` in a test and took four rounds to stop being wrong
+  // — word boundaries around a hyphen, truncation at the first `}` inside a
+  // template, a brace inside a string literal — and every one of those failed
+  // by silently passing. The selector gets a real parse for free and runs on
+  // every file rather than only when that test does.
+  //
+  // The `sr-only` in `TypingEffect`'s `h2` override is untouched: it sits in a
+  // `style` attribute, reading the class the markdown pipeline set rather than
+  // assigning one.
+  files: ['src/**/*.ts', 'src/**/*.tsx'],
+  rules: {
+    'no-restricted-syntax': ['error', {
+      selector: 'JSXAttribute[name.name=\'className\'] Literal[value=/(^|\\s)sr-only(\\s|$)/]',
+      message: 'Nothing defines .sr-only in MAIDR, so this element is visible. Use the visuallyHidden style object from @ui/visuallyHidden.',
+    }, {
+      selector: 'JSXAttribute[name.name=\'className\'] TemplateElement[value.raw=/(^|\\s)sr-only(\\s|$)/]',
+      message: 'Nothing defines .sr-only in MAIDR, so this element is visible. Use the visuallyHidden style object from @ui/visuallyHidden.',
+    }],
+  },
 });
 
 export default config;

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -87,21 +87,14 @@ const config: ReturnType<typeof antfu> = antfu({
     }],
   },
 }, {
-  // `sr-only` hides nothing here. MAIDR ships no stylesheet — `dist/maidr.css`
-  // is a placeholder and the UI is styled at runtime by emotion — so an element
-  // given that class is an ordinary visible one. `TypingEffect`'s live region
-  // carried it and rendered every finished chat message a second time, in full.
+  // `sr-only` hides nothing here — MAIDR ships no stylesheet to define it, so
+  // the class leaves an ordinary visible element. `src/ui/visuallyHidden.ts`
+  // holds the reasoning and the replacement.
   //
-  // Matched on the AST rather than by scanning source text. This started as a
-  // regex over `className=` in a test and took four rounds to stop being wrong
-  // — word boundaries around a hyphen, truncation at the first `}` inside a
-  // template, a brace inside a string literal — and every one of those failed
-  // by silently passing. The selector gets a real parse for free and runs on
-  // every file rather than only when that test does.
-  //
-  // The `sr-only` in `TypingEffect`'s `h2` override is untouched: it sits in a
-  // `style` attribute, reading the class the markdown pipeline set rather than
-  // assigning one.
+  // Matched on the AST because the source-text version of this guard was wrong
+  // three times over, each in a way that passed silently. Scoping to
+  // `className` also leaves `TypingEffect`'s `h2` override alone, since that
+  // reads the class in a `style` attribute rather than assigning one.
   files: ['src/**/*.ts', 'src/**/*.tsx'],
   rules: {
     'no-restricted-syntax': ['error', {

--- a/src/ui/component/Text.tsx
+++ b/src/ui/component/Text.tsx
@@ -1,22 +1,7 @@
 import { useViewModelState } from '@state/hook/useViewModel';
+import { visuallyHidden } from '@ui/visuallyHidden';
 import { Constant } from '@util/constant';
 import React from 'react';
-
-/**
- * Visually-hidden style that keeps an element in the accessibility tree
- * but invisible on screen (standard "sr-only" / "clip" pattern).
- */
-const visuallyHidden: React.CSSProperties = {
-  position: 'absolute',
-  width: '1px',
-  height: '1px',
-  padding: 0,
-  margin: '-1px',
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  border: 0,
-};
 
 const Text: React.FC = () => {
   const { enabled, announce, value, revision, message } = useViewModelState('text');

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -170,9 +170,8 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
             ),
             // The footnotes heading arrives as `<h2 class="sr-only">`, which
             // mdast-util-to-hast hardcodes and expects a stylesheet to honour.
-            // MAIDR has none, so the class alone leaves a literal "Footnotes"
-            // heading in the bubble. Applied here rather than as a global rule
-            // because a global `.sr-only` would collide with the host page's.
+            // Nothing can style pipeline-generated markup inline, so the class
+            // is matched here instead — see `visuallyHidden` for why not a rule.
             h2: ({ node, className, ...props }) => {
               const hidden = (className ?? '').split(/\s+/).includes('sr-only');
               return <h2 {...props} className={className} style={hidden ? visuallyHidden : undefined} />;

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import { useViewModelState } from '@state/hook/useViewModel';
+import { visuallyHidden } from '@ui/visuallyHidden';
 import { containsLatex, ensureKatexStylesheet } from '@util/katex';
 import { createChatSanitizeSchema } from '@util/markdownSanitize';
 import React, { memo, useEffect, useMemo, useState } from 'react';
@@ -167,6 +168,18 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
             img: ({ node, ...props }) => (
               <img {...props} alt={props.alt || 'Image in message'} />
             ),
+            // The footnotes heading arrives as `<h2 class="sr-only">`, which
+            // mdast-util-to-hast hardcodes and expects a stylesheet to honour.
+            // MAIDR has none, so the class alone leaves a literal "Footnotes"
+            // heading in the bubble. Applied here rather than as a global rule
+            // because a global `.sr-only` would collide with the host page's.
+            h2: ({ node, className, ...props }) => (
+              <h2
+                {...props}
+                className={className}
+                style={className?.split(/\s+/).includes('sr-only') ? visuallyHidden : undefined}
+              />
+            ),
           }}
         >
           {displayedText}
@@ -174,7 +187,7 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
       </div>
       {/* Visually hidden live region for screen readers */}
       <div
-        className="sr-only"
+        style={visuallyHidden}
         aria-live={settings.general.ariaMode}
         aria-atomic="true"
       >

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -173,13 +173,10 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
             // MAIDR has none, so the class alone leaves a literal "Footnotes"
             // heading in the bubble. Applied here rather than as a global rule
             // because a global `.sr-only` would collide with the host page's.
-            h2: ({ node, className, ...props }) => (
-              <h2
-                {...props}
-                className={className}
-                style={className?.split(/\s+/).includes('sr-only') ? visuallyHidden : undefined}
-              />
-            ),
+            h2: ({ node, className, ...props }) => {
+              const hidden = (className ?? '').split(/\s+/).includes('sr-only');
+              return <h2 {...props} className={className} style={hidden ? visuallyHidden : undefined} />;
+            },
           }}
         >
           {displayedText}

--- a/src/ui/visuallyHidden.ts
+++ b/src/ui/visuallyHidden.ts
@@ -1,0 +1,28 @@
+import type React from 'react';
+
+/**
+ * Style that keeps an element in the accessibility tree but off the screen.
+ *
+ * The standard clip pattern. Used rather than a `.sr-only` class because MAIDR
+ * has no stylesheet to put one in: `dist/maidr.css` is a placeholder emitted so
+ * integrations that link it by name keep working, and the UI is styled at
+ * runtime by emotion (see `scripts/vite-plugin-math-stylesheet.js`).
+ *
+ * Shipping a global `.sr-only` rule instead would be worse than merely
+ * inconvenient. MAIDR embeds in pages it does not control, and `sr-only` is a
+ * common name — Bootstrap 4 and Tailwind both define it — so a global rule
+ * would either be overridden by the host's or silently override the host's for
+ * the rest of the page. An inline style on the elements MAIDR owns cannot
+ * reach anything outside them.
+ */
+export const visuallyHidden: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};

--- a/src/ui/visuallyHidden.ts
+++ b/src/ui/visuallyHidden.ts
@@ -22,7 +22,12 @@ export const visuallyHidden: React.CSSProperties = {
   padding: 0,
   margin: '-1px',
   overflow: 'hidden',
+  // `clip` is deprecated and `clipPath` is its replacement, but both are here
+  // on purpose: this is the one idiom every browser still honours `clip` for,
+  // and dropping it would silently widen the set of engines where the element
+  // becomes visible. Belt and braces is the standard form of this pattern.
   clip: 'rect(0, 0, 0, 0)',
+  clipPath: 'inset(50%)',
   whiteSpace: 'nowrap',
   border: 0,
 };

--- a/src/util/constant.ts
+++ b/src/util/constant.ts
@@ -39,10 +39,6 @@ export abstract class Constant {
   /** ID for the rotor navigation area */
   static readonly ROTOR_AREA = 'maidr-rotor-area';
 
-  // CSS classes.
-  /** CSS class for screen reader only content */
-  static readonly SR_ONLY_CLASS = 'maidr-sr-only';
-
   // HTML attributes.
   /** ARIA label attribute name */
   static readonly ARIA_LABEL = 'aria-label';

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -46,20 +46,27 @@ describe('visuallyHidden', () => {
     // hidden element, it is a plain one — `TypingEffect`'s live region carried
     // it and rendered every finished chat message a second time, in full, on
     // any page that did not happen to define the class itself.
-    // Matches the quoted, braced and template forms — `className="sr-only"`,
-    // `className={'sr-only'}` and `` className={`sr-only`} `` — since only the
-    // first is the obvious way to write it.
-    //
-    // Compares whole class tokens rather than testing `\bsr-only\b`, which
-    // looks equivalent and is not: `-` is a non-word character, so that
-    // pattern also matches `not-sr-only` and `sr-only-thing` and would fail
-    // this suite over a class that has nothing to do with hiding anything.
-    const ASSIGNED_CLASS = /className=\{?\s*["'`]([^"'`]*)["'`]/g;
+    // Takes whatever `className=` is given — a quoted string, or a braced
+    // expression — and looks for the class in any string literal inside it.
+    // A braced expression is included so a conditional
+    // `className={hidden ? 'sr-only' : undefined}` is caught as well as a
+    // plain literal; `className={someVariable}` contains no literal and so
+    // matches nothing, which is what leaves the `h2` override below alone.
+    const CLASS_NAME = /className=(\{[^}]*\}|["'`][^"'`]*["'`])/g;
+    const STRING_LITERAL = /["'`]([^"'`]*)["'`]/g;
+
+    // Whole tokens, not `\bsr-only\b` — that looks equivalent and is not:
+    // `-` is a non-word character, so it sits beside the boundary and also
+    // matches `not-sr-only` and `sr-only-thing`, failing this suite over a
+    // class with nothing to do with hiding anything.
+    const assignsSrOnly = (expression: string): boolean =>
+      [...expression.matchAll(STRING_LITERAL)]
+        .some(([, value]) => value.split(/\s+/).includes('sr-only'));
 
     const offenders = sourceFiles().filter((file) => {
       const contents = readFileSync(join(ROOT, file), 'utf8');
-      return [...contents.matchAll(ASSIGNED_CLASS)]
-        .some(([, value]) => value.split(/\s+/).includes('sr-only'));
+      return [...contents.matchAll(CLASS_NAME)]
+        .some(([, expression]) => assignsSrOnly(expression));
     });
 
     expect(offenders).toEqual([]);

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -29,6 +29,11 @@ function sourceFiles(): string[] {
  * first `}` — so a template holding any interpolation is truncated there and
  * its class names are never seen. `` className={`${cond} sr-only`} `` reduces
  * to `` {`${cond} ``, which contains no complete string and reads as clean.
+ *
+ * The count skips over string contents, so a brace inside a literal cannot
+ * unbalance it. Both failures are the same kind and the reason this is worth
+ * the care: they do not report a wrong answer, they drop the expression and
+ * leave the guard looking clean.
  * @param contents - The source file to scan.
  * @returns Each expression, including its delimiters.
  */
@@ -42,9 +47,25 @@ function classNameExpressions(contents: string): string[] {
     if (opener === '{') {
       let depth = 0;
       for (let i = start; i < contents.length; i++) {
-        if (contents[i] === '{') {
+        const char = contents[i];
+
+        // Skip the contents of a string, so a brace inside one cannot move
+        // the depth. `className={cond ? 'a{b' : 'sr-only'}` otherwise never
+        // returns to depth 0, and the expression is dropped from the scan
+        // entirely rather than reported — the guard passing on the one shape
+        // it cannot read.
+        if (char === '"' || char === '\'' || char === '`') {
+          const close = contents.indexOf(char, i + 1);
+          if (close === -1) {
+            break;
+          }
+          i = close;
+          continue;
+        }
+
+        if (char === '{') {
           depth++;
-        } else if (contents[i] === '}') {
+        } else if (char === '}') {
           depth--;
           if (depth === 0) {
             expressions.push(contents.slice(start, i + 1));

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -31,9 +31,13 @@ describe('visuallyHidden', () => {
     expect(visuallyHidden.display).toBeUndefined();
     expect(visuallyHidden.visibility).toBeUndefined();
 
-    expect(visuallyHidden.clip).toBe('rect(0, 0, 0, 0)');
     expect(visuallyHidden.position).toBe('absolute');
     expect(visuallyHidden.overflow).toBe('hidden');
+    // Both spellings. `clip` is deprecated in favour of `clipPath`, but it is
+    // the one every engine still honours for this idiom, so dropping either
+    // widens the set of browsers that render the element.
+    expect(visuallyHidden.clip).toBe('rect(0, 0, 0, 0)');
+    expect(visuallyHidden.clipPath).toBe('inset(50%)');
   });
 
   it('should be used instead of an sr-only class no stylesheet defines', () => {
@@ -42,9 +46,20 @@ describe('visuallyHidden', () => {
     // hidden element, it is a plain one — `TypingEffect`'s live region carried
     // it and rendered every finished chat message a second time, in full, on
     // any page that did not happen to define the class itself.
+    // Matches the quoted, braced and template forms — `className="sr-only"`,
+    // `className={'sr-only'}` and `` className={`sr-only`} `` — since only the
+    // first is the obvious way to write it.
+    //
+    // Compares whole class tokens rather than testing `\bsr-only\b`, which
+    // looks equivalent and is not: `-` is a non-word character, so that
+    // pattern also matches `not-sr-only` and `sr-only-thing` and would fail
+    // this suite over a class that has nothing to do with hiding anything.
+    const ASSIGNED_CLASS = /className=\{?\s*["'`]([^"'`]*)["'`]/g;
+
     const offenders = sourceFiles().filter((file) => {
       const contents = readFileSync(join(ROOT, file), 'utf8');
-      return /className=["'][^"']*\bsr-only\b/.test(contents);
+      return [...contents.matchAll(ASSIGNED_CLASS)]
+        .some(([, value]) => value.split(/\s+/).includes('sr-only'));
     });
 
     expect(offenders).toEqual([]);

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -22,6 +22,66 @@ function sourceFiles(): string[] {
     .filter(file => file.endsWith('.tsx') || file.endsWith('.ts'));
 }
 
+/**
+ * Every expression handed to a `className=` prop.
+ *
+ * Braces are counted rather than matched with `\{[^}]*\}`, which ends at the
+ * first `}` — so a template holding any interpolation is truncated there and
+ * its class names are never seen. `` className={`${cond} sr-only`} `` reduces
+ * to `` {`${cond} ``, which contains no complete string and reads as clean.
+ * @param contents - The source file to scan.
+ * @returns Each expression, including its delimiters.
+ */
+function classNameExpressions(contents: string): string[] {
+  const expressions: string[] = [];
+
+  for (const match of contents.matchAll(/className=/g)) {
+    const start = (match.index ?? 0) + match[0].length;
+    const opener = contents[start];
+
+    if (opener === '{') {
+      let depth = 0;
+      for (let i = start; i < contents.length; i++) {
+        if (contents[i] === '{') {
+          depth++;
+        } else if (contents[i] === '}') {
+          depth--;
+          if (depth === 0) {
+            expressions.push(contents.slice(start, i + 1));
+            break;
+          }
+        }
+      }
+    } else if (opener === '"' || opener === '\'' || opener === '`') {
+      const end = contents.indexOf(opener, start + 1);
+      if (end !== -1) {
+        expressions.push(contents.slice(start, end + 1));
+      }
+    }
+  }
+
+  return expressions;
+}
+
+/**
+ * Whether an expression puts the `sr-only` class on an element.
+ *
+ * Compares whole tokens rather than testing `\bsr-only\b`, which looks
+ * equivalent and is not: `-` is a non-word character, so that pattern sits
+ * beside the boundary and also matches `not-sr-only` and `sr-only-thing` —
+ * failing this suite over a class with nothing to do with hiding anything.
+ *
+ * An expression with no string literal in it — `className={someVariable}` —
+ * matches nothing, which is what leaves the `h2` override alone. That
+ * override is the one place here that legitimately *reads* the class.
+ * @param expression - One `className=` expression.
+ * @returns True if any string literal in it carries the class.
+ */
+function assignsSrOnly(expression: string): boolean {
+  return [...expression.matchAll(/["'`]([^"'`]*)["'`]/g)]
+    .some(([, value]) => value.split(/\s+/).includes('sr-only'));
+}
+
 describe('visuallyHidden', () => {
   it('should keep hidden content in the accessibility tree', () => {
     // The whole point, and the easiest thing to lose while "simplifying":
@@ -46,27 +106,9 @@ describe('visuallyHidden', () => {
     // hidden element, it is a plain one — `TypingEffect`'s live region carried
     // it and rendered every finished chat message a second time, in full, on
     // any page that did not happen to define the class itself.
-    // Takes whatever `className=` is given — a quoted string, or a braced
-    // expression — and looks for the class in any string literal inside it.
-    // A braced expression is included so a conditional
-    // `className={hidden ? 'sr-only' : undefined}` is caught as well as a
-    // plain literal; `className={someVariable}` contains no literal and so
-    // matches nothing, which is what leaves the `h2` override below alone.
-    const CLASS_NAME = /className=(\{[^}]*\}|["'`][^"'`]*["'`])/g;
-    const STRING_LITERAL = /["'`]([^"'`]*)["'`]/g;
-
-    // Whole tokens, not `\bsr-only\b` — that looks equivalent and is not:
-    // `-` is a non-word character, so it sits beside the boundary and also
-    // matches `not-sr-only` and `sr-only-thing`, failing this suite over a
-    // class with nothing to do with hiding anything.
-    const assignsSrOnly = (expression: string): boolean =>
-      [...expression.matchAll(STRING_LITERAL)]
-        .some(([, value]) => value.split(/\s+/).includes('sr-only'));
-
     const offenders = sourceFiles().filter((file) => {
       const contents = readFileSync(join(ROOT, file), 'utf8');
-      return [...contents.matchAll(CLASS_NAME)]
-        .some(([, expression]) => assignsSrOnly(expression));
+      return classNameExpressions(contents).some(assignsSrOnly);
     });
 
     expect(offenders).toEqual([]);

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -1,107 +1,12 @@
-import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
 import { describe, expect, it } from '@jest/globals';
 import { visuallyHidden } from '@ui/visuallyHidden';
 
 /**
- * Guards the two ways visually-hidden content silently stops working here.
+ * The one property of this style that is not obvious from reading it.
  *
- * Neither is visible in a component test: `TypingEffect` imports
- * `react-markdown`, which is ESM and unloadable by this CommonJS suite (#678),
- * and the failure that prompted this is a *missing* stylesheet rather than
- * anything a rendered tree would show.
+ * Reintroducing an `sr-only` class is guarded by `no-restricted-syntax` in
+ * `eslint.config.ts` rather than here — that needs an AST, not a test.
  */
-
-const ROOT = resolve(__dirname, '../..');
-
-/** Every tracked source file that could render markup. */
-function sourceFiles(): string[] {
-  return execFileSync('git', ['ls-files', 'src'], { cwd: ROOT, encoding: 'utf8' })
-    .split('\n')
-    .filter(file => file.endsWith('.tsx') || file.endsWith('.ts'));
-}
-
-/**
- * Every expression handed to a `className=` prop.
- *
- * Braces are counted rather than matched with `\{[^}]*\}`, which ends at the
- * first `}` — so a template holding any interpolation is truncated there and
- * its class names are never seen. `` className={`${cond} sr-only`} `` reduces
- * to `` {`${cond} ``, which contains no complete string and reads as clean.
- *
- * The count skips over string contents, so a brace inside a literal cannot
- * unbalance it. Both failures are the same kind and the reason this is worth
- * the care: they do not report a wrong answer, they drop the expression and
- * leave the guard looking clean.
- * @param contents - The source file to scan.
- * @returns Each expression, including its delimiters.
- */
-function classNameExpressions(contents: string): string[] {
-  const expressions: string[] = [];
-
-  for (const match of contents.matchAll(/className=/g)) {
-    const start = (match.index ?? 0) + match[0].length;
-    const opener = contents[start];
-
-    if (opener === '{') {
-      let depth = 0;
-      for (let i = start; i < contents.length; i++) {
-        const char = contents[i];
-
-        // Skip the contents of a string, so a brace inside one cannot move
-        // the depth. `className={cond ? 'a{b' : 'sr-only'}` otherwise never
-        // returns to depth 0, and the expression is dropped from the scan
-        // entirely rather than reported — the guard passing on the one shape
-        // it cannot read.
-        if (char === '"' || char === '\'' || char === '`') {
-          const close = contents.indexOf(char, i + 1);
-          if (close === -1) {
-            break;
-          }
-          i = close;
-          continue;
-        }
-
-        if (char === '{') {
-          depth++;
-        } else if (char === '}') {
-          depth--;
-          if (depth === 0) {
-            expressions.push(contents.slice(start, i + 1));
-            break;
-          }
-        }
-      }
-    } else if (opener === '"' || opener === '\'' || opener === '`') {
-      const end = contents.indexOf(opener, start + 1);
-      if (end !== -1) {
-        expressions.push(contents.slice(start, end + 1));
-      }
-    }
-  }
-
-  return expressions;
-}
-
-/**
- * Whether an expression puts the `sr-only` class on an element.
- *
- * Compares whole tokens rather than testing `\bsr-only\b`, which looks
- * equivalent and is not: `-` is a non-word character, so that pattern sits
- * beside the boundary and also matches `not-sr-only` and `sr-only-thing` —
- * failing this suite over a class with nothing to do with hiding anything.
- *
- * An expression with no string literal in it — `className={someVariable}` —
- * matches nothing, which is what leaves the `h2` override alone. That
- * override is the one place here that legitimately *reads* the class.
- * @param expression - One `className=` expression.
- * @returns True if any string literal in it carries the class.
- */
-function assignsSrOnly(expression: string): boolean {
-  return [...expression.matchAll(/["'`]([^"'`]*)["'`]/g)]
-    .some(([, value]) => value.split(/\s+/).includes('sr-only'));
-}
 
 describe('visuallyHidden', () => {
   it('should keep hidden content in the accessibility tree', () => {
@@ -119,19 +24,5 @@ describe('visuallyHidden', () => {
     // widens the set of browsers that render the element.
     expect(visuallyHidden.clip).toBe('rect(0, 0, 0, 0)');
     expect(visuallyHidden.clipPath).toBe('inset(50%)');
-  });
-
-  it('should be used instead of an sr-only class no stylesheet defines', () => {
-    // MAIDR ships no stylesheet: `dist/maidr.css` is a placeholder and the UI
-    // is styled at runtime by emotion. So `className="sr-only"` is not a
-    // hidden element, it is a plain one — `TypingEffect`'s live region carried
-    // it and rendered every finished chat message a second time, in full, on
-    // any page that did not happen to define the class itself.
-    const offenders = sourceFiles().filter((file) => {
-      const contents = readFileSync(join(ROOT, file), 'utf8');
-      return classNameExpressions(contents).some(assignsSrOnly);
-    });
-
-    expect(offenders).toEqual([]);
   });
 });

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+import { visuallyHidden } from '@ui/visuallyHidden';
+
+/**
+ * Guards the two ways visually-hidden content silently stops working here.
+ *
+ * Neither is visible in a component test: `TypingEffect` imports
+ * `react-markdown`, which is ESM and unloadable by this CommonJS suite (#678),
+ * and the failure that prompted this is a *missing* stylesheet rather than
+ * anything a rendered tree would show.
+ */
+
+const ROOT = resolve(__dirname, '../..');
+
+/** Every tracked source file that could render markup. */
+function sourceFiles(): string[] {
+  return execFileSync('git', ['ls-files', 'src'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n')
+    .filter(file => file.endsWith('.tsx') || file.endsWith('.ts'));
+}
+
+describe('visuallyHidden', () => {
+  it('should keep hidden content in the accessibility tree', () => {
+    // The whole point, and the easiest thing to lose while "simplifying":
+    // `display: none` and `visibility: hidden` are shorter, look equivalent,
+    // and remove the element from the accessibility tree — which would mute
+    // the live regions that use this rather than merely restyling them.
+    expect(visuallyHidden.display).toBeUndefined();
+    expect(visuallyHidden.visibility).toBeUndefined();
+
+    expect(visuallyHidden.clip).toBe('rect(0, 0, 0, 0)');
+    expect(visuallyHidden.position).toBe('absolute');
+    expect(visuallyHidden.overflow).toBe('hidden');
+  });
+
+  it('should be used instead of an sr-only class no stylesheet defines', () => {
+    // MAIDR ships no stylesheet: `dist/maidr.css` is a placeholder and the UI
+    // is styled at runtime by emotion. So `className="sr-only"` is not a
+    // hidden element, it is a plain one — `TypingEffect`'s live region carried
+    // it and rendered every finished chat message a second time, in full, on
+    // any page that did not happen to define the class itself.
+    const offenders = sourceFiles().filter((file) => {
+      const contents = readFileSync(join(ROOT, file), 'utf8');
+      return /className=["'][^"']*\bsr-only\b/.test(contents);
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -1,12 +1,76 @@
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from '@jest/globals';
 import { visuallyHidden } from '@ui/visuallyHidden';
 
+const ROOT = resolve(__dirname, '../..');
+
 /**
- * The one property of this style that is not obvious from reading it.
+ * One case for the `sr-only` lint rule, and whether it should be reported.
  *
- * Reintroducing an `sr-only` class is guarded by `no-restricted-syntax` in
- * `eslint.config.ts` rather than here — that needs an AST, not a test.
+ * The forms are not hypothetical. Each is one the guard this rule replaced got
+ * wrong at some point while it was a regex over source text — a hyphen next to
+ * a word boundary, a template truncated at the first `}`, a brace inside a
+ * string literal — and each failed by silently passing.
  */
+// The `${...}` below are fixture text, not interpolations that lost their
+// backticks — two of these cases exist precisely because a template
+// interpolation is what used to break the guard.
+/* eslint-disable no-template-curly-in-string */
+const CASES: readonly { code: string; flagged: boolean }[] = [
+  { code: 'className="sr-only"', flagged: true },
+  { code: 'className={\'sr-only\'}', flagged: true },
+  { code: 'className={`sr-only`}', flagged: true },
+  { code: 'className={cond ? \'sr-only\' : undefined}', flagged: true },
+  { code: 'className={`${cond} sr-only`}', flagged: true },
+  { code: 'className={cond ? \'a{b\' : \'sr-only\'}', flagged: true },
+  // Different classes that merely contain the text, and an expression with no
+  // literal in it — which is the shape the `h2` override uses to read the
+  // class rather than assign one.
+  { code: 'className="not-sr-only"', flagged: false },
+  { code: 'className={`${cond}-sr-only`}', flagged: false },
+  { code: 'className={someVariable}', flagged: false },
+];
+/* eslint-enable no-template-curly-in-string */
+
+/**
+ * Lines that `no-restricted-syntax` reports, one case per line.
+ *
+ * Runs the repo's own ESLint config rather than reconstructing the rule, so
+ * this cannot pass against a selector that differs from the one in force.
+ * Piped through stdin so no fixture file has to exist under `src/`, where it
+ * would be linted and type-checked on its own account.
+ * @param source - The fixture to lint.
+ * @returns The 1-based line numbers reported.
+ */
+function restrictedSyntaxLines(source: string): number[] {
+  let output: string;
+  try {
+    output = execFileSync(
+      join(ROOT, 'node_modules/.bin/eslint'),
+      ['--stdin', '--stdin-filename', 'src/srOnlyFixture.tsx', '--format', 'json'],
+      { cwd: ROOT, input: source, encoding: 'utf8' },
+    );
+  } catch (error) {
+    // Expected: the fixture is written to produce errors, and eslint exits
+    // non-zero when it finds any. The report is still on stdout — but only if
+    // it ran at all, so an empty one means the process failed for some other
+    // reason and must not be read as "nothing was reported".
+    const { stdout } = error as { stdout?: string };
+    if (!stdout) {
+      throw error;
+    }
+    output = stdout;
+  }
+
+  const [result] = JSON.parse(output) as {
+    messages: { line: number; ruleId: string | null }[];
+  }[];
+
+  return result.messages
+    .filter(message => message.ruleId === 'no-restricted-syntax')
+    .map(message => message.line);
+}
 
 describe('visuallyHidden', () => {
   it('should keep hidden content in the accessibility tree', () => {
@@ -24,5 +88,20 @@ describe('visuallyHidden', () => {
     // widens the set of browsers that render the element.
     expect(visuallyHidden.clip).toBe('rect(0, 0, 0, 0)');
     expect(visuallyHidden.clipPath).toBe('inset(50%)');
+  });
+});
+
+describe('the sr-only lint rule', () => {
+  it('should report the class however it is written, and nothing else', () => {
+    const source = CASES.map(({ code }) => `export const x = () => <div ${code} />;`).join('\n');
+
+    const reported = new Set(restrictedSyntaxLines(source));
+
+    // Both directions in one assertion: a selector that matched everything
+    // would pass a check for the flagged cases alone, and one that matched
+    // nothing would pass a check for the ignored ones.
+    const actual = CASES.map(({ code }, index) => `${code} -> ${reported.has(index + 1)}`);
+    const expected = CASES.map(({ code, flagged }) => `${code} -> ${flagged}`);
+    expect(actual).toEqual(expected);
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

`TypingEffect`'s screen-reader live region was marked hidden with a class nothing defines:

```tsx
<div className="sr-only" aria-live={settings.general.ariaMode} aria-atomic="true">
  {isTyping ? '' : text}
</div>
```

```
grep -c "sr-only" dist/maidr.css dist/maidr-math.css
  dist/maidr.css:0
  dist/maidr-math.css:0

tailwind / bootstrap in dependencies:  []
```

So it was an ordinary block element holding the **full message text**, and every finished assistant message rendered a second time, in full, below the typed one.

This is not an oversight that happened to be harmless — MAIDR embeds in pages it does not control, so "the host might define `.sr-only`" is not something the library can lean on. Bootstrap 4 shipped it, Bootstrap 5 renamed it to `.visually-hidden`, Tailwind provides it only if the page uses Tailwind. Any page with none of those gets the duplicate.

## Related Issues

Closes #697. Found while reviewing #695.

## Changes Made

The project already had the right mechanism, used in exactly one place — `Text.tsx`'s clip-pattern style object. Lifted to `src/ui/visuallyHidden.ts` now that there is a second caller, and used for the chat live region.

**A global `.sr-only` rule was the other option and is worse.** `sr-only` is a common name, so a rule shipped by an embedded library either loses to the host page's or silently wins over it for the rest of the page — restyling markup that has nothing to do with MAIDR. An inline style cannot reach past the elements MAIDR renders.

It also would not have been possible without changing the build: `dist/maidr.css` is a deliberate **placeholder**, emitted so integrations that link it by name keep working after KaTeX's stylesheet was split out. `scripts/vite-plugin-math-stylesheet.js` documents that MAIDR has no static CSS left at all.

Two smaller things in the same area:

- **The footnotes heading** arrives from the markdown pipeline as `<h2 class="sr-only">` — `mdast-util-to-hast` hardcodes both, and expects a stylesheet to honour the class. React cannot put an inline style on markup the pipeline generates, so the class is matched in the existing `h2` component override. This is **not a regression from #695**: before it, `h2` was disallowed and `rehype-sanitize` dropped the element while keeping its text, so "Footnotes" was already visible, just as loose prose.
- **`Constant.SR_ONLY_CLASS`** is removed. It named a third spelling of the same idea — `'maidr-sr-only'` — that nothing styled and nothing used, which is worse than absent because it reads like the mechanism.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no documented behaviour changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Verified in a real browser

`TypingEffect` cannot be rendered here — the chat needs an LLM backend, and it imports ESM-only `react-markdown` besides (#678). But the style is shared with `Text.tsx` and needs neither. Chromium, with the exact style object and three `role="alert"` elements:

```
#hidden   box=1x1          (visuallyHidden)
#visible  box=1264x18      (ordinary block)
#none     box=null         (display:none)
```

```
ARIA snapshot of <main>:
  - alert: Announced but unseen
```

Three went in, **one came out**. The `visuallyHidden` element is invisible *and* announced; `display: none` and `visibility: hidden` are absent from the accessibility tree entirely — which is why the unit test pins both as unset rather than trusting a comment about what they do.

### On the guard

The two ways this regresses silently are guarded separately.

**The class returning** is a `no-restricted-syntax` rule in `eslint.config.ts`, matched on the AST. It began as a regex over `className=` in a test and was wrong three times — a word boundary beside a hyphen, truncation at the first `}` inside a template, a brace inside a string literal — each failing by *silently passing*, which is the wrong failure mode for the only protection a fix has. The selector gets a real parse for free, runs on every file rather than only when one test does, and needs no allowlist: scoping to `JSXAttribute[name.name='className']` leaves the `h2` override alone, since that reads the class in a `style` attribute rather than assigning one.

That rule is itself pinned by a test that lints a fixture through **the repo's own eslint binary and config**, not `RuleTester` — a reconstruction can agree with itself while disagreeing with what CI enforces. Nine cases, both directions:

```
className="sr-only"                        FLAGGED
className={'sr-only'}                      FLAGGED
className={`sr-only`}                      FLAGGED
className={cond ? 'sr-only' : undefined}   FLAGGED
className={`${cond} sr-only`}              FLAGGED
className={cond ? 'a{b' : 'sr-only'}       FLAGGED
className="not-sr-only"                    ignored
className={`${cond}-sr-only`}              ignored
className={someVariable}                   ignored
```

**The style being "simplified"** to `display: none` or `visibility: hidden` is a unit assertion. Both are shorter and look equivalent, and the browser check above shows what they actually do.

### What is still not verified

That the duplicate text is gone and the region announces in a real screen reader. Chromium's accessibility tree is not a screen reader any more than jsdom is, and the component cannot be rendered by this suite at all. That needs #678 and a human with assistive technology.

| check | result |
|---|---|
| `npm test` | 1328 passed, 104 suites |
| `npm run build` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npx eslint . --fix` | exit 0 |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz