### PR TITLE
feat(plotly): support violin traces, and examine an unsupported chart once

### DIFF
--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -64,6 +64,7 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Scatter | `type: 'scatter'`, `mode: 'markers'` | [Scatter plot](examples.html) |
 | Line | `type: 'scatter'`, `mode: 'lines'` | [Line chart](examples.html) |
 | Box Plot | `type: 'box'` | [Box plot](examples.html) |
+| Violin Plot | `type: 'violin'` | [Violin plot](examples.html) |
 | Heatmap | `type: 'heatmap'` | [Heatmap](examples.html) |
 | Histogram | `type: 'histogram'` | [Histogram](examples.html) |
 | Candlestick | `type: 'candlestick'` | [Candlestick](examples.html) |
@@ -156,6 +157,32 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   });
 </script>
 ```
+
+### Violin Plot
+
+A violin becomes two layers in one subplot: the quartile summary (`violin_box`)
+you land on, and the density curve (`violin_kde`) behind it. `PageUp` and
+`PageDown` switch between them. Both come from Plotly's own calculations, so
+the numbers announced are the ones the chart was drawn from.
+
+```html
+<div id="violin-chart" style="width: 700px; height: 500px"></div>
+<script>
+  Plotly.newPlot('violin-chart', [
+    { y: [2.3, 2.5, 2.8, 3.0, 3.2, 3.4, 3.6, 4.0, 4.5], type: 'violin', name: 'Setosa', box: { visible: true }, meanline: { visible: true } },
+    { y: [4.7, 4.9, 5.2, 5.5, 5.9, 6.0, 6.3, 6.5, 7.0], type: 'violin', name: 'Versicolor', box: { visible: true }, meanline: { visible: true } }
+  ], {
+    title: { text: 'Iris Sepal Length Distribution' },
+    xaxis: { title: { text: 'Species' } },
+    yaxis: { title: { text: 'Sepal Length (cm)' } }
+  });
+</script>
+```
+
+The inner box (`box: { visible: true }`) and the mean line
+(`meanline: { visible: true }`) are optional: without them the statistics stay
+navigable, they simply have no drawn element to highlight, and the mean is left
+out of the sections.
 
 ### Heatmap
 

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -184,6 +184,11 @@ The inner box (`box: { visible: true }`) and the mean line
 navigable, they simply have no drawn element to highlight, and the mean is left
 out of the sections.
 
+Those two settings are per trace, while the sections a violin plot offers are
+one list for the whole plot. So when only some traces draw a mean line, every
+violin still has a mean to read — it is a statistic of each of them — and only
+the ones drawn with a mean line highlight it.
+
 ### Heatmap
 
 ```html

