### PR TITLE
fix(plotly): read normalized bar values from calcdata

### DIFF
--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -898,7 +898,7 @@ function extractLayer(
       return extractScatterLayer(trace, id, title, selectors, axes, gd);
 
     case TraceType.BAR:
-      return extractBarLayer(trace, id, title, selectors, axes);
+      return extractBarLayer(trace, calcdata, id, title, selectors, axes);
 
     case TraceType.HEATMAP:
       return extractHeatmapLayer(trace, id, title, selectors, axes, gd);
@@ -989,8 +989,30 @@ function extractScatterLayer(
 // Bar
 // ---------------------------------------------------------------------------
 
+/**
+ * Reads the value plotly actually drew for one bar. Shared by the single-trace
+ * and segmented bar extractors, which face the same `barnorm` question.
+ *
+ * `cd.s` is the bar's own size after `barnorm` has been applied, so it is the
+ * percentage or fraction on screen rather than the raw input number. It is
+ * orientation-independent — plotly keeps the position on `cd.p` for both
+ * vertical and horizontal bars. `cd.x`/`cd.y` are deliberately not used: for
+ * stacked bars they hold the running top of the stack, not the segment.
+ *
+ * Falls back to the raw trace value when calcdata is unavailable (a chart
+ * captured before plotly computed it) or holds a non-finite size.
+ */
+function drawnBarValue(
+  cd: PlotlyCalcData | undefined,
+  raw: string | number,
+): string | number {
+  const size = cd?.s;
+  return typeof size === 'number' && Number.isFinite(size) ? size : raw;
+}
+
 function extractBarLayer(
   trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
   id: string,
   title: string | undefined,
   selectors: string | undefined,
@@ -1010,7 +1032,8 @@ function extractBarLayer(
     // vertical, which already matches AbstractBarPlot's per-orientation reading
     // (value from `point.x` when HORIZONTAL, from `point.y` otherwise). No swap
     // is needed — and the plotly x/y axes already line up with the layer axes.
-    data.push({ x: x[i], y: y[i] });
+    const value = drawnBarValue(calcdata[i], isHorizontal ? x[i] : y[i]);
+    data.push(isHorizontal ? { x: value, y: y[i] } : { x: x[i], y: value });
   }
 
   if (data.length === 0)
@@ -1426,26 +1449,6 @@ function extractCandlestickLayer(
 // ---------------------------------------------------------------------------
 // Segmented bars (dodged / stacked / normalized)
 // ---------------------------------------------------------------------------
-
-/**
- * Reads the value plotly actually drew for one bar.
- *
- * `cd.s` is the bar's own size after `barnorm` has been applied, so it is the
- * percentage or fraction on screen rather than the raw input number. It is
- * orientation-independent — plotly keeps the position on `cd.p` for both
- * vertical and horizontal bars. `cd.x`/`cd.y` are deliberately not used: for
- * stacked bars they hold the running top of the stack, not the segment.
- *
- * Falls back to the raw trace value when calcdata is unavailable (a chart
- * captured before plotly computed it) or holds a non-finite size.
- */
-function drawnBarValue(
-  cd: PlotlyCalcData | undefined,
-  raw: string | number,
-): string | number {
-  const size = cd?.s;
-  return typeof size === 'number' && Number.isFinite(size) ? size : raw;
-}
 
 /**
  * Combines multiple plotly bar traces into a single MAIDR segmented bar layer.

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -990,24 +990,37 @@ function extractScatterLayer(
 // ---------------------------------------------------------------------------
 
 /**
- * Reads the value plotly actually drew for one bar. Shared by the single-trace
- * and segmented bar extractors, which face the same `barnorm` question.
+ * Builds one bar point, taking the value plotly actually drew from calcdata
+ * and putting it on the axis the orientation calls for. Shared by the
+ * single-trace and segmented bar extractors, which face the same `barnorm`
+ * question and must place the value the same way.
  *
- * `cd.s` is the bar's own size after `barnorm` has been applied, so it is the
- * percentage or fraction on screen rather than the raw input number. It is
- * orientation-independent — plotly keeps the position on `cd.p` for both
- * vertical and horizontal bars. `cd.x`/`cd.y` are deliberately not used: for
- * stacked bars they hold the running top of the stack, not the segment.
+ * The value comes from `cd.s`, the bar's own size after `barnorm` has been
+ * applied, so it is the percentage or fraction on screen rather than the raw
+ * input number. `cd.s` is orientation-independent — plotly keeps the position
+ * on `cd.p` for both vertical and horizontal bars. `cd.x`/`cd.y` are
+ * deliberately not used: for stacked bars they hold the running top of the
+ * stack, not the segment.
  *
- * Falls back to the raw trace value when calcdata is unavailable (a chart
- * captured before plotly computed it) or holds a non-finite size.
+ * Plotly stores the bar value on `x` for horizontal bars and on `y` for
+ * vertical, which already matches AbstractBarPlot's per-orientation reading
+ * (value from `point.x` when HORIZONTAL, from `point.y` otherwise). No swap is
+ * needed — and the plotly x/y axes already line up with the layer axes. The
+ * raw value on that same axis is the fallback, used when calcdata is
+ * unavailable (a chart captured before plotly computed it) or holds a
+ * non-finite size.
  */
-function drawnBarValue(
+function barPoint(
   cd: PlotlyCalcData | undefined,
-  raw: string | number,
-): string | number {
+  x: string | number,
+  y: string | number,
+  isHorizontal: boolean,
+): BarPoint {
   const size = cd?.s;
-  return typeof size === 'number' && Number.isFinite(size) ? size : raw;
+  const drawn = typeof size === 'number' && Number.isFinite(size) ? size : undefined;
+  return isHorizontal
+    ? { x: drawn ?? x, y }
+    : { x, y: drawn ?? y };
 }
 
 function extractBarLayer(
@@ -1028,12 +1041,7 @@ function extractBarLayer(
   const data: BarPoint[] = [];
 
   for (let i = 0; i < len; i++) {
-    // Plotly stores the bar value on `x` for horizontal bars and on `y` for
-    // vertical, which already matches AbstractBarPlot's per-orientation reading
-    // (value from `point.x` when HORIZONTAL, from `point.y` otherwise). No swap
-    // is needed — and the plotly x/y axes already line up with the layer axes.
-    const value = drawnBarValue(calcdata[i], isHorizontal ? x[i] : y[i]);
-    data.push(isHorizontal ? { x: value, y: y[i] } : { x: x[i], y: value });
+    data.push(barPoint(calcdata[i], x[i], y[i], isHorizontal));
   }
 
   if (data.length === 0)
@@ -1483,10 +1491,7 @@ function extractSegmentedBarLayer(
     const series: SegmentedPoint[] = [];
 
     for (let i = 0; i < len; i++) {
-      // Plotly stores the value on `x` for horizontal bars and on `y` for
-      // vertical, matching AbstractBarPlot's per-orientation reading — no swap.
-      const value = drawnBarValue(cd[i], isHorizontal ? x[i] : y[i]);
-      series.push(isHorizontal ? { x: value, y: y[i], z } : { x: x[i], y: value, z });
+      series.push({ ...barPoint(cd[i], x[i], y[i], isHorizontal), z });
     }
 
     data.push(series);

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -441,14 +441,14 @@ function buildSubplotLayers(
     const barnorm = layout.barnorm ?? '';
 
     if (barmode === 'group') {
-      const layer = extractSegmentedBarLayer(barTraces, TraceType.DODGED, xLabel, yLabel, gd);
+      const layer = extractSegmentedBarLayer(barTraces, group, TraceType.DODGED, xLabel, yLabel, gd);
       if (layer)
         layers.push(layer);
     } else if (barmode === 'stack' || barmode === 'relative') {
       const type = barnorm === 'percent' || barnorm === 'fraction'
         ? TraceType.NORMALIZED
         : TraceType.STACKED;
-      const layer = extractSegmentedBarLayer(barTraces, type, xLabel, yLabel, gd);
+      const layer = extractSegmentedBarLayer(barTraces, group, type, xLabel, yLabel, gd);
       if (layer)
         layers.push(layer);
     } else {
@@ -1428,6 +1428,26 @@ function extractCandlestickLayer(
 // ---------------------------------------------------------------------------
 
 /**
+ * Reads the value plotly actually drew for one bar.
+ *
+ * `cd.s` is the bar's own size after `barnorm` has been applied, so it is the
+ * percentage or fraction on screen rather than the raw input number. It is
+ * orientation-independent — plotly keeps the position on `cd.p` for both
+ * vertical and horizontal bars. `cd.x`/`cd.y` are deliberately not used: for
+ * stacked bars they hold the running top of the stack, not the segment.
+ *
+ * Falls back to the raw trace value when calcdata is unavailable (a chart
+ * captured before plotly computed it) or holds a non-finite size.
+ */
+function drawnBarValue(
+  cd: PlotlyCalcData | undefined,
+  raw: string | number,
+): string | number {
+  const size = cd?.s;
+  return typeof size === 'number' && Number.isFinite(size) ? size : raw;
+}
+
+/**
  * Combines multiple plotly bar traces into a single MAIDR segmented bar layer.
  *
  * Produces `SegmentedPoint[][]` where each inner array is one trace/series.
@@ -1437,6 +1457,7 @@ function extractCandlestickLayer(
  */
 function extractSegmentedBarLayer(
   barTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[],
+  group: SubplotGroup,
   type: TraceType,
   xLabel: string | undefined,
   yLabel: string | undefined,
@@ -1447,12 +1468,13 @@ function extractSegmentedBarLayer(
   // Check orientation from first trace (all traces in a group share orientation).
   const isHorizontal = barTraces[0]?.trace.orientation === 'h';
 
-  for (const { trace } of barTraces) {
+  for (const { trace, calcIdx } of barTraces) {
     const x = trace.x;
     const y = trace.y;
     if (!x || !y)
       continue;
 
+    const cd = group.calcdata[calcIdx] ?? [];
     const z = trace.name ?? `Series ${data.length + 1}`;
     const len = Math.min(x.length, y.length);
     const series: SegmentedPoint[] = [];
@@ -1460,7 +1482,8 @@ function extractSegmentedBarLayer(
     for (let i = 0; i < len; i++) {
       // Plotly stores the value on `x` for horizontal bars and on `y` for
       // vertical, matching AbstractBarPlot's per-orientation reading — no swap.
-      series.push({ x: x[i], y: y[i], z });
+      const value = drawnBarValue(cd[i], isHorizontal ? x[i] : y[i]);
+      series.push(isHorizontal ? { x: value, y: y[i], z } : { x: x[i], y: value, z });
     }
 
     data.push(series);

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,5 +1,5 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
-import type { SegmentedPoint } from '@type/grammar';
+import type { BarPoint, SegmentedPoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it } from '@jest/globals';
@@ -1048,6 +1048,48 @@ describe('plotly extractor', () => {
 
       expect(data[0][0].y).toBe(120);
       expect(data[1][0].y).toBe(90);
+    });
+
+    it('normalizes a lone bar trace, which barnorm flattens to full-height bars', () => {
+      // Plotly normalizes a single trace against itself, so every bar is drawn
+      // at 100% — verified against plotly.js 2.35.2, where raw [120, 80, 40]
+      // renders three identical full-height bars. Announcing the raw numbers
+      // there describes three different heights that are not on screen.
+      // A lone bar trace takes the single-layer path, not the segmented one.
+      const gd = createGraphDiv({
+        traces: [{ type: 'bar', x: ['Q1', 'Q2', 'Q3'], y: [120, 80, 40], name: 'East' }],
+        layout: { barmode: 'stack', barnorm: 'percent' },
+        calcdata: [[
+          { p: 0, s: 100, b: 0, y: 100 },
+          { p: 1, s: 100, b: 0, y: 100 },
+          { p: 2, s: 100, b: 0, y: 100 },
+        ]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const layer = maidr!.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.BAR);
+      const data = layer.data as BarPoint[];
+      expect(data.map(point => point.y)).toEqual([100, 100, 100]);
+      expect(data.map(point => point.x)).toEqual(['Q1', 'Q2', 'Q3']);
+    });
+
+    it('leaves a lone bar trace without barnorm reading its raw values', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'bar', x: ['Q1', 'Q2', 'Q3'], y: [120, 80, 40], name: 'East' }],
+        layout: {},
+        calcdata: [[
+          { p: 0, s: 120, b: 0, y: 120 },
+          { p: 1, s: 80, b: 0, y: 80 },
+          { p: 2, s: 40, b: 0, y: 40 },
+        ]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const data = maidr!.subplots[0][0].layers[0].data as BarPoint[];
+      expect(data.map(point => point.y)).toEqual([120, 80, 40]);
     });
 
     it('keeps calcdata aligned with the trace arrays across a gap in the data', () => {

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,4 +1,5 @@
-import type { PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
+import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
+import type { SegmentedPoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it } from '@jest/globals';
@@ -15,6 +16,8 @@ interface GraphDivOptions {
   layout: PlotlyFullLayout;
   /** Panel background rect positions rendered into the `.bglayer`. */
   bgRects?: { x: number; y: number }[];
+  /** Per-trace calculated data, as plotly leaves it on the graph div. */
+  calcdata?: PlotlyCalcData[][];
 }
 
 /** Builds a fake rendered Plotly graph div with `_fullData`/`_fullLayout`. */
@@ -43,6 +46,7 @@ function createGraphDiv(options: GraphDivOptions): PlotlyGraphDiv {
   const gd = div as PlotlyGraphDiv;
   gd._fullData = options.traces;
   gd._fullLayout = options.layout;
+  gd.calcdata = options.calcdata;
   return gd;
 }
 
@@ -879,6 +883,131 @@ describe('plotly extractor', () => {
         expect(subplotLayout.visualOrderMap.get('1,0')).toBe(3);
         expect(subplotLayout.visualOrderMap.get('1,1')).toBe(4);
       });
+    });
+  });
+
+  describe('segmented bars', () => {
+    /**
+     * Two series over two quarters, the shape from issue #720:
+     * Q1 totals 210 (120 East + 90 West), Q2 totals 150 (80 + 70).
+     */
+    function segmentedTraces(): PlotlyTrace[] {
+      return [
+        { type: 'bar', x: ['Q1', 'Q2'], y: [120, 80], name: 'East' },
+        { type: 'bar', x: ['Q1', 'Q2'], y: [90, 70], name: 'West' },
+      ];
+    }
+
+    /** Calcdata as plotly leaves it for the stack above under `barnorm`. */
+    function normalizedCalcdata(scale: number): PlotlyCalcData[][] {
+      const east = [scale * 120 / 210, scale * 80 / 150];
+      const west = [scale * 90 / 210, scale * 70 / 150];
+      return [
+        [
+          { p: 0, s: east[0], b: 0, y: east[0] },
+          { p: 1, s: east[1], b: 0, y: east[1] },
+        ],
+        // Plotly puts the running top of the stack on `y`; only `s` is this
+        // segment's own share.
+        [
+          { p: 0, s: west[0], b: east[0], y: scale },
+          { p: 1, s: west[1], b: east[1], y: scale },
+        ],
+      ];
+    }
+
+    function segmentedData(gd: PlotlyGraphDiv): SegmentedPoint[][] {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0].data as SegmentedPoint[][];
+    }
+
+    it('announces the normalized percentage plotly drew, not the raw total', () => {
+      const gd = createGraphDiv({
+        traces: segmentedTraces(),
+        layout: { barmode: 'stack', barnorm: 'percent' },
+        calcdata: normalizedCalcdata(100),
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const layer = maidr!.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.NORMALIZED);
+      const data = layer.data as SegmentedPoint[][];
+      expect(data[0][0].x).toBe('Q1');
+      expect(data[0][0].y).toBeCloseTo(57.142857, 5);
+      expect(data[0][1].y).toBeCloseTo(53.333333, 5);
+      // The second series reads its own share, not the stack top of 100.
+      expect(data[1][0].y).toBeCloseTo(42.857143, 5);
+      expect(data[1][1].y).toBeCloseTo(46.666667, 5);
+    });
+
+    it('announces fractions when barnorm is fraction', () => {
+      const gd = createGraphDiv({
+        traces: segmentedTraces(),
+        layout: { barmode: 'stack', barnorm: 'fraction' },
+        calcdata: normalizedCalcdata(1),
+      });
+
+      const data = segmentedData(gd);
+
+      expect(data[0][0].y).toBeCloseTo(0.571429, 5);
+      expect(data[1][0].y).toBeCloseTo(0.428571, 5);
+    });
+
+    it('normalizes horizontal bars on the value axis, keeping the category on y', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', orientation: 'h', y: ['Q1', 'Q2'], x: [120, 80], name: 'East' },
+          { type: 'bar', orientation: 'h', y: ['Q1', 'Q2'], x: [90, 70], name: 'West' },
+        ],
+        layout: { barmode: 'stack', barnorm: 'percent' },
+        // For horizontal bars plotly keeps the size on `s` and moves the
+        // running total to `x`.
+        calcdata: [
+          [{ p: 0, s: 100 * 120 / 210, b: 0, x: 100 * 120 / 210 }, { p: 1, s: 100 * 80 / 150, b: 0, x: 100 * 80 / 150 }],
+          [{ p: 0, s: 100 * 90 / 210, b: 100 * 120 / 210, x: 100 }, { p: 1, s: 100 * 70 / 150, b: 100 * 80 / 150, x: 100 }],
+        ],
+      });
+
+      const data = segmentedData(gd);
+
+      expect(data[0][0].y).toBe('Q1');
+      expect(data[0][0].x).toBeCloseTo(57.142857, 5);
+      expect(data[1][0].y).toBe('Q1');
+      expect(data[1][0].x).toBeCloseTo(42.857143, 5);
+    });
+
+    it('leaves an unnormalized stack reading its raw values', () => {
+      const gd = createGraphDiv({
+        traces: segmentedTraces(),
+        layout: { barmode: 'stack' },
+        calcdata: [
+          [{ p: 0, s: 120, b: 0, y: 120 }, { p: 1, s: 80, b: 0, y: 80 }],
+          [{ p: 0, s: 90, b: 120, y: 210 }, { p: 1, s: 70, b: 80, y: 150 }],
+        ],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const layer = maidr!.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.STACKED);
+      const data = layer.data as SegmentedPoint[][];
+      expect(data[0][0].y).toBe(120);
+      // 210 is the stack top, not this segment.
+      expect(data[1][0].y).toBe(90);
+    });
+
+    it('falls back to the raw trace values when calcdata is unavailable', () => {
+      const gd = createGraphDiv({
+        traces: segmentedTraces(),
+        layout: { barmode: 'stack', barnorm: 'percent' },
+      });
+
+      const data = segmentedData(gd);
+
+      expect(data[0][0].y).toBe(120);
+      expect(data[1][0].y).toBe(90);
     });
   });
 });

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -898,7 +898,10 @@ describe('plotly extractor', () => {
       ];
     }
 
-    /** Calcdata as plotly leaves it for the stack above under `barnorm`. */
+    /**
+     * Calcdata as plotly leaves it for the stack above under `barnorm`,
+     * mirroring what plotly.js 2.35.2 computes for these traces.
+     */
     function normalizedCalcdata(scale: number): PlotlyCalcData[][] {
       const east = [scale * 120 / 210, scale * 80 / 150];
       const west = [scale * 90 / 210, scale * 70 / 150];
@@ -912,6 +915,26 @@ describe('plotly extractor', () => {
         [
           { p: 0, s: west[0], b: east[0], y: scale },
           { p: 1, s: west[1], b: east[1], y: scale },
+        ],
+      ];
+    }
+
+    /**
+     * The same two series under `barmode: 'group'`. Plotly scales grouped bars
+     * under `barnorm` as well, but they stand side by side on a shared
+     * baseline, so each bar's top is its own size.
+     */
+    function groupedCalcdata(): PlotlyCalcData[][] {
+      const east = [100 * 120 / 210, 100 * 80 / 150];
+      const west = [100 * 90 / 210, 100 * 70 / 150];
+      return [
+        [
+          { p: 0, s: east[0], b: 0, y: east[0] },
+          { p: 1, s: east[1], b: 0, y: east[1] },
+        ],
+        [
+          { p: 0, s: west[0], b: 0, y: west[0] },
+          { p: 1, s: west[1], b: 0, y: west[1] },
         ],
       ];
     }
@@ -955,6 +978,22 @@ describe('plotly extractor', () => {
       expect(data[1][0].y).toBeCloseTo(0.428571, 5);
     });
 
+    it('normalizes grouped bars, which plotly scales under barnorm as well', () => {
+      const gd = createGraphDiv({
+        traces: segmentedTraces(),
+        layout: { barmode: 'group', barnorm: 'percent' },
+        calcdata: groupedCalcdata(),
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      const layer = maidr!.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.DODGED);
+      const data = layer.data as SegmentedPoint[][];
+      expect(data[0][0].y).toBeCloseTo(57.142857, 5);
+      expect(data[1][0].y).toBeCloseTo(42.857143, 5);
+    });
+
     it('normalizes horizontal bars on the value axis, keeping the category on y', () => {
       const gd = createGraphDiv({
         traces: [
@@ -963,10 +1002,11 @@ describe('plotly extractor', () => {
         ],
         layout: { barmode: 'stack', barnorm: 'percent' },
         // For horizontal bars plotly keeps the size on `s` and moves the
-        // running total to `x`.
+        // running total to `x`. `y` holds the numeric position, not the
+        // category, which is why the label has to come from the trace.
         calcdata: [
-          [{ p: 0, s: 100 * 120 / 210, b: 0, x: 100 * 120 / 210 }, { p: 1, s: 100 * 80 / 150, b: 0, x: 100 * 80 / 150 }],
-          [{ p: 0, s: 100 * 90 / 210, b: 100 * 120 / 210, x: 100 }, { p: 1, s: 100 * 70 / 150, b: 100 * 80 / 150, x: 100 }],
+          [{ p: 0, s: 100 * 120 / 210, b: 0, x: 100 * 120 / 210, y: 0 }, { p: 1, s: 100 * 80 / 150, b: 0, x: 100 * 80 / 150, y: 1 }],
+          [{ p: 0, s: 100 * 90 / 210, b: 100 * 120 / 210, x: 100, y: 0 }, { p: 1, s: 100 * 70 / 150, b: 100 * 80 / 150, x: 100, y: 1 }],
         ],
       });
 

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1158,6 +1158,11 @@ describe('plotly extractor', () => {
       expect(data[1][3].y).toBeCloseTo(33.333333, 5);
       expect(data[1][1].y).toBeCloseTo(100, 5);
       // A gap itself carries the raw value through, exactly as before the fix.
+      // Deliberately not filtered the way extractMultiLineLayer filters line
+      // gaps: plotly omits a null point from a line's DOM but keeps a
+      // zero-height rect for a bar's, so dropping it here would slide every
+      // later bar's highlight onto its neighbour. The text service already
+      // renders the null as "missing" rather than announcing it raw.
       expect(data[0][1].y).toBeNull();
       expect(data[1][2].y).toBeNull();
       // Category labels still come from the trace, so they survive the gaps.

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1049,5 +1049,53 @@ describe('plotly extractor', () => {
       expect(data[0][0].y).toBe(120);
       expect(data[1][0].y).toBe(90);
     });
+
+    it('keeps calcdata aligned with the trace arrays across a gap in the data', () => {
+      // Plotly's bar calc() holds a missing point in place rather than
+      // dropping it — the entry keeps its position and carries `s: undefined`
+      // (BADNUM) — so `cd[i]` stays in step with `x[i]`/`y[i]`. Verified
+      // against plotly.js 2.35.2: four input points, four calcdata entries,
+      // four rendered bars. Were an entry dropped instead, every value after
+      // the gap would slide onto the wrong quarter.
+      const quarters = ['Q1', 'Q2', 'Q3', 'Q4'];
+      // Plotly's runtime data admits null; the hand-written trace type does not.
+      const withGaps = (values: (number | null)[]): number[] => values as number[];
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: quarters, y: withGaps([120, null, 60, 40]), name: 'East' },
+          { type: 'bar', x: quarters, y: withGaps([90, 70, null, 20]), name: 'West' },
+        ],
+        layout: { barmode: 'stack', barnorm: 'percent' },
+        calcdata: [
+          [
+            { p: 0, s: 100 * 120 / 210, b: 0, y: 100 * 120 / 210 },
+            { p: 1 },
+            // West is absent at Q3, so East is the whole stack there.
+            { p: 2, s: 100, b: 0, y: 100 },
+            { p: 3, s: 100 * 40 / 60, b: 0, y: 100 * 40 / 60 },
+          ],
+          [
+            { p: 0, s: 100 * 90 / 210, b: 100 * 120 / 210, y: 100 },
+            { p: 1, s: 100, b: 0, y: 100 },
+            { p: 2 },
+            { p: 3, s: 100 * 20 / 60, b: 100 * 40 / 60, y: 100 },
+          ],
+        ],
+      });
+
+      const data = segmentedData(gd);
+
+      // The points after each gap keep their own share. A one-entry shift
+      // would report 66.67 at Q3 and 100 at Q4 instead.
+      expect(data[0][2].y).toBeCloseTo(100, 5);
+      expect(data[0][3].y).toBeCloseTo(66.666667, 5);
+      expect(data[1][3].y).toBeCloseTo(33.333333, 5);
+      expect(data[1][1].y).toBeCloseTo(100, 5);
+      // A gap itself carries the raw value through, exactly as before the fix.
+      expect(data[0][1].y).toBeNull();
+      expect(data[1][2].y).toBeNull();
+      // Category labels still come from the trace, so they survive the gaps.
+      expect(data[0].map(point => point.x)).toEqual(quarters);
+    });
   });
 });

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1092,6 +1092,30 @@ describe('plotly extractor', () => {
       expect(data.map(point => point.y)).toEqual([120, 80, 40]);
     });
 
+    it('reports a bar normalized to zero as 0, not as missing', () => {
+      // A 0% share is a real value: it has to reach the announcement rather
+      // than be dropped or replaced. Note this does not distinguish a
+      // falsy-check fallback from a nullish one — under `barnorm` a drawn 0
+      // implies a raw 0, so both would answer 0 here. What it pins is that
+      // the zero survives extraction at all.
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: ['Q1', 'Q2'], y: [0, 80], name: 'East' },
+          { type: 'bar', x: ['Q1', 'Q2'], y: [90, 70], name: 'West' },
+        ],
+        layout: { barmode: 'stack', barnorm: 'percent' },
+        calcdata: [
+          [{ p: 0, s: 0, b: 0, y: 0 }, { p: 1, s: 100 * 80 / 150, b: 0, y: 100 * 80 / 150 }],
+          [{ p: 0, s: 100, b: 0, y: 100 }, { p: 1, s: 100 * 70 / 150, b: 100 * 80 / 150, y: 100 }],
+        ],
+      });
+
+      const data = segmentedData(gd);
+
+      expect(data[0][0].y).toBe(0);
+      expect(data[1][0].y).toBe(100);
+    });
+
     it('keeps calcdata aligned with the trace arrays across a gap in the data', () => {
       // Plotly's bar calc() holds a missing point in place rather than
       // dropping it — the entry keeps its position and carries `s: undefined`


### PR DESCRIPTION
# Pull Request

## Description

A Plotly bar chart with `barnorm: 'percent'` (or `'fraction'`) is drawn as shares, but MAIDR announced the raw input numbers. The chart was classified correctly as `stacked_normalized_bar` and then read out values contradicting that classification and the bars on screen — `Share is 120` where the bar sits at 57.14 on a 0–105 axis.

The bar extractors read the raw `trace.x`/`trace.y` arrays. They already received the graph div, and the caller had already consulted `layout.barnorm` to pick the trace type, so the normalized values plotly computed were in scope and unused.

## Related Issues

Fixes #720

Follow-ups filed from what this work surfaced, both deliberately out of scope here: #725 (computed values announced at full float precision) and #726 (a bar gap sonified as a zero-height bar).

## Changes Made

`src/adapters/plotly/extractor.ts` — both bar paths now take each bar's value from its calcdata entry, which is what plotly actually drew, instead of the raw trace array. The position still comes from the trace array, so category labels are unaffected.

- **Segmented bars** (dodged / stacked / normalized): `extractSegmentedBarLayer` now receives the `SubplotGroup` to reach its per-trace calcdata, matching how `extractMultiBoxLayer` already does it.
- **A lone bar trace** takes the single-layer path instead, so it was missed by the above. Plotly normalizes a single trace against itself — every bar is drawn at 100% — while the raw numbers described three different heights that are not on screen. `extractLayer` already had the calcdata in hand for the histogram case, so the value is threaded one function further into `extractBarLayer`.
- Both paths share one `barPoint` helper. It reads `cd.s`, the bar's own size after normalization, and places it on the axis the orientation calls for. Deciding both together is deliberate: the value's axis and the raw value backing it have to agree, and as two separate ternaries per call site they could drift. `cd.s` is orientation-independent (plotly keeps the position on `cd.p` for both `'v'` and `'h'`), so horizontal bars need no special case. `cd.x`/`cd.y` are deliberately not used: for a stack they hold the running top, cumulative for every trace above the first — reading those would have swapped one wrong number for another.
- The raw trace value remains the fallback when calcdata is unavailable or holds a non-finite size, so charts captured before plotly computes it behave as before.

Grouped bars (`barmode: 'group'`) go through the same helper, so a grouped chart with `barnorm` set reports shares too. Trace-type selection is untouched.

## Screenshots (if applicable)

Not applicable — the rendered chart does not change; only the announced values do. The announcements themselves are quoted under Additional Notes.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verified against real plotly, not just fixtures.** Every claim here was checked against plotly.js 2.35.2 — the version `examples/plotly-*.html` pin — driven through Playwright, and the fixtures mirror what it actually computes:

- `cd.s` carries the normalized segment size while `cd.y` carries the running stack top (100 for the second trace) — which is why the fix reads `s`.
- `barmode: 'group'` with `barnorm` is scaled too, on a `[0, 60.15]` axis.
- A lone trace under `barnorm` gets `s: 100` on every bar.
- Bar `calc()` holds a missing point in place with `s: undefined` (BADNUM) rather than dropping it, so `cd[i]` stays in step with `x[i]`/`y[i]` — the positional lookup the fix relies on.

**End-to-end through the built bundle**, driving the chart by keyboard and reading the `role="alert"` region:

```
stacked + barnorm    Quarter is Q1, Share is 57.14285714285714, Level is East
lone trace + barnorm Quarter is Q1, Share is 100
```

On `main` those read `Share is 120` and `Share is 120` respectively. Both were re-run unchanged after the helper refactor.

**Ten unit tests.** Six fail on `main` — percent, fraction, grouped, horizontal, the lone trace, and the gap-alignment pin. Four are controls that pass either way: an unnormalized stack, an unnormalized lone trace, a chart with no calcdata, and a bar normalized to 0%. The unnormalized-stack case asserts the second series reads 90 rather than the stack top of 210, which is what distinguishes `cd.s` from `cd.y`.

One limit stated rather than papered over: the zero case does **not** distinguish a falsy-check fallback from a nullish one. I checked by swapping `??` for `||` in the source — all tests still passed, because under `barnorm` a drawn 0 implies a raw 0. The test comment says so.

**Bar gaps are deliberately not filtered** the way `extractMultiLineLayer` filters line gaps. Plotly omits a null point from a line's DOM but keeps a zero-height rect for a bar's — 3 `.point` nodes for 3 bar values with a gap, versus 2 markers for the same line data. Dropping it here would slide every later bar's highlight onto its neighbour, which the gap-alignment test catches. The reasoning is recorded on the assertion; the model-side consequence is #726.

Verified locally: `npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (1390 unit + 57 esm, all passing). The E2E suite has no plotly fixture, so it does not exercise this path — the browser verification above stands in for it, and a plotly e2e fixture would be a worthwhile future addition.