### PR TITLE
feat(adapters): bind a step chart as a step trace, not a line

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -93,8 +93,11 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Stacked Bar | multiple `ColumnSeries` | `stacked: true` |
 | 100% Stacked (Normalized) | multiple `ColumnSeries` | `stacked: true` + `valueYShow: "valueYTotalPercent"` |
 | Line (single & multi-series) | `LineSeries` | line series class |
+| Step (single & multi-series) | `StepLineSeries` | step-line series class |
 | Histogram | `ColumnSeries` | value X axis + `openValueXField` bin edges |
 | Heatmap | `ColumnSeries` | category X **and** category Y axes + `value` field |
+
+A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
 > Box plots, candlestick, scatter, violin, and smooth/regression layers are **not** supported by the amCharts binder. amCharts 5 has no dedicated scatter or box series, and there is no reliable runtime signal to distinguish a scatter (hidden-stroke `LineSeries`) from a normal line chart.
 

--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -73,6 +73,7 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Stacked Bar | `'bar'` with `scales.x.stacked` / `scales.y.stacked` | — | [Stacked bar](examples.html) |
 | Dodged Bar | `'bar'` with multiple datasets (no stacking) | — | [Dodged bar](examples.html) |
 | Line | `'line'` | — | [Line chart](examples.html) |
+| Step | `'line'` with `stepped` on the dataset (or `elements.line`) | — | [Line chart](examples.html) |
 | Scatter | `'scatter'` | — | [Scatter plot](examples.html) |
 | Box Plot | `'boxplot'` | `@sgratzl/chartjs-chart-boxplot` | [Box plot](examples.html) |
 | Candlestick | `'candlestick'` | `chartjs-chart-financial` + a date adapter | [Candlestick](examples.html) |

--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -105,7 +105,7 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 |------------|---------------------------|---------|
 | Bar | `bar`, `column` | [highcharts-bar.html](highcharts-bar.html) |
 | Line | `line`, `spline`, `area`, `areaspline` | [highcharts-line.html](highcharts-line.html) |
-| Step | any of the above + `step: 'left' \| 'center' \| 'right'` | [highcharts-line.html](highcharts-line.html) |
+| Step | `line`, `spline`, `area`, `areaspline` + `step: 'left' \| 'center' \| 'right'` | [highcharts-line.html](highcharts-line.html) |
 | Scatter | `scatter` | [highcharts-scatter.html](highcharts-scatter.html) |
 | Box Plot | `boxplot` | [highcharts-box.html](highcharts-box.html) |
 | Heatmap | `heatmap` (requires `modules/heatmap.js`) | [highcharts-heatmap.html](highcharts-heatmap.html) |

--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -105,6 +105,7 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 |------------|---------------------------|---------|
 | Bar | `bar`, `column` | [highcharts-bar.html](highcharts-bar.html) |
 | Line | `line`, `spline`, `area`, `areaspline` | [highcharts-line.html](highcharts-line.html) |
+| Step | any of the above + `step: 'left' \| 'center' \| 'right'` | [highcharts-line.html](highcharts-line.html) |
 | Scatter | `scatter` | [highcharts-scatter.html](highcharts-scatter.html) |
 | Box Plot | `boxplot` | [highcharts-box.html](highcharts-box.html) |
 | Heatmap | `heatmap` (requires `modules/heatmap.js`) | [highcharts-heatmap.html](highcharts-heatmap.html) |

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -63,6 +63,7 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Bar | `type: 'bar'` | [Bar chart](examples.html) |
 | Scatter | `type: 'scatter'`, `mode: 'markers'` | [Scatter plot](examples.html) |
 | Line | `type: 'scatter'`, `mode: 'lines'` | [Line chart](examples.html) |
+| Step | `type: 'scatter'`, `mode: 'lines'`, `line: { shape: 'hv' \| 'vh' \| 'hvh' \| 'vhv' }` | [Step chart](examples.html) |
 | Box Plot | `type: 'box'` | [Box plot](examples.html) |
 | Violin Plot | `type: 'violin'` | [Violin plot](examples.html) |
 | Heatmap | `type: 'heatmap'` | [Heatmap](examples.html) |
@@ -71,6 +72,17 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Grouped Bar | `barmode: 'group'` + multiple bar traces | [Grouped bar](examples.html) |
 | Stacked Bar | `barmode: 'stack'` + multiple bar traces | [Stacked bar](examples.html) |
 | Subplots / Facets | multiple `xaxis`/`yaxis` pairs, `layout.grid`, or Plotly Express facets | [Subplots](examples.html) |
+
+**Notes on chart-type detection:**
+
+- A line trace whose `line.shape` is one of the step-wise shapes is piecewise
+  constant — the value is held and then jumps — so it maps to MAIDR's step
+  trace rather than to a line, and is announced and navigated as a step plot
+  (including the Transitions rotor, which moves only between the points where
+  the level changes). `hv` and `vh` carry across to MAIDR's `stepDirection`
+  unchanged, and `hvh` becomes `mid`. `vhv` binds as a step but names no
+  convention: its flat segments sit at the mean of the two levels rather than
+  at either one, which none of MAIDR's three conventions describes.
 
 ## Code Examples
 