--- a/examples/plotly-violin.html
+++ b/examples/plotly-violin.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Violin Plot - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Violin Plot</h1>
+    <p>
+      A plotly.js violin plot auto-detected by MAIDR. Click on the chart and use
+      arrow keys to navigate. Page Up / Page Down switches between the box
+      summary and the density curve.
+    </p>
+
+    <div id="violin-chart" style="width: 700px; height: 500px"></div>
+
+    <script>
+      var trace1 = {
+        y: [2.3, 2.5, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.5, 5.0],
+        type: 'violin',
+        name: 'Setosa',
+        box: { visible: true },
+        meanline: { visible: true }
+      };
+
+      var trace2 = {
+        y: [4.7, 4.9, 5.0, 5.2, 5.5, 5.7, 5.9, 6.0, 6.3, 6.5, 6.7, 7.0],
+        type: 'violin',
+        name: 'Versicolor',
+        box: { visible: true },
+        meanline: { visible: true }
+      };
+
+      var trace3 = {
+        y: [6.0, 6.2, 6.3, 6.5, 6.7, 6.9, 7.1, 7.3, 7.5, 7.7, 7.9, 8.0],
+        type: 'violin',
+        name: 'Virginica',
+        box: { visible: true },
+        meanline: { visible: true }
+      };
+
+      var layout = {
+        title: { text: 'Iris Sepal Length Distribution' },
+        xaxis: { title: { text: 'Species' } },
+        yaxis: { title: { text: 'Sepal Length (cm)' } }
+      };
+
+      Plotly.newPlot('violin-chart', [trace1, trace2, trace3], layout);
+    </script>
+  </body>
+</html>

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -53,7 +53,7 @@ const PAGE_DESCRIPTIONS = {
   'home': 'MAIDR provides accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions.',
   'react': 'How to integrate MAIDR accessible data visualizations into React applications with TypeScript support.',
   'recharts': 'How to integrate MAIDR accessibility features with Recharts React components for accessible data visualizations.',
-  'plotly': 'How to make Plotly.js charts accessible with MAIDR — zero configuration auto-detection for bar, scatter, line, box, heatmap, histogram, and candlestick charts.',
+  'plotly': 'How to make Plotly.js charts accessible with MAIDR — zero configuration auto-detection for bar, scatter, line, box, violin, heatmap, histogram, and candlestick charts.',
   'google-charts': 'How to make Google Charts accessible with MAIDR — support for bar, line, scatter, candlestick, stacked, and dodged charts.',
   'd3': 'How to make D3.js charts accessible with MAIDR — binders for bar, line, scatter, box, heatmap, histogram, candlestick, segmented, and smooth charts plus a React wrapper.',
   'vegalite': 'How to make Vega-Lite charts accessible with MAIDR — support for bar, stacked, dodged, normalized, histogram, line, scatter, heatmap, and box plot specs.',
@@ -394,6 +394,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('plotly-scatter.html', 'Plotly Scatter Plot'); return false;">Scatter Plot</a></li>
     <li><a href="#" onclick="loadHTML('plotly-line.html', 'Plotly Line Chart'); return false;">Line Chart</a></li>
     <li><a href="#" onclick="loadHTML('plotly-box.html', 'Plotly Box Plot'); return false;">Box Plot</a></li>
+    <li><a href="#" onclick="loadHTML('plotly-violin.html', 'Plotly Violin Plot'); return false;">Violin Plot</a></li>
     <li><a href="#" onclick="loadHTML('plotly-heatmap.html', 'Plotly Heatmap'); return false;">Heatmap</a></li>
     <li><a href="#" onclick="loadHTML('plotly-histogram.html', 'Plotly Histogram'); return false;">Histogram</a></li>
     <li><a href="#" onclick="loadHTML('plotly-candlestick.html', 'Plotly Candlestick'); return false;">Candlestick</a></li>

--- a/src/adapters/plotly/examination.ts
+++ b/src/adapters/plotly/examination.ts
@@ -1,0 +1,50 @@
+/**
+ * Bookkeeping for how often a plotly chart is examined.
+ *
+ * Deciding whether MAIDR can represent a chart means reading everything plotly
+ * computed for it, and a chart it cannot represent says so in the console.
+ * Neither belongs on every DOM mutation, so the decision is kept to once per
+ * set of inputs.
+ */
+
+import type { PlotlyGraphDiv } from './types';
+import { findGraphDiv } from './extractor';
+
+/** What a chart was examined against, held for comparison with what it holds now. */
+interface ExaminationInputs {
+  traces: unknown;
+  calcdata: unknown;
+}
+
+const examinedCharts = new WeakMap<PlotlyGraphDiv, ExaminationInputs>();
+
+/**
+ * Claims a chart for examination, so a caller examines it once per set of
+ * inputs rather than once per DOM mutation.
+ *
+ * A verdict is reached from plotly's `_fullData` and `calcdata`, which it
+ * builds afresh whenever it recomputes a chart and leaves alone otherwise — a
+ * pan or a zoom keeps them, as does a mutation elsewhere on the page. An
+ * unchanged pair therefore means an unchanged verdict and no claim, while new
+ * traces, or the points a chart was drawn without, yield a new pair and a
+ * fresh one. (Were a future plotly to recompute a chart in place instead, the
+ * pair would look unchanged and the chart would stop being re-examined.)
+ *
+ * A chart plotly has not computed yet is not claimed either, and nothing is
+ * recorded for it, so it can be claimed once it has been.
+ *
+ * @param element - Any element inside the plotly graph div, or the div itself.
+ * @returns Whether the caller should examine the chart now.
+ */
+export function claimPlotlyExamination(element: HTMLElement): boolean {
+  const gd = findGraphDiv(element);
+  if (!gd?._fullData || !gd.calcdata)
+    return false;
+
+  const examined = examinedCharts.get(gd);
+  if (examined?.traces === gd._fullData && examined.calcdata === gd.calcdata)
+    return false;
+
+  examinedCharts.set(gd, { traces: gd._fullData, calcdata: gd.calcdata });
+  return true;
+}

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -1499,7 +1499,9 @@ function buildViolinBoxLayer(
     orientation,
     ...(selectors ? { selectors } : {}),
     axes,
-    // The mean is navigable only where plotly draws a mean line for it.
+    // One list of sections serves every violin here, so a mean line on any of
+    // them makes the mean navigable on all — it is a statistic each of them
+    // has. Only the violins drawn with one carry a selector to highlight.
     violinOptions: { showMean: violins.some(violin => violin.meanSelector !== null) },
     data,
   };

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -1322,8 +1322,10 @@ interface ViolinEntry {
   posCenterPx: number | undefined;
   /** Selector for the KDE outline `path.violin`. */
   kdeSelector: string;
-  /** Selector for the inner box `path.box`, when plotly draws one. */
-  boxSelector: string | null;
+  /** Selector for the inner box `path.box`, which matches only if drawn. */
+  boxSelector: string;
+  /** Whether this violin's trace draws that inner box. */
+  hasBox: boolean;
   /** Selector for the mean line, when plotly draws one. */
   meanSelector: string | null;
 }
@@ -1409,9 +1411,11 @@ function collectViolins(
         cd,
         posCenterPx: resolveViolinCenter(cd, cds[0].t?.bPos, posAxis),
         kdeSelector: `${traceGroup} > path.violin:nth-child(${i + 1})`,
-        boxSelector: hasBox
-          ? `${traceGroup} > path.box:nth-child(${count + i + 1})`
-          : null,
+        // Written whether or not this trace draws the box: the position it
+        // would occupy holds no `path.box` otherwise, so the selector simply
+        // finds nothing and leaves the violins that do have one alone.
+        boxSelector: `${traceGroup} > path.box:nth-child(${count + i + 1})`,
+        hasBox,
         // Plotly renders the mean inside the box as `path.mean`, and as
         // `path.meanline` when there is no box to draw it in.
         meanSelector: hasMean
@@ -1529,30 +1533,28 @@ function buildViolinBoxLayer(
 }
 
 /**
- * Builds one {@link BoxSelector} per violin, or `undefined` when any violin
- * lacks a drawn inner box — the core needs one selector per data row.
+ * Builds one {@link BoxSelector} per violin, or `undefined` when the chart
+ * draws no inner box at all — there is nothing to highlight then, and the core
+ * skips highlighting rather than tracking elements that do not exist.
+ *
+ * A chart that draws some of them still gets a selector per violin, so the
+ * ones with a box keep their highlight and the rest match nothing.
  */
 function buildViolinBoxSelectors(violins: ViolinEntry[]): BoxSelector[] | undefined {
-  const selectors: BoxSelector[] = [];
+  if (!violins.some(violin => violin.hasBox))
+    return undefined;
 
-  for (const violin of violins) {
-    if (violin.boxSelector === null)
-      return undefined;
-
-    selectors.push({
-      lowerOutliers: [],
-      // Plotly draws the whole box — whiskers, quartile box and median — as a
-      // single path, so every section highlights the same element.
-      min: violin.boxSelector,
-      iq: violin.boxSelector,
-      q2: violin.boxSelector,
-      max: violin.boxSelector,
-      upperOutliers: [],
-      ...(violin.meanSelector ? { mean: violin.meanSelector } : {}),
-    });
-  }
-
-  return selectors;
+  return violins.map(violin => ({
+    lowerOutliers: [],
+    // Plotly draws the whole box — whiskers, quartile box and median — as a
+    // single path, so every section highlights the same element.
+    min: violin.boxSelector,
+    iq: violin.boxSelector,
+    q2: violin.boxSelector,
+    max: violin.boxSelector,
+    upperOutliers: [],
+    ...(violin.meanSelector ? { mean: violin.meanSelector } : {}),
+  }));
 }
 
 /**

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -80,33 +80,6 @@ export function extractPlotlyData(element: HTMLElement): Maidr | null {
   return { id, title, subplots: subplotGrid };
 }
 
-/** Everything {@link extractPlotlyData} reads a chart's schema out of. */
-export interface PlotlyExtractionInputs {
-  traces: unknown;
-  calcdata: unknown;
-}
-
-/**
- * Hands back the two things a verdict on a chart is reached from, for a caller
- * that needs to know whether examining it again could reach a different one.
- *
- * Plotly builds both afresh whenever it recomputes a chart and leaves them
- * alone otherwise — a pan or a zoom keeps them — so an unchanged pair means an
- * unchanged verdict, and a chart replotted with other traces or with the
- * points it was drawn without yields a new one. `null` stands for a chart that
- * cannot be judged yet, its calc data still to come.
- *
- * @param element - Any element inside the plotly graph div, or the div itself.
- * @returns The inputs of a chart ready to be examined, else `null`.
- */
-export function plotlyExtractionInputs(element: HTMLElement): PlotlyExtractionInputs | null {
-  const gd = findGraphDiv(element);
-  if (!gd?._fullData || !gd.calcdata)
-    return null;
-
-  return { traces: gd._fullData, calcdata: gd.calcdata };
-}
-
 /**
  * Finds the `.js-plotly-plot` ancestor (or self) of the given element.
  */

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -81,6 +81,33 @@ export function extractPlotlyData(element: HTMLElement): Maidr | null {
 }
 
 /**
+ * Summarises what a rendered plotly chart holds, for a caller that needs to
+ * know whether examining it again could reach a different verdict than before.
+ *
+ * That verdict turns on the trace types, and on plotly having computed the
+ * data behind them: the signature is the trace types, and `null` stands for a
+ * chart that cannot be judged yet because plotly has not populated its
+ * internals or its calc data.
+ *
+ * @param element - Any element inside the plotly graph div, or the div itself.
+ * @returns The trace types of a chart ready to be examined, else `null`.
+ */
+export function plotlyTraceSignature(element: HTMLElement): string | null {
+  const gd = findGraphDiv(element);
+  const traces = gd?._fullData ?? gd?.data;
+  if (!gd || !traces)
+    return null;
+
+  // Calc data lands with the draw, and the box, histogram and violin layers
+  // are read from it — a chart caught mid-render would otherwise be judged on
+  // data that is not there yet.
+  if (!gd.calcdata || gd.calcdata.length < traces.length)
+    return null;
+
+  return traces.map(trace => trace.type ?? 'scatter').join(',');
+}
+
+/**
  * Finds the `.js-plotly-plot` ancestor (or self) of the given element.
  */
 export function findGraphDiv(element: HTMLElement): PlotlyGraphDiv | null {
@@ -1354,13 +1381,13 @@ function collectViolins(
 ): ViolinEntry[] {
   const violins: ViolinEntry[] = [];
 
-  // Plotly drops the group of an empty trace, so only traces that render
-  // advance the `nth-child` index.
+  // Plotly drops the group of a trace it drew nothing for, so only traces that
+  // render advance the `nth-child` index.
   let renderedTraces = 0;
 
   for (const { trace, calcIdx } of violinTraces) {
     const cds = group.calcdata[calcIdx] ?? [];
-    if (cds.length === 0 || !cds[0].density?.length)
+    if (!cds.some(cd => cd.density?.length))
       continue;
 
     renderedTraces += 1;
@@ -1371,6 +1398,12 @@ function collectViolins(
 
     for (let i = 0; i < count; i++) {
       const cd = cds[i];
+      // A position without a computed density would become a violin of
+      // zeroes. Skipping it leaves the others' `nth-child` indices alone,
+      // since plotly renders an element per calc entry either way.
+      if (!cd.density?.length)
+        continue;
+
       violins.push({
         label: resolveViolinLabel(trace, cd, posAxis, count),
         cd,

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -22,6 +22,7 @@ import type {
   MaidrSubplot,
   ScatterPoint,
   SegmentedPoint,
+  ViolinKdePoint,
 } from '../../type/grammar';
 import type {
   PlotlyAnnotation,
@@ -271,6 +272,11 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
     case 'box':
       return TraceType.BOX;
 
+    // A violin becomes two layers (`violin_box` + `violin_kde`); the KDE type
+    // stands for the pair while traces are grouped.
+    case 'violin':
+      return TraceType.VIOLIN_KDE;
+
     case 'heatmap':
     case 'heatmapgl':
       return TraceType.HEATMAP;
@@ -416,6 +422,7 @@ function buildSubplotLayers(
   const lineTraces: TraceEntry[] = [];
   const boxTraces: TraceEntry[] = [];
   const barTraces: TraceEntry[] = [];
+  const violinTraces: TraceEntry[] = [];
   const otherTraces: TraceEntry[] = [];
 
   for (let i = 0; i < group.traces.length; i++) {
@@ -434,6 +441,8 @@ function buildSubplotLayers(
       boxTraces.push(entry);
     } else if (entry.maidrType === TraceType.BAR) {
       barTraces.push(entry);
+    } else if (entry.maidrType === TraceType.VIOLIN_KDE) {
+      violinTraces.push(entry);
     } else {
       otherTraces.push(entry);
     }
@@ -451,6 +460,12 @@ function buildSubplotLayers(
     const layer = extractMultiBoxLayer(boxTraces, group, xLabel, yLabel, gd);
     if (layer)
       layers.push(layer);
+  }
+
+  // Build the violin pair: every violin in the subplot shares one box layer
+  // and one KDE layer.
+  if (violinTraces.length > 0) {
+    layers.push(...extractViolinLayers(violinTraces, group, layout, xLabel, yLabel));
   }
 
   // Build bar layers: grouped/stacked/normalized for multiple bar traces.
@@ -1264,6 +1279,294 @@ function extractSingleBoxData(
   }
 
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Violin
+// ---------------------------------------------------------------------------
+
+/** One violin — a single position within a plotly violin trace. */
+interface ViolinEntry {
+  /** Category label announced for this violin. */
+  label: string;
+  /** The calcdata entry plotly computed for it. */
+  cd: PlotlyCalcData;
+  /** Centre of the violin on the position axis, in plot-area pixels. */
+  posCenterPx: number | undefined;
+  /** Selector for the KDE outline `path.violin`. */
+  kdeSelector: string;
+  /** Selector for the inner box `path.box`, when plotly draws one. */
+  boxSelector: string | null;
+  /** Selector for the mean line, when plotly draws one. */
+  meanSelector: string | null;
+}
+
+/**
+ * Builds the `violin_box` + `violin_kde` layer pair for a subplot's violin
+ * traces.
+ *
+ * Plotly has already computed both halves: `cd.density` holds the KDE samples
+ * and the quartiles sit on the same calcdata entry, so nothing is recomputed
+ * here. The box layer comes first because MAIDR shows a subplot's first layer
+ * on entry, and the summary is the better starting point.
+ */
+function extractViolinLayers(
+  violinTraces: TraceEntry[],
+  group: SubplotGroup,
+  layout: PlotlyFullLayout,
+  xLabel: string | undefined,
+  yLabel: string | undefined,
+): MaidrLayer[] {
+  const isHorizontal = violinTraces[0].trace.orientation === 'h';
+  const posAxis = getAxis(layout, isHorizontal ? group.yAxisId : group.xAxisId);
+  const valueAxis = getAxis(layout, isHorizontal ? group.xAxisId : group.yAxisId);
+
+  const violins = collectViolins(violinTraces, group, posAxis);
+  if (violins.length === 0)
+    return [];
+
+  // The core reverses the rows of a horizontal violin plot into visual order,
+  // so emit them reversed to keep plotly's own bottom-to-top order afterwards.
+  if (isHorizontal)
+    violins.reverse();
+
+  const id = String(violinTraces[0].globalIdx);
+  const orientation = isHorizontal ? Orientation.HORIZONTAL : Orientation.VERTICAL;
+
+  return [
+    buildViolinBoxLayer(violins, `${id}-box`, orientation, xLabel, yLabel),
+    buildViolinKdeLayer(violins, `${id}-kde`, orientation, isHorizontal, valueAxis, xLabel, yLabel),
+  ];
+}
+
+/**
+ * Flattens the subplot's violin traces into one violin per calcdata entry,
+ * in the order plotly renders them, and builds each one's selectors.
+ *
+ * A trace holds several violins when its categories come from a `x`/`y`
+ * array, and plotly draws them as siblings inside the trace's group:
+ * every `path.violin` first, then every `path.box`, then every `path.mean`.
+ */
+function collectViolins(
+  violinTraces: TraceEntry[],
+  group: SubplotGroup,
+  posAxis: PlotlyAxis | undefined,
+): ViolinEntry[] {
+  const violins: ViolinEntry[] = [];
+
+  // Plotly drops the group of an empty trace, so only traces that render
+  // advance the `nth-child` index.
+  let renderedTraces = 0;
+
+  for (const { trace, calcIdx } of violinTraces) {
+    const cds = group.calcdata[calcIdx] ?? [];
+    if (cds.length === 0 || !cds[0].density?.length)
+      continue;
+
+    renderedTraces += 1;
+    const traceGroup = `${subplotCssPrefix(trace.xaxis, trace.yaxis)}.violinlayer > g:nth-child(${renderedTraces})`;
+    const count = cds.length;
+    const hasBox = trace.box?.visible === true;
+    const hasMean = trace.meanline?.visible === true;
+
+    for (let i = 0; i < count; i++) {
+      const cd = cds[i];
+      violins.push({
+        label: resolveViolinLabel(trace, cd, posAxis, count),
+        cd,
+        posCenterPx: resolveViolinCenter(cd, cds[0].t?.bPos, posAxis),
+        kdeSelector: `${traceGroup} > path.violin:nth-child(${i + 1})`,
+        boxSelector: hasBox
+          ? `${traceGroup} > path.box:nth-child(${count + i + 1})`
+          : null,
+        // Plotly renders the mean inside the box as `path.mean`, and as
+        // `path.meanline` when there is no box to draw it in.
+        meanSelector: hasMean
+          ? (hasBox
+              ? `${traceGroup} > path.mean:nth-child(${2 * count + i + 1})`
+              : `${traceGroup} > path.meanline:nth-child(${count + i + 1})`)
+          : null,
+      });
+    }
+  }
+
+  return violins;
+}
+
+/**
+ * Names a violin after its category, falling back to the trace name.
+ *
+ * A trace that draws a single violin is a group of its own — plotly even
+ * derives the category from `trace.name` — so the trace name is the label
+ * there. A trace that draws several is one series across categories, and both
+ * parts are needed to tell its violins apart.
+ */
+function resolveViolinLabel(
+  trace: PlotlyTrace,
+  cd: PlotlyCalcData,
+  posAxis: PlotlyAxis | undefined,
+  violinsInTrace: number,
+): string {
+  const category = resolveViolinCategory(cd.pos, posAxis);
+  if (violinsInTrace > 1 && category) {
+    return trace.name ? `${trace.name}, ${category}` : category;
+  }
+  return trace.name ?? category ?? '';
+}
+
+function resolveViolinCategory(
+  pos: number | string | undefined,
+  posAxis: PlotlyAxis | undefined,
+): string | undefined {
+  if (typeof pos === 'string')
+    return pos;
+  if (pos === undefined)
+    return undefined;
+
+  const categories = posAxis?._categories;
+  if (categories && pos >= 0 && pos < categories.length)
+    return String(categories[pos]);
+  return String(pos);
+}
+
+/**
+ * Resolves the violin's centre on the position axis, in the plot-area pixel
+ * space its `path.violin` is drawn in. Plotly stores it while drawing;
+ * `bPos` — the offset that separates grouped violins — reproduces it
+ * otherwise.
+ */
+function resolveViolinCenter(
+  cd: PlotlyCalcData,
+  bPos: number | undefined,
+  posAxis: PlotlyAxis | undefined,
+): number | undefined {
+  if (typeof cd.posCenterPx === 'number')
+    return cd.posCenterPx;
+  if (typeof cd.pos !== 'number' || !posAxis?.c2p)
+    return undefined;
+  return posAxis.c2p(cd.pos + (bPos ?? 0));
+}
+
+/**
+ * Builds the `violin_box` layer: the quartile summary of every violin.
+ *
+ * Selectors are emitted only when plotly draws the inner box for all of them —
+ * a violin without one has no element to highlight, and the statistics stay
+ * navigable regardless.
+ */
+function buildViolinBoxLayer(
+  violins: ViolinEntry[],
+  id: string,
+  orientation: Orientation,
+  xLabel: string | undefined,
+  yLabel: string | undefined,
+): MaidrLayer {
+  const data: BoxPoint[] = violins.map(({ label, cd }) => ({
+    z: label,
+    // Violin box layers have no outlier sections — the KDE curve covers the
+    // tails of the distribution.
+    lowerOutliers: [],
+    min: cd.min ?? cd.lf ?? 0,
+    q1: cd.q1 ?? 0,
+    q2: cd.med ?? 0,
+    q3: cd.q3 ?? 0,
+    max: cd.max ?? cd.uf ?? 0,
+    upperOutliers: [],
+    ...(cd.mean !== undefined ? { mean: cd.mean } : {}),
+  }));
+
+  const axes: MaidrLayer['axes'] = {};
+  if (xLabel)
+    axes.x = { label: xLabel };
+  if (yLabel)
+    axes.y = { label: yLabel };
+
+  const selectors = buildViolinBoxSelectors(violins);
+
+  return {
+    id,
+    type: TraceType.VIOLIN_BOX,
+    orientation,
+    ...(selectors ? { selectors } : {}),
+    axes,
+    // The mean is navigable only where plotly draws a mean line for it.
+    violinOptions: { showMean: violins.some(violin => violin.meanSelector !== null) },
+    data,
+  };
+}
+
+/**
+ * Builds one {@link BoxSelector} per violin, or `undefined` when any violin
+ * lacks a drawn inner box — the core needs one selector per data row.
+ */
+function buildViolinBoxSelectors(violins: ViolinEntry[]): BoxSelector[] | undefined {
+  const selectors: BoxSelector[] = [];
+
+  for (const violin of violins) {
+    if (violin.boxSelector === null)
+      return undefined;
+
+    selectors.push({
+      lowerOutliers: [],
+      // Plotly draws the whole box — whiskers, quartile box and median — as a
+      // single path, so every section highlights the same element.
+      min: violin.boxSelector,
+      iq: violin.boxSelector,
+      q2: violin.boxSelector,
+      max: violin.boxSelector,
+      upperOutliers: [],
+      ...(violin.meanSelector ? { mean: violin.meanSelector } : {}),
+    });
+  }
+
+  return selectors;
+}
+
+/**
+ * Builds the `violin_kde` layer from plotly's density samples, ordered from
+ * the bottom of each curve upwards.
+ *
+ * Highlight circles are appended next to the `path.violin` element, which
+ * plotly draws in plot-area coordinates — the same space `c2p` returns — so
+ * the centre line of the violin locates each point.
+ */
+function buildViolinKdeLayer(
+  violins: ViolinEntry[],
+  id: string,
+  orientation: Orientation,
+  isHorizontal: boolean,
+  valueAxis: PlotlyAxis | undefined,
+  xLabel: string | undefined,
+  yLabel: string | undefined,
+): MaidrLayer {
+  const data: ViolinKdePoint[][] = violins.map(({ label, cd, posCenterPx }) =>
+    (cd.density ?? []).map((sample) => {
+      const point: ViolinKdePoint = { x: label, y: sample.t, density: sample.v };
+
+      const valuePx = valueAxis?.c2p?.(sample.t);
+      if (valuePx !== undefined && posCenterPx !== undefined) {
+        point.svg_x = isHorizontal ? valuePx : posCenterPx;
+        point.svg_y = isHorizontal ? posCenterPx : valuePx;
+      }
+
+      return point;
+    }),
+  );
+
+  const axes: MaidrLayer['axes'] = {};
+  if (xLabel)
+    axes.x = { label: xLabel };
+  if (yLabel)
+    axes.y = { label: yLabel };
+
+  return {
+    id,
+    type: TraceType.VIOLIN_KDE,
+    orientation,
+    selectors: violins.map(violin => violin.kdeSelector),
+    axes,
+    data,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -80,31 +80,31 @@ export function extractPlotlyData(element: HTMLElement): Maidr | null {
   return { id, title, subplots: subplotGrid };
 }
 
+/** Everything {@link extractPlotlyData} reads a chart's schema out of. */
+export interface PlotlyExtractionInputs {
+  traces: unknown;
+  calcdata: unknown;
+}
+
 /**
- * Summarises what a rendered plotly chart holds, for a caller that needs to
- * know whether examining it again could reach a different verdict than before.
+ * Hands back the two things a verdict on a chart is reached from, for a caller
+ * that needs to know whether examining it again could reach a different one.
  *
- * That verdict turns on the trace types, and on plotly having computed the
- * data behind them: the signature is the trace types, and `null` stands for a
- * chart that cannot be judged yet because plotly has not populated its
- * internals or its calc data.
+ * Plotly builds both afresh whenever it recomputes a chart and leaves them
+ * alone otherwise — a pan or a zoom keeps them — so an unchanged pair means an
+ * unchanged verdict, and a chart replotted with other traces or with the
+ * points it was drawn without yields a new one. `null` stands for a chart that
+ * cannot be judged yet, its calc data still to come.
  *
  * @param element - Any element inside the plotly graph div, or the div itself.
- * @returns The trace types of a chart ready to be examined, else `null`.
+ * @returns The inputs of a chart ready to be examined, else `null`.
  */
-export function plotlyTraceSignature(element: HTMLElement): string | null {
+export function plotlyExtractionInputs(element: HTMLElement): PlotlyExtractionInputs | null {
   const gd = findGraphDiv(element);
-  const traces = gd?._fullData ?? gd?.data;
-  if (!gd || !traces)
+  if (!gd?._fullData || !gd.calcdata)
     return null;
 
-  // Calc data lands with the draw, and the box, histogram and violin layers
-  // are read from it — a chart caught mid-render would otherwise be judged on
-  // data that is not there yet.
-  if (!gd.calcdata || gd.calcdata.length < traces.length)
-    return null;
-
-  return traces.map(trace => trace.type ?? 'scatter').join(',');
+  return { traces: gd._fullData, calcdata: gd.calcdata };
 }
 
 /**

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -310,6 +310,17 @@ interface SubplotGroup {
   traceIndices: number[];
 }
 
+/** A trace within a subplot group, keyed to its calcdata and its global index. */
+interface TraceEntry {
+  trace: PlotlyTrace;
+  /** The MAIDR type it maps to, or `null` when MAIDR has no equivalent. */
+  maidrType: TraceType | null;
+  /** Index within the group, used to look up `group.calcdata`. */
+  calcIdx: number;
+  /** Index within `gd._fullData`. */
+  globalIdx: number;
+}
+
 function groupTracesBySubplot(
   traces: PlotlyTrace[],
   calcdata?: PlotlyCalcData[][],
@@ -402,22 +413,29 @@ function buildSubplotLayers(
   const layers: MaidrLayer[] = [];
 
   // Group traces that need multi-trace handling.
-  const lineTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
-  const boxTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
-  const barTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
-  const otherTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[] = [];
+  const lineTraces: TraceEntry[] = [];
+  const boxTraces: TraceEntry[] = [];
+  const barTraces: TraceEntry[] = [];
+  const otherTraces: TraceEntry[] = [];
 
   for (let i = 0; i < group.traces.length; i++) {
     const trace = group.traces[i];
-    const maidrType = mapTraceType(trace);
-    if (maidrType === TraceType.LINE) {
-      lineTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
-    } else if (maidrType === TraceType.BOX) {
-      boxTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
-    } else if (maidrType === TraceType.BAR) {
-      barTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
+    // Resolved once per trace: mapping an unsupported type warns, and doing it
+    // again below would log the same line twice.
+    const entry: TraceEntry = {
+      trace,
+      maidrType: mapTraceType(trace),
+      calcIdx: i,
+      globalIdx: group.traceIndices[i],
+    };
+    if (entry.maidrType === TraceType.LINE) {
+      lineTraces.push(entry);
+    } else if (entry.maidrType === TraceType.BOX) {
+      boxTraces.push(entry);
+    } else if (entry.maidrType === TraceType.BAR) {
+      barTraces.push(entry);
     } else {
-      otherTraces.push({ trace, calcIdx: i, globalIdx: group.traceIndices[i] });
+      otherTraces.push(entry);
     }
   }
 
@@ -462,8 +480,7 @@ function buildSubplotLayers(
   }
 
   // Build individual layers for remaining traces.
-  for (const { trace, calcIdx, globalIdx } of otherTraces) {
-    const maidrType = mapTraceType(trace);
+  for (const { trace, maidrType, calcIdx, globalIdx } of otherTraces) {
     if (!maidrType)
       continue;
 

--- a/src/adapters/plotly/index.ts
+++ b/src/adapters/plotly/index.ts
@@ -5,5 +5,6 @@
  * modules. Internal helpers remain private to each module.
  */
 
-export { extractPlotlyData, plotlyTraceSignature } from './extractor';
+export type { PlotlyExtractionInputs } from './extractor';
+export { extractPlotlyData, plotlyExtractionInputs } from './extractor';
 export { disconnectPlotlyObservers, isPlotlyPlot, normalizePlotlySvg } from './normalizer';

--- a/src/adapters/plotly/index.ts
+++ b/src/adapters/plotly/index.ts
@@ -5,5 +5,5 @@
  * modules. Internal helpers remain private to each module.
  */
 
-export { extractPlotlyData } from './extractor';
+export { extractPlotlyData, plotlyTraceSignature } from './extractor';
 export { disconnectPlotlyObservers, isPlotlyPlot, normalizePlotlySvg } from './normalizer';

--- a/src/adapters/plotly/index.ts
+++ b/src/adapters/plotly/index.ts
@@ -5,6 +5,6 @@
  * modules. Internal helpers remain private to each module.
  */
 
-export type { PlotlyExtractionInputs } from './extractor';
-export { extractPlotlyData, plotlyExtractionInputs } from './extractor';
+export { claimPlotlyExamination } from './examination';
+export { extractPlotlyData } from './extractor';
 export { disconnectPlotlyObservers, isPlotlyPlot, normalizePlotlySvg } from './normalizer';

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -30,6 +30,11 @@ export interface PlotlyTrace {
   lowerfence?: number[];
   upperfence?: number[];
   mean?: number[];
+  // Violin-specific
+  /** Inner box overlay. Plotly draws `path.box` only when `visible` is true. */
+  box?: { visible?: boolean };
+  /** Mean line overlay drawn across the violin. */
+  meanline?: { visible?: boolean };
   // Candlestick-specific
   open?: number[];
   high?: number[];
@@ -123,6 +128,13 @@ export interface PlotlyAxis {
   _offset?: number;
   /** Computed pixel length of the axis within the SVG (plotly internal). */
   _length?: number;
+  /** Category labels in axis order, indexed by a categorical coordinate. */
+  _categories?: (number | string)[];
+  /**
+   * Converts a data coordinate to a pixel position within the plot area
+   * (plotly internal, available once the chart has been drawn).
+   */
+  c2p?: (value: number) => number;
 }
 
 export interface PlotlyCalcData {
@@ -146,10 +158,31 @@ export interface PlotlyCalcData {
   uo?: number; // upper outlier threshold
   pts?: PlotlyCalcPoint[];
   pts2?: PlotlyCalcPoint[];
+  // Violin calc data
+  /** KDE samples: `t` is the value-axis coordinate, `v` the density there. */
+  density?: PlotlyDensitySample[];
+  /** Pixel centre of this violin on the position axis, set when plotly draws it. */
+  posCenterPx?: number;
+  /** Per-trace calc metadata; plotly stores it on the first entry of a trace. */
+  t?: PlotlyCalcMeta;
   // Heatmap
   z?: number[][];
   trace?: PlotlyTrace;
   [key: string]: unknown;
+}
+
+export interface PlotlyDensitySample {
+  /** Density at this position. */
+  v: number;
+  /** Value-axis coordinate of the sample. */
+  t: number;
+}
+
+export interface PlotlyCalcMeta {
+  /** Offset from the position-axis centre, non-zero for grouped box/violin traces. */
+  bPos?: number;
+  /** Set when the trace holds no plottable points; plotly then draws nothing. */
+  empty?: boolean;
 }
 
 export interface PlotlyCalcPoint {

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -181,8 +181,6 @@ export interface PlotlyDensitySample {
 export interface PlotlyCalcMeta {
   /** Offset from the position-axis centre, non-zero for grouped box/violin traces. */
   bPos?: number;
-  /** Set when the trace holds no plottable points; plotly then draws nothing. */
-  empty?: boolean;
 }
 
 export interface PlotlyCalcPoint {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,22 +184,36 @@ function autoInitPlotlyCharts(): void {
 }
 
 /**
+ * Marks a rendered chart MAIDR has already examined, whatever the outcome.
+ * A chart that binds also carries `data-maidr-auto`, which the plotly
+ * stylesheet is scoped to; this one only records that the decision was made.
+ */
+const PLOTLY_EXAMINED_ATTRIBUTE = 'data-maidr-examined';
+
+/**
  * Extracts data and initialises MAIDR for a fully-rendered Plotly chart.
  * Only proceeds when `svg.main-svg` exists — never replaces the graph
  * div itself, which would break Plotly's internal event pipeline.
+ *
+ * A chart whose traces MAIDR cannot represent is examined once: without the
+ * mark, every later DOM mutation reconsiders it and logs the same warning
+ * again.
  */
 function initPlotlyChart(gd: HTMLElement): void {
-  if (gd.hasAttribute('data-maidr-auto'))
-    return;
-
-  const maidrData = extractPlotlyData(gd);
-  if (!maidrData)
+  if (gd.hasAttribute(PLOTLY_EXAMINED_ATTRIBUTE))
     return;
 
   // Require the SVG to exist. Replacing the graph div in the DOM would
   // break Plotly's rendering pipeline — only the SVG is safe to adopt.
+  // A chart that has not rendered yet stays unmarked so it is revisited.
   const svg = gd.querySelector<SVGSVGElement>('svg.main-svg');
   if (!svg)
+    return;
+
+  gd.setAttribute(PLOTLY_EXAMINED_ATTRIBUTE, '1');
+
+  const maidrData = extractPlotlyData(gd);
+  if (!maidrData)
     return;
 
   gd.setAttribute('data-maidr-auto', '1');
@@ -223,7 +237,7 @@ function observeForPlotlyDivs(): void {
 
   plotlyDivObserver = new MutationObserver(() => {
     const divs = document.querySelectorAll<HTMLElement>(
-      '.js-plotly-plot:not([data-maidr-auto])',
+      `.js-plotly-plot:not([${PLOTLY_EXAMINED_ATTRIBUTE}])`,
     );
     if (divs.length === 0)
       return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import type { MaidrLiveApi } from './service/liveData';
 import type { Maidr } from './type/grammar';
-import { extractPlotlyData, isPlotlyPlot, normalizePlotlySvg } from './adapters/plotly';
+import { extractPlotlyData, isPlotlyPlot, normalizePlotlySvg, plotlyTraceSignature } from './adapters/plotly';
 import { liveDataManager } from './service/liveData';
 import { DomEventType } from './type/event';
 import { Constant } from './util/constant';
@@ -184,8 +184,8 @@ function autoInitPlotlyCharts(): void {
 }
 
 /**
- * Marks a rendered chart MAIDR has already examined, whatever the outcome.
- * A chart that binds also carries `data-maidr-auto`, which the plotly
+ * Records the traces a chart held when MAIDR examined it and could not bind
+ * it. A chart that binds carries `data-maidr-auto` instead, which the plotly
  * stylesheet is scoped to; this one only records that the decision was made.
  */
 const PLOTLY_EXAMINED_ATTRIBUTE = 'data-maidr-examined';
@@ -195,22 +195,29 @@ const PLOTLY_EXAMINED_ATTRIBUTE = 'data-maidr-examined';
  * Only proceeds when `svg.main-svg` exists — never replaces the graph
  * div itself, which would break Plotly's internal event pipeline.
  *
- * A chart whose traces MAIDR cannot represent is examined once: without the
- * mark, every later DOM mutation reconsiders it and logs the same warning
- * again.
+ * The verdict on a chart MAIDR cannot represent is recorded against the traces
+ * it was made about. An idle DOM mutation then reconsiders nothing — without
+ * the mark, every one of them re-examined the chart and logged the same
+ * warning again — while a chart replotted with different traces
+ * (`Plotly.react`) is examined afresh and can still become accessible.
  */
 function initPlotlyChart(gd: HTMLElement): void {
-  if (gd.hasAttribute(PLOTLY_EXAMINED_ATTRIBUTE))
+  if (gd.hasAttribute('data-maidr-auto'))
     return;
 
   // Require the SVG to exist. Replacing the graph div in the DOM would
   // break Plotly's rendering pipeline — only the SVG is safe to adopt.
-  // A chart that has not rendered yet stays unmarked so it is revisited.
   const svg = gd.querySelector<SVGSVGElement>('svg.main-svg');
   if (!svg)
     return;
 
-  gd.setAttribute(PLOTLY_EXAMINED_ATTRIBUTE, '1');
+  // A chart plotly is still populating cannot be judged yet, and is left
+  // unmarked so a later mutation examines it once it can be.
+  const traces = plotlyTraceSignature(gd);
+  if (traces === null || gd.getAttribute(PLOTLY_EXAMINED_ATTRIBUTE) === traces)
+    return;
+
+  gd.setAttribute(PLOTLY_EXAMINED_ATTRIBUTE, traces);
 
   const maidrData = extractPlotlyData(gd);
   if (!maidrData)
@@ -236,8 +243,10 @@ function observeForPlotlyDivs(): void {
     return;
 
   plotlyDivObserver = new MutationObserver(() => {
+    // Charts MAIDR bound are done with; every other one is offered to
+    // `initPlotlyChart`, which decides from the traces it holds now.
     const divs = document.querySelectorAll<HTMLElement>(
-      `.js-plotly-plot:not([${PLOTLY_EXAMINED_ATTRIBUTE}])`,
+      '.js-plotly-plot:not([data-maidr-auto])',
     );
     if (divs.length === 0)
       return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
+import type { PlotlyExtractionInputs } from './adapters/plotly';
 import type { MaidrLiveApi } from './service/liveData';
 import type { Maidr } from './type/grammar';
-import { extractPlotlyData, isPlotlyPlot, normalizePlotlySvg, plotlyTraceSignature } from './adapters/plotly';
+import { extractPlotlyData, isPlotlyPlot, normalizePlotlySvg, plotlyExtractionInputs } from './adapters/plotly';
 import { liveDataManager } from './service/liveData';
 import { DomEventType } from './type/event';
 import { Constant } from './util/constant';
@@ -184,22 +185,21 @@ function autoInitPlotlyCharts(): void {
 }
 
 /**
- * Records the traces a chart held when MAIDR examined it and could not bind
- * it. A chart that binds carries `data-maidr-auto` instead, which the plotly
- * stylesheet is scoped to; this one only records that the decision was made.
+ * What each chart MAIDR examined, and could not bind, was examined against.
+ * Charts that bind carry `data-maidr-auto` and are never revisited.
  */
-const PLOTLY_EXAMINED_ATTRIBUTE = 'data-maidr-examined';
+const examinedPlotlyCharts = new WeakMap<Element, PlotlyExtractionInputs>();
 
 /**
  * Extracts data and initialises MAIDR for a fully-rendered Plotly chart.
  * Only proceeds when `svg.main-svg` exists — never replaces the graph
  * div itself, which would break Plotly's internal event pipeline.
  *
- * The verdict on a chart MAIDR cannot represent is recorded against the traces
- * it was made about. An idle DOM mutation then reconsiders nothing — without
- * the mark, every one of them re-examined the chart and logged the same
- * warning again — while a chart replotted with different traces
- * (`Plotly.react`) is examined afresh and can still become accessible.
+ * A chart MAIDR cannot represent is examined once per set of inputs. Every DOM
+ * mutation used to reconsider it and log the same warning again — 28 copies of
+ * one warning on an idle page in the reported case — while a chart plotly
+ * recomputed, whether swapped to other traces or given the points it was drawn
+ * without, is examined afresh and can still become accessible.
  */
 function initPlotlyChart(gd: HTMLElement): void {
   if (gd.hasAttribute('data-maidr-auto'))
@@ -211,13 +211,17 @@ function initPlotlyChart(gd: HTMLElement): void {
   if (!svg)
     return;
 
-  // A chart plotly is still populating cannot be judged yet, and is left
-  // unmarked so a later mutation examines it once it can be.
-  const traces = plotlyTraceSignature(gd);
-  if (traces === null || gd.getAttribute(PLOTLY_EXAMINED_ATTRIBUTE) === traces)
+  // A chart plotly is still computing cannot be judged yet, and nothing is
+  // recorded for it, so a later mutation examines it once it can be.
+  const inputs = plotlyExtractionInputs(gd);
+  if (!inputs)
     return;
 
-  gd.setAttribute(PLOTLY_EXAMINED_ATTRIBUTE, traces);
+  const examined = examinedPlotlyCharts.get(gd);
+  if (examined?.traces === inputs.traces && examined?.calcdata === inputs.calcdata)
+    return;
+
+  examinedPlotlyCharts.set(gd, inputs);
 
   const maidrData = extractPlotlyData(gd);
   if (!maidrData)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -188,11 +188,8 @@ function autoInitPlotlyCharts(): void {
  * Only proceeds when `svg.main-svg` exists — never replaces the graph
  * div itself, which would break Plotly's internal event pipeline.
  *
- * A chart MAIDR cannot represent is examined once per set of inputs. Every DOM
- * mutation used to reconsider it and log the same warning again — 28 copies of
- * one warning on an idle page in the reported case — while a chart plotly
- * recomputed, whether swapped to other traces or given the points it was drawn
- * without, is examined afresh and can still become accessible.
+ * Which charts this looks at, and how often, is
+ * {@link claimPlotlyExamination}'s to decide.
  */
 function initPlotlyChart(gd: HTMLElement): void {
   if (gd.hasAttribute('data-maidr-auto'))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
-import type { PlotlyExtractionInputs } from './adapters/plotly';
 import type { MaidrLiveApi } from './service/liveData';
 import type { Maidr } from './type/grammar';
-import { extractPlotlyData, isPlotlyPlot, normalizePlotlySvg, plotlyExtractionInputs } from './adapters/plotly';
+import { claimPlotlyExamination, extractPlotlyData, isPlotlyPlot, normalizePlotlySvg } from './adapters/plotly';
 import { liveDataManager } from './service/liveData';
 import { DomEventType } from './type/event';
 import { Constant } from './util/constant';
@@ -185,12 +184,6 @@ function autoInitPlotlyCharts(): void {
 }
 
 /**
- * What each chart MAIDR examined, and could not bind, was examined against.
- * Charts that bind carry `data-maidr-auto` and are never revisited.
- */
-const examinedPlotlyCharts = new WeakMap<Element, PlotlyExtractionInputs>();
-
-/**
  * Extracts data and initialises MAIDR for a fully-rendered Plotly chart.
  * Only proceeds when `svg.main-svg` exists — never replaces the graph
  * div itself, which would break Plotly's internal event pipeline.
@@ -211,17 +204,8 @@ function initPlotlyChart(gd: HTMLElement): void {
   if (!svg)
     return;
 
-  // A chart plotly is still computing cannot be judged yet, and nothing is
-  // recorded for it, so a later mutation examines it once it can be.
-  const inputs = plotlyExtractionInputs(gd);
-  if (!inputs)
+  if (!claimPlotlyExamination(gd))
     return;
-
-  const examined = examinedPlotlyCharts.get(gd);
-  if (examined?.traces === inputs.traces && examined?.calcdata === inputs.calcdata)
-    return;
-
-  examinedPlotlyCharts.set(gd, inputs);
 
   const maidrData = extractPlotlyData(gd);
   if (!maidrData)

--- a/test/adapters/plotly/examination.test.ts
+++ b/test/adapters/plotly/examination.test.ts
@@ -1,0 +1,75 @@
+import type { PlotlyCalcData, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
+import { claimPlotlyExamination } from '@adapters/plotly/examination';
+import { describe, expect, it } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+/** Builds a rendered plotly graph div holding the given internals. */
+function createGraphDiv(
+  traces: PlotlyTrace[],
+  calcdata?: PlotlyCalcData[][],
+): PlotlyGraphDiv {
+  const dom = new JSDOM('<!doctype html><body></body>');
+  const div = dom.window.document.createElement('div');
+  div.className = 'js-plotly-plot';
+  dom.window.document.body.appendChild(div);
+
+  const gd = div as unknown as PlotlyGraphDiv;
+  gd._fullData = traces;
+  gd.calcdata = calcdata;
+  return gd;
+}
+
+const BAR: PlotlyTrace[] = [{ type: 'bar', x: ['a'], y: [1] }];
+
+describe('plotly examination', () => {
+  it('claims a chart once for the inputs it holds', () => {
+    const gd = createGraphDiv(BAR, [[{ x: 0, y: 1 }]]);
+
+    expect(claimPlotlyExamination(gd)).toBe(true);
+
+    // The DOM mutating around an untouched chart is not a reason to look at
+    // it again — the repeated warnings came from doing exactly that.
+    expect(claimPlotlyExamination(gd)).toBe(false);
+    expect(claimPlotlyExamination(gd)).toBe(false);
+  });
+
+  it('does not claim a chart plotly has not computed yet', () => {
+    const gd = createGraphDiv(BAR);
+
+    expect(claimPlotlyExamination(gd)).toBe(false);
+
+    // Nothing was recorded for it, so it is claimed once the calc data lands.
+    gd.calcdata = [[{ x: 0, y: 1 }]];
+    expect(claimPlotlyExamination(gd)).toBe(true);
+  });
+
+  it('claims a chart again once plotly recomputes its points', () => {
+    const gd = createGraphDiv(BAR, [[]]);
+    claimPlotlyExamination(gd);
+
+    // A chart drawn empty and filled in later: same traces, new calc data.
+    gd.calcdata = [[{ x: 0, y: 1 }]];
+
+    expect(claimPlotlyExamination(gd)).toBe(true);
+  });
+
+  it('claims a chart again once plotly replaces its traces', () => {
+    const gd = createGraphDiv([{ type: 'pie', y: [1, 2] }], [[{}]]);
+    claimPlotlyExamination(gd);
+
+    // What `Plotly.react` does to a chart swapped in place.
+    gd._fullData = [{ type: 'violin', y: [1, 2] }];
+    gd.calcdata = [[{ min: 1, max: 2 }]];
+
+    expect(claimPlotlyExamination(gd)).toBe(true);
+  });
+
+  it('keeps charts apart', () => {
+    const first = createGraphDiv(BAR, [[{ x: 0, y: 1 }]]);
+    const second = createGraphDiv(BAR, [[{ x: 0, y: 1 }]]);
+
+    expect(claimPlotlyExamination(first)).toBe(true);
+    expect(claimPlotlyExamination(second)).toBe(true);
+    expect(claimPlotlyExamination(first)).toBe(false);
+  });
+});

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,6 +1,6 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
 import type { BoxPoint, BoxSelector, ViolinKdePoint } from '@type/grammar';
-import { extractPlotlyData, plotlyTraceSignature } from '@adapters/plotly/extractor';
+import { extractPlotlyData, plotlyExtractionInputs } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
 import { Figure } from '@model/plot';
@@ -143,33 +143,40 @@ describe('plotly extractor', () => {
     });
   });
 
-  describe('trace signature', () => {
-    it('withholds a signature until plotly has computed the chart', () => {
+  describe('extraction inputs', () => {
+    it('withholds them until plotly has computed the chart', () => {
       const gd = createGraphDiv({
         traces: [{ type: 'bar', x: ['a'], y: [1] }],
         layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
       });
 
       // Mid-render: the traces are wired up but their calc data is not.
-      expect(plotlyTraceSignature(gd)).toBeNull();
+      expect(plotlyExtractionInputs(gd)).toBeNull();
 
       gd.calcdata = [[{ x: 0, y: 1 }]];
-      expect(plotlyTraceSignature(gd)).toBe('bar');
+      expect(plotlyExtractionInputs(gd)).toEqual({
+        traces: gd._fullData,
+        calcdata: gd.calcdata,
+      });
     });
 
-    it('changes when a chart is replotted with different traces', () => {
+    it('hands back what plotly currently holds, so a recompute is visible', () => {
       const gd = createGraphDiv({
         traces: [{ type: 'pie', y: [1, 2] }],
         layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
         calcdata: [[{}]],
       });
-      const before = plotlyTraceSignature(gd);
+      const before = plotlyExtractionInputs(gd);
 
-      // What `Plotly.react` does to a chart swapped in place.
+      // What plotly does to a chart it recomputes: both are built afresh,
+      // whether the traces changed or only the points they were drawn from.
       gd._fullData = [{ type: 'violin', y: [1, 2] }];
+      gd.calcdata = [[{ min: 1, max: 2 }]];
+      const after = plotlyExtractionInputs(gd);
 
-      expect(before).toBe('pie');
-      expect(plotlyTraceSignature(gd)).toBe('violin');
+      expect(before!.traces).not.toBe(after!.traces);
+      expect(before!.calcdata).not.toBe(after!.calcdata);
+      expect(after!.traces).toBe(gd._fullData);
     });
   });
 

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,6 +1,6 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
 import type { BoxPoint, BoxSelector, ViolinKdePoint } from '@type/grammar';
-import { extractPlotlyData, plotlyExtractionInputs } from '@adapters/plotly/extractor';
+import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
 import { Figure } from '@model/plot';
@@ -140,43 +140,6 @@ describe('plotly extractor', () => {
         // A failed assertion must not leave the spy in place for later tests.
         warn.mockRestore();
       }
-    });
-  });
-
-  describe('extraction inputs', () => {
-    it('withholds them until plotly has computed the chart', () => {
-      const gd = createGraphDiv({
-        traces: [{ type: 'bar', x: ['a'], y: [1] }],
-        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
-      });
-
-      // Mid-render: the traces are wired up but their calc data is not.
-      expect(plotlyExtractionInputs(gd)).toBeNull();
-
-      gd.calcdata = [[{ x: 0, y: 1 }]];
-      expect(plotlyExtractionInputs(gd)).toEqual({
-        traces: gd._fullData,
-        calcdata: gd.calcdata,
-      });
-    });
-
-    it('hands back what plotly currently holds, so a recompute is visible', () => {
-      const gd = createGraphDiv({
-        traces: [{ type: 'pie', y: [1, 2] }],
-        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
-        calcdata: [[{}]],
-      });
-      const before = plotlyExtractionInputs(gd);
-
-      // What plotly does to a chart it recomputes: both are built afresh,
-      // whether the traces changed or only the points they were drawn from.
-      gd._fullData = [{ type: 'violin', y: [1, 2] }];
-      gd.calcdata = [[{ min: 1, max: 2 }]];
-      const after = plotlyExtractionInputs(gd);
-
-      expect(before!.traces).not.toBe(after!.traces);
-      expect(before!.calcdata).not.toBe(after!.calcdata);
-      expect(after!.traces).toBe(gd._fullData);
     });
   });
 

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,4 +1,5 @@
-import type { PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
+import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
+import type { BoxPoint, BoxSelector, ViolinKdePoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
@@ -15,6 +16,8 @@ interface GraphDivOptions {
   layout: PlotlyFullLayout;
   /** Panel background rect positions rendered into the `.bglayer`. */
   bgRects?: { x: number; y: number }[];
+  /** Plotly's computed per-trace calc data, indexed like `traces`. */
+  calcdata?: PlotlyCalcData[][];
 }
 
 /** Builds a fake rendered Plotly graph div with `_fullData`/`_fullLayout`. */
@@ -43,6 +46,7 @@ function createGraphDiv(options: GraphDivOptions): PlotlyGraphDiv {
   const gd = div as PlotlyGraphDiv;
   gd._fullData = options.traces;
   gd._fullLayout = options.layout;
+  gd.calcdata = options.calcdata;
   return gd;
 }
 
@@ -244,7 +248,7 @@ describe('plotly extractor', () => {
           scatterTrace({ name: 'B', xaxis: 'x2', yaxis: 'y2' }),
           scatterTrace({ name: 'C', xaxis: 'x3', yaxis: 'y3' }),
           scatterTrace({ name: 'D', xaxis: 'x4', yaxis: 'y4' }),
-          { type: 'violin', y: [1, 2, 3], xaxis: 'x5', yaxis: 'y5' },
+          { type: 'pie', y: [1, 2, 3], xaxis: 'x5', yaxis: 'y5' },
         ],
         layout: twoByTwoLayout({
           xaxis5: { domain: [0, 0.45] },
@@ -732,6 +736,262 @@ describe('plotly extractor', () => {
     });
   });
 
+  describe('violin traces', () => {
+    /**
+     * One violin's calc data, shaped like plotly's: the box statistics from
+     * the shared box calc, the KDE samples (`t` is the value-axis coordinate,
+     * `v` the density there) and the pixel centre plotly records while drawing.
+     */
+    function violinCalc(overrides: Partial<PlotlyCalcData> = {}): PlotlyCalcData {
+      return {
+        pos: 0,
+        min: 1,
+        q1: 2,
+        med: 3,
+        q3: 4,
+        max: 9,
+        mean: 3.6,
+        posCenterPx: 110,
+        density: [
+          { v: 0.1, t: 1 },
+          { v: 0.3, t: 3 },
+          { v: 0.05, t: 9 },
+        ],
+        ...overrides,
+      };
+    }
+
+    /** Categorical position axis on x, value axis on y (plotly's default). */
+    function violinLayout(extra: Partial<PlotlyFullLayout> = {}): PlotlyFullLayout {
+      return {
+        xaxis: {
+          domain: [0, 1],
+          title: { text: 'Group' },
+          _categories: ['A', 'B'],
+          c2p: value => 110 + 220 * value,
+        },
+        yaxis: {
+          domain: [0, 1],
+          title: { text: 'Value' },
+          c2p: value => 300 - 20 * value,
+        },
+        ...extra,
+      };
+    }
+
+    it('emits the box layer and the KDE layer, box first', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'violin', y: [1, 2, 3], name: 'A', box: { visible: true } }],
+        layout: violinLayout(),
+        calcdata: [[violinCalc()]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers.map(layer => layer.type)).toEqual([
+        TraceType.VIOLIN_BOX,
+        TraceType.VIOLIN_KDE,
+      ]);
+      expect(new Set(layers.map(layer => layer.id)).size).toBe(2);
+      for (const layer of layers) {
+        expect(layer.orientation).toBe('vert');
+        expect(layer.axes?.x?.label).toBe('Group');
+        expect(layer.axes?.y?.label).toBe('Value');
+      }
+    });
+
+    it('reads the quartile summary and the KDE curve from plotly calc data', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'violin', y: [1, 2, 3], name: 'A', box: { visible: true } }],
+        layout: violinLayout(),
+        calcdata: [[violinCalc()]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+
+      expect(boxLayer.data as BoxPoint[]).toEqual([{
+        z: 'A',
+        lowerOutliers: [],
+        min: 1,
+        q1: 2,
+        q2: 3,
+        q3: 4,
+        max: 9,
+        upperOutliers: [],
+        mean: 3.6,
+      }]);
+
+      // Highlight circles are placed on the violin's centre line, at the
+      // value-axis pixel of each density sample.
+      expect(kdeLayer.data as ViolinKdePoint[][]).toEqual([[
+        { x: 'A', y: 1, density: 0.1, svg_x: 110, svg_y: 280 },
+        { x: 'A', y: 3, density: 0.3, svg_x: 110, svg_y: 240 },
+        { x: 'A', y: 9, density: 0.05, svg_x: 110, svg_y: 120 },
+      ]]);
+    });
+
+    it('points each layer at the elements plotly draws for that violin', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'violin', y: [1, 2, 3], name: 'A', box: { visible: true } }],
+        layout: violinLayout(),
+        calcdata: [[violinCalc()]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+      const group = '.subplot.xy .violinlayer > g:nth-child(1)';
+
+      expect(kdeLayer.selectors).toEqual([`${group} > path.violin:nth-child(1)`]);
+      // The inner boxes follow every violin outline in the trace's group.
+      expect(boxLayer.selectors as BoxSelector[]).toEqual([{
+        lowerOutliers: [],
+        min: `${group} > path.box:nth-child(2)`,
+        iq: `${group} > path.box:nth-child(2)`,
+        q2: `${group} > path.box:nth-child(2)`,
+        max: `${group} > path.box:nth-child(2)`,
+        upperOutliers: [],
+      }]);
+    });
+
+    it('names each violin of a categorical trace after its category', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'violin',
+          x: ['a', 'a', 'b', 'b'],
+          y: [1, 2, 3, 4],
+          name: 'g1',
+          box: { visible: true },
+        }],
+        layout: violinLayout({
+          xaxis: { domain: [0, 1], _categories: ['a', 'b'], c2p: value => 110 + 220 * value },
+        }),
+        calcdata: [[
+          violinCalc({ pos: 0, posCenterPx: 110 }),
+          violinCalc({ pos: 1, posCenterPx: 330 }),
+        ]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+      const group = '.subplot.xy .violinlayer > g:nth-child(1)';
+
+      expect((boxLayer.data as BoxPoint[]).map(point => point.z)).toEqual(['g1, a', 'g1, b']);
+      expect(kdeLayer.selectors).toEqual([
+        `${group} > path.violin:nth-child(1)`,
+        `${group} > path.violin:nth-child(2)`,
+      ]);
+      expect((boxLayer.selectors as BoxSelector[]).map(selector => selector.iq)).toEqual([
+        `${group} > path.box:nth-child(3)`,
+        `${group} > path.box:nth-child(4)`,
+      ]);
+    });
+
+    it('gathers the violins of several traces into one pair of layers', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'violin', y: [1, 2, 3], name: 'A', box: { visible: true } },
+          { type: 'violin', y: [2, 3, 4], name: 'B', box: { visible: true } },
+        ],
+        layout: violinLayout(),
+        calcdata: [
+          [violinCalc({ pos: 0, posCenterPx: 110 })],
+          [violinCalc({ pos: 1, posCenterPx: 330 })],
+        ],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+
+      expect((boxLayer.data as BoxPoint[]).map(point => point.z)).toEqual(['A', 'B']);
+      expect(kdeLayer.selectors).toEqual([
+        '.subplot.xy .violinlayer > g:nth-child(1) > path.violin:nth-child(1)',
+        '.subplot.xy .violinlayer > g:nth-child(2) > path.violin:nth-child(1)',
+      ]);
+    });
+
+    it('keeps the statistics but drops the selectors when no inner box is drawn', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'violin', y: [1, 2, 3], name: 'A' }],
+        layout: violinLayout(),
+        calcdata: [[violinCalc()]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+
+      expect(boxLayer.data).toHaveLength(1);
+      expect(boxLayer.selectors).toBeUndefined();
+      expect(kdeLayer.selectors).toHaveLength(1);
+    });
+
+    it('makes the mean navigable where plotly draws a mean line', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'violin',
+          y: [1, 2, 3],
+          name: 'A',
+          box: { visible: true },
+          meanline: { visible: true },
+        }],
+        layout: violinLayout(),
+        calcdata: [[violinCalc()]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer] = maidr!.subplots[0][0].layers;
+
+      expect(boxLayer.violinOptions).toEqual({ showMean: true });
+      expect((boxLayer.selectors as BoxSelector[])[0].mean)
+        .toBe('.subplot.xy .violinlayer > g:nth-child(1) > path.mean:nth-child(3)');
+    });
+
+    it('emits a horizontal violin bottom-first, with the axes swapped', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'violin',
+          x: [1, 2, 3],
+          orientation: 'h',
+          name: 'A',
+          box: { visible: true },
+        }],
+        layout: {
+          xaxis: { domain: [0, 1], title: { text: 'Value' }, c2p: value => 20 + 10 * value },
+          yaxis: { domain: [0, 1], title: { text: 'Group' }, _categories: ['A', 'B'], c2p: value => 300 - 100 * value },
+        },
+        calcdata: [[
+          violinCalc({ pos: 0, posCenterPx: 300 }),
+          violinCalc({ pos: 1, posCenterPx: 200 }),
+        ]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+
+      expect(boxLayer.orientation).toBe('horz');
+      // The core reverses horizontal rows into visual order, so the topmost
+      // violin is emitted first and comes back as plotly's last one.
+      expect((boxLayer.data as BoxPoint[]).map(point => point.z)).toEqual(['A, B', 'A, A']);
+      expect((kdeLayer.data as ViolinKdePoint[][])[1][0]).toEqual({
+        x: 'A, A',
+        y: 1,
+        density: 0.1,
+        svg_x: 30,
+        svg_y: 300,
+      });
+    });
+
+    it('skips a violin chart whose calc data plotly has not computed', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'violin', y: [1, 2, 3], name: 'A' }],
+        layout: violinLayout(),
+      });
+
+      expect(extractPlotlyData(gd)).toBeNull();
+    });
+  });
+
   describe('core-model integration', () => {
     /**
      * The model and normalizer resolve elements via page globals; point
@@ -740,27 +1000,34 @@ describe('plotly extractor', () => {
     function withDomGlobals(gd: PlotlyGraphDiv, fn: (doc: Document) => void): void {
       const doc = gd.ownerDocument;
       const win = doc.defaultView!;
-      const testGlobals = globalThis as {
-        document?: Document;
-        MutationObserver?: typeof MutationObserver;
-        requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+      // jsdom implements only part of the SVG DOM, so stand in for the element
+      // classes it lacks: the model's `instanceof` checks then resolve and
+      // match nothing, leaving highlight elements a browser-only concern.
+      const svgClass = (name: string): unknown =>
+        (win as unknown as Record<string, unknown>)[name] ?? class {};
+      const overrides: Record<string, unknown> = {
+        document: doc,
+        window: win,
+        MutationObserver: win.MutationObserver,
+        requestAnimationFrame: () => 0,
+        SVGUseElement: svgClass('SVGUseElement'),
+        SVGPathElement: svgClass('SVGPathElement'),
+        SVGPolygonElement: svgClass('SVGPolygonElement'),
       };
-      const saved = {
-        document: testGlobals.document,
-        MutationObserver: testGlobals.MutationObserver,
-        requestAnimationFrame: testGlobals.requestAnimationFrame,
-      };
-      testGlobals.document = doc;
-      testGlobals.MutationObserver = win.MutationObserver;
-      testGlobals.requestAnimationFrame = () => 0;
+      const testGlobals = globalThis as Record<string, unknown>;
+      const saved = new Map<string, unknown>();
+      for (const [key, value] of Object.entries(overrides)) {
+        saved.set(key, testGlobals[key]);
+        testGlobals[key] = value;
+      }
       try {
         fn(doc);
       } finally {
-        for (const key of Object.keys(saved) as (keyof typeof saved)[]) {
-          if (saved[key] === undefined) {
+        for (const [key, value] of saved) {
+          if (value === undefined) {
             delete testGlobals[key];
           } else {
-            (testGlobals as Record<string, unknown>)[key] = saved[key];
+            testGlobals[key] = value;
           }
         }
       }
@@ -897,6 +1164,82 @@ describe('plotly extractor', () => {
         expect(subplotLayout.visualOrderMap.get('0,1')).toBe(2);
         expect(subplotLayout.visualOrderMap.get('1,0')).toBe(3);
         expect(subplotLayout.visualOrderMap.get('1,1')).toBe(4);
+      });
+    });
+
+    it('the emitted violin Maidr constructs a two-layer Figure with resolvable selectors', () => {
+      const violinCalcData = (pos: number, posCenterPx: number): PlotlyCalcData => ({
+        pos,
+        posCenterPx,
+        min: 1,
+        q1: 2,
+        med: 3,
+        q3: 4,
+        max: 9,
+        mean: 3.6,
+        density: [{ v: 0.1, t: 1 }, { v: 0.3, t: 3 }],
+      });
+
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'violin', y: [1, 2, 3], name: 'A', box: { visible: true } },
+          { type: 'violin', y: [2, 3, 4], name: 'B', box: { visible: true } },
+        ],
+        layout: {
+          xaxis: { domain: [0, 1], _categories: ['A', 'B'], c2p: value => 110 + 220 * value },
+          yaxis: { domain: [0, 1], c2p: value => 300 - 20 * value },
+        },
+        bgRects: [{ x: 0, y: 0 }],
+      });
+      gd.calcdata = [[violinCalcData(0, 110)], [violinCalcData(1, 330)]];
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      // Rebuild the layer plotly renders for these two traces: every violin
+      // outline of a trace, then its inner boxes, inside one group per trace.
+      const doc = gd.ownerDocument;
+      const svg = gd.querySelector('svg.main-svg')!;
+      const subplot = doc.createElementNS(SVG_NS, 'g');
+      subplot.setAttribute('class', 'subplot xy');
+      const violinLayer = doc.createElementNS(SVG_NS, 'g');
+      violinLayer.setAttribute('class', 'violinlayer mlayer');
+      for (let trace = 0; trace < 2; trace++) {
+        const traceGroup = doc.createElementNS(SVG_NS, 'g');
+        traceGroup.setAttribute('class', 'trace violins');
+        for (const className of ['violin', 'box']) {
+          const path = doc.createElementNS(SVG_NS, 'path');
+          path.setAttribute('class', className);
+          // jsdom has no layout engine; the model reads getBBox() off the
+          // inner box to place the Q1/Q3 highlight lines.
+          Object.defineProperty(path, 'getBBox', {
+            value: () => ({ x: 100, y: 200, width: 20, height: 60 }),
+            configurable: true,
+          });
+          traceGroup.appendChild(path);
+        }
+        violinLayer.appendChild(traceGroup);
+      }
+      subplot.appendChild(violinLayer);
+      svg.appendChild(subplot);
+
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+      const selectors = [
+        ...(kdeLayer.selectors as string[]),
+        ...(boxLayer.selectors as BoxSelector[]).map(selector => selector.iq),
+      ];
+      for (const selector of selectors) {
+        expect(doc.querySelectorAll(selector)).toHaveLength(1);
+      }
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        // Both violin traces are constructed, and the box layer is the one
+        // the user lands on.
+        expect(figure.subplots[0][0].traceTypes).toEqual(['violin_box', 'violin_kde']);
+        expect(figure.state).toMatchObject({ empty: false });
       });
     });
   });

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,7 +1,7 @@
 import type { PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import { Figure } from '@model/plot';
 import { TraceType } from '@type/grammar';
 import { resolveSubplotLayout } from '@util/subplotLayout';
@@ -114,6 +114,25 @@ describe('plotly extractor', () => {
       expect(layer.selectors).toBe('.subplot.xy .trace.bars .point > path');
       expect(layer.axes?.x?.label).toBe('Day');
       expect(layer.axes?.y?.label).toBe('Count');
+    });
+  });
+
+  describe('unsupported traces', () => {
+    it('warns once for a trace type MAIDR has no equivalent for', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const gd = createGraphDiv({
+        traces: [{ type: 'pie', y: [1, 2, 3] }],
+        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
+      });
+
+      extractPlotlyData(gd);
+
+      const skipped = warn.mock.calls.filter(([message]) =>
+        String(message).includes('Unsupported plotly trace type'),
+      );
+      expect(skipped).toHaveLength(1);
+
+      warn.mockRestore();
     });
   });
 

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -951,6 +951,49 @@ describe('plotly extractor', () => {
       ]);
     });
 
+    it('keeps the highlight of the violins that do have an inner box', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'violin', y: [1, 2, 3], name: 'A', box: { visible: true } },
+          { type: 'violin', y: [2, 3, 4], name: 'B' },
+        ],
+        layout: violinLayout(),
+        calcdata: [
+          [violinCalc({ pos: 0, posCenterPx: 110 })],
+          [violinCalc({ pos: 1, posCenterPx: 330 })],
+        ],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer] = maidr!.subplots[0][0].layers;
+
+      // One trace drawing no box does not cost the other one its highlight;
+      // the second selector points at a position that holds no `path.box`.
+      expect((boxLayer.selectors as BoxSelector[]).map(selector => selector.iq)).toEqual([
+        '.subplot.xy .violinlayer > g:nth-child(1) > path.box:nth-child(2)',
+        '.subplot.xy .violinlayer > g:nth-child(2) > path.box:nth-child(2)',
+      ]);
+    });
+
+    it('places a violin from its position when plotly recorded no pixel centre', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'violin', y: [1, 2, 3], name: 'A' }],
+        layout: violinLayout(),
+        calcdata: [[{
+          ...violinCalc({ pos: 1 }),
+          posCenterPx: undefined,
+          // Grouped violins sit either side of the category centre.
+          t: { bPos: 0.5 },
+        }]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [, kdeLayer] = maidr!.subplots[0][0].layers;
+
+      // c2p(pos + bPos) = 110 + 220 * 1.5
+      expect((kdeLayer.data as ViolinKdePoint[][])[0][0].svg_x).toBe(440);
+    });
+
     it('keeps the statistics but drops the selectors when no inner box is drawn', () => {
       const gd = createGraphDiv({
         traces: [{ type: 'violin', y: [1, 2, 3], name: 'A' }],

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,6 +1,6 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
 import type { BoxPoint, BoxSelector, ViolinKdePoint } from '@type/grammar';
-import { extractPlotlyData } from '@adapters/plotly/extractor';
+import { extractPlotlyData, plotlyTraceSignature } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
 import { Figure } from '@model/plot';
@@ -129,14 +129,47 @@ describe('plotly extractor', () => {
         layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
       });
 
-      extractPlotlyData(gd);
+      try {
+        extractPlotlyData(gd);
 
-      const skipped = warn.mock.calls.filter(([message]) =>
-        String(message).includes('Unsupported plotly trace type'),
-      );
-      expect(skipped).toHaveLength(1);
+        const skipped = warn.mock.calls.filter(([message]) =>
+          String(message).includes('Unsupported plotly trace type'),
+        );
+        expect(skipped).toHaveLength(1);
+      } finally {
+        // A failed assertion must not leave the spy in place for later tests.
+        warn.mockRestore();
+      }
+    });
+  });
 
-      warn.mockRestore();
+  describe('trace signature', () => {
+    it('withholds a signature until plotly has computed the chart', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'bar', x: ['a'], y: [1] }],
+        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
+      });
+
+      // Mid-render: the traces are wired up but their calc data is not.
+      expect(plotlyTraceSignature(gd)).toBeNull();
+
+      gd.calcdata = [[{ x: 0, y: 1 }]];
+      expect(plotlyTraceSignature(gd)).toBe('bar');
+    });
+
+    it('changes when a chart is replotted with different traces', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'pie', y: [1, 2] }],
+        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
+        calcdata: [[{}]],
+      });
+      const before = plotlyTraceSignature(gd);
+
+      // What `Plotly.react` does to a chart swapped in place.
+      gd._fullData = [{ type: 'violin', y: [1, 2] }];
+
+      expect(before).toBe('pie');
+      expect(plotlyTraceSignature(gd)).toBe('violin');
     });
   });
 
@@ -980,6 +1013,38 @@ describe('plotly extractor', () => {
         svg_x: 30,
         svg_y: 300,
       });
+    });
+
+    it('leaves out a position plotly computed no density for', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'violin',
+          x: ['a', 'b', 'c'],
+          y: [1, 2, 3],
+          name: 'g1',
+          box: { visible: true },
+        }],
+        layout: violinLayout({
+          xaxis: { domain: [0, 1], _categories: ['a', 'b', 'c'], c2p: value => 110 + 220 * value },
+        }),
+        calcdata: [[
+          violinCalc({ pos: 0, posCenterPx: 110 }),
+          { pos: 1, posCenterPx: 330 },
+          violinCalc({ pos: 2, posCenterPx: 550 }),
+        ]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const [boxLayer, kdeLayer] = maidr!.subplots[0][0].layers;
+      const group = '.subplot.xy .violinlayer > g:nth-child(1)';
+
+      // No violin of zeroes for the position without a curve, and the third
+      // violin still points at the third element plotly rendered.
+      expect((boxLayer.data as BoxPoint[]).map(point => point.z)).toEqual(['g1, a', 'g1, c']);
+      expect(kdeLayer.selectors).toEqual([
+        `${group} > path.violin:nth-child(1)`,
+        `${group} > path.violin:nth-child(3)`,
+      ]);
     });
 
     it('skips a violin chart whose calc data plotly has not computed', () => {


### PR DESCRIPTION
# Pull Request

## Description

Plotly violin charts had no non-visual equivalent: the adapter's `mapTraceType` had no `violin` case, so a chart on screen produced no MAIDR wrapper, nothing focusable, and no audio, text, or braille. Separately, a chart MAIDR could not represent was reconsidered on every DOM mutation, so the same skip warning was logged again and again on an idle page.

Both are addressed. The examine-once half took three follow-up commits to get right — the review threads below have the details, and the description here reflects where it landed.

## Related Issues

Closes #721

## Changes Made

**Violin support** (`feat(plotly): make violin charts accessible`)

- `mapTraceType` maps `type: 'violin'` to the pair of layers MAIDR already has — `violin_box` and `violin_kde` — and violin traces are grouped like box traces so every violin in a subplot lands in one pair, whether the chart draws one trace per group or one trace across categories (`x` as an array).
- Both layers are read from plotly's own calculations: `cd.density` holds the KDE samples (`t` = value-axis coordinate, `v` = density) and the quartiles sit on the same calcdata entry, so nothing is recomputed. The box layer is emitted first, since MAIDR shows a subplot's first layer on entry and the summary is the better starting point.
- Selectors follow plotly's geometry: `path.violin` per violin, `path.box` for the inner box and `path.mean`/`path.meanline` for the mean line where the chart draws them. Each violin carries its own box selector, so a subplot mixing traces that draw the inner box with traces that do not keeps the highlight for the ones that have it; the layer drops its selectors only when no violin has a box at all. The mean becomes a navigable section only when a mean line exists.
- Each KDE point resolves to the violin's centre line at the value-axis pixel of its density sample, in the plot-area coordinates the violin path itself is drawn in.
- Horizontal violins are emitted top-first so the core's reversal into visual order restores plotly's own bottom-to-top ordering.
- Adds `examples/plotly-violin.html`, a violin section in `docs/plotly.md`, and the example-gallery entry.

**Examine once** (`fix(plotly): examine a chart once…` and its two follow-ups, plus `refactor(plotly): move the examine-once bookkeeping into the adapter`)

- `claimPlotlyExamination` in the adapter decides whether a chart is due to be looked at, from the two things a verdict is reached out of: plotly's `_fullData` and `calcdata`. Plotly builds both afresh whenever it recomputes a chart and leaves them alone otherwise, so an unchanged pair means an unchanged verdict and nothing is re-run; a chart replotted with other traces, or given the points it was drawn without, is examined again and can still become accessible. A chart plotly has not computed yet is not claimed and records nothing, so it is examined once it can be.
- Each trace's type is resolved once per pass rather than twice, so an unsupported chart logs its decision a single time.

## Screenshots (if applicable)

Verified in Chromium against the new example with plotly 3.1.1. On entry: *"This is a maidr plot containing 2 layers, and this is layer 1 of 2: vertical violin_box plot."* Navigating the box layer announces `Species is Setosa, minimum Sepal Length (cm) is 2.3`, `25% … 2.9`, `50% … 3.5`, and the mean; `PageUp` switches to *"Layer 2 of 2: violin_kde plot"* and arrow keys walk the density curve. The highlight lands on the right element in both layers — the inner box for the summary, and a circle on the violin's centre line at the navigated value for the curve. In a subplot mixing a boxed and an unboxed violin, the boxed one highlights and the other stays silent, both reading correctly.

Examine-once, same browser: an empty violin and a pie, 20 DOM mutations, 3 console lines and no growth; filling the violin binds it; swapping the pie for a bar binds it; 20 further mutations add nothing. The reported case grew to 28 + 14.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass (1399 unit/component + 57 ESM tests). Twelve extractor tests cover the layer pair, the calcdata reading, the selector contract, categorical and multi-trace violins, the mixed and absent inner-box cases, the mean line, horizontal orientation, a position without a computed density, a violin chart without calcdata, warn-once, and a Figure built end-to-end from an emitted violin schema; five more cover the examine-once rule directly.

Three limits worth naming. Violin extraction requires `gd.calcdata`; a violin trace without it yields no layers, as before. The KDE highlight is a circle on the centre line rather than on the outline — placing it on the edge would mean reproducing plotly's `scalemode`/`side`/scale-group arithmetic, which the centre line makes unnecessary. And a chart plotly genuinely recomputes, and that MAIDR still cannot represent, logs its skip line once per recompute: a live-updating unsupported chart is not silent, only an idle page is.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)