### PR TITLE
feat(pie): announce where a slice sits on the dial

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -879,10 +879,14 @@ export class AnnouncePositionCommand extends AnnounceCommand {
     if (Math.round((end - start) * 12) >= 12) {
       // A slice can be the whole dial -- a pie of one category, or one
       // category at 100%. Both ends then round to 12, and calling that a
-      // point would be the exact opposite of what it is. A slice within half
-      // an hour of the full turn reads the same way, since at this
-      // granularity it is the circle; the percentage carries the remainder.
-      where = 'the whole circle';
+      // point would be the exact opposite of what it is.
+      //
+      // A slice within half an hour of the full turn rounds the same way
+      // without being the same thing: the slices beside it still occupy arc,
+      // and "1 of 3, the whole circle" would contradict itself in one
+      // sentence. Only a slice that is the entire basis gets the plain
+      // reading.
+      where = end - start >= 1 ? 'the whole circle' : 'nearly the whole circle';
     } else if (startHour === endHour) {
       // A slice too thin to span an hour reads as a point rather than as a
       // range from a position to itself.

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -607,10 +607,6 @@ export class AnnouncePointCommand extends AnnounceCommand {
 }
 
 /**
- * Command to announce the current position in the chart.
- * Formats output based on text mode (terse/verbose) and chart type.
- */
-/**
  * Turns a fraction of the way round the dial into a clock hour.
  *
  * Twelve o'clock is both the origin and the full turn, so a fraction of 0 and
@@ -624,6 +620,10 @@ function toClockHour(fraction: number): number {
   return hour === 0 ? 12 : hour;
 }
 
+/**
+ * Command to announce the current position in the chart.
+ * Formats output based on text mode (terse/verbose) and chart type.
+ */
 export class AnnouncePositionCommand extends AnnounceCommand {
   /**
    * Creates an instance of AnnouncePositionCommand.
@@ -829,10 +829,6 @@ export class AnnouncePositionCommand extends AnnounceCommand {
   }
 
   /**
-   * Announces position for segmented bar charts (stacked, normalized, dodged).
-   * Shows column position and level information.
-   */
-  /**
    * Announces where a pie slice sits on the dial, as clock positions.
    *
    * "Position is 2 of 3" says which slice; it does not say where it is, and a
@@ -879,11 +875,21 @@ export class AnnouncePositionCommand extends AnnounceCommand {
 
     const startHour = toClockHour(start);
     const endHour = toClockHour(end);
-    // A slice too thin to span an hour reads as a point rather than as a
-    // range from a position to itself.
-    const where = startHour === endHour
-      ? `at ${startHour} o'clock`
-      : `from ${startHour} o'clock to ${endHour} o'clock`;
+    let where: string;
+    if (Math.round((end - start) * 12) >= 12) {
+      // A slice can be the whole dial -- a pie of one category, or one
+      // category at 100%. Both ends then round to 12, and calling that a
+      // point would be the exact opposite of what it is. A slice within half
+      // an hour of the full turn reads the same way, since at this
+      // granularity it is the circle; the percentage carries the remainder.
+      where = 'the whole circle';
+    } else if (startHour === endHour) {
+      // A slice too thin to span an hour reads as a point rather than as a
+      // range from a position to itself.
+      where = `at ${startHour} o'clock`;
+    } else {
+      where = `from ${startHour} o'clock to ${endHour} o'clock`;
+    }
 
     if (this.textService.isTerse() || this.textService.isOff()) {
       this.textViewModel.update(where);
@@ -892,6 +898,10 @@ export class AnnouncePositionCommand extends AnnounceCommand {
     }
   }
 
+  /**
+   * Announces position for segmented bar charts (stacked, normalized, dodged).
+   * Shows column position and level information.
+   */
   private announceSegmentedBarPosition(state: NonEmptyTraceState, x: number, cols: number): void {
     const level = state.text.z?.value ?? '';
     const position = x + 1;

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -5,7 +5,7 @@ import type { HighlightService } from '@service/highlight';
 import type { TextService } from '@service/text';
 import type { BrailleViewModel } from '@state/viewModel/brailleViewModel';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
-import type { BoxBrailleState, LineBrailleState, NonEmptyTraceState } from '@type/state';
+import type { BarBrailleState, BoxBrailleState, LineBrailleState, NonEmptyTraceState } from '@type/state';
 import type { Command } from './command';
 import { focusedSubplotTitle } from '@model/plot';
 import { Scope } from '@type/event';
@@ -610,6 +610,20 @@ export class AnnouncePointCommand extends AnnounceCommand {
  * Command to announce the current position in the chart.
  * Formats output based on text mode (terse/verbose) and chart type.
  */
+/**
+ * Turns a fraction of the way round the dial into a clock hour.
+ *
+ * Twelve o'clock is both the origin and the full turn, so a fraction of 0 and
+ * a fraction of 1 both read as 12 rather than one of them reading as 0.
+ *
+ * @param fraction - How far round the circle, from 0 at 12 o'clock
+ * @returns The hour, 1 through 12
+ */
+function toClockHour(fraction: number): number {
+  const hour = Math.round(fraction * 12) % 12;
+  return hour === 0 ? 12 : hour;
+}
+
 export class AnnouncePositionCommand extends AnnounceCommand {
   /**
    * Creates an instance of AnnouncePositionCommand.
@@ -662,6 +676,8 @@ export class AnnouncePositionCommand extends AnnounceCommand {
 
     if (traceType === TraceType.BOX) {
       this.announceBoxplotPosition(state);
+    } else if (traceType === TraceType.PIE) {
+      this.announcePiePosition(state);
     } else if (traceType === TraceType.CANDLESTICK) {
       this.announceCandlestickPosition(state);
     } else if (
@@ -816,6 +832,66 @@ export class AnnouncePositionCommand extends AnnounceCommand {
    * Announces position for segmented bar charts (stacked, normalized, dodged).
    * Shows column position and level information.
    */
+  /**
+   * Announces where a pie slice sits on the dial, as clock positions.
+   *
+   * "Position is 2 of 3" says which slice; it does not say where it is, and a
+   * pie's whole shape is where its slices are. A sighted colleague describing
+   * one says "the big slice on the right", and until now there was no reading
+   * that could meet that.
+   *
+   * The angles come from the braille state's magnitudes, the same route
+   * {@link announceBoxplotPosition} takes for its own trace-specific data, so
+   * no state has to grow a field. A slice's arc is its share of the sum of the
+   * absolute values — the circle as drawn, matching what the percentages are
+   * of — accumulated in order from 12 o'clock, clockwise. That origin is a
+   * convention rather than something the payload declares, and it is the one
+   * every producer wired up so far uses.
+   *
+   * Clock positions rather than degrees because they are what people say out
+   * loud. Rounded to the hour for the same reason: this is for orientation and
+   * for matching someone else's description, not for measurement — the
+   * percentage already carries the precise width.
+   * @param state - The active trace state.
+   */
+  private announcePiePosition(state: NonEmptyTraceState): void {
+    const braille = state.braille as BarBrailleState;
+    const values = braille.values[0] ?? [];
+    const col = braille.col;
+
+    const magnitude = (value: number): number =>
+      Number.isFinite(value) ? Math.abs(value) : 0;
+    const basis = values.reduce((sum, value) => sum + magnitude(value), 0);
+    const position = col + 1;
+    const total = values.length;
+
+    if (basis === 0) {
+      // Nothing is drawn, so there is no dial to place anything on.
+      this.textViewModel.update(`Position is ${position} of ${total}`);
+      return;
+    }
+
+    const before = values
+      .slice(0, col)
+      .reduce((sum, value) => sum + magnitude(value), 0);
+    const start = before / basis;
+    const end = (before + magnitude(values[col])) / basis;
+
+    const startHour = toClockHour(start);
+    const endHour = toClockHour(end);
+    // A slice too thin to span an hour reads as a point rather than as a
+    // range from a position to itself.
+    const where = startHour === endHour
+      ? `at ${startHour} o'clock`
+      : `from ${startHour} o'clock to ${endHour} o'clock`;
+
+    if (this.textService.isTerse() || this.textService.isOff()) {
+      this.textViewModel.update(where);
+    } else {
+      this.textViewModel.update(`Position is ${position} of ${total}, ${where}`);
+    }
+  }
+
   private announceSegmentedBarPosition(state: NonEmptyTraceState, x: number, cols: number): void {
     const level = state.text.z?.value ?? '';
     const position = x + 1;

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -204,3 +204,109 @@ describe('AnnouncePositionCommand on multi-series step plots', () => {
     expect(textViewModel.update).toHaveBeenCalledWith('Line 1 of 3, Position is 3 of 10');
   });
 });
+
+/**
+ * Builds a pie trace state as `PieTrace` reports it.
+ *
+ * The angles are read from the braille row, the same route the boxplot branch
+ * takes for its own trace-specific data, so this mirrors what the trace
+ * actually puts there rather than inventing a shape.
+ */
+function pieState(values: number[], col: number): PlotState {
+  return {
+    empty: false,
+    type: 'trace',
+    traceType: TraceType.PIE,
+    plotType: 'pie',
+    audio: { panning: { x: 0, y: 0, rows: 1, cols: 2 } },
+    braille: {
+      empty: false,
+      id: 'pie',
+      values: [values],
+      min: [Math.min(...values)],
+      max: [Math.max(...values)],
+      row: 0,
+      col,
+    },
+    text: {
+      main: { label: 'Fruit', value: 'A' },
+      cross: { label: 'Units', value: values[col] },
+    },
+  } as unknown as PlotState;
+}
+
+describe('AnnouncePositionCommand on a pie', () => {
+  test('places the slice on the dial, not just in the order', () => {
+    // Four equal slices, so each is exactly a quarter turn: 12 to 3, 3 to 6,
+    // 6 to 9, 9 back to 12. Chosen so the arithmetic is checkable by eye.
+    const { command, textViewModel } = createCommand(pieState([1, 1, 1, 1], 0));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 1 of 4, from 12 o\'clock to 3 o\'clock',
+    );
+  });
+
+  test('carries on round the dial rather than restarting each slice', () => {
+    const { command, textViewModel } = createCommand(pieState([1, 1, 1, 1], 2));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 3 of 4, from 6 o\'clock to 9 o\'clock',
+    );
+  });
+
+  test('reads the last slice as ending at 12, not at 0', () => {
+    const { command, textViewModel } = createCommand(pieState([1, 1, 1, 1], 3));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 4 of 4, from 9 o\'clock to 12 o\'clock',
+    );
+  });
+
+  test('reads a slice thinner than an hour as a point', () => {
+    // 1 out of 200 is under a thirtieth of an hour, so its start and end round
+    // together; "from 12 o'clock to 12 o'clock" would say nothing.
+    const { command, textViewModel } = createCommand(pieState([1, 199], 0));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 1 of 2, at 12 o\'clock',
+    );
+  });
+
+  test('measures a negative slice by the arc it occupies', () => {
+    // The wedge for -1 is drawn a quarter of the way round like any other, so
+    // the slices after it must not shift.
+    const { command, textViewModel } = createCommand(pieState([1, -1, 1, 1], 2));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 3 of 4, from 6 o\'clock to 9 o\'clock',
+    );
+  });
+
+  test('says only where it is when text is terse', () => {
+    const { command, textViewModel } = createCommand(pieState([1, 1, 1, 1], 1), 'terse');
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('from 3 o\'clock to 6 o\'clock');
+  });
+
+  test('falls back to the ordinal when nothing is drawn', () => {
+    // An all-gap pie has no dial to place anything on, and dividing by its
+    // basis would be 0/0.
+    const { command, textViewModel } = createCommand(pieState([0, 0], 0));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Position is 1 of 2');
+  });
+});

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -322,15 +322,42 @@ describe('AnnouncePositionCommand on a pie', () => {
     );
   });
 
