### PR TITLE
perf(build): ship React's production build

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -370,8 +370,9 @@ export function createViteConfig(config) {
     },
     // `process.env.NODE_ENV` is spelled out alongside `process.env` because
     // rolldown only substitutes a `define` key that matches the whole member
-    // expression; see the matching comment in vite.config.ts.
-    define: { 'process.env': {}, 'process.env.NODE_ENV': 'undefined' },
+    // expression, and it is `production` because these are the bundles that get
+    // published; see the matching comment in vite.config.ts.
+    define: { 'process.env': {}, 'process.env.NODE_ENV': JSON.stringify('production') },
     resolve: { alias: config.aliases },
   };
 }

--- a/test/scripts/buildDefineNodeEnv.test.ts
+++ b/test/scripts/buildDefineNodeEnv.test.ts
@@ -20,6 +20,12 @@ import { pathToFileURL } from 'node:url';
  * focused, but found body". This asserts the config directly so the next
  * bundler swap fails here instead of there.
  *
+ * The value is asserted too, not just the key. While the prefix entry was the
+ * only one here the flag resolved to `undefined`, which is falsy for React's
+ * purposes -- so the published bundles shipped its development build without
+ * anything failing. Both halves of that need pinning: the key so the bundle
+ * loads at all, the value so it loads the right React.
+ *
  * `scripts/build.js` is plain ESM JavaScript and `allowJs` is false, so it
  * cannot be imported from a ts-jest test directly. Each case runs in a real
  * node subprocess with `--input-type=module`, as in buildOutputFilenames.test.
