### PR TITLE
fix(model): keep a figure navigable when a subplot has no layers

### DIFF
--- a/e2e_tests/fixtures/empty-subplot.html
+++ b/e2e_tests/fixtures/empty-subplot.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <!--
+  Regression fixture for issue #749: a subplot authored with an empty `layers`
+  array used to throw during figure construction, so MAIDR never attached and
+  the whole figure went inert — well-formed panels included.
+
+  This lives here rather than in `examples/` on purpose: it is a deliberately
+  degenerate input, not a demonstration of a chart type, and it should not be
+  copied into the published example gallery. Producers do emit this shape —
+  r-maidr emits a zero-layer subplot for an unoccupied cell in a
+  non-rectangular patchwork layout — so the figure must stay navigable and the
+  empty panel must announce that it has nothing to describe.
+
+  Panel 1 (top) has no layers at all. Panel 2 (bottom) is a well-formed bar
+  plot, and is what proves a malformed sibling no longer takes the whole
+  figure down with it.
+-->
+
+  <head>
+    <meta charset="utf-8" />
+    <title>Empty subplot (regression fixture)</title>
+    <link rel="stylesheet" href="../../dist/maidr.css" />
+    <script type="text/javascript" src="../../dist/maidr.js"></script>
+  </head>
+
+  <body>
+    <svg
+      id="empty-subplot-figure"
+      xmlns="http://www.w3.org/2000/svg"
+      width="400"
+      height="400"
+      viewBox="0 0 400 400"
+      version="1.1"
+      maidr-data='{"id":"empty-subplot-figure","title":"Empty subplot regression","subplots":[[{"id":"sp-empty","selector":"#panel1 > rect","layers":[]}],[{"id":"sp-bars","selector":"#bars > rect","layers":[{"id":"layer-bars","type":"bar","title":"Well-formed panel","axes":{"x":{"label":"Category"},"y":{"label":"Value"}},"data":[{"x":"A","y":1},{"x":"B","y":2},{"x":"C","y":3}],"selectors":"#bars > rect"}]}]]}'
+    >
+      <g id="axes_1">
+        <g id="panel1">
+          <rect x="10" y="10" width="120" height="120" style="fill: #dddddd" />
+        </g>
+      </g>
+      <g id="axes_2">
+        <g id="bars">
+          <rect x="10" y="350" width="30" height="40" style="fill: #4477aa" />
+          <rect x="50" y="320" width="30" height="70" style="fill: #4477aa" />
+          <rect x="90" y="290" width="30" height="100" style="fill: #4477aa" />
+        </g>
+      </g>
+    </svg>
+  </body>
+</html>

