### PR TITLE
feat(text): announce orientation for every plot type that has one

### DIFF
--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -110,21 +110,24 @@ export abstract class TestConstants {
   /**
    * Instruction text for different plot types
    */
-  static readonly BAR_INSTRUCTION_TEXT = 'This is a maidr plot of type: bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  static readonly HISTOGRAM_INSTRUCTION_TEXT = 'This is a maidr plot of type: hist. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // Every trace type that has an orientation is announced with it — see
+  // `resolveOrientation` in src/util/orientation.ts — and a layer that does not
+  // declare one is navigated, and so announced, as vertical.
+  static readonly BAR_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly HISTOGRAM_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical hist. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly HEATMAP_INSTRUCTION_TEXT = 'This is a maidr plot of type: heat. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly LINEPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: single line. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // `StepTrace.state` overrides the inherited line plotType, so a step chart
   // announces itself as a step plot rather than as a line one.
   static readonly STEPPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: step. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  // `formatPlotType` in src/model/context.ts prefixes the box type with its
+  static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // `formatPlotType` in src/util/orientation.ts prefixes the box type with its
   // orientation, so a screen reader user hears which axis the boxes run along.
   static readonly BOXPLOT_VERTICAL_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical box. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly BOXPLOT_HORIZONTAL_INSTRUCTION_TEXT = 'This is a maidr plot of type: horizontal box. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly MULTI_LINEPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: multiline with 3 groups. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
-  static readonly MULTI_LAYER_PLOT_INSTRUCTION_TEXT = 'This is a maidr plot containing 2 layers, and this is layer 1 of 2: bar plot. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly MULTI_LAYER_PLOT_INSTRUCTION_TEXT = 'This is a maidr plot containing 2 layers, and this is layer 1 of 2: vertical bar plot. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // Violin layers are their own trace types (violin_kde / violin_box), not the
   // smooth + box pair they used to be modelled as.
   static readonly VIOLIN_PLOT_INSTRUCTION_TEXT = 'This is a maidr plot containing 2 layers, and this is layer 1 of 2: vertical violin_box plot. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';

--- a/src/maidr-component.tsx
+++ b/src/maidr-component.tsx
@@ -1,7 +1,8 @@
 import type { AppStore } from '@state/store';
 import type { Maidr as MaidrData } from '@type/grammar';
 import type { JSX, ReactNode, PointerEvent as ReactPointerEvent } from 'react';
-import { Orientation, TraceType } from '@type/grammar';
+import { TraceType } from '@type/grammar';
+import { formatPlotType, resolveOrientation } from '@util/orientation';
 import { useCallback, useMemo, useRef } from 'react';
 import { useMaidrController } from './state/hook/useMaidrController';
 import { createMaidrStore } from './state/store';
@@ -44,23 +45,6 @@ export interface MaidrProps {
  * Once the Controller is created on focus-in, {@link DisplayService} overwrites
  * these attributes with the authoritative values.
  */
-/**
- * Build a human-readable plot type string with optional orientation prefix.
- * Returns just the type when orientation is absent/empty (no extra whitespace).
- */
-function formatPlotType(plotType: string, orientation?: string): string {
-  if (!orientation) {
-    return plotType;
-  }
-  if (orientation === Orientation.HORIZONTAL || orientation === 'horz') {
-    return `horizontal ${plotType}`;
-  }
-  if (orientation === Orientation.VERTICAL || orientation === 'vert') {
-    return `vertical ${plotType}`;
-  }
-  return plotType;
-}
-
 function getInitialInstruction(data: MaidrData): string {
   const subplots = data.subplots;
   const subplotCount = subplots.flat().length;
@@ -98,7 +82,12 @@ function getInitialInstruction(data: MaidrData): string {
     }
   }
 
-  const displayType = formatPlotType(plotType, firstLayer?.orientation);
+  // Resolved the same way the trace model resolves it, so the pre-activation
+  // announcement and the one DisplayService writes on focus-in agree.
+  const displayType = formatPlotType(
+    plotType,
+    resolveOrientation(traceType, firstLayer?.orientation),
+  );
 
   if (layerCount > 1) {
     return `This is a maidr plot containing ${layerCount} layers, and this is layer 1 of ${layerCount}: ${displayType} plot. Click to activate. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.`;

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -18,6 +18,7 @@ import type { Trace } from './plot';
 import { NavigationService } from '@service/navigation';
 import { TraceType } from '@type/grammar';
 import { Constant } from '@util/constant';
+import { resolveOrientation } from '@util/orientation';
 import { Svg } from '@util/svg';
 
 export const DEFAULT_SUBPLOT_TITLE = 'unavailable';
@@ -442,7 +443,10 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
       text: this.text,
       autoplay: this.autoplay,
       highlight: this.highlight,
-      orientation: this.layer.orientation,
+      // The effective orientation, not the declared one: a trace type that has
+      // an orientation is navigated as vertical when the JSON omits it, and
+      // the announcement has to say so rather than stay silent.
+      orientation: resolveOrientation(this.type, this.layer.orientation),
     };
   }
 

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -5,29 +5,12 @@ import type { Figure, Subplot, Trace } from './plot';
 import { DEFAULT_SUBPLOT_TITLE } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Scope } from '@type/event';