@@ -92,6 +98,23 @@ describe('the build script\'s define config', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('BAD:0');
+  });
+
+  // Pinned by value, not just by shape: these bundles are the published ones,
+  // and the flag decides which React build they carry. `undefined` -- what the
+  // `process.env` prefix entry used to leave behind -- silently shipped the
+  // development build, so a regression here is invisible until someone weighs
+  // the tarball or reads the console.
+  it('should substitute production, so the published bundles carry React\'s production build', () => {
+    const result = runModule(`
+      import { builds, createViteConfig } from '${BUILD_SCRIPT}';
+      const values = builds
+        .map(b => createViteConfig(b).define['process.env.NODE_ENV']);
+      console.log('NOT_PRODUCTION:' + values.filter(v => v !== JSON.stringify('production')).length);
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('NOT_PRODUCTION:0');
   });
 });
 

--- a/test/scripts/buildDefineNodeEnv.test.ts
+++ b/test/scripts/buildDefineNodeEnv.test.ts
@@ -119,9 +119,13 @@ describe('the build script\'s define config', () => {
 });
 
 describe('the root vite config\'s define', () => {
-  // vite.config.ts serves the dev servers and the example builds, so it needs
-  // the same entry; the two configs are maintained separately, and drifting
-  // apart is exactly how this would come back.
+  // Nothing builds through this file today: `createViteConfig` passes
+  // `configFile: false`, the example builds and dev servers each pass
+  // `--config examples/*/vite.config.ts`, and no script invokes vite bare. So
+  // this case guards a latent trap rather than a live path -- the day someone
+  // points a build at the root config, it should already be correct instead of
+  // reintroducing a bug that took an e2e run to find. Checked here rather than
+  // left to a comment because an unused config is exactly the kind that drifts.
   //
   // Asserted against the source text rather than the module: node cannot
   // import a .ts file in a subprocess the way it imports scripts/build.js, and
@@ -131,5 +135,11 @@ describe('the root vite config\'s define', () => {
     const source = readFileSync(resolve(ROOT, 'vite.config.ts'), 'utf8');
 
     expect(source).toContain('\'process.env.NODE_ENV\'');
+  });
+
+  it('should substitute production there too, matching the published builds', () => {
+    const source = readFileSync(resolve(ROOT, 'vite.config.ts'), 'utf8');
+
+    expect(source).toMatch(/'process\.env\.NODE_ENV':\s*JSON\.stringify\('production'\)/);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,14 +38,17 @@ export default defineConfig({
   },
   define: {
     'process.env': {},
-    // Rolldown, which vite 8 bundles instead of rollup, only substitutes a
-    // `define` key when it matches the whole member expression. `process.env`
-    // alone therefore leaves `process.env.NODE_ENV` -- React's development
-    // guard -- untouched, and the bundle dies on load with "process is not
-    // defined" before MAIDR can attach to a chart. Rollup replaced the prefix
-    // and left `({}).NODE_ENV` behind, so spelling the full expression out
-    // keeps the value it has always had: `undefined`.
-    'process.env.NODE_ENV': 'undefined',
+    // Spelled out as a whole member expression because rolldown, which vite 8
+    // bundles instead of rollup, substitutes a `define` key only on an exact
+    // match. Left to the `process.env` prefix alone this survives into the
+    // bundle and throws "process is not defined" on load.
+    //
+    // `production` is what a published bundle wants: it is the flag React reads
+    // to pick its build. It resolved to `undefined` for as long as the prefix
+    // entry was the only one here, so every release so far shipped React's
+    // development build -- roughly 90 kB gzipped of warnings and dev-only
+    // invariants that no consumer of a released bundle can act on.
+    'process.env.NODE_ENV': JSON.stringify('production'),
   },
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,14 +40,16 @@ export default defineConfig({
     'process.env': {},
     // Spelled out as a whole member expression because rolldown, which vite 8
     // bundles instead of rollup, substitutes a `define` key only on an exact
-    // match. Left to the `process.env` prefix alone this survives into the
-    // bundle and throws "process is not defined" on load.
+    // match. Left to the `process.env` prefix alone it survives into the output
+    // and throws "process is not defined" on load.
     //
-    // `production` is what a published bundle wants: it is the flag React reads
-    // to pick its build. It resolved to `undefined` for as long as the prefix
-    // entry was the only one here, so every release so far shipped React's
-    // development build -- roughly 90 kB gzipped of warnings and dev-only
-    // invariants that no consumer of a released bundle can act on.
+    // `production` is the flag React reads to pick its build, and these values
+    // are kept identical to the ones in `createViteConfig` in scripts/build.js.
+    // That function is what actually builds the published bundles -- it passes
+    // `configFile: false`, so this file is not merged into them, and no npm
+    // script invokes vite without naming its own config either. Keeping the two
+    // in step is therefore about not leaving a trap for whoever first points a
+    // build at this file, not about the bundles on disk today.
     'process.env.NODE_ENV': JSON.stringify('production'),
   },
   resolve: {


### PR DESCRIPTION
# Pull Request

## Description

Every MAIDR release so far has shipped **React's development build**.

`process.env.NODE_ENV` resolved to `undefined` for as long as `define` carried only the `process.env` prefix entry — rollup rewrote it to `({}).NODE_ENV`, which is `undefined`, which is `!== 'production'`, which is React's development path. Nothing failed, so nothing surfaced it. The visible tell was a console notice on any built example:

```
Download the React DevTools for a better development experience
```

That is ~300 kB of warnings, invariant checks and DevTools hooks that no consumer of a released bundle can act on.

#759 deliberately kept the value at `undefined`. It was fixing the rolldown switch that made the flag visible in the first place, and swapping which React ships as a side effect of a dependency bump would have buried a behavioural change inside a build-tool change. This is that change, on its own.

## Related Issues

Follow-up from #759, where this was found and deferred.

## Changes Made

- `vite.config.ts` and `scripts/build.js`: `'process.env.NODE_ENV'` → `JSON.stringify('production')`
- `test/scripts/buildDefineNodeEnv.test.ts`: pin the **value**, not just the key

### Size

| | before | after | change |
|---|---|---|---|
| `dist/maidr.js` | 1,666,923 B | 1,366,082 B | **−300 KB (−18%)** |
| gzipped | 475,955 B | 394,686 B | **−81 KB (−17%)** |

Measured on the same machine, same command (`node scripts/build.js core`), toggling only the define value.

### Why the test changed

The existing regression test asserted the *key* was present, because #759's failure was a hard crash — the bundle threw `process is not defined` and MAIDR never loaded. This failure mode is the opposite: `undefined` loads fine and works, it just quietly carries the wrong React. A key-only assertion would stay green through a regression here, so the test now also pins the value to `"production"`.

## Screenshots (if applicable)

Not applicable — the observable difference is the absence of the DevTools console notice.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verified locally:

| Check | Result |
|---|---|
| `npm run type-check` | pass |
| `npm run lint` | pass |
| `npm test` | **127/127 suites, 1663 tests** |
| `npm run build` | pass |
| **`npx playwright test --project=chromium`** | **330/330 passed** |
| Console of a built example | DevTools notice gone; `window.maidr` still initialises |

**The e2e run is the gate here, not the unit suite.** React's production build removes development-only warnings and the extra checks behind them, so a component relying on dev-mode behaviour would break at runtime while every unit test stayed green — the unit suite renders components but never loads the built bundle. 330/330 unchanged is the evidence that nothing depended on it.

### Risk

This changes which React runs in the published bundle. The upside is size and a quieter console; the downside is that dev-only warnings no longer fire for downstream integrators who were (perhaps unknowingly) relying on seeing them. That seems clearly right for a published artefact, but it is a behavioural change and worth a maintainer's eye rather than a rubber stamp — which is why it is separate from #759 instead of folded into it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FA4dYokG4c7fkRj45XQvJx)_