### PR TITLE
fix: give blank axis labels a name, and stamp only the wedges a pie fills

### DIFF
--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -2036,6 +2036,50 @@ function findPieWedgeLayer(svg: SVGElement): Element | null {
  *
  * On any other chart type this is a no-op.
  */
+/**
+ * Stamps the highlight attributes this chart's own kind needs.
+ *
+ * Every stamper used to be tried on every chart, each in its own `try`. That
+ * is harmless for an XY chart — a bar stamper finds no line series and
+ * returns — but a pie carries no series API at all: `getSeriesCount` is not a
+ * function on one, so the bar and line stampers each threw and warned before
+ * the pie stamper did the real work. Two console warnings on every correctly
+ * rendered pie, which is noise in exactly the place someone debugging a
+ * genuine stamping failure would look.
+ *
+ * Asking what the chart is costs one call and makes the warnings mean
+ * something again: past this point, a warning is a stamper failing at a job
+ * that was actually its own.
+ *
+ * @param chart - The AnyChart instance being bound
+ * @param svg - The rendered SVG to stamp
+ * @param stampPrefix - Panel token prefix, empty for a single chart
+ */
+function stampChartAttributes(
+  chart: AnyChartInstance,
+  svg: SVGElement,
+  stampPrefix = '',
+): void {
+  const stampers: [string, typeof stampPieAttributes][] = isPieChart(chart)
+    ? [['pie', stampPieAttributes]]
+    : [
+        ['bar', stampBarAttributes],
+        ['line', stampLineAttributes],
+        ['scatter', stampScatterAttributes],
+        ['box', stampBoxAttributes],
+        ['heatmap', stampHeatmapAttributes],
+        ['candlestick', stampCandlestickAttributes],
+      ];
+
+  for (const [kind, stamp] of stampers) {
+    try {
+      stamp(chart, svg, stampPrefix);
+    } catch (err) {
+      console.warn(`[maidr/anychart] Failed to stamp ${kind} attributes:`, err);
+    }
+  }
+}
+
 function stampPieAttributes(
   chart: AnyChartInstance,
   svg: SVGElement,
@@ -2075,6 +2119,18 @@ function stampPieAttributes(
     // `fill-opacity`, so any value below 1 is the overlay.
     const fillOpacityAttr = path.getAttribute('fill-opacity');
     if (fillOpacityAttr !== null && Number.parseFloat(fillOpacityAttr) < 1)
+      continue;
+    // Skip the wedge outlines. AnyChart draws every slice twice — once filled
+    // in the slice's colour, once with `fill="none"` for the stroke — so a
+    // four-slice pie offers eight arc paths. Both halves sit in the same
+    // layer and both carry an arc command, and only the fill is the datum.
+    //
+    // Taking the first N in DOM order happens to pick the fills, because
+    // AnyChart emits them first. That is an ordering accident, not a
+    // guarantee: were it ever to emit outlines first, every highlight would
+    // land on an invisible path while the announcement carried on naming the
+    // right slice — the silent mislabel this whole lookup exists to avoid.
+    if (path.getAttribute('fill') === 'none')
       continue;
     candidates.push(path);
   }
@@ -2810,41 +2866,7 @@ export function bindAnyChart(
   // best-effort, but the chart must always become focusable so audio /
   // text / braille modalities work even when highlight cannot.
   whenChartRendered(chart, container, (svg) => {
-    try {
-      stampBarAttributes(chart, svg);
-    } catch (err) {
-      console.warn('[maidr/anychart] Failed to stamp bar attributes:', err);
-    }
-    try {
-      stampLineAttributes(chart, svg);
-    } catch (err) {
-      console.warn('[maidr/anychart] Failed to stamp line attributes:', err);
-    }
-    try {
-      stampScatterAttributes(chart, svg);
-    } catch (err) {
-      console.warn('[maidr/anychart] Failed to stamp scatter attributes:', err);
-    }
-    try {
-      stampBoxAttributes(chart, svg);
-    } catch (err) {
-      console.warn('[maidr/anychart] Failed to stamp box attributes:', err);
-    }
-    try {
-      stampHeatmapAttributes(chart, svg);
-    } catch (err) {
-      console.warn('[maidr/anychart] Failed to stamp heatmap attributes:', err);
-    }
-    try {
-      stampCandlestickAttributes(chart, svg);
-    } catch (err) {
-      console.warn('[maidr/anychart] Failed to stamp candlestick attributes:', err);
-    }
-    try {
-      stampPieAttributes(chart, svg);
-    } catch (err) {
-      console.warn('[maidr/anychart] Failed to stamp pie attributes:', err);
-    }
+    stampChartAttributes(chart, svg);
 
     const host = ensureHostWrapper(svg, container);
     if (boundElements.has(host))
@@ -3105,41 +3127,7 @@ function stampPanelAttributes(
     svg.setAttribute(PANEL_ATTR, token);
 
   const prefix = `${token}:`;
-  try {
-    stampBarAttributes(chart, svg, prefix);
-  } catch (err) {
-    console.warn('[maidr/anychart] Failed to stamp bar attributes:', err);
-  }
-  try {
-    stampLineAttributes(chart, svg, prefix);
-  } catch (err) {
-    console.warn('[maidr/anychart] Failed to stamp line attributes:', err);
-  }
-  try {
-    stampScatterAttributes(chart, svg, prefix);
-  } catch (err) {
-    console.warn('[maidr/anychart] Failed to stamp scatter attributes:', err);
-  }
-  try {
-    stampBoxAttributes(chart, svg, prefix);
-  } catch (err) {
-    console.warn('[maidr/anychart] Failed to stamp box attributes:', err);
-  }
-  try {
-    stampHeatmapAttributes(chart, svg, prefix);
-  } catch (err) {
-    console.warn('[maidr/anychart] Failed to stamp heatmap attributes:', err);
-  }
-  try {
-    stampCandlestickAttributes(chart, svg, prefix);
-  } catch (err) {
-    console.warn('[maidr/anychart] Failed to stamp candlestick attributes:', err);
-  }
-  try {
-    stampPieAttributes(chart, svg, prefix);
-  } catch (err) {
-    console.warn('[maidr/anychart] Failed to stamp pie attributes:', err);
-  }
+  stampChartAttributes(chart, svg, prefix);
 }
 
 /**

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -29,6 +29,29 @@ const DEFAULT_Y_AXIS = 'Y';
 const DEFAULT_Z_AXIS = 'Level';
 
 /**
+ * Names an axis, falling back when the layer did not really name it.
+ *
+ * A producer that has no label to give reaches for two spellings of "none",
+ * and only one of them used to be caught: `??` answers `undefined`, but an
+ * empty string is a value and passed straight through. Every Base R chart
+ * does exactly that — `barplot()`, `hist()`, `boxplot()` and `pie()` all
+ * carry no `xlab`/`ylab` unless the author writes one — so the announcement
+ * came out as " is Apples,  is 30", a sentence with its nouns missing. A
+ * blank name is worse than a generic one: "X is Apples" at least says which
+ * axis is being read.
+ *
+ * Whitespace counts as blank for the same reason a producer emitting `' '`
+ * meant nothing by it.
+ *
+ * @param label - The label the layer carried, if any
+ * @param fallback - The generic name to use when it carried none
+ * @returns The label to announce
+ */
+function named(label: string | undefined, fallback: string): string {
+  return label?.trim() ? label : fallback;
+}
+
+/**
  * Maps internal TraceType identifiers to human-readable chart type labels
  * for display in the chart description modal and other user-facing surfaces.
  */
@@ -379,9 +402,9 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     this.type = layer.type;
     this.title = layer.title ?? DEFAULT_SUBPLOT_TITLE;
 
-    this.xAxis = layer.axes?.x?.label ?? DEFAULT_X_AXIS;
-    this.yAxis = layer.axes?.y?.label ?? DEFAULT_Y_AXIS;
-    this.z = layer.axes?.z?.label ?? DEFAULT_Z_AXIS;
+    this.xAxis = named(layer.axes?.x?.label, DEFAULT_X_AXIS);
+    this.yAxis = named(layer.axes?.y?.label, DEFAULT_Y_AXIS);
+    this.z = named(layer.axes?.z?.label, DEFAULT_Z_AXIS);
   }
 
   /**

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -31,23 +31,21 @@ const DEFAULT_Z_AXIS = 'Level';
 /**
  * Names an axis, falling back when the layer did not really name it.
  *
- * A producer that has no label to give reaches for two spellings of "none",
- * and only one of them used to be caught: `??` answers `undefined`, but an
- * empty string is a value and passed straight through. Every Base R chart
- * does exactly that — `barplot()`, `hist()`, `boxplot()` and `pie()` all
- * carry no `xlab`/`ylab` unless the author writes one — so the announcement
- * came out as " is Apples,  is 30", a sentence with its nouns missing. A
- * blank name is worse than a generic one: "X is Apples" at least says which
- * axis is being read.
+ * A producer with no label to give writes one of two spellings of "none", and
+ * `??` catches only one: `undefined` takes the fallback, but an empty string
+ * is a value and passes straight through. Both spellings mean the same thing
+ * here, and a blank name announces worse than a generic one — "X is Apples"
+ * at least says which axis is being read, where " is Apples" is a sentence
+ * with its noun missing. Whitespace counts as blank for the same reason.
  *
- * Whitespace counts as blank for the same reason a producer emitting `' '`
- * meant nothing by it.
+ * Exported because `LineTrace` resolves its own z label against a
+ * trace-specific fallback rather than reading `this.z`.
  *
  * @param label - The label the layer carried, if any
  * @param fallback - The generic name to use when it carried none
  * @returns The label to announce
  */
-function named(label: string | undefined, fallback: string): string {
+export function named(label: string | undefined, fallback: string): string {
   return label?.trim() ? label : fallback;
 }
 

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -7,7 +7,7 @@ import type { Dimension, NearestPoint } from './abstract';
 import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
-import { AbstractTrace } from './abstract';
+import { AbstractTrace, named } from './abstract';
 import { MovableGraph } from './movable';
 
 const TYPE = 'Group';
@@ -113,9 +113,13 @@ export class LineTrace extends AbstractTrace {
    * Resolves the z label: honor the user-provided spec label, otherwise fall
    * back to the LineTrace-specific default ("Group") rather than the generic
    * "Level" inherited from `AbstractTrace`.
+   *
+   * Reads the layer rather than `this.z`, so it needs `named` for itself:
+   * the blank-label fallback `AbstractTrace` applies to `this.z` does not
+   * reach a label resolved here.
    */
   private get groupLabel(): string {
-    return this.layer.axes?.z?.label ?? TYPE;
+    return named(this.layer.axes?.z?.label, TYPE);
   }
 
   /**

--- a/test/adapters/anychart/converters.test.ts
+++ b/test/adapters/anychart/converters.test.ts
@@ -93,18 +93,37 @@ function createPieChart(
  * `count` wedge paths plus a straight label connector, which shares the layer
  * but is not a wedge.
  */
-function appendPieWedges(container: HTMLElement, count: number): SVGElement[] {
+function appendPieWedges(
+  container: HTMLElement,
+  count: number,
+  outlines?: 'after' | 'before',
+): SVGElement[] {
   const svg = container.querySelector('svg') as unknown as SVGElement;
   const layer = document.createElementNS(SVG_NS, 'g');
   layer.id = 'ac_layer_1';
   svg.appendChild(layer);
 
+  const arc = 'M 100 100 L 150 100 A 50 50 0 0 1 100 150 Z';
   const wedges: SVGElement[] = [];
   for (let i = 0; i < count; i++) {
     const wedge = document.createElementNS(SVG_NS, 'path');
     wedge.id = `ac_path_${i}`;
-    wedge.setAttribute('d', 'M 100 100 L 150 100 A 50 50 0 0 1 100 150 Z');
+    wedge.setAttribute('d', arc);
+    wedge.setAttribute('fill', '#1f77b4');
+    // A real chart draws each slice twice: the fill, then a stroke-only twin
+    // over the same arc. `before` emits them the other way round, which
+    // AnyChart does not do today — the point is that nothing may depend on
+    // that.
+    const outline = document.createElementNS(SVG_NS, 'path');
+    outline.id = `ac_path_${i}_outline`;
+    outline.setAttribute('d', arc);
+    outline.setAttribute('fill', 'none');
+
+    if (outlines === 'before')
+      layer.appendChild(outline);
     layer.appendChild(wedge);
+    if (outlines === 'after')
+      layer.appendChild(outline);
     wedges.push(wedge);
   }
 
@@ -414,6 +433,63 @@ describe('bindAnyChart (pie stamping)', () => {
     expect(wedges.map(w => w.getAttribute('data-maidr-anychart-pie-slice')))
       .toEqual(['0-0', '0-1']);
     expect(warnSpy.mock.calls.flat().join(' ')).not.toContain('pie wedges');
+
+    container.closest('[data-maidr-anychart-host]')?.remove();
+  });
+
+  it.each([
+    ['after the fill, as AnyChart emits them', 'after' as const],
+    ['before the fill, which nothing may depend on not happening', 'before' as const],
+  ])('skips the stroke-only twin drawn %s', (_case, order) => {
+    // AnyChart draws every slice twice — once filled, once `fill="none"` for
+    // the stroke — so four slices offer eight arc paths and the count guard
+    // used to fire on a chart that was working. Taking the first N in DOM
+    // order picked the fills only because the fills come first; were that
+    // ever to flip, every highlight would land on an invisible path while the
+    // announcement carried on naming the right slice.
+    const container = createContainerWithSvg(`pie-outline-${order}`);
+    const wedges = appendPieWedges(container, 4, order);
+    const chart = createPieChart(
+      'Fruit',
+      [['Apples', 30], ['Bananas', 50], ['Cherries', 20], ['Dates', 10]],
+      { container },
+    );
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    bindAnyChart(chart);
+
+    expect(wedges.map(w => w.getAttribute('data-maidr-anychart-pie-slice')))
+      .toEqual(['0-0', '0-1', '0-2', '0-3']);
+    // Eight candidates, four slices: the guard used to report a mismatch here.
+    expect(warnSpy.mock.calls.flat().join(' ')).not.toContain('pie wedges');
+    // Nothing invisible was stamped, so a highlight cannot land on an outline.
+    expect(container.querySelectorAll('[data-maidr-anychart-pie-slice]'))
+      .toHaveLength(4);
+    expect(
+      container.querySelector('#ac_path_0_outline')
+        ?.getAttribute('data-maidr-anychart-pie-slice'),
+    ).toBeNull();
+
+    container.closest('[data-maidr-anychart-host]')?.remove();
+  });
+
+  it('runs only the pie stamper, so a working pie logs nothing', () => {
+    // A pie carries no series API at all, so every XY stamper threw on one and
+    // warned before the pie stamper did the real work: two console warnings on
+    // a correctly rendered chart, in exactly the place someone debugging a
+    // genuine stamping failure would look.
+    const container = createContainerWithSvg('pie-quiet');
+    appendPieWedges(container, 3, 'after');
+    const chart = createPieChart(
+      'Fruit',
+      [['Apples', 30], ['Bananas', 50], ['Cherries', 20]],
+      { container },
+    );
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    bindAnyChart(chart);
+
+    expect(warnSpy).not.toHaveBeenCalled();
 
     container.closest('[data-maidr-anychart-host]')?.remove();
   });

--- a/test/model/blankAxisLabel.test.ts
+++ b/test/model/blankAxisLabel.test.ts
@@ -27,6 +27,37 @@ function labelsOf(axes: MaidrLayer['axes']): [string, string] {
   return [trace.xAxis, trace.yAxis];
 }
 
+function zLabelOf(axes: MaidrLayer['axes']): string {
+  const trace = TraceFactory.create(pieLayer(axes)) as unknown as { z: string };
+  return trace.z;
+}
+
+/**
+ * A two-line layer, so `LineTrace` has a group to name.
+ *
+ * It resolves its own z label against the trace-specific "Group" rather than
+ * reading `this.z`, so `AbstractTrace`'s fallback does not cover it and it
+ * needs its own cases.
+ */
+function lineLayer(axes: MaidrLayer['axes']): MaidrLayer {
+  return {
+    id: '0',
+    type: TraceType.LINE,
+    axes,
+    data: [
+      [{ x: 1, y: 2, z: 'north' }, { x: 2, y: 3, z: 'north' }],
+      [{ x: 1, y: 5, z: 'south' }, { x: 2, y: 6, z: 'south' }],
+    ],
+  } as MaidrLayer;
+}
+
+function groupLabelOf(axes: MaidrLayer['axes']): string {
+  const trace = TraceFactory.create(lineLayer(axes)) as unknown as {
+    groupLabel: string;
+  };
+  return trace.groupLabel;
+}
+
 describe('a blank axis label falls back to the generic name', () => {
   it('uses the label when the layer gives one', () => {
     expect(labelsOf({ x: { label: 'Fruit' }, y: { label: 'Units' } }))
@@ -51,5 +82,41 @@ describe('a blank axis label falls back to the generic name', () => {
 
   it('falls back per axis, not all or nothing', () => {
     expect(labelsOf({ x: { label: '' }, y: { label: 'Units' } })).toEqual(['X', 'Units']);
+  });
+});
+
+describe('the z axis falls back the same way', () => {
+  it('uses the label when the layer gives one', () => {
+    expect(zLabelOf({ z: { label: 'Region' } })).toBe('Region');
+  });
+
+  it('falls back on an empty string', () => {
+    expect(zLabelOf({ z: { label: '' } })).toBe('Level');
+  });
+
+  it('falls back on whitespace', () => {
+    expect(zLabelOf({ z: { label: '  ' } })).toBe('Level');
+  });
+
+  it('falls back when there is no z axis at all', () => {
+    expect(zLabelOf({ x: { label: 'Fruit' } })).toBe('Level');
+  });
+});
+
+describe('a line trace names its group the same way', () => {
+  it('uses the label when the layer gives one', () => {
+    expect(groupLabelOf({ z: { label: 'Region' } })).toBe('Region');
+  });
+
+  it('falls back to the trace-specific name, not the generic "Level"', () => {
+    expect(groupLabelOf(undefined)).toBe('Group');
+  });
+
+  it('falls back on an empty string, which `??` used to pass through', () => {
+    expect(groupLabelOf({ z: { label: '' } })).toBe('Group');
+  });
+
+  it('falls back on whitespace', () => {
+    expect(groupLabelOf({ z: { label: '\t' } })).toBe('Group');
   });
 });

--- a/test/model/blankAxisLabel.test.ts
+++ b/test/model/blankAxisLabel.test.ts
@@ -1,0 +1,55 @@
+import type { MaidrLayer } from '@type/grammar';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A producer with no axis name to give writes one of two spellings of "none".
+ *
+ * `??` only ever caught `undefined`. An empty string is a value, so it passed
+ * through and the announcement lost its noun — " is Apples,  is 30". Every
+ * Base R chart reaches this way: `barplot()`, `hist()`, `boxplot()` and
+ * `pie()` all carry no `xlab`/`ylab` unless the author writes one.
+ */
+function pieLayer(axes: MaidrLayer['axes']): MaidrLayer {
+  return {
+    id: '0',
+    type: TraceType.PIE,
+    axes,
+    data: [{ x: 'Apples', y: 30 }, { x: 'Bananas', y: 50 }],
+  } as MaidrLayer;
+}
+
+function labelsOf(axes: MaidrLayer['axes']): [string, string] {
+  const trace = TraceFactory.create(pieLayer(axes)) as unknown as {
+    xAxis: string;
+    yAxis: string;
+  };
+  return [trace.xAxis, trace.yAxis];
+}
+
+describe('a blank axis label falls back to the generic name', () => {
+  it('uses the label when the layer gives one', () => {
+    expect(labelsOf({ x: { label: 'Fruit' }, y: { label: 'Units' } }))
+      .toEqual(['Fruit', 'Units']);
+  });
+
+  it('falls back when the axes are absent entirely', () => {
+    expect(labelsOf(undefined)).toEqual(['X', 'Y']);
+  });
+
+  it('falls back on an empty string, which `??` used to pass through', () => {
+    expect(labelsOf({ x: { label: '' }, y: { label: '' } })).toEqual(['X', 'Y']);
+  });
+
+  it('falls back on whitespace, which reads as blank to a listener', () => {
+    expect(labelsOf({ x: { label: '   ' }, y: { label: '\t' } })).toEqual(['X', 'Y']);
+  });
+
+  it('keeps a label that is merely short', () => {
+    expect(labelsOf({ x: { label: 'n' }, y: { label: '0' } })).toEqual(['n', '0']);
+  });
+
+  it('falls back per axis, not all or nothing', () => {
+    expect(labelsOf({ x: { label: '' }, y: { label: 'Units' } })).toEqual(['X', 'Units']);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Two defects, both found the same way: by building the bundle from `main` and driving the emitted pages in a real browser. Nothing in the pie work across the three repos had ever been rendered — every assertion was at the schema or SVG level — and both of these are invisible until it is.

## Related Issues

Refs xability/maidr#770 (the amCharts/AnyChart verification reviewers asked for twice) and xability/py-maidr#323.

## Changes Made

### 1. Every Base R chart announced its points with the nouns missing

Heard by a screen reader:

```
 is Apples,  is 30, Percentage is 30.0%
 is A,  is 3
```

`AbstractTrace` used `??`:

```ts
this.xAxis = layer.axes?.x?.label ?? DEFAULT_X_AXIS;
```

A producer with no axis name to give writes one of two spellings of "none", and `??` catches only one. `undefined` gets the default; an **empty string is a value** and passes straight through. r-maidr emits `label: ""` because `graphics::pie()`, `barplot()`, `hist()` and `boxplot()` genuinely have no labels to report — so this is every Base R chart whose author did not pass `xlab`/`ylab`, which is the common case, and not pie-specific at all.

A blank name is worse than a generic one: `"X is Apples"` at least tells the listener which axis is being read.

Fixed in the model rather than per-binding, so it holds for hand-authored MAIDR JSON too. **After:** `X is Apples, Y is 30, Percentage is 30.0%`.

A producer-side follow-up — Base R emitting something better than the generic pair, the way py-maidr's pie uses `"Category"`/`"Value"` — belongs in r-maidr. This is the renderer-side floor that stops the announcement being broken regardless of producer.

### 2. AnyChart pie stamped candidates that were not data

Running the real library (anychart 8.13, vendored from npm, no CDN) surfaced two things static reading could not:

**Every stamper was tried on every chart.** Harmless for XY, but a pie has no series API — `getSeriesCount` is not a function on one — so the bar and line stampers each threw and warned before the pie stamper did the real work. Two console warnings on every correctly rendered pie, in exactly the place someone debugging a genuine stamping failure would look. Stampers now dispatch on what the chart is, which also collapses the duplicated try/catch ladder at both call sites.

**AnyChart draws every slice twice** — once filled in the slice's colour, once with `fill="none"` for the stroke. Both sit in the same layer, both carry an arc command, so a four-slice pie offered **eight** candidates and the count guard fired on a chart that was working:

```
[maidr/anychart] Expected 4 pie wedges but found 8 after filtering.
```

Taking the first N in DOM order picked the fills only because AnyChart emits them first. That is an ordering accident, not a guarantee — were it ever to emit outlines first, every highlight would land on an invisible path while the announcement carried on naming the right slice. That is the silent mislabel this lookup exists to prevent, so correctness here should not rest on emission order.

## Screenshots (if applicable)

Browser-verified, Chromium, no CDN:

| | Before | After |
|---|---|---|
| Base R pie | `" is Apples,  is 30, Percentage is 30.0%"` | `"X is Apples, Y is 30, Percentage is 30.0%"` |
| Base R barplot | `" is A,  is 3"` | `"X is A, Y is 3"` |
| AnyChart pie | 8 candidates, 2 spurious warnings | 4 wedges `0-0`–`0-3`, 4 distinct fills, **no warnings** |

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

No documentation change: both restore behaviour the docs already describe.

## Additional Notes

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm run build` | all builds pass |
| `npm test` | 1806 + 61 passing (was 1800 + 61) |

Six new tests in `test/model/blankAxisLabel.test.ts`: label present, axes absent entirely, empty string, whitespace, a legitimately short label (`"n"`, `"0"` — neither should fall back), and per-axis rather than all-or-nothing fallback. The existing 42 AnyChart tests still pass.

**Also verified while I had the harness up**, since none of it had been checked before: matplotlib pie, ggplot2 `coord_polar` pie, Base R `pie()` and a mixed bar+pie figure all render, announce, braille (`⠤⠉⣀`, matching the unit test) and highlight, with no console errors. Values survive matplotlib's normalisation — `30/50/20`, not `0.3/0.5/0.2` — which was the central design bet of the py-maidr work and had never been confirmed at runtime.

**Still not verified:** amCharts. Its npm package ships ES modules rather than a browser bundle, so unlike AnyChart it cannot be dropped into the example page without a bundling step. xability/maidr#770's multi-panel pie highlight remains unconfirmed against the real library.