### PR TITLE
fix(chat): let a link's own text be its accessible name

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -119,11 +119,14 @@ const config: ReturnType<typeof antfu> = antfu({
       // selector was redundant, and only showed up as redundant because
       // breaking it left the test still passing.
       //
-      // Matches the name, not the value, so a renamed binding
-      // (`const { children: kids } = props`) passes. That is the limit of a
-      // syntactic selector rather than something to widen: guessing at names
-      // would cost false positives, and the shape this exists to stop is the
-      // one that was actually written.
+      // Matches the name, not the value, so it errs in both directions: a
+      // renamed binding (`const { children: kids } = props`) passes, and a
+      // `children` belonging to something other than React would be reported.
+      // Both are the limit of a syntactic selector rather than something to
+      // widen — closing either needs scope or type information the rule does
+      // not have — and the shape this exists to stop is the one that was
+      // actually written. A false report is at least loud, and silenced at
+      // the line with a reason.
       selector: 'JSXAttribute[name.name=\'aria-label\'] Identifier[name=\'children\']',
       message: 'Do not build aria-label from children: it stringifies to "[object Object]" unless the child is a plain string, and aria-label replaces the accessible name the element already had.',
     }],

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -103,6 +103,23 @@ const config: ReturnType<typeof antfu> = antfu({
     }, {
       selector: 'JSXAttribute[name.name=\'className\'] TemplateElement[value.raw=/(^|\\s)sr-only(\\s|$)/]',
       message: 'Nothing defines .sr-only in MAIDR, so this element is visible. Use the visuallyHidden style object from @ui/visuallyHidden.',
+    }, {
+      // `children` is a React node, not a string. Interpolating it yields
+      // "[object Object]" for anything but a bare string — an element for
+      // `[**bold**](url)`, an array for mixed content — and `aria-label`
+      // replaces the accessible name rather than supplementing it, so the
+      // visible text is not a fallback. A chat link announced as
+      // "Link: [object Object]" is where this came from.
+      //
+      // An element's own text is already its accessible name. Deriving one
+      // from children can at best reproduce that and at worst destroy it.
+      // One selector, not two. `props.children` is a MemberExpression whose
+      // property is an Identifier named `children`, so matching the identifier
+      // covers the member access as well — a separate MemberExpression
+      // selector was redundant, and only showed up as redundant because
+      // breaking it left the test still passing.
+      selector: 'JSXAttribute[name.name=\'aria-label\'] Identifier[name=\'children\']',
+      message: 'Do not build aria-label from children: it stringifies to "[object Object]" unless the child is a plain string, and aria-label replaces the accessible name the element already had.',
     }],
   },
 });

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -118,6 +118,12 @@ const config: ReturnType<typeof antfu> = antfu({
       // covers the member access as well — a separate MemberExpression
       // selector was redundant, and only showed up as redundant because
       // breaking it left the test still passing.
+      //
+      // Matches the name, not the value, so a renamed binding
+      // (`const { children: kids } = props`) passes. That is the limit of a
+      // syntactic selector rather than something to widen: guessing at names
+      // would cost false positives, and the shape this exists to stop is the
+      // one that was actually written.
       selector: 'JSXAttribute[name.name=\'aria-label\'] Identifier[name=\'children\']',
       message: 'Do not build aria-label from children: it stringifies to "[object Object]" unless the child is a plain string, and aria-label replaces the accessible name the element already had.',
     }],

--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -156,15 +156,15 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
             pre: ({ node, ...props }) => (
               <pre {...props} role="text" aria-label="Code block" />
             ),
-            // Fall back rather than overwrite, the way the `img` override
-            // below already does. A prop after a spread wins unconditionally,
-            // so this used to discard any `aria-label` the pipeline had set —
-            // and the one case that has one is the footnote backref, whose
-            // visible text is a bare return arrow. It announced as "Link: ↩"
-            // in place of "Back to reference 1".
-            a: ({ node, ...props }) => (
-              <a {...props} aria-label={props['aria-label'] ?? `Link: ${props.children}`} />
-            ),
+            // No `a` override. A link's accessible name comes from its own
+            // text, which is right in every case and needs no help: the one
+            // this used to build — `Link: ${children}` — was a worse copy of
+            // that when children was a string, and `[object Object]` when it
+            // was anything else. `aria-label` replaces the name rather than
+            // supplementing it, so there was no fallback to the visible text.
+            //
+            // Dropping it also lets the footnote backref keep the label
+            // remark-gfm gives it, without a fallback expression to get wrong.
             img: ({ node, ...props }) => (
               <img {...props} alt={props.alt || 'Image in message'} />
             ),

