### PR TITLE
fix(errorbar): implement the extrema navigation the trace advertises

### DIFF
--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -1,3 +1,4 @@
+import type { ExtremaTarget } from '@type/extrema';
 import type { ErrorBarPoint, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
@@ -18,7 +19,15 @@ const SECTIONS = ['lower', 'value', 'upper'] as const;
 
 type Section = (typeof SECTIONS)[number];
 
-/** How each section is announced. */
+/**
+ * How each section is announced.
+ *
+ * Lower case deliberately: the text service announces a section ahead of the
+ * axis label when the state carries a section and no `z`, which an error bar
+ * does, and that branch lower-cases the section first. Capitalising these
+ * would therefore be silently undone in verbose mode and kept in terse mode,
+ * so the same bound would read two different ways.
+ */
 const SECTION_LABEL: Record<Section, string> = {
   lower: 'lower bound',
   value: 'value',
@@ -300,6 +309,73 @@ export class ErrorBarTrace extends AbstractTrace {
       stats,
       dataTable: { headers, rows },
     };
+  }
+
+  /**
+   * Offers the highest and lowest estimate as extrema targets.
+   *
+   * The estimates are what a reader compares across samples, so they are what
+   * "go to the extreme" should mean here. The bounds are deliberately not
+   * ranked: the widest interval is a different question from the largest
+   * value, and offering both under one menu would leave the reader unable to
+   * tell which sense of "extreme" they had just jumped to.
+   *
+   * Both targets land on the estimate row, so a reader arriving there hears
+   * the value and can step up or down into its interval — the same motion the
+   * trace exists for.
+   *
+   * @returns The maximum and minimum estimate, when any sample carries one
+   */
+  public override getExtremaTargets(): ExtremaTarget[] {
+    const estimates = this.sectionValues[this.valueRow];
+    const measured = estimates
+      .map((value, index) => ({ value, index }))
+      .filter(({ value }) => isMeasured(value));
+
+    if (measured.length === 0) {
+      return [];
+    }
+
+    const highest = measured.reduce((a, b) => (b.value > a.value ? b : a));
+    const lowest = measured.reduce((a, b) => (b.value < a.value ? b : a));
+
+    const targets: ExtremaTarget[] = [{
+      label: `Max value at ${this.points[highest.index].x}`,
+      value: highest.value,
+      pointIndex: highest.index,
+      segment: 'value',
+      type: 'max',
+      navigationType: 'point',
+      xValue: this.points[highest.index].x,
+    }];
+
+    // One sample, or a chart where every estimate is equal, has a single
+    // extreme. Naming the same sample as both would report a spread the chart
+    // does not have.
+    if (lowest.index !== highest.index) {
+      targets.push({
+        label: `Min value at ${this.points[lowest.index].x}`,
+        value: lowest.value,
+        pointIndex: lowest.index,
+        segment: 'value',
+        type: 'min',
+        navigationType: 'point',
+        xValue: this.points[lowest.index].x,
+      });
+    }
+
+    return targets;
+  }
+
+  /**
+   * Moves the cursor to a chosen extrema target, on the estimate row.
+   *
+   * @param target - The extrema target to navigate to
+   */
+  public override navigateToExtrema(target: ExtremaTarget): void {
+    this.row = this.valueRow;
+    this.col = target.pointIndex;
+    this.finalizeNavigation();
   }
 
   /**

--- a/test/model/errorBar.test.ts
+++ b/test/model/errorBar.test.ts
@@ -181,6 +181,47 @@ describe('horizontal orientation', () => {
   });
 });
 
+describe('extrema navigation', () => {
+  test('offers the highest and lowest estimate', () => {
+    // The estimates are what a reader compares across samples, so they are
+    // what "go to the extreme" has to mean. The bounds are a different
+    // question -- widest interval is not largest value -- and ranking both in
+    // one menu would leave the reader unable to tell which they jumped to.
+    const targets = at(MEANS, 1, 0).getExtremaTargets();
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({ type: 'max', value: 7.3, pointIndex: 2 });
+    expect(targets[1]).toMatchObject({ type: 'min', value: 4.2, pointIndex: 0 });
+  });
+
+  test('lands on the estimate row, not on a bound', () => {
+    // The base `navigateToExtrema` throws when `supportsExtrema` is set, so a
+    // trace advertising extrema without this is worse than one that does not.
+    // Starting from the upper bound proves the row is set rather than kept.
+    const trace = at(MEANS, 2, 0);
+    const [highest] = trace.getExtremaTargets();
+
+    trace.navigateToExtrema(highest);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.section).toBe('value');
+    expect(text.cross.value).toBe(7.3);
+  });
+
+  test('offers one target when every estimate is equal', () => {
+    // Naming the same sample as both the highest and the lowest would report
+    // a spread the chart does not have.
+    const flat: ErrorBarPoint[] = [
+      { x: 'a', y: 5, yMin: 4, yMax: 6 },
+      { x: 'b', y: 5, yMin: 3, yMax: 7 },
+    ];
+    const targets = at(flat, 1, 0).getExtremaTargets();
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ type: 'max', value: 5 });
+  });
+});
+
 describe('audio', () => {
   test('scales every section against one range', () => {
     // The bounds and the estimate are the same quantity on the same axis, so


### PR DESCRIPTION
Follow-up to #819, which shipped this bug. Surfaced while reviewing #820 — the same mistake was in both traces, and this is the one already on `main`.

## The bug

`ErrorBarTrace` sets `supportsExtrema = true` but never overrides `getExtremaTargets()` or `navigateToExtrema()`:

```
sets supportsExtrema = true:  bar, candlestick, candlestickDelta, errorBar, heatmap, line
overrides getExtremaTargets:  bar, candlestick, candlestickDelta, heatmap, line
                                                ↑ errorBar missing
```

So today, on any error bar chart:

- <kbd>g</kbd> reports the trace as extrema-navigable and opens the Go to Extrema dialog, with the menu-open cue,
- `getExtremaTargets()` falls through to the base, which returns `[]` — the dialog opens **empty, every time**,
- and if a target could be selected, the base `navigateToExtrema` **throws**, because it raises precisely when `supportsExtrema` is set.

Advertising the feature is therefore strictly worse than not advertising it: the reader gets a cue, a dialog, and nothing in it.

## The fix

Implemented the targets rather than clearing the flag, because an error bar chart has a clear answer to "where are the extremes": **the highest and lowest estimate**. Those are what a reader compares across samples.

The **bounds are deliberately not ranked.** "Widest interval" is a genuinely different question from "largest value", and offering both under one menu would leave the reader unable to tell which sense of *extreme* they had just jumped to. If interval width turns out to be wanted, it deserves its own rotor unit rather than being mixed into this one.

Both targets land on the **estimate row**, not on whichever row the cursor happened to be on. A reader arriving at an extreme hears the value and can then step up or down into its interval — the motion this trace type exists for. `test('lands on the estimate row, not on a bound')` starts the cursor on the upper bound so it fails if the row is merely kept.

A chart whose estimates are all equal offers one target instead of naming the same sample as both the highest and the lowest, which would report a spread the chart does not have.

## Also here

`SECTION_LABEL` now records why its labels have to stay lower case. The text service announces a section ahead of the axis label when the state carries a section and no `z` — which an error bar does — and lower-cases it on that path. Capitalising these would be silently undone in verbose mode and kept in terse mode, so the same bound would read two different ways. (#820 adds the matching note on the waterfall's `KIND_LABEL` and renames the predicate that does this.)

## Verification actually run

| Step | Result |
|---|---|
| `npm test` | **1974 passed** + **73 passed** |
| `npx jest --testPathPattern errorBar` | **22 passed** (was 19) |
| `npx playwright test errorbar.spec.ts` | **8 passed** |
| `npm run type-check` | clean |
| `npm run lint:fix` | clean |
| `npm run build` | clean |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_