### PR TITLE
chore: ignore agent worktrees and Playwright MCP snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,17 @@ playwright-report/
 # Claude Code local developer settings
 .claude/settings.local.json
 
+# Isolated worktrees Claude Code creates for background agents. Each is a
+# full checkout — three of them came to 1.4 GB — and each contains its own
+# .git, so `git add -A` stages them as embedded repositories rather than
+# skipping them. That has already put three bogus submodule entries into a
+# commit once.
+.claude/worktrees/
+
+# Page snapshots written by the Playwright MCP server during a debugging
+# session. Scratch output, never part of a change.
+.playwright-mcp/
+
 # Site
 _site/
 


### PR DESCRIPTION
## Problem

Claude Code creates an isolated git worktree per background agent, under `.claude/worktrees/`. Two things make those hostile to a wide `git add`:

- each is a **full checkout** — three of them measured **1.4 GB**
- each carries its own `.git`, so `git add -A` stages them as **embedded repositories** (mode `160000`) rather than skipping them

That already happened on this repo: a `git add -A` on #716 committed three bogus submodule entries plus two `.playwright-mcp/` page snapshots and a stray screenshot. It was caught and force-pushed away, but nothing stops the next one.

`.playwright-mcp/` has the same character — scratch page snapshots the Playwright MCP server writes during a debugging session.

## Change

Two entries in `.gitignore`, with the reasoning inline so the next person does not have to rediscover why an ignored directory is 1.4 GB.

Deliberately scoped to the two directories rather than widening the existing `.claude/` entry: **20 files under `.claude/` are tracked** — the shared rules, agents and skills — and they must stay that way.

## Verification

- `git status --porcelain` no longer lists `.claude/worktrees/` or `.playwright-mcp/`.
- `git ls-files .claude/ | wc -l` still returns **20**, so no tracked file was affected.

## Cleanup done alongside this

Not part of the diff, but done in the same pass:

- Removed the three agent worktrees (`git worktree remove`, all clean: 0 uncommitted, 0 unpushed, all three PRs merged) — **1.4 GB → 4 KB**.
- Deleted the local branches for this run's merged PRs (#653, #661, #667, #668, #713) and the three `worktree-agent-*` artifacts. Note `git branch --merged main` reports squash-merged branches as unmerged, so those were confirmed against PR state rather than ancestry before deleting.
- Left `katex-woff2-check.png` alone. It is untracked scratch, but its timestamp does not clearly place it in this run's work, and deleting someone else's file on a guess is worse than leaving 13 KB in the working tree. It is deliberately **not** added to `.gitignore` either — hiding a file that might not be mine is the wrong direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
