### PR TITLE
build: declare the node versions the toolchain requires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,9 @@
         "vite-plugin-dts": "^4.5.4",
         "vite-plugin-singlefile": "^2.3.2"
       },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
       "peerDependencies": {
         "chart.js": "^4.0.0",
         "react": "^18.0.0 || ^19.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
     "dist",
     "!dist/**/*.map"
   ],
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "build": "node scripts/build.js",
     "build:preview": "npm run build && npm run build:recharts-example && npm run build:victory-example && node scripts/build-site.js",


### PR DESCRIPTION
# Pull Request

## Description

Adds the `engines` field that #759 made necessary and left as a follow-up.

`vite@8` and `@vitejs/plugin-react@5.2.0` both declare `node: "^20.19.0 || >=22.12.0"`, and nothing in this repo said so. A contributor on an older Node hits an `ERESOLVE` wall of text from `npm ci` instead of a sentence naming the version — the same unreadable failure mode that made #669 hard to diagnose in the first place.

## Related Issues

Follow-up from #759, where this was raised in review and deferred as out of scope.

## Changes Made

```json
"engines": {
  "node": "^20.19.0 || >=22.12.0"
}
```

Placed before `scripts` because `jsonc/sort-keys` enforces a canonical key order — putting it next to `overrides`, which read more naturally to me, fails lint.

**Declared, not enforced.** There is no `.npmrc` setting `engine-strict`, so npm warns and continues. That is deliberate: the published artefact is a browser bundle, and none of this constrains a consumer at runtime, so turning a dependency install into a hard failure for someone using maidr would be the wrong trade. The value here is the error message a contributor gets, not a gate.

The version range is copied from what the toolchain actually requires rather than picked — if vite's floor moves, this should move with it.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

Verified locally:

| Check | Result |
|---|---|
| `npm run lint` | pass (after moving the key to satisfy `jsonc/sort-keys`) |
| `npm ci` | pass |
| `npm run type-check` | pass |
| `npm test` | **127/127 suites, 1662 tests** |
| `package-lock.json` root `engines` | synced to `^20.19.0 \|\| >=22.12.0` |

The lockfile is included because npm records `engines` in the root package entry; editing `package.json` alone leaves the two out of sync and the next `npm install` would produce this diff anyway.

**CI already satisfies the range** — `lts/*` resolves to Node 24, and the two jobs pinned to `node-version: '20'` get 20.20.x from `actions/setup-node`, above the 20.19 floor. So this should be a no-op for CI and only change what contributors see locally.

No unit test added: asserting a static field against itself would restate the diff rather than guard anything. The real check is `npm ci` on the pinned CI versions, which already runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FA4dYokG4c7fkRj45XQvJx)_