### PR TITLE
feat(pie): pan a slice by where it sits on the dial

### DIFF
--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -49,6 +49,39 @@ function toPercentage(value: number, basis: number): string {
 }
 
 /**
+ * Where each slice sits on the dial, in radians clockwise from 12 o'clock.
+ *
+ * The angle a slice occupies is its share of the circle, so the midpoint of
+ * slice *i* is everything before it plus half of itself. Producers lay a pie
+ * out from 12 o'clock going clockwise — matplotlib, `graphics::pie`, ggplot2's
+ * `coord_polar`, amCharts and AnyChart all do — so that is the origin used
+ * here. The payload states no start angle, so a producer that ever laid one
+ * out differently would pan the wrong way round; that is a grammar question,
+ * noted in #780.
+ *
+ * A gap occupies no angle, having contributed nothing to the basis. It still
+ * gets a midpoint — wherever the sweep has reached — so panning it is
+ * meaningful rather than `NaN`.
+ *
+ * @param values - Every slice's value, `NaN` for a gap
+ * @param basis - The sum of the absolute values of the measured slices
+ * @returns One angle per slice, in the same order
+ */
+function toMidAngles(values: readonly number[], basis: number): number[] {
+  if (basis === 0) {
+    // Nothing is drawn, so every slice sits at 12 o'clock and pans centre.
+    return values.map(() => 0);
+  }
+  let swept = 0;
+  return values.map((value) => {
+    const share = isMeasured(value) ? Math.abs(value) / basis : 0;
+    const mid = swept + share / 2;
+    swept += share;
+    return mid * 2 * Math.PI;
+  });
+}
+
+/**
  * Whether a screen-space point falls inside an element's filled geometry.
  *
  * `isPointInFill` works in the element's own user space, so the point has to be
@@ -109,6 +142,8 @@ export class PieTrace extends AbstractTrace {
   private readonly total: number;
   private readonly shareBasis: number;
   private readonly hasNegative: boolean;
+  /** Each slice's angular midpoint, radians clockwise from 12 o'clock. */
+  private readonly midAngles: number[];
 
   protected readonly supportsExtrema = false;
 
