### PR TITLE
docs: document the cdnjs mirror now that the listing is live

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ To use maidr, follow these steps:
    </html>
    ```
 
+   maidr is also served by [cdnjs](https://cdnjs.com/libraries/maidr), which matters when a page cannot reach jsDelivr: sandboxed embedding contexts allow a fixed set of CDN hosts, and a page whose `script-src` names `cdnjs.cloudflare.com` cannot load maidr from jsDelivr however well jsDelivr works everywhere else.
+
+   ```html
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/maidr/3.75.1/maidr.min.js"></script>
+   ```
+
+   cdnjs serves no floating alias, so that URL names a version and stays on it until you change it — [the library page](https://cdnjs.com/libraries/maidr) lists the current one. Only `maidr.js` is mirrored there, not the per-chart-library adapter bundles the guides below use; those load from jsDelivr.
+
 3. **Add your data**: Define the maidr JSON schema for your plot. See the [Data Schema](docs/SCHEMA.md) documentation for the full schema structure, object properties, and data formats for each plot type.
 
 ## Data Schema

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To use maidr, follow these steps:
 
    That URL names a version, because cdnjs serves no floating alias: it stays on 3.75.1 until someone changes it, and [the library page](https://cdnjs.com/libraries/maidr) lists the current release.
 
-   Only `maidr.js` is mirrored on cdnjs. The per-chart-library adapter bundles the guides below use — `anychart.mjs`, `chartjs.js` and the rest — are not, so those examples load from jsDelivr.
+   `maidr.js` is the only script mirrored on cdnjs, which decides where each guide below can load from. The [D3](docs/d3.md) and [Plotly](docs/plotly.md) guides use it on its own, so they work from cdnjs unchanged. The rest also load a per-chart-library adapter bundle — `anychart.mjs`, `chartjs.js`, `highcharts.js` and so on — and those are not mirrored, so those examples load from jsDelivr.
 
 3. **Add your data**: Define the maidr JSON schema for your plot. See the [Data Schema](docs/SCHEMA.md) documentation for the full schema structure, object properties, and data formats for each plot type.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To use maidr, follow these steps:
 
    That URL names a version, because cdnjs serves no floating alias: it stays on 3.75.1 until someone changes it, and [the library page](https://cdnjs.com/libraries/maidr) lists the current release.
 
-   `maidr.js` is the only script mirrored on cdnjs, which decides where each guide below can load from. The [D3](docs/d3.md) and [Plotly](docs/plotly.md) guides use it on its own, so they work from cdnjs unchanged. The rest also load a per-chart-library adapter bundle — `anychart.mjs`, `chartjs.js`, `highcharts.js` and so on — and those are not mirrored, so those examples load from jsDelivr.
+   `maidr.js` is the only script mirrored on cdnjs, which decides how much of a guide below cdnjs can serve. The [Plotly](docs/plotly.md) guide needs nothing else from maidr — Plotly charts are detected without help — so swapping in the URL above covers its whole maidr side. Every other guide also loads a per-chart-library adapter bundle (`d3.js`, `anychart.mjs`, `chartjs.js`, `highcharts.js` and so on) to bind the chart, and those are not mirrored, so they load from jsDelivr. The charting library itself is separate again: each guide names its own CDN, and most are on cdnjs too.
 
 3. **Add your data**: Define the maidr JSON schema for your plot. See the [Data Schema](docs/SCHEMA.md) documentation for the full schema structure, object properties, and data formats for each plot type.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To use maidr, follow these steps:
 
    That URL names a version, because cdnjs serves no floating alias: it stays on 3.75.1 until someone changes it, and [the library page](https://cdnjs.com/libraries/maidr) lists the current release.
 
-   `maidr.js` is the only script mirrored on cdnjs, which decides how much of a guide below cdnjs can serve. The [Plotly](docs/plotly.md) guide needs nothing else from maidr — Plotly charts are detected without help — so swapping in the URL above covers its whole maidr side. Every other guide also loads a per-chart-library adapter bundle (`d3.js`, `anychart.mjs`, `chartjs.js`, `highcharts.js` and so on) to bind the chart, and those are not mirrored, so they load from jsDelivr. The charting library itself is separate again: each guide names its own CDN, and most are on cdnjs too.
+   `maidr.js` is the only script mirrored on cdnjs, which decides how much of a guide below cdnjs can serve. The [Plotly](docs/plotly.md) guide needs nothing else from maidr — Plotly charts are detected without help — so swapping in the URL above covers its whole maidr side. Every other guide also loads a per-chart-library adapter bundle (`d3.js`, `anychart.mjs`, `chartjs.js`, `highcharts.js` and so on) to bind the chart, and those are not mirrored, so they load from jsDelivr. Where the charting library itself comes from is a third question, which each guide answers for itself.
 
 3. **Add your data**: Define the maidr JSON schema for your plot. See the [Data Schema](docs/SCHEMA.md) documentation for the full schema structure, object properties, and data formats for each plot type.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ To use maidr, follow these steps:
    <script src="https://cdnjs.cloudflare.com/ajax/libs/maidr/3.75.1/maidr.min.js"></script>
    ```
 
