### PR TITLE
feat(pie): support pie charts across the core and every adapter

### DIFF
--- a/.claude/rules/model.md
+++ b/.claude/rules/model.md
@@ -18,8 +18,8 @@ element is active without knowing which level that is.
 
 Trace implementations live directly in `src/model/` — `bar.ts`, `line.ts`,
 `scatter.ts`, `box.ts`, `heatmap.ts`, `histogram.ts`, `candlestick.ts`,
-`segmented.ts`, `smooth.ts`, `violin.ts`. There is no `src/model/trace/`
-subdirectory.
+`segmented.ts`, `smooth.ts`, `violin.ts`, `pie.ts`. There is no
+`src/model/trace/` subdirectory.
 
 ## Rules
 
@@ -30,7 +30,9 @@ subdirectory.
   bounds check consistent with the data shape you actually index into.
 - **Never import from `src/service/`, `src/state/`, or `src/ui/`.** The model
   notifies; it does not call.
-- **One trace class per file**, extending `AbstractTrace<T>`.
+- **One trace class per file**, extending `AbstractTrace`. It is not generic —
+  the point type lives on the subclass's own `points` field, not in a type
+  parameter.
 
 ## Strategy pattern: the four modalities
 
@@ -50,12 +52,35 @@ returned state consistent with the other traces.
 
 ## Registering a new trace type
 
-1. Add the class in `src/model/`, extending `AbstractTrace<YourPoint>`.
-2. Implement `moveOnce()`, `isMovable()`, and the four modality accessors.
-3. Add the `case` to `TraceFactory.create()` in `src/model/factory.ts` —
-   an unregistered type throws at runtime.
-4. Add the type to `TraceType` and the point shape to `src/type/grammar.ts`.
-5. Confirm the audio, text, braille, and highlight services handle it.
+A trace type is registered in six places, then verified across the modality
+services. `TraceType` keys a total `Record` in two of them, so those two fail
+the build if you forget; the rest fail at runtime, or — for braille — not at
+all. `PieTrace` is the most recent worked example; grep `TraceType.PIE` to see
+every one of them at once.
+
+1. In `src/type/grammar.ts`: add the `TraceType` member, the point shape
+   (`PiePoint`), and that point to the `MaidrLayer.data` union.
+2. Add the class in `src/model/`, extending `AbstractTrace` — which is **not**
+   generic. Assign `movable` (usually a `MovableGrid` over your points, which
+   supplies `moveOnce()` and `isMovable()`), and implement the abstract
+   accessors: `audio`, `braille`, `text`, `description`, `dimension`,
+   `highlightValues`, `values`, `supportsExtrema`, and `findNearestPoint`.
+3. Add the `case` to `TraceFactory.create()` in `src/model/factory.ts` — an
+   unregistered type throws `Invalid trace type`, and the throw propagates out
+   of `new Figure(...)`, so nothing renders at all.
+4. Add the display name to `CHART_TYPE_LABEL` in `src/model/abstract.ts`. It is
+   a `Record<TraceType, string>`, so omitting it is a compile error.
+5. Answer `IS_ORIENTED` in `src/util/orientation.ts` — also a total `Record`,
+   and also a compile error to omit. `true` means the trace resolves
+   `layer.orientation` and swaps its main and cross axes; a pie is `false`,
+   because slices sit around a circle rather than along an axis.
+6. Register a braille encoder in the `encoders` Map in `src/service/braille.ts`.
+   **An unregistered type is silent**, not a crash: the guarded early return
+   leaves braille users with an empty display and no error anywhere. Reuse an
+   existing encoder when the state shape matches — a pie's single row of
+   magnitudes is the `BarBrailleEncoder`'s input exactly.
+7. Confirm the audio, text, highlight, and high-contrast services handle it, and
+   document the braille encoding in `docs/BRAILLE.md`.
 
 ## Ownership-aware highlight disposal
 

--- a/.github/instructions/model.instructions.md
+++ b/.github/instructions/model.instructions.md
@@ -20,8 +20,8 @@ element is active without knowing which level that is.
 
 Trace implementations live directly in `src/model/` — `bar.ts`, `line.ts`,
 `scatter.ts`, `box.ts`, `heatmap.ts`, `histogram.ts`, `candlestick.ts`,
-`segmented.ts`, `smooth.ts`, `violin.ts`. There is no `src/model/trace/`
-subdirectory.
+`segmented.ts`, `smooth.ts`, `violin.ts`, `pie.ts`. There is no
+`src/model/trace/` subdirectory.
 
 ## Rules
 
@@ -32,7 +32,9 @@ subdirectory.
   bounds check consistent with the data shape you actually index into.
 - **Never import from `src/service/`, `src/state/`, or `src/ui/`.** The model
   notifies; it does not call.
-- **One trace class per file**, extending `AbstractTrace<T>`.
+- **One trace class per file**, extending `AbstractTrace`. It is not generic —
+  the point type lives on the subclass's own `points` field, not in a type
+  parameter.
 
 ## Strategy pattern: the four modalities
 
@@ -52,12 +54,35 @@ returned state consistent with the other traces.
 
 ## Registering a new trace type
 
-1. Add the class in `src/model/`, extending `AbstractTrace<YourPoint>`.
-2. Implement `moveOnce()`, `isMovable()`, and the four modality accessors.
-3. Add the `case` to `TraceFactory.create()` in `src/model/factory.ts` —
-   an unregistered type throws at runtime.
-4. Add the type to `TraceType` and the point shape to `src/type/grammar.ts`.
-5. Confirm the audio, text, braille, and highlight services handle it.
+A trace type is registered in six places, then verified across the modality
+services. `TraceType` keys a total `Record` in two of them, so those two fail
+the build if you forget; the rest fail at runtime, or — for braille — not at
+all. `PieTrace` is the most recent worked example; grep `TraceType.PIE` to see
+every one of them at once.
+
+1. In `src/type/grammar.ts`: add the `TraceType` member, the point shape
+   (`PiePoint`), and that point to the `MaidrLayer.data` union.
+2. Add the class in `src/model/`, extending `AbstractTrace` — which is **not**
+   generic. Assign `movable` (usually a `MovableGrid` over your points, which
+   supplies `moveOnce()` and `isMovable()`), and implement the abstract
+   accessors: `audio`, `braille`, `text`, `description`, `dimension`,
+   `highlightValues`, `values`, `supportsExtrema`, and `findNearestPoint`.
+3. Add the `case` to `TraceFactory.create()` in `src/model/factory.ts` — an
+   unregistered type throws `Invalid trace type`, and the throw propagates out
+   of `new Figure(...)`, so nothing renders at all.
+4. Add the display name to `CHART_TYPE_LABEL` in `src/model/abstract.ts`. It is
+   a `Record<TraceType, string>`, so omitting it is a compile error.
+5. Answer `IS_ORIENTED` in `src/util/orientation.ts` — also a total `Record`,
+   and also a compile error to omit. `true` means the trace resolves
+   `layer.orientation` and swaps its main and cross axes; a pie is `false`,
+   because slices sit around a circle rather than along an axis.
+6. Register a braille encoder in the `encoders` Map in `src/service/braille.ts`.
+   **An unregistered type is silent**, not a crash: the guarded early return
+   leaves braille users with an empty display and no error anywhere. Reuse an
+   existing encoder when the state shape matches — a pie's single row of
+   magnitudes is the `BarBrailleEncoder`'s input exactly.
+7. Confirm the audio, text, highlight, and high-contrast services handle it, and
+   document the braille encoding in `docs/BRAILLE.md`.
 
 ## Ownership-aware highlight disposal
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and encourages a multi-modal exploration on visualization.
 
 To use maidr, follow these steps:
 
-1. **Import your plot**: maidr is designed to work seamlessly with scalable vector graphics (SVG) objects for visual highlighting. However, maidr is inherently visual-agnostic, and it also supports other raster image formats such as PNG and JPG without the visual highlight feature. Regardless of the image format, maidr provides support for all non-visual modalities, including Braille, text, and sonification (BTS). Additionally, it offers interactive and artificial intelligence (AI) plot descriptions powered by OpenAI GPT, Anthropic Claude, Google Gemini, or local models running on your own machine via [Ollama](https://ollama.com) (no API key required, suitable for sensitive data). The supported plot types include bar plot, boxplot, heatmap, scatter plot, line plot, step plot, histogram, segmented bar plots (e.g., stacked bar plot, side-by-side dodged plot, and normalized stacked bar plot).
+1. **Import your plot**: maidr is designed to work seamlessly with scalable vector graphics (SVG) objects for visual highlighting. However, maidr is inherently visual-agnostic, and it also supports other raster image formats such as PNG and JPG without the visual highlight feature. Regardless of the image format, maidr provides support for all non-visual modalities, including Braille, text, and sonification (BTS). Additionally, it offers interactive and artificial intelligence (AI) plot descriptions powered by OpenAI GPT, Anthropic Claude, Google Gemini, or local models running on your own machine via [Ollama](https://ollama.com) (no API key required, suitable for sensitive data). The supported plot types include bar plot, boxplot, heatmap, scatter plot, line plot, step plot, histogram, pie chart, segmented bar plots (e.g., stacked bar plot, side-by-side dodged plot, and normalized stacked bar plot).
 
 2. **Create an HTML file**: Include the main script file `maidr.js`. No stylesheet link is needed — maidr styles its own interface at runtime, and fetches the stylesheet for mathematical notation on demand when it is actually required. Add the SVG of your plot to the main HTML body, and add an ID attribute of your choice to the SVG. Note that this can be automated with R. Your HTML file should now have the following structure:
 
@@ -57,7 +57,7 @@ To use maidr, follow these steps:
 
 ## Data Schema
 
-The maidr JSON schema defines how plot data is structured for each supported plot type, including bar plots, boxplots, heatmaps, scatter plots, line plots, step plots, histograms, and segmented bar plots.
+The maidr JSON schema defines how plot data is structured for each supported plot type, including bar plots, boxplots, heatmaps, scatter plots, line plots, step plots, histograms, pie charts, and segmented bar plots.
 For the full schema structure, object properties, and data formats, see the [Data Schema documentation](docs/SCHEMA.md).
 
 ## React Integration

--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -214,6 +214,40 @@ series occupies its own line, so several step series can be compared at once. In
 single-line displays, the up and down arrow keys move between series and the
 braille representation updates to the current one.
 
+## Pie chart
+
+A pie's slices are a single row, so its braille is the bar plot encoding above,
+unchanged: one Braille character per slice, in the order the slices are drawn,
+whose dot height is that slice's magnitude relative to the range of the pie's
+own slice values.
+
+- ⣀ represents values from 0% to 25% of the range
+- ⠤ represents values from 25% to 50%
+- ⠒ represents values from 50% to 75%
+- ⠉ represents values from 75% to 100%
+- "⠀" (braille space) represents a zero slice or one with no value
+
+Note that the bands are relative to the smallest and largest slice, not to the
+whole circle: the smallest measured slice reads as ⣀ and the largest as ⠉,
+however close their shares are. Read the braille for which slices are large
+relative to one another, and the text output for what share of the whole any one
+of them is.
+
+The heights encode the raw values, not the percentages — the two are a monotone
+rescale of each other, so the characters come out identical either way, and the
+raw values keep braille agreeing with the sonification and the reported
+statistics. The percentage itself is not encoded in braille; it is announced in
+text as ", Percentage is 33.3%" after the slice label and its value.
+
+Slices with no measurement are left out of the range entirely, so one missing
+slice cannot compress every other slice's dot height, and they read as a braille
+space the same way a zero slice does.
+
+### Multiline Displays
+
+Pie charts use a single-line representation. On multiline braille displays the
+pie appears on the first line and the remaining lines are unused.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -380,16 +380,16 @@ The data property is defined as a list of objects where each object is a record 
       "selectors": "#chart path.slice",
       "data":[
         {
-                    "x": "Apples",
-                    "y": 30
+          "x": "Apples",
+          "y": 30
         },
         {
-                    "x": "Bananas",
-                    "y": 50
+          "x": "Bananas",
+          "y": 50
         },
         {
-                    "x": "Cherries",
-                    "y": 20
+          "x": "Cherries",
+          "y": 20
         }
       ]
     }

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -121,7 +121,7 @@ Or multiple plots:
 
 Use the following to define the object properties:
 
-- `type`: the type of plot. Currently supported are 'bar', 'box', 'candlestick', 'dodged_bar', 'heat', 'hist', 'line', 'stacked_normalized_bar', 'point', 'smooth', 'stacked_bar', 'step', 'violin_kde', 'violin_box',
+- `type`: the type of plot. Currently supported are 'bar', 'box', 'candlestick', 'dodged_bar', 'heat', 'hist', 'line', 'stacked_normalized_bar', 'pie', 'point', 'smooth', 'stacked_bar', 'step', 'violin_kde', 'violin_box',
 - `id`: the id that you added as an attribute of your main SVG.
 - `title`: the title of the plot. (optional)
 - `axes`: axes info for your plot. Each axis is a per-axis object: `maidr.axes.x`, `maidr.axes.y`, and (when used) `maidr.axes.z`. Supported properties per axis: `label` (string), `min` / `max` (number bounds), `tickStep` (number), and `format` (an `AxisFormat` object controlling numeric / categorical rendering). `label` is optional and defaults to `X`, `Y`, or `Level` for the respective axis. Bare string values for axes are no longer accepted.
@@ -348,6 +348,49 @@ The data property is defined as a list of objects where each object is a record 
           }
         ]
         //add multiple arrays for multiple step series
+      ]
+    }
+
+    //pie: a FLAT array, one object per slice, in the order the slices are
+    //drawn. Never the nested array the bar-family types use — a pie is one
+    //row of N slices.
+    //
+    //`x` is the slice label and `y` its magnitude. `y` is strictly NUMERIC
+    //(unlike a bar's), because it is both the sonified value and the
+    //numerator of the slice's percentage.
+    //
+    //There is deliberately no `percentage` field. MAIDR derives the share of
+    //the whole as `y / sum(y) * 100`, so an authored percentage can never
+    //disagree with the values it is supposedly derived from. There is no
+    //`orientation` either: slices sit around a circle, not along an axis.
+    //
+    //`axes` here names what the two dimensions mean rather than any drawn
+    //axis: `x` what the slice labels are, `y` what their values measure.
+    //`selectors` must resolve to exactly N elements in slice order, so data
+    //index k and element k are the same wedge; a different count is treated
+    //as addressing something other than the wedges and the layer is left
+    //without highlighting rather than highlighting the wrong slice.
+    //A doughnut is the same layer — the hole is a visual detail.
+    maidr = {
+      "type": "pie",
+      "axes": {
+        "x": { "label": "Fruit" },
+        "y": { "label": "Units" }
+      },
+      "selectors": "#chart path.slice",
+      "data":[
+        {
+                    "x": "Apples",
+                    "y": 30
+        },
+        {
+                    "x": "Bananas",
+                    "y": 50
+        },
+        {
+                    "x": "Cherries",
+                    "y": 20
+        }
       ]
     }
 

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -96,12 +96,17 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Step (single & multi-series) | `StepLineSeries` | step-line series class |
 | Histogram | `ColumnSeries` | value X axis + `openValueXField` bin edges |
 | Heatmap | `ColumnSeries` | category X **and** category Y axes + `value` field |
+| Pie / Doughnut | `am5percent.PieSeries` | series class (requires `percent.js`) |
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
+
+A `PieSeries` lives in amCharts' separate `percent.js` module and is bound to no axis, so `axes.x` and `axes.y` default to `Label` and `Value`; the `axisLabels` option overrides both. A doughnut is a `PieChart` with an `innerRadius` and reads identically. Slices with no category or no numeric value are skipped rather than counted as zero.
 
 > Box plots, candlestick, scatter, violin, and smooth/regression layers are **not** supported by the amCharts binder. amCharts 5 has no dedicated scatter or box series, and there is no reliable runtime signal to distinguish a scatter (hidden-stroke `LineSeries`) from a normal line chart.
 
 ## Multi-Panel Charts
+
+Every `PieChart` in the root's container is a subplot too, on the same terms as the XYCharts below — a root holding a pie and a doughnut is one MAIDR figure with two panels.
 
 When one amCharts `Root` contains **multiple XYCharts** — amCharts' native multi-panel pattern (`root.container.set("layout", root.verticalLayout)` plus several `XYChart` children, or a `horizontalLayout`/`GridLayout`) — both `bindAmCharts` and `fromAmCharts` convert **each chart into its own MAIDR subplot**. The same applies to **am5stock `StockChart` panels** (`StockPanel` extends `XYChart`), which the binder finds by walking the root's container tree; scrollbar preview charts (`XYChartScrollbar`) are excluded.
 
@@ -209,6 +214,28 @@ var series = chart.series.push(am5xy.ColumnSeries.new(root, {
   categoryXField: "weekday", categoryYField: "hour", valueField: "value",
 }));
 ```
+
+### Pie / Doughnut
+
+A `PieChart` is not an `XYChart`, so it needs `percent.js` alongside `xy.js` and takes no axes. Give the binder `axisLabels` to name the two dimensions; without them the layer reads "Label is Apples, Value is 30". A runnable page is at [`examples/amcharts-pie.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-pie.html).
+
+```js
+var chart = root.container.children.push(am5percent.PieChart.new(root, {
+  layout: root.verticalLayout,
+  // innerRadius: am5.percent(50)  // makes it a doughnut; nothing else changes
+}));
+var series = chart.series.push(am5percent.PieSeries.new(root, {
+  name: "Units sold", valueField: "units", categoryField: "fruit",
+}));
+series.data.setAll([
+  { fruit: "Apples", units: 30 }, { fruit: "Bananas", units: 50 },
+  { fruit: "Cherries", units: 20 }, { fruit: "Dates", units: 15 },
+]);
+
+maidrAmCharts.bindAmCharts(root, { axisLabels: { x: "Fruit", y: "Units sold" } });
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Fruit is Apples, Units sold is 30, Percentage is 26.1%".
 
 ## Keyboard Controls
 

--- a/docs/anychart.md
+++ b/docs/anychart.md
@@ -73,6 +73,7 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 | Box Plot | `box` | [Box plot](examples.html) |
 | Heatmap | `heatmap`, `heat` | [Heatmap](examples.html) |
 | Candlestick | `candlestick`, `ohlc` | [Candlestick](examples.html) |
+| Pie | `pie` (a doughnut is a pie with `innerRadius()`) | [Pie chart](examples.html) |
 
 Area series are represented as line traces — the filled-area visual is lost in the accessible representation. A console warning is emitted when this downgrade occurs. `step-area` downgrades to a step trace rather than a line one, so it still warns about the lost fill.
 
@@ -82,6 +83,7 @@ Area series are represented as line traces — the filled-area visual is lost in
 
 - **Heatmap** charts use AnyChart's separate `anychart-heatmap.min.js` module and expose a chart-level data API (no `getSeriesCount()`). The adapter detects them via `chart.getType()` returning `'heatmap'` or `'heat'`, with a defensive fallback when `getType()` is unavailable.
 - **Candlestick** support also covers OHLC series. Both come from AnyChart's financial / stock module (`anychart-stock.min.js`). Each row is `[x, open, high, low, close]`; outlier and volume fields are not extracted by AnyChart's iterator API.
+- **Pie** charts are the other single-dataset type: like the heatmap they hold their data on `chart.data()` rather than on a series, and `getType()` reports `'pie'` for a doughnut too (AnyChart draws one by giving an ordinary pie an inner radius), so both read identically. A pie is bound to no axis, so its axis labels fall back to `Label` and `Value` unless `options.axes` names them. Slices with no numeric value are dropped — AnyChart draws no wedge for one, and keeping it would slide every later slice's highlight onto its neighbour.
 
 ## Code Examples
 
@@ -261,6 +263,30 @@ Each `chart.bar(...)` call adds one series. The adapter walks every series via `
   });
 </script>
 ```
+
+### Pie Chart
+
+```html
+<div id="container" style="width: 700px; height: 400px"></div>
+<script type="module">
+  import { bindAnyChart } from 'https://cdn.jsdelivr.net/npm/maidr/dist/anychart.mjs';
+
+  const chart = anychart.pie([
+    ['Apples', 30], ['Bananas', 50], ['Cherries', 20], ['Dates', 12],
+  ]);
+  chart.title('Fruit Sales by Variety');
+  // chart.innerRadius('40%');  // makes it a doughnut; nothing else changes
+  chart.container('container').draw();
+
+  bindAnyChart(chart, {
+    id: 'fruit-pie',
+    title: 'Fruit Sales by Variety',
+    axes: { x: 'Fruit', y: 'Units sold' },
+  });
+</script>
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Fruit is Apples, Units sold is 30, Percentage is 26.8%". The binder stamps a `data-maidr-anychart-pie-slice` attribute on each rendered wedge in data order, so highlighting needs no manual `selectors` entry.
 
 ## Binder Options
 

--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -78,6 +78,9 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Box Plot | `'boxplot'` | `@sgratzl/chartjs-chart-boxplot` | [Box plot](examples.html) |
 | Candlestick | `'candlestick'` | `chartjs-chart-financial` + a date adapter | [Candlestick](examples.html) |
 | Heatmap | `'matrix'` | `chartjs-chart-matrix` | [Heatmap](examples.html) |
+| Pie / Doughnut | `'pie'`, `'doughnut'` | — | [Pie chart](examples.html) |
+
+> **Pie note:** a pie has no Chart.js scales, so there is no axis title to read. `axes.x` and `axes.y` default to `Category` and `Value`; set `plugins.maidr.axes` to name what the slice labels and their values actually mean. Multiple datasets are concentric rings, not slices of one circle — each becomes its own MAIDR layer with its own total and percentages, and Page Up / Page Down move between them.
 
 ## Code Examples
 
@@ -382,6 +385,39 @@ Requires [`chartjs-chart-matrix`](https://github.com/kurkle/chartjs-chart-matrix
   });
 </script>
 ```
+
+### Pie / Doughnut Chart
+
+```html
+<div style="width: 500px; height: 500px">
+  <canvas id="pie-chart"></canvas>
+</div>
+<script>
+  Chart.register(maidrChartjs.maidrPlugin);
+
+  new Chart(document.getElementById('pie-chart'), {
+    // 'doughnut' works the same way: it is a pie with a cutout, and the cutout
+    // changes nothing about the data or the navigation.
+    type: 'pie',
+    data: {
+      labels: ['Apples', 'Bananas', 'Cherries', 'Dates', 'Elderberries'],
+      datasets: [{
+        label: 'Units Sold',
+        data: [30, 50, 20, 15, 10],
+        backgroundColor: ['#4682b4', '#d2691e', '#6b8e23', '#8b4789', '#b8860b'],
+      }],
+    },
+    options: {
+      plugins: {
+        title: { display: true, text: 'Fruit Sales' },
+        maidr: { axes: { x: 'Fruit', y: 'Units' } },
+      },
+    },
+  });
+</script>
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Fruit is Apples, Units is 30, Percentage is 24.0%". Slices whose value is `null` or `NaN` are dropped rather than counted as zero, so a gap in the data neither takes a share of the total nor pins the bottom of the range the other slices are pitched against.
 
 ## Multi-Panel Charts (Axis Stacking)
 

--- a/docs/d3.md
+++ b/docs/d3.md
@@ -201,6 +201,7 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Candlestick` | OHLC candlestick | `<rect>` per candle | [Candlestick](examples.html) |
 | `bindD3Segmented` | Stacked / dodged / normalized bars | `<rect>` per segment | [Stacked](examples.html), [Dodged](examples.html) |
 | `bindD3Smooth` | Smooth / regression curve | `<circle>` per sample | [Smooth curve](examples.html) |
+| `bindD3Pie` | Pie / doughnut | `<path>` per wedge | [Pie chart](examples.html) |
 
 ## Multi-Panel Charts
 
@@ -221,7 +222,7 @@ svg.selectAll('g.panel')
 
 maidrD3.bindD3Facets(svgElement, {
   panelSelector: 'g.panel',
-  chartType: 'bar',                       // any of the nine chart types
+  chartType: 'bar',                       // any of the ten chart types
   config: {                               // the usual per-type config;
     selector: 'rect.bar',                 // resolved inside each panel
     title: 'Sales by Day, faceted by Region',  // figure title
@@ -506,6 +507,35 @@ maidrD3.bindD3Smooth(svgElement, {
 });
 ```
 
+### Pie / Doughnut Chart
+
+The canonical D3 pie is `d3.pie()` + `d3.arc()` drawn as one `<path>` per wedge. `d3.pie()` wraps each of your data objects in an arc object, and the binder unwraps it for you, so accessors address your own datum (`'fruit'`), not the layout's (`'data.fruit'`):
+
+```js
+const data = [
+  { fruit: 'Apples', units: 30 },
+  { fruit: 'Bananas', units: 50 },
+  { fruit: 'Cherries', units: 20 },
+];
+
+svg.selectAll('path.slice')
+  .data(d3.pie().value(d => d.units)(data)).join('path')
+  .attr('class', 'slice')
+  .attr('d', d3.arc().innerRadius(0).outerRadius(150));
+
+maidrD3.bindD3Pie(svgElement, {
+  selector: 'path.slice',
+  title: 'Fruit Sales',
+  axes: { x: 'Fruit', y: 'Units' },
+  x: 'fruit',
+  // No `y`: the magnitude defaults to the value d3.pie() itself computed,
+  // which is what the drawn angle is proportional to. Supply one only for a
+  // pie drawn without the layout.
+});
+```
+
+A doughnut is the same layout drawn with a non-zero `innerRadius`, and reads identically. Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Fruit is Apples, Units is 30, Percentage is 30.0%". There is no fill axis: the share is derived from the values themselves, so there is nothing for a third axis to name.
+
 ## TypeScript Types
 
 All public types are exported from the `maidr/d3` entry (and re-exported from `maidr/react` for the React wrapper):
@@ -522,6 +552,7 @@ import type {
   D3CandlestickConfig,
   D3SegmentedConfig,
   D3SmoothConfig,
+  D3PieConfig,
   // Multi-panel
   D3FacetsConfig,
   D3SubplotsConfig,

--- a/docs/frappe.md
+++ b/docs/frappe.md
@@ -100,8 +100,12 @@ The `activateMaidrWhenSettled` helper in the Quick Start handles this: it waits 
 | Multi-line | `'line'` (multiple datasets) | `'line'` |
 | Scatter | `'line'` + `lineOptions: { hideLine: 1 }` | `'scatter'` |
 | Mixed axis (bar + line) | `'axis-mixed'` | `'axis-mixed'` |
+| Pie | `'pie'` | `'pie'` |
+| Donut | `'donut'` | `'donut'` |
 
-**Not supported:** Pie, Donut, and Percentage charts (no MAIDR equivalent), and Frappe's calendar-style Heatmap (structurally unlike MAIDR's matrix heatmap).
+**Not supported:** Percentage charts (no MAIDR equivalent), and Frappe's calendar-style Heatmap (structurally unlike MAIDR's matrix heatmap).
+
+> **Pie note:** Frappe aggregates before it draws — it sums every dataset at each label, drops labels whose total is negative, and collapses everything past `maxSlices` (default 20) into one "Rest" wedge. The adapter reproduces that aggregation so each announced slice is the wedge it highlights. Pass the chart instance (not a plain `{ data }` object) when you override `maxSlices`, so the adapter can read it.
 
 > **Scatter note:** Frappe Charts v1.6.2 has no native `scatter` type. Render a dot plot with a line chart whose connecting line is hidden (`lineOptions: { hideLine: 1 }`); pass `chartType: 'scatter'` to the adapter so it is treated as a scatter plot. Frappe spaces x-axis labels evenly regardless of their numeric value, so use evenly spaced numeric labels.
 

--- a/docs/google-charts.md
+++ b/docs/google-charts.md
@@ -87,8 +87,11 @@ The adapter must be called inside the chart's `ready` event to ensure the SVG is
 | Candlestick | `CandlestickChart` | `'CandlestickChart'` |
 | Stacked Column | `ColumnChart` + `isStacked: true` | `'StackedColumnChart'` |
 | Dodged/Grouped Column | `ColumnChart` (multi-series) | `'DodgedColumnChart'` |
+| Pie / Doughnut | `PieChart` (a doughnut is the same class with `pieHole`) | `'PieChart'` |
 
 **Not supported:** Histogram (Google Charts API doesn't expose bin boundaries), Heatmap (not a native Google Charts type).
+
+> **Pie note:** column 0 supplies the slice labels and the first non-role column their values; `axes.x` / `axes.y` take those two column labels, since a `PieChart` has no drawn axis to name. Google Charts gives its wedges no class or id, so the adapter picks them out of the SVG by the arc command in their `d` attribute. When the wedge count does not match the row count the data-to-DOM mapping is unknown and highlighting is dropped for that chart — which is what happens with `is3D: true` (several paths per slice) and with `sliceVisibilityThreshold` (small slices folded into one "Other" wedge). Audio, text, and braille are unaffected.
 
 ## Code Examples
 
@@ -301,6 +304,41 @@ The adapter must be called inside the chart's `ready` event to ensure the SVG is
   });
 </script>
 ```
+
+### Pie Chart
+
+```html
+<div id="pie-chart"></div>
+<script>
+  var data = google.visualization.arrayToDataTable([
+    ['Task', 'Hours per Day'],
+    ['Work', 11],
+    ['Eat', 2],
+    ['Commute', 2],
+    ['Watch TV', 2],
+    ['Sleep', 7],
+  ]);
+
+  var container = document.getElementById('pie-chart');
+  var chart = new google.visualization.PieChart(container);
+
+  google.visualization.events.addListener(chart, 'ready', function () {
+    var maidr = maidrGoogleCharts.createMaidrFromGoogleChart(chart, data, container, {
+      chartType: 'PieChart',
+      title: 'My Daily Activities',
+    });
+    container.setAttribute('maidr', JSON.stringify(maidr));
+  });
+
+  chart.draw(data, {
+    title: 'My Daily Activities',
+    width: 600,
+    height: 400,
+  });
+</script>
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Work, 11, 45.8%". Draw a doughnut by adding `pieHole: 0.4` to the draw options; the adapter `chartType` stays `'PieChart'`.
 
 ## Multi-Panel (Faceted) Figures
 

--- a/docs/highcharts.md
+++ b/docs/highcharts.md
@@ -114,6 +114,9 @@ import { createHighchartsSync, highchartsToMaidr } from 'maidr/highcharts';
 | Stacked Bar | `column`/`bar` + `plotOptions.column.stacking: 'normal'` | [highcharts-stacked.html](highcharts-stacked.html) |
 | Dodged (Grouped) Bar | `column`/`bar` (default, no stacking) with multiple series | [highcharts-dodged.html](highcharts-dodged.html) |
 | Normalized Bar | `column`/`bar` + `plotOptions.column.stacking: 'percent'` | [highcharts-normalized.html](highcharts-normalized.html) |
+| Pie | `pie` (a doughnut is a `pie` with an `innerSize`) | [highcharts-pie.html](highcharts-pie.html) |
+
+> **Pie note:** a pie series is bound to no axis, so `axes.x` and `axes.y` are named `Label` and `Value` rather than read from an axis title. Highcharts renders the wedges in `series.data` order, so slice *k* is wedge *k* and highlighting is index-aligned without any extra configuration.
 
 ## Multi-Panel Charts
 
@@ -395,6 +398,29 @@ const chart = Highcharts.chart('normalized-chart', {
   ],
 });
 ```
+
+### Pie Chart
+
+```js
+const chart = Highcharts.chart('pie-chart', {
+  chart: { type: 'pie' },
+  title: { text: 'Units Sold by Fruit' },
+  series: [{
+    name: 'Fruit sales',
+    data: [
+      { name: 'Apples', y: 30 },
+      { name: 'Bananas', y: 50 },
+      { name: 'Cherries', y: 20 },
+      { name: 'Dates', y: 15 },
+    ],
+  }],
+});
+
+const maidrData = maidrHighcharts.highchartsToMaidr(chart, { id: 'pie-chart' });
+document.getElementById('pie-chart').setAttribute('maidr-data', JSON.stringify(maidrData));
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Apples, 30, 26.1%". Adding `plotOptions: { pie: { innerSize: '50%' } }` makes it a doughnut, which reads identically.
 
 ## Advanced Usage
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > MAIDR (Multimodal Access and Interactive Data Representation) is a TypeScript/React library that provides accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-MAIDR converts data visualizations into interactive, multimodal formats navigable entirely by keyboard. It supports bar charts, stacked/dodged bar charts, histograms, line plots, multi-line plots, step plots, scatter plots, box plots, violin plots, heatmaps, candlestick charts, smooth curves, faceted plots, and multi-panel layouts. Available as an npm package and as a React component library.
+MAIDR converts data visualizations into interactive, multimodal formats navigable entirely by keyboard. It supports bar charts, stacked/dodged bar charts, histograms, line plots, multi-line plots, step plots, scatter plots, box plots, violin plots, heatmaps, candlestick charts, pie and doughnut charts, smooth curves, faceted plots, and multi-panel layouts. Available as an npm package and as a React component library.
 
 ## Docs
 - [Home](https://maidr.ai/): Overview and getting started guide

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -69,6 +69,7 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Heatmap | `type: 'heatmap'` | [Heatmap](examples.html) |
 | Histogram | `type: 'histogram'` | [Histogram](examples.html) |
 | Candlestick | `type: 'candlestick'` | [Candlestick](examples.html) |
+| Pie | `type: 'pie'` | [Pie chart](examples.html) |
 | Grouped Bar | `barmode: 'group'` + multiple bar traces | [Grouped bar](examples.html) |
 | Stacked Bar | `barmode: 'stack'` + multiple bar traces | [Stacked bar](examples.html) |
 | Subplots / Facets | multiple `xaxis`/`yaxis` pairs, `layout.grid`, or Plotly Express facets | [Subplots](examples.html) |
@@ -83,6 +84,20 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   unchanged, and `hvh` becomes `mid`. `vhv` binds as a step but names no
   convention: its flat segments sit at the mean of the two levels rather than
   at either one, which none of MAIDR's three conventions describes.
+
+- A pie trace is bound to no axes — Plotly positions it by its own `domain`
+  instead — so each pie becomes its own MAIDR subplot rather than joining
+  whichever cartesian panel happens to use the first axis pair. `axes.x` and
+  `axes.y` are named `Label` and `Value`, since there is no drawn axis title to
+  read them from. A doughnut (`hole`) is the same trace and reads identically.
+
+- Plotly sorts pie slices by descending value unless the trace sets
+  `sort: false`, so the authored order is not necessarily the drawn order. The
+  adapter reads the slices Plotly actually drew where the rendered chart exposes
+  them; where it can only see the authored order and Plotly may have re-sorted,
+  it emits the layer without selectors, since slice *k* is then not wedge *k*.
+  That costs visual highlighting only — audio, text, and braille are unaffected.
+  Set `sort: false` to keep both.
 
 ## Code Examples
 
@@ -295,6 +310,27 @@ the ones drawn with a mean line highlight it.
   });
 </script>
 ```
+
+### Pie Chart
+
+```html
+<div id="pie-chart" style="width: 700px; height: 500px"></div>
+<script>
+  Plotly.newPlot('pie-chart', [{
+    labels: ['Apples', 'Bananas', 'Cherries', 'Dates'],
+    values: [30, 50, 20, 15],
+    type: 'pie',
+    sort: false
+  }], {
+    title: { text: 'Units Sold by Fruit' }
+  });
+</script>
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie
+is a single row. Each slice announces its label, its value, and its share of the
+whole — "Apples, 30, 26.1%". The share is derived from the values themselves, so
+there is nothing to author for it.
 
 ### Subplots (2x2 Grid)
 

--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -135,6 +135,7 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'histogram'` | `<Bar>` | Histogram with bin ranges (requires `binConfig`) |
 | `'line'` | `<Line>` | Line chart |
 | `'scatter'` | `<Scatter>` | Scatter/point plot |
+| `'pie'` | `<Pie>` | Pie chart (a doughnut is a `<Pie>` with an `innerRadius`) |
 
 ## Data Examples by Chart Type
 
@@ -312,6 +313,37 @@ const data = [
 </MaidrRecharts>
 ```
 
+### Pie Chart
+
+`xKey` is the `<Pie nameKey>` (the slice label) and the single entry in `yKeys` is its `dataKey` (the magnitude):
+
+```tsx
+const data = [
+  { fruit: 'Apples', units: 30 },
+  { fruit: 'Bananas', units: 50 },
+  { fruit: 'Cherries', units: 20 },
+];
+
+<MaidrRecharts
+  id="pie-example"
+  title="Units Sold by Fruit"
+  data={data}
+  chartType="pie"
+  xKey="fruit"
+  yKeys={['units']}
+  xLabel="Fruit"
+  yLabel="Units"
+>
+  <PieChart width={500} height={400}>
+    <Pie data={data} dataKey="units" nameKey="fruit" outerRadius={150} />
+  </PieChart>
+</MaidrRecharts>
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Fruit is Apples, Units is 30, Percentage is 30.0%". Adding an `innerRadius` makes it a doughnut, which reads identically.
+
+> Recharts draws no sector at all for a slice whose value is `0` (its start and end angles are both zero). MAIDR then sees fewer elements than slices and turns highlighting off for the layer rather than index-aligning the wrong wedges; audio, text, and braille still cover every slice.
+
 ### Composed Chart (Bar + Line)
 
 Use `layers` mode to mix different chart types in a single chart:
@@ -437,7 +469,8 @@ type RechartsChartType =
   | 'normalized_bar'
   | 'histogram'
   | 'line'
-  | 'scatter';
+  | 'scatter'
+  | 'pie';
 ```
 
 ### `RechartsLayerConfig`

--- a/docs/vegalite.md
+++ b/docs/vegalite.md
@@ -99,6 +99,9 @@ Because Vega-Lite renders **asynchronously** through `vegaEmbed()`, the adapter 
 | `point`, `circle`, `square`, `tick` | — | Scatter | [vegalite-bindscatter.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindscatter.html) |
 | `rect` | — | Heatmap | [vegalite-bindheatmap.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindheatmap.html) |
 | `boxplot` | — | Box plot (vertical & horizontal) | [vegalite-bindbox.html](https://github.com/xability/maidr/blob/main/examples/vegalite-bindbox.html) |
+| `arc` | `theta` encoding | Pie (`mark.innerRadius` makes it a doughnut) | [vegalite-pie.html](https://github.com/xability/maidr/blob/main/examples/vegalite-pie.html) |
+
+An `arc` mark is only a pie when it has a `theta` encoding: `theta` is the channel carrying the slice magnitudes, and an `arc` without one has no values to sonify, announce, or take percentages of. Such a spec is left unbound rather than announced as a pie whose numbers MAIDR would have to invent.
 
 ## Code Examples
 
@@ -377,6 +380,36 @@ const spec = {
 ```
 
 Both **vertical** (categorical x, quantitative y) and **horizontal** (categorical y, quantitative x) box plots are supported. See [`examples/vegalite-bindbox.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-bindbox.html) for a runnable version.
+
+### Pie chart
+
+```js
+const spec = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+  width: 400,
+  height: 400,
+  title: 'Units Sold by Fruit',
+  data: {
+    values: [
+      { fruit: 'Apples', units: 30 },
+      { fruit: 'Bananas', units: 50 },
+      { fruit: 'Cherries', units: 20 },
+      { fruit: 'Dates', units: 15 },
+    ],
+  },
+  mark: 'arc',
+  encoding: {
+    theta: { field: 'units', type: 'quantitative', title: 'Units' },
+    color: { field: 'fruit', type: 'nominal', title: 'Fruit' },
+  },
+};
+
+maidrVegaLite.embed('#chart', spec, { id: 'fruit-pie' });
+```
+
+An `arc` has no `x` or `y` to name its axes after, so the slice labels come from the `color` (or `fill`) channel and the magnitudes from `theta`, and the layer's axis labels are taken from those two channels' titles. Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Apples, 30, 26.1%". Adding `mark: { type: 'arc', innerRadius: 60 }` makes it a doughnut, which reads identically.
+
+See [`examples/vegalite-pie.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-pie.html) for a runnable version.
 
 ## Multi-panel charts (facet, repeat, concat)
 

--- a/docs/victory.md
+++ b/docs/victory.md
@@ -69,6 +69,7 @@ Unlike config-driven adapters, you do not pass `data`/`chartType` props to `<Mai
 | `VictoryHistogram` | Histogram | ⚠️ | The adapter derives equal-width bins from the raw values, which may not exactly match Victory's rendered bins. |
 | `VictoryBoxPlot` | Box plot | ✅ | Per-section highlight (min, Q1, median, Q3, max). Requires pre-computed statistics. |
 | `VictoryCandlestick` | Candlestick chart | ✅ | Per-section highlight (open, high, low, close, volatility). |
+| `VictoryPie` | Pie chart | ✅ | A doughnut is the same component with an `innerRadius`. Standing alone it has no `VictoryAxis` to read labels from, so the axes are named `Category` and `Value`; wrap it in a `<VictoryChart>` with axis labels to override. |
 
 > Box and candlestick are composite shapes (rects + lines) with no semantic classes, so the adapter classifies their parts by geometry. If a future Victory version changes that layout, highlighting degrades gracefully — audio, text, and braille are unaffected.
 
@@ -211,6 +212,24 @@ Provide pre-computed quartile statistics. The adapter reads these directly and d
 </MaidrVictory>
 ```
 
+### Pie Chart
+
+`VictoryPie` follows Victory's usual `x`/`y` convention: `x` names the slice, `y` is its magnitude. It stands on its own — no `VictoryChart`, no `VictoryAxis`:
+
+```tsx
+<MaidrVictory id="pie-example" title="Units Sold by Fruit">
+  <VictoryPie
+    data={[
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]}
+  />
+</MaidrVictory>
+```
+
+Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Category is Apples, Value is 30, Percentage is 30.0%". Victory renders the wedges in data order, so highlighting is index-aligned with no extra configuration, and an `innerRadius` makes it a doughnut without changing any of that.
+
 ## Multi-Panel Figures
 
 Nest two or more `<VictoryChart>` components inside one `<MaidrVictory>` to build a multi-panel (small-multiples) figure. Each chart becomes one MAIDR subplot: arrow keys move between panels, `Enter` drills into the focused panel, and `Escape` returns to panel navigation. Give each chart a `title` prop — it becomes the panel's name in subplot announcements.
@@ -318,7 +337,8 @@ type VictoryComponentType =
   | 'VictoryBoxPlot'
   | 'VictoryCandlestick'
   | 'VictoryHistogram'
-  | 'VictoryStack';
+  | 'VictoryStack'
+  | 'VictoryPie';
 ```
 
 ## Advanced

--- a/e2e_tests/page-objects/plots/pie-page.ts
+++ b/e2e_tests/page-objects/plots/pie-page.ts
@@ -1,0 +1,241 @@
+import type { Page } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { PiePlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object representing the pie plot page
+ * Handles all pie plot specific interactions and verifications
+ */
+export class PiePlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.PIE_ID}`,
+    svg: `svg#${TestConstants.PIE_ID}`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the pie plot
+   */
+  private readonly plotId = TestConstants.PIE_ID;
+
+  /**
+   * Creates a new PiePlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the pie plot page
+   * @throws PiePlotError if navigation fails
+   */
+  public async navigateToPiePlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/pie.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new PiePlotError('Failed to navigate to pie plot', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the pie plot
+   * @throws PiePlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new PiePlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR by clicking on the pie plot
+   * @throws PiePlotError if MAIDR cannot be activated by clicking
+   */
+  public override async activateMaidrOnClick(): Promise<void> {
+    try {
+      await super.activateMaidrOnClick(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new PiePlotError('Failed to activate MAIDR by clicking', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws PiePlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new PiePlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws PiePlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new PiePlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if braille mode is active
+   * @param brailleMode - The braille mode to check
+   * @returns Promise resolving to true if braille mode is active, false otherwise
+   * @throws PiePlotError if braille mode status cannot be checked
+   */
+  public async isBrailleModeActive(brailleMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.BRAILLE_ON]: TestConstants.BRAILLE_MODE_ON,
+        [TestConstants.BRAILLE_OFF]: TestConstants.BRAILLE_MODE_OFF,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        brailleMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new PiePlotError('Failed to check braille mode status', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the braille cells currently on the braille display.
+   *
+   * A trace type whose encoder was never registered fails silently here — the
+   * braille service returns early and leaves the display blank while text and
+   * audio keep working — so the spec asserts on the raw cell string.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws PiePlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new PiePlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if sonification mode is active
+   * @param sonificationMode - The sonification mode to check
+   * @returns Promise resolving to true if sonification mode is active, false otherwise
+   * @throws PiePlotError if sonification mode status cannot be checked
+   */
+  public async isSonificationActive(sonificationMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.SOUND_ON]: TestConstants.SOUND_MODE_ON,
+        [TestConstants.SOUND_OFF]: TestConstants.SOUND_MODE_OFF,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        sonificationMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new PiePlotError('Failed to check sonification mode status', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the X-axis title, which on a pie names what the slice labels mean
+   * @returns Promise resolving to the X-axis title
+   * @throws PiePlotError if X-axis title cannot be retrieved
+   */
+  public async getXAxisTitle(): Promise<string> {
+    try {
+      return await super.getAxisTitle(this.selectors.info);
+    } catch (error) {
+      throw new PiePlotError('Failed to get X-axis title', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the Y-axis title, which on a pie names what the slice values measure
+   * @returns Promise resolving to the Y-axis title
+   * @throws PiePlotError if Y-axis title cannot be retrieved
+   */
+  public async getYAxisTitle(): Promise<string> {
+    try {
+      return await super.getAxisTitle(this.selectors.info);
+    } catch (error) {
+      throw new PiePlotError('Failed to get Y-axis title', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the current playback speed
+   * @returns Promise resolving to the current speed value
+   * @throws PiePlotError if speed cannot be retrieved
+   */
+  public override async getPlaybackSpeed(): Promise<number> {
+    try {
+      return await super.getPlaybackSpeed(this.selectors.speedIndicator);
+    } catch (error) {
+      throw new PiePlotError('Failed to get playback speed', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the current data point information
+   * @returns Promise resolving to the current data point information
+   * @throws PiePlotError if data point information cannot be retrieved
+   */
+  public override async getCurrentDataPointInfo(): Promise<string> {
+    try {
+      return await super.getCurrentDataPointInfo(this.selectors.info);
+    } catch (error) {
+      throw new PiePlotError('Failed to get current data point information', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws PiePlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new PiePlotError('Pie plot failed to load correctly', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/pieplot.spec.ts
+++ b/e2e_tests/specs/pieplot.spec.ts
@@ -1,0 +1,337 @@
+import type { Page } from '@playwright/test';
+import type { Maidr, MaidrLayer, PiePoint } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { PiePlotPage } from '../page-objects/plots/pie-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output. Written as escapes rather than literal glyphs because the range
+ * endpoints are indistinguishable by eye: U+2800 is the blank cell.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * The label the slice's share of the whole is announced under. Verbose text
+ * renders the optional third value as `<label> is <value>`, so this is the
+ * literal a screen reader hears immediately before the percentage.
+ */
+const PERCENTAGE_LABEL = 'Percentage';
+
+/**
+ * Helper function to create and initialize a pie plot page
+ * @param page - The Playwright page
+ * @param activateMaidr - Whether to activate MAIDR
+ * @returns Initialized PiePlotPage instance
+ */
+async function setupPiePlotPage(
+  page: Page,
+  activateMaidr = true,
+): Promise<PiePlotPage> {
+  const piePlotPage = new PiePlotPage(page);
+  if (activateMaidr) {
+    await piePlotPage.activateMaidr();
+  }
+  return piePlotPage;
+}
+
+/**
+ * Extracts the slices from a pie plot layer.
+ *
+ * A pie layer is flat — one entry per slice, never the nested per-series array
+ * the bar and line families use — so a nested payload is rejected here rather
+ * than left to fail as an unhelpful `undefined` several assertions later.
+ * @param layer - The MAIDR layer containing pie plot data
+ * @returns The slices, in the order they are drawn
+ * @throws Error if the data is not a flat array of points
+ */
+function getPieSlices(layer: MaidrLayer | undefined): PiePoint[] {
+  if (!layer?.data || !Array.isArray(layer.data)) {
+    throw new TypeError('Pie layer data is undefined');
+  }
+
+  if (Array.isArray(layer.data[0])) {
+    throw new TypeError('Pie layer data is nested; a pie layer carries a flat PiePoint[]');
+  }
+
+  return layer.data as PiePoint[];
+}
+
+/**
+ * Reads one slice, failing loudly rather than returning `undefined` for an
+ * index the example does not have.
+ * @param slices - The pie's slices
+ * @param index - Index of the slice to read
+ * @returns The slice at that index
+ * @throws Error if the index is out of bounds
+ */
+function getPieSlice(slices: PiePoint[], index: number): PiePoint {
+  if (index < 0 || index >= slices.length) {
+    throw new Error(`Index ${index} is out of bounds for ${slices.length} slices`);
+  }
+
+  return slices[index];
+}
+
+/**
+ * Derives the share a slice should be announced as.
+ *
+ * Recomputed here from the values on the wire, deliberately: the percentage is
+ * not a field a producer sends, it is derived once in the model, and the point
+ * of the assertion is that what the user hears agrees with the numbers it is
+ * supposedly derived from. Reading an authored percentage back out of the
+ * schema would assert nothing at all.
+ * @param slices - The pie's slices
+ * @param index - Index of the slice whose share is wanted
+ * @returns The share as display text, e.g. `25.0%`
+ */
+function expectedPercentage(slices: PiePoint[], index: number): string {
+  const total = slices.reduce((sum, slice) => sum + slice.y, 0);
+  return `${((getPieSlice(slices, index).y / total) * 100).toFixed(1)}%`;
+}
+
+test.describe('Pie Plot', () => {
+  let maidrData: Maidr;
+  let pieLayer: MaidrLayer;
+  let slices: PiePoint[];
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const piePlotPage = new PiePlotPage(page);
+      await piePlotPage.navigateToPiePlot();
+      await page.waitForSelector(`svg#${TestConstants.PIE_ID}`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+
+      pieLayer = maidrData.subplots[0][0].layers[0];
+      slices = getPieSlices(pieLayer);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const piePlotPage = new PiePlotPage(page);
+    await piePlotPage.navigateToPiePlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the pie plot with maidr data', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page, false);
+      await piePlotPage.verifyPlotLoaded();
+    });
+
+    test('should activate maidr on click', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page, false);
+      await piePlotPage.activateMaidrOnClick();
+    });
+
+    test('should declare the layer as a pie', () => {
+      expect(pieLayer.type).toBe(TestConstants.PIE_ID);
+    });
+
+    test('should carry no authored percentage on the wire', () => {
+      // There is exactly one source of truth for a slice's share, and it is the
+      // model. A producer that shipped its own percentage could disagree with
+      // the values beside it, and nothing downstream could tell which was
+      // right — so the field must not exist here in the first place.
+      for (const slice of slices) {
+        expect('percentage' in slice).toBe(false);
+      }
+    });
+
+    test('should display instruction text naming a pie', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      const instructionText = await piePlotPage.getInstructionText();
+      expect(instructionText).toBe(TestConstants.PIE_INSTRUCTION_TEXT);
+    });
+  });
+
+  test.describe('Mode Controls', () => {
+    test('should toggle text mode on and off', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.toggleTextMode();
+      const isTextModeTerse = await piePlotPage.isTextModeActive(TestConstants.TEXT_MODE_TERSE);
+      await piePlotPage.toggleTextMode();
+      const isTextModeOff = await piePlotPage.isTextModeActive(TestConstants.TEXT_MODE_OFF);
+      await piePlotPage.toggleTextMode();
+      const isTextModeVerbose = await piePlotPage.isTextModeActive(TestConstants.TEXT_MODE_VERBOSE);
+      expect(isTextModeTerse).toBe(true);
+      expect(isTextModeOff).toBe(true);
+      expect(isTextModeVerbose).toBe(true);
+    });
+
+    test('should toggle braille mode on and off', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.toggleBrailleMode();
+      const isBrailleModeOn = await piePlotPage.isBrailleModeActive(TestConstants.BRAILLE_ON);
+      await piePlotPage.toggleBrailleMode();
+      const isBrailleModeOff = await piePlotPage.isBrailleModeActive(TestConstants.BRAILLE_OFF);
+      expect(isBrailleModeOn).toBe(true);
+      expect(isBrailleModeOff).toBe(true);
+    });
+
+    test('should toggle sound mode on and off', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.toggleSonification();
+      const isSoundModeOff = await piePlotPage.isSonificationActive(TestConstants.SOUND_OFF);
+      await piePlotPage.toggleSonification();
+      const isSoundModeOn = await piePlotPage.isSonificationActive(TestConstants.SOUND_ON);
+      expect(isSoundModeOff).toBe(true);
+      expect(isSoundModeOn).toBe(true);
+    });
+  });
+
+  test.describe('Slice Announcements', () => {
+    test('should announce the slice label, its value and its share', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.moveToNextDataPoint();
+
+      const first = getPieSlice(slices, 0);
+      const announcement = normalizeText(await piePlotPage.getCurrentDataPointInfo());
+
+      expect(announcement).toContain(String(first.x));
+      expect(announcement).toContain(String(first.y));
+      // The share is the one thing a pie announces that no other trace does.
+      // Asserted with its label attached, because the bare number reaching the
+      // announcement by some other route would satisfy a `toContain` on the
+      // percentage alone.
+      expect(announcement).toContain(`${PERCENTAGE_LABEL} is ${expectedPercentage(slices, 0)}`);
+    });
+
+    test('should announce each slice with its own share while navigating', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+
+      for (let index = 0; index < slices.length; index++) {
+        await piePlotPage.moveToNextDataPoint();
+
+        const slice = getPieSlice(slices, index);
+        const announcement = normalizeText(await piePlotPage.getCurrentDataPointInfo());
+
+        expect(announcement).toContain(String(slice.x));
+        expect(announcement).toContain(
+          `${PERCENTAGE_LABEL} is ${expectedPercentage(slices, index)}`,
+        );
+      }
+    });
+
+    test('should never announce a share of NaN', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.moveToNextDataPoint();
+
+      const announcement = await piePlotPage.getCurrentDataPointInfo();
+
+      // `0 / 0` is the shape this guards: a total that never divides cleanly
+      // must still report a share, and "NaN percent" is the one thing a slice
+      // must never be announced as.
+      expect(announcement).not.toContain('NaN');
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render one braille cell per slice', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.moveToNextDataPoint();
+      await piePlotPage.toggleBrailleMode();
+
+      const braille = await piePlotPage.getBrailleContent();
+
+      expect(braille).not.toBe('');
+      expect(braille).toMatch(BRAILLE_CELL);
+      expect([...braille]).toHaveLength(slices.length);
+    });
+  });
+
+  test.describe('Axis Controls', () => {
+    test('should display X-axis Title', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.toggleXAxisTitle();
+      const xAxisTitle = await piePlotPage.getXAxisTitle();
+      expect(xAxisTitle).toContain(pieLayer?.axes?.x?.label ?? '');
+    });
+
+    test('should display Y-Axis Title', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.toggleYAxisTitle();
+      const yAxisTitle = await piePlotPage.getYAxisTitle();
+      expect(yAxisTitle).toContain(pieLayer?.axes?.y?.label ?? '');
+    });
+  });
+
+  test.describe('Navigation Controls', () => {
+    test('should move from left to right', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      for (let i = 0; i <= slices.length; i++) {
+        await piePlotPage.moveToNextDataPoint();
+      }
+      const currentDataPoint = await piePlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+
+    test('should move from right to left', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      for (let i = 0; i <= slices.length; i++) {
+        await piePlotPage.moveToPreviousDataPoint();
+      }
+      const currentDataPoint = await piePlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+
+    test('should move to the first slice', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.moveToFirstDataPoint();
+
+      const first = getPieSlice(slices, 0);
+      const announcement = normalizeText(await piePlotPage.getCurrentDataPointInfo());
+
+      expect(announcement).toContain(String(first.x));
+      expect(announcement).toContain(`${PERCENTAGE_LABEL} is ${expectedPercentage(slices, 0)}`);
+    });
+
+    test('should move to the last slice', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.moveToLastDataPoint();
+
+      const lastIndex = slices.length - 1;
+      const last = getPieSlice(slices, lastIndex);
+      const announcement = normalizeText(await piePlotPage.getCurrentDataPointInfo());
+
+      expect(announcement).toContain(String(last.x));
+      expect(announcement).toContain(
+        `${PERCENTAGE_LABEL} is ${expectedPercentage(slices, lastIndex)}`,
+      );
+    });
+
+    // A pie is one row of slices, so the vertical axis has nowhere to go. Both
+    // directions are checked: a trace that reported the wrong number of rows
+    // would still refuse one of them, and only the pair pins the single row.
+    test('should not be able to move up', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.moveToNextDataPoint();
+      await piePlotPage.moveToDataPointAbove();
+      const currentDataPoint = await piePlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+
+    test('should not be able to move down', async ({ page }) => {
+      const piePlotPage = await setupPiePlotPage(page);
+      await piePlotPage.moveToNextDataPoint();
+      await piePlotPage.moveToDataPointBelow();
+      const currentDataPoint = await piePlotPage.getCurrentDataPointInfo();
+      expect(currentDataPoint).toEqual(TestConstants.PLOT_EXTREME_VERIFICATION);
+    });
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -37,6 +37,7 @@ export abstract class TestConstants {
   static readonly MULTI_LINEPLOT_ID = 'line';
   static readonly MULTI_LAYER_PLOT_ID = 'multi-layer';
   static readonly VIOLIN_PLOT_ID = 'violin';
+  static readonly PIE_ID = 'pie';
 
   /**
    * MAIDR plot identifiers
@@ -132,6 +133,10 @@ export abstract class TestConstants {
   // Violin layers are their own trace types (violin_kde / violin_box), not the
   // smooth + box pair they used to be modelled as.
   static readonly VIOLIN_PLOT_INSTRUCTION_TEXT = 'This is a maidr plot containing 2 layers, and this is layer 1 of 2: vertical violin_box plot. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // No orientation prefix: `IS_ORIENTED[PIE]` is false, so unlike a bar chart a
+  // pie is announced by its bare type. Slices run around a circle, and calling
+  // one "vertical" would describe nothing.
+  static readonly PIE_INSTRUCTION_TEXT = 'This is a maidr plot of type: pie. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
 
   /**
    * Text Modes

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -280,6 +280,22 @@ export class ViolinPlotError extends Error {
 }
 
 /**
+ * Error thrown when Pie plot related operations fail
+ */
+export class PiePlotError extends Error {
+  /**
+   * Creates a new PiePlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'PiePlotError';
+  }
+}
+
+/**
  * Error thrown when operations on the empty-subplot regression fixture fail
  */
 export class EmptySubplotError extends Error {

--- a/examples/amcharts-pie.html
+++ b/examples/amcharts-pie.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Pie Chart</title>
+
+    <!-- 1. Load amCharts 5 (core + percent charts, which is where PieChart lives) -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/percent.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 600px;
+        height: 380px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Pie Chart</h1>
+    <p>
+      Click the chart and use the left and right arrow keys to move between
+      slices — a pie is a single row, so up and down are out of bounds. Each
+      slice announces its label, its value, and its share of the whole. Toggle
+      B for Braille, T for Text, S for Sonification, and R for Review mode.
+    </p>
+    <p>
+      amCharts renders to a canvas, so there is no SVG wedge for MAIDR to
+      outline. <code>bindAmCharts</code> draws its own highlight box over the
+      active slice instead; a box around a wedge is coarse, but it tracks which
+      way round the circle navigation has moved.
+    </p>
+
+    <h2>Pie Chart</h2>
+    <div id="pie-chart" class="chart"></div>
+
+    <h2>Doughnut (a pie with an inner radius)</h2>
+    <p>
+      The same series with <code>innerRadius</code> set. It is the same
+      <code>PieSeries</code> underneath and reads identically.
+    </p>
+    <div id="doughnut-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      var FRUIT_DATA = [
+        { fruit: "Apples", units: 300 },
+        { fruit: "Bananas", units: 500 },
+        { fruit: "Cherries", units: 200 },
+        { fruit: "Dates", units: 120 },
+        { fruit: "Elderberries", units: 80 },
+      ];
+
+      // Build one pie chart into `elId`. `innerRadius` (optional) turns it into
+      // a doughnut without changing anything MAIDR reads.
+      function makePie(elId, title, innerRadius) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5percent.PieChart.new(root, {
+            layout: root.verticalLayout,
+            innerRadius: innerRadius,
+          })
+        );
+        chart.children.unshift(
+          am5.Label.new(root, { text: title, fontSize: 16, x: am5.p50, centerX: am5.p50 })
+        );
+        var series = chart.series.push(
+          am5percent.PieSeries.new(root, {
+            name: "Units sold",
+            valueField: "units",
+            categoryField: "fruit",
+          })
+        );
+        series.data.setAll(FRUIT_DATA);
+
+        register(root, {
+          title: title,
+          // A pie is bound to no axis, so there is no axis title to extract.
+          // These name what each dimension holds; drop them and the adapter
+          // falls back to "Label" and "Value".
+          axisLabels: { x: "Fruit", y: "Units sold" },
+        });
+      }
+
+      makePie("pie-chart", "Fruit Sales by Variety");
+      makePie("doughnut-chart", "Fruit Sales by Variety", am5.percent(50));
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/anychart/pie.html
+++ b/examples/anychart/pie.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + AnyChart Pie Example</title>
+    <style>
+      body { font-family: sans-serif; margin: 2rem; }
+      #container { width: 700px; height: 400px; margin-bottom: 1rem; }
+      p { max-width: 700px; }
+    </style>
+    <!-- 1. Load AnyChart (CDN). -->
+    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-base.min.js"></script>
+    <!-- 2. Load the core MAIDR runtime. -->
+    <script src="../../dist/maidr.js"></script>
+    <!-- 3. Load the MAIDR AnyChart adapter (UMD build — exposes window.maidrAnyChart). -->
+    <script src="../../dist/anychart.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const chart = anychart.pie([
+          ['Apples', 30],
+          ['Bananas', 50],
+          ['Cherries', 20],
+          ['Dates', 12],
+        ]);
+
+        chart.title('Fruit Sales by Variety');
+        chart.container('container');
+        chart.draw();
+
+        maidrAnyChart.bindAnyChart(chart, {
+          id: 'anychart-pie',
+          title: 'Fruit Sales by Variety',
+          // A pie is bound to no axis, so there is no axis title to extract.
+          // These name what each dimension holds; drop them and the adapter
+          // falls back to "Label" and "Value".
+          axes: { x: 'Fruit', y: 'Units sold' },
+          // The adapter stamps a stable `data-maidr-anychart-pie-slice`
+          // attribute on each rendered wedge, so no manual `selectors` entry
+          // is required for highlighting to work.
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <h1>MAIDR + AnyChart Pie Chart</h1>
+    <p>
+      Click on the chart and use the left and right arrow keys to move between
+      slices — a pie is a single row, so up and down are out of bounds. Each
+      slice announces its label, its value, and its share of the whole. Press
+      <kbd>B</kbd> for braille, <kbd>T</kbd> for text descriptions, and
+      <kbd>S</kbd> to toggle sonification.
+    </p>
+    <div id="container"></div>
+  </body>
+</html>

--- a/examples/chartjs/pie.html
+++ b/examples/chartjs/pie.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Pie Chart Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Pie Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions.</p>
+    <p>
+      A pie is one row of slices: Left and Right move between them, and each
+      slice announces its label, its value, and its share of the whole.
+    </p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="pie-chart"></canvas>
+    </div>
+
+    <script>
+      // Register the MAIDR plugin globally — every Chart.js chart on the page
+      // becomes accessible automatically.
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      new Chart(document.getElementById('pie-chart'), {
+        // 'doughnut' works the same way: it is a pie with a cutout, and the
+        // cutout changes nothing about the data or the navigation.
+        type: 'pie',
+        data: {
+          labels: ['Apples', 'Bananas', 'Cherries', 'Dates', 'Elderberries'],
+          datasets: [{
+            label: 'Units Sold',
+            data: [30, 50, 20, 15, 10],
+            backgroundColor: ['#4682b4', '#d2691e', '#6b8e23', '#8b4789', '#b8860b'],
+          }],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Fruit Sales' },
+            // A pie has no scales, so there is no axis title for MAIDR to read.
+            // Name what the slice labels and their values mean, or every slice
+            // is announced as "X is Apples, Y is 30".
+            maidr: { axes: { x: 'Fruit', y: 'Units' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindpie.html
+++ b/examples/d3-bindpie.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Pie Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Pie Chart</h1>
+    <p>Click on the chart and use left and right arrow keys to move between slices. Press 'b' for braille, 't' for text descriptions.</p>
+    <div id="chart"></div>
+
+    <script>
+      // Sample data
+      const data = [
+        { fruit: 'Apples', units: 30 },
+        { fruit: 'Bananas', units: 50 },
+        { fruit: 'Cherries', units: 20 },
+        { fruit: 'Dates', units: 12 },
+        { fruit: 'Elderberries', units: 8 },
+      ];
+
+      // Chart dimensions
+      const width = 480;
+      const height = 420;
+      const radius = Math.min(width, height) / 2 - 20;
+
+      // Create SVG
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-pie-chart')
+        .attr('width', width)
+        .attr('height', height)
+        .append('g')
+        .attr('transform', `translate(${width / 2},${height / 2})`);
+
+      // Layout. `.sort(null)` keeps the wedges in data order on screen; the
+      // binder works either way, because d3.pie() returns its arcs in data
+      // order even when it sorts them for drawing.
+      const pie = d3.pie()
+        .sort(null)
+        .value(d => d.units);
+
+      // Set innerRadius above 0 to draw a doughnut instead — the wedges are
+      // still one <path> each, so the MAIDR call below is unchanged.
+      const arc = d3.arc()
+        .innerRadius(0)
+        .outerRadius(radius);
+
+      const color = d3.scaleOrdinal()
+        .domain(data.map(d => d.fruit))
+        .range(d3.schemeTableau10);
+
+      const arcs = pie(data);
+
+      // Slices
+      svg.selectAll('path.slice')
+        .data(arcs)
+        .join('path')
+        .attr('class', 'slice')
+        .attr('d', arc)
+        .attr('fill', d => color(d.data.fruit))
+        .attr('stroke', '#ffffff')
+        .attr('stroke-width', 1);
+
+      // Slice labels
+      svg.selectAll('text.slice-label')
+        .data(arcs)
+        .join('text')
+        .attr('class', 'slice-label')
+        .attr('transform', d => `translate(${arc.centroid(d)})`)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '12px')
+        .style('fill', '#ffffff')
+        .text(d => d.data.fruit);
+
+      // Title
+      svg.append('text')
+        .attr('x', 0)
+        .attr('y', -height / 2 + 24)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '16px')
+        .text('Fruit Sales');
+
+      // === MAIDR Integration ===
+      // Use the D3 binder to generate MAIDR data from the D3 chart
+      const svgElement = document.getElementById('d3-pie-chart');
+      const result = maidrD3.bindD3Pie(svgElement, {
+        selector: 'path.slice',
+        title: 'Fruit Sales',
+        axes: { x: 'Fruit', y: 'Units' },
+        // Read against YOUR datum, not the d3.pie() arc around it. The slice
+        // magnitude needs no accessor: the layout already computed it.
+        x: 'fruit',
+      });
+      // The binder auto-applies `maidr-data` to the SVG. Pass `autoApply: false`
+      // in the config above if you want to handle the attribute yourself.
+      void result;
+    </script>
+  </body>
+</html>

--- a/examples/frappe-pie.html
+++ b/examples/frappe-pie.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frappe Charts Pie - MAIDR Example</title>
+    <!-- Frappe Charts v1.6.2 - the adapter's CSS selectors are specific to this
+         version. If upgrading, verify SVG class names match. -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.umd.js"
+      integrity="sha384-JQa9VKO4+ZAEaRWDOmQM5LPHQTv8t9B4y8kBn36iar33TxUZByrYAa3o+PsU7hYk"
+      crossorigin="anonymous"
+    ></script>
+    <!-- MAIDR core + Frappe Charts adapter -->
+    <script src="../dist/maidr.js"></script>
+    <script src="../dist/frappe.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Frappe Charts Pie Chart with MAIDR</h1>
+      <p>
+        Click the chart and use the left and right arrow keys to move between
+        slices — a pie is a single row, so up and down are out of bounds. Each
+        slice announces its label, its value, and its share of the whole.
+      </p>
+      <p id="error" hidden>
+        Failed to load Frappe Charts from CDN. Please check your internet
+        connection.
+      </p>
+      <div id="chart"></div>
+      <h2>The same data as a donut</h2>
+      <p>
+        Frappe draws a donut with a different component (<code>donut-slices</code>
+        rather than <code>pie-slices</code>), so the adapter is told which of the
+        two was rendered — everything else about the two charts reads alike.
+      </p>
+      <div id="donut-chart"></div>
+    </main>
+
+    <script>
+      // Surface an error if Frappe Charts failed to load from CDN; otherwise
+      // build the charts and hand them to the MAIDR adapter.
+      const errorEl = document.getElementById('error');
+      if (typeof frappe === 'undefined') {
+        if (errorEl) {
+          errorEl.hidden = false;
+        }
+      } else {
+        const data = {
+          labels: ['Apples', 'Bananas', 'Cherries', 'Dates', 'Elderberries'],
+          datasets: [
+            {
+              name: 'Units sold',
+              values: [300, 500, 200, 120, 80],
+            },
+          ],
+        };
+
+        const pieChart = new frappe.Chart('#chart', {
+          title: 'Fruit Sales by Variety',
+          data: data,
+          type: 'pie',
+          height: 400,
+        });
+
+        const donutChart = new frappe.Chart('#donut-chart', {
+          title: 'Fruit Sales by Variety',
+          data: data,
+          type: 'donut',
+          height: 400,
+        });
+
+        // Frappe runs an entrance animation and re-creates the SVG nodes once it
+        // finishes. Wait until the chart DOM stops mutating before handing it to
+        // MAIDR, so MAIDR captures the final, stable elements for highlighting
+        // (otherwise highlights bind to nodes Frappe later replaces, and only
+        // start working after the chart is re-initialized).
+        activateMaidrWhenSettled(pieChart, document.querySelector('#chart'), {
+          chartType: 'pie',
+          title: 'Fruit Sales by Variety',
+          // A pie has no axes to take labels from; these name what each
+          // dimension holds. Drop them and the adapter falls back to "Label"
+          // and "Value".
+          axes: { x: 'Fruit', y: 'Units sold' },
+        });
+
+        activateMaidrWhenSettled(donutChart, document.querySelector('#donut-chart'), {
+          chartType: 'donut',
+          title: 'Fruit Sales by Variety (donut)',
+          axes: { x: 'Fruit', y: 'Units sold' },
+        });
+
+        function activateMaidrWhenSettled(chart, container, options) {
+          if (!container.querySelector('svg.frappe-chart')) {
+            requestAnimationFrame(() => activateMaidrWhenSettled(chart, container, options));
+            return;
+          }
+          let settleTimer;
+          const observer = new MutationObserver(scheduleSettle);
+          function scheduleSettle() {
+            clearTimeout(settleTimer);
+            settleTimer = setTimeout(finish, 300);
+          }
+          function finish() {
+            observer.disconnect();
+            const maidr = maidrFrappe.createMaidrFromFrappeChart(chart, container, options);
+            container.setAttribute('maidr', JSON.stringify(maidr));
+          }
+          observer.observe(container, { childList: true, subtree: true, attributes: true });
+          scheduleSettle();
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/examples/google-charts-pie.html
+++ b/examples/google-charts-pie.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Google Charts Pie Example</title>
+
+    <!-- 1. Load Google Charts -->
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+
+    <!--
+      2. Load MAIDR core and Google Charts adapter.
+         For bundled projects, import from 'maidr/google-charts' instead.
+    -->
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/google-charts.js"></script>
+
+    <script>
+      // Wait for Google Charts to load
+      google.charts.load('current', { packages: ['corechart'] });
+      google.charts.setOnLoadCallback(drawCharts);
+
+      function drawCharts() {
+        drawPieChart();
+        drawDoughnutChart();
+      }
+
+      // Helper: wire up a Google Charts chart with MAIDR.
+      function bindMaidr(chart, data, container, options) {
+        google.visualization.events.addListener(chart, 'ready', function () {
+          // Use the UMD global: maidrGoogleCharts
+          var maidr = maidrGoogleCharts.createMaidrFromGoogleChart(chart, data, container, options);
+          container.setAttribute('maidr', JSON.stringify(maidr));
+        });
+      }
+
+      // ---------------------------------------------------------------
+      // Pie Chart
+      // ---------------------------------------------------------------
+      function drawPieChart() {
+        var data = google.visualization.arrayToDataTable([
+          ['Task', 'Hours per Day'],
+          ['Work', 11],
+          ['Eat', 2],
+          ['Commute', 2],
+          ['Watch TV', 2],
+          ['Sleep', 7],
+        ]);
+
+        var container = document.getElementById('pie-chart');
+        var chart = new google.visualization.PieChart(container);
+
+        bindMaidr(chart, data, container, {
+          chartType: 'PieChart',
+          title: 'My Daily Activities',
+        });
+
+        // `is3D` is not supported: a 3-D pie draws several paths per slice,
+        // so the adapter cannot tell which path belongs to which slice and
+        // turns visual highlighting off (the audio, text, and braille still
+        // work). Leave it flat to keep the highlight.
+        chart.draw(data, {
+          title: 'My Daily Activities',
+          width: 600,
+          height: 400,
+        });
+      }
+
+      // ---------------------------------------------------------------
+      // Doughnut Chart — a PieChart drawn with a pieHole
+      // ---------------------------------------------------------------
+      function drawDoughnutChart() {
+        var data = google.visualization.arrayToDataTable([
+          ['Browser', 'Share'],
+          ['Chrome', 64],
+          ['Safari', 19],
+          ['Edge', 5],
+          ['Firefox', 3],
+          ['Other', 9],
+        ]);
+
+        var container = document.getElementById('doughnut-chart');
+        var chart = new google.visualization.PieChart(container);
+
+        // Google has no separate doughnut class, so the adapter chart type is
+        // 'PieChart' here too.
+        bindMaidr(chart, data, container, {
+          chartType: 'PieChart',
+          title: 'Browser Market Share',
+        });
+
+        chart.draw(data, {
+          title: 'Browser Market Share',
+          pieHole: 0.4,
+          width: 600,
+          height: 400,
+        });
+      }
+    </script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart-container { margin-bottom: 24px; }
+    </style>
+  </head>
+  <body>
+    <h1>MAIDR + Google Charts Pie Charts</h1>
+    <p>
+      Each chart below is rendered by Google Charts and then made accessible
+      via MAIDR. Click on a chart and use the left and right arrow keys to move
+      between slices; each one is announced with its label, its value, and its
+      share of the whole.
+    </p>
+
+    <h2>Pie Chart</h2>
+    <div id="pie-chart" class="chart-container"></div>
+
+    <h2>Doughnut Chart</h2>
+    <div id="doughnut-chart" class="chart-container"></div>
+  </body>
+</html>

--- a/examples/highcharts-pie.html
+++ b/examples/highcharts-pie.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Highcharts Pie Chart - MAIDR</title>
+    <script src="https://cdn.jsdelivr.net/npm/highcharts/highcharts.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/highcharts.js"></script>
+  </head>
+  <body>
+    <h1>Highcharts Pie Chart</h1>
+    <p>
+      A Highcharts pie chart made accessible by the MAIDR Highcharts adapter.
+      Click on the chart and use left and right arrow keys to navigate slices;
+      each one announces its label, its value and its share of the whole.
+    </p>
+
+    <div id="pie-chart" style="width: 700px; height: 500px"></div>
+
+    <script>
+      const chart = Highcharts.chart('pie-chart', {
+        chart: { type: 'pie' },
+        title: { text: 'Units Sold by Fruit' },
+        series: [{
+          name: 'Fruit sales',
+          data: [
+            { name: 'Apples', y: 30 },
+            { name: 'Bananas', y: 50 },
+            { name: 'Cherries', y: 20 },
+            { name: 'Dates', y: 15 },
+          ],
+        }],
+      });
+
+      const maidrData = maidrHighcharts.highchartsToMaidr(chart, { id: 'pie-chart' });
+      document.getElementById('pie-chart').setAttribute('maidr-data', JSON.stringify(maidrData));
+      maidrHighcharts.createHighchartsSync(chart);
+    </script>
+  </body>
+</html>

--- a/examples/pie.html
+++ b/examples/pie.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>maidr Example</title>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script>
+      var maidr = {
+  "id": "pie",
+  "title": "Fruit Sales by Variety",
+  "subplots": [
+    [
+      {
+        "layers": [
+          {
+            "id": "0",
+            "type": "pie",
+            "title": "Fruit Sales by Variety",
+            "selectors": "svg#pie path.slice",
+            "axes": {
+              "x": { "label": "Fruit" },
+              "y": { "label": "Units sold" }
+            },
+            "data": [
+              {
+                "x": "Apples",
+                "y": 30
+              },
+              {
+                "x": "Bananas",
+                "y": 45
+              },
+              {
+                "x": "Cherries",
+                "y": 25
+              },
+              {
+                "x": "Dates",
+                "y": 20
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  ]
+}
+    </script>
+  </head>
+
+  <body>
+    <!--
+      Hand-drawn rather than exported from a plotting library: the slices are
+      the only geometry the pie trace addresses, and a four-wedge circle is
+      small enough to write out exactly. The 120-unit total is deliberately not
+      100, so the announced percentages can only come from the model deriving
+      them — an example that added up to 100 would pass even if the values were
+      being reported as percentages unchanged.
+
+      Wedges are drawn clockwise from twelve o'clock, one `path.slice` each, in
+      the same order as the `data` array above: the selector has to resolve to
+      exactly four elements in slice order for highlighting to land on the
+      slice being announced.
+    -->
+    <svg
+      id="pie"
+      width="600pt"
+      height="400pt"
+      viewBox="0 0 600 400"
+      xmlns="http://www.w3.org/2000/svg"
+      version="1.1"
+    >
+      <rect x="0" y="0" width="600" height="400" style="fill: #ffffff" />
+      <g id="slices">
+        <!-- Apples: 30 of 120, 90 degrees -->
+        <path
+          class="slice"
+          d="M 300 200
+          L 300 60
+          A 140 140 0 0 1 440 200
+          z
+          "
+          style="fill: #4e79a7"
+        />
+        <!-- Bananas: 45 of 120, 135 degrees -->
+        <path
+          class="slice"
+          d="M 300 200
+          L 440 200
+          A 140 140 0 0 1 201.005 298.995
+          z
+          "
+          style="fill: #f28e2b"
+        />
+        <!-- Cherries: 25 of 120, 75 degrees -->
+        <path
+          class="slice"
+          d="M 300 200
+          L 201.005 298.995
+          A 140 140 0 0 1 178.756 130
+          z
+          "
+          style="fill: #e15759"
+        />
+        <!-- Dates: 20 of 120, 60 degrees -->
+        <path
+          class="slice"
+          d="M 300 200
+          L 178.756 130
+          A 140 140 0 0 1 300 60
+          z
+          "
+          style="fill: #76b7b2"
+        />
+      </g>
+      <g id="slice_labels" style="font-family: sans-serif; font-size: 14px; fill: #ffffff">
+        <text x="359.4" y="140.6" text-anchor="middle">Apples</text>
+        <text x="332.1" y="277.6" text-anchor="middle">Bananas</text>
+        <text x="216.7" y="211" text-anchor="middle">Cherries</text>
+        <text x="258" y="127.2" text-anchor="middle">Dates</text>
+      </g>
+      <g id="title">
+        <text
+          x="300"
+          y="32"
+          text-anchor="middle"
+          style="font-family: sans-serif; font-size: 17px; fill: #000000"
+        >
+          Fruit Sales by Variety
+        </text>
+      </g>
+    </svg>
+  </body>
+</html>

--- a/examples/plotly-pie.html
+++ b/examples/plotly-pie.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Pie Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Pie Chart</h1>
+    <p>
+      A plotly.js pie chart auto-detected by MAIDR.
+      Click on the chart and use left and right arrow keys to navigate slices;
+      each one announces its label, its value and its share of the whole.
+    </p>
+
+    <div id="pie-chart" style="width: 700px; height: 500px"></div>
+
+    <script>
+      var data = [{
+        labels: ['Apples', 'Bananas', 'Cherries', 'Dates'],
+        values: [30, 50, 20, 15],
+        type: 'pie',
+        name: 'Fruit sales'
+      }];
+
+      var layout = {
+        title: { text: 'Units Sold by Fruit' }
+      };
+
+      Plotly.newPlot('pie-chart', data, layout);
+    </script>
+  </body>
+</html>

--- a/examples/vegalite-pie.html
+++ b/examples/vegalite-pie.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Vega-Lite Pie Chart Example</title>
+    <!-- Vega-Lite and its dependencies -->
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+    <!-- MAIDR Vega-Lite adapter (bundles MAIDR core) -->
+    <script src="../dist/vegalite.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Vega-Lite Pie Chart</h1>
+    <p>
+      Click on the chart and use left and right arrow keys to navigate slices;
+      each one announces its label, its value and its share of the whole.
+      Press 'b' for braille, 't' for text descriptions.
+    </p>
+    <div
+      id="pie-chart"
+      aria-label="Pie chart loading"
+      style="min-height: 400px"
+    ></div>
+
+    <script>
+      // Pie: `arc` mark with the magnitudes on `theta` and the slice labels
+      // on `color`. Adding `innerRadius` to the mark makes it a doughnut,
+      // which the MAIDR binder reads identically. Both map to PIE.
+      const spec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        width: 400,
+        height: 400,
+        title: 'Units Sold by Fruit',
+        data: {
+          values: [
+            { fruit: 'Apples', units: 30 },
+            { fruit: 'Bananas', units: 50 },
+            { fruit: 'Cherries', units: 20 },
+            { fruit: 'Dates', units: 15 },
+          ],
+        },
+        mark: 'arc',
+        encoding: {
+          theta: { field: 'units', type: 'quantitative', title: 'Units' },
+          color: { field: 'fruit', type: 'nominal', title: 'Fruit' },
+        },
+      };
+
+      // === MAIDR Integration ===
+      // maidrVegaLite.embed() runs vegaEmbed() internally and mounts the
+      // accessible MAIDR UI on the rendered SVG once it's ready.
+      maidrVegaLite
+        .embed('#pie-chart', spec, { id: 'fruit-pie' })
+        .catch((err) => console.error('[vegalite-pie]', err));
+    </script>
+  </body>
+</html>

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -53,16 +53,16 @@ const PAGE_DESCRIPTIONS = {
   'home': 'MAIDR provides accessible, non-visual access to statistical charts through audio sonification, text descriptions, braille output, and AI-powered descriptions.',
   'react': 'How to integrate MAIDR accessible data visualizations into React applications with TypeScript support.',
   'recharts': 'How to integrate MAIDR accessibility features with Recharts React components for accessible data visualizations.',
-  'plotly': 'How to make Plotly.js charts accessible with MAIDR — zero configuration auto-detection for bar, scatter, line, box, violin, heatmap, histogram, and candlestick charts.',
-  'google-charts': 'How to make Google Charts accessible with MAIDR — support for bar, line, scatter, candlestick, stacked, and dodged charts.',
-  'd3': 'How to make D3.js charts accessible with MAIDR — binders for bar, line, scatter, box, heatmap, histogram, candlestick, segmented, and smooth charts plus a React wrapper.',
-  'vegalite': 'How to make Vega-Lite charts accessible with MAIDR — support for bar, stacked, dodged, normalized, histogram, line, scatter, heatmap, and box plot specs.',
-  'chartjs': 'How to make Chart.js charts accessible with MAIDR — support for bar, line, scatter, stacked, dodged, box plot, candlestick, and heatmap (matrix) chart types.',
-  'amcharts': 'How to make amCharts 5 charts accessible with MAIDR — support for bar, dodged, stacked, normalized, line, histogram, and heatmap chart types.',
-  'frappe': 'How to make Frappe Charts accessible with MAIDR — support for bar, line, multi-line, scatter, and mixed axis (bar + line) chart types.',
-  'victory': 'How to make Victory charts accessible with MAIDR — support for bar, line, scatter, stacked, histogram, box plot, and candlestick chart types.',
-  'anychart': 'How to make AnyChart charts accessible with MAIDR — support for bar, line, step, scatter, box, heatmap, and candlestick chart types via a one-line binder.',
-  'highcharts': 'How to make Highcharts charts accessible with MAIDR — support for bar, line, scatter, box, heatmap, histogram, candlestick, stacked, dodged, and normalized chart types.',
+  'plotly': 'How to make Plotly.js charts accessible with MAIDR — zero configuration auto-detection for bar, scatter, line, box, violin, heatmap, histogram, candlestick, and pie charts.',
+  'google-charts': 'How to make Google Charts accessible with MAIDR — support for bar, line, scatter, candlestick, stacked, dodged, and pie charts.',
+  'd3': 'How to make D3.js charts accessible with MAIDR — binders for bar, line, scatter, box, heatmap, histogram, candlestick, segmented, smooth, and pie charts plus a React wrapper.',
+  'vegalite': 'How to make Vega-Lite charts accessible with MAIDR — support for bar, stacked, dodged, normalized, histogram, line, scatter, heatmap, box plot, and arc (pie) specs.',
+  'chartjs': 'How to make Chart.js charts accessible with MAIDR — support for bar, line, scatter, stacked, dodged, box plot, candlestick, heatmap (matrix), and pie / doughnut chart types.',
+  'amcharts': 'How to make amCharts 5 charts accessible with MAIDR — support for bar, dodged, stacked, normalized, line, histogram, heatmap, and pie chart types.',
+  'frappe': 'How to make Frappe Charts accessible with MAIDR — support for bar, line, multi-line, scatter, mixed axis (bar + line), pie, and donut chart types.',
+  'victory': 'How to make Victory charts accessible with MAIDR — support for bar, line, scatter, stacked, histogram, box plot, candlestick, and pie chart types.',
+  'anychart': 'How to make AnyChart charts accessible with MAIDR — support for bar, line, step, scatter, box, heatmap, candlestick, and pie chart types via a one-line binder.',
+  'highcharts': 'How to make Highcharts charts accessible with MAIDR — support for bar, line, scatter, box, heatmap, histogram, candlestick, stacked, dodged, normalized, and pie chart types.',
   'examples': 'Interactive examples of accessible bar plots, line charts, heatmaps, scatter plots, box plots, and more using MAIDR.',
   'Data Schema': 'MAIDR data schema specification for defining accessible chart data structures.',
   'Braille Generation': 'Documentation for MAIDR braille output generation for tactile data exploration.',
@@ -401,6 +401,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('plotly-candlestick.html', 'Plotly Candlestick'); return false;">Candlestick</a></li>
     <li><a href="#" onclick="loadHTML('plotly-grouped-bar.html', 'Plotly Grouped Bar'); return false;">Grouped Bar</a></li>
     <li><a href="#" onclick="loadHTML('plotly-stacked-bar.html', 'Plotly Stacked Bar'); return false;">Stacked Bar</a></li>
+    <li><a href="#" onclick="loadHTML('plotly-pie.html', 'Plotly Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="plotly.html">Plotly.js Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 
@@ -413,6 +414,7 @@ const examplesContent = `
   <h3>Google Charts</h3>
   <ul>
     <li><a href="#" onclick="loadGoogleCharts(); return false;">Google Charts Examples (Bar, Line, Scatter, Stacked, Dodged, Candlestick)</a></li>
+    <li><a href="#" onclick="loadHTML('google-charts-pie.html', 'Google Charts Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="google-charts.html">Google Charts Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 
@@ -426,6 +428,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('chartjs/boxplot.html', 'Chart.js Box Plot'); return false;">Box Plot</a></li>
     <li><a href="#" onclick="loadHTML('chartjs/candlestick.html', 'Chart.js Candlestick'); return false;">Candlestick</a></li>
     <li><a href="#" onclick="loadHTML('chartjs/heatmap.html', 'Chart.js Heatmap'); return false;">Heatmap (Matrix)</a></li>
+    <li><a href="#" onclick="loadHTML('chartjs/pie.html', 'Chart.js Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="chartjs.html">Chart.js Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 
@@ -436,6 +439,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('frappe-multiline.html', 'Frappe Multi-Line Chart'); return false;">Multi-Line Chart</a></li>
     <li><a href="#" onclick="loadHTML('frappe-scatter.html', 'Frappe Scatter Plot'); return false;">Scatter Plot</a></li>
     <li><a href="#" onclick="loadHTML('frappe-mixed.html', 'Frappe Mixed Axis Chart'); return false;">Mixed Axis (Bar + Line)</a></li>
+    <li><a href="#" onclick="loadHTML('frappe-pie.html', 'Frappe Pie Chart'); return false;">Pie / Donut</a></li>
   </ul>
   <p>See the <a href="frappe.html">Frappe Charts Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 
@@ -451,6 +455,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('d3-bindstacked.html', 'D3 Stacked Bar'); return false;">Stacked Bar</a></li>
     <li><a href="#" onclick="loadHTML('d3-binddodged.html', 'D3 Dodged Bar'); return false;">Dodged Bar</a></li>
     <li><a href="#" onclick="loadHTML('d3-bindsmooth.html', 'D3 Smooth Curve'); return false;">Smooth Curve</a></li>
+    <li><a href="#" onclick="loadHTML('d3-bindpie.html', 'D3 Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="d3.html">D3.js Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.</p>
 
@@ -465,12 +470,14 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('vegalite-bindscatter.html', 'Vega-Lite Scatter Plot'); return false;">Scatter Plot</a></li>
     <li><a href="#" onclick="loadHTML('vegalite-bindheatmap.html', 'Vega-Lite Heatmap'); return false;">Heatmap</a></li>
     <li><a href="#" onclick="loadHTML('vegalite-bindbox.html', 'Vega-Lite Box Plot'); return false;">Box Plot</a></li>
+    <li><a href="#" onclick="loadHTML('vegalite-pie.html', 'Vega-Lite Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="vegalite.html">Vega-Lite Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 
   <h3>amCharts 5</h3>
   <ul>
     <li><a href="#" onclick="loadHTML('amcharts.html', 'amCharts 5 Examples'); return false;">amCharts 5 Examples (Bar, Dodged, Stacked, Normalized, Line, Histogram, Heatmap)</a></li>
+    <li><a href="#" onclick="loadHTML('amcharts-pie.html', 'amCharts 5 Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="amcharts.html">amCharts 5 Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 
@@ -488,6 +495,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('anychart/box.html', 'AnyChart Box Plot'); return false;">Box Plot</a></li>
     <li><a href="#" onclick="loadHTML('anychart/heatmap.html', 'AnyChart Heatmap'); return false;">Heatmap</a></li>
     <li><a href="#" onclick="loadHTML('anychart/candlestick.html', 'AnyChart Candlestick'); return false;">Candlestick</a></li>
+    <li><a href="#" onclick="loadHTML('anychart/pie.html', 'AnyChart Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="anychart.html">AnyChart Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 
@@ -503,6 +511,7 @@ const examplesContent = `
     <li><a href="#" onclick="loadHTML('highcharts-stacked.html', 'Highcharts Stacked Bar'); return false;">Stacked Bar</a></li>
     <li><a href="#" onclick="loadHTML('highcharts-dodged.html', 'Highcharts Dodged Bar'); return false;">Dodged Bar</a></li>
     <li><a href="#" onclick="loadHTML('highcharts-normalized.html', 'Highcharts Normalized Bar'); return false;">Normalized Bar</a></li>
+    <li><a href="#" onclick="loadHTML('highcharts-pie.html', 'Highcharts Pie Chart'); return false;">Pie Chart</a></li>
   </ul>
   <p>See the <a href="highcharts.html">Highcharts Integration Guide</a> for setup instructions and code examples for all chart types.</p>
 

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -3,10 +3,10 @@
  *
  * Supports single charts and multi-panel roots: every `XYChart` found in the
  * root's container tree (including am5stock `StockPanel`s, which extend
- * `XYChart`) becomes one MAIDR subplot, arranged in a grid mirroring the
- * on-screen layout with rows emitted bottom-first (see
- * {@link computeChartGrid}) so the core's UPWARD = row+1 mapping moves
- * visually up.
+ * `XYChart`) and every am5percent `PieChart` becomes one MAIDR subplot,
+ * arranged in a grid mirroring the on-screen layout with rows emitted
+ * bottom-first (see {@link computeChartGrid}) so the core's UPWARD = row+1
+ * mapping moves visually up.
  *
  * @example
  * ```ts
@@ -30,12 +30,13 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   SegmentedPoint,
 } from '@type/grammar';
 import type {
+  AmChart,
   AmChartsBinderOptions,
   AmRoot,
-  AmXYChart,
   AmXYSeries,
 } from './types';
 import { Orientation, TraceType } from '@type/grammar';
@@ -45,6 +46,7 @@ import {
   extractHeatmapData,
   extractHistogramPoints,
   extractLinePoints,
+  extractPiePoints,
   extractSegmentedPoints,
   readAxisLabel,
 } from './extractor';
@@ -63,7 +65,7 @@ import {
  * it. One entry per emitted subplot, in row-major grid order.
  */
 export interface AmChartPanel {
-  chart: AmXYChart;
+  chart: AmChart;
   layers: MaidrLayer[];
 }
 
@@ -81,8 +83,8 @@ export interface AmChartsConversion {
  * Convert an amCharts 5 {@link AmRoot} into a MAIDR data object.
  *
  * The function walks the root's container tree, collects every XY chart
- * (including am5stock `StockPanel`s), and converts each one into a MAIDR
- * subplot. A single chart produces a 1x1 grid; multiple charts are arranged
+ * (including am5stock `StockPanel`s) and every pie chart, and converts each
+ * one into a MAIDR subplot. A single chart produces a 1x1 grid; multiple charts are arranged
  * in a grid mirroring their on-screen layout, rows ordered bottom-first so
  * that pressing Up moves to the visually upper panel.
  *
@@ -94,10 +96,10 @@ export interface AmChartsConversion {
  *         contains a supported series with data.
  */
 export function fromAmCharts(root: AmRoot, options?: AmChartsBinderOptions): Maidr {
-  const charts = findXYCharts(root);
+  const charts = findCharts(root);
   if (charts.length === 0) {
     throw new Error(
-      'maidr amCharts binder: no XYChart found in root.container. '
+      'maidr amCharts binder: no XYChart or PieChart found in root.container. '
       + 'Ensure the chart is fully initialized before calling fromAmCharts().',
     );
   }
@@ -106,7 +108,7 @@ export function fromAmCharts(root: AmRoot, options?: AmChartsBinderOptions): Mai
 }
 
 /**
- * Convert an amCharts 5 {@link AmXYChart} directly into a MAIDR data object.
+ * Convert an amCharts 5 {@link AmChart} directly into a MAIDR data object.
  *
  * Use this when you already hold a reference to the chart object.
  *
@@ -115,7 +117,7 @@ export function fromAmCharts(root: AmRoot, options?: AmChartsBinderOptions): Mai
  * @param options      Optional overrides.
  */
 export function fromXYChart(
-  chart: AmXYChart,
+  chart: AmChart,
   containerEl: HTMLElement,
   options?: AmChartsBinderOptions,
 ): Maidr {
@@ -123,7 +125,7 @@ export function fromXYChart(
 }
 
 /**
- * Convert several amCharts 5 {@link AmXYChart}s (all sharing one root/DOM
+ * Convert several amCharts 5 {@link AmChart}s (all sharing one root/DOM
  * element) into a single multi-panel MAIDR data object — one subplot per
  * chart, arranged in a grid mirroring the rendered layout.
  *
@@ -132,7 +134,7 @@ export function fromXYChart(
  * @param options      Optional overrides (applied figure-wide).
  */
 export function fromXYCharts(
-  charts: AmXYChart[],
+  charts: AmChart[],
   containerEl: HTMLElement,
   options?: AmChartsBinderOptions,
 ): Maidr {
@@ -153,7 +155,7 @@ export function fromXYCharts(
  * @throws If no chart contains a supported series with data.
  */
 export function convertCharts(
-  charts: AmXYChart[],
+  charts: AmChart[],
   containerEl: HTMLElement,
   options?: AmChartsBinderOptions,
 ): AmChartsConversion {
@@ -223,12 +225,14 @@ export function convertCharts(
  * first x/y axis; `options.axisLabels` acts as a figure-wide override.
  */
 function buildChartLayers(
-  chart: AmXYChart,
+  chart: AmChart,
   containerEl: HTMLElement,
   options?: AmChartsBinderOptions,
 ): MaidrLayer[] {
-  const xLabel = options?.axisLabels?.x ?? readAxisLabel(chart.xAxes.values[0], 'x');
-  const yLabel = options?.axisLabels?.y ?? readAxisLabel(chart.yAxes.values[0], 'y');
+  // A pie chart is bound to no axis, so both reads find nothing and fall back;
+  // the pie layer names its own dimensions rather than using these.
+  const xLabel = options?.axisLabels?.x ?? readAxisLabel(chart.xAxes?.values[0], 'x');
+  const yLabel = options?.axisLabels?.y ?? readAxisLabel(chart.yAxes?.values[0], 'y');
 
   const layers: MaidrLayer[] = [];
   // Line and step series each merge into one layer of their own type. The
@@ -268,6 +272,13 @@ function buildChartLayers(
         if (points.length === 0)
           break;
         collectSeries(kind === 'step' ? stepSeries : lineSeries, series, points, containerEl);
+        break;
+      }
+      case 'pie': {
+        const data = extractPiePoints(series);
+        if (data.length === 0)
+          break;
+        layers.push(buildPieLayer(series, data, options));
         break;
       }
       default:
@@ -398,6 +409,39 @@ function buildHistogramLayer(
   };
 }
 
+/**
+ * What a pie's two dimensions are called. A pie series is bound to no axis, so
+ * the chart-level `readAxisLabel` fallback would name them `x` and `y` — after
+ * coordinates a pie does not have. These name what each one actually holds.
+ */
+const PIE_LABEL_AXIS = 'Label';
+const PIE_VALUE_AXIS = 'Value';
+
+/**
+ * Builds the layer for one pie series. A `PieChart` normally holds exactly
+ * one, but amCharts allows several (concentric rings), and each becomes its
+ * own layer — navigable with PageUp / PageDown like any other stack of layers.
+ *
+ * No `selectors` are emitted: amCharts renders to canvas, so there is no SVG
+ * wedge to address. The binder's overlay highlights the active slice instead.
+ */
+function buildPieLayer(
+  series: AmXYSeries,
+  data: PiePoint[],
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  return {
+    id: layerId(series),
+    type: TraceType.PIE,
+    title: seriesName(series),
+    axes: {
+      x: { label: options?.axisLabels?.x ?? PIE_LABEL_AXIS },
+      y: { label: options?.axisLabels?.y ?? PIE_VALUE_AXIS },
+    },
+    data,
+  };
+}
+
 function buildHeatmapLayer(
   data: HeatmapData,
   xLabel: string,
@@ -489,7 +533,7 @@ function noSupportedDataError(): Error {
 }
 
 /**
- * Collect every XY chart in the root's container tree, in depth-first
+ * Collect every convertible chart in the root's container tree, in depth-first
  * (insertion) order.
  *
  * Recursion reaches charts nested inside intermediate containers — notably
@@ -501,24 +545,35 @@ function noSupportedDataError(): Error {
  * toolsContainer, the standard am5stock pattern). Found charts are also not
  * descended into, so an in-chart scrollbar preview is never visited either.
  */
-export function findXYCharts(root: AmRoot): AmXYChart[] {
-  const found: AmXYChart[] = [];
-  collectXYCharts(root.container, found);
+export function findCharts(root: AmRoot): AmChart[] {
+  const found: AmChart[] = [];
+  collectCharts(root.container, found);
   return found;
 }
 
-function collectXYCharts(node: unknown, found: AmXYChart[]): void {
+/**
+ * Collect only the XY charts in the root's container tree.
+ *
+ * The narrower counterpart of {@link findCharts}, kept because it is part of
+ * the adapter's public API and because "every XY chart" is still a question
+ * worth asking of a mixed root.
+ */
+export function findXYCharts(root: AmRoot): AmChart[] {
+  return findCharts(root).filter(isXYChartLike);
+}
+
+function collectCharts(node: unknown, found: AmChart[]): void {
   for (const child of childValues(node)) {
     const cls = (child as { className?: string } | null)?.className;
     if (cls === 'XYChartScrollbar') {
       // Never a panel; its child preview XYChart must not be found either.
       continue;
     }
-    if (isXYChartLike(child)) {
+    if (isXYChartLike(child) || isPieChartLike(child)) {
       found.push(child);
       continue;
     }
-    collectXYCharts(child, found);
+    collectCharts(child, found);
   }
 }
 
@@ -532,11 +587,25 @@ function childValues(node: unknown): unknown[] {
 }
 
 /** Duck-type check: an XYChart has series, xAxes, and yAxes. */
-function isXYChartLike(candidate: unknown): candidate is AmXYChart {
+function isXYChartLike(candidate: unknown): candidate is AmChart {
   if (candidate == null || typeof candidate !== 'object')
     return false;
-  const c = candidate as Partial<AmXYChart>;
+  const c = candidate as Partial<AmChart>;
   return Boolean(c.series && c.xAxes && c.yAxes);
+}
+
+/**
+ * Duck-type check for an am5percent `PieChart`.
+ *
+ * A pie chart has a series list but no axes, which on its own is too weak a
+ * signature — plenty of am5 containers carry a `series` property of some kind.
+ * The class name is what makes it specific, and am5 sets it on every entity.
+ */
+function isPieChartLike(candidate: unknown): candidate is AmChart {
+  if (candidate == null || typeof candidate !== 'object')
+    return false;
+  const c = candidate as Partial<AmChart>;
+  return c.className === 'PieChart' && Boolean(c.series);
 }
 
 /**
@@ -561,7 +630,7 @@ function detectStackMode(barSeriesList: AmXYSeries[]): 'none' | 'normal' | '100%
   return anyStacked ? 'normal' : 'none';
 }
 
-function readChartTitle(chart: AmXYChart): string | undefined {
+function readChartTitle(chart: AmChart): string | undefined {
   // amCharts 5 titles are typically children of the chart.
   // A title entity has className "Label" or "Title" and a text property.
   if (!('children' in chart))

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -26,15 +26,15 @@ import type { JSX } from 'react';
 import type { Root as ReactRoot } from 'react-dom/client';
 import type { NavMap } from './navmap';
 import type {
+  AmChart,
   AmChartsBinderOptions,
   AmRoot,
-  AmXYChart,
   AmXYSeries,
 } from './types';
 import { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
-import { convertCharts, findXYCharts } from './adapter';
+import { convertCharts, findCharts } from './adapter';
 import { classifySeriesKind } from './extractor';
 import { readPlotBounds } from './geometry';
 import { getHighlightColor } from './highlightColor';
@@ -172,18 +172,20 @@ function createHighlightCallback(
 // Series grouping (mirrors fromXYChart in adapter.ts)
 // ---------------------------------------------------------------------------
 
-function groupSeries(chart: AmXYChart): {
+function groupSeries(chart: AmChart): {
   barSeriesList: AmXYSeries[];
   lineSeriesList: AmXYSeries[];
   stepSeriesList: AmXYSeries[];
   histogramSeries: AmXYSeries[];
   heatmapSeries: AmXYSeries[];
+  pieSeriesList: AmXYSeries[];
 } {
   const barSeriesList: AmXYSeries[] = [];
   const lineSeriesList: AmXYSeries[] = [];
   const stepSeriesList: AmXYSeries[] = [];
   const histogramSeries: AmXYSeries[] = [];
   const heatmapSeries: AmXYSeries[] = [];
+  const pieSeriesList: AmXYSeries[] = [];
 
   for (const series of chart.series.values) {
     switch (classifySeriesKind(series)) {
@@ -202,12 +204,22 @@ function groupSeries(chart: AmXYChart): {
       case 'heatmap':
         heatmapSeries.push(series);
         break;
+      case 'pie':
+        pieSeriesList.push(series);
+        break;
       default:
         break;
     }
   }
 
-  return { barSeriesList, lineSeriesList, stepSeriesList, histogramSeries, heatmapSeries };
+  return {
+    barSeriesList,
+    lineSeriesList,
+    stepSeriesList,
+    histogramSeries,
+    heatmapSeries,
+    pieSeriesList,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -269,17 +281,17 @@ function renderMaidr(maidrData: MaidrData, rootDom: HTMLElement): RenderResult |
 /**
  * Bind MAIDR to an amCharts 5 {@link AmRoot}, mounting the accessible UI and
  * (by default) a canvas highlight overlay. Finds every XYChart in the root's
- * container tree (including am5stock StockPanels); each chart becomes one
- * MAIDR subplot, navigable with the arrow keys.
+ * container tree (including am5stock StockPanels) and every PieChart; each
+ * chart becomes one MAIDR subplot, navigable with the arrow keys.
  *
- * @throws If no supported XYChart is found in `root.container`, or if no
- *         chart contains a supported series with data.
+ * @throws If no supported chart is found in `root.container`, or if no chart
+ *         contains a supported series with data.
  */
 export function bindAmCharts(root: AmRoot, options?: AmChartsBindOptions): AmChartsBinding {
-  const charts = findXYCharts(root);
+  const charts = findCharts(root);
   if (charts.length === 0) {
     throw new Error(
-      'maidr amCharts binder: no XYChart found in root.container. '
+      'maidr amCharts binder: no XYChart or PieChart found in root.container. '
       + 'Ensure the chart is fully initialized before calling bindAmCharts().',
     );
   }
@@ -287,11 +299,11 @@ export function bindAmCharts(root: AmRoot, options?: AmChartsBindOptions): AmCha
 }
 
 /**
- * Bind MAIDR to a known amCharts 5 {@link AmXYChart}. Use when you already hold
+ * Bind MAIDR to a known amCharts 5 {@link AmChart}. Use when you already hold
  * the chart reference. `root` is required for its DOM element and render events.
  */
 export function bindXYChart(
-  chart: AmXYChart,
+  chart: AmChart,
   root: AmRoot,
   options?: AmChartsBindOptions,
 ): AmChartsBinding {
@@ -306,7 +318,7 @@ export function bindXYChart(
  * bounds via the navigation map's owning-chart record.
  */
 function bindCharts(
-  charts: AmXYChart[],
+  charts: AmChart[],
   root: AmRoot,
   options?: AmChartsBindOptions,
 ): AmChartsBinding {

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -8,6 +8,7 @@ import type {
   HeatmapData,
   HistogramPoint,
   LinePoint,
+  PiePoint,
   SegmentedPoint,
 } from '@type/grammar';
 import type { AmAxis, AmDataItem, AmXYSeries } from './types';
@@ -263,6 +264,43 @@ export function extractLinePoints(series: AmXYSeries): LinePoint[] {
 }
 
 // ---------------------------------------------------------------------------
+// Pie extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract {@link PiePoint} data from an am5percent pie series.
+ *
+ * A pie series is bound to no axis: each data item carries the slice's
+ * `category` and its `value`, and the wedges are drawn in data-item order.
+ * Items with no category or no finite value are skipped — a slice with
+ * nothing to sonify would still take a navigation step and shift every later
+ * slice away from the wedge it names.
+ *
+ * The share each slice represents is deliberately not computed here. MAIDR's
+ * pie trace derives it from the values, so a percentage cannot drift out of
+ * step with the numbers it was supposedly derived from.
+ */
+export function extractPiePoints(series: AmXYSeries): PiePoint[] {
+  const points: PiePoint[] = [];
+
+  for (const item of series.dataItems) {
+    const category = item.get('category');
+    const value = item.get('value');
+
+    if (category == null || value == null)
+      continue;
+
+    const numValue = toNumber(value);
+    if (numValue == null)
+      continue;
+
+    points.push({ x: toStringOrNumber(category), y: numValue });
+  }
+
+  return points;
+}
+
+// ---------------------------------------------------------------------------
 // Series type detection
 // ---------------------------------------------------------------------------
 
@@ -288,7 +326,17 @@ const STEP_CLASSES = new Set([
   'StepLineSeries',
 ]);
 
-export type SeriesKind = 'bar' | 'line' | 'step' | 'histogram' | 'heatmap' | 'unknown';
+/**
+ * Series drawn as wedges of a circle by an am5percent `PieChart`. They must be
+ * recognised explicitly: {@link classifySeriesKind} answers `'bar'` for
+ * anything it does not know, so an unlisted pie series would be silently
+ * converted into a bar chart of its slices rather than failing loudly.
+ */
+const PIE_CLASSES = new Set([
+  'PieSeries',
+]);
+
+export type SeriesKind = 'bar' | 'line' | 'step' | 'histogram' | 'heatmap' | 'pie' | 'unknown';
 
 /**
  * Determine the MAIDR trace kind for a given amCharts series.
@@ -317,6 +365,10 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
 
   if (STEP_CLASSES.has(className)) {
     return 'step';
+  }
+
+  if (PIE_CLASSES.has(className)) {
+    return 'pie';
   }
 
   // Default to bar for category-based series.

--- a/src/adapters/amcharts/geometry.ts
+++ b/src/adapters/amcharts/geometry.ts
@@ -8,7 +8,7 @@
  * mirrors their on-screen arrangement (vertical/horizontal/Grid layouts).
  */
 
-import type { AmBounds, AmXYChart } from './types';
+import type { AmBounds, AmChart } from './types';
 
 /**
  * Read the plot-area bounds (CSS px, root-relative) used to clip highlights.
@@ -16,7 +16,7 @@ import type { AmBounds, AmXYChart } from './types';
  * `null` if neither is available (the overlay's `overflow:hidden` still clips
  * to the chart box).
  */
-export function readPlotBounds(chart: AmXYChart): AmBounds | null {
+export function readPlotBounds(chart: AmChart): AmBounds | null {
   const pc = chart.plotContainer;
   if (!pc) {
     return null;
@@ -38,7 +38,7 @@ export function readPlotBounds(chart: AmXYChart): AmBounds | null {
 
 /** A chart paired with the normalized geometry used for grid clustering. */
 interface ChartCell {
-  chart: AmXYChart;
+  chart: AmChart;
   top: number;
   left: number;
   height: number;
@@ -63,7 +63,7 @@ interface ChartCell {
  * Falls back to a single row in insertion order when any chart's geometry is
  * unavailable (e.g. before layout, on the JSON `fromAmCharts` path).
  */
-export function computeChartGrid(charts: AmXYChart[]): AmXYChart[][] {
+export function computeChartGrid(charts: AmChart[]): AmChart[][] {
   if (charts.length <= 1) {
     return [charts];
   }

--- a/src/adapters/amcharts/index.ts
+++ b/src/adapters/amcharts/index.ts
@@ -22,9 +22,10 @@
  *    visual highlighting (the highlight callback cannot survive JSON).
  *
  * Multi-panel roots are supported by both paths: every `XYChart` in the
- * root's container tree (including am5stock `StockPanel`s) becomes one MAIDR
- * subplot, arranged in a grid matching the rendered layout. Arrow keys move
- * between panels; Enter drills into a panel and Escape returns.
+ * root's container tree (including am5stock `StockPanel`s) and every
+ * `PieChart` becomes one MAIDR subplot, arranged in a grid matching the
+ * rendered layout. Arrow keys move between panels; Enter drills into a panel
+ * and Escape returns.
  *
  * @example
  * ```ts
@@ -39,7 +40,7 @@
  * @packageDocumentation
  */
 
-export { findXYCharts, fromAmCharts, fromXYChart, fromXYCharts } from './adapter';
+export { findCharts, findXYCharts, fromAmCharts, fromXYChart, fromXYCharts } from './adapter';
 export { bindAmCharts, bindXYChart } from './binder';
 export type { AmChartsBinding, AmChartsBindOptions } from './binder';
-export type { AmChartsBinderOptions, AmRoot, AmXYChart, AmXYSeries } from './types';
+export type { AmChart, AmChartsBinderOptions, AmRoot, AmXYChart, AmXYSeries } from './types';

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -10,17 +10,18 @@
  */
 
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
-import type { AmDataItem, AmXYChart, AmXYSeries } from './types';
+import type { AmChart, AmDataItem, AmXYSeries } from './types';
 import { TraceType } from '@type/grammar';
 
 /**
  * The am5 entities to highlight for a navigation position.
- * `kind` tells the overlay whether to read column-box geometry or a point.
+ * `kind` tells the overlay which geometry to read: a column's box, a line
+ * point, or a pie slice's wedge.
  */
 export interface NavTarget {
   series: AmXYSeries;
   dataItem: AmDataItem;
-  kind: 'column' | 'point';
+  kind: 'column' | 'point' | 'slice';
 }
 
 /**
@@ -33,7 +34,7 @@ export interface NavMap {
    * panel's plot bounds. Layer ids are unique figure-wide, so the id alone
    * disambiguates the panel.
    */
-  chartFor: (layerId: string) => AmXYChart | undefined;
+  chartFor: (layerId: string) => AmChart | undefined;
   /** Number of distinct charts (panels) in the map. */
   chartCount: number;
 }
@@ -46,7 +47,7 @@ export interface NavMap {
 export interface NavMapEntry {
   layers: MaidrLayer[];
   groups: SeriesGroups;
-  chart: AmXYChart;
+  chart: AmChart;
 }
 
 /**
@@ -64,6 +65,8 @@ export interface SeriesGroups {
   histogramSeries: AmXYSeries[];
   /** One HEATMAP layer each, in series order. */
   heatmapSeries: AmXYSeries[];
+  /** One PIE layer each, in series order. */
+  pieSeriesList: AmXYSeries[];
 }
 
 type Resolver = (row: number, col: number) => NavTarget[];
@@ -127,6 +130,21 @@ function filterLineItems(series: AmXYSeries): AmDataItem[] {
   return kept;
 }
 
+/** Mirror `extractPiePoints`: keep items with a category and a finite value. */
+function filterPieItems(series: AmXYSeries): AmDataItem[] {
+  const kept: AmDataItem[] = [];
+  for (const item of series.dataItems) {
+    const category = item.get('category');
+    const value = item.get('value');
+    if (category == null || value == null)
+      continue;
+    if (!Number.isFinite(Number(value)))
+      continue;
+    kept.push(item);
+  }
+  return kept;
+}
+
 /** Mirror `extractHistogramPoints`: keep items with finite valueX and valueY. */
 function filterHistogramItems(series: AmXYSeries): AmDataItem[] {
   const kept: AmDataItem[] = [];
@@ -183,7 +201,7 @@ function buildHeatmapResolver(series: AmXYSeries, data: HeatmapData): Resolver {
  */
 export function buildNavigationMap(entries: readonly NavMapEntry[]): NavMap {
   const resolvers = new Map<string, Resolver>();
-  const owners = new Map<string, AmXYChart>();
+  const owners = new Map<string, AmChart>();
 
   for (const entry of entries) {
     addEntryResolvers(entry, resolvers, owners);
@@ -200,7 +218,7 @@ export function buildNavigationMap(entries: readonly NavMapEntry[]): NavMap {
 function addEntryResolvers(
   { layers, groups, chart }: NavMapEntry,
   resolvers: Map<string, Resolver>,
-  owners: Map<string, AmXYChart>,
+  owners: Map<string, AmChart>,
 ): void {
   // Precompute gap-filtered items per series, then drop empty series exactly as
   // the adapter does when building layers (`buildSegmentedLayer` / `fromXYChart`
@@ -220,9 +238,13 @@ function addEntryResolvers(
   const histogramSeries = groups.histogramSeries
     .map(series => ({ series, items: filterHistogramItems(series) }))
     .filter(entry => entry.items.length > 0);
+  const pieSeries = groups.pieSeriesList
+    .map(series => ({ series, items: filterPieItems(series) }))
+    .filter(entry => entry.items.length > 0);
 
   let histIdx = 0;
   let heatIdx = 0;
+  let pieIdx = 0;
 
   const register = (layerId: string, resolver: Resolver): void => {
     resolvers.set(layerId, resolver);
@@ -259,6 +281,17 @@ function addEntryResolvers(
       case TraceType.HISTOGRAM: {
         const entry = histogramSeries[histIdx++];
         register(layer.id, (_row, col) => columnTargetFrom(entry, col));
+        break;
+      }
+      case TraceType.PIE: {
+        // A pie is a single row of slices, so only the column moves.
+        const entry = pieSeries[pieIdx++];
+        register(layer.id, (_row, col) => {
+          const dataItem = entry?.items[col];
+          return entry && dataItem
+            ? [{ series: entry.series, dataItem, kind: 'slice' }]
+            : [];
+        });
         break;
       }
       case TraceType.HEATMAP: {

--- a/src/adapters/amcharts/overlay.ts
+++ b/src/adapters/amcharts/overlay.ts
@@ -132,11 +132,23 @@ export function dataItemToOverlayRect(
   target: NavTarget,
   plotBounds: AmBounds | null,
 ): OverlayRect | null {
-  const rect = target.kind === 'point' ? pointRect(target) : columnRect(target);
+  const rect = readRect(target);
   if (!rect) {
     return null;
   }
   return plotBounds ? intersectRect(rect, plotBounds) : rect;
+}
+
+/** Read the geometry the target's kind is drawn with. */
+function readRect(target: NavTarget): OverlayRect | null {
+  switch (target.kind) {
+    case 'point':
+      return pointRect(target);
+    case 'slice':
+      return sliceRect(target);
+    case 'column':
+      return columnRect(target);
+  }
 }
 
 /**
@@ -167,6 +179,21 @@ function columnRect(target: NavTarget): OverlayRect | null {
 
   // Fallback for builds where toGlobal isn't exposed.
   const bounds = sprite.globalBounds?.();
+  return bounds ? boundsToRect(bounds) : null;
+}
+
+/**
+ * Rectangle for a pie slice: the bounding box of the wedge graphic.
+ *
+ * A box around a wedge is coarse — a large slice's box covers most of the pie
+ * — but the overlay can only draw rectangles, and amCharts paints the wedge
+ * into a shared canvas where there is no path to outline. A box that hugs the
+ * active wedge still tells a low-vision reader which way round the circle
+ * navigation has moved, which is the point of the highlight.
+ */
+function sliceRect(target: NavTarget): OverlayRect | null {
+  const slice = target.dataItem.get('slice') as AmSprite | undefined;
+  const bounds = slice?.globalBounds?.();
   return bounds ? boundsToRect(bounds) : null;
 }
 

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -73,12 +73,17 @@ export interface AmEntity {
 }
 
 /**
- * Minimal interface for an amCharts 5 XY chart.
+ * Minimal interface for a chart the adapter can convert: an `XYChart` (or an
+ * am5stock `StockPanel`, which extends it) or an am5percent `PieChart`.
+ *
+ * Both expose their data through a series list. Only an XY chart is bound to
+ * axes and owns a plot area, so `xAxes` / `yAxes` / `plotContainer` are
+ * optional — a pie has none of the three, and every read of them is guarded.
  */
-export interface AmXYChart extends AmEntity {
+export interface AmChart extends AmEntity {
   series: AmListLike<AmXYSeries>;
-  xAxes: AmListLike<AmAxis>;
-  yAxes: AmListLike<AmAxis>;
+  xAxes?: AmListLike<AmAxis>;
+  yAxes?: AmListLike<AmAxis>;
   /** The masked plot area container; its bounds clip the visible columns. */
   plotContainer?: {
     toGlobal?: (point: AmPoint) => AmPoint;
@@ -89,8 +94,20 @@ export interface AmXYChart extends AmEntity {
 }
 
 /**
- * Minimal interface for an amCharts 5 XY series
- * (ColumnSeries, LineSeries, etc.).
+ * The name this chart interface has always carried in the adapter's public
+ * API, kept as an alias so existing imports keep working now that a pie chart
+ * satisfies the same surface.
+ */
+export type AmXYChart = AmChart;
+
+/**
+ * Minimal interface for an amCharts 5 series (ColumnSeries, LineSeries,
+ * PieSeries, etc.).
+ *
+ * The per-kind collections are optional because no series type has them all:
+ * `columns` belongs to a column series, `bullets` / `strokes` to a line one,
+ * and a pie series has neither — its wedges are reached through each data
+ * item's `slice` instead.
  */
 export interface AmXYSeries extends AmEntity {
   dataItems: AmDataItem[];

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -30,6 +30,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   ScatterPoint,
 } from '@type/grammar';
 import type {
@@ -59,7 +60,7 @@ const AREA_TYPES = new Set(['area', 'step-area', 'spline-area']);
 /**
  * The subset of {@link TraceType}s the AnyChart adapter can produce from a
  * chart series. AnyChart exposes no stacked/histogram/smooth series types,
- * so {@link mapSeriesType} only ever yields these six. Narrowing here lets
+ * so {@link mapSeriesType} only ever yields these. Narrowing here lets
  * {@link buildLayer}'s switch be provably exhaustive at compile time.
  */
 type AnyChartTraceType
@@ -69,7 +70,8 @@ type AnyChartTraceType
     | TraceType.STEP
     | TraceType.BOX
     | TraceType.HEATMAP
-    | TraceType.CANDLESTICK;
+    | TraceType.CANDLESTICK
+    | TraceType.PIE;
 
 /**
  * Map AnyChart series type strings to MAIDR TraceType values.
@@ -89,6 +91,11 @@ type AnyChartTraceType
  * - The step-drawn types (`step-line`, `step-area`) map to
  *   {@link TraceType.STEP} so they are announced and navigated as the
  *   piecewise-constant series they are, rather than as interpolated lines.
+ * - `"pie"` covers doughnuts too: AnyChart draws one with `chart.innerRadius()`
+ *   on an ordinary pie, so both report the same type and read identically.
+ *   A pie chart has no series API of its own, so this branch only fires for
+ *   builds that expose one — {@link buildSubplot} routes the chart-level pie
+ *   before ever asking for a series.
  */
 export function mapSeriesType(anyChartType: string): AnyChartTraceType | null {
   const normalized = anyChartType.toLowerCase().replace(/[_\s]/g, '-');
@@ -114,6 +121,7 @@ export function mapSeriesType(anyChartType: string): AnyChartTraceType | null {
     'heat': TraceType.HEATMAP,
     'candlestick': TraceType.CANDLESTICK,
     'ohlc': TraceType.CANDLESTICK,
+    'pie': TraceType.PIE,
   };
 
   const traceType = mapping[normalized] ?? null;
@@ -233,10 +241,19 @@ function resolveIterator(series: AnyChartSeries): AnyChartIterator | undefined {
 export function extractRawRows(
   series: AnyChartSeries,
 ): Array<Record<string, unknown>> {
-  const rows: Array<Record<string, unknown>> = [];
   const iterator: AnyChartIterator | undefined = resolveIterator(series);
-  if (!iterator)
-    return rows;
+  return iterator ? readRows(iterator) : [];
+}
+
+/**
+ * Walk an AnyChart iterator and collect every field the adapter reads.
+ *
+ * Shared by {@link extractRawRows} (series-backed charts) and the chart-level
+ * pie path, whose data lives on `chart.data()` rather than on a series — the
+ * rows carry the same `x` / `value` fields either way.
+ */
+function readRows(iterator: AnyChartIterator): Array<Record<string, unknown>> {
+  const rows: Array<Record<string, unknown>> = [];
   iterator.reset();
   while (iterator.advance()) {
     const row: Record<string, unknown> = { _index: iterator.getIndex() };
@@ -346,6 +363,14 @@ const HEATMAP_ATTR = 'data-maidr-anychart-heatmap-cell';
  * highlight the whole candle across all OHLC segments.
  */
 const CANDLESTICK_ATTR = 'data-maidr-anychart-candlestick-cell';
+
+/**
+ * Attribute name stamped onto each pie wedge's SVG element by
+ * {@link stampPieAttributes}. A pie chart holds a single dataset, but the
+ * value still encodes `<seriesIndex>-<sliceIndex>` so it shares the selector
+ * shape of every other trace family (the chart-level path stamps series `0`).
+ */
+const PIE_ATTR = 'data-maidr-anychart-pie-slice';
 
 /**
  * Attribute name stamped onto each panel's own `<svg>` root by
@@ -458,6 +483,8 @@ function resolveSelector(
       return `${scope}[${LINE_ATTR}^="${stamp}${seriesIndex}-"]`;
     case TraceType.SCATTER:
       return `${scope}[${POINT_ATTR}^="${stamp}${seriesIndex}-"]`;
+    case TraceType.PIE:
+      return `${scope}[${PIE_ATTR}^="${stamp}${seriesIndex}-"]`;
     // Heatmaps are single-series (no series-index prefix); the chart-level
     // builder constructs the selector itself, so this branch only matters as
     // a defensive default when the heatmap path is bypassed.
@@ -638,6 +665,11 @@ function enableLineMarkersIfNeeded(chart: AnyChartInstance): boolean {
   // may return `'heatmap'` / `'heat'`. Match by substring (as
   // stampHeatmapAttributes does) so all three route correctly.
   if (chartType?.includes('heat'))
+    return false;
+  // A pie is the other single-dataset chart type, and its wedges are already
+  // one element per slice — there is nothing to enable and no series API to
+  // ask.
+  if (chartType?.includes('pie'))
     return false;
 
   const seriesCount = chart.getSeriesCount();
@@ -1869,6 +1901,146 @@ function stampCandlestickAttributes(
 }
 
 // ---------------------------------------------------------------------------
+// Pie attribute stamping
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a chart is a pie.
+ *
+ * `getType()` reports `'pie'` for both a pie and a doughnut (AnyChart draws
+ * the latter by giving an ordinary pie an inner radius), and no other chart
+ * type name contains the substring — so the same tolerant match the heatmap
+ * path uses is safe here too.
+ */
+function isPieChart(chart: AnyChartInstance): boolean {
+  try {
+    return chart.getType?.().includes('pie') ?? false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a pie chart's slices from its chart-level data view.
+ *
+ * A pie is a single-dataset chart: like the heatmap it exposes no
+ * `getSeriesCount()` / `getSeriesAt()`, and its rows live on `chart.data()`.
+ */
+function readPieRows(chart: AnyChartInstance): Array<Record<string, unknown>> {
+  const dataView = chart.data?.();
+  if (!dataView)
+    return [];
+  try {
+    return readRows(dataView.getIterator());
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Whether a path's `d` attribute contains an elliptical-arc command.
+ *
+ * A wedge is the only thing an AnyChart pie draws with an arc: the label
+ * connector lines, the legend swatches and the chart frame are all straight
+ * `M`/`L` paths. (A single 100 % slice is drawn as a full circle, which
+ * `acgraph` also emits as two arcs, so it is matched as well.) Numbers in a
+ * path can carry an `e` exponent but never an `a`, so a bare letter test is
+ * unambiguous.
+ */
+function hasArcCommand(path: SVGElement): boolean {
+  const d = path.getAttribute('d');
+  return d !== null && /a/i.test(d);
+}
+
+/**
+ * Locate the SVG `<g>` layer holding the pie wedges.
+ *
+ * Same idea as {@link findCandlestickPathLayer} — pick the `ac_layer_*` group
+ * with the most matching shapes — but without its `clip-path` requirement:
+ * AnyChart clips series data to the plot area of a Cartesian chart, and a pie
+ * has no plot area to clip to, so requiring the attribute would reject the
+ * wedge layer outright. Combining the layer scoping with the arc test below
+ * keeps circular legend markers (which live in their own, smaller layer) out.
+ *
+ * Returns the parent SVG itself if no AnyChart layer structure is found, so
+ * the caller falls back to whole-SVG querying.
+ */
+function findPieWedgeLayer(svg: SVGElement): Element {
+  const layers = svg.querySelectorAll<SVGGElement>('g[id^="ac_layer_"]');
+  let bestLayer: Element | null = null;
+  let bestCount = 0;
+  for (const layer of Array.from(layers)) {
+    const wedges = Array.from(
+      layer.querySelectorAll<SVGElement>('path[id^="ac_path_"]'),
+    ).filter(hasArcCommand);
+    if (wedges.length > bestCount) {
+      bestCount = wedges.length;
+      bestLayer = layer;
+    }
+  }
+  return bestLayer ?? svg;
+}
+
+/**
+ * Stamp `data-maidr-anychart-pie-slice="0-<sliceIndex>"` on every wedge of an
+ * AnyChart pie (or doughnut) chart.
+ *
+ * A pie is a single-dataset chart — it has no series API — so the series part
+ * of the stamp is always `0`, keeping the selector shape uniform across trace
+ * families. DOM order within the wedge layer is the order AnyChart consumed
+ * the data in, which is the order {@link buildPieLayerFromChart} emits its
+ * slices in, so wedge k is slice k.
+ *
+ * On any other chart type this is a no-op.
+ */
+function stampPieAttributes(
+  chart: AnyChartInstance,
+  svg: SVGElement,
+  stampPrefix = '',
+): void {
+  if (!isPieChart(chart))
+    return;
+
+  const sliceCount = readPieRows(chart).length;
+  if (sliceCount === 0)
+    return;
+
+  const wedgeLayer = findPieWedgeLayer(svg);
+  const candidates: SVGElement[] = [];
+  for (const path of Array.from(
+    wedgeLayer.querySelectorAll<SVGElement>('path[id^="ac_path_"]'),
+  )) {
+    // Idempotency — skip wedges stamped on a prior bind.
+    if (path.hasAttribute(PIE_ATTR))
+      continue;
+    if (path.closest('defs, clipPath'))
+      continue;
+    if (!hasArcCommand(path))
+      continue;
+    // Skip AnyChart's hover / selection indicator, which it draws as an extra
+    // semi-transparent wedge on top of the data wedge. Data wedges never set
+    // `fill-opacity`, so any value below 1 is the overlay.
+    const fillOpacityAttr = path.getAttribute('fill-opacity');
+    if (fillOpacityAttr !== null && Number.parseFloat(fillOpacityAttr) < 1)
+      continue;
+    candidates.push(path);
+  }
+
+  if (candidates.length < sliceCount) {
+    console.warn(
+      `[maidr/anychart] Expected ${sliceCount} pie wedges but found `
+      + `${candidates.length} after filtering. Highlighting may be incomplete; `
+      + 'pass an explicit `selectors` entry to override.',
+    );
+  }
+
+  const stampCount = Math.min(sliceCount, candidates.length);
+  for (let i = 0; i < stampCount; i++) {
+    candidates[i].setAttribute(PIE_ATTR, `${stampPrefix}0-${i}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Layer builders – one per MAIDR trace type
 // ---------------------------------------------------------------------------
 
@@ -2199,6 +2371,46 @@ function buildCandlestickLayer(
   };
 }
 
+/**
+ * Build a PIE layer from already-read slice rows.
+ *
+ * Slices with no numeric value are dropped rather than carried through as
+ * gaps: AnyChart draws no wedge for one, so keeping it would slide every later
+ * slice's highlight onto its neighbour. The percentage each slice represents
+ * is deliberately not emitted — MAIDR's pie trace derives it from the values,
+ * so there is exactly one source of truth for it.
+ *
+ * @param rows - The chart's (or series') raw data rows, in slice order
+ * @param seriesIndex - Index used as the layer id and in the default selector
+ * @param selectors - Caller-supplied selector override, when there is one
+ * @param panel - The owning panel, in multi-panel mode
+ * @returns The MAIDR pie layer
+ */
+function buildPieLayer(
+  rows: Array<Record<string, unknown>>,
+  seriesIndex: number,
+  selectors: string | string[] | undefined,
+  panel?: PanelContext,
+): MaidrLayer {
+  const data: PiePoint[] = rows
+    .filter(r => Number.isFinite(Number(r.value ?? r.y)))
+    .map(r => ({
+      x: asString(r.x ?? r.name ?? r._index),
+      y: asNumber(r.value ?? r.y),
+    }));
+
+  // Default selector targets the attribute stamped by
+  // {@link stampPieAttributes}, which writes one per wedge in slice order.
+  const defaultSelector
+    = `${panelScope(panel)}[${PIE_ATTR}^="${panelStampPrefix(panel)}${seriesIndex}-"]`;
+  return {
+    id: String(seriesIndex),
+    type: TraceType.PIE,
+    selectors: selectors ?? defaultSelector,
+    data,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Layer builder dispatch
 // ---------------------------------------------------------------------------
@@ -2231,12 +2443,21 @@ function buildLayer(
       return buildHeatmapLayer(series, seriesIndex, selectors);
     case TraceType.CANDLESTICK:
       return buildCandlestickLayer(series, seriesIndex, selectors, panel);
+    case TraceType.PIE:
+      return buildPieLayer(extractRawRows(series), seriesIndex, selectors, panel);
   }
 }
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/**
+ * What a pie's two dimensions are called when the chart names neither. A pie
+ * is bound to no axis, so there is no axis title to extract — these name what
+ * each dimension actually holds rather than leaving the slices unlabelled.
+ */
+const PIE_AXIS_FALLBACKS = { x: 'Label', y: 'Value' };
 
 /**
  * Build one {@link MaidrSubplot} from a single AnyChart chart instance.
@@ -2265,11 +2486,20 @@ function buildSubplot(
   const xAxisLabel = options?.axes?.x ?? extractAxisTitle(chart, 'x');
   const yAxisLabel = options?.axes?.y ?? extractAxisTitle(chart, 'y');
 
-  const attachAxes = (layer: MaidrLayer): void => {
-    if (xAxisLabel || yAxisLabel) {
+  /**
+   * `fallbacks` name the two dimensions of a trace that is bound to no axis
+   * (a pie), where the chart-level extraction has nothing to attach.
+   */
+  const attachAxes = (
+    layer: MaidrLayer,
+    fallbacks?: { x: string; y: string },
+  ): void => {
+    const x = xAxisLabel ?? fallbacks?.x;
+    const y = yAxisLabel ?? fallbacks?.y;
+    if (x || y) {
       layer.axes = {
-        ...(xAxisLabel ? { x: { label: xAxisLabel } } : {}),
-        ...(yAxisLabel ? { y: { label: yAxisLabel } } : {}),
+        ...(x ? { x: { label: x } } : {}),
+        ...(y ? { y: { label: y } } : {}),
       };
     }
   };
@@ -2321,6 +2551,23 @@ function buildSubplot(
     return finalize([layer]);
   }
 
+  // A pie is the other single-dataset chart type: it exposes no series API
+  // either, and reaching the `getSeriesCount()` fallback below would hand its
+  // slices to the heatmap builder, which would emit a one-row heatmap. Route
+  // it here, before the series API is touched.
+  if (isPieChart(chart)) {
+    const rows = readPieRows(chart);
+    if (rows.length === 0)
+      return null;
+    const userPieSelector = (options?.selectors?.[0] ?? undefined) as
+      | string
+      | string[]
+      | undefined;
+    const layer = buildPieLayer(rows, 0, userPieSelector, panel);
+    attachAxes(layer, PIE_AXIS_FALLBACKS);
+    return finalize([layer]);
+  }
+
   // Defensive fallback: if getType is unavailable but getSeriesCount throws
   // (heatmap-like single-dataset chart), route to the heatmap path anyway.
   let seriesCount = 0;
@@ -2363,7 +2610,7 @@ function buildSubplot(
     const layer = buildLayer(series, i, traceType, selectors, panel);
 
     // Attach axis labels.
-    attachAxes(layer);
+    attachAxes(layer, traceType === TraceType.PIE ? PIE_AXIS_FALLBACKS : undefined);
 
     layers.push(layer);
   }
@@ -2538,6 +2785,11 @@ export function bindAnyChart(
       stampCandlestickAttributes(chart, svg);
     } catch (err) {
       console.warn('[maidr/anychart] Failed to stamp candlestick attributes:', err);
+    }
+    try {
+      stampPieAttributes(chart, svg);
+    } catch (err) {
+      console.warn('[maidr/anychart] Failed to stamp pie attributes:', err);
     }
 
     const host = ensureHostWrapper(svg, container);
@@ -2828,6 +3080,11 @@ function stampPanelAttributes(
     stampCandlestickAttributes(chart, svg, prefix);
   } catch (err) {
     console.warn('[maidr/anychart] Failed to stamp candlestick attributes:', err);
+  }
+  try {
+    stampPieAttributes(chart, svg, prefix);
+  } catch (err) {
+    console.warn('[maidr/anychart] Failed to stamp pie attributes:', err);
   }
 }
 

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -1938,6 +1938,20 @@ function readPieRows(chart: AnyChartInstance): Array<Record<string, unknown>> {
 }
 
 /**
+ * Whether a data row is a slice AnyChart actually draws a wedge for.
+ *
+ * A row with no numeric value has no angle, so no wedge is rendered for it.
+ * {@link buildPieLayer} drops such a row and {@link stampPieAttributes} counts
+ * rows through the same predicate — counting the raw rows there instead would
+ * make the expected wedge count disagree with the emitted slice count the
+ * moment a chart carries a null, turning a correct chart into a warning and an
+ * unexpectedly drawn empty wedge into a silent off-by-one.
+ */
+function isDrawnSlice(row: Record<string, unknown>): boolean {
+  return Number.isFinite(Number(row.value ?? row.y));
+}
+
+/**
  * Whether a path's `d` attribute contains an elliptical-arc command.
  *
  * A wedge is the only thing an AnyChart pie draws with an arc: the label
@@ -1962,10 +1976,16 @@ function hasArcCommand(path: SVGElement): boolean {
  * wedge layer outright. Combining the layer scoping with the arc test below
  * keeps circular legend markers (which live in their own, smaller layer) out.
  *
- * Returns the parent SVG itself if no AnyChart layer structure is found, so
- * the caller falls back to whole-SVG querying.
+ * Returns the parent SVG itself when the SVG has no AnyChart layer structure
+ * at all, so the caller falls back to whole-SVG querying. When layers *are*
+ * present but none of them holds an arc-drawn path, this returns `null`
+ * instead: the wedges are then not where this function knows how to look, and
+ * widening the search to the whole SVG would stamp whatever arc-shaped path it
+ * met first — a legend marker, a rounded frame — onto slice index 0. Reporting
+ * nothing found costs the highlight; guessing would point it at the wrong
+ * shape.
  */
-function findPieWedgeLayer(svg: SVGElement): Element {
+function findPieWedgeLayer(svg: SVGElement): Element | null {
   const layers = svg.querySelectorAll<SVGGElement>('g[id^="ac_layer_"]');
   let bestLayer: Element | null = null;
   let bestCount = 0;
@@ -1978,7 +1998,9 @@ function findPieWedgeLayer(svg: SVGElement): Element {
       bestLayer = layer;
     }
   }
-  return bestLayer ?? svg;
+  if (bestLayer)
+    return bestLayer;
+  return layers.length > 0 ? null : svg;
 }
 
 /**
@@ -1988,8 +2010,13 @@ function findPieWedgeLayer(svg: SVGElement): Element {
  * A pie is a single-dataset chart — it has no series API — so the series part
  * of the stamp is always `0`, keeping the selector shape uniform across trace
  * families. DOM order within the wedge layer is the order AnyChart consumed
- * the data in, which is the order {@link buildPieLayerFromChart} emits its
- * slices in, so wedge k is slice k.
+ * the data in, which is the order {@link buildPieLayer} emits its slices in,
+ * so wedge k is slice k.
+ *
+ * That mapping only holds while the wedge candidates and the emitted slices
+ * are the same set, so any disagreement between the two counts is reported:
+ * it means one of the DOM assumptions above no longer describes what AnyChart
+ * drew, and every stamp from that point on may name the wrong slice.
  *
  * On any other chart type this is a no-op.
  */
@@ -2001,11 +2028,21 @@ function stampPieAttributes(
   if (!isPieChart(chart))
     return;
 
-  const sliceCount = readPieRows(chart).length;
+  const sliceCount = readPieRows(chart).filter(isDrawnSlice).length;
   if (sliceCount === 0)
     return;
 
   const wedgeLayer = findPieWedgeLayer(svg);
+  if (!wedgeLayer) {
+    console.warn(
+      '[maidr/anychart] Found no pie wedges to highlight: this chart\'s SVG '
+      + 'has AnyChart layers but none of them holds an arc-drawn path. '
+      + 'Highlighting is disabled for this chart; pass an explicit '
+      + '`selectors` entry to override.',
+    );
+    return;
+  }
+
   const candidates: SVGElement[] = [];
   for (const path of Array.from(
     wedgeLayer.querySelectorAll<SVGElement>('path[id^="ac_path_"]'),
@@ -2026,11 +2063,12 @@ function stampPieAttributes(
     candidates.push(path);
   }
 
-  if (candidates.length < sliceCount) {
+  if (candidates.length !== sliceCount) {
     console.warn(
       `[maidr/anychart] Expected ${sliceCount} pie wedges but found `
-      + `${candidates.length} after filtering. Highlighting may be incomplete; `
-      + 'pass an explicit `selectors` entry to override.',
+      + `${candidates.length} after filtering. Highlighting may be incomplete `
+      + 'or land on the wrong slice; pass an explicit `selectors` entry to '
+      + 'override.',
     );
   }
 
@@ -2393,7 +2431,7 @@ function buildPieLayer(
   panel?: PanelContext,
 ): MaidrLayer {
   const data: PiePoint[] = rows
-    .filter(r => Number.isFinite(Number(r.value ?? r.y)))
+    .filter(isDrawnSlice)
     .map(r => ({
       x: asString(r.x ?? r.name ?? r._index),
       y: asNumber(r.value ?? r.y),

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -3,15 +3,16 @@
  * JSON schema format.
  *
  * Supported chart types (those with a genuine MAIDR trace-type equivalent):
- * - Native: bar (plain/stacked/dodged), line (plain or stepped), scatter, bubble
+ * - Native: bar (plain/stacked/dodged), line (plain or stepped), scatter,
+ *   bubble, pie, doughnut
  * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap)
  *
- * Unsupported types (pie, doughnut, radar, polarArea, treemap, sankey, etc.)
- * are rejected with an explicit error rather than silently mapped to a bar
- * chart, because MAIDR has no semantically equivalent trace for them.
+ * Unsupported types (radar, polarArea, treemap, sankey, etc.) are rejected with
+ * an explicit error rather than silently mapped to a bar chart, because MAIDR
+ * has no semantically equivalent trace for them.
  */
 
-import type { BarPoint, BoxPoint, CandlestickPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, ScatterPoint, SegmentedPoint, StepDirection } from '../../type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection } from '../../type/grammar';
 import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 
@@ -565,6 +566,9 @@ function extractLayers(
     case 'scatter':
     case 'bubble':
       return extractScatterLayers(chart, pluginOptions);
+    case 'pie':
+    case 'doughnut':
+      return extractPieLayers(chart, pluginOptions, datasetIndices);
     case 'boxplot':
       return extractBoxplotLayers(chart, pluginOptions);
     case 'candlestick':
@@ -575,7 +579,8 @@ function extractLayers(
     default:
       throw new Error(
         `MAIDR Chart.js adapter: unsupported chart type "${chartType}". `
-        + 'Supported types: bar, line, scatter, bubble, boxplot, candlestick, ohlc, matrix.',
+        + 'Supported types: bar, line, scatter, bubble, pie, doughnut, boxplot, '
+        + 'candlestick, ohlc, matrix.',
       );
   }
 }
@@ -824,6 +829,71 @@ function datasetToScatterPoints(dataset: ChartJsDataset): ScatterPoint[] {
     }
   }
   return points;
+}
+
+// ---------------------------------------------------------------------------
+// Pie / doughnut chart extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Axis labels for a pie layer.
+ *
+ * A pie has no Chart.js scales, so {@link getAxisLabel} would fall through to
+ * its `'X'`/`'Y'` default and announce "X is Apples, Y is 30" — naming neither
+ * position. Name what the two mean on a pie instead: `x` is what the slice
+ * labels are, `y` is what their magnitudes measure. An explicit plugin `axes`
+ * override still wins.
+ */
+function getPieAxes(pluginOptions?: MaidrPluginOptions): MaidrLayer['axes'] {
+  return {
+    x: { label: pluginOptions?.axes?.x ?? 'Category' },
+    y: { label: pluginOptions?.axes?.y ?? 'Value' },
+  };
+}
+
+/**
+ * Extracts one pie layer per dataset.
+ *
+ * Chart.js draws a second dataset as a concentric ring rather than as more
+ * slices of the same circle, so each dataset is its own pie with its own total
+ * and its own percentages. One layer each keeps those totals honest and lets
+ * Page Up / Page Down move between the rings. A doughnut differs from a pie
+ * only by its cutout, so both arrive here.
+ */
+function extractPieLayers(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+  datasetIndices?: LocalDatasetIndices,
+): MaidrLayer[] {
+  const labels = chart.data.labels ?? [];
+  const axes = getPieAxes(pluginOptions);
+
+  return chart.data.datasets.map((dataset, dsIdx) => {
+    // Gap markers (`null` / `NaN`) are skipped rather than collapsed to 0: a
+    // fabricated zero would be announced and sonified as a measured slice, and
+    // would pin the bottom of the range every other slice is pitched against.
+    const points: PiePoint[] = [];
+    dataset.data.forEach((value, i) => {
+      const num = toFiniteNumber(value);
+      if (num === null)
+        return;
+      points.push({ x: labels[i] ?? i, y: num });
+    });
+
+    // Each layer is backed by exactly one dataset, so say which: the caller's
+    // per-type default (all datasets, in order) would route every ring's
+    // highlight to the first one.
+    const id = String(dsIdx);
+    datasetIndices?.set(id, [dsIdx]);
+
+    return {
+      id,
+      type: TraceType.PIE,
+      title: dataset.label,
+      axes,
+      data: points,
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -133,8 +133,11 @@ export function computeTargetMaps(
         scatterBuckets.set(layer.id, buildScatterBuckets(datasets[dsIdx]?.data ?? []));
         break;
       }
-      case TraceType.BAR: {
-        // Single-dataset bar: one MAIDR row backed by the layer's dataset.
+      case TraceType.BAR:
+      case TraceType.PIE: {
+        // Single-dataset bar, or one pie/doughnut ring: a single MAIDR row
+        // backed by the layer's own dataset. A pie's row is always 0 and its
+        // col is the slice, which is the same shape.
         const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
         barLineIndices.set(layer.id, [finiteIndices(datasets[dsIdx]?.data ?? [])]);
         break;
@@ -216,9 +219,10 @@ export function resolveActiveTargets(
     return [{ datasetIndex: firstDatasetIndex(layerDatasetIndices, layer.id), index: flatIndex }];
   }
 
-  // Bar / line: MAIDR row = dataset, col = point (into the gap-skipped list).
-  // Map col back to the original Chart.js element index so highlights stay
-  // aligned when the dataset contains gap markers.
+  // Bar / line / pie: MAIDR row = dataset (always 0 for a pie, whose slices are
+  // one row), col = point (into the gap-skipped list). Map col back to the
+  // original Chart.js element index so highlights stay aligned when the dataset
+  // contains gap markers.
   const indexMap = maps.barLineIndices.get(layer.id);
   const datasetIndex = rowDatasetIndex(layerDatasetIndices, layerId, row);
   if (indexMap) {

--- a/src/adapters/chartjs/overlay.ts
+++ b/src/adapters/chartjs/overlay.ts
@@ -3,27 +3,58 @@
  *
  * Chart.js draws into a single `<canvas>` bitmap, so MAIDR's SVG-based
  * `HighlightService` cannot find per-bar DOM elements to highlight. This
- * module compensates by drawing absolute-positioned `<div>` overlays on top
- * of the canvas at the geometry reported by Chart.js for the active element.
+ * module compensates by drawing absolute-positioned overlays on top of the
+ * canvas at the geometry reported by Chart.js for the active element.
+ *
+ * Most elements are boxes and are drawn as `<div>`s. A pie or doughnut slice
+ * is not: its bounding box spans a quadrant of the circle and overlaps its
+ * neighbours', so a box would routinely point at a slice the user is not on.
+ * Those are drawn as an SVG wedge path over the canvas instead.
  *
  * Coordinates: Chart.js stores element positions in CSS pixels relative to
  * the canvas's top-left. We mount the overlay container inside the same
  * positioned wrapper as the canvas, sized to match the canvas exactly, so
  * Chart.js coordinates can be used directly as CSS `left`/`top` on the
- * overlay children.
+ * overlay children (and as user units in the wedge svg, which is unscaled).
  */
 
 import type { ChartJsMetaElement } from './types';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
 
 /**
  * Rectangle in CSS pixels relative to the canvas top-left.
  */
 export interface OverlayRect {
+  kind: 'rect';
   left: number;
   top: number;
   width: number;
   height: number;
 }
+
+/**
+ * One pie or doughnut slice, in CSS pixels relative to the canvas top-left.
+ *
+ * Angles are radians as Chart.js stores them on an `ArcElement`: measured from
+ * 3 o'clock and increasing clockwise, with the chart's `rotation` already
+ * folded in. Both `<canvas>` and SVG put +y downwards, so the same angle maps
+ * to the same point in either — no conversion is needed here.
+ */
+export interface OverlayWedge {
+  kind: 'wedge';
+  /** Centre of the circle the slice belongs to. */
+  x: number;
+  y: number;
+  /** Zero for a pie; the cutout radius for a doughnut. */
+  innerRadius: number;
+  outerRadius: number;
+  startAngle: number;
+  endAngle: number;
+}
+
+/** A shape the overlay can draw for one active Chart.js element. */
+export type OverlayShape = OverlayRect | OverlayWedge;
 
 /**
  * Default visual style for the highlight rect.
@@ -32,7 +63,7 @@ const DEFAULT_HIGHLIGHT_COLOR = 'rgba(255, 140, 0, 0.9)';
 const DEFAULT_FILL_COLOR = 'rgba(255, 165, 0, 0.25)';
 
 /**
- * Manages DOM rectangles drawn on top of a Chart.js canvas to provide
+ * Manages the DOM shapes drawn on top of a Chart.js canvas to provide
  * MAIDR-style highlight feedback for keyboard navigation.
  */
 export class HighlightOverlay {
@@ -65,30 +96,21 @@ export class HighlightOverlay {
   }
 
   /**
-   * Draw one rect per provided geometry. Existing rects are cleared first.
+   * Draw one node per provided geometry. Existing nodes are cleared first.
    */
-  show(rects: readonly OverlayRect[]): void {
+  show(shapes: readonly OverlayShape[]): void {
     this.syncToCanvas();
     this.clear();
 
-    for (const rect of rects) {
-      const node = document.createElement('div');
-      node.setAttribute('data-maidr-chartjs-highlight', '');
-      node.style.position = 'absolute';
-      node.style.left = `${rect.left}px`;
-      node.style.top = `${rect.top}px`;
-      node.style.width = `${Math.max(rect.width, 1)}px`;
-      node.style.height = `${Math.max(rect.height, 1)}px`;
-      node.style.background = this.fillColor;
-      node.style.outline = `2px solid ${this.outlineColor}`;
-      node.style.boxSizing = 'border-box';
-      node.style.pointerEvents = 'none';
-      this.container.appendChild(node);
+    for (const shape of shapes) {
+      this.container.appendChild(
+        shape.kind === 'wedge' ? this.createWedgeNode(shape) : this.createRectNode(shape),
+      );
     }
   }
 
   /**
-   * Remove all highlight rects (e.g., on chart resize before recompute).
+   * Remove all highlight nodes (e.g., on chart resize before recompute).
    */
   clear(): void {
     while (this.container.firstChild) {
@@ -101,6 +123,50 @@ export class HighlightOverlay {
    */
   dispose(): void {
     this.container.remove();
+  }
+
+  /** Builds the `<div>` highlight for a box-shaped element. */
+  private createRectNode(rect: OverlayRect): HTMLDivElement {
+    const node = document.createElement('div');
+    node.setAttribute('data-maidr-chartjs-highlight', '');
+    node.style.position = 'absolute';
+    node.style.left = `${rect.left}px`;
+    node.style.top = `${rect.top}px`;
+    node.style.width = `${Math.max(rect.width, 1)}px`;
+    node.style.height = `${Math.max(rect.height, 1)}px`;
+    node.style.background = this.fillColor;
+    node.style.outline = `2px solid ${this.outlineColor}`;
+    node.style.boxSizing = 'border-box';
+    node.style.pointerEvents = 'none';
+    return node;
+  }
+
+  /**
+   * Builds the SVG highlight for one pie/doughnut slice.
+   *
+   * The svg covers the whole overlay (which already matches the canvas box) so
+   * the wedge path can be written in the same canvas pixel coordinates as
+   * every rect. `stroke` rather than `outline` because the highlight has to
+   * follow the wedge's curved edge, which a CSS outline cannot.
+   */
+  private createWedgeNode(wedge: OverlayWedge): SVGSVGElement {
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('data-maidr-chartjs-highlight', '');
+    svg.style.position = 'absolute';
+    svg.style.left = '0';
+    svg.style.top = '0';
+    svg.style.width = '100%';
+    svg.style.height = '100%';
+    svg.style.pointerEvents = 'none';
+
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('d', wedgePath(wedge));
+    path.setAttribute('fill', this.fillColor);
+    path.setAttribute('stroke', this.outlineColor);
+    path.setAttribute('stroke-width', '2');
+    svg.appendChild(path);
+
+    return svg;
   }
 
   /**
@@ -125,10 +191,58 @@ export class HighlightOverlay {
   }
 }
 
+/** A point on a circle, rounded to keep the emitted path readable. */
+function polar(cx: number, cy: number, radius: number, angle: number): { x: number; y: number } {
+  return {
+    x: Math.round((cx + radius * Math.cos(angle)) * 100) / 100,
+    y: Math.round((cy + radius * Math.sin(angle)) * 100) / 100,
+  };
+}
+
 /**
- * Convert a Chart.js element (bar, point, etc.) into an overlay rectangle.
+ * Builds the SVG path of one wedge: the outer arc, then either the inner arc
+ * back (doughnut) or a line to the centre (pie).
+ */
+function wedgePath(wedge: OverlayWedge): string {
+  const { x, y, innerRadius, outerRadius, startAngle } = wedge;
+
+  // An arc whose two endpoints coincide draws nothing at all, so a slice that
+  // fills the entire circle (a one-slice pie) is drawn a hair short of 360°.
+  const sweep = Math.min(wedge.endAngle - startAngle, Math.PI * 2 - 1e-3);
+  const endAngle = startAngle + sweep;
+  const largeArc = sweep > Math.PI ? 1 : 0;
+
+  const outerStart = polar(x, y, outerRadius, startAngle);
+  const outerEnd = polar(x, y, outerRadius, endAngle);
+
+  // Sweep flag 1 follows increasing angle, which is clockwise in the y-down
+  // space; the inner arc runs back the other way, hence flag 0.
+  const commands = [
+    `M ${outerStart.x} ${outerStart.y}`,
+    `A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${outerEnd.x} ${outerEnd.y}`,
+  ];
+
+  if (innerRadius > 0) {
+    const innerEnd = polar(x, y, innerRadius, endAngle);
+    const innerStart = polar(x, y, innerRadius, startAngle);
+    commands.push(
+      `L ${innerEnd.x} ${innerEnd.y}`,
+      `A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${innerStart.x} ${innerStart.y}`,
+    );
+  } else {
+    commands.push(`L ${x} ${y}`);
+  }
+
+  commands.push('Z');
+  return commands.join(' ');
+}
+
+/**
+ * Convert a Chart.js element (bar, slice, point, etc.) into an overlay shape.
  *
  * Element types expose different geometry properties:
+ * - Arc (pie / doughnut slice): `x`, `y` (circle centre), `innerRadius`,
+ *   `outerRadius`, `startAngle`, `endAngle` — no box of any kind.
  * - Bar: `x`, `y`, `base`, `width`, `height`, `horizontal` (read directly).
  * - Candlestick / OHLC: `x` (center), `width`, `high`/`low` (top/bottom pixel
  *   y), `open`/`close` (body endpoints in pixels).
@@ -137,7 +251,7 @@ export class HighlightOverlay {
  *
  * Returns `null` if the element does not expose enough geometry to render.
  */
-export function elementToOverlayRect(element: ChartJsMetaElement): OverlayRect | null {
+export function elementToOverlayShape(element: ChartJsMetaElement): OverlayShape | null {
   // Chart.js element instances carry additional runtime properties beyond
   // the minimal `ChartJsMetaElement` interface. Access them defensively.
   const el = element as ChartJsMetaElement & {
@@ -151,10 +265,34 @@ export function elementToOverlayRect(element: ChartJsMetaElement): OverlayRect |
     high?: number;
     low?: number;
     close?: number;
+    innerRadius?: number;
+    outerRadius?: number;
+    startAngle?: number;
+    endAngle?: number;
   };
 
   if (typeof el.x !== 'number' || typeof el.y !== 'number')
     return null;
+
+  // Arc element (pie / doughnut slice). Checked first because an arc reports
+  // no `base`, `width`, or `height` at all, so it would otherwise fall through
+  // to the point branch and draw the same small box at the circle's centre for
+  // every slice.
+  if (
+    typeof el.outerRadius === 'number'
+    && typeof el.startAngle === 'number'
+    && typeof el.endAngle === 'number'
+  ) {
+    return {
+      kind: 'wedge',
+      x: el.x,
+      y: el.y,
+      innerRadius: el.innerRadius ?? 0,
+      outerRadius: el.outerRadius,
+      startAngle: el.startAngle,
+      endAngle: el.endAngle,
+    };
+  }
 
   // Bar-shaped element: has a baseline and a box.
   if (
@@ -167,13 +305,13 @@ export function elementToOverlayRect(element: ChartJsMetaElement): OverlayRect |
       const width = Math.abs(el.x - el.base);
       const top = el.y - el.height / 2;
       const height = el.height;
-      return { left, top, width, height };
+      return { kind: 'rect', left, top, width, height };
     }
     const top = Math.min(el.y, el.base);
     const height = Math.abs(el.y - el.base);
     const left = el.x - el.width / 2;
     const width = el.width;
-    return { left, top, width, height };
+    return { kind: 'rect', left, top, width, height };
   }
 
   // Candlestick / OHLC element (chartjs-chart-financial). The element exposes
@@ -189,7 +327,7 @@ export function elementToOverlayRect(element: ChartJsMetaElement): OverlayRect |
     const left = el.x - el.width / 2;
     const top = Math.min(el.high, el.low);
     const height = Math.abs(el.low - el.high);
-    return { left, top, width: el.width, height };
+    return { kind: 'rect', left, top, width: el.width, height };
   }
 
   // Matrix element (chartjs-chart-matrix). Rectangular heatmap cell with
@@ -204,6 +342,7 @@ export function elementToOverlayRect(element: ChartJsMetaElement): OverlayRect |
     && typeof el.height === 'number'
   ) {
     return {
+      kind: 'rect',
       left: el.x,
       top: el.y,
       width: el.width,
@@ -215,6 +354,7 @@ export function elementToOverlayRect(element: ChartJsMetaElement): OverlayRect |
   const radius = el.options?.radius ?? el.radius ?? 4;
   const size = (radius + 2) * 2;
   return {
+    kind: 'rect',
     left: el.x - size / 2,
     top: el.y - size / 2,
     width: size,

--- a/src/adapters/chartjs/plugin.tsx
+++ b/src/adapters/chartjs/plugin.tsx
@@ -5,7 +5,7 @@
  * converts it to the MAIDR JSON schema, and renders the MAIDR accessible
  * interface around the chart canvas. Navigation events are bridged back
  * to Chart.js for visual highlighting via `setActiveElements`, and DOM
- * rect overlays are drawn on top of the canvas so users see MAIDR-style
+ * overlays are drawn on top of the canvas so users see MAIDR-style
  * highlight feedback (since canvas has no per-element DOM nodes).
  *
  * @example
@@ -32,7 +32,7 @@ import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
 import { extractChartData } from './extractor';
 import { computeTargetMaps, resolveActiveTargets } from './highlightTargets';
-import { elementToOverlayRect, HighlightOverlay } from './overlay';
+import { elementToOverlayShape, HighlightOverlay } from './overlay';
 
 // ---------------------------------------------------------------------------
 // Internal state per chart
@@ -150,18 +150,18 @@ function applyHighlight(
   if (!overlay)
     return;
 
-  const rects = [];
+  const shapes = [];
   for (const t of targets) {
     const meta = chart.getDatasetMeta(t.datasetIndex);
     const element = meta?.data?.[t.index];
     if (!element)
       continue;
-    const rect = elementToOverlayRect(element);
-    if (rect)
-      rects.push(rect);
+    const shape = elementToOverlayShape(element);
+    if (shape)
+      shapes.push(shape);
   }
-  if (rects.length > 0)
-    overlay.show(rects);
+  if (shapes.length > 0)
+    overlay.show(shapes);
   else
     overlay.clear();
 }
@@ -287,9 +287,9 @@ function initMaidrForChart(chart: ChartJsChart): void {
     return;
 
   // Extract data first, then create a layer-aware highlight callback. When the
-  // plugin is registered globally, unsupported chart types (pie, doughnut,
-  // radar, polarArea, ...) reach this hook too; extraction throws for them, so
-  // catch it and leave the chart untouched rather than breaking construction.
+  // plugin is registered globally, unsupported chart types (radar, polarArea,
+  // ...) reach this hook too; extraction throws for them, so catch it and leave
+  // the chart untouched rather than breaking construction.
   let extracted: MaidrData;
   let layerDatasetIndices: LayerDatasetIndices;
   try {

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -158,6 +158,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'histogram', config: props.config };
     case 'line':
       return { chartType: 'line', config: props.config };
+    case 'pie':
+      return { chartType: 'pie', config: props.config };
     case 'scatter':
       return { chartType: 'scatter', config: props.config };
     case 'segmented':

--- a/src/adapters/d3/binders/pie.ts
+++ b/src/adapters/d3/binders/pie.ts
@@ -1,0 +1,222 @@
+/**
+ * D3 binder for pie and doughnut charts.
+ *
+ * Extracts data from D3.js-rendered wedges and generates the MAIDR JSON
+ * schema for accessible slice-by-slice interaction.
+ */
+
+import type { MaidrLayer, PiePoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3PieConfig, DataAccessor } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+
+/**
+ * The object `d3.pie()` emits for one slice: the caller's own datum under
+ * `data`, the magnitude the layout read from it under `value`, and the
+ * geometry `d3.arc()` turns into a `<path>`.
+ *
+ * A doughnut is the same layout drawn with an inner radius, so nothing here
+ * distinguishes the two — and nothing needs to.
+ */
+interface D3PieArc {
+  data: unknown;
+  value: number;
+  startAngle: number;
+  endAngle: number;
+}
+
+/**
+ * Whether a bound datum is a `d3.pie()` arc rather than the user's own datum.
+ *
+ * `d3.pie()` is a plain function returning object literals, so there is no
+ * constructor to test against — the arc is recognised by the shape the layout
+ * documents. Worth detecting: without it every accessor would have to address
+ * the layout's wrapper (`d.data.fruit`) rather than what the user wrote
+ * (`fruit`), and the automatic key inference would have nothing to look at.
+ *
+ * @param datum - The element's D3-bound datum
+ * @returns True when the datum is a pie layout arc
+ */
+function isPieArc(datum: unknown): datum is D3PieArc {
+  if (typeof datum !== 'object' || datum === null) {
+    return false;
+  }
+  return 'data' in datum && 'value' in datum && 'startAngle' in datum && 'endAngle' in datum;
+}
+
+/**
+ * Reads one slice's label.
+ *
+ * `d3.pie()` accepts a bare array of numbers as readily as an array of
+ * objects, in which case the arc's `data` is the number itself. A string
+ * accessor cannot address a primitive — the `in` check inside
+ * {@link resolveAccessor} throws a `TypeError` that names neither the slice
+ * nor the fix — so a primitive labels its own slice. A function accessor is
+ * always invoked: it may be index-based and never touch the datum at all.
+ *
+ * @param slice - The user's datum for this slice (the arc already unwrapped)
+ * @param accessor - The resolved label accessor
+ * @param index - Position of the slice in the selection
+ * @returns The slice label
+ */
+function resolveSliceLabel(
+  slice: unknown,
+  accessor: DataAccessor<string | number>,
+  index: number,
+): string | number {
+  if (typeof accessor === 'string' && (slice === null || typeof slice !== 'object')) {
+    return typeof slice === 'number' ? slice : String(slice);
+  }
+  return resolveAccessor<string | number>(slice, accessor, index);
+}
+
+/**
+ * Coerces a resolved magnitude to the number {@link PiePoint.y} requires,
+ * keeping a gap distinguishable from a zero.
+ *
+ * `Number(null)` is `0`, and a slice nobody measured must not be sonified and
+ * totalled as a real zero. `NaN` is how the pie model spells an absent
+ * measurement, and it survives the trip through `maidr-data`: `JSON.stringify`
+ * writes it as `null`, which the model reads back as a gap.
+ *
+ * @param raw - The value the accessor produced
+ * @returns The magnitude, or `NaN` when the slice is a gap
+ */
+function toSliceValue(raw: unknown): number {
+  if (raw === null || raw === undefined) {
+    return Number.NaN;
+  }
+  if (typeof raw === 'string' && raw.trim() === '') {
+    return Number.NaN;
+  }
+  return Number(raw);
+}
+
+/**
+ * Binds a D3.js pie or doughnut chart to MAIDR, generating the accessible
+ * data representation.
+ *
+ * Extracts data from the wedge `<path>` elements produced by the canonical
+ * `d3.pie()` + `d3.arc()` pair and produces a complete {@link Maidr} data
+ * structure for sonification, text descriptions, braille output, and keyboard
+ * navigation. A pie is one row of slices: left and right move between them.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** This function reads each matched
+ * element's D3-bound `__data__`. When the marks were joined to `d3.pie()`
+ * output — the usual case — the slice magnitude is taken from the arc's
+ * `value`, which is what the layout itself drew the angle from, so only the
+ * label accessor is normally needed. Calling the binder before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * Typical call sites:
+ * - **Vanilla JS:** right after your `selectAll(...).data(...).join(...)` chain.
+ * - **React:** inside `useEffect`, never during render. Prefer
+ *   {@link MaidrD3} / {@link useD3Adapter} from `maidr/react`, which
+ *   handle the post-render timing for you.
+ * - **Async data:** inside the `.then(...)` of your fetch, after drawing.
+ *
+ * **Slice order.** `d3.pie()` returns its arcs in the input data order even
+ * when it sorts them by value for drawing, so the wedges a single
+ * `.data(pie(data)).join('path')` produces are already in the order MAIDR
+ * needs: matched element k is data point k.
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element (or container) containing the D3 pie chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * // svg.selectAll('path.slice').data(d3.pie().value(d => d.units)(data))
+ * const result = bindD3Pie(svgElement, {
+ *   selector: 'path.slice',
+ *   title: 'Fruit sales',
+ *   axes: { x: 'Fruit', y: 'Units' },
+ *   x: 'fruit',   // property name on YOUR datum, not on the arc
+ * });
+ * ```
+ */
+export function bindD3Pie(svg: Element, config: D3PieConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildPieLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for pie charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildPieLayer(root: Element, config: D3PieConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    y: yOverride,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'pie slice');
+  }
+
+  // Infer accessors from the USER's first datum, not from the arc wrapping
+  // it: the keys worth guessing (`label`, `value`, …) are the ones the caller
+  // wrote, and every arc carries the same four layout keys regardless.
+  const firstDatum = elements[0].datum;
+  const firstSlice = isPieArc(firstDatum) ? firstDatum.data : firstDatum;
+  const xAccessor = inferAccessor<string | number>(
+    config,
+    'x',
+    'x',
+    ['label', 'name', 'category', 'key'],
+    firstSlice,
+  );
+  const yAccessor = inferAccessor<number>(
+    config,
+    'y',
+    'y',
+    ['value', 'count', 'amount', 'total'],
+    firstSlice,
+  );
+
+  const data: PiePoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const arc = isPieArc(datum) ? datum : null;
+    const slice = arc ? arc.data : datum;
+
+    return {
+      x: resolveSliceLabel(slice, xAccessor, index),
+      // The layout has already applied the caller's own `.value(...)` to each
+      // datum and stored the result on the arc, so reading it back keeps the
+      // sonified magnitude identical to the angle drawn on screen. An
+      // explicit `y` still wins — it is what binds a pie drawn by hand.
+      y: arc && yOverride === undefined
+        ? toSliceValue(arc.value)
+        : toSliceValue(resolveAccessor<number>(slice, yAccessor, index)),
+    };
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.PIE,
+    title,
+    selectors: scopeSelector(root, selector, panel),
+    // No `orientation`: a pie's slices are arranged around a circle, not
+    // along an axis. No `z` either — the percentage the model announces is
+    // derived from the values, so there is nothing for a fill axis to label.
+    axes: buildAxes({ x: axes?.x, y: axes?.y }, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -42,6 +42,7 @@ import { buildCandlestickLayer } from './candlestick';
 import { buildHeatmapLayer } from './heatmap';
 import { buildHistogramLayer } from './histogram';
 import { buildLineLayer } from './line';
+import { buildPieLayer } from './pie';
 import { buildScatterLayer } from './scatter';
 import { buildSegmentedLayer } from './segmented';
 import { buildSmoothLayer } from './smooth';
@@ -240,6 +241,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildHistogramLayer(root, spec.config, panel);
     case 'line':
       return buildLineLayer(root, spec.config, panel);
+    case 'pie':
+      return buildPieLayer(root, spec.config, panel);
     case 'scatter':
       return buildScatterLayer(root, spec.config, panel);
     case 'segmented':

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -13,6 +13,7 @@
  *
  * - **Bar charts** via {@link bindD3Bar}
  * - **Line charts** (single and multi-line) via {@link bindD3Line}
+ * - **Pie and doughnut charts** via {@link bindD3Pie}
  * - **Scatter plots** via {@link bindD3Scatter}
  * - **Heatmaps** via {@link bindD3Heatmap}
  * - **Box plots** via {@link bindD3Box}
@@ -98,6 +99,7 @@ export { bindD3Candlestick } from './binders/candlestick';
 export { bindD3Heatmap } from './binders/heatmap';
 export { bindD3Histogram } from './binders/histogram';
 export { bindD3Line } from './binders/line';
+export { bindD3Pie } from './binders/pie';
 export { bindD3Scatter } from './binders/scatter';
 export { bindD3Segmented } from './binders/segmented';
 export { bindD3Smooth } from './binders/smooth';
@@ -117,6 +119,7 @@ export type {
   D3MultiPanelResult,
   D3PanelChartSpec,
   D3PanelLayout,
+  D3PieConfig,
   D3ScatterConfig,
   D3SegmentedConfig,
   D3SmoothConfig,

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -17,6 +17,7 @@ import type {
   Maidr,
   MaidrLayer,
   Orientation,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
   SmoothPoint,
@@ -312,6 +313,50 @@ export interface D3SmoothConfig extends D3BinderConfig {
 }
 
 /**
+ * Configuration for binding a D3 pie or doughnut chart.
+ *
+ * The canonical D3 pie is `d3.pie()` + `d3.arc()` drawn as one `<path>` per
+ * slice, so `selector` should match those paths. Both accessors are read
+ * against YOUR datum, not the arc the layout wraps it in — the binder unwraps
+ * the arc first.
+ *
+ * @example
+ * ```ts
+ * bindD3Pie(svg, {
+ *   selector: 'path.slice',
+ *   axes: { x: 'Fruit', y: 'Units' },
+ *   x: 'fruit',
+ * });
+ * ```
+ */
+export interface D3PieConfig extends D3BinderConfig {
+  /** CSS selector for the wedge elements (e.g., `'path.slice'`, `'path.arc'`). */
+  selector: string;
+  /**
+   * Accessor for the slice label. @default 'x', falling back to `label`,
+   * `name`, `category`, or `key` when the datum has one of those instead.
+   * A datum that is a bare number or string labels its own slice.
+   */
+  x?: DataAccessor<string | number>;
+  /**
+   * Accessor for the slice magnitude. Defaults to the value `d3.pie()` itself
+   * computed for the slice, which is what the drawn angle is proportional to;
+   * supply this only for a pie drawn without the layout.
+   */
+  y?: DataAccessor<number>;
+  /**
+   * Axis labels. A pie has no fill axis: the share of the whole is derived
+   * from the values themselves, so there is nothing for a third axis to name.
+   */
+  axes?: {
+    /** What the slice labels mean, e.g. `'Fruit'`. */
+    x?: D3AxisInput;
+    /** What the slice values measure, e.g. `'Units'`. */
+    y?: D3AxisInput;
+  };
+}
+
+/**
  * Result of a D3 binder function.
  * Contains the complete MAIDR data structure and the generated layer
  * for further customization if needed.
@@ -346,6 +391,7 @@ export type D3PanelChartSpec
     | { chartType: 'heatmap'; config: D3HeatmapConfig }
     | { chartType: 'histogram'; config: D3HistogramConfig }
     | { chartType: 'line'; config: D3LineConfig }
+    | { chartType: 'pie'; config: D3PieConfig }
     | { chartType: 'scatter'; config: D3ScatterConfig }
     | { chartType: 'segmented'; config: D3SegmentedConfig }
     | { chartType: 'smooth'; config: D3SmoothConfig };
@@ -464,6 +510,7 @@ export type D3ExtractedData
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]
+    | PiePoint[]
     | ScatterPoint[]
     | SegmentedPoint[][]
     | SmoothPoint[][];

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -69,6 +69,7 @@ import { bindD3Candlestick } from './binders/candlestick';
 import { bindD3Heatmap } from './binders/heatmap';
 import { bindD3Histogram } from './binders/histogram';
 import { bindD3Line } from './binders/line';
+import { bindD3Pie } from './binders/pie';
 import { bindD3Scatter } from './binders/scatter';
 import { bindD3Segmented } from './binders/segmented';
 import { bindD3Smooth } from './binders/smooth';
@@ -80,7 +81,7 @@ import { bindD3Facets, bindD3Subplots } from './binders/subplots';
  * The `chartType` field narrows the associated `config` to the correct
  * binder-specific type. This is what `useD3Adapter` and `<MaidrD3>` consume.
  *
- * Besides the nine single-chart types, `'facets'` (homogeneous small
+ * Besides the ten single-chart types, `'facets'` (homogeneous small
  * multiples) and `'subplots'` (heterogeneous panel grids) select the
  * multi-panel binders.
  */
@@ -125,6 +126,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Histogram(svg, { ...spec.config, autoApply: false });
     case 'line':
       return bindD3Line(svg, { ...spec.config, autoApply: false });
+    case 'pie':
+      return bindD3Pie(svg, { ...spec.config, autoApply: false });
     case 'scatter':
       return bindD3Scatter(svg, { ...spec.config, autoApply: false });
     case 'segmented':
@@ -156,6 +159,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
     case 'histogram':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'line':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'pie':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'scatter':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };

--- a/src/adapters/frappe/converters.ts
+++ b/src/adapters/frappe/converters.ts
@@ -18,6 +18,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   ScatterPoint,
 } from '@type/grammar';
 import type { FrappeChart, FrappeChartType, FrappeData, FrappePanel } from './types';
@@ -29,6 +30,7 @@ import {
   lineSelectorForDataset,
   nextId,
   scatterSelector,
+  sliceSelector,
 } from './selectors';
 
 // ---------------------------------------------------------------------------
@@ -212,6 +214,11 @@ interface BuildSubplotOptions {
   /** Axis labels for the panel's layers. */
   axes?: { x?: string; y?: string };
   /**
+   * The chart's `maxSlices` setting, read from the instance. Pie / donut only
+   * — see {@link buildPieLayer}.
+   */
+  maxSlices?: number;
+  /**
    * Panel display name. MAIDR has no subplot-level title field — the FIRST
    * layer's `title` is the panel's display name in subplot summaries, so this
    * is stamped onto `layers[0]`.
@@ -243,7 +250,10 @@ function buildSubplot(
   // Assign a stable container id (used for scoped CSS selectors).
   ensureContainerId(container);
 
-  const layers = buildLayers(data, container.id, options);
+  const layers = buildLayers(data, container.id, {
+    ...options,
+    maxSlices: chart.config?.maxSlices,
+  });
   if (options.panelTitle && layers.length > 0) {
     layers[0] = { ...layers[0], title: options.panelTitle };
   }
@@ -300,7 +310,7 @@ function normalizePanelGrid(
 function buildLayers(
   data: FrappeData,
   containerId: string,
-  options: FrappeChartAdapterOptions,
+  options: BuildSubplotOptions,
 ): MaidrLayer[] {
   switch (options.chartType) {
     case 'bar':
@@ -311,10 +321,13 @@ function buildLayers(
       return [buildScatterLayer(data, containerId, options)];
     case 'axis-mixed':
       return buildMixedLayers(data, containerId, options);
+    case 'pie':
+    case 'donut':
+      return [buildPieLayer(data, containerId, options)];
     default:
       throw new Error(
         `Unsupported Frappe chart type: ${options.chartType as string}. `
-        + 'Supported types: bar, line, scatter, axis-mixed.',
+        + 'Supported types: bar, line, scatter, axis-mixed, pie, donut.',
       );
   }
 }
@@ -455,17 +468,108 @@ function buildMixedLayers(
   });
 }
 
+/**
+ * Frappe's own `maxSlices` default: everything past the 19th largest slice is
+ * collapsed into one "Rest" wedge. Assumed when the adapter is handed a plain
+ * `{ data }` object with no live config to read.
+ */
+const DEFAULT_MAX_SLICES = 20;
+
+/** The label Frappe gives the collapsed tail slice. */
+const REST_SLICE_LABEL = 'Rest';
+
+/**
+ * What a pie's two dimensions are called when the caller names neither. A pie
+ * has no axes to take labels from, so these name what each dimension holds
+ * rather than leaving the slices unlabelled.
+ */
+const PIE_AXIS_FALLBACKS = { x: 'Label', y: 'Value' };
+
+/**
+ * Builds the layer for a pie or donut chart.
+ *
+ * Frappe aggregates before it draws (`AggregationChart.calc()`, v1.6.2): it
+ * sums every dataset at each label, drops any label whose total is not a
+ * number `>= 0`, and — only when there are more labels than `maxSlices` —
+ * sorts the totals descending and collapses the tail into a single "Rest"
+ * slice. The wedges are appended in exactly that order, so the conversion has
+ * to reproduce it: slice k must be wedge k or every highlight past the first
+ * reordered label lands on the wrong wedge.
+ *
+ * The percentage each slice represents is deliberately not emitted — MAIDR's
+ * pie trace derives it from the values, so there is one source of truth.
+ */
+function buildPieLayer(
+  data: FrappeData,
+  containerId: string,
+  options: BuildSubplotOptions,
+): MaidrLayer {
+  const chartType = options.chartType === 'donut' ? 'donut' : 'pie';
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.PIE,
+    selectors: sliceSelector(containerId, chartType),
+    axes: buildAxes(options, PIE_AXIS_FALLBACKS),
+    data: aggregateSlices(data, options.maxSlices ?? DEFAULT_MAX_SLICES),
+  };
+}
+
+/**
+ * Sums the datasets per label and collapses the tail exactly as Frappe does,
+ * yielding one point per rendered wedge, in wedge order.
+ */
+function aggregateSlices(data: FrappeData, maxSlices: number): PiePoint[] {
+  const totals: PiePoint[] = data.labels
+    .map((label, i) => ({
+      x: label,
+      // Frappe rounds each total to four decimals before drawing it; matching
+      // that keeps the announced value identical to the chart's own tooltip
+      // instead of the float noise a sum of several datasets can leave.
+      y: round4(data.datasets.reduce((sum, dataset) => sum + dataset.values[i], 0)),
+    }))
+    // A label whose datasets do not sum to a number `>= 0` gets no wedge — a
+    // negative total is meaningless in a pie, and a missing value sums to NaN,
+    // which fails the same comparison. Dropping both here is what keeps the
+    // points index-aligned with the wedges.
+    .filter(point => point.y >= 0);
+
+  if (totals.length <= maxSlices) {
+    return totals;
+  }
+
+  const sorted = [...totals].sort((a, b) => b.y - a.y);
+  const rest = sorted
+    .slice(maxSlices - 1)
+    .reduce((sum, point) => sum + point.y, 0);
+  return [...sorted.slice(0, maxSlices - 1), { x: REST_SLICE_LABEL, y: round4(rest) }];
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function buildAxes(options: FrappeChartAdapterOptions): { x?: AxisConfig; y?: AxisConfig } {
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}
+
+/**
+ * Builds the layer's axis labels. `fallbacks` name the two dimensions of a
+ * chart that has no axes to take them from (a pie), where an unlabelled layer
+ * would leave the reader with nothing to call the slices or their values.
+ */
+function buildAxes(
+  options: FrappeChartAdapterOptions,
+  fallbacks?: { x: string; y: string },
+): { x?: AxisConfig; y?: AxisConfig } {
   const axes: { x?: AxisConfig; y?: AxisConfig } = {};
-  if (options.axes?.x) {
-    axes.x = { label: options.axes.x };
+  const x = options.axes?.x ?? fallbacks?.x;
+  const y = options.axes?.y ?? fallbacks?.y;
+  if (x) {
+    axes.x = { label: x };
   }
-  if (options.axes?.y) {
-    axes.y = { label: options.axes.y };
+  if (y) {
+    axes.y = { label: y };
   }
   return axes;
 }

--- a/src/adapters/frappe/selectors.ts
+++ b/src/adapters/frappe/selectors.ts
@@ -11,6 +11,8 @@
  *   Lines:   <path class="line-graph-path"> + one <circle> per data point, inside
  *            <g class="dataset-units dataset-line dataset-{i}">
  *   Points:  <circle> inside <g class="dataset-units dataset-line dataset-{i}">  (scatter reuses the line group)
+ *   Pie:     <path class="pie-path"> inside <g class="pie-slices">
+ *   Donut:   <path class="donut-path"> inside <g class="donut-slices">
  *
  * For line traces MAIDR highlights one element per data point, so the line
  * selectors target the per-point `<circle>` dots (not the single `<path>`).
@@ -88,4 +90,20 @@ export function lineSelectorForDataset(containerId: string, index: number): stri
 /** Scoped selector for scatter point circles (rendered in the line dataset group). */
 export function scatterSelector(containerId: string): string {
   return `#${containerId} svg.frappe-chart .dataset-units.dataset-line circle`;
+}
+
+/**
+ * Scoped selector for the wedges of a pie or donut chart.
+ *
+ * Frappe draws the two with different components — a pie wedge is a filled
+ * `path.pie-path` in `g.pie-slices`, a donut wedge a stroked `path.donut-path`
+ * in `g.donut-slices` — so the selector follows the chart type. Both are
+ * appended in slice order, which is the order the adapter emits its points in.
+ *
+ * @param containerId - The chart container's id, for scoping.
+ * @param chartType - Which of the two aggregation charts was rendered.
+ * @returns The selector matching one element per slice, in slice order.
+ */
+export function sliceSelector(containerId: string, chartType: 'donut' | 'pie'): string {
+  return `#${containerId} svg.frappe-chart .${chartType}-slices path.${chartType}-path`;
 }

--- a/src/adapters/frappe/types.ts
+++ b/src/adapters/frappe/types.ts
@@ -33,21 +33,28 @@ export interface FrappeData {
 }
 
 /**
- * A rendered Frappe Charts instance. Only the `data` field that the adapter
- * reads is declared here.
+ * A rendered Frappe Charts instance. Only the fields the adapter reads are
+ * declared here.
  */
 export interface FrappeChart {
   data: FrappeData;
+  /**
+   * The chart's resolved configuration. Only `maxSlices` is read, and only for
+   * pie / donut charts: Frappe collapses everything past that many slices into
+   * a single "Rest" wedge, and the conversion has to collapse the same way to
+   * stay aligned with the wedges it draws. Absent on a plain `{ data }` object,
+   * in which case Frappe's own default (20) is assumed.
+   */
+  config?: { maxSlices?: number };
 }
 
 /**
  * Frappe Charts chart-type strings the adapter can convert.
  *
- * Frappe additionally supports `pie`, `donut`, `percentage`, and a
- * calendar-style `heatmap`; those have no clean MAIDR equivalent and are not
- * supported by this adapter.
+ * Frappe additionally supports `percentage` and a calendar-style `heatmap`;
+ * those have no clean MAIDR equivalent and are not supported by this adapter.
  */
-export type FrappeChartType = 'axis-mixed' | 'bar' | 'line' | 'scatter';
+export type FrappeChartType = 'axis-mixed' | 'bar' | 'donut' | 'line' | 'pie' | 'scatter';
 
 /**
  * One panel of a multi-panel (small-multiples) figure built from several

--- a/src/adapters/google-charts/converters.ts
+++ b/src/adapters/google-charts/converters.ts
@@ -9,6 +9,7 @@
  * MAIDR uses typed data structures per chart type:
  *   BarPoint[]          = [{ x, y }, ...]
  *   LinePoint[][]       = [[{ x, y, fill? }, ...], ...]
+ *   PiePoint[]          = [{ x, y }, ...]  (flat: one entry per slice)
  *   ScatterPoint[]      = [{ x, y }, ...]
  *   SegmentedPoint[][]  = [[{ x, y, fill }, ...], ...]  (stacked/dodged/normalized)
  *   CandlestickPoint[]  = [{ value, open, high, low, close, ... }, ...]
@@ -23,6 +24,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
 } from '@type/grammar';
@@ -50,6 +52,18 @@ const POSITION_TOLERANCE = 2;
 const CANDLESTICK_GRID_MAX_WIDTH = 1;
 const CANDLESTICK_WICK_MAX_WIDTH = 3;
 const CANDLESTICK_BODY_MIN_WIDTH = 10;
+
+/**
+ * Matches the elliptical-arc command in an SVG path's `d` attribute.
+ *
+ * Google Charts gives its pie slices no class or id, so the wedges have to be
+ * told apart from the other paths in the SVG by their geometry. An arc
+ * command is the one thing every wedge has and no legend swatch, axis line,
+ * or gridline does; `A`/`a` cannot appear anywhere else in a `d` attribute,
+ * whose only other letters are the remaining commands and the `e` of an
+ * exponent.
+ */
+const SVG_ARC_COMMAND = /a/i;
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -443,6 +457,10 @@ function buildLayer(
       return buildBarOrSegmentedLayer(chart, dt, container, Orientation.HORIZONTAL);
     case 'LineChart':
       return buildLineLayer(chart, dt, container);
+    case 'PieChart':
+      // No `chart`: unlike the axis-based charts, a PieChart has no
+      // `getChartLayoutInterface()` to ask where each slice was drawn.
+      return buildPieLayer(dt, container);
     case 'ScatterChart':
       return buildScatterLayer(chart, dt, container);
     case 'StackedColumnChart':
@@ -459,7 +477,8 @@ function buildLayer(
       throw new Error(
         `Unsupported Google Charts type: ${chartType as string}. `
         + 'Supported types: BarChart, CandlestickChart, ColumnChart, DodgedBarChart, '
-        + 'DodgedColumnChart, LineChart, ScatterChart, StackedBarChart, StackedColumnChart.',
+        + 'DodgedColumnChart, LineChart, PieChart, ScatterChart, StackedBarChart, '
+        + 'StackedColumnChart.',
       );
   }
 }
@@ -494,15 +513,7 @@ function buildBarLayer(
 ): MaidrLayer {
   const data: BarPoint[] = [];
   const rows = dt.getNumberOfRows();
-
-  // Find first non-role data column (defensive: don't assume column 1 is data)
-  let dataCol = 1;
-  for (let c = 1; c < dt.getNumberOfColumns(); c++) {
-    if (!isRoleColumn(dt, c)) {
-      dataCol = c;
-      break;
-    }
-  }
+  const dataCol = firstDataColumn(dt);
 
   for (let r = 0; r < rows; r++) {
     const label = formatCellValue(dt, r, 0);
@@ -666,6 +677,103 @@ function buildScatterLayer(
 }
 
 // ---------------------------------------------------------------------------
+// Pie / doughnut
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a pie layer from a Google Charts PieChart.
+ *
+ * A doughnut is the same chart class drawn with a `pieHole` option, so it
+ * needs no separate branch. Column 0 supplies the slice labels and the first
+ * data column their magnitudes; the share of the whole is NOT emitted — the
+ * model derives it from the values, so there is exactly one source of truth.
+ *
+ * A PieChart is not axis-based, so `axes.x` / `axes.y` here name what the
+ * slice labels mean and what their values measure rather than any drawn axis.
+ */
+function buildPieLayer(
+  dt: GoogleDataTable,
+  container: HTMLElement,
+): MaidrLayer {
+  const rows = dt.getNumberOfRows();
+  const dataCol = firstDataColumn(dt);
+
+  const data: PiePoint[] = [];
+  for (let r = 0; r < rows; r++) {
+    data.push({
+      x: formatCellValue(dt, r, 0),
+      y: numericValue(dt, r, dataCol),
+    });
+  }
+
+  const selector = markPieSliceElements(container, rows);
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.PIE,
+    ...(selector ? { selectors: selector } : {}),
+    axes: {
+      x: { label: dt.getColumnLabel(0) || undefined },
+      y: { label: dt.getColumnLabel(dataCol) || undefined },
+    },
+    data,
+  };
+}
+
+/**
+ * Marks the SVG wedge paths of a pie chart and returns a selector for them.
+ *
+ * Google Charts renders each slice as one `<path>`, in DataTable row order,
+ * with no class or id to select on — so the wedges are picked out by the arc
+ * command in their `d` attribute (see {@link SVG_ARC_COMMAND}), which no
+ * legend swatch or axis line has.
+ *
+ * When the wedge count does not match the row count the mapping between data
+ * and DOM is unknown, and the marks are left off entirely: a 3-D pie draws
+ * several paths per slice, and `sliceVisibilityThreshold` folds tiny slices
+ * into a single "Other" wedge. Highlighting the wrong slice would tell a
+ * sighted collaborator one thing while the audio and text say another, so no
+ * highlight is the safer answer.
+ *
+ * @param container - The DOM container element
+ * @param sliceCount - Number of data rows (one per slice)
+ * @returns CSS selector for the marked wedges, or undefined when they could
+ *          not be identified with confidence
+ */
+function markPieSliceElements(
+  container: HTMLElement,
+  sliceCount: number,
+): string | undefined {
+  const svg = container.querySelector('svg');
+  if (!svg) {
+    return undefined;
+  }
+
+  // Clear any existing marks from previous initializations
+  const existingMarked = svg.querySelectorAll('path[data-maidr-slice]');
+  existingMarked.forEach(path => path.removeAttribute('data-maidr-slice'));
+
+  const wedges = Array.from(svg.querySelectorAll('path'))
+    .filter(path => SVG_ARC_COMMAND.test(path.getAttribute('d') ?? ''));
+  if (wedges.length === 0) {
+    return undefined;
+  }
+
+  if (wedges.length !== sliceCount) {
+    console.warn(
+      `[MAIDR] Pie slice count mismatch: expected ${sliceCount}, found ${wedges.length}. `
+      + 'Visual highlighting is disabled for this chart. 3-D pies (is3D) draw several '
+      + 'paths per slice, and sliceVisibilityThreshold merges small slices into one.',
+    );
+    return undefined;
+  }
+
+  wedges.forEach((wedge, index) => wedge.setAttribute('data-maidr-slice', `${index}`));
+
+  return `#${container.id} svg path[data-maidr-slice]`;
+}
+
+// ---------------------------------------------------------------------------
 // Candlestick
 // ---------------------------------------------------------------------------
 
@@ -779,6 +887,23 @@ function isRoleColumn(dt: GoogleDataTable, c: number): boolean {
     return role !== '' && role !== 'data';
   }
   return false;
+}
+
+/**
+ * Returns the index of the first non-role data column.
+ *
+ * Defensive: a DataTable may carry a role column (tooltip, style, …) directly
+ * after the domain column, so column 1 is not necessarily data. Falls back to
+ * column 1 when every column past the domain is a role column, which leaves
+ * the value lookup to fail loudly rather than silently reading a tooltip.
+ */
+function firstDataColumn(dt: GoogleDataTable): number {
+  for (let c = 1; c < dt.getNumberOfColumns(); c++) {
+    if (!isRoleColumn(dt, c)) {
+      return c;
+    }
+  }
+  return 1;
 }
 
 /**

--- a/src/adapters/google-charts/types.ts
+++ b/src/adapters/google-charts/types.ts
@@ -132,6 +132,8 @@ export type GoogleChartType
     | 'DodgedBarChart'
     | 'DodgedColumnChart'
     | 'LineChart'
+    /** Also covers doughnuts, which Google draws as a `PieChart` with a `pieHole`. */
+    | 'PieChart'
     | 'ScatterChart'
     | 'StackedBarChart'
     | 'StackedColumnChart';

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -26,6 +26,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
@@ -40,6 +41,7 @@ import {
   heatmapSelectors,
   histogramSelector,
   lineSelectors,
+  pieSelector,
   scatterSelector,
   seriesGroupSelector,
 } from './selectors';
@@ -61,6 +63,8 @@ let chartCounter = 0;
  * - `heatmap` → {@link TraceType.HEATMAP}
  * - `histogram` → {@link TraceType.HISTOGRAM}
  * - `candlestick`, `ohlc` → {@link TraceType.CANDLESTICK}
+ * - `pie` (including doughnuts, which are a pie with an `innerSize`) →
+ *   {@link TraceType.PIE}
  * - Stacked `column`/`bar` → {@link TraceType.STACKED}
  * - Grouped (dodged) `column`/`bar` → {@link TraceType.DODGED}
  * - Percent-stacked `column`/`bar` → {@link TraceType.NORMALIZED}
@@ -711,6 +715,8 @@ function convertSeries(
     case 'candlestick':
     case 'ohlc':
       return convertCandlestickSeries(series, chart, containerId);
+    case 'pie':
+      return convertPieSeries(series, containerId);
     default:
       console.warn(`[MAIDR Highcharts] Unsupported series type: "${seriesType}"; skipping.`);
       return null;
@@ -809,6 +815,47 @@ function convertScatterSeries(
     axes: {
       x: getAxisLabel(series, 'x'),
       y: getAxisLabel(series, 'y'),
+    },
+    data,
+  };
+}
+
+/**
+ * What a pie's two dimensions are called. A pie series is bound to no axis, so
+ * {@link getAxisLabel}'s `'X'` / `'Y'` fallback would name them after
+ * coordinates a pie does not have; these name what each one actually holds.
+ */
+const PIE_LABEL_AXIS = 'Label';
+const PIE_VALUE_AXIS = 'Value';
+
+/**
+ * Converts a `pie` series — a doughnut is the same series type with an
+ * `innerSize`, and reads identically — into a pie layer.
+ *
+ * Highcharts draws the wedges in `series.data` order, so slice k is wedge k
+ * with no reordering to undo. A point with no value is dropped rather than
+ * carried through as a gap, because Highcharts draws no wedge for it: keeping
+ * it would slide every later slice's highlight onto its neighbour.
+ */
+function convertPieSeries(
+  series: HighchartsSeries,
+  containerId: string,
+): MaidrLayer {
+  const data: PiePoint[] = series.data
+    .filter(p => p.y != null)
+    .map(p => ({
+      x: pointLabel(p),
+      y: p.y as number,
+    }));
+
+  return {
+    id: String(series.index),
+    type: TraceType.PIE,
+    title: series.name || undefined,
+    selectors: pieSelector(containerId, series.index),
+    axes: {
+      x: { label: PIE_LABEL_AXIS },
+      y: { label: PIE_VALUE_AXIS },
     },
     data,
   };

--- a/src/adapters/highcharts/selectors.ts
+++ b/src/adapters/highcharts/selectors.ts
@@ -114,6 +114,21 @@ export function scatterSelector(containerId: string, seriesIndex: number): strin
 }
 
 /**
+ * Generates a CSS selector for the wedges of a pie (or doughnut) series.
+ *
+ * Highcharts draws each slice as a `<path class="highcharts-point">` inside
+ * the series group, in `series.data` order — a pie is not reordered the way a
+ * plotly one is. The data labels Highcharts places around the pie live in a
+ * separate `.highcharts-data-labels` group and carry neither that class nor a
+ * `<path>` of their own, so no filtering is needed beyond the
+ * `.highcharts-series-group` scoping that already excludes the legend swatch
+ * (see file header).
+ */
+export function pieSelector(containerId: string, seriesIndex: number): string {
+  return `#${containerId} .highcharts-series-group .highcharts-series-${seriesIndex} .highcharts-point`;
+}
+
+/**
  * Generates a CSS selector for histogram bar elements.
  *
  * Histogram bins carry the `highcharts-point` class. Like bar/column, the

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -20,6 +20,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
@@ -288,6 +289,9 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
     case 'candlestick':
       return TraceType.CANDLESTICK;
 
+    case 'pie':
+      return TraceType.PIE;
+
     default:
       console.warn(`[maidr] Unsupported plotly trace type: "${type}". Skipping.`);
       return null;
@@ -356,6 +360,11 @@ function stepDirectionOf(trace: PlotlyTrace): StepDirection | undefined {
 interface SubplotGroup {
   xAxisId: string;
   yAxisId: string;
+  /**
+   * Where the panel sits on the paper, when it is not an axis pair that says
+   * so. Only a pie sets this — see {@link groupTracesBySubplot}.
+   */
+  domain?: { x: DomainInterval; y: DomainInterval };
   traces: PlotlyTrace[];
   calcdata: PlotlyCalcData[][];
   traceIndices: number[];
@@ -385,14 +394,22 @@ function groupTracesBySubplot(
     if (trace.visible === false || trace.visible === 'legendonly')
       continue;
 
-    const xAxisId = trace.xaxis ?? 'x';
-    const yAxisId = trace.yaxis ?? 'y';
-    const key = `${xAxisId}${yAxisId}`;
+    // A pie has no axes: plotly positions it by its own `domain` instead, and
+    // `trace.xaxis`/`trace.yaxis` are unset. Falling through to the 'x'/'y'
+    // defaults below would file it under the cartesian panel that happens to
+    // use the first axis pair, giving it that panel's axis labels and putting
+    // two unrelated charts in one subplot. Each pie is its own panel, keyed by
+    // its trace index and positioned from its own domain.
+    const isPie = trace.type === 'pie';
+    const xAxisId = isPie ? '' : (trace.xaxis ?? 'x');
+    const yAxisId = isPie ? '' : (trace.yaxis ?? 'y');
+    const key = isPie ? `pie${i}` : `${xAxisId}${yAxisId}`;
 
     if (!map.has(key)) {
       map.set(key, {
         xAxisId,
         yAxisId,
+        ...(isPie ? { domain: readTraceDomain(trace) } : {}),
         traces: [],
         calcdata: [],
         traceIndices: [],
@@ -605,8 +622,10 @@ function arrangePanelsIntoGrid(
 ): PositionedPanel[][] | null {
   const positioned: PositionedPanel[] = [];
   for (const panel of panels) {
-    const xDomain = readAxisDomain(getAxis(layout, panel.group.xAxisId));
-    const yDomain = readAxisDomain(getAxis(layout, panel.group.yAxisId));
+    // A pie panel carries its own domain (it has no axes to read one from);
+    // everything else takes it from the axis pair it was grouped by.
+    const xDomain = panel.group.domain?.x ?? readAxisDomain(getAxis(layout, panel.group.xAxisId));
+    const yDomain = panel.group.domain?.y ?? readAxisDomain(getAxis(layout, panel.group.yAxisId));
     if (!xDomain || !yDomain)
       return null;
     positioned.push({ ...panel, xDomain, yDomain });
@@ -682,8 +701,22 @@ function containsValue(interval: DomainInterval, value: number): boolean {
   return value >= interval[0] - DOMAIN_EPS && value <= interval[1] + DOMAIN_EPS;
 }
 
+/**
+ * Reads a trace's own paper domain, which is how plotly positions the traces
+ * that have no axes. Returns `undefined` unless BOTH sides are usable — half a
+ * domain cannot place a panel in a grid.
+ */
+function readTraceDomain(trace: PlotlyTrace): { x: DomainInterval; y: DomainInterval } | undefined {
+  const x = readInterval(trace.domain?.x);
+  const y = readInterval(trace.domain?.y);
+  return x && y ? { x, y } : undefined;
+}
+
 function readAxisDomain(axis: PlotlyAxis | undefined): DomainInterval | null {
-  const domain = axis?.domain;
+  return readInterval(axis?.domain);
+}
+
+function readInterval(domain: [number, number] | undefined): DomainInterval | null {
   if (!domain || domain.length < 2)
     return null;
   const start = Number(domain[0]);
@@ -965,6 +998,13 @@ function assignSubplotSelectors(grid: PanelEntry[][], maidrId: string): void {
   for (const row of grid) {
     for (const panel of row) {
       const axisPair = `${panel.group.xAxisId}${panel.group.yAxisId}`;
+      // A pie panel has no axis pair. It also has no background rect in the
+      // `.bglayer` for the normalizer to wrap in an `axes_…` group, and the
+      // normalizer pairs the ids collected here with those rects positionally
+      // — so emitting one for a pie would not just point at a group that does
+      // not exist, it would shift every cartesian panel onto its neighbour's.
+      if (!axisPair)
+        continue;
       panel.subplot.selector = `g[id="axes_${tag}_${axisPair}"]`;
     }
   }
@@ -1008,6 +1048,11 @@ function extractLayer(
 
     case TraceType.CANDLESTICK:
       return extractCandlestickLayer(trace, id, title, selectors, axes);
+
+    // `axes` is deliberately not passed on: a pie group has no axis ids, so it
+    // is always empty, and the pie names its own two dimensions.
+    case TraceType.PIE:
+      return extractPieLayer(trace, calcdata, id, title, selectors);
 
     default:
       return null;
@@ -1737,6 +1782,104 @@ function extractHeatmapLayer(
  */
 function extractColorbarTitle(trace: PlotlyTrace, layout: PlotlyLayout | undefined): string | undefined {
   return extractGivenTitle(trace.colorbar?.title, layout);
+}
+
+// ---------------------------------------------------------------------------
+// Pie
+// ---------------------------------------------------------------------------
+
+/**
+ * What a pie's two dimensions are called. Plotly gives a pie no axes and so no
+ * titles to take these from; they are named after the attributes an author
+ * writes, `labels` and `values`.
+ */
+const PIE_LABEL_AXIS = 'Label';
+const PIE_VALUE_AXIS = 'Value';
+
+/** One slice as the layer needs it: a label and the magnitude behind it. */
+interface PieSlice {
+  label: string | number;
+  value: number;
+}
+
+/**
+ * Reads the slices out of what plotly computed for the pie.
+ *
+ * calcdata is the only source that describes the pie as it was drawn. Plotly
+ * does not draw one in the order it was authored: `sort` — on unless a trace
+ * turns it off — puts the largest slice first, and calc drops any slice it
+ * will not draw at all (a missing or negative value). What survives is exactly
+ * the wedges in the DOM, in their order, which is what the layer's
+ * data-index-k-is-wedge-k contract needs.
+ *
+ * @returns The drawn slices, or `null` when plotly has not computed the trace.
+ */
+function drawnPieSlices(calcdata: PlotlyCalcData[]): PieSlice[] | null {
+  if (calcdata.length === 0) {
+    return null;
+  }
+
+  const slices: PieSlice[] = [];
+  for (const cd of calcdata) {
+    if (typeof cd.v !== 'number') {
+      return null;
+    }
+    slices.push({ label: cd.label ?? '', value: cd.v });
+  }
+  return slices;
+}
+
+/**
+ * Reads the slices from the trace's own arrays, as the author wrote them.
+ *
+ * The fallback for a chart captured before plotly computed it. A label with no
+ * value (and the reverse) is not a slice, so the two arrays are read only as
+ * far as both reach.
+ */
+function authoredPieSlices(trace: PlotlyTrace): PieSlice[] {
+  const labels = trace.labels ?? [];
+  const values = trace.values ?? [];
+
+  const len = Math.min(labels.length, values.length);
+  const slices: PieSlice[] = [];
+  for (let i = 0; i < len; i++) {
+    slices.push({ label: labels[i], value: Number(values[i]) });
+  }
+  return slices;
+}
+
+function extractPieLayer(
+  trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
+  id: string,
+  title: string | undefined,
+  selectors: string | undefined,
+): MaidrLayer | null {
+  const drawn = drawnPieSlices(calcdata);
+  const slices = drawn ?? authoredPieSlices(trace);
+  if (slices.length === 0)
+    return null;
+
+  // The authored order is also the drawn order only when the trace turned
+  // `sort` off. Otherwise plotly reordered the wedges and slice k is not
+  // wedge k, so the layer goes out without selectors — no highlight at all
+  // beats a highlight that lands on a neighbouring slice while the text
+  // announces this one.
+  const inDrawnOrder = drawn !== null || trace.sort === false;
+
+  const data: PiePoint[] = slices.map(slice => ({ x: slice.label, y: slice.value }));
+
+  return {
+    id,
+    type: TraceType.PIE,
+    title,
+    selectors: inDrawnOrder ? selectors : undefined,
+    axes: {
+      x: { label: PIE_LABEL_AXIS },
+      y: { label: PIE_VALUE_AXIS },
+    },
+    data,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -15,7 +15,7 @@
  * py-maidr's proven approach.
  */
 
-import type { PlotlyGraphDiv } from './types';
+import type { PlotlyGraphDiv, PlotlyTrace } from './types';
 import { TraceType } from '../../type/grammar';
 
 /**
@@ -64,6 +64,9 @@ export function generatePlotlySelectors(
       // Candlestick reuses box plot rendering: boxlayer > trace.boxes > path.box
       return `${prefix}.trace.boxes .box`;
 
+    case TraceType.PIE:
+      return pieSelector(plotlyGd, traceIndex);
+
     default:
       return undefined;
   }
@@ -99,4 +102,36 @@ function lineSelector(prefix: string, mode?: string): string | undefined {
   }
   // Lines-only mode: no per-point SVG elements to highlight.
   return undefined;
+}
+
+/**
+ * Pie selector: the wedge paths of one pie trace, in drawing order.
+ *
+ * A pie has no axes, so plotly draws it in `.pielayer` rather than in a
+ * `.subplot.xy` group — the prefix every other selector here is scoped by does
+ * not exist for one. It also gives each pie a bare `<g class="trace">` with no
+ * uid class (scatter's `trace{uid}` has no pie counterpart), so the only thing
+ * distinguishing one pie from another on the same paper is its position among
+ * them. Plotly orders those groups to match the traces it drew, skipping the
+ * ones it did not, hence counting only the drawn pies before this one.
+ */
+function pieSelector(gd: PlotlyGraphDiv, traceIndex: number): string {
+  const traces = gd._fullData ?? [];
+  let drawnBefore = 0;
+  for (let i = 0; i < traceIndex; i++) {
+    if (isDrawnPie(traces[i])) {
+      drawnBefore++;
+    }
+  }
+  return `.pielayer > g.trace:nth-of-type(${drawnBefore + 1}) g.slice path.surface`;
+}
+
+/**
+ * Whether a trace is a pie plotly put on the paper. A hidden or legend-only
+ * trace gets no group in `.pielayer`, so it must not shift the count.
+ */
+function isDrawnPie(trace: PlotlyTrace | undefined): boolean {
+  return trace?.type === 'pie'
+    && trace.visible !== false
+    && trace.visible !== 'legendonly';
 }

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -48,6 +48,23 @@ export interface PlotlyTrace {
   close?: number[];
   // Histogram-specific
   xbins?: { start?: number; end?: number; size?: number };
+  // Pie-specific
+  /** Slice labels, in the order the trace was authored. */
+  labels?: (number | string)[];
+  /** Slice magnitudes, parallel to {@link labels}. */
+  values?: (number | string)[];
+  /**
+   * Whether plotly reorders the slices largest-first before drawing them.
+   * Defaults to true, so the authored order is NOT the drawn order unless a
+   * trace turns this off.
+   */
+  sort?: boolean;
+  /**
+   * Fraction of the paper the trace occupies, `[start, end]` in [0, 1] on each
+   * side. A pie is positioned by this rather than by axes, so it is the only
+   * thing that says where one sits relative to its siblings.
+   */
+  domain?: { x?: [number, number]; y?: [number, number] };
   // Heatmap colorbar
   colorbar?: { title?: { text?: string } | string };
 }
@@ -171,6 +188,11 @@ export interface PlotlyCalcData {
   posCenterPx?: number;
   /** Per-trace calc metadata; plotly stores it on the first entry of a trace. */
   t?: PlotlyCalcMeta;
+  // Pie calc data
+  /** Slice magnitude, after plotly dropped the values it would not draw. */
+  v?: number;
+  /** Slice label. */
+  label?: number | string;
   // Heatmap
   z?: number[][];
   trace?: PlotlyTrace;

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -11,6 +11,7 @@
  *   ScatterPoint[]      = [{ x, y }, ...]
  *   SegmentedPoint[][]  = [[{ x, y, fill }, ...], ...]  (stacked/dodged/normalized)
  *   HistogramPoint[]    = [{ x, y, xMin, xMax, yMin, yMax }, ...]
+ *   PiePoint[]          = [{ x, y }, ...]                (flat, one per slice)
  */
 
 import type {
@@ -20,6 +21,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
 } from '@type/grammar';
@@ -236,7 +238,7 @@ function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): 
       title: hasMultipleSeries ? (fillKeys?.[index] ?? yKey) : undefined,
       // LineTrace expects selectors as string[] (one per series), not a single string
       selectors: isLineType(chartType) ? (selector ? [selector] : undefined) : selector,
-      orientation: orientation ?? (isBarType(chartType) ? Orientation.VERTICAL : undefined),
+      orientation: layerOrientation(chartType, orientation),
       axes: {
         x: { label: xLabel },
         y: { label: yLabel },
@@ -416,7 +418,7 @@ function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string)
       title: name,
       // LineTrace expects selectors as string[] (one per series), not a single string
       selectors: isLineType(chartType) ? (selector ? [selector] : undefined) : selector,
-      orientation: orientation ?? (isBarType(chartType) ? Orientation.VERTICAL : undefined),
+      orientation: layerOrientation(chartType, orientation),
       axes: {
         x: { label: xLabel },
         y: { label: yLabel },
@@ -434,7 +436,7 @@ function convertData(
   data: Record<string, unknown>[],
   xKey: string,
   yKey: string,
-): BarPoint[] | LinePoint[][] | ScatterPoint[] {
+): BarPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] {
   switch (chartType) {
     case 'bar':
       return convertToBarPoints(data, xKey, yKey);
@@ -442,6 +444,8 @@ function convertData(
       return convertToLinePoints(data, xKey, yKey);
     case 'scatter':
       return convertToScatterPoints(data, xKey, yKey);
+    case 'pie':
+      return convertToPiePoints(data, xKey, yKey);
     // Stacked/dodged/normalized/histogram handled by dedicated builders
     case 'stacked_bar':
     case 'dodged_bar':
@@ -485,6 +489,24 @@ function convertToLinePoints(
 }
 
 /**
+ * Converts data to PiePoint[] format — a flat array, one entry per slice.
+ *
+ * `xKey` is the Recharts `<Pie nameKey>` (the slice label) and `yKey` its
+ * `dataKey` (the magnitude). `PiePoint.y` is strictly numeric, unlike
+ * `BarPoint.y`, because it is also the numerator of the slice's percentage.
+ */
+function convertToPiePoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+): PiePoint[] {
+  return data.map(item => ({
+    x: item[xKey] as string | number,
+    y: toNumber(item[yKey]),
+  }));
+}
+
+/**
  * Converts data to ScatterPoint[] format.
  */
 function convertToScatterPoints(
@@ -507,6 +529,23 @@ function isBarType(chartType: RechartsChartType): boolean {
     || chartType === 'dodged_bar'
     || chartType === 'normalized_bar'
     || chartType === 'histogram';
+}
+
+/**
+ * Returns the orientation to emit for a layer of the given chart type.
+ *
+ * Bar-like layers default to vertical. A pie is never oriented — its slices sit
+ * around a circle rather than along an axis — so a config-level `orientation`
+ * (meaningful for the other layers of a composed chart) must not leak onto one.
+ */
+function layerOrientation(
+  chartType: RechartsChartType,
+  orientation?: Orientation,
+): Orientation | undefined {
+  if (chartType === 'pie') {
+    return undefined;
+  }
+  return orientation ?? (isBarType(chartType) ? Orientation.VERTICAL : undefined);
 }
 
 /**
@@ -544,6 +583,8 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.LINE;
     case 'scatter':
       return TraceType.SCATTER;
+    case 'pie':
+      return TraceType.PIE;
   }
 }
 

--- a/src/adapters/recharts/selectors.ts
+++ b/src/adapters/recharts/selectors.ts
@@ -23,6 +23,22 @@
  *   g.recharts-scatter > g.recharts-scatter-symbol > path.recharts-symbols
  *   [target: .recharts-scatter-symbol .recharts-symbols]
  *
+ * PieChart:
+ *   g.recharts-pie > g.recharts-pie-sector > path.recharts-sector
+ *   [target: .recharts-pie-sector .recharts-sector]
+ *
+ *   Recharts emits one sector group per slice in data order, so the selector
+ *   already satisfies the pie contract of N elements index-aligned to the
+ *   data. The `.recharts-pie-sector` parent scope matters here: the pie's
+ *   label lines (`<path class="recharts-curve">`) and, in an active-shape
+ *   chart, the enlarged active sector live under `.recharts-pie` too.
+ *
+ *   One exception is out of the adapter's hands: Recharts renders no sector at
+ *   all for a zero-value slice (`Pie.js` drops sectors whose start and end
+ *   angles are both 0). `PieTrace` sees fewer elements than slices and turns
+ *   highlighting off for the layer rather than mis-aligning it, so audio,
+ *   text, and braille still describe every slice including the zero.
+ *
  * Selectors are scoped to their parent container classes to avoid matching
  * Recharts utility elements (e.g. Tooltip cursor rectangles) that share the
  * same leaf class name.
@@ -138,5 +154,7 @@ function baseRechartsSelector(chartType: RechartsChartType): string | undefined 
       return '.recharts-line-dots .recharts-line-dot';
     case 'scatter':
       return '.recharts-scatter-symbol .recharts-symbols';
+    case 'pie':
+      return '.recharts-pie-sector .recharts-sector';
   }
 }

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -18,6 +18,9 @@ import type { Orientation } from '@type/grammar';
  * - `'histogram'` → `TraceType.HISTOGRAM` — Histogram rendered as bar chart with bin ranges
  * - `'line'` → `TraceType.LINE` — Line chart
  * - `'scatter'` → `TraceType.SCATTER` — Scatter/point plot
+ * - `'pie'` → `TraceType.PIE` — Pie/doughnut chart (Recharts `<Pie>`); a
+ *   doughnut is a pie with an `innerRadius`, which changes nothing about the
+ *   data, so both use this type
  */
 export type RechartsChartType
   = | 'bar'
@@ -26,7 +29,8 @@ export type RechartsChartType
     | 'normalized_bar'
     | 'histogram'
     | 'line'
-    | 'scatter';
+    | 'scatter'
+    | 'pie';
 
 /**
  * A single data series/layer configuration for composed charts.
@@ -165,6 +169,22 @@ export interface RechartsSubplotConfig {
  *   binConfig: { xMinKey: 'xMin', xMaxKey: 'xMax' },
  *   xLabel: 'Score',
  *   yLabel: 'Frequency',
+ * };
+ * ```
+ *
+ * @example Pie chart
+ * ```typescript
+ * // `xKey` is the Recharts `<Pie nameKey>` (the slice label) and the single
+ * // `yKeys` entry is its `dataKey` (the slice magnitude).
+ * const config: RechartsAdapterConfig = {
+ *   id: 'fruit-chart',
+ *   title: 'Fruit Sales',
+ *   data: [{ fruit: 'Apples', units: 30 }, { fruit: 'Bananas', units: 50 }],
+ *   chartType: 'pie',
+ *   xKey: 'fruit',
+ *   yKeys: ['units'],
+ *   xLabel: 'Fruit',
+ *   yLabel: 'Units',
  * };
  * ```
  *

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -25,6 +25,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
@@ -596,6 +597,8 @@ function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
  *   - `rect`                           → HEATMAP
  *   - `tick`                           → SCATTER (individual value marks)
  *   - `line`/`area` with a stepping `interpolate` → STEP
+ *   - `arc` with a `theta` encoding    → PIE (a doughnut is the same mark
+ *     with an `innerRadius`, and reads identically)
  */
 function resolveTraceType(
   mark: string,
@@ -636,6 +639,12 @@ function resolveTraceType(
       return TraceType.HEATMAP;
     case 'boxplot':
       return TraceType.BOX;
+    // `theta` is what turns an arc into a pie: it is the channel the slice
+    // magnitudes ride on. An arc encoded by `radius` alone is a radial plot
+    // with no slices to navigate, so it stays unsupported rather than being
+    // announced as a pie whose values MAIDR would have to invent.
+    case 'arc':
+      return encoding?.theta ? TraceType.PIE : null;
     default:
       return null;
   }
@@ -1001,6 +1010,29 @@ function extractBarData(
       y: Number(readEncodedValue(row, encoding.y, yField) ?? 0),
     };
   });
+}
+
+/**
+ * Read one slice per row: the colour channel names it, `theta` measures it.
+ *
+ * Rows stay in dataset order, which for an arc mark IS the drawn order — the
+ * `stack` transform Vega-Lite compiles a `theta` encoding into computes each
+ * slice's start and end angle without reordering the rows it reads. So no
+ * visual-order pass is needed at bind time the way simple bars need one: slice
+ * k is already wedge k.
+ */
+function extractPieData(
+  rows: Record<string, unknown>[],
+  encoding: VegaLiteEncoding,
+): PiePoint[] {
+  const labelChannel = encoding.color ?? encoding.fill;
+  const labelField = labelChannel?.field ?? 'category';
+  const thetaField = encoding.theta?.field ?? 'theta';
+
+  return rows.map(row => ({
+    x: String(row[labelField] ?? ''),
+    y: Number(readEncodedValue(row, encoding.theta, thetaField) ?? 0),
+  }));
 }
 
 function extractHistogramData(
@@ -1451,6 +1483,15 @@ function convertLayerSpec(
     case TraceType.HEATMAP:
       data = extractHeatmapData(rows, encoding);
       selectors = buildSelector(mark, selectorLayerIndex, layered, markGroupPrefix);
+      break;
+    case TraceType.PIE:
+      data = extractPieData(rows, encoding);
+      selectors = buildSelector(mark, selectorLayerIndex, layered, markGroupPrefix);
+      // An arc has no x or y to name the axes after — the pair built above is
+      // two empty labels. The slice labels come from the colour channel and
+      // the magnitudes from `theta`, so the layer's axes are named after those.
+      axes.x = getAxisConfig(encoding.color ?? encoding.fill);
+      axes.y = getAxisConfig(encoding.theta);
       break;
     case TraceType.BOX: {
       data = extractBoxData(rows, encoding);

--- a/src/adapters/vegalite/types.ts
+++ b/src/adapters/vegalite/types.ts
@@ -98,9 +98,10 @@ export interface VegaLiteSpec {
    * The mark, as a shorthand string or a mark def. `interpolate` is how
    * Vega-Lite joins consecutive points: the `step`, `step-before` and
    * `step-after` values draw a piecewise-constant staircase, the rest
-   * interpolate.
+   * interpolate. `innerRadius` is what turns an `arc` pie into a doughnut —
+   * purely visual, so the two convert identically.
    */
-  mark?: string | { type: string; interpolate?: string };
+  mark?: string | { type: string; interpolate?: string; innerRadius?: number };
   encoding?: VegaLiteEncoding;
   layer?: VegaLiteSpec[];
   hconcat?: VegaLiteSpec[];
@@ -133,6 +134,12 @@ export interface VegaLiteEncoding {
   xOffset?: VegaLiteChannelDef;
   /** Vertical counterpart of `xOffset`. */
   yOffset?: VegaLiteChannelDef;
+  /**
+   * Angular extent of an `arc` mark — the channel that makes one a pie (or,
+   * with `mark.innerRadius`, a doughnut). It carries the slice magnitudes;
+   * the slice labels come from `color`/`fill`, since an arc has no x or y.
+   */
+  theta?: VegaLiteChannelDef;
   color?: VegaLiteChannelDef;
   fill?: VegaLiteChannelDef;
   row?: VegaLiteChannelDef;

--- a/src/adapters/victory/MaidrVictory.tsx
+++ b/src/adapters/victory/MaidrVictory.tsx
@@ -17,6 +17,8 @@ import { useVictoryAdapter } from './useVictoryAdapter';
  * - `VictoryHistogram` → histogram
  * - `VictoryBoxPlot` → box plot
  * - `VictoryCandlestick` → candlestick chart
+ * - `VictoryPie` → pie chart (a doughnut is the same component with an
+ *   `innerRadius`, and needs nothing extra)
  *
  * Multi-panel figures: nest two or more `<VictoryChart>` components — each
  * chart becomes one navigable MAIDR subplot. Give each chart a `title` prop

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -8,6 +8,7 @@ import type {
   HistogramPoint,
   LinePoint,
   MaidrLayer,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
@@ -73,6 +74,7 @@ function isDataComponent(name: string): name is VictoryComponentType {
     || name === 'VictoryBoxPlot'
     || name === 'VictoryCandlestick'
     || name === 'VictoryHistogram'
+    || name === 'VictoryPie'
   );
 }
 
@@ -231,6 +233,35 @@ function extractScatterData(
   }));
 
   return { data: { kind: 'scatter', points }, count: rawData.length };
+}
+
+/**
+ * Extracts data from a VictoryPie element.
+ *
+ * VictoryPie shares Victory's `x`/`y` accessor convention: `x` names the slice
+ * and `y` is its magnitude. A doughnut is the same component with an
+ * `innerRadius`, which changes the drawing and not the data, so it needs no
+ * separate handling.
+ *
+ * Unlike `BarPoint.y`, `PiePoint.y` is strictly numeric — it is also the
+ * numerator of the slice's percentage — so the accessor result is coerced here
+ * rather than passed through.
+ */
+function extractPieData(
+  props: Record<string, unknown>,
+): { data: VictoryLayerData; count: number } | null {
+  const rawData = props.data;
+  if (!validateRawData(rawData))
+    return null;
+
+  const getX = resolveAccessor(props.x, 'x');
+  const getY = resolveAccessor(props.y, 'y');
+  const points: PiePoint[] = rawData.map(d => ({
+    x: getX(d) as string | number,
+    y: Number(getY(d)),
+  }));
+
+  return { data: { kind: 'pie', points }, count: rawData.length };
 }
 
 /**
@@ -455,6 +486,9 @@ function extractLayerFromElement(
       break;
     case 'VictoryHistogram':
       extracted = extractHistogramData(props);
+      break;
+    case 'VictoryPie':
+      extracted = extractPieData(props);
       break;
   }
 
@@ -777,6 +811,22 @@ export function toMaidrLayer(
         id: layer.id,
         type: TraceType.HISTOGRAM,
         axes,
+        selectors: selector,
+        data: data.points,
+      };
+
+    case 'pie':
+      return {
+        id: layer.id,
+        type: TraceType.PIE,
+        // A VictoryPie stands alone — there is no VictoryAxis to read a label
+        // off, and the core's "X"/"Y" fallback would announce "X is Apples, Y
+        // is 30", naming neither position. Name what the two actually mean on
+        // a pie instead; a label from an enclosing VictoryChart still wins.
+        axes: {
+          x: { label: layer.xAxisLabel ?? 'Category' },
+          y: { label: layer.yAxisLabel ?? 'Value' },
+        },
         selectors: selector,
         data: data.points,
       };

--- a/src/adapters/victory/selectors.ts
+++ b/src/adapters/victory/selectors.ts
@@ -194,9 +194,12 @@ export function tagLayerElements(
   }
 
   // Discrete-element charts: one <path role="presentation"> per data point.
-  // VictoryBar, VictoryHistogram, VictoryScatter, and VictoryStack all render
-  // their data points as <path> elements — Victory's Bar primitive renders a
-  // <path> (with arc commands for corner radius), never a <rect>.
+  // VictoryBar, VictoryHistogram, VictoryScatter, VictoryStack, and VictoryPie
+  // all render their data points as <path> elements — Victory's Bar primitive
+  // renders a <path> (with arc commands for corner radius), never a <rect>,
+  // and its Slice primitive renders the d3-shape arc path for one wedge.
+  // Pie wedges come out in data order, which is the index alignment a pie
+  // layer's selectors have to satisfy.
   return tagDiscreteElements(svg, layer, attrName, claimed, scope);
 }
 

--- a/src/adapters/victory/types.ts
+++ b/src/adapters/victory/types.ts
@@ -4,6 +4,7 @@ import type {
   CandlestickPoint,
   HistogramPoint,
   LinePoint,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
@@ -66,6 +67,7 @@ export type VictoryComponentType
     | 'VictoryBoxPlot'
     | 'VictoryCandlestick'
     | 'VictoryHistogram'
+    | 'VictoryPie'
     | 'VictoryStack';
 
 /**
@@ -86,6 +88,8 @@ export type VictoryLayerData
     | { kind: 'box'; points: BoxPoint[] }
     | { kind: 'candlestick'; points: CandlestickPoint[] }
     | { kind: 'histogram'; points: HistogramPoint[] }
+    /** A `VictoryPie` (or a doughnut — the same component with an `innerRadius`). */
+    | { kind: 'pie'; points: PiePoint[] }
     | { kind: 'segmented'; points: SegmentedPoint[][] };
 
 /**

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -262,7 +262,7 @@ export class AnnounceYCommand extends AnnounceCommand {
 /**
  * Command to describe the z (level) property.
  * Works with candlestick (trend), heatmap (z value), segmented bars (level),
- * and multi-series line charts (group).
+ * multi-series line charts (group), and pie charts (percentage).
  */
 export class AnnounceZCommand extends AnnounceCommand {
   /**
@@ -286,7 +286,8 @@ export class AnnounceZCommand extends AnnounceCommand {
   /**
    * Executes the command to display the z (level) information.
    * Checks for valid z-axis data which is in state.text.z with label and value properties.
-   * Supports: candlestick (trend), heatmap (z), segmented bars (level), multi-line (group).
+   * Supports: candlestick (trend), heatmap (z), segmented bars (level),
+   * multi-line (group), pie (percentage).
    *
    * Works at the figure lobby too: {@link resolveActiveTraceState} reads the
    * active subplot's trace so `l z` announces its level/group label in

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -42,6 +42,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.HISTOGRAM]: 'Histogram',
   [TraceType.LINE]: 'Line Chart',
   [TraceType.NORMALIZED]: 'Normalized Stacked Bar Chart',
+  [TraceType.PIE]: 'Pie Chart',
   [TraceType.SCATTER]: 'Scatter Plot',
   [TraceType.SMOOTH]: 'Smooth Line Chart',
   [TraceType.STACKED]: 'Stacked Bar Chart',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -7,6 +7,7 @@ import { Candlestick } from './candlestick';
 import { Heatmap } from './heatmap';
 import { Histogram } from './histogram';
 import { LineTrace } from './line';
+import { PieTrace } from './pie';
 import { ScatterTrace } from './scatter';
 import { SegmentedTrace } from './segmented';
 import { createSmoothTrace } from './smoothtraceFactory';
@@ -42,6 +43,9 @@ export abstract class TraceFactory {
 
       case TraceType.LINE:
         return new LineTrace(layer);
+
+      case TraceType.PIE:
+        return new PieTrace(layer);
 
       case TraceType.SCATTER:
         return new ScatterTrace(layer);

--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -1,0 +1,358 @@
+import type { MaidrLayer, PiePoint } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { MathUtil } from '@util/math';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { isMeasured } from './bar';
+import { MovableGrid } from './movable';
+
+/** Label the percentage rides under in text and in the data table. */
+const PERCENTAGE_LABEL = 'Percentage';
+
+/** How a gap is named wherever a slice has no measurement to report. */
+const MISSING_TEXT = 'missing';
+
+/**
+ * Reads one slice's magnitude, keeping a gap distinguishable from a zero.
+ *
+ * {@link PiePoint.y} is declared numeric, but it arrives from parsed JSON: a
+ * producer with no measurement for a slice emits `null`, and `Number(null)` is
+ * `0`. A zero slice is a real measurement — it counts toward the total and can
+ * be the minimum — so an absent one must not collapse into it. `NaN` keeps it
+ * absent, which is what {@link isMeasured} and the text layer already read as
+ * a gap. Mirrors `toBarValue` in `bar.ts`, for the same reasons.
+ *
+ * @param raw - The value from the slice
+ * @returns The magnitude, or `NaN` when the slice is a gap
+ */
+function toSliceValue(raw: number | string | null | undefined): number {
+  if (raw === null || raw === undefined) {
+    return Number.NaN;
+  }
+  if (typeof raw === 'string' && raw.trim() === '') {
+    return Number.NaN;
+  }
+  return Number(raw);
+}
+
+/**
+ * Formats one slice's share of the whole.
+ *
+ * A gap has no share to report, so it reads the way its value does. A total of
+ * zero has no share to divide by either: `0 / 0` is `NaN`, and "NaN percent" is
+ * the one thing this must never announce. It reports an exact zero rather than
+ * the one-decimal form used for real ratios, because nothing was rounded to
+ * get there.
+ *
+ * @param value - The slice's magnitude, `NaN` when it is a gap
+ * @param total - The sum of every measured slice
+ * @returns The percentage as display text, e.g. `33.3%`
+ */
+function toPercentage(value: number, total: number): string {
+  if (!isMeasured(value)) {
+    return MISSING_TEXT;
+  }
+  if (total === 0) {
+    return '0%';
+  }
+  return `${((value / total) * 100).toFixed(1)}%`;
+}
+
+/**
+ * Whether a screen-space point falls inside an element's filled geometry.
+ *
+ * `isPointInFill` works in the element's own user space, so the point has to be
+ * pushed back through the screen transform first. Both that transform and the
+ * method itself are absent on a non-geometry element (a producer whose selector
+ * resolves to the `<g>` wrapping each wedge) and in non-rendering environments;
+ * there the slice simply cannot be hit-tested, which costs pointer guidance and
+ * nothing else.
+ *
+ * @param element - The candidate wedge
+ * @param x - Screen-space x position of the pointer
+ * @param y - Screen-space y position of the pointer
+ * @returns True when the pointer is inside the wedge
+ */
+function containsScreenPoint(element: SVGElement, x: number, y: number): boolean {
+  const geometry = element as SVGGeometryElement;
+  if (
+    typeof geometry.isPointInFill !== 'function'
+    || typeof geometry.getScreenCTM !== 'function'
+  ) {
+    return false;
+  }
+
+  const screenToUser = geometry.getScreenCTM()?.inverse();
+  if (!screenToUser) {
+    return false;
+  }
+
+  return geometry.isPointInFill(new DOMPoint(x, y).matrixTransform(screenToUser));
+}
+
+/**
+ * A pie chart: N slices read as one row, left and right.
+ *
+ * Extends {@link AbstractTrace} directly rather than `AbstractBarPlot`, which
+ * bakes an orientation into its bar values, audio panning, text axes and
+ * description. A pie has no orientation — its slices are arranged around a
+ * circle, not along an axis — so every one of those derived values would have
+ * to be undone again here.
+ *
+ * The slices are wrapped in a single row so {@link MovableGrid} navigates
+ * them: with one row, up and down are out of bounds by its own bounds checks,
+ * which is exactly the navigation a pie wants.
+ */
+export class PieTrace extends AbstractTrace {
+  protected readonly movable: Movable;
+
+  protected readonly points: PiePoint[][];
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /** Slice magnitudes, in the same single-row shape as {@link points}. */
+  private readonly sliceValues: number[][];
+  /** Each slice's share of the whole, as display text. */
+  private readonly percentages: string[];
+
+  private readonly min: number;
+  private readonly max: number;
+  private readonly total: number;
+
+  protected readonly supportsExtrema = false;
+
+  /**
+   * Constructs a new PieTrace instance.
+   * @param layer - The MAIDR layer configuration
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.points = [layer.data as PiePoint[]];
+
+    const values = this.points[0].map(point => toSliceValue(point.y));
+    this.sliceValues = [values];
+
+    // A gap is not a measurement, so it must take part in neither the range
+    // every slice's pitch is scaled against nor the total the percentages are
+    // shares of — a missing slice that silently counted as zero would still
+    // shrink every other slice's reported share.
+    const measured = values.filter(isMeasured);
+    this.min = MathUtil.safeMin(measured);
+    this.max = MathUtil.safeMax(measured);
+    this.total = measured.reduce((sum, value) => sum + value, 0);
+
+    // Derived once here, not per state read: the state getters are called on
+    // every navigation step (and again by getStateAt for monitor mode), and
+    // they must stay cheap and side-effect free.
+    this.percentages = values.map(value => toPercentage(value, this.total));
+
+    this.highlightValues = this.mapToSvgElements(layer.selectors as string);
+    this.movable = new MovableGrid<PiePoint>(this.points);
+  }
+
+  /**
+   * Cleans up pie resources including points and percentages.
+   *
+   * {@link sliceValues} is deliberately left alone: {@link dimension} reads it,
+   * and a disposed trace can still be asked for an out-of-bounds state.
+   */
+  public override dispose(): void {
+    this.points.length = 0;
+    this.percentages.length = 0;
+
+    super.dispose();
+  }
+
+  protected get audio(): AudioState {
+    // Pitch maps the raw magnitude, not the percentage. The two are a monotone
+    // rescale of each other, so the pitch ordering is identical either way, and
+    // the raw value keeps audio agreeing with braille and the reported stats.
+    return {
+      freq: {
+        min: this.min,
+        max: this.max,
+        raw: this.sliceValues[this.row][this.col],
+      },
+      panning: {
+        x: this.col,
+        y: 0,
+        rows: 1,
+        cols: this.sliceValues[this.row].length,
+      },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    // The bar encoding, over a single row: each cell's height is the slice's
+    // magnitude within the range of the pie's slices.
+    return {
+      empty: false,
+      id: this.id,
+      values: this.sliceValues,
+      min: [this.min],
+      max: [this.max],
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const point = this.points[this.row][this.col];
+
+    // The percentage rides the optional z slot, which the text service renders
+    // as ", Percentage is 33.3%" after the label and the value.
+    return {
+      main: { label: this.xAxis, value: point.x },
+      cross: { label: this.yAxis, value: this.sliceValues[this.row][this.col] },
+      z: { label: PERCENTAGE_LABEL, value: this.percentages[this.col] },
+      mainAxis: 'x',
+      crossAxis: 'y',
+    };
+  }
+
+  /**
+   * Gets the description state for the pie trace.
+   * @returns The description state containing chart metadata and data table
+   */
+  public get description(): DescriptionState {
+    // A pie of nothing but gaps has no range and nothing to add up, and
+    // safeMin/safeMax answer an empty set with ±Infinity. Report all three the
+    // way every other modality reports an absent value, rather than announcing
+    // an infinity or a total of zero that was never measured.
+    const hasMeasured = isMeasured(this.min);
+    const stats: DescriptionState['stats'] = [
+      { label: 'Number of slices', value: this.points[0].length },
+      { label: 'Min value', value: hasMeasured ? this.min : MISSING_TEXT },
+      { label: 'Max value', value: hasMeasured ? this.max : MISSING_TEXT },
+      { label: 'Total', value: hasMeasured ? this.total : MISSING_TEXT },
+    ];
+
+    const headers = [this.xAxis, this.yAxis, PERCENTAGE_LABEL];
+    // A gap is spelled out rather than left as the NaN the dialog would blank:
+    // a blank cell and a cell nobody filled in read the same way to a screen
+    // reader walking the table, and the percentage column has to say something
+    // in any case.
+    const rows: (string | number)[][] = this.points[0].map((point, col) => [
+      point.x,
+      isMeasured(this.sliceValues[0][col]) ? this.sliceValues[0][col] : MISSING_TEXT,
+      this.percentages[col],
+    ]);
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  protected get dimension(): Dimension {
+    return {
+      rows: 1,
+      cols: this.sliceValues[this.row].length,
+    };
+  }
+
+  protected get values(): number[][] {
+    return this.sliceValues;
+  }
+
+  /**
+   * Resolves the layer's selector to one SVG element per slice.
+   *
+   * The contract is exactly N elements in slice order, so data index k and
+   * element k are the same slice. A different count means the selector is
+   * addressing something other than the wedges, and index-aligning it anyway
+   * would highlight the wrong slice — better to report no highlight for this
+   * layer than a confidently wrong one.
+   *
+   * @param selector - The layer's CSS selector, when it declares one
+   * @returns The single row of wedge elements, or null when unresolvable
+   */
+  private mapToSvgElements(selector?: string): SVGElement[][] | null {
+    if (!selector) {
+      return null;
+    }
+
+    const wedges = Svg.selectAllElements(selector);
+    if (wedges.length !== this.points[0].length) {
+      // Discard the just-inserted hidden clones so they don't leak into the
+      // DOM (dispose only removes elements reachable via highlightValues).
+      wedges.forEach(wedge => wedge.remove());
+      return null;
+    }
+
+    return [wedges];
+  }
+
+  /**
+   * Finds the slice under the specified coordinates.
+   *
+   * Hit-tests the wedge geometry itself rather than its bounding box, which is
+   * what the bar and box traces can get away with: a wedge's box covers a whole
+   * quadrant of the circle and overlaps its neighbours', so a box test would
+   * routinely report a slice the pointer is nowhere near.
+   *
+   * @param x - The x-coordinate
+   * @param y - The y-coordinate
+   * @returns The slice under the pointer, or null when it is between slices
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    if (!this.highlightValues) {
+      return null;
+    }
+
+    const wedges = this.highlightValues[0];
+    for (let col = 0; col < wedges.length; col++) {
+      const wedge = wedges[col];
+      if (!containsScreenPoint(wedge, x, y)) {
+        continue;
+      }
+
+      const box = wedge.getBoundingClientRect();
+      return {
+        element: wedge,
+        row: 0,
+        col,
+        centerX: box.x + box.width / 2,
+        centerY: box.y + box.height / 2,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Moves to the next slice that matches the comparison criteria in rotor mode.
+   *
+   * A gap loses every comparison — `NaN < x` and `NaN > x` are both false — so
+   * an unmeasured slice is stepped over rather than being offered as the next
+   * larger or smaller one.
+   *
+   * @param direction - The direction to move (left or right)
+   * @param type - The comparison type (lower or higher)
+   * @returns True if a matching slice was found, false otherwise
+   */
+  public override moveToNextCompareValue(
+    direction: 'left' | 'right',
+    type: 'lower' | 'higher',
+  ): boolean {
+    const values = this.sliceValues[this.row];
+    const current = this.col;
+    const step = direction === 'right' ? 1 : -1;
+
+    for (let i = current + step; i >= 0 && i < values.length; i += step) {
+      if (this.compare(values[i], values[current], type)) {
+        this.col = i;
+        this.notifyStateUpdate();
+        return true;
+      }
+    }
+
+    this.notifyRotorBounds();
+    return false;
+  }
+}

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1106,6 +1106,9 @@ implements Observer<SubplotState | TraceState>, Disposable {
       [TraceType.HISTOGRAM, asGeneric(new BarBrailleEncoder())],
       [TraceType.LINE, asGeneric(new LineBrailleEncoder())],
       [TraceType.NORMALIZED, asGeneric(new BarBrailleEncoder())],
+      // A pie's braille state is a single row of slice magnitudes scaled
+      // against that row's own range — the bar encoder's input exactly.
+      [TraceType.PIE, asGeneric(new BarBrailleEncoder())],
       [TraceType.SCATTER, asGeneric(new HeatmapBrailleEncoder())],
       [TraceType.SMOOTH, asGeneric(new LineBrailleEncoder())],
       [TraceType.STACKED, asGeneric(new BarBrailleEncoder())],

--- a/src/service/highContrast.ts
+++ b/src/service/highContrast.ts
@@ -367,11 +367,19 @@ export class HighContrastService implements Disposable {
     // styles on the plot element (e.g. React's `width: fit-content`) are preserved.
     this.displayService.plot.style.setProperty('fill', this.highContrastLightColor);
 
-    // Handle stacked/dodged bar exception: apply patterns
+    // Handle stacked/dodged bar and pie exceptions: apply patterns.
+    //
+    // These are the chart types whose marks touch each other, so the boundary
+    // between two of them is carried by their fill alone. High contrast then
+    // pushes neighbouring fills toward the same end of the ramp and the marks
+    // merge into one shape — adjacent pie wedges of a similar hue are the worst
+    // case, since a pie is nothing but touching marks. A distinct pattern per
+    // original fill keeps them separable without relying on colour.
     if ('type' in this.context.instructionContext) {
       if (
         this.context.instructionContext.type === 'stacked_bar'
         || this.context.instructionContext.type === 'dodged_bar'
+        || this.context.instructionContext.type === 'pie'
       ) {
         this.applyPatternsToElements(highContrastElInfo);
       }

--- a/src/service/liveData.ts
+++ b/src/service/liveData.ts
@@ -8,6 +8,7 @@ import type {
   LinePoint,
   Maidr,
   MaidrLayer,
+  PiePoint,
   ScatterPoint,
   SegmentedPoint,
   SmoothPoint,
@@ -43,6 +44,7 @@ export type LiveDataPoint
     | CandlestickPoint
     | HistogramPoint
     | LinePoint
+    | PiePoint
     | ScatterPoint
     | SegmentedPoint
     | SmoothPoint

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -479,7 +479,9 @@ export class TextService implements Observer<PlotState>, Disposable {
       verbose.push(Constant.IS, this.formatArrayValue(state.cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE));
     }
 
-    // Format for heatmap and scatter plot.
+    // Format for the plots that carry a third value: the heatmap's cell value,
+    // the segmented bar's level, the candlestick's trend, the pie's percentage.
+    // Reads as ", Percentage is 33.3%" after the label and the value.
     if (state.z !== undefined) {
       // Convert candlestick trend values to lowercase for text mode
       let zValue: string;
@@ -558,7 +560,8 @@ export class TextService implements Observer<PlotState>, Disposable {
       terse.push(Constant.OPEN_BRACKET, this.formatArrayValue(state.cross.value as (number | string)[], crossAxisType).join(Constant.COMMA_SPACE), Constant.CLOSE_BRACKET);
     }
 
-    // Format for heatmap and segmented plots.
+    // Format for heatmap, segmented and pie plots. Terse drops the label, so a
+    // pie slice reads "Apples, 30, 33.3%".
     if (state.z !== undefined) {
       // Convert candlestick trend values to lowercase for text mode
       let zValue: string;

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -329,6 +329,28 @@ export interface LinePoint {
 }
 
 /**
+ * Data point for one slice of a pie chart.
+ *
+ * A pie layer's `data` is a flat `PiePoint[]` — one entry per slice, in the
+ * order the slices are drawn — never the nested group array the bar-family
+ * types use.
+ *
+ * `y` is strictly numeric, unlike {@link BarPoint.y}: it is both the sonified
+ * magnitude and the numerator of the slice's percentage, and a percentage
+ * derived from a string is not a percentage.
+ *
+ * There is deliberately no `percentage` field. The share of the whole is
+ * derived once in the model as `y / sum(y) * 100`, so an authored percentage
+ * can never disagree with the values it is supposedly derived from.
+ */
+export interface PiePoint {
+  /** Slice label, e.g. the category the slice stands for. */
+  x: string | number;
+  /** Slice magnitude. Negative values are not meaningful in a pie. */
+  y: number;
+}
+
+/**
  * Data point for scatter plots with x and y coordinates.
  */
 export interface ScatterPoint {
@@ -531,6 +553,7 @@ export interface MaidrLayer {
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]
+    | PiePoint[]
     | ScatterPoint[]
     | SegmentedPoint[][]
     | SmoothPoint[][]
@@ -566,6 +589,7 @@ export enum TraceType {
   HISTOGRAM = 'hist',
   LINE = 'line',
   NORMALIZED = 'stacked_normalized_bar',
+  PIE = 'pie',
   SCATTER = 'point',
   SMOOTH = 'smooth',
   STACKED = 'stacked_bar',

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -29,6 +29,9 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   [TraceType.HISTOGRAM]: true,
   [TraceType.LINE]: false,
   [TraceType.NORMALIZED]: true,
+  // Slices are arranged around a circle, not along an axis: there is no
+  // orientation to declare and none to fall back to.
+  [TraceType.PIE]: false,
   [TraceType.SCATTER]: false,
   [TraceType.SMOOTH]: false,
   [TraceType.STACKED]: true,

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -1,5 +1,5 @@
-import type { BarPoint, MaidrLayer } from '@type/grammar';
-import { findXYCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
+import type { BarPoint, MaidrLayer, PiePoint } from '@type/grammar';
+import { findCharts, findXYCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
 import { TraceType } from '@type/grammar';
 import {
   fakeBarSeries,
@@ -7,6 +7,8 @@ import {
   fakeContainer,
   fakeContainerEl,
   fakeLineSeries,
+  fakePieChart,
+  fakePieSeries,
   fakeRoot,
   fakeStepSeries,
 } from './helpers';
@@ -117,7 +119,7 @@ describe('fromAmCharts (single chart)', () => {
   });
 
   it('throws when the root contains no chart', () => {
-    expect(() => fromAmCharts(fakeRoot([]))).toThrow(/no XYChart found/);
+    expect(() => fromAmCharts(fakeRoot([]))).toThrow(/no XYChart or PieChart found/);
   });
 
   it('binds a StepLineSeries as a step layer, not a line', () => {
@@ -169,6 +171,94 @@ describe('fromAmCharts (single chart)', () => {
     expect(result.title).toBe('Tips by Day');
     expect(result.subplots).toHaveLength(1);
     expect(result.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+  });
+});
+
+describe('fromAmCharts (pie chart)', () => {
+  const PIE_DATA = [
+    { category: 'Apples', value: 30 },
+    { category: 'Bananas', value: 50 },
+    { category: 'Cherries', value: 20 },
+  ];
+
+  it('finds a PieChart, which has a series list but no axes', () => {
+    const pie = fakePieChart({ series: [fakePieSeries('Fruit', PIE_DATA)] });
+    const root = fakeRoot([pie]);
+
+    expect(findCharts(root)).toEqual([pie]);
+    // The narrower query still answers only for XY charts.
+    expect(findXYCharts(root)).toEqual([]);
+  });
+
+  it('converts a pie series into a flat pie layer', () => {
+    const pie = fakePieChart({
+      series: [fakePieSeries('Fruit', PIE_DATA)],
+      title: 'Fruit sales',
+    });
+
+    const result = fromAmCharts(fakeRoot([pie], 'pie-chart'));
+
+    expect(result.id).toBe('amcharts-pie-chart');
+    expect(result.title).toBe('Fruit sales');
+
+    const layer = result.subplots[0][0].layers[0];
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.title).toBe('Fruit');
+    // A pie is bound to no axis, so the dimensions are named for what they hold.
+    expect(layer.axes).toEqual({ x: { label: 'Label' }, y: { label: 'Value' } });
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]);
+  });
+
+  it('skips slices with no value so slice k stays the wedge k it names', () => {
+    const pie = fakePieChart({
+      series: [fakePieSeries('Fruit', [
+        { category: 'Apples', value: 30 },
+        { category: 'Bananas', value: null },
+        { category: 'Cherries', value: 20 },
+      ])],
+    });
+
+    const layer = fromAmCharts(fakeRoot([pie])).subplots[0][0].layers[0];
+
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Cherries', y: 20 },
+    ]);
+  });
+
+  it('honors axis-label overrides on a pie layer', () => {
+    const pie = fakePieChart({ series: [fakePieSeries('Fruit', PIE_DATA)] });
+
+    const result = fromAmCharts(fakeRoot([pie]), {
+      axisLabels: { x: 'Fruit', y: 'Units' },
+    });
+
+    expect(result.subplots[0][0].layers[0].axes)
+      .toEqual({ x: { label: 'Fruit' }, y: { label: 'Units' } });
+  });
+
+  it('emits no selectors: amCharts renders wedges to canvas, not to SVG', () => {
+    const pie = fakePieChart({ series: [fakePieSeries('Fruit', PIE_DATA)] });
+
+    const layer = fromAmCharts(fakeRoot([pie])).subplots[0][0].layers[0];
+
+    expect(layer.selectors).toBeUndefined();
+  });
+
+  it('pairs a pie chart with an XY chart as two panels of one figure', () => {
+    const bar = fakeChart({ series: [fakeBarSeries('Tips', BAR_DATA)], title: 'Tips' });
+    const pie = fakePieChart({ series: [fakePieSeries('Fruit', PIE_DATA)], title: 'Fruit' });
+
+    const result = fromAmCharts(fakeRoot([bar, pie]));
+
+    // Neither chart reports bounds, so the grid falls back to one row.
+    expect(result.subplots).toHaveLength(1);
+    expect(result.subplots[0].map(subplot => subplot.layers[0].type))
+      .toEqual([TraceType.BAR, TraceType.PIE]);
   });
 });
 

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -9,8 +9,8 @@
 import type {
   AmAxis,
   AmBounds,
+  AmChart,
   AmRoot,
-  AmXYChart,
   AmXYSeries,
 } from '@adapters/amcharts/types';
 
@@ -68,6 +68,22 @@ export function fakeLineSeries(
   });
 }
 
+/**
+ * An am5percent pie series: `category`/`value` data items, no axis fields.
+ * `slice` stands in for the wedge graphic the overlay reads geometry from.
+ */
+export function fakePieSeries(
+  name: string,
+  slices: Array<{ category: string; value: number | null; slice?: unknown }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'PieSeries',
+    name,
+    settings: { categoryField: 'category', valueField: 'value' },
+    data: slices,
+  });
+}
+
 /** A step-line series, drawn as a staircase rather than an interpolated line. */
 export function fakeStepSeries(
   name: string,
@@ -104,7 +120,7 @@ export interface FakeChartConfig {
   className?: string;
 }
 
-export function fakeChart(config: FakeChartConfig = {}): AmXYChart {
+export function fakeChart(config: FakeChartConfig = {}): AmChart {
   const chart: Record<string, unknown> = {
     className: config.className ?? 'XYChart',
     uid: nextUid++,
@@ -126,7 +142,30 @@ export function fakeChart(config: FakeChartConfig = {}): AmXYChart {
       }],
     };
   }
-  return chart as unknown as AmXYChart;
+  return chart as unknown as AmChart;
+}
+
+/**
+ * An am5percent `PieChart`: a series list and a class name, but no axes and no
+ * plot container — the shape the adapter has to recognise without them.
+ */
+export function fakePieChart(config: { series?: AmXYSeries[]; title?: string } = {}): AmChart {
+  const chart: Record<string, unknown> = {
+    className: 'PieChart',
+    uid: nextUid++,
+    get: () => undefined,
+    series: { values: config.series ?? [] },
+  };
+  if (config.title != null) {
+    const title = config.title;
+    chart.children = {
+      values: [{
+        className: 'Label',
+        get: (key: string) => (key === 'text' ? title : undefined),
+      }],
+    };
+  }
+  return chart as unknown as AmChart;
 }
 
 /**

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -3,7 +3,7 @@ import type { AmXYChart, AmXYSeries } from '@adapters/amcharts/types';
 import type { MaidrLayer } from '@type/grammar';
 import { buildNavigationMap } from '@adapters/amcharts/navmap';
 import { TraceType } from '@type/grammar';
-import { fakeBarSeries, fakeChart, fakeLineSeries } from './helpers';
+import { fakeBarSeries, fakeChart, fakeLineSeries, fakePieChart, fakePieSeries } from './helpers';
 
 function emptyGroups(): SeriesGroups {
   return {
@@ -12,6 +12,7 @@ function emptyGroups(): SeriesGroups {
     stepSeriesList: [],
     histogramSeries: [],
     heatmapSeries: [],
+    pieSeriesList: [],
   };
 }
 
@@ -93,6 +94,26 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     expect(targets).toHaveLength(1);
     // col 1 is the SECOND kept item, i.e. category C (the gap is skipped).
     expect(targets[0].dataItem.get('categoryX')).toBe('C');
+  });
+
+  it('resolves a pie layer to slice targets, skipping valueless slices', () => {
+    const series = fakePieSeries('Fruit', [
+      { category: 'Apples', value: 30 },
+      { category: 'Bananas', value: null },
+      { category: 'Cherries', value: 20 },
+    ]);
+    const chart = fakePieChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'pie', type: TraceType.PIE, data: [] }],
+      groups: { ...emptyGroups(), pieSeriesList: [series] },
+    }]);
+
+    const targets = navMap.resolve('pie', 0, 1);
+    expect(targets).toHaveLength(1);
+    // col 1 is the SECOND kept slice, i.e. Cherries (the gap is skipped).
+    expect(targets[0].dataItem.get('category')).toBe('Cherries');
+    expect(targets[0].kind).toBe('slice');
   });
 
   it('resolves line layers to point targets by [row, col]', () => {

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -4,10 +4,11 @@ import type {
   AnyChartIterator,
   AnyChartSeries,
 } from '@adapters/anychart/types';
-import type { BarPoint, BoxSelector, MaidrLayer } from '@type/grammar';
+import type { BarPoint, BoxSelector, MaidrLayer, PiePoint } from '@type/grammar';
 import {
   anyChartsToMaidr,
   anyChartToMaidr,
+  bindAnyChart,
   bindAnyCharts,
   mapSeriesType,
 } from '@adapters/anychart/converters';
@@ -68,6 +69,53 @@ function createBarSeries(data: Array<[string, number]>): AnyChartSeries {
   return createSeries('column', data.map(([x, value]) => ({ x, value })));
 }
 
+/**
+ * A drawn AnyChart pie. A real one exposes NO series API — `getSeriesCount()`
+ * and `getSeriesAt()` are absent and its slices live on `chart.data()` — so
+ * the mock omits them deliberately: the conversion has to work without them.
+ */
+function createPieChart(
+  title: string,
+  slices: Array<[string, number | null]>,
+  extra: { container?: HTMLElement } = {},
+): AnyChartInstance {
+  const rows = slices.map(([x, value]) => ({ x, value }));
+  return {
+    title: () => title,
+    container: () => extra.container ?? '',
+    getType: () => 'pie',
+    data: () => ({ getIterator: () => createIterator(rows) }),
+  } as unknown as AnyChartInstance;
+}
+
+/**
+ * Append a rendered pie to a container's `<svg>`: one AnyChart layer holding
+ * `count` wedge paths plus a straight label connector, which shares the layer
+ * but is not a wedge.
+ */
+function appendPieWedges(container: HTMLElement, count: number): SVGElement[] {
+  const svg = container.querySelector('svg') as unknown as SVGElement;
+  const layer = document.createElementNS(SVG_NS, 'g');
+  layer.id = 'ac_layer_1';
+  svg.appendChild(layer);
+
+  const wedges: SVGElement[] = [];
+  for (let i = 0; i < count; i++) {
+    const wedge = document.createElementNS(SVG_NS, 'path');
+    wedge.id = `ac_path_${i}`;
+    wedge.setAttribute('d', 'M 100 100 L 150 100 A 50 50 0 0 1 100 150 Z');
+    layer.appendChild(wedge);
+    wedges.push(wedge);
+  }
+
+  const connector = document.createElementNS(SVG_NS, 'path');
+  connector.id = 'ac_path_connector';
+  connector.setAttribute('d', 'M 150 100 L 180 90');
+  layer.appendChild(connector);
+
+  return wedges;
+}
+
 function createAxis(titleText: string): AnyChartAxis {
   return {
     title: () => ({ text: () => titleText }),
@@ -82,14 +130,14 @@ interface MockChartConfig {
   type?: string;
   xTitle?: string;
   yTitle?: string;
-  /** Chart-level data rows (heatmap-style single-dataset charts). */
-  heatRows?: Array<Record<string, unknown>>;
+  /** Chart-level data rows (single-dataset charts: heatmap, pie). */
+  dataRows?: Array<Record<string, unknown>>;
 }
 
 function createChart(config: MockChartConfig): AnyChartInstance {
   const series = config.series ?? [];
   const chartType = config.type;
-  const heatRows = config.heatRows;
+  const dataRows = config.dataRows;
   const xTitle = config.xTitle;
   const yTitle = config.yTitle;
   return {
@@ -98,8 +146,8 @@ function createChart(config: MockChartConfig): AnyChartInstance {
     getSeriesCount: () => series.length,
     getSeriesAt: (i: number) => series[i] ?? null,
     ...(chartType ? { getType: () => chartType } : {}),
-    ...(heatRows
-      ? { data: () => ({ getIterator: () => createIterator(heatRows) }) }
+    ...(dataRows
+      ? { data: () => ({ getIterator: () => createIterator(dataRows) }) }
       : {}),
     ...(xTitle ? { xAxis: () => createAxis(xTitle) } : {}),
     ...(yTitle ? { yAxis: () => createAxis(yTitle) } : {}),
@@ -195,8 +243,107 @@ describe('anyChartToMaidr (single panel, unchanged)', () => {
   });
 
   it('returns null for a chart with no convertible series', () => {
-    const chart = createChart({ series: [createSeries('pie', [{ x: 'A', value: 1 }])] });
+    const chart = createChart({ series: [createSeries('funnel', [{ x: 'A', value: 1 }])] });
     expect(anyChartToMaidr(chart)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pie charts (single-dataset, no series API)
+// ---------------------------------------------------------------------------
+
+describe('anyChartToMaidr (pie chart)', () => {
+  it('emits a flat pie layer from the chart-level data view', () => {
+    const chart = createPieChart('Fruit sales', [
+      ['Apples', 30],
+      ['Bananas', 50],
+      ['Cherries', 20],
+    ]);
+
+    const result = anyChartToMaidr(chart);
+
+    expect(result?.title).toBe('Fruit sales');
+    const layer = result!.subplots[0][0].layers[0];
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.selectors).toBe('[data-maidr-anychart-pie-slice^="0-"]');
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]);
+  });
+
+  it('names the two dimensions a pie has no axis to name', () => {
+    const chart = createPieChart('Fruit', [['Apples', 30]]);
+
+    const layer = anyChartToMaidr(chart)!.subplots[0][0].layers[0];
+
+    expect(layer.axes).toEqual({ x: { label: 'Label' }, y: { label: 'Value' } });
+  });
+
+  it('keeps caller-supplied axis labels', () => {
+    const chart = createPieChart('Fruit', [['Apples', 30]]);
+
+    const layer = anyChartToMaidr(chart, { axes: { x: 'Fruit', y: 'Units' } })!
+      .subplots[0][0]
+      .layers[0];
+
+    expect(layer.axes).toEqual({ x: { label: 'Fruit' }, y: { label: 'Units' } });
+  });
+
+  it('drops slices with no numeric value, which AnyChart draws no wedge for', () => {
+    const chart = createPieChart('Fruit', [
+      ['Apples', 30],
+      ['Bananas', null],
+      ['Cherries', 20],
+    ]);
+
+    const layer = anyChartToMaidr(chart)!.subplots[0][0].layers[0];
+
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Cherries', y: 20 },
+    ]);
+  });
+
+  it('scopes pie selectors to the panel token in multi-panel mode', () => {
+    const pie = createPieChart('Pie', [['Apples', 30]]);
+    const bar = createBarChart('Bar');
+
+    const result = anyChartsToMaidr([[pie, bar]], { id: 'fig' });
+
+    expect(firstLayer(result!, 0, 0).type).toBe(TraceType.PIE);
+    expect(firstLayer(result!, 0, 0).selectors).toBe(
+      '[data-maidr-anychart-panel="fig-0-0"] '
+      + '[data-maidr-anychart-pie-slice^="fig-0-0:0-"]',
+    );
+  });
+});
+
+describe('bindAnyChart (pie stamping)', () => {
+  it('stamps one attribute per wedge, in slice order, and skips the connector', () => {
+    const container = createContainerWithSvg('pie-bind');
+    const wedges = appendPieWedges(container, 3);
+    const chart = createPieChart(
+      'Fruit',
+      [['Apples', 30], ['Bananas', 50], ['Cherries', 20]],
+      { container },
+    );
+
+    bindAnyChart(chart);
+
+    expect(wedges.map(w => w.getAttribute('data-maidr-anychart-pie-slice')))
+      .toEqual(['0-0', '0-1', '0-2']);
+    // The straight label connector is not a wedge and must stay unstamped.
+    const connector = container.querySelector('#ac_path_connector');
+    expect(connector?.getAttribute('data-maidr-anychart-pie-slice')).toBeNull();
+    // Every stamped wedge is reachable through the layer's own selector.
+    expect(container.querySelectorAll('[data-maidr-anychart-pie-slice^="0-"]'))
+      .toHaveLength(3);
+
+    // Binding wraps the container in a host element; drop the pair so the
+    // multi-panel bind tests below still find their own host first.
+    container.closest('[data-maidr-anychart-host]')?.remove();
   });
 });
 
@@ -292,7 +439,7 @@ describe('anyChartsToMaidr', () => {
     const heat = createChart({
       title: 'Heat',
       type: 'heat-map',
-      heatRows: [
+      dataRows: [
         { x: 'X1', y: 'Y1', heat: 1 },
         { x: 'X2', y: 'Y1', heat: 2 },
       ],
@@ -335,7 +482,7 @@ describe('anyChartsToMaidr', () => {
   });
 
   it('drops panels with no convertible series, keeping original tokens', () => {
-    const bad = createChart({ series: [createSeries('pie', [{ x: 'A', value: 1 }])] });
+    const bad = createChart({ series: [createSeries('funnel', [{ x: 'A', value: 1 }])] });
     const good = createBarChart('Good');
 
     const result = anyChartsToMaidr([[bad, good]], { id: 'fig' });
@@ -349,7 +496,7 @@ describe('anyChartsToMaidr', () => {
   });
 
   it('returns null when no panel is convertible', () => {
-    const bad = createChart({ series: [createSeries('pie', [{ x: 'A', value: 1 }])] });
+    const bad = createChart({ series: [createSeries('funnel', [{ x: 'A', value: 1 }])] });
     expect(anyChartsToMaidr([[bad]], { id: 'fig' })).toBeNull();
   });
 
@@ -659,7 +806,7 @@ describe('mapSeriesType', () => {
   });
 
   it('returns null for a series type the adapter cannot represent', () => {
-    expect(mapSeriesType('pie')).toBeNull();
+    expect(mapSeriesType('funnel')).toBeNull();
   });
 });
 

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -345,6 +345,60 @@ describe('bindAnyChart (pie stamping)', () => {
     // multi-panel bind tests below still find their own host first.
     container.closest('[data-maidr-anychart-host]')?.remove();
   });
+
+  it('counts only the slices the layer emits, so a null row does not warn', () => {
+    // AnyChart draws no wedge for a valueless row, so a three-row pie renders
+    // two wedges — and the layer emits two slices. Counting the raw rows would
+    // report a shortfall on a chart that is in fact perfectly aligned.
+    const container = createContainerWithSvg('pie-null');
+    const wedges = appendPieWedges(container, 2);
+    const chart = createPieChart(
+      'Fruit',
+      [['Apples', 30], ['Bananas', null], ['Cherries', 20]],
+      { container },
+    );
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    bindAnyChart(chart);
+
+    expect(wedges.map(w => w.getAttribute('data-maidr-anychart-pie-slice')))
+      .toEqual(['0-0', '0-1']);
+    expect(warnSpy.mock.calls.flat().join(' ')).not.toContain('pie wedges');
+
+    container.closest('[data-maidr-anychart-host]')?.remove();
+  });
+
+  it('warns and stamps nothing when no AnyChart layer holds an arc path', () => {
+    // The wedge-DOM assumption has failed: the layers are there but nothing in
+    // them is arc-drawn. Stamping the first arc-shaped paths found anywhere in
+    // the SVG would point slice 0 at a legend marker or a rounded frame, so
+    // the highlight is dropped and the reason is reported instead.
+    const container = createContainerWithSvg('pie-no-arcs');
+    const svg = container.querySelector('svg') as unknown as SVGElement;
+    const layer = document.createElementNS(SVG_NS, 'g');
+    layer.id = 'ac_layer_1';
+    svg.appendChild(layer);
+    const straight = document.createElementNS(SVG_NS, 'path');
+    straight.id = 'ac_path_0';
+    straight.setAttribute('d', 'M 0 0 L 10 10 Z');
+    layer.appendChild(straight);
+    // An arc-drawn path outside every layer — exactly what the whole-SVG
+    // fallback would have mistaken for slice 0.
+    const decoration = document.createElementNS(SVG_NS, 'path');
+    decoration.id = 'ac_path_frame';
+    decoration.setAttribute('d', 'M 0 0 A 4 4 0 0 1 8 0 Z');
+    svg.appendChild(decoration);
+    const chart = createPieChart('Fruit', [['Apples', 30]], { container });
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    bindAnyChart(chart);
+
+    expect(decoration.getAttribute('data-maidr-anychart-pie-slice')).toBeNull();
+    expect(straight.getAttribute('data-maidr-anychart-pie-slice')).toBeNull();
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('no pie wedges to highlight');
+
+    container.closest('[data-maidr-anychart-host]')?.remove();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/adapters/chartjs/extractor.test.ts
+++ b/test/adapters/chartjs/extractor.test.ts
@@ -458,8 +458,10 @@ describe('chart.js extractor', () => {
     });
 
     it('still throws for unsupported chart types', () => {
+      // 'radar', not 'pie' — a pie is supported now, and a supported type here
+      // would assert nothing about the unsupported path.
       const chart = createChart({
-        type: 'pie',
+        type: 'radar',
         data: { datasets: [{ data: [1, 2] }] },
         options: {
           scales: { x: {}, y: { stack: 'demo' }, y2: { stack: 'demo' } },
@@ -636,6 +638,84 @@ describe('chart.js extractor', () => {
 
       expect(maidr.subplots).toHaveLength(1);
       expect(maidr.subplots[0]).toHaveLength(1);
+    });
+  });
+
+  describe('pie and doughnut charts', () => {
+    const pieData: ChartJsData = {
+      labels: ['Apples', 'Bananas', 'Cherries'],
+      datasets: [{ label: 'Units', data: [30, 50, 20] }],
+    };
+
+    it.each(['pie', 'doughnut'])('emits a flat PiePoint[] layer for a %s chart', (type) => {
+      const { maidr, layerDatasetIndices } = extractChartData(createChart({ type, data: pieData }));
+
+      const layer = maidr.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.PIE);
+      expect(layer.title).toBe('Units');
+      // Flat, never nested, and with no producer-authored percentage.
+      expect(layer.data).toEqual([
+        { x: 'Apples', y: 30 },
+        { x: 'Bananas', y: 50 },
+        { x: 'Cherries', y: 20 },
+      ]);
+      expect(layer.orientation).toBeUndefined();
+      expect(layerDatasetIndices.get('0')).toEqual([0]);
+    });
+
+    it('names the axes for a chart that has no scales to read', () => {
+      const { maidr } = extractChartData(createChart({ type: 'pie', data: pieData }));
+
+      // Without this the core would fall back to announcing "X is Apples".
+      const layer = maidr.subplots[0][0].layers[0];
+      expect(layer.axes?.x).toEqual({ label: 'Category' });
+      expect(layer.axes?.y).toEqual({ label: 'Value' });
+    });
+
+    it('honours the plugin axis overrides', () => {
+      const { maidr } = extractChartData(
+        createChart({ type: 'pie', data: pieData }),
+        { axes: { x: 'Fruit', y: 'Units sold' } },
+      );
+
+      const layer = maidr.subplots[0][0].layers[0];
+      expect(layer.axes?.x).toEqual({ label: 'Fruit' });
+      expect(layer.axes?.y).toEqual({ label: 'Units sold' });
+    });
+
+    it('skips gap markers rather than announcing them as measured zeros', () => {
+      const { maidr } = extractChartData(createChart({
+        type: 'pie',
+        data: {
+          labels: ['Apples', 'Bananas', 'Cherries'],
+          datasets: [{ data: [30, null, 20] }],
+        },
+      }));
+
+      expect(maidr.subplots[0][0].layers[0].data).toEqual([
+        { x: 'Apples', y: 30 },
+        { x: 'Cherries', y: 20 },
+      ]);
+    });
+
+    it('gives each concentric ring its own layer and dataset', () => {
+      const { maidr, layerDatasetIndices } = extractChartData(createChart({
+        type: 'doughnut',
+        data: {
+          labels: ['A', 'B'],
+          datasets: [
+            { label: 'Inner', data: [1, 2] },
+            { label: 'Outer', data: [3, 4] },
+          ],
+        },
+      }));
+
+      // Chart.js draws a second dataset as its own ring with its own total, so
+      // the two must not be merged into one pie.
+      const layers = maidr.subplots[0][0].layers;
+      expect(layers.map(l => l.id)).toEqual(['0', '1']);
+      expect(layers.map(l => l.title)).toEqual(['Inner', 'Outer']);
+      expect(layerDatasetIndices.get('1')).toEqual([1]);
     });
   });
 

--- a/test/adapters/chartjs/highlightTargets.test.ts
+++ b/test/adapters/chartjs/highlightTargets.test.ts
@@ -82,6 +82,33 @@ describe('chart.js highlight target resolution', () => {
       ]);
     });
 
+    it('maps pie navigation to the slice, skipping gap markers', () => {
+      const chart = createChart('pie', {
+        labels: ['Apples', 'Bananas', 'Cherries'],
+        datasets: [{ label: 'Units', data: [30, null, 20] }],
+      });
+
+      const { resolve } = setup(chart);
+
+      // A pie is one row; col 1 is the second FINITE slice, element index 2.
+      expect(resolve('0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+      expect(resolve('0', 0, 1)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    });
+
+    it('routes each doughnut ring to its own dataset', () => {
+      const chart = createChart('doughnut', {
+        labels: ['A', 'B'],
+        datasets: [
+          { label: 'Inner', data: [1, 2] },
+          { label: 'Outer', data: [3, 4] },
+        ],
+      });
+
+      const { resolve } = setup(chart);
+
+      expect(resolve('1', 0, 1)).toEqual([{ datasetIndex: 1, index: 1 }]);
+    });
+
     it('routes segmented bars by MAIDR row = dataset index', () => {
       const chart = createChart('bar', {
         labels: ['A', 'B'],

--- a/test/adapters/chartjs/overlay.test.ts
+++ b/test/adapters/chartjs/overlay.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { ChartJsMetaElement } from '@adapters/chartjs/types';
+import { elementToOverlayShape, HighlightOverlay } from '@adapters/chartjs/overlay';
+
+/**
+ * Chart.js element instances carry far more geometry than the minimal
+ * `ChartJsMetaElement` interface declares, and that extra geometry is exactly
+ * what the shape detection reads — so build them loosely.
+ */
+function element(props: Record<string, number | boolean>): ChartJsMetaElement {
+  return props as unknown as ChartJsMetaElement;
+}
+
+/** A mounted overlay plus the host to query the drawn nodes from. */
+function mount(): { host: HTMLElement; overlay: HighlightOverlay } {
+  const host = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  host.appendChild(canvas);
+  document.body.appendChild(host);
+
+  return { host, overlay: new HighlightOverlay(host, canvas) };
+}
+
+/** A quarter slice of a 50px circle centred at (100, 100), starting at 3 o'clock. */
+const quarterSlice = {
+  kind: 'wedge',
+  x: 100,
+  y: 100,
+  innerRadius: 0,
+  outerRadius: 50,
+  startAngle: 0,
+  endAngle: Math.PI / 2,
+} as const;
+
+describe('chart.js highlight overlay', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('elementToOverlayShape', () => {
+    it('reads a pie slice as a wedge rather than a box', () => {
+      const shape = elementToOverlayShape(element({
+        x: 100,
+        y: 100,
+        innerRadius: 0,
+        outerRadius: 50,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+      }));
+
+      expect(shape).toEqual(quarterSlice);
+    });
+
+    it('carries a doughnut cutout through as the inner radius', () => {
+      const shape = elementToOverlayShape(element({
+        x: 100,
+        y: 100,
+        innerRadius: 20,
+        outerRadius: 50,
+        startAngle: 0,
+        endAngle: Math.PI / 2,
+      }));
+
+      expect(shape).toEqual({ ...quarterSlice, innerRadius: 20 });
+    });
+
+    it('still reads a bar element as a rect', () => {
+      const shape = elementToOverlayShape(element({
+        x: 50,
+        y: 20,
+        base: 120,
+        width: 30,
+        height: 100,
+      }));
+
+      expect(shape).toEqual({ kind: 'rect', left: 35, top: 20, width: 30, height: 100 });
+    });
+  });
+
+  describe('drawing', () => {
+    it('draws a slice as an svg wedge path, not a div', () => {
+      const { host, overlay } = mount();
+
+      overlay.show([quarterSlice]);
+
+      // A quarter turn clockwise from 3 o'clock — (150,100) round to (100,150)
+      // — then straight back to the centre. A box would instead cover the
+      // three slices around it.
+      const path = host.querySelector('svg[data-maidr-chartjs-highlight] path');
+      expect(path?.getAttribute('d')).toBe('M 150 100 A 50 50 0 0 1 100 150 L 100 100 Z');
+      expect(host.querySelector('div[data-maidr-chartjs-highlight]')).toBeNull();
+    });
+
+    it('closes a doughnut wedge along its inner arc', () => {
+      const { host, overlay } = mount();
+
+      overlay.show([{ ...quarterSlice, innerRadius: 20 }]);
+
+      const path = host.querySelector('svg[data-maidr-chartjs-highlight] path');
+      expect(path?.getAttribute('d')).toBe(
+        'M 150 100 A 50 50 0 0 1 100 150 L 100 120 A 20 20 0 0 0 120 100 Z',
+      );
+    });
+
+    it('keeps a whole-circle slice visible instead of collapsing it', () => {
+      const { host, overlay } = mount();
+
+      overlay.show([{ ...quarterSlice, endAngle: Math.PI * 2 }]);
+
+      // An arc whose endpoints coincide draws nothing, so the sweep stops just
+      // short of 360° — the endpoint must differ from the start point.
+      const path = host.querySelector('svg[data-maidr-chartjs-highlight] path');
+      expect(path?.getAttribute('d')).toBe('M 150 100 A 50 50 0 1 1 150 99.95 L 100 100 Z');
+    });
+
+    it('draws a rect element as a positioned div', () => {
+      const { host, overlay } = mount();
+
+      overlay.show([{ kind: 'rect', left: 10, top: 20, width: 30, height: 40 }]);
+
+      const node = host.querySelector<HTMLDivElement>('div[data-maidr-chartjs-highlight]');
+      expect(node?.style.left).toBe('10px');
+      expect(node?.style.width).toBe('30px');
+    });
+
+    it('replaces the previous highlight on every show', () => {
+      const { host, overlay } = mount();
+
+      overlay.show([quarterSlice]);
+      overlay.show([{ ...quarterSlice, startAngle: Math.PI / 2, endAngle: Math.PI }]);
+
+      expect(host.querySelectorAll('[data-maidr-chartjs-highlight]')).toHaveLength(1);
+    });
+  });
+});

--- a/test/adapters/d3/pie.test.ts
+++ b/test/adapters/d3/pie.test.ts
@@ -1,0 +1,137 @@
+import type { PiePoint } from '@type/grammar';
+import { bindD3Pie } from '@adapters/d3/binders/pie';
+import { describe, expect, test } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/** The shape `d3.pie()` emits for one slice, around the caller's own datum. */
+function arc(data: unknown, value: number, index: number): unknown {
+  return {
+    data,
+    value,
+    index,
+    startAngle: index,
+    endAngle: index + 1,
+    padAngle: 0,
+  };
+}
+
+/**
+ * Builds an SVG holding one `path.slice` per datum, in the order given, with
+ * each datum bound the way `selectAll('path.slice').data(...).join('path')`
+ * would leave it.
+ */
+function buildPieSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="pie-svg"></svg>`);
+  const svg = dom.window.document.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const path = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('class', 'slice');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+describe('bindD3Pie', () => {
+  test('emits a flat pie layer from d3.pie() arcs, taking the magnitude from the layout', () => {
+    const svg = buildPieSvg([
+      arc({ fruit: 'Apples', units: 30 }, 30, 0),
+      arc({ fruit: 'Bananas', units: 50 }, 50, 1),
+      arc({ fruit: 'Cherries', units: 20 }, 20, 2),
+    ]);
+
+    const result = bindD3Pie(svg, {
+      selector: 'path.slice',
+      title: 'Fruit sales',
+      axes: { x: 'Fruit', y: 'Units' },
+      x: 'fruit',
+    });
+
+    expect(result.layer.type).toBe(TraceType.PIE);
+    // Flat PiePoint[], never the nested array the bar family uses.
+    expect(result.layer.data).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]);
+    expect(result.layer.selectors).toBe('#pie-svg path.slice');
+    expect(result.layer.axes).toEqual({ x: { label: 'Fruit' }, y: { label: 'Units' } });
+  });
+
+  test('emits no orientation and no z axis', () => {
+    const svg = buildPieSvg([
+      arc({ label: 'A', value: 1 }, 1, 0),
+      arc({ label: 'B', value: 2 }, 2, 1),
+    ]);
+
+    const result = bindD3Pie(svg, {
+      selector: 'path.slice',
+      axes: { x: 'Group', y: 'Count' },
+    });
+
+    // A pie has no orientation, and its percentage is derived from the values
+    // rather than labelled by a fill axis.
+    expect(result.layer.orientation).toBeUndefined();
+    expect(result.layer.axes?.z).toBeUndefined();
+    // `label` / `value` are inferred from the user's datum, not from the arc.
+    expect(result.layer.data).toEqual([
+      { x: 'A', y: 1 },
+      { x: 'B', y: 2 },
+    ]);
+  });
+
+  test('keeps slices in DOM order, which is the order d3.pie() returns arcs in', () => {
+    // d3.pie() sorts by value for drawing but returns arcs in input order, so
+    // a sorted pie still joins its wedges in the data's own order.
+    const svg = buildPieSvg([
+      arc({ label: 'Small', value: 5 }, 5, 2),
+      arc({ label: 'Large', value: 60 }, 60, 0),
+      arc({ label: 'Medium', value: 35 }, 35, 1),
+    ]);
+
+    const result = bindD3Pie(svg, { selector: 'path.slice' });
+
+    expect((result.layer.data as PiePoint[]).map(point => point.x))
+      .toEqual(['Small', 'Large', 'Medium']);
+  });
+
+  test('labels a slice with its own datum when the pie was drawn from bare numbers', () => {
+    const svg = buildPieSvg([arc(30, 30, 0), arc(70, 70, 1)]);
+
+    const result = bindD3Pie(svg, { selector: 'path.slice' });
+
+    expect(result.layer.data).toEqual([
+      { x: 30, y: 30 },
+      { x: 70, y: 70 },
+    ]);
+  });
+
+  test('reads a hand-drawn pie through the accessors, treating an absent value as a gap', () => {
+    // No d3.pie() layout: the wedge carries the user's datum directly.
+    const svg = buildPieSvg([
+      { name: 'Measured', units: 40 },
+      { name: 'Unmeasured', units: null },
+    ]);
+
+    const result = bindD3Pie(svg, {
+      selector: 'path.slice',
+      x: 'name',
+      y: 'units',
+    });
+
+    const data = result.layer.data as PiePoint[];
+    expect(data[0]).toEqual({ x: 'Measured', y: 40 });
+    // A gap must not collapse into a real zero: `Number(null)` is 0, which
+    // would be sonified, totalled, and offered as a minimum.
+    expect(data[1].x).toBe('Unmeasured');
+    expect(Number.isNaN(data[1].y)).toBe(true);
+  });
+
+  test('throws an actionable error when the selector matches no wedges', () => {
+    const svg = buildPieSvg([arc({ label: 'A', value: 1 }, 1, 0)]);
+
+    expect(() => bindD3Pie(svg, { selector: 'path.wedge' }))
+      .toThrow(/pie slice/);
+  });
+});

--- a/test/adapters/frappe/converters.test.ts
+++ b/test/adapters/frappe/converters.test.ts
@@ -1,5 +1,5 @@
 import type { FrappeChart, FrappePanel } from '@adapters/frappe/types';
-import type { BarPoint, MaidrLayer } from '@type/grammar';
+import type { BarPoint, MaidrLayer, PiePoint } from '@type/grammar';
 import { createMaidrFromFrappeChart, createMaidrFromFrappeCharts } from '@adapters/frappe/converters';
 import { TraceType } from '@type/grammar';
 import { JSDOM } from 'jsdom';
@@ -80,6 +80,125 @@ describe('createMaidrFromFrappeChart (single chart)', () => {
     expect(maidr.id).toBe(container.id);
     expect(maidr.subplots[0][0].layers[0].selectors)
       .toBe(`#${container.id} svg.frappe-chart .dataset-units.dataset-bars.dataset-0 rect.bar`);
+  });
+});
+
+describe('createMaidrFromFrappeChart (pie and donut)', () => {
+  /** A chart whose labels each carry one value, as a pie is normally built. */
+  function makePieChart(
+    slices: Array<[string, number]>,
+    config?: { maxSlices?: number },
+  ): FrappeChart {
+    return {
+      data: {
+        labels: slices.map(([label]) => label),
+        datasets: [{ name: 'Sales', values: slices.map(([, value]) => value) }],
+      },
+      ...(config ? { config } : {}),
+    };
+  }
+
+  function pieLayer(chart: FrappeChart, chartType: 'donut' | 'pie'): MaidrLayer {
+    const { containers } = makeDom(1);
+    containers[0].id = 'chart';
+    const maidr = createMaidrFromFrappeChart(chart, containers[0], { chartType });
+    return maidr.subplots[0][0].layers[0];
+  }
+
+  it('emits a flat pie layer whose selector matches the pie wedges', () => {
+    const layer = pieLayer(
+      makePieChart([['Apples', 30], ['Bananas', 50], ['Cherries', 20]]),
+      'pie',
+    );
+
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.selectors).toBe('#chart svg.frappe-chart .pie-slices path.pie-path');
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]);
+  });
+
+  it('targets the donut components for a donut chart', () => {
+    const layer = pieLayer(makePieChart([['Apples', 30]]), 'donut');
+
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.selectors).toBe('#chart svg.frappe-chart .donut-slices path.donut-path');
+  });
+
+  it('names the two dimensions when the caller supplies no axis labels', () => {
+    const layer = pieLayer(makePieChart([['Apples', 30]]), 'pie');
+
+    expect(layer.axes).toEqual({ x: { label: 'Label' }, y: { label: 'Value' } });
+  });
+
+  it('keeps caller-supplied axis labels', () => {
+    const { containers } = makeDom(1);
+    const maidr = createMaidrFromFrappeChart(
+      makePieChart([['Apples', 30]]),
+      containers[0],
+      { chartType: 'pie', axes: { x: 'Fruit', y: 'Units' } },
+    );
+
+    expect(maidr.subplots[0][0].layers[0].axes)
+      .toEqual({ x: { label: 'Fruit' }, y: { label: 'Units' } });
+  });
+
+  it('sums every dataset at each label, as Frappe does before drawing', () => {
+    const layer = pieLayer(
+      {
+        data: {
+          labels: ['Apples', 'Bananas'],
+          datasets: [
+            { name: 'Q1', values: [10, 20] },
+            { name: 'Q2', values: [5, 1] },
+          ],
+        },
+      },
+      'pie',
+    );
+
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 15 },
+      { x: 'Bananas', y: 21 },
+    ]);
+  });
+
+  it('drops labels Frappe draws no wedge for, keeping slice k aligned with wedge k', () => {
+    const layer = pieLayer(
+      makePieChart([['Apples', 30], ['Owed', -5], ['Cherries', 20]]),
+      'pie',
+    );
+
+    // The negative total gets no wedge, so carrying it would slide Cherries'
+    // highlight onto the wedge before it. A zero total is a real slice.
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Cherries', y: 20 },
+    ]);
+  });
+
+  it('collapses everything past maxSlices into one Rest slice, largest first', () => {
+    const layer = pieLayer(
+      makePieChart([['A', 1], ['B', 5], ['C', 3], ['D', 2]], { maxSlices: 3 }),
+      'pie',
+    );
+
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'B', y: 5 },
+      { x: 'C', y: 3 },
+      { x: 'Rest', y: 3 },
+    ]);
+  });
+
+  it('leaves the label order alone while the slices fit within maxSlices', () => {
+    const layer = pieLayer(
+      makePieChart([['A', 1], ['B', 5], ['C', 3]], { maxSlices: 3 }),
+      'pie',
+    );
+
+    expect((layer.data as PiePoint[]).map(point => point.x)).toEqual(['A', 'B', 'C']);
   });
 });
 

--- a/test/adapters/google-charts/pie.test.ts
+++ b/test/adapters/google-charts/pie.test.ts
@@ -1,0 +1,162 @@
+import type { GoogleChart, GoogleDataTable } from '@adapters/google-charts/types';
+import type { PiePoint } from '@type/grammar';
+import { createMaidrFromGoogleChart } from '@adapters/google-charts/converters';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+type PieRow = [string, number | null];
+
+/** Minimal DataTable fake for a two-column (label, value) pie chart. */
+function makePieDataTable(
+  rows: PieRow[],
+  labels: [string, string] = ['Fruit', 'Units'],
+): GoogleDataTable {
+  return {
+    getNumberOfRows: () => rows.length,
+    getNumberOfColumns: () => 2,
+    getValue: (r, c) => rows[r][c],
+    getFormattedValue: (r, c) => (rows[r][c] === null ? '' : String(rows[r][c])),
+    getColumnLabel: c => labels[c],
+    getColumnType: c => (c === 0 ? 'string' : 'number'),
+  };
+}
+
+/**
+ * A PieChart is not axis-based and exposes no layout interface, so the
+ * adapter must never ask for one — this fake fails loudly if it does.
+ */
+const PIE_CHART: GoogleChart = {
+  getSelection: () => [],
+  setSelection: () => {},
+  getChartLayoutInterface: () => {
+    throw new Error('a PieChart has no chart layout interface');
+  },
+};
+
+/**
+ * Builds a rendered pie chart: a container div holding an SVG with a legend
+ * swatch (a plain rectangular path, as Google draws it), then `pathsPerSlice`
+ * wedge paths per row. A wedge is an arc; the swatch is not.
+ */
+function makePieContainer(rowCount: number, pathsPerSlice = 1): HTMLElement {
+  const dom = new JSDOM('<!doctype html><body><div id="pie-chart"></div></body>');
+  const doc = dom.window.document;
+  const container = doc.getElementById('pie-chart') as HTMLElement;
+
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+
+  const swatch = doc.createElementNS(SVG_NS, 'path');
+  swatch.setAttribute('d', 'M0,0 L12,0 L12,12 L0,12 Z');
+  svg.appendChild(swatch);
+
+  for (let slice = 0; slice < rowCount; slice++) {
+    for (let part = 0; part < pathsPerSlice; part++) {
+      const wedge = doc.createElementNS(SVG_NS, 'path');
+      wedge.setAttribute('d', `M100,100 L180,100 A80,80 0 0,1 ${140 + slice},${170 + part} Z`);
+      svg.appendChild(wedge);
+    }
+  }
+
+  return container;
+}
+
+const ROWS: PieRow[] = [['Apples', 30], ['Bananas', 50], ['Cherries', 20]];
+
+// The mismatch case warns on purpose; installing the spy per test would let it
+// print on every run instead.
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
+afterAll(() => {
+  warnSpy.mockRestore();
+});
+
+describe('createMaidrFromGoogleChart with a PieChart', () => {
+  it('emits a flat pie layer with the label and value column labels as axes', () => {
+    const container = makePieContainer(ROWS.length);
+
+    const maidr = createMaidrFromGoogleChart(
+      PIE_CHART,
+      makePieDataTable(ROWS),
+      container,
+      { chartType: 'PieChart', title: 'Fruit sales' },
+    );
+
+    const layer = maidr.subplots[0][0].layers[0];
+    expect(layer.type).toBe(TraceType.PIE);
+    // Flat PiePoint[], never the nested array the bar family uses.
+    expect(layer.data).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]);
+    expect(layer.axes).toEqual({ x: { label: 'Fruit' }, y: { label: 'Units' } });
+    // A pie has no orientation, and its percentage is derived from the values
+    // rather than labelled by a fill axis.
+    expect(layer.orientation).toBeUndefined();
+    expect(layer.axes?.z).toBeUndefined();
+  });
+
+  it('marks one wedge per slice in row order, ignoring the legend swatch', () => {
+    const container = makePieContainer(ROWS.length);
+
+    const maidr = createMaidrFromGoogleChart(
+      PIE_CHART,
+      makePieDataTable(ROWS),
+      container,
+      { chartType: 'PieChart' },
+    );
+
+    const layer = maidr.subplots[0][0].layers[0];
+    // Resolve the emitted selector the way MAIDR does: page-globally.
+    const marked = Array.from(
+      container.ownerDocument.querySelectorAll(String(layer.selectors)),
+    );
+    expect(marked).toHaveLength(ROWS.length);
+    expect(marked.map(path => path.getAttribute('data-maidr-slice'))).toEqual(['0', '1', '2']);
+    // The swatch has no arc command, so it is not a wedge.
+    expect(container.querySelector('path')?.hasAttribute('data-maidr-slice')).toBe(false);
+  });
+
+  it('omits the selectors when the wedge count does not match the row count', () => {
+    // A 3-D pie draws several paths per slice: which path is which slice is
+    // then unknown, and a wrong highlight is worse than none.
+    const container = makePieContainer(ROWS.length, 2);
+
+    const maidr = createMaidrFromGoogleChart(
+      PIE_CHART,
+      makePieDataTable(ROWS),
+      container,
+      { chartType: 'PieChart' },
+    );
+
+    const layer = maidr.subplots[0][0].layers[0];
+    expect(layer.selectors).toBeUndefined();
+    expect(container.querySelectorAll('path[data-maidr-slice]')).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Pie slice count mismatch'));
+  });
+
+  it('reports a slice with no measurement as a gap rather than a zero', () => {
+    const rows: PieRow[] = [['Apples', 30], ['Bananas', null]];
+    const container = makePieContainer(rows.length);
+
+    const maidr = createMaidrFromGoogleChart(
+      PIE_CHART,
+      makePieDataTable(rows),
+      container,
+      { chartType: 'PieChart' },
+    );
+
+    const data = maidr.subplots[0][0].layers[0].data as PiePoint[];
+    // `Number(null)` is 0, which would be sonified, totalled, and offered as
+    // a minimum — the pie model reads NaN as the absence it actually is.
+    expect(Number.isNaN(data[1].y)).toBe(true);
+  });
+});

--- a/test/adapters/highcharts/grid.test.ts
+++ b/test/adapters/highcharts/grid.test.ts
@@ -219,9 +219,9 @@ describe('highchartsGridToMaidr', () => {
     try {
       const noSeries = fakeChart({ type: 'column', renderToId: 'grid-none-1', series: [] });
       const unsupported = fakeChart({
-        type: 'pie',
+        type: 'treemap',
         renderToId: 'grid-none-2',
-        series: [fakeSeries({ index: 0, type: 'pie', name: 'Share', data: categoryPoints([1], ['a']) })],
+        series: [fakeSeries({ index: 0, type: 'treemap', name: 'Share', data: categoryPoints([1], ['a']) })],
       });
 
       expect(() => highchartsGridToMaidr([noSeries, unsupported]))

--- a/test/adapters/highcharts/pie.test.ts
+++ b/test/adapters/highcharts/pie.test.ts
@@ -1,0 +1,94 @@
+import type { PiePoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { TraceType } from '@type/grammar';
+import { fakeChart, fakeSeries } from './helpers';
+
+/** Points as Highcharts builds them from `data: [{ name, y }, …]`. */
+const BROWSERS = [
+  { name: 'Chrome', y: 61.4 },
+  { name: 'Safari', y: 24.5 },
+  { name: 'Edge', y: 14.1 },
+];
+
+describe('highcharts pie series', () => {
+  it('converts a pie series into a flat pie layer in slice order', () => {
+    const chart = fakeChart({
+      title: 'Browser share',
+      type: 'pie',
+      renderToId: 'pie-chart',
+      series: [fakeSeries({ index: 0, type: 'pie', name: 'Browsers', data: BROWSERS })],
+    });
+
+    const result = highchartsToMaidr(chart, { id: 'test-pie' });
+    const layer = result.subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.title).toBe('Browsers');
+    // Highcharts draws the wedges in data order, so no reordering to undo.
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Chrome', y: 61.4 },
+      { x: 'Safari', y: 24.5 },
+      { x: 'Edge', y: 14.1 },
+    ]);
+    expect(layer.selectors).toBe(
+      '#pie-chart .highcharts-series-group .highcharts-series-0 .highcharts-point',
+    );
+    // A pie is bound to no axis, so neither dimension is named after one.
+    expect(layer.axes?.x?.label).toBe('Label');
+    expect(layer.axes?.y?.label).toBe('Value');
+    expect(layer.orientation).toBeUndefined();
+  });
+
+  it('resolves the series type from the chart when the series omits it', () => {
+    const chart = fakeChart({
+      type: 'pie',
+      renderToId: 'chart-typed-pie',
+      // No per-series `type`: `chart.type` is what makes this a pie, which is
+      // how the Highcharts pie demos are written.
+      series: [fakeSeries({ index: 0, type: '', name: 'Browsers', data: BROWSERS })],
+    });
+
+    const result = highchartsToMaidr(chart);
+
+    expect(result.subplots[0][0].layers[0].type).toBe(TraceType.PIE);
+  });
+
+  it('drops a valueless point, which Highcharts draws no wedge for', () => {
+    const chart = fakeChart({
+      type: 'pie',
+      renderToId: 'pie-with-gap',
+      series: [fakeSeries({
+        index: 0,
+        type: 'pie',
+        data: [{ name: 'Chrome', y: 61.4 }, { name: 'Unknown', y: null }, { name: 'Edge', y: 14.1 }],
+      })],
+    });
+
+    const result = highchartsToMaidr(chart);
+    const data = result.subplots[0][0].layers[0].data as PiePoint[];
+
+    // Keeping the gap would leave three slices against two wedges, sliding
+    // Edge's highlight onto Chrome's.
+    expect(data).toEqual([
+      { x: 'Chrome', y: 61.4 },
+      { x: 'Edge', y: 14.1 },
+    ]);
+  });
+
+  it('labels a slice by its index when the point carries no name', () => {
+    const chart = fakeChart({
+      type: 'pie',
+      renderToId: 'pie-unnamed',
+      // `data: [8, 3]` — Highcharts leaves such points nameless.
+      series: [fakeSeries({ index: 0, type: 'pie', data: [{ y: 8 }, { y: 3 }] })],
+    });
+
+    const result = highchartsToMaidr(chart);
+    const data = result.subplots[0][0].layers[0].data as PiePoint[];
+
+    expect(data).toEqual([
+      { x: 0, y: 8 },
+      { x: 1, y: 3 },
+    ]);
+  });
+});

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,5 +1,5 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
-import type { BarPoint, BoxPoint, BoxSelector, MaidrLayer, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, BoxSelector, MaidrLayer, PiePoint, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
@@ -125,7 +125,7 @@ describe('plotly extractor', () => {
     it('warns once for a trace type MAIDR has no equivalent for', () => {
       const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const gd = createGraphDiv({
-        traces: [{ type: 'pie', y: [1, 2, 3] }],
+        traces: [{ type: 'sunburst', y: [1, 2, 3] }],
         layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
       });
 
@@ -140,6 +140,159 @@ describe('plotly extractor', () => {
         // A failed assertion must not leave the spy in place for later tests.
         warn.mockRestore();
       }
+    });
+  });
+
+  describe('pie traces', () => {
+    const FRUIT: Partial<PlotlyTrace> = {
+      type: 'pie',
+      labels: ['Apples', 'Bananas', 'Cherries'],
+      values: [30, 50, 20],
+      domain: { x: [0, 1], y: [0, 1] },
+    };
+
+    /** Calcdata as plotly leaves it once `sort` has put the biggest first. */
+    const SORTED_CALCDATA: PlotlyCalcData[][] = [[
+      { label: 'Bananas', v: 50 },
+      { label: 'Apples', v: 30 },
+      { label: 'Cherries', v: 20 },
+    ]];
+
+    function onlyPieLayer(gd: PlotlyGraphDiv): MaidrLayer {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it('emits a flat pie layer with the slices in the order plotly drew them', () => {
+      const gd = createGraphDiv({
+        traces: [{ ...FRUIT, name: 'Fruit sales' }],
+        layout: {},
+        calcdata: SORTED_CALCDATA,
+      });
+
+      const layer = onlyPieLayer(gd);
+
+      expect(layer.type).toBe(TraceType.PIE);
+      expect(layer.title).toBe('Fruit sales');
+      // Drawn order, not authored order: plotly sorts a pie largest-first, and
+      // the wedge elements follow suit.
+      expect(layer.data as PiePoint[]).toEqual([
+        { x: 'Bananas', y: 50 },
+        { x: 'Apples', y: 30 },
+        { x: 'Cherries', y: 20 },
+      ]);
+      expect(layer.selectors).toBe(
+        '.pielayer > g.trace:nth-of-type(1) g.slice path.surface',
+      );
+      expect(layer.axes?.x?.label).toBe('Label');
+      expect(layer.axes?.y?.label).toBe('Value');
+      expect(layer.orientation).toBeUndefined();
+    });
+
+    it('withholds the selectors when only the authored order is known', () => {
+      const gd = createGraphDiv({ traces: [{ ...FRUIT }], layout: {} });
+
+      const layer = onlyPieLayer(gd);
+
+      // Without calcdata the authored order is all there is, and plotly's
+      // default sort means it is not the order of the wedges — highlighting
+      // by index would land on the wrong slice.
+      expect(layer.data as PiePoint[]).toEqual([
+        { x: 'Apples', y: 30 },
+        { x: 'Bananas', y: 50 },
+        { x: 'Cherries', y: 20 },
+      ]);
+      expect(layer.selectors).toBeUndefined();
+    });
+
+    it('keeps the selectors without calcdata when the trace turned sort off', () => {
+      const gd = createGraphDiv({
+        traces: [{ ...FRUIT, sort: false }],
+        layout: {},
+      });
+
+      const layer = onlyPieLayer(gd);
+
+      expect(layer.data as PiePoint[]).toEqual([
+        { x: 'Apples', y: 30 },
+        { x: 'Bananas', y: 50 },
+        { x: 'Cherries', y: 20 },
+      ]);
+      expect(layer.selectors).toBe(
+        '.pielayer > g.trace:nth-of-type(1) g.slice path.surface',
+      );
+    });
+
+    it('counts only the pies plotly drew when addressing a wedge group', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { ...FRUIT, visible: false },
+          { ...FRUIT, sort: false },
+        ],
+        layout: {},
+      });
+
+      // A hidden trace gets no group in `.pielayer`, so the visible pie is
+      // still the first one there.
+      const layer = onlyPieLayer(gd);
+
+      expect(layer.selectors).toBe(
+        '.pielayer > g.trace:nth-of-type(1) g.slice path.surface',
+      );
+    });
+
+    it('arranges several pies into a grid from their own domains', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { ...FRUIT, sort: false, domain: { x: [0, 0.45], y: [0, 1] } },
+          { ...FRUIT, sort: false, domain: { x: [0.55, 1], y: [0, 1] } },
+        ],
+        layout: {},
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr).not.toBeNull();
+      // One panel per pie: a pie has no axis pair to be grouped by, so they
+      // must not land in the same subplot.
+      expect(maidr!.subplots).toHaveLength(1);
+      expect(maidr!.subplots[0]).toHaveLength(2);
+      expect(maidr!.subplots[0][0].layers[0].selectors).toBe(
+        '.pielayer > g.trace:nth-of-type(1) g.slice path.surface',
+      );
+      expect(maidr!.subplots[0][1].layers[0].selectors).toBe(
+        '.pielayer > g.trace:nth-of-type(2) g.slice path.surface',
+      );
+      // There is no `axes_…` group around a pie to point a subplot selector at.
+      expect(maidr!.subplots[0][0].selector).toBeUndefined();
+    });
+
+    it('keeps a pie out of the cartesian panel it shares a figure with', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'Tips' },
+          { ...FRUIT, sort: false },
+        ],
+        layout: {
+          xaxis: { title: { text: 'Day' }, domain: [0, 1] },
+          yaxis: { title: { text: 'Count' }, domain: [0, 1] },
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr).not.toBeNull();
+      const panels = maidr!.subplots.flat();
+      expect(panels).toHaveLength(2);
+      expect(panels.map(panel => panel.layers[0].type))
+        .toEqual([TraceType.BAR, TraceType.PIE]);
+      // The bar's axis titles stay with the bar rather than naming the pie's
+      // slices and magnitudes.
+      expect(panels[0].layers[0].axes?.x?.label).toBe('Day');
+      expect(panels[1].layers[0].axes?.x?.label).toBe('Label');
     });
   });
 

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -1,7 +1,7 @@
 import type { RechartsAdapterConfig } from '@adapters/recharts/types';
-import type { BarPoint, HistogramPoint, LinePoint, ScatterPoint, SegmentedPoint } from '@type/grammar';
+import type { BarPoint, HistogramPoint, LinePoint, PiePoint, ScatterPoint, SegmentedPoint } from '@type/grammar';
 import { convertRechartsToMaidr } from '@adapters/recharts/converters';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 
 describe('convertRechartsToMaidr', () => {
   describe('bar chart', () => {
@@ -366,6 +366,64 @@ describe('convertRechartsToMaidr', () => {
       const data = layer.data as ScatterPoint[];
       expect(data).toHaveLength(2);
       expect(data[0]).toEqual({ x: 1, y: 10 });
+    });
+  });
+
+  describe('pie chart', () => {
+    const pieConfig: RechartsAdapterConfig = {
+      id: 'fruit',
+      title: 'Fruit Sales',
+      data: [
+        { fruit: 'Apples', units: 30 },
+        { fruit: 'Bananas', units: 50 },
+        { fruit: 'Cherries', units: 20 },
+      ],
+      chartType: 'pie',
+      xKey: 'fruit',
+      yKeys: ['units'],
+      xLabel: 'Fruit',
+      yLabel: 'Units',
+    };
+
+    it('converts pie data to a flat PiePoint[]', () => {
+      const layer = convertRechartsToMaidr(pieConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.PIE);
+      expect(layer.axes?.x).toEqual({ label: 'Fruit' });
+      expect(layer.axes?.y).toEqual({ label: 'Units' });
+
+      // Flat, never nested: PieTrace wraps the slices into its single row itself.
+      const data = layer.data as PiePoint[];
+      expect(data).toEqual([
+        { x: 'Apples', y: 30 },
+        { x: 'Bananas', y: 50 },
+        { x: 'Cherries', y: 20 },
+      ]);
+    });
+
+    it('targets the sector paths, in slice order', () => {
+      const layer = convertRechartsToMaidr(pieConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe(
+        '#maidr-article-fruit .recharts-pie-sector .recharts-sector',
+      );
+    });
+
+    it('never emits an orientation, even when the config sets one', () => {
+      const layer = convertRechartsToMaidr({
+        ...pieConfig,
+        orientation: Orientation.HORIZONTAL,
+      }).subplots[0][0].layers[0];
+
+      expect(layer.orientation).toBeUndefined();
+    });
+
+    it('carries no percentage on the wire (the model derives it)', () => {
+      const layer = convertRechartsToMaidr(pieConfig).subplots[0][0].layers[0];
+
+      for (const point of layer.data as PiePoint[]) {
+        expect(point).not.toHaveProperty('percentage');
+      }
     });
   });
 

--- a/test/adapters/recharts/selectors.test.ts
+++ b/test/adapters/recharts/selectors.test.ts
@@ -29,6 +29,10 @@ describe('getRechartsSelector', () => {
     it('returns scoped scatter symbol selector for scatter type', () => {
       expect(getRechartsSelector('scatter')).toBe('.recharts-scatter-symbol .recharts-symbols');
     });
+
+    it('returns scoped pie sector selector for pie type', () => {
+      expect(getRechartsSelector('pie')).toBe('.recharts-pie-sector .recharts-sector');
+    });
   });
 
   describe('multi-series (with seriesIndex)', () => {

--- a/test/adapters/vegalite/pie.test.ts
+++ b/test/adapters/vegalite/pie.test.ts
@@ -1,0 +1,108 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { MaidrLayer, PiePoint } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { TraceType } from '@type/grammar';
+
+const FRUIT = {
+  values: [
+    { fruit: 'Apples', units: 30 },
+    { fruit: 'Bananas', units: 50 },
+    { fruit: 'Cherries', units: 20 },
+  ],
+};
+
+/**
+ * A pie: an `arc` mark whose magnitudes ride `theta` and whose slice labels
+ * come from the colour channel. No view is supplied, so the converter reads
+ * the spec's inline data — the same fallback the other converter tests use.
+ */
+function pieSpec(mark: VegaLiteSpec['mark']): VegaLiteSpec {
+  return {
+    data: FRUIT,
+    mark,
+    encoding: {
+      theta: { field: 'units', type: 'quantitative', title: 'Units' },
+      color: { field: 'fruit', type: 'nominal', title: 'Fruit' },
+    },
+  };
+}
+
+function onlyLayer(spec: VegaLiteSpec): MaidrLayer {
+  const result = vegaLiteToMaidr(spec);
+  const layers = result.subplots[0][0].layers;
+  expect(layers).toHaveLength(1);
+  return layers[0];
+}
+
+describe('vega-Lite arc marks', () => {
+  it('converts an arc mark with a theta encoding into a flat pie layer', () => {
+    const layer = onlyLayer(pieSpec('arc'));
+
+    expect(layer.type).toBe(TraceType.PIE);
+    // Row order is the drawn order: the stack transform behind a `theta`
+    // encoding computes angles without reordering the rows.
+    expect(layer.data as PiePoint[]).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]);
+    expect(layer.selectors).toBe(
+      'g.mark-arc.role-mark.marks path, g.mark-arc.role-mark.layer_0_marks path',
+    );
+    expect(layer.orientation).toBeUndefined();
+  });
+
+  it('names the axes after the colour and theta channels, not the absent x/y', () => {
+    const layer = onlyLayer(pieSpec('arc'));
+
+    expect(layer.axes?.x?.label).toBe('Fruit');
+    expect(layer.axes?.y?.label).toBe('Units');
+  });
+
+  it('falls back to the field names when the channels carry no title', () => {
+    const layer = onlyLayer({
+      data: FRUIT,
+      mark: 'arc',
+      encoding: {
+        theta: { field: 'units', type: 'quantitative' },
+        color: { field: 'fruit', type: 'nominal' },
+      },
+    });
+
+    expect(layer.axes?.x?.label).toBe('fruit');
+    expect(layer.axes?.y?.label).toBe('units');
+  });
+
+  it('reads a doughnut exactly as it reads a pie', () => {
+    const layer = onlyLayer(pieSpec({ type: 'arc', innerRadius: 50 }));
+
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.data as PiePoint[]).toHaveLength(3);
+  });
+
+  it('takes the slice labels from fill when that is the channel in use', () => {
+    const layer = onlyLayer({
+      data: FRUIT,
+      mark: 'arc',
+      encoding: {
+        theta: { field: 'units', type: 'quantitative' },
+        fill: { field: 'fruit', type: 'nominal', title: 'Fruit' },
+      },
+    });
+
+    expect((layer.data as PiePoint[]).map(point => point.x))
+      .toEqual(['Apples', 'Bananas', 'Cherries']);
+    expect(layer.axes?.x?.label).toBe('Fruit');
+  });
+
+  it('leaves an arc without theta unsupported rather than inventing slices', () => {
+    // A radial mark with no angular encoding has no slices to navigate.
+    const result = vegaLiteToMaidr({
+      data: FRUIT,
+      mark: 'arc',
+      encoding: { color: { field: 'fruit', type: 'nominal' } },
+    });
+
+    expect(result.subplots[0][0].layers).toHaveLength(0);
+  });
+});

--- a/test/adapters/victory/converters.test.ts
+++ b/test/adapters/victory/converters.test.ts
@@ -36,6 +36,7 @@ const VictoryBar = stub('VictoryBar');
 const VictoryLine = stub('VictoryLine');
 const VictoryScatter = stub('VictoryScatter');
 const VictoryStack = stub('VictoryStack');
+const VictoryPie = stub('VictoryPie');
 
 const barData = [
   { x: 'A', y: 1 },
@@ -48,6 +49,11 @@ const lineData = [
 const scatterData = [
   { x: 1, y: 2 },
   { x: 3, y: 4 },
+];
+const pieData = [
+  { x: 'Apples', y: 30 },
+  { x: 'Bananas', y: 50 },
+  { x: 'Cherries', y: 20 },
 ];
 
 function chart(props: Record<string, unknown>, ...children: ReactNode[]): ReactNode {
@@ -344,6 +350,63 @@ describe('toMaidrLayer', () => {
     );
 
     expect(toMaidrLayer(info, '#mv path').type).toBe(TraceType.LINE);
+  });
+
+  it('converts a pie layer to a flat PiePoint[] with named axes', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryPie, { data: pieData }),
+    );
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-0]');
+
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.selectors).toBe('#mv [data-maidr-victory-0]');
+    // A standalone VictoryPie has no VictoryAxis, so the adapter names what the
+    // two positions mean rather than leaving the core to announce "X"/"Y".
+    expect(layer.axes?.x).toEqual({ label: 'Category' });
+    expect(layer.axes?.y).toEqual({ label: 'Value' });
+    // Flat, never nested, and with no producer-authored percentage.
+    expect(layer.data).toEqual([
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: 50 },
+      { x: 'Cherries', y: 20 },
+    ]);
+    expect(layer.orientation).toBeUndefined();
+  });
+
+  it('prefers an enclosing chart axis label over the pie fallback', () => {
+    const [info] = extractVictoryLayers(
+      chart(
+        {},
+        createElement(VictoryAxis, { label: 'Fruit' }),
+        createElement(VictoryPie, { data: pieData }),
+      ),
+    );
+
+    const layer = toMaidrLayer(info);
+
+    expect(layer.axes?.x).toEqual({ label: 'Fruit' });
+    expect(layer.axes?.y).toEqual({ label: 'Value' });
+  });
+
+  it('coerces a pie slice magnitude to a number', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryPie, { data: [{ x: 'Apples', y: '30' }] }),
+    );
+
+    expect(toMaidrLayer(info).data).toEqual([{ x: 'Apples', y: 30 }]);
+  });
+
+  it('reads pie accessors declared as prop keys', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryPie, {
+        data: [{ fruit: 'Apples', units: 30 }],
+        x: 'fruit',
+        y: 'units',
+      }),
+    );
+
+    expect(toMaidrLayer(info).data).toEqual([{ x: 'Apples', y: 30 }]);
   });
 
   it('converts a segmented layer to stacked type', () => {

--- a/test/model/pie.test.ts
+++ b/test/model/pie.test.ts
@@ -1,0 +1,378 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { BarBrailleState, DescriptionStat, TraceState } from '@type/state';
+import { describe, expect, it, jest } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { PieTrace } from '@model/pie';
+import { TraceType } from '@type/grammar';
+
+/** Fixture slice labels, in slice order. */
+const SLICE_LABELS = ['Apples', 'Bananas', 'Cherries', 'Dates'];
+
+/**
+ * Builds a pie layer. A gap is passed as `null`, which is what a producer with
+ * no measurement for a slice emits; `PiePoint.y` is declared numeric but is
+ * parsed from JSON, so `null` really does arrive there — hence the cast.
+ */
+function pieLayer(values: (number | null)[]): MaidrLayer {
+  return {
+    id: 'slices',
+    type: TraceType.PIE,
+    title: 'Fruit sales',
+    axes: { x: { label: 'Fruit' }, y: { label: 'Units' } },
+    data: values.map((y, index) => ({ x: SLICE_LABELS[index], y: y as number })),
+  };
+}
+
+/** Narrows the trace state union to the populated case. */
+function stateOf(trace: PieTrace): Extract<TraceState, { empty: false }> {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state;
+}
+
+/** The state the trace reports with the cursor parked on one slice. */
+function stateAtSlice(trace: PieTrace, col: number): Extract<TraceState, { empty: false }> {
+  trace.moveToIndex(0, col);
+  return stateOf(trace);
+}
+
+/** The share of the whole the trace announces for one slice. */
+function shareAtSlice(trace: PieTrace, col: number): string {
+  return stateAtSlice(trace, col).text.z?.value as string;
+}
+
+/** Reads one description stat by its label. */
+function statValue(stats: DescriptionStat[], label: string): string | number | undefined {
+  return stats.find(stat => stat.label === label)?.value;
+}
+
+describe('pie trace audio', () => {
+  it('scales every slice against the range of the slice values', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const { audio } = stateAtSlice(trace, 0);
+
+    expect(audio.freq.min).toBe(20);
+    expect(audio.freq.max).toBe(50);
+    expect(audio.freq.raw).toBe(30);
+  });
+
+  it('sonifies the raw magnitude rather than the share of the whole', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const { audio } = stateAtSlice(trace, 2);
+
+    // The two are a monotone rescale of each other, so this cannot be caught
+    // by pitch ordering — but a percentage here would leave audio disagreeing
+    // with the braille row and the reported total, which are both raw.
+    expect(audio.freq.raw).toBe(20);
+  });
+
+  it('pans across the slices as a single row', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const { audio } = stateAtSlice(trace, 1);
+
+    expect(audio.panning).toEqual({ x: 1, y: 0, rows: 1, cols: 3 });
+  });
+
+  it('keeps a gap out of the range so it cannot drag an endpoint', () => {
+    const trace = new PieTrace(pieLayer([30, null, 20]));
+
+    const { audio } = stateAtSlice(trace, 0);
+
+    // Number(null) is 0, which would put a slice that is not on the chart at
+    // the bottom of the range every other slice's pitch is scaled against.
+    expect(audio.freq.min).toBe(20);
+    expect(audio.freq.max).toBe(30);
+  });
+
+  it('reports a gap as having no magnitude, so the empty tone sounds', () => {
+    const trace = new PieTrace(pieLayer([30, null, 20]));
+
+    const { audio } = stateAtSlice(trace, 1);
+
+    // A non-finite raw is what tells AudioService to sound the empty tone
+    // instead of interpolating a frequency.
+    expect(Number.isFinite(audio.freq.raw as number)).toBe(false);
+  });
+
+  it('still treats a slice genuinely measured at zero as a real value', () => {
+    const trace = new PieTrace(pieLayer([30, 0, 20]));
+
+    const { audio } = stateAtSlice(trace, 1);
+
+    expect(audio.freq.min).toBe(0);
+    expect(Number.isFinite(audio.freq.raw as number)).toBe(true);
+  });
+});
+
+describe('pie trace text', () => {
+  it('announces the slice label, its value and its share', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const { text } = stateAtSlice(trace, 0);
+
+    expect(text.main).toEqual({ label: 'Fruit', value: 'Apples' });
+    expect(text.cross).toEqual({ label: 'Units', value: 30 });
+    expect(text.z).toEqual({ label: 'Percentage', value: '30.0%' });
+  });
+
+  it('keeps the label on x and the value on y at every slice', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const first = stateAtSlice(trace, 0).text;
+    const last = stateAtSlice(trace, 2).text;
+
+    // A pie has no orientation to swap the axes by, so these never move — and
+    // the formatter picks the per-axis format off them.
+    expect([first.mainAxis, last.mainAxis]).toEqual(['x', 'x']);
+    expect([first.crossAxis, last.crossAxis]).toEqual(['y', 'y']);
+  });
+
+  it('announces the share of the slice the cursor is actually on', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    expect(shareAtSlice(trace, 1)).toBe('50.0%');
+    expect(shareAtSlice(trace, 2)).toBe('20.0%');
+  });
+});
+
+describe('pie slice percentages', () => {
+  it('adds up to a hundred within the rounding of one decimal place', () => {
+    const trace = new PieTrace(pieLayer([1, 1, 1]));
+
+    const shares = [0, 1, 2].map(col => shareAtSlice(trace, col));
+
+    expect(shares).toEqual(['33.3%', '33.3%', '33.3%']);
+    // Each share is rounded to within 0.05 of its exact value, so the sum can
+    // miss 100 by at most 0.05 per slice — and by nothing more.
+    const total = shares.reduce((sum, share) => sum + Number.parseFloat(share), 0);
+    expect(Math.abs(total - 100)).toBeLessThanOrEqual(shares.length * 0.05);
+  });
+
+  it('reports a zero total as zero percent rather than NaN percent', () => {
+    const trace = new PieTrace(pieLayer([0, 0]));
+
+    const shares = [0, 1].map(col => shareAtSlice(trace, col));
+
+    // 0 / 0 is NaN, and "NaN percent" is the one thing this must never say.
+    // The exact form, not '0.0%': nothing was rounded to get there.
+    expect(shares).toEqual(['0%', '0%']);
+  });
+
+  it('reads a gap as missing rather than as a zero-percent slice', () => {
+    const trace = new PieTrace(pieLayer([30, null, 10]));
+
+    expect(shareAtSlice(trace, 1)).toBe('missing');
+  });
+
+  it('still gives a slice measured at zero a real zero-percent share', () => {
+    const trace = new PieTrace(pieLayer([30, 0, 10]));
+
+    // The discriminator between a gap and a zero: both have no share to speak
+    // of, but only one of them was measured.
+    expect(shareAtSlice(trace, 1)).toBe('0.0%');
+  });
+
+  it('divides the measured slices by a total the gap took no part in', () => {
+    const trace = new PieTrace(pieLayer([30, null, 10]));
+
+    expect(shareAtSlice(trace, 0)).toBe('75.0%');
+    expect(shareAtSlice(trace, 2)).toBe('25.0%');
+  });
+});
+
+describe('pie trace braille', () => {
+  it('encodes the slices as a single row of raw magnitudes', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const braille = stateAtSlice(trace, 0).braille as BarBrailleState;
+
+    // One row, scaled against its own range — the bar encoder's input exactly.
+    expect(braille.values).toEqual([[30, 50, 20]]);
+    expect(braille.min).toEqual([20]);
+    expect(braille.max).toEqual([50]);
+  });
+
+  it('tracks the cursor along that one row', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const braille = stateAtSlice(trace, 2).braille as BarBrailleState;
+
+    expect(braille.row).toBe(0);
+    expect(braille.col).toBe(2);
+  });
+
+  it('carries a gap through as a gap so it encodes blank, not tallest', () => {
+    const trace = new PieTrace(pieLayer([30, null, 20]));
+
+    const braille = stateAtSlice(trace, 0).braille as BarBrailleState;
+
+    // NaN loses every comparison in BarBrailleEncoder, which is what routes it
+    // to the blank cell; a 0 there would be blank too, but it would also have
+    // pulled `min` down to 0 and shifted every other cell's band.
+    expect(Number.isFinite(braille.values[0][1])).toBe(false);
+    expect(braille.min).toEqual([20]);
+  });
+});
+
+describe('pie navigation', () => {
+  it('moves right and left across the slices', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    // The first key press lands on the first slice rather than stepping off it.
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.col).toBe(0);
+
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.col).toBe(1);
+
+    expect(trace.moveOnce('BACKWARD')).toBe(true);
+    expect(trace.col).toBe(0);
+  });
+
+  it('stops at the last slice rather than wrapping round the circle', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+    trace.moveToIndex(0, 2);
+
+    expect(trace.moveOnce('FORWARD')).toBe(false);
+    expect(trace.col).toBe(2);
+  });
+
+  it('treats up and down as out of bounds, since a pie is one row', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+    trace.moveToIndex(0, 1);
+    const update = jest.fn();
+    trace.addObserver({ update });
+
+    expect(trace.moveOnce('UPWARD')).toBe(false);
+    expect(trace.moveOnce('DOWNWARD')).toBe(false);
+
+    expect(trace.row).toBe(0);
+    expect(trace.col).toBe(1);
+    // A rejected move still has to say something, or the key press is silent.
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(update.mock.calls[0][0]).toMatchObject({ empty: true, type: 'trace' });
+  });
+
+  it('rejects a jump to a second row', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    expect(trace.moveToIndex(1, 0)).toBe(false);
+    expect(trace.moveToIndex(0, 3)).toBe(false);
+    expect(trace.moveToIndex(0, 2)).toBe(true);
+  });
+
+  it('runs to the far slice on an extreme move', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    expect(trace.moveToExtreme('FORWARD')).toBe(true);
+    expect(trace.col).toBe(2);
+
+    expect(trace.moveToExtreme('BACKWARD')).toBe(true);
+    expect(trace.col).toBe(0);
+  });
+});
+
+describe('pie description', () => {
+  it('reports the slice count and the total alongside the range', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const { stats } = trace.description;
+
+    expect(stats).toEqual([
+      { label: 'Number of slices', value: 3 },
+      { label: 'Min value', value: 20 },
+      { label: 'Max value', value: 50 },
+      { label: 'Total', value: 100 },
+    ]);
+  });
+
+  it('counts a gap as a slice but leaves it out of the total', () => {
+    const trace = new PieTrace(pieLayer([30, null, 20]));
+
+    const { stats } = trace.description;
+
+    // The slice is on the chart, so it is one of the slices; it was never
+    // measured, so it contributes nothing to the sum.
+    expect(statValue(stats, 'Number of slices')).toBe(3);
+    expect(statValue(stats, 'Total')).toBe(50);
+  });
+
+  it('names the chart and tabulates label, value and share', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const { chartType, title, axes, dataTable } = trace.description;
+
+    expect(chartType).toBe('Pie Chart');
+    expect(title).toBe('Fruit sales');
+    expect(axes).toEqual({ x: 'Fruit', y: 'Units' });
+    expect(dataTable.headers).toEqual(['Fruit', 'Units', 'Percentage']);
+    expect(dataTable.rows).toEqual([
+      ['Apples', 30, '30.0%'],
+      ['Bananas', 50, '50.0%'],
+      ['Cherries', 20, '20.0%'],
+    ]);
+  });
+
+  it('spells a gap out in the table rather than leaving the cell blank', () => {
+    const trace = new PieTrace(pieLayer([30, null, 20]));
+
+    const { rows } = trace.description.dataTable;
+
+    // A blank cell and a cell nobody filled in read the same way to a screen
+    // reader walking the table.
+    expect(rows[1]).toEqual(['Bananas', 'missing', 'missing']);
+  });
+
+  it('describes a pie of nothing but gaps as missing, not as an infinity', () => {
+    // safeMin/safeMax answer an empty set with ±Infinity, and the total of a
+    // pie nobody measured is not zero — nothing was measured to add up.
+    const trace = new PieTrace(pieLayer([null, null]));
+
+    const { stats } = trace.description;
+
+    expect(statValue(stats, 'Number of slices')).toBe(2);
+    expect(statValue(stats, 'Min value')).toBe('missing');
+    expect(statValue(stats, 'Max value')).toBe('missing');
+    expect(statValue(stats, 'Total')).toBe('missing');
+  });
+});
+
+describe('pie trace registration', () => {
+  it('builds a PieTrace for a layer typed pie', () => {
+    // TraceFactory throws on an unregistered type, and the throw propagates
+    // out of figure construction — an unregistered pie takes the whole figure
+    // down, not just its own layer.
+    const trace = TraceFactory.create(pieLayer([30, 50, 20]));
+
+    expect(trace).toBeInstanceOf(PieTrace);
+  });
+
+  it('announces itself as a pie, with no orientation to prefix', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const state = stateAtSlice(trace, 0);
+
+    expect(state.traceType).toBe(TraceType.PIE);
+    // Slices are arranged around a circle, not along an axis: "vertical pie"
+    // is not a thing to announce.
+    expect(state.orientation).toBeUndefined();
+  });
+});
+
+describe('pie trace disposal', () => {
+  it('can still answer with an out-of-bounds state after disposal', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+    trace.moveToIndex(0, 1);
+
+    trace.dispose();
+
+    // `dimension` reads the slice values, which disposal deliberately leaves
+    // alone: a disposed trace is still asked for an out-of-bounds state.
+    expect(() => trace.notifyOutOfBounds()).not.toThrow();
+  });
+});

--- a/test/model/pieHighlight.test.ts
+++ b/test/model/pieHighlight.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Highlight resolution for a pie layer.
+ *
+ * The contract is exactly one element per slice, in slice order, so data index
+ * k and element k are the same wedge. Nothing else in the model enforces that
+ * — a selector matching a different number of elements would be index-aligned
+ * anyway and would highlight a wedge the announcement is not describing.
+ */
+
+import type { MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { PieTrace } from '@model/pie';
+import { TraceType } from '@type/grammar';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+const SLICE_LABELS = ['Apples', 'Bananas', 'Cherries'];
+
+/** Renders `count` wedges under `#pie`, each carrying its slice label. */
+function renderWedges(count: number): void {
+  document.body.innerHTML = '';
+  const svg = document.createElementNS(SVG_NAMESPACE, 'svg');
+  const group = document.createElementNS(SVG_NAMESPACE, 'g');
+  group.setAttribute('id', 'pie');
+  for (let index = 0; index < count; index++) {
+    const wedge = document.createElementNS(SVG_NAMESPACE, 'path');
+    wedge.setAttribute('class', 'slice');
+    wedge.setAttribute('data-slice', SLICE_LABELS[index] ?? `Slice ${index + 1}`);
+    group.appendChild(wedge);
+  }
+  svg.appendChild(group);
+  document.body.appendChild(svg);
+}
+
+/** A three-slice pie layer pointed at whatever `#pie` currently holds. */
+function pieLayer(selectors: string): MaidrLayer {
+  return {
+    id: 'slices',
+    type: TraceType.PIE,
+    selectors,
+    axes: { x: { label: 'Fruit' }, y: { label: 'Units' } },
+    data: SLICE_LABELS.map((x, index) => ({ x, y: (index + 1) * 10 })),
+  };
+}
+
+/** Narrows the trace state union to the populated case. */
+function stateOf(trace: PieTrace): Extract<TraceState, { empty: false }> {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('expected a populated trace state');
+  }
+  return state;
+}
+
+describe('pie highlight resolution', () => {
+  beforeEach(() => {
+    renderWedges(3);
+  });
+
+  it('highlights the wedge that shares the slice index', () => {
+    const trace = new PieTrace(pieLayer('#pie path.slice'));
+
+    trace.moveToIndex(0, 1);
+    const { highlight } = stateOf(trace);
+
+    if (highlight.empty) {
+      throw new Error('expected the second wedge to be highlighted');
+    }
+    const element = Array.isArray(highlight.elements)
+      ? highlight.elements[0]
+      : highlight.elements;
+    expect(element.getAttribute('data-slice')).toBe('Bananas');
+  });
+
+  it('reports no highlight when the selector resolves the wrong number of wedges', () => {
+    renderWedges(2);
+
+    const trace = new PieTrace(pieLayer('#pie path.slice'));
+
+    trace.moveToIndex(0, 0);
+    // Index-aligning two elements to three slices would confidently highlight
+    // the wrong wedge; no highlight is the better answer.
+    expect(stateOf(trace).highlight.empty).toBe(true);
+  });
+
+  it('leaves no orphaned clones behind when it rejects the selector', () => {
+    renderWedges(2);
+
+    const trace = new PieTrace(pieLayer('#pie path.slice'));
+
+    // The clones are inserted by the selection itself, and disposal only
+    // reaches elements the trace kept a reference to — so the rejecting path
+    // has to remove them itself or they leak into the chart's DOM.
+    expect(document.querySelectorAll('[data-maidr-owned]')).toHaveLength(0);
+    expect(stateOf(trace).highlight.empty).toBe(true);
+  });
+
+  it('reports no highlight for a layer that declares no selector', () => {
+    const trace = new PieTrace({ ...pieLayer('#pie path.slice'), selectors: undefined });
+
+    trace.moveToIndex(0, 0);
+
+    expect(stateOf(trace).highlight.empty).toBe(true);
+  });
+
+  it('removes the clones it owns on disposal', () => {
+    const trace = new PieTrace(pieLayer('#pie path.slice'));
+    expect(document.querySelectorAll('[data-maidr-owned]')).toHaveLength(3);
+
+    trace.dispose();
+
+    expect(document.querySelectorAll('[data-maidr-owned]')).toHaveLength(0);
+    // The chart's own wedges are not MAIDR's to remove.
+    expect(document.querySelectorAll('#pie path.slice')).toHaveLength(3);
+  });
+});

--- a/test/service/pie.test.ts
+++ b/test/service/pie.test.ts
@@ -1,0 +1,193 @@
+import type { Context } from '@model/context';
+import type { DisplayService } from '@service/display';
+import type { NotificationService } from '@service/notification';
+import type { SettingsService } from '@service/settings';
+import type { MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { PieTrace } from '@model/pie';
+import { BrailleService } from '@service/braille';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * The two services a pie has to be registered with by hand, exercised against
+ * states a real {@link PieTrace} produced.
+ *
+ * Braille is the one that fails quietly: `BrailleService.update` returns early
+ * for a trace type with no encoder in its map, so an unregistered pie leaves
+ * braille users with an empty display and no error anywhere to explain it.
+ */
+
+const SLICE_LABELS = ['Apples', 'Bananas', 'Cherries'];
+
+/** Builds a three-slice pie layer. A gap is passed as `null`. */
+function pieLayer(values: (number | null)[]): MaidrLayer {
+  return {
+    id: 'slices',
+    type: TraceType.PIE,
+    title: 'Fruit sales',
+    axes: { x: { label: 'Fruit' }, y: { label: 'Units' } },
+    data: values.map((y, index) => ({ x: SLICE_LABELS[index], y: y as number })),
+  };
+}
+
+/** The state a real pie trace reports with the cursor on one slice. */
+function pieStateAt(values: (number | null)[], col: number): TraceState {
+  const trace = new PieTrace(pieLayer(values));
+  const state = trace.getStateAt(0, col);
+  expect(state.empty).toBe(false);
+  return state;
+}
+
+/** Minimal NotificationService stub whose notify is a jest mock. */
+function createMockNotificationService(): NotificationService {
+  return {
+    notify: jest.fn(),
+  } as unknown as NotificationService;
+}
+
+/**
+ * Builds a BrailleService with lightweight dependency mocks.
+ * @param displaySize - Braille display size setting to use
+ * @returns Service instance and a context `moveToIndex` spy
+ */
+function createBrailleService(displaySize: number): {
+  service: BrailleService;
+  contextMoveToIndex: ReturnType<typeof jest.fn>;
+} {
+  const contextMoveToIndex = jest.fn<(row: number, col: number) => void>();
+  const context = {
+    moveToIndex: contextMoveToIndex,
+  } as unknown as Context;
+
+  const notification = {
+    notify: jest.fn<(message: string) => void>(),
+  } as unknown as NotificationService;
+
+  const display = {
+    toggleFocus: jest.fn(),
+  } as unknown as DisplayService;
+
+  const settings = {
+    get: <T>(settingPath: string): T => {
+      if (settingPath === 'general.brailleDisplayLines')
+        return 1 as T;
+      return displaySize as T;
+    },
+    onChange: () => ({ dispose: () => {} }),
+  } as unknown as SettingsService;
+
+  const service = new BrailleService(context, notification, display, settings);
+  return { service, contextMoveToIndex };
+}
+
+describe('braille output for a pie', () => {
+  test('encodes the slices instead of leaving the display empty', () => {
+    const { service } = createBrailleService(10);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(pieStateAt([30, 50, 20], 0));
+
+    // Bands over 20..50: 30 falls in the second quarter, 50 is the top of the
+    // range, 20 is the bottom. An unregistered encoder emits nothing at all,
+    // so the assertion that matters most here is that anything came out.
+    expect(emitted.replace(/\n/g, '')).toBe('⠤⠉⣀');
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('maps a braille cell back to the slice it stands for', () => {
+    const { service, contextMoveToIndex } = createBrailleService(10);
+
+    let cursorIndex = -1;
+    const disposable = service.onChange((event) => {
+      cursorIndex = event.index;
+    });
+
+    service.toggle(pieStateAt([30, 50, 20], 2));
+
+    // Routing a cursor move back to the model is what makes the braille
+    // display an input as well as an output.
+    service.moveToIndex(cursorIndex);
+    expect(contextMoveToIndex).toHaveBeenLastCalledWith(0, 2);
+
+    disposable.dispose();
+    service.dispose();
+  });
+
+  test('leaves a gap blank rather than drawing it as the tallest slice', () => {
+    const { service } = createBrailleService(10);
+
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(pieStateAt([30, null, 20], 0));
+
+    // The gap is excluded from the range, so the two measured slices sit at
+    // the top and the bottom of a 20..30 scale; the gap itself is a blank.
+    expect(emitted.replace(/\n/g, '')).toBe('⠉ ⣀');
+
+    disposable.dispose();
+    service.dispose();
+  });
+});
+
+describe('text announcement for a pie', () => {
+  test('reads the label, the value and the share in verbose mode', () => {
+    const text = new TextService(createMockNotificationService());
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(pieStateAt([30, 50, 20], 0));
+
+    // The percentage rides the optional z slot, which is what puts it after
+    // the value rather than in place of it.
+    const event = changeListener.mock.calls[0][0] as { value: string };
+    expect(event.value).toBe('Fruit is Apples, Units is 30, Percentage is 30.0%');
+  });
+
+  test('drops the labels but keeps the share in terse mode', () => {
+    const text = new TextService(createMockNotificationService());
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.toggle(); // VERBOSE -> TERSE
+    text.update(pieStateAt([30, 50, 20], 1));
+
+    const event = changeListener.mock.calls[0][0] as { value: string };
+    expect(event.value).toBe('Bananas, 50, 50.0%');
+  });
+
+  test('says a gap is missing rather than announcing a share of NaN percent', () => {
+    const text = new TextService(createMockNotificationService());
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(pieStateAt([30, null, 20], 1));
+
+    const event = changeListener.mock.calls[0][0] as { value: string };
+    expect(event.value).toContain('Percentage is missing');
+    expect(event.value).not.toContain('NaN%');
+  });
+
+  test('says zero percent for every slice of a pie that totals zero', () => {
+    const text = new TextService(createMockNotificationService());
+    const changeListener = jest.fn();
+    text.onChange(changeListener);
+
+    text.update(pieStateAt([0, 0, 0], 0));
+
+    // 0 / 0 is NaN, and the whole point of the zero-total branch is that no
+    // screen reader ever has to say "Percentage is NaN percent".
+    const event = changeListener.mock.calls[0][0] as { value: string };
+    expect(event.value).toContain('Percentage is 0%');
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -28,6 +28,7 @@ describe('resolveOrientation', () => {
     TraceType.CANDLESTICK_DELTA,
     TraceType.HEATMAP,
     TraceType.LINE,
+    TraceType.PIE,
     TraceType.SCATTER,
     TraceType.SMOOTH,
     TraceType.STEP,
@@ -48,6 +49,9 @@ describe('resolveOrientation', () => {
 
   test('ignores an orientation declared on a type that has none', () => {
     expect(resolveOrientation(TraceType.LINE, Orientation.HORIZONTAL)).toBeUndefined();
+    // Slices sit around a circle, so a producer that emits an orientation for
+    // a pie anyway must not get "vertical pie" announced.
+    expect(resolveOrientation(TraceType.PIE, Orientation.VERTICAL)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Description

Adds pie chart as a first-class trace type: `TraceType.PIE`, a `PieTrace` model, and pie support in all eleven chart-library adapters. A pie is now navigable, sonified, brailled, highlighted and announced like any other trace.

This is the foundation of a three-repo change. `src/model/factory.ts` throws on an unregistered trace type and that throw propagates out of `new Figure(...)`, so **this PR must merge before** the py-maidr and r-maidr pie PRs can render anything.

## Related Issues

None — this implements pie support from scratch.

## Changes Made

**Model and grammar**

- `PiePoint { x: string | number; y: number }` — flat `PiePoint[]`, never nested. `y` is numeric (unlike `BarPoint`) because it is both the sonified magnitude and the percentage numerator.
- `TraceType.PIE = 'pie'`, plus entries in the two total `Record<TraceType, …>` maps (`CHART_TYPE_LABEL`, `IS_ORIENTED`).
- `src/model/pie.ts` — `PieTrace extends AbstractTrace` **directly**, not `AbstractBarPlot`. The latter's constructor bakes an orientation into its values, audio panning, text axes and description; a pie has none, so all of that would have to be undone again.
- Slices are wrapped in a single row so `MovableGrid` navigates them — with one row its own bounds checks make up and down out of bounds, so no suppression code is needed.

**Design decisions worth a reviewer's eye**

- **Percentage is derived, not authored.** Computed once in the constructor from the slice values, so it cannot disagree with the values it is a share of. There is deliberately no `percentage` field on the wire.
- **Sonification pitches the raw value, not the percentage.** Percentage is a monotone rescale, so pitch ordering is identical either way; the raw value keeps audio consistent with braille and the reported min/max.
- **Gaps follow the bar convention.** A non-finite slice is excluded from the total and the range and announced as missing, rather than collapsing into a real zero. A zero total reports `0%`, never `NaN%`.
- `findNearestPoint` hit-tests wedge geometry via `isPointInFill` rather than bounding boxes — wedge boxes overlap heavily, so a box test picks the wrong slice.

**Services**

- Braille reuses the existing `BarBrailleEncoder`, registered for `PIE`. (An unregistered encoder fails *silently* at the `encoders.has` guard, not loudly.)
- Text puts the share on the existing optional `z` slot: "Fruit is Apples, Units is 30, Percentage is 25.0%".
- High contrast: pie joins stacked/dodged in the pattern-fill branch, so adjacent same-hue wedges stay distinguishable.

**Adapters** — recharts, victory, chartjs, plotly, highcharts, vegalite, d3 (new `binders/pie.ts`), google-charts, anychart, amcharts, frappe. Two adapters needed structural work rather than a new branch: amcharts was XY-only and never *found* a `PieChart`, and anychart's `anychart.pie()` exposes no series API so it is detected chart-level. Chart.js is canvas-based and gained an SVG wedge overlay — a bounding box would have covered three neighbouring slices.

**Docs, examples, tests** — nine adapter pie examples plus a vanilla `examples/pie.html`, all registered in `scripts/build-site.js`; `docs/BRAILLE.md`, `docs/SCHEMA.md`, `docs/llms.txt`, README and the ten adapter doc pages; unit tests for the model, services and every adapter; and an e2e spec with page object.

`.claude/rules/model.md`'s "Registering a new trace type" checklist was incomplete and partly wrong (it omitted the two total `Record` maps and the braille encoder map, and said `AbstractTrace` is generic when it is not) — corrected, with the `.github/` counterpart regenerated via `npm run sync:copilot`.

## Screenshots (if applicable)

n/a — accessibility behaviour is covered by the e2e assertions on announcements and braille output.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verification actually run on this branch:

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm run build` | all 12 builds pass |
| `npm test` | 135 suites / 1779 tests + 6 suites / 61 tests, all passing |
| `npx playwright test` (chromium) | **350 passed**, including 20 new pie tests |

One note on the e2e run: the sandbox ships chromium-1194 while `@playwright/test` 1.59.1 pins 1217, and firefox/webkit are absent, so the suite was run against the installed chromium via a temporary config that was **not** committed. Firefox and WebKit were therefore not exercised here and will be covered by CI.

Two spots where I made a judgement call the spec did not settle:

- A gap slice announces `Units is NaN` in the value slot. This is pre-existing behaviour shared with `BarTrace` (which announces `Revenue is null`), not something pie introduced; fixing it belongs in `TextService.formatSingleValue` and would benefit every trace. Filed as follow-up rather than fixed here.
- Position announces the generic "Position is 3 of 5" rather than "Slice 3 of 5". Happy to change if you'd prefer pie-specific wording.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_