@@ -149,6 +184,7 @@ export class PieTrace extends AbstractTrace {
     // every navigation step (and again by getStateAt for monitor mode), and
     // they must stay cheap and side-effect free.
     this.percentages = values.map(value => toPercentage(value, this.shareBasis));
+    this.midAngles = toMidAngles(values, this.shareBasis);
 
     this.highlightValues = this.mapToSvgElements(layer.selectors as string);
     this.movable = new MovableGrid<PiePoint>(this.points);
@@ -171,6 +207,16 @@ export class PieTrace extends AbstractTrace {
     // Pitch maps the raw magnitude, not the percentage. The two are a monotone
     // rescale of each other, so the pitch ordering is identical either way, and
     // the raw value keeps audio agreeing with braille and the reported stats.
+    //
+    // The pan follows the slice around the dial rather than its index. Panning
+    // by index is what a bar chart does -- hard left to hard right, a straight
+    // line -- and it made a pie sound like one. `AudioService` reads the pan as
+    // `interpolate(x, 0, cols - 1, -1, 1)`, so `cols: 2` makes the mapping
+    // `2x - 1` and `x = (sin θ + 1) / 2` lands the pan on `sin θ` exactly:
+    // 12 o'clock centre, 3 o'clock hard right, 6 o'clock centre again, 9
+    // o'clock hard left. Sweeping the slices now goes out and comes back,
+    // which is what distinguishes a circle from a row.
+    const pan = Math.sin(this.midAngles[this.col]);
     return {
       freq: {
         min: this.min,
@@ -178,10 +224,10 @@ export class PieTrace extends AbstractTrace {
         raw: this.sliceValues[this.row][this.col],
       },
       panning: {
-        x: this.col,
+        x: (pan + 1) / 2,
         y: 0,
         rows: 1,
-        cols: this.sliceValues[this.row].length,
+        cols: 2,
       },
     };
   }

--- a/src/model/pie.ts
+++ b/src/model/pie.ts
@@ -114,7 +114,11 @@ function containsScreenPoint(element: SVGElement, x: number, y: number): boolean
 }
 
 /**
- * A pie chart: N slices read as one row, left and right.
+ * A pie chart: N slices stepped through one at a time, left and right.
+ *
+ * They are one row to navigate and a circle to listen to — the pan follows
+ * each slice around the dial rather than along the row, so a sweep goes out
+ * and comes back.
  *
  * Extends {@link AbstractTrace} directly rather than `AbstractBarPlot`, which
  * bakes an orientation into its bar values, audio panning, text axes and

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -160,6 +160,17 @@ export interface AudioState {
     max: number;
     raw: number | number[];
   };
+  /**
+   * Stereo position, read by `AudioService` as
+   * `interpolate(x, 0, cols - 1, -1, 1)` and clamped to that range.
+   *
+   * `x` and `cols` are usually a column index and a column count, which pans a
+   * trace left to right. They are not required to be: what the service needs
+   * is a position and the range to read it against. `PieTrace` supplies
+   * `cols: 2` and a fractional `x` so the pan follows a slice around the dial
+   * rather than along a row — a circle sweeps out and back, which an index
+   * cannot express.
+   */
   panning: {
     y: number;
     x: number;

--- a/test/model/pie.test.ts
+++ b/test/model/pie.test.ts
@@ -70,12 +70,49 @@ describe('pie trace audio', () => {
     expect(audio.freq.raw).toBe(20);
   });
 
-  it('pans across the slices as a single row', () => {
-    const trace = new PieTrace(pieLayer([30, 50, 20]));
+  it('pans by where the slice sits on the dial, not by its index', () => {
+    // `AudioService` reads the pan as `interpolate(x, 0, cols - 1, -1, 1)`, so
+    // `cols: 2` makes it `2x - 1`: x of 1 is hard right, 0 is hard left, 0.5
+    // is centre. Two equal slices put the first midpoint at 3 o'clock and the
+    // second at 9 o'clock, which is the cleanest statement of the mapping.
+    const trace = new PieTrace(pieLayer([50, 50]));
 
-    const { audio } = stateAtSlice(trace, 1);
+    expect(stateAtSlice(trace, 0).audio.panning).toEqual({ x: 1, y: 0, rows: 1, cols: 2 });
+    expect(stateAtSlice(trace, 1).audio.panning.x).toBeCloseTo(0, 10);
+  });
 
-    expect(audio.panning).toEqual({ x: 1, y: 0, rows: 1, cols: 3 });
+  it('brings the pan back to centre at the bottom of the circle', () => {
+    // One slice fills the dial, so its midpoint is 6 o'clock. Panning by index
+    // would put a lone slice hard left; a circle puts it back in the middle,
+    // and that difference is the whole point of the change.
+    const trace = new PieTrace(pieLayer([100]));
+
+    expect(stateAtSlice(trace, 0).audio.panning.x).toBeCloseTo(0.5, 10);
+  });
+
+  it('sweeps out and back rather than left to right', () => {
+    // Four equal slices: 1.5, 4.5, 7.5 and 10.5 o'clock. A row would step
+    // evenly from -1 to 1; a circle rises to the right, returns, and mirrors.
+    const trace = new PieTrace(pieLayer([1, 1, 1, 1]));
+
+    const pans = [0, 1, 2, 3].map(i => stateAtSlice(trace, i).audio.panning.x);
+
+    expect(pans[0]).toBeCloseTo(pans[1], 10);
+    expect(pans[2]).toBeCloseTo(pans[3], 10);
+    expect(pans[0]).toBeGreaterThan(0.5);
+    expect(pans[2]).toBeLessThan(0.5);
+  });
+
+  it('gives a gap no angle of its own', () => {
+    // A gap is drawn as nothing, so it consumes no arc: the slices around it
+    // sit exactly where they would if it were not in the data at all.
+    const withGap = new PieTrace(pieLayer([50, null, 50]));
+    const without = new PieTrace(pieLayer([50, 50]));
+
+    expect(stateAtSlice(withGap, 0).audio.panning.x)
+      .toBeCloseTo(stateAtSlice(without, 0).audio.panning.x, 10);
+    expect(stateAtSlice(withGap, 2).audio.panning.x)
+      .toBeCloseTo(stateAtSlice(without, 1).audio.panning.x, 10);
   });
 
   it('keeps a gap out of the range so it cannot drag an endpoint', () => {


### PR DESCRIPTION
# Pull Request

> [!NOTE]
> **Stacked on #781** — the base branch is `claude/pie-negative-share-jh7gl6`, not `main`. The angles are computed against the same absolute-value basis #781 introduces, and building them separately would have meant two PRs each adding their own copy of that sum, then conflicting. Merge #781 first; this retargets to `main` on its own. The diff against #781 is `src/model/pie.ts` and its test only.

## Description

Refs #780.

A pie sounded like a bar chart. `panning.x` was the slice **index** against `cols = number of slices`, so the sweep ran hard left to hard right in a straight line. The one thing that makes a pie a pie was present in the visual highlight and in no other modality.

## Related Issues

Refs #780. Raised from the question of how a screen-reader user is meant to know where they are in the circle — the honest answer being that they could not.

## Changes Made

`AudioService` reads the pan as:

```ts
interpolate(panning.x, 0, panning.cols - 1, -1, 1)
```

so `cols: 2` makes the mapping `2x - 1`, and `x = (sin θ + 1) / 2` lands the pan on `sin θ` exactly:

| Slice midpoint | θ | pan |
|---|---|---|
| 12 o'clock | 0 | 0 — centre |
| 3 o'clock | π/2 | +1 — hard right |
| 6 o'clock | π | 0 — centre again |
| 9 o'clock | 3π/2 | −1 — hard left |

θ is the slice's angular midpoint — everything swept before it, plus half of itself — clockwise from 12 o'clock. **A sweep of the slices now goes out and comes back**, which is the difference between hearing a circle and hearing a row.

The clearest case is a single slice: by index it panned **hard left**, and it is now **centre**, because one slice fills the dial and its midpoint is 6 o'clock.

A gap consumes no arc, having contributed nothing to the basis, so the slices either side sit exactly where they would if it were absent from the data.

## Scope

Only the panning half of #780. The other half — announcing the clock position on `p` — is left out deliberately: `AnnouncePositionCommand` reads `TraceState`, which carries no angular information, so it needs either a grammar addition or a new field, and that is a design decision rather than a line change. Filed thinking in #780.

Also recorded there, and worth repeating because it bounds this change too: **the payload states no start angle.** Clockwise-from-12 is the convention of every producer wired up so far, not something `PiePoint` declares. A producer laying a pie out counter-clockwise would pan the wrong way round, and nothing here would know.

## Screenshots (if applicable)

n/a — the change is audible, not visual. The cardinal positions are pinned by test rather than by listening.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm run build` | all builds pass |
| `npm test` | **1838 + 73** (was 1835 + 73 on #781) |

The existing `pans across the slices as a single row` asserted the old mapping literally (`{ x: 1, y: 0, rows: 1, cols: 3 }`). It was rewritten rather than deleted, and three cases added around it, chosen so the arithmetic is checkable by eye rather than by trusting a decimal:

- **two equal slices** → midpoints at 3 and 9 o'clock → pan exactly `+1` then `−1`;
- **one slice** → midpoint at 6 o'clock → back to centre;
- **four equal slices** → symmetric pairs, rising right then mirroring left;
- **a gap** → the slices around it land where they would without it.

**Verified all four bite:** with the index mapping restored, `4 failed, 34 passed`.

`feat:` rather than `fix:` — nothing was broken, and a listener who has learned the old left-to-right sweep will notice the change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_