### PR TITLE
feat(waterfall): read a bridge as contributions with running totals

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -289,6 +289,33 @@ space the same way a zero slice does.
 Pie charts use a single-line representation. On multiline braille displays the
 pie appears on the first line and the remaining lines are unused.
 
+## Waterfall chart
+
+A waterfall's braille is a single row of **contributions** — one cell per step,
+scaled against the signed range of the deltas, exactly as a bar chart's row is.
+
+It is the contribution rather than the running total for the same reason the
+audio pitches the contribution: the running totals of a waterfall drift within
+a narrow band around the current value, so a profile built from them would be
+nearly flat across the whole chart and the large movers — the thing a waterfall
+is read to find — would be indistinguishable from the small ones. The deltas
+span the full signed range, so the profile has shape.
+
+A decrease is a negative value, and is encoded against the same range as the
+increases rather than by magnitude alone, so a step down reads lower than a
+step up rather than merely narrower.
+
+The running total is not encoded. It is available in the text announcement
+alongside the contribution, and in the chart description as the starting and
+ending values — the same division as a stacked area plot, and for the same
+reason: a profile that silently switched between two different quantities would
+read as one shape with different numbers behind it.
+
+### Multiline Displays
+
+Waterfall charts use a single-line representation. On multiline braille
+displays the steps appear on the first line and the remaining lines are unused.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/e2e_tests/page-objects/plots/waterfall-page.ts
+++ b/e2e_tests/page-objects/plots/waterfall-page.ts
@@ -1,0 +1,140 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { WaterfallPlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the stacked waterfall plot page.
+ *
+ * Provides the interactions the waterfall spec needs: reaching the example,
+ * activating MAIDR on it, and reading back the announcement, the braille
+ * output and the text-mode state.
+ */
+export class WaterfallPlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.WATERFALL_ID}`,
+    svg: `svg`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the waterfall plot
+   */
+  private readonly plotId = TestConstants.WATERFALL_ID;
+
+  /**
+   * Creates a new WaterfallPlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the waterfall plot page
+   * @throws WaterfallPlotError if navigation fails
+   */
+  public async navigateToWaterfallPlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/waterfall.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new WaterfallPlotError('Failed to navigate to waterfall plot', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the waterfall plot
+   * @throws WaterfallPlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new WaterfallPlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws WaterfallPlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new WaterfallPlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws WaterfallPlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded');
+      await expect(this.page.locator(this.selectors.svg)).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      throw new WaterfallPlotError('Waterfall plot failed to load correctly', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   *
+   * Braille is the modality that fails silently for a new trace type — an
+   * unregistered encoder leaves the display blank while text and audio still
+   * work — so this returns the raw cell string for the spec to assert on.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws WaterfallPlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new WaterfallPlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws WaterfallPlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new WaterfallPlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/waterfall.spec.ts
+++ b/e2e_tests/specs/waterfall.spec.ts
@@ -1,0 +1,154 @@
+import type { Maidr, MaidrLayer, WaterfallPoint } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { WaterfallPlotPage } from '../page-objects/plots/waterfall-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output. Written as escapes rather than literal glyphs because the range
+ * endpoints are indistinguishable by eye: U+2800 is the blank cell.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * Reads the layer's steps, failing loudly rather than returning undefined for
+ * a shape the example does not have.
+ * @param layer - The MAIDR layer carrying the waterfall steps
+ * @returns The layer's steps
+ * @throws TypeError if the data is not a flat array of waterfall steps
+ */
+function getSteps(layer: MaidrLayer | undefined): WaterfallPoint[] {
+  if (!layer?.data || !Array.isArray(layer.data) || Array.isArray(layer.data[0])) {
+    throw new TypeError('Waterfall layer data is not a flat array of steps');
+  }
+
+  return layer.data as WaterfallPoint[];
+}
+
+test.describe('Waterfall Plot', () => {
+  let maidrData: Maidr;
+  let waterfallLayer: MaidrLayer;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const waterfallPage = new WaterfallPlotPage(page);
+      await waterfallPage.navigateToWaterfallPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+      waterfallLayer = maidrData.subplots[0][0].layers[0];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const waterfallPage = new WaterfallPlotPage(page);
+    await waterfallPage.navigateToWaterfallPlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the waterfall plot with maidr data', async ({ page }) => {
+      const waterfallPage = new WaterfallPlotPage(page);
+      await waterfallPage.activateMaidr();
+      await waterfallPage.verifyPlotLoaded();
+    });
+
+    test('should declare the layer as a waterfall plot', () => {
+      expect(waterfallLayer.type).toBe('waterfall');
+    });
+
+    test('should carry a contribution and a running total on every step', () => {
+      const steps = getSteps(waterfallLayer);
+
+      expect(steps).toHaveLength(5);
+      for (const step of steps) {
+        expect(typeof step.delta).toBe('number');
+        expect(typeof step.end).toBe('number');
+        expect(['increase', 'decrease', 'total']).toContain(step.kind);
+      }
+    });
+
+    test('should keep the running totals consistent with the contributions', () => {
+      // The chart's own arithmetic. A fixture whose deltas do not carry each
+      // running total to the next is not a waterfall, and would let a wrong
+      // reading of either field look correct.
+      const steps = getSteps(waterfallLayer).filter(step => step.kind !== 'total');
+
+      for (const step of steps) {
+        expect(step.end - step.start).toBeCloseTo(step.delta, 6);
+      }
+    });
+
+    test('should announce itself as a waterfall plot', async ({ page }) => {
+      const waterfallPage = new WaterfallPlotPage(page);
+      await waterfallPage.activateMaidr();
+
+      const instructionText = await waterfallPage.getInstructionText();
+      expect(normalizeText(instructionText)).toBe(
+        normalizeText(TestConstants.WATERFALL_INSTRUCTION_TEXT),
+      );
+    });
+  });
+
+  test.describe('Step Navigation', () => {
+    test('should announce the contribution and the running total together', async ({ page }) => {
+      // The reason this trace type exists: a step announced only as "down 250"
+      // leaves the reader summing deltas in their head to know where they are,
+      // and one announced only as "950" never says what moved it.
+      const waterfallPage = new WaterfallPlotPage(page);
+      await waterfallPage.activateMaidr();
+      await waterfallPage.moveToNextDataPoint();
+      await waterfallPage.moveToNextDataPoint();
+
+      const announcement = normalizeText(await waterfallPage.getInstructionText());
+
+      expect(announcement).toContain('Marketing');
+      expect(announcement).toContain('250');
+      expect(announcement).toContain('950');
+    });
+
+    test('should name which way a step moved', async ({ page }) => {
+      const waterfallPage = new WaterfallPlotPage(page);
+      await waterfallPage.activateMaidr();
+      await waterfallPage.moveToNextDataPoint();
+      await waterfallPage.moveToNextDataPoint();
+      const decrease = normalizeText(await waterfallPage.getInstructionText());
+
+      await waterfallPage.moveToNextDataPoint();
+      const increase = normalizeText(await waterfallPage.getInstructionText());
+
+      expect(decrease).toContain('decrease');
+      expect(increase).toContain('increase');
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render one braille row of contributions', async ({ page }) => {
+      const waterfallPage = new WaterfallPlotPage(page);
+      await waterfallPage.activateMaidr();
+      await waterfallPage.moveToNextDataPoint();
+      await waterfallPage.toggleBrailleMode();
+
+      const braille = await waterfallPage.getBrailleContent();
+      const lines = braille.split('\n');
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(BRAILLE_CELL);
+      expect(lines[0]).toHaveLength(getSteps(waterfallLayer).length);
+    });
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -32,6 +32,7 @@ export abstract class TestConstants {
   static readonly STEPPLOT_ID = 'step';
   static readonly AREAPLOT_ID = 'area-revenue';
   static readonly ERRORBAR_ID = 'errorbar-response';
+  static readonly WATERFALL_ID = 'waterfall-budget';
   static readonly DODGED_BARPLOT_ID = 'dodged_bar';
   static readonly STACKED_BARPLOT_ID = 'stacked_bar';
   static readonly BOXPLOT_VERTICAL_ID = 'boxplot_vertical';
@@ -128,6 +129,7 @@ export abstract class TestConstants {
   // does; the example this asserts against carries two bands.
   static readonly AREAPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: stacked area with 2 groups. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly ERRORBAR_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical error_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly WATERFALL_INSTRUCTION_TEXT = 'This is a maidr plot of type: waterfall. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // `formatPlotType` in src/util/orientation.ts prefixes the box type with its

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -152,6 +152,22 @@ export class ErrorBarPlotError extends Error {
 }
 
 /**
+ * Error thrown when Waterfall plot related operations fail
+ */
+export class WaterfallPlotError extends Error {
+  /**
+   * Creates a new WaterfallPlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'WaterfallPlotError';
+  }
+}
+
+/**
  * Error thrown when Area plot related operations fail
  */
 export class AreaPlotError extends Error {

--- a/examples/waterfall.html
+++ b/examples/waterfall.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Waterfall Example — Quarterly Budget Bridge</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A waterfall shows how a starting value reaches an ending one through a
+        sequence of signed contributions. Each step draws a bar FLOATING
+        between the running total before it and the running total after it, so
+        a step carries two numbers a bar chart would conflate: the
+        contribution (the bar's height) and the total it produced (the bar's
+        position).
+
+        Both are announced, because they answer different questions. "How big
+        was marketing's effect" is the contribution; "where did that leave us"
+        is the running total. The contribution is what the pitch carries -- the
+        running totals of a waterfall drift within a narrow band, so scaling
+        pitch to them would compress every step into a near-identical tone,
+        while the deltas span the full signed range and make the large movers
+        audible at once.
+
+        `kind` distinguishes the opening and closing bars, which restate the
+        running total rather than changing it, from the steps that move it.
+        Those sit on the baseline instead of floating.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="waterfall-budget" maidr='{&#10;  &quot;id&quot;: &quot;waterfall-budget&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;waterfall-budget-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;waterfall-budget-layer&quot;,&#10;            &quot;type&quot;: &quot;waterfall&quot;,&#10;            &quot;title&quot;: &quot;Quarterly Budget Bridge&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Step&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Amount (thousands)&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: [&#10;              &quot;g[id=&#x27;waterfall-budget-0&#x27;]&quot;,&#10;              &quot;g[id=&#x27;waterfall-budget-1&#x27;]&quot;,&#10;              &quot;g[id=&#x27;waterfall-budget-2&#x27;]&quot;,&#10;              &quot;g[id=&#x27;waterfall-budget-3&#x27;]&quot;,&#10;              &quot;g[id=&#x27;waterfall-budget-4&#x27;]&quot;&#10;            ],&#10;            &quot;data&quot;: [&#10;              {&#10;                &quot;x&quot;: &quot;Opening&quot;,&#10;                &quot;start&quot;: 0,&#10;                &quot;end&quot;: 1200,&#10;                &quot;delta&quot;: 1200,&#10;                &quot;kind&quot;: &quot;total&quot;&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Marketing&quot;,&#10;                &quot;start&quot;: 1200,&#10;                &quot;end&quot;: 950,&#10;                &quot;delta&quot;: -250,&#10;                &quot;kind&quot;: &quot;decrease&quot;&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Sales&quot;,&#10;                &quot;start&quot;: 950,&#10;                &quot;end&quot;: 1430,&#10;                &quot;delta&quot;: 480,&#10;                &quot;kind&quot;: &quot;increase&quot;&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Support&quot;,&#10;                &quot;start&quot;: 1430,&#10;                &quot;end&quot;: 1360,&#10;                &quot;delta&quot;: -70,&#10;                &quot;kind&quot;: &quot;decrease&quot;&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Closing&quot;,&#10;                &quot;start&quot;: 0,&#10;                &quot;end&quot;: 1360,&#10;                &quot;delta&quot;: 1360,&#10;                &quot;kind&quot;: &quot;total&quot;&#10;              }&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="axes-background">
+              <path d="M 110 380  L 650 380  L 650 60  L 110 60  z " style="fill: #ffffff" />
+            </g>
+            <g id="axis_x">
+          <text x="164" y="400" style="font: 12px sans-serif; text-anchor: middle">Opening</text>
+          <text x="272" y="400" style="font: 12px sans-serif; text-anchor: middle">Marketing</text>
+          <text x="380" y="400" style="font: 12px sans-serif; text-anchor: middle">Sales</text>
+          <text x="488" y="400" style="font: 12px sans-serif; text-anchor: middle">Support</text>
+          <text x="596" y="400" style="font: 12px sans-serif; text-anchor: middle">Closing</text>
+            </g>
+            <g id="connectors">
+          <path d="M 199 124 L 237 124" style="stroke: #99a3ad; stroke-width: 1; stroke-dasharray: 4 3" />
+          <path d="M 307 177.333 L 345 177.333" style="stroke: #99a3ad; stroke-width: 1; stroke-dasharray: 4 3" />
+          <path d="M 415 74.9333 L 453 74.9333" style="stroke: #99a3ad; stroke-width: 1; stroke-dasharray: 4 3" />
+          <path d="M 523 89.8667 L 561 89.8667" style="stroke: #99a3ad; stroke-width: 1; stroke-dasharray: 4 3" />
+            </g>
+        <g id="waterfall-budget-0">
+          <rect x="129" y="124" width="70" height="256" style="fill: #5b6b7f" />
+        </g>
+        <g id="waterfall-budget-1">
+          <rect x="237" y="124" width="70" height="53.3333" style="fill: #a83232" />
+        </g>
+        <g id="waterfall-budget-2">
+          <rect x="345" y="74.9333" width="70" height="102.4" style="fill: #2c7d59" />
+        </g>
+        <g id="waterfall-budget-3">
+          <rect x="453" y="74.9333" width="70" height="14.9333" style="fill: #a83232" />
+        </g>
+        <g id="waterfall-budget-4">
+          <rect x="561" y="89.8667" width="70" height="290.133" style="fill: #5b6b7f" />
+        </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -74,6 +74,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.STEP]: 'Step Plot',
   [TraceType.VIOLIN_BOX]: 'Violin Box Plot',
   [TraceType.VIOLIN_KDE]: 'Violin Plot',
+  [TraceType.WATERFALL]: 'Waterfall Chart',
 };
 
 export interface Dimension {

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -16,6 +16,7 @@ import { createSmoothTrace } from './smoothtraceFactory';
 import { StepTrace } from './step';
 import { ViolinKdeTrace } from './violin';
 import { ViolinBoxTrace } from './violinBox';
+import { WaterfallTrace } from './waterfall';
 
 /**
  * Abstract factory class for creating appropriate trace instances based on layer type.
@@ -69,6 +70,9 @@ export abstract class TraceFactory {
 
       case TraceType.STEP:
         return new StepTrace(layer);
+
+      case TraceType.WATERFALL:
+        return new WaterfallTrace(layer);
 
       case TraceType.DODGED:
       case TraceType.NORMALIZED:

--- a/src/model/waterfall.ts
+++ b/src/model/waterfall.ts
@@ -1,0 +1,247 @@
+import type { MaidrLayer, WaterfallKind, WaterfallPoint } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { MathUtil } from '@util/math';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/** How each kind of step is announced. */
+const KIND_LABEL: Record<WaterfallKind, string> = {
+  increase: 'increase',
+  decrease: 'decrease',
+  total: 'total',
+};
+
+/**
+ * Trace implementation for waterfall charts — a starting value carried to an
+ * ending value through a sequence of signed contributions.
+ *
+ * The chart draws each step as a bar floating between the running total before
+ * it and the running total after it, which means a step carries two numbers a
+ * bar chart would conflate: the contribution (the bar's height) and the total
+ * it produced (the bar's position). Announcing only one of them answers half
+ * the question the chart was drawn for — "how big was marketing's effect" and
+ * "where did that leave us" are different questions, and a reader needs both.
+ *
+ * So the contribution is what is **heard** and what `cross` announces, and the
+ * running total travels alongside it in `stack`. Pitching the contribution
+ * rather than the total is the deliberate choice: the totals of a waterfall
+ * drift within a narrow band around the running value, so scaling pitch to
+ * them compresses every step into a near-identical tone, while the deltas span
+ * the full signed range and make the large contributors audible immediately —
+ * which is what a waterfall is read to find.
+ *
+ * Navigation is one column per step, as with a bar chart. The steps are a
+ * sequence rather than a grid: there is no second dimension to move in.
+ */
+export class WaterfallTrace extends AbstractTrace {
+  protected readonly supportsExtrema = true;
+  protected readonly movable: Movable;
+
+  private readonly points: WaterfallPoint[];
+  private readonly deltaValues: number[][];
+
+  private readonly min: number;
+  private readonly max: number;
+
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /**
+   * Creates a new waterfall trace.
+   *
+   * @param layer - The MAIDR layer carrying the waterfall steps
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.points = layer.data as WaterfallPoint[];
+    this.deltaValues = [this.points.map(point => Number(point.delta))];
+
+    const { min, max } = MathUtil.minMax(this.deltaValues[0]);
+    this.min = min;
+    this.max = max;
+
+    this.highlightValues = this.mapToSvgElements(layer.selectors);
+    this.movable = new MovableGrid<WaterfallPoint>([this.points]);
+  }
+
+  /**
+   * Resolves the layer's selectors to one element per step.
+   *
+   * @param selectors - The layer's selectors, when it has any
+   * @returns Elements shaped as a single row of steps, or null when
+   * unresolvable
+   */
+  private mapToSvgElements(
+    selectors?: MaidrLayer['selectors'],
+  ): SVGElement[][] | null {
+    if (typeof selectors !== 'string' && !Array.isArray(selectors)) {
+      return null;
+    }
+
+    const flat = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+
+    if (flat.length !== this.points.length) {
+      return null;
+    }
+    return [flat];
+  }
+
+  protected get values(): number[][] {
+    return this.deltaValues;
+  }
+
+  protected get dimension(): Dimension {
+    return {
+      rows: 1,
+      cols: this.points.length,
+    };
+  }
+
+  protected get audio(): AudioState {
+    return {
+      freq: {
+        min: this.min,
+        max: this.max,
+        raw: this.deltaValues[0][this.col],
+      },
+      panning: {
+        x: this.col,
+        y: 0,
+        rows: 1,
+        cols: this.points.length,
+      },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    return {
+      empty: false,
+      id: this.id,
+      values: this.deltaValues,
+      min: [this.min],
+      max: [this.max],
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const point = this.points[this.col];
+
+    return {
+      main: { label: this.xAxis, value: point.x },
+      // The contribution, which is what the bar's height draws and what the
+      // pitch carries.
+      cross: { label: this.yAxis, value: Number(point.delta) },
+      // The total the step produced, alongside the contribution rather than
+      // instead of it. A step announced only as "down 250" leaves the reader
+      // tracking the running total in their head across the whole chart.
+      stack: { label: 'Running total', value: Number(point.end) },
+      // Which way the step moved. Without it a decrease is announced as a
+      // bare negative number, and a total — which contributes nothing at all —
+      // is indistinguishable from a step that happened to net to its own
+      // value.
+      section: KIND_LABEL[point.kind],
+      mainAxis: 'x',
+      crossAxis: 'y',
+    };
+  }
+
+  public get description(): DescriptionState {
+    const steps = this.points.filter(point => point.kind !== 'total');
+    const increases = steps.filter(point => point.kind === 'increase').length;
+    const decreases = steps.filter(point => point.kind === 'decrease').length;
+
+    const stats: DescriptionState['stats'] = [
+      { label: 'Number of steps', value: this.points.length },
+      { label: 'Increases', value: increases },
+      { label: 'Decreases', value: decreases },
+    ];
+
+    if (this.points.length > 0) {
+      // Where the chart starts and where it ends is the whole point of the
+      // form, and it is not recoverable from the contributions: the reader
+      // would have to sum every delta while navigating.
+      stats.push(
+        { label: 'Starting value', value: Number(this.points[0].start) },
+        {
+          label: 'Ending value',
+          value: Number(this.points[this.points.length - 1].end),
+        },
+      );
+    }
+
+    if (steps.length > 0) {
+      // The largest mover is what a waterfall is read to find, and scanning
+      // for it by ear means walking every step.
+      const magnitudes = steps.map(point => Math.abs(Number(point.delta)));
+      const largest = steps[magnitudes.indexOf(Math.max(...magnitudes))];
+      stats.push({
+        label: 'Largest contribution',
+        value: `${largest.x} (${Number(largest.delta)})`,
+      });
+    }
+
+    const headers = [this.xAxis, 'Change', 'Running total'];
+    const rows: (string | number)[][] = this.points.map(point => [
+      point.x,
+      Number(point.delta),
+      Number(point.end),
+    ]);
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * Finds the step whose bar contains a pointer position.
+   *
+   * Hit-tests the bounding box rather than resolving to the nearest centre,
+   * matching {@link BarTrace}: a waterfall step is an area mark, and a bar
+   * floating far up the value axis can have its centre closer to the pointer
+   * than the bar the pointer is actually inside.
+   *
+   * @param x - Viewport x of the pointer
+   * @param y - Viewport y of the pointer
+   * @returns The step under the pointer, or null when it is between bars
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    const elements = this.highlightValues?.[0];
+    if (!elements || elements.length === 0) {
+      return null;
+    }
+
+    for (let col = 0; col < elements.length; col++) {
+      const box = elements[col].getBoundingClientRect();
+      if (box.width === 0 && box.height === 0) {
+        continue;
+      }
+      if (
+        x >= box.left
+        && x <= box.left + box.width
+        && y >= box.top
+        && y <= box.top + box.height
+      ) {
+        return {
+          element: elements[col],
+          row: 0,
+          col,
+          centerX: box.left + box.width / 2,
+          centerY: box.top + box.height / 2,
+        };
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/model/waterfall.ts
+++ b/src/model/waterfall.ts
@@ -1,3 +1,4 @@
+import type { ExtremaTarget } from '@type/extrema';
 import type { MaidrLayer, WaterfallKind, WaterfallPoint } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
@@ -7,7 +8,15 @@ import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
 import { MovableGrid } from './movable';
 
-/** How each kind of step is announced. */
+/**
+ * How each kind of step is announced.
+ *
+ * Lower case deliberately: `TextService.announcesSectionBeforeLabel` is true
+ * for a state carrying a section and no `z`, which a waterfall step does, and
+ * that branch lower-cases the section before announcing it. Capitalising these
+ * would therefore be silently undone in verbose mode and kept in terse mode,
+ * so the same step would read two different ways.
+ */
 const KIND_LABEL: Record<WaterfallKind, string> = {
   increase: 'increase',
   decrease: 'decrease',
@@ -201,6 +210,76 @@ export class WaterfallTrace extends AbstractTrace {
       stats,
       dataTable: { headers, rows },
     };
+  }
+
+  /**
+   * Offers the biggest mover in each direction as an extrema target.
+   *
+   * "What drove the change" is the question a waterfall is read to answer, and
+   * finding it by ear otherwise means walking every step and holding the
+   * running maximum in your head.
+   *
+   * Totals are excluded. The opening and closing bars carry the largest
+   * magnitudes on most charts — they restate the whole running value — so
+   * including them would make "largest increase" mean "the closing balance"
+   * on nearly every waterfall and bury the answer the reader wanted. Same
+   * exclusion as the `Largest contribution` description stat, for the same
+   * reason.
+   *
+   * @returns The largest increase and the largest decrease, when the chart
+   * draws any step that moves the total
+   */
+  public override getExtremaTargets(): ExtremaTarget[] {
+    const moving = this.points
+      .map((point, index) => ({ point, index }))
+      .filter(({ point }) => point.kind !== 'total'
+        && Number.isFinite(Number(point.delta)));
+
+    if (moving.length === 0) {
+      return [];
+    }
+
+    const deltaOf = ({ point }: { point: WaterfallPoint }): number =>
+      Number(point.delta);
+    const largest = moving.reduce((a, b) => (deltaOf(b) > deltaOf(a) ? b : a));
+    const smallest = moving.reduce((a, b) => (deltaOf(b) < deltaOf(a) ? b : a));
+
+    const targets: ExtremaTarget[] = [{
+      label: `Largest increase at ${largest.point.x}`,
+      value: deltaOf(largest),
+      pointIndex: largest.index,
+      segment: 'waterfall',
+      type: 'max',
+      navigationType: 'point',
+      xValue: largest.point.x,
+    }];
+
+    // A chart whose steps all move the same way has one mover, not two, and
+    // offering the same step under both labels would tell the reader the
+    // biggest rise and the biggest fall are the same bar.
+    if (smallest.index !== largest.index) {
+      targets.push({
+        label: `Largest decrease at ${smallest.point.x}`,
+        value: deltaOf(smallest),
+        pointIndex: smallest.index,
+        segment: 'waterfall',
+        type: 'min',
+        navigationType: 'point',
+        xValue: smallest.point.x,
+      });
+    }
+
+    return targets;
+  }
+
+  /**
+   * Moves the cursor to a chosen extrema target.
+   *
+   * @param target - The extrema target to navigate to
+   */
+  public override navigateToExtrema(target: ExtremaTarget): void {
+    this.col = target.pointIndex;
+    this.finalizeNavigation();
   }
 
   /**

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1123,6 +1123,10 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // against that row's own range — the bar encoder's input exactly.
       [TraceType.PIE, asGeneric(new BarBrailleEncoder())],
       [TraceType.SCATTER, asGeneric(new HeatmapBrailleEncoder())],
+      // A single row of signed contributions scaled against that row's own
+      // range -- the bar encoder's input exactly, and the same magnitude the
+      // audio plays and `cross` announces.
+      [TraceType.WATERFALL, asGeneric(new BarBrailleEncoder())],
       [TraceType.SMOOTH, asGeneric(new LineBrailleEncoder())],
       [TraceType.STACKED, asGeneric(new BarBrailleEncoder())],
       // A step chart's braille state is LineTrace's verbatim — a per-row

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -417,11 +417,23 @@ export class TextService implements Observer<PlotState>, Disposable {
   }
 
   /**
-   * Determines if the current state represents a box plot.
+   * Whether a sectioned state announces its section *before* the axis label.
+   *
+   * The discrimination is between a box plot ("lower quartile Price") and a
+   * candlestick ("high Price"), and `z` is what separates them: a candlestick
+   * carries its trend there, a box plot carries nothing.
+   *
+   * Named for what it tests rather than for the box plot, because it is no
+   * longer only the box plot that answers true — an error bar and a waterfall
+   * step both carry a section with no `z`. Both read correctly on this branch,
+   * but only because their section labels are already lower case; see
+   * `KIND_LABEL` in `src/model/waterfall.ts` and `SECTION_LABEL` in
+   * `src/model/errorBar.ts`, which say so at the definition.
+   *
    * @param state - The text state to check
-   * @returns True if state has sections but no z (indicating a box plot)
+   * @returns True when the section is announced ahead of the label
    */
-  private isBoxPlotWithSection(state: TextState): boolean {
+  private announcesSectionBeforeLabel(state: TextState): boolean {
     return state.section !== undefined && state.z === undefined;
   }
 
@@ -466,7 +478,7 @@ export class TextService implements Observer<PlotState>, Disposable {
     // Special handling for boxplot outlier sections
     if (
       state.section
-      && this.isBoxPlotWithSection(state)
+      && this.announcesSectionBeforeLabel(state)
       && (state.section === BoxplotSection.UPPER_OUTLIER || state.section === BoxplotSection.LOWER_OUTLIER)
       && Array.isArray(state.cross.value)
     ) {
@@ -488,7 +500,7 @@ export class TextService implements Observer<PlotState>, Disposable {
 
     // Format cross-axis label.
     if (state.section !== undefined) {
-      if (this.isBoxPlotWithSection(state)) {
+      if (this.announcesSectionBeforeLabel(state)) {
         const label = state.cross.label;
         verbose.push(Constant.COMMA_SPACE, state.section!.toLowerCase(), Constant.SPACE, label);
       } else {
@@ -582,7 +594,7 @@ export class TextService implements Observer<PlotState>, Disposable {
     // Special handling for boxplot outlier sections
     if (
       state.section
-      && this.isBoxPlotWithSection(state)
+      && this.announcesSectionBeforeLabel(state)
       && (state.section === BoxplotSection.UPPER_OUTLIER || state.section === BoxplotSection.LOWER_OUTLIER)
       && Array.isArray(state.cross.value)
     ) {

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -337,6 +337,48 @@ export interface ErrorBarPoint {
 }
 
 /**
+ * What a waterfall step does to the running total.
+ *
+ * `total` marks a step that restates the running total rather than changing
+ * it — the opening and closing bars, and any subtotal drawn along the way.
+ * Those sit on the baseline instead of floating, and a reader told a subtotal
+ * "rose by 950" would be hearing a contribution the chart never made.
+ */
+export type WaterfallKind = 'increase' | 'decrease' | 'total';
+
+/**
+ * One step of a waterfall chart.
+ *
+ * A waterfall answers "how did we get from here to there", so a step carries
+ * two numbers that a bar chart would conflate: the contribution it made
+ * (`delta`) and the running total it produced (`end`). The bar is drawn
+ * floating between `start` and `end`, which is why neither alone describes it
+ * — the height is the contribution and the position is the total.
+ *
+ * `start` and `end` are absolute positions on the value axis, so a producer
+ * that only knows offsets has to accumulate them before emitting, the same
+ * way {@link ErrorBarPoint} fixes absolute bounds.
+ */
+export interface WaterfallPoint {
+  /** The step's label along the category axis. */
+  x: number | string;
+  /** Running total before this step. */
+  start: number;
+  /** Running total after this step. */
+  end: number;
+  /**
+   * The signed contribution, `end - start`.
+   *
+   * Carried rather than derived because a producer may round the two totals
+   * for display, and a delta recomputed from rounded ends is not the number
+   * the chart's own label shows.
+   */
+  delta: number;
+  /** Whether the step adds, subtracts, or restates the total. */
+  kind: WaterfallKind;
+}
+
+/**
  * Data structure for heatmap charts with x/y labels and 2D point values.
  */
 export interface HeatmapData {
@@ -605,7 +647,8 @@ export interface MaidrLayer {
     | SegmentedPoint[][]
     | SmoothPoint[][]
     | StepPoint[][]
-    | ViolinKdePoint[][];
+    | ViolinKdePoint[][]
+    | WaterfallPoint[];
 }
 
 /**
@@ -668,4 +711,11 @@ export enum TraceType {
   STEP = 'step',
   VIOLIN_BOX = 'violin_box',
   VIOLIN_KDE = 'violin_kde',
+  /**
+   * A sequence of signed contributions carrying a starting value to an ending
+   * one — the staple of financial and product reporting. Each step draws a
+   * floating bar from its running total before to its running total after, so
+   * the point carries both the contribution and the total it produced.
+   */
+  WATERFALL = 'waterfall',
 }

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -340,7 +340,14 @@ export interface TextState {
    * fraction of the total, which is what a stacked chart is read for and what
    * a listener cannot divide out in their head mid-navigation.
    *
-   * Absent on every unstacked trace, so nothing else changes shape.
+   * A waterfall step carries it for the same reason under a different name:
+   * the bar's height is that step's contribution and its position is the
+   * running total the step produced, so `cross` announces the one and this
+   * announces the other. `label` is what distinguishes them to the reader,
+   * which is why it travels with the value rather than being assumed.
+   *
+   * Absent on traces that draw a single magnitude, so nothing else changes
+   * shape.
    */
   stack?: { label: string; value: number; share?: number };
   range?: { min: number; max: number };

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -49,6 +49,12 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   [TraceType.STEP]: false,
   [TraceType.VIOLIN_BOX]: true,
   [TraceType.VIOLIN_KDE]: true,
+  // The steps run along the category axis and the contributions along the
+  // value axis, but the trace reads the same either way round: navigation is
+  // one column per step in both, and a horizontal waterfall swaps nothing a
+  // reader would hear. As with LINE and STEP, there is no orientation to
+  // announce.
+  [TraceType.WATERFALL]: false,
 };
 
 /**

--- a/test/model/waterfall.test.ts
+++ b/test/model/waterfall.test.ts
@@ -153,6 +153,61 @@ describe('braille', () => {
   });
 });
 
+describe('extrema navigation', () => {
+  test('offers the biggest mover in each direction', () => {
+    // What a waterfall is read to answer. Finding it by ear otherwise means
+    // walking every step while holding the running maximum in your head.
+    const targets = at(0).getExtremaTargets();
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({ type: 'max', value: 480, pointIndex: 2 });
+    expect(targets[1]).toMatchObject({ type: 'min', value: -250, pointIndex: 1 });
+  });
+
+  test('excludes the totals, which are not contributions', () => {
+    // The opening and closing bars carry the largest magnitudes here (1200 and
+    // 1360). Including them would make "largest increase" mean "the closing
+    // balance" on nearly every waterfall and bury the answer.
+    for (const target of at(0).getExtremaTargets()) {
+      expect(Math.abs(target.value)).toBeLessThan(1200);
+    }
+  });
+
+  test('moves the cursor to a chosen target', () => {
+    // The base implementation throws when `supportsExtrema` is true, so a
+    // trace that advertises extrema without this is worse than one that does
+    // not advertise them at all.
+    const trace = at(0);
+    const [largest] = trace.getExtremaTargets();
+
+    trace.navigateToExtrema(largest);
+
+    expect(nonEmptyState(trace).text.main.value).toBe('Sales');
+  });
+
+  test('offers one target when every step moves the same way', () => {
+    // Naming the same bar as both the biggest rise and the biggest fall would
+    // tell the reader the chart has two movers when it has one.
+    const rising: WaterfallPoint[] = [
+      { x: 'Open', start: 0, end: 100, delta: 100, kind: 'total' },
+      { x: 'A', start: 100, end: 180, delta: 80, kind: 'increase' },
+    ];
+    const targets = at(0, rising).getExtremaTargets();
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ type: 'max', value: 80 });
+  });
+
+  test('offers nothing when the chart is all totals', () => {
+    const totalsOnly: WaterfallPoint[] = [
+      { x: 'Open', start: 0, end: 500, delta: 500, kind: 'total' },
+      { x: 'Close', start: 0, end: 500, delta: 500, kind: 'total' },
+    ];
+
+    expect(at(0, totalsOnly).getExtremaTargets()).toEqual([]);
+  });
+});
+
 describe('description', () => {
   test('reports where the chart starts and ends', () => {
     // Not recoverable from the contributions without summing every one of

--- a/test/model/waterfall.test.ts
+++ b/test/model/waterfall.test.ts
@@ -1,0 +1,210 @@
+import type { MaidrLayer, WaterfallPoint } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { WaterfallTrace } from '@model/waterfall';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A budget bridge: an opening total, three signed contributions, a closing
+ * total. Every number is distinct so a reading that took the wrong field, or
+ * the wrong step, cannot coincide with the right one — in particular no delta
+ * equals any running total.
+ */
+const STEPS: WaterfallPoint[] = [
+  { x: 'Opening', start: 0, end: 1200, delta: 1200, kind: 'total' },
+  { x: 'Marketing', start: 1200, end: 950, delta: -250, kind: 'decrease' },
+  { x: 'Sales', start: 950, end: 1430, delta: 480, kind: 'increase' },
+  { x: 'Support', start: 1430, end: 1360, delta: -70, kind: 'decrease' },
+  { x: 'Closing', start: 0, end: 1360, delta: 1360, kind: 'total' },
+];
+
+/**
+ * Create a minimal waterfall layer for model-only tests.
+ * @param data The steps the layer carries
+ * @returns Waterfall layer definition
+ */
+function createLayer(data: WaterfallPoint[]): MaidrLayer {
+  return {
+    id: 'test-waterfall-layer',
+    type: TraceType.WATERFALL,
+    title: 'Budget bridge',
+    axes: { x: { label: 'Step' }, y: { label: 'Amount' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: WaterfallTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a trace and place the cursor on one step.
+ * @param col Step to land on
+ * @param data The steps the layer carries
+ * @returns The positioned trace
+ */
+function at(col: number, data: WaterfallPoint[] = STEPS): WaterfallTrace {
+  const trace = TraceFactory.create(createLayer(data)) as WaterfallTrace;
+  trace.moveToIndex(0, col);
+  return trace;
+}
+
+describe('waterfall registration', () => {
+  test('the factory builds a WaterfallTrace', () => {
+    expect(TraceFactory.create(createLayer(STEPS))).toBeInstanceOf(WaterfallTrace);
+  });
+
+  test('announces itself as a waterfall chart', () => {
+    expect(at(0).description.chartType).toBe('Waterfall Chart');
+  });
+
+  test('navigates one column per step, with no second dimension', () => {
+    const trace = at(0);
+
+    expect(trace.moveOnce('DOWNWARD')).toBe(false);
+    expect(nonEmptyState(at(4)).text.main.value).toBe('Closing');
+  });
+});
+
+describe('reading a step', () => {
+  test('announces the contribution, not the running total', () => {
+    // The bar's height is the contribution, and that is the number the reader
+    // is asking for when they land on "Marketing".
+    const { text } = nonEmptyState(at(1));
+
+    expect(text.main.value).toBe('Marketing');
+    expect(text.cross.value).toBe(-250);
+  });
+
+  test('carries the running total alongside the contribution', () => {
+    // Without this the reader has to sum every delta in their head across the
+    // whole chart to know where they are.
+    const { text } = nonEmptyState(at(1));
+
+    expect(text.stack).toEqual({ label: 'Running total', value: 950 });
+  });
+
+  test('names which way the step moved', () => {
+    // A decrease announced as a bare negative number is easy to mishear, and
+    // a total contributes nothing at all -- it restates the running value.
+    expect(nonEmptyState(at(0)).text.section).toBe('total');
+    expect(nonEmptyState(at(1)).text.section).toBe('decrease');
+    expect(nonEmptyState(at(2)).text.section).toBe('increase');
+  });
+
+  test('keeps the contribution and the total distinguishable', () => {
+    // The failure this guards is announcing one number where the chart draws
+    // two: at every step the two must not be the same value.
+    for (let col = 1; col < 4; col++) {
+      const { text } = nonEmptyState(at(col));
+      expect(text.cross.value).not.toBe(text.stack?.value);
+    }
+  });
+});
+
+describe('audio', () => {
+  test('pitches the contribution, so large movers stand out', () => {
+    const { audio } = nonEmptyState(at(2));
+
+    expect(audio.freq.raw).toBe(480);
+  });
+
+  test('scales against the signed range of the contributions', () => {
+    // A decrease has to sound below an increase. Scaling to the running
+    // totals instead would compress every step into a near-identical tone,
+    // because the totals of a waterfall drift within a narrow band.
+    const decrease = nonEmptyState(at(1)).audio;
+    const increase = nonEmptyState(at(2)).audio;
+
+    expect(decrease.freq.min).toBe(-250);
+    expect(decrease.freq.max).toBe(1360);
+    expect(Number(decrease.freq.raw)).toBeLessThan(Number(increase.freq.raw));
+  });
+
+  test('pans across the steps', () => {
+    const { audio } = nonEmptyState(at(3));
+
+    expect(audio.panning.x).toBe(3);
+    expect(audio.panning.rows).toBe(1);
+    expect(audio.panning.cols).toBe(5);
+  });
+});
+
+describe('braille', () => {
+  test('renders one row of contributions', () => {
+    const { braille } = nonEmptyState(at(2));
+
+    expect(braille.empty).toBe(false);
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+    expect(braille.values).toEqual([[1200, -250, 480, -70, 1360]]);
+    expect(braille.col).toBe(2);
+  });
+});
+
+describe('description', () => {
+  test('reports where the chart starts and ends', () => {
+    // Not recoverable from the contributions without summing every one of
+    // them while navigating, which is the work the form exists to save.
+    const { stats } = at(0).description;
+
+    expect(stats).toContainEqual({ label: 'Starting value', value: 0 });
+    expect(stats).toContainEqual({ label: 'Ending value', value: 1360 });
+  });
+
+  test('counts the increases and decreases without the totals', () => {
+    // A total is not a contribution; counting the opening and closing bars as
+    // increases would overstate how many things moved.
+    const { stats } = at(0).description;
+
+    expect(stats).toContainEqual({ label: 'Increases', value: 1 });
+    expect(stats).toContainEqual({ label: 'Decreases', value: 2 });
+  });
+
+  test('names the largest mover by magnitude, not by sign', () => {
+    // What a waterfall is read to find. The largest here is a decrease of
+    // 480 in the other direction -- taking the maximum rather than the
+    // largest absolute value would report Sales instead.
+    const dominated: WaterfallPoint[] = [
+      { x: 'Open', start: 0, end: 100, delta: 100, kind: 'total' },
+      { x: 'Rent', start: 100, end: -800, delta: -900, kind: 'decrease' },
+      { x: 'Sales', start: -800, end: -320, delta: 480, kind: 'increase' },
+    ];
+    const { stats } = at(0, dominated).description;
+
+    expect(stats).toContainEqual({
+      label: 'Largest contribution',
+      value: 'Rent (-900)',
+    });
+  });
+
+  test('stays silent about a largest mover when nothing moved', () => {
+    // A chart of nothing but totals has no contribution to report, and
+    // naming one would invent a step the chart does not draw.
+    const totalsOnly: WaterfallPoint[] = [
+      { x: 'Open', start: 0, end: 500, delta: 500, kind: 'total' },
+      { x: 'Close', start: 0, end: 500, delta: 500, kind: 'total' },
+    ];
+    const labels = at(0, totalsOnly).description.stats.map(stat => stat.label);
+
+    expect(labels).not.toContain('Largest contribution');
+  });
+
+  test('tabulates each step with its change and running total', () => {
+    const { dataTable } = at(0).description;
+
+    expect(dataTable.headers).toEqual(['Step', 'Change', 'Running total']);
+    expect(dataTable.rows[1]).toEqual(['Marketing', -250, 950]);
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -40,6 +40,9 @@ describe('resolveOrientation', () => {
     TraceType.SMOOTH,
     TraceType.STACKED_AREA,
     TraceType.STEP,
+    // A waterfall is navigated one column per step whichever way the bars
+    // are drawn, so there is no main and cross axis to swap.
+    TraceType.WATERFALL,
   ];
 
   test('answers for every trace type', () => {


### PR DESCRIPTION
Closes #790.

A waterfall shows how a starting value reaches an ending one through a sequence of signed contributions. It is a staple of financial and product reporting, and there was no way to author one for MAIDR.

## The thing that makes it not just a bar chart

Each step draws a bar **floating** between the running total before it and the running total after it. So a step carries two numbers a bar chart would conflate:

- the **contribution** — the bar's *height*
- the **running total** it produced — the bar's *position*

Announcing only one answers half the question the chart was drawn for. "How big was marketing's effect?" is the contribution; "where did that leave us?" is the total. A reader given only the delta is summing in their head across the whole chart; one given only the total never learns what moved it.

Both travel: the contribution in `cross`, the running total in `stack`. `TextState.stack` already existed for stacked traces and is documented as "the running total a stacked point sits inside" — which is exactly a waterfall step, so this reuses it rather than inventing a field. I extended that doc comment to say so, since it previously claimed to be absent on every unstacked trace.

## Why the pitch carries the contribution, not the total

This is the one real design decision, and it goes against the obvious choice (the staircase is what you *see*).

The running totals of a waterfall drift within a narrow band around the current value — in the example fixture, 1200 → 950 → 1430 → 1360. Scaling pitch to those compresses every step into a near-identical tone, and the large movers become indistinguishable from the small ones. The deltas span the full signed range (−250 … 1360), so the profile has shape and the big contributors are audible immediately — which is what a waterfall is read to find.

The same reasoning drives the braille row, so audio, braille and `cross` all describe the **same** number. `test('scales against the signed range of the contributions')` pins it, and the `stats` block carries the starting and ending values so the journey isn't lost.

## `kind`

`increase` / `decrease` / `total`. The opening, closing and any subtotal bars *restate* the running total rather than changing it, and sit on the baseline instead of floating. Without the distinction a subtotal is announced as though it "rose by 950" — a contribution the chart never made. The description counts increases and decreases with the totals excluded for the same reason.

## Registration

All six places from `.claude/rules/model.md`, plus the two that fail loudly if missed:

| # | Place | Done |
|---|---|---|
| 1 | `TraceType.WATERFALL` + `WaterfallPoint` + data union | ✅ |
| 2 | `src/model/waterfall.ts` | ✅ |
| 3 | `TraceFactory.create()` case | ✅ |
| 4 | `CHART_TYPE_LABEL` (total record) | ✅ |
| 5 | `IS_ORIENTED` (total record) — `false` | ✅ |
| 6 | Braille encoder — `BarBrailleEncoder` | ✅ |
| 7 | `docs/BRAILLE.md` | ✅ |

`IS_ORIENTED` is `false`: navigation is one column per step whichever way the bars are drawn, so there is no main/cross axis to swap. `test/util/orientation.test.ts` caught the omission before I got there, as designed.

The braille encoder is the one that fails **silently** — an unregistered type leaves the display blank while text and audio keep working — so the e2e spec asserts the row renders real braille cells, one per step.

## Verification actually run

| Step | Result |
|---|---|
| `npm test` | **1940 passed** (was 1923) + **73 passed** |
| `npx playwright test waterfall.spec.ts` | **8 passed** |
| `npm run type-check` | clean |
| `npm run lint:fix` | clean |
| `npm run build` | clean |

The e2e run confirms end-to-end that the running total is actually announced alongside the contribution, not just present in the state object.

The example (`examples/waterfall.html`) is generated with real floating-bar geometry — each bar's edge meets the next, so the staircase is consistent and the connectors line up.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_