### PR TITLE
refactor(format): drop the formatter gate that could never close

### DIFF
--- a/src/service/formatter.ts
+++ b/src/service/formatter.ts
@@ -117,22 +117,6 @@ export class FormatterService implements Disposable {
   }
 
   /**
-   * Checks if a layer has a custom formatter for the specified axis.
-   *
-   * @param layerId - The ID of the layer
-   * @param axis - The axis type ('x', 'y', or 'z')
-   * @returns True if a custom formatter is configured
-   */
-  public hasCustomFormatter(layerId: string, axis: AxisType): boolean {
-    const layerFormatters = this.formatters.get(layerId);
-    if (!layerFormatters) {
-      return false;
-    }
-    // Check if the formatter is not the default
-    return layerFormatters[axis] !== defaultFormat;
-  }
-
-  /**
    * Formats a value (single or array) using the formatter for the specified layer and axis.
    *
    * This is the primary method for formatting values in the application.

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -220,10 +220,15 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
 
   /**
    * Format extrema target labels by replacing raw xValues with formatted ones.
-   * When no custom formatter is configured the labels pass through unchanged.
+   *
+   * Every layer is formatted, not only those with an author-supplied
+   * `AxisFormat`: the default formatter rounds a long float to two decimals,
+   * which is what the announcement says, and a dialog label that disagreed with
+   * the announcement for the same point would be worse than either. A value the
+   * formatter leaves alone is detected below and passes through untouched.
    */
   private formatTargetLabels(targets: ExtremaTarget[], layerId: string): ExtremaTarget[] {
-    if (!this.formatter || !this.formatter.hasCustomFormatter(layerId, 'x')) {
+    if (!this.formatter) {
       return targets;
     }
 
@@ -279,9 +284,10 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     }
 
     const layerId = this.activeLayerId();
-    // Same gate the extrema target labels use (formatTargetLabels): pass through
-    // unchanged when the active layer has no custom x formatter.
-    if (!this.formatter || layerId === null || !this.formatter.hasCustomFormatter(layerId, 'x')) {
+    // Same rule the extrema target labels follow (formatTargetLabels): format
+    // whenever there is a formatter and a layer to look it up by, so these
+    // labels round the way the announcement does.
+    if (!this.formatter || layerId === null) {
       return rawValues.map(value => ({ value, label: String(value) }));
     }
 

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -228,7 +228,8 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
    * formatter leaves alone is detected below and passes through untouched.
    */
   private formatTargetLabels(targets: ExtremaTarget[], layerId: string): ExtremaTarget[] {
-    if (!this.formatter) {
+    const formatter = this.formatter;
+    if (!formatter) {
       return targets;
     }
 
@@ -236,7 +237,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       if (target.xValue === undefined) {
         return target;
       }
-      const formatted = this.formatter!.formatSingleValue(target.xValue, layerId, 'x');
+      const formatted = formatter.formatSingleValue(target.xValue, layerId, 'x');
       const raw = String(target.xValue);
       if (formatted === raw) {
         return target;
@@ -274,7 +275,8 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
    * XValue (navigation matches on it); `label` is the x-axis formatted string so
    * the search options read the same as the terse layer text and the extrema
    * target labels (e.g. "Nov 3" rather than the raw "2019-11-03"). Falls back to
-   * String(value) when no custom x formatter is configured for the active layer.
+   * String(value) only when no formatter was injected or the active layer has
+   * no id — every known layer is formatted, configured or not.
    * @returns Array of {value, label} options for the search combobox.
    */
   public getAvailableXValueOptions(): XValueOption[] {
@@ -283,11 +285,12 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       return [];
     }
 
+    const formatter = this.formatter;
     const layerId = this.activeLayerId();
     // Same rule the extrema target labels follow (formatTargetLabels): format
     // whenever there is a formatter and a layer to look it up by, so these
     // labels round the way the announcement does.
-    if (!this.formatter || layerId === null) {
+    if (!formatter || layerId === null) {
       return rawValues.map(value => ({ value, label: String(value) }));
     }
 
@@ -297,7 +300,7 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
     // tolerance of formatTargetLabels.
     return rawValues.map(value => ({
       value,
-      label: String(this.formatter!.formatSingleValue(value, layerId, 'x')),
+      label: String(formatter.formatSingleValue(value, layerId, 'x')),
     }));
   }
 

--- a/test/service/formatter.test.ts
+++ b/test/service/formatter.test.ts
@@ -69,4 +69,25 @@ describe('formatterService', () => {
 
     service.dispose();
   });
+
+  it('applies the same formatting whether or not the axis configured one', () => {
+    // The service used to expose `hasCustomFormatter` for callers to branch on,
+    // but it compared the stored function against the `defaultFormat` export
+    // while always storing a fresh `wrapFormat` closure — so it answered true
+    // for every layer it knew. Callers now format unconditionally, and this
+    // pins the property that makes that safe: an unconfigured axis produces a
+    // sensible string rather than something a caller would need to skip.
+    const plain = new FormatterService(figure());
+    const configured = new FormatterService(figure({ type: 'fixed', decimals: 2 }));
+
+    expect(plain.formatSingleValue(57.14285714285714, 'layer-1', 'y')).toBe('57.14');
+    expect(configured.formatSingleValue(57.14285714285714, 'layer-1', 'y')).toBe('57.14');
+    // Strings and integers survive the unconfigured path untouched, which is
+    // what the removed gate was protecting.
+    expect(plain.formatSingleValue('Q1', 'layer-1', 'x')).toBe('Q1');
+    expect(plain.formatSingleValue(120, 'layer-1', 'x')).toBe('120');
+
+    plain.dispose();
+    configured.dispose();
+  });
 });

--- a/test/state/viewModel/goToExtremaViewModel.test.ts
+++ b/test/state/viewModel/goToExtremaViewModel.test.ts
@@ -8,13 +8,14 @@
  */
 import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
-import type { FormatterService } from '@service/formatter';
 import type { GoToExtremaService } from '@service/goToExtrema';
 import type { ExtremaTarget } from '@type/extrema';
 import type { TraceState } from '@type/state';
 import { describe, expect, jest, test } from '@jest/globals';
+import { FormatterService } from '@service/formatter';
 import { createMaidrStore } from '@state/store';
 import { GoToExtremaViewModel } from '@state/viewModel/goToExtremaViewModel';
+import { TraceType } from '@type/grammar';
 
 function createAudioStub(): AudioService {
   return {
@@ -55,7 +56,6 @@ function createContextStub(active: unknown, layerId: string | null): Context {
 /** Formatter stub: x axis has a custom formatter mapping via `map`. */
 function createFormatterStub(map: Record<string, string>): FormatterService {
   return {
-    hasCustomFormatter: (_layerId: string, axis: string) => axis === 'x',
     formatSingleValue: (value: string | number) => map[String(value)] ?? String(value),
   } as unknown as FormatterService;
 }
@@ -81,21 +81,34 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     ]);
   });
 
-  test('falls back to String(value) when the layer has no custom x formatter', () => {
+  test('formats a layer with no author-supplied format, matching the announcement', () => {
+    // A real FormatterService, so this exercises the default path rather than
+    // a stub's idea of it: an axis with no `AxisFormat` still rounds, because
+    // that is what the announcement for the same point says. This used to be
+    // gated behind `hasCustomFormatter`, which could never answer false.
     const store = createMaidrStore();
-    const trace = createTraceStub([1, 2, 3]);
+    const trace = createTraceStub([57.14285714285714, 2, 3]);
     const context = createContextStub(trace, 'layer-1');
-    const formatter = {
-      hasCustomFormatter: () => false,
-      formatSingleValue: () => 'SHOULD_NOT_BE_USED',
-    } as unknown as FormatterService;
+    const formatter = new FormatterService({
+      id: 'chart',
+      subplots: [[{
+        layers: [{
+          id: 'layer-1',
+          type: TraceType.BAR,
+          axes: { x: { label: 'Quarter' }, y: { label: 'Share' } },
+          data: [],
+        }],
+      }]],
+    });
     const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub(), formatter);
 
     expect(vm.getAvailableXValueOptions()).toEqual([
-      { value: 1, label: '1' },
+      { value: 57.14285714285714, label: '57.14' },
       { value: 2, label: '2' },
       { value: 3, label: '3' },
     ]);
+
+    formatter.dispose();
   });
 
   test('coerces a non-string formatter result to a string label', () => {
@@ -106,7 +119,6 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     // number rather than a string. The label must still be a string so
     // downstream string operations (e.g. filter's toLowerCase) don't throw.
     const formatter = {
-      hasCustomFormatter: () => true,
       formatSingleValue: (v: number) => (v * 100) as unknown as string,
     } as unknown as FormatterService;
     const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub(), formatter);

--- a/test/state/viewModel/goToExtremaViewModel.test.ts
+++ b/test/state/viewModel/goToExtremaViewModel.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests for GoToExtremaViewModel covering:
- *  - getAvailableXValueOptions(): raw value preserved, label x-axis formatted
- *    (matching the terse layer text) with clean fallback to String(value).
+ *  - getAvailableXValueOptions() and formatTargetLabels(): raw value preserved,
+ *    label x-axis formatted (matching the terse layer text) for every known
+ *    layer, falling back to String(value) only with no formatter or no layer id.
  *  - moveToIndex(): Home/End index clamping.
  *  - the menu open/close audio cues fired on toggle()/hide()/selectCurrent(),
  *    and the silence on dispose().
@@ -10,6 +11,7 @@ import type { Context } from '@model/context';
 import type { AudioService } from '@service/audio';
 import type { GoToExtremaService } from '@service/goToExtrema';
 import type { ExtremaTarget } from '@type/extrema';
+import type { AxisFormat } from '@type/grammar';
 import type { TraceState } from '@type/state';
 import { describe, expect, jest, test } from '@jest/globals';
 import { FormatterService } from '@service/formatter';
@@ -33,16 +35,37 @@ function createServiceStub(navigable: boolean = true): GoToExtremaService {
 }
 
 /** Builds a trace stub exposing the X-value navigation surface the VM ducks. */
-function createTraceStub(xValues: (string | number)[]): {
+function createTraceStub(
+  xValues: (string | number)[],
+  extremaTargets: ExtremaTarget[] = [],
+): {
   getAvailableXValues: () => (string | number)[];
   getExtremaTargets: () => ExtremaTarget[];
   navigateToExtrema: jest.Mock;
 } {
   return {
     getAvailableXValues: () => xValues,
-    getExtremaTargets: () => [],
+    getExtremaTargets: () => extremaTargets,
     navigateToExtrema: jest.fn(),
   };
+}
+
+/** A FormatterService over one layer, with no `AxisFormat` unless given. */
+function createRealFormatter(format?: AxisFormat): FormatterService {
+  return new FormatterService({
+    id: 'chart',
+    subplots: [[{
+      layers: [{
+        id: 'layer-1',
+        type: TraceType.BAR,
+        axes: {
+          x: { label: 'Quarter', ...(format ? { format } : {}) },
+          y: { label: 'Share' },
+        },
+        data: [],
+      }],
+    }]],
+  });
 }
 
 /** Context stub whose `active` is the trace and whose `state` carries layerId. */
@@ -89,17 +112,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     const store = createMaidrStore();
     const trace = createTraceStub([57.14285714285714, 2, 3]);
     const context = createContextStub(trace, 'layer-1');
-    const formatter = new FormatterService({
-      id: 'chart',
-      subplots: [[{
-        layers: [{
-          id: 'layer-1',
-          type: TraceType.BAR,
-          axes: { x: { label: 'Quarter' }, y: { label: 'Share' } },
-          data: [],
-        }],
-      }]],
-    });
+    const formatter = createRealFormatter();
     const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub(), formatter);
 
     expect(vm.getAvailableXValueOptions()).toEqual([
@@ -188,6 +201,78 @@ describe('GoToExtremaViewModel.moveToIndex', () => {
     const vm = new GoToExtremaViewModel(store, createServiceStub(), createContextStub({}, 'layer-1'), createAudioStub());
     vm.moveToIndex(2);
     expect(store.getState().goToExtrema.selectedIndex).toBe(0); // unchanged initial
+  });
+});
+
+describe('GoToExtremaViewModel.formatTargetLabels (via toggle)', () => {
+  test('rounds a long float in an extrema label for a layer with no format', () => {
+    // The sibling of the getAvailableXValueOptions case: this caller lost the
+    // same dead gate, and nothing asserted it. A real FormatterService over a
+    // layer with no `AxisFormat` still shortens the label, so the dialog and
+    // the announcement say the same number for the same point.
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Max Bar at 57.14285714285714',
+      xValue: 57.14285714285714,
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter();
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1'),
+      createAudioStub(),
+      formatter,
+    );
+
+    vm.toggle(TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label).toBe('Max Bar at 57.14');
+
+    formatter.dispose();
+  });
+
+  test('leaves a label alone when the formatter does not change the value', () => {
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Max Bar at Q1',
+      xValue: 'Q1',
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter();
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1'),
+      createAudioStub(),
+      formatter,
+    );
+
+    vm.toggle(TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label).toBe('Max Bar at Q1');
+
+    formatter.dispose();
+  });
+
+  test('still honours an author-supplied format on the same path', () => {
+    const store = createMaidrStore();
+    const trace = createTraceStub([], [{
+      label: 'Max Bar at 57.14285714285714',
+      xValue: 57.14285714285714,
+    } as unknown as ExtremaTarget]);
+    const formatter = createRealFormatter({ type: 'fixed', decimals: 4 });
+    const vm = new GoToExtremaViewModel(
+      store,
+      createServiceStub(true),
+      createContextStub(trace, 'layer-1'),
+      createAudioStub(),
+      formatter,
+    );
+
+    vm.toggle(TRACE_STATE);
+
+    expect(store.getState().goToExtrema.targets[0].label).toBe('Max Bar at 57.1429');
+
+    formatter.dispose();
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Description

`FormatterService.hasCustomFormatter` asked whether a layer's axis had an author-supplied `AxisFormat` by comparing the stored function against the `defaultFormat` export. But `resolveAxisFormat` never stores `defaultFormat` — it stores `FormatUtil.wrapFormat(...)`, a fresh closure built on every call. The comparison could not match, so the method answered `true` for every layer the service knew about.

Measured before changing anything:

```
hasCustomFormatter(layer with no format) = true
hasCustomFormatter(unknown layer)        = false
```

Only the unknown-layer path answers `false`, and it returns early before the comparison ever happens.

## Related Issues

Fixes #729

## Changes Made

Both callers live in `goToExtremaViewModel.ts`, and both documented a pass-through that never ran:

- `formatTargetLabels` — *"When no custom formatter is configured the labels pass through unchanged."*
- `getAvailableXValueOptions` — *"pass through unchanged when the active layer has no custom x formatter."*

**Removed the gate rather than repairing it.** Repairing it would mean making the false branch reachable — and that branch is the wrong behaviour now. Until #727, `defaultFormat` was `` `${value}` ``, so calling it and skipping it produced the same string and the bug was invisible. #727 gave it real behaviour: it rounds a long float to two decimals. Running it is what keeps a Go To Extrema label in step with the announcement for the same point; skipping it would put `57.14285714285714` in the dialog while the announcement says `57.14`.

So the callers now format whenever they have a formatter and a layer id to look it up by — which is what has always happened in practice. `hasCustomFormatter` had no other callers and `FormatterService` is constructed only by `controller.ts`, so nothing public changes.

Two things review asked for on the way, both inside functions this PR already rewrites:

- The `this.formatter!` non-null assertions in both callers are gone, replaced by a narrowed local `const` that holds across the closure — `.claude/rules/typescript.md` asks for exactly that.
- `getAvailableXValueOptions`'s JSDoc still promised a fallback "when no custom x formatter is configured" after that stopped being what decides it. It now names what does: no formatter injected, or no layer id.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Behaviour is unchanged for every case production reaches.** The gate's false branch required `hasCustomFormatter` to answer false, which it only did for a layer id the service has never seen. Both callers source that id from the same place — `getAvailableXValueOptions` through `activeLayerId()`, `formatTargetLabels` from `state.layerId` at the `toggle()` call site — so neither can be handed an id the service has not seen. If one ever were, the label now rounds instead of being stringified raw, which is the more consistent of the two.

**A test went with the method.** `test/state/viewModel/goToExtremaViewModel.test.ts` had a case stubbing `hasCustomFormatter: () => false` and asserting the raw-label path. It passed, and proved nothing — it pinned a branch production cannot enter, which is the second reason this went unnoticed for so long.

**Six tests in its place**, all built on a real `FormatterService` rather than a stub's idea of one:

- `getAvailableXValueOptions` on a layer with no `AxisFormat` — `57.14285714285714` becomes `57.14`, while `2` and `3` come through untouched.
- `formatTargetLabels`, reached through `toggle()` — a long float rounds in the label (`Max Bar at 57.14285714285714` → `Max Bar at 57.14`), a value the formatter leaves alone keeps its label (`Q1`), and an author-supplied `fixed`/4 format still wins (`57.1429`). This caller had the same dead branch removed and was asserted nowhere until the second commit: its only prior coverage was the audio-cue test, which passes no formatter and no targets.
- In `test/service/formatter.test.ts`, the property that makes unconditional formatting safe: a configured and an unconfigured axis both produce a sensible string, so there is nothing a caller would need to branch around.

**Reading the results against `main`:** six cases in the ViewModel file fail there, but only the behavioural ones are evidence. The rest fail because the stubs no longer define `hasCustomFormatter` and `main` still calls it.

**Noticed, not changed:** `getFormatter` returns the bare `defaultFormat` for an unknown layer rather than a `wrapFormat`-wrapped one, so that path renders `NaN` as `"NaN"` instead of `"missing"`. It predates this change and is unreachable through the callers above; worth its own issue if anyone can find a way in.

Verified locally: `npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (1483 unit + 57 esm, all passing).