-import { Orientation } from '@type/grammar';
 import { isGridNavigable } from '@type/navigation';
 import { Constant } from '@util/constant';
+import { formatPlotType } from '@util/orientation';
 import { Stack } from '@util/stack';
 import hotkeys from 'hotkeys-js';
 import { DEFAULT_CAPTION, DEFAULT_FIGURE_AXIS, DEFAULT_SUBTITLE, isAuthoredTitle as isAuthoredTitleValue } from './plot';
-
-/**
- * Build a human-readable plot type string with optional orientation prefix.
- * Returns just the type when orientation is absent/empty (no extra whitespace).
- */
-function formatPlotType(plotType: string, orientation?: Orientation | string): string {
-  if (!orientation) {
-    return plotType;
-  }
-  if (orientation === Orientation.HORIZONTAL || orientation === 'horz') {
-    return `horizontal ${plotType}`;
-  }
-  if (orientation === Orientation.VERTICAL || orientation === 'vert') {
-    return `vertical ${plotType}`;
-  }
-  return plotType;
-}
 
 type Plot = Figure | Subplot | Trace;
 

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -1,29 +1,41 @@
 import { Orientation, TraceType } from '@type/grammar';
 
 /**
- * Trace types whose model navigates along an orientation.
+ * Whether each trace type's model navigates along an orientation.
  *
- * Every trace in this set resolves `layer.orientation` to a concrete
+ * A type marked true resolves `layer.orientation` to a concrete
  * {@link Orientation} at construction — falling back to
  * {@link Orientation.VERTICAL} when the MAIDR JSON omits it — and swaps its
  * main and cross axes accordingly. Orientation is therefore never unknown for
- * these types, only undeclared, which is why {@link resolveOrientation} can
+ * those types, only undeclared, which is why {@link resolveOrientation} can
  * report it for every one of them.
  *
- * Types that are absent here have no orientation at all: a scatter, heatmap,
- * line, step, or smooth trace reads the same way whichever way it is drawn.
+ * A type marked false has no orientation at all: a scatter, heatmap, line,
+ * step, or smooth trace reads the same way whichever way it is drawn.
+ *
+ * Keyed by every {@link TraceType} so a new trace type cannot be added without
+ * answering the question here — the same reason `CHART_TYPE_LABEL` in
+ * `src/model/abstract.ts` is a full record rather than a partial one.
  */
