### PR TITLE
ci: harden Claude workflows (skip secretless PRs, gate @claude)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,17 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Neither fork PRs nor Dependabot PRs are given repository secrets, so
+    # CLAUDE_CODE_OAUTH_TOKEN resolves empty and the job fails rather than
+    # reviewing anything -- as it did on
+    # dependabot/npm_and_yarn/npm_and_yarn-4ea3fa4d3d. Skip cleanly instead.
+    # pull_request_target is deliberately not used as the workaround: it runs
+    # with write-scoped secrets on attacker-controlled input, and the action
+    # does not treat it as an entity context, so its own write-permission
+    # check never runs.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,20 @@ on:
 
 jobs:
   claude:
+    # This repository is public, so anyone can write '@claude' anywhere. The
+    # action itself already refuses actors without write access, but gating
+    # here means a drive-by mention never starts a runner or spends the OAuth
+    # token in the first place.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Ports the two hardening changes that came out of Copilot's review on xability/r-maidr#50.

## 1. Review job skips PRs that can never have the secret

Neither fork PRs nor Dependabot PRs receive repository secrets, so `CLAUDE_CODE_OAUTH_TOKEN` resolves empty and the job **fails** rather than reviewing anything. Observed, not hypothetical — the run on `dependabot/npm_and_yarn/npm_and_yarn-4ea3fa4d3d` failed exactly this way.

```yaml
if: |
  github.event.pull_request.head.repo.full_name == github.repository &&
  github.actor != 'dependabot[bot]'
```

`pull_request_target` is deliberately *not* used as the workaround. Two reasons:

1. It runs with write-scoped secrets against attacker-controlled input.
2. It is absent from the action's [`ENTITY_EVENT_NAMES`](https://github.com/anthropics/claude-code-action/blob/main/src/github/context.ts), so `checkWritePermissions` never runs for it — the action's own actor gate is silently bypassed.

This repo has taken 0 fork PRs in its last 100, so the fork half of the guard is pre-emptive; the Dependabot half fixes a live failure.

## 2. `@claude` gated on `author_association`

Restricted to `OWNER`/`MEMBER`/`COLLABORATOR`. This narrows nothing in practice — `claude-code-action` already refuses actors without write access on these events. What it buys is that a drive-by `@claude` on this public repo never starts a runner or reaches the OAuth token.

## Not changed

The `permissions:` block stays read-only. Claude comments using the **GitHub App installation token** obtained via the `id-token: write` OIDC exchange, not `GITHUB_TOKEN`, so `pull-requests: write` would grant privileges nothing here consumes.

Both files pass `actionlint 1.7.12`.

Companion PRs: xability/r-maidr#50 (adds the workflows, which that repo never had) and the matching py-maidr PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why `CONTRIBUTOR` is not in the allowlist

Raised in review. `CONTRIBUTOR` is someone with a merged PR but no collaborator role — so no write access, and `claude-code-action` would refuse them regardless. Leaving them out of the `if:` changes only *how* they are refused: a silent no-op instead of a visible "Actor does not have write permissions" failure. That is the intended trade for a gate whose entire purpose is to avoid starting a runner. Add `CONTRIBUTOR` to the list if a visible error is preferred over silence.