-  test('calls a slice within half an hour of the full turn the whole circle', () => {
-    // 199 of 200 is 11.94 hours. Both ends still round to 12, so this needs the
-    // same answer as the exact case rather than "at 12 o'clock".
+  test('still calls the dial whole when the rest of it is gaps', () => {
+    // A gap and a zero are drawn as nothing, so a slice beside them is the
+    // entire basis and the plain reading is the true one.
+    const { command, textViewModel } = createCommand(
+      pieState([100, Number.NaN, 0], 0),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 1 of 3, the whole circle',
+    );
+  });
+
+  test('qualifies a slice that only rounds to the full turn', () => {
+    // 199 of 200 is 11.94 hours, so both ends still round to 12 and this must
+    // not read as a point. But the second slice is drawn, however thin, and
+    // "1 of 2, the whole circle" would contradict itself in one sentence.
     const { command, textViewModel } = createCommand(pieState([199, 1], 0));
 
     command.execute();
 
     expect(textViewModel.update).toHaveBeenCalledWith(
-      'Position is 1 of 2, the whole circle',
+      'Position is 1 of 2, nearly the whole circle',
+    );
+  });
+
+  test('qualifies it however many slices share the remainder', () => {
+    // 1150 of 1152 rounds to the full turn while two other slices exist to be
+    // navigated to -- the case the per-slice threshold has to get right.
+    const { command, textViewModel } = createCommand(pieState([1150, 1, 1], 0));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 1 of 3, nearly the whole circle',
     );
   });
 

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -309,4 +309,45 @@ describe('AnnouncePositionCommand on a pie', () => {
 
     expect(textViewModel.update).toHaveBeenCalledWith('Position is 1 of 2');
   });
+
+  test('calls a slice that fills the dial the whole circle', () => {
+    // One slice starts and ends at 12, so the point branch would announce the
+    // entire circle as a single position -- the opposite of what it is.
+    const { command, textViewModel } = createCommand(pieState([100], 0));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 1 of 1, the whole circle',
+    );
+  });
+
+  test('calls a slice within half an hour of the full turn the whole circle', () => {
+    // 199 of 200 is 11.94 hours. Both ends still round to 12, so this needs the
+    // same answer as the exact case rather than "at 12 o'clock".
+    const { command, textViewModel } = createCommand(pieState([199, 1], 0));
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Position is 1 of 2, the whole circle',
+    );
+  });
+
+  test('gives a gap between measured slices no arc of its own', () => {
+    // A gap is NaN rather than 0, and it is not drawn, so the slice after it
+    // must sit where it would if the gap were absent from the data.
+    const gapped = createCommand(pieState([1, Number.NaN, 1, 1], 2));
+    const gapless = createCommand(pieState([1, 1, 1], 1));
+
+    gapped.command.execute();
+    gapless.command.execute();
+
+    expect(gapped.textViewModel.update).toHaveBeenCalledWith(
+      'Position is 3 of 4, from 4 o\'clock to 8 o\'clock',
+    );
+    expect(gapless.textViewModel.update).toHaveBeenCalledWith(
+      'Position is 2 of 3, from 4 o\'clock to 8 o\'clock',
+    );
+  });
 });