-const ORIENTED_TRACE_TYPES: ReadonlySet<string> = new Set<string>([
-  TraceType.BAR,
-  TraceType.BOX,
-  TraceType.CANDLESTICK,
-  TraceType.DODGED,
-  TraceType.HISTOGRAM,
-  TraceType.NORMALIZED,
-  TraceType.STACKED,
-  TraceType.VIOLIN_BOX,
-  TraceType.VIOLIN_KDE,
-]);
+const IS_ORIENTED: Record<TraceType, boolean> = {
+  [TraceType.BAR]: true,
+  [TraceType.BOX]: true,
+  [TraceType.CANDLESTICK]: true,
+  // Built at runtime from a candlestick and a reference line, never declared
+  // in the JSON; it is navigated by field and candle, not by an orientation.
+  [TraceType.CANDLESTICK_DELTA]: false,
+  [TraceType.DODGED]: true,
+  [TraceType.HEATMAP]: false,
+  [TraceType.HISTOGRAM]: true,
+  [TraceType.LINE]: false,
+  [TraceType.NORMALIZED]: true,
+  [TraceType.SCATTER]: false,
+  [TraceType.SMOOTH]: false,
+  [TraceType.STACKED]: true,
+  [TraceType.STEP]: false,
+  [TraceType.VIOLIN_BOX]: true,
+  [TraceType.VIOLIN_KDE]: true,
+};
 
 /**
  * Resolves the orientation a trace is actually navigated by.
@@ -46,7 +58,7 @@ export function resolveOrientation(
   traceType: string,
   declared?: Orientation,
 ): Orientation | undefined {
-  if (!ORIENTED_TRACE_TYPES.has(traceType)) {
+  if (!IS_ORIENTED[traceType as TraceType]) {
     return undefined;
   }
   return declared === Orientation.HORIZONTAL

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -33,6 +33,11 @@ const ORIENTED_TRACE_TYPES: ReadonlySet<string> = new Set<string>([
  * of a key in the JSON. A bar chart whose layer omits `orientation` is
  * navigated as a vertical bar chart, so it is announced as one.
  *
+ * `traceType` is a plain string rather than a `TraceType`: the pre-activation
+ * builder in `maidr-component.tsx` reads it straight off the JSON, where an
+ * absent or unknown type is possible, and an unknown type simply has no
+ * orientation.
+ *
  * @param traceType - The layer's `type`, as declared in the MAIDR JSON
  * @param declared - The layer's `orientation`, when the JSON declares one
  * @returns The effective orientation, or undefined for types that have none
@@ -51,7 +56,11 @@ export function resolveOrientation(
 
 /**
  * Builds a human-readable plot type string with optional orientation prefix.
- * Returns just the type when orientation is absent/empty (no extra whitespace).
+ * Returns just the type when there is no orientation (no extra whitespace).
+ *
+ * Takes the resolved orientation, not the raw layer field — pass
+ * {@link resolveOrientation}'s result so an undeclared orientation still
+ * announces the one the trace is navigated by.
  *
  * @param plotType - The display name of the plot type, e.g. `bar`
  * @param orientation - The orientation to prefix with, when there is one
@@ -59,16 +68,12 @@ export function resolveOrientation(
  */
 export function formatPlotType(
   plotType: string,
-  orientation?: Orientation | string,
+  orientation?: Orientation,
 ): string {
   if (!orientation) {
     return plotType;
   }
-  if (orientation === Orientation.HORIZONTAL) {
-    return `horizontal ${plotType}`;
-  }
-  if (orientation === Orientation.VERTICAL) {
-    return `vertical ${plotType}`;
-  }
-  return plotType;
+  return orientation === Orientation.HORIZONTAL
+    ? `horizontal ${plotType}`
+    : `vertical ${plotType}`;
 }

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -1,0 +1,74 @@
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Trace types whose model navigates along an orientation.
+ *
+ * Every trace in this set resolves `layer.orientation` to a concrete
+ * {@link Orientation} at construction — falling back to
+ * {@link Orientation.VERTICAL} when the MAIDR JSON omits it — and swaps its
+ * main and cross axes accordingly. Orientation is therefore never unknown for
+ * these types, only undeclared, which is why {@link resolveOrientation} can
+ * report it for every one of them.
+ *
+ * Types that are absent here have no orientation at all: a scatter, heatmap,
+ * line, step, or smooth trace reads the same way whichever way it is drawn.
+ */
+const ORIENTED_TRACE_TYPES: ReadonlySet<string> = new Set<string>([
+  TraceType.BAR,
+  TraceType.BOX,
+  TraceType.CANDLESTICK,
+  TraceType.DODGED,
+  TraceType.HISTOGRAM,
+  TraceType.NORMALIZED,
+  TraceType.STACKED,
+  TraceType.VIOLIN_BOX,
+  TraceType.VIOLIN_KDE,
+]);
+
+/**
+ * Resolves the orientation a trace is actually navigated by.
+ *
+ * Mirrors what the trace constructors do — `layer.orientation ?? VERTICAL` —
+ * so the announcement matches the model's behaviour rather than the presence
+ * of a key in the JSON. A bar chart whose layer omits `orientation` is
+ * navigated as a vertical bar chart, so it is announced as one.
+ *
+ * @param traceType - The layer's `type`, as declared in the MAIDR JSON
+ * @param declared - The layer's `orientation`, when the JSON declares one
+ * @returns The effective orientation, or undefined for types that have none
+ */
+export function resolveOrientation(
+  traceType: string,
+  declared?: Orientation,
+): Orientation | undefined {
+  if (!ORIENTED_TRACE_TYPES.has(traceType)) {
+    return undefined;
+  }
+  return declared === Orientation.HORIZONTAL
+    ? Orientation.HORIZONTAL
+    : Orientation.VERTICAL;
+}
+
+/**
+ * Builds a human-readable plot type string with optional orientation prefix.
+ * Returns just the type when orientation is absent/empty (no extra whitespace).
+ *
+ * @param plotType - The display name of the plot type, e.g. `bar`
+ * @param orientation - The orientation to prefix with, when there is one
+ * @returns The plot type, prefixed with `vertical` or `horizontal` when known
+ */
+export function formatPlotType(
+  plotType: string,
+  orientation?: Orientation | string,
+): string {
+  if (!orientation) {
+    return plotType;
+  }
+  if (orientation === Orientation.HORIZONTAL) {
+    return `horizontal ${plotType}`;
+  }
+  if (orientation === Orientation.VERTICAL) {
+    return `vertical ${plotType}`;
+  }
+  return plotType;
+}

