### PR TITLE
fix(chat): give every message an id no other message can have

### DIFF
--- a/src/state/viewModel/chatViewModel.ts
+++ b/src/state/viewModel/chatViewModel.ts
@@ -22,39 +22,89 @@ const initialState: ChatState = {
   suggestions: [],
 };
 
+/**
+ * Distinguishes ids minted within the same millisecond.
+ *
+ * These used to be `Date.now()` alone, which is unique only if no two are
+ * created in the same tick — a bound nothing enforces, and one that anything
+ * adding two messages programmatically crosses. What made it matter is that
+ * #704 derives each message's DOM id scope from its message id, so two
+ * messages sharing one share a scope: their footnote ids collide again, and a
+ * reference resolves to the first match in document order, which is the other
+ * message's note. Everything still renders, so the failure is silent.
+ */
+let sequence = 0;
+
+/**
+ * A unique id for a message or a suggestion.
+ *
+ * The timestamp is kept for readability and ordering in devtools; the sequence
+ * is what actually carries the uniqueness, being monotonic for the life of the
+ * page. `kind` leads because `MessageBubble` distinguishes system messages by
+ * it (`message.id.startsWith('system-')`).
+ * @param kind - The id's leading segment.
+ * @returns An id no other call can produce.
+ */
+function nextId(kind: string): string {
+  sequence += 1;
+  return `${kind}-${Date.now()}-${sequence}`;
+}
+
 const chatSlice = createSlice({
   name: 'chat',
   initialState,
   reducers: {
-    addUserMessage: (state, action: PayloadAction<{ text: string; timestamp: string }>) => {
-      state.messages.push({
-        id: `msg-${Date.now()}`,
-        text: action.payload.text,
-        isUser: true,
-        timestamp: action.payload.timestamp,
-        status: 'SUCCESS',
-      });
+    // The three that add a message mint its id in `prepare` rather than in the
+    // reducer. `rules/viewmodel.md` asks reducers to assign the payload and
+    // nothing more, and an id is the one thing here that cannot come from the
+    // caller — so it is generated where Redux Toolkit puts non-determinism,
+    // leaving each reducer pure. The action creators' signatures are unchanged.
+    addUserMessage: {
+      reducer: (state, action: PayloadAction<{ id: string; text: string; timestamp: string }>) => {
+        state.messages.push({
+          id: action.payload.id,
+          text: action.payload.text,
+          isUser: true,
+          timestamp: action.payload.timestamp,
+          status: 'SUCCESS',
+        });
+      },
+      prepare: (message: { text: string; timestamp: string }) => ({
+        payload: { ...message, id: nextId('msg') },
+      }),
     },
-    addSystemMessage: (state, action: PayloadAction<{ text: string; timestamp: string; modelSelections?: { modelKey: Llm; name: string; version: string }[]; isWelcomeMessage?: boolean }>) => {
-      state.messages.push({
-        id: `system-${Date.now()}`,
-        text: action.payload.text,
-        isUser: false,
-        timestamp: action.payload.timestamp,
-        status: 'SUCCESS',
-        modelSelections: action.payload.modelSelections,
-        isWelcomeMessage: action.payload.isWelcomeMessage,
-      });
+    addSystemMessage: {
+      reducer: (state, action: PayloadAction<{ id: string; text: string; timestamp: string; modelSelections?: { modelKey: Llm; name: string; version: string }[]; isWelcomeMessage?: boolean }>) => {
+        state.messages.push({
+          id: action.payload.id,
+          text: action.payload.text,
+          isUser: false,
+          timestamp: action.payload.timestamp,
+          status: 'SUCCESS',
+          modelSelections: action.payload.modelSelections,
+          isWelcomeMessage: action.payload.isWelcomeMessage,
+        });
+      },
+      prepare: (message: { text: string; timestamp: string; modelSelections?: { modelKey: Llm; name: string; version: string }[]; isWelcomeMessage?: boolean }) => ({
+        payload: { ...message, id: nextId('system') },
+      }),
     },
-    addPendingResponse: (state, action: PayloadAction<{ model: Llm; timestamp: string }>) => {
-      state.messages.push({
-        id: `resp-${Date.now()}-${action.payload.model}`,
-        text: 'Processing request...',
-        isUser: false,
-        model: action.payload.model,
-        timestamp: action.payload.timestamp,
-        status: 'PENDING',
-      });
+    addPendingResponse: {
+      reducer: (state, action: PayloadAction<{ id: string; model: Llm; timestamp: string }>) => {
+        state.messages.push({
+          id: action.payload.id,
+          text: 'Processing request...',
+          isUser: false,
+          model: action.payload.model,
+          timestamp: action.payload.timestamp,
+          status: 'PENDING',
+        });
+      },
+      // The model stays in the id, where it has always been, because it is what
+      // makes a pending response identifiable in devtools.
+      prepare: (response: { model: Llm; timestamp: string }) => ({
+        payload: { ...response, id: `${nextId('resp')}-${response.model}` },
+      }),
     },
     updateResponse: (state, action: PayloadAction<{ model: Llm; data: string; timestamp: string }>) => {
       const message = state.messages.find(m =>
@@ -95,6 +145,16 @@ const chatSlice = createSlice({
   },
 });
 const { addUserMessage, addSystemMessage, addPendingResponse, updateResponse, updateError, updateSuggestions, updateWelcomeMessage, reset } = chatSlice.actions;
+
+/**
+ * The slice's action creators.
+ *
+ * Exported because the three that add a message mint the id in `prepare`, so
+ * dispatching those by action type — which is how the other view model tests
+ * reach their reducers — skips the only step that generates one. A test of the
+ * ids has to go through the creators.
+ */
+export const chatActions = chatSlice.actions;
 
 /**
  * View model for managing chat interface state and AI model interactions.
@@ -239,21 +299,19 @@ export class ChatViewModel extends AbstractViewModel<ChatState> {
 
       const { llm } = this.snapshot.settings;
       const expertise = llm.expertiseLevel;
-      const timestamp = Date.now();
-
       const baseSuggestions: Suggestion[] = [
         {
-          id: `suggestion-${timestamp}-1`,
+          id: nextId('suggestion'),
           text: 'Can you explain that in more detail?',
           type: 'clarification',
         },
         {
-          id: `suggestion-${timestamp}-2`,
+          id: nextId('suggestion'),
           text: 'What can you say about the current datapoint?',
           type: 'analysis',
         },
         {
-          id: `suggestion-${timestamp}-3`,
+          id: nextId('suggestion'),
           text: 'How does this compare to other data points?',
           type: 'analysis',
         },
@@ -263,12 +321,12 @@ export class ChatViewModel extends AbstractViewModel<ChatState> {
       if (expertise === 'advanced') {
         baseSuggestions.push(
           {
-            id: `suggestion-${timestamp}-4`,
+            id: nextId('suggestion'),
             text: 'Can you perform a statistical analysis of this data?',
             type: 'analysis',
           },
           {
-            id: `suggestion-${timestamp}-5`,
+            id: nextId('suggestion'),
             text: 'What are the potential outliers in this dataset?',
             type: 'analysis',
           },

--- a/src/util/footnoteScope.ts
+++ b/src/util/footnoteScope.ts
@@ -83,8 +83,9 @@ function namesFragment(element: Element): boolean {
  * Every character outside `[A-Za-z0-9]` becomes `_<hex>_`. That is injective on
  * its own — `_` is itself outside the set, so an underscore in the output only
  * ever begins an escape — and it is exercised in practice: a response id is
- * `resp-<time>-<provider>` and the providers are `OPENAI`, `ANTHROPIC_CLAUDE`,
- * `GOOGLE_GEMINI` and `OLLAMA`, three of which carry an underscore.
+ * `resp-<time>-<sequence>-<provider>` and two of the four providers —
+ * `ANTHROPIC_CLAUDE` and `GOOGLE_GEMINI`, against `OPENAI` and `OLLAMA` —
+ * carry an underscore.
  *
  * `-` is escaped along with everything else, which matters for a reason
  * injectivity alone does not cover. The final id is

--- a/test/state/viewModel/chatViewModel.test.ts
+++ b/test/state/viewModel/chatViewModel.test.ts
@@ -1,0 +1,83 @@
+import type { UnknownAction } from '@reduxjs/toolkit';
+import type { ChatState } from '@state/viewModel/chatViewModel';
+import { describe, expect, jest, test } from '@jest/globals';
+import chatReducer, { chatActions } from '@state/viewModel/chatViewModel';
+
+/**
+ * Message ids have to be unique within a conversation (#705).
+ *
+ * They were `Date.now()` alone, which is unique only if no two are minted in
+ * the same millisecond — a bound nothing enforces. What made it matter is #704:
+ * each message's DOM id scope is derived from its message id, so two messages
+ * sharing one share a scope, their footnote ids collide again, and a reference
+ * resolves to whichever note comes first in document order. Everything still
+ * renders, which is why it would not have been noticed.
+ *
+ * The clock is frozen rather than left to run, because a real clock makes the
+ * old behaviour pass whenever two dispatches happen to straddle a millisecond
+ * boundary — the flakiness being removed, used as the test's own oracle.
+ *
+ * These go through the action creators rather than dispatching by action type
+ * as the other view model tests do. The id is minted in `prepare`, so an action
+ * built by hand carries no id at all and the test would pass on `undefined`
+ * being equal to itself.
+ */
+
+/** Applies a sequence of actions to a fresh chat state. */
+function dispatch(...actions: UnknownAction[]): ChatState {
+  return actions.reduce<ChatState>(
+    (state, action) => chatReducer(state, action),
+    chatReducer(undefined, { type: '@@INIT' }),
+  );
+}
+
+describe('chat message ids', () => {
+  test('are distinct for messages added in the same millisecond', () => {
+    // Frozen, so every id below is minted from one `Date.now()`. Without the
+    // sequence they are all the same string.
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-02T00:00:00.000Z'));
+
+    const state = dispatch(
+      chatActions.addUserMessage({ text: 'first', timestamp: 'now' }),
+      chatActions.addUserMessage({ text: 'second', timestamp: 'now' }),
+      chatActions.addSystemMessage({ text: 'third', timestamp: 'now' }),
+      chatActions.addPendingResponse({ model: 'OPENAI', timestamp: 'now' }),
+      chatActions.addPendingResponse({ model: 'OPENAI', timestamp: 'now' }),
+    );
+
+    const ids = state.messages.map(message => message.id);
+    expect(ids).toHaveLength(5);
+    expect(new Set(ids).size).toBe(5);
+
+    jest.useRealTimers();
+  });
+
+  test('keep the prefix MessageBubble reads them by', () => {
+    // `MessageBubble` shows the disabled-state hint only for a system message
+    // and tells one apart with `id.startsWith('system-')`. Nothing else about
+    // the format is depended on, but that much is.
+    const state = dispatch(
+      chatActions.addUserMessage({ text: 'a', timestamp: 'now' }),
+      chatActions.addSystemMessage({ text: 'b', timestamp: 'now' }),
+      chatActions.addPendingResponse({ model: 'ANTHROPIC_CLAUDE', timestamp: 'now' }),
+    );
+
+    const [user, system, response] = state.messages.map(message => message.id);
+    expect(user.startsWith('msg-')).toBe(true);
+    expect(system.startsWith('system-')).toBe(true);
+    expect(response.startsWith('resp-')).toBe(true);
+    // The model stays in the id, where it has always been.
+    expect(response.endsWith('-ANTHROPIC_CLAUDE')).toBe(true);
+  });
+
+  test('are minted in the action, leaving the reducer pure', () => {
+    // Applying one action twice must give the same state — which is what
+    // "reducers assign the payload and nothing more" means in
+    // `rules/viewmodel.md`. Generating the id inside the reducer would produce
+    // a different id each time the same action was replayed.
+    const action = chatActions.addUserMessage({ text: 'a', timestamp: 'now' });
+    const initial = chatReducer(undefined, { type: '@@INIT' });
+
+    expect(chatReducer(initial, action)).toEqual(chatReducer(initial, action));
+  });
+});

--- a/test/state/viewModel/chatViewModel.test.ts
+++ b/test/state/viewModel/chatViewModel.test.ts
@@ -1,6 +1,6 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 import type { ChatState } from '@state/viewModel/chatViewModel';
-import { describe, expect, jest, test } from '@jest/globals';
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
 import chatReducer, { chatActions } from '@state/viewModel/chatViewModel';
 
 /**
@@ -31,6 +31,15 @@ function dispatch(...actions: UnknownAction[]): ChatState {
   );
 }
 
+// Restored here rather than at the end of the one test that fakes them: an
+// assertion that throws never reaches a trailing call, which would leave the
+// clock frozen for the rest of the file. Harmless as the cases stand — neither
+// of the others reads the clock — but the failure it would cause is the kind
+// that looks like it belongs to the test it surfaces in.
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe('chat message ids', () => {
   test('are distinct for messages added in the same millisecond', () => {
     // Frozen, so every id below is minted from one `Date.now()`. Without the
@@ -48,8 +57,6 @@ describe('chat message ids', () => {
     const ids = state.messages.map(message => message.id);
     expect(ids).toHaveLength(5);
     expect(new Set(ids).size).toBe(5);
-
-    jest.useRealTimers();
   });
 
   test('keep the prefix MessageBubble reads them by', () => {

--- a/test/state/viewModel/chatViewModel.test.ts
+++ b/test/state/viewModel/chatViewModel.test.ts
@@ -1,7 +1,10 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
+import type { AudioService } from '@service/audio';
+import type { ChatService } from '@service/chat';
 import type { ChatState } from '@state/viewModel/chatViewModel';
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
-import chatReducer, { chatActions } from '@state/viewModel/chatViewModel';
+import { createMaidrStore } from '@state/store';
+import chatReducer, { chatActions, ChatViewModel } from '@state/viewModel/chatViewModel';
 
 /**
  * Message ids have to be unique within a conversation (#705).
@@ -86,5 +89,52 @@ describe('chat message ids', () => {
     const initial = chatReducer(undefined, { type: '@@INIT' });
 
     expect(chatReducer(initial, action)).toEqual(chatReducer(initial, action));
+  });
+});
+
+/**
+ * Suggestion ids, which the same fix reached and no test covered.
+ *
+ * Asserting that one batch's ids are distinct would not test this. They were
+ * `suggestion-<time>-1..5`, numbered within the batch, so one batch was already
+ * unique and stayed unique — such a case passes both before and after the fix.
+ * What changed is across batches: the counter used to restart at 1 for every
+ * call, so two batches generated in the same millisecond were the same five
+ * strings. That is the assertion below.
+ *
+ * This goes through `ChatViewModel` rather than the reducer because
+ * `generateSuggestions` is a private method on the class; `updateSuggestions`
+ * is the public surface that reaches it.
+ */
+describe('chat suggestion ids', () => {
+  /**
+   * A view model whose store is real and whose services are never reached.
+   *
+   * The constructor calls `loadInitialMessage`, which only dispatches, and the
+   * path under test only reads settings and messages — so neither service is
+   * touched. Should that stop being true, the call throws on the spot rather
+   * than reading a plausible stub value.
+   * @returns The view model, and the store to read suggestions back from.
+   */
+  function chatViewModel(): { model: ChatViewModel; store: ReturnType<typeof createMaidrStore> } {
+    const store = createMaidrStore();
+    const model = new ChatViewModel(store, {} as ChatService, {} as AudioService);
+    return { model, store };
+  }
+
+  test('are distinct across two batches generated in the same millisecond', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-02T00:00:00.000Z'));
+    const { model, store } = chatViewModel();
+
+    // The welcome message the constructor adds is a system message, so it is
+    // not from the user and suggestions are generated rather than skipped.
+    model.updateSuggestions();
+    const first = store.getState().chat.suggestions.map(suggestion => suggestion.id);
+    model.updateSuggestions();
+    const second = store.getState().chat.suggestions.map(suggestion => suggestion.id);
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(second).toHaveLength(first.length);
+    expect(new Set([...first, ...second]).size).toBe(first.length + second.length);
   });
 });

--- a/test/util/footnoteScope.esm-test.ts
+++ b/test/util/footnoteScope.esm-test.ts
@@ -146,8 +146,8 @@ describe('scoping a message\'s ids', () => {
     // Stripping unsafe characters rather than escaping them would map `a.b`,
     // `a-b` and `a_b` onto one scope and silently reintroduce the collision
     // this exists to prevent. The underscore case is the one that happens:
-    // a response id is `resp-<time>-<provider>`, and three of the four
-    // providers are spelled `ANTHROPIC_CLAUDE`, `GOOGLE_GEMINI`, `OPENAI`.
+    // a response id is `resp-<time>-<sequence>-<provider>`, and two of the
+    // four providers are spelled `ANTHROPIC_CLAUDE` and `GOOGLE_GEMINI`.
     const dotted = ids(await render(FOOTNOTE, 'resp-1-a.b'));
     const dashed = ids(await render(FOOTNOTE, 'resp-1-a-b'));
     const underscored = ids(await render(FOOTNOTE, 'resp-1-a_b'));


### PR DESCRIPTION
# Pull Request

## Description

Message ids were `Date.now()` alone, so two created in the same millisecond were the same string. A human typing cannot reach that; anything adding two messages programmatically can.

## Related Issues

Closes #705. Raised in review on #704, which is what makes it matter. Review here spun off #707.

## Changes Made

**A monotonic sequence, appended.** The timestamp stays for readability and ordering in devtools; the sequence is what carries the uniqueness, being monotonic for the life of the page.

```diff
- id: `msg-${Date.now()}`
+ id: nextId('msg')            // msg-1770000000000-1
```

**The id is minted in `prepare`, not in the reducer.** `rules/viewmodel.md` asks reducers to "assign the payload, nothing more", and the id is the one thing here that cannot come from the caller — so it is generated where Redux Toolkit puts non-determinism, leaving all three reducers pure. The action creators' signatures are unchanged, so no dispatch site moves.

**Suggestion ids get the same treatment.** They were `suggestion-<time>-1..5`: unique within one batch, colliding across two in the same millisecond. Same shape, same fix.

## Why it matters now

#704 derives each message's DOM id scope from its message id. Two messages sharing an id share a scope, so their footnote ids collide again, and a reference resolves to whichever note comes first in document order — the other message's.

Everything still renders. The failure is silent, which is the same shape as the bug #704 removed, arriving through a different door.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no rule or command changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Three things checked rather than assumed

**The `kind` prefix is load-bearing.** `MessageBubble.tsx:86` tells a system message apart with `message.id.startsWith('system-')`. That is the only thing in `src/` that reads the id's format, and it still holds — with a test, because the fix was one careless refactor away from breaking it.

**A collision never misrouted a response.** `updateResponse` and `updateError` look up by `model` **and** `timestamp`, not by id:

```ts
const message = state.messages.find(m =>
  m.model === action.payload.model
  && m.timestamp === action.payload.timestamp,
);
```

Worth knowing, because it means the real blast radius was the DOM ids from #704 and React keys, rather than the conversation itself.

**A third consumer, surfaced in review.** `TypingEffect.tsx:112` keys its `completedAnimations` set on `` `${messageId}\0${text}` ``. Two same-millisecond messages with identical text shared that key, and the second would have skipped its typing animation because the first had already marked it complete. The message still renders in full on the skip path, so nothing is lost visually or to a screen reader — cosmetic, but a real behavioural difference rather than a no-op.

### The test needed the action creators exported

Dispatching by action type — how the other view model tests reach their reducers — **skips `prepare`**, which is now the only step that generates an id. So an action built by hand carries no id at all.

The first version of this test did exactly that and "passed" on `undefined` being equal to itself, until five ids collapsing to one made me look. `chatActions` is exported so the test can go through the creators, which is the path production takes.

### The clock is frozen

Deliberately. With a real clock the old behaviour passes whenever two dispatches straddle a millisecond boundary — the flakiness being removed, used as the test's own oracle. Freezing it makes every id in the case come from one `Date.now()`, where the old code produces one string five times.

### Verified against all three defects

| reverted | case that fails |
|---|---|
| the sequence dropped, back to `Date.now()` alone | `are distinct for messages added in the same millisecond` — 5 ids collapse to 3 |
| the old per-batch suggestion scheme restored | `are distinct across two batches generated in the same millisecond` — 6 collapse to 3 |
| the id minted in the reducer instead of `prepare` | `are minted in the action, leaving the reducer pure` |

The suggestion case is the one worth spelling out. Asserting that a *single* batch's ids are distinct would not have tested this: they were `suggestion-<time>-1..5`, numbered within the batch, so one batch was already unique before the fix. What changed is across batches, because the `1..5` restarted on every call. In the counterfactual run above, the single-batch assertions in that same case still passed — direct evidence that the obvious test would have been green on the bug.

### Commits

| | |
|---|---|
| `a6ed63c` | the fix |
| `c266ee6` | timers restored in `afterEach` rather than at the end of the test |
| `74476f7` | `footnoteScope` doc corrections — the id shape went stale, and the same sentence had a provider count wrong since #704 |
| `ad4a37d` | the suggestion-id case above |

### Verification

| check | result |
|---|---|
| `npm test` | 111 suites, 1390 tests |
| `npm run build` | exit 0 |
| `npm run type-check` | exit 0 |
| `npx eslint .` | exit 0 |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz)_