### PR TITLE
fix: announce gaps as missing, and stop two adapters mislabelling or dropping highlights

### DIFF
--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -36,7 +36,7 @@ import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
 import { convertCharts, findCharts } from './adapter';
 import { classifySeriesKind } from './extractor';
-import { readPlotBounds } from './geometry';
+import { readPlotBounds, readSliceBounds } from './geometry';
 import { getHighlightColor } from './highlightColor';
 import { buildNavigationMap } from './navmap';
 import { dataItemToOverlayRect, HighlightOverlay } from './overlay';
@@ -125,8 +125,12 @@ function applyHighlight(
   // Clip the highlight to the OWNING panel's visible plot area; a column's
   // geometry can extend to the value=0 baseline beyond a clipped (min > 0)
   // axis, and in multi-panel roots it must not bleed into sibling panels.
+  // A pie panel has no plot container to read, so its rectangle comes from the
+  // wedges instead. The fallback is pie-only by construction — an XY chart's
+  // data items carry no `slice` — so an XY panel with no readable plot area
+  // still falls through to the suppression below.
   const chart = navMap.chartFor(event.layerId);
-  const plotBounds = chart ? readPlotBounds(chart) : null;
+  const plotBounds = chart ? readPlotBounds(chart) ?? readSliceBounds(chart) : null;
 
   // Without readable panel bounds an unclipped rect could bleed into a
   // sibling panel (all panels share one overlay canvas), so suppress the

--- a/src/adapters/amcharts/geometry.ts
+++ b/src/adapters/amcharts/geometry.ts
@@ -8,7 +8,7 @@
  * mirrors their on-screen arrangement (vertical/horizontal/Grid layouts).
  */
 
-import type { AmBounds, AmChart } from './types';
+import type { AmBounds, AmChart, AmSprite } from './types';
 
 /**
  * Read the plot-area bounds (CSS px, root-relative) used to clip highlights.
@@ -34,6 +34,57 @@ export function readPlotBounds(chart: AmChart): AmBounds | null {
     // Fall through; overlay overflow:hidden still clips to the chart box.
   }
   return null;
+}
+
+/**
+ * Read a pie panel's bounds as the union of its wedges' global boxes.
+ *
+ * An am5percent `PieChart` has no `plotContainer` — it has no plot area, which
+ * is why {@link AmChart.plotContainer} is optional — so {@link readPlotBounds}
+ * reports nothing for it and the binder, which suppresses a highlight it cannot
+ * clip to a panel, would leave every pie in a multi-panel root unhighlighted.
+ * Each slice is a sprite with `globalBounds()`, and the union of those boxes is
+ * the rectangle the pie occupies: the panel rectangle the overlay needs, in the
+ * same root-relative CSS px `readPlotBounds` returns.
+ *
+ * Returns `null` when no wedge reports usable geometry — an XY chart, whose
+ * data items carry no `slice` at all, or a pie asked before its first layout.
+ * The caller then behaves exactly as it does today, so a chart this cannot
+ * measure loses a highlight rather than gaining a misplaced one.
+ */
+export function readSliceBounds(chart: AmChart): AmBounds | null {
+  let left = Number.POSITIVE_INFINITY;
+  let top = Number.POSITIVE_INFINITY;
+  let right = Number.NEGATIVE_INFINITY;
+  let bottom = Number.NEGATIVE_INFINITY;
+
+  try {
+    for (const series of chart.series.values) {
+      for (const dataItem of series.dataItems) {
+        const slice = dataItem.get('slice') as AmSprite | undefined;
+        const bounds = slice?.globalBounds?.();
+        if (!bounds) {
+          continue;
+        }
+        const { left: l, right: r, top: t, bottom: b } = bounds;
+        if (![l, r, t, b].every(Number.isFinite)) {
+          continue;
+        }
+        left = Math.min(left, l, r);
+        right = Math.max(right, l, r);
+        top = Math.min(top, t, b);
+        bottom = Math.max(bottom, t, b);
+      }
+    }
+  } catch {
+    // Fall through; a chart mid-teardown reports no panel rectangle.
+    return null;
+  }
+
+  if (!Number.isFinite(left) || !Number.isFinite(top)) {
+    return null;
+  }
+  return { left, top, right, bottom };
 }
 
 /** A chart paired with the normalized geometry used for grid clustering. */

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -1782,10 +1782,15 @@ function stampHeatmapAttributes(
  * candlestick layer for single-series candlestick charts and the
  * candlestick portion of mixed charts.
  *
- * Returns the parent SVG itself if no AnyChart layer structure is found,
- * so the caller falls back to whole-SVG querying.
+ * Returns the parent SVG itself when the SVG has no AnyChart layer structure
+ * at all, so the caller falls back to whole-SVG querying. When layers *are*
+ * present but none of them is clipped, this returns `null` instead: the candles
+ * are then not where this function knows how to look, and widening the search
+ * to the whole SVG would stamp whatever `ac_path_*` elements it met first — a
+ * legend marker, a decorative frame — as the leading candles. Reporting nothing
+ * found costs the highlight; guessing would label decoration as data.
  */
-function findCandlestickPathLayer(svg: SVGElement): Element {
+function findCandlestickPathLayer(svg: SVGElement): Element | null {
   const layers = svg.querySelectorAll<SVGGElement>('g[id^="ac_layer_"]');
   let bestLayer: Element | null = null;
   let bestCount = 0;
@@ -1804,7 +1809,9 @@ function findCandlestickPathLayer(svg: SVGElement): Element {
       bestLayer = layer;
     }
   }
-  return bestLayer ?? svg;
+  if (bestLayer)
+    return bestLayer;
+  return layers.length > 0 ? null : svg;
 }
 
 /**
@@ -1850,6 +1857,15 @@ function stampCandlestickAttributes(
     return;
 
   const candleLayer = findCandlestickPathLayer(svg);
+  if (!candleLayer) {
+    console.warn(
+      '[maidr/anychart] Found no candlestick paths to highlight: this chart\'s '
+      + 'SVG has AnyChart layers but none of them is clipped to the plot area. '
+      + 'Highlighting is disabled for this chart; pass an explicit '
+      + '`selectors` entry to override.',
+    );
+    return;
+  }
   const paths = candleLayer.querySelectorAll<SVGElement>(
     'path[id^="ac_path_"]',
   );

--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -24,6 +24,15 @@ const MISSING_TEXT = 'missing';
  * absent, which is what {@link isMeasured} and the text layer already read as
  * a gap. Mirrors `toBarValue` in `bar.ts`, for the same reasons.
  *
+ * A negative slice is read as a gap too. {@link PiePoint.y} documents that a
+ * negative value is not meaningful in a pie, and nothing upstream is obliged to
+ * enforce that: left in, it subtracts from the total every other slice's share
+ * is divided by, so a pie of 60, -40 and 30 announces its first slice as 120%
+ * and the percentages stop summing to anything. Reading it as a gap is the
+ * treatment this trace already has for a slice with nothing to report — out of
+ * the total, out of the range, announced as missing — which tells the reader
+ * about the one bad slice instead of quietly corrupting every other one.
+ *
  * @param raw - The value from the slice
  * @returns The magnitude, or `NaN` when the slice is a gap
  */
@@ -34,7 +43,9 @@ function toSliceValue(raw: number | string | null | undefined): number {
   if (typeof raw === 'string' && raw.trim() === '') {
     return Number.NaN;
   }
-  return Number(raw);
+  const value = Number(raw);
+  // `NaN < 0` is false, so an unparseable value falls through unchanged.
+  return value < 0 ? Number.NaN : value;
 }
 
 /**

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -10,6 +10,9 @@ import { Emitter } from '@type/event';
 import { isLayerSwitchTraceState } from '@type/state';
 import { Constant } from '@util/constant';
 
+/** How an absent value is named wherever a trace has nothing to report. */
+const MISSING_TEXT = 'missing';
+
 /**
  * Enumeration of available text output modes.
  */
@@ -81,11 +84,30 @@ export class TextService implements Observer<PlotState>, Disposable {
    * Formats a single value using the formatter service if available.
    * Falls back to String() conversion if no formatter is configured.
    *
-   * @param value - The value to format
+   * A gap arrives here as whatever sentinel the wire carried: the `null` a
+   * producer emits for a slot it has no measurement for, or the `NaN` the bar
+   * and pie models normalize that to. Neither is a value to read out, so both
+   * are named the way `AbstractBarPlot.rangeStats` and `PieTrace` already name
+   * an absent value. Doing it here rather than per trace means every trace with
+   * gap support says the same word, and says it whether or not a formatter is
+   * wired up — `FormatUtil.wrapFormat` catches a `null` or a `NaN` only for a
+   * layer the formatter service actually has an entry for, and never catches an
+   * infinity.
+   *
+   * Only an absent NUMBER is caught. A measured `0` is a real reading and an
+   * empty category label is a label, so both go on to be formatted as usual.
+   *
+   * @param value - The value to format, absent when the point is a gap
    * @param axis - The axis type ('x', 'y', or 'z')
    * @returns Formatted string representation of the value
    */
-  private formatSingleValue(value: number | string, axis: AxisType): string {
+  private formatSingleValue(value: number | string | null | undefined, axis: AxisType): string {
+    if (value === null || value === undefined) {
+      return MISSING_TEXT;
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      return MISSING_TEXT;
+    }
     if (this.formatter && this.currentLayerId) {
       return this.formatter.formatSingleValue(value, this.currentLayerId, axis);
     }

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -115,18 +115,25 @@ export class TextService implements Observer<PlotState>, Disposable {
   }
 
   /**
-   * Formats an array of values using the formatter service if available.
-   * Falls back to String() conversion for each element if no formatter is configured.
+   * Formats an array of values, one element at a time.
    *
-   * @param values - The array of values to format
+   * Each element goes through {@link formatSingleValue} rather than through
+   * the formatter's own array method. The two are the same operation —
+   * `FormatterService.formatArrayValue` is a per-element map over the very
+   * formatter `formatSingleValue` looks up — so delegating costs nothing and
+   * means the two cannot drift: an absent element reads as "missing" here
+   * for the same reason it does anywhere else, rather than because this
+   * method remembered to say so.
+   *
+   * @param values - The array of values to format, elements absent on a gap
    * @param axis - The axis type ('x', 'y', or 'z')
    * @returns Array of formatted strings
    */
-  private formatArrayValue(values: (number | string)[], axis: AxisType): string[] {
-    if (this.formatter && this.currentLayerId) {
-      return this.formatter.formatArrayValue(values, this.currentLayerId, axis);
-    }
-    return values.map(v => String(v));
+  private formatArrayValue(
+    values: (number | string | null | undefined)[],
+    axis: AxisType,
+  ): string[] {
+    return values.map(value => this.formatSingleValue(value, axis));
   }
 
   /**

--- a/test/adapters/amcharts/geometry.test.ts
+++ b/test/adapters/amcharts/geometry.test.ts
@@ -1,5 +1,11 @@
-import { computeChartGrid, readPlotBounds } from '@adapters/amcharts/geometry';
-import { fakeChart } from './helpers';
+import type { AmBounds } from '@adapters/amcharts/types';
+import { computeChartGrid, readPlotBounds, readSliceBounds } from '@adapters/amcharts/geometry';
+import { fakeBarSeries, fakeChart, fakePieChart, fakePieSeries } from './helpers';
+
+/** A wedge graphic reporting the global box the overlay reads geometry from. */
+function fakeSlice(bounds: AmBounds): unknown {
+  return { globalBounds: () => bounds };
+}
 
 describe('readPlotBounds', () => {
   it('reads globalBounds from the plot container', () => {
@@ -9,6 +15,65 @@ describe('readPlotBounds', () => {
 
   it('returns null without a plot container', () => {
     expect(readPlotBounds(fakeChart())).toBeNull();
+  });
+});
+
+describe('readSliceBounds', () => {
+  it('unions the wedge boxes into the rectangle the pie occupies', () => {
+    // A PieChart has no plotContainer, so this is the only panel rectangle
+    // available — without it the binder suppresses the highlight of every pie
+    // sharing a root with another panel.
+    const chart = fakePieChart({
+      series: [fakePieSeries('Fruit', [
+        { category: 'Apples', value: 30, slice: fakeSlice({ left: 40, top: 30, right: 140, bottom: 120 }) },
+        { category: 'Bananas', value: 50, slice: fakeSlice({ left: 90, top: 60, right: 180, bottom: 170 }) },
+      ])],
+    });
+
+    expect(readPlotBounds(chart)).toBeNull();
+    expect(readSliceBounds(chart)).toEqual({ left: 40, top: 30, right: 180, bottom: 170 });
+  });
+
+  it('normalizes a wedge box reported with inverted edges', () => {
+    const chart = fakePieChart({
+      series: [fakePieSeries('Fruit', [
+        { category: 'Apples', value: 30, slice: fakeSlice({ left: 140, top: 120, right: 40, bottom: 30 }) },
+      ])],
+    });
+
+    expect(readSliceBounds(chart)).toEqual({ left: 40, top: 30, right: 140, bottom: 120 });
+  });
+
+  it('skips a wedge with no readable geometry (pre-layout)', () => {
+    const chart = fakePieChart({
+      series: [fakePieSeries('Fruit', [
+        { category: 'Apples', value: 30 },
+        { category: 'Bananas', value: 50, slice: fakeSlice({ left: 10, top: 10, right: 60, bottom: 70 }) },
+      ])],
+    });
+
+    expect(readSliceBounds(chart)).toEqual({ left: 10, top: 10, right: 60, bottom: 70 });
+  });
+
+  it('returns null for a chart whose data items carry no wedge at all', () => {
+    // An XY panel, which is what keeps this fallback pie-only: one with no
+    // readable plot area still reports nothing, so the binder keeps suppressing
+    // a highlight it cannot clip to the right panel.
+    const chart = fakeChart({
+      series: [fakeBarSeries('Sales', [{ categoryX: 'Jan', valueY: 10 }])],
+    });
+
+    expect(readSliceBounds(chart)).toBeNull();
+  });
+
+  it('returns null when a wedge reports a non-finite box', () => {
+    const chart = fakePieChart({
+      series: [fakePieSeries('Fruit', [
+        { category: 'Apples', value: 30, slice: fakeSlice({ left: Number.NaN, top: 0, right: 10, bottom: 10 }) },
+      ])],
+    });
+
+    expect(readSliceBounds(chart)).toBeNull();
   });
 });
 

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -116,6 +116,56 @@ function appendPieWedges(container: HTMLElement, count: number): SVGElement[] {
   return wedges;
 }
 
+/**
+ * Append a rendered candlestick series to a container's `<svg>`: `count` candle
+ * paths inside an AnyChart layer.
+ *
+ * A real series layer carries the `clip-path` that bounds it to the plot area,
+ * which is how the lookup tells it apart from the axes and background layers.
+ * Pass `clipped: false` for a chart whose layers do not carry one, and
+ * `layered: false` for an SVG with no AnyChart layer structure at all.
+ */
+function appendCandlePaths(
+  container: HTMLElement,
+  count: number,
+  options: { clipped?: boolean; layered?: boolean } = {},
+): SVGElement[] {
+  const svg = container.querySelector('svg') as unknown as SVGElement;
+  let parent = svg;
+  if (options.layered !== false) {
+    const layer = document.createElementNS(SVG_NS, 'g');
+    layer.id = 'ac_layer_1';
+    if (options.clipped !== false) {
+      layer.setAttribute('clip-path', 'url(#ac_clip_1)');
+    }
+    svg.appendChild(layer);
+    parent = layer as unknown as SVGElement;
+  }
+
+  const candles: SVGElement[] = [];
+  for (let i = 0; i < count; i++) {
+    const candle = document.createElementNS(SVG_NS, 'path');
+    candle.id = `ac_path_${i}`;
+    // Wick plus body: a real candle always draws more than one command, which
+    // is how the stamper rejects single-command clip-boundary sentinels.
+    candle.setAttribute('d', 'M 10 0 L 10 40 M 5 10 L 15 10 L 15 30 L 5 30 Z');
+    candle.setAttribute('fill', '#00aa00');
+    parent.appendChild(candle);
+    candles.push(candle);
+  }
+
+  return candles;
+}
+
+function createCandlestickChart(
+  title: string,
+  days: string[],
+  extra: Omit<MockChartConfig, 'title' | 'series'> = {},
+): AnyChartInstance {
+  const rows = days.map(x => ({ x, open: 1, high: 4, low: 0.5, close: 3 }));
+  return createChart({ title, series: [createSeries('candlestick', rows)], ...extra });
+}
+
 function createAxis(titleText: string): AnyChartAxis {
   return {
     title: () => ({ text: () => titleText }),
@@ -396,6 +446,66 @@ describe('bindAnyChart (pie stamping)', () => {
     expect(decoration.getAttribute('data-maidr-anychart-pie-slice')).toBeNull();
     expect(straight.getAttribute('data-maidr-anychart-pie-slice')).toBeNull();
     expect(warnSpy.mock.calls.flat().join(' ')).toContain('no pie wedges to highlight');
+
+    container.closest('[data-maidr-anychart-host]')?.remove();
+  });
+});
+
+describe('bindAnyChart (candlestick stamping)', () => {
+  it('stamps one attribute per candle, in point order', () => {
+    const container = createContainerWithSvg('candle-bind');
+    const candles = appendCandlePaths(container, 3);
+    const chart = createCandlestickChart('Prices', ['Mon', 'Tue', 'Wed'], { container });
+
+    bindAnyChart(chart);
+
+    expect(candles.map(c => c.getAttribute('data-maidr-anychart-candlestick-cell')))
+      .toEqual(['0-0', '0-1', '0-2']);
+
+    container.closest('[data-maidr-anychart-host]')?.remove();
+  });
+
+  it('falls back to the whole SVG when there is no AnyChart layer structure', () => {
+    // No `ac_layer_*` group anywhere: the lookup's assumption has not failed,
+    // there is simply nothing to scope to, and whole-SVG querying is the only
+    // way to reach the candles. This fallback must survive.
+    const container = createContainerWithSvg('candle-unlayered');
+    const candles = appendCandlePaths(container, 2, { layered: false });
+    const chart = createCandlestickChart('Prices', ['Mon', 'Tue'], { container });
+
+    bindAnyChart(chart);
+
+    expect(candles.map(c => c.getAttribute('data-maidr-anychart-candlestick-cell')))
+      .toEqual(['0-0', '0-1']);
+
+    container.closest('[data-maidr-anychart-host]')?.remove();
+  });
+
+  it('warns and stamps nothing when no AnyChart layer is clipped to the plot area', () => {
+    // The candle-DOM assumption has failed: the layers are there but none of
+    // them is a clipped series layer. Stamping the first `ac_path_*` elements
+    // found anywhere in the SVG would label a legend marker or a decorative
+    // frame as candle 0, so the highlight is dropped and the reason reported.
+    const container = createContainerWithSvg('candle-unclipped');
+    appendCandlePaths(container, 1, { clipped: false });
+    const svg = container.querySelector('svg') as unknown as SVGElement;
+    // A multi-command path outside every layer — exactly what the whole-SVG
+    // fallback would have mistaken for candle 0.
+    const decoration = document.createElementNS(SVG_NS, 'path');
+    decoration.id = 'ac_path_frame';
+    decoration.setAttribute('d', 'M 0 0 L 10 0 L 10 10 Z');
+    decoration.setAttribute('stroke', '#000000');
+    svg.appendChild(decoration);
+    const chart = createCandlestickChart('Prices', ['Mon'], { container });
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    bindAnyChart(chart);
+
+    expect(decoration.getAttribute('data-maidr-anychart-candlestick-cell')).toBeNull();
+    expect(container.querySelectorAll('[data-maidr-anychart-candlestick-cell]'))
+      .toHaveLength(0);
+    expect(warnSpy.mock.calls.flat().join(' '))
+      .toContain('no candlestick paths to highlight');
 
     container.closest('[data-maidr-anychart-host]')?.remove();
   });

--- a/test/model/pie.test.ts
+++ b/test/model/pie.test.ts
@@ -185,6 +185,52 @@ describe('pie slice percentages', () => {
   });
 });
 
+/**
+ * `PiePoint.y` documents that a negative value is not meaningful in a pie, and
+ * nothing upstream is obliged to reject one. Left in, it subtracts from the
+ * total every other slice's share is divided by, so the renderer reads it as
+ * the gap it effectively is.
+ */
+describe('pie slices with a negative value', () => {
+  it('divides the measured slices by a total the negative took no part in', () => {
+    const trace = new PieTrace(pieLayer([60, -40, 30]));
+
+    // Counting the -40 leaves a total of 50, which announces the first slice
+    // as 120% — a share of the whole that cannot exist.
+    expect(shareAtSlice(trace, 0)).toBe('66.7%');
+    expect(shareAtSlice(trace, 2)).toBe('33.3%');
+  });
+
+  it('reads the negative slice itself as missing', () => {
+    const trace = new PieTrace(pieLayer([60, -40, 30]));
+
+    const { text } = stateAtSlice(trace, 1);
+
+    expect(shareAtSlice(trace, 1)).toBe('missing');
+    expect(Number.isFinite(text.cross.value as number)).toBe(false);
+  });
+
+  it('keeps the negative out of the range the other slices are scaled against', () => {
+    const trace = new PieTrace(pieLayer([60, -40, 30]));
+
+    const { audio } = stateAtSlice(trace, 0);
+
+    expect(audio.freq.min).toBe(30);
+    expect(audio.freq.max).toBe(60);
+  });
+
+  it('leaves it out of the described range and total as well', () => {
+    const trace = new PieTrace(pieLayer([60, -40, 30]));
+
+    const { stats } = trace.description;
+
+    expect(statValue(stats, 'Number of slices')).toBe(3);
+    expect(statValue(stats, 'Min value')).toBe(30);
+    expect(statValue(stats, 'Max value')).toBe(60);
+    expect(statValue(stats, 'Total')).toBe(90);
+  });
+});
+
 describe('pie trace braille', () => {
   it('encodes the slices as a single row of raw magnitudes', () => {
     const trace = new PieTrace(pieLayer([30, 50, 20]));

--- a/test/service/textGaps.test.ts
+++ b/test/service/textGaps.test.ts
@@ -1,0 +1,153 @@
+import type { NotificationService } from '@service/notification';
+import type { Maidr, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { BarTrace } from '@model/bar';
+import { PieTrace } from '@model/pie';
+import { FormatterService } from '@service/formatter';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * How the text layer announces a data point the producer had no measurement
+ * for, across the traces that carry gaps.
+ *
+ * The wire sentinel differs by trace — a bar arrives as the `null` the producer
+ * emitted, a pie as the `NaN` its model normalizes that to — and neither is a
+ * value to read out. `TextService` names both, so a trace does not have to
+ * pre-render its own value slot to be announced correctly, and so the wording
+ * does not depend on a formatter being wired up to catch it:
+ * `FormatUtil.wrapFormat` only sees a value for a layer the formatter service
+ * has an entry for.
+ */
+
+const BAR_LAYER_ID = 'bars';
+
+/** Minimal NotificationService stub whose notify is a jest mock. */
+function createMockNotificationService(): NotificationService {
+  return {
+    notify: jest.fn(),
+  } as unknown as NotificationService;
+}
+
+/** Builds a two-bar layer whose second bar carries the given value. */
+function barLayer(second: number | null): MaidrLayer {
+  return {
+    id: BAR_LAYER_ID,
+    type: TraceType.BAR,
+    title: 'Monthly revenue',
+    axes: { x: { label: 'Month' }, y: { label: 'Revenue' } },
+    data: [
+      { x: 'Jan', y: 10 },
+      { x: 'Feb', y: second as number },
+    ],
+  };
+}
+
+/** Builds a two-slice pie layer whose second slice carries the given value. */
+function pieLayer(second: number | null): MaidrLayer {
+  return {
+    id: 'slices',
+    type: TraceType.PIE,
+    title: 'Fruit sales',
+    axes: { x: { label: 'Fruit' }, y: { label: 'Units' } },
+    data: [
+      { x: 'Apples', y: 30 },
+      { x: 'Bananas', y: second as number },
+    ],
+  };
+}
+
+/** A figure carrying one layer, as the formatter service reads it. */
+function figureOf(layer: MaidrLayer): Maidr {
+  return {
+    id: 'figure',
+    title: 'Figure',
+    subplots: [[{ layers: [layer] }]],
+  } as unknown as Maidr;
+}
+
+/** The text a service emits for one trace state, in the current text mode. */
+function announce(text: TextService, state: TraceState): string {
+  const changeListener = jest.fn();
+  const disposable = text.onChange(changeListener);
+
+  text.update(state);
+
+  disposable.dispose();
+  const event = changeListener.mock.calls[0][0] as { value: string };
+  return event.value;
+}
+
+describe('announcing an absent value', () => {
+  test('names a null bar rather than reading the wire sentinel out', () => {
+    const trace = new BarTrace(barLayer(null));
+    const text = new TextService(createMockNotificationService());
+
+    expect(announce(text, trace.getStateAt(0, 1))).toBe('Month is Feb, Revenue is missing');
+  });
+
+  test('names it in terse mode too', () => {
+    const trace = new BarTrace(barLayer(null));
+    const text = new TextService(createMockNotificationService());
+    text.toggle(); // VERBOSE -> TERSE
+
+    expect(announce(text, trace.getStateAt(0, 1))).toBe('Feb, missing');
+  });
+
+  test('names a gapped pie slice, so one sentence does not use both words', () => {
+    const trace = new PieTrace(pieLayer(null));
+    const text = new TextService(createMockNotificationService());
+
+    // The share already said 'missing'; the value slot said 'NaN' beside it.
+    expect(announce(text, trace.getStateAt(0, 1)))
+      .toBe('Fruit is Bananas, Units is missing, Percentage is missing');
+  });
+
+  test('names it even for a layer the formatter service has no entry for', () => {
+    // `FormatterService.getFormatter` answers an unknown layer id with the
+    // bare `defaultFormat`, which is not wrapped and renders a null as 'null'.
+    // This is the path that reaches a reader in a wired-up figure.
+    const layer = barLayer(null);
+    const trace = new BarTrace(layer);
+    const formatter = new FormatterService(figureOf({ ...layer, id: 'other' }));
+    const text = new TextService(createMockNotificationService(), formatter);
+
+    expect(announce(text, trace.getStateAt(0, 1))).toBe('Month is Feb, Revenue is missing');
+  });
+
+  test('names an infinity, which the formatter wrapper lets through', () => {
+    const layer = barLayer(Number.POSITIVE_INFINITY);
+    const trace = new BarTrace(layer);
+    const text = new TextService(
+      createMockNotificationService(),
+      new FormatterService(figureOf(layer)),
+    );
+
+    expect(announce(text, trace.getStateAt(0, 1))).toBe('Month is Feb, Revenue is missing');
+  });
+});
+
+describe('values that only look absent', () => {
+  test('still announces a bar measured at zero as zero', () => {
+    // The discriminator the guard must not blur: a measured 0 is a reading.
+    const trace = new BarTrace(barLayer(0));
+    const text = new TextService(createMockNotificationService());
+
+    expect(announce(text, trace.getStateAt(0, 1))).toBe('Month is Feb, Revenue is 0');
+  });
+
+  test('leaves an empty category label as the empty label it is', () => {
+    const layer: MaidrLayer = {
+      id: BAR_LAYER_ID,
+      type: TraceType.BAR,
+      title: 'Monthly revenue',
+      axes: { x: { label: 'Month' }, y: { label: 'Revenue' } },
+      data: [{ x: '', y: 10 }],
+    };
+    const trace = new BarTrace(layer);
+    const text = new TextService(createMockNotificationService());
+
+    expect(announce(text, trace.getStateAt(0, 0))).toBe('Month is , Revenue is 10');
+  });
+});


### PR DESCRIPTION
# Pull Request

Closes #769, #768, #770. Refs #771.

## Description

Four follow-ups filed off #767, one commit each. All four were reproduced before being fixed, and **one issue's own reproduction turned out to be narrower than it claimed** — detailed below, because it changes how the fix should be read.

## Related Issues

- #769 — a gap announces the raw NaN/null in the value slot
- #768 — candlestick wedge lookup falls back to the whole SVG
- #770 — an amCharts pie in a multi-panel root never highlights
- #771 — negative-value policy (**renderer half only**; the issue's open question is left open)

## Changes Made

### #769 — gaps announce their sentinel

Reproduced: a null bar announced `"Month is Feb, Revenue is null"`; a gapped pie slice announced `"Fruit is B, Units is NaN, Percentage is missing"` — one sentence carrying both the right wording and the wrong one.

`TextService.formatSingleValue` now answers a nullish or non-finite number with `"missing"` before consulting a formatter. Only absent *numbers* are caught: a measured `0` still announces `"0"`, and an empty category label stays an empty label.

**The issue's reproduction is narrower than written, and this matters.** With the production wiring, `FormatUtil.wrapFormat` already converted null and NaN — I measured `"Revenue is missing"` through that path. The quoted symptoms appear when `TextService` is built *without* the optional formatter, which is what the unit tests do. The bug is still reachable in production by a second route I verified: `FormatterService.getFormatter` answers an unmapped layer id with the bare, unwrapped `defaultFormat`, and that really does announce `"Revenue is null"`. `wrapFormat` also never covered ±Infinity. So the fix stands on making the wording independent of formatter wiring and closing the infinity hole — not on the symptom as originally described.

### #768 — candlestick lookup stamps the whole SVG

Reproduced: with an `ac_layer_*` group present but unclipped, a decorative `ac_path_frame` outside every layer was stamped `data-maidr-anychart-candlestick-cell="0-0"`.

`findCandlestickPathLayer` now returns `Element | null`, mirroring the fix `findPieWedgeLayer` already carries: the layer when one qualifies, `null` when layers exist but none is clipped, and the bare `svg` when there is no `ac_layer_*` structure at all. That last fallback is legitimate and is kept — now with a test. The caller warns and stamps nothing on `null`.

### #770 — amCharts pie loses its highlight in a multi-panel root

A pie has no `plotContainer`, so `readPlotBounds` answers `null` and the binder suppresses the overlay whenever the root holds more than one chart. Navigation, audio and braille carried on; only the visual highlight vanished, silently.

The guard is right for an XY panel — without plot bounds an overlay cannot be clipped to the correct panel — so it is left alone and the pie gets its own bounds source: `readSliceBounds`, the union of its wedges' `globalBounds()`, in the same root-relative pixels. An XY chart's data items carry no `slice`, so the fallback answers `null` there and the suppression still applies. `readPlotBounds` is unchanged, so `computeChartGrid` is unaffected.

### #771 — renderer-side backstop only

A pie of `60, -40, 30` announced shares of `120.0%`, `-80.0%`, `60.0%` with a total of 50 — every slice wrong, not just the negative one. `toSliceValue` now maps a negative to `NaN`, routing it through the gap machinery the trace already has.

This is correct under **every** option #771 weighs: harmless if producers come to reject negatives, load-bearing if they do not. No producer-side behaviour is touched and the issue's question about where rejection belongs is deliberately left open.

## Screenshots (if applicable)

n/a — the behaviour is announcements and highlight geometry, covered by the tests below.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm test` | **1800 + 61 passing** (1781 + 61 before) |
| `npm run build` | all builds pass |

New tests: `test/service/textGaps.test.ts` (7 cases, including the two "only look absent" cases and an infinity), three candlestick-stamping cases, five `readSliceBounds` cases, four negative-slice cases. The candlestick degenerate case was verified to go red against the unmodified source.

**#770 could not be verified against the real library** — no network in the build sandbox, so `readSliceBounds` is reasoned from `types.ts` and from `overlay.ts`'s existing `sliceRect`, which already reads the wedge through the same `dataItem.get('slice')?.globalBounds?.()` accessor. The failure mode is safe: anything unreadable returns `null` and the binder behaves exactly as today. Two things a reviewer with a browser should confirm: that wedge `globalBounds()` are populated by the time the first navigation callback fires, and that the union rectangle is the clip they want (it is a no-op clip for the active wedge by construction).

`applyHighlight` now iterates a chart's data items on each keypress when `readPlotBounds` returns null — cheap for a pie, and only reached in the degenerate case for XY, but it is per-navigation work that did not exist before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_