### PR TITLE
feat(step): add a step plot trace type for piecewise-constant data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and encourages a multi-modal exploration on visualization.
 
 To use maidr, follow these steps:
 
-1. **Import your plot**: maidr is designed to work seamlessly with scalable vector graphics (SVG) objects for visual highlighting. However, maidr is inherently visual-agnostic, and it also supports other raster image formats such as PNG and JPG without the visual highlight feature. Regardless of the image format, maidr provides support for all non-visual modalities, including Braille, text, and sonification (BTS). Additionally, it offers interactive and artificial intelligence (AI) plot descriptions powered by OpenAI GPT, Anthropic Claude, Google Gemini, or local models running on your own machine via [Ollama](https://ollama.com) (no API key required, suitable for sensitive data). The supported plot types include bar plot, boxplot, heatmap, scatter plot, line plot, histogram, segmented bar plots (e.g., stacked bar plot, side-by-side dodged plot, and normalized stacked bar plot).
+1. **Import your plot**: maidr is designed to work seamlessly with scalable vector graphics (SVG) objects for visual highlighting. However, maidr is inherently visual-agnostic, and it also supports other raster image formats such as PNG and JPG without the visual highlight feature. Regardless of the image format, maidr provides support for all non-visual modalities, including Braille, text, and sonification (BTS). Additionally, it offers interactive and artificial intelligence (AI) plot descriptions powered by OpenAI GPT, Anthropic Claude, Google Gemini, or local models running on your own machine via [Ollama](https://ollama.com) (no API key required, suitable for sensitive data). The supported plot types include bar plot, boxplot, heatmap, scatter plot, line plot, step plot, histogram, segmented bar plots (e.g., stacked bar plot, side-by-side dodged plot, and normalized stacked bar plot).
 
 2. **Create an HTML file**: Include the main script file `maidr.js`. No stylesheet link is needed — maidr styles its own interface at runtime, and fetches the stylesheet for mathematical notation on demand when it is actually required. Add the SVG of your plot to the main HTML body, and add an ID attribute of your choice to the SVG. Note that this can be automated with R. Your HTML file should now have the following structure:
 
@@ -57,7 +57,7 @@ To use maidr, follow these steps:
 
 ## Data Schema
 
-The maidr JSON schema defines how plot data is structured for each supported plot type, including bar plots, boxplots, heatmaps, scatter plots, line plots, histograms, and segmented bar plots.
+The maidr JSON schema defines how plot data is structured for each supported plot type, including bar plots, boxplots, heatmaps, scatter plots, line plots, step plots, histograms, and segmented bar plots.
 For the full schema structure, object properties, and data formats, see the [Data Schema documentation](docs/SCHEMA.md).
 
 ## React Integration

--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -178,6 +178,42 @@ In multiline braille displays, all data series are represented simultaneously. H
 
 In single-line braille displays, the user can navigate vertically with the up and down arrow keys to move between lines, and the braille representation updates to show the values for the current line.
 
+## Step plot
+
+A step plot's braille is the line plot encoding above, unchanged: each data
+point becomes one Braille character whose dot height is its numeric `y` relative
+to the row's own range. The staircase corners the chart draws are not encoded —
+braille represents the samples, not the rendered geometry — so a run of equal
+levels reads as a run of identical characters and a transition reads as a change
+in dot height.
+
+### Known limitation: ordinal levels collapse
+
+The line encoder quarters each row's range into **four** buckets:
+
+- ⣀ represents values from 0% to 25%
+- ⠤ represents values from 25% to 50%
+- ⠒ represents values from 50% to 75%
+- ⠉ represents values from 75% to 100%
+
+A step plot whose Y axis is an ordinal scale with **five or more levels**
+therefore has more levels than the encoding has heights, and adjacent levels
+land on the same character. A hypnogram coded N3=1, N2=2, N1=3, REM=4, Awake=5
+quarters into bands of one unit, so N3 and N2 both render as ⣀ and cannot be
+told apart by touch alone.
+
+The exact stage name is still available: it comes from the text announcement,
+which reads the point's `label` ("Sleep stage is N2") rather than its numeric
+code. Use braille for the shape of the night — how long each run is, where the
+transitions fall — and the text output to name the level you are standing on.
+
+### Multiline Displays
+
+Step plots follow the line plot rules. In multiline braille displays, each
+series occupies its own line, so several step series can be compared at once. In
+single-line displays, the up and down arrow keys move between series and the
+braille representation updates to the current one.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/docs/LIVE_DATA.md
+++ b/docs/LIVE_DATA.md
@@ -70,7 +70,7 @@ window.maidrLive.appendData(
 
 The shape of `point` matches the layer's data format (see the [Data Schema](SCHEMA.html)): `{ x, y }` for bar/line/scatter points, a full OHLC object for candlestick, and so on.
 
-**Supported layer types:** any layer whose `data` is an array — bar, line (and multiline), scatter, histogram, candlestick, box, smooth, and segmented bar charts. Heatmaps (object-shaped data) do not support appending; use `setData` instead. Violin KDE layers accept appends structurally, but KDE points are pre-computed density samples — appending raw observations does not recompute the distribution, so prefer `setData` with freshly computed densities for violins.
+**Supported layer types:** any layer whose `data` is an array — bar, line (and multiline), step, scatter, histogram, candlestick, box, smooth, and segmented bar charts. Heatmaps (object-shaped data) do not support appending; use `setData` instead. Violin KDE layers accept appends structurally, but KDE points are pre-computed density samples — appending raw observations does not recompute the distribution, so prefer `setData` with freshly computed densities for violins.
 
 ### Streaming candlesticks (stock ticker)
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -345,7 +345,7 @@ The data property is defined as a list of objects where each object is a record 
                       "x": 1.0,
                       "y": 2,
                       "label": "N2"
-          },
+          }
         ]
         //add multiple arrays for multiple step series
       ]

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -121,7 +121,7 @@ Or multiple plots:
 
 Use the following to define the object properties:
 
-- `type`: the type of plot. Currently supported are 'bar', 'box', 'candlestick', 'dodged_bar', 'heat', 'hist', 'line', 'stacked_normalized_bar', 'point', 'smooth', 'stacked_bar', 'violin_kde', 'violin_box',
+- `type`: the type of plot. Currently supported are 'bar', 'box', 'candlestick', 'dodged_bar', 'heat', 'hist', 'line', 'stacked_normalized_bar', 'point', 'smooth', 'stacked_bar', 'step', 'violin_kde', 'violin_box',
 - `id`: the id that you added as an attribute of your main SVG.
 - `title`: the title of the plot. (optional)
 - `axes`: axes info for your plot. Each axis is a per-axis object: `maidr.axes.x`, `maidr.axes.y`, and (when used) `maidr.axes.z`. Supported properties per axis: `label` (string), `min` / `max` (number bounds), `tickStep` (number), and `format` (an `AxisFormat` object controlling numeric / categorical rendering). `label` is optional and defaults to `X`, `Y`, or `Level` for the respective axis. Bare string values for axes are no longer accepted.
@@ -305,6 +305,49 @@ The data property is defined as a list of objects where each object is a record 
           },
         ]
         //add multiple arrays for multiline plots
+      ]
+    }
+
+    //step: piecewise-constant data — the value is HELD across an interval and
+    //then jumps, rather than being interpolated the way a line implies.
+    //Data is nested exactly like `line`: one inner array per series.
+    //
+    //`y` stays NUMERIC — it drives sonification, braille and the min/max range.
+    //`label` is optional and names the ordinal level that `y` encodes; when
+    //present it is announced INSTEAD of the number, so a hypnogram says
+    //"Sleep stage is REM" rather than "Sleep stage is 4".
+    //
+    //`stepDirection` is a layer-level property (a sibling of `axes` and
+    //`data`), not a per-point one. It says where the jump happens between two
+    //consecutive samples:
+    //  "hv"  hold y[i] until x[i+1], then jump  (matplotlib 'steps-post',
+    //                                            ggplot2 direction 'hv')
+    //  "vh"  jump at x[i], then hold            (matplotlib 'steps-pre')
+    //  "mid" jump midway between the two x values (matplotlib 'steps-mid')
+    //Omit it entirely when the producing library does not report one — the
+    //description only names a direction the data actually authored.
+    maidr = {
+      "type": "step",
+      "stepDirection": "hv",
+      "data":[
+        [
+          {
+                      "x": 0.0,
+                      "y": 5,
+                      "label": "Awake"
+          },
+          {
+                      "x": 0.5,
+                      "y": 3,
+                      "label": "N1"
+          },
+          {
+                      "x": 1.0,
+                      "y": 2,
+                      "label": "N2"
+          },
+        ]
+        //add multiple arrays for multiple step series
       ]
     }
 

--- a/docs/anychart.md
+++ b/docs/anychart.md
@@ -67,15 +67,18 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 | MAIDR Type | AnyChart Series | Example |
 |-----------|----------------|---------|
 | Bar | `bar`, `column` | [Bar chart](examples.html) |
-| Line | `line`, `spline`, `step-line`, `area`, `step-area`, `spline-area` | [Line chart](examples.html) |
+| Line | `line`, `spline`, `area`, `spline-area` | [Line chart](examples.html) |
+| Step | `step-line`, `step-area` | [Step plot](examples.html) |
 | Scatter | `scatter`, `marker`, `bubble` | [Scatter plot](examples.html) |
 | Box Plot | `box` | [Box plot](examples.html) |
 | Heatmap | `heatmap`, `heat` | [Heatmap](examples.html) |
 | Candlestick | `candlestick`, `ohlc` | [Candlestick](examples.html) |
 
-Area series are represented as line traces — the filled-area visual is lost in the accessible representation. A console warning is emitted when this downgrade occurs.
+Area series are represented as line traces — the filled-area visual is lost in the accessible representation. A console warning is emitted when this downgrade occurs. `step-area` downgrades to a step trace rather than a line one, so it still warns about the lost fill.
 
 **Notes on chart-type detection:**
+
+- **Step** series (`step-line`, `step-area`) are piecewise constant — the value is held and then jumps — so they map to MAIDR's step trace rather than to a line, and are announced and navigated as step plots. AnyChart does not expose which step convention a series was drawn with, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
 - **Heatmap** charts use AnyChart's separate `anychart-heatmap.min.js` module and expose a chart-level data API (no `getSeriesCount()`). The adapter detects them via `chart.getType()` returning `'heatmap'` or `'heat'`, with a defensive fallback when `getType()` is unavailable.
 - **Candlestick** support also covers OHLC series. Both come from AnyChart's financial / stock module (`anychart-stock.min.js`). Each row is `[x, open, high, low, close]`; outlier and volume fields are not extracted by AnyChart's iterator API.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > MAIDR (Multimodal Access and Interactive Data Representation) is a TypeScript/React library that provides accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-MAIDR converts data visualizations into interactive, multimodal formats navigable entirely by keyboard. It supports bar charts, stacked/dodged bar charts, histograms, line plots, multi-line plots, scatter plots, box plots, violin plots, heatmaps, candlestick charts, smooth curves, faceted plots, and multi-panel layouts. Available as an npm package and as a React component library.
