### PR TITLE
refactor(chat): name the model-selection shape instead of repeating it

### DIFF
--- a/src/state/viewModel/chatViewModel.ts
+++ b/src/state/viewModel/chatViewModel.ts
@@ -2,7 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import type { AudioService } from '@service/audio';
 import type { ChatService } from '@service/chat';
 import type { Suggestion } from '@type/chat';
-import type { Llm, Message } from '@type/llm';
+import type { Llm, Message, SelectedModel } from '@type/llm';
 import type { AppStore, RootState } from '../store';
 import { createSlice } from '@reduxjs/toolkit';
 import { MODEL_VERSIONS } from '@service/modelVersions';
@@ -74,7 +74,7 @@ const chatSlice = createSlice({
       }),
     },
     addSystemMessage: {
-      reducer: (state, action: PayloadAction<{ id: string; text: string; timestamp: string; modelSelections?: { modelKey: Llm; name: string; version: string }[]; isWelcomeMessage?: boolean }>) => {
+      reducer: (state, action: PayloadAction<{ id: string; text: string; timestamp: string; modelSelections?: SelectedModel[]; isWelcomeMessage?: boolean }>) => {
         state.messages.push({
           id: action.payload.id,
           text: action.payload.text,
@@ -85,7 +85,7 @@ const chatSlice = createSlice({
           isWelcomeMessage: action.payload.isWelcomeMessage,
         });
       },
-      prepare: (message: { text: string; timestamp: string; modelSelections?: { modelKey: Llm; name: string; version: string }[]; isWelcomeMessage?: boolean }) => ({
+      prepare: (message: { text: string; timestamp: string; modelSelections?: SelectedModel[]; isWelcomeMessage?: boolean }) => ({
         payload: { ...message, id: nextId('system') },
       }),
     },
@@ -129,7 +129,7 @@ const chatSlice = createSlice({
     updateSuggestions: (state, action: PayloadAction<Suggestion[]>) => {
       state.suggestions = action.payload;
     },
-    updateWelcomeMessage: (state, action: PayloadAction<{ text: string; modelSelections?: { modelKey: Llm; name: string; version: string }[] }>) => {
+    updateWelcomeMessage: (state, action: PayloadAction<{ text: string; modelSelections?: SelectedModel[] }>) => {
       // Find the welcome message (first system message with isWelcomeMessage flag)
       const welcomeMessageIndex = state.messages.findIndex(msg => msg.isWelcomeMessage);
       if (welcomeMessageIndex !== -1) {
@@ -218,9 +218,9 @@ export class ChatViewModel extends AbstractViewModel<ChatState> {
 
   /**
    * Retrieves data about enabled AI models including display names and versions.
-   * @returns {{ enabledModels: string[]; modelSelections: { modelKey: Llm; name: string; version: string }[] }} Enabled models data.
+   * @returns {{ enabledModels: string[]; modelSelections: SelectedModel[] }} Enabled models data.
    */
-  private getEnabledModelsData(): { enabledModels: string[]; modelSelections: { modelKey: Llm; name: string; version: string }[] } {
+  private getEnabledModelsData(): { enabledModels: string[]; modelSelections: SelectedModel[] } {
     const llmModels = this.snapshot.settings.llm.models;
 
     const enabledModels = Object.entries(llmModels)

--- a/src/type/llm.ts
+++ b/src/type/llm.ts
@@ -89,11 +89,17 @@ export interface LlmResponse {
  *
  * Held on the message rather than read from settings at render time, so a
  * message keeps saying which model answered it after the setting changes.
+ *
+ * `version` is `LlmVersion` to agree with `getValidVersion`, which produces it.
+ * That is naming, not narrowing: `OllamaVersion` is `string & Record<never,
+ * never>`, so the union accepts any string — deliberately, as the comment on
+ * that type explains, because versions come from live provider APIs. Nothing
+ * here validates a version; `getValidVersion` does, at runtime.
  */
 export interface SelectedModel {
   modelKey: Llm;
   name: string;
-  version: string;
+  version: LlmVersion;
 }
 
 /**

--- a/src/type/llm.ts
+++ b/src/type/llm.ts
@@ -84,6 +84,19 @@ export interface LlmResponse {
 }
 
 /**
+ * A model that was enabled when a message was created, as that message records
+ * it: the provider it came from, and the display name and version to show.
+ *
+ * Held on the message rather than read from settings at render time, so a
+ * message keeps saying which model answered it after the setting changes.
+ */
+export interface SelectedModel {
+  modelKey: Llm;
+  name: string;
+  version: string;
+}
+
+/**
  * Chat message in the conversation history with metadata and status.
  */
 export interface Message {
@@ -93,11 +106,7 @@ export interface Message {
   model?: Llm;
   timestamp: string;
   status: Status;
-  modelSelections?: {
-    modelKey: Llm;
-    name: string;
-    version: string;
-  }[];
+  modelSelections?: SelectedModel[];
   isWelcomeMessage?: boolean;
 }
 

--- a/src/ui/components/ModelSelection.tsx
+++ b/src/ui/components/ModelSelection.tsx
@@ -1,4 +1,4 @@
-import type { Llm, LlmVersion } from '@type/llm';
+import type { Llm, LlmVersion, SelectedModel } from '@type/llm';
 import { Box, FormControl, MenuItem, Select, Typography } from '@mui/material';
 import { getValidVersion, MODEL_VERSIONS } from '@service/modelVersions';
 import { useModalContainer } from '@state/hook/useModalContainer';
@@ -8,11 +8,7 @@ import { resolveVersionOptions } from '@util/llm';
 import React from 'react';
 
 interface ModelSelectionProps {
-  enabledModels: Array<{
-    modelKey: Llm;
-    name: string;
-    version: string;
-  }>;
+  enabledModels: SelectedModel[];
 }
 
 interface ModelVersionSelectProps {


### PR DESCRIPTION
# Pull Request

## Description

`{ modelKey: Llm; name: string; version: string }[]` was written out **six** times across three files, with nothing tying the copies together.

## Related Issues

Closes #707. Raised as a non-blocking nit in review on #706.

## Changes Made

`SelectedModel` is exported from `src/type/llm.ts`, next to `Message` — which owns the canonical shape — per `rules/typescript.md` putting shared domain types in `src/type/`.

| site | what it was |
|---|---|
| `type/llm.ts` | inline in `Message.modelSelections` |
| `chatViewModel.ts` | `addSystemMessage`'s reducer `PayloadAction` generic |
| `chatViewModel.ts` | `addSystemMessage`'s `prepare` parameter |
| `chatViewModel.ts` | `updateWelcomeMessage`'s `PayloadAction` generic |
| `chatViewModel.ts` | `getEnabledModelsData`'s return type |
| `ModelSelection.tsx` | `ModelSelectionProps.enabledModels` |

A seventh copy sat in prose, in `getEnabledModelsData`'s `@returns`.

#707 listed five of these. The sixth — `ModelSelectionProps` — turned up while doing the work, and is the one that decided the name.

## On the name

`ModelSelection` is the obvious choice and the wrong one. It is already a React component, and **that component's own file is one of the sites that has to import the type**, so the collision would land inside the file least able to work around it. `MessageBubble` is in the same position from the other side: it imports the `ModelSelection` component *and* reads `message.modelSelections`.

`SelectedModel` matches the field it types and collides with nothing.

## `version` is `LlmVersion`, and that is naming rather than narrowing

Raised in review, by both reviewers, as tightening the field. It tightens nothing, and the docstring now says so, because the alternative is that someone later reads it as validation.

```ts
// src/type/llm.ts — the string-with-autocomplete trick
export type OllamaVersion = string & Record<never, never>;
export type LlmVersion = GptVersion | ClaudeVersion | GeminiVersion | OllamaVersion;

// so a union containing `string` IS `string`:
const nonsense: LlmVersion = 'definitely-not-a-real-model-xyz';  // compiles
declare const anyString: string;
const fromString: LlmVersion = anyString;                        // compiles, no cast
```

This is deliberate, and `OllamaVersion`'s own comment says why: model dropdowns are populated from live provider APIs, so the curated literals are suggestions, and correctness is enforced at runtime by `getValidVersion`.

The change is still worth making — `getValidVersion` is declared to return `LlmVersion` and is where the value comes from, so the field naming that type says what it holds rather than merely how wide it is.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no rule or command changed.
- [ ] I have added appropriate unit tests, if applicable. — types only; `tsc` is the test, see below.

## Additional Notes

### What was left alone

`Settings.tsx:183` also has a `modelKey: Llm` field, but it is `LlmModelSettingRowProps` — a settings row's props, a different shape that happens to share one member. Not folded in.

### Verification

Types only, no behaviour, so `tsc` carries the whole check. On its own that only proves the code still compiles — it does not show the sites are actually *bound* to the new type rather than each independently compatible with it. So: renaming `name` to `label` on the extracted interface.

```
src/state/viewModel/chatViewModel.ts(243,29): error TS2322: Type '{ modelKey: Llm; name: string; version: LlmVersion; }[]'
  is not assignable to type 'SelectedModel[]'.
src/ui/components/ModelSelection.tsx(125,20): error TS2339: Property 'name' does not exist on type 'SelectedModel'.
src/ui/components/ModelSelection.tsx(129,36): error TS2339: Property 'name' does not exist on type 'SelectedModel'.
```

Three failures spanning the producer (`getEnabledModelsData`) and the consumer (`ModelSelection` reading `.name`) — which is the property that matters. The four `PayloadAction` generics do not appear, and should not: they pass the type through without constructing or reading a value, so there is nothing there for a field rename to break.

Note the contrast with the `version` swap above, which produced zero errors — that was not evidence of anything, since swapping a type for what amounts to its alias cannot fail. `name` is the field where a rename actually bites.

| check | result |
|---|---|
| `npm test` | 111 suites, 1390 tests |
| `npm run build` | exit 0 |
| `npm run type-check` | exit 0 |
| `npx eslint .` | exit 0 |

CI: 13/13 green on `8743676`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz)_