--- a/docs/vegalite.md
+++ b/docs/vegalite.md
@@ -95,6 +95,7 @@ Because Vega-Lite renders **asynchronously** through `vegaEmbed()`, the adapter 
 | `bar` | `color`/`fill`, `stack: null` or `false` | Dodged (grouped) bar | [vegalite-binddodged.html](https://github.com/xability/maidr/blob/main/examples/vegalite-binddodged.html) |
 | `bar` | `color`/`fill`, `stack: 'normalize'` | Normalized stacked bar | [vegalite-bindnormalized.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindnormalized.html) |
 | `line`, `area` | — | Line | [vegalite-bindline.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindline.html) |
+| `line`, `area` | `interpolate: 'step'`, `'step-before'`, `'step-after'` | Step | [vegalite-bindline.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindline.html) |
 | `point`, `circle`, `square`, `tick` | — | Scatter | [vegalite-bindscatter.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindscatter.html) |
 | `rect` | — | Heatmap | [vegalite-bindheatmap.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindheatmap.html) |
 | `boxplot` | — | Box plot (vertical & horizontal) | [vegalite-bindbox.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindbox.html) |

--- a/docs/victory.md
+++ b/docs/victory.md
@@ -63,6 +63,7 @@ Unlike config-driven adapters, you do not pass `data`/`chartType` props to `<Mai
 |---|---|---|---|
 | `VictoryBar` | Bar chart | ✅ | |
 | `VictoryLine` | Line chart | ✅ | |
+| `VictoryLine` | Step chart | ✅ | With `interpolation="step"`, `"stepBefore"` or `"stepAfter"`. |
 | `VictoryScatter` | Scatter plot | ✅ | |
 | `VictoryStack` | Stacked bar chart | ✅ | Each child `<VictoryBar name="...">` becomes one series. |
 | `VictoryHistogram` | Histogram | ⚠️ | The adapter derives equal-width bins from the raw values, which may not exactly match Victory's rendered bins. |

--- a/examples/plotly-step.html
+++ b/examples/plotly-step.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Step Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Step Chart</h1>
+    <p>
+      A plotly.js chart drawn with <code>line.shape</code> auto-detected by MAIDR
+      as a step plot rather than a line. Click on a chart and use arrow keys to
+      navigate; press <kbd>R</kbd> to reach the Transitions rotor, which moves
+      only between the points where the level actually changes.
+    </p>
+
+    <h2>hold, then jump at the next x (<code>hv</code>)</h2>
+    <div id="step-hv" style="width: 700px; height: 400px"></div>
+
+    <h2>jump at this x, then hold (<code>vh</code>)</h2>
+    <div id="step-vh" style="width: 700px; height: 400px"></div>
+
+    <h2>jump midway between x values (<code>hvh</code>)</h2>
+    <div id="step-hvh" style="width: 700px; height: 400px"></div>
+
+    <script>
+      // A staffing level: held for whole hours, then stepped. Nothing is
+      // interpolated between samples, which is exactly what a line chart
+      // would imply and a step chart does not.
+      var hours = [8, 9, 10, 11, 12, 13, 14, 15, 16];
+      var staff = [2, 2, 5, 5, 5, 3, 3, 6, 6];
+
+      function stepChart(divId, shape) {
+        var trace = {
+          x: hours,
+          y: staff,
+          mode: 'lines',
+          type: 'scatter',
+          line: { shape: shape },
+          name: 'On shift'
+        };
+
+        var layout = {
+          title: { text: 'Staff on shift (' + shape + ')' },
+          xaxis: { title: { text: 'Hour' } },
+          yaxis: { title: { text: 'Staff' } }
+        };
+
+        Plotly.newPlot(divId, [trace], layout);
+      }
+
+      stepChart('step-hv', 'hv');
+      stepChart('step-vh', 'vh');
+      stepChart('step-hvh', 'hvh');
+    </script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maidr",
-  "version": "3.74.0",
+  "version": "3.75.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maidr",
-      "version": "3.74.0",
+      "version": "3.75.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -3500,9 +3500,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3520,9 +3517,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3540,9 +3534,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3560,9 +3551,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3580,9 +3568,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3600,9 +3585,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3620,9 +3602,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3640,9 +3619,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3952,9 +3928,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3969,9 +3942,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3986,9 +3956,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4003,9 +3970,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4020,9 +3984,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4037,9 +3998,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4054,9 +4012,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4071,9 +4026,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4088,9 +4040,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4105,9 +4054,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4122,9 +4068,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4139,9 +4082,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4156,9 +4096,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maidr",
-  "version": "3.75.1",
+  "version": "3.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maidr",
-      "version": "3.75.1",
+      "version": "3.74.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -3500,6 +3500,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3517,6 +3520,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3534,6 +3540,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3551,6 +3560,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3568,6 +3580,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3585,6 +3600,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3602,6 +3620,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3619,6 +3640,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3928,6 +3952,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3942,6 +3969,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3956,6 +3986,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3970,6 +4003,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3984,6 +4020,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3998,6 +4037,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4012,6 +4054,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4026,6 +4071,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4040,6 +4088,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4054,6 +4105,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4068,6 +4122,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4082,6 +4139,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4096,6 +4156,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -429,10 +429,6 @@ function emptyMergedSeries(): MergedSeries {
 
 /**
  * Adds one series' points, name and selector to the layer it will merge into.
- * @param merged - The accumulator for that layer
- * @param series - The amCharts series being read
- * @param points - Its extracted points
- * @param containerEl - The chart's container, used to resolve the selector
  */
 function collectSeries(
   merged: MergedSeries,
@@ -460,11 +456,6 @@ function collectSeries(
  * positions the staircase from the axis cell rather than reporting a
  * convention, so naming one here would be a guess. MAIDR then stays silent
  * about it rather than describing a chart amCharts did not draw.
- * @param merged - Every series merging into this layer
- * @param type - The layer type, LINE or STEP
- * @param xLabel - The x axis label
- * @param yLabel - The y axis label
- * @returns The merged layer
  */
 function buildLineLayer(
   merged: MergedSeries,

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -231,9 +231,11 @@ function buildChartLayers(
   const yLabel = options?.axisLabels?.y ?? readAxisLabel(chart.yAxes.values[0], 'y');
 
   const layers: MaidrLayer[] = [];
-  const lineLayers: LinePoint[][] = [];
-  let lineLayerSelectors: string[] | undefined;
-  const lineSeriesNames: string[] = [];
+  // Line and step series each merge into one layer of their own type. The
+  // points are extracted identically — amCharts varies only how it draws
+  // between them — so they differ here only in which bucket they land in.
+  const lineSeries = emptyMergedSeries();
+  const stepSeries = emptyMergedSeries();
 
   // Collect bar series for grouped handling (stacked/dodged/normalized).
   const barSeriesList: AmXYSeries[] = [];
@@ -260,21 +262,12 @@ function buildChartLayers(
         layers.push(buildHeatmapLayer(data, xLabel, yLabel));
         break;
       }
-      case 'line': {
+      case 'line':
+      case 'step': {
         const points = extractLinePoints(series);
         if (points.length === 0)
           break;
-        lineLayers.push(points);
-
-        const name = seriesName(series);
-        if (name)
-          lineSeriesNames.push(name);
-
-        const sel = buildLineSelector(series, containerEl);
-        if (sel) {
-          lineLayerSelectors ??= [];
-          lineLayerSelectors.push(sel);
-        }
+        collectSeries(kind === 'step' ? stepSeries : lineSeries, series, points, containerEl);
         break;
       }
       default:
@@ -297,12 +290,13 @@ function buildChartLayers(
     }
   }
 
-  // Merge all line series into a single multi-line layer.
-  if (lineLayers.length > 0) {
-    const lineTitle = lineSeriesNames.length > 0
-      ? lineSeriesNames.join(', ')
-      : undefined;
-    layers.push(buildLineLayer(lineLayers, lineLayerSelectors, xLabel, yLabel, lineTitle));
+  // Merge all line series into a single multi-line layer, and likewise the
+  // step series into a step layer of their own.
+  if (lineSeries.data.length > 0) {
+    layers.push(buildLineLayer(lineSeries, TraceType.LINE, xLabel, yLabel));
+  }
+  if (stepSeries.data.length > 0) {
+    layers.push(buildLineLayer(stepSeries, TraceType.STEP, xLabel, yLabel));
   }
 
   return layers;
@@ -417,20 +411,77 @@ function buildHeatmapLayer(
   };
 }
 
+/**
+ * Series that merge into one layer, gathered as the chart is walked.
+ */
+interface MergedSeries {
+  /** One entry per series, in chart order. */
+  data: LinePoint[][];
+  /** Names of the series that have one, joined into the layer title. */
+  names: string[];
+  /** Highlight selectors, for the series whose path could be resolved. */
+  selectors?: string[];
+}
+
+function emptyMergedSeries(): MergedSeries {
+  return { data: [], names: [] };
+}
+
+/**
+ * Adds one series' points, name and selector to the layer it will merge into.
+ * @param merged - The accumulator for that layer
+ * @param series - The amCharts series being read
+ * @param points - Its extracted points
+ * @param containerEl - The chart's container, used to resolve the selector
+ */
+function collectSeries(
+  merged: MergedSeries,
+  series: AmXYSeries,
+  points: LinePoint[],
+  containerEl: HTMLElement,
+): void {
+  merged.data.push(points);
+
+  const name = seriesName(series);
+  if (name)
+    merged.names.push(name);
+
+  const sel = buildLineSelector(series, containerEl);
+  if (sel) {
+    merged.selectors ??= [];
+    merged.selectors.push(sel);
+  }
+}
+
+/**
+ * Builds the merged line or step layer.
+ *
+ * `stepDirection` is deliberately not emitted for a step layer: amCharts
+ * positions the staircase from the axis cell rather than reporting a
+ * convention, so naming one here would be a guess. MAIDR then stays silent
+ * about it rather than describing a chart amCharts did not draw.
+ * @param merged - Every series merging into this layer
+ * @param type - The layer type, LINE or STEP
+ * @param xLabel - The x axis label
+ * @param yLabel - The y axis label
+ * @returns The merged layer
+ */
 function buildLineLayer(
-  data: LinePoint[][],
-  selectors: string[] | undefined,
+  merged: MergedSeries,
+  type: TraceType.LINE | TraceType.STEP,
   xLabel: string,
   yLabel: string,
-  title?: string,
 ): MaidrLayer {
+  const title = merged.names.length > 0 ? merged.names.join(', ') : undefined;
+  const selectors = merged.selectors;
+
   return {
-    id: `line-${uid()}`,
-    type: TraceType.LINE,
+    id: `${type === TraceType.STEP ? 'step' : 'line'}-${uid()}`,
+    type,
     ...(title ? { title } : {}),
     ...(selectors && selectors.length > 0 ? { selectors } : {}),
     axes: { x: { label: xLabel }, y: { label: yLabel } },
-    data,
+    data: merged.data,
   };
 }
 

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -175,11 +175,13 @@ function createHighlightCallback(
 function groupSeries(chart: AmXYChart): {
   barSeriesList: AmXYSeries[];
   lineSeriesList: AmXYSeries[];
+  stepSeriesList: AmXYSeries[];
   histogramSeries: AmXYSeries[];
   heatmapSeries: AmXYSeries[];
 } {
   const barSeriesList: AmXYSeries[] = [];
   const lineSeriesList: AmXYSeries[] = [];
+  const stepSeriesList: AmXYSeries[] = [];
   const histogramSeries: AmXYSeries[] = [];
   const heatmapSeries: AmXYSeries[] = [];
 
@@ -190,6 +192,9 @@ function groupSeries(chart: AmXYChart): {
         break;
       case 'line':
         lineSeriesList.push(series);
+        break;
+      case 'step':
+        stepSeriesList.push(series);
         break;
       case 'histogram':
         histogramSeries.push(series);
@@ -202,7 +207,7 @@ function groupSeries(chart: AmXYChart): {
     }
   }
 
-  return { barSeriesList, lineSeriesList, histogramSeries, heatmapSeries };
+  return { barSeriesList, lineSeriesList, stepSeriesList, histogramSeries, heatmapSeries };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -277,10 +277,18 @@ const LINE_CLASSES = new Set([
   'SmoothedXLineSeries',
   'SmoothedYLineSeries',
   'SmoothedXYLineSeries',
+]);
+
+/**
+ * Series amCharts draws as a staircase. The values are piecewise constant —
+ * held across an interval and then jumped — so describing one as a line would
+ * tell a reader the value moved gradually between samples when it did not.
+ */
+const STEP_CLASSES = new Set([
   'StepLineSeries',
 ]);
 
-export type SeriesKind = 'bar' | 'line' | 'histogram' | 'heatmap' | 'unknown';
+export type SeriesKind = 'bar' | 'line' | 'step' | 'histogram' | 'heatmap' | 'unknown';
 
 /**
  * Determine the MAIDR trace kind for a given amCharts series.
@@ -305,6 +313,10 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
   if (LINE_CLASSES.has(className)) {
     // A "line" series with value-only axes (no category) is still a line in MAIDR.
     return 'line';
+  }
+
+  if (STEP_CLASSES.has(className)) {
+    return 'step';
   }
 
   // Default to bar for category-based series.

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -58,6 +58,8 @@ export interface SeriesGroups {
   barSeriesList: AmXYSeries[];
   /** Merged into a single multi-line LINE layer (one entry per line). */
   lineSeriesList: AmXYSeries[];
+  /** Merged into a single STEP layer, the staircase counterpart of the above. */
+  stepSeriesList: AmXYSeries[];
   /** One HISTOGRAM layer each, in series order. */
   histogramSeries: AmXYSeries[];
   /** One HEATMAP layer each, in series order. */
@@ -212,6 +214,9 @@ function addEntryResolvers(
   const lineSeries = groups.lineSeriesList
     .map(series => ({ series, items: filterLineItems(series) }))
     .filter(entry => entry.items.length > 0);
+  const stepSeries = groups.stepSeriesList
+    .map(series => ({ series, items: filterLineItems(series) }))
+    .filter(entry => entry.items.length > 0);
   const histogramSeries = groups.histogramSeries
     .map(series => ({ series, items: filterHistogramItems(series) }))
     .filter(entry => entry.items.length > 0);
@@ -237,9 +242,13 @@ function addEntryResolvers(
         register(layer.id, (row, col) => columnTargetFrom(segmentedBars[row], col));
         break;
       }
-      case TraceType.LINE: {
+      case TraceType.LINE:
+      case TraceType.STEP: {
+        // A step layer holds its own series, so it indexes its own list —
+        // sharing one would misplace every highlight on a chart with both.
+        const seriesList = layer.type === TraceType.STEP ? stepSeries : lineSeries;
         register(layer.id, (row, col) => {
-          const entry = lineSeries[row];
+          const entry = seriesList[row];
           const dataItem = entry?.items[col];
           return entry && dataItem
             ? [{ series: entry.series, dataItem, kind: 'point' }]

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -3,7 +3,7 @@
  * JSON schema format.
  *
  * Supported chart types (those with a genuine MAIDR trace-type equivalent):
- * - Native: bar (plain/stacked/dodged), line, scatter, bubble
+ * - Native: bar (plain/stacked/dodged), line (plain or stepped), scatter, bubble
  * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap)
  *
  * Unsupported types (pie, doughnut, radar, polarArea, treemap, sankey, etc.)
@@ -11,7 +11,7 @@
  * chart, because MAIDR has no semantically equivalent trace for them.
  */
 
-import type { BarPoint, BoxPoint, CandlestickPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, ScatterPoint, SegmentedPoint } from '../../type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, ScatterPoint, SegmentedPoint, StepDirection } from '../../type/grammar';
 import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 
@@ -89,7 +89,8 @@ export function extractChartData(
     };
   }
 
-  const layers = extractLayers(chart, chartType, pluginOptions);
+  const localDatasets: LocalDatasetIndices = new Map();
+  const layers = extractLayers(chart, chartType, pluginOptions, localDatasets);
 
   return {
     maidr: {
@@ -98,7 +99,7 @@ export function extractChartData(
       subplots: [[{ layers }]],
       ...(onNavigate ? { onNavigate } : {}),
     },
-    layerDatasetIndices: singleSubplotDatasetIndices(chart, layers),
+    layerDatasetIndices: singleSubplotDatasetIndices(chart, layers, localDatasets),
   };
 }
 
@@ -353,7 +354,8 @@ function extractPanelSubplots(
 
   for (const panel of layout.panels) {
     const view = createPanelView(chart, panel, layout.axisKind);
-    const layers = extractLayers(view, chartType, pluginOptions);
+    const localDatasets: LocalDatasetIndices = new Map();
+    const layers = extractLayers(view, chartType, pluginOptions, localDatasets);
     // Never emit a subplot with no layers — it crashes the core Figure model.
     if (layers.length === 0)
       continue;
@@ -362,7 +364,7 @@ function extractPanelSubplots(
     for (const layer of layers) {
       const localId = layer.id;
       layer.id = `${panelIndex}_${localId}`;
-      layerDatasetIndices.set(layer.id, layerDatasets(layer, localId, panel));
+      layerDatasetIndices.set(layer.id, layerDatasets(layer, localId, panel, localDatasets));
     }
 
     // The first layer's title is the panel's display name in subplot
@@ -396,7 +398,15 @@ function layerDatasets(
   layer: MaidrLayer,
   localId: string,
   panel: PanelPartition,
+  localDatasets: LocalDatasetIndices,
 ): number[] {
+  // A layer backed by only some of the panel's datasets says which, in panel
+  // positions; translate those into indices within the whole chart.
+  const declared = localDatasets.get(localId);
+  if (declared) {
+    return declared.map(local => panel.datasetIndices[local] ?? 0);
+  }
+
   if (layer.type === TraceType.SCATTER) {
     // Scatter emits one layer per dataset with local id = partition position.
     const localIndex = Number.parseInt(localId, 10) || 0;
@@ -413,15 +423,17 @@ function layerDatasets(
 function singleSubplotDatasetIndices(
   chart: ChartJsChart,
   layers: MaidrLayer[],
+  localDatasets: LocalDatasetIndices,
 ): Map<string, number[]> {
   const allIndices = chart.data.datasets.map((_, index) => index);
   const map = new Map<string, number[]>();
   for (const layer of layers) {
+    const declared = localDatasets.get(layer.id);
     map.set(
       layer.id,
-      layer.type === TraceType.SCATTER
+      declared ?? (layer.type === TraceType.SCATTER
         ? [Number.parseInt(layer.id, 10) || 0]
-        : allIndices,
+        : allIndices),
     );
   }
   return map;
@@ -524,16 +536,25 @@ function isStacked(chart: ChartJsChart): boolean {
 // Layer extraction dispatcher
 // ---------------------------------------------------------------------------
 
+/**
+ * Positions within the datasets an extractor was given — the whole chart, or
+ * one panel's partition of it — backing each layer id it emitted, in MAIDR row
+ * order. Only filled in where a layer is backed by some of those datasets
+ * rather than all of them; callers fall back to the per-type default.
+ */
+type LocalDatasetIndices = Map<string, number[]>;
+
 function extractLayers(
   chart: ChartJsChart,
   chartType: string,
   pluginOptions?: MaidrPluginOptions,
+  datasetIndices?: LocalDatasetIndices,
 ): MaidrLayer[] {
   switch (chartType) {
     case 'bar':
       return extractBarLayers(chart, pluginOptions);
     case 'line':
-      return extractLineLayers(chart, pluginOptions);
+      return extractLineLayers(chart, pluginOptions, datasetIndices);
     case 'scatter':
     case 'bubble':
       return extractScatterLayers(chart, pluginOptions);
@@ -656,41 +677,113 @@ function extractSegmentedBarLayers(
 // Line chart extraction
 // ---------------------------------------------------------------------------
 
+/**
+ * Where each Chart.js `stepped` value puts the riser, in {@link StepDirection}
+ * terms, read off `_steppedLineTo`: `'after'` draws the riser at the previous
+ * x and then runs flat at the new level (`vh`), while `'before'` runs flat at
+ * the old level up to the next x and rises there (`hv`).
+ */
+const STEP_DIRECTION_BY_OPTION: Record<string, StepDirection> = {
+  before: 'hv',
+  after: 'vh',
+  middle: 'mid',
+};
+
+/**
+ * The step convention a line dataset draws, or `undefined` when it draws an
+ * ordinary interpolated line. A dataset's own `stepped` wins over the chart's
+ * `elements.line` default, which is how Chart.js resolves it.
+ * @param dataset - The dataset being read
+ * @param chart - The chart it belongs to, for the element default
+ * @returns The step direction, or undefined when the dataset is not stepped
+ */
+function stepDirectionOf(
+  dataset: ChartJsDataset,
+  chart: ChartJsChart,
+): StepDirection | undefined {
+  const stepped = dataset.stepped ?? chart.options.elements?.line?.stepped;
+  if (stepped === undefined || stepped === false) {
+    return undefined;
+  }
+  // Chart.js documents the bare `true` as its 'before' default.
+  return stepped === true ? 'hv' : STEP_DIRECTION_BY_OPTION[stepped];
+}
+
 function extractLineLayers(
   chart: ChartJsChart,
   pluginOptions?: MaidrPluginOptions,
+  datasetIndices?: LocalDatasetIndices,
 ): MaidrLayer[] {
   const data = chart.data;
   const labels = data.labels ?? [];
 
-  // Skip gap markers (`null` / `NaN`) so they are never sonified as a 0 tone;
-  // the plugin re-derives the original Chart.js indices for highlight alignment.
-  const lineData: LinePoint[][] = data.datasets.map((dataset, dsIdx) => {
-    const linePoints: LinePoint[] = [];
-    dataset.data.forEach((value, i) => {
-      const num = toFiniteNumber(value);
-      if (num === null)
-        return;
-      linePoints.push({
-        x: labels[i] ?? i,
-        y: num,
-        z: dataset.label ?? `Line ${dsIdx + 1}`,
-      });
-    });
-    return linePoints;
-  });
-
-  return [
-    {
+  // A chart with no datasets still emits its (empty) line layer, as callers
+  // downstream expect one layer per line chart.
+  if (data.datasets.length === 0) {
+    return [{
       id: '0',
       type: TraceType.LINE,
       axes: {
         x: { label: getAxisLabel(chart, 'x', pluginOptions) },
         y: { label: getAxisLabel(chart, 'y', pluginOptions) },
       },
-      data: lineData,
-    },
-  ];
+      data: [],
+    }];
+  }
+
+  // Skip gap markers (`null` / `NaN`) so they are never sonified as a 0 tone;
+  // the plugin re-derives the original Chart.js indices for highlight alignment.
+  const linePoints = (dataset: ChartJsDataset, dsIdx: number): LinePoint[] => {
+    const points: LinePoint[] = [];
+    dataset.data.forEach((value, i) => {
+      const num = toFiniteNumber(value);
+      if (num === null)
+        return;
+      points.push({
+        x: labels[i] ?? i,
+        y: num,
+        z: dataset.label ?? `Line ${dsIdx + 1}`,
+      });
+    });
+    return points;
+  };
+
+  // A stepped dataset is piecewise constant rather than interpolated, so it
+  // belongs to a step layer instead — one per convention, since a layer
+  // announces a single `stepDirection` for all of its series. Datasets keep
+  // their chart order within whichever layer they land in.
+  const groups = new Map<StepDirection | '', number[]>();
+  for (let dsIdx = 0; dsIdx < data.datasets.length; dsIdx++) {
+    const key = stepDirectionOf(data.datasets[dsIdx], chart) ?? '';
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(dsIdx);
+    } else {
+      groups.set(key, [dsIdx]);
+    }
+  }
+
+  const axes = {
+    x: { label: getAxisLabel(chart, 'x', pluginOptions) },
+    y: { label: getAxisLabel(chart, 'y', pluginOptions) },
+  };
+
+  const layers: MaidrLayer[] = [];
+  // Plain lines first, so a mixed chart keeps the line layer where it was.
+  const ordered = [...groups].sort(([a], [b]) => Number(a !== '') - Number(b !== ''));
+  for (const [direction, indices] of ordered) {
+    const id = String(layers.length);
+    datasetIndices?.set(id, indices);
+    layers.push({
+      id,
+      type: direction === '' ? TraceType.LINE : TraceType.STEP,
+      axes,
+      ...(direction === '' ? {} : { stepDirection: direction }),
+      data: indices.map(dsIdx => linePoints(data.datasets[dsIdx], dsIdx)),
+    });
+  }
+
+  return layers;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -402,6 +402,13 @@ function layerDatasets(
 ): number[] {
   // A layer backed by only some of the panel's datasets says which, in panel
   // positions; translate those into indices within the whole chart.
+  //
+  // The `?? 0` is unreachable while the invariant holds: an extractor fills
+  // `localDatasets` by walking the very datasets it was handed — this panel's
+  // partition — so every position it declares indexes `datasetIndices`. It is
+  // a fallback rather than a throw because a stray index would misroute one
+  // highlight, and taking the chart's whole accessibility layer down over that
+  // is the worse failure.
   const declared = localDatasets.get(localId);
   if (declared) {
     return declared.map(local => panel.datasetIndices[local] ?? 0);

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -700,9 +700,6 @@ const STEP_DIRECTION_BY_OPTION: Record<string, StepDirection> = {
  * The step convention a line dataset draws, or `undefined` when it draws an
  * ordinary interpolated line. A dataset's own `stepped` wins over the chart's
  * `elements.line` default, which is how Chart.js resolves it.
- * @param dataset - The dataset being read
- * @param chart - The chart it belongs to, for the element default
- * @returns The step direction, or undefined when the dataset is not stepped
  */
 function stepDirectionOf(
   dataset: ChartJsDataset,

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -690,7 +690,7 @@ function extractSegmentedBarLayers(
  * x and then runs flat at the new level (`vh`), while `'before'` runs flat at
  * the old level up to the next x and rises there (`hv`).
  */
-const STEP_DIRECTION_BY_OPTION: Record<string, StepDirection> = {
+const STEP_DIRECTION_BY_OPTION: Partial<Record<string, StepDirection>> = {
   before: 'hv',
   after: 'vh',
   middle: 'mid',

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -139,7 +139,8 @@ export function computeTargetMaps(
         barLineIndices.set(layer.id, [finiteIndices(datasets[dsIdx]?.data ?? [])]);
         break;
       }
-      case TraceType.LINE: {
+      case TraceType.LINE:
+      case TraceType.STEP: {
         // One MAIDR row per backing dataset, in MAIDR row order.
         const dsIndices = layerDatasetIndices.get(layer.id) ?? datasets.map((_, i) => i);
         barLineIndices.set(

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -68,6 +68,13 @@ export interface ChartJsDataset {
   yAxisID?: string;
   backgroundColor?: string | string[];
   borderColor?: string | string[];
+  /**
+   * Step interpolation for a line dataset. `'before'` (and the legacy `true`)
+   * hold the current value until the next x and jump there, `'after'` jumps at
+   * the current x and holds the new value across, `'middle'` jumps midway.
+   * `false` or absent draws an ordinary interpolated line.
+   */
+  stepped?: boolean | 'before' | 'after' | 'middle';
 }
 
 /**
@@ -77,6 +84,10 @@ export interface ChartJsOptions {
   indexAxis?: 'x' | 'y';
   scales?: Record<string, ChartJsScale>;
   plugins?: Record<string, unknown>;
+  /** Chart-wide element defaults; a dataset's own setting wins over these. */
+  elements?: {
+    line?: { stepped?: ChartJsDataset['stepped'] };
+  };
 }
 
 /**

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -724,7 +724,7 @@ function convertSeries(
  * jumps at the current x and holds the new value across (`vh`), and `center`
  * jumps midway between the two (`mid`).
  */
-const STEP_DIRECTION_BY_OPTION: Record<string, StepDirection> = {
+const STEP_DIRECTION_BY_OPTION: Partial<Record<string, StepDirection>> = {
   left: 'hv',
   center: 'mid',
   right: 'vh',

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -28,6 +28,7 @@ import type {
   MaidrSubplot,
   ScatterPoint,
   SegmentedPoint,
+  StepDirection,
 } from '../../type/grammar';
 import type { HighchartsAdapterOptions, HighchartsAxis, HighchartsChart, HighchartsPoint, HighchartsSeries } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
@@ -53,7 +54,8 @@ let chartCounter = 0;
  *
  * Supported Highcharts series types:
  * - `bar`, `column` → {@link TraceType.BAR}
- * - `line`, `spline`, `area`, `areaspline` → {@link TraceType.LINE}
+ * - `line`, `spline`, `area`, `areaspline` → {@link TraceType.LINE}, or
+ *   {@link TraceType.STEP} when the series sets `step`
  * - `scatter` → {@link TraceType.SCATTER}
  * - `boxplot` → {@link TraceType.BOX}
  * - `heatmap` → {@link TraceType.HEATMAP}
@@ -171,9 +173,35 @@ export function buildSubplot(
     }
   }
 
-  // Convert line series together as a single multi-line layer (MAIDR expects LinePoint[][]).
-  if (lineSeries.length > 0) {
-    const layer = convertLineSeries(lineSeries, chart, containerId);
+  // Convert line series together as a single multi-line layer (MAIDR expects
+  // LinePoint[][]). A series drawn with `step` is piecewise constant rather
+  // than interpolated, so it becomes a step layer instead — one per convention,
+  // since a layer carries a single `stepDirection` for all of its series.
+  const stepSeries = new Map<StepDirection, HighchartsSeries[]>();
+  const plainLineSeries: HighchartsSeries[] = [];
+  for (const series of lineSeries) {
+    const direction = stepDirectionOf(series);
+    if (direction === undefined) {
+      plainLineSeries.push(series);
+      continue;
+    }
+    const bucket = stepSeries.get(direction);
+    if (bucket) {
+      bucket.push(series);
+    } else {
+      stepSeries.set(direction, [series]);
+    }
+  }
+
+  if (plainLineSeries.length > 0) {
+    const layer = convertLineSeries(plainLineSeries, chart, containerId);
+    if (layer) {
+      layers.push(layer);
+    }
+  }
+
+  for (const [direction, series] of stepSeries) {
+    const layer = convertLineSeries(series, chart, containerId, direction);
     if (layer) {
       layers.push(layer);
     }
@@ -689,10 +717,51 @@ function convertSeries(
   }
 }
 
+/**
+ * Where each Highcharts `step` value puts the riser, in {@link StepDirection}
+ * terms. Highcharts names the side the horizontal segment sits on: `left`
+ * holds the current value until the next x and jumps there (`hv`), `right`
+ * jumps at the current x and holds the new value across (`vh`), and `center`
+ * jumps midway between the two (`mid`).
+ */
+const STEP_DIRECTION_BY_OPTION: Record<string, StepDirection> = {
+  left: 'hv',
+  center: 'mid',
+  right: 'vh',
+};
+
+/**
+ * The step convention a line series draws, or `undefined` when it draws an
+ * ordinary interpolated line.
+ * @param series - The Highcharts series
+ * @returns The step direction, or undefined when the series is not stepped
+ */
+function stepDirectionOf(series: HighchartsSeries): StepDirection | undefined {
+  const step = series.options.step;
+  if (step === undefined || step === false) {
+    return undefined;
+  }
+  // Highcharts' legacy boolean is its 'left' default.
+  return step === true ? 'hv' : STEP_DIRECTION_BY_OPTION[step];
+}
+
+/**
+ * Converts line-family series into one merged layer.
+ *
+ * Step series reuse this because their points are identical — Highcharts
+ * varies only how it draws between them.
+ * @param seriesList - The series to merge, all drawn the same way
+ * @param chart - The owning chart
+ * @param containerId - The chart container's id, used for selectors
+ * @param stepDirection - Set when these series are stepped, making the layer
+ * a step layer that announces this convention
+ * @returns The layer, or null when the list is empty
+ */
 function convertLineSeries(
   seriesList: HighchartsSeries[],
   chart: HighchartsChart,
   containerId: string,
+  stepDirection?: StepDirection,
 ): MaidrLayer | null {
   if (seriesList.length === 0)
     return null;
@@ -717,13 +786,14 @@ function convertLineSeries(
 
   return {
     id: seriesList.map(s => String(s.index)).join('-'),
-    type: TraceType.LINE,
+    type: stepDirection ? TraceType.STEP : TraceType.LINE,
     title: layerTitle,
     selectors,
     axes: {
       x: getAxisLabel(first, 'x'),
       y: getAxisLabel(first, 'y'),
     },
+    ...(stepDirection ? { stepDirection } : {}),
     data,
   };
 }

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -733,8 +733,6 @@ const STEP_DIRECTION_BY_OPTION: Record<string, StepDirection> = {
 /**
  * The step convention a line series draws, or `undefined` when it draws an
  * ordinary interpolated line.
- * @param series - The Highcharts series
- * @returns The step direction, or undefined when the series is not stepped
  */
 function stepDirectionOf(series: HighchartsSeries): StepDirection | undefined {
   const step = series.options.step;
@@ -750,12 +748,6 @@ function stepDirectionOf(series: HighchartsSeries): StepDirection | undefined {
  *
  * Step series reuse this because their points are identical — Highcharts
  * varies only how it draws between them.
- * @param seriesList - The series to merge, all drawn the same way
- * @param chart - The owning chart
- * @param containerId - The chart container's id, used for selectors
- * @param stepDirection - Set when these series are stepped, making the layer
- * a step layer that announces this convention
- * @returns The layer, or null when the list is empty
  */
 function convertLineSeries(
   seriesList: HighchartsSeries[],

--- a/src/adapters/highcharts/types.ts
+++ b/src/adapters/highcharts/types.ts
@@ -86,6 +86,12 @@ export interface HighchartsSeries {
   options: {
     type?: string;
     stacking?: string;
+    /**
+     * Where a line series' staircase rises, when it draws one. Highcharts
+     * resolves `plotOptions` into here, so this is set however the chart
+     * asked for it. Legacy `true` means `'left'`.
+     */
+    step?: 'left' | 'center' | 'right' | boolean;
     /** Set by Highcharts on internal series (e.g. the Highstock navigator). */
     isInternal?: boolean;
     /** User- or Highcharts-assigned class name (e.g. `highcharts-navigator-series`). */

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -22,6 +22,7 @@ import type {
   MaidrSubplot,
   ScatterPoint,
   SegmentedPoint,
+  StepDirection,
   ViolinKdePoint,
 } from '../../type/grammar';
 import type {
@@ -264,7 +265,7 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
   switch (type) {
     case 'scatter':
     case 'scattergl':
-      return mapScatterMode(trace.mode);
+      return mapScatterMode(trace);
 
     case 'bar':
       return TraceType.BAR;
@@ -293,15 +294,63 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
   }
 }
 
-function mapScatterMode(mode?: string): TraceType {
+function mapScatterMode(trace: PlotlyTrace): TraceType {
+  const mode = trace.mode;
   if (!mode)
     return TraceType.SCATTER;
   // When both lines and markers exist, prefer LINE for navigational context.
   if (mode.includes('lines'))
-    return TraceType.LINE;
+    return isStepShape(trace.line?.shape) ? TraceType.STEP : TraceType.LINE;
   if (mode.includes('markers'))
     return TraceType.SCATTER;
   return TraceType.SCATTER;
+}
+
+/**
+ * The `line.shape` values plotly draws as a staircase rather than as an
+ * interpolated line. `linear`, `spline` and an absent shape are not here:
+ * those really do move gradually between samples.
+ */
+const STEP_SHAPES = new Set(['hv', 'vh', 'hvh', 'vhv']);
+
+/**
+ * Where each staircase shape jumps, in {@link StepDirection} terms.
+ *
+ * `vhv` is deliberately absent rather than mapped to `mid`. It is the one
+ * shape whose horizontal segments do not sit at a sample's own value: it
+ * rises at `x[i]`, runs flat at the *mean* of `y[i]` and `y[i+1]` across the
+ * interval, then rises again at `x[i+1]`. None of the three conventions
+ * describes that, and `mid` would actively mislead — it promises a jump
+ * midway between x values, where `vhv` jumps at the x values themselves. The
+ * trace still binds as a step (the data is piecewise constant, and the
+ * transition rotor is the navigation it wants); only the spoken convention is
+ * withheld, which is what {@link MaidrLayer.stepDirection} being optional is
+ * for.
+ */
+const STEP_SHAPE_DIRECTION: Partial<Record<string, StepDirection>> = {
+  hv: 'hv',
+  vh: 'vh',
+  hvh: 'mid',
+};
+
+/**
+ * Whether plotly draws this `line.shape` as a piecewise-constant staircase.
+ * @param shape - The trace's `line.shape`, if it set one
+ * @returns True for the step-wise shapes
+ */
+function isStepShape(shape?: string): boolean {
+  return shape !== undefined && STEP_SHAPES.has(shape);
+}
+
+/**
+ * The step convention a trace authored, or `undefined` when plotly's shape has
+ * no {@link StepDirection} equivalent.
+ * @param trace - The plotly trace
+ * @returns The step direction, or undefined when none applies
+ */
+function stepDirectionOf(trace: PlotlyTrace): StepDirection | undefined {
+  const shape = trace.line?.shape;
+  return shape === undefined ? undefined : STEP_SHAPE_DIRECTION[shape];
 }
 
 // ---------------------------------------------------------------------------
@@ -420,6 +469,11 @@ function buildSubplotLayers(
 
   // Group traces that need multi-trace handling.
   const lineTraces: TraceEntry[] = [];
+  // Step traces are grouped by the convention they authored, because a layer
+  // carries one `stepDirection` for all of its series: merging an `hv` trace
+  // with a `vh` one would describe one of them wrongly. Keyed by direction,
+  // with '' for the shapes that report none, so those stay together too.
+  const stepTraces = new Map<StepDirection | '', TraceEntry[]>();
   const boxTraces: TraceEntry[] = [];
   const barTraces: TraceEntry[] = [];
   const violinTraces: TraceEntry[] = [];
@@ -437,6 +491,14 @@ function buildSubplotLayers(
     };
     if (entry.maidrType === TraceType.LINE) {
       lineTraces.push(entry);
+    } else if (entry.maidrType === TraceType.STEP) {
+      const key = stepDirectionOf(trace) ?? '';
+      const bucket = stepTraces.get(key);
+      if (bucket) {
+        bucket.push(entry);
+      } else {
+        stepTraces.set(key, [entry]);
+      }
     } else if (entry.maidrType === TraceType.BOX) {
       boxTraces.push(entry);
     } else if (entry.maidrType === TraceType.BAR) {
@@ -451,6 +513,16 @@ function buildSubplotLayers(
   // Build multi-line layer if applicable.
   if (lineTraces.length > 0) {
     const layer = extractMultiLineLayer(lineTraces, xLabel, yLabel, gd);
+    if (layer)
+      layers.push(layer);
+  }
+
+  // One step layer per authored convention (usually exactly one).
+  for (const [direction, traces] of stepTraces) {
+    const layer = extractMultiLineLayer(traces, xLabel, yLabel, gd, {
+      type: TraceType.STEP,
+      stepDirection: direction === '' ? undefined : direction,
+    });
     if (layer)
       layers.push(layer);
   }
@@ -1094,11 +1166,29 @@ function extractBarLayer(
 // Line (multi-series)
 // ---------------------------------------------------------------------------
 
+/**
+ * Builds one line-shaped layer from every line (or step) trace in a subplot.
+ *
+ * Step traces reuse this because their point shape is identical — plotly
+ * varies only how the segments between samples are drawn, not the samples
+ * themselves — so `step` differs from `line` here by its layer type and the
+ * convention it announces.
+ * @param lineTraces - The traces to merge, all of the same layer type
+ * @param xLabel - The x axis label, when the layout names one
+ * @param yLabel - The y axis label, when the layout names one
+ * @param gd - The plotly graph div, used to resolve selectors
+ * @param step - Set when building a step layer
+ * @param step.type - The layer type, always {@link TraceType.STEP}
+ * @param step.stepDirection - The convention plotly's shape authored, where
+ * MAIDR can name it
+ * @returns The layer, or null when no trace carried usable data
+ */
 function extractMultiLineLayer(
   lineTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[],
   xLabel: string | undefined,
   yLabel: string | undefined,
   gd: PlotlyGraphDiv,
+  step?: { type: TraceType.STEP; stepDirection?: StepDirection },
 ): MaidrLayer | null {
   const data: LinePoint[][] = [];
   const legend: string[] = [];
@@ -1143,17 +1233,18 @@ function extractMultiLineLayer(
   // All line traces in the same subplot share the same unscoped selector
   // (e.g. `.subplot.xy .trace.scatter .point`), so any trace index works here.
   const selectors = generatePlotlySelectors(
-    TraceType.LINE,
+    step?.type ?? TraceType.LINE,
     lineTraces[0].globalIdx,
     gd,
   );
 
   return {
     id: String(lineTraces[0].globalIdx),
-    type: TraceType.LINE,
+    type: step?.type ?? TraceType.LINE,
     title: legend.length === 1 ? legend[0] : undefined,
     selectors,
     axes,
+    ...(step?.stepDirection ? { stepDirection: step.stepDirection } : {}),
     data,
   };
 }

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -335,8 +335,6 @@ const STEP_SHAPE_DIRECTION: Partial<Record<string, StepDirection>> = {
 
 /**
  * Whether plotly draws this `line.shape` as a piecewise-constant staircase.
- * @param shape - The trace's `line.shape`, if it set one
- * @returns True for the step-wise shapes
  */
 function isStepShape(shape?: string): boolean {
   return shape !== undefined && STEP_SHAPES.has(shape);
@@ -345,8 +343,6 @@ function isStepShape(shape?: string): boolean {
 /**
  * The step convention a trace authored, or `undefined` when plotly's shape has
  * no {@link StepDirection} equivalent.
- * @param trace - The plotly trace
- * @returns The step direction, or undefined when none applies
  */
 function stepDirectionOf(trace: PlotlyTrace): StepDirection | undefined {
   const shape = trace.line?.shape;
@@ -1173,15 +1169,6 @@ function extractBarLayer(
  * varies only how the segments between samples are drawn, not the samples
  * themselves — so `step` differs from `line` here by its layer type and the
  * convention it announces.
- * @param lineTraces - The traces to merge, all of the same layer type
- * @param xLabel - The x axis label, when the layout names one
- * @param yLabel - The y axis label, when the layout names one
- * @param gd - The plotly graph div, used to resolve selectors
- * @param step - Set when building a step layer
- * @param step.type - The layer type, always {@link TraceType.STEP}
- * @param step.stepDirection - The convention plotly's shape authored, where
- * MAIDR can name it
- * @returns The layer, or null when no trace carried usable data
  */
 function extractMultiLineLayer(
   lineTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[],

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -48,7 +48,10 @@ export function generatePlotlySelectors(
     case TraceType.NORMALIZED:
       return `${prefix}.trace.bars .point > path`;
 
+    // A step trace is a scatter trace plotly drew as a staircase, so its
+    // markers — when it has any — are the same `.point` elements.
     case TraceType.LINE:
+    case TraceType.STEP:
       return lineSelector(prefix, traceData?.mode);
 
     case TraceType.BOX:

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -17,6 +17,12 @@ export interface PlotlyTrace {
   name?: string;
   uid?: string;
   visible?: boolean | 'legendonly';
+  /**
+   * Line styling. `shape` is how plotly joins consecutive samples: `linear`
+   * and `spline` interpolate, while `hv`, `vh`, `hvh` and `vhv` draw a
+   * piecewise-constant staircase.
+   */
+  line?: { shape?: string };
   x?: (number | string)[];
   y?: (number | string)[];
   z?: number[][];

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -579,8 +579,6 @@ const STEP_DIRECTION_BY_INTERPOLATE: Record<string, StepDirection> = {
 /**
  * The step convention a spec's mark draws, or `undefined` when it draws an
  * ordinary interpolated line.
- * @param spec - The (single-view or layer) spec being converted
- * @returns The step direction, or undefined when the mark is not stepped
  */
 function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
   if (!spec.mark || typeof spec.mark === 'string')

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -27,6 +27,7 @@ import type {
   MaidrSubplot,
   ScatterPoint,
   SegmentedPoint,
+  StepDirection,
 } from '@type/grammar';
 import type { FacetDescriptor, RepeatCellMapping, RepeatDescriptor } from './facets';
 import type {
@@ -180,16 +181,20 @@ function coalesceSiblingLineLayers(
   while (i < entries.length) {
     const current = entries[i];
 
-    if (current.layer.type !== TraceType.LINE) {
+    if (current.layer.type !== TraceType.LINE && current.layer.type !== TraceType.STEP) {
       out.push(current.layer);
       i += 1;
       continue;
     }
 
-    // Walk forward gathering consecutive LINE layers whose axes match.
+    // Walk forward gathering consecutive line-family layers whose axes match.
+    // A step layer only joins a run of steps that jump the same way: the
+    // merged layer announces one convention, so a run mixing two would
+    // describe one of them wrongly.
     const run: ConvertedLayer[] = [current];
     let j = i + 1;
-    while (j < entries.length && entries[j].layer.type === TraceType.LINE
+    while (j < entries.length && entries[j].layer.type === current.layer.type
+      && entries[j].layer.stepDirection === current.layer.stepDirection
       && axesAreCompatible(current.layer.axes, entries[j].layer.axes)) {
       run.push(entries[j]);
       j += 1;
@@ -558,6 +563,33 @@ function getMarkType(spec: VegaLiteSpec): string | null {
 }
 
 /**
+ * Where each stepping `interpolate` value puts the riser, in
+ * {@link StepDirection} terms. Vega-Lite hands these to the matching d3
+ * curve, so `step-after` rises after the horizontal run at the next x
+ * (`hv`), `step-before` rises first at the current x (`vh`), and plain
+ * `step` rises at the midpoint (`mid`). Every other value — `linear`,
+ * `monotone`, `basis`, absent — interpolates and is not a step.
+ */
+const STEP_DIRECTION_BY_INTERPOLATE: Record<string, StepDirection> = {
+  'step': 'mid',
+  'step-before': 'vh',
+  'step-after': 'hv',
+};
+
+/**
+ * The step convention a spec's mark draws, or `undefined` when it draws an
+ * ordinary interpolated line.
+ * @param spec - The (single-view or layer) spec being converted
+ * @returns The step direction, or undefined when the mark is not stepped
+ */
+function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
+  if (!spec.mark || typeof spec.mark === 'string')
+    return undefined;
+  const { interpolate } = spec.mark;
+  return interpolate === undefined ? undefined : STEP_DIRECTION_BY_INTERPOLATE[interpolate];
+}
+
+/**
  * Map a Vega-Lite mark type + encoding to a MAIDR trace type.
  *
  * Some marks produce different MAIDR types depending on encoding:
@@ -565,10 +597,12 @@ function getMarkType(spec: VegaLiteSpec): string | null {
  *   - `bar` with color/fill + stack    → STACKED / NORMALIZED / DODGED
  *   - `rect`                           → HEATMAP
  *   - `tick`                           → SCATTER (individual value marks)
+ *   - `line`/`area` with a stepping `interpolate` → STEP
  */
 function resolveTraceType(
   mark: string,
   encoding?: VegaLiteEncoding,
+  stepDirection?: StepDirection,
 ): TraceType | null {
   switch (mark) {
     case 'bar': {
@@ -593,14 +627,13 @@ function resolveTraceType(
       return TraceType.BAR;
     }
     case 'line':
-      return TraceType.LINE;
+    case 'area':
+      return stepDirection ? TraceType.STEP : TraceType.LINE;
     case 'point':
     case 'circle':
     case 'square':
     case 'tick':
       return TraceType.SCATTER;
-    case 'area':
-      return TraceType.LINE;
     case 'rect':
       return TraceType.HEATMAP;
     case 'boxplot':
@@ -1322,7 +1355,8 @@ function convertLayerSpec(
     ...spec.encoding,
   };
 
-  const traceType = resolveTraceType(mark, encoding);
+  const stepDirection = getStepDirection(spec);
+  const traceType = resolveTraceType(mark, encoding, stepDirection);
 
   if (!traceType)
     return null;
@@ -1402,7 +1436,10 @@ function convertLayerSpec(
       }
       break;
     }
-    case TraceType.LINE: {
+    // A step mark is a line Vega-Lite draws as a staircase: same points,
+    // same one-path-per-series geometry, so the extraction is identical.
+    case TraceType.LINE:
+    case TraceType.STEP: {
       const lineData = extractLineData(rows, encoding);
       data = lineData;
       // Line/area traces expect selectors as string[] (one per series).
@@ -1463,6 +1500,9 @@ function convertLayerSpec(
     data,
   };
 
+  if (stepDirection && traceType === TraceType.STEP) {
+    layer.stepDirection = stepDirection;
+  }
   if (orientation) {
     layer.orientation = orientation;
   }

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -570,7 +570,7 @@ function getMarkType(spec: VegaLiteSpec): string | null {
  * `step` rises at the midpoint (`mid`). Every other value — `linear`,
  * `monotone`, `basis`, absent — interpolates and is not a step.
  */
-const STEP_DIRECTION_BY_INTERPOLATE: Record<string, StepDirection> = {
+const STEP_DIRECTION_BY_INTERPOLATE: Partial<Record<string, StepDirection>> = {
   'step': 'mid',
   'step-before': 'vh',
   'step-after': 'hv',

--- a/src/adapters/vegalite/types.ts
+++ b/src/adapters/vegalite/types.ts
@@ -94,7 +94,13 @@ export interface VegaLiteSpec {
   description?: string;
   data?: unknown;
   transform?: VegaLiteTransform[];
-  mark?: string | { type: string };
+  /**
+   * The mark, as a shorthand string or a mark def. `interpolate` is how
+   * Vega-Lite joins consecutive points: the `step`, `step-before` and
+   * `step-after` values draw a piecewise-constant staircase, the rest
+   * interpolate.
+   */
+  mark?: string | { type: string; interpolate?: string };
   encoding?: VegaLiteEncoding;
   layer?: VegaLiteSpec[];
   hconcat?: VegaLiteSpec[];

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -175,8 +175,6 @@ const STEP_DIRECTION_BY_INTERPOLATION: Record<string, StepDirection> = {
 /**
  * The step convention a line's `interpolation` prop draws, or `undefined`
  * when it draws an ordinary interpolated line.
- * @param interpolation - The component's `interpolation` prop
- * @returns The step direction, or undefined when it is not a step
  */
 function stepDirectionOf(interpolation: unknown): StepDirection | undefined {
   // Victory also accepts a function here, for a custom d3 curve factory.

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -166,7 +166,7 @@ function extractBarData(
  * midpoint (`mid`). Every other interpolation — `linear`, `natural`,
  * `monotoneX`, absent — interpolates and is not a step.
  */
-const STEP_DIRECTION_BY_INTERPOLATION: Record<string, StepDirection> = {
+const STEP_DIRECTION_BY_INTERPOLATION: Partial<Record<string, StepDirection>> = {
   step: 'mid',
   stepBefore: 'vh',
   stepAfter: 'hv',

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -10,6 +10,7 @@ import type {
   MaidrLayer,
   ScatterPoint,
   SegmentedPoint,
+  StepDirection,
 } from '@type/grammar';
 import type { ReactElement, ReactNode } from 'react';
 import type {
@@ -158,6 +159,34 @@ function extractBarData(
 }
 
 /**
+ * Where each stepping `interpolation` puts the riser, in
+ * {@link StepDirection} terms. Victory hands these straight to the matching
+ * d3 curve, so `stepAfter` runs flat and rises at the next x (`hv`),
+ * `stepBefore` rises first at the current x (`vh`), and `step` rises at the
+ * midpoint (`mid`). Every other interpolation — `linear`, `natural`,
+ * `monotoneX`, absent — interpolates and is not a step.
+ */
+const STEP_DIRECTION_BY_INTERPOLATION: Record<string, StepDirection> = {
+  step: 'mid',
+  stepBefore: 'vh',
+  stepAfter: 'hv',
+};
+
+/**
+ * The step convention a line's `interpolation` prop draws, or `undefined`
+ * when it draws an ordinary interpolated line.
+ * @param interpolation - The component's `interpolation` prop
+ * @returns The step direction, or undefined when it is not a step
+ */
+function stepDirectionOf(interpolation: unknown): StepDirection | undefined {
+  // Victory also accepts a function here, for a custom d3 curve factory.
+  // Nothing about such a curve is inspectable, so it stays a line.
+  return typeof interpolation === 'string'
+    ? STEP_DIRECTION_BY_INTERPOLATION[interpolation]
+    : undefined;
+}
+
+/**
  * Extracts data from a VictoryLine element.
  */
 function extractLineData(
@@ -174,7 +203,16 @@ function extractLineData(
     y: Number(getY(d)),
   }));
 
-  return { data: { kind: 'line', points: [points] }, count: rawData.length };
+  const stepDirection = stepDirectionOf(props.interpolation);
+
+  return {
+    data: {
+      kind: 'line',
+      points: [points],
+      ...(stepDirection ? { stepDirection } : {}),
+    },
+    count: rawData.length,
+  };
 }
 
 /**
@@ -702,9 +740,10 @@ export function toMaidrLayer(
     case 'line':
       return {
         id: layer.id,
-        type: TraceType.LINE,
+        type: data.stepDirection ? TraceType.STEP : TraceType.LINE,
         axes,
         selectors: selector ? [selector as string] : undefined,
+        ...(data.stepDirection ? { stepDirection: data.stepDirection } : {}),
         data: data.points,
       };
 

--- a/src/adapters/victory/types.ts
+++ b/src/adapters/victory/types.ts
@@ -6,6 +6,7 @@ import type {
   LinePoint,
   ScatterPoint,
   SegmentedPoint,
+  StepDirection,
 } from '@type/grammar';
 import type { ReactNode } from 'react';
 
@@ -76,7 +77,11 @@ export type VictoryComponentType
  */
 export type VictoryLayerData
   = | { kind: 'bar'; points: BarPoint[] }
-    | { kind: 'line'; points: LinePoint[][] }
+    /**
+     * A `VictoryLine`. `stepDirection` is set when its `interpolation` draws
+     * a staircase, making the layer a step rather than a line.
+     */
+    | { kind: 'line'; points: LinePoint[][]; stepDirection?: StepDirection }
     | { kind: 'scatter'; points: ScatterPoint[] }
     | { kind: 'box'; points: BoxPoint[] }
     | { kind: 'candlestick'; points: CandlestickPoint[] }

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -8,6 +8,7 @@ import {
   fakeContainerEl,
   fakeLineSeries,
   fakeRoot,
+  fakeStepSeries,
 } from './helpers';
 
 const BAR_DATA = [
@@ -117,6 +118,43 @@ describe('fromAmCharts (single chart)', () => {
 
   it('throws when the root contains no chart', () => {
     expect(() => fromAmCharts(fakeRoot([]))).toThrow(/no XYChart found/);
+  });
+
+  it('binds a StepLineSeries as a step layer, not a line', () => {
+    const chart = fakeChart({
+      series: [fakeStepSeries('Stage', BAR_DATA)],
+      xLabel: 'Day',
+      yLabel: 'Stage',
+    });
+
+    const result = fromAmCharts(fakeRoot([chart]));
+
+    const layer = result.subplots[0][0].layers[0];
+    expect(layer.type).toBe(TraceType.STEP);
+    expect(layer.title).toBe('Stage');
+    // amCharts reports no convention, so MAIDR names none rather than guessing.
+    expect(layer.stepDirection).toBeUndefined();
+    expect(layer.data).toEqual([[
+      { x: 'Sat', y: 87, z: 'Stage' },
+      { x: 'Sun', y: 76, z: 'Stage' },
+    ]]);
+  });
+
+  it('keeps step series out of the line layer when a chart has both', () => {
+    const chart = fakeChart({
+      series: [
+        fakeLineSeries('Trend', BAR_DATA),
+        fakeStepSeries('Stage', BAR_DATA),
+      ],
+    });
+
+    const result = fromAmCharts(fakeRoot([chart]));
+
+    const layers = result.subplots[0][0].layers;
+    expect(layers.map(layer => [layer.type, layer.title])).toEqual([
+      [TraceType.LINE, 'Trend'],
+      [TraceType.STEP, 'Stage'],
+    ]);
   });
 
   it('fromXYChart matches the fromAmCharts single-chart output', () => {

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -68,6 +68,19 @@ export function fakeLineSeries(
   });
 }
 
+/** A step-line series, drawn as a staircase rather than an interpolated line. */
+export function fakeStepSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'StepLineSeries',
+    name,
+    settings: { categoryXField: 'category' },
+    data: points,
+  });
+}
+
 function fakeAxis(label?: string): AmAxis {
   const title = label != null
     ? { get: (key: string) => (key === 'text' ? label : undefined) }

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -9,6 +9,7 @@ function emptyGroups(): SeriesGroups {
   return {
     barSeriesList: [],
     lineSeriesList: [],
+    stepSeriesList: [],
     histogramSeries: [],
     heatmapSeries: [],
   };

--- a/test/adapters/chartjs/extractor.test.ts
+++ b/test/adapters/chartjs/extractor.test.ts
@@ -1,4 +1,5 @@
-import type { ChartJsChart, ChartJsData, ChartJsOptions, ChartJsRuntimeScale } from '@adapters/chartjs/types';
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions, ChartJsRuntimeScale } from '@adapters/chartjs/types';
+import type { LinePoint } from '@type/grammar';
 import { extractChartData, extractMaidrData } from '@adapters/chartjs/extractor';
 import { TraceType } from '@type/grammar';
 
@@ -116,6 +117,125 @@ describe('chart.js extractor', () => {
       expect(maidr.subplots).toHaveLength(1);
       expect(maidr.subplots[0]).toHaveLength(1);
       expect(maidr.subplots[0][0].layers[0].id).toBe('0');
+    });
+  });
+
+  describe('stepped line datasets', () => {
+    const steppedChart = (
+      stepped: ChartJsDataset['stepped'],
+      options?: ChartJsOptions,
+    ): ChartJsChart => createChart({
+      type: 'line',
+      data: {
+        labels: ['a', 'b', 'c'],
+        datasets: [{ label: 'Stage', data: [1, 1, 2], stepped }],
+      },
+      options,
+    });
+
+    it.each([
+      ['before', 'hv'],
+      ['after', 'vh'],
+      ['middle', 'mid'],
+    ] as const)('binds stepped %s as a step layer jumping %s', (stepped, direction) => {
+      const layer = extractChartData(steppedChart(stepped)).maidr.subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe(direction);
+      expect(layer.data as LinePoint[][]).toEqual([[
+        { x: 'a', y: 1, z: 'Stage' },
+        { x: 'b', y: 1, z: 'Stage' },
+        { x: 'c', y: 2, z: 'Stage' },
+      ]]);
+    });
+
+    it('reads the bare boolean as the before default it stands for', () => {
+      const layer = extractChartData(steppedChart(true)).maidr.subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe('hv');
+    });
+
+    it.each([undefined, false] as const)('keeps an unstepped line a line (%s)', (stepped) => {
+      const layer = extractChartData(steppedChart(stepped)).maidr.subplots[0][0].layers[0];
+
+      expect(layer.id).toBe('0');
+      expect(layer.type).toBe(TraceType.LINE);
+      expect(layer.stepDirection).toBeUndefined();
+    });
+
+    it('falls back to the chart-wide elements.line default', () => {
+      const chart = steppedChart(undefined, { elements: { line: { stepped: 'middle' } } });
+
+      const layer = extractChartData(chart).maidr.subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe('mid');
+    });
+
+    it('lets a dataset\'s own setting win over the chart-wide default', () => {
+      const chart = steppedChart(false, { elements: { line: { stepped: 'before' } } });
+
+      expect(extractChartData(chart).maidr.subplots[0][0].layers[0].type).toBe(TraceType.LINE);
+    });
+
+    it('splits mixed datasets into layers that each route to their own data', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['a', 'b'],
+          datasets: [
+            { label: 'Trend', data: [1, 2] },
+            { label: 'Before', data: [3, 4], stepped: 'before' },
+            { label: 'After', data: [5, 6], stepped: 'after' },
+            { label: 'Trend 2', data: [7, 8] },
+          ],
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      const layers = maidr.subplots[0][0].layers;
+      expect(layers.map(layer => [layer.id, layer.type, layer.stepDirection])).toEqual([
+        ['0', TraceType.LINE, undefined],
+        ['1', TraceType.STEP, 'hv'],
+        ['2', TraceType.STEP, 'vh'],
+      ]);
+      // Each layer's MAIDR rows must route back to the datasets it holds, or
+      // every highlight on a mixed chart lands on the wrong series.
+      expect(layerDatasetIndices.get('0')).toEqual([0, 3]);
+      expect(layerDatasetIndices.get('1')).toEqual([1]);
+      expect(layerDatasetIndices.get('2')).toEqual([2]);
+    });
+
+    it('routes step rows to chart datasets inside an axis-stacked panel', () => {
+      const chart = createChart({
+        type: 'line',
+        data: {
+          labels: ['a', 'b'],
+          datasets: [
+            { label: 'Top line', data: [1, 2] },
+            { label: 'Top step', data: [3, 4], stepped: 'before' },
+            { label: 'Bottom', data: [5, 6], yAxisID: 'y2' },
+          ],
+        },
+        options: {
+          scales: { x: {}, y: { stack: 'panels' }, y2: { stack: 'panels' } },
+        },
+        scales: {
+          x: { axis: 'x', left: 0, right: 400, top: 300, bottom: 320 },
+          y: { axis: 'y', left: 0, right: 40, top: 0, bottom: 140 },
+          y2: { axis: 'y', left: 0, right: 40, top: 160, bottom: 300 },
+        },
+      });
+
+      const { maidr, layerDatasetIndices } = extractChartData(chart);
+
+      // y-stacks are emitted bottom row first, so the two-layer panel is last.
+      const topLayers = maidr.subplots[1][0].layers;
+      expect(topLayers.map(layer => layer.type)).toEqual([TraceType.LINE, TraceType.STEP]);
+      expect(layerDatasetIndices.get(topLayers[0].id)).toEqual([0]);
+      expect(layerDatasetIndices.get(topLayers[1].id)).toEqual([1]);
     });
   });
 

--- a/test/adapters/highcharts/adapter.test.ts
+++ b/test/adapters/highcharts/adapter.test.ts
@@ -1,3 +1,4 @@
+import type { HighchartsChart, HighchartsSeries } from '@adapters/highcharts/types';
 import type { BarPoint, HeatmapData, LinePoint, SegmentedPoint } from '@type/grammar';
 import { highchartsToMaidr } from '@adapters/highcharts/adapter';
 import { TraceType } from '@type/grammar';
@@ -100,6 +101,86 @@ describe('highchartsToMaidr', () => {
 
       expect(result.subplots).toHaveLength(1);
       expect(result.subplots[0]).toHaveLength(1);
+    });
+  });
+
+  describe('stepped line series', () => {
+    function steppedChart(step: HighchartsSeries['options']['step']): HighchartsChart {
+      return fakeChart({
+        type: 'line',
+        series: [fakeSeries({
+          index: 0,
+          type: 'line',
+          name: 'Stage',
+          options: { step },
+          data: categoryPoints([1, 1, 2], ['a', 'b', 'c']),
+        })],
+      });
+    }
+
+    it.each([
+      ['left', 'hv'],
+      ['center', 'mid'],
+      ['right', 'vh'],
+    ] as const)('binds step %s as a step layer jumping %s', (step, direction) => {
+      const layer = highchartsToMaidr(steppedChart(step)).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe(direction);
+      expect(layer.data as LinePoint[][]).toEqual([[
+        { x: 'a', y: 1, z: 'Stage' },
+        { x: 'b', y: 1, z: 'Stage' },
+        { x: 'c', y: 2, z: 'Stage' },
+      ]]);
+    });
+
+    it('reads the legacy boolean as the left default it stands for', () => {
+      const layer = highchartsToMaidr(steppedChart(true)).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe('hv');
+    });
+
+    it.each([undefined, false] as const)('keeps an unstepped line a line (%s)', (step) => {
+      const layer = highchartsToMaidr(steppedChart(step)).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.LINE);
+      expect(layer.stepDirection).toBeUndefined();
+    });
+
+    it('splits lines and steps that are drawn differently into their own layers', () => {
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({ index: 0, type: 'line', name: 'Trend', data: categoryPoints([1, 2], ['a', 'b']) }),
+          fakeSeries({ index: 1, type: 'line', name: 'Left', options: { step: 'left' }, data: categoryPoints([3, 4], ['a', 'b']) }),
+          fakeSeries({ index: 2, type: 'line', name: 'Right', options: { step: 'right' }, data: categoryPoints([5, 6], ['a', 'b']) }),
+        ],
+      });
+
+      const layers = highchartsToMaidr(chart).subplots[0][0].layers;
+
+      expect(layers.map(layer => [layer.type, layer.stepDirection, layer.title])).toEqual([
+        [TraceType.LINE, undefined, 'Trend'],
+        [TraceType.STEP, 'hv', 'Left'],
+        [TraceType.STEP, 'vh', 'Right'],
+      ]);
+    });
+
+    it('merges steps sharing a convention into one layer', () => {
+      const chart = fakeChart({
+        type: 'line',
+        series: [
+          fakeSeries({ index: 0, type: 'line', name: 'A', options: { step: 'left' }, data: categoryPoints([1, 2], ['a', 'b']) }),
+          fakeSeries({ index: 1, type: 'line', name: 'B', options: { step: 'left' }, data: categoryPoints([3, 4], ['a', 'b']) }),
+        ],
+      });
+
+      const layers = highchartsToMaidr(chart).subplots[0][0].layers;
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.STEP);
+      expect(layers[0].data).toHaveLength(2);
     });
   });
 

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,5 +1,5 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
-import type { BarPoint, BoxPoint, BoxSelector, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, BoxSelector, MaidrLayer, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
@@ -138,6 +138,154 @@ describe('plotly extractor', () => {
         expect(skipped).toHaveLength(1);
       } finally {
         // A failed assertion must not leave the spy in place for later tests.
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe('step traces', () => {
+    const SINGLE_PANEL = {
+      xaxis: { domain: [0, 1] as [number, number] },
+      yaxis: { domain: [0, 1] as [number, number] },
+    };
+
+    function stepTrace(shape: string, overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'scatter',
+        mode: 'lines',
+        x: [1, 2, 3],
+        y: [10, 10, 20],
+        line: { shape },
+        ...overrides,
+      };
+    }
+
+    function onlyLayer(gd: PlotlyGraphDiv): MaidrLayer {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it.each([
+      ['hv', 'hv'],
+      ['vh', 'vh'],
+      ['hvh', 'mid'],
+    ])('binds line.shape %s as a step layer jumping %s', (shape, direction) => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [stepTrace(shape)],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe(direction);
+      expect(layer.data).toEqual([[
+        { x: 1, y: 10, z: 'Series 1' },
+        { x: 2, y: 10, z: 'Series 1' },
+        { x: 3, y: 20, z: 'Series 1' },
+      ]]);
+    });
+
+    it('leaves vhv without a direction, since no convention describes it', () => {
+      // `vhv` runs flat at the mean of the two levels rather than at either
+      // one, so naming any of hv/vh/mid would describe a chart plotly did not
+      // draw. It is still a staircase, so it still binds as a step.
+      const layer = onlyLayer(createGraphDiv({
+        traces: [stepTrace('vhv')],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBeUndefined();
+    });
+
+    it.each(['linear', 'spline'])('keeps an interpolated %s shape a line', (shape) => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [stepTrace(shape)],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.LINE);
+      expect(layer.stepDirection).toBeUndefined();
+    });
+
+    it('keeps a line with no shape at all a line', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [{ type: 'scatter', mode: 'lines', x: [1, 2], y: [3, 4] }],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.LINE);
+    });
+
+    it('ignores line.shape on a markers-only trace, which draws no line', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [stepTrace('hv', { mode: 'markers' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.SCATTER);
+    });
+
+    it('highlights the markers of a lines+markers step, as a line does', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [stepTrace('hv', { mode: 'lines+markers' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.selectors).toBe('.subplot.xy .trace.scatter .point');
+    });
+
+    it('merges step traces sharing a convention into one layer', () => {
+      const gd = createGraphDiv({
+        traces: [
+          stepTrace('hv', { name: 'A' }),
+          stepTrace('hv', { name: 'B', y: [5, 15, 15] }),
+        ],
+        layout: SINGLE_PANEL,
+      });
+
+      const layer = onlyLayer(gd);
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe('hv');
+      expect(layer.data).toHaveLength(2);
+    });
+
+    it('splits step traces that jump differently, so neither is mislabelled', () => {
+      const gd = createGraphDiv({
+        traces: [
+          stepTrace('hv', { name: 'A' }),
+          stepTrace('vh', { name: 'B' }),
+          { type: 'scatter', mode: 'lines', x: [1, 2], y: [3, 4], name: 'C' },
+        ],
+        layout: SINGLE_PANEL,
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers.map(layer => [layer.type, layer.stepDirection])).toEqual([
+        [TraceType.LINE, undefined],
+        [TraceType.STEP, 'hv'],
+        [TraceType.STEP, 'vh'],
+      ]);
+    });
+
+    it('does not warn about a step trace, which is supported', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const gd = createGraphDiv({
+        traces: [stepTrace('hv')],
+        layout: SINGLE_PANEL,
+      });
+
+      try {
+        extractPlotlyData(gd);
+
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
         warn.mockRestore();
       }
     });
@@ -1158,6 +1306,36 @@ describe('plotly extractor', () => {
         if (!state.empty) {
           expect(state.size).toBe(4);
         }
+      });
+    });
+
+    it('a plotly step chart reaches the core as a step trace', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'scatter',
+          mode: 'lines',
+          x: [1, 2, 3, 4],
+          y: [10, 10, 20, 20],
+          line: { shape: 'hv' },
+          name: 'Level',
+        }],
+        layout: {
+          xaxis: { domain: [0, 1] },
+          yaxis: { domain: [0, 1] },
+        },
+        bgRects: [{ x: 0, y: 0 }],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        // 'step', not 'line': the trace a reader actually navigates, with the
+        // transition rotor and the step convention that come with it.
+        expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.STEP]);
       });
     });
 

--- a/test/adapters/vegalite/converters.test.ts
+++ b/test/adapters/vegalite/converters.test.ts
@@ -1,5 +1,5 @@
 import type { VegaLiteSpec } from '@adapters/vegalite/types';
-import type { BoxPoint } from '@type/grammar';
+import type { BoxPoint, MaidrLayer } from '@type/grammar';
 import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
 import { Orientation, TraceType } from '@type/grammar';
 
@@ -196,6 +196,104 @@ describe('vega-Lite converters', () => {
 
       const result = vegaLiteToMaidr(spec);
       expect(result.title).toBe('Vega-Lite Chart');
+    });
+  });
+
+  describe('stepped marks', () => {
+    const VALUES = [
+      { day: 1, level: 10 },
+      { day: 2, level: 10 },
+      { day: 3, level: 20 },
+    ];
+
+    function steppedSpec(interpolate?: string, type = 'line'): VegaLiteSpec {
+      return {
+        mark: interpolate === undefined ? { type } : { type, interpolate },
+        data: { values: VALUES },
+        encoding: {
+          x: { field: 'day', type: 'quantitative' },
+          y: { field: 'level', type: 'quantitative' },
+        },
+      };
+    }
+
+    function onlyLayer(spec: VegaLiteSpec): MaidrLayer {
+      return vegaLiteToMaidr(spec).subplots[0][0].layers[0];
+    }
+
+    it.each([
+      ['step', 'mid'],
+      ['step-before', 'vh'],
+      ['step-after', 'hv'],
+    ])('binds interpolate %s as a step layer jumping %s', (interpolate, direction) => {
+      const layer = onlyLayer(steppedSpec(interpolate));
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe(direction);
+      expect(layer.data).toEqual([[
+        { x: 1, y: 10 },
+        { x: 2, y: 10 },
+        { x: 3, y: 20 },
+      ]]);
+    });
+
+    it('binds a stepped area mark as a step too', () => {
+      const layer = onlyLayer(steppedSpec('step-after', 'area'));
+
+      expect(layer.type).toBe(TraceType.STEP);
+      expect(layer.stepDirection).toBe('hv');
+    });
+
+    it.each([undefined, 'linear', 'monotone'])(
+      'keeps an interpolated mark a line (%s)',
+      (interpolate) => {
+        const layer = onlyLayer(steppedSpec(interpolate));
+
+        expect(layer.type).toBe(TraceType.LINE);
+        expect(layer.stepDirection).toBeUndefined();
+      },
+    );
+
+    it('keeps sibling steps that jump differently in separate layers', () => {
+      const spec: VegaLiteSpec = {
+        data: { values: VALUES },
+        encoding: {
+          x: { field: 'day', type: 'quantitative' },
+          y: { field: 'level', type: 'quantitative' },
+        },
+        layer: [
+          { mark: { type: 'line', interpolate: 'step-after' } },
+          { mark: { type: 'line', interpolate: 'step-before' } },
+        ],
+      };
+
+      const layers = vegaLiteToMaidr(spec).subplots[0][0].layers;
+
+      expect(layers.map(layer => [layer.type, layer.stepDirection])).toEqual([
+        [TraceType.STEP, 'hv'],
+        [TraceType.STEP, 'vh'],
+      ]);
+    });
+
+    it('merges sibling steps that jump the same way', () => {
+      const spec: VegaLiteSpec = {
+        data: { values: VALUES },
+        encoding: {
+          x: { field: 'day', type: 'quantitative' },
+          y: { field: 'level', type: 'quantitative' },
+        },
+        layer: [
+          { mark: { type: 'line', interpolate: 'step-after' } },
+          { mark: { type: 'line', interpolate: 'step-after' } },
+        ],
+      };
+
+      const layers = vegaLiteToMaidr(spec).subplots[0][0].layers;
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.STEP);
+      expect(layers[0].stepDirection).toBe('hv');
+      expect(layers[0].data).toHaveLength(2);
     });
   });
 

--- a/test/adapters/victory/converters.test.ts
+++ b/test/adapters/victory/converters.test.ts
@@ -308,6 +308,44 @@ describe('toMaidrLayer', () => {
     expect(layer.axes?.x).toEqual({ label: 'X' });
   });
 
+  it.each([
+    ['step', 'mid'],
+    ['stepBefore', 'vh'],
+    ['stepAfter', 'hv'],
+  ])('converts an interpolation %s line into a step layer jumping %s', (interpolation, direction) => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryLine, { data: lineData, interpolation })),
+    );
+
+    const layer = toMaidrLayer(info, '#mv path');
+
+    expect(layer.type).toBe(TraceType.STEP);
+    expect(layer.stepDirection).toBe(direction);
+    expect(layer.data).toEqual([[{ x: 1, y: 10 }, { x: 2, y: 20 }]]);
+  });
+
+  it.each([undefined, 'linear', 'monotoneX'])(
+    'keeps an interpolated line a line (%s)',
+    (interpolation) => {
+      const [info] = extractVictoryLayers(
+        chart({}, createElement(VictoryLine, { data: lineData, interpolation })),
+      );
+
+      const layer = toMaidrLayer(info, '#mv path');
+
+      expect(layer.type).toBe(TraceType.LINE);
+      expect(layer.stepDirection).toBeUndefined();
+    },
+  );
+
+  it('keeps a line a line when interpolation is a custom curve function', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryLine, { data: lineData, interpolation: () => null })),
+    );
+
+    expect(toMaidrLayer(info, '#mv path').type).toBe(TraceType.LINE);
+  });
+
   it('converts a segmented layer to stacked type', () => {
     const points: SegmentedPoint[][] = [[{ x: 'A', y: 1, z: 'S1' }]];
     const info: VictoryLayerInfo = {


### PR DESCRIPTION
# Pull Request

## Description

`StepTrace` landed in #723 and works through the maidr JSON path, but no adapter that reads a chart library's own settings could reach it. A chart the library drew as stairs was described as a line — telling a reader the value moved gradually between samples when it holds and then jumps — and the transition rotor, the ordinal level names, and the spoken step convention were all unreachable.

This fixes that in every adapter that introspects the library and could therefore be wrong: Plotly (the reported case), Chart.js, Highcharts, Vega-Lite, Victory, and amCharts.

Each mapping was read off the drawing code rather than the docs, since the naming does not line up across libraries — Chart.js `stepped: 'after'` and d3's `curveStepAfter` are opposite conventions.

| Library | Setting | → `stepDirection` |
|---|---|---|
| Plotly | `line.shape: 'hv' \| 'vh' \| 'hvh'` | `hv` / `vh` / `mid` |
| Plotly | `line.shape: 'vhv'` | step, no direction (see below) |
| Chart.js | `stepped: 'before' \| 'after' \| 'middle'` (or `true`) | `hv` / `vh` / `mid` |
| Highcharts | `step: 'left' \| 'center' \| 'right'` (or `true`) | `hv` / `mid` / `vh` |
| Vega-Lite | `interpolate: 'step-after' \| 'step-before' \| 'step'` | `hv` / `vh` / `mid` |
| Victory | `interpolation="stepAfter" \| "stepBefore" \| "step"` | `hv` / `vh` / `mid` |
| amCharts | `StepLineSeries` | step, no direction |

**The `vhv` decision the issue asked for.** `hvh` is `mid` — it holds each sample's own value and jumps at the midpoint, exactly what `mid` describes. `vhv` is not: it rises at `x[i]`, runs flat at the *mean* of `y[i]` and `y[i+1]`, then rises again at `x[i+1]`. No MAIDR convention describes that, and `mid` would actively mislead, promising a jump midway between x values where `vhv` jumps at the x values themselves. It binds as a step — the data is piecewise constant and the transition rotor is the navigation it wants — with no direction named, which is what `stepDirection` being optional is for.

amCharts is the same reasoning from the other end: it positions the staircase from the axis cell rather than reporting a convention, so naming one would be a guess. This follows the precedent the AnyChart step layers already set.

**Splitting.** A layer announces one `stepDirection` for all of its series, so a chart mixing conventions splits into one layer per convention rather than merging and describing one of them wrongly. In Chart.js that also meant each layer now reports which datasets back its rows, so highlights on a mixed chart still route to the right series.

**Not changed, and why.** Recharts, D3 and Google Charts are declarative: the caller tells MAIDR the chart type, so MAIDR reports exactly what it was told and nothing is currently wrong. Supporting step there means adding a new value to a public config API, which is a separate change. Frappe Charts has no step option at all.

## Related Issues

Closes #744

## Changes Made

- **`adapters/plotly`** — pass the whole trace to `mapScatterMode` and read `line.shape`; group step traces by convention; extend the step selector to reuse the line one.
- **`adapters/chartjs`** — read `dataset.stepped`, falling back to `elements.line` as Chart.js resolves it; split line datasets into a line layer and one step layer per convention; thread per-layer dataset indices through both the single-subplot and axis-stacked-panel paths so highlight routing follows.
- **`adapters/highcharts`** — read `series.options.step` (which Highcharts resolves from `plotOptions`), including the legacy boolean.
- **`adapters/vegalite`** — read `interpolate` off the mark def for `line` and `area`; sibling-layer coalescing now requires matching type *and* direction.
- **`adapters/victory`** — read the `interpolation` prop; a function-valued one (a custom curve factory) stays a line, since nothing about it is inspectable.
- **`adapters/amcharts`** — classify `StepLineSeries` as its own kind, merge those series into a step layer, and give the navigation map its own series list so a chart with both keeps its highlights aligned.
- **docs** — a step row in each adapter's supported-type table, plus notes for the two adapters whose mapping needs one.
- **`examples/plotly-step.html`** — the three Plotly shapes side by side.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass — 1532 unit tests across 116 suites plus the ESM project, with 47 new cases covering the six adapters.

**`E2E (chromium)` runs in CI on this PR** and has been green on each commit. (An earlier version of this description said the E2E suite had not been run; that was wrong and is corrected here. What could not run was the suite *in my local environment*, where the browser cannot reach external hosts through the egress proxy — `curl` can, Chromium gets `ERR_CONNECTION_RESET`. Serving the built bundles over localhost with the chart libraries vendored works fine, which is how the checks below were done.)

Beyond CI and the unit tests, the two riskiest parts were verified against real renders:

**Chart.js direction mapping — measured from rendered pixels**, since it is the one mapping with no well-documented external convention to check against. A two-point dataset with everything but the line switched off, reading back the canvas `ImageData` to find where the line sits between the points:

| `stepped` | just after p0 | before mid | after mid | just before p1 | → |
|---|---|---|---|---|---|
| `before` | old | old | old | old | **`hv`** |
| `after` | **new** | new | new | new | **`vh`** |
| `middle` | old | old | **new** | new | **`mid`** |
| `true` | old | old | old | old | **`hv`** |
| `false` | between | between | between | between | not a step |

**Chart.js highlight routing — driven in Chromium** against the built `dist/chartjs.js` with a deliberately interleaved chart (`[Trend, Before(step), After(step), Trend 2]`), reading `chart.getActiveElements()`: the line layer's rows route to datasets **0** and **3**, and the two step layers to **1** and **2**. Row 1 landing on dataset 3 is the case that would break without the dataset-index threading.

**Plotly end to end** against the built `dist/maidr.js`: all three shapes announce `type: step` (a plain line still announces `multiline`); the Transitions rotor jumps 8 → 10 → 13 → 15 on a held series, exactly the level changes; and the spoken convention differs correctly per shape — `hv` "holds until the next x value, then jumps", `vh` "jumps at the current x value, then holds", `hvh` "jumps midway between x values".

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hv1rkb9z7AVZescynitfGd