--- a/test/model/instructionOrientation.test.ts
+++ b/test/model/instructionOrientation.test.ts
@@ -1,0 +1,116 @@
+import type { BoxPoint, Maidr, MaidrLayer } from '@type/grammar';
+import { describe, expect, jest, test } from '@jest/globals';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { Orientation, TraceType } from '@type/grammar';
+
+jest.mock('hotkeys-js', () => ({
+  __esModule: true,
+  default: { setScope: jest.fn() },
+}));
+
+/**
+ * Creates a bar layer, optionally declaring an orientation.
+ * @param orientation - The orientation to declare, or undefined to omit it
+ * @returns A bar layer definition
+ */
+function createBarLayer(orientation?: Orientation): MaidrLayer {
+  return {
+    id: 'bar-layer',
+    type: TraceType.BAR,
+    axes: { x: { label: 'Category' }, y: { label: 'Value' } },
+    orientation,
+    data: [
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 },
+    ],
+  };
+}
+
+/**
+ * Creates a box layer, optionally declaring an orientation.
+ * @param orientation - The orientation to declare, or undefined to omit it
+ * @returns A box layer definition
+ */
+function createBoxLayer(orientation?: Orientation): MaidrLayer {
+  const point: BoxPoint = {
+    z: 'A',
+    lowerOutliers: [],
+    min: 1,
+    q1: 2,
+    q2: 3,
+    q3: 4,
+    max: 5,
+    upperOutliers: [],
+  };
+  return {
+    id: 'box-layer',
+    type: TraceType.BOX,
+    axes: { x: { label: 'Category' }, y: { label: 'Value' } },
+    orientation,
+    data: [point],
+  };
+}
+
+/**
+ * Creates a single-group line layer, which has no orientation.
+ * @returns A line layer definition
+ */
+function createLineLayer(): MaidrLayer {
+  return {
+    id: 'line-layer',
+    type: TraceType.LINE,
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data: [[{ x: 1, y: 1 }, { x: 2, y: 2 }]],
+  };
+}
+
+/**
+ * Wraps layers into a single-subplot Maidr config.
+ * @param layers - The layers of the only subplot
+ * @returns A Maidr config
+ */
+function createMaidr(...layers: MaidrLayer[]): Maidr {
+  return { id: 'instruction-test', subplots: [[{ layers }]] };
+}
+
+/**
+ * Builds the instruction a user hears on entering the figure.
+ * @param layers - The layers of the only subplot
+ * @returns The instruction text, without the click prompt
+ */
+function instructionFor(...layers: MaidrLayer[]): string {
+  return new Context(new Figure(createMaidr(...layers))).getInstruction(false);
+}
+
+describe('context.getInstruction orientation', () => {
+  test('announces an undeclared bar orientation as vertical', () => {
+    expect(instructionFor(createBarLayer())).toContain('type: vertical bar.');
+  });
+
+  test('announces a declared horizontal bar orientation', () => {
+    expect(instructionFor(createBarLayer(Orientation.HORIZONTAL))).toContain(
+      'type: horizontal bar.',
+    );
+  });
+
+  test('announces an undeclared box orientation as vertical', () => {
+    expect(instructionFor(createBoxLayer())).toContain('type: vertical box.');
+  });
+
+  test('announces a declared horizontal box orientation', () => {
+    expect(instructionFor(createBoxLayer(Orientation.HORIZONTAL))).toContain(
+      'type: horizontal box.',
+    );
+  });
+
+  test('leaves a trace type that has no orientation unprefixed', () => {
+    expect(instructionFor(createLineLayer())).toContain('type: single line.');
+  });
+
+  test('announces the orientation of layer 1 of a multi-layer plot', () => {
+    expect(instructionFor(createBarLayer(), createLineLayer())).toContain(
+      'layer 1 of 2: vertical bar plot.',
+    );
+  });
+});