--- a/e2e_tests/page-objects/plots/emptySubplot-page.ts
+++ b/e2e_tests/page-objects/plots/emptySubplot-page.ts
@@ -1,0 +1,113 @@
+import type { Page } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { EmptySubplotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the empty-subplot regression fixture (issue #749).
+ *
+ * The fixture is a two-panel figure whose first panel has no layers at all, so
+ * the interactions this exposes are the multi-panel lobby ones — stepping
+ * between panels and pressing ENTER — rather than the data-point navigation
+ * the plot page objects wrap. It points at `e2e_tests/fixtures/`, not
+ * `examples/`, because a deliberately degenerate input is not a gallery demo.
+ */
+export class EmptySubplotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: 'svg#empty-subplot-figure',
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * Creates a new EmptySubplotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the empty-subplot fixture.
+   * @returns Promise resolving when navigation completes
+   * @throws EmptySubplotError if navigation fails
+   */
+  public async navigateToEmptySubplotFigure(): Promise<void> {
+    try {
+      await super.navigateTo('e2e_tests/fixtures/empty-subplot.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new EmptySubplotError('Failed to navigate to the empty-subplot fixture', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR by focusing the plot.
+   *
+   * This is the step the bug broke: construction threw before MAIDR ever
+   * attached, so Tab moved focus straight past the figure and this failed.
+   * @returns Promise resolving when MAIDR is activated
+   * @throws EmptySubplotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, 'empty-subplot-figure');
+    } catch (error) {
+      throw new EmptySubplotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Presses an arrow key to announce the panel the lobby starts on.
+   *
+   * The first arrow key in the lobby is consumed by initial entry: it reports
+   * the focused panel without moving off it (see `MovableGrid.moveOnce`). This
+   * is a separate method rather than a first call to {@link moveToNextSubplot}
+   * so a spec reads as what it does — a caller that wants to reach the *next*
+   * panel has to say so twice, which is what a user does.
+   * @returns Promise resolving once the panel has been announced
+   * @throws KeypressError if the keypress fails
+   */
+  public async announceStartingSubplot(): Promise<void> {
+    await super.pressKeyAwaitingAnnouncement(
+      TestConstants.DOWN_ARROW_KEY,
+      'announce starting subplot',
+    );
+  }
+
+  /**
+   * Steps to the next subplot in the figure lobby. Call
+   * {@link announceStartingSubplot} first, or this press is consumed by
+   * initial entry and moves nothing.
+   * @returns Promise resolving once the move has been announced
+   * @throws KeypressError if the keypress fails
+   */
+  public async moveToNextSubplot(): Promise<void> {
+    await super.pressKeyAwaitingAnnouncement(
+      TestConstants.DOWN_ARROW_KEY,
+      'move to next subplot',
+    );
+  }
+
+  /**
+   * Presses ENTER on the focused subplot. Named for the keypress rather than
+   * the outcome because on an empty panel the entry is refused — which is the
+   * behaviour the spec asserts.
+   * @returns Promise resolving once the result has been announced
+   * @throws KeypressError if the keypress fails
+   */
+  public async pressEnterOnFocusedSubplot(): Promise<void> {
+    await super.pressKeyAwaitingAnnouncement(
+      TestConstants.ENTER_KEY,
+      'enter focused subplot',
+    );
+  }
+}

--- a/e2e_tests/specs/emptySubplot.spec.ts
+++ b/e2e_tests/specs/emptySubplot.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+import { EmptySubplotPage } from '../page-objects/plots/emptySubplot-page';
+import { recordedAnnouncements } from '../utils/announcements';
+
+/**
+ * Regression coverage for issue #749.
+ *
+ * A subplot authored with an empty `layers` array threw in
+ * `Subplot.activeTrace` while the plot context was being built — before any
+ * user interaction. The exception escaped initialisation, so MAIDR never
+ * attached: Tab did nothing, nothing was ever announced, and *every* panel in
+ * the figure was unreachable, including well-formed ones.
+ *
+ * The unit suite (`test/model/emptySubplot.test.ts`) pins the model contract.
+ * These specs pin what the user actually gets, which is the part the unit
+ * tests cannot see: that MAIDR attaches at all, that the empty panel says so
+ * out loud, and that its well-formed sibling stays navigable. Every assertion
+ * below would have failed before the fix — the first at the Tab that never
+ * focused anything.
+ *
+ * The fixture's panel 1 is the layerless one and the lobby starts there, so
+ * the empty panel is what the user meets first.
+ */
+const EMPTY_PANEL_ANNOUNCEMENT = 'Subplot 1 of 2 is empty, nothing to describe.';
+
+test.describe('Subplot with no layers', () => {
+  test('attaches without an uncaught error', async ({ page }) => {
+    // The reported symptom is an exception, and it escaped *initialisation* —
+    // it never reached a state assertion. Watching for it directly is the only
+    // check here that fails for the original reason: MAIDR still renders a
+    // focusable wrapper after the throw, so asserting on focus alone passes
+    // against the unfixed build.
+    const pageErrors: string[] = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    const plotPage = new EmptySubplotPage(page);
+    await plotPage.navigateToEmptySubplotFigure();
+    await plotPage.activateMaidr();
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('announces the empty panel rather than describing a plot that is not there', async ({ page }) => {
+    const plotPage = new EmptySubplotPage(page);
+    await plotPage.navigateToEmptySubplotFigure();
+    await plotPage.activateMaidr();
+
+    // Verbose is the default text mode, so without the fix the lobby would
+    // read "a multi-layered plot containing  plots" — with the trace types
+    // missing from the middle — followed by an ENTER prompt that cannot do
+    // anything.
+    const before = (await recordedAnnouncements(page)).length;
+    await plotPage.announceStartingSubplot();
+
+    const recorded = (await recordedAnnouncements(page)).slice(before);
+    expect(recorded).toContain(EMPTY_PANEL_ANNOUNCEMENT);
+  });
+
+  test('refuses to enter the empty panel and says why', async ({ page }) => {
+    const plotPage = new EmptySubplotPage(page);
+    await plotPage.navigateToEmptySubplotFigure();
+    await plotPage.activateMaidr();
+    await plotPage.announceStartingSubplot();
+
+    const before = (await recordedAnnouncements(page)).length;
+    await plotPage.pressEnterOnFocusedSubplot();
+
+    // Refused rather than entered: the user stays in the lobby with every
+    // other panel reachable, and the keypress is not silent.
+    const recorded = (await recordedAnnouncements(page)).slice(before);
+    expect(recorded).toContain(EMPTY_PANEL_ANNOUNCEMENT);
+  });
+
+  test('keeps the well-formed sibling panel fully navigable', async ({ page }) => {
+    const plotPage = new EmptySubplotPage(page);
+    await plotPage.navigateToEmptySubplotFigure();
+    await plotPage.activateMaidr();
+
+    // This is what the bug cost: a figure where one malformed panel silenced
+    // the panels that were perfectly describable.
+    await plotPage.announceStartingSubplot();
+    await plotPage.moveToNextSubplot();
+    await plotPage.pressEnterOnFocusedSubplot();
+
+    const before = (await recordedAnnouncements(page)).length;
+    await plotPage.moveToNextDataPoint();
+
+    const recorded = (await recordedAnnouncements(page)).slice(before);
+    expect(recorded).toContain('Category is A, Value is 1');
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -73,6 +73,7 @@ export abstract class TestConstants {
    * Keyboard key constants
    */
   static readonly TAB_KEY = 'Tab';
+  static readonly ENTER_KEY = 'Enter';
   static readonly LEFT_ARROW_KEY = 'ArrowLeft';
   static readonly RIGHT_ARROW_KEY = 'ArrowRight';
   static readonly UP_ARROW_KEY = 'ArrowUp';

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -278,3 +278,19 @@ export class ViolinPlotError extends Error {
     this.name = 'ViolinPlotError';
   }
 }
+
+/**
+ * Error thrown when operations on the empty-subplot regression fixture fail
+ */
+export class EmptySubplotError extends Error {
+  /**
+   * Creates a new EmptySubplotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'EmptySubplotError';
+  }
+}

--- a/src/command/move.ts
+++ b/src/command/move.ts
@@ -240,7 +240,16 @@ export class MoveToTraceContextCommand implements Command {
     const before = this.context.state;
     const lobby = before.type === 'figure' && !before.empty ? before : null;
 
-    this.context.enterSubplot();
+    const entered = this.context.enterSubplot();
+    if (lobby && !entered) {
+      // The focused panel has no layers to descend into. Stay in the lobby so
+      // every other panel remains reachable, and say why nothing happened
+      // instead of leaving the keypress silent. An empty panel has no trace to
+      // carry a title, so it is announced by position alone.
+      this.cue.announceEmpty(lobby.index, lobby.size, '');
+      return;
+    }
+
     const brailleEnabled = this.brailleService.isEnabled;
     if (brailleEnabled) {
       const state = this.context.state;

--- a/src/command/subplotCue.ts
+++ b/src/command/subplotCue.ts
@@ -74,6 +74,22 @@ export class SubplotCue {
   }
 
   /**
+   * Announces that the focused subplot has no layers to enter, respecting the
+   * current text mode (OFF -> TextService returns null -> nothing is spoken).
+   * Plays no enter tone: nothing was entered, and a rising cue would signal a
+   * transition that did not happen.
+   * @param {number} index - 1-based visual position of the empty subplot.
+   * @param {number} size - Total number of subplots in the figure.
+   * @param {string} title - The subplot's authored title ('' when none).
+   */
+  public announceEmpty(index: number, size: number, title: string): void {
+    const message = this.textService.emptySubplotText(index, size, title);
+    if (message) {
+      this.notificationService.notify(message);
+    }
+  }
+
+  /**
    * Full "returned to the figure lobby" cue: plays the exit tone, then (in
    * TERSE/VERBOSE mode) announces the lobby position; in OFF mode only the tone
    * plays. The caller must run the navigation transition (exitSubplot) BEFORE

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -443,12 +443,16 @@ export class Controller implements Disposable {
         return;
       }
       // The focused layer's trace IS the active trace (one single-trace row
-      // per layer; see Subplot.activeLayerIndex) — the focus predicate above
-      // guarantees the indices are in range, so no null guard is needed;
-      // any residual access failure lands in the catch below. Compute the
+      // per layer; see Subplot.activeLayerIndex); the focus predicate above
+      // guarantees the indices are in range. It is null only for a subplot
+      // with no layers, which has no appended point to announce. Compute the
       // new point's state without moving the user's cursor; observers are
       // only notified via MonitorService.
-      const state = this.figure.activeSubplot.activeTrace.getStateAt(appended.row, appended.col);
+      const trace = this.figure.activeSubplot.activeTrace;
+      if (!trace) {
+        return;
+      }
+      const state = trace.getStateAt(appended.row, appended.col);
       this.monitorService.handleNewPoint(state);
     } catch (error) {
       console.warn('[maidr] Failed to announce appended data point:', error);

--- a/src/model/context.ts
+++ b/src/model/context.ts
@@ -84,7 +84,14 @@ export class Context implements Disposable {
    */
   private isFigureLevel(figure: Figure): boolean {
     const figureState = figure.state;
-    return figureState.empty || figureState.size !== 1;
+    if (figureState.empty || figureState.size !== 1) {
+      return true;
+    }
+    // A lone subplot authored with an empty `layers` array reports the empty
+    // state variant: it has no trace to descend into. Keep such a figure at
+    // figure level so the stack never exposes a bare Subplot and the figure
+    // still describes itself instead of reaching for a trace that is not there.
+    return figureState.subplot.empty;
   }
 
   /**
@@ -95,8 +102,15 @@ export class Context implements Disposable {
    * @returns The instruction context element
    */
   private initializePlotContext(figure: Figure): Plot {
-    // Set the context to figure level.
-    if (this.isFigureLevel(figure)) {
+    // Read the trace only when the figure is not already figure level: a
+    // figure-level check must not touch the subplot (an empty figure state has
+    // no subplot to read).
+    const trace = this.isFigureLevel(figure) ? null : figure.activeSubplot.activeTrace;
+
+    // Set the context to figure level. A null trace lands here too: that is
+    // what isFigureLevel() already decides for a subplot with no layers, and
+    // repeating it narrows the trace to non-null below.
+    if (!trace) {
       this.plotContext.push(figure);
       this.scopeContext.push(Scope.SUBPLOT);
       return figure;
@@ -104,16 +118,17 @@ export class Context implements Disposable {
 
     // Set the context to subplot level.
     this.scopeContext.push(Scope.TRACE);
-    const subplotState = figure.activeSubplot.state;
+    const subplot = figure.activeSubplot;
+    const subplotState = subplot.state;
     if (subplotState.empty || subplotState.size !== 1) {
-      this.plotContext.push(figure.activeSubplot);
-      this.plotContext.push(figure.activeSubplot.activeTrace);
-      return figure.activeSubplot;
+      this.plotContext.push(subplot);
+      this.plotContext.push(trace);
+      return subplot;
     }
 
     // Set the context to trace level (single-layer plot)
-    this.plotContext.push(figure.activeSubplot.activeTrace);
-    return figure.activeSubplot.activeTrace;
+    this.plotContext.push(trace);
+    return trace;
   }
 
   /**
@@ -178,9 +193,11 @@ export class Context implements Disposable {
         subplotRow: subplot.row,
         subplotCol: subplot.col,
         subplotEntry: subplot.isInitialEntry,
-        traceRow: trace.row,
-        traceCol: trace.col,
-        traceEntry: trace.isInitialEntry,
+        // A layerless subplot has no trace cursor to capture; the figure and
+        // subplot positions are still worth preserving across the update.
+        traceRow: trace?.row ?? 0,
+        traceCol: trace?.col ?? 0,
+        traceEntry: trace?.isInitialEntry ?? true,
         shape: this.describeShape(figure),
       };
     } catch {
@@ -228,9 +245,17 @@ export class Context implements Disposable {
     const subplot = figure.activeSubplot;
     subplot.isInitialEntry = snapshot.subplotEntry;
     subplot.row = clamp(snapshot.subplotRow, subplot.traces.length - 1);
-    subplot.col = clamp(snapshot.subplotCol, subplot.traces[subplot.row].length - 1);
+    subplot.col = clamp(snapshot.subplotCol, (subplot.traces[subplot.row]?.length ?? 0) - 1);
 
     const trace = subplot.activeTrace;
+    if (!trace) {
+      // The rebuilt model's active subplot has no layers, so there is no trace
+      // to restore onto and no depth below the lobby to restore to. Park at
+      // figure level, which is where such a figure initializes anyway.
+      this.plotContext.push(figure);
+      return;
+    }
+
     if (!snapshot.traceEntry) {
       trace.isInitialEntry = false;
       this.restoreTracePosition(trace, snapshot, options);
@@ -285,14 +310,16 @@ export class Context implements Disposable {
    * choice made at construction time.
    */
   private resolveInstructionContext(figure: Figure): Plot {
-    if (this.isFigureLevel(figure)) {
+    const trace = this.isFigureLevel(figure) ? null : figure.activeSubplot.activeTrace;
+    if (!trace) {
       return figure;
     }
-    const subplotState = figure.activeSubplot.state;
+    const subplot = figure.activeSubplot;
+    const subplotState = subplot.state;
     if (subplotState.empty || subplotState.size !== 1) {
-      return figure.activeSubplot;
+      return subplot;
     }
-    return figure.activeSubplot.activeTrace;
+    return trace;
   }
 
   public dispose(): void {
@@ -561,16 +588,36 @@ export class Context implements Disposable {
     }
   }
 
-  public enterSubplot(): void {
+  /**
+   * Descends from the multi-panel lobby into the focused subplot, pushing the
+   * Subplot and its active Trace together so the stack never exposes a bare
+   * Subplot.
+   *
+   * @returns True when the subplot was entered; false when the active element
+   *   is not the figure, or the focused subplot has no layers to enter — the
+   *   caller then stays in the lobby and announces that the panel is empty.
+   */
+  public enterSubplot(): boolean {
     const activeState = this.active.state;
-    if (activeState.type === 'figure') {
-      const activeFigure = this.active as Figure;
-      this.plotContext.push(activeFigure.activeSubplot);
-      const trace = activeFigure.activeSubplot.activeTrace;
-      trace.resetToInitialEntry();
-      this.plotContext.push(trace);
-      this.toggleScope(Scope.TRACE);
+    if (activeState.type !== 'figure') {
+      return false;
     }
+
+    const activeFigure = this.active as Figure;
+    const subplot = activeFigure.activeSubplot;
+    const trace = subplot.activeTrace;
+    if (!trace) {
+      // A subplot authored with an empty `layers` array has nothing to enter.
+      // Refusing keeps the user in the lobby with every other panel reachable,
+      // rather than pushing a Subplot with no Trace under it.
+      return false;
+    }
+
+    this.plotContext.push(subplot);
+    trace.resetToInitialEntry();
+    this.plotContext.push(trace);
+    this.toggleScope(Scope.TRACE);
+    return true;
   }
 
   public exitSubplot(): void {

--- a/src/model/movable.ts
+++ b/src/model/movable.ts
@@ -46,6 +46,12 @@ export class MovableGrid<Element> extends AbstractMovable {
   }
 
   public moveOnce(direction: MovableDirection): boolean {
+    // An element-less grid (e.g. a subplot authored with an empty `layers`
+    // array) has nowhere to move and no row to clamp against.
+    if (this.elements.length === 0) {
+      return false;
+    }
+
     if (this.isInitialEntry) {
       this.handleInitialEntry();
       return true;
@@ -76,6 +82,10 @@ export class MovableGrid<Element> extends AbstractMovable {
   }
 
   public moveToExtreme(direction: MovableDirection): boolean {
+    if (this.elements.length === 0) {
+      return false;
+    }
+
     if (this.isInitialEntry) {
       this.handleInitialEntry();
     }
@@ -127,7 +137,8 @@ export class MovableGrid<Element> extends AbstractMovable {
       case 'DOWNWARD':
         return this.row > 0;
       case 'FORWARD':
-        return this.col < this.elements[this.row].length - 1;
+        // Optional index: an element-less grid has no row to measure.
+        return this.col < (this.elements[this.row]?.length ?? 0) - 1;
       case 'BACKWARD':
         return this.col > 0;
     }

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -351,7 +351,9 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
   protected get dimension(): Dimension {
     return {
       rows: this.values.length,
-      cols: this.values[this.row].length,
+      // Optional index: a subplot authored with an empty `layers` array has
+      // no rows at all, so there is no row length to read.
+      cols: this.values[this.row]?.length ?? 0,
     };
   }
 
@@ -444,11 +446,19 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
   }
 
   /**
-   * Gets the currently active trace based on row and column position
-   * @returns The active trace
+   * Gets the currently active trace based on row and column position.
+   *
+   * Nullable because a subplot is allowed to have no layers at all: producers
+   * legitimately emit `layers: []` for an unoccupied grid cell in a
+   * non-rectangular layout, or for a panel whose geom MAIDR does not support
+   * yet. Callers must treat `null` as "this panel has nothing to describe"
+   * rather than assume a trace is always there — before this was nullable, an
+   * empty `layers` array threw here during figure construction and left the
+   * whole figure inert.
+   * @returns The active trace, or `null` when the subplot has no layers.
    */
-  public get activeTrace(): Trace {
-    return this.traces[this.row][this.col];
+  public get activeTrace(): Trace | null {
+    return this.traces[this.row]?.[this.col] ?? null;
   }
 
   /**
@@ -481,12 +491,21 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
   }
 
   public get state(): SubplotState {
+    const trace = this.activeTrace;
+    // A subplot with no layers has no trace state to report. Fall through to
+    // the empty variant the state union already defines, so `Context` and the
+    // observing services take their existing "nothing to describe" branches
+    // instead of walking into a trace that does not exist.
+    if (trace === null) {
+      return this.outOfBoundsState;
+    }
+
     return {
       empty: false,
       type: 'subplot',
       size: this.size,
       index: this.row + 1,
-      trace: this.activeTrace.state,
+      trace: trace.state,
       highlight: this.highlight,
     };
   }
@@ -507,7 +526,7 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
           y: this.row,
           x: this.col,
           rows: this.values.length,
-          cols: this.values[this.row].length,
+          cols: this.values[this.row]?.length ?? 0,
         },
       };
     }

--- a/src/service/liveData.ts
+++ b/src/service/liveData.ts
@@ -460,7 +460,9 @@ export function isAppendedPointFocused(
   if (activeSubplot.activeLayerIndex !== appended.layerIndex) {
     return false;
   }
-  if (appended.nested && activeSubplot.activeTrace.row !== appended.row) {
+  // A subplot with no layers has no active trace, and therefore no series the
+  // append could be landing on — optional chaining makes that read as unfocused.
+  if (appended.nested && activeSubplot.activeTrace?.row !== appended.row) {
     return false;
   }
   return true;

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -253,6 +253,12 @@ export class TextService implements Observer<PlotState>, Disposable {
    * @returns Formatted figure description text
    */
   private formatFigureText(index: number, size: number, traceTypes: string[], subplotTitle: string): string {
+    // A subplot authored with an empty `layers` array contributes no trace
+    // types. Say the panel is empty instead of building "a multi-layered plot
+    // containing  plots" and inviting an ENTER that cannot do anything.
+    if (traceTypes.length === 0) {
+      return this.emptySubplotText(index, size, subplotTitle) ?? Constant.EMPTY;
+    }
     // Terse: keep lobby navigation quick to scan by reading back just the
     // focused subplot's own title (e.g. a facet label) — no "Subplot N"
     // framing. Only when the subplot has no authored title does it fall back
@@ -308,6 +314,33 @@ export class TextService implements Observer<PlotState>, Disposable {
     const titlePart = title ? `, ${title}` : '';
     const suffix = plotType ? `, ${plotType} plot` : '';
     return `Entered subplot ${index} of ${size}${titlePart}${suffix}.`;
+  }
+
+  /**
+   * Builds the wording for a subplot that has nothing to describe — one the
+   * producer authored with an empty `layers` array, which is legitimate for an
+   * unoccupied cell in a non-rectangular grid or a panel whose geom MAIDR does
+   * not support yet. Respects the current text mode:
+   *  - OFF: `null`;
+   *  - TERSE: "<title or Subplot N>, empty";
+   *  - VERBOSE: "Subplot 2 of 4 is empty, nothing to describe.".
+   *
+   * Shared by the lobby navigation text ({@link formatFigureText}) and the
+   * refused-entry cue, so both name the panel the same way.
+   * @param index - 1-based visual position of the subplot.
+   * @param size - Total number of subplots in the figure.
+   * @param title - The subplot's authored title ('' when none).
+   * @returns The message to announce, or `null` when text mode is OFF.
+   */
+  public emptySubplotText(index: number, size: number, title: string): string | null {
+    if (this.mode === TextMode.OFF) {
+      return null;
+    }
+    if (this.mode === TextMode.TERSE) {
+      return `${this.terseSubplotLabel(index, title)}, empty`;
+    }
+    const titlePart = title ? `, ${title}` : '';
+    return `Subplot ${index} of ${size}${titlePart} is empty, nothing to describe.`;
   }
 
   /**

--- a/src/vegalite-entry.ts
+++ b/src/vegalite-entry.ts
@@ -1647,10 +1647,10 @@ export function bindVegaLite(
   const layers = collectLayers(maidr);
 
   // A schema with no usable layer at all is the converter's fallback for
-  // unsupported specs (a lone `{ layers: [] }` subplot). That shape
-  // crashes MAIDR core the moment the chart receives focus
-  // (`Subplot.activeTrace` on an empty traces array), so skip binding
-  // entirely — the chart still renders, it just isn't navigable.
+  // unsupported specs (a lone `{ layers: [] }` subplot). Core tolerates that
+  // shape now, but binding it would only give the user a figure that reports
+  // itself as empty on every keystroke, so skip binding entirely — the chart
+  // still renders, it just isn't navigable.
   if (layers.length === 0) {
     console.warn(
       '[maidr/vegalite] Spec produced no accessible layers; skipping MAIDR '

--- a/test/command/subplot-transitions.test.ts
+++ b/test/command/subplot-transitions.test.ts
@@ -96,8 +96,9 @@ describe('MoveToTraceContextCommand entry cue', () => {
       plotType: 'bar',
     } as unknown as PlotState;
     const context = { state: figureState, isAuthoredTitle } as unknown as Context;
-    (context as { enterSubplot: () => void }).enterSubplot = jest.fn(() => {
+    (context as { enterSubplot: () => boolean }).enterSubplot = jest.fn(() => {
       (context as { state: PlotState }).state = traceState;
+      return true;
     });
 
     const audioService = createMockAudioService();
@@ -126,11 +127,12 @@ describe('MoveToTraceContextCommand entry cue', () => {
       size: 3,
     } as unknown as PlotState;
     const context = { state: figureState, isAuthoredTitle } as unknown as Context;
-    (context as { enterSubplot: () => void }).enterSubplot = jest.fn(() => {
+    (context as { enterSubplot: () => boolean }).enterSubplot = jest.fn(() => {
       (context as { state: PlotState }).state = {
         type: 'trace',
         empty: true,
       } as unknown as PlotState;
+      return true;
     });
 
     const notificationService = createMockNotificationService();
@@ -154,12 +156,13 @@ describe('MoveToTraceContextCommand entry cue', () => {
       size: 4,
     } as unknown as PlotState;
     const context = { state: figureState, isAuthoredTitle } as unknown as Context;
-    (context as { enterSubplot: () => void }).enterSubplot = jest.fn(() => {
+    (context as { enterSubplot: () => boolean }).enterSubplot = jest.fn(() => {
       (context as { state: PlotState }).state = {
         type: 'trace',
         empty: false,
         plotType: 'bar',
       } as unknown as PlotState;
+      return true;
     });
 
     const audioService = createMockAudioService();
@@ -182,12 +185,13 @@ describe('MoveToTraceContextCommand entry cue', () => {
   test('announces a terse entry message (no title) in terse mode', () => {
     const figureState = { type: 'figure', empty: false, index: 2, size: 4 } as unknown as PlotState;
     const context = { state: figureState, isAuthoredTitle } as unknown as Context;
-    (context as { enterSubplot: () => void }).enterSubplot = jest.fn(() => {
+    (context as { enterSubplot: () => boolean }).enterSubplot = jest.fn(() => {
       (context as { state: PlotState }).state = {
         type: 'trace',
         empty: false,
         plotType: 'bar',
       } as unknown as PlotState;
+      return true;
     });
 
     const notificationService = createMockNotificationService();
@@ -208,13 +212,14 @@ describe('MoveToTraceContextCommand entry cue', () => {
   test('announces the subplot title in terse mode when the subplot has one', () => {
     const figureState = { type: 'figure', empty: false, index: 2, size: 4 } as unknown as PlotState;
     const context = { state: figureState, isAuthoredTitle } as unknown as Context;
-    (context as { enterSubplot: () => void }).enterSubplot = jest.fn(() => {
+    (context as { enterSubplot: () => boolean }).enterSubplot = jest.fn(() => {
       (context as { state: PlotState }).state = {
         type: 'trace',
         empty: false,
         plotType: 'bar',
         title: 'Sales in North',
       } as unknown as PlotState;
+      return true;
     });
 
     const notificationService = createMockNotificationService();
@@ -234,13 +239,14 @@ describe('MoveToTraceContextCommand entry cue', () => {
   test('announces the full title in verbose mode when the subplot has one', () => {
     const figureState = { type: 'figure', empty: false, index: 2, size: 4 } as unknown as PlotState;
     const context = { state: figureState, isAuthoredTitle } as unknown as Context;
-    (context as { enterSubplot: () => void }).enterSubplot = jest.fn(() => {
+    (context as { enterSubplot: () => boolean }).enterSubplot = jest.fn(() => {
       (context as { state: PlotState }).state = {
         type: 'trace',
         empty: false,
         plotType: 'bar',
         title: 'Sales in North',
       } as unknown as PlotState;
+      return true;
     });
 
     const notificationService = createMockNotificationService();
@@ -260,12 +266,13 @@ describe('MoveToTraceContextCommand entry cue', () => {
   test('plays the tone but announces nothing in OFF text mode', () => {
     const figureState = { type: 'figure', empty: false, index: 2, size: 4 } as unknown as PlotState;
     const context = { state: figureState, isAuthoredTitle } as unknown as Context;
-    (context as { enterSubplot: () => void }).enterSubplot = jest.fn(() => {
+    (context as { enterSubplot: () => boolean }).enterSubplot = jest.fn(() => {
       (context as { state: PlotState }).state = {
         type: 'trace',
         empty: false,
         plotType: 'bar',
       } as unknown as PlotState;
+      return true;
     });
 
     const audioService = createMockAudioService();

--- a/test/model/contextReplaceFigure.test.ts
+++ b/test/model/contextReplaceFigure.test.ts
@@ -186,8 +186,13 @@ describe('context.replaceFigure', () => {
     const subplot = oldFigure.subplots[0][0];
     subplot.isInitialEntry = false;
     subplot.row = 1;
-    subplot.activeTrace.isInitialEntry = false;
-    subplot.activeTrace.col = 2;
+    // activeTrace is nullable for layerless subplots; this fixture has layers.
+    const trace = subplot.activeTrace;
+    if (!trace) {
+      throw new Error('fixture subplot should have an active trace');
+    }
+    trace.isInitialEntry = false;
+    trace.col = 2;
 
     // Simulate a streaming tick: one more point in every layer.
     const newFigure = new Figure(createMultiLayer(4));

--- a/test/model/emptySubplot.test.ts
+++ b/test/model/emptySubplot.test.ts
@@ -1,0 +1,141 @@
+import type { NotificationService } from '@service/notification';
+import type { Maidr, MaidrSubplot } from '@type/grammar';
+import type { PlotState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A subplot authored with an empty `layers` array used to throw in
+ * `Subplot.activeTrace` while the plot context was being built — before any
+ * user interaction — so MAIDR never attached and the *entire* figure went
+ * inert, well-formed panels included (issue #749).
+ *
+ * An empty subplot is a legitimate thing for a producer to emit: an unoccupied
+ * cell in a non-rectangular grid, or a panel whose geom is not supported yet.
+ * It must read as "this panel has nothing to describe" and leave the rest of
+ * the figure navigable.
+ */
+const EMPTY_SUBPLOT: MaidrSubplot = { layers: [] };
+
+function barSubplot(id: string, value: number): MaidrSubplot {
+  return { layers: [{ id, type: TraceType.BAR, data: [{ x: 'A', y: value }] }] };
+}
+
+/** First panel empty, second well-formed — the reported reproduction. */
+function createFigureWithEmptyFirstPanel(): Figure {
+  const maidr: Maidr = {
+    id: 'empty-first-panel',
+    subplots: [[EMPTY_SUBPLOT], [barSubplot('sp-2', 2)]],
+  } as Maidr;
+  return new Figure(maidr);
+}
+
+/** A single panel with no layers at all — nothing in the figure to describe. */
+function createFigureWithOnlyAnEmptyPanel(): Figure {
+  const maidr: Maidr = {
+    id: 'only-empty-panel',
+    subplots: [[EMPTY_SUBPLOT]],
+  } as Maidr;
+  return new Figure(maidr);
+}
+
+describe('subplot with no layers', () => {
+  test('reports the empty state instead of throwing on activeTrace', () => {
+    const subplot = createFigureWithEmptyFirstPanel().subplots[0][0];
+
+    expect(subplot.activeTrace).toBeNull();
+    expect(subplot.state).toEqual({ empty: true, type: 'subplot' });
+  });
+
+  test('building the context does not throw and the figure still describes itself', () => {
+    const figure = createFigureWithEmptyFirstPanel();
+
+    // The reported crash happened here, in `Context.initializePlotContext` ->
+    // `isFigureLevel` -> `figure.state`, before any keystroke.
+    const context = new Context(figure);
+
+    const state = context.state;
+    expect(state.type).toBe('figure');
+    expect(state.empty).toBe(false);
+  });
+
+  test('the well-formed sibling panel stays reachable', () => {
+    const figure = createFigureWithEmptyFirstPanel();
+    const context = new Context(figure);
+
+    // Move off the empty panel onto the bar panel, then enter it.
+    expect(figure.moveToIndex(1, 0)).toBe(true);
+    expect(context.enterSubplot()).toBe(true);
+
+    const state = context.state;
+    expect(state.type).toBe('trace');
+    expect(state.empty).toBe(false);
+  });
+
+  test('entering an empty panel is refused, leaving the user in the lobby', () => {
+    const context = new Context(createFigureWithEmptyFirstPanel());
+
+    expect(context.enterSubplot()).toBe(false);
+    // No bare Subplot is left on the stack: the lobby is still the context.
+    expect(context.state.type).toBe('figure');
+  });
+
+  test('a figure whose only panel is empty starts at figure level without throwing', () => {
+    const context = new Context(createFigureWithOnlyAnEmptyPanel());
+
+    expect(context.state.type).toBe('figure');
+    expect(context.getInstruction(false)).toContain('maidr figure');
+  });
+
+  test('navigating within an empty panel reports out of bounds rather than throwing', () => {
+    const subplot = createFigureWithOnlyAnEmptyPanel().subplots[0][0];
+
+    expect(subplot.moveOnce('FORWARD')).toBe(false);
+    expect(subplot.moveToExtreme('FORWARD')).toBe(false);
+    expect(subplot.isMovable('FORWARD')).toBe(false);
+  });
+});
+
+describe('TextService wording for a panel with no layers', () => {
+  /** A lobby state focused on a panel that contributed no trace types. */
+  function emptyPanelLobbyState(): PlotState {
+    return {
+      empty: false,
+      type: 'figure',
+      index: 1,
+      size: 2,
+      traceTypes: [],
+      subplot: { empty: true, type: 'subplot' },
+    } as unknown as PlotState;
+  }
+
+  function createTextService(): TextService {
+    return new TextService({ notify: jest.fn() } as unknown as NotificationService);
+  }
+
+  test('verbose says the panel is empty instead of listing no plot types', () => {
+    const text = createTextService();
+
+    expect(text.format(emptyPanelLobbyState())).toBe(
+      'Subplot 1 of 2 is empty, nothing to describe.',
+    );
+  });
+
+  test('terse marks the panel as empty', () => {
+    const text = createTextService();
+    text.toggle(); // VERBOSE -> TERSE
+
+    expect(text.format(emptyPanelLobbyState())).toBe('Subplot 1, empty');
+  });
+
+  test('says nothing in OFF text mode', () => {
+    const text = createTextService();
+    text.toggle(); // VERBOSE -> TERSE
+    text.toggle(); // TERSE -> OFF
+
+    expect(text.emptySubplotText(1, 2, '')).toBeNull();
+  });
+});

--- a/test/service/liveData.test.ts
+++ b/test/service/liveData.test.ts
@@ -536,8 +536,13 @@ describe('isAppendedPointFocused', () => {
     const figure = createMultiLayerFigure();
     const subplot = figure.subplots[0][0];
     subplot.row = 2; // user on the multiline layer
-    subplot.activeTrace.isInitialEntry = false;
-    subplot.activeTrace.row = 0; // user on series 0
+    // activeTrace is nullable for layerless subplots; this fixture has layers.
+    const trace = subplot.activeTrace;
+    if (!trace) {
+      throw new Error('fixture subplot should have an active trace');
+    }
+    trace.isInitialEntry = false;
+    trace.row = 0; // user on series 0
 
     expect(isAppendedPointFocused(figure, createAppended({ layerIndex: 2, nested: true, row: 0 }))).toBe(true);
     expect(isAppendedPointFocused(figure, createAppended({ layerIndex: 2, nested: true, row: 1 }))).toBe(false);
@@ -547,8 +552,13 @@ describe('isAppendedPointFocused', () => {
     const figure = createMultiLayerFigure();
     const subplot = figure.subplots[0][0];
     subplot.row = 0; // user on the candle layer
-    subplot.activeTrace.isInitialEntry = false;
-    subplot.activeTrace.row = 2; // user on the "high" section
+    // activeTrace is nullable for layerless subplots; this fixture has layers.
+    const trace = subplot.activeTrace;
+    if (!trace) {
+      throw new Error('fixture subplot should have an active trace');
+    }
+    trace.isInitialEntry = false;
+    trace.row = 2; // user on the "high" section
 
     // Announce coordinates target the close section (row 4) — still focused.
     expect(isAppendedPointFocused(figure, createAppended({ layerIndex: 0, row: 4 }))).toBe(true);


### PR DESCRIPTION
# Pull Request

## Description

A subplot authored with an empty `layers` array threw in `Subplot.activeTrace` while the plot context was being built — before any user interaction. The exception escaped initialisation, so MAIDR never attached and the **entire figure** went inert: Tab did nothing and no panel was reachable, including well-formed ones.

```
Uncaught TypeError: Cannot read properties of undefined (reading '0')
    at get activeTrace
    at get state
    at getStateWithFigurePosition
    at isFigureLevel
    at initializePlotContext
```

An empty subplot is legitimate producer output — an unoccupied cell in a non-rectangular grid, or a panel whose geom is not supported yet — so it now reads as "this panel has nothing to describe" and leaves the rest of the figure navigable.

## Related Issues

Closes #749.

Sibling of #748 (empty `selectors` array), which is a different path and is not touched here. See the note under **Additional Notes** on a cross-PR interaction with #750.

## Changes Made

**Model**

- `Subplot.activeTrace` returns `Trace | null` rather than lying about the invariant. Making it nullable was the point: the compiler then surfaced every reader (`Context`, `Controller`, `NavigationService`, `liveData`) so each one got an explicit decision instead of an unguarded index. `NavigationService.stepTraceInSubplot` already null-checked it — that check is now meaningful.
- `Subplot.state` falls through to `outOfBoundsState` (`{ empty: true, type: 'subplot' }`) when there is no active trace — the empty variant `SubplotState` already defines and that `isFigureLevel`, `TextService`, `AudioService`, and `HighlightService` already branch on.
- `Subplot.dimension` and the subplot highlight state read the row length optionally instead of indexing a row that does not exist.
- `MovableGrid` treats an element-less grid as unmovable (`moveOnce` / `moveToExtreme` return `false`, `isMovable('FORWARD')` no longer indexes a missing row), so navigation inside an empty panel reports out of bounds rather than throwing.

**Context**

- `isFigureLevel` — the documented single source of truth for level discrimination — also returns `true` for a lone subplot that reports the empty state, so the stack never exposes a bare `Subplot` (the invariant pinned by `contextStackInvariant.test.ts`) and construction completes.
- `enterSubplot()` now returns `boolean` and refuses to descend into a layerless panel, keeping the user in the lobby with every other panel reachable.
- `captureNavigationSnapshot` / `restoreNavigation` survive a live-data update whose active subplot has no layers instead of falling into the catch-all.

**Command / service**

- `MoveToTraceContextCommand` gates the enter tone and entry announcement on the new return value, and announces the empty panel instead of leaving the keypress silent.
- `TextService.emptySubplotText()` owns the mode-aware wording (OFF silent, TERSE `"Subplot 1, empty"`, VERBOSE `"Subplot 1 of 2 is empty, nothing to describe."`), shared by the lobby navigation text and the refused-entry cue. Previously a zero-layer panel produced `"This is a multi-layered plot containing  plots"` with a `Press 'ENTER'` prompt that could not do anything.
- The vega-lite entry still skips binding a zero-layer spec; only its comment changed, since the crash it cited no longer exists.

## Screenshots (if applicable)

Driven in Chromium against the built bundle, with a layerless first panel and a well-formed bar panel. No page errors; before this change the same file threw during initialisation and announced nothing at all:

```
ArrowUp (lobby)        : ["Subplot 1 of 2 is empty, nothing to describe."]
ArrowDown (lobby)      : ["Subplot 2 of 2, Well-formed panel: This is a bar plot. Press 'ENTER' to select this subplot."]
ENTER on bar panel     : ["Entered subplot 2 of 2, Well-formed panel, bar plot."]
ArrowRight             : ["Category is A, Value is 1"]
Escape                 : ["Returned to figure overview, subplot 2 of 2, Well-formed panel."]
ENTER on empty panel   : ["Subplot 1 of 2 is empty, nothing to describe."]
```

That sequence is now an e2e spec rather than a one-off manual run — see below.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Tests

`test/model/emptySubplot.test.ts` (unit) reproduces the bug: run against the unfixed source it fails with the reported `TypeError: Cannot read properties of undefined (reading '0')`. It covers the empty state, context construction, the sibling panel staying reachable, the refused entry, a figure whose only panel is empty, out-of-bounds navigation inside it, and the three text modes.

`e2e_tests/specs/emptySubplot.spec.ts` (added in `d1e8297`) closes the gap the unit suite structurally cannot cover — that MAIDR attaches at all in a real browser. No checked-in example emits a zero-layer subplot, so CI never exercised that path. The fixture lives in `e2e_tests/fixtures/` rather than `examples/` because a deliberately degenerate input is not a gallery demo.

All four e2e cases fail against the unfixed build, the first with the reported error:

```
✘ attaches without an uncaught error
  + "Cannot read properties of undefined (reading '0')"
✘ announces the empty panel rather than describing a plot that is not there
✘ refuses to enter the empty panel and says why
✘ keeps the well-formed sibling panel fully navigable
```

Worth noting for anyone extending the spec: the first arrow key in the multi-panel lobby is consumed by initial entry — it announces the focused panel without moving off it. The page object exposes that as `announceStartingSubplot()` so a spec reads as what it does.

Three existing tests were updated for the nullable `activeTrace`, and the `enterSubplot` stubs in `subplot-transitions.test.ts` now model the new `boolean` return.

### Verification run locally

`npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (119 unit suites / 1577 tests, plus 6 suites / 61 tests across the component and ESM projects), and the full Playwright chromium suite — **330 passed** (326 existing + 4 new), so the new spec is confirmed run and the rest of the suite is confirmed unaffected.

### Cross-PR interaction with #750

Not a merge conflict — #750 and this PR share no files, so git merges them silently — but the merged tree does not type-check, and neither PR's CI can see it because each only builds its own branch. #750's new `test/model/emptySelectors.test.ts` reads `subplot.activeTrace` without a null guard, which this PR makes nullable:

```
test/model/emptySelectors.test.ts(80,3): error TS18047: 'trace' is possibly 'null'.
test/model/emptySelectors.test.ts(81,3): error TS18047: 'trace' is possibly 'null'.
test/model/emptySelectors.test.ts(83,17): error TS18047: 'trace' is possibly 'null'.
```

Confirmed by trial-merging both branches locally: no textual conflict, three type errors, and runtime behaviour fine (both suites' 13 tests pass). Whichever PR merges second breaks `npm run type-check` on `main`. Flagged on #750 with the one-guard fix; a rebase onto `main` after this lands will surface it in CI there anyway.