### PR TITLE
fix(chat): make footnote anchors in a chat response resolve

### DIFF
--- a/src/ui/components/TypingEffect.tsx
+++ b/src/ui/components/TypingEffect.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import { useViewModelState } from '@state/hook/useViewModel';
 import { visuallyHidden } from '@ui/visuallyHidden';
+import { rehypeScopeIds } from '@util/footnoteScope';
 import { containsLatex, ensureKatexStylesheet } from '@util/katex';
 import { createChatSanitizeSchema } from '@util/markdownSanitize';
 import React, { memo, useEffect, useMemo, useState } from 'react';
@@ -150,6 +151,13 @@ export const TypingEffect: React.FC<TypingEffectProps> = memo(({ text, isUser, m
             // allowlist rather than around it.
             ...mathPlugins,
             [rehypeSanitize, SANITIZE_SCHEMA],
+            // After it, and it has to be: the sanitiser renames `id` and the
+            // ARIA references but not `href`, so a footnote anchor is left
+            // naming where its target used to be. Scoping both sides here puts
+            // them back in agreement and makes the ids unique to this message,
+            // which they are not otherwise — footnotes are numbered per
+            // document and a transcript is one DOM. See `footnoteScope`.
+            [rehypeScopeIds, { messageId }],
           ]}
           remarkPlugins={[remarkGfm, remarkMath]}
           components={{

--- a/src/util/footnoteScope.ts
+++ b/src/util/footnoteScope.ts
@@ -57,21 +57,62 @@ const CLOBBERED = defaultSchema.clobberPrefix ?? '';
 const ID_REFERENCES = ['ariaDescribedBy', 'ariaLabelledBy'] as const;
 
 /**
+ * Whether this element's `name` is a fragment target rather than a field name.
+ *
+ * `name` is in the sanitiser's `clobber` list for the same reason `id` is —
+ * a browser resolves `#foo` against an anchor's `name` as well as an `id` — so
+ * it has to be scoped alongside `id` or an `href` aimed at one would dangle
+ * exactly as this fixes for `id`.
+ *
+ * Only on an anchor, though. Everywhere else `name` is a form control's field
+ * name, and renaming that would change what a form submits rather than where a
+ * link goes. The chat schema admits neither today — `input` is pinned to
+ * `type`, `checked` and `disabled` precisely to keep `name` out — so this is
+ * about the plugin staying correct if one is ever allowed in, not about markup
+ * that reaches it now.
+ * @param element - The element to test.
+ * @returns True if `name` on this element names a fragment.
+ */
+function namesFragment(element: Element): boolean {
+  return element.tagName === 'a';
+}
+
+/**
  * Turns a message id into something safe to put in an `id`, injectively.
  *
- * A message id is `msg-1234` or `resp-1234-<model>`, and a model name can
- * carry a dot or a slash. Every character outside `[A-Za-z0-9-]` becomes
- * `_<hex>_`, which cannot be confused with a literal because `_` is itself
- * outside the set and so is escaped too. Two different message ids therefore
- * cannot encode to the same token, which is what the uniqueness rests on.
+ * A message id is `msg-1234` or `resp-1234-<model>`, and a model name really
+ * does carry a dot — `gpt-5.5`, `gemini-3.5-flash`. Every character outside
+ * `[A-Za-z0-9-]` becomes `_<hex>_`, underscore included, so no two message ids
+ * can encode to the same token. Stripping instead would map `a.b` and `a-b`
+ * together and quietly reintroduce the collision this exists to prevent.
  * @param messageId - The message's id.
  * @returns An id-safe token.
  */
 function token(messageId: string): string {
   return messageId.replace(
-    /[^\w-]|_/g,
+    /[^a-z0-9-]/gi,
     character => `_${character.charCodeAt(0).toString(16)}_`,
   );
+}
+
+/**
+ * The properties on this element that define a fragment target.
+ * @param element - The element to inspect.
+ * @returns `['id']`, or `['id', 'name']` on an anchor.
+ */
+function targetAttributes(element: Element): readonly string[] {
+  return namesFragment(element) ? ['id', 'name'] : ['id'];
+}
+
+/**
+ * The fragment targets this element defines.
+ * @param element - The element to inspect.
+ * @returns Every non-empty target name on it.
+ */
+function targets(element: Element): string[] {
+  return targetAttributes(element)
+    .map(attribute => element.properties?.[attribute])
+    .filter((value): value is string => typeof value === 'string' && value !== '');
 }
 
 /** Every element in the tree, in document order. */
@@ -130,10 +171,11 @@ export function rehypeScopeIds(options: { messageId: string }): (tree: Root) => 
     const all = elements(tree);
     const present = new Set<string>();
 
+    // Collected in a pass of its own, before anything is written, so the
+    // rewriting below cannot see a half-renamed tree and is order-independent.
     for (const element of all) {
-      const id = element.properties?.id;
-      if (typeof id === 'string' && id !== '') {
-        present.add(id);
+      for (const target of targets(element)) {
+        present.add(target);
       }
     }
 
@@ -154,8 +196,11 @@ export function rehypeScopeIds(options: { messageId: string }): (tree: Root) => 
         continue;
       }
 
-      if (typeof properties.id === 'string' && properties.id !== '') {
-        properties.id = scope + properties.id;
+      for (const attribute of targetAttributes(element)) {
+        const value = properties[attribute];
+        if (typeof value === 'string' && value !== '') {
+          properties[attribute] = scope + value;
+        }
       }
 
       for (const attribute of ID_REFERENCES) {

--- a/src/util/footnoteScope.ts
+++ b/src/util/footnoteScope.ts
@@ -78,19 +78,28 @@ function namesFragment(element: Element): boolean {
 }
 
 /**
- * Turns a message id into something safe to put in an `id`, injectively.
+ * Turns a message id into an id-safe token that no other message id can share.
  *
- * A message id is `msg-1234` or `resp-1234-<model>`, and a model name really
- * does carry a dot — `gpt-5.5`, `gemini-3.5-flash`. Every character outside
- * `[A-Za-z0-9-]` becomes `_<hex>_`, underscore included, so no two message ids
- * can encode to the same token. Stripping instead would map `a.b` and `a-b`
- * together and quietly reintroduce the collision this exists to prevent.
+ * Every character outside `[A-Za-z0-9]` becomes `_<hex>_`. That is injective on
+ * its own — `_` is itself outside the set, so an underscore in the output only
+ * ever begins an escape — and it is exercised in practice: a response id is
+ * `resp-<time>-<provider>` and the providers are `OPENAI`, `ANTHROPIC_CLAUDE`,
+ * `GOOGLE_GEMINI` and `OLLAMA`, three of which carry an underscore.
+ *
+ * `-` is escaped along with everything else, which matters for a reason
+ * injectivity alone does not cover. The final id is
+ * `user-content-<token>-<id>`, so what has to be unique is the whole
+ * concatenation rather than the token: with `-` left intact, token `m` with id
+ * `x-y` and token `m-x` with id `y` both spell `user-content-m-x-y`. Escaping
+ * it keeps `-` out of every token, which makes the first one the boundary and
+ * the decomposition unique — the property the cross-message guarantee actually
+ * rests on.
  * @param messageId - The message's id.
- * @returns An id-safe token.
+ * @returns An id-safe token containing no separator.
  */
 function token(messageId: string): string {
   return messageId.replace(
-    /[^a-z0-9-]/gi,
+    /[^a-z0-9]/gi,
     character => `_${character.charCodeAt(0).toString(16)}_`,
   );
 }
@@ -115,12 +124,22 @@ function targets(element: Element): string[] {
     .filter((value): value is string => typeof value === 'string' && value !== '');
 }
 
-/** Every element in the tree, in document order. */
-function elements(node: Nodes): Element[] {
-  const found: Element[] = node.type === 'element' ? [node] : [];
+/**
+ * Every element in the tree, in document order.
+ *
+ * Accumulates into one array rather than spreading a new one at each level:
+ * this runs on every render, and the typing animation renders every 10 ms.
+ * @param node - Where to start.
+ * @param found - The array being filled.
+ * @returns `found`.
+ */
+function elements(node: Nodes, found: Element[] = []): Element[] {
+  if (node.type === 'element') {
+    found.push(node);
+  }
   if ('children' in node) {
     for (const child of node.children) {
-      found.push(...elements(child));
+      elements(child, found);
     }
   }
   return found;

--- a/src/util/footnoteScope.ts
+++ b/src/util/footnoteScope.ts
@@ -1,0 +1,184 @@
+import type { Element, Nodes, Properties, Root } from 'hast';
+import { defaultSchema } from 'rehype-sanitize';
+
+/** One entry of a hast element's properties, in every shape hast allows. */
+type PropertyValue = Properties[string];
+
+/**
+ * Repairs and namespaces the ids in a rendered chat message, so footnote
+ * anchors resolve and two messages cannot claim the same id.
+ *
+ * Two faults, one pass, because fixing either alone leaves the other (#696).
+ *
+ * **The anchors dangle.** `mdast-util-to-hast` writes matching pairs, and then
+ * `hast-util-sanitize` applies its `clobberPrefix` to everything in `clobber`
+ * — `ariaDescribedBy`, `ariaLabelledBy`, `id`, `name`. `href` is not in that
+ * list, so the target moves and the link is left naming where it used to be:
+ *
+ * ```
+ * a  href="#user-content-fn-1"          <- untouched
+ * li id="user-content-user-content-fn-1" <- prefixed again
+ * ```
+ *
+ * `aria-describedby` survives precisely because it *is* in `clobber`, so it
+ * moves in step with the `id` it names.
+ *
+ * **The ids collide across messages.** Footnotes are numbered per document and
+ * each message is its own document, so every message with a footnote emits
+ * `fn-1`. A transcript is one DOM, which makes them duplicates — and once the
+ * anchors resolve, `getElementById` returns the first match, so a reference in
+ * the second message would jump to the first message's note. The dangling
+ * above is the only reason that has not been visible.
+ *
+ * Configuring a prefix cannot do this. `remark-rehype` takes `clobberPrefix`,
+ * but it only reaches ids derived from the footnote label —
+ * `mdast-util-to-hast` hardcodes the footnotes heading as `id: 'footnote-label'`
+ * (`lib/footer.js:236`) and documents that it is "always added" — so a
+ * per-message prefix still leaves that one colliding. Rewriting the tree is the
+ * only place both can be fixed.
+ */
+
+/**
+ * The prefix `hast-util-sanitize` has already applied to every `id`.
+ *
+ * Read from the library rather than written out, because it is the value the
+ * sanitiser actually used: the chat schema declares only `tagNames` and
+ * `attributes`, so `clobberPrefix` is whatever the default says, and a copy
+ * here would be a second source of truth that could silently stop matching.
+ */
+const CLOBBERED = defaultSchema.clobberPrefix ?? '';
+
+/**
+ * Properties naming other elements' ids, which have to move with them.
+ *
+ * `href` is handled separately: the others were rewritten by the sanitiser and
+ * so already name the current id, while `href` still names the original.
+ */
+const ID_REFERENCES = ['ariaDescribedBy', 'ariaLabelledBy'] as const;
+
+/**
+ * Turns a message id into something safe to put in an `id`, injectively.
+ *
+ * A message id is `msg-1234` or `resp-1234-<model>`, and a model name can
+ * carry a dot or a slash. Every character outside `[A-Za-z0-9-]` becomes
+ * `_<hex>_`, which cannot be confused with a literal because `_` is itself
+ * outside the set and so is escaped too. Two different message ids therefore
+ * cannot encode to the same token, which is what the uniqueness rests on.
+ * @param messageId - The message's id.
+ * @returns An id-safe token.
+ */
+function token(messageId: string): string {
+  return messageId.replace(
+    /[^\w-]|_/g,
+    character => `_${character.charCodeAt(0).toString(16)}_`,
+  );
+}
+
+/** Every element in the tree, in document order. */
+function elements(node: Nodes): Element[] {
+  const found: Element[] = node.type === 'element' ? [node] : [];
+  if ('children' in node) {
+    for (const child of node.children) {
+      found.push(...elements(child));
+    }
+  }
+  return found;
+}
+
+/**
+ * Rewrites an id-valued property, which hast may hold as a string or a list.
+ *
+ * `ariaDescribedBy` arrives as `['user-content-footnote-label']` — hast models
+ * space-separated attributes as arrays, and reading it as a string is why the
+ * first version of this left the one reference that worked pointing at an id
+ * that no longer existed.
+ * @param value - The property's current value.
+ * @param rename - Maps a current id to its scoped replacement.
+ * @returns The value with known ids replaced, in the shape it arrived in.
+ */
+function reference(value: PropertyValue, rename: (id: string) => string): PropertyValue {
+  if (typeof value === 'string') {
+    return value.split(/\s+/).filter(Boolean).map(rename).join(' ');
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => (typeof item === 'string' ? rename(item) : item));
+  }
+  return value;
+}
+
+/**
+ * A rehype plugin that scopes a message's ids to that message and re-points
+ * everything naming them.
+ *
+ * Must run **after** `rehype-sanitize`. Before it, the sanitiser would prefix
+ * the ids again and undo the agreement this restores.
+ *
+ * The scope keeps the `user-content-` convention that carries the
+ * anti-clobbering guarantee — chat content cannot define an `id` that shadows
+ * one on the host page — and adds the per-message part that makes it unique.
+ * That guarantee now comes from here rather than from the sanitiser's prefix,
+ * which is the trade this fix makes knowingly; `test/util/footnoteScope.esm-test.ts`
+ * pins it.
+ * @param options - The message this tree belongs to.
+ * @param options.messageId - Its id, which becomes the scope.
+ * @returns The transform.
+ */
+export function rehypeScopeIds(options: { messageId: string }): (tree: Root) => void {
+  const scope = `user-content-${token(options.messageId)}-`;
+
+  return (tree: Root): void => {
+    const all = elements(tree);
+    const present = new Set<string>();
+
+    for (const element of all) {
+      const id = element.properties?.id;
+      if (typeof id === 'string' && id !== '') {
+        present.add(id);
+      }
+    }
+
+    if (present.size === 0) {
+      return;
+    }
+
+    /**
+     * The scoped name for an id that already exists in this tree.
+     * @param id - An id as it appears now.
+     * @returns The scoped id, or the input if this tree does not define it.
+     */
+    const scoped = (id: string): string => (present.has(id) ? scope + id : id);
+
+    for (const element of all) {
+      const properties = element.properties;
+      if (!properties) {
+        continue;
+      }
+
+      if (typeof properties.id === 'string' && properties.id !== '') {
+        properties.id = scope + properties.id;
+      }
+
+      for (const attribute of ID_REFERENCES) {
+        if (attribute in properties) {
+          properties[attribute] = reference(properties[attribute], scoped);
+        }
+      }
+
+      const href = properties.href;
+      if (typeof href === 'string' && href.startsWith('#')) {
+        // The one place the sanitiser's damage is undone rather than followed.
+        // Every other reference was rewritten alongside its target, so it names
+        // the current id; `href` was not, so it still names the original and
+        // has to be matched against the prefixed form first.
+        const named = href.slice(1);
+        const target = present.has(CLOBBERED + named)
+          ? CLOBBERED + named
+          : named;
+
+        if (present.has(target)) {
+          properties.href = `#${scope}${target}`;
+        }
+      }
+    }
+  };
+}

--- a/src/util/footnoteScope.ts
+++ b/src/util/footnoteScope.ts
@@ -93,7 +93,8 @@ function namesFragment(element: Element): boolean {
  * `x-y` and token `m-x` with id `y` both spell `user-content-m-x-y`. Escaping
  * it keeps `-` out of every token, which makes the first one the boundary and
  * the decomposition unique — the property the cross-message guarantee actually
- * rests on.
+ * rests on. `should keep the scope and the id it prefixes tellable apart`, in
+ * `test/util/footnoteScope.esm-test.ts`, is that pair as a test.
  * @param messageId - The message's id.
  * @returns An id-safe token containing no separator.
  */

--- a/test/ui/typingEffect.esm-test.tsx
+++ b/test/ui/typingEffect.esm-test.tsx
@@ -196,32 +196,54 @@ describe('footnote anchors', () => {
     expect(target(reference, 'aria-describedby')).not.toBeNull();
   });
 
-  // The two below are `it.failing` rather than skipped: #696 is a live bug
-  // that belongs to its own fix, so the cases run, the suite stays green while
-  // the bug stands, and they turn red the day it is fixed — which is the
-  // reminder to delete the marker and keep the assertion.
-  it.failing('should point the reference at the footnote it names (#696)', () => {
+  // These two were `it.failing` pins for #696 until the fix landed. Kept as
+  // assertions of the fixed behaviour rather than dropped, and strengthened:
+  // "the href resolves to something" is what the pin could say while the bug
+  // stood, and it would still pass if an anchor resolved to the wrong note.
+  it('should point the reference at the footnote it names', () => {
     renderMessages(FOOTNOTE);
 
-    // `mdast-util-to-hast` already prefixes footnote ids with `user-content-`,
-    // then `hast-util-sanitize` prefixes every `id` again — so the target
-    // becomes `user-content-user-content-fn-1` while the `href` stays
-    // `#user-content-fn-1`, because `href` is not in `clobber`. The link is
-    // announced normally and goes nowhere.
+    // The fault was that `hast-util-sanitize` renames `id` but not `href`, so
+    // the target moved to `user-content-user-content-fn-1` and the link kept
+    // naming `#user-content-fn-1`. Announced normally, went nowhere.
     const reference = screen.getByRole('link', { name: '1' });
+    const note = target(reference, 'href');
 
-    expect(target(reference, 'href')).not.toBeNull();
+    expect(note?.textContent).toContain('the note');
   });
 
-  it.failing('should give two messages distinct footnote ids (#696)', () => {
+  it('should send a backref to the reference that names it', () => {
+    renderMessages(FOOTNOTE);
+
+    const backref = screen.getByRole('link', { name: 'Back to reference 1' });
+    const reference = target(backref, 'href');
+
+    expect(reference?.textContent).toBe('1');
+  });
+
+  it('should give two messages distinct footnote ids', () => {
     const container = renderMessages(FOOTNOTE, 'other[^1]\n\n[^1]: second note\n');
 
     // Footnotes are numbered per document, and each message is its own
-    // document, so every message with a footnote emits the same ids. A chat
-    // transcript is one page, which makes them duplicates — and a duplicate
-    // id is the case a single-document test cannot see at all.
+    // document, so every message with a footnote emitted the same ids. A chat
+    // transcript is one page, which made them duplicates — the case a
+    // single-document test cannot see at all.
     const ids = Array.from(container.querySelectorAll('[id]')).map(element => element.id);
 
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('should keep a second message\'s footnote pointing inside that message', () => {
+    renderMessages(FOOTNOTE, 'other[^1]\n\n[^1]: second note\n');
+
+    // The reason duplicate ids mattered rather than merely being untidy:
+    // `getElementById` returns the first match in document order, so the
+    // second message's reference would have jumped to the first message's
+    // note. This is the assertion the id-uniqueness one exists to protect.
+    const references = screen.getAllByRole('link', { name: '1' });
+    expect(references).toHaveLength(2);
+
+    expect(target(references[0], 'href')?.textContent).toContain('the note');
+    expect(target(references[1], 'href')?.textContent).toContain('second note');
   });
 });

--- a/test/util/footnoteScope.esm-test.ts
+++ b/test/util/footnoteScope.esm-test.ts
@@ -19,16 +19,36 @@ import { unified } from 'unified';
  * message is left alone.
  */
 
-/** The chain `TypingEffect` renders with, stopped at the tree. */
-async function render(markdown: string, messageId: string): Promise<Root> {
+/**
+ * The chain `TypingEffect` renders with, stopped at the tree.
+ * @param markdown - The message body.
+ * @param messageId - The message's id, which becomes the scope.
+ * @param clobberPrefix - What `remark-rehype` namespaces footnote ids with.
+ * Its own default unless a case is about not depending on it.
+ * @returns The rendered tree.
+ */
+async function render(
+  markdown: string,
+  messageId: string,
+  clobberPrefix?: string,
+): Promise<Root> {
   const processor = unified()
     .use(remarkParse)
     .use(remarkGfm)
-    .use(remarkRehype)
+    .use(remarkRehype, clobberPrefix === undefined ? {} : { clobberPrefix })
     .use(rehypeSanitize, createChatSanitizeSchema())
     .use(rehypeScopeIds, { messageId });
 
   return processor.run(processor.parse(markdown)) as Promise<Root>;
+}
+
+/** Fragment links in the tree that name an id it does not contain. */
+function dangling(tree: Root): string[] {
+  const present = ids(tree);
+
+  return hrefs(tree)
+    .filter(href => href.startsWith('#'))
+    .filter(href => !present.includes(href.slice(1)));
 }
 
 /** Every element in the tree. */
@@ -62,11 +82,21 @@ describe('scoping a message\'s ids', () => {
   it('should leave every fragment link naming an id that exists', async () => {
     const tree = await render(FOOTNOTE, 'msg-1');
 
-    const dangling = hrefs(tree)
-      .filter(href => href.startsWith('#'))
-      .filter(href => !ids(tree).includes(href.slice(1)));
+    expect(dangling(tree)).toEqual([]);
+  });
 
-    expect(dangling).toEqual([]);
+  it('should repair the link whatever remark-rehype namespaced it with', async () => {
+    // The repair looks for `<sanitiser's prefix><what the href names>`, and
+    // the sanitiser prefixes whatever remark-rehype produced — so the two
+    // defaults both being `user-content-` is a coincidence the repair does not
+    // rest on. Pinned because it reads like it might: a version bump moving one
+    // default and not the other would otherwise be a silent return of the
+    // dangling anchor, for footnotes only.
+    for (const prefix of ['user-content-', 'totally-different-', '']) {
+      const tree = await render(FOOTNOTE, 'msg-1', prefix);
+
+      expect(dangling(tree)).toEqual([]);
+    }
   });
 
   it('should keep the prefix that stops chat ids shadowing the page', async () => {

--- a/test/util/footnoteScope.esm-test.ts
+++ b/test/util/footnoteScope.esm-test.ts
@@ -1,0 +1,123 @@
+import type { Element, Root } from 'hast';
+import { describe, expect, it } from '@jest/globals';
+import { rehypeScopeIds } from '@util/footnoteScope';
+import { createChatSanitizeSchema } from '@util/markdownSanitize';
+import rehypeSanitize from 'rehype-sanitize';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
+
+/**
+ * The id scoping that makes footnote anchors resolve (#696).
+ *
+ * `test/ui/typingEffect.esm-test.tsx` covers the outcome — a reference reaches
+ * its own note, two messages do not collide — by rendering the component. This
+ * covers the properties that outcome rests on and that a rendered assertion
+ * cannot show: that the scope is a namespace rather than a rename, that two
+ * message ids can never produce the same scope, and that a link out of the
+ * message is left alone.
+ */
+
+/** The chain `TypingEffect` renders with, stopped at the tree. */
+async function render(markdown: string, messageId: string): Promise<Root> {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeSanitize, createChatSanitizeSchema())
+    .use(rehypeScopeIds, { messageId });
+
+  return processor.run(processor.parse(markdown)) as Promise<Root>;
+}
+
+/** Every element in the tree. */
+function elements(node: Root | Element): Element[] {
+  const found: Element[] = node.type === 'element' ? [node] : [];
+  for (const child of node.children) {
+    if (child.type === 'element') {
+      found.push(...elements(child));
+    }
+  }
+  return found;
+}
+
+/** Every id in the tree. */
+function ids(tree: Root): string[] {
+  return elements(tree)
+    .map(element => element.properties?.id)
+    .filter((id): id is string => typeof id === 'string');
+}
+
+/** Every `href` in the tree. */
+function hrefs(tree: Root): string[] {
+  return elements(tree)
+    .map(element => element.properties?.href)
+    .filter((href): href is string => typeof href === 'string');
+}
+
+const FOOTNOTE = 'text[^1]\n\n[^1]: the note\n';
+
+describe('scoping a message\'s ids', () => {
+  it('should leave every fragment link naming an id that exists', async () => {
+    const tree = await render(FOOTNOTE, 'msg-1');
+
+    const dangling = hrefs(tree)
+      .filter(href => href.startsWith('#'))
+      .filter(href => !ids(tree).includes(href.slice(1)));
+
+    expect(dangling).toEqual([]);
+  });
+
+  it('should keep the prefix that stops chat ids shadowing the page', async () => {
+    const tree = await render(FOOTNOTE, 'msg-1');
+
+    // The anti-clobbering guarantee moves here from the sanitiser's own
+    // `clobberPrefix`, which this plugin's rewriting supersedes. Worth pinning
+    // where it now lives, because losing it is silent: ids would still be
+    // unique per message and every test above would still pass while chat
+    // content could define `id="search"` and shadow `document.forms.search`.
+    expect(ids(tree).length).toBeGreaterThan(0);
+    for (const id of ids(tree)) {
+      expect(id.startsWith('user-content-')).toBe(true);
+    }
+  });
+
+  it('should give two messages disjoint ids', async () => {
+    const first = ids(await render(FOOTNOTE, 'msg-1'));
+    const second = ids(await render(FOOTNOTE, 'msg-2'));
+
+    expect(first).not.toEqual([]);
+    expect(first.filter(id => second.includes(id))).toEqual([]);
+  });
+
+  it('should not let two different message ids encode to one scope', async () => {
+    // `resp-<time>-<model>` puts a model name in the id, and a model name can
+    // carry a dot or a slash. Stripping unsafe characters would map `a.b` and
+    // `a-b` onto the same scope and silently reintroduce the collision this
+    // exists to prevent, so they are escaped instead.
+    const dotted = ids(await render(FOOTNOTE, 'resp-1-a.b'));
+    const dashed = ids(await render(FOOTNOTE, 'resp-1-a-b'));
+    const underscored = ids(await render(FOOTNOTE, 'resp-1-a_b'));
+
+    expect(dotted.filter(id => dashed.includes(id))).toEqual([]);
+    expect(dotted.filter(id => underscored.includes(id))).toEqual([]);
+    expect(dashed.filter(id => underscored.includes(id))).toEqual([]);
+  });
+
+  it('should leave a link to somewhere outside the message alone', async () => {
+    const tree = await render('[up](#top) and [out](https://example.com)', 'msg-1');
+
+    // `#top` names nothing in this message. Scoping it would point it at an id
+    // that does not exist either, so it is left as written — the page it was
+    // aimed at is not this plugin's business.
+    expect(hrefs(tree)).toEqual(['#top', 'https://example.com']);
+  });
+
+  it('should do nothing to a message with no ids in it', async () => {
+    const tree = await render('just a [link](https://example.com)', 'msg-1');
+
+    expect(ids(tree)).toEqual([]);
+    expect(hrefs(tree)).toEqual(['https://example.com']);
+  });
+});

--- a/test/util/footnoteScope.esm-test.ts
+++ b/test/util/footnoteScope.esm-test.ts
@@ -173,3 +173,47 @@ describe('the reference shapes hast can hold', () => {
     ]);
   });
 });
+
+describe('an anchor\'s name, which is a fragment target too', () => {
+  /**
+   * Runs the plugin over a hand-built tree with one target and one link.
+   *
+   * `name` is in the sanitiser's `clobber` list alongside `id`, and the chat
+   * allowlist admits it nowhere — so, like `ariaLabelledBy`, this is the only
+   * way to reach it, and it is handled for the same reason: if it is ever
+   * allowed in, an `href` aimed at one must not be left dangling.
+   * @param tagName - The element carrying the `name`.
+   * @returns The target and the link, after scoping.
+   */
+  function scope(tagName: string): { target: Element; link: Element } {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        { type: 'element', tagName, properties: { name: 'here' }, children: [] },
+        { type: 'element', tagName: 'a', properties: { href: '#here', id: 'link' }, children: [] },
+      ],
+    };
+
+    rehypeScopeIds({ messageId: 'msg-1' })(tree);
+    const found = elements(tree);
+
+    return { target: found[0], link: found[1] };
+  }
+
+  it('should scope it, and point a link at where it went', () => {
+    const { target, link } = scope('a');
+
+    expect(target.properties?.name).toBe('user-content-msg-1-here');
+    expect(link.properties?.href).toBe('#user-content-msg-1-here');
+  });
+
+  it('should leave a form control\'s name alone', () => {
+    const { target, link } = scope('input');
+
+    // On anything but an anchor, `name` is what a form submits under, not
+    // somewhere a link can go. Renaming it would change the submitted data to
+    // fix a link that does not exist — so the link is the one left alone.
+    expect(target.properties?.name).toBe('here');
+    expect(link.properties?.href).toBe('#here');
+  });
+});

--- a/test/util/footnoteScope.esm-test.ts
+++ b/test/util/footnoteScope.esm-test.ts
@@ -91,11 +91,33 @@ describe('scoping a message\'s ids', () => {
     expect(first.filter(id => second.includes(id))).toEqual([]);
   });
 
+  it('should keep the scope and the id it prefixes tellable apart', async () => {
+    // What has to be unique is the whole `user-content-<token>-<id>`, not the
+    // token alone. With `-` left intact in a token, message `m` with id `x-y`
+    // and message `m-x` with id `y` would both spell `user-content-m-x-y` —
+    // the same cross-message collision this fixes, arriving through the
+    // separator instead of through the numbering.
+    const shorter: Root = {
+      type: 'root',
+      children: [{ type: 'element', tagName: 'p', properties: { id: 'x-y' }, children: [] }],
+    };
+    const longer: Root = {
+      type: 'root',
+      children: [{ type: 'element', tagName: 'p', properties: { id: 'y' }, children: [] }],
+    };
+
+    rehypeScopeIds({ messageId: 'm' })(shorter);
+    rehypeScopeIds({ messageId: 'm-x' })(longer);
+
+    expect(ids(shorter)).not.toEqual(ids(longer));
+  });
+
   it('should not let two different message ids encode to one scope', async () => {
-    // `resp-<time>-<model>` puts a model name in the id, and a model name can
-    // carry a dot or a slash. Stripping unsafe characters would map `a.b` and
-    // `a-b` onto the same scope and silently reintroduce the collision this
-    // exists to prevent, so they are escaped instead.
+    // Stripping unsafe characters rather than escaping them would map `a.b`,
+    // `a-b` and `a_b` onto one scope and silently reintroduce the collision
+    // this exists to prevent. The underscore case is the one that happens:
+    // a response id is `resp-<time>-<provider>`, and three of the four
+    // providers are spelled `ANTHROPIC_CLAUDE`, `GOOGLE_GEMINI`, `OPENAI`.
     const dotted = ids(await render(FOOTNOTE, 'resp-1-a.b'));
     const dashed = ids(await render(FOOTNOTE, 'resp-1-a-b'));
     const underscored = ids(await render(FOOTNOTE, 'resp-1-a_b'));
@@ -153,13 +175,13 @@ describe('the reference shapes hast can hold', () => {
   it('should move a list-valued reference with the id it names', () => {
     const referring = scope({ ariaLabelledBy: ['label'] });
 
-    expect(referring.properties?.ariaLabelledBy).toEqual(['user-content-msg-1-label']);
+    expect(referring.properties?.ariaLabelledBy).toEqual(['user-content-msg_2d_1-label']);
   });
 
   it('should move a string-valued reference with the id it names', () => {
     const referring = scope({ ariaDescribedBy: 'label' });
 
-    expect(referring.properties?.ariaDescribedBy).toBe('user-content-msg-1-label');
+    expect(referring.properties?.ariaDescribedBy).toBe('user-content-msg_2d_1-label');
   });
 
   it('should leave a reference to an id this message does not define', () => {
@@ -168,7 +190,7 @@ describe('the reference shapes hast can hold', () => {
     // Half known, half not — the unknown name belongs to the host page, and
     // scoping it would point it at nothing.
     expect(referring.properties?.ariaLabelledBy).toEqual([
-      'user-content-msg-1-label',
+      'user-content-msg_2d_1-label',
       'elsewhere',
     ]);
   });
@@ -203,8 +225,8 @@ describe('an anchor\'s name, which is a fragment target too', () => {
   it('should scope it, and point a link at where it went', () => {
     const { target, link } = scope('a');
 
-    expect(target.properties?.name).toBe('user-content-msg-1-here');
-    expect(link.properties?.href).toBe('#user-content-msg-1-here');
+    expect(target.properties?.name).toBe('user-content-msg_2d_1-here');
+    expect(link.properties?.href).toBe('#user-content-msg_2d_1-here');
   });
 
   it('should leave a form control\'s name alone', () => {

--- a/test/util/footnoteScope.esm-test.ts
+++ b/test/util/footnoteScope.esm-test.ts
@@ -121,3 +121,55 @@ describe('scoping a message\'s ids', () => {
     expect(hrefs(tree)).toEqual(['https://example.com']);
   });
 });
+
+describe('the reference shapes hast can hold', () => {
+  /**
+   * Runs the plugin over a hand-built tree.
+   *
+   * Not through the pipeline, on purpose. `ariaLabelledBy` is not in the chat
+   * allowlist, so the sanitiser strips it before the plugin could ever see it,
+   * and a rendered message therefore cannot exercise that branch — nor the
+   * string form below, since `mdast-util-to-hast` only ever emits the array.
+   * Both are handled because the plugin scopes ids in general rather than
+   * footnote ids in particular, and admitting either to the schema later must
+   * not quietly produce a reference pointing at an id that no longer exists.
+   * @param properties - Properties for the referring element.
+   * @returns The referring element after scoping.
+   */
+  function scope(properties: Element['properties']): Element {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        { type: 'element', tagName: 'h2', properties: { id: 'label' }, children: [] },
+        { type: 'element', tagName: 'p', properties, children: [] },
+      ],
+    };
+
+    rehypeScopeIds({ messageId: 'msg-1' })(tree);
+
+    return elements(tree).filter(element => element.tagName === 'p')[0];
+  }
+
+  it('should move a list-valued reference with the id it names', () => {
+    const referring = scope({ ariaLabelledBy: ['label'] });
+
+    expect(referring.properties?.ariaLabelledBy).toEqual(['user-content-msg-1-label']);
+  });
+
+  it('should move a string-valued reference with the id it names', () => {
+    const referring = scope({ ariaDescribedBy: 'label' });
+
+    expect(referring.properties?.ariaDescribedBy).toBe('user-content-msg-1-label');
+  });
+
+  it('should leave a reference to an id this message does not define', () => {
+    const referring = scope({ ariaLabelledBy: ['label', 'elsewhere'] });
+
+    // Half known, half not — the unknown name belongs to the host page, and
+    // scoping it would point it at nothing.
+    expect(referring.properties?.ariaLabelledBy).toEqual([
+      'user-content-msg-1-label',
+      'elsewhere',
+    ]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

A footnote reference in an AI chat response renders, is announced, and goes nowhere. Both of its links name ids that no longer exist by the time the DOM is built.

## Related Issues

Closes #696. Turns the two `it.failing` pins added in #702 into assertions of the fixed behaviour. Filed #705 for a pre-existing gap this makes load-bearing.

## Changes Made

**`src/util/footnoteScope.ts`** — a rehype plugin that runs **after** `rehype-sanitize`, namespaces every `id` in the message, and re-points everything that names them.

### Why the anchors dangle

`mdast-util-to-hast` writes matching pairs. `hast-util-sanitize` then applies its `clobberPrefix` to everything in `clobber` — `ariaDescribedBy`, `ariaLabelledBy`, `id`, `name`. `href` is not in that list:

```
a  href="#user-content-fn-1"             <- untouched
li id="user-content-user-content-fn-1"   <- prefixed again
```

`aria-describedby` survives *precisely because* it is in `clobber`, so it moves in step with the `id` it names. The double-prefixing is not the bug — `aria-describedby` is double-prefixed on neither side and works. The bug is that `href` is not clobbered at all, so it cannot follow its target.

### The second fault, which the first one hides

Footnotes are numbered per document and each message is its own document, so every message with a footnote emits `fn-1`. A transcript is one DOM, which makes them duplicates — and once anchors resolve, `getElementById` returns the first match, so a reference in the second message would jump to the **first** message's note.

That is why this is one change rather than two: fixing the anchors without fixing the ids would turn a dead link into a link to the wrong place, which is worse.

### Why post-processing rather than configuring a prefix

`remark-rehype` takes `clobberPrefix`, and it looked like the smaller fix. It reaches only ids derived from the footnote label:

```
--- per-message prefix ---
m1 a#user-content-msg-m1-fnref-1     m2 a#user-content-msg-m2-fnref-1     <- fixed
m1 li#user-content-msg-m1-fn-1       m2 li#user-content-msg-m2-fn-1       <- fixed
m1 h2#user-content-footnote-label    m2 h2#user-content-footnote-label    <- STILL COLLIDES
```

`mdast-util-to-hast` hardcodes the heading as `id: 'footnote-label'` (`lib/footer.js:236`) and documents that it is "always added". No option scopes it. Rewriting the tree is the only place both faults can be fixed, so that is what this does.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no rule or command changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Found by looking rather than reasoning

**`ariaDescribedBy` is an array, not a space-separated string.** hast models it as `['user-content-footnote-label']`. My first version read it as a string, skipped it, and broke the one reference that had been working — caught by the test that has passed since #702, which is the argument for having written it.

**The `href` names the pre-sanitisation id**, so renaming ids consistently is not enough on its own. The rewrite has to match a fragment against the prefixed form first — the sanitiser's damage undone rather than followed.

**The prefix is read from the library.** `defaultSchema.clobberPrefix` comes from `rehype-sanitize` rather than being written out here, so the two cannot drift apart. That also means no new dependency: `rehype-sanitize` is already one, and it re-exports the schema.

**`name` is a fragment target too, but only on an anchor.** It is in `clobber` for the same reason `id` is — a browser resolves `#foo` against an anchor's `name` — and the schema admits it nowhere today, exactly like `ariaLabelledBy`. Both are handled anyway, because this scopes ids in general and admitting either later must not quietly produce a dangling reference. Scoping `name` *everywhere* would be wrong: on a form control it is what the field submits under, and renaming it would change the submitted data to repair a link that does not exist.

### The security trade, stated

The anti-clobbering guarantee moves from the sanitiser's `clobberPrefix` to this plugin's scope, which keeps `user-content-` for exactly that reason. Losing it would be **silent** — ids would still be unique per message and every other test here would still pass — so it has a test of its own.

The chat schema is untouched, so it still declares only `tagNames` and `attributes` and every other `hast-util-sanitize` default stays in force, including the `protocols` map that strips `javascript:`. The plugin only ever rewrites a fragment `href` to another fragment, so it cannot introduce a protocol.

**The scope is escaped injectively rather than stripped**, `-` included. A message id is `msg-<time>`, `system-<time>` or `resp-<time>-<provider>`, and the providers are `OPENAI`, `ANTHROPIC_CLAUDE`, `GOOGLE_GEMINI` and `OLLAMA` — three of which carry an underscore, so the escape path runs in production. (An earlier version of this description claimed a message id carries a *dot*, citing `gpt-5.5`. That was wrong: `addPendingResponse` uses the `Llm` provider key, not `LlmVersion`. Review caught it.)

Escaping `-` is a second, separate reason. The final id is `user-content-<token>-<id>`, so what must be unique is the whole concatenation, not the token: with `-` intact, message `m` with id `x-y` and message `m-x` with id `y` both spell `user-content-m-x-y`. Keeping `-` out of every token makes the first one the boundary and the decomposition unique — an unenforced invariant turned into a proven one.

### Every case verified against the defect it names

| reverted | cases that fail |
|---|---|
| the plugin removed from `TypingEffect` | 4 of the 11 component cases |
| the scope stripped instead of escaped | the injectivity case |
| `user-content-` dropped from the scope | the anti-clobbering case |
| `ariaDescribedBy`'s array form unhandled | the `aria-describedby` case |
| `name` not scoped at all | the anchor case |
| `name` scoped on **every** element | the form-control case |
| `-` left unescaped in the token | the separator case |
| the repair assuming the href carries `user-content-` | the `clobberPrefix`-independence case |

The fourth is not hypothetical — it is the bug I actually wrote, caught by an existing test. The sixth and eighth are the straightforward readings of two review suggestions, which is why both directions are pinned rather than one.

### Acceptance criteria from #696

| criterion | |
|---|---|
| a reference and its backref both resolve after sanitisation | ✅ and each reaches *its own* note, which is stronger than the pins could assert |
| `javascript:` filtering on `href` still applies | ✅ schema untouched; pinned by `markdownPipeline.esm-test.ts` |
| whatever provides anti-clobbering is named in a comment and pinned by a test | ✅ `footnoteScope.esm-test.ts` |
| two messages produce no duplicate DOM ids | ✅ |
| a backref in the second message returns to its own reference | ✅ |

### What this does not fix

The cross-message guarantee rests on `messageId` being unique, and those are `Date.now()`-based, so two messages created in the same millisecond share a scope. Pre-existing, in another layer, and filed as **#705** rather than folded in — but worth naming here, because this PR is what makes message-id uniqueness load-bearing for the first time.

### Verification

| check | result |
|---|---|
| `npm test` | 110 suites, 1386 tests |
| `npm run build` | exit 0 |
| `npm run type-check` | exit 0 |
| `npx eslint .` | exit 0 |

jsdom is not a screen reader. These pin the wiring; they do not replace checking with real assistive technology.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz