### PR TITLE
feat(audio): play the menu open/close cue for every dialog

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -164,12 +164,11 @@ export class Controller implements Disposable {
       store,
       this.goToExtremaService,
       this.context,
-      this.audioService,
       this.formatterService,
     );
     this.reviewViewModel = new ReviewViewModel(store, this.reviewService);
     this.descriptionViewModel = new DescriptionViewModel(store, this.descriptionService);
-    this.displayViewModel = new DisplayViewModel(store, this.displayService);
+    this.displayViewModel = new DisplayViewModel(store, this.displayService, this.audioService);
     this.helpViewModel = new HelpViewModel(store, this.helpService);
     this.settingsViewModel = new SettingsViewModel(store, this.settingsService);
 

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -906,17 +906,19 @@ export class AudioService implements Observer<PlotState>, Disposable {
   }
 
   /**
-   * Plays the "menu open" cue — a short rising two-note tick — when the Go-To
-   * modal opens. A navigational affordance, so it plays in any audio mode
-   * except OFF (mirroring playWarningToneIfEnabled).
+   * Plays the "menu open" cue — a short rising two-note tick — when a dialog
+   * opens: Go To Extrema, help, settings, chat, the chart description, the
+   * command palette, or the candlestick reference picker all share it. A
+   * navigational affordance, so it plays in any audio mode except OFF
+   * (mirroring playWarningToneIfEnabled).
    */
   public playMenuOpenTone(): void {
     this.playMenuTone(MENU_OPEN_FREQUENCIES);
   }
 
   /**
-   * Plays the "menu close" cue — a short falling two-note tick — when the Go-To
-   * modal is dismissed. Plays in any audio mode except OFF.
+   * Plays the "menu close" cue — a short falling two-note tick — when a dialog
+   * is dismissed. Plays in any audio mode except OFF.
    */
   public playMenuCloseTone(): void {
     this.playMenuTone(MENU_CLOSE_FREQUENCIES);

--- a/src/service/display.ts
+++ b/src/service/display.ts
@@ -2,7 +2,7 @@ import type { Context } from '@model/context';
 import type { TextService } from '@service/text';
 import type { Disposable } from '@type/disposable';
 import type { Event, Focus } from '@type/event';
-import { Emitter, Scope } from '@type/event';
+import { Emitter, MODAL_SCOPES, Scope } from '@type/event';
 import { Constant } from '@util/constant';
 import { Stack } from '@util/stack';
 
@@ -197,16 +197,7 @@ export class DisplayService implements Disposable {
    */
   public toggleFocus(focus: Focus): void {
     // Treat modal scopes as mode toggles so we suppress instruction re-announce on return
-    this.isReturningFromModeToggle
-      = focus === 'BRAILLE'
-        || focus === 'REVIEW'
-        || focus === 'GO_TO_EXTREMA'
-        || focus === 'COMMAND_PALETTE'
-        || focus === 'DESCRIPTION'
-        || focus === 'SETTINGS'
-        || focus === 'CHAT'
-        || focus === 'HELP'
-        || focus === 'CANDLESTICK_DELTA_SETTINGS';
+    this.isReturningFromModeToggle = MODAL_SCOPES.has(focus);
 
     // Clear any existing instruction label when entering a modal
     if (this.isReturningFromModeToggle) {

--- a/src/state/viewModel/displayViewModel.ts
+++ b/src/state/viewModel/displayViewModel.ts
@@ -1,9 +1,32 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
+import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { AppStore } from '@state/store';
 import type { Focus } from '@type/event';
 import { createSlice } from '@reduxjs/toolkit';
 import { AbstractViewModel } from '@state/viewModel/viewModel';
+import { Scope } from '@type/event';
+
+/**
+ * Focus scopes that render as a dialog — a surface that overlays the chart,
+ * traps the keyboard until dismissed, and closes with Escape. Entering one
+ * plays the menu open cue and leaving it plays the menu close cue, so every
+ * dialog sounds the same as the Go To Extrema modal that first had the cue.
+ *
+ * `BRAILLE` and `REVIEW` are deliberately absent: they render as an inline
+ * text field next to the chart rather than as an overlay, so a dialog cue
+ * would describe them wrongly. `CANDLESTICK_DELTA` is plot navigation, not a
+ * dialog, and already has its own enter/exit arpeggio.
+ */
+const DIALOG_SCOPES: ReadonlySet<Focus> = new Set<Focus>([
+  Scope.CANDLESTICK_DELTA_SETTINGS,
+  Scope.CHAT,
+  Scope.COMMAND_PALETTE,
+  Scope.DESCRIPTION,
+  Scope.GO_TO_EXTREMA,
+  Scope.HELP,
+  Scope.SETTINGS,
+]);
 
 /**
  * Represents the state of a tooltip UI element.
@@ -54,16 +77,26 @@ const { hideTooltip, showTooltip, updateFocus, clearFocus } = displaySlice.actio
  */
 export class DisplayViewModel extends AbstractViewModel<DisplayState> {
   private readonly displayService: DisplayService;
+  private readonly audioService: AudioService;
+
+  /**
+   * The scope the last focus event reported, used to tell an open transition
+   * from a close one. Starts as `null` so the first event of a focus session —
+   * always the plot's own navigation scope — is silent.
+   */
+  private previousFocus: Focus | null = null;
 
   /**
    * Creates a new DisplayViewModel instance and initializes display listeners.
    * @param {AppStore} store - The Redux store instance.
    * @param {DisplayService} displayService - The display service for managing UI elements.
+   * @param {AudioService} audioService - The audio service that plays the dialog open/close cues.
    */
-  public constructor(store: AppStore, displayService: DisplayService) {
+  public constructor(store: AppStore, displayService: DisplayService, audioService: AudioService) {
     super(store);
 
     this.displayService = displayService;
+    this.audioService = audioService;
 
     this.registerListeners();
 
@@ -85,8 +118,37 @@ export class DisplayViewModel extends AbstractViewModel<DisplayState> {
    */
   private registerListeners(): void {
     this.disposables.push(this.displayService.onChange((e) => {
+      this.playDialogCue(e.value);
       this.store.dispatch(updateFocus(e.value));
     }));
+  }
+
+  /**
+   * Plays the shared dialog cue for a focus transition: the open cue when a
+   * dialog scope becomes focused, the close cue when the focus leaves one.
+   *
+   * Every dialog opens and closes by routing through
+   * {@link DisplayService.toggleFocus}, so keying the cue off the focus
+   * transition covers each dismissal path — Escape, the close button, the
+   * backdrop, re-pressing the shortcut, or choosing an entry — without each
+   * dialog having to remember to play it.
+   *
+   * Focus-out stays silent: disposal clears the focus without emitting a
+   * change, so a dialog left open when the chart loses focus makes no sound.
+   * @param {Focus} focus - The scope the focus just moved to.
+   */
+  private playDialogCue(focus: Focus): void {
+    const previous = this.previousFocus;
+    this.previousFocus = focus;
+    if (previous === focus) {
+      return;
+    }
+
+    if (DIALOG_SCOPES.has(focus)) {
+      this.audioService.playMenuOpenTone();
+    } else if (previous !== null && DIALOG_SCOPES.has(previous)) {
+      this.audioService.playMenuCloseTone();
+    }
   }
 
   /**

--- a/src/state/viewModel/displayViewModel.ts
+++ b/src/state/viewModel/displayViewModel.ts
@@ -5,28 +5,7 @@ import type { AppStore } from '@state/store';
 import type { Focus } from '@type/event';
 import { createSlice } from '@reduxjs/toolkit';
 import { AbstractViewModel } from '@state/viewModel/viewModel';
-import { Scope } from '@type/event';
-
-/**
- * Focus scopes that render as a dialog — a surface that overlays the chart,
- * traps the keyboard until dismissed, and closes with Escape. Entering one
- * plays the menu open cue and leaving it plays the menu close cue, so every
- * dialog sounds the same as the Go To Extrema modal that first had the cue.
- *
- * `BRAILLE` and `REVIEW` are deliberately absent: they render as an inline
- * text field next to the chart rather than as an overlay, so a dialog cue
- * would describe them wrongly. `CANDLESTICK_DELTA` is plot navigation, not a
- * dialog, and already has its own enter/exit arpeggio.
- */
-const DIALOG_SCOPES: ReadonlySet<Focus> = new Set<Focus>([
-  Scope.CANDLESTICK_DELTA_SETTINGS,
-  Scope.CHAT,
-  Scope.COMMAND_PALETTE,
-  Scope.DESCRIPTION,
-  Scope.GO_TO_EXTREMA,
-  Scope.HELP,
-  Scope.SETTINGS,
-]);
+import { DIALOG_SCOPES } from '@type/event';
 
 /**
  * Represents the state of a tooltip UI element.
@@ -124,8 +103,13 @@ export class DisplayViewModel extends AbstractViewModel<DisplayState> {
   }
 
   /**
-   * Plays the shared dialog cue for a focus transition: the open cue when a
-   * dialog scope becomes focused, the close cue when the focus leaves one.
+   * Plays the shared dialog cue for a focus transition. The cue describes the
+   * scope being entered, so it is the open cue whenever a dialog scope takes
+   * focus, and the close cue only when the focus leaves a dialog for a scope
+   * that is not one. Moving straight from one dialog to another therefore
+   * sounds a single open cue rather than a close followed by an open; no
+   * shortcut reaches a second dialog from inside the first today, so that is a
+   * rule for the case rather than a description of one that occurs.
    *
    * Every dialog opens and closes by routing through
    * {@link DisplayService.toggleFocus}, so keying the cue off the focus

--- a/src/state/viewModel/goToExtremaViewModel.ts
+++ b/src/state/viewModel/goToExtremaViewModel.ts
@@ -1,5 +1,4 @@
 import type { Context } from '@model/context';
-import type { AudioService } from '@service/audio';
 import type { FormatterService } from '@service/formatter';
 import type { GoToExtremaService } from '@service/goToExtrema';
 import type { AppStore } from '@state/store';
@@ -75,20 +74,17 @@ const { show, hide, updateSelectedIndex } = goToExtremaSlice.actions;
 export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
   private readonly goToExtremaService: GoToExtremaService;
   private readonly context: Context;
-  private readonly audioService: AudioService;
   private readonly formatter?: FormatterService;
 
   public constructor(
     store: AppStore,
     goToExtremaService: GoToExtremaService,
     context: Context,
-    audioService: AudioService,
     formatter?: FormatterService,
   ) {
     super(store);
     this.goToExtremaService = goToExtremaService;
     this.context = context;
-    this.audioService = audioService;
     this.formatter = formatter;
   }
 
@@ -123,25 +119,19 @@ export class GoToExtremaViewModel extends AbstractViewModel<GoToExtremaState> {
       // Store the targets and description in the state
       this.store.dispatch(show({ targets: formattedTargets, description }));
 
-      // Then change scope to show the modal
+      // Then change scope to show the modal. The scope change is what plays
+      // the shared "menu open" cue, from DisplayViewModel.
       this.goToExtremaService.toggle(state);
-
-      // Play the "menu open" cue now that the modal is actually shown.
-      this.audioService.playMenuOpenTone();
     }
   }
 
   public hide(): void {
     this.store.dispatch(hide());
 
-    // Return scope to TRACE so plot navigation works again
+    // Return scope to TRACE so plot navigation works again. Leaving the
+    // GO_TO_EXTREMA scope is what plays the shared "menu close" cue, from
+    // DisplayViewModel, so every dismissal path sounds it exactly once.
     this.goToExtremaService.returnToTraceScope();
-
-    // Play the "menu close" cue. Every user-initiated dismissal (backdrop, X
-    // button, Esc, re-pressing G, selecting a target/option) funnels through
-    // this method, so the cue fires exactly once per close. dispose() dispatches
-    // the hide action directly (not via this method), so focus-out is silent.
-    this.audioService.playMenuCloseTone();
   }
 
   public get activeContext(): Context {

--- a/src/type/event.ts
+++ b/src/type/event.ts
@@ -67,6 +67,38 @@ export enum Scope {
 export type Focus = Exclude<Scope, Scope.FIGURE_LABEL | Scope.TRACE_LABEL>;
 
 /**
+ * Scopes the user opens on top of the chart and dismisses with Escape, as
+ * opposed to the scopes they navigate the data in. Entering one is a mode
+ * toggle: the plot instruction is not re-announced on the way back out.
+ */
+export const MODAL_SCOPES: ReadonlySet<Focus> = new Set<Focus>([
+  Scope.BRAILLE,
+  Scope.CANDLESTICK_DELTA_SETTINGS,
+  Scope.CHAT,
+  Scope.COMMAND_PALETTE,
+  Scope.DESCRIPTION,
+  Scope.GO_TO_EXTREMA,
+  Scope.HELP,
+  Scope.REVIEW,
+  Scope.SETTINGS,
+]);
+
+/**
+ * The modal scopes that render as a dialog overlaying the chart, derived from
+ * {@link MODAL_SCOPES} so a scope cannot be added to one list and forgotten in
+ * the other.
+ *
+ * `BRAILLE` and `REVIEW` are the two exclusions: they render as an inline text
+ * field beside the chart rather than as an overlay, so anything that describes
+ * a dialog — the open/close audio cue, for one — would misdescribe them.
+ */
+export const DIALOG_SCOPES: ReadonlySet<Focus> = new Set<Focus>(
+  Array.from(MODAL_SCOPES).filter(
+    scope => scope !== Scope.BRAILLE && scope !== Scope.REVIEW,
+  ),
+);
+
+/**
  * Type representing valid keyboard shortcut keys for a given scope.
  */
 export type Keys = keyof Keymap[Scope];

--- a/test/service/audio.menuTone.test.ts
+++ b/test/service/audio.menuTone.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for AudioService.playMenuOpenTone / playMenuCloseTone — the Go-To modal
- * open/close cues. Each cue is a short two-note arpeggio, so a successful cue
+ * Tests for AudioService.playMenuOpenTone / playMenuCloseTone — the shared
+ * dialog open/close cues. Each cue is a short two-note arpeggio, so a successful cue
  * creates exactly two oscillators. The cue must be silent when audio is OFF or
  * when the volume is 0. On a suspended AudioContext the cue is deferred behind
  * resume() and only the most recent deferred cue plays (last one wins); it is

--- a/test/state/viewModel/displayViewModel.test.ts
+++ b/test/state/viewModel/displayViewModel.test.ts
@@ -13,7 +13,7 @@ import type { Focus } from '@type/event';
 import { describe, expect, jest, test } from '@jest/globals';
 import { createMaidrStore } from '@state/store';
 import { DisplayViewModel } from '@state/viewModel/displayViewModel';
-import { Emitter, Scope } from '@type/event';
+import { DIALOG_SCOPES, Emitter, Scope } from '@type/event';
 
 function createAudioStub(): AudioService {
   return {
@@ -49,8 +49,14 @@ function setup(): {
   return { audio, focus, viewModel };
 }
 
-/** Every scope that renders as a dialog and so earns the shared cue. */
-const DIALOG_SCOPES: Focus[] = [
+/**
+ * Every scope that renders as a dialog and so earns the shared cue, spelled
+ * out rather than read from `DIALOG_SCOPES` so the cases below assert what the
+ * cue is *for* — importing the set under test would make them agree with it by
+ * construction. The first case ties the two together, so a scope added to one
+ * and not the other fails here rather than going uncovered.
+ */
+const EXPECTED_DIALOG_SCOPES: Focus[] = [
   Scope.CANDLESTICK_DELTA_SETTINGS,
   Scope.CHAT,
   Scope.COMMAND_PALETTE,
@@ -61,7 +67,11 @@ const DIALOG_SCOPES: Focus[] = [
 ];
 
 describe('DisplayViewModel dialog audio cues', () => {
-  test.each(DIALOG_SCOPES)('plays the open cue when %s becomes focused', (scope) => {
+  test('covers exactly the scopes the view model treats as dialogs', () => {
+    expect(Array.from(DIALOG_SCOPES).sort()).toEqual([...EXPECTED_DIALOG_SCOPES].sort());
+  });
+
+  test.each(EXPECTED_DIALOG_SCOPES)('plays the open cue when %s becomes focused', (scope) => {
     const { audio, focus } = setup();
 
     focus(Scope.TRACE);
@@ -71,7 +81,7 @@ describe('DisplayViewModel dialog audio cues', () => {
     expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
   });
 
-  test.each(DIALOG_SCOPES)('plays the close cue when the focus leaves %s', (scope) => {
+  test.each(EXPECTED_DIALOG_SCOPES)('plays the close cue when the focus leaves %s', (scope) => {
     const { audio, focus } = setup();
 
     focus(Scope.TRACE);

--- a/test/state/viewModel/displayViewModel.test.ts
+++ b/test/state/viewModel/displayViewModel.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for DisplayViewModel's dialog audio cues — the shared open/close tick
+ * every dialog gets by virtue of the focus scope it moves the app into.
+ *
+ * The cue is keyed off the focus transition rather than off each dialog, so
+ * these cases stand in for every dismissal path a dialog has (Escape, the
+ * close button, the backdrop, re-pressing the shortcut, choosing an entry):
+ * all of them end in the same scope change.
+ */
+import type { AudioService } from '@service/audio';
+import type { DisplayService } from '@service/display';
+import type { Focus } from '@type/event';
+import { describe, expect, jest, test } from '@jest/globals';
+import { createMaidrStore } from '@state/store';
+import { DisplayViewModel } from '@state/viewModel/displayViewModel';
+import { Emitter, Scope } from '@type/event';
+
+function createAudioStub(): AudioService {
+  return {
+    playMenuOpenTone: jest.fn(),
+    playMenuCloseTone: jest.fn(),
+  } as unknown as AudioService;
+}
+
+/**
+ * A DisplayService stub whose focus events the test drives directly, so a
+ * transition can be asserted without standing up the model and the commands
+ * that would produce it at runtime.
+ */
+function createDisplayStub(): { service: DisplayService; focus: (value: Focus) => void } {
+  const emitter = new Emitter<{ value: Focus }>();
+  const service = {
+    onChange: emitter.event,
+    getInstruction: jest.fn(() => 'instruction'),
+  } as unknown as DisplayService;
+
+  return { service, focus: value => emitter.fire({ value }) };
+}
+
+function setup(): {
+  audio: AudioService;
+  focus: (value: Focus) => void;
+  viewModel: DisplayViewModel;
+} {
+  const { service, focus } = createDisplayStub();
+  const audio = createAudioStub();
+  const viewModel = new DisplayViewModel(createMaidrStore(), service, audio);
+
+  return { audio, focus, viewModel };
+}
+
+/** Every scope that renders as a dialog and so earns the shared cue. */
+const DIALOG_SCOPES: Focus[] = [
+  Scope.CANDLESTICK_DELTA_SETTINGS,
+  Scope.CHAT,
+  Scope.COMMAND_PALETTE,
+  Scope.DESCRIPTION,
+  Scope.GO_TO_EXTREMA,
+  Scope.HELP,
+  Scope.SETTINGS,
+];
+
+describe('DisplayViewModel dialog audio cues', () => {
+  test.each(DIALOG_SCOPES)('plays the open cue when %s becomes focused', (scope) => {
+    const { audio, focus } = setup();
+
+    focus(Scope.TRACE);
+    focus(scope);
+
+    expect(audio.playMenuOpenTone).toHaveBeenCalledTimes(1);
+    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+  });
+
+  test.each(DIALOG_SCOPES)('plays the close cue when the focus leaves %s', (scope) => {
+    const { audio, focus } = setup();
+
+    focus(Scope.TRACE);
+    focus(scope);
+    focus(Scope.TRACE);
+
+    expect(audio.playMenuOpenTone).toHaveBeenCalledTimes(1);
+    expect(audio.playMenuCloseTone).toHaveBeenCalledTimes(1);
+  });
+
+  test('is silent for the plot navigation scopes', () => {
+    const { audio, focus } = setup();
+
+    focus(Scope.TRACE);
+    focus(Scope.SUBPLOT);
+    focus(Scope.CANDLESTICK_DELTA);
+    focus(Scope.TRACE);
+
+    expect(audio.playMenuOpenTone).not.toHaveBeenCalled();
+    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+  });
+
+  test('is silent for the inline braille and review panels', () => {
+    // They are a text field beside the chart, not an overlay, so the dialog
+    // cue would misdescribe them.
+    const { audio, focus } = setup();
+
+    focus(Scope.TRACE);
+    focus(Scope.BRAILLE);
+    focus(Scope.TRACE);
+    focus(Scope.REVIEW);
+    focus(Scope.TRACE);
+
+    expect(audio.playMenuOpenTone).not.toHaveBeenCalled();
+    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+  });
+
+  test('does not play the close cue for the first focus event of a session', () => {
+    // A controller is built on every focus-in, so the first event it sees is
+    // the plot taking focus — nothing was open to close.
+    const { audio, focus } = setup();
+
+    focus(Scope.TRACE);
+
+    expect(audio.playMenuOpenTone).not.toHaveBeenCalled();
+    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+  });
+
+  test('plays each cue once when a scope is re-reported', () => {
+    // updateFocus can fire the same scope twice (a deferred emit racing a
+    // synchronous one); the cue must not double up.
+    const { audio, focus } = setup();
+
+    focus(Scope.TRACE);
+    focus(Scope.HELP);
+    focus(Scope.HELP);
+    focus(Scope.TRACE);
+    focus(Scope.TRACE);
+
+    expect(audio.playMenuOpenTone).toHaveBeenCalledTimes(1);
+    expect(audio.playMenuCloseTone).toHaveBeenCalledTimes(1);
+  });
+
+  test('plays only the open cue when one dialog replaces another', () => {
+    const { audio, focus } = setup();
+
+    focus(Scope.TRACE);
+    focus(Scope.HELP);
+    focus(Scope.SETTINGS);
+
+    expect(audio.playMenuOpenTone).toHaveBeenCalledTimes(2);
+    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+  });
+
+  test('stops playing cues once disposed', () => {
+    // Focus-out disposes the controller, so a dialog still open at that point
+    // must not sound a close cue.
+    const { audio, focus, viewModel } = setup();
+
+    focus(Scope.TRACE);
+    focus(Scope.CHAT);
+    viewModel.dispose();
+    focus(Scope.TRACE);
+
+    expect(audio.playMenuOpenTone).toHaveBeenCalledTimes(1);
+    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+  });
+});

--- a/test/state/viewModel/goToExtremaViewModel.test.ts
+++ b/test/state/viewModel/goToExtremaViewModel.test.ts
@@ -4,11 +4,10 @@
  *    label x-axis formatted (matching the terse layer text) for every known
  *    layer, falling back to String(value) only with no formatter or no layer id.
  *  - moveToIndex(): Home/End index clamping.
- *  - the menu open/close audio cues fired on toggle()/hide()/selectCurrent(),
- *    and the silence on dispose().
+ *  - the scope transitions on toggle()/hide()/selectCurrent() that DisplayViewModel
+ *    turns into the menu open/close cues, and the silence on dispose().
  */
 import type { Context } from '@model/context';
-import type { AudioService } from '@service/audio';
 import type { GoToExtremaService } from '@service/goToExtrema';
 import type { ExtremaTarget } from '@type/extrema';
 import type { AxisFormat } from '@type/grammar';
@@ -18,13 +17,6 @@ import { FormatterService } from '@service/formatter';
 import { createMaidrStore } from '@state/store';
 import { GoToExtremaViewModel } from '@state/viewModel/goToExtremaViewModel';
 import { TraceType } from '@type/grammar';
-
-function createAudioStub(): AudioService {
-  return {
-    playMenuOpenTone: jest.fn(),
-    playMenuCloseTone: jest.fn(),
-  } as unknown as AudioService;
-}
 
 function createServiceStub(navigable: boolean = true): GoToExtremaService {
   return {
@@ -96,7 +88,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     const trace = createTraceStub(['2019-11-03', '2019-11-04']);
     const context = createContextStub(trace, 'layer-1');
     const formatter = createFormatterStub({ '2019-11-03': 'Nov 3', '2019-11-04': 'Nov 4' });
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub(), formatter);
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, formatter);
 
     expect(vm.getAvailableXValueOptions()).toEqual([
       { value: '2019-11-03', label: 'Nov 3' },
@@ -113,7 +105,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     const trace = createTraceStub([57.14285714285714, 2, 3]);
     const context = createContextStub(trace, 'layer-1');
     const formatter = createRealFormatter();
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub(), formatter);
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, formatter);
 
     expect(vm.getAvailableXValueOptions()).toEqual([
       { value: 57.14285714285714, label: '57.14' },
@@ -134,7 +126,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     const formatter = {
       formatSingleValue: (v: number) => (v * 100) as unknown as string,
     } as unknown as FormatterService;
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub(), formatter);
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, formatter);
 
     const options = vm.getAvailableXValueOptions();
     expect(options).toEqual([{ value: 5, label: '500' }, { value: 6, label: '600' }]);
@@ -145,7 +137,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     const store = createMaidrStore();
     const trace = createTraceStub(['2019-11-03']);
     const context = createContextStub(trace, 'layer-1');
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub());
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), context);
 
     expect(vm.getAvailableXValueOptions()).toEqual([{ value: '2019-11-03', label: '2019-11-03' }]);
   });
@@ -155,7 +147,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
     const trace = createTraceStub(['2019-11-03']);
     const context = createContextStub(trace, null); // empty trace state -> no layerId
     const formatter = createFormatterStub({ '2019-11-03': 'Nov 3' });
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub(), formatter);
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, formatter);
 
     expect(vm.getAvailableXValueOptions()).toEqual([{ value: '2019-11-03', label: '2019-11-03' }]);
   });
@@ -163,7 +155,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
   test('returns [] when the active trace does not support X-value navigation', () => {
     const store = createMaidrStore();
     const context = createContextStub({}, 'layer-1'); // active has no getAvailableXValues
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), context, createAudioStub());
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), context);
 
     expect(vm.getAvailableXValueOptions()).toEqual([]);
   });
@@ -172,7 +164,7 @@ describe('GoToExtremaViewModel.getAvailableXValueOptions', () => {
 describe('GoToExtremaViewModel.moveToIndex', () => {
   function withTargets(count: number): { store: ReturnType<typeof createMaidrStore>; vm: GoToExtremaViewModel } {
     const store = createMaidrStore();
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), createContextStub({}, 'layer-1'), createAudioStub());
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), createContextStub({}, 'layer-1'));
     const targets = Array.from({ length: count }, (_, i) => ({ label: `t${i}` }));
     store.dispatch({ type: 'goToExtrema/show', payload: { targets, description: '' } });
     return { store, vm };
@@ -198,7 +190,7 @@ describe('GoToExtremaViewModel.moveToIndex', () => {
 
   test('is a no-op when there are no targets', () => {
     const store = createMaidrStore();
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), createContextStub({}, 'layer-1'), createAudioStub());
+    const vm = new GoToExtremaViewModel(store, createServiceStub(), createContextStub({}, 'layer-1'));
     vm.moveToIndex(2);
     expect(store.getState().goToExtrema.selectedIndex).toBe(0); // unchanged initial
   });
@@ -220,7 +212,6 @@ describe('GoToExtremaViewModel.formatTargetLabels (via toggle)', () => {
       store,
       createServiceStub(true),
       createContextStub(trace, 'layer-1'),
-      createAudioStub(),
       formatter,
     );
 
@@ -242,7 +233,6 @@ describe('GoToExtremaViewModel.formatTargetLabels (via toggle)', () => {
       store,
       createServiceStub(true),
       createContextStub(trace, 'layer-1'),
-      createAudioStub(),
       formatter,
     );
 
@@ -264,7 +254,6 @@ describe('GoToExtremaViewModel.formatTargetLabels (via toggle)', () => {
       store,
       createServiceStub(true),
       createContextStub(trace, 'layer-1'),
-      createAudioStub(),
       formatter,
     );
 
@@ -276,51 +265,65 @@ describe('GoToExtremaViewModel.formatTargetLabels (via toggle)', () => {
   });
 });
 
-describe('GoToExtremaViewModel menu audio cues', () => {
-  test('toggle() plays the open cue once when the trace is extrema-navigable', () => {
+describe('GoToExtremaViewModel scope transitions (what drives the menu cues)', () => {
+  // The open/close cues now come from DisplayViewModel, keyed off the scope
+  // change, so what this view model owes them is the scope change itself on
+  // every path — and none on disposal, which is what keeps focus-out silent.
+  test('toggle() enters the modal scope when the trace is extrema-navigable', () => {
     const store = createMaidrStore();
-    const audio = createAudioStub();
+    const service = createServiceStub(true);
     const trace = createTraceStub(['2019-11-03']);
-    const vm = new GoToExtremaViewModel(store, createServiceStub(true), createContextStub(trace, 'layer-1'), audio);
+    const vm = new GoToExtremaViewModel(store, service, createContextStub(trace, 'layer-1'));
 
     vm.toggle(TRACE_STATE);
 
-    expect(audio.playMenuOpenTone).toHaveBeenCalledTimes(1);
-    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+    expect(service.toggle).toHaveBeenCalledTimes(1);
+    expect(service.returnToTraceScope).not.toHaveBeenCalled();
   });
 
-  test('hide() plays the close cue once', () => {
+  test('toggle() does not enter the modal scope when the trace is not navigable', () => {
     const store = createMaidrStore();
-    const audio = createAudioStub();
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), createContextStub({}, 'layer-1'), audio);
+    const service = createServiceStub(false);
+    const trace = createTraceStub(['2019-11-03']);
+    const vm = new GoToExtremaViewModel(store, service, createContextStub(trace, 'layer-1'));
+
+    vm.toggle(TRACE_STATE);
+
+    expect(service.toggle).not.toHaveBeenCalled();
+  });
+
+  test('hide() leaves the modal scope once', () => {
+    const store = createMaidrStore();
+    const service = createServiceStub();
+    const vm = new GoToExtremaViewModel(store, service, createContextStub({}, 'layer-1'));
 
     vm.hide();
 
-    expect(audio.playMenuCloseTone).toHaveBeenCalledTimes(1);
-    expect(audio.playMenuOpenTone).not.toHaveBeenCalled();
+    expect(service.returnToTraceScope).toHaveBeenCalledTimes(1);
+    expect(service.toggle).not.toHaveBeenCalled();
   });
 
-  test('selectCurrent() closes the modal (plays the close cue) and navigates', () => {
+  test('selectCurrent() leaves the modal scope and navigates', () => {
     const store = createMaidrStore();
-    const audio = createAudioStub();
+    const service = createServiceStub(true);
     const trace = createTraceStub(['2019-11-03']);
-    const vm = new GoToExtremaViewModel(store, createServiceStub(true), createContextStub(trace, 'layer-1'), audio);
+    const vm = new GoToExtremaViewModel(store, service, createContextStub(trace, 'layer-1'));
     store.dispatch({ type: 'goToExtrema/show', payload: { targets: [{ label: 't0' }], description: '' } });
 
     vm.selectCurrent();
 
-    expect(audio.playMenuCloseTone).toHaveBeenCalledTimes(1);
+    expect(service.returnToTraceScope).toHaveBeenCalledTimes(1);
     expect(trace.navigateToExtrema).toHaveBeenCalledTimes(1);
   });
 
-  test('dispose() does not play any cue (focus-out is silent)', () => {
+  test('dispose() does not change scope (focus-out is silent)', () => {
     const store = createMaidrStore();
-    const audio = createAudioStub();
-    const vm = new GoToExtremaViewModel(store, createServiceStub(), createContextStub({}, 'layer-1'), audio);
+    const service = createServiceStub();
+    const vm = new GoToExtremaViewModel(store, service, createContextStub({}, 'layer-1'));
 
     vm.dispose();
 
-    expect(audio.playMenuOpenTone).not.toHaveBeenCalled();
-    expect(audio.playMenuCloseTone).not.toHaveBeenCalled();
+    expect(service.toggle).not.toHaveBeenCalled();
+    expect(service.returnToTraceScope).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Pressing `G` opens the Go To Extrema modal with a short rising two-note tick, and dismissing it plays the falling counterpart. No other dialog made a sound. This gives every dialog the same open/close cue.

## Related Issues

None.

## Changes Made

The cue lived in `GoToExtremaViewModel`, called by hand on `toggle()` and `hide()`, which is why only that one modal had it. Every dialog changes focus through `DisplayService.toggleFocus`, so the cue moves to `DisplayViewModel` and is keyed off the focus transition instead: entering a dialog scope plays the open cue, leaving one plays the close cue.

Keying it off the transition rather than off each dialog covers every dismissal path — Escape, the close button, the backdrop, re-pressing the shortcut, choosing an entry — without each dialog having to remember to play it. Focus-out stays silent, because disposal clears the focus without emitting a change, preserving the behaviour the Go To Extrema cue already had.

Dialogs that now sound:

| Dialog | Shortcut |
| --- | --- |
| Go To Extrema | `g` (unchanged behaviour) |
| Help | `Ctrl+/` |
| Chat | `?` |
| Settings | `Ctrl+,` |
| Chart description | `d` |
| Command palette | `Ctrl+Shift+P` |
| Candlestick reference picker | `Ctrl+Shift+L` |

Braille (`b`) and review (`r`) stay silent: they render as an inline text field beside the chart rather than as an overlay, so a dialog cue would misdescribe them. The plot navigation scopes — `TRACE`, `SUBPLOT`, `GRID_CELL`, and `CANDLESTICK_DELTA` — are not dialogs and are silent too; `CANDLESTICK_DELTA` keeps its own enter/exit arpeggio.

Files:

- `src/type/event.ts` — one `MODAL_SCOPES` set, with `DIALOG_SCOPES` derived from it by excluding the two inline panels, so a scope cannot be added to one list and forgotten in the other.
- `src/service/display.ts` — `toggleFocus` tests membership in `MODAL_SCOPES` instead of the hand-rolled chain of comparisons that restated the same list. Behaviour unchanged.
- `src/state/viewModel/displayViewModel.ts` — the previous-focus tracking and `playDialogCue()`; takes `AudioService`.
- `src/state/viewModel/goToExtremaViewModel.ts` — drops the two hand-rolled cue calls and the now-unused `AudioService` dependency.
- `src/controller.ts` — rewires the two constructors.
- `src/service/audio.ts` — JSDoc on `playMenuOpenTone`/`playMenuCloseTone` now describes the shared cue rather than the Go-To modal. No behaviour change.

## Screenshots (if applicable)

Not applicable — the change is audible, not visual. It was verified by instrumenting `AudioContext.prototype.createOscillator` in Chromium and driving `examples/barplot.html` against the built bundle, recording each oscillator's frequency at `start()`:

| Action | Oscillators played |
| --- | --- |
| Help open (`Ctrl+/`) | `[660, 990]` |
| Help close (`Escape`) | `[990, 660]` |
| Description open (`d`) | `[660, 990]` |
| Description close (`Escape`) | `[990, 660]` |
| Go To Extrema open (`g`) | `[660, 990]` |
| Go To Extrema close (`Escape`) | `[990, 660]` |
| Braille toggle (`b`, then `b`) | `[]` |

Rising on open, falling on close, identical across dialogs; Go To Extrema unchanged; braille silent, as intended.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project&#39;s coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`test/state/viewModel/displayViewModel.test.ts` is new: it drives focus events through a `DisplayService` stub and asserts the open cue for each of the seven dialog scopes, the close cue on leaving each, silence for the navigation scopes and for braille/review, silence on the first event of a focus session, no double cue when a scope is re-reported, a single open cue when one dialog replaces another, and silence after `dispose()`. A parity case asserts the production `DIALOG_SCOPES` equals the list those cases enumerate, so a scope added to one and not the other fails rather than going uncovered.

`test/state/viewModel/goToExtremaViewModel.test.ts` kept its coverage of the same paths, re-pointed at the scope transitions that now drive the cue.

Verified locally: `npm run lint:fix`, `npm run type-check`, `npm run build`, and `npm test` (1590 unit + 61 ESM tests, all passing). CI is green on all 14 checks including `E2E (chromium)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018L5NutBmFmMxUeVWGYE9sn)_