--- a/src/util/markdownSanitize.ts
+++ b/src/util/markdownSanitize.ts
@@ -122,10 +122,10 @@ export const MATHML_ATTRIBUTES: readonly string[] = [
  *
  * The list used to also carry `role`, `ariaLabel`, `ariaBusy`, `ariaLive` and
  * `ariaAtomic`, on the reasoning that nothing in the pipeline emitted any of
- * them — the `role` and `aria-label` `TypingEffect` puts on `<pre>` and `<a>`
- * are React props, applied after sanitisation — and that while they were
- * misspelled they were inert. Correcting the spelling would have made them
- * live for the first time, so they were dropped instead.
+ * them — the `role` and `aria-label` `TypingEffect` puts on `<pre>` are React
+ * props, applied after sanitisation — and that while they were misspelled
+ * they were inert. Correcting the spelling would have made them live for the
+ * first time, so they were dropped instead.
  *
  * That reasoning held only while footnotes were being dropped too. remark-gfm
  * emits `ariaLabel` and `ariaDescribedBy` on the reference and backref links,

--- a/test/ui/chatLinkLabel.test.ts
+++ b/test/ui/chatLinkLabel.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@jest/globals';
+import { lintOutcomes } from './restrictedSyntax';
+
+/**
+ * One case for the `aria-label`-from-children rule, and its expectation.
+ *
+ * The chat link override used to build `Link: ${props.children}`, which is a
+ * string only when the link text has no markup in it. Anything else — an
+ * element for `[**bold**](url)`, an array for mixed content — stringifies to
+ * `[object Object]`, and `aria-label` replaces the accessible name rather
+ * than supplementing it, so the visible text is not a fallback.
+ */
+// Fixture text, not interpolations missing their backticks.
+/* eslint-disable no-template-curly-in-string */
+const CASES: readonly { code: string; flagged: boolean }[] = [
+  { code: 'aria-label={`Link: ${props.children}`}', flagged: true },
+  { code: 'aria-label={`Link: ${children}`}', flagged: true },
+  { code: 'aria-label={String(props.children)}', flagged: true },
+  // Passing an existing label through, and a literal one. Both are names
+  // someone decided on, rather than a stringified React node.
+  { code: 'aria-label={props[\'aria-label\']}', flagged: false },
+  { code: 'aria-label="Back to reference 1"', flagged: false },
+  { code: 'aria-label={label}', flagged: false },
+];
+/* eslint-enable no-template-curly-in-string */
+
+describe('the aria-label lint rule', () => {
+  it('should report a label built from children, and nothing else', () => {
+    const { actual, expected } = lintOutcomes(CASES);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/test/ui/restrictedSyntax.ts
+++ b/test/ui/restrictedSyntax.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+
+/**
+ * Lines that `no-restricted-syntax` reports for a fixture.
+ *
+ * Runs the repo's own ESLint config rather than reconstructing a rule with
+ * `RuleTester`. A reconstruction can agree with itself while disagreeing with
+ * the config in force, which is the failure these tests exist to exclude.
+ * Piped through stdin so no fixture file has to exist under `src/`, where it
+ * would be linted and type-checked on its own account.
+ * @param source - The fixture to lint, one case per line.
+ * @returns The 1-based line numbers reported.
+ */
+export function restrictedSyntaxLines(source: string): number[] {
+  let output: string;
+  try {
+    output = execFileSync(
+      join(ROOT, 'node_modules/.bin/eslint'),
+      ['--stdin', '--stdin-filename', 'src/lintFixture.tsx', '--format', 'json'],
+      { cwd: ROOT, input: source, encoding: 'utf8' },
+    );
+  } catch (error) {
+    // Expected: the fixtures are written to produce errors, and eslint exits
+    // non-zero when it finds any. The report is still on stdout — but only if
+    // it ran at all, so an empty one means the process failed for some other
+    // reason and must not be read as "nothing was reported".
+    const { stdout } = error as { stdout?: string };
+    if (!stdout) {
+      throw error;
+    }
+    output = stdout;
+  }
+
+  const [result] = JSON.parse(output) as {
+    messages: { line: number; ruleId: string | null }[];
+  }[];
+
+  return result.messages
+    .filter(message => message.ruleId === 'no-restricted-syntax')
+    .map(message => message.line);
+}
+
+/**
+ * Asserts each case is reported or not, as declared.
+ *
+ * Compares the whole list in one go rather than case by case: a selector that
+ * matched everything would satisfy a check of the flagged cases alone, and one
+ * that matched nothing would satisfy a check of the ignored ones.
+ * @param cases - Each JSX attribute to place on a `div`, and its expectation.
+ * @returns Actual and expected labels, ready to compare.
+ */
+export function lintOutcomes(
+  cases: readonly { code: string; flagged: boolean }[],
+): { actual: string[]; expected: string[] } {
+  const source = cases.map(({ code }) => `export const x = () => <div ${code} />;`).join('\n');
+  const reported = new Set(restrictedSyntaxLines(source));
+
+  return {
+    actual: cases.map(({ code }, index) => `${code} -> ${reported.has(index + 1)}`),
+    expected: cases.map(({ code, flagged }) => `${code} -> ${flagged}`),
+  };
+}

--- a/test/ui/visuallyHidden.test.ts
+++ b/test/ui/visuallyHidden.test.ts
@@ -1,9 +1,6 @@
-import { execFileSync } from 'node:child_process';
-import { join, resolve } from 'node:path';
 import { describe, expect, it } from '@jest/globals';
 import { visuallyHidden } from '@ui/visuallyHidden';
-
-const ROOT = resolve(__dirname, '../..');
+import { lintOutcomes } from './restrictedSyntax';
 
 /**
  * One case for the `sr-only` lint rule, and whether it should be reported.
@@ -33,45 +30,6 @@ const CASES: readonly { code: string; flagged: boolean }[] = [
 ];
 /* eslint-enable no-template-curly-in-string */
 
-/**
- * Lines that `no-restricted-syntax` reports, one case per line.
- *
- * Runs the repo's own ESLint config rather than reconstructing the rule, so
- * this cannot pass against a selector that differs from the one in force.
- * Piped through stdin so no fixture file has to exist under `src/`, where it
- * would be linted and type-checked on its own account.
- * @param source - The fixture to lint.
- * @returns The 1-based line numbers reported.
- */
-function restrictedSyntaxLines(source: string): number[] {
-  let output: string;
-  try {
-    output = execFileSync(
-      join(ROOT, 'node_modules/.bin/eslint'),
-      ['--stdin', '--stdin-filename', 'src/srOnlyFixture.tsx', '--format', 'json'],
-      { cwd: ROOT, input: source, encoding: 'utf8' },
-    );
-  } catch (error) {
-    // Expected: the fixture is written to produce errors, and eslint exits
-    // non-zero when it finds any. The report is still on stdout — but only if
-    // it ran at all, so an empty one means the process failed for some other
-    // reason and must not be read as "nothing was reported".
-    const { stdout } = error as { stdout?: string };
-    if (!stdout) {
-      throw error;
-    }
-    output = stdout;
-  }
-
-  const [result] = JSON.parse(output) as {
-    messages: { line: number; ruleId: string | null }[];
-  }[];
-
-  return result.messages
-    .filter(message => message.ruleId === 'no-restricted-syntax')
-    .map(message => message.line);
-}
-
 describe('visuallyHidden', () => {
   it('should keep hidden content in the accessibility tree', () => {
     // The whole point, and the easiest thing to lose while "simplifying":
@@ -93,15 +51,8 @@ describe('visuallyHidden', () => {
 
 describe('the sr-only lint rule', () => {
   it('should report the class however it is written, and nothing else', () => {
-    const source = CASES.map(({ code }) => `export const x = () => <div ${code} />;`).join('\n');
+    const { actual, expected } = lintOutcomes(CASES);
 
-    const reported = new Set(restrictedSyntaxLines(source));
-
-    // Both directions in one assertion: a selector that matched everything
-    // would pass a check for the flagged cases alone, and one that matched
-    // nothing would pass a check for the ignored ones.
-    const actual = CASES.map(({ code }, index) => `${code} -> ${reported.has(index + 1)}`);
-    const expected = CASES.map(({ code, flagged }) => `${code} -> ${flagged}`);
     expect(actual).toEqual(expected);
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

`TypingEffect`'s link override built the accessible name by interpolating React children:

```tsx
a: ({ node, ...props }) => (
  <a {...props} aria-label={props['aria-label'] ?? `Link: ${props.children}`} />
),
```

`children` is a React node. It is a string only when the link text has no markup in it — anything else goes through `Object.prototype.toString`:

| markdown | announced as |
|---|---|
| `[plain](url)` | `Link: plain` |
| `[**bold**](url)` | `Link: [object Object]` |
| `` [a `b` c](url) `` | `Link: a,[object Object],c` |
| `[[alt](img.png)](url)` | `Link: [object Object]` |

`aria-label` **replaces** the accessible name rather than supplementing it, so the visible text is not a fallback: a screen reader user gets `[object Object]` and nothing else. Emphasis inside link text is ordinary in LLM output, so this is not a rare shape.

## Related Issues

Closes #698. Found while reviewing #695, and left out of #699 because it needed a decision rather than a fallback.

## Changes Made

**Removed the override** rather than extracting text from the React tree — the issue listed both options and this one needed deciding, so I checked it in Chromium's accessibility tree rather than reasoning about it:

```
aria-label="Link: [object Object]"    ->  link "Link: [object Object]"
no aria-label                         ->  link "Download the data"
aria-label="Link: Download the data"  ->  link "Link: Download the data"
```

The middle line is the name the element already had, computed from its own content — correct for every case in the table above, including the image-only link, where it resolves to the image's `alt`.

The third line shows what the override bought when `children` happened to be a string: a `"Link: "` prefix duplicating the role a screen reader announces anyway. So the override was, at best, a worse copy of the name it replaced.

Removing it also deletes a fallback expression that had to be right. The footnote backref keeps the `aria-label` remark-gfm gives it because nothing overwrites it now, rather than because the `??` branch is correct — `ariaLabel` is already allowlisted on `a` in `createChatSanitizeSchema`, so it flows through natively.

**A `no-restricted-syntax` rule** so the same construction cannot return. Deriving `aria-label` from `children` is the general form of this bug, not a MAIDR-specific one.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no documented behaviour changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### This is a behaviour change, deliberately

Every chat link stops announcing with a `"Link: "` prefix. That is the point rather than a side effect — an `<a href>` is already announced as a link by its role, so the prefix made a link read roughly as "link, Link: download the data". Worth a maintainer's eye even though I am confident it is an improvement.

### On the rule, and a redundancy it caught in itself

The rule is **one** selector, not two. `props.children` is a `MemberExpression` whose property is an `Identifier` named `children`, so matching the identifier covers the member access too.

I only noticed because of the check that follows every rule in this repo now: I broke the `MemberExpression` selector expecting the test to fail, and it passed. The second selector was doing nothing. That is the same discipline that turned up three defects in the `sr-only` guard on #699, and it is cheap.

```
aria-label={`Link: ${props.children}`}   FLAGGED
aria-label={`Link: ${children}`}         FLAGGED
aria-label={String(props.children)}      FLAGGED
aria-label={props['aria-label']}         ignored
aria-label="Back to reference 1"         ignored
aria-label={label}                       ignored
```

The three ignored cases are names someone decided on, rather than a stringified React node. Breaking the remaining selector fails the test.

The fixture helper moved to `test/ui/restrictedSyntax.ts` now that a second rule uses it. It still lints through the repo's **own** eslint binary and config rather than `RuleTester`, so it cannot drift from what CI enforces.

### Not fixed here

The `pre` override sets `role="text"`, which is not in the ARIA specification, alongside `aria-label="Code block"`. My issue flagged it as worth reviewing in the same pass, so I looked: I could **not** demonstrate a problem. Playwright's ARIA snapshot is normalised and reads the same in Chromium and WebKit, which is where `role="text"` would matter. Rather than assert a bug I could not reproduce, I left it for someone who can check against a real screen reader.

### What is not verified

That a real screen reader announces the link text as expected. Chromium's accessibility tree is not a screen reader, and `TypingEffect` cannot be rendered by this suite at all — it imports ESM-only `react-markdown` (#678).

| check | result |
|---|---|
| `npm test` | 1329 passed, 105 suites |
| `npm run build` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npx eslint . --fix` | exit 0 |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz)_