### PR TITLE
chore(cdnjs): add the package manifest for listing maidr on cdnjs

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -30,9 +30,21 @@ forget, because a project the runner omits simply never runs.
 
 `test/` mirrors `src/` — `test/model/`, `test/service/`, `test/state/`,
 `test/command/`, `test/ui/`, `test/util/`, `test/adapters/`. Put a new unit
-test in the directory matching the layer it covers. `test/scripts/` is the
-exception, and covers `scripts/` rather than a layer of the application: the
-build, the test runner, and the workflow bodies under `.github/`.
+test in the directory matching the layer it covers.
+
+Not everything worth testing is a layer of the application, so a directory here
+may instead mirror one at the repository root, under the same name:
+
+- `test/scripts/` covers `scripts/` — the build, the test runner, and the
+  workflow bodies under `.github/`.
+- `test/cdnjs/` covers `cdnjs/`, the payload for the cdnjs listing, which
+  nothing in this repository reads and which therefore has nowhere else to be
+  checked.
+
+Both follow the same rule as the layer directories: the test lives in the
+directory named after what it covers. Add another only when the thing under
+test genuinely is not application code — a config file that has to stay in step
+with the build is; a new module of `src/` is not.
 
 ```bash
 npm test              # jest, with coverage, one process per project

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -29,9 +29,21 @@ forget, because a project the runner omits simply never runs.
 
 `test/` mirrors `src/` — `test/model/`, `test/service/`, `test/state/`,
 `test/command/`, `test/ui/`, `test/util/`, `test/adapters/`. Put a new unit
-test in the directory matching the layer it covers. `test/scripts/` is the
-exception, and covers `scripts/` rather than a layer of the application: the
-build, the test runner, and the workflow bodies under `.github/`.
+test in the directory matching the layer it covers.
+
+Not everything worth testing is a layer of the application, so a directory here
+may instead mirror one at the repository root, under the same name:
+
+- `test/scripts/` covers `scripts/` — the build, the test runner, and the
+  workflow bodies under `.github/`.
+- `test/cdnjs/` covers `cdnjs/`, the payload for the cdnjs listing, which
+  nothing in this repository reads and which therefore has nowhere else to be
+  checked.
+
+Both follow the same rule as the layer directories: the test lives in the
+directory named after what it covers. Add another only when the thing under
+test genuinely is not application code — a config file that has to stay in step
+with the build is; a new module of `src/` is not.
 
 ```bash
 npm test              # jest, with coverage, one process per project

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To use maidr, follow these steps:
 
 1. **Import your plot**: maidr is designed to work seamlessly with scalable vector graphics (SVG) objects for visual highlighting. However, maidr is inherently visual-agnostic, and it also supports other raster image formats such as PNG and JPG without the visual highlight feature. Regardless of the image format, maidr provides support for all non-visual modalities, including Braille, text, and sonification (BTS). Additionally, it offers interactive and artificial intelligence (AI) plot descriptions powered by OpenAI GPT, Anthropic Claude, Google Gemini, or local models running on your own machine via [Ollama](https://ollama.com) (no API key required, suitable for sensitive data). The supported plot types include bar plot, boxplot, heatmap, scatter plot, line plot, histogram, segmented bar plots (e.g., stacked bar plot, side-by-side dodged plot, and normalized stacked bar plot).
 
-2. **Create an HTML file**: Include the main script file `maidr.js` or `maidr.min.js` as well as the stylesheet `styles.css` or `styles.min.css`. Add the SVG of your plot to the main HTML body, and add an ID attribute of your choice to the SVG. Note that this can be automated with R. Your HTML file should now have the following structure:
+2. **Create an HTML file**: Include the main script file `maidr.js` as well as the stylesheet `maidr.css`. Add the SVG of your plot to the main HTML body, and add an ID attribute of your choice to the SVG. Note that this can be automated with R. Your HTML file should now have the following structure:
 
    ```html
    <!doctype html>
@@ -43,7 +43,7 @@ To use maidr, follow these steps:
      <head>
        <meta charset="UTF-8" />
        <title>maidr Example</title>
-       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr_style.css" />
+       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.css" />
        <script src="https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js"></script>
      </head>
      <body>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To use maidr, follow these steps:
 
 1. **Import your plot**: maidr is designed to work seamlessly with scalable vector graphics (SVG) objects for visual highlighting. However, maidr is inherently visual-agnostic, and it also supports other raster image formats such as PNG and JPG without the visual highlight feature. Regardless of the image format, maidr provides support for all non-visual modalities, including Braille, text, and sonification (BTS). Additionally, it offers interactive and artificial intelligence (AI) plot descriptions powered by OpenAI GPT, Anthropic Claude, Google Gemini, or local models running on your own machine via [Ollama](https://ollama.com) (no API key required, suitable for sensitive data). The supported plot types include bar plot, boxplot, heatmap, scatter plot, line plot, histogram, segmented bar plots (e.g., stacked bar plot, side-by-side dodged plot, and normalized stacked bar plot).
 
-2. **Create an HTML file**: Include the main script file `maidr.js` as well as the stylesheet `maidr.css`. Add the SVG of your plot to the main HTML body, and add an ID attribute of your choice to the SVG. Note that this can be automated with R. Your HTML file should now have the following structure:
+2. **Create an HTML file**: Include the main script file `maidr.js`. No stylesheet link is needed — maidr styles its own interface at runtime, and fetches the stylesheet for mathematical notation on demand when it is actually required. Add the SVG of your plot to the main HTML body, and add an ID attribute of your choice to the SVG. Note that this can be automated with R. Your HTML file should now have the following structure:
 
    ```html
    <!doctype html>
@@ -43,7 +43,6 @@ To use maidr, follow these steps:
      <head>
        <meta charset="UTF-8" />
        <title>maidr Example</title>
-       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.css" />
        <script src="https://cdn.jsdelivr.net/npm/maidr@latest/dist/maidr.js"></script>
      </head>
      <body>

--- a/cdnjs/README.md
+++ b/cdnjs/README.md
@@ -20,7 +20,7 @@ JSON file.
 ## Submitting
 
 Fork [`cdnjs/packages`](https://github.com/cdnjs/packages) — **not**
-`cdnjs/cdnjs`, which is robot-only — and copy this file in verbatim:
+`cdnjs/cdnjs`, which is robot-only — and copy this file verbatim:
 
 ```bash
 cp cdnjs/maidr.json path/to/packages/packages/m/maidr.json

--- a/cdnjs/README.md
+++ b/cdnjs/README.md
@@ -26,11 +26,17 @@ Fork [`cdnjs/packages`](https://github.com/cdnjs/packages) — **not**
 cp cdnjs/maidr.json path/to/packages/packages/m/maidr.json
 ```
 
-Work on a branch rather than `master`, commit as
-`Add maidr w/ npm auto-update`, and open the pull request. CI runs
-`checker lint` against cdnjs's schema; `name`, `description`, `keywords`,
-`repository` and `autoupdate` are the required fields. Approval is at cdnjs
+Work on a branch rather than `master` — cdnjs asks for a descriptive name, so
+`add-maidr` — and commit as `Add maidr w/ npm auto-update`, which is their
+`Add <library> w/ npm/git auto-update` convention. Then open the pull request.
+CI validates the file against cdnjs's schema, and approval is at cdnjs
 maintainer discretion.
+
+The branch convention, the commit format and the minification cdnjs performs
+were read from
+[their CONTRIBUTING.md](https://github.com/cdnjs/packages/blob/master/CONTRIBUTING.md)
+on 2026-08-03. That process has changed before, so read it again rather than
+trusting this file if the submission happens much later.
 
 After the first release lands on cdnjs, nothing further is needed for
 subsequent releases: `autoupdate` pulls each new version straight from npm.
@@ -66,10 +72,14 @@ loading MAIDR from a CDN needs to fetch it by URL — which is what separates
 these three from the adapter bundles, whose users name them in a `<script>` tag
 and can be served by either CDN.
 
-`filename` names the file cdnjs offers as the default copy-paste URL. cdnjs
-generates the `.min.js` and `.min.css` variants itself, so `maidr.min.js` is a
-file it will have even though the build does not emit one; if its checker ever
-disagrees, `maidr.js` is the safe substitute.
+`filename` names the file cdnjs offers as the default copy-paste URL. It is
+`maidr.min.js`, a file cdnjs will have even though this build never emits one:
+their CONTRIBUTING.md commits to generating it — "for JavaScript and CSS files,
+we'll automatically generate minified versions of them and make them available
+at `filename.min.js` or `filename.min.css`" — and that generation is on unless a
+package opts out through the optional `optimization` property, which this
+manifest does not set. KaTeX's own cdnjs entry names `katex.min.js` on the same
+basis. Should their checker disagree anyway, `maidr.js` is the safe substitute.
 
 ## Keeping it honest
 

--- a/cdnjs/README.md
+++ b/cdnjs/README.md
@@ -47,8 +47,9 @@ effect once that pull request is merged.
 ## What is mirrored, and why only this
 
 ```
-dist/maidr.js        the library
-dist/maidr.css       the stylesheet every integration links by name
+dist/maidr.js        the library — the only file a page needs to link
+dist/maidr.css       a 406-byte placeholder, kept so that pages which still
+                     link it (as this README used to instruct) do not 404
 dist/maidr-math.css  KaTeX, fetched at runtime when a chat response has maths
 ```
 

--- a/cdnjs/README.md
+++ b/cdnjs/README.md
@@ -1,0 +1,93 @@
+# cdnjs submission
+
+`maidr.json` in this directory is the payload for listing MAIDR on
+[cdnjs](https://cdnjs.com). It is not read by any build step here — cdnjs
+serves packages from its own repository, and a copy has to be sent there. It
+lives in this repo so the contents are reviewed, versioned and tested alongside
+the build that produces the files it mirrors, rather than being retyped from
+memory the next time something about `dist` changes.
+
+## Why cdnjs as well as jsDelivr
+
+jsDelivr already serves every published version, and the documentation points
+at it. The reason to be on both is that sandboxed embedding contexts allow a
+fixed set of CDN hosts, and the two big ones are not interchangeable: a page
+whose `script-src` names `cdnjs.cloudflare.com` cannot load MAIDR from
+jsDelivr, however well jsDelivr works everywhere else. Being on both removes a
+class of "the CDN I was told to use does not carry it" failure, and costs one
+JSON file.
+
+## Submitting
+
+Fork [`cdnjs/packages`](https://github.com/cdnjs/packages) — **not**
+`cdnjs/cdnjs`, which is robot-only — and copy this file in verbatim:
+
+```bash
+cp cdnjs/maidr.json path/to/packages/packages/m/maidr.json
+```
+
+Work on a branch rather than `master`, commit as
+`Add maidr w/ npm auto-update`, and open the pull request. CI runs
+`checker lint` against cdnjs's schema; `name`, `description`, `keywords`,
+`repository` and `autoupdate` are the required fields. Approval is at cdnjs
+maintainer discretion.
+
+After the first release lands on cdnjs, nothing further is needed for
+subsequent releases: `autoupdate` pulls each new version straight from npm.
+Changing what is mirrored, though, means another pull request to
+`cdnjs/packages` — this file is the source to edit, and the change only takes
+effect once that pull request is merged.
+
+## What is mirrored, and why only this
+
+```
+dist/maidr.js        the library
+dist/maidr.css       the stylesheet every integration links by name
+dist/maidr-math.css  KaTeX, fetched at runtime when a chat response has maths
+```
+
+Three files, listed one by one. cdnjs
+[asks explicitly](https://github.com/cdnjs/packages/issues/186) that file globs
+stay narrow, and a `dist/*.js` here would pull in every adapter bundle
+(amcharts, chartjs, vegalite and the rest, each around 1.9 MB) plus their
+sourcemaps — `dist/maidr.js.map` alone is 8.7 MB. None of that belongs on a
+CDN mirror.
+
+`maidr-math.css` is the one entry that is easy to leave out and expensive to
+get wrong. `src/util/katex.ts` links it at runtime, resolving it _relative to
+the URL `maidr.js` was loaded from_ — so on a page served from cdnjs it
+resolves to a cdnjs URL, and if cdnjs is not mirroring the file that URL 404s.
+The failure is quiet and narrow: LaTeX in AI chat responses renders unstyled,
+everything else is fine, and no page that never opens the chat notices. Keep it
+in the `fileMap`.
+
+Adding a file to `dist` does not mean adding it here. Mirror a file when a page
+loading MAIDR from a CDN needs to fetch it by URL — which is what separates
+these three from the adapter bundles, whose users name them in a `<script>` tag
+and can be served by either CDN.
+
+`filename` names the file cdnjs offers as the default copy-paste URL. cdnjs
+generates the `.min.js` and `.min.css` variants itself, so `maidr.min.js` is a
+file it will have even though the build does not emit one; if its checker ever
+disagrees, `maidr.js` is the safe substitute.
+
+## Keeping it honest
+
+`test/cdnjs/manifest.test.ts` pins this file to the rest of the repository:
+`name`, `description`, `homepage`, `license` and `repository` against
+`package.json`, and every mirrored filename against what `scripts/build.js`
+actually emits. Rename an output or drop a field and that test fails here,
+rather than the mirror quietly serving a 404 for however long it takes someone
+to notice.
+
+The test cannot see cdnjs. It checks that this file is right about _this_
+repository; whether cdnjs has been told about a change is still a matter of
+having opened that second pull request.
+
+## Once it is listed
+
+- Add the cdnjs URLs alongside the jsDelivr ones in `README.md` and `docs/`.
+  Until then those URLs 404, so this is deliberately not done in advance.
+- Check `https://cdnjs.com/libraries/maidr` picks up the following release
+  automatically. If it does not, the `autoupdate` block is wrong and needs
+  another pull request to `cdnjs/packages`.

--- a/cdnjs/maidr.json
+++ b/cdnjs/maidr.json
@@ -1,0 +1,33 @@
+{
+  "name": "maidr",
+  "description": "Multimodal Access and Interactive Data Representation — non-visual access to data visualizations via sonification, text descriptions, and braille.",
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "data-visualization",
+    "sonification",
+    "braille",
+    "screen-reader"
+  ],
+  "filename": "maidr.min.js",
+  "homepage": "https://maidr.ai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xability/maidr.git"
+  },
+  "license": "GPL-3.0-or-later",
+  "autoupdate": {
+    "source": "npm",
+    "target": "maidr",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "maidr.js",
+          "maidr.css",
+          "maidr-math.css"
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
     "type": "git",
     "url": "https://github.com/xability/maidr"
   },
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "data-visualization",
+    "sonification",
+    "braille",
+    "screen-reader"
+  ],
   "exports": {
     ".": {
       "default": "./dist/maidr.js"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "maidr",
   "type": "module",
   "version": "3.75.0",
+  "description": "Multimodal Access and Interactive Data Representation — non-visual access to data visualizations via sonification, text descriptions, and braille.",
   "license": "GPL-3.0-or-later",
+  "homepage": "https://maidr.ai",
   "repository": {
     "type": "git",
     "url": "https://github.com/xability/maidr"

--- a/test/cdnjs/manifest.test.ts
+++ b/test/cdnjs/manifest.test.ts
@@ -127,9 +127,13 @@ const mirrored = manifest.autoupdate.fileMap.flatMap(entry => entry.files);
 /**
  * Whether a manifest value is missing, blank, or an empty container.
  *
- * Recurses, so an empty `files` array nested inside `autoupdate.fileMap`
- * counts — that is the one that would mirror nothing at all while the manifest
- * still validated.
+ * Recurses, and reports a container empty when *any* element is — so a blank
+ * entry in `keywords`, not only an absent list, fails the field it belongs to.
+ * That is deliberate: a half-filled list is the shape this is here to catch,
+ * and pinning the guilty element is worth less than failing on the field a
+ * reader can go and look at. Nested values count for the same reason, which is
+ * what makes an empty `files` array inside `autoupdate.fileMap` a failure —
+ * the one that would mirror nothing at all while the manifest still validated.
  * @param value - Any value read out of the manifest.
  * @returns True when the value carries nothing.
  */

--- a/test/cdnjs/manifest.test.ts
+++ b/test/cdnjs/manifest.test.ts
@@ -79,21 +79,30 @@ const pkg = JSON.parse(
 /**
  * Ask the real build config which filenames it produces.
  *
- * `fileName` is invoked the way Vite invokes it — `(format, entryName)` — so a
- * callback that varies by format is resolved for each of the formats its
- * bundle declares, rather than being assumed to yield one name.
+ * `fileName` is invoked exactly the way Vite invokes it — `(format, entryName)`,
+ * with `entryName` derived from the entry file's base name, as
+ * `assertUniqueOutputFilenames` in `scripts/build.js` does. Passing anything
+ * else would make this agree with the build only for as long as every callback
+ * keeps ignoring its arguments, which is not a property worth resting on: a
+ * callback that varies by format is already resolved per format here, and one
+ * that starts varying by entry name would be resolved against a name Vite never
+ * passes.
  */
 function readBuildOutputs(): BuildOutputs {
   const source = `
+    import path from 'node:path';
     import { builds } from ${JSON.stringify(BUILD_SCRIPT)};
     import {
       CORE_STYLESHEET_FILENAME,
       MATH_STYLESHEET_FILENAME,
     } from ${JSON.stringify(MATH_PLUGIN)};
 
+    const entryNameOf = build =>
+      path.basename(build.entry, path.extname(build.entry));
+
     const namesOf = build => (build.formats ?? ['es', 'umd']).map(format =>
       typeof build.fileName === 'function'
-        ? build.fileName(format, build.name)
+        ? build.fileName(format, entryNameOf(build))
         : build.fileName);
 
     process.stdout.write(JSON.stringify({

--- a/test/cdnjs/manifest.test.ts
+++ b/test/cdnjs/manifest.test.ts
@@ -123,14 +123,59 @@ function readBuildOutputs(): BuildOutputs {
 const outputs = readBuildOutputs();
 const mirrored = manifest.autoupdate.fileMap.flatMap(entry => entry.files);
 
-describe('cdnjs manifest metadata', () => {
-  it('should carry every field cdnjs requires', () => {
-    for (const field of ['name', 'description', 'keywords', 'repository', 'autoupdate'] as const) {
-      expect(manifest[field]).toBeDefined();
-    }
+/**
+ * Whether a manifest value is missing, blank, or an empty container.
+ *
+ * Recurses, so an empty `files` array nested inside `autoupdate.fileMap`
+ * counts — that is the one that would mirror nothing at all while the manifest
+ * still validated.
+ * @param value - Any value read out of the manifest.
+ * @returns True when the value carries nothing.
+ */
+function isEmpty(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return true;
+  }
+  if (typeof value === 'string') {
+    return value.trim().length === 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0 || value.some(isEmpty);
+  }
+  if (typeof value === 'object') {
+    const entries = Object.values(value);
+    return entries.length === 0 || entries.some(isEmpty);
+  }
+  return false;
+}
 
-    expect(manifest.keywords.length).toBeGreaterThan(0);
-    expect(manifest.description.length).toBeGreaterThan(0);
+describe('cdnjs manifest metadata', () => {
+  // Deliberately not "the fields cdnjs requires". That list could not be
+  // confirmed against their schema — see `cdnjs/README.md` — and a test
+  // asserting an unverified external requirement claims an authority it does
+  // not have. What this repository can state is which fields its own listing
+  // is built from, and that adding or dropping one is a change to review
+  // rather than something to notice on cdnjs later.
+  it('should declare exactly the fields this listing is built from', () => {
+    expect(Object.keys(manifest).sort()).toEqual([
+      'autoupdate',
+      'description',
+      'filename',
+      'homepage',
+      'keywords',
+      'license',
+      'name',
+      'repository',
+    ]);
+  });
+
+  // Emptiness is the failure that survives every other check here: a blank
+  // description or an empty `files` array is still the right shape, still
+  // parses, and still reaches cdnjs looking filled in.
+  it('should leave none of those fields empty', () => {
+    for (const [field, value] of Object.entries(manifest)) {
+      expect({ field, empty: isEmpty(value) }).toEqual({ field, empty: false });
+    }
   });
 
   it('should describe the same package as package.json', () => {

--- a/test/cdnjs/manifest.test.ts
+++ b/test/cdnjs/manifest.test.ts
@@ -1,0 +1,208 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Tests for `cdnjs/maidr.json`, the payload that lists MAIDR on cdnjs.
+ *
+ * Nothing in this repository reads that file — cdnjs serves packages from its
+ * own repository, so the copy that matters lives there and is updated by a
+ * pull request. That is exactly why it needs pinning: a rename in `dist` or a
+ * dropped field breaks the mirror silently, months after the change, in a
+ * place no CI run of ours can see.
+ *
+ * So the checks here answer one question: is this file still true about *this*
+ * repository? Every mirrored filename is compared against what
+ * `scripts/build.js` really emits, and the metadata against `package.json`.
+ * Whether cdnjs has been told about a change is a separate matter, and one no
+ * test can settle; `cdnjs/README.md` covers it.
+ *
+ * `scripts/build.js` and the stylesheet plugin are plain ESM JavaScript and
+ * `tsconfig.json` sets `allowJs: false`, so their facts are read out of a node
+ * subprocess — the same approach as `test/scripts/buildOutputFilenames` and
+ * `test/scripts/mathStylesheet`, and one that exercises the modules the way
+ * the build itself loads them.
+ */
+
+const ROOT = resolve(__dirname, '../..');
+const BUILD_SCRIPT = pathToFileURL(resolve(ROOT, 'scripts/build.js')).href;
+const MATH_PLUGIN = pathToFileURL(
+  resolve(ROOT, 'scripts/vite-plugin-math-stylesheet.js'),
+).href;
+
+interface Manifest {
+  name: string;
+  description: string;
+  keywords: string[];
+  filename: string;
+  homepage: string;
+  repository: { type: string; url: string };
+  license: string;
+  autoupdate: {
+    source: string;
+    target: string;
+    fileMap: { basePath: string; files: string[] }[];
+  };
+}
+
+interface PackageJson {
+  name: string;
+  description: string;
+  homepage: string;
+  license: string;
+  repository: { url: string };
+  files: string[];
+}
+
+/** What the build emits, read from the build config itself. */
+interface BuildOutputs {
+  /** Filenames the `core` bundle writes — `maidr.js` today. */
+  core: string[];
+  /** The stylesheet every integration links by name. */
+  coreStylesheet: string;
+  /** The KaTeX stylesheet `maidr.js` fetches on demand. */
+  mathStylesheet: string;
+  /** Every filename any bundle writes, adapters included. */
+  all: string[];
+}
+
+const manifest = JSON.parse(
+  readFileSync(resolve(ROOT, 'cdnjs/maidr.json'), 'utf8'),
+) as Manifest;
+
+const pkg = JSON.parse(
+  readFileSync(resolve(ROOT, 'package.json'), 'utf8'),
+) as PackageJson;
+
+/**
+ * Ask the real build config which filenames it produces.
+ *
+ * `fileName` is invoked the way Vite invokes it — `(format, entryName)` — so a
+ * callback that varies by format is resolved for each of the formats its
+ * bundle declares, rather than being assumed to yield one name.
+ */
+function readBuildOutputs(): BuildOutputs {
+  const source = `
+    import { builds } from ${JSON.stringify(BUILD_SCRIPT)};
+    import {
+      CORE_STYLESHEET_FILENAME,
+      MATH_STYLESHEET_FILENAME,
+    } from ${JSON.stringify(MATH_PLUGIN)};
+
+    const namesOf = build => (build.formats ?? ['es', 'umd']).map(format =>
+      typeof build.fileName === 'function'
+        ? build.fileName(format, build.name)
+        : build.fileName);
+
+    process.stdout.write(JSON.stringify({
+      core: namesOf(builds.find(build => build.name === 'core')),
+      coreStylesheet: CORE_STYLESHEET_FILENAME,
+      mathStylesheet: MATH_STYLESHEET_FILENAME,
+      all: builds.flatMap(namesOf),
+    }));
+  `;
+  const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', source], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  return JSON.parse(stdout) as BuildOutputs;
+}
+
+const outputs = readBuildOutputs();
+const mirrored = manifest.autoupdate.fileMap.flatMap(entry => entry.files);
+
+describe('cdnjs manifest metadata', () => {
+  it('should carry every field cdnjs requires', () => {
+    for (const field of ['name', 'description', 'keywords', 'repository', 'autoupdate'] as const) {
+      expect(manifest[field]).toBeDefined();
+    }
+
+    expect(manifest.keywords.length).toBeGreaterThan(0);
+    expect(manifest.description.length).toBeGreaterThan(0);
+  });
+
+  it('should describe the same package as package.json', () => {
+    expect(manifest.name).toBe(pkg.name);
+    expect(manifest.description).toBe(pkg.description);
+    expect(manifest.homepage).toBe(pkg.homepage);
+  });
+
+  // cdnjs redistributes the files, so a licence that disagrees with the one
+  // in the published package is a licensing claim we did not make. The
+  // GPL-3.0-or-later declaration is what unblocked this listing at all.
+  it('should declare the licence the package is published under', () => {
+    expect(manifest.license).toBe(pkg.license);
+  });
+
+  it('should point at this repository', () => {
+    const withoutSuffix = (url: string): string => url.replace(/\.git$/, '');
+
+    expect(withoutSuffix(manifest.repository.url)).toBe(withoutSuffix(pkg.repository.url));
+    expect(manifest.repository.type).toBe('git');
+  });
+});
+
+describe('cdnjs auto-update', () => {
+  it('should follow the npm package this repository publishes', () => {
+    expect(manifest.autoupdate.source).toBe('npm');
+    expect(manifest.autoupdate.target).toBe(pkg.name);
+  });
+
+  // `basePath` is a path inside the npm tarball. `files` in package.json is
+  // what npm puts there, so a basePath outside it mirrors nothing at all.
+  it('should mirror from a directory the npm tarball contains', () => {
+    for (const entry of manifest.autoupdate.fileMap) {
+      const root = entry.basePath.split('/')[0];
+
+      expect(pkg.files).toContain(root);
+    }
+  });
+});
+
+describe('cdnjs file map', () => {
+  it('should only mirror files the build emits', () => {
+    const emitted = [...outputs.core, outputs.coreStylesheet, outputs.mathStylesheet];
+
+    expect(mirrored.length).toBeGreaterThan(0);
+    for (const file of mirrored) {
+      expect(emitted).toContain(file);
+    }
+  });
+
+  // The stylesheet is linked at runtime by src/util/katex.ts, resolved against
+  // the URL maidr.js was loaded from — so on a cdnjs-served page it resolves
+  // to a cdnjs URL. Leave it unmirrored and that URL 404s, and LaTeX in AI
+  // chat responses renders unstyled with nothing else to show for it.
+  it('should mirror the maths stylesheet maidr.js fetches at runtime', () => {
+    expect(mirrored).toContain(outputs.mathStylesheet);
+  });
+
+  // cdnjs asks that globs stay narrow (cdnjs/packages#186). `dist/*.js` here
+  // would pull every adapter bundle and every sourcemap along with the library.
+  it('should list each file by name rather than by glob', () => {
+    for (const file of mirrored) {
+      expect(file).not.toMatch(/[*?[\]]/);
+    }
+  });
+
+  it('should not mirror sourcemaps or adapter bundles', () => {
+    const adapters = outputs.all.filter(name => !outputs.core.includes(name));
+
+    for (const file of mirrored) {
+      expect(file).not.toMatch(/\.map$/);
+      expect(adapters).not.toContain(file);
+    }
+  });
+
+  // cdnjs generates the .min variants itself, so the default file it offers is
+  // allowed to be one the build never writes — but only as the minified form
+  // of something actually mirrored, or the URL cdnjs advertises is a 404.
+  it('should default to a mirrored file, minified or not', () => {
+    const unminified = manifest.filename.replace(/\.min(\.\w+)$/, '$1');
+
+    expect(mirrored).toContain(unminified);
+  });
+});

--- a/test/cdnjs/manifest.test.ts
+++ b/test/cdnjs/manifest.test.ts
@@ -50,6 +50,7 @@ interface Manifest {
 interface PackageJson {
   name: string;
   description: string;
+  keywords: string[];
   homepage: string;
   license: string;
   repository: { url: string };
@@ -182,6 +183,9 @@ describe('cdnjs manifest metadata', () => {
     expect(manifest.name).toBe(pkg.name);
     expect(manifest.description).toBe(pkg.description);
     expect(manifest.homepage).toBe(pkg.homepage);
+    // Order included: these are two hand-maintained copies of one list, and
+    // "same set, different order" is a diff someone still has to read.
+    expect(manifest.keywords).toEqual(pkg.keywords);
   });
 
   // cdnjs redistributes the files, so a licence that disagrees with the one


### PR DESCRIPTION
# Pull Request

## Description

Prepares the cdnjs listing that the GPL-3.0-or-later declaration unblocked, and
does the parts of it that live in this repository: the submission payload, the
metadata it declares, and a test that keeps both true about the build.

The submission itself has to be a pull request against
[`cdnjs/packages`](https://github.com/cdnjs/packages) — cdnjs serves packages
from its own repository, and nothing here can put a file there. That step is
still a maintainer action; `cdnjs/README.md` in this PR is the instruction for
it, and the JSON is copy-paste ready.

## Related Issues

Addresses #672. Follows #661 (the `GPL-3.0-or-later` declaration) and #673 (the
KaTeX split that created `maidr-math.css`).

## Changes Made

**`cdnjs/maidr.json`** — the payload, as drafted in #672 with one correction:
the file map mirrors `maidr-math.css` as well as `maidr.js` and `maidr.css`.
`src/util/katex.ts` links the maths stylesheet at runtime, resolving it against
the URL `maidr.js` was loaded from — so on a page served from cdnjs it resolves
to a cdnjs URL, and an unmirrored file makes that a 404. The failure is quiet
and narrow: LaTeX in AI chat responses renders unstyled, everything else works,
and no page that never opens the chat notices.

Three files listed by name, no glob — cdnjs
[asks for that](https://github.com/cdnjs/packages/issues/186), and it matters
more here than most: `dist/*.js` would pull every adapter bundle plus every
sourcemap, and `dist/maidr.js.map` alone is 8.7 MB.

**`cdnjs/README.md`** — why the file is in this repo, how to submit it, what is
mirrored and why only that, and what to do once cdnjs approves (the cdnjs URLs
are deliberately *not* added to `README.md`/`docs/` yet — until the listing
lands they 404). The claims about cdnjs's own process — branch convention,
commit format, and that it generates `maidr.min.js` itself — are quoted from
[their CONTRIBUTING.md](https://github.com/cdnjs/packages/blob/master/CONTRIBUTING.md)
and date-stamped, since that process has changed before and this submission may
not happen for a while.

**`package.json`** — adds `description`, `homepage` and `keywords`. npm shows
none of the three for this package today, so it has no description, no link to
maidr.ai, and nothing for keyword search to match on. They are also what the
manifest declares, so it now has a single source of truth to be checked against.

**`README.md`** — the usage snippet linked `dist/maidr_style.css` and the prose
named `styles.css`. Neither has ever been emitted by this repo's build, which
writes `dist/maidr.css` — the name py-maidr and r-maidr link, and the one this
manifest mirrors. The first snippet a new user copies was asking a CDN for a
file that is not there.

**`.claude/rules/testing.md`** (and its synced `.github/instructions/`
counterpart) — the convention named `test/scripts/` as *the* exception to
`test/` mirroring `src/`, which this PR's `test/cdnjs/` made inaccurate. It now
states the general rule: a test directory mirrors either a layer of `src/` or a
directory at the repository root, under the same name. Both instances are
listed, with the bar for adding a third.

## Screenshots (if applicable)

N/A — no user-visible interface change.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`test/cdnjs/manifest.test.ts` is the point of the exercise. Nothing in this
repository reads `cdnjs/maidr.json`, so without a test a rename in `dist` or a
dropped field would break the mirror silently, months later, somewhere no CI run
of ours can see. It pins the manifest's metadata against `package.json` and
every mirrored filename against what `scripts/build.js` actually emits — reading
both out of a node subprocess, the same way `test/scripts/buildOutputFilenames`
and `test/scripts/mathStylesheet` do, since those modules are plain ESM JS and
`allowJs` is false, and resolving `fileName(format, entryName)` the way Vite
invokes it rather than assuming the callbacks ignore their arguments.

Mutation-checked throughout: dropping `maidr-math.css`, adding a `dist/*.js`
glob, adding a `.map`, adding an adapter bundle, adding or removing a manifest
field, blanking a value, emptying the nested `files` array, and reordering
`keywords` each fail it.

What it deliberately does not assert is anything about cdnjs's schema. An
earlier revision enumerated cdnjs's required fields, carried over from #672;
that list could not be confirmed against their schema, and since their checker
is what actually decides, an unverified list is worse than none. The test states
what this repository can state — the fields its own listing is built from.

Deliberately out of scope, flagged in #672: the ~107 MB unpacked npm tarball
(mostly sourcemaps) is a separate question, and the narrow file map is this PR's
only interaction with it.

Verified locally: `npm run lint`, `npm run type-check`, `npm run build`, and
`npm test` — 108 unit suites (1353 tests) plus 5 ESM suites (57 tests), all
passing.