--- a/test/ui/initialInstruction.esm-test.tsx
+++ b/test/ui/initialInstruction.esm-test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Component tests for the pre-activation announcement.
+ *
+ * `Maidr` labels the plot wrapper before any Controller exists, so a screen
+ * reader can find the chart (NVDA "g") without focusing it first. That string
+ * is built by a second instruction builder — the model's
+ * `Context.getInstruction` produces the post-activation one — and the two have
+ * to agree, or the announcement changes the moment the user focuses the chart.
+ *
+ * The Controller is created on focus-in, not on mount, so rendering here
+ * exercises the label alone.
+ */
+
+import type { BoxPoint, Maidr as MaidrData, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { Orientation, TraceType } from '@type/grammar';
+import { Maidr } from '../../src/maidr-component';
+
+/**
+ * Creates a bar layer, optionally declaring an orientation.
+ * @param orientation - The orientation to declare, or undefined to omit it
+ * @returns A bar layer definition
+ */
+function createBarLayer(orientation?: Orientation): MaidrLayer {
+  return {
+    id: 'bar-layer',
+    type: TraceType.BAR,
+    axes: { x: { label: 'Category' }, y: { label: 'Value' } },
+    orientation,
+    data: [
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 },
+    ],
+  };
+}
+
+/**
+ * Creates a box layer, optionally declaring an orientation.
+ * @param orientation - The orientation to declare, or undefined to omit it
+ * @returns A box layer definition
+ */
+function createBoxLayer(orientation?: Orientation): MaidrLayer {
+  const point: BoxPoint = {
+    z: 'A',
+    lowerOutliers: [],
+    min: 1,
+    q1: 2,
+    q2: 3,
+    q3: 4,
+    max: 5,
+    upperOutliers: [],
+  };
+  return {
+    id: 'box-layer',
+    type: TraceType.BOX,
+    axes: { x: { label: 'Category' }, y: { label: 'Value' } },
+    orientation,
+    data: [point],
+  };
+}
+
+/**
+ * Creates a single-group line layer, which has no orientation.
+ * @returns A line layer definition
+ */
+function createLineLayer(): MaidrLayer {
+  return {
+    id: 'line-layer',
+    type: TraceType.LINE,
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data: [[{ x: 1, y: 1 }, { x: 2, y: 2 }]],
+  };
+}
+
+/**
+ * Renders a figure of the given layers and returns its pre-activation label.
+ * @param layers - The layers of the only subplot
+ * @returns The wrapper's accessible name
+ */
+function labelFor(...layers: MaidrLayer[]): string {
+  const data: MaidrData = { id: 'label-test', subplots: [[{ layers }]] };
+  const { unmount } = render(
+    <Maidr data={data}>
+      <svg />
+    </Maidr>,
+  );
+  const label = screen.getByRole('img').getAttribute('aria-label') ?? '';
+  unmount();
+  return label;
+}
+
+describe('pre-activation instruction orientation', () => {
+  test('announces an undeclared bar orientation as vertical', () => {
+    expect(labelFor(createBarLayer())).toContain('type: vertical bar.');
+  });
+
+  test('announces a declared horizontal box orientation', () => {
+    expect(labelFor(createBoxLayer(Orientation.HORIZONTAL))).toContain(
+      'type: horizontal box.',
+    );
+  });
+
+  test('leaves a trace type that has no orientation unprefixed', () => {
+    expect(labelFor(createLineLayer())).toContain('type: single line.');
+  });
+
+  test('announces the orientation of layer 1 of a multi-layer plot', () => {
+    expect(labelFor(createBarLayer(), createLineLayer())).toContain(
+      'layer 1 of 2: vertical bar plot.',
+    );
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -25,12 +25,18 @@ describe('resolveOrientation', () => {
   });
 
   const unorientedTypes = [
+    TraceType.CANDLESTICK_DELTA,
     TraceType.HEATMAP,
     TraceType.LINE,
     TraceType.SCATTER,
     TraceType.SMOOTH,
     TraceType.STEP,
   ];
+
+  test('answers for every trace type', () => {
+    const covered = [...orientedTypes, ...unorientedTypes];
+    expect(covered.sort()).toEqual(Object.values(TraceType).sort());
+  });
 
   test.each(unorientedTypes)('reports no orientation for %s', (type) => {
     expect(resolveOrientation(type)).toBeUndefined();

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+import { formatPlotType, resolveOrientation } from '@util/orientation';
+
+describe('resolveOrientation', () => {
+  const orientedTypes = [
+    TraceType.BAR,
+    TraceType.BOX,
+    TraceType.CANDLESTICK,
+    TraceType.DODGED,
+    TraceType.HISTOGRAM,
+    TraceType.NORMALIZED,
+    TraceType.STACKED,
+    TraceType.VIOLIN_BOX,
+    TraceType.VIOLIN_KDE,
+  ];
+
+  test.each(orientedTypes)('defaults %s to vertical when undeclared', (type) => {
+    expect(resolveOrientation(type)).toBe(Orientation.VERTICAL);
+  });
+
+  test.each(orientedTypes)('keeps the declared orientation of %s', (type) => {
+    expect(resolveOrientation(type, Orientation.HORIZONTAL)).toBe(Orientation.HORIZONTAL);
+    expect(resolveOrientation(type, Orientation.VERTICAL)).toBe(Orientation.VERTICAL);
+  });
+
+  const unorientedTypes = [
+    TraceType.HEATMAP,
+    TraceType.LINE,
+    TraceType.SCATTER,
+    TraceType.SMOOTH,
+    TraceType.STEP,
+  ];
+
+  test.each(unorientedTypes)('reports no orientation for %s', (type) => {
+    expect(resolveOrientation(type)).toBeUndefined();
+  });
+
+  test('reports no orientation for a type it does not know', () => {
+    expect(resolveOrientation('not-a-trace-type')).toBeUndefined();
+  });
+
+  test('ignores an orientation declared on a type that has none', () => {
+    expect(resolveOrientation(TraceType.LINE, Orientation.HORIZONTAL)).toBeUndefined();
+  });
+});
+
+describe('formatPlotType', () => {
+  test('prefixes the type with its orientation', () => {
+    expect(formatPlotType('bar', Orientation.VERTICAL)).toBe('vertical bar');
+    expect(formatPlotType('box', Orientation.HORIZONTAL)).toBe('horizontal box');
+  });
+
+  test('returns the bare type when there is no orientation', () => {
+    expect(formatPlotType('heat')).toBe('heat');
+    expect(formatPlotType('single line', undefined)).toBe('single line');
+  });
+
+  test('returns the bare type for an unrecognized orientation', () => {
+    expect(formatPlotType('bar', 'sideways')).toBe('bar');
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -56,7 +56,7 @@ describe('formatPlotType', () => {
     expect(formatPlotType('single line', undefined)).toBe('single line');
   });
 
-  test('returns the bare type for an unrecognized orientation', () => {
-    expect(formatPlotType('bar', 'sideways')).toBe('bar');
+  test('prefixes what resolveOrientation returns for an oriented type', () => {
+    expect(formatPlotType('bar', resolveOrientation(TraceType.BAR))).toBe('vertical bar');
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

The instruction message ("This is a maidr plot of type: …") only named an orientation when the MAIDR JSON happened to declare one. A violin or box layer said *vertical violin_box* / *vertical box*, while a bar, histogram, stacked, dodged, normalized or candlestick layer said nothing at all about which way it runs — even though those traces are just as orientation-dependent to navigate.

Every one of those trace models already does `layer.orientation ?? Orientation.VERTICAL` in its constructor and swaps its main/cross axes on that basis. The orientation is therefore never *unknown* for them, only *undeclared* — so a bar chart whose layer omits `orientation` is navigated as a vertical bar chart, and can be announced as one truthfully.

After this change, all nine oriented trace types announce their orientation, and the types that genuinely have none (line, step, scatter, heatmap, smooth) stay unprefixed exactly as before.

| layer | before | after |
| --- | --- | --- |
| `bar` | `type: bar` | `type: vertical bar` |
| `hist` | `type: hist` | `type: vertical hist` |
| `stacked_bar` | `type: stacked_bar` | `type: vertical stacked_bar` |
| `dodged_bar` | `type: dodged_bar` | `type: vertical dodged_bar` |
| `box` (orientation declared) | `type: vertical box` | unchanged |
| `line` / `heat` / `step` | `type: single line` … | unchanged |

One implicit consequence worth stating: an oriented layer whose JSON carries a malformed `orientation` string is now announced as *vertical* rather than unprefixed. That matches what the models already do with it — each treats anything that is not `horz` as vertical — so the announcement and the navigation agree.

## Related Issues

None filed — reported directly: violin layers announced their orientation while box and the other oriented types did not.

## Changes Made

- **`src/util/orientation.ts` (new)** — `resolveOrientation(traceType, declared)` returns the orientation a trace is actually navigated by: the declared one for the trace types that have an orientation, `vert` when they declare none, and `undefined` for the types that have none at all. The answer is keyed off a `Record<TraceType, boolean>` rather than a set, so a new trace type fails to compile until it says which it is — the same device `CHART_TYPE_LABEL` in `src/model/abstract.ts` already uses. `formatPlotType` moves here from `src/model/context.ts` so the two instruction builders share one implementation and cannot drift apart.
- **`src/model/abstract.ts`** — `AbstractTrace.state` reports `resolveOrientation(this.type, this.layer.orientation)` instead of the raw layer field. `state.orientation` is consumed only by the instruction text, so nothing else changes behaviour.
- **`src/model/context.ts`** — imports `formatPlotType` instead of defining a local copy.
- **`src/maidr-component.tsx`** — the pre-activation `aria-label` builder drops its duplicate `formatPlotType` and resolves the orientation the same way, so the announcement does not change when the user focuses the chart.
- **`e2e_tests/utils/constants.ts`** — expected instruction text updated for the five oriented fixtures (bar, histogram, dodged, stacked, multi-layer).

## Screenshots (if applicable)

n/a — text announcement only.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verification run locally: `npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass (118 unit suites / 1519 tests, plus 6 ESM suites / 61 tests). Playwright e2e was **not** run in this environment; the five instruction constants above were updated to match the new text and need the CI e2e run to confirm.

Tests added:

- `test/util/orientation.test.ts` — resolution and formatting per trace type, including that the two lists it checks cover the `TraceType` enum between them, and that an orientation declared on an unoriented type is ignored.
- `test/model/instructionOrientation.test.ts` — the post-activation text, end to end through `Context.getInstruction`, including a horizontal box layer and a multi-layer plot.
- `test/ui/initialInstruction.esm-test.tsx` — the pre-activation `aria-label`, by rendering the component. It joins the `esm` project because `Maidr` pulls in the chat UI and its ESM-only markdown stack.

Companion fix in py-maidr: xability/py-maidr#301 — matplotlib box plots reported `orientation: "horz"` for every *vertical* box plot, and `ax.violinplot(data, orientation="horizontal")` was reported as vertical; both also made the extractor read statistics off the wrong axis.