### PR TITLE
fix(pie): announce a negative slice as the chart draws it

### DIFF
--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -27,7 +27,7 @@ import { MovableGrid } from './movable';
  * @param raw - The value from the point, on whichever axis carries magnitude
  * @returns The magnitude, or `NaN` when the bar is a gap
  */
-function toBarValue(raw: string | number | null | undefined): number {
+export function toBarValue(raw: string | number | null | undefined): number {
   if (raw === null || raw === undefined) {
     return Number.NaN;
   }

--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -24,17 +24,18 @@ const MISSING_TEXT = 'missing';
  * absent, which is what {@link isMeasured} and the text layer already read as
  * a gap. Mirrors `toBarValue` in `bar.ts`, for the same reasons.
  *
- * A negative slice is read as a gap too. {@link PiePoint.y} documents that a
- * negative value is not meaningful in a pie, and nothing upstream is obliged to
- * enforce that: left in, it subtracts from the total every other slice's share
- * is divided by, so a pie of 60, -40 and 30 announces its first slice as 120%
- * and the percentages stop summing to anything. Reading it as a gap is the
- * treatment this trace already has for a slice with nothing to report — out of
- * the total, out of the range, announced as missing — which tells the reader
- * about the one bad slice instead of quietly corrupting every other one.
+ * A negative slice keeps its sign. It used to be read as a gap, on the grounds
+ * that a negative is not meaningful in a pie — but the producer that emits one
+ * actually draws it: ggplot2's `geom_col` + `coord_polar` is a stacked bar bent
+ * into a circle, where a value below the baseline is ordinary, and it lays out
+ * `c(60, -40, 30)` as three wedges of 46.2%, 30.8% and 23.1%. Announcing that
+ * middle wedge as missing left a screen-reader user hearing two slices where a
+ * sighted reader sees three, with no percentage in common — the two cannot
+ * discuss the same chart. MAIDR conveys the chart; it does not correct it
+ * (#771).
  *
  * @param raw - The value from the slice
- * @returns The magnitude, or `NaN` when the slice is a gap
+ * @returns The value, or `NaN` when the slice is a gap
  */
 function toSliceValue(raw: number | string | null | undefined): number {
   if (raw === null || raw === undefined) {
@@ -43,9 +44,7 @@ function toSliceValue(raw: number | string | null | undefined): number {
   if (typeof raw === 'string' && raw.trim() === '') {
     return Number.NaN;
   }
-  const value = Number(raw);
-  // `NaN < 0` is false, so an unparseable value falls through unchanged.
-  return value < 0 ? Number.NaN : value;
+  return Number(raw);
 }
 
 /**
@@ -57,18 +56,28 @@ function toSliceValue(raw: number | string | null | undefined): number {
  * the one-decimal form used for real ratios, because nothing was rounded to
  * get there.
  *
- * @param value - The slice's magnitude, `NaN` when it is a gap
- * @param total - The sum of every measured slice
+ * The share is of the circle **as drawn**, so it divides by the sum of the
+ * absolute values rather than the signed total. That is the span a producer
+ * lays a pie out over: ggplot2 gives `c(60, -40, 30)` a range of 130, which is
+ * `60 + 40 + 30`, and draws the wedges at 46.2%, 30.8% and 23.1% of the
+ * circle. Dividing by the signed total (50) would announce shares no slice
+ * occupies and that sum to 260%.
+ *
+ * With no negatives the two bases are the same number, so every existing pie
+ * reports exactly what it reported before.
+ *
+ * @param value - The slice's value, `NaN` when it is a gap
+ * @param basis - The sum of the absolute values of every measured slice
  * @returns The percentage as display text, e.g. `33.3%`
  */
-function toPercentage(value: number, total: number): string {
+function toPercentage(value: number, basis: number): string {
   if (!isMeasured(value)) {
     return MISSING_TEXT;
   }
-  if (total === 0) {
+  if (basis === 0) {
     return '0%';
   }
-  return `${((value / total) * 100).toFixed(1)}%`;
+  return `${((Math.abs(value) / basis) * 100).toFixed(1)}%`;
 }
 
 /**
@@ -130,6 +139,8 @@ export class PieTrace extends AbstractTrace {
   private readonly min: number;
   private readonly max: number;
   private readonly total: number;
+  private readonly shareBasis: number;
+  private readonly hasNegative: boolean;
 
   protected readonly supportsExtrema = false;
 
@@ -153,11 +164,15 @@ export class PieTrace extends AbstractTrace {
     this.min = MathUtil.safeMin(measured);
     this.max = MathUtil.safeMax(measured);
     this.total = measured.reduce((sum, value) => sum + value, 0);
+    // What the circle is divided into, which is not the total once a slice is
+    // negative: the wedge for -40 occupies 40 of the circle, not -40 of it.
+    this.shareBasis = measured.reduce((sum, value) => sum + Math.abs(value), 0);
+    this.hasNegative = measured.some(value => value < 0);
 
     // Derived once here, not per state read: the state getters are called on
     // every navigation step (and again by getStateAt for monitor mode), and
     // they must stay cheap and side-effect free.
-    this.percentages = values.map(value => toPercentage(value, this.total));
+    this.percentages = values.map(value => toPercentage(value, this.shareBasis));
 
     this.highlightValues = this.mapToSvgElements(layer.selectors as string);
     this.movable = new MovableGrid<PiePoint>(this.points);
@@ -239,6 +254,19 @@ export class PieTrace extends AbstractTrace {
       { label: 'Max value', value: hasMeasured ? this.max : MISSING_TEXT },
       { label: 'Total', value: hasMeasured ? this.total : MISSING_TEXT },
     ];
+
+    // Said here rather than on every move, and here rather than in the cue for
+    // entering a subplot: a single-panel pie is never entered from a lobby, so
+    // a caveat placed there would be heard only in multi-panel figures. This
+    // is the one summary every layout can reach, on `d`.
+    if (this.hasNegative) {
+      stats.push({
+        label: 'Note',
+        value:
+          'This pie contains a negative value, so a slice cannot be a share of '
+          + `the total. Percentages are shares of the circle as drawn, out of ${this.shareBasis}.`,
+      });
+    }
 
     const headers = [this.xAxis, this.yAxis, PERCENTAGE_LABEL];
     // A gap is spelled out rather than left as the NaN the dialog would blank:

--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -2,10 +2,11 @@ import type { MaidrLayer, PiePoint } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
+import { defaultFormat } from '@util/format';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
-import { isMeasured } from './bar';
+import { isMeasured, toBarValue } from './bar';
 import { MovableGrid } from './movable';
 
 /** Label the percentage rides under in text and in the data table. */
@@ -13,39 +14,6 @@ const PERCENTAGE_LABEL = 'Percentage';
 
 /** How a gap is named wherever a slice has no measurement to report. */
 const MISSING_TEXT = 'missing';
-
-/**
- * Reads one slice's magnitude, keeping a gap distinguishable from a zero.
- *
- * {@link PiePoint.y} is declared numeric, but it arrives from parsed JSON: a
- * producer with no measurement for a slice emits `null`, and `Number(null)` is
- * `0`. A zero slice is a real measurement — it counts toward the total and can
- * be the minimum — so an absent one must not collapse into it. `NaN` keeps it
- * absent, which is what {@link isMeasured} and the text layer already read as
- * a gap. Mirrors `toBarValue` in `bar.ts`, for the same reasons.
- *
- * A negative slice keeps its sign. It used to be read as a gap, on the grounds
- * that a negative is not meaningful in a pie — but the producer that emits one
- * actually draws it: ggplot2's `geom_col` + `coord_polar` is a stacked bar bent
- * into a circle, where a value below the baseline is ordinary, and it lays out
- * `c(60, -40, 30)` as three wedges of 46.2%, 30.8% and 23.1%. Announcing that
- * middle wedge as missing left a screen-reader user hearing two slices where a
- * sighted reader sees three, with no percentage in common — the two cannot
- * discuss the same chart. MAIDR conveys the chart; it does not correct it
- * (#771).
- *
- * @param raw - The value from the slice
- * @returns The value, or `NaN` when the slice is a gap
- */
-function toSliceValue(raw: number | string | null | undefined): number {
-  if (raw === null || raw === undefined) {
-    return Number.NaN;
-  }
-  if (typeof raw === 'string' && raw.trim() === '') {
-    return Number.NaN;
-  }
-  return Number(raw);
-}
 
 /**
  * Formats one slice's share of the whole.
@@ -153,7 +121,15 @@ export class PieTrace extends AbstractTrace {
 
     this.points = [layer.data as PiePoint[]];
 
-    const values = this.points[0].map(point => toSliceValue(point.y));
+    // `toBarValue` and not a pie-specific reader: a negative slice keeps its
+    // sign, and once it does the two are the same function. It used to be read
+    // as a gap, on the grounds that a negative is not meaningful in a pie --
+    // but the producer that emits one draws it. `geom_col` + `coord_polar` is
+    // a stacked bar bent into a circle, where a value below the baseline is
+    // ordinary, and it lays `c(60, -40, 30)` out as three wedges. Calling the
+    // middle one missing left a screen-reader user hearing two slices where a
+    // sighted reader sees three, with no figure in common (#771).
+    const values = this.points[0].map(point => toBarValue(point.y));
     this.sliceValues = [values];
 
     // A gap is not a measurement, so it must take part in neither the range
@@ -264,7 +240,8 @@ export class PieTrace extends AbstractTrace {
         label: 'Note',
         value:
           'This pie contains a negative value, so a slice cannot be a share of '
-          + `the total. Percentages are shares of the circle as drawn, out of ${this.shareBasis}.`,
+          + 'the total. Percentages are shares of the circle as drawn, out of '
+          + `${defaultFormat(this.shareBasis)}.`,
       });
     }
 

--- a/test/model/pie.test.ts
+++ b/test/model/pie.test.ts
@@ -243,6 +243,21 @@ describe('pie slices with a negative value', () => {
     expect(String(statValue(stats, 'Note'))).toContain('130');
   });
 
+  it('rounds the basis in the note, like every other number in the summary', () => {
+    // `roundCell` formats a stat before it reaches the dialog, but only when
+    // the stat *is* a number -- this one is a finished sentence, so the number
+    // inside it has to be formatted here or it arrives raw. 10.1 + 20.2 + 5.3
+    // is 35.599999999999994 in binary floating point, and announcing that in
+    // the one sentence meant to reconcile the others would undo the point of
+    // it.
+    const trace = new PieTrace(pieLayer([10.1, -20.2, 5.3]));
+
+    const note = String(statValue(trace.description.stats, 'Note'));
+
+    expect(note).toContain('35.6');
+    expect(note).not.toContain('35.599999999999994');
+  });
+
   it('leaves an all-positive pie exactly as it was', () => {
     const trace = new PieTrace(pieLayer([30, 50, 20]));
 

--- a/test/model/pie.test.ts
+++ b/test/model/pie.test.ts
@@ -186,48 +186,73 @@ describe('pie slice percentages', () => {
 });
 
 /**
- * `PiePoint.y` documents that a negative value is not meaningful in a pie, and
- * nothing upstream is obliged to reject one. Left in, it subtracts from the
- * total every other slice's share is divided by, so the renderer reads it as
- * the gap it effectively is.
+ * A negative slice keeps its sign and its drawn share.
+ *
+ * It used to be read as a gap, which protected the other slices' percentages
+ * but cost more than it saved: the producer that emits a negative *draws* it.
+ * ggplot2's `geom_col` + `coord_polar` lays `c(60, -40, 30)` out over a span
+ * of 130 and draws three wedges at 46.2%, 30.8% and 23.1%. Calling the middle
+ * one missing left a screen-reader user hearing two slices where a sighted
+ * reader sees three, with no number in common (#771).
+ *
+ * So the share divides by the sum of the absolute values -- the circle as
+ * drawn -- and the caveat that these are not shares of a total is carried by
+ * the chart description rather than by dropping the slice.
  */
 describe('pie slices with a negative value', () => {
-  it('divides the measured slices by a total the negative took no part in', () => {
+  it('gives every slice the share it is actually drawn at', () => {
     const trace = new PieTrace(pieLayer([60, -40, 30]));
 
-    // Counting the -40 leaves a total of 50, which announces the first slice
-    // as 120% — a share of the whole that cannot exist.
-    expect(shareAtSlice(trace, 0)).toBe('66.7%');
-    expect(shareAtSlice(trace, 2)).toBe('33.3%');
+    // 60, 40 and 30 out of a span of 130 -- the figures ggplot2 lays out.
+    expect(shareAtSlice(trace, 0)).toBe('46.2%');
+    expect(shareAtSlice(trace, 1)).toBe('30.8%');
+    expect(shareAtSlice(trace, 2)).toBe('23.1%');
   });
 
-  it('reads the negative slice itself as missing', () => {
+  it('announces the negative slice with its sign, not as missing', () => {
     const trace = new PieTrace(pieLayer([60, -40, 30]));
 
     const { text } = stateAtSlice(trace, 1);
 
-    expect(shareAtSlice(trace, 1)).toBe('missing');
-    expect(Number.isFinite(text.cross.value as number)).toBe(false);
+    expect(text.cross.value).toBe(-40);
   });
 
-  it('keeps the negative out of the range the other slices are scaled against', () => {
+  it('scales the pitch over a range that includes the negative', () => {
     const trace = new PieTrace(pieLayer([60, -40, 30]));
 
     const { audio } = stateAtSlice(trace, 0);
 
-    expect(audio.freq.min).toBe(30);
+    // The lowest slice sounds lowest, which is the honest reading of a value
+    // below the baseline rather than a slice excluded from the sweep.
+    expect(audio.freq.min).toBe(-40);
     expect(audio.freq.max).toBe(60);
   });
 
-  it('leaves it out of the described range and total as well', () => {
+  it('reports the signed total, and says why it is not the share basis', () => {
     const trace = new PieTrace(pieLayer([60, -40, 30]));
 
     const { stats } = trace.description;
 
     expect(statValue(stats, 'Number of slices')).toBe(3);
-    expect(statValue(stats, 'Min value')).toBe(30);
+    expect(statValue(stats, 'Min value')).toBe(-40);
     expect(statValue(stats, 'Max value')).toBe(60);
-    expect(statValue(stats, 'Total')).toBe(90);
+    // The arithmetic total of the data, which is not what the circle is
+    // divided into -- hence the note.
+    expect(statValue(stats, 'Total')).toBe(50);
+    expect(String(statValue(stats, 'Note'))).toContain('negative');
+    expect(String(statValue(stats, 'Note'))).toContain('130');
+  });
+
+  it('leaves an all-positive pie exactly as it was', () => {
+    const trace = new PieTrace(pieLayer([30, 50, 20]));
+
+    const { stats } = trace.description;
+
+    // With no negatives the two bases are the same number, so nothing moves --
+    // and no note is added to a chart that has nothing to caveat.
+    expect(shareAtSlice(trace, 0)).toBe('30.0%');
+    expect(statValue(stats, 'Total')).toBe(100);
+    expect(statValue(stats, 'Note')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Description

Closes #771.

A negative slice was read as a gap — announced `missing`, kept out of the total and the range. That protected every *other* slice's percentage, which was the point of #772. But the decision was made without checking whether the slice is drawn, and **it is**.

## Related Issues

Closes #771. Follows #772 (which introduced the gap treatment) and xability/r-maidr#118 (which stopped the producer laundering the sign, so the value now arrives intact).

## Changes Made

`geom_col` + `coord_polar` is not a pie — it is a **stacked bar bent into a circle**, where a value below the baseline is ordinary. ggplot2 has nothing to object to, and lays `c(60, -40, 30)` out like this:

```
      ymin  ymax  extent    drawn share
A       30    90      60          46.2%
B      -40     0      40          30.8%
C        0    30      30          23.1%
total span 130
```

Against that, MAIDR announced **60 at 66.7%, missing, 30 at 33.3%** — two slices where three are drawn, and not one figure in common with what is on screen. Two people at the same screen could not discuss the same chart. For an accessibility tool that is a worse failure than the corrupted percentages the gap treatment was avoiding.

So:

- **The value keeps its sign** — `Units is -40`.
- **The share is of the circle as drawn** — divided by the sum of the absolute values, which is exactly the span a producer lays a pie out over. Dividing by the signed total (50) would announce shares no slice occupies, summing to 260%.
- **The caveat lives in the chart description**, not in the per-slice announcement, which is read on every move and already at the length where extra words cost more than they carry.

**On where the caveat went.** I had proposed announcing it once on entering the trace. Checking the code first showed that does not work: the entry cue is built by `TextService.subplotEntryText` from the figure lobby, and **a single-panel pie is never entered from a lobby** — the caveat would have been heard only in multi-panel figures. The chart description is the one summary every layout can reach.

**Nothing changes for the other producers**, both of which refuse a negative before MAIDR sees it — verified rather than assumed:

```
matplotlib   ValueError: Wedge sizes 'x' must be non negative values
graphics::pie  'x' values must be positive
```

**An all-positive pie is untouched.** With no negatives Σ|v| = Σv, so every existing chart reports exactly what it reported before — pinned by a test.

## Screenshots (if applicable)

Chromium, against a real ggplot2 chart rendered through r-maidr with this build swapped in:

```
f is A, Units is 60, Percentage is 46.2%
f is B, Units is -40, Percentage is 30.8%
f is C, Units is 30, Percentage is 23.1%
```

and `d`:

```
Number of slices: 3
Min value: -40
Max value: 60
Total: 50
Note: This pie contains a negative value, so a slice cannot be a share of the
      total. Percentages are shares of the circle as drawn, out of 130.
```

The three percentages are the three ggplot2 draws, to the decimal. No console errors.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm run build` | all builds pass |
| `npm test` | **1835 + 73** (was 1834 + 73) |

The four existing tests under *"pie slices with a negative value"* stated the old policy directly — `expect(shareAtSlice(trace, 1)).toBe('missing')`, `expect(audio.freq.min).toBe(30)`. They were **rewritten to state the new contract, not deleted**, so the file still documents what happens to a negative rather than falling silent about it. A fifth was added pinning that an all-positive pie is unchanged, which is the regression that would matter most.

**Not a breaking change under this repo's release config**, and worth saying why rather than leaving it to inference: it alters announced output, but `NavigateCallback`-style API surface is untouched, so `fix:` is the honest type. The percentages a user hears for a chart containing a negative *do* change — that is the fix.

`Total` deliberately stays the signed sum (50) rather than becoming the share basis (130). It is the arithmetic total of the data, which is a true and useful number; the note is what reconciles it with the percentages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_