### PR TITLE
fix(chat): announce the chat dialog as what its heading shows

### DIFF
--- a/e2e_tests/specs/dialogAccessibility.spec.ts
+++ b/e2e_tests/specs/dialogAccessibility.spec.ts
@@ -249,8 +249,12 @@ test.describe('dialog accessibility tree', () => {
     // cannot check its name: jsdom does not fold a descendant button's
     // `aria-label` into the row's computed name, so the polluted name never
     // appears there. The jsdom suite is not a superset of this one.
+    //
+    // #710 removed the heading's `aria-label`, so the name is now the visible
+    // text. `exact` still carries the assertion: without it this passes against
+    // a name with anything appended, which is the failure mode it exists for.
     await expect(
-      page.getByRole('dialog', { name: 'Chart Assistant - AI Chat Interface', exact: true }),
+      page.getByRole('dialog', { name: 'Chart Assistant', exact: true }),
     ).toBeVisible();
 
     const structure = await dialogStructure(page);

--- a/src/ui/component/Chat.tsx
+++ b/src/ui/component/Chat.tsx
@@ -234,21 +234,21 @@ const Chat: React.FC = () => {
       <DialogTitle component="div" id={`${id}-titlebar`} sx={{ p: 2 }}>
         <Grid container justifyContent="space-between" alignItems="center">
           <Grid size="auto">
-            {/* The `aria-label` below predates #665 and is left alone on
-                purpose. It makes the accessible name longer than the visible
-                text, and since the dialog is now named after this heading,
-                editing it would change the dialog's name too — a behaviour
-                change beyond giving each dialog one title heading. It is not a
-                2.5.3 failure either: the visible text is a prefix of the name.
-                Whether the suffix should be heard when navigating by heading,
-                rather than only when the dialog opens, is its own question. */}
+            {/* No `aria-label` here, so the name is the visible text. This
+                heading names the dialog as well as itself (the
+                `aria-labelledby` above points at it), and it used to carry
+                `aria-label="Chart Assistant - AI Chat Interface"` — announcing
+                more than it showed, in both roles. The suffix restated what
+                `role="dialog"` already conveys, and among MAIDR's five dialogs
+                "Chart Assistant" is unambiguous on its own. Naming it after
+                what is on screen also serves voice control, which speaks the
+                visible text. */}
             <Typography
               id={`${id}-title`}
               variant="h6"
               fontWeight="bold"
               component="h2"
               sx={{ margin: 0 }}
-              aria-label="Chart Assistant - AI Chat Interface"
             >
               Chart Assistant
             </Typography>

--- a/test/ui/dialogTitles.test.tsx
+++ b/test/ui/dialogTitles.test.tsx
@@ -48,7 +48,7 @@ import '@testing-library/jest-dom/jest-globals';
 // the same reason.
 jest.mock('@ui/components/MessageBubble', () => ({ MessageBubble: () => null }));
 
-const CHAT_NAME = 'Chart Assistant - AI Chat Interface';
+const CHAT_NAME = 'Chart Assistant';
 const CLOSE_BUTTON_NAME = 'Close chat dialog';
 
 const HELP_ITEMS: HelpMenuItem[] = [
@@ -294,14 +294,25 @@ describe('dialog titles', () => {
       ).toBeNull();
     });
 
-    it('should name the dialog after its heading', () => {
+    /**
+     * #710: the heading carried `aria-label="Chart Assistant - AI Chat
+     * Interface"`, so it announced more than it showed — both as a heading and
+     * as the dialog's name, since the dialog is named after it. Removing the
+     * label is what makes the two agree.
+     *
+     * Asserted as an equality between the visible text and the computed name
+     * rather than against the string alone: that is the contract, and it holds
+     * a re-added `aria-label` to account whatever wording it uses.
+     */
+    it('should announce the dialog as exactly what the heading shows', () => {
       renderChat();
 
       const dialog = screen.getByRole('dialog');
+      const title = document.getElementById(dialog.getAttribute('aria-labelledby') ?? '');
 
-      // Characterises the name as it stands; the reference above is what keeps
-      // the close button out of it.
-      expect(dialog).toHaveAccessibleName(CHAT_NAME);
+      expect(title?.textContent?.trim()).toBe(CHAT_NAME);
+      expect(title?.getAttribute('aria-label')).toBeNull();
+      expect(dialog).toHaveAccessibleName(title?.textContent?.trim() ?? '');
       expect(dialog.getAttribute('aria-label')).toBeNull();
     });
 


### PR DESCRIPTION
Closes #710. Follow-up to #666, which is what made this worth fixing.

## The problem

`Chat.tsx`'s title heading rendered **"Chart Assistant"** while carrying `aria-label="Chart Assistant - AI Chat Interface"`. It announced more than it showed — and in two places at once, because #666 pointed the dialog's `aria-labelledby` at this heading. One attribute was naming both the heading and the dialog.

Not a WCAG 2.5.3 failure (the visible text is a prefix of the accessible name, and a heading is not a labelled control), which is why #666 left it alone rather than scope-creeping. It is still a divergence between what is on screen and what is announced.

## The fix: drop the suffix

| | before | after |
| --- | --- | --- |
| On screen | Chart Assistant | Chart Assistant |
| Heading navigation | Chart Assistant - AI Chat Interface | Chart Assistant |
| Dialog opening | Chart Assistant - AI Chat Interface | Chart Assistant |

Removed rather than relocated:

- `role="dialog"` is already announced, so a screen reader says "Chart Assistant, dialog". "AI Chat Interface" largely restates the container type the role has just conveyed.
- Among MAIDR's five dialogs — Settings, Keyboard Shortcuts, Chart Description, Command Palette, Chart Assistant — the short name is unambiguous.
- Visible text and accessible name now match, which also serves voice control: those users speak what they see.

### The alternative, and why not

Genuinely giving the heading and the dialog *different* names means pointing `aria-labelledby` at a dedicated hidden element. That works, and `visuallyHidden` already exists (#699) — but it would put the dialog's name back on something nobody can see, which is the shape #664 and #666 both moved away from. Each replaced an invisible or dangling name source with the visible title.

A visually hidden *suffix inside the heading* does not split them either: name-from-content includes hidden-but-not-`display:none` text, so the heading would still announce the long form.

### One dead end worth recording

`aria-label` on `<Dialog>` is not an option. MUI spreads `...other` — `aria-label` included — onto the `role="presentation"` root, and only `role`, `aria-labelledby`, `aria-describedby` and `aria-modal` reach the paper:

```js
// Dialog.js:340 — the root
...other,

// Dialog.js:347-353 — the paper, which carries role="dialog"
role: role,
"aria-describedby": ariaDescribedby,
"aria-labelledby": ariaLabelledby,
"aria-modal": ariaModal,
```

That is exactly the #663 defect — `Settings.tsx` passed `aria-label="Settings"` and the dialog ended up with no accessible name at all. I suggested this route on #710 before checking, and [corrected it there](https://github.com/xability/maidr/issues/710#issuecomment-5160428480).

## Tests

Both assertions that pinned the old name are updated — they were written so this could not change silently, and it did not.

The jsdom case now asserts an **equality** rather than a string: that the dialog's computed name is exactly the heading's visible text. That holds a re-added `aria-label` to account whatever wording it uses, which a hard-coded expectation would not.

```ts
expect(title?.textContent?.trim()).toBe(CHAT_NAME);
expect(title?.getAttribute('aria-label')).toBeNull();
expect(dialog).toHaveAccessibleName(title?.textContent?.trim() ?? '');
expect(dialog.getAttribute('aria-label')).toBeNull();
```

**Bidirectional:** restoring the `aria-label` in `Chat.tsx` alone turns exactly one case red — `should announce the dialog as exactly what the heading shows` — and leaves the other seven green. The one that fails is the one written for this.

## Verification

- **`dialogAccessibility.spec.ts` on all three browsers — 21/21.** firefox and webkit included, not just chromium.
- Full chromium e2e suite — 308/308.
- jest — unit 107 suites / 1341 tests, esm 5 / 57.
- `tsc --noEmit`, `eslint`, `npm run build` — clean.

Cross-browser matters more than usual here: accessible-name computation is where engines diverge, and this PR changes a name. The three engines agree.

That coverage was possible because #711 established it — firefox and webkit were absent from this environment and needed `playwright install` plus `install-deps` (webkit pulls in a long list of system libraries). Worth knowing that the PR CI job remains chromium-only by design; the scheduled `e2e_tests.yml` is what covers the other two after merge.

## To flag

**This is a judgement, and it is the kind a tool cannot settle.** Playwright and jsdom compute accessible names; neither tells you whether the announcement is *better*. Someone should confirm with a real screen reader that "Chart Assistant, dialog" reads as well on open as the longer form did. The change is small and reversible if it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH49ExPkrEGyEWZJj1EFmm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH49ExPkrEGyEWZJj1EFmm)_