### PR TITLE
ci: lint the workflow files with actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,50 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+  # Nothing validated the workflow files, which matters most where a mistake is
+  # quietest: e2e_tests.yml runs on `schedule`, so a bad `if:` or an unknown
+  # context does not fail anything — the run just never happens, and nobody is
+  # watching for an absence. See issue #693.
+  #
+  # Runs on every PR rather than only those touching .github/workflows/. Job-level
+  # path filters do not exist, and a workflow-level one would gate every other job
+  # here too. The job takes seconds, so the cheaper thing is to always run it.
+  actionlint:
+    name: Lint Workflows
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # actionlint hands `run:` blocks to shellcheck and, when it is missing,
+      # simply checks less without saying so. That is not hypothetical: the
+      # first local run of this change reported zero problems, and the one real
+      # finding it had to fix only appeared once shellcheck was installed.
+      # ubuntu-latest ships it — asserting that here makes the day it stops a
+      # failure rather than a silently weaker check.
+      - name: Verify shellcheck is available
+        run: shellcheck --version
+
+      # Pinned by version and checksum rather than piping the upstream install
+      # script into bash, so a new actionlint release cannot turn an unrelated
+      # PR red and the download is verified rather than trusted.
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.7
+          ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+        run: |
+          curl -sSLo actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check
+          tar xzf actionlint.tar.gz actionlint
+
+      - name: Lint workflows
+        run: ./actionlint -color
+
   # Playwright on every PR: chromium only, core bundle only. The whole
   # chromium suite is green, so it all runs here — a subset let the specs rot
   # for two months while PRs stayed green (see issue #626). The other two

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           npx semantic-release
           if git describe --tags --exact-match HEAD 2>/dev/null; then
-            echo "new_release=true" >> $GITHUB_OUTPUT
+            echo "new_release=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to npm with trusted publishing


### PR DESCRIPTION
# Pull Request

## Description

Nothing validated `.github/workflows`. That matters most where a mistake is quietest: `e2e_tests.yml` runs on `schedule`, so a bad `if:` or an unknown context fails nothing — the run simply never happens, and an absence is not something anyone is watching for.

## Related Issues

Closes #693. Raised during review of #692.

## Changes Made

Two commits, in this order because the second depends on the first.

| commit | |
|---|---|
| `add7442` | quote `$GITHUB_OUTPUT` in `release.yml` — the one pre-existing finding |
| `e1a98fa` | add the `Lint Workflows` job to `ci.yml` |

## The question the issue left open

> Worth checking whether it should be `continue-on-error` at first — actionlint may flag pre-existing issues across the other workflows, and it would be better to see that list before making it blocking.

Checked by running it. There was **exactly one** finding across all twelve workflows:

```
.github/workflows/release.yml:60:9: shellcheck reported issue in this script:
  SC2086:info:3:30: Double quote to prevent globbing and word splitting [shellcheck]
```

`echo "new_release=true" >> $GITHUB_OUTPUT`, unquoted. The other three writes to a GitHub file command across the workflows already quote it, so this was the outlier rather than a style preference being imposed. Harmless in practice — `GITHUB_OUTPUT` is a runner-controlled path with no spaces or globs — and fixed in `add7442`.

So there is nothing to phase in, and the job goes in **blocking** rather than `continue-on-error`.

## The shellcheck assertion is not ceremony

The job asserts `shellcheck --version` before linting. That step exists because of how this change nearly went wrong.

The **first** local run of actionlint reported zero problems across every workflow. That looked like a clean bill of health and would have justified going straight to a blocking job with no `release.yml` fix at all. It was wrong: actionlint hands `run:` blocks to shellcheck and, when shellcheck is absent, checks less **without saying so**. Neither `shellcheck` nor `pyflakes` was installed locally. Installing shellcheck and re-running is what surfaced the SC2086 above.

`ubuntu-latest` ships shellcheck, so the job gets the full check today. Asserting it makes the day that stops being true a failure rather than a silently weaker check — which is the exact failure mode that just happened locally.

### A version skew the assertion exposed

The first CI run printed `ShellCheck ... version: 0.9.0`. Local verification used **0.10.0**, so this was never the like-for-like comparison it might read as.

The consequence is small but real: a rule added between 0.9.0 and 0.10.0 would fail locally and pass CI, and one removed would do the reverse. Not pinning shellcheck to close it — that means installing a second binary to make a linter agree with itself, for drift that produces a *confusing* result rather than a wrong one, and the assertion step prints the version into every run's log so any future disagreement is one glance from being explained.

Both versions agree on this tree: SC2086 under 0.10.0 locally before the fix, clean under 0.9.0 in CI after it.

## Pinning

The issue sketched the upstream one-liner:

```yaml
bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
```

Used a pinned release tarball with a checksum instead — `1.7.7`, SHA256 `023070a2…`. A new actionlint release cannot turn an unrelated PR red, and the binary is verified rather than trusted.

Verified three ways: against the release's own published `actionlint_1.7.7_checksums.txt`, against an independently re-downloaded artifact, and by the job itself on GitHub's runner (`actionlint.tar.gz: OK`).

## Scope

Runs on every PR, not only those touching `.github/workflows/`. Job-level `paths` filters do not exist, and a workflow-level one would gate every other job in `ci.yml` too. The job takes seconds, so always running it is the cheaper option — and it satisfies the acceptance criterion as a superset.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no rule or command changed.
- [ ] I have added appropriate unit tests, if applicable. — see below.

## Additional Notes

### On tests

`test/scripts/` covers workflow bodies, but `e2eReportWorkflow.test.ts` is there to exercise a `github-script` **JS body** — executable logic extracted from YAML. This job has no JS, only shell, and nothing in `test/` reads `ci.yml`. A test asserting "`ci.yml` contains an actionlint job" would only re-read the file it is testing, so the verification below is the real thing.

### Acceptance criteria, demonstrated

> A deliberately malformed workflow fails the job

| injected fault | result |
|---|---|
| unknown step context — `steps.no_such_step.outputs.thing` | ✅ exit 1, `property "no_such_step" is not defined` |
| misspelled runner label — `ubuntu-lastest` | ✅ exit 1, `label "ubuntu-lastest" is unknown` |
| `runs:` instead of `run:` | ✅ exit 1, `unexpected key "runs" for "step" section` |
| bogus property on `github.event` | ❌ **passes** — and correctly so |

The last one is worth recording rather than quietly dropping. It was my first attempt at a failing case and it did not fail: webhook payloads vary by event, so actionlint types `github.event` as open and cannot flag an arbitrary property on it. Not a gap in the check — a limit of what is knowable there.

> `actionlint` runs on every PR touching `.github/workflows/`

Superset — runs on every PR. This PR is itself the first live case, and the job passed in 4 s.

> Any pre-existing findings in other workflow files are either fixed or explicitly waived

One finding, fixed in `add7442`. Nothing waived.

### Verification

| check | result |
|---|---|
| `actionlint` locally, shellcheck on PATH | exit 0 on the tree as it stands |
| `actionlint` in CI (`Lint Workflows`) | ✅ 4 s |
| `npm test` | 111 suites, 1390 tests |

`actionlint 1.7.7`; shellcheck `0.10.0` locally, `0.9.0` on the runner — see the skew note above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM3PhrCKfM6pEh4iRQ2Fpz)_