### PR TITLE
fix(violin): attribute the described extremes to the violin they come from

### DIFF
--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -8,6 +8,7 @@ import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
+import { extremeStat, isHigher, isLower } from './boxExtremes';
 import { MovableGrid } from './movable';
 
 /**
@@ -180,56 +181,19 @@ export class BoxTrace extends AbstractTrace {
    */
   private rangeStats(): DescriptionState['stats'] {
     return [
-      this.extremeStat(
+      extremeStat(
+        this.points,
         { single: 'Minimum', grouped: 'Lowest minimum' },
         p => p.min,
-        (candidate, current) => candidate < current,
+        isLower,
       ),
-      this.extremeStat(
+      extremeStat(
+        this.points,
         { single: 'Maximum', grouped: 'Highest maximum' },
         p => p.max,
-        (candidate, current) => candidate > current,
+        isHigher,
       ),
     ];
-  }
-
-  /**
-   * Builds one range row: the winning value across groups, named with the group
-   * it belongs to once there is more than one group to tell apart.
-   *
-   * Both halves of the row — which label to use and whether the value carries a
-   * group name — hang off the one `grouped` check here, so a row can never pair
-   * a lone-group label with a group-suffixed value.
-   *
-   * Boxes tie on a whisker end readily, several bottoming out at the same floor
-   * being the ordinary case, and `beats` is strict, so the earliest group in
-   * navigation order wins: the group named is the first one the user reaches.
-   *
-   * @param labels - Row label for the one-group and the several-group case.
-   * @param labels.single - Label used when the chart holds a single box.
-   * @param labels.grouped - Label used when the chart holds several boxes.
-   * @param valueOf - Reads the whisker end being compared from a group.
-   * @param beats - True when the candidate value outranks the current winner.
-   * @returns The summary row, or a `missing` row when no group has the value.
-   */
-  private extremeStat(
-    labels: { single: string; grouped: string },
-    valueOf: (point: BoxPoint) => number,
-    beats: (candidate: number, current: number) => boolean,
-  ): DescriptionState['stats'][number] {
-    const grouped = this.points.length > 1;
-    const label = grouped ? labels.grouped : labels.single;
-
-    const measured = this.points.filter(point => Number.isFinite(valueOf(point)));
-    if (measured.length === 0) {
-      return { label, value: 'missing' };
-    }
-
-    const winner = measured.reduce((best, point) =>
-      beats(valueOf(point), valueOf(best)) ? point : best,
-    );
-    const value = valueOf(winner);
-    return { label, value: grouped ? `${value} (${winner.z})` : value };
   }
 
   public override dispose(): void {

--- a/src/model/boxExtremes.ts
+++ b/src/model/boxExtremes.ts
@@ -55,14 +55,12 @@ export function extremeStat(
     beats(valueOf(point), valueOf(best)) ? point : best,
   );
   const value = valueOf(winner);
-  return {
-    label,
-    value: grouped && hasName(winner) ? `${value} (${winner.z})` : value,
-  };
+  const name = grouped ? groupName(winner) : null;
+  return { label, value: name === null ? value : `${value} (${name})` };
 }
 
 /**
- * True when a group carries a name worth printing next to its value.
+ * Reads the name to print next to a group's value, or null when it has none.
  *
  * `BoxPoint.z` is typed as a string, but not every producer fills it — the
  * violin layers carry their group under `fill` and leave `z` undefined at
@@ -70,12 +68,20 @@ export function extremeStat(
  * out "326 (undefined)" is worse than reading out "326", so an unnamed group
  * falls back to the bare value.
  *
+ * The name comes back trimmed, since that is the form the blank check judges
+ * it by: padding is not part of the name, and announcing "326 (  Group 1  )"
+ * would read the padding out as a pause.
+ *
  * @param point - The group whose name is being printed.
- * @returns True when the group has a non-blank name.
+ * @returns The trimmed name, or null when the group is unnamed or blank.
  */
-function hasName(point: BoxPoint): boolean {
+function groupName(point: BoxPoint): string | null {
   const name = point.z as string | undefined;
-  return typeof name === 'string' && name.trim() !== '';
+  if (typeof name !== 'string') {
+    return null;
+  }
+  const trimmed = name.trim();
+  return trimmed === '' ? null : trimmed;
 }
 
 /**

--- a/src/model/boxExtremes.ts
+++ b/src/model/boxExtremes.ts
@@ -1,0 +1,101 @@
+import type { BoxPoint } from '@type/grammar';
+import type { DescriptionState } from '@type/state';
+
+/**
+ * Labels for a range row, one for each shape the summary can take.
+ */
+interface ExtremeLabels {
+  /** Used when the chart holds a single box. */
+  single: string;
+  /** Used when the chart holds several boxes. */
+  grouped: string;
+}
+
+/**
+ * Builds one range row of a box-shaped trace's description summary: the winning
+ * value across groups, named with the group it belongs to once there is more
+ * than one group to tell apart.
+ *
+ * Every box carries its own ends, so a single chart-wide pair reads as though a
+ * chart of several boxes had one minimum and one maximum. Attributing each
+ * extreme to its group is what makes the summary answer "which box?" — the
+ * per-group breakdown itself is left to the data table below it.
+ *
+ * Both halves of the row — which label to use and whether the value carries a
+ * group name — hang off the one `grouped` check here, so a row can never pair a
+ * lone-group label with a group-suffixed value.
+ *
+ * Boxes tie on an end readily, several bottoming out at the same floor being
+ * the ordinary case, and `beats` is strict, so the earliest group in navigation
+ * order wins: the group named is the first one the user reaches.
+ *
+ * @param points - The trace's groups, in navigation order.
+ * @param labels - Row label for the one-group and the several-group case.
+ * @param labels.single - Label used when the chart holds a single box.
+ * @param labels.grouped - Label used when the chart holds several boxes.
+ * @param valueOf - Reads the value being compared from a group.
+ * @param beats - True when the candidate value outranks the current winner.
+ * @returns The summary row, or a `missing` row when no group has the value.
+ */
+export function extremeStat(
+  points: BoxPoint[],
+  labels: ExtremeLabels,
+  valueOf: (point: BoxPoint) => number,
+  beats: (candidate: number, current: number) => boolean,
+): DescriptionState['stats'][number] {
+  const grouped = points.length > 1;
+  const label = grouped ? labels.grouped : labels.single;
+
+  const measured = points.filter(point => Number.isFinite(valueOf(point)));
+  if (measured.length === 0) {
+    return { label, value: 'missing' };
+  }
+
+  const winner = measured.reduce((best, point) =>
+    beats(valueOf(point), valueOf(best)) ? point : best,
+  );
+  const value = valueOf(winner);
+  return {
+    label,
+    value: grouped && hasName(winner) ? `${value} (${winner.z})` : value,
+  };
+}
+
+/**
+ * True when a group carries a name worth printing next to its value.
+ *
+ * `BoxPoint.z` is typed as a string, but not every producer fills it — the
+ * violin layers carry their group under `fill` and leave `z` undefined at
+ * runtime, which is why their data table shows a blank Group column. Reading
+ * out "326 (undefined)" is worse than reading out "326", so an unnamed group
+ * falls back to the bare value.
+ *
+ * @param point - The group whose name is being printed.
+ * @returns True when the group has a non-blank name.
+ */
+function hasName(point: BoxPoint): boolean {
+  const name = point.z as string | undefined;
+  return typeof name === 'string' && name.trim() !== '';
+}
+
+/**
+ * Reads the lowest of a value across groups — the `beats` rule for a minimum.
+ *
+ * @param candidate - The value under consideration.
+ * @param current - The current winner's value.
+ * @returns True when the candidate is lower.
+ */
+export function isLower(candidate: number, current: number): boolean {
+  return candidate < current;
+}
+
+/**
+ * Reads the highest of a value across groups — the `beats` rule for a maximum.
+ *
+ * @param candidate - The value under consideration.
+ * @param current - The current winner's value.
+ * @returns True when the candidate is higher.
+ */
+export function isHigher(candidate: number, current: number): boolean {
+  return candidate > current;
+}

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -9,6 +9,7 @@ import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
+import { extremeStat, isHigher, isLower } from './boxExtremes';
 import { MovableGrid } from './movable';
 
 /**
@@ -157,8 +158,7 @@ export class ViolinBoxTrace extends AbstractTrace {
     const stats: DescriptionState['stats'] = [
       { label: 'Number of groups', value: this.points.length },
       { label: 'Sections', value: this.sections.join(', ') },
-      { label: 'Min', value: this.min },
-      { label: 'Max', value: this.max },
+      ...this.rangeStats(),
     ];
 
     const headers = ['Group', ...this.sections];
@@ -184,6 +184,42 @@ export class ViolinBoxTrace extends AbstractTrace {
       stats,
       dataTable: { headers, rows },
     };
+  }
+
+  /**
+   * Builds the range rows of the summary.
+   *
+   * Each violin carries its own ends, so a single chart-wide Min/Max pair reads
+   * as though a chart of several violins had one minimum and one maximum. Each
+   * extreme is instead attributed to the violin it came from, and the per-group
+   * breakdown is left to the data table below.
+   *
+   * Only sections the violin actually draws get a row. The minimum is always
+   * drawn, but the maximum rides on `showExtrema`, and naming a maximum the
+   * user cannot navigate to would describe a section that is not there.
+   *
+   * @returns The range rows, minus any whose section this violin omits.
+   */
+  private rangeStats(): DescriptionState['stats'] {
+    const stats = [
+      extremeStat(
+        this.points,
+        { single: 'Minimum', grouped: 'Lowest minimum' },
+        p => p.min,
+        isLower,
+      ),
+    ];
+
+    if (this.sections.includes(BoxplotSection.MAX)) {
+      stats.push(extremeStat(
+        this.points,
+        { single: 'Maximum', grouped: 'Highest maximum' },
+        p => p.max,
+        isHigher,
+      ));
+    }
+
+    return stats;
   }
 
   public override dispose(): void {

--- a/test/model/violinBoxDescription.test.ts
+++ b/test/model/violinBoxDescription.test.ts
@@ -113,6 +113,15 @@ describe('violinBoxTrace description summary', () => {
     expect(stat(trace, 'Highest maximum')).toBe(12060);
   });
 
+  test('trims a padded group name rather than announcing the padding', () => {
+    const padded = [group('  A  ', 5, 10, 15, 20, 25), group('B', 1, 4, 6, 8, 12)];
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer(padded));
+
+    // The blank check already judges the name by its trimmed form, so the
+    // printed name has to match, or "25 (  A  )" reads the padding as a pause.
+    expect(stat(trace, 'Highest maximum')).toBe('25 (A)');
+  });
+
   test('still counts the groups and lists the sections', () => {
     const trace = new ViolinBoxTrace(makeViolinBoxLayer([
       group('A', 5, 10, 15, 20, 25),

--- a/test/model/violinBoxDescription.test.ts
+++ b/test/model/violinBoxDescription.test.ts
@@ -1,0 +1,125 @@
+import type { BoxPoint, MaidrLayer, ViolinOptions } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { ViolinBoxTrace } from '@model/violinBox';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Builds a violin's summary-statistics group. Violins produce no outliers, so
+ * both outlier lists stay empty.
+ */
+function group(
+  z: string,
+  min: number,
+  q1: number,
+  q2: number,
+  q3: number,
+  max: number,
+): BoxPoint {
+  return { z, lowerOutliers: [], min, q1, q2, q3, max, upperOutliers: [] };
+}
+
+/**
+ * Builds a violin box layer with no selectors, so the trace skips SVG
+ * resolution and the test needs no DOM.
+ */
+function makeViolinBoxLayer(
+  data: BoxPoint[],
+  violinOptions?: ViolinOptions,
+): MaidrLayer {
+  return {
+    id: 'violin-box',
+    type: TraceType.VIOLIN_BOX,
+    title: 'Violins',
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    data,
+    ...(violinOptions ? { violinOptions } : {}),
+  };
+}
+
+/**
+ * Reads a summary row by label, or undefined when the summary has no such row.
+ */
+function stat(
+  trace: ViolinBoxTrace,
+  label: string,
+): string | number | undefined {
+  return trace.description.stats.find(s => s.label === label)?.value;
+}
+
+describe('violinBoxTrace description summary', () => {
+  test('attributes each extreme to its violin when several are present', () => {
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer([
+      group('A', 5, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, 12),
+      group('C', 3, 9, 14, 22, 40),
+    ]));
+
+    expect(stat(trace, 'Lowest minimum')).toBe('1 (B)');
+    expect(stat(trace, 'Highest maximum')).toBe('40 (C)');
+    expect(stat(trace, 'Min')).toBeUndefined();
+    expect(stat(trace, 'Max')).toBeUndefined();
+  });
+
+  test('reports plain ends when there is only one violin', () => {
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer([
+      group('Only', 2, 4, 6, 8, 10),
+    ]));
+
+    expect(stat(trace, 'Minimum')).toBe(2);
+    expect(stat(trace, 'Maximum')).toBe(10);
+  });
+
+  test('omits the maximum row when the violin does not draw extrema', () => {
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer([
+      group('A', 5, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, 12),
+    ], { showExtrema: false }));
+
+    // Naming a maximum would describe a section the user cannot navigate to.
+    expect(trace.description.dataTable.headers).not.toContain('Maximum');
+    expect(stat(trace, 'Highest maximum')).toBeUndefined();
+    // The minimum is drawn unconditionally, so its row stays.
+    expect(stat(trace, 'Lowest minimum')).toBe('1 (B)');
+  });
+
+  test('keeps the maximum row when extrema are drawn explicitly', () => {
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer([
+      group('A', 5, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, 12),
+    ], { showExtrema: true }));
+
+    expect(stat(trace, 'Highest maximum')).toBe('25 (A)');
+  });
+
+  test('marks a range as missing when no violin carries the end', () => {
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer([
+      group('A', Number.NaN, 10, 15, 20, Number.NaN),
+      group('B', Number.NaN, 4, 6, 8, Number.NaN),
+    ]));
+
+    expect(stat(trace, 'Lowest minimum')).toBe('missing');
+    expect(stat(trace, 'Highest maximum')).toBe('missing');
+  });
+
+  test('falls back to the bare value when the violins carry no group name', () => {
+    // Violin layers carry their group under `fill` and leave `z` unset, so the
+    // real examples reach here — reading out "326 (undefined)" would be worse
+    // than reading out "326".
+    const unnamed = [group('A', 326, 878, 1810, 4678, 10378), group('B', 336, 912, 2648, 5372, 12060)]
+      .map(p => ({ ...p, z: undefined as unknown as string }));
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer(unnamed));
+
+    expect(stat(trace, 'Lowest minimum')).toBe(326);
+    expect(stat(trace, 'Highest maximum')).toBe(12060);
+  });
+
+  test('still counts the groups and lists the sections', () => {
+    const trace = new ViolinBoxTrace(makeViolinBoxLayer([
+      group('A', 5, 10, 15, 20, 25),
+      group('B', 1, 4, 6, 8, 12),
+    ]));
+
+    expect(stat(trace, 'Number of groups')).toBe(2);
+    expect(stat(trace, 'Sections')).toBe('Minimum, 25%, 50%, 75%, Maximum');
+  });
+});


### PR DESCRIPTION
# Pull Request

> **#752 has merged and this is now rebased onto `main`** — the two commits it stacked on are gone from this branch's history, and the diff is this PR's own change only.

## Description

`ViolinBoxTrace.description` carried the same single `Min`/`Max` summary the box plot shed in #752 — one pair taken across every violin, so a chart of five read as though it had one minimum and one maximum, with nothing saying which violin either belonged to. This applies the same group attribution, with two differences the violin's own shape forces.

## Related Issues

Follow-up to #752, requested after that review.

## Changes Made

**`src/model/boxExtremes.ts` (new).** The `extremeStat` helper moves out of `BoxTrace` now that a second caller exists — the project rule is no abstraction before that point, and this is that point. It keeps the behavior #752 pinned down: NaN ends skipped, `missing` when no group has one, group name only when there is more than one group, earliest group wins a tie. `isLower`/`isHigher` come along as the two `beats` rules.

**`src/model/violinBox.ts`.** `rangeStats()` replaces the `Min`/`Max` pair, with one violin-specific rule: **only sections the violin actually draws get a row**. The minimum is unconditional in `buildViolinSections()`, but the maximum rides on `showExtrema` — and naming a maximum the user cannot navigate to would describe a section that is not on screen. Today's code silently reports the Q3-derived range as `Max` in that configuration.

**`src/model/boxExtremes.ts`, unnamed groups.** A guard the box plot never needed. Verified against `examples/violin.html` in a browser and the summary came out `Lowest minimum: 326 (undefined)` — violin layers carry their group under `fill` and leave `z` unset, which is also why their data table has always shown a blank Group column. An unnamed group now falls back to the bare value.

**Name trimming** (2nd commit, from Copilot's review). `hasName()` judged the name by its trimmed form but printed the raw `z`, so a padded name announced as `25 (  A  )` — and for a screen reader that padding reads as a pause. Reading the name and testing it are now one step.

**`test/model/violinBoxDescription.test.ts` (new, 8 tests):** multi-violin attribution, single-violin form, the max row dropped under `showExtrema: false` and kept under `true`, all-missing ends, the unnamed-group fallback, padded-name trimming, and group count / section list.

## Screenshots (if applicable)

Driven with Playwright against `examples/violin.html` built from this branch:

```
Summary
  Number of groups: 5
  Sections: Minimum, 25%, 50%, 75%, Maximum
  Lowest minimum: 326        ← was "326 (undefined)" before the name guard
  Highest maximum: 14171
```

`examples/boxplot-vertical.html` and `examples/boxplot-horizontal.html` were re-driven after the helper extraction and still name their groups (`21.957… (Group 3)`), confirming the move is behavior-preserving for #752.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Re-verified after the rebase onto `main`: `npm run lint:fix`, `npm run type-check`, and `npm test` all green (1651 unit tests across 125 suites, plus 61 ESM tests across 6 suites).

Earlier red checks on this branch were two separate causes, both now resolved. A GitHub Actions outage (`Failed to resolve action download info. Error: Service Unavailable`) took out three jobs before any code ran; and `claude-review` then failed with `fatal: couldn't find remote ref claude/maidr-boxplot-d-key-description-t7oef8` — it restores its trusted config from the PR's base branch, and this PR's base was deleted when #752 merged. The rebase onto `main` fixes that.

**Out of scope, found while verifying:** the violin data table's Group column is blank because the layer data uses `fill` where `BoxPoint` declares `z`. That is a schema mismatch between the producer and `src/type/grammar.ts`, not a description bug, and fixing it likely means a change on the py-maidr side too — so this PR only stops the summary from reading out `undefined`. Worth its own issue.