### PR TITLE
fix(svg): treat an unusable selector as matching nothing

### DIFF
--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -221,6 +221,14 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
     }
 
     const queried = Svg.selectAllElements(selector);
+    // Nothing resolved — report no highlight for this layer rather than fall
+    // through to the zero-bar alignment below, which would stand a full row of
+    // detached placeholders in for elements that do not exist. `SegmentedTrace`
+    // bails on the same condition.
+    if (queried.length === 0) {
+      return null;
+    }
+
     const svgElements = [queried];
 
     if (svgElements.length !== this.points.length) {

--- a/src/model/heatmap.ts
+++ b/src/model/heatmap.ts
@@ -157,7 +157,9 @@ export class Heatmap extends AbstractTrace {
         }
         const row: SVGElement[] = [];
         for (let c = 0; c < numCols; c++) {
-          const el = document.querySelector<SVGElement>(rowSelectors[c]);
+          // Routed through `Svg` rather than `document` so a grid cell holding
+          // an unusable selector degrades to "no highlight" instead of throwing.
+          const el = Svg.selectElement<SVGElement>(rowSelectors[c], false);
           if (!el) {
             return null;
           }

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -95,13 +95,36 @@ export abstract class Svg {
   }
 
   /**
+   * Reports whether a value can be handed to `querySelector`/`querySelectorAll`.
+   *
+   * Selectors reach MAIDR through parsed JSON and are cast to `string` at the
+   * call site, so the declared type gives no runtime protection. A producer
+   * that resolves no elements for a layer emits `[]`, which is truthy — it
+   * passes every `if (!selector)` guard in the model layer and only fails once
+   * the DOM coerces it to `''` and throws `SyntaxError`. That exception escapes
+   * figure construction, so one unresolvable layer leaves the whole figure
+   * inert. Treating an unusable query as "matches nothing" keeps the failure
+   * local: that layer loses its highlight, every other layer still works.
+   *
+   * @param query - The value supplied as a CSS selector
+   * @returns True when the value is a non-empty selector string
+   */
+  private static isUsableSelector(query: unknown): query is string {
+    return typeof query === 'string' && query.trim() !== '';
+  }
+
+  /**
    * Selects all SVG elements matching a query and optionally clones them.
    * @template T - The type of SVG element to select
    * @param query - CSS selector string to query elements
    * @param shouldClone - Whether to clone elements and insert them as hidden copies (default: true)
-   * @returns Array of selected (or cloned) SVG elements
+   * @returns Array of selected (or cloned) SVG elements, empty when the query is not a usable selector
    */
   public static selectAllElements<T extends SVGElement>(query: string, shouldClone: boolean = true): T[] {
+    if (!this.isUsableSelector(query)) {
+      return [];
+    }
+
     return Array
       .from(document.querySelectorAll<T>(query))
       .map((element) => {
@@ -122,9 +145,13 @@ export abstract class Svg {
    * @template T - The type of SVG element to select
    * @param query - CSS selector string to query the element
    * @param shouldClone - Whether to clone the element and insert it as a hidden copy (default: true)
-   * @returns The selected (or cloned) SVG element
+   * @returns The selected (or cloned) SVG element, or null when the query is not a usable selector
    */
   public static selectElement<T extends SVGElement>(query: string, shouldClone: boolean = true): T {
+    if (!this.isUsableSelector(query)) {
+      return null as unknown as T;
+    }
+
     const element = document.querySelector<T>(query);
     if (!shouldClone) {
       return element as T;
@@ -156,12 +183,16 @@ export abstract class Svg {
    * @template T - The type of SVG element to select
    * @param query - CSS selector string
    * @param n - Zero-based index into the query results
-   * @returns The Nth matching element, or null if no Nth match exists
+   * @returns The Nth matching element, or null if no Nth match exists or the query is not a usable selector
    */
   public static selectNthElement<T extends SVGElement>(
     query: string,
     n: number,
   ): T | null {
+    if (!this.isUsableSelector(query)) {
+      return null;
+    }
+
     const all = document.querySelectorAll<T>(query);
     return all[n] ?? null;
   }

--- a/src/util/svg.ts
+++ b/src/util/svg.ts
@@ -145,25 +145,25 @@ export abstract class Svg {
    * @template T - The type of SVG element to select
    * @param query - CSS selector string to query the element
    * @param shouldClone - Whether to clone the element and insert it as a hidden copy (default: true)
-   * @returns The selected (or cloned) SVG element, or null when the query is not a usable selector
+   * @returns The selected (or cloned) SVG element, or null when nothing matches or the query is not a usable selector
    */
-  public static selectElement<T extends SVGElement>(query: string, shouldClone: boolean = true): T {
+  public static selectElement<T extends SVGElement>(query: string, shouldClone: boolean = true): T | null {
     if (!this.isUsableSelector(query)) {
-      return null as unknown as T;
+      return null;
     }
 
     const element = document.querySelector<T>(query);
     if (!shouldClone) {
-      return element as T;
+      return element;
     }
 
-    const clone = element?.cloneNode(true) as T;
-    clone?.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
-    if (clone) {
-      this.markOwned(clone);
+    if (!element) {
+      return null;
     }
 
-    element?.insertAdjacentElement(Constant.AFTER_END, clone);
+    const clone = this.markOwned(element.cloneNode(true) as T);
+    clone.setAttribute(Constant.VISIBILITY, Constant.HIDDEN);
+    element.insertAdjacentElement(Constant.AFTER_END, clone);
     return clone;
   }
 

--- a/test/model/emptySelectors.test.ts
+++ b/test/model/emptySelectors.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Regression coverage for a layer whose `selectors` is an empty array.
+ *
+ * Producers emit `[]` when they cannot resolve any element for a layer —
+ * r-maidr's patchwork output does this whenever a processor fails to resolve a
+ * panel, and jsonlite serialises the empty R list as `[]`. `[]` is truthy, so
+ * it slipped past every `if (!selector)` guard in the model layer and reached
+ * `querySelectorAll`, which coerced it to `''` and threw. The throw escaped
+ * figure construction, so MAIDR never attached: Tab did nothing and *every*
+ * subplot went silent, including the ones whose selectors were valid.
+ *
+ * What is asserted here is the degraded outcome: the malformed layer loses
+ * only its highlight, and the rest of the figure stays navigable.
+ */
+
+import type { Maidr, MaidrLayer, MaidrSubplot } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { Figure, Subplot } from '@model/plot';
+import { TraceType } from '@type/grammar';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/**
+ * Renders two bars under `#bars` so a valid selector has something to match.
+ */
+function renderBars(): void {
+  document.body.innerHTML = '';
+  const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+  const group = document.createElementNS(SVG_NAMESPACE, 'g');
+  group.setAttribute('id', 'bars');
+  group.appendChild(document.createElementNS(SVG_NAMESPACE, 'rect'));
+  group.appendChild(document.createElementNS(SVG_NAMESPACE, 'rect'));
+  svg.appendChild(group);
+  document.body.appendChild(svg);
+}
+
+/**
+ * Builds a bar layer. `selectors` is deliberately `unknown`: the point of this
+ * suite is values that the grammar types as `string` but that arrive from
+ * parsed JSON as something else.
+ */
+function barLayer(id: string, selectors: unknown): MaidrLayer {
+  return {
+    id,
+    type: TraceType.BAR,
+    selectors: selectors as string,
+    data: [{ x: 'A', y: 1 }, { x: 'B', y: 2 }],
+  };
+}
+
+function subplotWith(layer: MaidrLayer): MaidrSubplot {
+  return { layers: [layer] };
+}
+
+/**
+ * The reported figure: a well-formed subplot followed by one whose single
+ * layer resolved to no selectors at all.
+ */
+function createMaidr(): Maidr {
+  return {
+    id: 'empty-selectors-test',
+    subplots: [
+      [subplotWith(barLayer('valid', '#bars > rect'))],
+      [subplotWith(barLayer('broken', []))],
+    ],
+  };
+}
+
+/**
+ * Reads a subplot's trace highlight after stepping off the initial entry —
+ * `AbstractTrace.highlight` reports empty until the cursor has actually moved,
+ * so checking it straight after construction would pass for the wrong reason.
+ */
+function highlightIsEmptyAfterMove(subplot: Subplot): boolean {
+  const trace = subplot.activeTrace;
+  trace.moveOnce('FORWARD');
+  trace.moveOnce('FORWARD');
+
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('trace state unexpectedly empty');
+  }
+  return state.highlight.empty;
+}
+
+describe('layer with an empty selectors array', () => {
+  beforeEach(renderBars);
+
+  test('constructs the figure instead of throwing', () => {
+    expect(() => new Figure(createMaidr())).not.toThrow();
+  });
+
+  test('leaves every subplot in the figure reachable', () => {
+    const figure = new Figure(createMaidr());
+
+    // The whole point of the fix: the valid panel is still announced, rather
+    // than the malformed sibling taking the entire figure down with it.
+    expect(figure.state.empty).toBe(false);
+
+    for (const row of [0, 1]) {
+      expect(figure.moveToIndex(row, 0)).toBe(true);
+
+      const state = figure.state;
+      expect(state.empty).toBe(false);
+      if (!state.empty) {
+        expect(state.size).toBe(2);
+        expect(state.subplot.empty).toBe(false);
+      }
+    }
+  });
+
+  test('degrades the malformed layer to no highlight', () => {
+    // Silent layer, not an inert figure: the trace still reports audio,
+    // braille and text; only its highlight is gone.
+    const subplot = new Subplot(subplotWith(barLayer('broken', [])));
+    expect(highlightIsEmptyAfterMove(subplot)).toBe(true);
+  });
+
+  test('keeps the highlight for a layer whose selector does resolve', () => {
+    const subplot = new Subplot(subplotWith(barLayer('valid', '#bars > rect')));
+    expect(highlightIsEmptyAfterMove(subplot)).toBe(false);
+  });
+});

--- a/test/model/emptySelectors.test.ts
+++ b/test/model/emptySelectors.test.ts
@@ -77,6 +77,13 @@ function createMaidr(): Maidr {
  */
 function highlightIsEmptyAfterMove(subplot: Subplot): boolean {
   const trace = subplot.activeTrace;
+  // `activeTrace` is nullable since #751 — a subplot authored with `layers: []`
+  // genuinely has no trace. Every fixture here authors one, so a null means the
+  // fixture is wrong rather than the behaviour under test.
+  if (!trace) {
+    throw new Error('fixture subplot should have an active trace');
+  }
+
   trace.moveOnce('FORWARD');
   trace.moveOnce('FORWARD');
 

--- a/test/util/svg.test.ts
+++ b/test/util/svg.test.ts
@@ -17,6 +17,7 @@
  * throws.
  */
 
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { Svg } from '@util/svg';
 
 const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
@@ -75,8 +76,21 @@ describe('svg selector guards', () => {
       expect(Svg.selectElement(value)).toBeNull();
     });
 
+    it('returns null when a well-formed selector matches nothing', () => {
+      // `null`, not `undefined`: the declared return type is `T | null`, and
+      // the clone path used to fall through to an undefined clone.
+      expect(Svg.selectElement('#absent > rect')).toBeNull();
+      expect(Svg.selectElement('#absent > rect', false)).toBeNull();
+    });
+
     it('still resolves a valid selector', () => {
       expect(Svg.selectElement('#bars > rect', false)).not.toBeNull();
+    });
+
+    it('marks the clone it inserts as MAIDR-owned', () => {
+      const clone = Svg.selectElement('#bars > rect');
+      expect(clone).not.toBeNull();
+      expect(Svg.isOwned(clone as SVGElement)).toBe(true);
     });
   });
 

--- a/test/util/svg.test.ts
+++ b/test/util/svg.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for the selector guards in `src/util/svg.ts`.
+ *
+ * Selectors arrive from parsed JSON and are cast to `string` at the call site,
+ * so a producer that resolves nothing for a layer can send `[]` — truthy, and
+ * therefore past every `if (!selector)` guard in the model layer. Before the
+ * guard, `document.querySelectorAll([])` coerced it to `''` and threw a
+ * `SyntaxError` that escaped figure construction, leaving the entire figure
+ * inert: no announcements, no navigation, including for the subplots whose own
+ * selectors were valid.
+ *
+ * The contract these tests pin: an unusable query matches nothing, and never
+ * throws.
+ */
+
+import { Svg } from '@util/svg';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+/**
+ * Values that reach `Svg` typed as `string` but are not usable selectors.
+ * `[]` is the case reported from r-maidr's patchwork output; the rest share
+ * the same shape — truthy or otherwise unusable, and fatal to `querySelector`.
+ */
+const UNUSABLE: { label: string; value: string }[] = [
+  { label: 'an empty array', value: [] as unknown as string },
+  { label: 'an empty string', value: '' },
+  { label: 'a whitespace-only string', value: '   ' },
+  { label: 'undefined', value: undefined as unknown as string },
+  { label: 'null', value: null as unknown as string },
+  { label: 'a number', value: 42 as unknown as string },
+  { label: 'an object', value: {} as unknown as string },
+];
+
+describe('svg selector guards', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+    const group = document.createElementNS(SVG_NAMESPACE, 'g');
+    group.setAttribute('id', 'bars');
+    for (let i = 0; i < 3; i++) {
+      group.appendChild(document.createElementNS(SVG_NAMESPACE, 'rect'));
+    }
+    svg.appendChild(group);
+    document.body.appendChild(svg);
+  });
+
+  describe('selectAllElements', () => {
+    it.each(UNUSABLE)('returns an empty array for $label', ({ value }) => {
+      expect(() => Svg.selectAllElements(value)).not.toThrow();
+      expect(Svg.selectAllElements(value)).toEqual([]);
+    });
+
+    it('inserts no clones into the DOM for an unusable query', () => {
+      const before = document.querySelectorAll('#bars > rect').length;
+      Svg.selectAllElements([] as unknown as string);
+      expect(document.querySelectorAll('#bars > rect')).toHaveLength(before);
+    });
+
+    it('still resolves a valid selector', () => {
+      // Guarding the unusable cases must not change the working path: three
+      // rects in, three hidden clones out.
+      expect(Svg.selectAllElements('#bars > rect')).toHaveLength(3);
+      expect(document.querySelectorAll('#bars > rect')).toHaveLength(6);
+    });
+  });
+
+  describe('selectElement', () => {
+    it.each(UNUSABLE)('returns null for $label', ({ value }) => {
+      expect(() => Svg.selectElement(value)).not.toThrow();
+      expect(Svg.selectElement(value)).toBeNull();
+    });
+
+    it('still resolves a valid selector', () => {
+      expect(Svg.selectElement('#bars > rect', false)).not.toBeNull();
+    });
+  });
+
+  describe('selectNthElement', () => {
+    it.each(UNUSABLE)('returns null for $label', ({ value }) => {
+      expect(() => Svg.selectNthElement(value, 0)).not.toThrow();
+      expect(Svg.selectNthElement(value, 0)).toBeNull();
+    });
+
+    it('still resolves a valid selector', () => {
+      expect(Svg.selectNthElement('#bars > rect', 1)).not.toBeNull();
+      expect(Svg.selectNthElement('#bars > rect', 9)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

A layer whose `selectors` is `[]` threw during figure construction, and the exception escaped initialisation — so MAIDR never attached. Tab did nothing, nothing was ever announced, and **every other subplot in the figure went silent too**, including ones whose selectors were perfectly valid.

Selectors reach MAIDR through parsed JSON and are cast to `string` at the call site, so the declared type gives no runtime protection. `[]` is truthy, so it passed every `if (!selector)` guard in the model layer and only failed once `querySelectorAll` coerced it to `''`:

```
Uncaught SyntaxError: Failed to execute 'querySelectorAll' on 'Document': The provided selector is empty.
    at selectAllElements
    at mapToSvgElements
```

The fix guards the three `Svg` query helpers rather than each of the eight `mapToSvgElements` implementations, so an unusable query matches nothing instead of throwing. The failure then stays local: that one layer loses its highlight, and the rest of the figure keeps its audio, braille, text and navigation.

## Related Issues

Fixes #748.

Sibling report #749 (a subplot with an empty `layers` array) is fixed separately by #751, which has since merged and is now merged into this branch — see the third commit below.

## Changes Made

### `8cd3603` — the fix

**`src/util/svg.ts`** — added a private `isUsableSelector` type guard and applied it in `selectAllElements` (returns `[]`), `selectElement` (returns `null`) and `selectNthElement` (returns `null`). This is the one place that covers all callers, including `Subplot.mapToSvgElement`, which had the same defect for `subplot.selector`.

**`src/model/heatmap.ts`** — routed the per-cell selector grid through `Svg.selectElement` instead of calling `document.querySelector` directly. It was the last raw DOM query on a grammar-supplied selector, and a grid holding an unusable entry failed identically.

**`src/model/bar.ts`** — bail out of `AbstractBarPlot.mapToSvgElements` when the query resolved nothing, matching what `SegmentedTrace` already does. The issue predicted the existing length check would catch this, but `svgElements` is `[queried]`, so its length is always 1 — a single-row bar (the common case) fell through to the zero-bar alignment path and stood a full row of detached placeholder rects in for elements that do not exist. Reporting no highlight is the honest degraded outcome.

**Tests** — `test/util/svg.test.ts` pins the helper contract across `[]`, `''`, whitespace, `undefined`, `null`, a number and an object, and asserts the valid-selector path is unchanged. `test/model/emptySelectors.test.ts` reproduces the reported figure end to end: a well-formed subplot next to one whose layer has `selectors: []`.

Reverting only the three source files makes 21 of the 29 new assertions fail with `SyntaxError: '' is not a valid selector`, so they fail for the reported reason rather than incidentally.

### `aa11f9b` — review feedback

`selectElement` was declared to return `T` while three runtime paths could hand back something falsy. A signature that lies about runtime is the same defect class this branch is fixing, so it is now `T | null`, the `null as unknown as T` cast is gone, and both the no-match and unusable-selector paths return `null` rather than `undefined`.

Copilot caught a third path the first commit missed: the clone branch fell through to `element?.cloneNode(...)`, so a well-formed selector matching nothing returned `undefined`. It now guards on `element`, with a test pinning it.

Tightening the type is free — `tsc --noEmit` reports zero new errors across all 17 call sites, because every one already guards defensively. Also imported the jest globals in `test/util/svg.test.ts` rather than relying on the ambient ones, matching the other 97 suites.

### `6e8a580` + `6490a0a` — merge `main`, guard the nullable `activeTrace`

#751 landed on `main` and made `Subplot.activeTrace` return `Trace | null`, since a subplot authored with `layers: []` genuinely has no trace. The two branches share no files, so git merges them without a conflict — but the merged tree did not type-check, and neither branch's CI could see it while they were separate:

```
test/model/emptySelectors.test.ts(80,3): error TS18047: 'trace' is possibly 'null'.
test/model/emptySelectors.test.ts(81,3): error TS18047: 'trace' is possibly 'null'.
test/model/emptySelectors.test.ts(83,17): error TS18047: 'trace' is possibly 'null'.
```

Reproduced locally, then narrowed with an explicit `throw` rather than a non-null assertion, per the "avoid `!`, narrow instead" rule in `.claude/rules/typescript.md`. Every fixture in this suite authors a layer, so a null means the fixture is wrong, not the behaviour under test.

## Screenshots (if applicable)

Not applicable — no visual change. The behavioural change is that a figure which previously announced nothing at all now announces normally.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — no user-facing behaviour is documented for malformed input.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verification** — on the merged tree, `npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass locally: 127 suites, 1669 tests, no failures (including the 9 tests #751 brought in). Playwright E2E was not run locally; CI runs it.

**On the suggested `try`/`catch` boundary per layer** — the issue raises this as worth considering, and it is deliberately left out of this PR. Dropping a failing layer means deciding what a subplot with zero surviving traces should do, which is the degraded state #751 has now defined for an empty `layers` array. Happy to add it as a follow-up on top of that, if you'd like.