### PR TITLE
fix(format): round announced values to two decimals by default

### DIFF
--- a/e2e_tests/specs/histogram.spec.ts
+++ b/e2e_tests/specs/histogram.spec.ts
@@ -51,16 +51,30 @@ function getHistogramDisplayValue(layer: MaidrLayer | undefined, index: number):
   const dataPoint = layer.data[index];
 
   if (dataPoint && 'xMin' in dataPoint && 'xMax' in dataPoint) {
-    const xMin = defaultFormat(dataPoint.xMin as number);
-    const xMax = defaultFormat(dataPoint.xMax as number);
-    return `${xMin} through ${xMax}`;
+    return `${announced(dataPoint.xMin)} through ${announced(dataPoint.xMax)}`;
   }
 
   if (dataPoint && 'x' in dataPoint) {
-    return defaultFormat(dataPoint.x as number);
+    return announced(dataPoint.x);
   }
 
   throw new Error(`Data point at index ${index} has invalid format`);
+}
+
+/**
+ * Renders one datum the way MAIDR announces it.
+ *
+ * `MaidrLayer['data']` is a wide union, so narrowing rather than asserting
+ * keeps this honest about a point whose field is neither a number nor a
+ * string — `defaultFormat` only accepts those two.
+ *
+ * @param value - A raw field from a data point
+ * @returns The value as it reaches the screen reader
+ */
+function announced(value: unknown): string {
+  return typeof value === 'number' || typeof value === 'string'
+    ? defaultFormat(value)
+    : String(value);
 }
 
 test.describe('Histogram', () => {

--- a/e2e_tests/specs/histogram.spec.ts
+++ b/e2e_tests/specs/histogram.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test';
 import type { Maidr, MaidrLayer } from '../../src/type/grammar';
 import { expect, test } from '@playwright/test';
+import { defaultFormat } from '../../src/util/format';
 import { HistogramPage } from '../page-objects/plots/histogram-page';
 import { TestConstants } from '../utils/constants';
 import { extractMaidrData } from '../utils/maidr-data';
@@ -24,6 +25,15 @@ async function setupHistogramPage(
 
 /**
  * Safely extracts the display value from a histogram data point
+ *
+ * Values are put through {@link defaultFormat}, the same formatter the
+ * announcement goes through, rather than stringified raw. The iris bin edges
+ * in the fixture carry float artefacts — `1.5900000000000003` — and MAIDR
+ * announces the rounded `1.59`. Importing the real formatter rather than
+ * copying its rounding keeps this expectation tied to the app's contract: a
+ * change in default precision updates the spec with it, while landing on the
+ * wrong bin still fails.
+ *
  * @param layer - The histogram layer containing data points
  * @param index - Index of the data point to extract value from
  * @returns The formatted string value suitable for display comparison
@@ -41,13 +51,13 @@ function getHistogramDisplayValue(layer: MaidrLayer | undefined, index: number):
   const dataPoint = layer.data[index];
 
   if (dataPoint && 'xMin' in dataPoint && 'xMax' in dataPoint) {
-    const xMin = String(dataPoint.xMin);
-    const xMax = String(dataPoint.xMax);
+    const xMin = defaultFormat(dataPoint.xMin as number);
+    const xMax = defaultFormat(dataPoint.xMax as number);
     return `${xMin} through ${xMax}`;
   }
 
   if (dataPoint && 'x' in dataPoint) {
-    return String(dataPoint.x);
+    return defaultFormat(dataPoint.x as number);
   }
 
   throw new Error(`Data point at index ${index} has invalid format`);

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -48,6 +48,11 @@ export const defaultFormat: FormatFunction = (value: number | string): string =>
 
   // Rounding erased the value (0.00012 -> 0). Announcing `0` for something that
   // is not zero is worse than the extra digits, so keep it visible instead.
+  //
+  // The check catches the negative case as well, and relies on it: a small
+  // negative rounds to `-0`, and `-0 !== 0` is false in IEEE-754, so it lands
+  // here rather than being announced as a signed zero. Comparing against
+  // `Object.is(rounded, 0)` instead would let `-0` through.
   return `${Number(value.toPrecision(DEFAULT_SIGNIFICANT_DIGITS))}`;
 };
 

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -6,14 +6,49 @@ import type { AxisFormat, FormatFunction, FormatType } from '@type/grammar';
 export type FormattableValue = number | string | (number | string)[];
 
 /**
+ * Decimal places the default format keeps for a fractional number. Matches the
+ * precision the Go To Extrema dialog already displays values at.
+ */
+const DEFAULT_MAX_DECIMALS = 2;
+
+/**
+ * Significant digits used for a value too small to survive rounding to
+ * {@link DEFAULT_MAX_DECIMALS} places.
+ */
+const DEFAULT_SIGNIFICANT_DIGITS = 3;
+
+/**
  * Default format function - converts value to string.
- * Strings pass through unchanged, numbers are stringified.
+ * Strings pass through unchanged, integers are stringified as-is.
+ *
+ * A fractional number is rounded to {@link DEFAULT_MAX_DECIMALS} places, because
+ * this is what a screen reader speaks aloud. A value MAIDR computes rather than
+ * reads verbatim — a `barnorm` share, a percentage of a stack — carries the full
+ * float, and `57.14285714285714` is sixteen digits to listen through for two
+ * digits of meaning.
+ *
+ * Rounding stops at the announcement. Sonification, braille, and extrema all
+ * read the underlying numbers, so the pitch of a bar and the position of a
+ * braille cell are unchanged; only the spoken text is shortened. An author who
+ * needs different precision sets an explicit `AxisFormat` on the axis, which
+ * takes priority over this.
  *
  * @param value - The value to format
  * @returns String representation of the value
  */
 export const defaultFormat: FormatFunction = (value: number | string): string => {
-  return `${value}`;
+  if (typeof value !== 'number' || !Number.isFinite(value) || Number.isInteger(value)) {
+    return `${value}`;
+  }
+
+  const rounded = Number(value.toFixed(DEFAULT_MAX_DECIMALS));
+  if (rounded !== 0) {
+    return `${rounded}`;
+  }
+
+  // Rounding erased the value (0.00012 -> 0). Announcing `0` for something that
+  // is not zero is worse than the extra digits, so keep it visible instead.
+  return `${Number(value.toPrecision(DEFAULT_SIGNIFICANT_DIGITS))}`;
 };
 
 /**

--- a/test/service/formatter.test.ts
+++ b/test/service/formatter.test.ts
@@ -1,0 +1,72 @@
+import type { AxisFormat, Maidr } from '@type/grammar';
+import { describe, expect, it } from '@jest/globals';
+import { FormatterService } from '@service/formatter';
+import { TraceType } from '@type/grammar';
+
+/** A one-layer figure whose y axis optionally carries a format. */
+function figure(format?: AxisFormat): Maidr {
+  return {
+    id: 'chart',
+    subplots: [[{
+      layers: [{
+        id: 'layer-1',
+        type: TraceType.BAR,
+        axes: {
+          x: { label: 'Quarter' },
+          y: { label: 'Share', ...(format ? { format } : {}) },
+        },
+        data: [],
+      }],
+    }]],
+  };
+}
+
+describe('formatterService', () => {
+  it('applies the default rounding to a layer with no format configured', () => {
+    // The pure function is covered in test/util/format.test.ts; this pins the
+    // resolve → wrap → apply chain every chart actually goes through.
+    const service = new FormatterService(figure());
+
+    expect(service.formatSingleValue(57.14285714285714, 'layer-1', 'y')).toBe('57.14');
+
+    service.dispose();
+  });
+
+  it('applies an explicit axis format instead of the default', () => {
+    const service = new FormatterService(figure({ type: 'fixed', decimals: 4 }));
+
+    expect(service.formatSingleValue(57.14285714285714, 'layer-1', 'y')).toBe('57.1429');
+    // The unformatted axis still gets the default.
+    expect(service.formatSingleValue(57.14285714285714, 'layer-1', 'x')).toBe('57.14');
+
+    service.dispose();
+  });
+
+  it('rounds every element of an array, as boxplot outliers arrive', () => {
+    const service = new FormatterService(figure());
+
+    expect(service.formatArrayValue(
+      [-9.795123, 6.0570001, 14.736999],
+      'layer-1',
+      'y',
+    )).toEqual(['-9.8', '6.06', '14.74']);
+
+    service.dispose();
+  });
+
+  it('still renders a missing value as missing rather than rounding it', () => {
+    const service = new FormatterService(figure());
+
+    expect(service.formatSingleValue(Number.NaN, 'layer-1', 'y')).toBe('missing');
+
+    service.dispose();
+  });
+
+  it('falls back to the default formatter for an unknown layer', () => {
+    const service = new FormatterService(figure());
+
+    expect(service.formatSingleValue(57.14285714285714, 'no-such-layer', 'y')).toBe('57.14');
+
+    service.dispose();
+  });
+});

--- a/test/util/format.test.ts
+++ b/test/util/format.test.ts
@@ -36,6 +36,14 @@ describe('defaultFormat', () => {
     expect(defaultFormat(-0.000987654)).toBe('-0.000988');
   });
 
+  it('keeps exponential notation where JavaScript already used it', () => {
+    // Below ~1e-6 the fallback's toPrecision returns an exponent, but so does
+    // plain stringification — `String(1.234e-7)` is already `'1.234e-7'`. Only
+    // the mantissa gets shorter, so nothing switches notation because of this.
+    expect(defaultFormat(0.0000001234)).toBe('1.23e-7');
+    expect(defaultFormat(-0.0000001234)).toBe('-1.23e-7');
+  });
+
   it('passes strings through untouched', () => {
     expect(defaultFormat('Q1')).toBe('Q1');
     expect(defaultFormat('57.14285714285714')).toBe('57.14285714285714');

--- a/test/util/format.test.ts
+++ b/test/util/format.test.ts
@@ -3,9 +3,17 @@ import { defaultFormat, FormatUtil } from '@util/format';
 
 describe('defaultFormat', () => {
   it('shortens a computed share to something a screen reader can speak', () => {
-    // The value from issue #720: 120 of 210, under `barnorm: 'percent'`.
+    // 120 of 210 under `barnorm: 'percent'` — the chart from #720, whose fix
+    // made these shares announceable at all and left them at full precision.
     expect(defaultFormat(57.14285714285714)).toBe('57.14');
     expect(defaultFormat(42.857142857142854)).toBe('42.86');
+  });
+
+  it('drops the decimal point when rounding reaches a whole number', () => {
+    // Nothing is padded, so a computed value can come out looking like one
+    // that was read verbatim.
+    expect(defaultFormat(99.999)).toBe('100');
+    expect(defaultFormat(0.004)).toBe('0.004');
   });
 
   it('leaves an integer exactly as it was', () => {
@@ -33,9 +41,12 @@ describe('defaultFormat', () => {
     expect(defaultFormat('57.14285714285714')).toBe('57.14285714285714');
   });
 
-  it('leaves non-finite numbers to the missing-value wrapper', () => {
+  it('does not attempt to round a non-finite number', () => {
+    // Only NaN goes on to be rendered as `missing` by wrapFormat; Infinity is
+    // announced as-is, which is pre-existing behaviour this does not change.
     expect(defaultFormat(Number.NaN)).toBe('NaN');
     expect(defaultFormat(Number.POSITIVE_INFINITY)).toBe('Infinity');
+    expect(FormatUtil.wrapFormat(defaultFormat)(Number.POSITIVE_INFINITY)).toBe('Infinity');
   });
 
   it('is still overridden by an explicit axis format', () => {

--- a/test/util/format.test.ts
+++ b/test/util/format.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from '@jest/globals';
+import { defaultFormat, FormatUtil } from '@util/format';
+
+describe('defaultFormat', () => {
+  it('shortens a computed share to something a screen reader can speak', () => {
+    // The value from issue #720: 120 of 210, under `barnorm: 'percent'`.
+    expect(defaultFormat(57.14285714285714)).toBe('57.14');
+    expect(defaultFormat(42.857142857142854)).toBe('42.86');
+  });
+
+  it('leaves an integer exactly as it was', () => {
+    expect(defaultFormat(120)).toBe('120');
+    expect(defaultFormat(0)).toBe('0');
+    expect(defaultFormat(-40)).toBe('-40');
+  });
+
+  it('does not pad a value that is already short', () => {
+    expect(defaultFormat(0.5)).toBe('0.5');
+    expect(defaultFormat(2.25)).toBe('2.25');
+    expect(defaultFormat(-1.5)).toBe('-1.5');
+  });
+
+  it('keeps a small value visible rather than rounding it away', () => {
+    // Two decimals would announce each of these as `0`, which is not what the
+    // chart shows.
+    expect(defaultFormat(0.000123456)).toBe('0.000123');
+    expect(defaultFormat(0.0004)).toBe('0.0004');
+    expect(defaultFormat(-0.000987654)).toBe('-0.000988');
+  });
+
+  it('passes strings through untouched', () => {
+    expect(defaultFormat('Q1')).toBe('Q1');
+    expect(defaultFormat('57.14285714285714')).toBe('57.14285714285714');
+  });
+
+  it('leaves non-finite numbers to the missing-value wrapper', () => {
+    expect(defaultFormat(Number.NaN)).toBe('NaN');
+    expect(defaultFormat(Number.POSITIVE_INFINITY)).toBe('Infinity');
+  });
+
+  it('is still overridden by an explicit axis format', () => {
+    const fixed = FormatUtil.resolveFormat({ type: 'fixed', decimals: 4 });
+    const percent = FormatUtil.resolveFormat({ type: 'percent', decimals: 1 });
+
+    expect(fixed(57.14285714285714)).toBe('57.1429');
+    expect(percent(0.5714285714285714)).toBe('57.1%');
+  });
+
+  it('renders a missing value as missing once wrapped, not as a number', () => {
+    const wrapped = FormatUtil.wrapFormat(defaultFormat);
+
+    expect(wrapped(Number.NaN)).toBe('missing');
+    expect(wrapped(57.14285714285714)).toBe('57.14');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

A value MAIDR computes rather than reads verbatim is announced at full float precision. A `barnorm` share came out as:

```
Quarter is Q1, Share is 57.14285714285714, Level is East
```

Sixteen digits spoken aloud for two digits of meaning.

`defaultFormat` was `` `${value}` ``, so any value without an explicit `AxisFormat` reached the screen reader exactly as JavaScript stringifies it. Every adapter that derives a percentage rather than reading one has the same exposure — plotly's `barnorm`, highcharts' `p.percentage`, the amcharts and vega-lite normalized paths — which is why the default belongs here rather than in any one of them.

## Related Issues

Fixes #725

## Changes Made

`src/util/format.ts` — `defaultFormat` now rounds a fractional number to two decimal places.

- **Two places** matches what the Go To Extrema dialog already displays (`src/ui/components/GoToExtrema.tsx` uses `toFixed(2)`), so the two surfaces agree rather than each picking their own precision.
- **Integers and strings are untouched.** `120` stays `120`, `Q1` stays `Q1` — no trailing `.00` appears where nothing was fractional.
- **Nothing is padded.** `0.5` stays `0.5`, not `0.50`, because the result is re-parsed as a number rather than left as a `toFixed` string. A value that rounds up to a whole number therefore reads as one: `99.999` becomes `100`.
- **A small value is not rounded away.** `0.000123456` would become `0` at two places, which is a different claim about the chart than the truth. Those fall back to three significant digits — `0.000123`. Below ~1e-6 that returns an exponent, but so does plain stringification, so nothing changes notation because of this.
- **Non-finite values skip rounding**, leaving `NaN` for `FormatUtil.wrapFormat` to render as `missing`. `Infinity` is announced as `Infinity`, unchanged — `wrapFormat` maps only `NaN`.

An explicit `AxisFormat` still takes priority, so an author who needs four decimals or a currency still gets exactly that. `defaultFormat`'s identity as an export is preserved.

`e2e_tests/specs/histogram.spec.ts` builds its expected announcement through `defaultFormat` rather than stringifying the raw datum, since the iris bin edges carry float artefacts (`1.5900000000000003`) that are now announced as `1.59`. Importing the real formatter rather than copying its rounding keeps the expectation tied to the app's contract.

## Screenshots (if applicable)

Not applicable — this changes spoken text, quoted below.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Rounding stops at the announcement.** Sonification, braille, and extrema navigation all read the underlying numbers from the model, not the formatted string — `AbstractBarPlot.audio` uses `barValues`, `braille` uses `values`/`min`/`max`. So a bar's pitch and its braille cell are unchanged by this; only the spoken text is shorter. Rounding the extracted data instead would have changed all four modalities, which is why this sits in the formatting layer.

**Verified end to end** on the issue's own chart, driving the built bundle by keyboard and reading the `role="alert"` region:

```
before   Quarter is Q1, Share is 57.14285714285714, Level is East
after    Quarter is Q1, Share is 57.14, Level is East
```

**Fourteen unit tests**, across two files that had no coverage before:

- `test/util/format.test.ts` — the shortening, untouched integers and strings, no padding, whole-number rounding, the small-value fallback and its exponent, an explicit `AxisFormat` still winning, and the `missing` wrapper.
- `test/service/formatter.test.ts` — the same behaviour through `FormatterService`'s resolve → wrap → apply chain, which is the path every chart actually takes: the default on an unformatted axis, an explicit format winning while its sibling axis keeps the default, arrays as boxplot outliers arrive, a missing value, and an unknown layer falling back.

**On the choice of two decimals.** There is no way at this layer to tell deliberate precision from computed noise, so this is a default rather than a detection, and it reaches beyond the `barnorm` case in #725: any axis without an explicit `AxisFormat` now has its spoken value rounded, including data whose precision is deliberate. Two places is the same answer the extrema dialog already gives, and the `AxisFormat` escape hatch already exists for anything else — that is what it is for.

**Known, pre-existing, not changed here:** `FormatterService.hasCustomFormatter` compares `layerFormatters[axis] !== defaultFormat`, but `resolveAxisFormat` always stores a fresh `wrapFormat(...)` closure, so it returns `true` for every layer it knows about — measured, not inferred. Both `goToExtremaViewModel` call sites that gate on it therefore run values through the formatter regardless, despite comments saying otherwise. Benign here (extrema labels get the same two decimals as the announcement) but the gate does not do what it says. Worth its own issue rather than a drive-by fix inside a formatting change.

`toFixed`'s binary-rounding quirk (`1.005` → `1`) is inherited, not introduced — `GoToExtrema.tsx` already carries the same exposure, and diverging here would make the two surfaces disagree.

Verified locally: `npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (1405 unit + 57 esm, all passing), plus the histogram e2e spec against a matching build (23/23).