### PR TITLE
feat(area): read an area chart as its own trace type

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -178,6 +178,25 @@ In multiline braille displays, all data series are represented simultaneously. H
 
 In single-line braille displays, the user can navigate vertically with the up and down arrow keys to move between lines, and the braille representation updates to show the values for the current line.
 
+## Area plot
+
+An area plot's braille is the line plot encoding above, unchanged: each series
+becomes a height profile, and the fill under the curve is not encoded because
+it carries no value the curve does not already carry.
+
+For a stacked area plot the profile is each band's **own** height, not the
+height of the stack it sits in. That matches what the audio plays and what the
+text announces as the cross-axis value, so the three modalities describe the
+same number. The running total is available in the verbose text announcement
+and in the chart description; it is deliberately not folded into the braille,
+because a profile that silently switched from series values to cumulative ones
+would read as the same shape with different numbers behind it.
+
+### Multiline Displays
+
+As for a line plot: each line of the display is one series, and the user moves
+between series with the up and down arrow keys on a single-line display.
+
 ## Step plot
 
 A step plot's braille is the line plot encoding above, unchanged: each data

--- a/e2e_tests/page-objects/plots/area-page.ts
+++ b/e2e_tests/page-objects/plots/area-page.ts
@@ -1,0 +1,140 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { AreaPlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the stacked area plot page.
+ *
+ * Provides the interactions the area spec needs: reaching the example,
+ * activating MAIDR on it, and reading back the announcement, the braille
+ * output and the text-mode state.
+ */
+export class AreaPlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.AREAPLOT_ID}`,
+    svg: `svg`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the area plot
+   */
+  private readonly plotId = TestConstants.AREAPLOT_ID;
+
+  /**
+   * Creates a new AreaPlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the area plot page
+   * @throws AreaPlotError if navigation fails
+   */
+  public async navigateToAreaPlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/area.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new AreaPlotError('Failed to navigate to area plot', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the area plot
+   * @throws AreaPlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new AreaPlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws AreaPlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new AreaPlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws AreaPlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded');
+      await expect(this.page.locator(this.selectors.svg)).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      throw new AreaPlotError('Area plot failed to load correctly', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   *
+   * Braille is the modality that fails silently for a new trace type — an
+   * unregistered encoder leaves the display blank while text and audio still
+   * work — so this returns the raw cell string for the spec to assert on.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws AreaPlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new AreaPlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws AreaPlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new AreaPlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/area.spec.ts
+++ b/e2e_tests/specs/area.spec.ts
@@ -1,0 +1,179 @@
+import type { LinePoint, Maidr, MaidrLayer } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { AreaPlotPage } from '../page-objects/plots/area-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output. Written as escapes rather than literal glyphs because the range
+ * endpoints are indistinguishable by eye: U+2800 is the blank cell.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * Extracts one band's points from the stacked area layer.
+ *
+ * Area data is nested exactly like line data — one inner array per series —
+ * so the series, not the layer, is what the assertions index into.
+ * @param layer - The MAIDR layer containing the area data
+ * @param index - Zero-based index of the band to read
+ * @returns The points of that band
+ * @throws TypeError if the data is not in the nested per-series format
+ */
+function getBand(layer: MaidrLayer | undefined, index: number): LinePoint[] {
+  if (!layer?.data || !Array.isArray(layer.data) || !Array.isArray(layer.data[0])) {
+    throw new TypeError('Area layer data is not a nested array of points');
+  }
+
+  return layer.data[index] as LinePoint[];
+}
+
+/**
+ * Counts the bands a layer carries.
+ *
+ * `MaidrLayer.data` is a union that includes `HeatmapData`, an object with no
+ * length, so the nested-array shape has to be established before counting
+ * rather than assumed.
+ * @param layer - The MAIDR layer containing the area data
+ * @returns The number of bands
+ * @throws TypeError if the data is not in the nested per-series format
+ */
+function bandCount(layer: MaidrLayer | undefined): number {
+  if (!layer?.data || !Array.isArray(layer.data)) {
+    throw new TypeError('Area layer data is not a nested array of points');
+  }
+
+  return layer.data.length;
+}
+
+test.describe('Stacked Area Plot', () => {
+  let maidrData: Maidr;
+  let areaLayer: MaidrLayer;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const areaPlotPage = new AreaPlotPage(page);
+      await areaPlotPage.navigateToAreaPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+      areaLayer = maidrData.subplots[0][0].layers[0];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const areaPlotPage = new AreaPlotPage(page);
+    await areaPlotPage.navigateToAreaPlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the area plot with maidr data', async ({ page }) => {
+      const areaPlotPage = new AreaPlotPage(page);
+      await areaPlotPage.activateMaidr();
+      await areaPlotPage.verifyPlotLoaded();
+    });
+
+    test('should declare the layer as a stacked area plot', () => {
+      expect(areaLayer.type).toBe('stacked_area');
+    });
+
+    test('should carry one nested series per band', () => {
+      expect(Array.isArray(areaLayer.data)).toBe(true);
+      expect(areaLayer.data).toHaveLength(2);
+      expect(getBand(areaLayer, 0)).toHaveLength(5);
+      expect(getBand(areaLayer, 1)).toHaveLength(5);
+    });
+
+    test('should carry each band own value, not the running total', () => {
+      // The distinction this trace type exists for. The upper band's third
+      // point is drawn at a height of 100 because the stack reaches 100 there,
+      // but the value it carries is that band's own 70.
+      expect(getBand(areaLayer, 1)[2].y).toBe(70);
+    });
+
+    test('should announce itself as a stacked area plot', async ({ page }) => {
+      // A line reading was the bug: the user was told "single line" for a
+      // chart drawing two magnitudes per sample.
+      const areaPlotPage = new AreaPlotPage(page);
+      await areaPlotPage.activateMaidr();
+
+      const instructionText = await areaPlotPage.getInstructionText();
+      expect(normalizeText(instructionText)).toBe(
+        normalizeText(TestConstants.AREAPLOT_INSTRUCTION_TEXT),
+      );
+    });
+  });
+
+  test.describe('Mode Controls', () => {
+    test('should toggle text mode on and off', async ({ page }) => {
+      const areaPlotPage = new AreaPlotPage(page);
+      await areaPlotPage.activateMaidr();
+
+      await areaPlotPage.toggleTextMode();
+      const isTerse = await areaPlotPage.isTextModeActive(TestConstants.TEXT_MODE_TERSE);
+      await areaPlotPage.toggleTextMode();
+      const isOff = await areaPlotPage.isTextModeActive(TestConstants.TEXT_MODE_OFF);
+      await areaPlotPage.toggleTextMode();
+      const isVerbose = await areaPlotPage.isTextModeActive(TestConstants.TEXT_MODE_VERBOSE);
+
+      expect(isTerse).toBe(true);
+      expect(isOff).toBe(true);
+      expect(isVerbose).toBe(true);
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render one braille line per band, one cell per point', async ({ page }) => {
+      const areaPlotPage = new AreaPlotPage(page);
+      await areaPlotPage.activateMaidr();
+      await areaPlotPage.moveToNextDataPoint();
+      await areaPlotPage.toggleBrailleMode();
+
+      const braille = await areaPlotPage.getBrailleContent();
+      // A multi-series trace drives a multi-line display: one row per band, so
+      // a reader can feel the bands against each other rather than one at a
+      // time. Splitting is what makes the per-band assertion below possible —
+      // and the reason a whole-string match against the braille block fails,
+      // since the separator is a newline and not a braille cell.
+      const lines = braille.split('\n');
+
+      expect(lines).toHaveLength(bandCount(areaLayer));
+      for (const line of lines) {
+        expect(line).toMatch(BRAILLE_CELL);
+        expect(line).toHaveLength(getBand(areaLayer, 0).length);
+      }
+    });
+  });
+
+  test.describe('Announcements', () => {
+    test('should announce the running total alongside the band value', async ({ page }) => {
+      // The whole point of the trace type: verbose mode has to name both
+      // magnitudes, so the reader is never left guessing which one they heard.
+      const areaPlotPage = new AreaPlotPage(page);
+      await areaPlotPage.activateMaidr();
+      await areaPlotPage.moveToNextDataPoint();
+
+      const announcement = normalizeText(await areaPlotPage.getInstructionText());
+
+      // First point of the first band: value 10, stack total 15.
+      expect(announcement).toContain('10');
+      expect(announcement).toContain('Total');
+      expect(announcement).toContain('15');
+    });
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -30,6 +30,7 @@ export abstract class TestConstants {
   static readonly HISTOGRAM_ID = 'hist';
   static readonly LINEPLOT_ID = 'line';
   static readonly STEPPLOT_ID = 'step';
+  static readonly AREAPLOT_ID = 'area-revenue';
   static readonly DODGED_BARPLOT_ID = 'dodged_bar';
   static readonly STACKED_BARPLOT_ID = 'stacked_bar';
   static readonly BOXPLOT_VERTICAL_ID = 'boxplot_vertical';
@@ -122,6 +123,9 @@ export abstract class TestConstants {
   // `StepTrace.state` overrides the inherited line plotType, so a step chart
   // announces itself as a step plot rather than as a line one.
   static readonly STEPPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: step. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // A multi-series trace names its group count, as the multiline entry above
+  // does; the example this asserts against carries two bands.
+  static readonly AREAPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: stacked area with 2 groups. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // `formatPlotType` in src/util/orientation.ts prefixes the box type with its

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -136,6 +136,22 @@ export class LinePlotError extends Error {
 }
 
 /**
+ * Error thrown when Area plot related operations fail
+ */
+export class AreaPlotError extends Error {
+  /**
+   * Creates a new AreaPlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AreaPlotError';
+  }
+}
+
+/**
  * Error thrown when Step plot related operations fail
  */
 export class StepPlotError extends Error {

--- a/examples/area.html
+++ b/examples/area.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Stacked Area Example — Revenue by Line of Business</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A stacked area chart draws TWO magnitudes at every sample, which is the
+        whole reason it is a trace type of its own rather than a filled line:
+
+          - a band's HEIGHT is that series' own value, and
+          - a band's TOP EDGE is the running total of every series at that x.
+
+        The layer below carries the first of those — Services is 5, 20, 70, 25,
+        30, its own revenue — and MAIDR derives the second by summing the
+        series, so the verbose announcement reads out both ("Total is 100,
+        70.0% of it") and neither number has to be guessed at.
+
+        Each band is drawn the way every renderer draws one: out along its top
+        edge through each sample, then back along the edge beneath it, then
+        closed. That is 2N vertices for N samples, and only the first N are
+        data — MAIDR keeps those and drops the return journey, so a highlight
+        never lands on a baseline. `test/model/areaHighlight.test.ts` pins it.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="area-revenue" maidr='{&#10;  "id": "area-revenue",&#10;  "subplots": [&#10;    [&#10;      {&#10;        "id": "area-revenue-subplot",&#10;        "layers": [&#10;          {&#10;            "id": "area-revenue-layer",&#10;            "type": "stacked_area",&#10;            "title": "Revenue by Line of Business",&#10;            "axes": {&#10;              "x": {&#10;                "label": "Year"&#10;              },&#10;              "y": {&#10;                "label": "Revenue (millions)"&#10;              },&#10;              "z": {&#10;                "label": "Line of business"&#10;              }&#10;            },&#10;            "selectors": [&#10;              "g[id=&apos;area-revenue-subscriptions&apos;] path",&#10;              "g[id=&apos;area-revenue-services&apos;] path"&#10;            ],&#10;            "data": [&#10;              [&#10;                {&#10;                  "x": "2019",&#10;                  "y": 10,&#10;                  "z": "Subscriptions"&#10;                },&#10;                {&#10;                  "x": "2020",&#10;                  "y": 20,&#10;                  "z": "Subscriptions"&#10;                },&#10;                {&#10;                  "x": "2021",&#10;                  "y": 30,&#10;                  "z": "Subscriptions"&#10;                },&#10;                {&#10;                  "x": "2022",&#10;                  "y": 45,&#10;                  "z": "Subscriptions"&#10;                },&#10;                {&#10;                  "x": "2023",&#10;                  "y": 50,&#10;                  "z": "Subscriptions"&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  "x": "2019",&#10;                  "y": 5,&#10;                  "z": "Services"&#10;                },&#10;                {&#10;                  "x": "2020",&#10;                  "y": 20,&#10;                  "z": "Services"&#10;                },&#10;                {&#10;                  "x": "2021",&#10;                  "y": 70,&#10;                  "z": "Services"&#10;                },&#10;                {&#10;                  "x": "2022",&#10;                  "y": 25,&#10;                  "z": "Services"&#10;                },&#10;                {&#10;                  "x": "2023",&#10;                  "y": 30,&#10;                  "z": "Services"&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="axes-background">
+              <path d="M 80 380  L 660 380  L 660 60  L 80 60  z " style="fill: #ffffff" />
+            </g>
+            <g id="grid">
+          <path d="M 80 380 L 660 380 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 80 300 L 660 300 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 80 220 L 660 220 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 80 140 L 660 140 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 80 60 L 660 60 " style="stroke: #dddddd; stroke-width: 0.8" />
+            </g>
+            <g id="axis_x">
+          <text x="80" y="400" style="font: 12px sans-serif; text-anchor: middle">2019</text>
+          <text x="225" y="400" style="font: 12px sans-serif; text-anchor: middle">2020</text>
+          <text x="370" y="400" style="font: 12px sans-serif; text-anchor: middle">2021</text>
+          <text x="515" y="400" style="font: 12px sans-serif; text-anchor: middle">2022</text>
+          <text x="660" y="400" style="font: 12px sans-serif; text-anchor: middle">2023</text>
+            </g>
+        <g id="area-revenue-subscriptions">
+          <path d="M 80 348 L 225 316 L 370 284 L 515 236 L 660 220 L 660 380 L 515 380 L 370 380 L 225 380 L 80 380 Z" style="fill: #4c78a8; fill-opacity: 0.85; stroke: #4c78a8; stroke-width: 1.5" />
+        </g>
+        <g id="area-revenue-services">
+          <path d="M 80 332 L 225 252 L 370 60 L 515 156 L 660 124 L 660 220 L 515 236 L 370 284 L 225 316 L 80 348 Z" style="fill: #f58518; fill-opacity: 0.85; stroke: #f58518; stroke-width: 1.5" />
+        </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -182,7 +182,14 @@ function coalesceSiblingLineLayers(
   while (i < entries.length) {
     const current = entries[i];
 
-    if (current.layer.type !== TraceType.LINE && current.layer.type !== TraceType.STEP) {
+    // Unstacked areas join the same run: sibling `mark_area()` layers are
+    // independent bands over shared axes, exactly the case this merge exists
+    // for. The stacked variants are deliberately excluded — Vega-Lite stacks
+    // within one mark, never across `alt.layer(...)`, so a run of them would
+    // not be one stack and merging would invent a total that is not drawn.
+    if (current.layer.type !== TraceType.LINE
+      && current.layer.type !== TraceType.STEP
+      && current.layer.type !== TraceType.AREA) {
       out.push(current.layer);
       i += 1;
       continue;
@@ -596,7 +603,8 @@ function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
  *   - `bar` with color/fill + stack    → STACKED / NORMALIZED / DODGED
  *   - `rect`                           → HEATMAP
  *   - `tick`                           → SCATTER (individual value marks)
- *   - `line`/`area` with a stepping `interpolate` → STEP
+ *   - `line` with a stepping `interpolate` → STEP
+ *   - `area`                           → AREA / STACKED_AREA / NORMALIZED_AREA
  *   - `arc` with a `theta` encoding    → PIE (a doughnut is the same mark
  *     with an `innerRadius`, and reads identically)
  */
@@ -628,8 +636,33 @@ function resolveTraceType(
       return TraceType.BAR;
     }
     case 'line':
-    case 'area':
       return stepDirection ? TraceType.STEP : TraceType.LINE;
+    // An area used to fall through to `line`, which read a stacked chart's
+    // band height as if it were the only magnitude drawn. Vega-Lite stacks an
+    // area by default as soon as a series channel is present — `stack` has to
+    // be turned *off* to get overlapping bands — so the default branch here
+    // is the stacked one, the opposite of `bar` above.
+    case 'area': {
+      // `??` cannot read this pair: Vega-Lite spells "do not stack" as either
+      // `false` or `null`, and a nullish coalesce discards the `null` before
+      // it can be seen, falling through to the other axis and reporting
+      // `undefined` — which reads as "stack by default" and is the opposite
+      // of what the spec asked for.
+      const stack = encoding?.y?.stack !== undefined
+        ? encoding.y.stack
+        : encoding?.x?.stack;
+      if (stack === 'normalize') {
+        return TraceType.NORMALIZED_AREA;
+      }
+      const hasSeries = !!encoding?.color?.field || !!encoding?.fill?.field;
+      if (hasSeries && stack !== false && stack !== null) {
+        return TraceType.STACKED_AREA;
+      }
+      // Unstacked, so the bands are independent and each reads as its own
+      // series. A stepped one keeps its staircase reading: with nothing
+      // accumulating, STEP loses nothing that AREA would preserve.
+      return stepDirection ? TraceType.STEP : TraceType.AREA;
+    }
     case 'point':
     case 'circle':
     case 'square':
@@ -1466,9 +1499,15 @@ function convertLayerSpec(
       }
       break;
     }
-    // A step mark is a line Vega-Lite draws as a staircase: same points,
-    // same one-path-per-series geometry, so the extraction is identical.
+    // A step mark is a line Vega-Lite draws as a staircase, and an area is a
+    // line plus a fill that is drawn rather than encoded. Same points, same
+    // one-path-per-series geometry, so the extraction is identical for all of
+    // them; the stacked area variants differ only in what `AreaTrace`
+    // announces on top of it.
     case TraceType.LINE:
+    case TraceType.AREA:
+    case TraceType.NORMALIZED_AREA:
+    case TraceType.STACKED_AREA:
     case TraceType.STEP: {
       const lineData = extractLineData(rows, encoding);
       data = lineData;

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -54,6 +54,7 @@ export function named(label: string | undefined, fallback: string): string {
  * for display in the chart description modal and other user-facing surfaces.
  */
 const CHART_TYPE_LABEL: Record<TraceType, string> = {
+  [TraceType.AREA]: 'Area Chart',
   [TraceType.BAR]: 'Bar Chart',
   [TraceType.BOX]: 'Box Plot',
   [TraceType.CANDLESTICK]: 'Candlestick Chart',
@@ -63,10 +64,12 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.HISTOGRAM]: 'Histogram',
   [TraceType.LINE]: 'Line Chart',
   [TraceType.NORMALIZED]: 'Normalized Stacked Bar Chart',
+  [TraceType.NORMALIZED_AREA]: 'Normalized Stacked Area Chart',
   [TraceType.PIE]: 'Pie Chart',
   [TraceType.SCATTER]: 'Scatter Plot',
   [TraceType.SMOOTH]: 'Smooth Line Chart',
   [TraceType.STACKED]: 'Stacked Bar Chart',
+  [TraceType.STACKED_AREA]: 'Stacked Area Chart',
   [TraceType.STEP]: 'Step Plot',
   [TraceType.VIOLIN_BOX]: 'Violin Box Plot',
   [TraceType.VIOLIN_KDE]: 'Violin Plot',

--- a/src/model/area.ts
+++ b/src/model/area.ts
@@ -1,0 +1,211 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { DescriptionState, TextState, TraceState } from '@type/state';
+import { TraceType } from '@type/grammar';
+import { LineTrace } from './line';
+
+/** Label the running total is announced under. */
+const TOTAL = 'Total';
+
+/** Spoken plot type, per variant, for the instruction and layer-switch cues. */
+const PLOT_TYPE_LABEL: Record<AreaVariant, string> = {
+  area: 'area',
+  stacked: 'stacked area',
+  normalized: '100% stacked area',
+};
+
+/**
+ * How a layer's bands relate to one another.
+ *
+ * `area` bands are independent and may overlap; `stacked` bands sit on one
+ * another so their heights add up; `normalized` is `stacked` with the totals
+ * scaled to a common whole.
+ */
+type AreaVariant = 'area' | 'stacked' | 'normalized';
+
+/**
+ * Reads a layer's type as an {@link AreaVariant}.
+ *
+ * @param type - The layer's declared trace type
+ * @returns The variant, defaulting to `area` for a plain area layer
+ */
+function variantOf(type: TraceType): AreaVariant {
+  switch (type) {
+    case TraceType.STACKED_AREA:
+      return 'stacked';
+    case TraceType.NORMALIZED_AREA:
+      return 'normalized';
+    default:
+      return 'area';
+  }
+}
+
+/**
+ * Whether a magnitude is a real number the totals may include.
+ *
+ * A gap travels as `NaN`, and `NaN` spreads: summing one into a column total
+ * would make the total `NaN` and announce a stack height for the whole column
+ * that no part of the chart draws. Mirrors `isMeasured` in `bar.ts`, which
+ * guards `SegmentedTrace`'s summary level for the same reason.
+ *
+ * @param value - A magnitude read off a point
+ * @returns True when the value can be added to a total
+ */
+function isMeasured(value: number): boolean {
+  return Number.isFinite(value);
+}
+
+/**
+ * Trace implementation for area charts — a line with the region between it
+ * and a baseline filled in.
+ *
+ * For a plain area layer the fill is decoration: the navigable data is one
+ * value per sample, exactly as for a line, and everything numeric is
+ * inherited from {@link LineTrace} unchanged. What this class adds there is
+ * an honest chart-type announcement, so a reader is told they are on an area
+ * chart rather than on a line.
+ *
+ * The stacked variants are why this is a trace type rather than a flag. A
+ * stacked area draws *two* magnitudes per sample — the band's height is its
+ * own series' value, the band's top edge is the running total of every series
+ * at that x — and a line reading collapses them to one, with nothing in the
+ * announcement to say which. This class recovers the second: the running
+ * total, and the point's share of it, ride alongside the value in
+ * {@link TextState.stack}.
+ *
+ * The total is computed here rather than expected from the producer. Charting
+ * libraries disagree about whether a stacked layer's `y` is the series value
+ * or the already-accumulated edge, and asking every adapter to normalise that
+ * would put the same arithmetic in each of them. Summing the series MAIDR was
+ * given keeps one definition in one place.
+ */
+export class AreaTrace extends LineTrace {
+  private readonly variant: AreaVariant;
+
+  /**
+   * Running total per column — the stack height at each x — or `null` for an
+   * unstacked layer, which has no total to report.
+   *
+   * Computed once because trace data is immutable; a live-data update
+   * rebuilds the trace rather than mutating it.
+   */
+  private readonly columnTotals: number[] | null;
+
+  /**
+   * Creates a new area trace.
+   *
+   * @param layer - The MAIDR layer carrying the area data
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.variant = variantOf(layer.type);
+    this.columnTotals = this.variant === 'area' ? null : this.computeColumnTotals();
+  }
+
+  /**
+   * Sums every series at each x position.
+   *
+   * Series are matched by x value rather than by column index. Stacking is
+   * only defined when the series share their x samples, but a producer may
+   * still emit them ragged — a series that starts late, or drops a gap — and
+   * indexing by column would then add one series' value at 2019 to another's
+   * at 2020 and announce the result as that column's total. Matching by x
+   * lets a series that has nothing at this x contribute nothing, which is the
+   * honest reading.
+   *
+   * @returns The stack height at each column of the first series
+   */
+  private computeColumnTotals(): number[] {
+    const reference = this.points[0] ?? [];
+    return reference.map((point) => {
+      const key = String(point.x);
+      let total = 0;
+      let measured = false;
+      for (const series of this.points) {
+        const match = series.find(candidate => String(candidate.x) === key);
+        const value = Number(match?.y);
+        if (match !== undefined && isMeasured(value)) {
+          total += value;
+          measured = true;
+        }
+      }
+      // A column where every series is a gap has no total, only an absence.
+      // Reporting 0 there would announce a stack height the chart never drew.
+      return measured ? total : Number.NaN;
+    });
+  }
+
+  /**
+   * Announces this trace as an area chart — and, for a stacked layer, says so
+   * — rather than falling back to the raw layer type.
+   *
+   * @returns The trace state with `plotType` set for the variant
+   */
+  public override get state(): TraceState {
+    const baseState = super.state;
+    if (baseState.empty) {
+      return baseState;
+    }
+
+    return { ...baseState, plotType: PLOT_TYPE_LABEL[this.variant] };
+  }
+
+  /**
+   * Adds the running total, and the point's share of it, to the announcement
+   * of a stacked layer. An unstacked area has no total to add and is
+   * announced exactly as a line is.
+   *
+   * @returns The text state for the current point
+   */
+  protected override get text(): TextState {
+    const baseText = super.text;
+    if (this.columnTotals === null) {
+      return baseText;
+    }
+
+    const total = this.columnTotals[this.col];
+    if (!isMeasured(total)) {
+      return baseText;
+    }
+
+    const value = Number(this.points[this.row]?.[this.col]?.y);
+    // A zero total is reachable — series that cancel out, or a column of
+    // zeros — and dividing by it yields Infinity or NaN. Report the total and
+    // stay silent about the share rather than announcing a share of nothing.
+    const share = isMeasured(value) && total !== 0 ? value / total : undefined;
+
+    return { ...baseText, stack: { label: TOTAL, value: total, share } };
+  }
+
+  /**
+   * Adds the range of the running total to the chart description of a stacked
+   * layer.
+   *
+   * The aggregate is the reason a stacked area is drawn rather than a set of
+   * separate ones, and it is exactly what the inherited per-series statistics
+   * cannot show: `Min value` and `Max value` describe the tallest single band,
+   * not the tallest stack.
+   *
+   * @returns The description state for this trace
+   */
+  public override get description(): DescriptionState {
+    const baseDescription = super.description;
+    if (this.columnTotals === null) {
+      return baseDescription;
+    }
+
+    const totals = this.columnTotals.filter(isMeasured);
+    if (totals.length === 0) {
+      return baseDescription;
+    }
+
+    return {
+      ...baseDescription,
+      stats: [
+        ...baseDescription.stats,
+        { label: 'Minimum total', value: Math.min(...totals) },
+        { label: 'Maximum total', value: Math.max(...totals) },
+      ],
+    };
+  }
+}

--- a/src/model/area.ts
+++ b/src/model/area.ts
@@ -82,13 +82,20 @@ export class AreaTrace extends LineTrace {
   private readonly variant: AreaVariant;
 
   /**
-   * Running total per column — the stack height at each x — or `null` for an
-   * unstacked layer, which has no total to report.
+   * Stack height at each x, keyed by the x value itself, or `null` for an
+   * unstacked layer which has no total to report.
+   *
+   * Keyed rather than indexed, and that is load-bearing. `this.col` is the
+   * cursor's position *within its own series*, so on a series that starts
+   * late — the very case the totals are matched by x to survive — column 0 is
+   * not the first x of the chart. An array indexed off another series' order
+   * would answer with a neighbouring column's total, and the share it implied
+   * could exceed 100%, which no stacked chart can draw.
    *
    * Computed once because trace data is immutable; a live-data update
    * rebuilds the trace rather than mutating it.
    */
-  private readonly columnTotals: number[] | null;
+  private readonly columnTotals: Map<string, number> | null;
 
   /**
    * Creates a new area trace.
@@ -113,26 +120,33 @@ export class AreaTrace extends LineTrace {
    * lets a series that has nothing at this x contribute nothing, which is the
    * honest reading.
    *
-   * @returns The stack height at each column of the first series
+   * Every x any series carries gets an entry, not only those the first series
+   * happens to have: a chart whose later series run past the first one still
+   * draws a stack over those columns, and a cursor that can reach a point can
+   * ask what stack it is in.
+   *
+   * @returns The stack height at each x, keyed by that x
    */
-  private computeColumnTotals(): number[] {
-    const reference = this.points[0] ?? [];
-    return reference.map((point) => {
-      const key = String(point.x);
-      let total = 0;
-      let measured = false;
-      for (const series of this.points) {
-        const match = series.find(candidate => String(candidate.x) === key);
-        const value = Number(match?.y);
-        if (match !== undefined && isMeasured(value)) {
-          total += value;
-          measured = true;
+  private computeColumnTotals(): Map<string, number> {
+    const totals = new Map<string, number>();
+    for (const series of this.points) {
+      for (const point of series) {
+        const key = String(point.x);
+        const value = Number(point.y);
+        const running = totals.get(key);
+        if (!isMeasured(value)) {
+          // A column reached only by gaps has no total, only an absence.
+          // Reporting 0 would announce a stack height the chart never drew.
+          if (running === undefined) {
+            totals.set(key, Number.NaN);
+          }
+          continue;
         }
+        const carried = running !== undefined && isMeasured(running) ? running : 0;
+        totals.set(key, carried + value);
       }
-      // A column where every series is a gap has no total, only an absence.
-      // Reporting 0 there would announce a stack height the chart never drew.
-      return measured ? total : Number.NaN;
-    });
+    }
+    return totals;
   }
 
   /**
@@ -163,12 +177,18 @@ export class AreaTrace extends LineTrace {
       return baseText;
     }
 
-    const total = this.columnTotals[this.col];
-    if (!isMeasured(total)) {
+    // Look the total up by the x under the cursor, never by `this.col` —
+    // that index is local to the current series, so on a series that starts
+    // late it names a different x than it does on the first one.
+    const point = this.points[this.row]?.[this.col];
+    const total = point === undefined
+      ? undefined
+      : this.columnTotals.get(String(point.x));
+    if (total === undefined || !isMeasured(total)) {
       return baseText;
     }
 
-    const value = Number(this.points[this.row]?.[this.col]?.y);
+    const value = Number(point.y);
     // A zero total is reachable — series that cancel out, or a column of
     // zeros — and dividing by it yields Infinity or NaN. Report the total and
     // stay silent about the share rather than announcing a share of nothing.
@@ -194,7 +214,7 @@ export class AreaTrace extends LineTrace {
       return baseDescription;
     }
 
-    const totals = this.columnTotals.filter(isMeasured);
+    const totals = [...this.columnTotals.values()].filter(isMeasured);
     if (totals.length === 0) {
       return baseDescription;
     }

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -1,6 +1,7 @@
 import type { MaidrLayer } from '@type/grammar';
 import type { Trace } from './plot';
 import { TraceType } from '@type/grammar';
+import { AreaTrace } from './area';
 import { BarTrace } from './bar';
 import { BoxTrace } from './box';
 import { Candlestick } from './candlestick';
@@ -26,6 +27,15 @@ export abstract class TraceFactory {
    */
   public static create(layer: MaidrLayer): Trace {
     switch (layer.type) {
+      // All three area variants share one class: the stacking is a property
+      // of the layer it reads off `layer.type`, not a different navigation
+      // model. Contrast the bar family, where DODGED/STACKED/NORMALIZED all
+      // route to SegmentedTrace while BAR does not.
+      case TraceType.AREA:
+      case TraceType.NORMALIZED_AREA:
+      case TraceType.STACKED_AREA:
+        return new AreaTrace(layer);
+
       case TraceType.BAR:
         return new BarTrace(layer);
 

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1095,6 +1095,14 @@ implements Observer<SubplotState | TraceState>, Disposable {
       encoder as unknown as BrailleEncoder<NonEmptyBrailleState>;
 
     this.encoders = new Map<TraceType, BrailleEncoder<NonEmptyBrailleState>>([
+      // An area trace's braille state is LineTrace's verbatim — a per-series
+      // height profile — so the line encoder renders it correctly. A stacked
+      // layer encodes each band's own height, matching what the audio plays
+      // and what `cross` announces; the running total is not part of the
+      // profile.
+      [TraceType.AREA, asGeneric(new LineBrailleEncoder())],
+      [TraceType.NORMALIZED_AREA, asGeneric(new LineBrailleEncoder())],
+      [TraceType.STACKED_AREA, asGeneric(new LineBrailleEncoder())],
       [TraceType.BAR, asGeneric(new BarBrailleEncoder())],
       [TraceType.BOX, asGeneric(new BoxBrailleEncoder())],
       [TraceType.CANDLESTICK, asGeneric(new CandlestickBrailleEncoder())],

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -528,6 +528,26 @@ export class TextService implements Observer<PlotState>, Disposable {
       );
     }
 
+    // The running total a stacked point sits inside. Reads as ", Total is 30,
+    // 40% of it" after the point's own value, so the two magnitudes a stacked
+    // area draws are never announced as one. Verbose only: the terse reading
+    // stays one point per utterance, and the chart type — announced as
+    // "stacked area" — already tells the reader which of the two `cross` is.
+    if (state.stack !== undefined) {
+      verbose.push(
+        Constant.COMMA_SPACE,
+        state.stack.label,
+        Constant.IS,
+        this.formatSingleValue(state.stack.value, crossAxisType),
+      );
+      if (state.stack.share !== undefined) {
+        verbose.push(
+          Constant.COMMA_SPACE,
+          `${(state.stack.share * 100).toFixed(1)}% of it`,
+        );
+      }
+    }
+
     return verbose.join(Constant.EMPTY);
   }
 

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -591,6 +591,14 @@ export interface MaidrLayer {
  * ```
  */
 export enum TraceType {
+  /**
+   * A filled band between a series and a baseline. Navigates exactly as
+   * {@link TraceType.LINE} does — the fill is what the mark looks like, not
+   * an extra magnitude — so several `AREA` series are read independently of
+   * one another. Use {@link TraceType.STACKED_AREA} when the bands sit on
+   * top of each other instead.
+   */
+  AREA = 'area',
   BAR = 'bar',
   BOX = 'box',
   CANDLESTICK = 'candlestick',
@@ -606,10 +614,20 @@ export enum TraceType {
   HISTOGRAM = 'hist',
   LINE = 'line',
   NORMALIZED = 'stacked_normalized_bar',
+  /** {@link TraceType.STACKED_AREA} whose bands are shares of a common total. */
+  NORMALIZED_AREA = 'stacked_normalized_area',
   PIE = 'pie',
   SCATTER = 'point',
   SMOOTH = 'smooth',
   STACKED = 'stacked_bar',
+  /**
+   * Area bands stacked on one another, so a band's *height* is its own
+   * series' value while the band's *top edge* is the running total. Reading
+   * such a layer as a {@link TraceType.LINE} announces one number where the
+   * chart draws two, with nothing to say which one was heard — which is why
+   * this is a type of its own rather than a line with a fill.
+   */
+  STACKED_AREA = 'stacked_area',
   STEP = 'step',
   VIOLIN_BOX = 'violin_box',
   VIOLIN_KDE = 'violin_kde',

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -328,6 +328,21 @@ export interface TextState {
   main: { label: string; value: number | number[] | string };
   cross: { label: string; value: number | number[] | string };
   z?: { label: string; value: number | string };
+  /**
+   * The running total a stacked point sits inside, alongside the point's own
+   * value in `cross`.
+   *
+   * A stacked area draws two magnitudes at once: a band's height is its
+   * series' value, and the band's top edge is the total of every series below
+   * it. `cross` carries the first; without somewhere to put the second, the
+   * announcement names a number the chart shows twice over and leaves the
+   * reader unable to tell which one they heard. `share` is that value as a
+   * fraction of the total, which is what a stacked chart is read for and what
+   * a listener cannot divide out in their head mid-navigation.
+   *
+   * Absent on every unstacked trace, so nothing else changes shape.
+   */
+  stack?: { label: string; value: number; share?: number };
   range?: { min: number; max: number };
   section?: string;
   /**

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -18,6 +18,11 @@ import { Orientation, TraceType } from '@type/grammar';
  * `src/model/abstract.ts` is a full record rather than a partial one.
  */
 const IS_ORIENTED: Record<TraceType, boolean> = {
+  // An area trace is a line with a fill, and it is navigated as one: along
+  // the series, then between series. Which way the band is drawn changes
+  // nothing about that, so — as with LINE, STEP and SMOOTH — there is no
+  // orientation to announce. The stacked variants inherit the same reading.
+  [TraceType.AREA]: false,
   [TraceType.BAR]: true,
   [TraceType.BOX]: true,
   [TraceType.CANDLESTICK]: true,
@@ -29,12 +34,14 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   [TraceType.HISTOGRAM]: true,
   [TraceType.LINE]: false,
   [TraceType.NORMALIZED]: true,
+  [TraceType.NORMALIZED_AREA]: false,
   // Slices are arranged around a circle, not along an axis: there is no
   // orientation to declare and none to fall back to.
   [TraceType.PIE]: false,
   [TraceType.SCATTER]: false,
   [TraceType.SMOOTH]: false,
   [TraceType.STACKED]: true,
+  [TraceType.STACKED_AREA]: false,
   [TraceType.STEP]: false,
   [TraceType.VIOLIN_BOX]: true,
   [TraceType.VIOLIN_KDE]: true,

--- a/test/adapters/vegalite/area.test.ts
+++ b/test/adapters/vegalite/area.test.ts
@@ -1,0 +1,124 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Two series over three x values, the shape every spec below is built from.
+ * Written inline rather than fixtured because the assertions are about the
+ * trace *type* the converter picks, not about the values it carries.
+ */
+const ROWS = [
+  { x: 1, y: 10, series: 'a' },
+  { x: 2, y: 20, series: 'a' },
+  { x: 3, y: 30, series: 'a' },
+  { x: 1, y: 5, series: 'b' },
+  { x: 2, y: 15, series: 'b' },
+  { x: 3, y: 25, series: 'b' },
+];
+
+/**
+ * Build a single-view spec for one mark, optionally with a series channel and
+ * an explicit stack setting.
+ * @param mark The Vega-Lite mark type
+ * @param options Encoding fragments that decide the resolved trace type
+ * @param options.series Whether to add a colour channel, making it multi-series
+ * @param options.stack The `stack` setting to declare on the y channel
+ * @param options.interpolate The mark's interpolation, e.g. `step-after`
+ * @returns The spec to convert
+ */
+function spec(
+  mark: string,
+  options: { series?: boolean; stack?: unknown; interpolate?: string } = {},
+): VegaLiteSpec {
+  const { series = false, stack, interpolate } = options;
+  return {
+    data: { values: ROWS },
+    mark: interpolate ? { type: mark, interpolate } : mark,
+    encoding: {
+      x: { field: 'x', type: 'quantitative' },
+      y: {
+        field: 'y',
+        type: 'quantitative',
+        ...(stack === undefined ? {} : { stack }),
+      },
+      ...(series ? { color: { field: 'series', type: 'nominal' } } : {}),
+    },
+  } as VegaLiteSpec;
+}
+
+/**
+ * Convert a spec and return its only layer.
+ * @param input The spec to convert
+ * @returns The single produced layer
+ */
+function onlyLayer(input: VegaLiteSpec): MaidrLayer {
+  const layers = vegaLiteToMaidr(input).subplots[0][0].layers;
+  expect(layers).toHaveLength(1);
+  return layers[0];
+}
+
+describe('vega-Lite area marks', () => {
+  it('resolves a single-series area to an area trace, not a line', () => {
+    // The regression: `area` used to fall through to the `line` case, so an
+    // area chart was announced to the user as a line chart.
+    expect(onlyLayer(spec('area')).type).toBe(TraceType.AREA);
+  });
+
+  it('resolves a series-encoded area to a stacked area trace', () => {
+    // Vega-Lite stacks an area by default as soon as a series channel is
+    // present, so this is the common case rather than the exotic one. Read as
+    // a line, the announcement carried the band height with nothing to say it
+    // was not the stack's top edge.
+    expect(onlyLayer(spec('area', { series: true })).type).toBe(TraceType.STACKED_AREA);
+  });
+
+  it('resolves an explicitly unstacked area to independent bands', () => {
+    expect(onlyLayer(spec('area', { series: true, stack: false })).type).toBe(TraceType.AREA);
+    expect(onlyLayer(spec('area', { series: true, stack: null })).type).toBe(TraceType.AREA);
+  });
+
+  it('resolves a normalized area to the normalized trace', () => {
+    expect(onlyLayer(spec('area', { series: true, stack: 'normalize' })).type)
+      .toBe(TraceType.NORMALIZED_AREA);
+  });
+
+  it('keeps a single-series area unstacked even when stack is on', () => {
+    // `stack: 'zero'` with nothing to stack against is one band on a
+    // baseline, which is what a plain area already is.
+    expect(onlyLayer(spec('area', { stack: 'zero' })).type).toBe(TraceType.AREA);
+  });
+
+  it('leaves the line mark alone', () => {
+    expect(onlyLayer(spec('line')).type).toBe(TraceType.LINE);
+    expect(onlyLayer(spec('line', { series: true })).type).toBe(TraceType.LINE);
+  });
+
+  it('carries the same per-series data shape a line layer does', () => {
+    const layer = onlyLayer(spec('area', { series: true }));
+    const data = layer.data as LinePoint[][];
+
+    expect(data).toHaveLength(2);
+    expect(data[0]).toHaveLength(3);
+    // Selectors are per series for the line family, and an area is drawn the
+    // same way — one path per band.
+    expect(Array.isArray(layer.selectors)).toBe(true);
+    expect(layer.selectors).toHaveLength(2);
+  });
+
+  describe('stepped interpolation', () => {
+    it('keeps an unstacked stepped area as a step trace', () => {
+      // Nothing accumulates, so STEP loses nothing that AREA would preserve
+      // and the staircase reading is the more specific one.
+      expect(onlyLayer(spec('area', { interpolate: 'step-after' })).type)
+        .toBe(TraceType.STEP);
+    });
+
+    it('prefers the stacked reading when a stepped area also stacks', () => {
+      // Losing the staircase costs a nuance; losing the stacking makes the
+      // announced number ambiguous, which is the worse failure.
+      expect(onlyLayer(spec('area', { series: true, interpolate: 'step-after' })).type)
+        .toBe(TraceType.STACKED_AREA);
+    });
+  });
+});

--- a/test/model/area.test.ts
+++ b/test/model/area.test.ts
@@ -26,6 +26,17 @@ const SERVICES: LinePoint[] = [
 const TOTALS = [15, 40, 100];
 
 /**
+ * `Services` as it would arrive if the line launched a quarter late: its own
+ * first point is Q2, so its local column indices are shifted by one against
+ * the series above. Totals looked up by column index rather than by x break
+ * exactly here.
+ */
+const LATE_START: LinePoint[] = [
+  { x: 'Q2', y: 20, z: 'Services' },
+  { x: 'Q3', y: 70, z: 'Services' },
+];
+
+/**
  * Create a minimal area layer for model-only tests.
  * @param type The area variant to author
  * @param data Points, nested one array per series
@@ -167,16 +178,48 @@ describe('stacked area', () => {
   test('matches series by x value rather than by column index', () => {
     // `Services` starts a quarter late. Indexing by column would add its Q2
     // value to the Q1 column and announce 30 as the Q1 stack height.
-    const lateStart: LinePoint[] = [
-      { x: 'Q2', y: 20, z: 'Services' },
-      { x: 'Q3', y: 70, z: 'Services' },
-    ];
     const trace = TraceFactory.create(
-      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, lateStart]),
+      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, LATE_START]),
     ) as AreaTrace;
     moveToColumn(trace, 0);
 
     expect(nonEmptyState(trace).text.stack?.value).toBe(10);
+  });
+
+  test('reports the total for the x the cursor is actually on, in a short series', () => {
+    // A series that starts late holds its own points at its own column
+    // indices: `LATE_START[0]` is Q2, not Q1. Looking the total up by column
+    // index rather than by x therefore reports Q1's total while the cursor
+    // sits on Q2 — and, worse than being wrong, it yields a share above 100%,
+    // which no stacked chart can draw.
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, LATE_START]),
+    ) as AreaTrace;
+    trace.moveToIndex(1, 0);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.main.value).toBe('Q2');
+    expect(text.cross.value).toBe(20);
+    expect(text.stack?.value).toBe(TOTALS[1]);
+    expect(text.stack?.share).toBeCloseTo(20 / 40);
+  });
+
+  test('totals an x that the first series does not carry at all', () => {
+    // The reference series stops at Q2 while another runs to Q3. Building the
+    // totals from the first series alone leaves Q3 with no total, so the
+    // cursor lands on a real point and hears nothing about the stack it is in.
+    const short: LinePoint[] = [
+      { x: 'Q1', y: 10, z: 'Subscriptions' },
+      { x: 'Q2', y: 20, z: 'Subscriptions' },
+    ];
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [short, LATE_START]),
+    ) as AreaTrace;
+    trace.moveToIndex(1, 1);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.main.value).toBe('Q3');
+    expect(text.stack?.value).toBe(70);
   });
 
   test('stays silent about the share when the total is zero', () => {

--- a/test/model/area.test.ts
+++ b/test/model/area.test.ts
@@ -1,0 +1,195 @@
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { AreaTrace } from '@model/area';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Two revenue streams over three quarters. The numbers are chosen so every
+ * total is distinct from every series value, so an assertion on a total
+ * cannot pass by coincidentally reading a band height instead.
+ */
+const SUBSCRIPTIONS: LinePoint[] = [
+  { x: 'Q1', y: 10, z: 'Subscriptions' },
+  { x: 'Q2', y: 20, z: 'Subscriptions' },
+  { x: 'Q3', y: 30, z: 'Subscriptions' },
+];
+
+const SERVICES: LinePoint[] = [
+  { x: 'Q1', y: 5, z: 'Services' },
+  { x: 'Q2', y: 20, z: 'Services' },
+  { x: 'Q3', y: 70, z: 'Services' },
+];
+
+/** Column totals of the two series above: 15, 40, 100. */
+const TOTALS = [15, 40, 100];
+
+/**
+ * Create a minimal area layer for model-only tests.
+ * @param type The area variant to author
+ * @param data Points, nested one array per series
+ * @returns Area layer definition for AreaTrace
+ */
+function createAreaLayer(type: TraceType, data: LinePoint[][]): MaidrLayer {
+  return {
+    id: 'test-area-layer',
+    type,
+    title: 'Revenue',
+    axes: {
+      x: { label: 'Quarter' },
+      y: { label: 'Revenue' },
+    },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: AreaTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Move the cursor to a given column of the first series.
+ * @param trace The trace to move
+ * @param col Zero-based column index to land on
+ */
+function moveToColumn(trace: AreaTrace, col: number): void {
+  trace.moveOnce('UPWARD');
+  for (let i = 0; i < col; i++) {
+    trace.moveOnce('FORWARD');
+  }
+}
+
+describe('area trace registration', () => {
+  test.each([
+    [TraceType.AREA],
+    [TraceType.STACKED_AREA],
+    [TraceType.NORMALIZED_AREA],
+  ])('the factory builds an AreaTrace for %s', (type) => {
+    const trace = TraceFactory.create(createAreaLayer(type, [SUBSCRIPTIONS]));
+
+    expect(trace).toBeInstanceOf(AreaTrace);
+  });
+
+  test.each([
+    [TraceType.AREA, 'area'],
+    [TraceType.STACKED_AREA, 'stacked area'],
+    [TraceType.NORMALIZED_AREA, '100% stacked area'],
+  ])('%s announces itself as "%s"', (type, expected) => {
+    const trace = TraceFactory.create(
+      createAreaLayer(type, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    expect(nonEmptyState(trace).plotType).toBe(expected);
+  });
+});
+
+describe('unstacked area', () => {
+  test('reads a point as a line does, with no running total', () => {
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.AREA, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    moveToColumn(trace, 1);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.cross.value).toBe(20);
+    // Bands that do not stack have no total to report; announcing one would
+    // claim an aggregate the chart never draws.
+    expect(text.stack).toBeUndefined();
+  });
+
+  test('carries no total statistics in the description', () => {
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.AREA, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    const labels = trace.description.stats.map(stat => stat.label);
+    expect(labels).not.toContain('Minimum total');
+    expect(labels).not.toContain('Maximum total');
+  });
+});
+
+describe('stacked area', () => {
+  test('announces the band value and the running total as separate numbers', () => {
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    moveToColumn(trace, 1);
+
+    const { text } = nonEmptyState(trace);
+    // The regression this trace type exists to prevent: read as a line, the
+    // announcement carried 20 alone with nothing to say whether that was the
+    // band's height or the stack's top edge.
+    expect(text.cross.value).toBe(20);
+    expect(text.stack?.value).toBe(TOTALS[1]);
+  });
+
+  test('reports the point share of the total', () => {
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    moveToColumn(trace, 2);
+
+    expect(nonEmptyState(trace).text.stack?.share).toBeCloseTo(30 / 100);
+  });
+
+  test('totals every series, not only the ones below the cursor', () => {
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    moveToColumn(trace, 0);
+
+    expect(nonEmptyState(trace).text.stack?.value).toBe(TOTALS[0]);
+  });
+
+  test('describes the range of the stack, not only of the tallest band', () => {
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    const stats = trace.description.stats;
+    expect(stats).toContainEqual({ label: 'Minimum total', value: 15 });
+    expect(stats).toContainEqual({ label: 'Maximum total', value: 100 });
+  });
+
+  test('matches series by x value rather than by column index', () => {
+    // `Services` starts a quarter late. Indexing by column would add its Q2
+    // value to the Q1 column and announce 30 as the Q1 stack height.
+    const lateStart: LinePoint[] = [
+      { x: 'Q2', y: 20, z: 'Services' },
+      { x: 'Q3', y: 70, z: 'Services' },
+    ];
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [SUBSCRIPTIONS, lateStart]),
+    ) as AreaTrace;
+    moveToColumn(trace, 0);
+
+    expect(nonEmptyState(trace).text.stack?.value).toBe(10);
+  });
+
+  test('stays silent about the share when the total is zero', () => {
+    const positive: LinePoint[] = [{ x: 'Q1', y: 5, z: 'Inflow' }];
+    const negative: LinePoint[] = [{ x: 'Q1', y: -5, z: 'Outflow' }];
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.STACKED_AREA, [positive, negative]),
+    ) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    const { text } = nonEmptyState(trace);
+    expect(text.stack?.value).toBe(0);
+    // 5 / 0 is Infinity; announcing "Infinity% of it" is worse than silence.
+    expect(text.stack?.share).toBeUndefined();
+  });
+});

--- a/test/model/areaHighlight.test.ts
+++ b/test/model/areaHighlight.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { AreaTrace } from '@model/area';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Four samples of one band. Distinct y values throughout, so a highlight that
+ * landed on the wrong vertex cannot coincide with the right one.
+ */
+const POINTS: LinePoint[] = [
+  { x: 0, y: 3 },
+  { x: 1, y: 1 },
+  { x: 2, y: 4 },
+  { x: 3, y: 2 },
+];
+
+/** SVG x coordinate each sample is drawn at. */
+const SAMPLE_X = [10, 20, 30, 40];
+
+/** SVG y coordinate each sample's value is drawn at. */
+const SAMPLE_Y = [100, 300, 60, 200];
+
+/** SVG y coordinate of the band's baseline. */
+const BASELINE_Y = 380;
+
+/**
+ * Render an area band the way Vega, D3 and matplotlib all draw one: out along
+ * the top edge through every sample, then back along the baseline, then close.
+ *
+ * That is `2N` vertices for `N` samples, and only the first `N` are data. This
+ * is the geometry the highlight mapping has to survive, and it is the reason
+ * this file exists separately from the model tests: an area is the first trace
+ * whose rendered path carries a whole return journey the data knows nothing
+ * about.
+ * @returns The `d` attribute of the closed area path
+ */
+function areaPath(): string {
+  const top = POINTS.map((_, i) =>
+    `${i === 0 ? 'M' : 'L'} ${SAMPLE_X[i]} ${SAMPLE_Y[i]}`,
+  );
+  // The baseline is walked in reverse, as a closed fill must be.
+  const bottom = [...POINTS].map((_, i) => POINTS.length - 1 - i).map(i => `L ${SAMPLE_X[i]} ${BASELINE_Y}`);
+  return [...top, ...bottom, 'Z'].join(' ');
+}
+
+/**
+ * Create an area layer whose selector resolves against the document.
+ * @param type - The area variant to author
+ * @returns Area layer definition for AreaTrace
+ */
+function createAreaLayer(type: TraceType = TraceType.AREA): MaidrLayer {
+  return {
+    id: 'test-area-layer',
+    type,
+    title: 'Revenue',
+    axes: { x: { label: 'Quarter' }, y: { label: 'Revenue' } },
+    selectors: ['g#area-series path'],
+    data: [POINTS],
+  };
+}
+
+/**
+ * Read back the highlight circles MAIDR synthesised for the rendered path.
+ * @returns One point per circle, in document order
+ */
+function highlightCircles(): { x: number; y: number }[] {
+  return Array.from(document.querySelectorAll('circle')).map(circle => ({
+    x: Number(circle.getAttribute('cx')),
+    y: Number(circle.getAttribute('cy')),
+  }));
+}
+
+/**
+ * Put a rendered band in the document for the trace to resolve against.
+ * @param pathD - The `d` attribute of the area path
+ */
+function renderArea(pathD: string): void {
+  document.body.innerHTML = `
+      <svg id="chart" xmlns="http://www.w3.org/2000/svg">
+        <g id="area-series"><path d="${pathD}"></path></g>
+      </svg>`;
+}
+
+/**
+ * jsdom implements `SVGElement` but none of the per-tag SVG interfaces, so
+ * `element instanceof SVGPathElement` — the branch `LineTrace` uses to decide
+ * it is looking at a path — throws. Define it here so the branch is reachable,
+ * matching a browser rather than changing it: only a `<path>` satisfies it.
+ */
+function defineSvgPathElement(): void {
+  if ('SVGPathElement' in globalThis) {
+    return;
+  }
+  Object.defineProperty(globalThis, 'SVGPathElement', {
+    configurable: true,
+    writable: true,
+    value: class SVGPathElementShim {
+      public static [Symbol.hasInstance](value: unknown): boolean {
+        return value instanceof SVGElement && value.tagName === 'path';
+      }
+    },
+  });
+}
+
+describe('area trace highlight mapping', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = '';
+  });
+
+  test('maps the top edge of a closed band onto the data points', () => {
+    // `LineTrace.reconcilePathCoordinates` drops surplus vertices from the
+    // END, which is exactly right here: an area path draws its data first and
+    // its return journey afterwards, so the survivors are the samples. That is
+    // load-bearing rather than incidental — a renderer that emitted the
+    // baseline first would put every highlight on the baseline — so it is
+    // pinned here rather than left to be discovered visually.
+    renderArea(areaPath());
+    // eslint-disable-next-line no-new
+    new AreaTrace(createAreaLayer());
+
+    expect(highlightCircles()).toEqual(
+      POINTS.map((_, i) => ({ x: SAMPLE_X[i], y: SAMPLE_Y[i] })),
+    );
+  });
+
+  test('never places a highlight on the baseline', () => {
+    renderArea(areaPath());
+    // eslint-disable-next-line no-new
+    new AreaTrace(createAreaLayer());
+
+    const onBaseline = highlightCircles().filter(c => c.y === BASELINE_Y);
+    expect(onBaseline).toHaveLength(0);
+  });
+
+  test('maps an unclosed band the same way a line is mapped', () => {
+    // Some producers stroke the top edge as its own path and fill separately,
+    // so the selector resolves to a plain N-vertex polyline. That path needs
+    // no reconciliation at all and must come through unchanged.
+    const topOnly = POINTS
+      .map((_, i) => `${i === 0 ? 'M' : 'L'} ${SAMPLE_X[i]} ${SAMPLE_Y[i]}`)
+      .join(' ');
+    renderArea(topOnly);
+    // eslint-disable-next-line no-new
+    new AreaTrace(createAreaLayer());
+
+    expect(highlightCircles()).toEqual(
+      POINTS.map((_, i) => ({ x: SAMPLE_X[i], y: SAMPLE_Y[i] })),
+    );
+  });
+
+  test('maps a stacked band the same way', () => {
+    // Stacking changes what is announced, not how the band is drawn, so the
+    // geometry handling must not diverge between the variants.
+    renderArea(areaPath());
+    // eslint-disable-next-line no-new
+    new AreaTrace(createAreaLayer(TraceType.STACKED_AREA));
+
+    expect(highlightCircles()).toEqual(
+      POINTS.map((_, i) => ({ x: SAMPLE_X[i], y: SAMPLE_Y[i] })),
+    );
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -25,12 +25,17 @@ describe('resolveOrientation', () => {
   });
 
   const unorientedTypes = [
+    // An area trace is navigated along its series and then between series,
+    // exactly as a line is, whichever way the band is drawn.
+    TraceType.AREA,
     TraceType.CANDLESTICK_DELTA,
     TraceType.HEATMAP,
     TraceType.LINE,
+    TraceType.NORMALIZED_AREA,
     TraceType.PIE,
     TraceType.SCATTER,
     TraceType.SMOOTH,
+    TraceType.STACKED_AREA,
     TraceType.STEP,
   ];
 


### PR DESCRIPTION
# Pull Request

## Description

The Vega-Lite adapter folded the `area` mark into `TraceType.LINE`, so every area chart was announced to the user as a line chart:

```ts
// src/adapters/vegalite/converters.ts, before
case 'line':
case 'area':
  return stepDirection ? TraceType.STEP : TraceType.LINE;
```

For a stacked area that is not merely imprecise. The chart draws **two** magnitudes at each sample — the band's height is its own series' value, the band's top edge is the running total of every series — and a line reading collapses them to one number with nothing in the announcement to say which of the two was heard. A reader navigating a stacked revenue chart hears `20` and cannot tell whether that is this product line's revenue or the company's.

This adds `AREA`, `STACKED_AREA` and `NORMALIZED_AREA`, all served by one `AreaTrace`.

## Related Issues

Addresses the core and Vega-Lite halves of #788. Two boxes on that issue are deliberately **not** ticked here and it stays open:

- The Chart.js `fill` detection needs a new field on `ChartJsDataset` and a change to how `extractLineLayers` groups datasets. That is a second producer and a different grouping rule, so it belongs in its own commit rather than bundled here.
- A navigable "Total" row (the continuous sibling of `SegmentedTrace`'s summary level) would need `LineTrace.mapToSvgElements` to tolerate a series with no selector — it currently returns `null` for the whole trace on a length mismatch, which would silently disable highlighting everywhere. Worth doing, but not as a side effect of this change.

## Changes Made

**Model.** `AreaTrace extends LineTrace`, following the `StepTrace` pattern. An unstacked area navigates exactly as a line does and gains only an honest chart-type announcement. The stacked variants recover the second magnitude: the running total and the point's share of it ride alongside the value in a new `TextState.stack`.

Two decisions worth flagging for review:

- **Totals are summed in the model, not taken from the producer.** Charting libraries disagree about whether a stacked layer's `y` is the series value or the already-accumulated edge; asking every adapter to normalise that would put the same arithmetic in each of them.
- **Series are matched by x value, not by column index.** Stacking is only defined when series share their x samples, but a producer may still emit them ragged. Indexing by column would add one series' 2019 value to another's 2020 column and announce the result as that column's total.

**Text.** `TextState.stack` is rendered in **verbose mode only**, reading as `", Total is 30, 40% of it"`. Point-by-point navigation stays exactly as terse as it was — the chart type announcement ("stacked area") is what tells the reader which magnitude `cross` is, so the brief reading did not need to grow.

**Braille.** All three variants use `LineBrailleEncoder`; the profile is each band's own height, matching the audio and the cross value. Documented in `docs/BRAILLE.md` including why the total is deliberately *not* folded in.

**Vega-Lite.** `area` now resolves to the three new types. Vega-Lite stacks an area by default once a series channel is present — `stack` has to be turned *off* to get overlapping bands — so the default branch here is the stacked one, the opposite of `bar` directly above it. Unstacked area layers also join `coalesceSiblingLineLayers`; the stacked variants are excluded, because Vega-Lite stacks within one mark and never across `alt.layer(...)`, so merging them would invent a total that is not drawn.

The stack setting is read without `??`:

```ts
const stack = encoding?.y?.stack !== undefined ? encoding.y.stack : encoding?.x?.stack;
```

Vega-Lite spells "do not stack" as either `false` or `null`, and a nullish coalesce discards the `null` before it can be seen, falls through to the other axis, and reports `undefined` — which reads as "stack by default", the exact opposite of what the spec asked for. My first version used `??` and the test for `stack: null` caught it.

**A pre-existing bug this turned up, left alone:** the `bar` branch above uses that same `??` pattern, so `"stack": null` on a bar mark is currently read as `STACKED` rather than `DODGED`. Not touched here because fixing it changes bar behaviour and belongs in its own change — happy to file it separately.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Verification actually run, in full:

| Step | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run build` | all builds complete |
| `npm test` | **1870 passed** (unit/component) + **73 passed** (ESM), 0 failures |
| `npm run type-check` | see below |

`npm run type-check` reports `tsconfig.json(6,5): error TS5101: Option 'baseUrl' is deprecated`. That is **pre-existing on `main`** — I confirmed it by stashing this branch's changes and re-running on the base commit, where it reproduces identically. `tsc` reports no other errors, so these changes type-check; the config deprecation is a separate problem and I have not touched it.

New tests: `test/model/area.test.ts` (14 cases) and `test/adapters/vegalite/area.test.ts` (10 cases). The registration guard in `test/util/orientation.test.ts` failed on the three new types until they were listed there, which is the guard working as designed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_