### PR TITLE
fix(model)!: tell the navigate callback when the selection ends

### DIFF
--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -157,7 +157,7 @@ function applyHighlight(
 function createHighlightCallback(
   navMap: NavMap,
   getOverlay: () => HighlightOverlay | null,
-  recordActive: (event: NavEvent) => void,
+  recordActive: (event: NavEvent | null) => void,
 ): NavigateCallback {
   return (event) => {
     try {
@@ -165,6 +165,14 @@ function createHighlightCallback(
       const overlay = getOverlay();
       if (!overlay)
         return;
+      // `null` is the cursor leaving a subplot for the figure lobby: nothing
+      // is selected, so nothing should be outlined. Recording it also matters
+      // beyond this call -- the resize hook replays `lastActive`, and would
+      // otherwise put the stale box back on the next resize.
+      if (!event) {
+        overlay.clear();
+        return;
+      }
       applyHighlight(overlay, navMap, event);
     } catch {
       // Ignore highlight errors (e.g., during teardown or before layout).

--- a/src/adapters/chartjs/plugin.tsx
+++ b/src/adapters/chartjs/plugin.tsx
@@ -172,19 +172,25 @@ function createHighlightCallback(
   maps: TargetMaps,
   layerDatasetIndices: LayerDatasetIndices,
   getOverlay: () => HighlightOverlay | null,
-  recordActive: (event: NavEvent) => void,
+  recordActive: (event: NavEvent | null) => void,
 ): NavigateCallback {
   return (event) => {
     try {
       recordActive(event);
-      const targets = resolveActiveTargets(
-        layers,
-        maps,
-        layerDatasetIndices,
-        event.layerId,
-        event.row,
-        event.col,
-      );
+      // `null` is the cursor leaving a subplot for the figure lobby: nothing
+      // is selected, so no target is active. `applyHighlight` clears on an
+      // empty list, and recording the `null` keeps the resize hook from
+      // replaying the stale point.
+      const targets = event === null
+        ? []
+        : resolveActiveTargets(
+            layers,
+            maps,
+            layerDatasetIndices,
+            event.layerId,
+            event.row,
+            event.col,
+          );
       applyHighlight(chart, getOverlay(), targets);
     } catch {
       // Silently ignore highlight errors (e.g., after chart destruction)
@@ -317,7 +323,7 @@ function initMaidrForChart(chart: ChartJsChart): void {
 
   // Record the latest MAIDR navigation event on the per-chart binding so
   // the resize hook can replay it after Chart.js re-lays out the canvas.
-  const recordActive = (event: NavEvent): void => {
+  const recordActive = (event: NavEvent | null): void => {
     const b = chartBindings.get(chart);
     if (b)
       b.lastActive = event;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,7 +3,7 @@ import type { AppStore } from '@state/store';
 import type { Disposable } from '@type/disposable';
 import type { Maidr, NavigateCallback } from '@type/grammar';
 import type { Observer } from '@type/observable';
-import type { FigureState, TraceState } from '@type/state';
+import type { TraceState } from '@type/state';
 import { Context } from '@model/context';
 import { Figure } from '@model/plot';
 import { AudioService } from '@service/audio';
@@ -584,6 +584,6 @@ export class Controller implements Disposable {
     // move, so it is what reports the selection ending.
     this.figure.addObserver({
       update: () => callback(null),
-    } as Observer<FigureState>);
+    });
   }
 }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,7 +3,7 @@ import type { AppStore } from '@state/store';
 import type { Disposable } from '@type/disposable';
 import type { Maidr, NavigateCallback } from '@type/grammar';
 import type { Observer } from '@type/observable';
-import type { TraceState } from '@type/state';
+import type { FigureState, TraceState } from '@type/state';
 import { Context } from '@model/context';
 import { Figure } from '@model/plot';
 import { AudioService } from '@service/audio';
@@ -575,5 +575,15 @@ export class Controller implements Disposable {
         trace.addObserver(observer);
       }));
     }));
+
+    // Leaving a subplot makes the figure active rather than a trace, so the
+    // trace observers above go quiet and say nothing about having stopped.
+    // A consumer drawing an overlay would keep the last point highlighted and
+    // carry it to whichever panel the user moved to next, pointing at a chart
+    // it does not belong to. The figure is the only element that hears the
+    // move, so it is what reports the selection ending.
+    this.figure.addObserver({
+      update: () => callback(null),
+    } as Observer<FigureState>);
   }
 }

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -152,12 +152,19 @@ export interface ViolinKdePoint {
  * Callback invoked when the active data point changes during navigation.
  * Used by canvas-based charting libraries (e.g., Chart.js) for visual highlighting.
  *
- * @param info - Object containing the current navigation position
+ * `null` means no data point is active — the cursor has left a subplot for the
+ * figure lobby of a multi-panel chart. A consumer drawing an overlay must clear
+ * it, since there is no other signal that the selection ended: without one, the
+ * last point's highlight stays on screen and follows the user to another panel,
+ * pointing at a chart it does not belong to.
+ *
+ * @param info - The current navigation position, or `null` when nothing is
+ *   selected
  * @param info.layerId - The ID of the active layer/trace
  * @param info.row - The current row index (e.g., dataset index)
  * @param info.col - The current column index (e.g., data point index)
  */
-export type NavigateCallback = (info: { layerId: string; row: number; col: number }) => void;
+export type NavigateCallback = (info: { layerId: string; row: number; col: number } | null) => void;
 
 export interface Maidr {
   /** Unique identifier for the chart. Used for DOM element IDs. */

--- a/test/controller/navigateCallbackClear.test.ts
+++ b/test/controller/navigateCallbackClear.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { Maidr, NavigateCallback } from '@type/grammar';
+import type { MovableDirection } from '@type/movable';
+import type { TraceState } from '@type/state';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+
+/**
+ * Leaving a subplot has to reach a canvas adapter, or its highlight is stranded.
+ *
+ * `onNavigate` used to be observable only from traces, so the figure lobby --
+ * where no trace is active -- said nothing at all. An adapter drawing an
+ * overlay had no way to learn the selection had ended: it kept the last
+ * point's box on screen and carried it to whichever panel the user moved to
+ * next, outlining a chart the box does not belong to (#776).
+ *
+ * This exercises the wiring rather than the `Controller`, which needs a live
+ * DOM, a Redux store and every service to construct. What is under test is the
+ * contract between the model's observers and the callback, so the observers
+ * are registered the same way `Controller.registerNavigateCallback` registers
+ * them and the moves are driven through `Context` exactly as a keypress does.
+ */
+
+function twoPanels(): Maidr {
+  return {
+    id: 'two-panels',
+    subplots: [
+      [
+        {
+          layers: [{
+            id: '0',
+            type: TraceType.BAR,
+            data: [{ x: 'Apples', y: 30 }, { x: 'Bananas', y: 50 }],
+          }],
+        },
+        {
+          layers: [{
+            id: '1',
+            type: TraceType.BAR,
+            data: [{ x: 'Carrots', y: 40 }, { x: 'Peas', y: 60 }],
+          }],
+        },
+      ],
+    ],
+  } as Maidr;
+}
+
+const FORWARD: MovableDirection = 'FORWARD';
+
+describe('the navigate callback reports the selection ending', () => {
+  let figure: Figure;
+  let context: Context;
+  let seen: Array<{ layerId: string; row: number; col: number } | null>;
+
+  /** Mirrors `Controller.registerNavigateCallback`. */
+  function register(callback: NavigateCallback): void {
+    const observer = {
+      update: (state: TraceState): void => {
+        if (!state.empty && !state.braille.empty) {
+          callback({
+            layerId: state.layerId,
+            row: state.braille.row,
+            col: state.braille.col,
+          });
+        }
+      },
+    };
+    figure.subplots.forEach(row => row.forEach((subplot) => {
+      subplot.traces.forEach(traceRow => traceRow.forEach((trace) => {
+        trace.addObserver(observer as never);
+      }));
+    }));
+    figure.addObserver({ update: () => callback(null) } as never);
+  }
+
+  beforeEach(() => {
+    figure = new Figure(twoPanels());
+    figure.applyLayout(resolveSubplotLayout(figure.subplots));
+    context = new Context(figure);
+    seen = [];
+    register(event => void seen.push(event));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reports a position while a point is selected', () => {
+    context.enterSubplot();
+    seen.length = 0;
+
+    // The cursor sits before the first point on entry, so the first move
+    // lands on column 0 rather than stepping past it.
+    context.moveOnce(FORWARD);
+    expect(seen.at(-1)).toEqual({ layerId: '0', row: 0, col: 0 });
+
+    context.moveOnce(FORWARD);
+    expect(seen.at(-1)).toEqual({ layerId: '0', row: 0, col: 1 });
+  });
+
+  it('reports null on leaving the subplot for the figure lobby', () => {
+    context.enterSubplot();
+    context.moveOnce(FORWARD);
+    seen.length = 0;
+
+    context.exitSubplot();
+
+    // Without the figure observer this array stays empty, and an adapter goes
+    // on outlining the point the user has already left.
+    expect(seen).toContain(null);
+  });
+
+  it('reports null again while moving between panels at the lobby', () => {
+    context.enterSubplot();
+    context.moveOnce(FORWARD);
+    context.exitSubplot();
+    seen.length = 0;
+
+    context.moveOnce(FORWARD);
+
+    // Every lobby move must keep saying "nothing selected". A single clear on
+    // exit would be undone by nothing, but the box must not reappear either.
+    expect(seen.every(event => event === null)).toBe(true);
+    expect(seen.length).toBeGreaterThan(0);
+  });
+
+  it('reports a position again on entering the second panel', () => {
+    context.enterSubplot();
+    context.exitSubplot();
+    // The lobby cursor starts before the first panel too, so the first move
+    // lands on panel 1 and the second is what reaches panel 2.
+    context.moveOnce(FORWARD);
+    context.moveOnce(FORWARD);
+    seen.length = 0;
+
+    context.enterSubplot();
+    context.moveOnce(FORWARD);
+
+    // The second panel's own layer, so the highlight lands on this chart.
+    expect(seen.at(-1)).toEqual({ layerId: '1', row: 0, col: 0 });
+  });
+});


### PR DESCRIPTION
# Pull Request

> [!IMPORTANT]
> **This must be squashed with the `BREAKING CHANGE:` footer intact, or it will not release at all.**
>
> I originally wrote here that the `!` in `fix(model)!:` is what cuts the major. **That is wrong for this repository**, and the failure is silent. `.releaserc` configures `@semantic-release/commit-analyzer` with no `preset`, so the default **angular** preset applies, and its header pattern does not admit `!`. Measured against the installed version:
>
> | Commit message | Release |
> |---|---|
> | `fix(a)!: x` | **null — no release at all** |
> | `fix(a)!: x` + `BREAKING CHANGE:` footer | **major** |
> | `fix(a): x` + `BREAKING CHANGE:` footer | **major** |
> | `fix(a): x` | patch |
>
> So the footer is the only thing that produces a major, and a `!`-marked subject is *worse* than an unmarked one — it drops the commit from analysis entirely. The footer is reproduced verbatim at the bottom of this description so it survives whichever source your squash draws its body from. Repo-wide fix tracked in #778.

## Description

Closes #776.

Leaving a subplot makes the **figure** active rather than a trace, so the trace observers behind `onNavigate` went quiet and said nothing about having stopped. A canvas adapter has no other signal, so it kept the last point's box on screen — and carried it to whichever panel the user moved to next, outlining a chart the box does not belong to.

## Related Issues

Closes #776. Found while verifying #774 in a real browser.

## Changes Made

`Controller.registerNavigateCallback` attached its observer to traces only:

```ts
subplot.traces.forEach(traceRow => traceRow.forEach((trace) => {
  trace.addObserver(observer);
}));
```

There was no way to express "nothing is selected" at all — `NavigateCallback` could only ever say *where* the cursor is, never that it is nowhere. So the figure now reports `null` when it becomes the active element, and both canvas adapters clear on it.

Recording the `null` matters as much as clearing on it: both adapters keep a `lastActive` that the resize hook replays, so without it the next resize would put the stale box back.

**Not amCharts-specific.** Chart.js takes the same route through `createHighlightCallback` (`plugin.tsx:328`), so a multi-panel Chart.js figure stranded its highlight identically. Only amCharts surfaced it, because #774 meant its pie never drew a box to be stranded in the first place. Both adapters are fixed here.

An adapter could not have fixed this alone — `onNavigate` is its entire surface, and observing scope from the model or a service would cross the boundary `.claude/rules/architecture.md` draws.

## Breaking change

`NavigateCallback` becomes:

```ts
export type NavigateCallback = (info: { layerId: string; row: number; col: number } | null) => void;
```

A callback that dereferences its argument without checking will throw on leaving a subplot. TypeScript consumers get a compile error, which is the point; JavaScript consumers get a runtime one.

Blast radius is the two in-repo adapters, both updated here, plus anyone who set `onNavigate` while constructing MAIDR data programmatically — the field is documented as non-serializable and programmatic-only, so it is not reachable from JSON-authored charts.

The alternatives were a second `onNavigateClear?` hook or an `active: boolean` field on the payload; both are additive and neither says what happened as directly. **The choice of the breaking option was the maintainer's**, made explicitly after the trade-offs were laid out in #776.

## Screenshots (if applicable)

Chromium, amcharts5 5.20.1, two pie panels. Before → after, at the moment of returning to the lobby:

```
before:  back to lobby  | highlight: 72.831px/40px 152.169px x 160px   <- Cherries, still outlined
after:   back to lobby  | highlight: NONE
```

and it stays `NONE` through moving to panel 2 and entering it, until a slice there is selected — at which point the boxes appear at x=675 / 515, in the right-hand half where panel 2 actually is.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

Documentation: the `NavigateCallback` JSDoc now states what `null` means and why a consumer drawing an overlay has to act on it.

## Additional Notes

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm run build` | all builds pass |
| `npm test` | **1834 + 61** (was 1830 + 61) |

`test/controller/navigateCallbackClear.test.ts` drives moves through `Context` exactly as a keypress does, with the observers registered the same way `Controller.registerNavigateCallback` registers them — the `Controller` itself needs a live DOM, a Redux store and every service to construct, and the contract under test is between the model's observers and the callback.

**Verified they bite:** with the figure observer removed, the two `null` cases fail and the two position cases pass. The position cases are guards that the change did not cost the existing behaviour, not reproductions — saying so rather than implying all four reproduce the bug.

Two of my initial expectations in that test were wrong and the code was right: the cursor sits *before* the first point on entering a subplot, and before the first panel at the lobby, so the first move lands on index 0 rather than stepping past it. The test now documents that rather than asserting around it.

BREAKING CHANGE: `NavigateCallback` receives `null` when no data point is active. A callback that dereferences its argument without checking will throw on leaving a subplot. Consumers are the in-repo Chart.js plugin and amCharts binder, both updated here, plus anyone who set `onNavigate` when constructing MAIDR data programmatically.