### PR TITLE
ci: tell r-maidr when a new version reaches npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,55 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: |
           npx semantic-release
-          if git describe --tags --exact-match HEAD 2>/dev/null; then
+          # The tag semantic-release just created, when it created one. Also
+          # captured as the version so the downstream notification below can
+          # name it, rather than making the receiver guess from `latest`.
+          if TAG=$(git describe --tags --exact-match HEAD 2>/dev/null); then
             echo "new_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to npm with trusted publishing
         if: steps.semantic-release.outputs.new_release == 'true'
         run: npm publish --access public --provenance
+
+      # r-maidr ships a copy of this package's built bundle, and refreshes it
+      # from npm. Left to itself it discovers a release on a daily poll, so a
+      # fix can sit unread by users for up to a day after it is published.
+      # Telling it directly closes that gap to minutes.
+      #
+      # Deliberately after the publish step and gated on it: the receiver
+      # fetches the tarball straight from the registry, so announcing before
+      # the package is actually there would just make it fail.
+      #
+      # py-maidr is not notified, and that is not an oversight. It bundles
+      # upstream at *its own* release time so each py-maidr release pins the
+      # version it was tested against, rather than tracking upstream
+      # continuously. Pinging it would work against that design.
+      #
+      # continue-on-error, because the release is the thing that matters
+      # here. A missed ping costs at most a day -- r-maidr keeps its
+      # scheduled refresh precisely as the backstop for this step failing --
+      # whereas a red release job costs a manual re-run of a publish that
+      # already happened.
+      - name: Tell r-maidr the new version is on npm
+        if: steps.semantic-release.outputs.new_release == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+          VERSION: ${{ steps.semantic-release.outputs.version }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "DOWNSTREAM_DISPATCH_TOKEN is not configured."
+            echo "r-maidr will pick v${VERSION} up on its next scheduled refresh."
+            exit 0
+          fi
+          # jq builds the body so the version reaches JSON as data rather
+          # than as text spliced into a quoted string.
+          jq -n --arg version "$VERSION" \
+            '{event_type: "maidr-released", client_payload: {version: $version}}' \
+            | gh api repos/xability/r-maidr/dispatches --input -
+          echo "Notified r-maidr of v${VERSION}."
 
       - name: Upload npm logs on failure
         if: failure()


### PR DESCRIPTION
# Pull Request

## Description

Sending half of a two-repo change. The receiving half is xability/r-maidr#131.

r-maidr ships a copy of this package's built bundle and refreshes it from npm. Left to itself it discovers a release on a **daily poll**, so a fix published here can sit unread by users for up to a day. Publishing is an event this workflow already knows about, so it can say so directly and close the gap to minutes.

#785 is a live example of the cost: the fix is merged, and a reader on a `geom_line()` factor-y chart still hears the level code until a release goes out *and* r-maidr happens to poll.

## Related Issues

No issue — this came out of noticing the delay while tracking #785 through to r-maidr users.

## Changes Made

- **The release step now records the version**, not just whether a release happened. `semantic-release` does not report it back, so it is read off the tag the step was already inspecting: `git describe --tags --exact-match HEAD`, minus the leading `v`.
- **A new notification step** sends a `repository_dispatch` to `xability/r-maidr`:

  ```json
  {"event_type": "maidr-released", "client_payload": {"version": "4.0.1"}}
  ```

  Naming the version lets the receiver fetch that exact one instead of re-resolving `latest` in the window before the dist-tag has propagated. The body is built with `jq --arg` so the version arrives as data rather than as text spliced into a quoted string.

Three deliberate choices:

- **After the publish step, gated on it.** The receiver pulls the tarball straight from the registry, so announcing before the package is actually there would only make it fail.
- **`continue-on-error: true`.** The release is what matters. A missed ping costs at most a day — r-maidr keeps its scheduled refresh precisely as the backstop for this step failing — whereas a red release job costs a manual re-run of a publish that already happened.
- **py-maidr is not notified.** That is not an oversight: it bundles upstream at its *own* release time, so each py-maidr release pins the version it was tested against rather than tracking upstream continuously. Its `update-maidr-js.yml` says so and is `workflow_dispatch`-only. Pinging it would work against that design.

## Screenshots (if applicable)

Not applicable — CI-only change.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable — not applicable; there is no harness for workflow YAML beyond `actionlint`, which runs in CI and passes.

## Additional Notes

**This needs one manual step before it does anything.** The step reads a secret, `DOWNSTREAM_DISPATCH_TOKEN`, that does not exist yet and can only be created by an admin. Until it is set the step logs that it is unconfigured and exits 0, so releases keep working exactly as they do today and r-maidr keeps using its daily schedule. The change is inert, not broken, in the meantime.

The token needs write access to `xability/r-maidr` **only** — a fine-grained PAT scoped to that one repository with `Contents: write` is the tightest fit — and is stored here, in this repository's secrets. It is deliberately a separate secret from `SEMANTIC_RELEASE_TOKEN` so the publish credential does not also gain cross-repo reach.

Ordering note: `repository_dispatch` only ever triggers the workflow file as it exists on the receiver's default branch, so **r-maidr#131 should land first**. Merging this one first is harmless — without the token it is a no-op anyway.

**Verification.** `actionlint` — the same version CI runs — passes on the changed file. The version-capture shell was exercised under `bash -e`, the Actions default shell, for both branches:

| case | result |
|---|---|
| `git describe` succeeds (`v4.0.1`) | writes `new_release=true` and `version=4.0.1` |
| `git describe` fails (no tag) | writes neither, and does not abort the step under `-e` |

The second case matters: `set -e` is on by default in Actions, and an assignment inside an `if` condition is exempt from it, which is what keeps a no-release run green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_