### PR TITLE
refactor(model): narrow outOfBoundsState to the empty state it returns

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -12,6 +12,7 @@ import type {
   HighlightState,
   PointerGuidanceState,
   TextState,
+  TraceEmptyState,
   TraceState,
 } from '@type/state';
 import type { Trace } from './plot';
@@ -450,7 +451,20 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     };
   }
 
-  protected get outOfBoundsState(): TraceState {
+  /**
+   * The state pushed to observers when navigation leaves the data.
+   *
+   * Declared as `TraceEmptyState` rather than the whole `TraceState` union
+   * because that is what every implementation actually returns — the accessor
+   * exists so {@link AbstractPlot.notifyOutOfBounds} has an empty state to
+   * push. Narrowing it here is what lets the braille and highlight callers
+   * hand the value straight on: those states accept the empty trace shape but
+   * not a populated one, so a wider declaration would force each of them to
+   * cast, and a cast is exactly what stops the compiler from noticing if an
+   * override ever starts returning a populated state.
+   * @returns The empty trace state, positioned for out-of-bounds audio panning.
+   */
+  protected get outOfBoundsState(): TraceEmptyState {
     return {
       empty: true,
       type: 'trace',
@@ -466,7 +480,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
 
   protected get highlight(): HighlightState {
     if (this.highlightValues === null || this.isInitialEntry) {
-      return this.outOfBoundsState as HighlightState;
+      return this.outOfBoundsState;
     }
 
     return {

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1,7 +1,7 @@
 import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
 import type { GridNavigable } from '@type/navigation';
-import type { AudioState, BrailleState, DescriptionState, HighlightState, TextState, TraceState } from '@type/state';
+import type { AudioState, BrailleState, DescriptionState, HighlightState, TextState, TraceEmptyState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
@@ -272,7 +272,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
     }
 
     // Normal row/col mode: braille not supported (return empty state)
-    return this.outOfBoundsState as BrailleState;
+    return this.outOfBoundsState;
   }
 
   protected get audio(): AudioState {
@@ -435,7 +435,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
       if (this.isInGridCellMode && this.cellSvgGroups.length > 0) {
         const elements = this.cellSvgGroups[this.cellPointIndex];
         if (!elements || elements.length === 0) {
-          return this.outOfBoundsState as HighlightState;
+          return this.outOfBoundsState;
         }
         return {
           empty: false,
@@ -445,7 +445,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
 
       // Grid cell overview - highlight all points in cell
       if (cell.svgElements.length === 0) {
-        return this.outOfBoundsState as HighlightState;
+        return this.outOfBoundsState;
       }
       return {
         empty: false,
@@ -454,14 +454,14 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
     }
 
     if (this.highlightValues === null) {
-      return this.outOfBoundsState as HighlightState;
+      return this.outOfBoundsState;
     }
 
     const elements = this.mode === NavMode.COL
       ? this.col < this.highlightValues.length ? this.highlightValues![this.col] : null
       : this.row < this.highlightValues.length ? this.highlightValues![this.row] : null;
     if (!elements) {
-      return this.outOfBoundsState as HighlightState;
+      return this.outOfBoundsState;
     }
 
     return {
@@ -478,7 +478,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable {
    * Returns out-of-bounds state with correct position for grid mode panning.
    * In grid mode, uses gridCol/gridRow for correct left/right audio panning.
    */
-  protected override get outOfBoundsState(): TraceState {
+  protected override get outOfBoundsState(): TraceEmptyState {
     // Use grid position when in grid mode for correct panning
     if (this.isInGridMode && this.gridCells) {
       return {

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -279,13 +279,13 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
 
   protected override get highlight(): HighlightState {
     if (this.highlightValues === null || this.row === this.barValues.length - 1) {
-      return this.outOfBoundsState as HighlightState;
+      return this.outOfBoundsState;
     }
 
     // Defensive check: ensure row and col exist in highlightValues
     const rowElements = this.highlightValues[this.row];
     if (!rowElements || !rowElements[this.col]) {
-      return this.outOfBoundsState as HighlightState;
+      return this.outOfBoundsState;
     }
 
     return {

--- a/test/model/outOfBoundsState.test.ts
+++ b/test/model/outOfBoundsState.test.ts
@@ -1,0 +1,101 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, it, jest } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { ScatterTrace } from '@model/scatter';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Contract tests for `AbstractTrace.outOfBoundsState` (issue #754).
+ *
+ * The accessor is declared to return `TraceEmptyState`, not the whole
+ * `TraceState` union, because the empty variant is the only thing it ever
+ * returns — it exists so `notifyOutOfBounds()` has something to push. That
+ * narrowing is what lets the braille and highlight callers hand the value
+ * straight to consumers typed as `BrailleState` / `HighlightState`; those
+ * accept the empty trace shape but not a populated one, so a wider declaration
+ * forced a cast at each site, and the cast is what stopped the compiler from
+ * noticing if an override ever returned a populated state.
+ *
+ * The narrowed type already makes that a build error, so these tests are the
+ * runtime half: they pin the invariant so it survives even if the declaration
+ * is ever widened back. `ScatterTrace` is covered specifically because it is
+ * the one class that overrides the accessor.
+ */
+
+/** A bar layer with no selectors, so the trace resolves no highlight elements. */
+function barLayer(): MaidrLayer {
+  return {
+    id: 'bars',
+    type: TraceType.BAR,
+    axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+    data: [{ x: 'Q1', y: 10 }, { x: 'Q2', y: 20 }],
+  };
+}
+
+/** A scatter layer with no selectors, for the same reason. */
+function scatterLayer(): MaidrLayer {
+  return {
+    id: 'points',
+    type: TraceType.SCATTER,
+    axes: { x: { label: 'Weight' }, y: { label: 'Height' } },
+    data: [{ x: 1, y: 2 }, { x: 3, y: 4 }],
+  };
+}
+
+/** Narrows the trace state union to the populated case. */
+function stateOf(trace: BarTrace | ScatterTrace): Extract<TraceState, { empty: false }> {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state;
+}
+
+describe('trace out-of-bounds state', () => {
+  it('pushes an empty trace state to observers when navigation leaves the data', () => {
+    const trace = new ScatterTrace(scatterLayer());
+    const update = jest.fn();
+    trace.addObserver({ update });
+
+    trace.notifyOutOfBounds();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][0]).toMatchObject({ empty: true, type: 'trace' });
+  });
+
+  it('carries the cursor position so the empty tone still pans correctly', () => {
+    const trace = new ScatterTrace(scatterLayer());
+    const update = jest.fn();
+    trace.addObserver({ update });
+
+    trace.notifyOutOfBounds();
+
+    // AudioService reads these to place the boundary tone; an empty state that
+    // dropped them would play the edge cue dead centre.
+    const state = update.mock.calls[0][0] as { audio: unknown };
+    expect(state.audio).toEqual(
+      expect.objectContaining({
+        x: expect.any(Number),
+        y: expect.any(Number),
+        rows: expect.any(Number),
+        cols: expect.any(Number),
+      }),
+    );
+  });
+
+  it('is a valid highlight state when a trace resolved no elements', () => {
+    // The `as HighlightState` cast this replaces was asserting exactly this.
+    const trace = new BarTrace(barLayer());
+
+    expect(stateOf(trace).highlight.empty).toBe(true);
+  });
+
+  it('is a valid braille state where scatter has no braille to offer', () => {
+    // Scatter supports braille only in grid mode; row/col mode falls back to
+    // the same empty state, which used to need an `as BrailleState` cast.
+    const trace = new ScatterTrace(scatterLayer());
+
+    expect(stateOf(trace).braille.empty).toBe(true);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`AbstractTrace.outOfBoundsState` was declared to return the whole `TraceState` union, but every implementation returns only the empty variant — the accessor exists so `AbstractPlot.notifyOutOfBounds()` has an empty state to push.

Because the declaration was wider than the actual contract, the seven sites that hand the value to a `HighlightState` or `BrailleState` consumer each needed a cast:

```ts
return this.outOfBoundsState as HighlightState;
```

Those casts are sound only by a convention nothing enforces. The moment an override returns a populated state — which its own declared type explicitly permits — they silently produce a value that is not a valid `HighlightState`/`BrailleState`. There is no compile error, because the cast is the thing suppressing it, and nothing downstream would necessarily catch it either: consumers branch on `.empty` first, so a populated value flows on as "not empty" and reaches code reading fields that are not there.

`ScatterTrace` already overrides this accessor, so "an override returns something unexpected" is one edit away, not hypothetical.

This is the same class of defect as #748 and #749 — a declared type looser than reality, with `as` covering the difference so the compiler stops helping exactly where it would otherwise catch a regression.

## Related Issues

Closes #754.

Found while fixing #749 (#751, merged). Not shipped in that PR because it is unrelated to the empty-subplot fix and belonged in its own commit.

## Changes Made

**`src/model/abstract.ts`** — `outOfBoundsState` is declared `TraceEmptyState`, with a doc comment recording why the narrow type is load-bearing rather than incidental. Dropped the cast in the `highlight` fallback.

**`src/model/scatter.ts`** — same narrowing on the override (both its grid-mode and fall-through branches already returned empty variants). Dropped four `as HighlightState` casts and one `as BrailleState`. The now-unused `TraceState` import went with them.

**`src/model/segmented.ts`** — dropped two `as HighlightState` casts.

No other change was needed: `TraceEmptyState` is already assignable to both targets — `BrailleState` includes it as a union member (`src/type/state.ts:245`), and `HighlightState`'s empty variant (`src/type/state.ts:411`) declares the same fields with `traceType` optional. The narrowing is a valid covariant override of `AbstractPlot`'s `protected abstract get outOfBoundsState(): State`.

After this, an override that returns a populated state is a compile error at the override, which is where it should surface.

**No behavioural change.** The values observers receive are identical objects; only the declared type and the casts changed.

## Screenshots (if applicable)

Not applicable — no user-facing behaviour changes.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — no documented behaviour changes.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### On testing a type-level change

The narrowed type is itself the guard: an override returning a populated state now fails `tsc`. `test/model/outOfBoundsState.test.ts` adds the runtime half, so the invariant survives even if the declaration is ever widened back and the compile-time guard is lost. It pins, through the public surface:

- `notifyOutOfBounds()` delivers an empty trace state, and carries the cursor position `AudioService` needs to pan the boundary tone;
- the empty state is a valid `HighlightState` when a trace resolved no elements — precisely what the removed `as HighlightState` was asserting;
- the empty state is a valid `BrailleState` on scatter's row/col path, which is what `as BrailleState` was asserting.

`ScatterTrace` is used deliberately: it is the only class that overrides the accessor.

### Verification run locally

`npm run lint:fix`, `npm run type-check`, `npm run build`, and `npm test` all pass — **120 suites / 1581 tests** (up from 119 / 1577 with the four new cases). E2E was not run: this change is type-level with no behavioural delta, and the full chromium suite passed on #751 against the same model code.

### Not included

A review pass on #751 also flagged `Figure.outOfBoundsState` and `Subplot.outOfBoundsState` (`src/model/plot.ts`) as duplicated structure. I looked and left them alone: they differ in the `type` discriminant (`'figure'` vs `'subplot'`), which is exactly what makes the state unions narrowable, so a shared helper would have to be generic over the discriminant and would cost more in indirection than the four lines it saves. Recorded in #754 so it does not get re-raised.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCieDEXjDZbfB52xxaC9q6)_