### PR TITLE
fix(vegalite): read a bar's stack setting without discarding null

### DIFF
--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -622,7 +622,9 @@ function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
  * @param encoding - The layer's encoding, when it has one
  * @returns The declared stack setting, or undefined when none is declared
  */
-function declaredStack(encoding?: VegaLiteEncoding): unknown {
+function declaredStack(
+  encoding?: VegaLiteEncoding,
+): VegaLiteChannelDef['stack'] {
   return encoding?.y?.stack !== undefined
     ? encoding.y.stack
     : encoding?.x?.stack;
@@ -634,7 +636,7 @@ function declaredStack(encoding?: VegaLiteEncoding): unknown {
  * @param stack - The value {@link declaredStack} returned
  * @returns True when the spec asked for unstacked marks
  */
-function isUnstacked(stack: unknown): boolean {
+function isUnstacked(stack: VegaLiteChannelDef['stack']): boolean {
   return stack === false || stack === null;
 }
 

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -608,6 +608,36 @@ function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
  *   - `arc` with a `theta` encoding    → PIE (a doughnut is the same mark
  *     with an `innerRadius`, and reads identically)
  */
+/**
+ * Reads the `stack` setting a spec declares, from whichever axis carries it.
+ *
+ * `??` cannot do this job, and the difference is not cosmetic: Vega-Lite
+ * spells "do not stack" as either `false` or `null`, and a nullish coalesce
+ * discards the `null` before any check can see it, falls through to the other
+ * axis, and reports `undefined` — which every caller reads as "stack by
+ * default", the exact opposite of what the spec asked for.
+ *
+ * `undefined` here therefore means "no axis declared one", and only that.
+ *
+ * @param encoding - The layer's encoding, when it has one
+ * @returns The declared stack setting, or undefined when none is declared
+ */
+function declaredStack(encoding?: VegaLiteEncoding): unknown {
+  return encoding?.y?.stack !== undefined
+    ? encoding.y.stack
+    : encoding?.x?.stack;
+}
+
+/**
+ * Whether a declared stack setting turns stacking off.
+ *
+ * @param stack - The value {@link declaredStack} returned
+ * @returns True when the spec asked for unstacked marks
+ */
+function isUnstacked(stack: unknown): boolean {
+  return stack === false || stack === null;
+}
+
 function resolveTraceType(
   mark: string,
   encoding?: VegaLiteEncoding,
@@ -619,13 +649,13 @@ function resolveTraceType(
         return TraceType.HISTOGRAM;
       }
       if (encoding?.color?.field || encoding?.fill?.field) {
-        const stack = encoding?.y?.stack ?? encoding?.x?.stack;
+        const stack = declaredStack(encoding);
         // `xOffset` (or `yOffset`) with a field is the modern Vega-Lite way
         // to dodge bars side-by-side. Treat its presence as a DODGED hint
         // even when `stack` is not explicitly disabled.
         const hasOffsetField
           = !!encoding?.xOffset?.field || !!encoding?.yOffset?.field;
-        if (hasOffsetField || stack === false || stack === null) {
+        if (hasOffsetField || isUnstacked(stack)) {
           return TraceType.DODGED;
         }
         if (stack === 'normalize') {
@@ -643,19 +673,12 @@ function resolveTraceType(
     // be turned *off* to get overlapping bands — so the default branch here
     // is the stacked one, the opposite of `bar` above.
     case 'area': {
-      // `??` cannot read this pair: Vega-Lite spells "do not stack" as either
-      // `false` or `null`, and a nullish coalesce discards the `null` before
-      // it can be seen, falling through to the other axis and reporting
-      // `undefined` — which reads as "stack by default" and is the opposite
-      // of what the spec asked for.
-      const stack = encoding?.y?.stack !== undefined
-        ? encoding.y.stack
-        : encoding?.x?.stack;
+      const stack = declaredStack(encoding);
       if (stack === 'normalize') {
         return TraceType.NORMALIZED_AREA;
       }
       const hasSeries = !!encoding?.color?.field || !!encoding?.fill?.field;
-      if (hasSeries && stack !== false && stack !== null) {
+      if (hasSeries && !isUnstacked(stack)) {
         return TraceType.STACKED_AREA;
       }
       // Unstacked, so the bands are independent and each reads as its own

--- a/test/adapters/vegalite/barStacking.test.ts
+++ b/test/adapters/vegalite/barStacking.test.ts
@@ -1,0 +1,82 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { MaidrLayer } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { TraceType } from '@type/grammar';
+
+/** Two subcategories over two categories, the minimum a stack can be read on. */
+const ROWS = [
+  { x: 'a', y: 10, series: 'u' },
+  { x: 'a', y: 30, series: 'v' },
+  { x: 'b', y: 50, series: 'u' },
+  { x: 'b', y: 50, series: 'v' },
+];
+
+/**
+ * Build a single-view bar spec with a series channel and an explicit stack
+ * setting on one axis.
+ * @param options Which axis declares `stack`, and what it declares
+ * @param options.stack The `stack` value to declare
+ * @param options.axis Which axis carries the declaration
+ * @param options.offset Whether to add an `xOffset` dodge channel
+ * @returns The spec to convert
+ */
+function barSpec(
+  options: { stack?: unknown; axis?: 'x' | 'y'; offset?: boolean } = {},
+): VegaLiteSpec {
+  const { stack, axis = 'y', offset = false } = options;
+  const declare = (on: 'x' | 'y'): object =>
+    stack === undefined || axis !== on ? {} : { stack };
+
+  return {
+    data: { values: ROWS },
+    mark: 'bar',
+    encoding: {
+      x: { field: 'x', type: 'nominal', ...declare('x') },
+      y: { field: 'y', type: 'quantitative', ...declare('y') },
+      color: { field: 'series', type: 'nominal' },
+      ...(offset ? { xOffset: { field: 'series', type: 'nominal' } } : {}),
+    },
+  } as VegaLiteSpec;
+}
+
+/**
+ * Convert a spec and return its only layer.
+ * @param input The spec to convert
+ * @returns The single produced layer
+ */
+function onlyLayer(input: VegaLiteSpec): MaidrLayer {
+  const layers = vegaLiteToMaidr(input).subplots[0][0].layers;
+  expect(layers).toHaveLength(1);
+  return layers[0];
+}
+
+describe('vega-Lite bar stacking', () => {
+  it('stacks by default when a series channel is present', () => {
+    expect(onlyLayer(barSpec()).type).toBe(TraceType.STACKED);
+  });
+
+  it('reads an explicit stack: false as dodged', () => {
+    expect(onlyLayer(barSpec({ stack: false })).type).toBe(TraceType.DODGED);
+  });
+
+  it('reads an explicit stack: null as dodged', () => {
+    // Vega-Lite spells "do not stack" as either `false` or `null`. A nullish
+    // coalesce discards the `null` before the check can see it, falls through
+    // to the other axis, and reports `undefined` — which reads as "stack by
+    // default", the exact opposite of what the spec asked for.
+    expect(onlyLayer(barSpec({ stack: null })).type).toBe(TraceType.DODGED);
+  });
+
+  it('reads stack: normalize as the normalized trace', () => {
+    expect(onlyLayer(barSpec({ stack: 'normalize' })).type).toBe(TraceType.NORMALIZED);
+  });
+
+  it('honours a stack declared on the x axis for a horizontal bar', () => {
+    expect(onlyLayer(barSpec({ stack: null, axis: 'x' })).type).toBe(TraceType.DODGED);
+    expect(onlyLayer(barSpec({ stack: false, axis: 'x' })).type).toBe(TraceType.DODGED);
+  });
+
+  it('treats an offset channel as dodged whatever stack says', () => {
+    expect(onlyLayer(barSpec({ offset: true })).type).toBe(TraceType.DODGED);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Vega-Lite spells "do not stack" as either `false` or `null`. The `bar` branch read the setting with `??`:

```ts
const stack = encoding?.y?.stack ?? encoding?.x?.stack;
...
if (hasOffsetField || stack === false || stack === null) {
  return TraceType.DODGED;
}
```

`??` treats `null` as nullish, so the `null` is discarded before the `stack === null` check below can ever see it. The read falls through to the other axis, `stack` comes back `undefined`, and the branch treats that as "stack by default".

A bar chart authored with `"stack": null` therefore draws side-by-side bars and is announced as a **stacked** bar. The reader is told the segments accumulate into a category total when they do not, so any comparison they make between a bar's parts and its whole is against a total the chart never draws. `"stack": false` was unaffected, which is why this stood.

## Related Issues

Closes #816.

## Changes Made

Extracted the read and the off-test into two helpers, `declaredStack` and `isUnstacked`, and pointed both the `bar` and `area` branches at them.

The extraction is the point rather than a tidy-up: the `area` branch added in #815 was already written the long way round (`encoding?.y?.stack !== undefined ? ... : ...`) precisely because `??` gets this wrong, and it carried its own paragraph of comment explaining why. Two branches independently rediscovering the same trap — and one of them getting it wrong — is what a shared helper is for. `undefined` now means "no axis declared one", and only that.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

New file `test/adapters/vegalite/barStacking.test.ts` — 6 cases covering the full classification surface of the `bar` branch, not just the bug: default stacking, `false`, `null`, `normalize`, a stack declared on the **x** axis (the fallback arm of the read, which nothing exercised before), and an offset channel overriding all of it.

Written before the fix, and it failed exactly as predicted:

```
✕ reads an explicit stack: null as dodged
    Expected: "dodged_bar"
    Received: "stacked_bar"
```

Verification actually run:

| Step | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npx tsc --noEmit` | no errors beyond the pre-existing `TS5101` config deprecation |
| `npm test` | **1882 passed** + **73 passed** (ESM), 0 failures |
| `npx jest test/adapters/vegalite` | 134 passed |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_