### PR TITLE
fix(description): round the numbers the chart description reads out

### DIFF
--- a/src/model/box.ts
+++ b/src/model/box.ts
@@ -142,16 +142,13 @@ export class BoxTrace extends AbstractTrace {
     const headers = ['Group', ...this.sections];
     const isHorizontal = this.orientation === Orientation.HORIZONTAL;
 
-    const rows: (string | number)[][] = this.points.map((point, pointIdx) => {
+    const rows: DescriptionState['dataTable']['rows'] = this.points.map((point, pointIdx) => {
       const sectionValues = this.sections.map((_, sectionIdx) => {
         const value = isHorizontal
           ? this.boxValues[pointIdx]?.[sectionIdx]
           : this.boxValues[sectionIdx]?.[pointIdx];
-        // Outlier sections hold an array of values; a group with none renders
-        // as a blank cell rather than an empty-looking `[]`.
-        if (Array.isArray(value)) {
-          return value.join(', ');
-        }
+        // Outlier sections hold an array, which travels on unjoined so the
+        // description service can round each value before joining them.
         return value ?? '';
       });
       return [point.z, ...sectionValues];

--- a/src/model/boxExtremes.ts
+++ b/src/model/boxExtremes.ts
@@ -1,5 +1,6 @@
 import type { BoxPoint } from '@type/grammar';
 import type { DescriptionState } from '@type/state';
+import { defaultFormat } from '@util/format';
 
 /**
  * Labels for a range row, one for each shape the summary can take.
@@ -56,7 +57,14 @@ export function extremeStat(
   );
   const value = valueOf(winner);
   const name = grouped ? groupName(winner) : null;
-  return { label, value: name === null ? value : `${value} (${name})` };
+  if (name === null) {
+    // A bare number travels on for DescriptionService to round.
+    return { label, value };
+  }
+  // Composing the group name onto the value makes this a string, past the
+  // point where the service can round what is inside it, so the number is
+  // rounded here with the same `defaultFormat` the service would have used.
+  return { label, value: `${defaultFormat(value)} (${name})` };
 }
 
 /**

--- a/src/model/violinBox.ts
+++ b/src/model/violinBox.ts
@@ -164,14 +164,11 @@ export class ViolinBoxTrace extends AbstractTrace {
     const headers = ['Group', ...this.sections];
     const isHorizontal = this.orientation === Orientation.HORIZONTAL;
 
-    const rows: (string | number)[][] = this.points.map((point, pointIdx) => {
+    const rows: DescriptionState['dataTable']['rows'] = this.points.map((point, pointIdx) => {
       const sectionValues = this.sections.map((_, sectionIdx) => {
         const value = isHorizontal
           ? this.boxValues[pointIdx]?.[sectionIdx]
           : this.boxValues[sectionIdx]?.[pointIdx];
-        if (Array.isArray(value)) {
-          return value.join(', ');
-        }
         return value ?? '';
       });
       return [point.z, ...sectionValues];

--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -1,8 +1,33 @@
 import type { Context } from '@model/context';
 import type { DisplayService } from '@service/display';
-import type { DescriptionStat, DescriptionState } from '@type/state';
+import type { DescriptionStat, DescriptionState, DisplayDescriptionState } from '@type/state';
 import { AbstractTrace } from '@model/abstract';
 import { Scope } from '@type/event';
+import { defaultFormat } from '@util/format';
+
+/**
+ * Rounds one cell or summary value for display.
+ *
+ * A cell holding several values — a box plot's outliers — is rounded value by
+ * value and joined, which is why traces hand those over as an array rather than
+ * a string they joined themselves.
+ *
+ * A non-finite number is left as the number it is. `defaultFormat` would turn
+ * it into the literal text `"NaN"`, and the dialog's own `isDisplayable` check
+ * blanks a non-finite *number* but would happily print that *string*.
+ *
+ * @param value - The value as the trace reported it.
+ * @returns The value rounded for display, or unchanged if it is not a number.
+ */
+function roundCell(value: string | number | number[]): string | number {
+  if (Array.isArray(value)) {
+    return value.map(roundCell).join(', ');
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return value;
+  }
+  return defaultFormat(value);
+}
 
 /**
  * Service for managing the chart description modal.
@@ -21,7 +46,7 @@ export class DescriptionService {
    * Gets the description state from the currently active trace.
    * @returns The description state or null if no active trace
    */
-  public getDescription(): DescriptionState | null {
+  public getDescription(): DisplayDescriptionState | null {
     const active = this.context.active;
     if (active instanceof AbstractTrace) {
       const description = active.description;
@@ -37,6 +62,7 @@ export class DescriptionService {
       const subplots = this.context.getSubplotSummaries();
       return {
         ...description,
+        ...this.rounded(description),
         title,
         ...(subplots.length > 0 && { subplots }),
       };
@@ -66,6 +92,37 @@ export class DescriptionService {
   }
 
   /**
+   * Rounds the numbers a trace put in its description down to what a screen
+   * reader can reasonably speak.
+   *
+   * A trace reports the values it holds, and a computed one carries its full
+   * float: the box plot examples describe a whisker at `21.957700280519678`,
+   * which is seventeen digits to listen through for two digits of meaning. The
+   * same `defaultFormat` the announcements already use (see #727) is applied
+   * here, so the dialog and the spoken text agree on how a value reads.
+   *
+   * Only the announcement is shortened. Sonification, braille, and extrema all
+   * read the trace's own numbers and never pass through here.
+   *
+   * @param description - The description as the trace built it.
+   * @returns The stats and data table with their numbers rounded.
+   */
+  private rounded(
+    description: DescriptionState,
+  ): Pick<DisplayDescriptionState, 'stats' | 'dataTable'> {
+    return {
+      stats: description.stats.map(stat => ({
+        ...stat,
+        value: roundCell(stat.value),
+      })),
+      dataTable: {
+        headers: description.dataTable.headers,
+        rows: description.dataTable.rows.map(row => row.map(roundCell)),
+      },
+    };
+  }
+
+  /**
    * Builds a figure-level description for a multi-panel figure's lobby view.
    * Surfaces the authored figure title, subplot count, any authored
    * subtitle/caption, and the authored figure-wide axes (e.g. a facet grid's
@@ -77,7 +134,7 @@ export class DescriptionService {
    * @param size - The number of subplots in the figure.
    * @returns The figure-level description state.
    */
-  private getFigureDescription(size: number): DescriptionState {
+  private getFigureDescription(size: number): DisplayDescriptionState {
     const figureTitle = this.context.figureTitle;
     const title = this.context.isAuthoredTitle(figureTitle) ? figureTitle : '';
 

--- a/src/service/description.ts
+++ b/src/service/description.ts
@@ -8,20 +8,29 @@ import { defaultFormat } from '@util/format';
 /**
  * Rounds one cell or summary value for display.
  *
+ * A non-finite number comes back as the number it is, so the dialog's own
+ * `isDisplayable` check can blank the cell. Handing back `defaultFormat`'s
+ * output instead would give it the literal text `"NaN"`, which that check
+ * blanks as a *number* but would happily print as a *string*.
+ *
  * A cell holding several values — a box plot's outliers — is rounded value by
  * value and joined, which is why traces hand those over as an array rather than
- * a string they joined themselves.
+ * a string they joined themselves. A non-finite entry is dropped instead of
+ * blanked: `join` would coerce it back into that same `"NaN"` text, and a
+ * joined cell has no way to hand a blank back for one entry of it.
  *
- * A non-finite number is left as the number it is. `defaultFormat` would turn
- * it into the literal text `"NaN"`, and the dialog's own `isDisplayable` check
- * blanks a non-finite *number* but would happily print that *string*.
+ * A string is already display text and `defaultFormat` returns it untouched.
  *
  * @param value - The value as the trace reported it.
- * @returns The value rounded for display, or unchanged if it is not a number.
+ * @returns The rounded value, a number when it is non-finite, or the joined
+ * and rounded entries when the cell holds several values.
  */
 function roundCell(value: string | number | number[]): string | number {
   if (Array.isArray(value)) {
-    return value.map(roundCell).join(', ');
+    return value
+      .filter(entry => Number.isFinite(entry))
+      .map(entry => defaultFormat(entry))
+      .join(', ');
   }
   if (typeof value === 'number' && !Number.isFinite(value)) {
     return value;
@@ -101,8 +110,9 @@ export class DescriptionService {
    * same `defaultFormat` the announcements already use (see #727) is applied
    * here, so the dialog and the spoken text agree on how a value reads.
    *
-   * Only the announcement is shortened. Sonification, braille, and extrema all
-   * read the trace's own numbers and never pass through here.
+   * Only what the dialog shows is shortened, and only on the way out — the
+   * trace keeps its own numbers. Sonification, braille, and extrema read those
+   * directly and never pass through here.
    *
    * @param description - The description as the trace built it.
    * @returns The stats and data table with their numbers rounded.

--- a/src/state/viewModel/descriptionViewModel.ts
+++ b/src/state/viewModel/descriptionViewModel.ts
@@ -1,6 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { DescriptionService } from '@service/description';
-import type { DescriptionState } from '@type/state';
+import type { DisplayDescriptionState } from '@type/state';
 import type { AppStore } from '../store';
 import { createSlice } from '@reduxjs/toolkit';
 import { AbstractViewModel } from './viewModel';
@@ -9,7 +9,7 @@ import { AbstractViewModel } from './viewModel';
  * State interface for the chart description modal.
  */
 export interface DescriptionMenuState {
-  data: DescriptionState | null;
+  data: DisplayDescriptionState | null;
 }
 
 const initialState: DescriptionMenuState = {
@@ -20,7 +20,7 @@ const descriptionSlice = createSlice({
   name: 'description',
   initialState,
   reducers: {
-    setDescription(state, action: PayloadAction<DescriptionState | null>): void {
+    setDescription(state, action: PayloadAction<DisplayDescriptionState | null>): void {
       state.data = action.payload;
     },
     reset(): DescriptionMenuState {

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -395,10 +395,13 @@ export interface DescriptionState {
   /**
    * Data table for raw data display.
    *
-   * A cell holds an array when one row carries several values for a column —
-   * a box plot's outliers are the case. Traces hand the values over unjoined
-   * so `DescriptionService` can round each one before joining them for
-   * display; a pre-joined string would arrive as opaque text.
+   * A cell holds a `number[]` when one row carries several numbers for a
+   * column — a box plot's outliers are the only case today. Traces hand those
+   * over unjoined so `DescriptionService` can round each one before joining
+   * them for display; a pre-joined string would arrive as opaque text. The
+   * array form is numeric on purpose: a column of several *strings* has no
+   * caller, and widening it would mean rounding logic for a shape nothing
+   * produces.
    */
   dataTable: {
     headers: string[];

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -392,10 +392,17 @@ export interface DescriptionState {
   };
   /** Chart-specific summary statistics */
   stats: DescriptionStat[];
-  /** Data table for raw data display */
+  /**
+   * Data table for raw data display.
+   *
+   * A cell holds an array when one row carries several values for a column —
+   * a box plot's outliers are the case. Traces hand the values over unjoined
+   * so `DescriptionService` can round each one before joining them for
+   * display; a pre-joined string would arrive as opaque text.
+   */
   dataTable: {
     headers: string[];
-    rows: (string | number)[][];
+    rows: (string | number | number[])[][];
   };
   /**
    * List of all subplots in the figure, populated only when the figure has
@@ -403,6 +410,21 @@ export interface DescriptionState {
    * without having to navigate through them.
    */
   subplots?: SubplotSummary[];
+}
+
+/**
+ * A description whose values have been rounded for display — what
+ * `DescriptionService` hands the ViewModel, and what the dialog renders.
+ *
+ * The one difference from {@link DescriptionState} is the cell type: a
+ * multi-value cell has been rounded value by value and joined by the time it
+ * gets here, so the view never has to deal with an array.
+ */
+export interface DisplayDescriptionState extends Omit<DescriptionState, 'dataTable'> {
+  dataTable: {
+    headers: string[];
+    rows: (string | number)[][];
+  };
 }
 
 /**

--- a/test/model/boxDescription.test.ts
+++ b/test/model/boxDescription.test.ts
@@ -149,11 +149,11 @@ describe('boxTrace description data table', () => {
       'Maximum',
       'Upper outlier(s)',
     ]);
+    // Outlier cells travel as arrays; DescriptionService rounds each value and
+    // joins them, and a group with no outliers ends up a blank cell.
     expect(rows).toEqual([
-      ['A', '-2, 0', 5, 10, 15, 20, 25, '31'],
-      // A group with no outliers leaves the cell blank rather than showing an
-      // empty list.
-      ['B', '', 1, 4, 6, 8, 12, ''],
+      ['A', [-2, 0], 5, 10, 15, 20, 25, [31]],
+      ['B', [], 1, 4, 6, 8, 12, []],
     ]);
   });
 
@@ -167,8 +167,8 @@ describe('boxTrace description data table', () => {
     // A horizontal box plot reverses its groups so navigation starts at the
     // lower-left box; the table follows that same order.
     expect(rows).toEqual([
-      ['B', '-1', 1, 4, 6, 8, 12, ''],
-      ['A', '', 5, 10, 15, 20, 25, '30'],
+      ['B', [-1], 1, 4, 6, 8, 12, []],
+      ['A', [], 5, 10, 15, 20, 25, [30]],
     ]);
   });
 });

--- a/test/service/descriptionRounding.test.ts
+++ b/test/service/descriptionRounding.test.ts
@@ -108,6 +108,22 @@ describe('descriptionService value rounding', () => {
     expect(cells[7]).toBe('156.38');
   });
 
+  test('drops a non-finite outlier instead of joining the text "NaN" in', () => {
+    const description = describeTrace(
+      boxTrace(
+        { min: 5, q1: 10, q2: 15, q3: 20, max: 25 },
+        { lower: [-2.5551, Number.NaN, -1], upper: [Number.NaN] },
+      ),
+    );
+
+    // `join` coerces a non-finite number back into the very text the scalar
+    // guard exists to avoid, and a joined cell cannot hand a blank back for
+    // one entry, so the entry goes.
+    const cells = row(description, 'A');
+    expect(cells[1]).toBe('-2.56, -1');
+    expect(cells[7]).toBe('');
+  });
+
   test('leaves an integer alone rather than padding it with decimals', () => {
     const description = describeTrace(boxTrace({
       min: 5,

--- a/test/service/descriptionRounding.test.ts
+++ b/test/service/descriptionRounding.test.ts
@@ -1,0 +1,173 @@
+import type { Context } from '@model/context';
+import type { DisplayService } from '@service/display';
+import type { DescriptionState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { BoxTrace } from '@model/box';
+import { DescriptionService } from '@service/description';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Wraps a trace as the active element of a mock Context, exposing only the
+ * surface `DescriptionService` touches on the trace-level branch. The trace is
+ * a real `BoxTrace` so the rounding is exercised against a description a trace
+ * actually produces, not a hand-written one.
+ */
+function createMockContext(active: unknown): Context {
+  return {
+    active,
+    figureTitle: 'unavailable',
+    isAuthoredTitle: () => false,
+    isAuthoredSubtitle: () => false,
+    isAuthoredCaption: () => false,
+    isAuthoredAxisLabel: (value: string) => value.trim() !== '',
+    getSubplotSummaries: () => [],
+  } as unknown as Context;
+}
+
+function createMockDisplayService(): DisplayService {
+  return { toggleFocus: jest.fn() } as unknown as DisplayService;
+}
+
+/**
+ * Builds a single-group box trace with the given values, no selectors, so the
+ * trace needs no DOM.
+ */
+function boxTrace(
+  values: { min: number; q1: number; q2: number; q3: number; max: number },
+  outliers: { lower?: number[]; upper?: number[] } = {},
+): BoxTrace {
+  return new BoxTrace({
+    id: 'box',
+    type: TraceType.BOX,
+    title: 'Boxes',
+    axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+    data: [{
+      z: 'A',
+      lowerOutliers: outliers.lower ?? [],
+      upperOutliers: outliers.upper ?? [],
+      ...values,
+    }],
+  });
+}
+
+/**
+ * Runs a trace's description through the service and returns it.
+ */
+function describeTrace(trace: BoxTrace): DescriptionState {
+  const service = new DescriptionService(
+    createMockContext(trace),
+    createMockDisplayService(),
+  );
+  const description = service.getDescription();
+  expect(description).not.toBeNull();
+  return description as DescriptionState;
+}
+
+/**
+ * Reads a row of the data table by its group name.
+ */
+function row(description: DescriptionState, group: string): unknown[] {
+  return description.dataTable.rows.find(r => r[0] === group) as unknown[];
+}
+
+describe('descriptionService value rounding', () => {
+  test('rounds a computed float down to what a screen reader can speak', () => {
+    // The vertical box plot example really does report this whisker.
+    const description = describeTrace(boxTrace({
+      min: 21.957700280519678,
+      q1: 66.08295590961171,
+      q2: 81.78930318003049,
+      q3: 99.3836370729716,
+      max: 148.94899365313984,
+    }));
+
+    expect(row(description, 'A')).toEqual([
+      'A',
+      '',
+      '21.96',
+      '66.08',
+      '81.79',
+      '99.38',
+      '148.95',
+      '',
+    ]);
+  });
+
+  test('rounds each outlier before joining them into one cell', () => {
+    const description = describeTrace(
+      boxTrace(
+        { min: 21.957700280519678, q1: 66, q2: 81, q3: 99, max: 148 },
+        { lower: [-9.795014876280863, 6.057387303065189], upper: [156.3770136893095] },
+      ),
+    );
+
+    // Traces hand outliers over unjoined precisely so each one gets rounded;
+    // a pre-joined string would have arrived here as opaque text.
+    const cells = row(description, 'A');
+    expect(cells[1]).toBe('-9.8, 6.06');
+    expect(cells[7]).toBe('156.38');
+  });
+
+  test('leaves an integer alone rather than padding it with decimals', () => {
+    const description = describeTrace(boxTrace({
+      min: 5,
+      q1: 10,
+      q2: 15,
+      q3: 20,
+      max: 25,
+    }));
+
+    expect(row(description, 'A')).toEqual(['A', '', '5', '10', '15', '20', '25', '']);
+  });
+
+  test('keeps a non-finite value a number so the dialog still blanks it', () => {
+    const description = describeTrace(boxTrace({
+      min: Number.NaN,
+      q1: 10,
+      q2: 15,
+      q3: 20,
+      max: 25,
+    }));
+
+    // `defaultFormat` would hand back the literal text "NaN", which the
+    // dialog's isDisplayable check blanks as a number but would print as a
+    // string.
+    const cells = row(description, 'A');
+    expect(cells[2]).toBeNaN();
+    expect(typeof cells[2]).toBe('number');
+  });
+
+  test('rounds the summary rows too, group name intact', () => {
+    const trace = new BoxTrace({
+      id: 'box',
+      type: TraceType.BOX,
+      title: 'Boxes',
+      axes: { x: { label: 'Group' }, y: { label: 'Value' } },
+      data: [
+        { z: 'A', lowerOutliers: [], min: 21.957700280519678, q1: 66, q2: 81, q3: 99, max: 148.94899365313984, upperOutliers: [] },
+        { z: 'B', lowerOutliers: [], min: 34.19825007539889, q1: 74, q2: 89, q3: 102, max: 137.4429364944776, upperOutliers: [] },
+      ],
+    });
+    const description = describeTrace(trace);
+    const stat = (label: string): unknown =>
+      description.stats.find(s => s.label === label)?.value;
+
+    expect(stat('Lowest minimum')).toBe('21.96 (A)');
+    expect(stat('Highest maximum')).toBe('148.95 (A)');
+  });
+
+  test('leaves a label string untouched', () => {
+    const description = describeTrace(boxTrace({
+      min: 5,
+      q1: 10,
+      q2: 15,
+      q3: 20,
+      max: 25,
+    }));
+    const stat = (label: string): unknown =>
+      description.stats.find(s => s.label === label)?.value;
+
+    expect(stat('Group names')).toBe('A');
+    expect(description.dataTable.headers).toContain('Lower outlier(s)');
+  });
+});


### PR DESCRIPTION
# Pull Request

> **#755 has merged and this is now rebased onto `main`** — the commits it stacked on are gone from this branch's history, and the diff is this PR's own change only.

## Description

The description dialog printed whatever float the trace was holding. The box plot example describes a whisker as `21.957700280519678` — seventeen digits to listen through for two digits of meaning — and the histogram's bin edges were no better.

Announcements have been rounded to two decimals since #727, but the dialog never was. So the same value read one way when you navigated to it and another when you asked for a description of it.

## Related Issues

Found while verifying #752 in a browser; raised there and split out at the maintainer's request.

## Changes Made

**`src/service/description.ts`.** `DescriptionService` applies the same `defaultFormat` to every stat value and every table cell on the way out. It is a pure util, so no `FormatterService` plumbing or controller change is needed. Only what the dialog shows is shortened, and only on the way out — the trace keeps its own numbers, and sonification, braille, and extrema read those directly.

Two things had to move for it to reach everything:

- **Multi-value cells travel unjoined.** A box plot's outliers were joined into a string by the trace, so they arrived as opaque text no formatter could get inside. Traces now hand the values over as an array and the service rounds each one before joining. `DescriptionState.dataTable.rows` widens to carry `number[]`; the service returns the narrower `DisplayDescriptionState`, so the view still never sees an array.
- **Non-finite numbers stay numbers.** `defaultFormat(NaN)` returns the literal text `"NaN"`, and `Description.tsx`'s `isDisplayable` blanks a non-finite *number* but would happily print that *string*. Guarding this is what keeps the blank cell blank.

**`src/model/boxExtremes.ts`.** The group-attributed summary value (`21.96 (Group 3)`) is composed into a string in the model, past where the service can round what is inside it, so it rounds the number with the same `defaultFormat` before composing. A test caught this — the value was still going out at full precision.

**Second commit, from Copilot's review.** The array branch ran its result through `join`, which coerced a non-finite entry straight back into the `"NaN"` text the scalar guard exists to avoid. A joined cell cannot hand a blank back for one of its entries, so the entry is dropped instead — an outlier that isn't a number isn't an outlier. Two docstrings the code had outgrown were corrected in the same commit.

**Tests:** `test/service/descriptionRounding.test.ts` (new, 7 tests) — a computed float rounded, outliers rounded before joining, a non-finite outlier dropped, integers left unpadded, the non-finite scalar guard, summary rows rounded with the group name intact, and label strings untouched. `test/model/boxDescription.test.ts` updated for the unjoined cells.

## Screenshots (if applicable)

Driven with Playwright against the examples built from this branch:

```
examples/boxplot-vertical.html
  Lowest minimum: 21.96 (Group 3)          was 21.957700280519678 (Group 3)
  Group 3 | -20, -10, -9.8, 6.06, 14.74 | 21.96 | 66.08 | 81.79 | 99.38 | 148.95
                                          was -9.795014876280863, 6.057387303065189 …

examples/histogram.html                     bin edges, previously full floats
  1.44 | 33 | 1.29 | 1.59

examples/barplot.html                       integers stay unpadded
  Sat | 87
```

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Re-verified after the rebase onto `main`: `npm run lint:fix`, `npm run type-check`, `npm run build`, and `npm test` all green — 1658 unit tests across 126 suites, plus 61 ESM tests across 6 suites.

Earlier red checks on this branch were a GitHub Actions outage, not this diff. Five jobs across three workflows died at `Getting action download info` with `Service Unavailable`, before checkout — `main` was hit the same way (the **Push on main** run at 15:56 and a **PR Preview Deploy** at 16:02), so it was repo-wide. I also confirmed the one check that could plausibly have been real, `Lint Commit Messages`, passes: CI's exact command `commitlint --from=HEAD~1 --to=HEAD` exits 0 locally.

**A deliberate limit.** This applies `defaultFormat`, not the per-layer `FormatterService`. The formatter is per-axis, and `DescriptionState` has no column-to-axis mapping — a bar chart's table is `[x, y]` and a heatmap's values are `z`, so picking one axis for the whole table would apply, say, a currency format to a category column. Rounding is axis-agnostic and cannot produce a wrong number, only a less decorated one. Wiring authored `AxisFormat`s through would mean giving the table per-column axes; worth doing, but a larger change than this one and easy to get wrong in the direction of printing something false.