-   cdnjs serves no floating alias, so that URL names a version and stays on it until you change it — [the library page](https://cdnjs.com/libraries/maidr) lists the current one. Only `maidr.js` is mirrored there, not the per-chart-library adapter bundles the guides below use; those load from jsDelivr.
+   That URL names a version, because cdnjs serves no floating alias: it stays on 3.75.1 until someone changes it, and [the library page](https://cdnjs.com/libraries/maidr) lists the current release.
+
+   Only `maidr.js` is mirrored on cdnjs. The per-chart-library adapter bundles the guides below use — `anychart.mjs`, `chartjs.js` and the rest — are not, so those examples load from jsDelivr.
 
 3. **Add your data**: Define the maidr JSON schema for your plot. See the [Data Schema](docs/SCHEMA.md) documentation for the full schema structure, object properties, and data formats for each plot type.
 

--- a/cdnjs/README.md
+++ b/cdnjs/README.md
@@ -121,7 +121,20 @@ goes stale at the next release, and those pages are mostly about adapter
 bundles that are not mirrored at all. One pinned URL in the README, next to
 the reason someone would want it, costs one edit per release instead of ten.
 
-Still worth checking after the next release: that
-`https://cdnjs.com/libraries/maidr` picks it up on its own. If it does not,
-the `autoupdate` block is wrong and needs another pull request to
-`cdnjs/packages`.
+## After each release
+
+Two things, neither automated:
+
+- **Bump the version in `README.md`'s cdnjs URL.** cdnjs serves no floating
+  alias, so that example names a release and keeps naming it. Nothing fails
+  when it goes stale — the URL still resolves, it just serves an older build
+  — which is what makes it easy to miss. semantic-release owns `package.json`
+  and this repo has no release checklist to hang the step on, so it is
+  written here, in the file about cdnjs upkeep. Pinning it to `package.json`
+  with a test would catch it, but semantic-release commits the bump itself
+  and the test would then fail on `main` after every release until someone
+  edited the README; making that safe means teaching the release job to
+  rewrite the URL, which is a change to the pipeline rather than to a doc.
+- **Check `https://cdnjs.com/libraries/maidr` picked the release up on its
+  own.** If it did not, the `autoupdate` block is wrong and needs another
+  pull request to `cdnjs/packages`.

--- a/cdnjs/README.md
+++ b/cdnjs/README.md
@@ -95,10 +95,33 @@ The test cannot see cdnjs. It checks that this file is right about _this_
 repository; whether cdnjs has been told about a change is still a matter of
 having opened that second pull request.
 
-## Once it is listed
+## It is listed
 
-- Add the cdnjs URLs alongside the jsDelivr ones in `README.md` and `docs/`.
-  Until then those URLs 404, so this is deliberately not done in advance.
-- Check `https://cdnjs.com/libraries/maidr` picks up the following release
-  automatically. If it does not, the `autoupdate` block is wrong and needs
-  another pull request to `cdnjs/packages`.
+The pull request to `cdnjs/packages` was merged and
+[the library](https://cdnjs.com/libraries/maidr) is live. What was verified
+once the files actually appeared, since each was a way this could have been
+quietly wrong:
+
+- `maidr.min.js` exists (1,866,505 bytes, and minified rather than a copy of
+  `maidr.js` at 1,893,803). cdnjs generates it, exactly as their
+  CONTRIBUTING.md commits to — so the `filename` in the manifest resolves and
+  does not need swapping for `maidr.js`.
+- `maidr-math.css` exists and is byte-identical to npm's, KaTeX rules and all.
+  This is the entry the notes above call easy to leave out and expensive to
+  get wrong: `src/util/katex.ts` resolves it against the URL `maidr.js` was
+  loaded from, so a page served from cdnjs would render LaTeX in AI chat
+  responses unstyled if the mirror lacked it.
+- `maidr.css` is the 406-byte placeholder, matching what the build emits.
+- Ten versions were backfilled (3.68.0 through 3.75.1), so `autoupdate` is
+  reading npm correctly rather than pinning the submitted version.
+
+`README.md` documents the cdnjs URL. The `docs/` guides deliberately do not:
+cdnjs serves no floating alias, so every mention is a hard-coded version that
+goes stale at the next release, and those pages are mostly about adapter
+bundles that are not mirrored at all. One pinned URL in the README, next to
+the reason someone would want it, costs one edit per release instead of ten.
+
+Still worth checking after the next release: that
+`https://cdnjs.com/libraries/maidr` picks it up on its own. If it does not,
+the `autoupdate` block is wrong and needs another pull request to
+`cdnjs/packages`.


### PR DESCRIPTION
# Pull Request

## Description

The `cdnjs/packages` pull request merged and [the library](https://cdnjs.com/libraries/maidr) is now serving, so the URLs `cdnjs/README.md` deliberately kept out of the docs — they would have 404ed — can go in. This is the "Once it is listed" follow-up that file wrote for itself.

## Related Issues

Follow-up to the cdnjs submission added in #713.

## Changes Made

**`README.md`** — the cdnjs URL, placed next to the reason someone would reach for it: a sandboxed embedding context whose `script-src` names `cdnjs.cloudflare.com` cannot load maidr from jsDelivr, however well jsDelivr works everywhere else. It also states the two constraints a reader would otherwise discover the hard way — the URL is version-pinned because cdnjs serves no floating alias, and only `maidr.js` is mirrored, not the adapter bundles the guides use.

**`cdnjs/README.md`** — "Once it is listed" becomes "It is listed", recording what was verified and what is still worth watching.

### Where this departs from the checklist, and why

The checklist said to add the URLs to `README.md` **and `docs/`**. I did the README only.

cdnjs serves no floating alias — every mention is a hard-coded version string. There are nine core `dist/maidr.js` sites across `docs/` (anychart, d3, frappe, google-charts, highcharts ×2, plotly, vegalite), so following it literally means ten version strings to bump at each release instead of one, in a repo that has just spent a release cycle on the cost of stale URLs.

Those pages are also mostly about adapter bundles — `anychart.mjs`, `chartjs.js`, `highcharts.js` and the rest — which cdnjs does **not** mirror, by design, since the manifest keeps its file globs narrow. Putting a cdnjs URL on a page's `maidr.js` line while its adapter line stays on jsDelivr invites exactly the 404 the narrow mirror was chosen to avoid. Saying "only `maidr.js` is mirrored" once, in the README, seemed better than implying otherwise nine times.

Happy to fan it out across `docs/` if you would rather have the letter of the checklist.

## Verification

Checked against the live mirror rather than assumed — each of these was a way the listing could have been quietly wrong:

| Check | Result |
|---|---|
| `maidr.min.js` exists | **Yes** — 1,866,505 bytes, and genuinely minified (`!function(e){"function"==typeof define…`) rather than a copy of `maidr.js` at 1,893,803. cdnjs generates it as their CONTRIBUTING.md commits to, so the manifest's `filename` resolves and does not need swapping for `maidr.js`. |
| `maidr-math.css` exists | **Yes** — 367,928 bytes, KaTeX rules intact, byte-identical to npm's. This is the entry `cdnjs/README.md` calls easy to leave out and expensive to get wrong: `src/util/katex.ts` resolves it against the URL `maidr.js` was loaded from, so a page served from cdnjs would render LaTeX in AI chat responses unstyled if the mirror lacked it. |
| `maidr.css` | 406-byte placeholder, matching what the build emits. |
| `autoupdate` working | Ten versions backfilled (3.68.0 → 3.75.1), so it is reading npm rather than pinning the submitted version. |
| Both URLs in the README | HTTP 200. |

## Checklist

- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have updated the documentation, if applicable.
- [ ] I have tested the changes locally following `ManualTestingProcess.md` — **not run**: this is a Markdown-only change touching no source, and `node_modules` is not installed in this environment. `test/cdnjs/manifest.test.ts` pins `cdnjs/maidr.json` against `package.json` and `scripts/build.js`, none of which this touches. CI covers it.
- [ ] I have added appropriate unit tests, if applicable — not applicable.

## Additional Notes

Prose in `README.md` is unwrapped to match its neighbours; `cdnjs/README.md` stays wrapped to match its own. Worth re-checking after the next release that <https://cdnjs.com/libraries/maidr> picks it up unaided — if it does not, the `autoupdate` block needs another pull request to `cdnjs/packages`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0195xCq4AQ6273n8yWCGv3t1)_