### PR TITLE
fix(box): describe every box's range and outliers, not one chart-wide pair

### DIFF
--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -132,19 +132,29 @@ export class BoxTrace extends AbstractTrace {
     const stats: DescriptionState['stats'] = [
       { label: 'Number of groups', value: this.points.length },
       { label: 'Group names', value: groupNames },
-      { label: 'Min', value: this.min },
-      { label: 'Max', value: this.max },
+      ...this.rangeStats(),
     ];
 
-    const headers = ['Group', 'Min', 'Q1', 'Q2', 'Q3', 'Max'];
-    const rows: (string | number)[][] = this.points.map(p => [
-      p.z,
-      p.min,
-      p.q1,
-      p.q2,
-      p.q3,
-      p.max,
-    ]);
+    // Both the headers and the cells walk `this.sections`, so every section the
+    // user can navigate to — the outliers included — gets a column, and the two
+    // stay aligned if the section list ever changes.
+    const headers = ['Group', ...this.sections];
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+
+    const rows: (string | number)[][] = this.points.map((point, pointIdx) => {
+      const sectionValues = this.sections.map((_, sectionIdx) => {
+        const value = isHorizontal
+          ? this.boxValues[pointIdx]?.[sectionIdx]
+          : this.boxValues[sectionIdx]?.[pointIdx];
+        // Outlier sections hold an array of values; a group with none renders
+        // as a blank cell rather than an empty-looking `[]`.
+        if (Array.isArray(value)) {
+          return value.join(', ');
+        }
+        return value ?? '';
+      });
+      return [point.z, ...sectionValues];
+    });
 
     return {
       chartType: this.getChartTypeLabel(),
@@ -152,6 +162,64 @@ export class BoxTrace extends AbstractTrace {
       axes: this.getDescriptionAxes(),
       stats,
       dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * Builds the two range rows of the summary.
+   *
+   * Every box carries its own whisker ends, so a single chart-wide Min/Max pair
+   * reads as though a chart of several boxes had one minimum and one maximum. A
+   * lone group reports its whisker ends plainly; several report each extreme
+   * attributed to the group it came from, and the per-group breakdown is left
+   * to the data table below.
+   *
+   * These are whisker ends, not the trace-wide `min`/`max` used for
+   * sonification: those fold the outliers in, which would contradict the
+   * Minimum and Maximum columns of the very table underneath.
+   */
+  private rangeStats(): DescriptionState['stats'] {
+    const grouped = this.points.length > 1;
+    return [
+      this.extremeStat(
+        grouped ? 'Lowest minimum' : 'Minimum',
+        p => p.min,
+        (candidate, current) => candidate < current,
+      ),
+      this.extremeStat(
+        grouped ? 'Highest maximum' : 'Maximum',
+        p => p.max,
+        (candidate, current) => candidate > current,
+      ),
+    ];
+  }
+
+  /**
+   * Builds one range row: the winning value across groups, named with the group
+   * it belongs to once there is more than one group to tell apart.
+   *
+   * @param label - Row label to show in the summary.
+   * @param valueOf - Reads the whisker end being compared from a group.
+   * @param beats - True when the candidate value outranks the current winner.
+   * @returns The summary row, or a `missing` row when no group has the value.
+   */
+  private extremeStat(
+    label: string,
+    valueOf: (point: BoxPoint) => number,
+    beats: (candidate: number, current: number) => boolean,
+  ): DescriptionState['stats'][number] {
+    const measured = this.points.filter(point => Number.isFinite(valueOf(point)));
+    if (measured.length === 0) {
+      return { label, value: 'missing' };
+    }
+
+    const winner = measured.reduce((best, point) =>
+      beats(valueOf(point), valueOf(best)) ? point : best,
+    );
+    const value = valueOf(winner);
+    return {
+      label,
+      value: this.points.length > 1 ? `${value} (${winner.z})` : value,
     };
   }
 

--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -179,15 +179,14 @@ export class BoxTrace extends AbstractTrace {
    * Minimum and Maximum columns of the very table underneath.
    */
   private rangeStats(): DescriptionState['stats'] {
-    const grouped = this.points.length > 1;
     return [
       this.extremeStat(
-        grouped ? 'Lowest minimum' : 'Minimum',
+        { single: 'Minimum', grouped: 'Lowest minimum' },
         p => p.min,
         (candidate, current) => candidate < current,
       ),
       this.extremeStat(
-        grouped ? 'Highest maximum' : 'Maximum',
+        { single: 'Maximum', grouped: 'Highest maximum' },
         p => p.max,
         (candidate, current) => candidate > current,
       ),
@@ -198,16 +197,29 @@ export class BoxTrace extends AbstractTrace {
    * Builds one range row: the winning value across groups, named with the group
    * it belongs to once there is more than one group to tell apart.
    *
-   * @param label - Row label to show in the summary.
+   * Both halves of the row — which label to use and whether the value carries a
+   * group name — hang off the one `grouped` check here, so a row can never pair
+   * a lone-group label with a group-suffixed value.
+   *
+   * Boxes tie on a whisker end readily, several bottoming out at the same floor
+   * being the ordinary case, and `beats` is strict, so the earliest group in
+   * navigation order wins: the group named is the first one the user reaches.
+   *
+   * @param labels - Row label for the one-group and the several-group case.
+   * @param labels.single - Label used when the chart holds a single box.
+   * @param labels.grouped - Label used when the chart holds several boxes.
    * @param valueOf - Reads the whisker end being compared from a group.
    * @param beats - True when the candidate value outranks the current winner.
    * @returns The summary row, or a `missing` row when no group has the value.
    */
   private extremeStat(
-    label: string,
+    labels: { single: string; grouped: string },
     valueOf: (point: BoxPoint) => number,
     beats: (candidate: number, current: number) => boolean,
   ): DescriptionState['stats'][number] {
+    const grouped = this.points.length > 1;
+    const label = grouped ? labels.grouped : labels.single;
+
     const measured = this.points.filter(point => Number.isFinite(valueOf(point)));
     if (measured.length === 0) {
       return { label, value: 'missing' };
@@ -217,10 +229,7 @@ export class BoxTrace extends AbstractTrace {
       beats(valueOf(point), valueOf(best)) ? point : best,
     );
     const value = valueOf(winner);
-    return {
-      label,
-      value: this.points.length > 1 ? `${value} (${winner.z})` : value,
-    };
+    return { label, value: grouped ? `${value} (${winner.z})` : value };
   }
 
   public override dispose(): void {

--- a/test/model/boxDescription.test.ts
+++ b/test/model/boxDescription.test.ts
@@ -106,6 +106,20 @@ describe('boxTrace description summary', () => {
     expect(stat(trace, 'Highest maximum')).toBe('25 (A)');
   });
 
+  test('names the first group in navigation order when boxes tie', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', 1, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, 25),
+      group('C', 7, 9, 14, 22, 19),
+    ]));
+
+    // Boxes bottoming out at the same floor is the ordinary case, so the rule
+    // has to be stated: the earliest group wins, which is the first one the
+    // user reaches by navigating.
+    expect(stat(trace, 'Lowest minimum')).toBe('1 (A)');
+    expect(stat(trace, 'Highest maximum')).toBe('25 (A)');
+  });
+
   test('still counts and names the groups', () => {
     const trace = new BoxTrace(makeBoxLayer([
       group('A', 5, 10, 15, 20, 25),

--- a/test/model/boxDescription.test.ts
+++ b/test/model/boxDescription.test.ts
@@ -1,0 +1,160 @@
+import type { BoxPoint, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { BoxTrace } from '@model/box';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Builds a box plot group. Outliers default to none so a test only spells out
+ * the ones it cares about.
+ */
+function group(
+  z: string,
+  min: number,
+  q1: number,
+  q2: number,
+  q3: number,
+  max: number,
+  outliers: { lower?: number[]; upper?: number[] } = {},
+): BoxPoint {
+  return {
+    z,
+    lowerOutliers: outliers.lower ?? [],
+    min,
+    q1,
+    q2,
+    q3,
+    max,
+    upperOutliers: outliers.upper ?? [],
+  };
+}
+
+/**
+ * Builds a box layer with no selectors, so the trace skips SVG resolution and
+ * the test needs no DOM.
+ */
+function makeBoxLayer(data: BoxPoint[], orientation?: Orientation): MaidrLayer {
+  return {
+    id: 'box',
+    type: TraceType.BOX,
+    title: 'Boxes',
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    data,
+    ...(orientation ? { orientation } : {}),
+  };
+}
+
+/**
+ * Reads a summary row by label, or undefined when the summary has no such row.
+ */
+function stat(trace: BoxTrace, label: string): string | number | undefined {
+  return trace.description.stats.find(s => s.label === label)?.value;
+}
+
+describe('boxTrace description summary', () => {
+  test('attributes each extreme to its group when several boxes are present', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', 5, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, 12),
+      group('C', 3, 9, 14, 22, 40),
+    ]));
+
+    // A single chart-wide "Min: 1 / Max: 40" leaves the user unable to tell
+    // which of the three boxes those ends belong to.
+    expect(stat(trace, 'Lowest minimum')).toBe('1 (B)');
+    expect(stat(trace, 'Highest maximum')).toBe('40 (C)');
+    expect(stat(trace, 'Min')).toBeUndefined();
+    expect(stat(trace, 'Max')).toBeUndefined();
+  });
+
+  test('reports plain whisker ends when there is only one box', () => {
+    const trace = new BoxTrace(makeBoxLayer([group('Only', 2, 4, 6, 8, 10)]));
+
+    // Nothing to disambiguate, so no group name and the raw numbers survive.
+    expect(stat(trace, 'Minimum')).toBe(2);
+    expect(stat(trace, 'Maximum')).toBe(10);
+  });
+
+  test('reports whisker ends rather than the outlier-inclusive audio range', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', 5, 10, 15, 20, 25, { lower: [-40], upper: [90] }),
+    ]));
+
+    // -40 and 90 drive the sonification range, but reporting them as the
+    // minimum and maximum would contradict the table's own Minimum/Maximum
+    // columns directly underneath.
+    expect(stat(trace, 'Minimum')).toBe(5);
+    expect(stat(trace, 'Maximum')).toBe(25);
+  });
+
+  test('marks a range as missing when no group carries the whisker end', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', Number.NaN, 10, 15, 20, Number.NaN),
+      group('B', Number.NaN, 4, 6, 8, Number.NaN),
+    ]));
+
+    expect(stat(trace, 'Lowest minimum')).toBe('missing');
+    expect(stat(trace, 'Highest maximum')).toBe('missing');
+  });
+
+  test('skips groups without a whisker end instead of losing the range', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', Number.NaN, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, Number.NaN),
+    ]));
+
+    expect(stat(trace, 'Lowest minimum')).toBe('1 (B)');
+    expect(stat(trace, 'Highest maximum')).toBe('25 (A)');
+  });
+
+  test('still counts and names the groups', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', 5, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, 12),
+    ]));
+
+    expect(stat(trace, 'Number of groups')).toBe(2);
+    expect(stat(trace, 'Group names')).toBe('A, B');
+  });
+});
+
+describe('boxTrace description data table', () => {
+  test('gives the outlier sections their own columns', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', 5, 10, 15, 20, 25, { lower: [-2, 0], upper: [31] }),
+      group('B', 1, 4, 6, 8, 12),
+    ]));
+    const { headers, rows } = trace.description.dataTable;
+
+    expect(headers).toEqual([
+      'Group',
+      'Lower outlier(s)',
+      'Minimum',
+      '25%',
+      '50%',
+      '75%',
+      'Maximum',
+      'Upper outlier(s)',
+    ]);
+    expect(rows).toEqual([
+      ['A', '-2, 0', 5, 10, 15, 20, 25, '31'],
+      // A group with no outliers leaves the cell blank rather than showing an
+      // empty list.
+      ['B', '', 1, 4, 6, 8, 12, ''],
+    ]);
+  });
+
+  test('keeps the horizontal table in the order the user navigates', () => {
+    const trace = new BoxTrace(makeBoxLayer([
+      group('A', 5, 10, 15, 20, 25, { upper: [30] }),
+      group('B', 1, 4, 6, 8, 12, { lower: [-1] }),
+    ], Orientation.HORIZONTAL));
+    const { rows } = trace.description.dataTable;
+
+    // A horizontal box plot reverses its groups so navigation starts at the
+    // lower-left box; the table follows that same order.
+    expect(rows).toEqual([
+      ['B', '-1', 1, 4, 6, 8, 12, ''],
+      ['A', '', 5, 10, 15, 20, 25, '30'],
+    ]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Pressing `d` on a box plot opened a Chart Description whose summary claimed a single `Min` and a single `Max` for the whole chart. On a plot with several boxes that reads as though the chart had one minimum and one maximum, with nothing saying which box either belongs to. The data table underneath was also incomplete: it listed Min/Q1/Q2/Q3/Max but silently dropped the lower and upper outliers, even though both are sections the user can navigate to and hear announced.

There was a second, quieter inconsistency: the summary's `Min`/`Max` came from the trace-wide range used for sonification, which folds outliers in. So a chart with a low outlier showed `Min: -40` in the summary while the table's own Min column for that same group showed `5`.

## Related Issues

None filed — reported directly.

## Changes Made

`src/model/box.ts`, `BoxTrace.description`:

- **Summary extremes are now attributed to a group.** With more than one box, the summary reads `Lowest minimum: 1 (B)` and `Highest maximum: 40 (C)` instead of a bare `Min`/`Max` pair. A single-group box plot has nothing to disambiguate, so it keeps plain `Minimum: 2` / `Maximum: 10`. A group whose whisker end is missing is skipped rather than poisoning the range; if no group has one, the row reads `missing`, matching how the bar trace reports an unmeasurable range.
- **Summary extremes are whisker ends**, not the outlier-inclusive audio range, so they agree with the Minimum and Maximum columns of the table directly below.
- **The data table gained the outlier columns.** Headers and cells both walk `this.sections`, so the table now covers every navigable section — `Group, Lower outlier(s), Minimum, 25%, 50%, 75%, Maximum, Upper outlier(s)` — and the two can't drift apart if the section list changes. This also aligns the column names with the section names the user hears while navigating, and with how `ViolinBoxTrace` already builds its table. A group with no outliers renders a blank cell. Horizontal box plots keep their table in navigation order (groups are reversed at construction so navigation starts at the lower-left box).

`test/model/boxDescription.test.ts` (new, 8 tests): group attribution with several boxes, the single-group form, whisker-vs-outlier range, the all-missing and partially-missing cases, group count/names, the outlier columns, and horizontal row order.

## Screenshots (if applicable)

n/a — dialog content change; the assertions in the new test file show the exact before/after strings.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verification run locally, all green: `npm run lint:fix`, `npm run type-check`, `npm run build`, and `npm test` (119 unit suites / 1576 tests, plus 6 ESM suites / 61 tests). Documentation was left alone — the description dialog's contents are not spelled out in the docs site.

`ViolinBoxTrace` (`src/model/violinBox.ts`) carries the same single `Min`/`Max` summary shape. It is left untouched here to keep this change to the box plot that was reported; violin plots produce no outliers, so only the extreme-attribution half would apply to it. Happy to follow up in a separate PR if you want it aligned.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1NsuQkNcN8TCEwEmDHg2r)_