### PR DESCRIPTION
# Pull Request

> [!NOTE]
> **No longer stacked.** #781 and #782 have both landed, and this is now rebased onto `main` as a single commit — `src/command/describe.ts` and its test, 183 insertions across 2 files. The earlier note about a base of `claude/pie-circular-panning-jh7gl6` no longer applies.

## Description

Closes #780.

`p` answered *which* slice — "Position is 1 of 3" — and never *where*. A pie's whole shape is where its slices are, so that is the one thing the ordinal cannot carry. A sighted colleague describing the same chart says "the big slice on the right", and there was no reading that could meet that.

It now says:

```
Position is 1 of 4, from 12 o'clock to 3 o'clock
```

## Related Issues

Closes #780. Completes the second half of that issue; #782 did the panning.

## Changes Made

**No state grew a field.** The angles come from the braille row's magnitudes — the same route `announceBoxplotPosition` already takes for *its* trace-specific data (`state.braille as BoxBrailleState`), so this follows an established pattern rather than widening a shared type. A slice's arc is its share of the sum of the absolute values, accumulated in order: the circle **as drawn**, matching what the percentages are already of.

**Twelve o'clock is now a stated convention** rather than an assumption nobody had written down. I raised in #780 that the payload declares no start angle and a counter-clockwise producer would be announced wrongly; the decision is to fix the origin at 12 o'clock clockwise. It is what matplotlib, `graphics::pie`, ggplot2's `coord_polar`, amCharts and AnyChart all do, and the grammar carries nothing that could contradict it. Recorded in the method's own documentation so a future producer that breaks the convention has something to break against.

