### PR TITLE
fix(amcharts): measure a pie wedge instead of believing its reported box

### DIFF
--- a/src/adapters/amcharts/geometry.ts
+++ b/src/adapters/amcharts/geometry.ts
@@ -47,9 +47,9 @@ function numberSetting(slice: AmSprite, key: string): number | null {
 /**
  * The box a sprite reports, when it reports one with area.
  *
- * The area test is what makes this safe as a fallback: a `Slice` answers a
- * degenerate point, and unioning those is the bug in #774. Kept for any build
- * whose slices do report a real box but no radius to measure instead.
+ * The area test is what makes this safe as a fallback: a slice that reports a
+ * point rather than a box is rejected here rather than believed. Kept for any
+ * build whose slices do report a real box but no radius to measure instead.
  */
 function reportedBox(slice: AmSprite): AmBounds | null {
   const box = slice.globalBounds?.();
@@ -131,8 +131,14 @@ export function wedgeBounds(slice: AmSprite): AmBounds | null {
     }
   }
 
-  // Both radii at the arc ends; only the outer radius at a cardinal, since the
-  // inner point lies in the same direction and so is never further out.
+  // Both radii at the arc ends, but only the outer radius at a cardinal in
+  // between. A cardinal is where cos or sin is at a critical point, so it is
+  // the angle that governs one extreme of the box — and there the larger
+  // radius always reaches further in that direction. Sampling the inner
+  // radius at an interior cardinal could therefore only ever repeat a bound
+  // the outer one already set. At the sweep's two ends there is no such
+  // critical point, so the inner corners are their own extremes and do need
+  // sampling: that is what keeps a donut wedge from swallowing the centre.
   const xs: number[] = [];
   const ys: number[] = [];
   const add = (angle: number, r: number): void => {

--- a/src/adapters/amcharts/geometry.ts
+++ b/src/adapters/amcharts/geometry.ts
@@ -36,16 +36,140 @@ export function readPlotBounds(chart: AmChart): AmBounds | null {
   return null;
 }
 
+/** Cardinal directions, where a circle reaches its extreme in x or y. */
+const CARDINALS = [0, 90, 180, 270];
+
+function numberSetting(slice: AmSprite, key: string): number | null {
+  const value = slice.get?.(key);
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 /**
- * Read a pie panel's bounds as the union of its wedges' global boxes.
+ * The box a sprite reports, when it reports one with area.
+ *
+ * The area test is what makes this safe as a fallback: a `Slice` answers a
+ * degenerate point, and unioning those is the bug in #774. Kept for any build
+ * whose slices do report a real box but no radius to measure instead.
+ */
+function reportedBox(slice: AmSprite): AmBounds | null {
+  const box = slice.globalBounds?.();
+  if (!box || ![box.left, box.right, box.top, box.bottom].every(Number.isFinite)) {
+    return null;
+  }
+  const hasArea = box.left !== box.right && box.top !== box.bottom;
+  return hasArea ? box : null;
+}
+
+/**
+ * The extent of one pie wedge: its own geometry, or the box it reports.
+ *
+ * Prefers {@link wedgeBounds} so a real amCharts slice is measured rather than
+ * believed, and falls back to a reported box with area for a sprite that
+ * carries no radius to measure.
+ */
+export function sliceExtent(slice: AmSprite): AmBounds | null {
+  return wedgeBounds(slice) ?? reportedBox(slice);
+}
+
+/**
+ * The bounding box of one pie wedge, computed from what a `Slice` reports.
+ *
+ * A `Slice` paints through a draw callback rather than through primitives that
+ * feed amCharts' bounds accumulator, so `globalBounds()` answers a *degenerate
+ * box at the wedge's own centre* — `left === right`, `top === bottom`, and
+ * `width()`/`height()` both zero. Verified against amcharts5 5.20.1: measured
+ * after `datavalidated`, again after a resize, always a point. Every highlight
+ * derived from it collapsed and the overlay drew nothing at all (#774).
+ *
+ * The centre it reports is correct, though, and the wedge's extent is in its
+ * settings, so the box is recoverable: walk the wedge's corners — both arc
+ * ends at each radius — and add every cardinal angle the sweep crosses, which
+ * is where the arc, not its endpoints, reaches furthest out. A wedge with no
+ * inner radius includes its centre, which the inner-radius corners supply at
+ * radius zero.
+ *
+ * @param slice - The `Slice` sprite behind one pie data item
+ * @returns Its box in root-relative CSS px, or `null` when the sprite reports
+ *   no usable centre or radius (an XY chart's sprites, or a pie asked before
+ *   its first layout).
+ */
+export function wedgeBounds(slice: AmSprite): AmBounds | null {
+  const box = slice.globalBounds?.();
+  if (!box || ![box.left, box.right, box.top, box.bottom].every(Number.isFinite)) {
+    return null;
+  }
+  const cx = (box.left + box.right) / 2;
+  const cy = (box.top + box.bottom) / 2;
+
+  const radius = numberSetting(slice, 'radius');
+  if (radius === null || radius <= 0) {
+    return null;
+  }
+  const inner = Math.max(numberSetting(slice, 'innerRadius') ?? 0, 0);
+  const start = numberSetting(slice, 'startAngle') ?? 0;
+  const arc = numberSetting(slice, 'arc') ?? 360;
+
+  // A full circle needs no angular reasoning, and asking for it would make
+  // every cardinal a candidate anyway.
+  if (Math.abs(arc) >= 360) {
+    return { left: cx - radius, top: cy - radius, right: cx + radius, bottom: cy + radius };
+  }
+
+  const lo = Math.min(start, start + arc);
+  const hi = Math.max(start, start + arc);
+
+  const angles = [lo, hi];
+  // Cardinals inside the sweep. The sweep can start anywhere, so test each
+  // cardinal across the turns the sweep spans rather than only in [0, 360).
+  const firstTurn = Math.floor(lo / 360) * 360;
+  for (let turn = firstTurn; turn <= hi; turn += 360) {
+    for (const cardinal of CARDINALS) {
+      const angle = turn + cardinal;
+      if (angle >= lo && angle <= hi) {
+        angles.push(angle);
+      }
+    }
+  }
+
+  // Both radii at the arc ends; only the outer radius at a cardinal, since the
+  // inner point lies in the same direction and so is never further out.
+  const xs: number[] = [];
+  const ys: number[] = [];
+  const add = (angle: number, r: number): void => {
+    const rad = (angle * Math.PI) / 180;
+    xs.push(cx + r * Math.cos(rad));
+    ys.push(cy + r * Math.sin(rad));
+  };
+  for (const angle of angles) {
+    add(angle, radius);
+  }
+  add(lo, inner);
+  add(hi, inner);
+
+  return {
+    left: Math.min(...xs),
+    top: Math.min(...ys),
+    right: Math.max(...xs),
+    bottom: Math.max(...ys),
+  };
+}
+
+/**
+ * Read a pie panel's bounds as the union of its wedges' boxes.
  *
  * An am5percent `PieChart` has no `plotContainer` — it has no plot area, which
  * is why {@link AmChart.plotContainer} is optional — so {@link readPlotBounds}
  * reports nothing for it and the binder, which suppresses a highlight it cannot
  * clip to a panel, would leave every pie in a multi-panel root unhighlighted.
- * Each slice is a sprite with `globalBounds()`, and the union of those boxes is
- * the rectangle the pie occupies: the panel rectangle the overlay needs, in the
- * same root-relative CSS px `readPlotBounds` returns.
+ * The union of the wedges' boxes is the rectangle the pie occupies: the panel
+ * rectangle the overlay needs, in the same root-relative CSS px
+ * `readPlotBounds` returns.
+ *
+ * Each wedge is measured with {@link wedgeBounds} rather than by its reported
+ * `globalBounds()`, which is a degenerate point (#774). Unioning those points
+ * produced a zero-area panel rectangle — non-null, so the binder's
+ * suppression never fired, and every highlight was instead clipped away to
+ * nothing.
  *
  * Returns `null` when no wedge reports usable geometry — an XY chart, whose
  * data items carry no `slice` at all, or a pie asked before its first layout.
@@ -62,7 +186,7 @@ export function readSliceBounds(chart: AmChart): AmBounds | null {
     for (const series of chart.series.values) {
       for (const dataItem of series.dataItems) {
         const slice = dataItem.get('slice') as AmSprite | undefined;
-        const bounds = slice?.globalBounds?.();
+        const bounds = slice ? sliceExtent(slice) : undefined;
         if (!bounds) {
           continue;
         }

--- a/src/adapters/amcharts/overlay.ts
+++ b/src/adapters/amcharts/overlay.ts
@@ -19,6 +19,7 @@
 
 import type { NavTarget } from './navmap';
 import type { AmBounds, AmPoint, AmSprite } from './types';
+import { sliceExtent } from './geometry';
 
 /**
  * Rectangle in CSS pixels relative to the overlay container (root.dom) top-left.
@@ -190,10 +191,14 @@ function columnRect(target: NavTarget): OverlayRect | null {
  * into a shared canvas where there is no path to outline. A box that hugs the
  * active wedge still tells a low-vision reader which way round the circle
  * navigation has moved, which is the point of the highlight.
+ *
+ * Measured from the wedge's settings rather than its `globalBounds()`, which a
+ * `Slice` reports as a degenerate point at its own centre (#774) — a rect from
+ * that collapses to nothing, and the caller then drew no highlight at all.
  */
 function sliceRect(target: NavTarget): OverlayRect | null {
   const slice = target.dataItem.get('slice') as AmSprite | undefined;
-  const bounds = slice?.globalBounds?.();
+  const bounds = slice ? sliceExtent(slice) : null;
   return bounds ? boundsToRect(bounds) : null;
 }
 

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -158,8 +158,17 @@ export interface AmSprite {
   width?: () => number;
   height?: () => number;
   toGlobal?: (point: AmPoint) => AmPoint;
-  /** Global bounding box in CSS px; the reliable way to get a sprite's rect. */
+  /**
+   * Global bounding box in CSS px.
+   *
+   * Reliable for a sprite drawn from primitives. A `Slice` is not one: it
+   * paints through a draw callback, so nothing feeds the bounds accumulator
+   * and it reports a degenerate box at its own centre. Read a wedge's extent
+   * from its settings instead — see `wedgeBounds`.
+   */
   globalBounds?: () => AmBounds;
+  /** Settings accessor; a `Slice` carries radius / startAngle / arc here. */
+  get?: (key: string) => unknown;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/adapters/amcharts/wedgeBounds.test.ts
+++ b/test/adapters/amcharts/wedgeBounds.test.ts
@@ -1,5 +1,5 @@
 import type { AmSprite } from '@adapters/amcharts/types';
-import { readSliceBounds, wedgeBounds } from '@adapters/amcharts/geometry';
+import { readSliceBounds, sliceExtent, wedgeBounds } from '@adapters/amcharts/geometry';
 import { describe, expect, it } from '@jest/globals';
 
 /**
@@ -101,6 +101,38 @@ describe('wedgeBounds measures a wedge amCharts reports no box for', () => {
   it('returns null before the first layout, when there is no radius yet', () => {
     expect(wedgeBounds(slice(0, 0, {}))).toBeNull();
     expect(wedgeBounds(slice(0, 0, { radius: 0 }))).toBeNull();
+  });
+});
+
+describe('sliceExtent decides which measurement to trust', () => {
+  it('measures the wedge even when a box is reported alongside it', () => {
+    // Pins the precedence. A build that reported both would otherwise be free
+    // to fall back, and the reported box is the coarser of the two -- the
+    // whole point of the fix is that the wedge's own geometry wins.
+    const both: AmSprite = {
+      globalBounds: () => ({ left: 0, top: 0, right: 999, bottom: 999 }),
+      get: (key: string) =>
+        ({ radius: 50, startAngle: -90, arc: 90 } as Record<string, unknown>)[key],
+    };
+
+    // Centre is the reported box's midpoint, so the wedge sits around 499.5.
+    const [left, top, right, bottom] = near(sliceExtent(both));
+    expect([left, top, right, bottom]).toEqual([499.5, 449.5, 549.5, 499.5]);
+  });
+
+  it('falls back to a reported box when there is no radius to measure', () => {
+    const boxOnly: AmSprite = {
+      globalBounds: () => ({ left: 10, top: 20, right: 30, bottom: 40 }),
+      get: () => undefined,
+    };
+
+    expect(near(sliceExtent(boxOnly))).toEqual([10, 20, 30, 40]);
+  });
+
+  it('refuses a degenerate box, which is the shape that caused the bug', () => {
+    // No radius *and* a point for a box: nothing here can be measured, and
+    // believing the point is what collapsed every highlight.
+    expect(sliceExtent(slice(100, 100, {}))).toBeNull();
   });
 });
 

--- a/test/adapters/amcharts/wedgeBounds.test.ts
+++ b/test/adapters/amcharts/wedgeBounds.test.ts
@@ -1,0 +1,139 @@
+import type { AmSprite } from '@adapters/amcharts/types';
+import { readSliceBounds, wedgeBounds } from '@adapters/amcharts/geometry';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * A `Slice` as amCharts 5.20.1 actually reports one.
+ *
+ * The point of this helper is the `globalBounds` it returns: a **degenerate
+ * box at the wedge's centre**, which is what a real slice answers because it
+ * paints through a draw callback and never feeds the bounds accumulator. The
+ * existing amCharts tests give their fake slices real boxes, which is the one
+ * thing amCharts does not do — so they passed while the highlight drew
+ * nothing at all (#774).
+ */
+function slice(
+  cx: number,
+  cy: number,
+  settings: Record<string, unknown>,
+): AmSprite {
+  return {
+    globalBounds: () => ({ left: cx, top: cy, right: cx, bottom: cy }),
+    width: () => 0,
+    height: () => 0,
+    get: (key: string) => settings[key],
+  };
+}
+
+function near(bounds: ReturnType<typeof wedgeBounds>): number[] {
+  expect(bounds).not.toBeNull();
+  const b = bounds!;
+  return [b.left, b.top, b.right, b.bottom].map(n => Math.round(n * 100) / 100);
+}
+
+describe('wedgeBounds measures a wedge amCharts reports no box for', () => {
+  it('boxes the quarter from 12 to 3 o\'clock', () => {
+    // -90 is 12 o'clock and angles run clockwise, so this wedge occupies the
+    // top-right quarter: from the centre out to (cx + r, cy) and (cx, cy - r).
+    const s = slice(100, 100, { radius: 50, startAngle: -90, arc: 90 });
+
+    expect(near(wedgeBounds(s))).toEqual([100, 50, 150, 100]);
+  });
+
+  it('reaches the arc, not just its endpoints, when the sweep crosses a cardinal', () => {
+    // -45..45 crosses 0, where the arc bulges to cx + r = 150. Both endpoints
+    // sit at x = 135.36, so a box drawn from endpoints alone would stop short
+    // and leave the widest part of the wedge outside the highlight.
+    const s = slice(100, 100, { radius: 50, startAngle: -45, arc: 90 });
+
+    expect(near(wedgeBounds(s))).toEqual([100, 64.64, 150, 135.36]);
+  });
+
+  it('includes the centre, which a wedge with no inner radius owns', () => {
+    const s = slice(0, 0, { radius: 10, startAngle: 0, arc: 90 });
+
+    // 0..90 is the bottom-right quarter in screen coordinates (y grows down),
+    // so the box runs from the centre to (r, r) -- the centre is a corner.
+    expect(near(wedgeBounds(s))).toEqual([0, 0, 10, 10]);
+  });
+
+  it('excludes the centre for a donut wedge that does not touch it', () => {
+    const s = slice(100, 100, {
+      radius: 50,
+      innerRadius: 40,
+      startAngle: -10,
+      arc: 20,
+    });
+
+    const [left, top, right, bottom] = near(wedgeBounds(s));
+    // A thin band on the right: nowhere near the centre at x = 100.
+    expect(left).toBeCloseTo(139.39, 1);
+    expect(right).toBeCloseTo(150, 1);
+    expect(top).toBeCloseTo(91.32, 1);
+    expect(bottom).toBeCloseTo(108.68, 1);
+  });
+
+  it('boxes the whole circle when the sweep is a full turn', () => {
+    const s = slice(100, 100, { radius: 50, startAngle: -90, arc: 360 });
+
+    expect(near(wedgeBounds(s))).toEqual([50, 50, 150, 150]);
+  });
+
+  it('handles a sweep that starts past a full turn', () => {
+    // Same quarter as the first case, expressed 360 degrees round. The
+    // cardinal search must follow the sweep rather than assume [0, 360).
+    const s = slice(100, 100, { radius: 50, startAngle: 270, arc: 90 });
+
+    expect(near(wedgeBounds(s))).toEqual([100, 50, 150, 100]);
+  });
+
+  it('returns null for a sprite that is not a wedge', () => {
+    // An XY chart's column: a real box, no radius. Reporting a wedge box for
+    // it would put a highlight somewhere the data is not.
+    const column: AmSprite = {
+      globalBounds: () => ({ left: 10, top: 20, right: 30, bottom: 40 }),
+      get: () => undefined,
+    };
+
+    expect(wedgeBounds(column)).toBeNull();
+  });
+
+  it('returns null before the first layout, when there is no radius yet', () => {
+    expect(wedgeBounds(slice(0, 0, {}))).toBeNull();
+    expect(wedgeBounds(slice(0, 0, { radius: 0 }))).toBeNull();
+  });
+});
+
+describe('readSliceBounds gives the panel a real rectangle', () => {
+  it('unions the wedges instead of collapsing to their shared centre', () => {
+    // Two halves of one pie. Every slice reports the same centre point, so
+    // unioning the reported boxes gave a zero-area rectangle -- non-null, so
+    // the binder did not suppress, and every highlight was clipped to nothing.
+    const chart = {
+      series: {
+        values: [{
+          dataItems: [
+            { get: () => slice(100, 100, { radius: 50, startAngle: -90, arc: 180 }) },
+            { get: () => slice(100, 100, { radius: 50, startAngle: 90, arc: 180 }) },
+          ],
+        }],
+      },
+    } as never;
+
+    const bounds = readSliceBounds(chart);
+
+    expect(bounds).not.toBeNull();
+    expect(near(bounds)).toEqual([50, 50, 150, 150]);
+    // The bug this replaces: a rectangle with no area at all.
+    expect(bounds!.right - bounds!.left).toBeGreaterThan(0);
+    expect(bounds!.bottom - bounds!.top).toBeGreaterThan(0);
+  });
+
+  it('reports nothing for a chart whose data items carry no slice', () => {
+    const chart = {
+      series: { values: [{ dataItems: [{ get: () => undefined }] }] },
+    } as never;
+
+    expect(readSliceBounds(chart)).toBeNull();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Closes #774. Refs #770 — this is what that issue asked for, now that the verification is possible.

The amCharts pie highlight **never drew**. Not misplaced, not intermittent: the overlay container was created and never received a single box, on any slice, in any panel. Everything else worked, which is why nothing caught it.

## Related Issues

Closes #774. Refs #770.

## Changes Made

### How it was found

#770 asked for verification against the real library, twice, and it could not run: amcharts5 ships ES modules rather than a browser bundle, so there was no CDN drop-in. Bundling it with esbuild made it possible. Two `PieChart` panels in one root, amcharts5 **5.20.1** from npm, driven in Chromium.

**Everything except the highlight was already correct:**

```
lobby -> subplot 1   Subplot 1 of 2: This is a pie plot. Press 'ENTER' to select this subplot.
enter                Entered subplot 1 of 2, pie plot.
slice 1              Label is Apples, Value is 30, Percentage is 30.0%
slice 2              Label is Bananas, Value is 50, Percentage is 50.0%
slice 3              Label is Cherries, Value is 20, Percentage is 20.0%
braille              ⠤⠉⣀
-> subplot 2         Subplot 2 of 2: This is a pie plot. Press 'ENTER' to select this subplot.
slice 1              Label is Carrots, Value is 40, Percentage is 40.0%
slice 2              Label is Peas, Value is 60, Percentage is 60.0%
braille              ⣀⠉
```

Raw values, correct percentages, multi-panel navigation moving between panels, and both braille strings matching the unit-test encodings. Queried by the adapter's own attributes, the highlight was:

```
1 container(s), boxes: NONE
```

### Root cause

`readSliceBounds` documented its premise:

> Each slice is a sprite with `globalBounds()`, and the union of those boxes is the rectangle the pie occupies

**It does not hold.** Probing every slice:

```json
{ "bounds": { "left": 225, "top": 200, "right": 225, "bottom": 200 },
  "extra":  { "w": 0, "h": 0, "radius": 160, "arc": 108, "startAngle": -90,
              "dispW": { "left": 10000000, "right": -10000000, ... } } }
```

A degenerate **point at the wedge's own centre**. The display object's local bounds are amCharts' empty sentinel — nothing was ever recorded, because a `Slice` paints through a draw callback rather than through primitives that feed the bounds accumulator. Measured after `datavalidated`, then again after 3s plus a viewport resize; always a point.

Two consequences, from **two independent uses of the same premise**:

1. `readSliceBounds` unioned zero-area boxes → a zero-area panel rectangle. Non-null, so the binder's multi-panel suppression never fired.
2. `sliceRect` read the same `globalBounds()`, so each slice's own rect was degenerate too, and `intersectRect` clipped it to nothing.

Fixing only the first would have left every highlight a dot at the centre.

### The fix

The centre it reports is correct, and the extent is in the settings, so the box is recoverable. `wedgeBounds` walks the wedge's corners — both arc ends at each radius — and adds **every cardinal angle the sweep crosses**, which is where the arc rather than its endpoints reaches furthest out. A wedge with no inner radius gets its centre from the inner corners at radius zero; a full turn short-circuits to the circle.

The cardinal step is the part that is easy to get wrong: for a wedge spanning −45° to 45°, both endpoints sit at x = 135.36 while the arc bulges to 150. A box from endpoints alone stops short of the widest part of the wedge.

`sliceExtent` prefers that and falls back to a reported box **with area**. So a build whose slices do report real boxes keeps working, and a degenerate box can never be believed again — the area test is what makes the fallback safe rather than a way back into the bug.

## Screenshots (if applicable)

Re-run against the real library after the fix:

| Slice | Highlight box |
|---|---|
| Apples (30%) | `225px/40px 160 × 209.443` |
| Bananas (50%) | `65px/150.557px 312.169 × 209.443` |
| Cherries (20%) | `72.831px/40px 152.169 × 160` |
| Carrots (40%, panel 2) | `675px/40px 160 × 289.443` |
| Peas (60%, panel 2) | `515px/40px 254.046 × 320` |

Checked by hand rather than eyeballed. Apples is 108° from 12 o'clock, centre (225, 200), r = 160:

- arc ends (225, 40) and (377.2, 249.4)
- cardinal 0° at (385, 200)
- centre (225, 200)

→ left 225, top 40, width 160, height 209.44. That is the browser's output to the digit. Panel 2's centre lands at x = 675, which is right for a 900px root split into two 450px halves.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

No documentation change: this restores behaviour the docs already describe.

## Additional Notes

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm run build` | all builds pass |
| `npm test` | **1827 + 61** passing (was 1817 + 61) |

**Why the existing tests could not have caught this.** All 42 amCharts tests passed before and after. Their fake slices report real boxes — the one thing amCharts does not do — so they exercised a shape the library never produces. `test/adapters/amcharts/wedgeBounds.test.ts` models what it actually reports: a degenerate `globalBounds()` plus `radius` / `innerRadius` / `startAngle` / `arc`. Ten cases, including the cardinal-crossing bulge, a donut wedge that must *not* swallow the centre, a sweep expressed past a full turn, and an XY column that must return `null` rather than gain a wedge box somewhere the data is not.

The three existing `readSliceBounds` cases still pass unchanged — they now document the reported-box fallback rather than the premise.

**Noticed while verifying, not fixed here:** returning to the figure lobby leaves the last slice's box on screen, and it stays there while moving to another panel. `applyHighlight` is the only thing that clears the overlay and it runs on navigation events, so there is no hook for leaving a subplot — structural, and it applies to every chart type this adapter supports rather than to pie. It was simply never observable for pie before, since no box was ever drawn. Filed separately rather than folded in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_