### PR TITLE
feat(errorbar): read an estimate together with its interval

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -197,6 +197,28 @@ would read as the same shape with different numbers behind it.
 As for a line plot: each line of the display is one series, and the user moves
 between series with the up and down arrow keys on a single-line display.
 
+## Error bar plot
+
+An error bar layer becomes one braille row per magnitude it draws — the lower
+bounds, the estimates, the upper bounds — each scaled against its own row's
+range, exactly as a multi-series line plot is.
+
+Rows are ordered bottom to top, so moving down the display moves down the
+value axis. A layer whose data carries no lower bound has no lower row: an
+empty lane the reader can enter and feel nothing in reads as a broken chart
+rather than as an absent bound.
+
+The interval itself is not encoded as a span. Feeling the width means moving
+between the rows at one column, which is the same motion that hears it — the
+audio, the announcement and the braille all describe the same three
+magnitudes rather than three different summaries of them.
+
+### Multiline Displays
+
+Each line of the display is one magnitude, so a multi-line display shows the
+whole interval at once. On a single-line display the up and down arrows move
+between the bounds and the estimate.
+
 ## Step plot
 
 A step plot's braille is the line plot encoding above, unchanged: each data

--- a/e2e_tests/page-objects/plots/errorbar-page.ts
+++ b/e2e_tests/page-objects/plots/errorbar-page.ts
@@ -1,0 +1,140 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { ErrorBarPlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the stacked error bar plot page.
+ *
+ * Provides the interactions the area spec needs: reaching the example,
+ * activating MAIDR on it, and reading back the announcement, the braille
+ * output and the text-mode state.
+ */
+export class ErrorBarPlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.ERRORBAR_ID}`,
+    svg: `svg`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the error bar plot
+   */
+  private readonly plotId = TestConstants.ERRORBAR_ID;
+
+  /**
+   * Creates a new ErrorBarPlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the error bar plot page
+   * @throws ErrorBarPlotError if navigation fails
+   */
+  public async navigateToErrorBarPlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/errorbar.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new ErrorBarPlotError('Failed to navigate to error bar plot', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the error bar plot
+   * @throws ErrorBarPlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new ErrorBarPlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws ErrorBarPlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new ErrorBarPlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws ErrorBarPlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded');
+      await expect(this.page.locator(this.selectors.svg)).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      throw new ErrorBarPlotError('Error bar plot failed to load correctly', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   *
+   * Braille is the modality that fails silently for a new trace type — an
+   * unregistered encoder leaves the display blank while text and audio still
+   * work — so this returns the raw cell string for the spec to assert on.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws ErrorBarPlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new ErrorBarPlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws ErrorBarPlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new ErrorBarPlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/errorbar.spec.ts
+++ b/e2e_tests/specs/errorbar.spec.ts
@@ -1,0 +1,161 @@
+import type { ErrorBarPoint, Maidr, MaidrLayer } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { ErrorBarPlotPage } from '../page-objects/plots/errorbar-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output. Written as escapes rather than literal glyphs because the range
+ * endpoints are indistinguishable by eye: U+2800 is the blank cell.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * Reads the layer's points, failing loudly rather than returning undefined for
+ * a shape the example does not have.
+ * @param layer - The MAIDR layer carrying the interval data
+ * @returns The layer's points
+ * @throws TypeError if the data is not a flat array of interval points
+ */
+function getPoints(layer: MaidrLayer | undefined): ErrorBarPoint[] {
+  if (!layer?.data || !Array.isArray(layer.data) || Array.isArray(layer.data[0])) {
+    throw new TypeError('Error bar layer data is not a flat array of points');
+  }
+
+  return layer.data as ErrorBarPoint[];
+}
+
+test.describe('Error Bar Plot', () => {
+  let maidrData: Maidr;
+  let errorBarLayer: MaidrLayer;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const errorBarPage = new ErrorBarPlotPage(page);
+      await errorBarPage.navigateToErrorBarPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+      errorBarLayer = maidrData.subplots[0][0].layers[0];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const errorBarPage = new ErrorBarPlotPage(page);
+    await errorBarPage.navigateToErrorBarPlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the error bar plot with maidr data', async ({ page }) => {
+      const errorBarPage = new ErrorBarPlotPage(page);
+      await errorBarPage.activateMaidr();
+      await errorBarPage.verifyPlotLoaded();
+    });
+
+    test('should declare the layer as an error bar plot', () => {
+      expect(errorBarLayer.type).toBe('error_bar');
+    });
+
+    test('should carry a bound pair with every estimate', () => {
+      const points = getPoints(errorBarLayer);
+
+      expect(points).toHaveLength(3);
+      for (const point of points) {
+        expect(typeof point.yMin).toBe('number');
+        expect(typeof point.yMax).toBe('number');
+        expect(point.yMin!).toBeLessThan(point.y);
+        expect(point.y).toBeLessThan(point.yMax!);
+      }
+    });
+
+    test('should carry the bounds as absolute positions, not offsets', () => {
+      // The distinction the schema fixes: matplotlib hands out an offset,
+      // Vega-Lite computes bounds, and a reader told "0.4" instead of "4.6"
+      // is being given a number the chart does not draw anywhere.
+      const first = getPoints(errorBarLayer)[0];
+
+      expect(first.yMin).toBe(3.8);
+      expect(first.yMax).toBe(4.6);
+    });
+
+    test('should announce itself as an error bar plot', async ({ page }) => {
+      const errorBarPage = new ErrorBarPlotPage(page);
+      await errorBarPage.activateMaidr();
+
+      const instructionText = await errorBarPage.getInstructionText();
+      expect(normalizeText(instructionText)).toBe(
+        normalizeText(TestConstants.ERRORBAR_INSTRUCTION_TEXT),
+      );
+    });
+  });
+
+  test.describe('Interval Navigation', () => {
+    test('should walk the bounds and the estimate at one sample', async ({ page }) => {
+      // The motion this trace type exists for: up and down at one x trace a
+      // single interval, rather than making the reader rebuild it from three
+      // separate passes over the chart.
+      const errorBarPage = new ErrorBarPlotPage(page);
+      await errorBarPage.activateMaidr();
+      await errorBarPage.moveToNextDataPoint();
+
+      const atEntry = normalizeText(await errorBarPage.getInstructionText());
+      await errorBarPage.moveToDataPointBelow();
+      const below = normalizeText(await errorBarPage.getInstructionText());
+      await errorBarPage.moveToDataPointAbove();
+      await errorBarPage.moveToDataPointAbove();
+      const above = normalizeText(await errorBarPage.getInstructionText());
+
+      // Each of the three names which magnitude it is, so the numbers can
+      // never be mistaken for three separate samples.
+      expect(atEntry).toContain('value');
+      expect(below).toContain('lower bound');
+      expect(above).toContain('upper bound');
+    });
+
+    test('should announce the sample alongside the magnitude', async ({ page }) => {
+      const errorBarPage = new ErrorBarPlotPage(page);
+      await errorBarPage.activateMaidr();
+      await errorBarPage.moveToNextDataPoint();
+
+      const announcement = normalizeText(await errorBarPage.getInstructionText());
+
+      expect(announcement).toContain('control');
+      expect(announcement).toContain('4.2');
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render one braille row per magnitude', async ({ page }) => {
+      const errorBarPage = new ErrorBarPlotPage(page);
+      await errorBarPage.activateMaidr();
+      await errorBarPage.moveToNextDataPoint();
+      await errorBarPage.toggleBrailleMode();
+
+      const braille = await errorBarPage.getBrailleContent();
+      const lines = braille.split('\n');
+
+      // Lower bounds, estimates, upper bounds — one row each, one cell per
+      // sample.
+      expect(lines).toHaveLength(3);
+      for (const line of lines) {
+        expect(line).toMatch(BRAILLE_CELL);
+        expect(line).toHaveLength(getPoints(errorBarLayer).length);
+      }
+    });
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -31,6 +31,7 @@ export abstract class TestConstants {
   static readonly LINEPLOT_ID = 'line';
   static readonly STEPPLOT_ID = 'step';
   static readonly AREAPLOT_ID = 'area-revenue';
+  static readonly ERRORBAR_ID = 'errorbar-response';
   static readonly DODGED_BARPLOT_ID = 'dodged_bar';
   static readonly STACKED_BARPLOT_ID = 'stacked_bar';
   static readonly BOXPLOT_VERTICAL_ID = 'boxplot_vertical';
@@ -126,6 +127,7 @@ export abstract class TestConstants {
   // A multi-series trace names its group count, as the multiline entry above
   // does; the example this asserts against carries two bands.
   static readonly AREAPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: stacked area with 2 groups. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly ERRORBAR_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical error_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // `formatPlotType` in src/util/orientation.ts prefixes the box type with its

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -136,6 +136,22 @@ export class LinePlotError extends Error {
 }
 
 /**
+ * Error thrown when Error bar plot related operations fail
+ */
+export class ErrorBarPlotError extends Error {
+  /**
+   * Creates a new ErrorBarPlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ErrorBarPlotError';
+  }
+}
+
+/**
  * Error thrown when Area plot related operations fail
  */
 export class AreaPlotError extends Error {

--- a/examples/errorbar.html
+++ b/examples/errorbar.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Error Bar Example — Mean Response by Dose</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        An error bar chart draws TWO magnitudes at every sample: the estimate,
+        and how far from it the data is consistent with. Whether two groups
+        differ is answered by whether their intervals overlap - so a reading
+        that names only the estimate drops the finding, not a detail.
+
+        The layer carries the bounds as ABSOLUTE positions on the value axis
+        rather than as offsets from y. Producers disagree about which they hand
+        out (matplotlib's `yerr` is an offset, Vega-Lite computes bounds), so
+        the schema fixes one and each adapter converts to it.
+
+        Navigation is a grid: up and down at one x walk the lower bound, the
+        estimate and the upper bound, while left and right walk the samples.
+        That is what lets a reader trace ONE interval rather than rebuilding it
+        from three passes over the chart.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="errorbar-response" maidr='{&#10;  "id": "errorbar-response",&#10;  "subplots": [&#10;    [&#10;      {&#10;        "id": "errorbar-response-subplot",&#10;        "layers": [&#10;          {&#10;            "id": "errorbar-response-layer",&#10;            "type": "error_bar",&#10;            "title": "Mean Response by Dose, with 95% Confidence Intervals",&#10;            "axes": {&#10;              "x": {&#10;                "label": "Group"&#10;              },&#10;              "y": {&#10;                "label": "Response"&#10;              }&#10;            },&#10;            "selectors": [&#10;              "g[id=&apos;errorbar-response-0&apos;]",&#10;              "g[id=&apos;errorbar-response-1&apos;]",&#10;              "g[id=&apos;errorbar-response-2&apos;]"&#10;            ],&#10;            "data": [&#10;              {&#10;                "x": "control",&#10;                "y": 4.2,&#10;                "yMin": 3.8,&#10;                "yMax": 4.6&#10;              },&#10;              {&#10;                "x": "low dose",&#10;                "y": 5.1,&#10;                "yMin": 4,&#10;                "yMax": 6.6&#10;              },&#10;              {&#10;                "x": "high dose",&#10;                "y": 7.3,&#10;                "yMin": 7.1,&#10;                "yMax": 7.4&#10;              }&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="axes-background">
+              <path d="M 110 380  L 650 380  L 650 60  L 110 60  z " style="fill: #ffffff" />
+            </g>
+            <g id="axis_x">
+          <text x="200" y="400" style="font: 12px sans-serif; text-anchor: middle">control</text>
+          <text x="380" y="400" style="font: 12px sans-serif; text-anchor: middle">low dose</text>
+          <text x="560" y="400" style="font: 12px sans-serif; text-anchor: middle">high dose</text>
+            </g>
+        <g id="errorbar-response-0">
+          <path d="M 200 328.8 L 200 277.6" style="stroke: #4c78a8; stroke-width: 2" />
+          <path d="M 193 328.8 L 207 328.8" style="stroke: #4c78a8; stroke-width: 2" />
+          <path d="M 193 277.6 L 207 277.6" style="stroke: #4c78a8; stroke-width: 2" />
+          <circle cx="200" cy="303.2" r="4" style="fill: #4c78a8" />
+        </g>
+        <g id="errorbar-response-1">
+          <path d="M 380 316 L 380 149.60000000000002" style="stroke: #4c78a8; stroke-width: 2" />
+          <path d="M 373 316 L 387 316" style="stroke: #4c78a8; stroke-width: 2" />
+          <path d="M 373 149.60000000000002 L 387 149.60000000000002" style="stroke: #4c78a8; stroke-width: 2" />
+          <circle cx="380" cy="245.60000000000002" r="4" style="fill: #4c78a8" />
+        </g>
+        <g id="errorbar-response-2">
+          <path d="M 560 117.60000000000002 L 560 98.39999999999998" style="stroke: #4c78a8; stroke-width: 2" />
+          <path d="M 553 117.60000000000002 L 567 117.60000000000002" style="stroke: #4c78a8; stroke-width: 2" />
+          <path d="M 553 98.39999999999998 L 567 98.39999999999998" style="stroke: #4c78a8; stroke-width: 2" />
+          <circle cx="560" cy="104.80000000000001" r="4" style="fill: #4c78a8" />
+        </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -60,6 +60,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.CANDLESTICK]: 'Candlestick Chart',
   [TraceType.CANDLESTICK_DELTA]: 'Candlestick Reference Delta',
   [TraceType.DODGED]: 'Dodged Bar Chart',
+  [TraceType.ERROR_BAR]: 'Error Bar Chart',
   [TraceType.HEATMAP]: 'Heatmap',
   [TraceType.HISTOGRAM]: 'Histogram',
   [TraceType.LINE]: 'Line Chart',

--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -1,0 +1,319 @@
+import type { ErrorBarPoint, MaidrLayer } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { Orientation } from '@type/grammar';
+import { MathUtil } from '@util/math';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/**
+ * The three magnitudes an interval chart draws at one sample, bottom to top.
+ *
+ * Ordered rather than alphabetical: moving up the grid moves up the value
+ * axis, so the cursor's direction matches the chart's.
+ */
+const SECTIONS = ['lower', 'value', 'upper'] as const;
+
+type Section = (typeof SECTIONS)[number];
+
+/** How each section is announced. */
+const SECTION_LABEL: Record<Section, string> = {
+  lower: 'lower bound',
+  value: 'value',
+  upper: 'upper bound',
+};
+
+/**
+ * Reads one section's magnitude off a point.
+ *
+ * @param point - The point to read
+ * @param section - Which of the three magnitudes to take
+ * @returns The magnitude, or NaN when the chart draws no such bound here
+ */
+function magnitudeOf(point: ErrorBarPoint, section: Section): number {
+  switch (section) {
+    case 'lower':
+      return point.yMin ?? Number.NaN;
+    case 'upper':
+      return point.yMax ?? Number.NaN;
+    default:
+      return Number(point.y);
+  }
+}
+
+/**
+ * Whether a magnitude is one the chart actually drew.
+ *
+ * A missing bound travels as `NaN`, and `NaN` spreads: letting one into a
+ * range would hand the whole trace a `NaN` pitch scale.
+ *
+ * @param value - A magnitude read off a point
+ * @returns True when the value is real
+ */
+function isMeasured(value: number): boolean {
+  return Number.isFinite(value);
+}
+
+/**
+ * Strips binary floating-point noise from a subtracted magnitude.
+ *
+ * The interval width is derived, not authored: `4.6 - 3.8` is
+ * `0.30000000000000071` in IEEE 754, and announcing that to a screen reader
+ * spells out sixteen digits of an artifact the chart does not contain.
+ *
+ * Twelve significant figures rather than a fixed number of decimals, because
+ * the decimals a chart needs depend on its scale — rounding to two would
+ * report an interval of 0.003 as zero, which is worse than the noise.
+ *
+ * @param value - A magnitude obtained by subtraction
+ * @returns The same magnitude without the trailing artifact
+ */
+function withoutFloatNoise(value: number): number {
+  return Number(value.toPrecision(12));
+}
+
+/**
+ * Trace implementation for charts that draw an estimate together with the
+ * interval around it — error bars, confidence intervals, point ranges.
+ *
+ * Uncertainty is not decoration in a statistical graphic; it is frequently
+ * the finding. Whether two group means differ is answered by whether their
+ * intervals overlap, and until this trace existed that was the one thing a
+ * MAIDR reader could not hear: the estimate was announced and the interval
+ * was dropped, so the comparison the chart was drawn to support could not be
+ * made at all.
+ *
+ * Navigation follows {@link Candlestick}: the sections are the grid's rows
+ * and the samples its columns, so moving up and down at one x walks the
+ * bound, the estimate and the other bound, while left and right walk the
+ * samples. That is what lets a reader trace one interval rather than
+ * reconstructing it from three separate passes over the chart.
+ *
+ * Which sections exist is decided by the data. A layer whose points carry no
+ * `yMin` gets no lower row at all rather than a row of silence — an empty
+ * lane the cursor can enter and hear nothing in reads as a broken chart, not
+ * as an absent bound.
+ */
+export class ErrorBarTrace extends AbstractTrace {
+  protected readonly supportsExtrema = true;
+  protected readonly movable: Movable;
+
+  private readonly points: ErrorBarPoint[];
+  private readonly sections: readonly Section[];
+  private readonly sectionValues: number[][];
+  private readonly orientation: Orientation;
+
+  private readonly min: number;
+  private readonly max: number;
+  private readonly perRowMin: number[];
+  private readonly perRowMax: number[];
+
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /**
+   * Creates a new error bar trace.
+   *
+   * @param layer - The MAIDR layer carrying the interval data
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.points = layer.data as ErrorBarPoint[];
+    this.orientation = layer.orientation ?? Orientation.VERTICAL;
+    this.sections = SECTIONS.filter(section =>
+      section === 'value'
+      || this.points.some(point => isMeasured(magnitudeOf(point, section))),
+    );
+
+    this.sectionValues = this.sections.map(section =>
+      this.points.map(point => magnitudeOf(point, section)),
+    );
+
+    const measured = this.sectionValues.flat().filter(isMeasured);
+    const { min, max } = MathUtil.minMax(measured);
+    this.min = min;
+    this.max = max;
+    this.perRowMin = this.sectionValues.map(row =>
+      MathUtil.safeMin(row.filter(isMeasured)),
+    );
+    this.perRowMax = this.sectionValues.map(row =>
+      MathUtil.safeMax(row.filter(isMeasured)),
+    );
+
+    this.highlightValues = this.mapToSvgElements(layer.selectors);
+    // Enter on the estimate, not on whichever section happens to be last.
+    // A reader arriving at a sample is asking what the value is; landing them
+    // on the upper bound answers a question they have not asked yet, and does
+    // it with a number that looks like the value until they move.
+    this.movable = new MovableGrid<number>(this.sectionValues, {
+      row: Math.max(0, this.sections.indexOf('value')),
+    });
+  }
+
+  /**
+   * Resolves the layer's selectors to one element per sample, repeated across
+   * the sections.
+   *
+   * A chart draws one whip per sample, not one element per bound, so every
+   * section of a column highlights the same element. Announcing a move
+   * between bounds while the highlight sits still is the honest rendering of
+   * that — the alternative is inventing three elements the chart never drew.
+   *
+   * @param selectors - The layer's selectors, when it has any
+   * @returns Elements shaped sections x samples, or null when unresolvable
+   */
+  private mapToSvgElements(
+    selectors?: MaidrLayer['selectors'],
+  ): SVGElement[][] | null {
+    if (typeof selectors !== 'string' && !Array.isArray(selectors)) {
+      return null;
+    }
+
+    const flat = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+
+    if (flat.length !== this.points.length) {
+      return null;
+    }
+    return this.sections.map(() => flat);
+  }
+
+  protected get values(): number[][] {
+    return this.sectionValues;
+  }
+
+  protected get dimension(): Dimension {
+    return {
+      rows: this.sectionValues.length,
+      cols: this.points.length,
+    };
+  }
+
+  protected get audio(): AudioState {
+    return {
+      freq: {
+        // One scale across every section, not per row: the bounds and the
+        // estimate are the same quantity on the same axis, so a bound has to
+        // sound higher than the estimate it sits above. Per-row scaling would
+        // put them at the same pitch and erase the interval by ear.
+        min: this.min,
+        max: this.max,
+        raw: this.sectionValues[this.row][this.col],
+      },
+      panning: {
+        x: this.col,
+        y: this.row,
+        rows: this.sectionValues.length,
+        cols: this.points.length,
+      },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    return {
+      empty: false,
+      id: this.id,
+      values: this.sectionValues,
+      min: this.perRowMin,
+      max: this.perRowMax,
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const point = this.points[this.col];
+    const section = this.sections[this.row];
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+
+    return {
+      main: { label: isHorizontal ? this.yAxis : this.xAxis, value: point.x },
+      cross: {
+        label: isHorizontal ? this.xAxis : this.yAxis,
+        value: this.sectionValues[this.row][this.col],
+      },
+      // The same field the box plot and the candlestick use to say which of a
+      // point's several magnitudes is being read. Without it "3.8" and "4.6"
+      // at one x are indistinguishable from two samples.
+      section: SECTION_LABEL[section],
+    };
+  }
+
+  public get description(): DescriptionState {
+    const widths = this.points
+      .map(point => Number(point.yMax) - Number(point.yMin))
+      .filter(isMeasured)
+      .map(withoutFloatNoise);
+
+    const stats: DescriptionState['stats'] = [
+      { label: 'Number of points', value: this.points.length },
+      { label: 'Min value', value: this.min },
+      { label: 'Max value', value: this.max },
+    ];
+
+    if (widths.length > 0) {
+      // The width of the interval is what a reader is judging when they ask
+      // whether two estimates differ, and it is not recoverable from the
+      // per-section ranges above: those describe the bounds across the whole
+      // chart, not the spread at any one sample.
+      stats.push(
+        { label: 'Narrowest interval', value: Math.min(...widths) },
+        { label: 'Widest interval', value: Math.max(...widths) },
+      );
+    }
+
+    const headers = [this.xAxis, this.yAxis, 'Lower', 'Upper'];
+    const rows: (string | number)[][] = this.points.map(point => [
+      point.x,
+      point.y,
+      point.yMin ?? '',
+      point.yMax ?? '',
+    ]);
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * Finds the sample whose drawn element is nearest a pointer position.
+   *
+   * Resolves to the estimate's row rather than to whichever bound happens to
+   * be closest: a pointer lands on the whip as a whole, and the estimate is
+   * the magnitude a reader arriving there is asking for.
+   *
+   * @param x - Viewport x of the pointer
+   * @param y - Viewport y of the pointer
+   * @returns The nearest sample, or null when nothing is resolvable
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    const elements = this.highlightValues?.[0];
+    if (!elements || elements.length === 0) {
+      return null;
+    }
+
+    const valueRow = Math.max(0, this.sections.indexOf('value'));
+    let nearest: NearestPoint | null = null;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+
+    for (let col = 0; col < elements.length; col++) {
+      const box = elements[col].getBoundingClientRect();
+      const centerX = box.left + box.width / 2;
+      const centerY = box.top + box.height / 2;
+      const distance = (centerX - x) ** 2 + (centerY - y) ** 2;
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        nearest = { element: elements[col], row: valueRow, col, centerX, centerY };
+      }
+    }
+
+    return nearest;
+  }
+}

--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -39,7 +39,7 @@ function magnitudeOf(point: ErrorBarPoint, section: Section): number {
     case 'upper':
       return point.yMax ?? Number.NaN;
     default:
-      return Number(point.y);
+      return point.y;
   }
 }
 
@@ -110,6 +110,9 @@ export class ErrorBarTrace extends AbstractTrace {
   private readonly perRowMin: number[];
   private readonly perRowMax: number[];
 
+  /** Row the estimate lives on — the entry row, and the pointer's target. */
+  private readonly valueRow: number;
+
   protected readonly highlightValues: SVGElement[][] | null;
 
   /**
@@ -142,13 +145,14 @@ export class ErrorBarTrace extends AbstractTrace {
       MathUtil.safeMax(row.filter(isMeasured)),
     );
 
+    this.valueRow = Math.max(0, this.sections.indexOf('value'));
     this.highlightValues = this.mapToSvgElements(layer.selectors);
     // Enter on the estimate, not on whichever section happens to be last.
     // A reader arriving at a sample is asking what the value is; landing them
     // on the upper bound answers a question they have not asked yet, and does
     // it with a number that looks like the value until they move.
     this.movable = new MovableGrid<number>(this.sectionValues, {
-      row: Math.max(0, this.sections.indexOf('value')),
+      row: this.valueRow,
     });
   }
 
@@ -186,6 +190,11 @@ export class ErrorBarTrace extends AbstractTrace {
   }
 
   protected get dimension(): Dimension {
+    // Orientation-independent, matching `Candlestick.dimension`: up and down
+    // walk the sections and left and right walk the samples in BOTH
+    // orientations, so rows must always be the section count. `AutoplayState`
+    // is keyed by direction, so conditioning this on orientation mis-paces
+    // autoplay and mis-clamps the `isMovable` bounds.
     return {
       rows: this.sectionValues.length,
       cols: this.points.length,
@@ -204,8 +213,12 @@ export class ErrorBarTrace extends AbstractTrace {
         raw: this.sectionValues[this.row][this.col],
       },
       panning: {
-        x: this.col,
-        y: this.row,
+        // The grid stays sections-by-samples whichever way the chart is
+        // drawn, so panning has to swap here instead: stereo position tracks
+        // where a point sits on screen, and on a horizontal chart the samples
+        // run down the page rather than across it.
+        x: this.orientation === Orientation.HORIZONTAL ? this.row : this.col,
+        y: this.orientation === Orientation.HORIZONTAL ? this.col : this.row,
         rows: this.sectionValues.length,
         cols: this.points.length,
       },
@@ -239,6 +252,13 @@ export class ErrorBarTrace extends AbstractTrace {
       // point's several magnitudes is being read. Without it "3.8" and "4.6"
       // at one x are indistinguishable from two samples.
       section: SECTION_LABEL[section],
+      // Which real axis each value came from, so the formatter service picks
+      // the right per-axis format. It defaults to x/y when absent, which is
+      // silently wrong for a horizontal layer whose two axes format
+      // differently — a currency estimate would be announced as a bare
+      // number, and the category as currency.
+      mainAxis: isHorizontal ? 'y' : 'x',
+      crossAxis: isHorizontal ? 'x' : 'y',
     };
   }
 
@@ -299,7 +319,6 @@ export class ErrorBarTrace extends AbstractTrace {
       return null;
     }
 
-    const valueRow = Math.max(0, this.sections.indexOf('value'));
     let nearest: NearestPoint | null = null;
     let nearestDistance = Number.POSITIVE_INFINITY;
 
@@ -310,7 +329,7 @@ export class ErrorBarTrace extends AbstractTrace {
       const distance = (centerX - x) ** 2 + (centerY - y) ** 2;
       if (distance < nearestDistance) {
         nearestDistance = distance;
-        nearest = { element: elements[col], row: valueRow, col, centerX, centerY };
+        nearest = { element: elements[col], row: this.valueRow, col, centerX, centerY };
       }
     }
 

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -5,6 +5,7 @@ import { AreaTrace } from './area';
 import { BarTrace } from './bar';
 import { BoxTrace } from './box';
 import { Candlestick } from './candlestick';
+import { ErrorBarTrace } from './errorBar';
 import { Heatmap } from './heatmap';
 import { Histogram } from './histogram';
 import { LineTrace } from './line';
@@ -44,6 +45,9 @@ export abstract class TraceFactory {
 
       case TraceType.CANDLESTICK:
         return new Candlestick(layer);
+
+      case TraceType.ERROR_BAR:
+        return new ErrorBarTrace(layer);
 
       case TraceType.HEATMAP:
         return new Heatmap(layer);

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1110,6 +1110,11 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // |delta| and the 'Bear' trend adds dot 8 for below-line points.
       [TraceType.CANDLESTICK_DELTA, asGeneric(new CandlestickBrailleEncoder())],
       [TraceType.DODGED, asGeneric(new BarBrailleEncoder())],
+      // One row per section — a profile of lower bounds, of estimates, of
+      // upper bounds — which is the per-row height profile the line encoder
+      // renders. The reader feels the interval by moving between rows, the
+      // same way they hear it.
+      [TraceType.ERROR_BAR, asGeneric(new LineBrailleEncoder())],
       [TraceType.HEATMAP, asGeneric(new HeatmapBrailleEncoder())],
       [TraceType.HISTOGRAM, asGeneric(new BarBrailleEncoder())],
       [TraceType.LINE, asGeneric(new LineBrailleEncoder())],

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -308,6 +308,35 @@ export interface CandlestickPoint {
 }
 
 /**
+ * One estimate with the interval drawn around it.
+ *
+ * The interval is the reason this is a point shape of its own rather than a
+ * scatter point: a chart drawn this way carries two magnitudes at every
+ * sample — the estimate, and how far from it the data is consistent with —
+ * and a reading that names only the first drops the part most statistical
+ * graphics are drawn to show.
+ *
+ * `lower` and `upper` are absolute positions on the value axis, not offsets
+ * from `y`. Producers disagree about which they hand out (matplotlib's
+ * `yerr` is an offset, Vega-Lite's `errorbar` computes bounds), so the
+ * schema fixes one and each adapter converts to it.
+ *
+ * The bounds are optional and independently so: a one-sided interval — an
+ * upper bound with no lower, say — is a real chart, and dropping the point
+ * for want of its other half would lose the estimate too.
+ */
+export interface ErrorBarPoint {
+  /** Position along the main axis. */
+  x: number | string;
+  /** The estimate itself: a mean, a median, a fitted value. */
+  y: number;
+  /** Absolute lower bound of the interval, when the chart draws one. */
+  yMin?: number;
+  /** Absolute upper bound of the interval, when the chart draws one. */
+  yMax?: number;
+}
+
+/**
  * Data structure for heatmap charts with x/y labels and 2D point values.
  */
 export interface HeatmapData {
@@ -567,6 +596,7 @@ export interface MaidrLayer {
     | BarPoint[]
     | BoxPoint[]
     | CandlestickPoint[]
+    | ErrorBarPoint[]
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]
@@ -610,6 +640,13 @@ export enum TraceType {
    */
   CANDLESTICK_DELTA = 'candlestick_delta',
   DODGED = 'dodged_bar',
+  /**
+   * An estimate with the interval drawn around it — an error bar, a
+   * confidence interval, a point range. Navigated as a grid of
+   * `[lower, value, upper]` against the samples, so the reader can move
+   * between the three magnitudes at one x as readily as between samples.
+   */
+  ERROR_BAR = 'error_bar',
   HEATMAP = 'heat',
   HISTOGRAM = 'hist',
   LINE = 'line',

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -30,6 +30,10 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // in the JSON; it is navigated by field and candle, not by an orientation.
   [TraceType.CANDLESTICK_DELTA]: false,
   [TraceType.DODGED]: true,
+  // The interval runs along the value axis and the samples along the other,
+  // so which way round they are drawn decides which axis a bound moves on --
+  // the same reason a bar or a box is oriented.
+  [TraceType.ERROR_BAR]: true,
   [TraceType.HEATMAP]: false,
   [TraceType.HISTOGRAM]: true,
   [TraceType.LINE]: false,

--- a/test/model/errorBar.test.ts
+++ b/test/model/errorBar.test.ts
@@ -3,7 +3,7 @@ import type { NonEmptyTraceState } from '@type/state';
 import { describe, expect, test } from '@jest/globals';
 import { ErrorBarTrace } from '@model/errorBar';
 import { TraceFactory } from '@model/factory';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 
 /**
  * Three group means with asymmetric intervals. Every number is distinct so a
@@ -115,6 +115,69 @@ describe('sections', () => {
     const { text } = nonEmptyState(trace);
     expect(text.section).toBe('value');
     expect(text.cross.value).toBe(2);
+  });
+});
+
+describe('horizontal orientation', () => {
+  /**
+   * Build a horizontally drawn trace at a position.
+   * @param row Section row to land on
+   * @param col Sample column to land on
+   * @returns The positioned trace
+   */
+  function horizontal(row: number, col: number): ErrorBarTrace {
+    const trace = TraceFactory.create({
+      ...createLayer(MEANS),
+      orientation: Orientation.HORIZONTAL,
+    }) as ErrorBarTrace;
+    trace.moveToIndex(row, col);
+    return trace;
+  }
+
+  test('swaps which axis is announced as the main one', () => {
+    const { text } = nonEmptyState(horizontal(1, 0));
+
+    expect(text.main.label).toBe('Response');
+    expect(text.cross.label).toBe('Group');
+  });
+
+  test('names the real axis each value came from', () => {
+    // The formatter service defaults to x/y when these are absent, which is
+    // silently wrong for a layer whose two axes format differently: a
+    // currency estimate would be announced as a bare number and the category
+    // as currency.
+    const { text } = nonEmptyState(horizontal(1, 0));
+
+    expect(text.mainAxis).toBe('y');
+    expect(text.crossAxis).toBe('x');
+  });
+
+  test('pans by where the point sits on screen', () => {
+    // The grid stays sections-by-samples whichever way the chart is drawn, so
+    // panning is where the swap has to happen: on a horizontal chart the
+    // samples run down the page rather than across it.
+    const { audio } = nonEmptyState(horizontal(0, 2));
+
+    expect(audio.panning.x).toBe(0);
+    expect(audio.panning.y).toBe(2);
+  });
+
+  test('keeps the grid shape, so autoplay stays paced by direction', () => {
+    // Deliberately NOT transposed, matching `Candlestick.dimension`: up and
+    // down walk the sections in both orientations, and `AutoplayState` is
+    // keyed by direction, so a transposed grid would mis-pace autoplay and
+    // mis-clamp the movement bounds.
+    const vertical = nonEmptyState(at(MEANS, 0, 2)).audio.panning;
+    const flipped = nonEmptyState(horizontal(0, 2)).audio.panning;
+
+    expect(flipped.rows).toBe(vertical.rows);
+    expect(flipped.cols).toBe(vertical.cols);
+  });
+
+  test('reads the same magnitudes as the vertical chart', () => {
+    expect(nonEmptyState(horizontal(0, 0)).text.cross.value).toBe(3.8);
+    expect(nonEmptyState(horizontal(2, 0)).text.cross.value).toBe(4.6);
+    expect(nonEmptyState(horizontal(2, 0)).text.section).toBe('upper bound');
   });
 });
 

--- a/test/model/errorBar.test.ts
+++ b/test/model/errorBar.test.ts
@@ -1,0 +1,199 @@
+import type { ErrorBarPoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { ErrorBarTrace } from '@model/errorBar';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Three group means with asymmetric intervals. Every number is distinct so a
+ * reading that took the wrong section, or the wrong sample, cannot coincide
+ * with the right one.
+ */
+const MEANS: ErrorBarPoint[] = [
+  { x: 'control', y: 4.2, yMin: 3.8, yMax: 4.6 },
+  { x: 'low dose', y: 5.1, yMin: 4.0, yMax: 6.6 },
+  { x: 'high dose', y: 7.3, yMin: 7.1, yMax: 7.4 },
+];
+
+/**
+ * Create a minimal error bar layer for model-only tests.
+ * @param data The points the layer carries
+ * @returns Error bar layer definition
+ */
+function createLayer(data: ErrorBarPoint[]): MaidrLayer {
+  return {
+    id: 'test-error-bar-layer',
+    type: TraceType.ERROR_BAR,
+    title: 'Response by dose',
+    axes: { x: { label: 'Group' }, y: { label: 'Response' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: ErrorBarTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a trace and place the cursor.
+ * @param data The points the layer carries
+ * @param row Section row to land on
+ * @param col Sample column to land on
+ * @returns The positioned trace
+ */
+function at(data: ErrorBarPoint[], row: number, col: number): ErrorBarTrace {
+  const trace = TraceFactory.create(createLayer(data)) as ErrorBarTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+describe('error bar registration', () => {
+  test('the factory builds an ErrorBarTrace', () => {
+    expect(TraceFactory.create(createLayer(MEANS))).toBeInstanceOf(ErrorBarTrace);
+  });
+
+  test('announces itself as an error bar chart', () => {
+    expect(at(MEANS, 1, 0).description.chartType).toBe('Error Bar Chart');
+  });
+});
+
+describe('sections', () => {
+  test('lays the three magnitudes out bottom to top', () => {
+    // Moving up the grid must move up the value axis, or the cursor's
+    // direction contradicts the chart's.
+    expect(at(MEANS, 0, 0).state).toMatchObject({ empty: false });
+    expect(nonEmptyState(at(MEANS, 0, 0)).text.cross.value).toBe(3.8);
+    expect(nonEmptyState(at(MEANS, 1, 0)).text.cross.value).toBe(4.2);
+    expect(nonEmptyState(at(MEANS, 2, 0)).text.cross.value).toBe(4.6);
+  });
+
+  test('names which magnitude is being read', () => {
+    // Without this, 3.8 and 4.6 at one x are indistinguishable from two
+    // separate samples.
+    expect(nonEmptyState(at(MEANS, 0, 0)).text.section).toBe('lower bound');
+    expect(nonEmptyState(at(MEANS, 1, 0)).text.section).toBe('value');
+    expect(nonEmptyState(at(MEANS, 2, 0)).text.section).toBe('upper bound');
+  });
+
+  test('announces the sample alongside the magnitude', () => {
+    const { text } = nonEmptyState(at(MEANS, 2, 2));
+
+    expect(text.main.value).toBe('high dose');
+    expect(text.cross.value).toBe(7.4);
+  });
+
+  test('omits a bound the data never carries', () => {
+    // A row the cursor can enter and hear nothing in reads as a broken chart,
+    // not as an absent bound.
+    const upperOnly: ErrorBarPoint[] = [
+      { x: 'a', y: 1, yMax: 2 },
+      { x: 'b', y: 3, yMax: 5 },
+    ];
+    const trace = TraceFactory.create(createLayer(upperOnly)) as ErrorBarTrace;
+    trace.moveToIndex(0, 0);
+
+    expect(nonEmptyState(trace).text.section).toBe('value');
+    trace.moveToIndex(1, 0);
+    expect(nonEmptyState(trace).text.section).toBe('upper bound');
+  });
+
+  test('keeps a bare estimate navigable with no bounds at all', () => {
+    const bare: ErrorBarPoint[] = [{ x: 'a', y: 1 }, { x: 'b', y: 2 }];
+    const trace = TraceFactory.create(createLayer(bare)) as ErrorBarTrace;
+    trace.moveToIndex(0, 1);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.section).toBe('value');
+    expect(text.cross.value).toBe(2);
+  });
+});
+
+describe('audio', () => {
+  test('scales every section against one range', () => {
+    // The bounds and the estimate are the same quantity on the same axis, so
+    // a bound has to sound higher than the estimate it sits above. Per-row
+    // scaling would put them at the same pitch and erase the interval by ear.
+    const lower = nonEmptyState(at(MEANS, 0, 0)).audio;
+    const upper = nonEmptyState(at(MEANS, 2, 0)).audio;
+
+    expect(lower.freq.min).toBe(upper.freq.min);
+    expect(lower.freq.max).toBe(upper.freq.max);
+    expect(lower.freq.raw).toBeLessThan(Number(upper.freq.raw));
+  });
+
+  test('spans the whole chart, not one section', () => {
+    const { audio } = nonEmptyState(at(MEANS, 1, 0));
+
+    expect(audio.freq.min).toBe(3.8);
+    expect(audio.freq.max).toBe(7.4);
+  });
+});
+
+describe('braille', () => {
+  test('renders one row per section', () => {
+    const { braille } = nonEmptyState(at(MEANS, 1, 1));
+
+    expect(braille.empty).toBe(false);
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+    expect(braille.values).toHaveLength(3);
+    expect(braille.values[1]).toEqual([4.2, 5.1, 7.3]);
+    expect(braille.row).toBe(1);
+    expect(braille.col).toBe(1);
+  });
+});
+
+describe('description', () => {
+  test('reports the interval widths, not only the value range', () => {
+    // The width is what a reader judges when asking whether two estimates
+    // differ, and it is not recoverable from the per-section ranges.
+    const stats = at(MEANS, 1, 0).description.stats;
+
+    // Exact, not approximate: the width is derived by subtraction, so it
+    // carries float noise the source data does not (4.6 - 3.8 is
+    // 0.30000000000000071), and a screen reader would spell every digit of
+    // it out. Asserting the clean value is what holds that fix in place.
+    expect(stats).toContainEqual({ label: 'Narrowest interval', value: 0.3 });
+    expect(stats).toContainEqual({ label: 'Widest interval', value: 2.6 });
+  });
+
+  test('keeps an interval far below the noise threshold', () => {
+    // Rounding to a fixed number of decimals would report this as zero,
+    // which is a worse answer than the noise it was meant to remove.
+    const tiny: ErrorBarPoint[] = [{ x: 'a', y: 1, yMin: 0.9995, yMax: 1.0005 }];
+    const stats = (TraceFactory.create(createLayer(tiny)) as ErrorBarTrace)
+      .description
+      .stats;
+
+    expect(stats).toContainEqual({ label: 'Narrowest interval', value: 0.001 });
+  });
+
+  test('stays silent about widths when nothing carries an interval', () => {
+    const bare: ErrorBarPoint[] = [{ x: 'a', y: 1 }, { x: 'b', y: 2 }];
+    const labels = (TraceFactory.create(createLayer(bare)) as ErrorBarTrace)
+      .description
+      .stats
+      .map(stat => stat.label);
+
+    expect(labels).not.toContain('Narrowest interval');
+    expect(labels).not.toContain('Widest interval');
+  });
+
+  test('tabulates each point with its bounds', () => {
+    const { dataTable } = at(MEANS, 1, 0).description;
+
+    expect(dataTable.headers).toEqual(['Group', 'Response', 'Lower', 'Upper']);
+    expect(dataTable.rows[0]).toEqual(['control', 4.2, 3.8, 4.6]);
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -8,6 +8,9 @@ describe('resolveOrientation', () => {
     TraceType.BOX,
     TraceType.CANDLESTICK,
     TraceType.DODGED,
+    // The interval runs along the value axis and the samples along the other,
+    // so which way round they are drawn decides which axis a bound moves on.
+    TraceType.ERROR_BAR,
     TraceType.HISTOGRAM,
     TraceType.NORMALIZED,
     TraceType.STACKED,


### PR DESCRIPTION
# Pull Request

## Description

MAIDR had no way to express uncertainty. A point estimate with an error bar, a regression band, a confidence interval — all read as a bare value, with the interval dropped entirely.

That is not a missing detail. Whether two group means differ is answered by whether their intervals overlap, so a reading that names only the estimate drops the finding the chart was drawn to show.

Adds `ERROR_BAR`, carrying `{ x, y, yMin, yMax }`.

## Related Issues

Part of #789. Unblocks #805 (Kaplan-Meier survival curves) and #806 (forest plots) — both are this trace plus a step line and a category axis respectively.

## Changes Made

**Navigation follows `Candlestick`.** The sections are the grid's rows and the samples its columns, so up and down at one x walk the lower bound, the estimate and the upper bound, while left and right walk the samples. That is what lets a reader trace **one** interval rather than rebuilding it from three passes over the chart, and each magnitude names itself through `TextState.section` — the field the box plot and the candlestick already use — so `3.8` and `4.6` at one x can never be mistaken for two samples.

Three decisions worth review:

- **Bounds are absolute positions on the value axis, not offsets from `y`.** Producers disagree about which they hand out — matplotlib's `yerr` is an offset, Vega-Lite's `errorbar` computes bounds — so the schema fixes one and each adapter converts to it. A reader told `0.4` instead of `4.6` is being given a number the chart does not draw anywhere.
- **Audio scales every section against one range, not per row.** The bounds and the estimate are the same quantity on the same axis, so a bound has to *sound* higher than the estimate it sits above. Per-row scaling would put them at the same pitch and erase the interval by ear. There is a test for it.
- **Which sections exist is decided by the data.** A layer whose points carry no `yMin` gets no lower row at all, rather than a row of silence — an empty lane the cursor can enter and hear nothing in reads as a broken chart, not as an absent bound. One-sided intervals and bare estimates both stay navigable.

**Braille** is one row per magnitude via `LineBrailleEncoder` — a profile of lower bounds, of estimates, of upper bounds. Documented in `docs/BRAILLE.md`, including why the interval is deliberately not encoded as a span.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Two bugs the tests caught, both of which shipped as fixes:**

1. **The E2E spec caught a navigation bug.** Entering the trace landed on the *upper bound*, because I had copied `Candlestick`'s `{ row: sections.length - 1 }` option without thinking about what "last section" means here. A reader arriving at a sample is asking what the value is; landing them on the upper bound answers a question they have not asked, with a number that looks like the value until they move. Entry is now the estimate row.

2. **The unit test caught a float artifact.** Interval width is derived by subtraction, so `4.6 - 3.8` is `0.30000000000000071` — sixteen digits a screen reader would spell out, of an artifact the chart does not contain. Cleaned to 12 significant figures rather than a fixed decimal count, because rounding to two would report an interval of `0.003` as zero, which is worse than the noise. There is a case for that too.

**Producers are deliberately not in this PR.** The trace is reachable today by authoring MAIDR JSON directly — the primary API, and what `examples/errorbar.html` uses — but Vega-Lite `errorbar`/`errorband`, matplotlib `plt.errorbar` and `geom_errorbar` emission are each their own change in their own adapter or binding repo. That is the shape #815 → #818 took for area, and it keeps each producer's field-name mapping reviewable on its own. I would rather not ship an extractor for Vega-Lite's compiled `lower_<field>` naming that I cannot execute here to verify.

Verification actually run, in full:

| Step | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npx tsc --noEmit` | no errors beyond the pre-existing `TS5101` config deprecation |
| `npm test` | **1918 passed** + **73 passed** (ESM), 0 failures |
| `npm run build` | all builds complete |
| `npx playwright test --project=chromium` | **366 passed**, full suite |

New tests: `test/model/errorBar.test.ts` (14 cases) and `e2e_tests/specs/errorbar.spec.ts` (8 cases) with `examples/errorbar.html`. The registration guard in `test/util/orientation.test.ts` failed on the new type until it was listed there, which is the guard working as designed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_