### PR TITLE
fix(bar): keep a gap in bar data out of pitch, braille, and extrema

### DIFF
--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -20,14 +20,18 @@ import { MovableGrid } from './movable';
  * that every other bar's pitch is scaled against. `NaN` keeps it absent, which
  * is what the text layer already announces it as.
  *
- * An empty string counts as a gap for the same reason: `Number('')` is also
- * `0`, so a hand-authored figure with a blank cell would land in the same trap.
+ * A blank cell counts as a gap for the same reason: `Number('')` and
+ * `Number('  ')` are also `0`, so a hand-authored figure with an empty cell
+ * would land in the same trap.
  *
  * @param raw - The value from the point, on whichever axis carries magnitude
  * @returns The magnitude, or `NaN` when the bar is a gap
  */
 function toBarValue(raw: string | number | null | undefined): number {
-  if (raw === null || raw === undefined || raw === '') {
+  if (raw === null || raw === undefined) {
+    return Number.NaN;
+  }
+  if (typeof raw === 'string' && raw.trim() === '') {
     return Number.NaN;
   }
   return Number(raw);

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -145,20 +145,36 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
   }
 
   /**
+   * The chart's min and max description stats.
+   *
+   * A chart of nothing but gaps has no range at all, and `safeMin`/`safeMax`
+   * answer an empty set with positive and negative Infinity. Report that the
+   * way every other modality reports an absent value rather than announcing an
+   * infinity.
+   *
+   * Shared so `SegmentedTrace`, which replaces the whole stats block rather
+   * than extending it, cannot drift back to announcing an infinity.
+   *
+   * @returns The min and max stats, in that order
+   */
+  protected rangeStats(): DescriptionState['stats'] {
+    const chartMin = MathUtil.safeMin(this.min);
+    const chartMax = MathUtil.safeMax(this.max);
+    return [
+      { label: 'Min value', value: isMeasured(chartMin) ? chartMin : 'missing' },
+      { label: 'Max value', value: isMeasured(chartMax) ? chartMax : 'missing' },
+    ];
+  }
+
+  /**
    * Gets the description state for the bar plot trace.
    * @returns The description state containing chart metadata and data table
    */
   public get description(): DescriptionState {
     const isVertical = this.orientation === Orientation.VERTICAL;
-    // A chart of nothing but gaps has no range at all, and safeMin/safeMax
-    // answer an empty set with ±Infinity. Report it the way every other
-    // modality reports an absent value rather than announcing an infinity.
-    const chartMin = MathUtil.safeMin(this.min);
-    const chartMax = MathUtil.safeMax(this.max);
     const stats: DescriptionState['stats'] = [
       { label: 'Number of bars', value: this.points[0].length },
-      { label: 'Min value', value: isMeasured(chartMin) ? chartMin : 'missing' },
-      { label: 'Max value', value: isMeasured(chartMax) ? chartMax : 'missing' },
+      ...this.rangeStats(),
     ];
 
     if (this.points.length > 1) {

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -20,6 +20,9 @@ import { MovableGrid } from './movable';
  * that every other bar's pitch is scaled against. `NaN` keeps it absent, which
  * is what the text layer already announces it as.
  *
+ * An empty string counts as a gap for the same reason: `Number('')` is also
+ * `0`, so a hand-authored figure with a blank cell would land in the same trap.
+ *
  * @param raw - The value from the point, on whichever axis carries magnitude
  * @returns The magnitude, or `NaN` when the bar is a gap
  */
@@ -147,10 +150,15 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
    */
   public get description(): DescriptionState {
     const isVertical = this.orientation === Orientation.VERTICAL;
+    // A chart of nothing but gaps has no range at all, and safeMin/safeMax
+    // answer an empty set with ±Infinity. Report it the way every other
+    // modality reports an absent value rather than announcing an infinity.
+    const chartMin = MathUtil.safeMin(this.min);
+    const chartMax = MathUtil.safeMax(this.max);
     const stats: DescriptionState['stats'] = [
       { label: 'Number of bars', value: this.points[0].length },
-      { label: 'Min value', value: MathUtil.safeMin(this.min) },
-      { label: 'Max value', value: MathUtil.safeMax(this.max) },
+      { label: 'Min value', value: isMeasured(chartMin) ? chartMin : 'missing' },
+      { label: 'Max value', value: isMeasured(chartMax) ? chartMax : 'missing' },
     ];
 
     if (this.points.length > 1) {

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -9,6 +9,37 @@ import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
 import { MovableGrid } from './movable';
 
+/**
+ * Reads one bar's magnitude, keeping a gap distinguishable from a zero.
+ *
+ * A chart library reports a missing bar as `null` — plotly renders a
+ * zero-height rect and keeps the point, so the gap arrives here rather than
+ * being dropped. `Number(null)` is `0`, which makes an absent bar
+ * indistinguishable from one genuinely measured at zero: it sounds like a real
+ * low point, it can be reached as the row's minimum, and it pulls the range
+ * that every other bar's pitch is scaled against. `NaN` keeps it absent, which
+ * is what the text layer already announces it as.
+ *
+ * @param raw - The value from the point, on whichever axis carries magnitude
+ * @returns The magnitude, or `NaN` when the bar is a gap
+ */
+function toBarValue(raw: string | number | null | undefined): number {
+  if (raw === null || raw === undefined || raw === '') {
+    return Number.NaN;
+  }
+  return Number(raw);
+}
+
+/**
+ * Reports whether a bar value is a real measurement rather than a gap.
+ *
+ * @param value - A magnitude from `barValues`
+ * @returns True when the value can take part in a range or a comparison
+ */
+function isMeasured(value: number): boolean {
+  return Number.isFinite(value);
+}
+
 export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace {
   protected readonly movable: Movable;
 
@@ -29,13 +60,15 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
 
     this.barValues = points.map(row =>
       row.map(point =>
-        this.orientation === Orientation.VERTICAL
-          ? Number(point.y)
-          : Number(point.x),
+        toBarValue(
+          this.orientation === Orientation.VERTICAL ? point.y : point.x,
+        ),
       ),
     );
-    this.min = this.barValues.map(row => MathUtil.safeMin(row));
-    this.max = this.barValues.map(row => MathUtil.safeMax(row));
+    // A gap is not a measurement, so it must not set the row's range. Left in,
+    // it drags the minimum to 0 and every other bar's pitch along with it.
+    this.min = this.barValues.map(row => MathUtil.safeMin(row.filter(isMeasured)));
+    this.max = this.barValues.map(row => MathUtil.safeMax(row.filter(isMeasured)));
     this.highlightValues = this.mapToSvgElements(layer.selectors as string);
     this.movable = new MovableGrid<T>(this.points);
   }

--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -33,10 +33,13 @@ function toBarValue(raw: string | number | null | undefined): number {
 /**
  * Reports whether a bar value is a real measurement rather than a gap.
  *
+ * Exported for `SegmentedTrace`, which builds a summary row from these values
+ * and has to keep gaps out of it for the same reason.
+ *
  * @param value - A magnitude from `barValues`
  * @returns True when the value can take part in a range or a comparison
  */
-function isMeasured(value: number): boolean {
+export function isMeasured(value: number): boolean {
   return Number.isFinite(value);
 }
 
@@ -398,6 +401,13 @@ export class BarTrace extends AbstractBarPlot<BarPoint> {
     // Use pre-computed min/max values instead of recalculating
     const groupMin = this.min[currentGroup];
     const groupMax = this.max[currentGroup];
+
+    // A row of nothing but gaps leaves the range empty, so safeMin/safeMax
+    // return ±Infinity, which indexOf cannot find. There is no extreme to
+    // navigate to; offering one would move the cursor to column -1.
+    if (!isMeasured(groupMin) || !isMeasured(groupMax)) {
+      return targets;
+    }
 
     // Find indices of min/max values
     const maxIndex = groupValues.indexOf(groupMax);

--- a/src/model/histogram.ts
+++ b/src/model/histogram.ts
@@ -1,7 +1,6 @@
 import type { HistogramPoint, MaidrLayer } from '@type/grammar';
 import type { DescriptionState, TextState } from '@type/state';
 import { Orientation } from '@type/grammar';
-import { MathUtil } from '@util/math';
 import { AbstractBarPlot } from './bar';
 
 export class Histogram extends AbstractBarPlot<HistogramPoint> {
@@ -25,8 +24,7 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
 
     const stats: DescriptionState['stats'] = [
       { label: 'Number of bins', value: points.length },
-      { label: 'Min value', value: MathUtil.safeMin(this.min) },
-      { label: 'Max value', value: MathUtil.safeMax(this.max) },
+      ...this.rangeStats(),
       { label: 'Bin range', value: `${binRangeMin} to ${binRangeMax}` },
     ];
 

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -9,6 +9,22 @@ import { AbstractBarPlot, isMeasured } from './bar';
 const SUM = 'Sum';
 const UNDEFINED = 'undefined';
 
+/**
+ * Whether a cell is one the chart library may have left out of the DOM.
+ *
+ * The `skipZeros` alignment below counts a gap as a zero, which is what it did
+ * before gaps became `NaN` — `Number(null)` was `0`, so both matched the same
+ * check. Keeping that reading is deliberate: this path decides which rendered
+ * element belongs to which datum, not what a value means, and treating a gap
+ * differently here would shift every later highlight in the row by one.
+ *
+ * @param value - A magnitude from `barValues`
+ * @returns True when the cell may have no element of its own
+ */
+function isDomOmittable(value: number): boolean {
+  return value === 0 || !isMeasured(value);
+}
+
 export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
   public constructor(layer: MaidrLayer) {
     super(layer, layer.data as SegmentedPoint[][]);
@@ -225,8 +241,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
 
     const stats: DescriptionState['stats'] = [
       { label: 'Number of bars', value: this.points[0].length },
-      { label: 'Min value', value: MathUtil.safeMin(this.min) },
-      { label: 'Max value', value: MathUtil.safeMax(this.max) },
+      ...this.rangeStats(),
       { label: 'Number of groups', value: dataPoints.length },
       { label: `${this.z} categories`, value: zCategories.join(', ') },
     ];
@@ -316,7 +331,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
         // no `domMapping` hint is supplied by an adapter.
         for (let r = 0, domIndex = 0; r < this.barValues.length; r++) {
           for (let c = 0; c < this.barValues[r].length; c++) {
-            if (skipZeros && this.barValues[r][c] === 0) {
+            if (skipZeros && isDomOmittable(this.barValues[r][c])) {
               svgElements[r].push(Svg.createEmptyElement());
             } else if (domIndex >= domElements.length) {
               svgElements[r].push(Svg.createEmptyElement());
@@ -334,7 +349,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
         for (let c = 0, domIndex = 0; c < this.barValues[0].length; c++) {
           if (isForward) {
             for (let r = 0; r < this.barValues.length; r++) {
-              if (skipZeros && this.barValues[r][c] === 0) {
+              if (skipZeros && isDomOmittable(this.barValues[r][c])) {
                 svgElements[r].push(Svg.createEmptyElement());
               } else if (domIndex >= domElements.length) {
                 svgElements[r].push(Svg.createEmptyElement());
@@ -344,7 +359,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
             }
           } else {
             for (let r = this.barValues.length - 1; r >= 0; r--) {
-              if (skipZeros && this.barValues[r][c] === 0) {
+              if (skipZeros && isDomOmittable(this.barValues[r][c])) {
                 svgElements[r].push(Svg.createEmptyElement());
               } else if (domIndex >= domElements.length) {
                 svgElements[r].push(Svg.createEmptyElement());
@@ -376,7 +391,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
             continue;
           }
           for (let c = 0; c < this.barValues[r].length; c++) {
-            if (skipZeros && this.barValues[r][c] === 0) {
+            if (skipZeros && isDomOmittable(this.barValues[r][c])) {
               svgElements[r].push(Svg.createEmptyElement());
             } else if (domIndex >= domElements.length) {
               // Fill with empty element instead of returning empty array
@@ -394,7 +409,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
         for (let c = 0, domIndex = 0; c < this.barValues[0].length; c++) {
           if (isForward) {
             for (let r = 0; r < this.barValues.length; r++) {
-              if (skipZeros && this.barValues[r][c] === 0) {
+              if (skipZeros && isDomOmittable(this.barValues[r][c])) {
                 svgElements[r].push(Svg.createEmptyElement());
               } else if (domIndex >= domElements.length) {
                 // Fill with empty element instead of returning empty array
@@ -405,7 +420,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
             }
           } else {
             for (let r = this.barValues.length - 1; r >= 0; r--) {
-              if (skipZeros && this.barValues[r][c] === 0) {
+              if (skipZeros && isDomOmittable(this.barValues[r][c])) {
                 svgElements[r].push(Svg.createEmptyElement());
               } else if (domIndex >= domElements.length) {
                 // Fill with empty element instead of returning empty array

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -4,7 +4,7 @@ import type { DescriptionState, HighlightState, TextState } from '@type/state';
 import { Orientation } from '@type/grammar';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
-import { AbstractBarPlot } from './bar';
+import { AbstractBarPlot, isMeasured } from './bar';
 
 const SUM = 'Sum';
 const UNDEFINED = 'undefined';
@@ -19,7 +19,14 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     const summaryValues = new Array<number>();
     const summaryPoints = new Array<SegmentedPoint>();
     for (let i = 0; i < this.barValues[0].length; i++) {
-      const sum = this.barValues.reduce((sum, row) => sum + row[i], 0);
+      // Sum the measured segments only. Adding a gap in would make the total
+      // NaN, and NaN spreads: it would seed MathUtil.minMax below and, through
+      // safeMin/safeMax over every row, hand the whole chart a NaN pitch range.
+      // A category is only a gap in the total when every segment in it is one.
+      const segments = this.barValues.map(row => row[i]).filter(isMeasured);
+      const sum = segments.length > 0
+        ? segments.reduce((total, value) => total + value, 0)
+        : Number.NaN;
       summaryValues.push(sum);
 
       const point = this.orientation === Orientation.VERTICAL
@@ -38,7 +45,9 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     this.points.push(summaryPoints);
     this.barValues.push(summaryValues);
 
-    const { min: summaryMin, max: summaryMax } = MathUtil.minMax(summaryValues);
+    const { min: summaryMin, max: summaryMax } = MathUtil.minMax(
+      summaryValues.filter(isMeasured),
+    );
     this.min.push(summaryMin);
     this.max.push(summaryMax);
   }
@@ -62,6 +71,13 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     const groupValues = this.barValues[currentGroup];
 
     if (!groupValues || groupValues.length === 0) {
+      return targets;
+    }
+
+    // A row of nothing but gaps leaves the range empty, so safeMin/safeMax
+    // return ±Infinity, which indexOf cannot find. There is no extreme to
+    // navigate to; offering one would move the cursor to column -1.
+    if (!isMeasured(groupMin) || !isMeasured(groupMax)) {
       return targets;
     }
 

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -258,6 +258,15 @@ export class AudioService implements Observer<PlotState>, Disposable {
 
     const audio = state.audio;
 
+    // A gap carries no magnitude to pitch. Interpolating it would hand the
+    // oscillator a non-finite frequency, so sound it the way an out-of-bounds
+    // move already sounds — the point exists to navigate to, it just has no
+    // value, which is what the text layer announces as "missing".
+    if (typeof audio.freq.raw === 'number' && !Number.isFinite(audio.freq.raw)) {
+      this.playEmptyTone(audio.panning);
+      return;
+    }
+
     // Resolve palette entry from group index or candlestick trend
     let groupIndex = audio.group;
     if (audio.trend && groupIndex === undefined) {

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -262,6 +262,10 @@ export class AudioService implements Observer<PlotState>, Disposable {
     // oscillator a non-finite frequency, so sound it the way an out-of-bounds
     // move already sounds — the point exists to navigate to, it just has no
     // value, which is what the text layer announces as "missing".
+    //
+    // Deliberately not scoped to bar traces: bars are where a gap reaches this
+    // today, but a non-finite magnitude from any trace would be just as
+    // unplayable, and this service has no business knowing which type sent it.
     if (typeof audio.freq.raw === 'number' && !Number.isFinite(audio.freq.raw)) {
       this.playEmptyTone(audio.panning);
       return;

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -404,7 +404,11 @@ class BarBrailleEncoder implements BrailleEncoder<BarBrailleState> {
         // ⠤ (25-50%), ⠒ (50-75%), ⠉ (75-100%). The lowest band uses the
         // dots-7-8 bottom glyph so it is distinguishable on a braille display
         // from the second band rather than collapsing into three levels.
-        if (value === 0)
+        //
+        // A gap arrives as NaN, which loses every comparison below and would
+        // otherwise fall through to the tallest glyph — a missing bar drawn as
+        // the highest one. It reads as blank, as a zero does.
+        if (value === 0 || !Number.isFinite(value))
           return ' ';
         if (value <= low)
           return '⣀';

--- a/test/model/barGaps.test.ts
+++ b/test/model/barGaps.test.ts
@@ -1,9 +1,10 @@
 import type { MaidrLayer } from '@type/grammar';
 import type { BarBrailleState, TraceState } from '@type/state';
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 import { BarTrace } from '@model/bar';
 import { SegmentedTrace } from '@model/segmented';
 import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
 
 /**
  * Builds a single-series bar layer. A gap is passed as `null`, which is how a
@@ -129,6 +130,86 @@ function stackedLayer(east: (number | null)[], west: (number | null)[]): MaidrLa
   };
 }
 
+describe('segmented bar gap DOM alignment', () => {
+  /**
+   * Provisions the globals `Svg.selectAllElements` and the rect branch of
+   * `mapToSvgElements` reach for, mirroring test/model/heatmap.test.ts.
+   */
+  function installDom(html: string): void {
+    const dom = new JSDOM(html);
+    const g = globalThis as unknown as Record<string, unknown>;
+    g.document = dom.window.document;
+    g.SVGElement = dom.window.SVGElement;
+    g.SVGRectElement = dom.window.SVGRectElement ?? dom.window.SVGElement;
+    g.SVGPathElement = dom.window.SVGPathElement ?? class SVGPathElementStub {};
+  }
+
+  function uninstallDom(): void {
+    const g = globalThis as unknown as Record<string, unknown>;
+    delete g.document;
+    delete g.SVGElement;
+    delete g.SVGRectElement;
+    delete g.SVGPathElement;
+  }
+
+  afterEach(() => {
+    uninstallDom();
+  });
+
+  const FIVE_RECTS = `<!doctype html><svg xmlns="http://www.w3.org/2000/svg">${
+    ['e0', 'e1', 'e2', 'e3', 'e4']
+      .map(id => `<rect class="bar" id="${id}"/>`)
+      .join('')
+  }</svg>`;
+
+  /**
+   * Reads the id of the rect the trace would highlight at a position.
+   * @param values - Two series of three categories
+   * @param row - Series index
+   * @param col - Category index
+   * @returns The rect's id, or undefined when the cell has no rendered element
+   */
+  function highlightedIdAt(
+    values: [(number | null)[], (number | null)[]],
+    row: number,
+    col: number,
+  ): string | undefined {
+    // A fresh document per call: selecting elements inserts hidden clones, so
+    // a second trace built against the same DOM would see more rects than the
+    // chart has.
+    installDom(FIVE_RECTS);
+
+    const layer = stackedLayer(values[0], values[1]);
+    layer.selectors = 'rect.bar';
+    const trace = new SegmentedTrace(layer);
+
+    trace.moveToIndex(row, col);
+    const highlight = stateOf(trace).highlight as { empty?: boolean; elements?: SVGElement };
+    return (highlight.elements as unknown as Element | undefined)?.id || undefined;
+  }
+
+  it('lets a gap stand in for an omitted element rather than consuming a real one', () => {
+    // Six data cells but five rendered rects, so `skipZeros` is on: the chart
+    // library left one element out. The default DOM order walks each category
+    // through the series in reverse, so with the gap standing aside the row
+    // reads West e0, East e1 | West e2, East gap | West e3, East e4.
+    //
+    // Were the gap to take a rect instead, it would consume e3 and East at Q3
+    // would run past the end of the list — the cell the user is on would
+    // highlight nothing at all.
+    expect(highlightedIdAt([[120, null, 60], [90, 70, 20]], 0, 2)).toBe('e4');
+  });
+
+  it('aligns a gap exactly as a real zero does', () => {
+    // The two must agree: this path is about which rects exist, not about what
+    // a value means, and a zero has always been read as possibly-omitted.
+    const withGap = highlightedIdAt([[120, null, 60], [90, 70, 20]], 0, 2);
+    const withZero = highlightedIdAt([[120, 0, 60], [90, 70, 20]], 0, 2);
+
+    expect(withGap).toBe(withZero);
+  });
+});
+
 describe('segmented bar gaps', () => {
   it('keeps a gapped segment from turning the whole chart\'s pitch range to NaN', () => {
     // The Total row sums each category. Adding a gap straight in makes that
@@ -162,6 +243,17 @@ describe('segmented bar gaps', () => {
 
     expect(Number.isFinite(totals?.[0] as number)).toBe(false);
     expect(totals?.[1]).toBe(150);
+  });
+
+  it('describes a stack of nothing but gaps as missing, not as an infinity', () => {
+    // SegmentedTrace replaces the whole stats block rather than extending it,
+    // so the guard has to be shared or this drifts back on its own.
+    const trace = new SegmentedTrace(stackedLayer([null, null], [null, null]));
+
+    const stats = trace.description.stats;
+
+    expect(stats.find(stat => stat.label === 'Min value')?.value).toBe('missing');
+    expect(stats.find(stat => stat.label === 'Max value')?.value).toBe('missing');
   });
 
   it('leaves a stack with no gaps totalling exactly as before', () => {

--- a/test/model/barGaps.test.ts
+++ b/test/model/barGaps.test.ts
@@ -245,6 +245,29 @@ describe('segmented bar gaps', () => {
     expect(totals?.[1]).toBe(150);
   });
 
+  it('announces the Total of an all-gap category as absent, not as a number', () => {
+    // The Total row is navigable, and its point carries the computed sum
+    // rather than a raw null. A non-finite sum is what routes it through
+    // FormatUtil.wrapFormat's missing-value path, the same way a null does —
+    // confirmed in a browser, where this cell reads "Revenue is missing".
+    const trace = new SegmentedTrace(stackedLayer([null, 80], [null, 70]));
+
+    // Last row is the Total; first column is the all-gap category.
+    trace.moveToIndex(2, 0);
+    const { text } = stateOf(trace);
+
+    expect(Number.isFinite(text.cross?.value as number)).toBe(false);
+  });
+
+  it('announces a Total that does have measured segments as its sum', () => {
+    const trace = new SegmentedTrace(stackedLayer([null, 80], [90, 70]));
+
+    trace.moveToIndex(2, 0);
+    const { text } = stateOf(trace);
+
+    expect(text.cross?.value).toBe(90);
+  });
+
   it('describes a stack of nothing but gaps as missing, not as an infinity', () => {
     // SegmentedTrace replaces the whole stats block rather than extending it,
     // so the guard has to be shared or this drifts back on its own.

--- a/test/model/barGaps.test.ts
+++ b/test/model/barGaps.test.ts
@@ -2,6 +2,7 @@ import type { MaidrLayer } from '@type/grammar';
 import type { BarBrailleState, TraceState } from '@type/state';
 import { describe, expect, it } from '@jest/globals';
 import { BarTrace } from '@model/bar';
+import { SegmentedTrace } from '@model/segmented';
 import { TraceType } from '@type/grammar';
 
 /**
@@ -19,7 +20,7 @@ function barLayer(values: (number | null)[]): MaidrLayer {
 }
 
 /** Narrows the trace state union to the populated case. */
-function stateOf(trace: BarTrace): Extract<TraceState, { empty: false }> {
+function stateOf(trace: BarTrace | SegmentedTrace): Extract<TraceState, { empty: false }> {
   const state = trace.state;
   if (state.empty || state.type !== 'trace') {
     throw new Error('expected a populated trace state');
@@ -80,5 +81,75 @@ describe('bar plot gaps', () => {
 
     const min = targets.find(target => target.label.toLowerCase().includes('min'));
     expect(min?.value).toBe(40);
+  });
+
+  it('offers no extreme for a row that is entirely gaps', () => {
+    // The range is empty, so safeMin/safeMax return ±Infinity, which indexOf
+    // cannot find — the target would have carried pointIndex -1 and moved the
+    // cursor off the row.
+    const trace = new BarTrace(barLayer([null, null]));
+
+    expect(trace.getExtremaTargets()).toEqual([]);
+  });
+});
+
+/**
+ * Builds a two-series stacked layer. `SegmentedTrace` appends a Total row
+ * summing the series, which is where a gap has the furthest to spread.
+ */
+function stackedLayer(east: (number | null)[], west: (number | null)[]): MaidrLayer {
+  const series = (values: (number | null)[], name: string): { x: string; y: number; z: string }[] =>
+    values.map((y, index) => ({ x: `Q${index + 1}`, y: y as number, z: name }));
+
+  return {
+    id: 'stack',
+    type: TraceType.STACKED,
+    axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+    data: [series(east, 'East'), series(west, 'West')],
+  };
+}
+
+describe('segmented bar gaps', () => {
+  it('keeps a gapped segment from turning the whole chart\'s pitch range to NaN', () => {
+    // The Total row sums each category. Adding a gap straight in makes that
+    // sum NaN, which seeds MathUtil.minMax and then spreads through
+    // safeMin/safeMax over every row — so a single missing segment handed the
+    // oscillator a NaN frequency for every real bar on the chart.
+    const trace = new SegmentedTrace(stackedLayer([null, 80], [90, 70]));
+
+    const state = stateOf(trace);
+
+    expect(Number.isFinite(state.audio.freq.min)).toBe(true);
+    expect(Number.isFinite(state.audio.freq.max)).toBe(true);
+  });
+
+  it('totals the measured segments of a category with a gap', () => {
+    const trace = new SegmentedTrace(stackedLayer([null, 80], [90, 70]));
+
+    const { braille } = stateOf(trace);
+    const totals = (braille as BarBrailleState).values.at(-1);
+
+    // Q1 has one real segment (90) and one gap; Q2 has both.
+    expect(totals?.[0]).toBe(90);
+    expect(totals?.[1]).toBe(150);
+  });
+
+  it('leaves a category with no measured segment as a gap in the total', () => {
+    const trace = new SegmentedTrace(stackedLayer([null, 80], [null, 70]));
+
+    const { braille } = stateOf(trace);
+    const totals = (braille as BarBrailleState).values.at(-1);
+
+    expect(Number.isFinite(totals?.[0] as number)).toBe(false);
+    expect(totals?.[1]).toBe(150);
+  });
+
+  it('leaves a stack with no gaps totalling exactly as before', () => {
+    const trace = new SegmentedTrace(stackedLayer([120, 80], [90, 70]));
+
+    const { braille } = stateOf(trace);
+    const totals = (braille as BarBrailleState).values.at(-1);
+
+    expect(totals).toEqual([210, 150]);
   });
 });

--- a/test/model/barGaps.test.ts
+++ b/test/model/barGaps.test.ts
@@ -2,6 +2,7 @@ import type { MaidrLayer } from '@type/grammar';
 import type { BarBrailleState, TraceState } from '@type/state';
 import { afterEach, describe, expect, it } from '@jest/globals';
 import { BarTrace } from '@model/bar';
+import { Histogram } from '@model/histogram';
 import { SegmentedTrace } from '@model/segmented';
 import { TraceType } from '@type/grammar';
 import { JSDOM } from 'jsdom';
@@ -93,6 +94,16 @@ describe('bar plot gaps', () => {
     expect(audio.freq.max).toBe(120);
   });
 
+  it('treats a whitespace-only cell as blank too', () => {
+    // Number('  ') is 0 as surely as Number('') is.
+    const trace = new BarTrace(barLayer([120, '  ' as unknown as number, 40]));
+
+    const { audio } = stateOf(trace);
+
+    expect(audio.freq.min).toBe(40);
+    expect(audio.freq.max).toBe(120);
+  });
+
   it('describes a chart of nothing but gaps as missing, not as an infinity', () => {
     // safeMin/safeMax answer an empty set with ±Infinity, which is not
     // something to read out as a chart's minimum.
@@ -111,6 +122,46 @@ describe('bar plot gaps', () => {
     const trace = new BarTrace(barLayer([null, null]));
 
     expect(trace.getExtremaTargets()).toEqual([]);
+  });
+});
+
+describe('histogram gaps', () => {
+  it('describes a histogram of nothing but gaps as missing, not as an infinity', () => {
+    // Histogram is the third AbstractBarPlot subclass and overrides
+    // `description` too. Plotly's precomputed bin counts mean a gap is not
+    // reachable here today, but the guard is shared precisely so the next
+    // subclass to override the stats block cannot quietly reintroduce it.
+    const layer: MaidrLayer = {
+      id: 'bins',
+      type: TraceType.HISTOGRAM,
+      axes: { x: { label: 'Petal Length' }, y: { label: 'Frequency' } },
+      data: [
+        { x: 1, y: null as unknown as number, xMin: 0, xMax: 2, yMin: 0, yMax: 0 },
+        { x: 3, y: null as unknown as number, xMin: 2, xMax: 4, yMin: 0, yMax: 0 },
+      ],
+    };
+
+    const stats = new Histogram(layer).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Min value')?.value).toBe('missing');
+    expect(stats.find(stat => stat.label === 'Max value')?.value).toBe('missing');
+  });
+
+  it('still reports a real range for ordinary bin counts', () => {
+    const layer: MaidrLayer = {
+      id: 'bins',
+      type: TraceType.HISTOGRAM,
+      axes: { x: { label: 'Petal Length' }, y: { label: 'Frequency' } },
+      data: [
+        { x: 1, y: 4, xMin: 0, xMax: 2, yMin: 0, yMax: 4 },
+        { x: 3, y: 33, xMin: 2, xMax: 4, yMin: 0, yMax: 33 },
+      ],
+    };
+
+    const stats = new Histogram(layer).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Min value')?.value).toBe(4);
+    expect(stats.find(stat => stat.label === 'Max value')?.value).toBe(33);
   });
 });
 

--- a/test/model/barGaps.test.ts
+++ b/test/model/barGaps.test.ts
@@ -1,0 +1,84 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { BarBrailleState, TraceState } from '@type/state';
+import { describe, expect, it } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Builds a single-series bar layer. A gap is passed as `null`, which is how a
+ * chart library reports a missing bar and what the plotly adapter carries
+ * through; the grammar types the field as `number | string`, hence the cast.
+ */
+function barLayer(values: (number | null)[]): MaidrLayer {
+  return {
+    id: 'bars',
+    type: TraceType.BAR,
+    axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+    data: values.map((y, index) => ({ x: `Q${index + 1}`, y: y as number })),
+  };
+}
+
+/** Narrows the trace state union to the populated case. */
+function stateOf(trace: BarTrace): Extract<TraceState, { empty: false }> {
+  const state = trace.state;
+  if (state.empty || state.type !== 'trace') {
+    throw new Error('expected a populated trace state');
+  }
+  return state;
+}
+
+describe('bar plot gaps', () => {
+  it('keeps a gap out of the row range so it cannot drag the minimum down', () => {
+    const trace = new BarTrace(barLayer([120, null, 40]));
+
+    const { audio } = stateOf(trace);
+
+    // Without this, Number(null) puts a 0 in the row and the range becomes
+    // 0..120 — every other bar's pitch is scaled against a bar that is not
+    // on the chart.
+    expect(audio.freq.min).toBe(40);
+    expect(audio.freq.max).toBe(120);
+  });
+
+  it('reports a gap as having no magnitude rather than as a zero', () => {
+    const trace = new BarTrace(barLayer([120, null, 40]));
+
+    trace.moveToIndex(0, 1);
+    const { audio, text } = stateOf(trace);
+
+    // A non-finite raw is what tells AudioService to sound the empty tone
+    // instead of interpolating a frequency.
+    expect(Number.isFinite(audio.freq.raw as number)).toBe(false);
+    // The text layer keeps saying "missing", which it derives from the raw
+    // point rather than from barValues.
+    expect(text.cross?.value).toBeNull();
+  });
+
+  it('still treats a bar genuinely measured at zero as a real value', () => {
+    const trace = new BarTrace(barLayer([0, 80, 40]));
+
+    const { audio } = stateOf(trace);
+
+    expect(audio.freq.min).toBe(0);
+    expect(Number.isFinite(audio.freq.raw as number)).toBe(true);
+  });
+
+  it('leaves a row of real values completely unchanged', () => {
+    const trace = new BarTrace(barLayer([120, 80, 40]));
+
+    const { audio, braille } = stateOf(trace);
+
+    expect(audio.freq.min).toBe(40);
+    expect(audio.freq.max).toBe(120);
+    expect((braille as BarBrailleState).values).toEqual([[120, 80, 40]]);
+  });
+
+  it('reaches the true extreme rather than the gap when navigating to the minimum', () => {
+    const trace = new BarTrace(barLayer([120, null, 40]));
+
+    const targets = trace.getExtremaTargets();
+
+    const min = targets.find(target => target.label.toLowerCase().includes('min'));
+    expect(min?.value).toBe(40);
+  });
+});

--- a/test/model/barGaps.test.ts
+++ b/test/model/barGaps.test.ts
@@ -83,6 +83,26 @@ describe('bar plot gaps', () => {
     expect(min?.value).toBe(40);
   });
 
+  it('treats a blank cell as a gap, since Number("") is also 0', () => {
+    const trace = new BarTrace(barLayer([120, '' as unknown as number, 40]));
+
+    const { audio } = stateOf(trace);
+
+    expect(audio.freq.min).toBe(40);
+    expect(audio.freq.max).toBe(120);
+  });
+
+  it('describes a chart of nothing but gaps as missing, not as an infinity', () => {
+    // safeMin/safeMax answer an empty set with ±Infinity, which is not
+    // something to read out as a chart's minimum.
+    const trace = new BarTrace(barLayer([null, null]));
+
+    const stats = trace.description.stats;
+
+    expect(stats.find(stat => stat.label === 'Min value')?.value).toBe('missing');
+    expect(stats.find(stat => stat.label === 'Max value')?.value).toBe('missing');
+  });
+
   it('offers no extreme for a row that is entirely gaps', () => {
     // The range is empty, so safeMin/safeMax return ±Infinity, which indexOf
     // cannot find — the target would have carried pointIndex -1 and moved the

--- a/test/service/audio.emptyTone.test.ts
+++ b/test/service/audio.emptyTone.test.ts
@@ -126,6 +126,24 @@ const INITIAL_STATE: PlotState = { empty: true, type: 'figure' };
 // An empty subplot state routes update() to the default-panning empty tone.
 const EMPTY_SUBPLOT_STATE = { empty: true, type: 'subplot' } as unknown as PlotState;
 
+/**
+ * A populated single-bar trace state carrying the given magnitude, so the
+ * pitched path and the gap path can be told apart by oscillator count.
+ * @param raw - The magnitude the bar reports
+ * @returns A non-empty trace state for update()
+ */
+function barStateWithRaw(raw: number): PlotState {
+  return {
+    empty: false,
+    type: 'trace',
+    traceType: 'bar',
+    audio: {
+      freq: { min: 40, max: 120, raw },
+      panning: { x: 0, y: 0, rows: 1, cols: 1 },
+    },
+  } as unknown as PlotState;
+}
+
 describe('AudioService empty-state tone', () => {
   it('update() with an empty state plays the five-oscillator empty tone', async () => {
     const ctx = installAudioContextMock();
@@ -230,6 +248,35 @@ describe('AudioService empty-state tone', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(ctx.oscillators.length).toBe(before + EMPTY_TONE_OSCILLATORS);
+    service.dispose();
+  });
+
+  it('sounds a bar with no magnitude as empty rather than pitching it', async () => {
+    // A gap in bar data reaches here as a non-finite raw (see
+    // AbstractBarPlot's toBarValue). Interpolating it would hand the
+    // oscillator a NaN frequency; the point still exists to navigate to, it
+    // just has no value — which is what the empty tone already means.
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.update(barStateWithRaw(Number.NaN));
+
+    expect(ctx.oscillators.length).toBe(before + EMPTY_TONE_OSCILLATORS);
+    service.dispose();
+  });
+
+  it('still pitches a bar measured at zero, which is a real value', async () => {
+    const ctx = installAudioContextMock();
+    const { AudioService } = await import('@service/audio');
+    const service = new AudioService(createNotification(), createSettings(), INITIAL_STATE);
+
+    const before = ctx.oscillators.length;
+    service.update(barStateWithRaw(0));
+
+    // One oscillator for a single pitched tone, not the five-harmonic cue.
+    expect(ctx.oscillators.length).toBe(before + 1);
     service.dispose();
   });
 });

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -88,8 +88,10 @@ function createBarTraceState(values: number[][], row: number, col: number): Trac
     row,
     col,
     values,
-    min: values.map(items => Math.min(...items)),
-    max: values.map(items => Math.max(...items)),
+    // Gaps arrive as NaN and are excluded from the range, matching what
+    // AbstractBarPlot builds.
+    min: values.map(items => Math.min(...items.filter(Number.isFinite))),
+    max: values.map(items => Math.max(...items.filter(Number.isFinite))),
   };
 
   return {
@@ -568,6 +570,28 @@ describe('BrailleService display-size encoding', () => {
     service.toggle(state);
 
     expect(emitted.endsWith('\n')).toBe(true);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('renders a gap as a blank cell rather than the tallest bar', () => {
+    const { service } = createBrailleService(8);
+    // NaN loses every band comparison, so before the guard it fell through to
+    // the 75-100% glyph — a missing bar drawn as the highest one on the chart.
+    const state = createBarTraceState([[120, Number.NaN, 40]], 0, 0);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+
+    const cells = emitted.replace(/\n/g, '');
+    expect(cells[1]).toBe(' ');
+    expect(cells[0]).toBe('⠉');
+    expect(cells[2]).toBe('⣀');
 
     disposable.dispose();
     service.dispose();


### PR DESCRIPTION
# Pull Request

## Description

A missing bar was announced correctly as `missing` and treated as a measurement of zero by every other modality. `AbstractBarPlot` built its numeric array with `Number(point.y)`, and `Number(null)` is `0`, so the gap:

- set the row's minimum, and through it the range every other bar's pitch is scaled against,
- sounded like a real bar at the bottom of the chart,
- could be reached as the row's extreme,
- and rendered in braille as the **tallest** glyph, because `0` was the only blank case and every band comparison a gap loses falls through to the top band.

The text layer knew the data was absent while the audio layer reported a real zero. The two modalities disagreed about what was on screen, and only the spoken one was right.

## Related Issues

Fixes #726

## Changes Made

**The core fix**

- **`src/model/bar.ts`** — a gap reads as `NaN` rather than `0`, via a `toBarValue` helper, and `min`/`max` are computed from finite values only. A gap is not a measurement, so it cannot set a range. A blank cell counts as a gap for the same reason `null` does: `Number('')` and `Number('  ')` are also `0`.
- **`src/service/audio.ts`** — a non-finite magnitude sounds the empty tone, the same cue an out-of-bounds move already uses. Interpolating it would have handed the oscillator a non-finite frequency. Deliberately not scoped to bar traces.
- **`src/service/braille.ts`** — a non-finite value renders blank, alongside the existing zero case. Without it a gap fell through to `⠉`, drawing the missing bar as the highest one on the chart.

**Reaching the paths the first commit missed.** Review found four, two of which were regressions this branch introduced:

- **`SegmentedTrace.createSummaryLevel`** summed gaps straight into the Total row, making that total `NaN`. NaN spreads: it seeded `MathUtil.minMax`, and `safeMin`/`safeMax` over every row use `Math.min`/`Math.max`, which propagate it. **One missing segment gave the whole chart a NaN pitch range**, and every real bar in it a non-finite frequency — the bug this PR set out to fix, reintroduced. Now only measured segments are summed, and a category is a gap in the total only when every segment in it is one.
- **`SegmentedTrace.mapToSvgElements`** reads `barValues` directly for its `skipZeros` DOM alignment, where the base class recomputes `Number(point.y)`. A gap used to be `0` there and matched; as `NaN` it stopped matching, so a gapped cell would have taken a rect belonging to a later bar and shifted every highlight after it in the row. The old reading is restored — this path decides which rendered element belongs to which datum, not what a value means.
- **`description`** in all three `AbstractBarPlot` subclasses now shares a `rangeStats()` helper, so an all-gap chart reports `missing` rather than the `±Infinity` `safeMin`/`safeMax` answer an empty set with. Sharing it is the point: two of the three override the stats block, and the guard existed for one commit before drifting was possible again.
- **`getExtremaTargets`**, in both classes that define it, offers no extreme for an all-gap row. `indexOf(±Infinity)` returns `-1`, and the target would have carried `pointIndex: -1` and moved the cursor off the row.

## Screenshots (if applicable)

Not applicable — the change is to sound, braille, and navigation.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Gaps are still not filtered out of the data**, and that is deliberate. `extractMultiLineLayer` drops null points for lines because plotly omits them from a line's DOM — its comment says "skipping keeps indices aligned with the DOM". Bars are the opposite case: plotly renders a zero-height rect and keeps it, measured at 3 `.point` nodes for 3 bar values with a gap versus 2 markers for the same line data. Dropping the point here would slide every later bar's highlight onto its neighbour, which the gap-alignment test added in #724 catches.

**Twenty-one unit tests**, across three files:

- `test/model/barGaps.test.ts` — range exclusion, a gap reporting no magnitude while the text still reads `missing`, blank and whitespace-only cells, an all-gap chart describing itself as `missing` for both `BarTrace` and `Histogram`, extrema reaching the true extreme and offering none for an all-gap row, the segmented Total row's NaN spread and its sums and announcement, and two that drive a real five-rect DOM to assert which rect the cursor highlights past a gap and that a gap and a real zero land on the same one.
- `test/service/braille.test.ts` — a gap renders as a blank cell between `⠉` and `⣀` rather than as the tallest bar.
- `test/service/audio.emptyTone.test.ts` — a non-finite magnitude plays the five-harmonic empty cue; a magnitude of zero still plays a single pitched tone.

Several are controls that pass either way — an unmodified row, a real zero, a stack with no gaps totalling `[210, 150]`, a histogram with ordinary bin counts — pinning that this only changes what a gap does.

**Corrections to earlier framing in this PR, kept rather than quietly edited away:**

- The all-gap `description` case **did not** announce the word `Infinity`, as an earlier revision of this description and the commit message for it both claimed. `Description.tsx`'s `isDisplayable` already filters non-finite numbers, and nothing else consumes `DescriptionState.stats`, so the Min and Max rows simply vanished from the dialog. Reporting `missing` is still better than a row silently disappearing, but the severity was "the stat quietly goes away", not "the user is told Infinity".
- A review held that the Total row announces the literal string `NaN`. It does not: driven in a browser, a Total whose every segment is a gap announces `Quarter is Q1, Revenue is missing, Level is Sum`. `TextService.formatSingleValue` has no missing-value mapping of its own, but it delegates to `FormatterService`, which wraps every formatter in `FormatUtil.wrapFormat` — and that maps `NaN` exactly as it maps `null`. Pinned with tests anyway, since nothing had asserted the summary row's text.

**Two limits worth stating rather than leaving to be discovered:**

- **This reaches only adapters that preserve `null` through to the point.** Highcharts filters null points out (`adapter.ts:1038`) and Chart.js coerces them to `0` (`extractor.ts:632`), so a gap in those charts still behaves as it did. #726 is fixed for the model and for plotly, not universally.
- **`BarPoint` stays typed as `number | string`.** Widening it to admit the `null` that really flows through is honest, and I tried it — it produces 9 errors cascading into `TextState`, `BrailleState`, and `ExtremaTarget` and their consumers. That is a type-accuracy refactor with no behavioural content, better as its own change than smuggled into a sonification fix.

Verified locally: `npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (1413 unit + 57 esm, all passing).