### PR TITLE
fix(line): announce an ordinal y by name instead of by level code

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -292,6 +292,14 @@ The data property is defined as a list of objects where each object is a record 
     }
 
     //line
+    //
+    //`label` is optional and names the ordinal level that a numeric `y`
+    //encodes, for a line whose y axis is a category rather than a magnitude
+    //(a sleep stage, a Likert response, a severity grade). When present it is
+    //announced INSTEAD of the number, so the reader hears "Sleep stage is
+    //REM" rather than "Sleep stage is 4"; `y` stays NUMERIC either way,
+    //because it drives sonification, braille and the min/max range. Omit it
+    //for the continuous y most line charts have.
     maidr = {
       "data":[
         [
@@ -313,9 +321,9 @@ The data property is defined as a list of objects where each object is a record 
     //Data is nested exactly like `line`: one inner array per series.
     //
     //`y` stays NUMERIC — it drives sonification, braille and the min/max range.
-    //`label` is optional and names the ordinal level that `y` encodes; when
-    //present it is announced INSTEAD of the number, so a hypnogram says
-    //"Sleep stage is REM" rather than "Sleep stage is 4".
+    //`label` is the same optional per-point ordinal name documented under
+    //`line` above, and is read identically here; a hypnogram is its canonical
+    //case, which is why the example below carries one on every point.
     //
     //`stepDirection` is a layer-level property (a sibling of `axes` and
     //`data`), not a per-point one. It says where the jump happens between two

--- a/docs/react.md
+++ b/docs/react.md
@@ -196,6 +196,13 @@ const data: MaidrData = {
 
 Line chart data is a 2D array — each inner array is one line series:
 
+Each point also takes an optional `label`, for a line whose y axis is a
+category rather than a magnitude — a sleep stage, a Likert response, a severity
+grade. `y` stays numeric because it drives sonification, braille and the
+min/max range, and `label` names the level that number encodes; it is announced
+in place of the number, so the chart reads "Sleep stage is REM" rather than
+"Sleep stage is 4". Omit it for the continuous y most line charts have.
+
 ```typescript
 const data: MaidrData = {
   id: 'temperature-line',
@@ -222,9 +229,9 @@ right type for piecewise-constant data — a hypnogram's sleep stages, a status
 timeline, a rate that changes on fixed dates. Data is nested like a line chart,
 one inner array per series.
 
-`y` stays numeric: it drives sonification, braille and the min/max range.
-`label` names the ordinal level that number encodes and is announced in its
-place, so the chart reads "Sleep stage is REM" rather than "Sleep stage is 4".
+`label` is the same per-point ordinal name described under Line Chart above,
+and is read identically here; a hypnogram is its canonical case, which is why
+every point in the example carries one.
 
 `stepDirection` is a layer property, not a per-point one: `'hv'` holds until the
 next x value then jumps (matplotlib `steps-post`, ggplot2's default), `'vh'`

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -350,9 +350,17 @@ export class LineTrace extends AbstractTrace {
       zData = point.z ? { z: { label: zLabel, value: point.z } } : {};
     }
 
+    // An ordinal y travels as a numeric level plus the level's name: `y` has
+    // to stay numeric because it drives sonification, braille and the range,
+    // so the human-readable name rides alongside as `label`. Announce the name
+    // when there is one, and the number otherwise — which is the right reading
+    // for the continuous y that most line charts have.
+    const label = point.label;
+    const crossValue = label === undefined || label === '' ? point.y : label;
+
     return {
       main: { label: this.xAxis, value: this.points[this.row][this.col].x },
-      cross: { label: this.yAxis, value: this.points[this.row][this.col].y },
+      cross: { label: this.yAxis, value: crossValue },
       ...zData,
     };
   }

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -1,5 +1,5 @@
 import type { LinePoint, MaidrLayer, StepDirection, StepPoint } from '@type/grammar';
-import type { DescriptionState, TextState, TraceState } from '@type/state';
+import type { DescriptionState, TraceState } from '@type/state';
 import type { RotorFilterUnit } from './abstract';
 import { LineTrace } from './line';
 
@@ -29,9 +29,12 @@ const STEP_DIRECTION_LABEL: Record<StepDirection, string> = {
  * glissando that `SmoothTrace` uses would interpolate between levels, which is
  * exactly what a step chart does not do.
  *
- * What this class adds is the two things a step chart has that a line chart
- * does not: ordinal level names ("REM" rather than "3"), and navigation by
- * transition rather than by sample.
+ * What this class adds is what a step chart has that a line chart does not:
+ * navigation by transition rather than by sample, and a description written in
+ * terms of runs. Announcing an ordinal level by name ("REM" rather than "3")
+ * used to live here too, but a line or path over the same ordinal y needs it
+ * just as much, so `LineTrace` reads the point's `label` and this class
+ * inherits that unchanged.
  */
 export class StepTrace extends LineTrace {
   private readonly stepPoints: StepPoint[][];
@@ -84,25 +87,6 @@ export class StepTrace extends LineTrace {
     return {
       ...baseState,
       plotType: 'step',
-    };
-  }
-
-  /**
-   * Substitutes the ordinal level name for the raw numeric level, so a
-   * hypnogram announces "Sleep stage is REM" rather than "Sleep stage is 3".
-   * Points without a `label` keep the inherited numeric announcement.
-   * @returns The text state for the current point
-   */
-  protected override get text(): TextState {
-    const baseText = super.text;
-    const label = this.stepPoints[this.row]?.[this.col]?.label;
-    if (label === undefined || label === '') {
-      return baseText;
-    }
-
-    return {
-      ...baseText,
-      cross: { label: baseText.cross.label, value: label },
     };
   }
 

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -333,6 +333,21 @@ export interface LinePoint {
   x: number | string;
   y: number;
   z?: string;
+  /**
+   * Ordinal level name announced in place of the raw numeric `y`, for a chart
+   * whose y axis is a category rather than a magnitude — a hypnogram's sleep
+   * stages, a Likert response, a severity grade. `y` stays numeric because it
+   * drives sonification, braille and the min/max range, so the human-readable
+   * name has to travel alongside it.
+   *
+   * An empty string counts as absent, so a producer that emits `''` for an
+   * unnamed level gets the numeric announcement rather than a blank one.
+   * Omitting it entirely is the right shape for a continuous y.
+   *
+   * @example
+   * { x: 1.5, y: 3, label: 'REM' }
+   */
+  label?: string;
 }
 
 /**
@@ -395,25 +410,20 @@ export interface SmoothPoint {
 export type StepDirection = 'hv' | 'vh' | 'mid';
 
 /**
- * Data point for step charts. Extends {@link LinePoint} with the name of an
- * ordinal level, so charts whose y axis is a category rather than a magnitude
- * — a hypnogram's sleep stages, a status timeline's states — can announce
- * "REM" instead of the numeric level that encodes it.
+ * Data point for step charts — structurally a {@link LinePoint}.
  *
- * `y` stays numeric because it drives sonification, braille and the min/max
- * range; `label` is the human-readable name of that level.
+ * The ordinal `label` that lets a hypnogram announce "REM" instead of "3"
+ * started here, but it is not a step-only pairing: a line or path over the
+ * same ordinal y needs it just as much, so it now lives on `LinePoint` and
+ * every trace in the line family reads it.
+ *
+ * The name is kept because a step layer's `data` is authored as
+ * `StepPoint[][]`, and it says which chart the points belong to.
  *
  * @example
  * { x: 1.5, y: 3, label: 'REM' }
  */
-export interface StepPoint extends LinePoint {
-  /**
-   * Ordinal level name announced in place of the raw numeric `y`. An empty
-   * string counts as absent, so a producer that emits `''` for an unnamed
-   * level gets the numeric announcement rather than a blank one.
-   */
-  label?: string;
-}
+export type StepPoint = LinePoint;
 
 /**
  * Canonical axis configuration. Every axis (x, y, z) must be specified as an

--- a/test/model/line.test.ts
+++ b/test/model/line.test.ts
@@ -1,5 +1,6 @@
 import type { ExtremaTarget } from '@type/extrema';
 import type { MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
 import { describe, expect, test } from '@jest/globals';
 import { LineTrace } from '@model/line';
 import { TraceType } from '@type/grammar';
@@ -29,6 +30,19 @@ function createLineLayer(data: MaidrLayer['data']): MaidrLayer {
  */
 function getIntersectionTargets(targets: ExtremaTarget[]): ExtremaTarget[] {
   return targets.filter(target => target.type === 'intersection');
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: LineTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
 }
 
 describe('LineTrace intersection classification', () => {
@@ -338,5 +352,78 @@ describe('LineTrace intersections with categorical x values', () => {
     expect(intersections).toHaveLength(1);
     expect(intersections[0].intersectionKind).toBe('slope');
     expect(intersections[0].value).toBe(5);
+  });
+});
+
+describe('lineTrace ordinal levels', () => {
+  /**
+   * A hypnogram drawn as a line rather than as steps: the y values are level
+   * codes, and the names of those levels ride alongside as `label`.
+   */
+  const HYPNOGRAM: MaidrLayer['data'] = [[
+    { x: 0, y: 3, label: 'Awake' },
+    { x: 1, y: 1, label: 'N2' },
+    { x: 2, y: 2, label: 'REM' },
+  ]];
+
+  test('announces the level name instead of the numeric level', () => {
+    const trace = new LineTrace(createLineLayer(HYPNOGRAM));
+    trace.moveOnce('FORWARD');
+
+    const { text } = nonEmptyState(trace);
+    expect(text.cross).toEqual({ label: 'Y', value: 'Awake' });
+    expect(text.main).toEqual({ label: 'X', value: 0 });
+  });
+
+  test('falls back to the numeric value when the data names no level', () => {
+    const trace = new LineTrace(createLineLayer([[
+      { x: 0, y: 3 },
+      { x: 1, y: 1 },
+    ]]));
+    trace.moveOnce('FORWARD');
+
+    expect(nonEmptyState(trace).text.cross).toEqual({ label: 'Y', value: 3 });
+  });
+
+  test('treats an empty level name as absent rather than announcing nothing', () => {
+    const trace = new LineTrace(createLineLayer([[
+      { x: 0, y: 3, label: '' },
+      { x: 1, y: 1, label: '' },
+    ]]));
+    trace.moveOnce('FORWARD');
+
+    expect(nonEmptyState(trace).text.cross).toEqual({ label: 'Y', value: 3 });
+  });
+
+  test('sonifies and brailles the numeric level, not the name', () => {
+    const trace = new LineTrace(createLineLayer(HYPNOGRAM));
+    trace.moveOnce('FORWARD');
+
+    const { audio, braille } = nonEmptyState(trace);
+    expect(audio.freq).toEqual({ min: 1, max: 3, raw: 3 });
+    expect(braille).toMatchObject({
+      empty: false,
+      values: [[3, 1, 2]],
+      min: [1],
+      max: [3],
+    });
+  });
+
+  test('keeps the series name alongside the level name on a multi-series line', () => {
+    const trace = new LineTrace(createLineLayer([
+      [
+        { x: 0, y: 3, label: 'Awake', z: 'Night one' },
+        { x: 1, y: 1, label: 'N2', z: 'Night one' },
+      ],
+      [
+        { x: 0, y: 2, label: 'REM', z: 'Night two' },
+        { x: 1, y: 1, label: 'N2', z: 'Night two' },
+      ],
+    ]));
+    trace.moveOnce('FORWARD');
+
+    const { text } = nonEmptyState(trace);
+    expect(text.cross).toEqual({ label: 'Y', value: 'Awake' });
+    expect(text.z).toEqual({ label: 'Group', value: 'Night one' });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

A point's `label` names the ordinal level that a numeric `y` encodes, so a hypnogram reads "Sleep stage is REM" rather than "Sleep stage is 4". The step trace read it; the line trace did not, and silently announced the level code instead — same payload, same shape, two different readings.

The pairing was never step-specific. `y` has to stay numeric wherever it appears, because it drives sonification, braille and the min/max range, so a human-readable name can only travel alongside it — and that is as true of a line or a path over an ordinal y as of a step.

## Related Issues

Closes #785.

Unblocks xability/r-maidr#121: r-maidr already emits the pairing for `geom_line()` and `geom_path()` as well as `geom_step()`, so the producer side has been done since xability/r-maidr#122. `geom_path()` and `tidyquant::geom_ma()` share the line trace, so they inherited the gap too.

## Changes Made

- **`src/type/grammar.ts`** — `label` moves from `StepPoint` onto `LinePoint`, where the whole line family can see it. `StepPoint` stays as an alias of `LinePoint`: a step layer's `data` is authored as `StepPoint[][]`, and the name says which chart the points belong to.
- **`src/model/line.ts`** — `LineTrace.text` substitutes the label for the numeric cross value when one is present. Only the announcement changes; `audio`, `braille` and the range keep reading the number.
- **`src/model/step.ts`** — `StepTrace` drops its own `text` override and inherits the behaviour it used to own. Its class doc now says so.
- **`docs/SCHEMA.md`, `docs/react.md`** — `label` is documented under `line`, and the `step` sections point at that description instead of repeating it as though it were step-only.
- **`test/model/line.test.ts`** — five tests for the line side.

An empty string still counts as absent, so a producer that emits `''` for an unnamed level gets the number rather than a blank announcement. A point with no label keeps announcing its value, which is the right reading for the continuous y most line charts have.

Scatter has the same latent case, but no producer emits it and `ScatterPoint` does not carry the field, so it is left alone rather than given a speculative one.

### Reach of the change beyond `line` and `step`

`SmoothTrace` (and `SmoothTraceSvgXY` through it) also extends `LineTrace`, and overrides only `state` and `audio` — not `text` — so it inherits the substitution as well. That is an implicit consequence of the class hierarchy rather than an explicit change, so it is worth stating: a smooth trace whose points carry a `label` will now announce the name too.

Nothing needs to change for it. `SmoothPoint` does not declare `label` and a fitted curve's y is continuous by construction, so no producer emits one today; if one ever did, announcing the name is the same reading the rest of the line family gives it.

## Screenshots (if applicable)

Not applicable — the change is in what is announced, not in what is drawn. The before/after is in the table below.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verified in Chromium against a built bundle**, walking the r-maidr-produced line and step hypnograms side by side with the arrow keys and reading the live region:

| bundle | `line` chart | `step` chart |
|---|---|---|
| `v4.0.0` (shipped) | Sleep stage is **5, 4, 3, 2, 1** | Sleep stage is Awake, REM, N1, N2, N3 |
| this branch | Sleep stage is **Awake, REM, N1, N2, N3** | Sleep stage is Awake, REM, N1, N2, N3 |

The two now agree, and the step reading is unchanged.

Both branches of the new condition are mutation-checked: replacing the substitution with the bare number fails 4 tests (2 new line tests and 2 existing step tests, the latter confirming the step behaviour genuinely flows through the shared code path now), and dropping the empty-string guard fails 1.

`e2e_tests/specs/stepplot.spec.ts` needed no change but now exercises the shared implementation end to end, since `StepTrace` inherits it.

Full gate run locally: `npm run lint:fix`, `npm run type-check`, `npm run build`, and `npm test` — 1844 unit/component tests and 73 ESM tests, all passing.