+MAIDR converts data visualizations into interactive, multimodal formats navigable entirely by keyboard. It supports bar charts, stacked/dodged bar charts, histograms, line plots, multi-line plots, step plots, scatter plots, box plots, violin plots, heatmaps, candlestick charts, smooth curves, faceted plots, and multi-panel layouts. Available as an npm package and as a React component library.
 
 ## Docs
 - [Home](https://maidr.ai/): Overview and getting started guide

--- a/docs/react.md
+++ b/docs/react.md
@@ -155,6 +155,7 @@ enum TraceType {
   SCATTER = 'point',
   SMOOTH = 'smooth',
   STACKED = 'stacked_bar',
+  STEP = 'step',
 }
 ```
 
@@ -208,6 +209,44 @@ const data: MaidrData = {
         { x: 1, y: 32, fill: '2023' },
         { x: 2, y: 35, fill: '2023' },
         { x: 3, y: 45, fill: '2023' },
+      ]],
+    }],
+  }]],
+};
+```
+
+### Step Chart
+
+A step chart holds its value across an interval and then jumps, so it is the
+right type for piecewise-constant data — a hypnogram's sleep stages, a status
+timeline, a rate that changes on fixed dates. Data is nested like a line chart,
+one inner array per series.
+
+`y` stays numeric: it drives sonification, braille and the min/max range.
+`label` names the ordinal level that number encodes and is announced in its
+place, so the chart reads "Sleep stage is REM" rather than "Sleep stage is 4".
+
+`stepDirection` is a layer property, not a per-point one: `'hv'` holds until the
+next x value then jumps (matplotlib `steps-post`, ggplot2's default), `'vh'`
+jumps at the current x value then holds (`steps-pre`), and `'mid'` jumps midway
+between the two x values (`steps-mid`). Omit it when your chart library does not
+report one — MAIDR then describes the chart without naming a direction:
+
+```typescript
+const data: MaidrData = {
+  id: 'hypnogram',
+  title: 'Sleep Stage Through One Night',
+  subplots: [[{
+    layers: [{
+      id: '0',
+      type: 'step',
+      stepDirection: 'hv',
+      axes: { x: { label: 'Time since lights out (h)' }, y: { label: 'Sleep stage' } },
+      data: [[
+        { x: 0, y: 5, label: 'Awake' },
+        { x: 0.5, y: 3, label: 'N1' },
+        { x: 1, y: 2, label: 'N2' },
+        { x: 1.5, y: 1, label: 'N3' },
       ]],
     }],
   }]],

--- a/e2e_tests/page-objects/plots/stepplot-page.ts
+++ b/e2e_tests/page-objects/plots/stepplot-page.ts
@@ -1,0 +1,245 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { StepPlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the step plot page
+ * Provides methods for interacting with the step (stairs) plot
+ */
+export class StepPlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.STEPPLOT_ID}`,
+    svg: `svg`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the step plot
+   */
+  private readonly plotId = TestConstants.STEPPLOT_ID;
+
+  /**
+   * Creates a new StepPlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the step plot page
+   * @throws StepPlotError if navigation fails
+   */
+  public async navigateToStepPlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/stepplot.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new StepPlotError('Failed to navigate to step plot', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the step plot
+   * @throws StepPlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new StepPlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR by clicking on the step plot
+   * @throws StepPlotError if MAIDR cannot be activated by clicking
+   */
+  public override async activateMaidrOnClick(): Promise<void> {
+    try {
+      await super.activateMaidrOnClick(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new StepPlotError('Failed to activate MAIDR by clicking', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws StepPlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new StepPlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws StepPlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new StepPlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if braille mode is active
+   * @param brailleMode - The braille mode to check
+   * @returns Promise resolving to true if braille mode is active, false otherwise
+   * @throws StepPlotError if braille mode status cannot be checked
+   */
+  public async isBrailleModeActive(brailleMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.BRAILLE_ON]: TestConstants.BRAILLE_MODE_ON,
+        [TestConstants.BRAILLE_OFF]: TestConstants.BRAILLE_MODE_OFF,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        brailleMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new StepPlotError('Failed to check braille mode status', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the braille cells currently on the braille display.
+   *
+   * Braille is the modality that fails silently for a new trace type — an
+   * unregistered encoder leaves the display blank while text and audio still
+   * work — so this returns the raw cell string for the spec to assert on.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws StepPlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new StepPlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if sonification mode is active
+   * @param sonificationMode - The sonification mode to check
+   * @returns Promise resolving to true if sonification mode is active, false otherwise
+   * @throws StepPlotError if sonification mode status cannot be checked
+   */
+  public async isSonificationActive(sonificationMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.SOUND_ON]: TestConstants.SOUND_MODE_ON,
+        [TestConstants.SOUND_OFF]: TestConstants.SOUND_MODE_OFF,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        sonificationMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new StepPlotError('Failed to check sonification mode status', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the X-axis title
+   * @returns Promise resolving to the X-axis title
+   * @throws StepPlotError if X-axis title cannot be retrieved
+   */
+  public async getXAxisTitle(): Promise<string> {
+    try {
+      return await super.getAxisTitle(this.selectors.info);
+    } catch (error) {
+      throw new StepPlotError('Failed to get X-axis title', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the Y-axis title
+   * @returns Promise resolving to the Y-axis title
+   * @throws StepPlotError if Y-axis title cannot be retrieved
+   */
+  public async getYAxisTitle(): Promise<string> {
+    try {
+      return await super.getAxisTitle(this.selectors.info);
+    } catch (error) {
+      throw new StepPlotError('Failed to get Y-axis title', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the current playback speed
+   * @returns Promise resolving to the current speed value
+   * @throws StepPlotError if speed cannot be retrieved
+   */
+  public override async getPlaybackSpeed(): Promise<number> {
+    try {
+      return await super.getPlaybackSpeed(this.selectors.speedIndicator);
+    } catch (error) {
+      throw new StepPlotError('Failed to get playback speed', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the current data point information
+   * @returns Promise resolving to the current data point information
+   * @throws StepPlotError if data point information cannot be retrieved
+   */
+  public override async getCurrentDataPointInfo(): Promise<string> {
+    try {
+      return await super.getCurrentDataPointInfo(this.selectors.info);
+    } catch (error) {
+      throw new StepPlotError('Failed to get current data point information', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws StepPlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded');
+      await expect(this.page.locator(this.selectors.svg)).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      throw new StepPlotError('StepPlot plot failed to load correctly', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/stepplot.spec.ts
+++ b/e2e_tests/specs/stepplot.spec.ts
@@ -1,0 +1,280 @@
+import type { Page } from '@playwright/test';
+import type { Maidr, MaidrLayer, StepPoint } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { StepPlotPage } from '../page-objects/plots/stepplot-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output. Written as escapes rather than literal glyphs because the range
+ * endpoints are indistinguishable by eye: U+2800 is the blank cell.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * Helper function to create and initialize a step plot page
+ * @param page - The Playwright page
+ * @param activateMaidr - Whether to activate MAIDR
+ * @returns Initialized StepPlotPage instance
+ */
+async function setupStepPlotPage(
+  page: Page,
+  activateMaidr = true,
+): Promise<StepPlotPage> {
+  const stepPlotPage = new StepPlotPage(page);
+  if (activateMaidr) {
+    await stepPlotPage.activateMaidr();
+  }
+  return stepPlotPage;
+}
+
+/**
+ * Extracts the single step series from a step plot layer.
+ *
+ * Step data is nested exactly like line data — one inner array per series —
+ * so the series, not the layer, is what the assertions index into.
+ * @param layer - The MAIDR layer containing step plot data
+ * @returns The points of the first (only) series
+ * @throws Error if the data is not in the nested step format
+ */
+function getStepSeries(layer: MaidrLayer | undefined): StepPoint[] {
+  if (!layer?.data || !Array.isArray(layer.data) || !Array.isArray(layer.data[0])) {
+    throw new TypeError('Step layer data is not a nested array of points');
+  }
+
+  return layer.data[0] as StepPoint[];
+}
+
+/**
+ * Reads one point of the step series, failing loudly rather than returning
+ * `undefined` for an index the example does not have. The return type narrows
+ * `label` to a string, since a hypnogram point without a level name has
+ * nothing for these assertions to check.
+ * @param series - The step series
+ * @param index - Index of the point to read
+ * @returns The point at that index, with its ordinal level name
+ * @throws Error if the index is out of bounds or the point carries no level name
+ */
+function getStepPoint(series: StepPoint[], index: number): StepPoint & { label: string } {
+  if (index < 0 || index >= series.length) {
+    throw new Error(`Index ${index} is out of bounds for series length ${series.length}`);
+  }
+
+  const point = series[index];
+  if (!point || point.label === undefined) {
+    throw new Error(`Step point at index ${index} has no ordinal level name`);
+  }
+
+  return { ...point, label: point.label };
+}
+
+test.describe('Step Plot', () => {
+  let maidrData: Maidr;
+  let stepPlotLayer: MaidrLayer;
+  let stepSeries: StepPoint[];
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const stepPlotPage = new StepPlotPage(page);
+      await stepPlotPage.navigateToStepPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+
+      stepPlotLayer = maidrData.subplots[0][0].layers[0];
+      stepSeries = getStepSeries(stepPlotLayer);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const stepPlotPage = new StepPlotPage(page);
+    await stepPlotPage.navigateToStepPlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the stepplot with maidr data', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.verifyPlotLoaded();
+    });
+
+    test('should activate maidr on click', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.activateMaidrOnClick();
+    });
+
+    test('should declare the layer as a step plot', () => {
+      expect(stepPlotLayer.type).toBe(TestConstants.STEPPLOT_ID);
+    });
+
+    test('should display instruction text naming a step plot', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      const instructionText = await stepPlotPage.getInstructionText();
+      expect(instructionText).toBe(TestConstants.STEPPLOT_INSTRUCTION_TEXT);
+    });
+  });
+
+  test.describe('Mode Controls', () => {
+    test('should toggle text mode on and off', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.toggleTextMode();
+      const isTextModeTerse = await stepPlotPage.isTextModeActive(TestConstants.TEXT_MODE_TERSE);
+      await stepPlotPage.toggleTextMode();
+      const isTextModeOff = await stepPlotPage.isTextModeActive(TestConstants.TEXT_MODE_OFF);
+      await stepPlotPage.toggleTextMode();
+      const isTextModeVerbose = await stepPlotPage.isTextModeActive(TestConstants.TEXT_MODE_VERBOSE);
+      expect(isTextModeTerse).toBe(true);
+      expect(isTextModeOff).toBe(true);
+      expect(isTextModeVerbose).toBe(true);
+    });
+
+    test('should toggle braille mode on and off', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.toggleBrailleMode();
+      const isBrailleModeOn = await stepPlotPage.isBrailleModeActive(TestConstants.BRAILLE_ON);
+      await stepPlotPage.toggleBrailleMode();
+      const isBrailleModeOff = await stepPlotPage.isBrailleModeActive(TestConstants.BRAILLE_OFF);
+      expect(isBrailleModeOn).toBe(true);
+      expect(isBrailleModeOff).toBe(true);
+    });
+
+    test('should toggle sound mode on and off', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.toggleSonification();
+      const isSoundModeOff = await stepPlotPage.isSonificationActive(TestConstants.SOUND_OFF);
+      await stepPlotPage.toggleSonification();
+      const isSoundModeOn = await stepPlotPage.isSonificationActive(TestConstants.SOUND_ON);
+      expect(isSoundModeOff).toBe(true);
+      expect(isSoundModeOn).toBe(true);
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render one braille cell per data point', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.moveToNextDataPoint();
+      await stepPlotPage.toggleBrailleMode();
+
+      const braille = await stepPlotPage.getBrailleContent();
+
+      expect(braille).not.toBe('');
+      expect(braille).toMatch(BRAILLE_CELL);
+      expect([...braille]).toHaveLength(stepSeries.length);
+    });
+  });
+
+  test.describe('Ordinal Level Announcements', () => {
+    test('should announce the level name rather than its numeric code', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.moveToNextDataPoint();
+
+      const first = getStepPoint(stepSeries, 0);
+      const announcement = normalizeText(await stepPlotPage.getCurrentDataPointInfo());
+
+      // The cross-axis value is the last thing announced for a step point, so
+      // the tail is exactly where the level name has to replace the code.
+      expect(announcement.endsWith(first.label)).toBe(true);
+      expect(announcement.endsWith(String(first.y))).toBe(false);
+    });
+
+    test('should announce the new level name after a transition', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.moveToNextDataPoint();
+      await stepPlotPage.moveToNextDataPoint();
+
+      const second = getStepPoint(stepSeries, 1);
+      const announcement = normalizeText(await stepPlotPage.getCurrentDataPointInfo());
+
+      expect(announcement).toContain(second.label);
+      expect(announcement.endsWith(second.label)).toBe(true);
+    });
+  });
+
+  test.describe('Axis Controls', () => {
+    test('should display X-axis Title', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.toggleXAxisTitle();
+      const xAxisTitle = await stepPlotPage.getXAxisTitle();
+      expect(xAxisTitle).toContain(stepPlotLayer?.axes?.x?.label ?? '');
+    });
+
+    test('should display Y-Axis Title', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.toggleYAxisTitle();
+      const yAxisTitle = await stepPlotPage.getYAxisTitle();
+      expect(yAxisTitle).toContain(stepPlotLayer?.axes?.y?.label ?? '');
+    });
+  });
+
+  test.describe('Navigation Controls', () => {
+    test('should move from left to right', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      for (let i = 0; i <= stepSeries.length; i++) {
+        await stepPlotPage.moveToNextDataPoint();
+      }
+      const currentDataPoint = await stepPlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+
+    test('should move from right to left', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      for (let i = 0; i <= stepSeries.length; i++) {
+        await stepPlotPage.moveToPreviousDataPoint();
+      }
+      const currentDataPoint = await stepPlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+
+    test('should move to the first data point', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.moveToFirstDataPoint();
+
+      const first = getStepPoint(stepSeries, 0);
+      const announcement = normalizeText(await stepPlotPage.getCurrentDataPointInfo());
+
+      expect(announcement).toContain(String(first.x));
+      expect(announcement).toContain(first.label);
+    });
+
+    test('should move to the last data point', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.moveToLastDataPoint();
+
+      const last = getStepPoint(stepSeries, stepSeries.length - 1);
+      const announcement = normalizeText(await stepPlotPage.getCurrentDataPointInfo());
+
+      expect(announcement).toContain(String(last.x));
+      expect(announcement).toContain(last.label);
+    });
+
+    test('should not be able to move up', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.moveToNextDataPoint();
+      await stepPlotPage.moveToDataPointAbove();
+      const currentDataPoint = await stepPlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+
+    test('should not be able to move down', async ({ page }) => {
+      const stepPlotPage = await setupStepPlotPage(page);
+      await stepPlotPage.moveToNextDataPoint();
+      await stepPlotPage.moveToDataPointBelow();
+      const currentDataPoint = await stepPlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -29,6 +29,7 @@ export abstract class TestConstants {
   static readonly HEATMAP_ID = 'heatmap';
   static readonly HISTOGRAM_ID = 'hist';
   static readonly LINEPLOT_ID = 'line';
+  static readonly STEPPLOT_ID = 'step';
   static readonly DODGED_BARPLOT_ID = 'dodged_bar';
   static readonly STACKED_BARPLOT_ID = 'stacked_bar';
   static readonly BOXPLOT_VERTICAL_ID = 'boxplot_vertical';
@@ -113,6 +114,9 @@ export abstract class TestConstants {
   static readonly HISTOGRAM_INSTRUCTION_TEXT = 'This is a maidr plot of type: hist. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly HEATMAP_INSTRUCTION_TEXT = 'This is a maidr plot of type: heat. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly LINEPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: single line. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // `StepTrace.state` overrides the inherited line plotType, so a step chart
+  // announces itself as a step plot rather than as a line one.
+  static readonly STEPPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: step. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // `formatPlotType` in src/model/context.ts prefixes the box type with its

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -136,6 +136,22 @@ export class LinePlotError extends Error {
 }
 
 /**
+ * Error thrown when Step plot related operations fail
+ */
+export class StepPlotError extends Error {
+  /**
+   * Creates a new StepPlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'StepPlotError';
+  }
+}
+
+/**
  * Error thrown when Heatmap related operations fail
  */
 export class HeatmapError extends Error {

--- a/examples/stepplot.html
+++ b/examples/stepplot.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Step Plot Example — Hypnogram</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A hypnogram is the motivating case for a step plot: the sleep stage is
+        an ordinal level (Awake / REM / N1 / N2 / N3) that is HELD across a
+        scoring epoch and then JUMPS, so the value between two samples is the
+        earlier one and never something interpolated.
+
+        The layer therefore carries:
+          - a numeric `y` (the stage code), which drives sonification, braille
+            and the min/max range, and
+          - a `label` per point (the stage name), which is announced in place
+            of that number.
+        `stepDirection: "hv"` is matplotlib's `steps-post` and ggplot2's
+        default `direction = "hv"`: hold until the next x value, then jump.
+
+        The line below is drawn as a genuine staircase with 2N - 1 vertices,
+        which is what matplotlib emits for `hv`; MAIDR maps the even-indexed
+        vertices back onto the 15 data points for highlighting.
+      -->
+      <svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt"
+        viewBox="0 0 720 432" version="1.1" id="step-hypnogram"
+        maidr='{&#10;  "id": "step-hypnogram",&#10;  "subplots": [&#10;    [&#10;      {&#10;        "id": "step-hypnogram-subplot",&#10;        "layers": [&#10;          {&#10;            "id": "step-hypnogram-layer",&#10;            "type": "step",&#10;            "title": "Hypnogram: Sleep Stage Through One Night",&#10;            "stepDirection": "hv",&#10;            "axes": {&#10;              "x": {&#10;                "label": "Time since lights out (h)"&#10;              },&#10;              "y": {&#10;                "label": "Sleep stage"&#10;              }&#10;            },&#10;            "selectors": [&#10;              "g[id=&apos;maidr-step-hypnogram&apos;] path"&#10;            ],&#10;            "data": [&#10;              [&#10;                {&#10;                  "x": 0,&#10;                  "y": 5,&#10;                  "label": "Awake"&#10;                },&#10;                {&#10;                  "x": 0.5,&#10;                  "y": 3,&#10;                  "label": "N1"&#10;                },&#10;                {&#10;                  "x": 1,&#10;                  "y": 2,&#10;                  "label": "N2"&#10;                },&#10;                {&#10;                  "x": 1.5,&#10;                  "y": 1,&#10;                  "label": "N3"&#10;                },&#10;                {&#10;                  "x": 2,&#10;                  "y": 1,&#10;                  "label": "N3"&#10;                },&#10;                {&#10;                  "x": 2.5,&#10;                  "y": 2,&#10;                  "label": "N2"&#10;                },&#10;                {&#10;                  "x": 3,&#10;                  "y": 4,&#10;                  "label": "REM"&#10;                },&#10;                {&#10;                  "x": 3.5,&#10;                  "y": 2,&#10;                  "label": "N2"&#10;                },&#10;                {&#10;                  "x": 4,&#10;                  "y": 1,&#10;                  "label": "N3"&#10;                },&#10;                {&#10;                  "x": 4.5,&#10;                  "y": 2,&#10;                  "label": "N2"&#10;                },&#10;                {&#10;                  "x": 5,&#10;                  "y": 4,&#10;                  "label": "REM"&#10;                },&#10;                {&#10;                  "x": 5.5,&#10;                  "y": 2,&#10;                  "label": "N2"&#10;                },&#10;                {&#10;                  "x": 6,&#10;                  "y": 4,&#10;                  "label": "REM"&#10;                },&#10;                {&#10;                  "x": 6.5,&#10;                  "y": 3,&#10;                  "label": "N1"&#10;                },&#10;                {&#10;                  "x": 7,&#10;                  "y": 5,&#10;                  "label": "Awake"&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="axes-background">
+              <path d="M 70 380  L 670 380  L 670 60  L 70 60  z " style="fill: #ffffff" />
+            </g>
+            <g id="axis_x">
+              <g>
+                <path d="M 90 380  L 90 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="90" y="400" text-anchor="middle" style="font: 12px sans-serif">0</text>
+              </g>
+              <g>
+                <path d="M 170 380  L 170 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="170" y="400" text-anchor="middle" style="font: 12px sans-serif">1</text>
+              </g>
+              <g>
+                <path d="M 250 380  L 250 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="250" y="400" text-anchor="middle" style="font: 12px sans-serif">2</text>
+              </g>
+              <g>
+                <path d="M 330 380  L 330 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="330" y="400" text-anchor="middle" style="font: 12px sans-serif">3</text>
+              </g>
+              <g>
+                <path d="M 410 380  L 410 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="410" y="400" text-anchor="middle" style="font: 12px sans-serif">4</text>
+              </g>
+              <g>
+                <path d="M 490 380  L 490 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="490" y="400" text-anchor="middle" style="font: 12px sans-serif">5</text>
+              </g>
+              <g>
+                <path d="M 570 380  L 570 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="570" y="400" text-anchor="middle" style="font: 12px sans-serif">6</text>
+              </g>
+              <g>
+                <path d="M 650 380  L 650 386  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="650" y="400" text-anchor="middle" style="font: 12px sans-serif">7</text>
+              </g>
+              <text x="370" y="418" text-anchor="middle" style="font: 13px sans-serif">Time since lights out (h)</text>
+            </g>
+            <g id="axis_y">
+              <g>
+                <path d="M 70 90  L 64 90  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="58" y="94" text-anchor="end" style="font: 12px sans-serif">Awake</text>
+              </g>
+              <g>
+                <path d="M 70 155  L 64 155  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="58" y="159" text-anchor="end" style="font: 12px sans-serif">REM</text>
+              </g>
+              <g>
+                <path d="M 70 220  L 64 220  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="58" y="224" text-anchor="end" style="font: 12px sans-serif">N1</text>
+              </g>
+              <g>
+                <path d="M 70 285  L 64 285  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="58" y="289" text-anchor="end" style="font: 12px sans-serif">N2</text>
+              </g>
+              <g>
+                <path d="M 70 350  L 64 350  " style="stroke: #000000; stroke-width: 0.8" />
+                <text x="58" y="354" text-anchor="end" style="font: 12px sans-serif">N3</text>
+              </g>
+              <text x="20" y="220" text-anchor="middle" transform="rotate(-90 20 220)" style="font: 13px sans-serif">Sleep stage</text>
+            </g>
+            <g id="maidr-step-hypnogram">
+              <path d="M 90 90  L 130 90  L 130 220  L 170 220  L 170 285  L 210 285  L 210 350  L 250 350  L 250 350  L 290 350  L 290 285  L 330 285  L 330 155  L 370 155  L 370 285  L 410 285  L 410 350  L 450 350  L 450 285  L 490 285  L 490 155  L 530 155  L 530 285  L 570 285  L 570 155  L 610 155  L 610 220  L 650 220  L 650 90  "
+                style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: butt; stroke-linejoin: miter" />
+            </g>
+            <g id="axes-spines">
+              <path d="M 70 60  L 70 380  L 670 380  "
+                style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square" />
+            </g>
+            <text x="370" y="40" text-anchor="middle" style="font: 16px sans-serif">Hypnogram: Sleep Stage Through One Night</text>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -383,6 +383,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('scatter_plot.html', 'Scatter plot'); return false;">Scatter plot</a></li>
     <li><a href="#" onclick="loadHTML('smooth_plot.html', 'Smooth plot'); return false;">Smooth plot</a></li>
     <li><a href="#" onclick="loadHTML('stacked_bar.html', 'Stacked Bar plot'); return false;">Stacked Bar plot</a></li>
+    <li><a href="#" onclick="loadHTML('stepplot.html', 'Step plot (hypnogram)'); return false;">Step plot (hypnogram)</a></li>
     <li><a href="#" onclick="loadHTML('vertical-boxplot.html', 'Vertical box plot'); return false;">Vertical box plot</a></li>
     <li><a href="#" onclick="loadHTML('vertical-candlestick.html', 'Vertical candle stick plot'); return false;">Vertical candle stick plot</a></li>
     <li><a href="#" onclick="loadHTML('violin.html', 'Violin plot'); return false;">Violin plot</a></li>

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -61,7 +61,7 @@ const PAGE_DESCRIPTIONS = {
   'amcharts': 'How to make amCharts 5 charts accessible with MAIDR — support for bar, dodged, stacked, normalized, line, histogram, and heatmap chart types.',
   'frappe': 'How to make Frappe Charts accessible with MAIDR — support for bar, line, multi-line, scatter, and mixed axis (bar + line) chart types.',
   'victory': 'How to make Victory charts accessible with MAIDR — support for bar, line, scatter, stacked, histogram, box plot, and candlestick chart types.',
-  'anychart': 'How to make AnyChart charts accessible with MAIDR — support for bar, line, scatter, box, heatmap, and candlestick chart types via a one-line binder.',
+  'anychart': 'How to make AnyChart charts accessible with MAIDR — support for bar, line, step, scatter, box, heatmap, and candlestick chart types via a one-line binder.',
   'highcharts': 'How to make Highcharts charts accessible with MAIDR — support for bar, line, scatter, box, heatmap, histogram, candlestick, stacked, dodged, and normalized chart types.',
   'examples': 'Interactive examples of accessible bar plots, line charts, heatmaps, scatter plots, box plots, and more using MAIDR.',
   'Data Schema': 'MAIDR data schema specification for defining accessible chart data structures.',

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -66,6 +66,7 @@ type AnyChartTraceType
   = | TraceType.BAR
     | TraceType.LINE
     | TraceType.SCATTER
+    | TraceType.STEP
     | TraceType.BOX
     | TraceType.HEATMAP
     | TraceType.CANDLESTICK;
@@ -81,9 +82,13 @@ type AnyChartTraceType
  * - `"bar"` (horizontal) and `"column"` (vertical) both map to
  *   {@link TraceType.BAR}. MAIDR does not currently distinguish
  *   bar orientation at the trace-type level.
- * - Area-family types (`area`, `step-area`, `spline-area`) map to
- *   {@link TraceType.LINE}. The fill is lost in the conversion; a
- *   runtime warning is emitted so developers are aware.
+ * - Area-family types (`area`, `step-area`, `spline-area`) map to their
+ *   unfilled equivalent — {@link TraceType.LINE}, or {@link TraceType.STEP}
+ *   for `step-area`. The fill is lost in the conversion; a runtime warning is
+ *   emitted so developers are aware.
+ * - The step-drawn types (`step-line`, `step-area`) map to
+ *   {@link TraceType.STEP} so they are announced and navigated as the
+ *   piecewise-constant series they are, rather than as interpolated lines.
  */
 export function mapSeriesType(anyChartType: string): AnyChartTraceType | null {
   const normalized = anyChartType.toLowerCase().replace(/[_\s]/g, '-');
@@ -94,10 +99,12 @@ export function mapSeriesType(anyChartType: string): AnyChartTraceType | null {
     'column': TraceType.BAR,
     'line': TraceType.LINE,
     'spline': TraceType.LINE,
-    'step-line': TraceType.LINE,
-    // Area types are represented as LINE; the fill is lost.
+    // Step-drawn series are piecewise constant, not interpolated.
+    'step-line': TraceType.STEP,
+    // Area types lose their fill and are represented by the corresponding
+    // unfilled trace.
     'area': TraceType.LINE,
-    'step-area': TraceType.LINE,
+    'step-area': TraceType.STEP,
     'spline-area': TraceType.LINE,
     'scatter': TraceType.SCATTER,
     'marker': TraceType.SCATTER,
@@ -111,11 +118,12 @@ export function mapSeriesType(anyChartType: string): AnyChartTraceType | null {
 
   const traceType = mapping[normalized] ?? null;
 
-  // Warn when an area series is silently downgraded to a line trace.
-  if (traceType === TraceType.LINE && AREA_TYPES.has(normalized)) {
+  // Warn when an area series loses its fill. Checked on the source type, not
+  // the mapped one, so `step-area` (now a STEP trace) still warns.
+  if (traceType !== null && AREA_TYPES.has(normalized)) {
     console.warn(
-      `[maidr/anychart] AnyChart "${anyChartType}" series mapped to LINE trace. `
-      + 'The filled-area visual will be represented as a line for accessibility.',
+      `[maidr/anychart] AnyChart "${anyChartType}" series mapped to ${traceType} trace. `
+      + 'The filled-area visual will be represented as an unfilled series for accessibility.',
     );
   }
 
@@ -1886,6 +1894,26 @@ function buildLineLayer(
   };
 }
 
+/**
+ * Build a step layer from an AnyChart `step-line` / `step-area` series.
+ *
+ * The point shape is identical to a line series — AnyChart varies only how the
+ * segments are drawn. `stepDirection` is deliberately not emitted: AnyChart
+ * exposes it as a per-series setting that the raw series rows do not carry, so
+ * claiming a direction here would be a guess.
+ * @param series - The AnyChart series to convert
+ * @param seriesIndex - Index of the series within its chart, used as the layer id
+ * @param selectors - CSS selectors for highlighting, when resolvable
+ * @returns The MAIDR step layer
+ */
+function buildStepLayer(
+  series: AnyChartSeries,
+  seriesIndex: number,
+  selectors: string | string[] | undefined,
+): MaidrLayer {
+  return { ...buildLineLayer(series, seriesIndex, selectors), type: TraceType.STEP };
+}
+
 function buildScatterLayer(
   series: AnyChartSeries,
   seriesIndex: number,
@@ -2178,6 +2206,8 @@ function buildLayer(
       return buildBarLayer(series, seriesIndex, selectors);
     case TraceType.LINE:
       return buildLineLayer(series, seriesIndex, selectors);
+    case TraceType.STEP:
+      return buildStepLayer(series, seriesIndex, selectors);
     case TraceType.SCATTER:
       return buildScatterLayer(series, seriesIndex, selectors);
     case TraceType.BOX:

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -289,7 +289,10 @@ const LINE_ATTR = 'data-maidr-anychart-line-point';
 /**
  * AnyChart series types that render as a connected line and therefore need
  * markers enabled for per-point highlighting. Area variants are included
- * because {@link mapSeriesType} downgrades them to {@link TraceType.LINE}.
+ * because {@link mapSeriesType} maps them to their unfilled equivalent, and
+ * the step variants because a staircase is still a stroked polyline whose
+ * points need markers — {@link resolveSelector} gives STEP the same
+ * attribute selector as LINE for exactly that reason.
  */
 const LINE_LIKE_SERIES_TYPES = new Set([
   'line',
@@ -405,10 +408,12 @@ function sanitizePanelToken(value: string): string {
  * attributes. When the caller does not supply selectors, we therefore rely
  * on per-element attributes that the adapter stamps during render:
  * - BAR: {@link stampBarAttributes} writes `data-maidr-anychart-bar`.
- * - LINE: {@link stampLineAttributes} writes
+ * - LINE and STEP: {@link stampLineAttributes} writes
  *   `data-maidr-anychart-line-point` using a class-free geometric DOM walk
  *   (markers must be enabled, which {@link enableLineMarkersIfNeeded}
- *   ensures by mutating the series and forcing a redraw).
+ *   ensures by mutating the series and forcing a redraw). Step series are
+ *   stamped by the same pass — they are in {@link LINE_LIKE_SERIES_TYPES} —
+ *   so they share the LINE selector rather than having one of their own.
  * - BOX: handled inside {@link buildBoxLayer} — it constructs a
  *   `BoxSelector[]` referring to the per-part attributes
  *   ({@link BOX_ATTR} + {@link BOX_PART_ATTR}) stamped by
@@ -419,7 +424,7 @@ function sanitizePanelToken(value: string): string {
  */
 function resolveSelector(
   seriesIndex: number,
-  traceType: TraceType,
+  traceType: AnyChartTraceType,
   options?: AnyChartBinderOptions,
   panel?: PanelContext,
 ): string | string[] | undefined {
@@ -441,19 +446,29 @@ function resolveSelector(
   // and the attribute value (token prefix) are scoped to the panel.
   const scope = panelScope(panel);
   const stamp = panelStampPrefix(panel);
-  if (traceType === TraceType.BAR)
-    return `${scope}[${BAR_ATTR}^="${stamp}${seriesIndex}-"]`;
-  if (traceType === TraceType.LINE)
-    return `${scope}[${LINE_ATTR}^="${stamp}${seriesIndex}-"]`;
-  if (traceType === TraceType.SCATTER)
-    return `${scope}[${POINT_ATTR}^="${stamp}${seriesIndex}-"]`;
-  // Heatmaps are single-series (no series-index prefix); the chart-level
-  // builder constructs the selector itself, so this branch only matters as
-  // a defensive default when the heatmap path is bypassed.
-  if (traceType === TraceType.HEATMAP)
-    return `${scope}[${HEATMAP_ATTR}]`;
-
-  return undefined;
+  // Exhaustive over AnyChartTraceType, mirroring buildLayer, so adding a
+  // member to that union is a compile error here rather than a silent
+  // `undefined` — which is a missing selector, which is a chart that
+  // announces correctly but never highlights.
+  switch (traceType) {
+    case TraceType.BAR:
+      return `${scope}[${BAR_ATTR}^="${stamp}${seriesIndex}-"]`;
+    case TraceType.LINE:
+    case TraceType.STEP:
+      return `${scope}[${LINE_ATTR}^="${stamp}${seriesIndex}-"]`;
+    case TraceType.SCATTER:
+      return `${scope}[${POINT_ATTR}^="${stamp}${seriesIndex}-"]`;
+    // Heatmaps are single-series (no series-index prefix); the chart-level
+    // builder constructs the selector itself, so this branch only matters as
+    // a defensive default when the heatmap path is bypassed.
+    case TraceType.HEATMAP:
+      return `${scope}[${HEATMAP_ATTR}]`;
+    // Both own their selector construction in their layer builder — see the
+    // BOX note above; candlestick likewise emits a CandlestickSelector.
+    case TraceType.BOX:
+    case TraceType.CANDLESTICK:
+      return undefined;
+  }
 }
 
 /**

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -686,7 +686,14 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       // Multi-line plots: x=position in the line, y=line index
       // A step trace navigates identically — series on one axis, samples on
       // the other — so it wants the same announcement, not the generic 2-D one.
-      this.announceMultiLinePosition(x, cols, y, rows, state.group);
+      this.announceMultiLinePosition(
+        x,
+        cols,
+        y,
+        rows,
+        state.group,
+        traceType === TraceType.STEP ? 'Series' : 'Line',
+      );
     } else if (traceType === TraceType.SCATTER) {
       // Scatter plot: use x/y for column/row position, but don't include 'Position' as it sounds weird
       this.announceScatter(x, y, rows, cols);
@@ -859,7 +866,9 @@ export class AnnouncePositionCommand extends AnnounceCommand {
    * Announces position for multi-line plots.
    *
    * Lines are identified as "Line X of Y", not "Plot X of Y" — the whole
-   * multiline chart is the plot; its members are lines.
+   * multiline chart is the plot; its members are lines. A step chart passes
+   * "Series" instead, so the position announcement does not call something a
+   * line when every other surface of the same chart calls it a step.
    *
    * Verbose spells out both the line's ordinal and its group name:
    * "Line 1 of 3, Group is Series 1, Position is 3 of 10". Terse keeps only
@@ -874,10 +883,11 @@ export class AnnouncePositionCommand extends AnnounceCommand {
     lineIndex: number,
     totalLines: number,
     group?: { label: string; value: string },
+    seriesNoun: string = 'Line',
   ): void {
     const linePos = lineIndex + 1;
     const pos = posIndex + 1;
-    const linePrefix = `Line ${linePos} of ${totalLines}`;
+    const linePrefix = `${seriesNoun} ${linePos} of ${totalLines}`;
 
     if (this.textService.isTerse() || this.textService.isOff()) {
       const posPercent = totalPos > 1 ? Math.round((posIndex / (totalPos - 1)) * 100) : 0;

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -677,9 +677,15 @@ export class AnnouncePositionCommand extends AnnounceCommand {
         // Single smooth/violin plot: 1D position within the curve
         this.announceSmoothPosition(x, cols);
       }
-    } else if (traceType === TraceType.LINE && state.groupCount && state.groupCount > 1) {
+    } else if (
+      (traceType === TraceType.LINE || traceType === TraceType.STEP)
+      && state.groupCount
+      && state.groupCount > 1
+    ) {
       // Check for multi plots (multiline, panel, layer, facet)
       // Multi-line plots: x=position in the line, y=line index
+      // A step trace navigates identically — series on one axis, samples on
+      // the other — so it wants the same announcement, not the generic 2-D one.
       this.announceMultiLinePosition(x, cols, y, rows, state.group);
     } else if (traceType === TraceType.SCATTER) {
       // Scatter plot: use x/y for column/row position, but don't include 'Position' as it sounds weird

--- a/src/maidr-component.tsx
+++ b/src/maidr-component.tsx
@@ -87,6 +87,15 @@ function getInitialInstruction(data: MaidrData): string {
     } else {
       plotType = 'single line';
     }
+  } else if (traceType === TraceType.STEP && Array.isArray(firstLayer?.data)) {
+    // A step trace keeps calling itself 'step' whatever its series count —
+    // only the group count is added, matching what StepTrace reports once the
+    // model exists. The two builders have to agree or the announcement
+    // changes when the user clicks.
+    const groupCount = firstLayer.data.length;
+    if (groupCount > 1) {
+      groupCountText = ` with ${groupCount} groups`;
+    }
   }
 
   const displayType = formatPlotType(plotType, firstLayer?.orientation);

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -43,6 +43,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.SCATTER]: 'Scatter Plot',
   [TraceType.SMOOTH]: 'Smooth Line Chart',
   [TraceType.STACKED]: 'Stacked Bar Chart',
+  [TraceType.STEP]: 'Step Plot',
   [TraceType.VIOLIN_BOX]: 'Violin Box Plot',
   [TraceType.VIOLIN_KDE]: 'Violin Plot',
 };

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -677,8 +677,13 @@ export class Context implements Disposable {
           effectivePlotType = 'single line';
         }
 
+        // Gated on the group count itself rather than on the plot type naming
+        // itself 'multiline', so a trace that reports groups under its own
+        // name — a multi-series step chart calls itself 'step' — still says
+        // how many it has. Unchanged for line charts: LineTrace only sets
+        // groupCount when there is more than one series.
         const groupCountText
-          = effectivePlotType === 'multiline' && state.groupCount
+          = state.groupCount && state.groupCount > 1
             ? ` with ${state.groupCount} groups`
             : '';
 

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -10,6 +10,7 @@ import { LineTrace } from './line';
 import { ScatterTrace } from './scatter';
 import { SegmentedTrace } from './segmented';
 import { createSmoothTrace } from './smoothtraceFactory';
+import { StepTrace } from './step';
 import { ViolinKdeTrace } from './violin';
 import { ViolinBoxTrace } from './violinBox';
 
@@ -47,6 +48,9 @@ export abstract class TraceFactory {
 
       case TraceType.SMOOTH:
         return createSmoothTrace(layer);
+
+      case TraceType.STEP:
+        return new StepTrace(layer);
 
       case TraceType.DODGED:
       case TraceType.NORMALIZED:

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -730,7 +730,7 @@ export class LineTrace extends AbstractTrace {
    * by interpolating along the surviving segments. Extra vertices are dropped
    * from the end, which is right for a straight polyline whose vertices are
    * its data points — subclasses whose rendered geometry has vertices that are
-   * not* data points (see {@link StepTrace}) override this.
+   * not data points (see {@link StepTrace}) override this.
    * @param coordinates - Vertices parsed from the path, mutated in place
    * @param row - Index of the series these coordinates belong to
    */

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -691,52 +691,7 @@ export class LineTrace extends AbstractTrace {
           });
         }
       }
-      // Handle coordinate count mismatch.
-      // SVG renderers (e.g. Plotly) may simplify paths by removing collinear
-      // points.  When fewer coordinates than data points are found, interpolate
-      // the missing positions along the simplified path segments so every data
-      // point gets a highlight circle at the correct visual position.
-      const expected = this.lineValues[r].length;
-      if (coordinates.length !== expected) {
-        if (coordinates.length >= 2 && coordinates.length < expected) {
-          const pathXMin = Number(coordinates[0].x);
-          const pathXMax = Number(coordinates[coordinates.length - 1].x);
-          const dataPoints = this.points[r];
-          const dataXMin = Number(dataPoints[0].x);
-          const dataXMax = Number(dataPoints[dataPoints.length - 1].x);
-          const dataXRange = dataXMax - dataXMin;
-
-          const full: LinePoint[] = [];
-          for (let i = 0; i < expected; i++) {
-            const dataX = Number(dataPoints[i].x);
-            const svgX = dataXRange > 0
-              ? pathXMin + ((dataX - dataXMin) / dataXRange) * (pathXMax - pathXMin)
-              : pathXMin;
-
-            // Find y by interpolating along the simplified path segments
-            let svgY = Number(coordinates[0].y);
-            for (let j = 0; j < coordinates.length - 1; j++) {
-              const cjx = Number(coordinates[j].x);
-              const cj1x = Number(coordinates[j + 1].x);
-              if (svgX >= cjx - 0.01 && svgX <= cj1x + 0.01) {
-                const segLen = cj1x - cjx;
-                const t = segLen > 0 ? (svgX - cjx) / segLen : 0;
-                svgY = Number(coordinates[j].y) + t * (Number(coordinates[j + 1].y) - Number(coordinates[j].y));
-                break;
-              }
-            }
-            full.push({ x: svgX, y: svgY });
-          }
-          coordinates.length = 0;
-          coordinates.push(...full);
-        } else if (coordinates.length < expected) {
-          while (coordinates.length < expected) {
-            coordinates.push({ x: Number.NaN, y: Number.NaN });
-          }
-        } else {
-          coordinates.length = expected;
-        }
-      }
+      this.reconcilePathCoordinates(coordinates, r);
 
       const linePointElements: SVGElement[] = [];
       let lineFailed = false;
@@ -763,6 +718,66 @@ export class LineTrace extends AbstractTrace {
       return null;
     }
     return svgElements;
+  }
+
+  /**
+   * Reconciles the vertices parsed out of a rendered `<path>` with the number
+   * of data points in a series, mutating `coordinates` in place so it ends up
+   * one entry per data point in data order.
+   *
+   * SVG renderers (e.g. Plotly) may simplify a path by dropping collinear
+   * vertices, leaving fewer coordinates than data points; those are recovered
+   * by interpolating along the surviving segments. Extra vertices are dropped
+   * from the end, which is right for a straight polyline whose vertices are
+   * its data points — subclasses whose rendered geometry has vertices that are
+   * not* data points (see {@link StepTrace}) override this.
+   * @param coordinates - Vertices parsed from the path, mutated in place
+   * @param row - Index of the series these coordinates belong to
+   */
+  protected reconcilePathCoordinates(coordinates: LinePoint[], row: number): void {
+    const expected = this.lineValues[row].length;
+    if (coordinates.length === expected) {
+      return;
+    }
+
+    if (coordinates.length >= 2 && coordinates.length < expected) {
+      const pathXMin = Number(coordinates[0].x);
+      const pathXMax = Number(coordinates[coordinates.length - 1].x);
+      const dataPoints = this.points[row];
+      const dataXMin = Number(dataPoints[0].x);
+      const dataXMax = Number(dataPoints[dataPoints.length - 1].x);
+      const dataXRange = dataXMax - dataXMin;
+
+      const full: LinePoint[] = [];
+      for (let i = 0; i < expected; i++) {
+        const dataX = Number(dataPoints[i].x);
+        const svgX = dataXRange > 0
+          ? pathXMin + ((dataX - dataXMin) / dataXRange) * (pathXMax - pathXMin)
+          : pathXMin;
+
+        // Find y by interpolating along the simplified path segments
+        let svgY = Number(coordinates[0].y);
+        for (let j = 0; j < coordinates.length - 1; j++) {
+          const cjx = Number(coordinates[j].x);
+          const cj1x = Number(coordinates[j + 1].x);
+          if (svgX >= cjx - 0.01 && svgX <= cj1x + 0.01) {
+            const segLen = cj1x - cjx;
+            const t = segLen > 0 ? (svgX - cjx) / segLen : 0;
+            svgY = Number(coordinates[j].y) + t * (Number(coordinates[j + 1].y) - Number(coordinates[j].y));
+            break;
+          }
+        }
+        full.push({ x: svgX, y: svgY });
+      }
+      coordinates.length = 0;
+      coordinates.push(...full);
+    } else if (coordinates.length < expected) {
+      while (coordinates.length < expected) {
+        coordinates.push({ x: Number.NaN, y: Number.NaN });
+      }
+    } else {
+      coordinates.length = expected;
+    }
   }
 
   /**

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -201,7 +201,16 @@ export class StepTrace extends LineTrace {
     coordinates: LinePoint[],
     row: number,
   ): void {
-    const expected = this.stepPoints[row]?.length ?? 0;
+    // `this.points`, not `this.stepPoints`, and that is load-bearing: this
+    // method runs during `super(layer)` — LineTrace's constructor calls
+    // mapToSvgElements, which reaches this override — so `stepPoints` has not
+    // been assigned yet and reading it throws, leaving MAIDR unmounted and the
+    // chart unusable. `points` is the same array, is assigned by LineTrace
+    // before mapToSvgElements, and is what the base class itself indexes here.
+    // Optional-chaining `stepPoints` instead would not fix it: `expected` would
+    // be 0 during construction and fall through to the trim-from-the-end
+    // branch, silently highlighting the wrong vertices.
+    const expected = this.points[row]?.length ?? 0;
 
     if (expected > 1 && coordinates.length === 2 * expected - 1) {
       const dataVertices = coordinates.filter((_, index) => index % 2 === 0);

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -187,8 +187,11 @@ export class StepTrace extends LineTrace {
    *
    * - `2N - 1` vertices (`hv`/`vh`): the even-indexed vertices are exactly the
    *   data points; the odd-indexed ones are the corners.
-   * - `2N` vertices (`mid`): each data point owns a horizontal pair, and sits
-   *   at its midpoint.
+   * - `2N` vertices (`mid`): each data point owns a horizontal pair. The
+   *   interior runs span midpoint to midpoint and are centred on their sample,
+   *   but the first and last runs are half-width — `steps-mid` starts at
+   *   `x[0]` and ends at `x[N-1]` rather than at a midpoint — so those two
+   *   samples sit at the outer end of their run, not at its centre.
    *
    * Any other count is left to the inherited handling — a library that
    * simplifies collinear vertices (a long flat run in a hypnogram is exactly
@@ -224,10 +227,18 @@ export class StepTrace extends LineTrace {
       for (let i = 0; i < expected; i++) {
         const left = coordinates[2 * i];
         const right = coordinates[2 * i + 1];
-        dataVertices.push({
-          x: (Number(left.x) + Number(right.x)) / 2,
-          y: Number(left.y),
-        });
+        // The outermost runs are half-width, so their sample is at the outer
+        // end rather than the centre; averaging there would offset the first
+        // and last highlight by a quarter of the sample interval.
+        let x: number;
+        if (i === 0) {
+          x = Number(left.x);
+        } else if (i === expected - 1) {
+          x = Number(right.x);
+        } else {
+          x = (Number(left.x) + Number(right.x)) / 2;
+        }
+        dataVertices.push({ x, y: Number(left.y) });
       }
       coordinates.length = 0;
       coordinates.push(...dataVertices);

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -1,0 +1,292 @@
+import type { LinePoint, MaidrLayer, StepDirection, StepPoint } from '@type/grammar';
+import type { DescriptionState, TextState, TraceState } from '@type/state';
+import type { RotorFilterUnit } from './abstract';
+import { LineTrace } from './line';
+
+/** Rotor unit that restricts navigation to the points where the level changes. */
+const TRANSITION_ROTOR_UNIT: RotorFilterUnit = {
+  key: 'transition',
+  label: 'Transitions',
+  noun: 'transitions',
+};
+
+/** Spoken description of each step convention, used in the description modal. */
+const STEP_DIRECTION_LABEL: Record<StepDirection, string> = {
+  hv: 'value holds until the next x value, then jumps',
+  vh: 'value jumps at the current x value, then holds',
+  mid: 'value jumps midway between x values',
+};
+
+/**
+ * Trace implementation for step (stairs) charts, where the value is piecewise
+ * constant: it is held across an interval and then jumps, rather than being
+ * interpolated between samples as a line chart implies.
+ *
+ * Everything numeric is inherited from {@link LineTrace} unchanged. In
+ * particular the audio stays one discrete tone per point, which is already the
+ * right sonification for piecewise-constant data — a run of equal levels sounds
+ * as a repeated pitch, and a transition is an audible jump. The continuous
+ * glissando that `SmoothTrace` uses would interpolate between levels, which is
+ * exactly what a step chart does not do.
+ *
+ * What this class adds is the two things a step chart has that a line chart
+ * does not: ordinal level names ("REM" rather than "3"), and navigation by
+ * transition rather than by sample.
+ */
+export class StepTrace extends LineTrace {
+  private readonly stepPoints: StepPoint[][];
+
+  /**
+   * The authored step convention, or undefined when the data does not say.
+   * Left undefined rather than defaulted so the description never claims a
+   * direction the producing library did not actually report.
+   */
+  private readonly stepDirection?: StepDirection;
+
+  /**
+   * Column indices, per series, at which the level differs from the previous
+   * column — that is, the first point of every run after the first. Computed
+   * once because trace data is immutable (live-data updates rebuild the trace).
+   */
+  private readonly transitionIndices: number[][];
+
+  /**
+   * Creates a new step trace instance.
+   * @param layer - The MAIDR layer containing step plot data
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.stepPoints = layer.data as StepPoint[][];
+    this.stepDirection = layer.stepDirection;
+    this.transitionIndices = this.stepPoints.map((series) => {
+      const indices = new Array<number>();
+      for (let col = 1; col < series.length; col++) {
+        if (series[col].y !== series[col - 1].y) {
+          indices.push(col);
+        }
+      }
+      return indices;
+    });
+  }
+
+  /**
+   * Announces this trace as a step plot in the instruction text, layer-switch
+   * cue and subplot entry cue, rather than falling back to the raw layer type.
+   * @returns The trace state with `plotType` set to 'step'
+   */
+  public override get state(): TraceState {
+    const baseState = super.state;
+    if (baseState.empty) {
+      return baseState;
+    }
+
+    return {
+      ...baseState,
+      plotType: 'step',
+    };
+  }
+
+  /**
+   * Substitutes the ordinal level name for the raw numeric level, so a
+   * hypnogram announces "Sleep stage is REM" rather than "Sleep stage is 3".
+   * Points without a `label` keep the inherited numeric announcement.
+   * @returns The text state for the current point
+   */
+  protected override get text(): TextState {
+    const baseText = super.text;
+    const label = this.stepPoints[this.row]?.[this.col]?.label;
+    if (label === undefined || label === '') {
+      return baseText;
+    }
+
+    return {
+      ...baseText,
+      cross: { label: baseText.cross.label, value: label },
+    };
+  }
+
+  /**
+   * Describes the step chart in terms of its runs rather than its points: how
+   * many times the level changes, which levels occur, and how long the longest
+   * unbroken run is. That is the shape of the data a step chart encodes, and
+   * it is what the point-by-point data table cannot show at a glance.
+   * @returns The description state containing chart metadata and data table
+   */
+  public override get description(): DescriptionState {
+    const baseDescription = super.description;
+    const series = this.stepPoints[this.row] ?? [];
+
+    const stats: DescriptionState['stats'] = [
+      ...baseDescription.stats,
+      {
+        label: 'Transitions',
+        value: this.transitionIndices[this.row]?.length ?? 0,
+      },
+      { label: 'Longest run', value: this.longestRunLength(series) },
+    ];
+
+    if (this.stepDirection !== undefined) {
+      stats.push({
+        label: 'Step direction',
+        value: STEP_DIRECTION_LABEL[this.stepDirection],
+      });
+    }
+
+    const levelNames = this.levelNames(series);
+    if (levelNames.length > 0) {
+      stats.push({ label: 'Levels', value: levelNames.join(', ') });
+    }
+
+    return { ...baseDescription, stats };
+  }
+
+  /**
+   * Distinct level names in the order they first occur. Empty when the data
+   * carries no `label`, so a purely numeric step chart says nothing about
+   * levels rather than listing bare numbers the stats already cover.
+   * @param series - The points of the series being described
+   * @returns The distinct level names, first-occurrence order
+   */
+  private levelNames(series: readonly StepPoint[]): string[] {
+    const names = new Array<string>();
+    const seen = new Set<string>();
+    for (const point of series) {
+      if (point.label !== undefined && point.label !== '' && !seen.has(point.label)) {
+        seen.add(point.label);
+        names.push(point.label);
+      }
+    }
+    return names;
+  }
+
+  /**
+   * Length, in samples, of the longest run of consecutive equal levels.
+   * @param series - The points of the series being described
+   * @returns The run length, or 0 for an empty series
+   */
+  private longestRunLength(series: readonly StepPoint[]): number {
+    let longest = 0;
+    let current = 0;
+    for (let col = 0; col < series.length; col++) {
+      current = col > 0 && series[col].y === series[col - 1].y ? current + 1 : 1;
+      longest = Math.max(longest, current);
+    }
+    return longest;
+  }
+
+  /**
+   * Maps the vertices of a rendered step path back onto the data points.
+   *
+   * A step chart is drawn with the corner vertices the steps introduce, so the
+   * rendered path carries more vertices than the series has points — matplotlib
+   * emits `2N - 1` for `hv`/`vh` and `2N` for `mid`. The inherited
+   * reconciliation drops the surplus from the end, which would place every
+   * highlight on the first half of the chart. Here the surplus is *interleaved*
+   * rather than trailing, so it is removed by stride instead:
+   *
+   * - `2N - 1` vertices (`hv`/`vh`): the even-indexed vertices are exactly the
+   *   data points; the odd-indexed ones are the corners.
+   * - `2N` vertices (`mid`): each data point owns a horizontal pair, and sits
+   *   at its midpoint.
+   *
+   * Any other count is left to the inherited handling — a library that
+   * simplifies collinear vertices (a long flat run in a hypnogram is exactly
+   * that) produces neither shape, and interpolating along the surviving
+   * segments is the right recovery there.
+   * @param coordinates - Vertices parsed from the path, mutated in place
+   * @param row - Index of the series these coordinates belong to
+   */
+  protected override reconcilePathCoordinates(
+    coordinates: LinePoint[],
+    row: number,
+  ): void {
+    const expected = this.stepPoints[row]?.length ?? 0;
+
+    if (expected > 1 && coordinates.length === 2 * expected - 1) {
+      const dataVertices = coordinates.filter((_, index) => index % 2 === 0);
+      coordinates.length = 0;
+      coordinates.push(...dataVertices);
+      return;
+    }
+
+    if (expected > 0 && coordinates.length === 2 * expected) {
+      const dataVertices = new Array<LinePoint>();
+      for (let i = 0; i < expected; i++) {
+        const left = coordinates[2 * i];
+        const right = coordinates[2 * i + 1];
+        dataVertices.push({
+          x: (Number(left.x) + Number(right.x)) / 2,
+          y: Number(left.y),
+        });
+      }
+      coordinates.length = 0;
+      coordinates.push(...dataVertices);
+      return;
+    }
+
+    super.reconcilePathCoordinates(coordinates, row);
+  }
+
+  /**
+   * Offers a "Transitions" rotor mode whenever the current series actually
+   * changes level. Point-by-point navigation across a long step chart — a
+   * whole night of sleep epochs, say — is unusable; jumping between the
+   * moments the level changes is the navigation this chart type calls for.
+   * @returns The transition rotor unit, or none when the series never changes
+   */
+  public override getRotorFilterUnits(): readonly RotorFilterUnit[] {
+    const hasTransition = this.transitionIndices.some(indices => indices.length > 0);
+    return hasTransition ? [TRANSITION_ROTOR_UNIT] : [];
+  }
+
+  /**
+   * Jumps to the previous or next point at which the level changes, staying
+   * within the current series.
+   * @param key - The {@link RotorFilterUnit.key} of the active unit
+   * @param direction - The direction to search
+   * @returns True if the cursor moved, false when no further transition exists
+   */
+  public override moveToRotorFilter(
+    key: string,
+    direction: 'left' | 'right',
+  ): boolean {
+    if (key !== TRANSITION_ROTOR_UNIT.key) {
+      return super.moveToRotorFilter(key, direction);
+    }
+
+    // Establish the entry position on the first move so this jump highlights
+    // and the initial-entry branch of moveOnce doesn't later swallow a
+    // keypress (mirrors Candlestick.moveToRotorFilter).
+    if (this.isInitialEntry) {
+      this.movable.handleInitialEntry();
+    }
+
+    const indices = this.transitionIndices[this.row] ?? [];
+    let target: number | undefined;
+    if (direction === 'right') {
+      target = indices.find(index => index > this.col);
+    } else {
+      // Walk backwards for the largest index below the cursor. A reverse loop
+      // avoids Array.prototype.findLast (ES2023) and the array allocation a
+      // [...indices].reverse() would introduce — same reasoning as
+      // LineTrace.moveToPrevIntersection.
+      for (let i = indices.length - 1; i >= 0; i--) {
+        if (indices[i] < this.col) {
+          target = indices[i];
+          break;
+        }
+      }
+    }
+
+    if (target === undefined) {
+      this.notifyRotorBounds();
+      return false;
+    }
+
+    this.col = target;
+    this.updateVisualPointPosition();
+    this.notifyStateUpdate();
+    return true;
+  }
+}

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -188,10 +188,18 @@ export class StepTrace extends LineTrace {
    * - `2N - 1` vertices (`hv`/`vh`): the even-indexed vertices are exactly the
    *   data points; the odd-indexed ones are the corners.
    * - `2N` vertices (`mid`): each data point owns a horizontal pair. The
-   *   interior runs span midpoint to midpoint and are centred on their sample,
-   *   but the first and last runs are half-width — `steps-mid` starts at
-   *   `x[0]` and ends at `x[N-1]` rather than at a midpoint — so those two
-   *   samples sit at the outer end of their run, not at its centre.
+   *   first and last runs are half-width — `steps-mid` starts at `x[0]` and
+   *   ends at `x[N-1]` rather than at a midpoint — so those two samples sit at
+   *   the outer end of their run and are read off directly. An interior run
+   *   spans midpoint to midpoint, and its centre is the sample only when the
+   *   spacing either side is equal: in general the centre is
+   *   `(x[i-1] + 2x[i] + x[i+1]) / 4`, off by a quarter of the local second
+   *   difference. The highlight therefore always lands inside the sample's own
+   *   run — never on a neighbour's — but on an irregularly sampled `mid` chart
+   *   it is not exactly on the sample. Recovering `x[i]` exactly would mean
+   *   iterating `x[i+1] = 2m[i] - x[i]` from one end, which is numerically
+   *   unstable over a long series; a bounded sub-run offset is the better
+   *   trade.
    *
    * Any other count is left to the inherited handling — a library that
    * simplifies collinear vertices (a long flat run in a hypnogram is exactly

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -4,6 +4,7 @@ import type { AudioState, PlotState, PointerGuidanceState } from '@type/state';
 import type { AudioPaletteEntry } from './audioPalette';
 import type { NotificationService } from './notification';
 import type { SettingsService } from './settings';
+import { TraceType } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { AudioPaletteIndex, AudioPaletteService } from './audioPalette';
 import { resolvePointerGuidanceBeep } from './pointerGuidance';
@@ -244,9 +245,13 @@ export class AudioService implements Observer<PlotState>, Disposable {
       return;
     }
 
-    // Handle intersection logic for multiline plots
+    // Handle intersection logic for multiline plots. Step traces inherit
+    // LineTrace's intersection detection — two series sharing an exact (x, y)
+    // sample is a data property, not a path-geometry one — so they belong here
+    // too. Compared against the enum rather than a bare string so a renamed
+    // member breaks the build instead of silently disabling the chord.
     if (
-      state.traceType === 'line'
+      (state.traceType === TraceType.LINE || state.traceType === TraceType.STEP)
       && !state.empty
       && Array.isArray(state.intersections)
       && state.intersections.length > 1

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1105,6 +1105,9 @@ implements Observer<SubplotState | TraceState>, Disposable {
       [TraceType.SCATTER, asGeneric(new HeatmapBrailleEncoder())],
       [TraceType.SMOOTH, asGeneric(new LineBrailleEncoder())],
       [TraceType.STACKED, asGeneric(new BarBrailleEncoder())],
+      // A step chart's braille state is LineTrace's verbatim — a per-row
+      // height profile — so the line encoder renders it correctly.
+      [TraceType.STEP, asGeneric(new LineBrailleEncoder())],
       [TraceType.VIOLIN_KDE, asGeneric(new LineBrailleEncoder())],
       [TraceType.VIOLIN_BOX, asGeneric(new BoxBrailleEncoder())],
     ]);

--- a/src/service/highContrast.ts
+++ b/src/service/highContrast.ts
@@ -352,9 +352,13 @@ export class HighContrastService implements Disposable {
       }
     });
 
-    // Handle line chart exception
+    // Handle line chart exception. Step charts render as the same kind of
+    // stroked polyline, so they need the same treatment.
     if ('type' in this.context.instructionContext) {
-      if (this.context.instructionContext.type === 'line') {
+      if (
+        this.context.instructionContext.type === 'line'
+        || this.context.instructionContext.type === 'step'
+      ) {
         document.getElementById(this.context.id)?.classList.add('high-contrast');
       }
     }
@@ -405,9 +409,12 @@ export class HighContrastService implements Disposable {
       }
     });
 
-    // Handle line chart exception
+    // Handle line chart exception. Mirrors the add path above, including step.
     if ('type' in this.context.instructionContext) {
-      if (this.context.instructionContext.type === 'line') {
+      if (
+        this.context.instructionContext.type === 'line'
+        || this.context.instructionContext.type === 'step'
+      ) {
         document
           .getElementById(this.context.id)
           ?.classList

--- a/src/service/liveData.ts
+++ b/src/service/liveData.ts
@@ -11,6 +11,7 @@ import type {
   ScatterPoint,
   SegmentedPoint,
   SmoothPoint,
+  StepPoint,
   ViolinKdePoint,
 } from '@type/grammar';
 import { CANDLESTICK_SECTIONS } from '@model/candlestick';
@@ -27,6 +28,7 @@ const NESTED_DATA_TYPES: ReadonlySet<TraceType> = new Set([
   TraceType.STACKED,
   TraceType.DODGED,
   TraceType.NORMALIZED,
+  TraceType.STEP,
   // Violin KDE data is ViolinKdePoint[][] (one group per violin) — unlike
   // heatmap, which uses object-shaped data and cannot be appended to.
   TraceType.VIOLIN_KDE,
@@ -44,6 +46,7 @@ export type LiveDataPoint
     | ScatterPoint
     | SegmentedPoint
     | SmoothPoint
+    | StepPoint
     | ViolinKdePoint;
 
 /**

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -360,7 +360,8 @@ export interface SmoothPoint {
  * - `vh` — jump at `x[i]`, then hold until `x[i+1]` (matplotlib `steps-pre`).
  * - `mid` — jump at the midpoint of the two x values (matplotlib `steps-mid`).
  *
- * Defaults to `hv`, matching `ggplot2::geom_step()`.
+ * `hv` is what `ggplot2::geom_step()` draws by default, but MAIDR substitutes
+ * no default of its own: see {@link MaidrLayer.stepDirection}.
  */
 export type StepDirection = 'hv' | 'vh' | 'mid';
 
@@ -511,7 +512,9 @@ export interface MaidrLayer {
   violinOptions?: ViolinOptions;
   /**
    * Where a {@link TraceType.STEP} layer jumps between samples. Ignored by
-   * every other trace type. Omitted means `hv`.
+   * every other trace type. Omit it when the producing library does not report
+   * one: MAIDR does not substitute a default, so the description stays silent
+   * about the convention rather than naming one the data never authored.
    *
    * @example
    * stepDirection: 'hv'

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -354,6 +354,34 @@ export interface SmoothPoint {
 }
 
 /**
+ * Where a step chart jumps between two consecutive samples.
+ *
+ * - `hv` — hold `y[i]` until `x[i+1]`, then jump (matplotlib `steps-post`).
+ * - `vh` — jump at `x[i]`, then hold until `x[i+1]` (matplotlib `steps-pre`).
+ * - `mid` — jump at the midpoint of the two x values (matplotlib `steps-mid`).
+ *
+ * Defaults to `hv`, matching `ggplot2::geom_step()`.
+ */
+export type StepDirection = 'hv' | 'vh' | 'mid';
+
+/**
+ * Data point for step charts. Extends {@link LinePoint} with the name of an
+ * ordinal level, so charts whose y axis is a category rather than a magnitude
+ * — a hypnogram's sleep stages, a status timeline's states — can announce
+ * "REM" instead of the numeric level that encodes it.
+ *
+ * `y` stays numeric because it drives sonification, braille and the min/max
+ * range; `label` is the human-readable name of that level.
+ *
+ * @example
+ * { x: 1.5, y: 3, label: 'REM' }
+ */
+export interface StepPoint extends LinePoint {
+  /** Ordinal level name announced in place of the raw numeric `y`. */
+  label?: string;
+}
+
+/**
  * Canonical axis configuration. Every axis (x, y, z) must be specified as an
  * object of this shape. The `label` is optional and falls back to built-in
  * defaults ('X', 'Y', 'Level') when omitted.
@@ -481,6 +509,14 @@ export interface MaidrLayer {
    * Controls which summary statistics are shown in the violin box overlay.
    */
   violinOptions?: ViolinOptions;
+  /**
+   * Where a {@link TraceType.STEP} layer jumps between samples. Ignored by
+   * every other trace type. Omitted means `hv`.
+   *
+   * @example
+   * stepDirection: 'hv'
+   */
+  stepDirection?: StepDirection;
   data:
     | BarPoint[]
     | BoxPoint[]
@@ -491,6 +527,7 @@ export interface MaidrLayer {
     | ScatterPoint[]
     | SegmentedPoint[][]
     | SmoothPoint[][]
+    | StepPoint[][]
     | ViolinKdePoint[][];
 }
 
@@ -525,6 +562,7 @@ export enum TraceType {
   SCATTER = 'point',
   SMOOTH = 'smooth',
   STACKED = 'stacked_bar',
+  STEP = 'step',
   VIOLIN_BOX = 'violin_box',
   VIOLIN_KDE = 'violin_kde',
 }

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -378,7 +378,11 @@ export type StepDirection = 'hv' | 'vh' | 'mid';
  * { x: 1.5, y: 3, label: 'REM' }
  */
 export interface StepPoint extends LinePoint {
-  /** Ordinal level name announced in place of the raw numeric `y`. */
+  /**
+   * Ordinal level name announced in place of the raw numeric `y`. An empty
+   * string counts as absent, so a producer that emits `''` for an unnamed
+   * level gets the numeric announcement rather than a blank one.
+   */
   label?: string;
 }
 

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -662,3 +662,45 @@ describe('mapSeriesType', () => {
     expect(mapSeriesType('pie')).toBeNull();
   });
 });
+
+describe('selector resolution per trace type', () => {
+  /**
+   * Build a single-series chart of an arbitrary AnyChart series type.
+   * @param seriesType The AnyChart series type string
+   * @returns A mock chart instance carrying one series of that type
+   */
+  function chartOf(seriesType: string): AnyChartInstance {
+    return createChart({
+      title: seriesType,
+      series: [createSeries(seriesType, [
+        { x: 'A', value: 1 },
+        { x: 'B', value: 2 },
+      ])],
+    });
+  }
+
+  it('gives a step series the same stamped selector a line series gets', () => {
+    // stampLineAttributes writes data-maidr-anychart-line-point onto step
+    // series too — they are in LINE_LIKE_SERIES_TYPES — so a step layer that
+    // resolved to no selector would leave those stamped elements unreachable
+    // and the chart would announce correctly while never highlighting.
+    const line = anyChartToMaidr(chartOf('line'), { id: 'l' });
+    const step = anyChartToMaidr(chartOf('step-line'), { id: 's' });
+
+    const lineLayer = line?.subplots[0][0].layers[0];
+    const stepLayer = step?.subplots[0][0].layers[0];
+
+    expect(lineLayer?.type).toBe(TraceType.LINE);
+    expect(stepLayer?.type).toBe(TraceType.STEP);
+    expect(stepLayer?.selectors).toBeDefined();
+    expect(stepLayer?.selectors).toEqual(lineLayer?.selectors);
+  });
+
+  it('gives a step-area series a selector too', () => {
+    const stepArea = anyChartToMaidr(chartOf('step-area'), { id: 'sa' });
+    const layer = stepArea?.subplots[0][0].layers[0];
+
+    expect(layer?.type).toBe(TraceType.STEP);
+    expect(layer?.selectors).toBeDefined();
+  });
+});

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -9,6 +9,7 @@ import {
   anyChartsToMaidr,
   anyChartToMaidr,
   bindAnyCharts,
+  mapSeriesType,
 } from '@adapters/anychart/converters';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { TraceType } from '@type/grammar';
@@ -609,5 +610,55 @@ describe('bindAnyCharts', () => {
 
     expect(bindAnyCharts([[chartA, chartB]], { id: 'fig' })).toBeNull();
     container.remove();
+  });
+});
+
+describe('mapSeriesType', () => {
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('maps the step-drawn series to a step trace, not a line one', () => {
+    // AnyChart draws these as staircases, so announcing and navigating them as
+    // interpolated lines misdescribes the data.
+    expect(mapSeriesType('step-line')).toBe(TraceType.STEP);
+    expect(mapSeriesType('step-area')).toBe(TraceType.STEP);
+  });
+
+  it('leaves the interpolated series as line traces', () => {
+    expect(mapSeriesType('line')).toBe(TraceType.LINE);
+    expect(mapSeriesType('spline')).toBe(TraceType.LINE);
+    expect(mapSeriesType('area')).toBe(TraceType.LINE);
+    expect(mapSeriesType('spline-area')).toBe(TraceType.LINE);
+  });
+
+  it('normalises the series name before looking it up', () => {
+    expect(mapSeriesType('Step_Line')).toBe(TraceType.STEP);
+    expect(mapSeriesType('STEP LINE')).toBe(TraceType.STEP);
+  });
+
+  it('warns that an area series loses its fill, whichever trace it becomes', () => {
+    // The warning keys on the source type rather than the mapped one, so
+    // step-area still warns now that it no longer maps to LINE.
+    mapSeriesType('step-area');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('step-area'));
+
+    warnSpy.mockClear();
+    mapSeriesType('area');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockClear();
+    mapSeriesType('step-line');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a series type the adapter cannot represent', () => {
+    expect(mapSeriesType('pie')).toBeNull();
   });
 });

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -149,3 +149,58 @@ describe('AnnouncePositionCommand on multiline plots (terse)', () => {
     expect(terseText.length).toBeLessThan(verboseText.length);
   });
 });
+
+/**
+ * Builds a multi-series step trace state as `StepTrace` reports it: the same
+ * shape `LineTrace` produces, but typed `step` and naming itself `step`.
+ * @param options Cursor position and group, as for {@link multilineState}
+ * @returns A non-empty multi-series step trace state
+ */
+function multiStepState(options: MultilineOptions = {}): PlotState {
+  return {
+    ...(multilineState(options) as object),
+    traceType: TraceType.STEP,
+    plotType: 'step',
+  } as unknown as PlotState;
+}
+
+describe('AnnouncePositionCommand on multi-series step plots', () => {
+  it('calls a step series a series, not a line', () => {
+    // The instruction text and chartType for this same chart both say "step",
+    // so announcing "Line 1 of 3" here would have the chart contradict itself.
+    const { command, textViewModel } = createCommand(multiStepState());
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Series 1 of 3, Position is 3 of 10',
+    );
+  });
+
+  it('keeps the series wording in terse mode when the data names no group', () => {
+    const { command, textViewModel } = createCommand(multiStepState(), 'terse');
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Series 1 of 3, 22%');
+  });
+
+  it('still prefers an authored group name over the ordinal', () => {
+    const { command, textViewModel } = createCommand(
+      multiStepState({ group: { label: 'Night', value: 'Night 2' } }),
+      'terse',
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Night 2, 22%');
+  });
+
+  it('leaves a multiline chart saying line', () => {
+    const { command, textViewModel } = createCommand(multilineState());
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Line 1 of 3, Position is 3 of 10');
+  });
+});

--- a/test/model/step.test.ts
+++ b/test/model/step.test.ts
@@ -196,3 +196,51 @@ describe('step trace transition navigation', () => {
     expect(trace.col).toBe(0);
   });
 });
+
+describe('multi-series step trace', () => {
+  const NIGHT_TWO: StepPoint[] = [
+    { x: 0, y: 2, label: 'REM' },
+    { x: 1, y: 3, label: 'Awake' },
+    { x: 2, y: 1, label: 'N2' },
+    { x: 3, y: 1, label: 'N2' },
+  ];
+
+  test('reports its group count so the instruction can name it', () => {
+    // Context.getInstruction appends " with N groups" from groupCount. A step
+    // trace calls itself 'step' rather than 'multiline', so the count is the
+    // only thing telling a listener there is more than one night here.
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM, NIGHT_TWO]));
+    trace.moveOnce('FORWARD');
+
+    const state = nonEmptyState(trace);
+    expect(state.plotType).toBe('step');
+    expect(state.groupCount).toBe(2);
+  });
+
+  test('offers the transitions unit when only one series ever changes level', () => {
+    const flat: StepPoint[] = [
+      { x: 0, y: 1, label: 'N2' },
+      { x: 1, y: 1, label: 'N2' },
+    ];
+    const changing: StepPoint[] = [
+      { x: 0, y: 1, label: 'N2' },
+      { x: 1, y: 2, label: 'REM' },
+    ];
+
+    expect(new StepTrace(createStepLayer([flat, changing])).getRotorFilterUnits())
+      .toHaveLength(1);
+  });
+
+  test('keeps transition jumps within the series the cursor is on', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM, NIGHT_TWO]));
+    trace.moveOnce('FORWARD');
+    trace.moveToIndex(1, 0);
+
+    // NIGHT_TWO changes at columns 1 and 2, where HYPNOGRAM changes at 1 and 3.
+    expect(trace.moveToRotorFilter('transition', 'right')).toBe(true);
+    expect(trace.col).toBe(1);
+    expect(trace.moveToRotorFilter('transition', 'right')).toBe(true);
+    expect(trace.col).toBe(2);
+    expect(trace.moveToRotorFilter('transition', 'right')).toBe(false);
+  });
+});

--- a/test/model/step.test.ts
+++ b/test/model/step.test.ts
@@ -1,0 +1,198 @@
+import type { MaidrLayer, StepDirection, StepPoint } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { StepTrace } from '@model/step';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A four-stage hypnogram: one hour awake, two hours of N2, then REM. The runs
+ * matter more than the values — this is the shape every assertion below leans
+ * on.
+ */
+const HYPNOGRAM: StepPoint[] = [
+  { x: 0, y: 3, label: 'Awake' },
+  { x: 1, y: 1, label: 'N2' },
+  { x: 2, y: 1, label: 'N2' },
+  { x: 3, y: 2, label: 'REM' },
+];
+
+/**
+ * Create a minimal step layer for model-only tests.
+ * @param data Step data points, nested one array per series
+ * @param stepDirection Optional step convention to author on the layer
+ * @returns Step layer definition for StepTrace
+ */
+function createStepLayer(
+  data: StepPoint[][],
+  stepDirection?: StepDirection,
+): MaidrLayer {
+  return {
+    id: 'test-step-layer',
+    type: TraceType.STEP,
+    title: 'Hypnogram',
+    axes: {
+      x: { label: 'Time' },
+      y: { label: 'Sleep stage' },
+    },
+    ...(stepDirection ? { stepDirection } : {}),
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: StepTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+describe('step trace registration', () => {
+  test('the factory builds a StepTrace for a step layer', () => {
+    const trace = TraceFactory.create(createStepLayer([HYPNOGRAM]));
+
+    expect(trace).toBeInstanceOf(StepTrace);
+    expect(trace.traceType).toBe(TraceType.STEP);
+  });
+
+  test('announces itself as a step plot rather than as a line', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    trace.moveOnce('FORWARD');
+
+    expect(nonEmptyState(trace).plotType).toBe('step');
+  });
+
+  test('names the chart type in the description', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+
+    expect(trace.description.chartType).toBe('Step Plot');
+  });
+});
+
+describe('step trace ordinal levels', () => {
+  test('announces the level name instead of the numeric level', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    trace.moveOnce('FORWARD');
+
+    const { text } = nonEmptyState(trace);
+    expect(text.cross).toEqual({ label: 'Sleep stage', value: 'Awake' });
+    expect(text.main).toEqual({ label: 'Time', value: 0 });
+  });
+
+  test('falls back to the numeric level when the data names none', () => {
+    const trace = new StepTrace(createStepLayer([[
+      { x: 0, y: 3 },
+      { x: 1, y: 1 },
+    ]]));
+    trace.moveOnce('FORWARD');
+
+    expect(nonEmptyState(trace).text.cross).toEqual({ label: 'Sleep stage', value: 3 });
+  });
+
+  test('sonifies and brailles the numeric level, not the name', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    trace.moveOnce('FORWARD');
+
+    const { audio, braille } = nonEmptyState(trace);
+    expect(audio.freq).toEqual({ min: 1, max: 3, raw: 3 });
+    expect(braille).toMatchObject({
+      empty: false,
+      values: [[3, 1, 1, 2]],
+      min: [1],
+      max: [3],
+    });
+  });
+});
+
+describe('step trace description', () => {
+  test('reports the runs, not just the points', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    const stats = new Map(
+      trace.description.stats.map(stat => [stat.label, stat.value]),
+    );
+
+    expect(stats.get('Transitions')).toBe(2);
+    expect(stats.get('Longest run')).toBe(2);
+    expect(stats.get('Levels')).toBe('Awake, N2, REM');
+  });
+
+  test('reports the step direction only when the data authors one', () => {
+    const withoutDirection = new StepTrace(createStepLayer([HYPNOGRAM]));
+    expect(
+      withoutDirection.description.stats.some(stat => stat.label === 'Step direction'),
+    ).toBe(false);
+
+    const withDirection = new StepTrace(createStepLayer([HYPNOGRAM], 'vh'));
+    expect(
+      withDirection.description.stats.find(stat => stat.label === 'Step direction')?.value,
+    ).toBe('value jumps at the current x value, then holds');
+  });
+});
+
+describe('step trace transition navigation', () => {
+  test('offers the transitions rotor unit when the level changes', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+
+    expect(trace.getRotorFilterUnits()).toEqual([
+      { key: 'transition', label: 'Transitions', noun: 'transitions' },
+    ]);
+  });
+
+  test('offers no rotor unit for a series that never changes level', () => {
+    const trace = new StepTrace(createStepLayer([[
+      { x: 0, y: 1, label: 'N2' },
+      { x: 1, y: 1, label: 'N2' },
+    ]]));
+
+    expect(trace.getRotorFilterUnits()).toEqual([]);
+  });
+
+  test('jumps forward to the point where the level changes', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    trace.moveOnce('FORWARD');
+
+    expect(trace.moveToRotorFilter('transition', 'right')).toBe(true);
+    expect(trace.col).toBe(1);
+    expect(nonEmptyState(trace).text.cross.value).toBe('N2');
+
+    // Column 2 repeats N2, so the next transition is column 3, not column 2.
+    expect(trace.moveToRotorFilter('transition', 'right')).toBe(true);
+    expect(trace.col).toBe(3);
+    expect(nonEmptyState(trace).text.cross.value).toBe('REM');
+  });
+
+  test('jumps backward to the previous change and reports the boundary', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    trace.moveOnce('FORWARD');
+    trace.moveToIndex(0, 3);
+
+    expect(trace.moveToRotorFilter('transition', 'left')).toBe(true);
+    expect(trace.col).toBe(1);
+
+    expect(trace.moveToRotorFilter('transition', 'left')).toBe(false);
+    expect(trace.col).toBe(1);
+  });
+
+  test('reports the boundary rather than moving past the last transition', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    trace.moveOnce('FORWARD');
+    trace.moveToIndex(0, 3);
+
+    expect(trace.moveToRotorFilter('transition', 'right')).toBe(false);
+    expect(trace.col).toBe(3);
+  });
+
+  test('leaves unknown rotor units to the inherited handling', () => {
+    const trace = new StepTrace(createStepLayer([HYPNOGRAM]));
+    trace.moveOnce('FORWARD');
+
+    expect(trace.moveToRotorFilter('bull', 'right')).toBe(false);
+    expect(trace.col).toBe(0);
+  });
+});

--- a/test/model/stepHighlight.test.ts
+++ b/test/model/stepHighlight.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { MaidrLayer, StepPoint } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { StepTrace } from '@model/step';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Four samples with one repeated level — enough that the rendered staircase
+ * has a different vertex count from the data, which is the whole point here.
+ */
+const POINTS: StepPoint[] = [
+  { x: 0, y: 3, label: 'Awake' },
+  { x: 1, y: 1, label: 'N2' },
+  { x: 2, y: 1, label: 'N2' },
+  { x: 3, y: 2, label: 'REM' },
+];
+
+/** SVG y coordinate a level is drawn at, so assertions can name real pixels. */
+const PIXEL_FOR_LEVEL: Record<number, number> = { 1: 300, 2: 200, 3: 100 };
+
+/** SVG x coordinate a sample is drawn at. */
+const PIXEL_FOR_SAMPLE = [10, 20, 30, 40];
+
+/**
+ * Render a `steps-post` staircase through {@link POINTS} the way matplotlib
+ * and ggplot2 do: hold the level to the next x, then jump. That is `2N - 1`
+ * vertices for `N` samples, with the samples on the even indices.
+ * @returns The `d` attribute of the staircase path
+ */
+function staircasePath(): string {
+  const commands = [`M ${PIXEL_FOR_SAMPLE[0]} ${PIXEL_FOR_LEVEL[POINTS[0].y]}`];
+  for (let i = 1; i < POINTS.length; i++) {
+    // Horizontal to the next x at the old level, then vertical to the new one.
+    commands.push(`L ${PIXEL_FOR_SAMPLE[i]} ${PIXEL_FOR_LEVEL[POINTS[i - 1].y]}`);
+    commands.push(`L ${PIXEL_FOR_SAMPLE[i]} ${PIXEL_FOR_LEVEL[POINTS[i].y]}`);
+  }
+  return commands.join(' ');
+}
+
+/**
+ * Create a step layer whose selector resolves against the document.
+ * @returns Step layer definition for StepTrace
+ */
+function createStepLayer(): MaidrLayer {
+  return {
+    id: 'test-step-layer',
+    type: TraceType.STEP,
+    title: 'Hypnogram',
+    axes: { x: { label: 'Time' }, y: { label: 'Sleep stage' } },
+    stepDirection: 'hv',
+    selectors: ['g#step-series path'],
+    data: [POINTS],
+  };
+}
+
+/**
+ * jsdom implements `SVGElement` but none of the per-tag SVG interfaces, so
+ * `element instanceof SVGPathElement` — the branch `LineTrace` uses to decide
+ * it is looking at a path — throws `SVGPathElement is not defined`. Define it
+ * here so the branch is reachable, matching a browser's behaviour rather than
+ * changing it: only a `<path>` satisfies the check.
+ */
+function defineSvgPathElement(): void {
+  if ('SVGPathElement' in globalThis) {
+    return;
+  }
+  Object.defineProperty(globalThis, 'SVGPathElement', {
+    configurable: true,
+    value: class SVGPathElementShim {
+      public static [Symbol.hasInstance](value: unknown): boolean {
+        return value instanceof SVGElement && value.tagName === 'path';
+      }
+    },
+  });
+}
+
+describe('step trace highlight mapping', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = `
+      <svg id="chart" xmlns="http://www.w3.org/2000/svg">
+        <g id="step-series"><path d="${staircasePath()}"></path></g>
+      </svg>`;
+  });
+
+  test('constructs against a rendered staircase without throwing', () => {
+    // A regression guard with real teeth: reconcilePathCoordinates runs during
+    // `super(layer)`, before StepTrace's own fields exist. Reading a field
+    // assigned after `super()` throws there, MAIDR never mounts, and the chart
+    // is unusable — while every model test that passes no selectors still
+    // passes, because the path-parsing branch is never reached.
+    expect(() => new StepTrace(createStepLayer())).not.toThrow();
+  });
+
+  test('places one highlight per sample, on the sample, not on a step corner', () => {
+    const trace = new StepTrace(createStepLayer());
+    const circles = Array.from(
+      document.querySelectorAll('circle'),
+    ).map(circle => ({
+      x: Number(circle.getAttribute('cx')),
+      y: Number(circle.getAttribute('cy')),
+    }));
+
+    // 7 vertices are rendered for 4 samples; only the 4 samples get a circle.
+    expect(circles).toHaveLength(POINTS.length);
+    expect(circles).toEqual(
+      POINTS.map((point, i) => ({
+        x: PIXEL_FOR_SAMPLE[i],
+        y: PIXEL_FOR_LEVEL[point.y],
+      })),
+    );
+
+    // Trimming the surplus from the end — the inherited behaviour a step path
+    // must not fall back to — would put sample 2 on the first corner instead.
+    expect(circles[1]).not.toEqual({ x: PIXEL_FOR_SAMPLE[1], y: PIXEL_FOR_LEVEL[3] });
+
+    trace.dispose();
+  });
+});

--- a/test/model/stepHighlight.test.ts
+++ b/test/model/stepHighlight.test.ts
@@ -40,19 +40,67 @@ function staircasePath(): string {
 }
 
 /**
+ * Render a `steps-mid` staircase through {@link POINTS} the way matplotlib
+ * does (`cbook.pts_to_midstep`): the jump happens midway between two samples,
+ * so the x sequence is `x0, m0, m0, m1, m1, ..., m(N-2), m(N-2), x(N-1)` and
+ * each sample owns one horizontal run. That is `2N` vertices, and — the part
+ * an average over the run gets wrong — the first and last runs are half-width,
+ * with their sample at the outer end rather than at the centre.
+ * @returns The `d` attribute of the staircase path
+ */
+function midStaircasePath(): string {
+  const xs = [PIXEL_FOR_SAMPLE[0]];
+  for (let i = 0; i < POINTS.length - 1; i++) {
+    const midpoint = (PIXEL_FOR_SAMPLE[i] + PIXEL_FOR_SAMPLE[i + 1]) / 2;
+    xs.push(midpoint, midpoint);
+  }
+  xs.push(PIXEL_FOR_SAMPLE[POINTS.length - 1]);
+
+  const ys = POINTS.flatMap(point => [
+    PIXEL_FOR_LEVEL[point.y],
+    PIXEL_FOR_LEVEL[point.y],
+  ]);
+
+  return xs.map((x, i) => `${i === 0 ? 'M' : 'L'} ${x} ${ys[i]}`).join(' ');
+}
+
+/**
  * Create a step layer whose selector resolves against the document.
+ * @param stepDirection - The step convention the rendered path was drawn with
  * @returns Step layer definition for StepTrace
  */
-function createStepLayer(): MaidrLayer {
+function createStepLayer(stepDirection: 'hv' | 'mid' = 'hv'): MaidrLayer {
   return {
     id: 'test-step-layer',
     type: TraceType.STEP,
     title: 'Hypnogram',
     axes: { x: { label: 'Time' }, y: { label: 'Sleep stage' } },
-    stepDirection: 'hv',
+    stepDirection,
     selectors: ['g#step-series path'],
     data: [POINTS],
   };
+}
+
+/**
+ * Read back the highlight circles MAIDR synthesised for the rendered path.
+ * @returns One point per circle, in document order
+ */
+function highlightCircles(): { x: number; y: number }[] {
+  return Array.from(document.querySelectorAll('circle')).map(circle => ({
+    x: Number(circle.getAttribute('cx')),
+    y: Number(circle.getAttribute('cy')),
+  }));
+}
+
+/**
+ * Put a rendered staircase in the document for the trace to resolve against.
+ * @param pathD - The `d` attribute of the staircase path
+ */
+function renderStaircase(pathD: string): void {
+  document.body.innerHTML = `
+      <svg id="chart" xmlns="http://www.w3.org/2000/svg">
+        <g id="step-series"><path d="${pathD}"></path></g>
+      </svg>`;
 }
 
 /**
@@ -68,6 +116,9 @@ function defineSvgPathElement(): void {
   }
   Object.defineProperty(globalThis, 'SVGPathElement', {
     configurable: true,
+    // Writable so a suite that assigns its own stub — test/model/heatmap.test.ts
+    // does — is never blocked by ours having been defined first.
+    writable: true,
     value: class SVGPathElementShim {
       public static [Symbol.hasInstance](value: unknown): boolean {
         return value instanceof SVGElement && value.tagName === 'path';
@@ -79,10 +130,7 @@ function defineSvgPathElement(): void {
 describe('step trace highlight mapping', () => {
   beforeEach(() => {
     defineSvgPathElement();
-    document.body.innerHTML = `
-      <svg id="chart" xmlns="http://www.w3.org/2000/svg">
-        <g id="step-series"><path d="${staircasePath()}"></path></g>
-      </svg>`;
+    renderStaircase(staircasePath());
   });
 
   test('constructs against a rendered staircase without throwing', () => {
@@ -96,12 +144,7 @@ describe('step trace highlight mapping', () => {
 
   test('places one highlight per sample, on the sample, not on a step corner', () => {
     const trace = new StepTrace(createStepLayer());
-    const circles = Array.from(
-      document.querySelectorAll('circle'),
-    ).map(circle => ({
-      x: Number(circle.getAttribute('cx')),
-      y: Number(circle.getAttribute('cy')),
-    }));
+    const circles = highlightCircles();
 
     // 7 vertices are rendered for 4 samples; only the 4 samples get a circle.
     expect(circles).toHaveLength(POINTS.length);
@@ -115,6 +158,27 @@ describe('step trace highlight mapping', () => {
     // Trimming the surplus from the end — the inherited behaviour a step path
     // must not fall back to — would put sample 2 on the first corner instead.
     expect(circles[1]).not.toEqual({ x: PIXEL_FOR_SAMPLE[1], y: PIXEL_FOR_LEVEL[3] });
+
+    trace.dispose();
+  });
+
+  test('places every sample of a steps-mid staircase on its own x', () => {
+    renderStaircase(midStaircasePath());
+
+    const trace = new StepTrace(createStepLayer('mid'));
+    const circles = highlightCircles();
+
+    // 8 vertices are rendered for 4 samples. The two half-width end runs are
+    // the ones an average over the pair gets wrong: sample 0 would land a
+    // quarter of the sample interval to the right of x[0], and the last sample
+    // the same distance to the left of x[N-1].
+    expect(circles).toHaveLength(POINTS.length);
+    expect(circles).toEqual(
+      POINTS.map((point, i) => ({
+        x: PIXEL_FOR_SAMPLE[i],
+        y: PIXEL_FOR_LEVEL[point.y],
+      })),
+    );
 
     trace.dispose();
   });

--- a/test/model/stepHighlight.test.ts
+++ b/test/model/stepHighlight.test.ts
@@ -182,4 +182,41 @@ describe('step trace highlight mapping', () => {
 
     trace.dispose();
   });
+  test('keeps an irregularly spaced steps-mid sample inside its own run', () => {
+    // Interior runs of a steps-mid path span midpoint to midpoint, so their
+    // centre is the sample only when the spacing either side is equal. With
+    // uneven spacing the highlight is offset — the guarantee that matters is
+    // that it stays within the sample's own horizontal run rather than
+    // drifting onto a neighbour's, so it still reads as the right sample.
+    const unevenX = [10, 20, 60, 80];
+    const midpoints = unevenX.slice(0, -1).map((x, i) => (x + unevenX[i + 1]) / 2);
+    const xs = [unevenX[0]];
+    for (const midpoint of midpoints) {
+      xs.push(midpoint, midpoint);
+    }
+    xs.push(unevenX[unevenX.length - 1]);
+    const ys = POINTS.flatMap(point => [
+      PIXEL_FOR_LEVEL[point.y],
+      PIXEL_FOR_LEVEL[point.y],
+    ]);
+    renderStaircase(xs.map((x, i) => `${i === 0 ? 'M' : 'L'} ${x} ${ys[i]}`).join(' '));
+
+    const trace = new StepTrace(createStepLayer('mid'));
+    const circles = highlightCircles();
+
+    expect(circles).toHaveLength(POINTS.length);
+    // The two half-width end runs are read off directly, so they are exact.
+    expect(circles[0].x).toBe(unevenX[0]);
+    expect(circles[POINTS.length - 1].x).toBe(unevenX[unevenX.length - 1]);
+
+    circles.forEach((circle, i) => {
+      const runStart = i === 0 ? unevenX[0] : midpoints[i - 1];
+      const runEnd = i === POINTS.length - 1 ? unevenX[unevenX.length - 1] : midpoints[i];
+      expect(circle.x).toBeGreaterThanOrEqual(runStart);
+      expect(circle.x).toBeLessThanOrEqual(runEnd);
+      expect(circle.y).toBe(PIXEL_FOR_LEVEL[POINTS[i].y]);
+    });
+
+    trace.dispose();
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

Adds `TraceType.STEP`. A step chart *holds* its value across an interval and then jumps, rather than interpolating between samples the way a line chart implies.

The motivating case is a **hypnogram** — sleep stage against time. Two things distinguish it from a line chart, and both are accessibility problems today:

1. The y axis is an **ordinal category** (Awake / REM / N1 / N2 / N3), not a magnitude. Announcing "3" is useless; it has to say "REM".
2. The interesting events are the **transitions**. Arrowing point-by-point through a whole night of scoring epochs is unusable; a user needs to jump from stage change to stage change.

`StepTrace extends LineTrace`, so everything numeric is inherited unchanged. Notably the audio is *deliberately* left alone: `LineTrace` already emits one discrete tone per point, which is the correct sonification for piecewise-constant data — a run of equal levels sounds as a repeated pitch, and a transition is an audible jump. `SmoothTrace`'s continuous glissando would interpolate between levels, which is exactly what a step chart does not do.

## Related Issues

Companion to the step-plot work in xability/py-maidr#299 and the matching r-maidr change. This is the prerequisite: `TraceFactory.create` throws `Invalid trace type: step` until this lands, so the bindings should merge after it.

## Changes Made

**Grammar** — `TraceType.STEP`, `StepPoint extends LinePoint { label?: string }`, and a layer-level `stepDirection?: 'hv' | 'vh' | 'mid'`. `y` stays strictly numeric because it drives sonification, braille and the min/max range; `label` is the name of the level that `y` encodes. `stepDirection` is omitted rather than defaulted when the producing library does not report one, so the description never names a convention the data did not author.

**`StepTrace`** overrides four things and inherits the rest:
- `state` → `plotType: 'step'`, so every spoken surface says "step plot".
- `text` → substitutes the level name for the number.
- `description` → reports the *runs*: transition count, longest run, level names, direction.
- `getRotorFilterUnits()` / `moveToRotorFilter()` → a **"Transitions" rotor unit**. This is the headline navigation feature and it cost nothing outside `step.ts`: `AbstractTrace` already exposes trace-specific rotor units (`Candlestick` uses them for bull/bear filtering), so the rotor service needed no change at all.

**A highlight-placement fix.** `LineTrace.reconcilePathCoordinates` is extracted from `mapViaPathParsing` as a protected seam — a pure extraction, no behaviour change — so `StepTrace` can override it. This matters: a step path is rendered with the corner vertices the steps introduce, `2N-1` for `hv`/`vh` and `2N` for `mid`. The inherited handling trims the surplus from the *end*, but a step path's surplus is *interleaved*, so every highlight would have landed on the first half of the chart. The override removes it by stride instead. I verified the even-index rule against both matplotlib's `STEP_LOOKUP_MAP` and ggplot2's `stairstep()`, and the r-maidr work confirmed it live: a 10-point series renders 19 / 19 / 20 vertices at `hv` / `vh` / `mid`.

**AnyChart.** `step-line` and `step-area` were already being downgraded to line traces (documented as such). They now map to `TraceType.STEP`. `AnyChartTraceType` is a deliberately narrowed union that forces `buildLayer`'s switch to be exhaustive, so this could not be partial. The area-fill warning now keys on the source type rather than the mapped one, so `step-area` still warns that its fill is lost.

**Registration.** Adding a `TraceType` member produces exactly **one** compile error in this repo (`CHART_TYPE_LABEL`); every other site fails silently or at runtime, so the rest were walked by hand: the factory case, the braille encoder `Map` (a missing entry announces "Braille is on" and then shows nothing), `NESTED_DATA_TYPES` in `liveData.ts`, and the `'line'` branches in `highContrast.ts`.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verification actually run:** `npm run lint:fix`, `npm run type-check` (both `tsconfig.json` and `tsconfig.ci.json`, so the e2e sources are covered), `npx jest --selectProjects unit` — **1396 passed, 112 suites** — and `npm run build` (all 12 targets). The Playwright spec runs **18/18 in chromium**; browsers were not present in the sandbox, so they were installed first and this is a real run rather than a skipped one.

**One bug worth calling out, because it shipped broken through the unit suite.** `reconcilePathCoordinates` runs during `super(layer)` — `LineTrace`'s constructor calls `mapToSvgElements`, which reaches the override — so `StepTrace`'s own field was not assigned yet. It threw, MAIDR never mounted, and 15 of the 18 e2e assertions died on an uncaught `TypeError` before reaching any step behaviour. The model tests could not see it: they pass no selectors, so `mapViaPathParsing` returns before the override is reached. Fixed in 49423bb, with a jsdom test that constructs a trace against a real staircase and asserts the highlights land on the samples rather than the step corners — it fails on both counts if the field reference is put back.

**Known limitation, stated in `docs/BRAILLE.md`.** Braille reuses `LineBrailleEncoder`, which buckets each row's range into four levels. A hypnogram with five or more stages therefore collapses adjacent stages onto one glyph. Reuse is the established pattern (`SMOOTH` and `VIOLIN_KDE` both map to it) and a finer encoding would mean extending the 8-dot glyph vocabulary in `getBrailleChar`, which is a separate change. Braille conveys the shape of the night; the exact stage name comes from the text announcement.

**Deliberately out of scope.** Other adapters can detect step charts too — Plotly's `line.shape`, Chart.js's `dataset.stepped`, Vega-Lite's `mark.interpolate`, Recharts' `type="stepAfter"`, amCharts' `StepLineSeries`, Highcharts' `plotOptions.series.step`. Each is new detection logic with its own selector/highlight path, not a one-line mapping, and I could not exercise those libraries here. AnyChart is included only because it was already producing wrong output and its narrowed union forced the exhaustive case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_