**Clock positions, rounded to the hour.** Degrees would be more precise and less useful — clock positions are what people say out loud, and this exists to make two readings of one chart meet. The percentage already carries the exact width, so precision here would be duplicated and harder to hear.

A slice too thin to span an hour reads as a point — `at 12 o'clock` — rather than as a range from a position to itself.

## Screenshots (if applicable)

Chromium, a four-quarter ggplot2 pie rendered through r-maidr with this build swapped in:

```
f is A, Units is 25, Percentage is 25.0%
    p -> Position is 1 of 4, from 12 o'clock to 3 o'clock
f is B, Units is 25, Percentage is 25.0%
    p -> Position is 2 of 4, from 3 o'clock to 6 o'clock
f is C, Units is 25, Percentage is 25.0%
    p -> Position is 3 of 4, from 6 o'clock to 9 o'clock
f is D, Units is 25, Percentage is 25.0%
    p -> Position is 4 of 4, from 9 o'clock to 12 o'clock
```

No console errors.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean, no files changed |
| `npm run type-check` | clean |
| `npm run build` | all builds pass (135.1s) |
| `npm test` | **1846 + 73** (main is at 1839 + 73 after #782) |

Re-run after the rebase onto `main`, not carried over from the stacked run.

Seven cases in `test/command/announce-position.test.ts`, built on the file's existing mock harness. Four equal slices throughout, so the arithmetic is checkable by eye rather than by trusting a decimal:

- each quarter lands on its own quarter of the dial, and the sweep **accumulates** rather than restarting per slice;
- the last slice ends at **12, not 0** — the modulo case that would otherwise announce an hour that does not exist;
- a slice thinner than an hour reads as a point;
- a **negative** slice occupies its arc like any other, so the slices after it do not shift (the case #781 makes reachable);
- terse mode says only where it is;
- an all-zero pie falls back to the ordinal rather than dividing by a basis of zero.

**Verified they bite:** with the `TraceType.PIE` dispatch removed, `6 failed, 12 passed` — the seventh passes either way, since the fallback is what the generic path already produced.