### PR TITLE
feat(wordcloud): read a cloud as terms walked by weight

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -316,6 +316,26 @@ read as one shape with different numbers behind it.
 Waterfall charts use a single-line representation. On multiline braille
 displays the steps appear on the first line and the remaining lines are unused.
 
+## Word cloud
+
+A word cloud's braille is a single row of **weights**, one cell per term,
+scaled against the row's own range -- the bar encoding above, unchanged.
+
+The row is ordered by weight, heaviest first, which is also the order the
+cursor walks. A cloud's drawn arrangement is chosen to pack glyphs into a
+rectangle and encodes nothing, so a profile in layout order would be an
+arbitrary sequence of heights; in weight order it descends, and the shape of
+that descent is the distribution -- whether one term dominates or many are
+comparable, which is what a cloud is read for.
+
+The terms themselves are not in the braille. They are what the text mode
+announces, and a display of five cells cannot carry five words.
+
+### Multiline Displays
+
+Word clouds use a single-line representation. On multiline braille displays
+the terms appear on the first line and the remaining lines are unused.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/e2e_tests/page-objects/plots/wordcloud-page.ts
+++ b/e2e_tests/page-objects/plots/wordcloud-page.ts
@@ -1,0 +1,140 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { WordCloudPlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the stacked word cloud page.
+ *
+ * Provides the interactions the word cloud spec needs: reaching the example,
+ * activating MAIDR on it, and reading back the announcement, the braille
+ * output and the text-mode state.
+ */
+export class WordCloudPlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.WORDCLOUD_ID}`,
+    svg: `svg`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the word cloud
+   */
+  private readonly plotId = TestConstants.WORDCLOUD_ID;
+
+  /**
+   * Creates a new WordCloudPlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the word cloud page
+   * @throws WordCloudPlotError if navigation fails
+   */
+  public async navigateToWordCloudPlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/wordcloud.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new WordCloudPlotError('Failed to navigate to word cloud', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the word cloud
+   * @throws WordCloudPlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new WordCloudPlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws WordCloudPlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new WordCloudPlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws WordCloudPlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded');
+      await expect(this.page.locator(this.selectors.svg)).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      throw new WordCloudPlotError('Word cloud failed to load correctly', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   *
+   * Braille is the modality that fails silently for a new trace type — an
+   * unregistered encoder leaves the display blank while text and audio still
+   * work — so this returns the raw cell string for the spec to assert on.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws WordCloudPlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new WordCloudPlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws WordCloudPlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new WordCloudPlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/wordcloud.spec.ts
+++ b/e2e_tests/specs/wordcloud.spec.ts
@@ -73,7 +73,7 @@ test.describe('Word Cloud', () => {
       // sort removed entirely.
       const authored = getTerms(wordCloudLayer).map(term => term.x);
       const byWeight = [...getTerms(wordCloudLayer)]
-        .sort((a, b) => b.y - a.y)
+        .sort((a, b) => Number(b.y) - Number(a.y))
         .map(term => term.x);
 
       expect(authored).not.toEqual(byWeight);

--- a/e2e_tests/specs/wordcloud.spec.ts
+++ b/e2e_tests/specs/wordcloud.spec.ts
@@ -1,0 +1,148 @@
+import type { Maidr, MaidrLayer, WordCloudPoint } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { WordCloudPlotPage } from '../page-objects/plots/wordcloud-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * Reads the layer's terms, failing loudly rather than returning undefined for
+ * a shape the example does not have.
+ * @param layer - The MAIDR layer carrying the terms
+ * @returns The layer's terms, in the order the document draws them
+ * @throws TypeError if the data is not a flat array of terms
+ */
+function getTerms(layer: MaidrLayer | undefined): WordCloudPoint[] {
+  if (!layer?.data || !Array.isArray(layer.data) || Array.isArray(layer.data[0])) {
+    throw new TypeError('Word cloud layer data is not a flat array of terms');
+  }
+
+  return layer.data as WordCloudPoint[];
+}
+
+test.describe('Word Cloud', () => {
+  let maidrData: Maidr;
+  let wordCloudLayer: MaidrLayer;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const wordCloudPage = new WordCloudPlotPage(page);
+      await wordCloudPage.navigateToWordCloudPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+      wordCloudLayer = maidrData.subplots[0][0].layers[0];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const wordCloudPage = new WordCloudPlotPage(page);
+    await wordCloudPage.navigateToWordCloudPlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the word cloud with maidr data', async ({ page }) => {
+      const wordCloudPage = new WordCloudPlotPage(page);
+      await wordCloudPage.activateMaidr();
+      await wordCloudPage.verifyPlotLoaded();
+    });
+
+    test('should declare the layer as a word cloud', () => {
+      expect(wordCloudLayer.type).toBe('word_cloud');
+    });
+
+    test('should author the terms in packing order, not weight order', () => {
+      // The fixture only proves anything if the two orders differ: a cloud
+      // authored heaviest-first would pass every assertion below even with the
+      // sort removed entirely.
+      const authored = getTerms(wordCloudLayer).map(term => term.x);
+      const byWeight = [...getTerms(wordCloudLayer)]
+        .sort((a, b) => b.y - a.y)
+        .map(term => term.x);
+
+      expect(authored).not.toEqual(byWeight);
+    });
+
+    test('should announce itself as a word cloud', async ({ page }) => {
+      const wordCloudPage = new WordCloudPlotPage(page);
+      await wordCloudPage.activateMaidr();
+
+      const instructionText = await wordCloudPage.getInstructionText();
+      expect(normalizeText(instructionText)).toBe(
+        normalizeText(TestConstants.WORDCLOUD_INSTRUCTION_TEXT),
+      );
+    });
+  });
+
+  test.describe('Weight-Ordered Navigation', () => {
+    test('should walk the terms heaviest first', async ({ page }) => {
+      const wordCloudPage = new WordCloudPlotPage(page);
+      await wordCloudPage.activateMaidr();
+      await wordCloudPage.moveToNextDataPoint();
+
+      const first = normalizeText(await wordCloudPage.getInstructionText());
+      await wordCloudPage.moveToNextDataPoint();
+      const second = normalizeText(await wordCloudPage.getInstructionText());
+
+      // `machine` is the SECOND element in the document and the heaviest term.
+      expect(first).toContain('machine');
+      expect(first).toContain('412');
+      expect(second).toContain('tensor');
+    });
+  });
+
+  test.describe('Highlight', () => {
+    test('should highlight the glyph it just announced', async ({ page }) => {
+      // The assertion the whole design turns on, and the one no model-level
+      // test can make. MAIDR highlights by inserting a clone of the drawn
+      // element, so the clone's text is the term actually lit up on screen.
+      // Sorting the terms without permuting the resolved elements would
+      // announce `machine` while highlighting `neural`, which is drawn first —
+      // and text, audio and braille would all still be correct.
+      const wordCloudPage = new WordCloudPlotPage(page);
+      await wordCloudPage.activateMaidr();
+      await wordCloudPage.moveToNextDataPoint();
+
+      const announcement = normalizeText(await wordCloudPage.getInstructionText());
+      expect(announcement).toContain('machine');
+
+      const highlighted = page.locator('[id^="maidr-highlight"]').first();
+      await expect(highlighted).toHaveText('machine');
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render one braille row of weights', async ({ page }) => {
+      const wordCloudPage = new WordCloudPlotPage(page);
+      await wordCloudPage.activateMaidr();
+      await wordCloudPage.moveToNextDataPoint();
+      await wordCloudPage.toggleBrailleMode();
+
+      const braille = await wordCloudPage.getBrailleContent();
+      const lines = braille.split('\n');
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(BRAILLE_CELL);
+      expect(lines[0]).toHaveLength(getTerms(wordCloudLayer).length);
+    });
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -33,6 +33,7 @@ export abstract class TestConstants {
   static readonly AREAPLOT_ID = 'area-revenue';
   static readonly ERRORBAR_ID = 'errorbar-response';
   static readonly WATERFALL_ID = 'waterfall-budget';
+  static readonly WORDCLOUD_ID = 'wordcloud-terms';
   static readonly DODGED_BARPLOT_ID = 'dodged_bar';
   static readonly STACKED_BARPLOT_ID = 'stacked_bar';
   static readonly BOXPLOT_VERTICAL_ID = 'boxplot_vertical';
@@ -130,6 +131,7 @@ export abstract class TestConstants {
   static readonly AREAPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: stacked area with 2 groups. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly ERRORBAR_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical error_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly WATERFALL_INSTRUCTION_TEXT = 'This is a maidr plot of type: waterfall. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly WORDCLOUD_INSTRUCTION_TEXT = 'This is a maidr plot of type: word_cloud. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // `formatPlotType` in src/util/orientation.ts prefixes the box type with its

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -168,6 +168,22 @@ export class WaterfallPlotError extends Error {
 }
 
 /**
+ * Error thrown when Word cloud related operations fail
+ */
+export class WordCloudPlotError extends Error {
+  /**
+   * Creates a new WordCloudPlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'WordCloudPlotError';
+  }
+}
+
+/**
  * Error thrown when Area plot related operations fail
  */
 export class AreaPlotError extends Error {

--- a/examples/wordcloud.html
+++ b/examples/wordcloud.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Word Cloud Example — Terms in the Abstracts</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A word cloud carries real data while being readable only by eye: each
+        term's weight is drawn as glyph size and written down nowhere on the
+        page. Structurally it is a term and a number, which is what the trace
+        announces - "machine, 412".
+
+        NOTE the ordering. The glyphs below are in PACKING order, which is
+        what a cloud layout produces and which encodes nothing: `machine` is
+        the second element in the document but the heaviest term. MAIDR walks
+        the terms by weight instead, and permutes the resolved elements to
+        match - so arrowing to the first term announces `machine` AND
+        highlights `machine`. Sorting the data without permuting the elements
+        would announce the right term and highlight the wrong glyph, which no
+        model-level test can see.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="wordcloud-terms" maidr='{&#10;  &quot;id&quot;: &quot;wordcloud-terms&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;wordcloud-terms-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;wordcloud-terms-layer&quot;,&#10;            &quot;type&quot;: &quot;word_cloud&quot;,&#10;            &quot;title&quot;: &quot;Terms in the Abstracts&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Term&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Occurrences&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: [&#10;              &quot;g[id=&#x27;wordcloud-terms-0&#x27;]&quot;,&#10;              &quot;g[id=&#x27;wordcloud-terms-1&#x27;]&quot;,&#10;              &quot;g[id=&#x27;wordcloud-terms-2&#x27;]&quot;,&#10;              &quot;g[id=&#x27;wordcloud-terms-3&#x27;]&quot;,&#10;              &quot;g[id=&#x27;wordcloud-terms-4&#x27;]&quot;&#10;            ],&#10;            &quot;data&quot;: [&#10;              {&#10;                &quot;x&quot;: &quot;neural&quot;,&#10;                &quot;y&quot;: 128&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;machine&quot;,&#10;                &quot;y&quot;: 412&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;gradient&quot;,&#10;                &quot;y&quot;: 57&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;tensor&quot;,&#10;                &quot;y&quot;: 233&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;embedding&quot;,&#10;                &quot;y&quot;: 96&#10;              }&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+        <g id="wordcloud-terms-0">
+          <text x="200" y="150" style="font: 26px sans-serif; fill: #4c78a8; text-anchor: middle">neural</text>
+        </g>
+        <g id="wordcloud-terms-1">
+          <text x="360" y="220" style="font: 54px sans-serif; fill: #f58518; text-anchor: middle">machine</text>
+        </g>
+        <g id="wordcloud-terms-2">
+          <text x="520" y="300" style="font: 18px sans-serif; fill: #54a24b; text-anchor: middle">gradient</text>
+        </g>
+        <g id="wordcloud-terms-3">
+          <text x="280" y="300" style="font: 38px sans-serif; fill: #b279a2; text-anchor: middle">tensor</text>
+        </g>
+        <g id="wordcloud-terms-4">
+          <text x="470" y="160" style="font: 22px sans-serif; fill: #e45756; text-anchor: middle">embedding</text>
+        </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -75,6 +75,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.VIOLIN_BOX]: 'Violin Box Plot',
   [TraceType.VIOLIN_KDE]: 'Violin Plot',
   [TraceType.WATERFALL]: 'Waterfall Chart',
+  [TraceType.WORD_CLOUD]: 'Word Cloud',
 };
 
 export interface Dimension {

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -17,6 +17,7 @@ import { StepTrace } from './step';
 import { ViolinKdeTrace } from './violin';
 import { ViolinBoxTrace } from './violinBox';
 import { WaterfallTrace } from './waterfall';
+import { WordCloudTrace } from './wordCloud';
 
 /**
  * Abstract factory class for creating appropriate trace instances based on layer type.
@@ -73,6 +74,9 @@ export abstract class TraceFactory {
 
       case TraceType.WATERFALL:
         return new WaterfallTrace(layer);
+
+      case TraceType.WORD_CLOUD:
+        return new WordCloudTrace(layer);
 
       case TraceType.DODGED:
       case TraceType.NORMALIZED:

--- a/src/model/wordCloud.ts
+++ b/src/model/wordCloud.ts
@@ -1,0 +1,304 @@
+import type { ExtremaTarget } from '@type/extrema';
+import type { MaidrLayer, WordCloudPoint } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { MathUtil } from '@util/math';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/**
+ * Orders terms by weight, heaviest first, keeping each term's original index.
+ *
+ * The index is the point of this: the drawn glyphs resolve in document order,
+ * so reordering the terms without carrying the permutation would leave every
+ * highlight on the wrong word. Returning both keeps the two in step.
+ *
+ * Ties keep their original relative order, so a chart whose weights repeat
+ * still reads the same way twice.
+ *
+ * @param points - The terms as authored
+ * @returns The terms heaviest first, each with the index it was authored at
+ */
+function byDescendingWeight(
+  points: WordCloudPoint[],
+): { point: WordCloudPoint; source: number }[] {
+  return points
+    .map((point, source) => ({ point, source }))
+    .sort((a, b) => Number(b.point.y) - Number(a.point.y));
+}
+
+/**
+ * Trace implementation for word clouds.
+ *
+ * A word cloud is the canonical chart that carries real data while being
+ * readable only by eye: each term's weight is encoded as glyph size and
+ * written down nowhere on the page. Structurally it is a categorical label
+ * and a magnitude, so the reading is a term and its number — "machine, 412"
+ * — which is the whole of what the chart encodes and none of what it draws.
+ *
+ * **Navigation is in weight order, not layout order.** A cloud's spatial
+ * arrangement is chosen to pack glyphs into a rectangle; it carries no
+ * information, and walking it would hand the reader an arbitrary sequence.
+ * Descending weight is the order the chart is read for.
+ *
+ * Sorting is why this extends {@link AbstractTrace} rather than
+ * `AbstractBarPlot`, which it otherwise resembles. That base resolves its
+ * highlight elements in **document order** inside its own constructor and
+ * pairs `elements[i]` with `points[i]`, so a subclass that sorted its points
+ * would announce one term and highlight another — and no model-level test
+ * would see it, because the text, the audio and the braille would all be
+ * right. Owning the constructor keeps the sort and the permutation together.
+ */
+export class WordCloudTrace extends AbstractTrace {
+  protected readonly supportsExtrema = true;
+  protected readonly movable: Movable;
+
+  private readonly points: WordCloudPoint[];
+  private readonly weights: number[][];
+
+  private readonly min: number;
+  private readonly max: number;
+
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /**
+   * Creates a new word cloud trace.
+   *
+   * @param layer - The MAIDR layer carrying the terms and their weights
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    const ordered = byDescendingWeight(layer.data as WordCloudPoint[]);
+    this.points = ordered.map(entry => entry.point);
+    this.weights = [this.points.map(point => Number(point.y))];
+
+    const { min, max } = MathUtil.minMax(this.weights[0]);
+    this.min = min;
+    this.max = max;
+
+    this.highlightValues = this.mapToSvgElements(
+      layer.selectors,
+      ordered.map(entry => entry.source),
+    );
+    this.movable = new MovableGrid<WordCloudPoint>([this.points]);
+  }
+
+  /**
+   * Resolves the layer's selectors and reorders them to match the terms.
+   *
+   * `Svg.selectAllElements` answers in document order, which for a cloud is
+   * packing order — unrelated to weight. The permutation from the sort is
+   * applied here so element *i* is the glyph for term *i*, whichever order
+   * the two happened to start in.
+   *
+   * @param selectors - The layer's selectors, when it has any
+   * @param order - Each term's index in the authored data, heaviest first
+   * @returns One row of elements in weight order, or null when unresolvable
+   */
+  private mapToSvgElements(
+    selectors: MaidrLayer['selectors'],
+    order: number[],
+  ): SVGElement[][] | null {
+    if (typeof selectors !== 'string' && !Array.isArray(selectors)) {
+      return null;
+    }
+
+    const drawn = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+
+    // A partial resolution cannot be repaired by reordering: it is not known
+    // which terms the missing glyphs belonged to, so every pairing after the
+    // gap would be a guess. Report no highlight rather than a plausible one.
+    if (drawn.length !== order.length) {
+      return null;
+    }
+    return [order.map(source => drawn[source])];
+  }
+
+  protected get values(): number[][] {
+    return this.weights;
+  }
+
+  protected get dimension(): Dimension {
+    return {
+      rows: 1,
+      cols: this.points.length,
+    };
+  }
+
+  protected get audio(): AudioState {
+    return {
+      freq: {
+        min: this.min,
+        max: this.max,
+        raw: this.weights[0][this.col],
+      },
+      panning: {
+        x: this.col,
+        y: 0,
+        rows: 1,
+        cols: this.points.length,
+      },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    return {
+      empty: false,
+      id: this.id,
+      values: this.weights,
+      min: [this.min],
+      max: [this.max],
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const point = this.points[this.col];
+
+    return {
+      main: { label: this.xAxis, value: point.x },
+      // The number the chart encodes as glyph size and prints nowhere. Without
+      // it a reader gets the terms and no way to tell which one is heaviest,
+      // which is the only thing a cloud is drawn to say.
+      cross: { label: this.yAxis, value: Number(point.y) },
+      mainAxis: 'x',
+      crossAxis: 'y',
+    };
+  }
+
+  public get description(): DescriptionState {
+    const weights = this.weights[0];
+    const total = weights.reduce((sum, weight) => sum + weight, 0);
+
+    const stats: DescriptionState['stats'] = [
+      { label: 'Number of terms', value: this.points.length },
+    ];
+
+    if (this.points.length > 0) {
+      // Which term is heaviest is the question a cloud is drawn to answer at a
+      // glance, and it is the one thing a reader walking the terms one at a
+      // time has to hold in their head to recover.
+      stats.push(
+        { label: 'Heaviest term', value: `${this.points[0].x} (${weights[0]})` },
+        {
+          label: 'Lightest term',
+          value: `${this.points[this.points.length - 1].x} `
+            + `(${weights[weights.length - 1]})`,
+        },
+        { label: 'Total weight', value: total },
+      );
+    }
+
+    const headers = [this.xAxis, this.yAxis];
+    const rows: (string | number)[][] = this.points.map(point => [
+      point.x,
+      Number(point.y),
+    ]);
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * Offers the heaviest and lightest terms as extrema targets.
+   *
+   * They sit at the two ends of the sorted row, so this is a lookup rather
+   * than a search — but it still has to exist: the base `navigateToExtrema`
+   * throws precisely when `supportsExtrema` is set.
+   *
+   * @returns The heaviest and lightest terms, when the cloud has any
+   */
+  public override getExtremaTargets(): ExtremaTarget[] {
+    if (this.points.length === 0) {
+      return [];
+    }
+
+    const last = this.points.length - 1;
+    const targets: ExtremaTarget[] = [{
+      label: `Heaviest term, ${this.points[0].x}`,
+      value: this.weights[0][0],
+      pointIndex: 0,
+      segment: 'term',
+      type: 'max',
+      navigationType: 'point',
+      xValue: this.points[0].x,
+    }];
+
+    // One term, or a cloud whose weights are all equal, has a single extreme.
+    if (last !== 0 && this.weights[0][last] !== this.weights[0][0]) {
+      targets.push({
+        label: `Lightest term, ${this.points[last].x}`,
+        value: this.weights[0][last],
+        pointIndex: last,
+        segment: 'term',
+        type: 'min',
+        navigationType: 'point',
+        xValue: this.points[last].x,
+      });
+    }
+
+    return targets;
+  }
+
+  /**
+   * Moves the cursor to a chosen extrema target.
+   *
+   * @param target - The extrema target to navigate to
+   */
+  public override navigateToExtrema(target: ExtremaTarget): void {
+    this.col = target.pointIndex;
+    this.finalizeNavigation();
+  }
+
+  /**
+   * Finds the term whose glyph contains a pointer position.
+   *
+   * Hit-tests the bounding box rather than resolving to the nearest centre: a
+   * cloud's glyphs vary hugely in size, so the centre of a large term can sit
+   * further from the pointer than a small term the pointer is nowhere near.
+   *
+   * @param x - Viewport x of the pointer
+   * @param y - Viewport y of the pointer
+   * @returns The term under the pointer, or null when between glyphs
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    const elements = this.highlightValues?.[0];
+    if (!elements || elements.length === 0) {
+      return null;
+    }
+
+    for (let col = 0; col < elements.length; col++) {
+      const box = elements[col].getBoundingClientRect();
+      if (box.width === 0 && box.height === 0) {
+        continue;
+      }
+      if (
+        x >= box.left
+        && x <= box.left + box.width
+        && y >= box.top
+        && y <= box.top + box.height
+      ) {
+        return {
+          element: elements[col],
+          row: 0,
+          col,
+          centerX: box.left + box.width / 2,
+          centerY: box.top + box.height / 2,
+        };
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1127,6 +1127,9 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // range -- the bar encoder's input exactly, and the same magnitude the
       // audio plays and `cross` announces.
       [TraceType.WATERFALL, asGeneric(new BarBrailleEncoder())],
+      // A single row of weights scaled against that row's own range -- the bar
+      // encoder's input exactly, and the same magnitude the audio plays.
+      [TraceType.WORD_CLOUD, asGeneric(new BarBrailleEncoder())],
       [TraceType.SMOOTH, asGeneric(new LineBrailleEncoder())],
       [TraceType.STACKED, asGeneric(new BarBrailleEncoder())],
       // A step chart's braille state is LineTrace's verbatim — a per-row

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -389,8 +389,17 @@ export interface WaterfallPoint {
 export interface WordCloudPoint {
   /** The term. */
   x: string;
-  /** Its weight -- a frequency, a score, a count. */
-  y: number;
+  /**
+   * Its weight -- a frequency, a score, a count.
+   *
+   * Widened to accept a string for the same reason {@link BarPoint.y} is:
+   * hand-authored JSON and some producers send numbers as strings, and the
+   * trace coerces on the way in. Declaring it `number` alone would not stop
+   * one arriving, it would only stop the compiler from admitting it -- and a
+   * string reaching the description's running total would concatenate rather
+   * than add.
+   */
+  y: number | string;
 }
 
 /**

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -379,6 +379,21 @@ export interface WaterfallPoint {
 }
 
 /**
+ * One term of a word cloud.
+ *
+ * A word cloud is the canonical chart that carries real data while being
+ * readable only by eye: the weight is encoded as glyph size and written down
+ * nowhere on the page. Structurally it is a categorical label and a
+ * magnitude, which is why it needs no shape of its own beyond naming them.
+ */
+export interface WordCloudPoint {
+  /** The term. */
+  x: string;
+  /** Its weight -- a frequency, a score, a count. */
+  y: number;
+}
+
+/**
  * Data structure for heatmap charts with x/y labels and 2D point values.
  */
 export interface HeatmapData {
@@ -649,7 +664,8 @@ export interface MaidrLayer {
     | SmoothPoint[][]
     | StepPoint[][]
     | ViolinKdePoint[][]
-    | WaterfallPoint[];
+    | WaterfallPoint[]
+    | WordCloudPoint[];
 }
 
 /**
@@ -719,4 +735,10 @@ export enum TraceType {
    * the point carries both the contribution and the total it produced.
    */
   WATERFALL = 'waterfall',
+  /**
+   * Terms sized by weight. The layout carries no information -- it is chosen
+   * to pack glyphs, not to encode anything -- so the trace reads it as what
+   * it measures: a term and a magnitude, walked in weight order.
+   */
+  WORD_CLOUD = 'word_cloud',
 }

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -55,6 +55,10 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // reader would hear. As with LINE and STEP, there is no orientation to
   // announce.
   [TraceType.WATERFALL]: false,
+  // Terms are packed into a rectangle, not laid along an axis, and the trace
+  // walks them by weight rather than by position. There is no main and cross
+  // axis to swap, the same as a pie.
+  [TraceType.WORD_CLOUD]: false,
 };
 
 /**

--- a/test/model/wordCloud.test.ts
+++ b/test/model/wordCloud.test.ts
@@ -107,6 +107,27 @@ describe('reading a term', () => {
   });
 });
 
+describe('string weights', () => {
+  test('sorts, sums and announces a weight sent as a string', () => {
+    // Hand-authored JSON sends numbers as strings, which is why the type
+    // admits them. The running total is the assertion that matters: `sum +
+    // weight` concatenates rather than adds if the coercion is ever dropped,
+    // so a chart of 10 and 2 would report a total of "102".
+    const asText: WordCloudPoint[] = [
+      { x: 'small', y: '2' },
+      { x: 'large', y: '10' },
+    ];
+    const trace = at(0, asText);
+
+    expect(nonEmptyState(trace).text.main.value).toBe('large');
+    expect(nonEmptyState(trace).text.cross.value).toBe(10);
+    expect(trace.description.stats).toContainEqual({
+      label: 'Total weight',
+      value: 12,
+    });
+  });
+});
+
 describe('audio', () => {
   test('pitches the weight, scaled across the cloud', () => {
     const heaviest = nonEmptyState(at(0)).audio;

--- a/test/model/wordCloud.test.ts
+++ b/test/model/wordCloud.test.ts
@@ -1,0 +1,194 @@
+import type { MaidrLayer, WordCloudPoint } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { WordCloudTrace } from '@model/wordCloud';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Terms deliberately authored in an order that is neither alphabetical nor by
+ * weight, so a reading that kept the authored order cannot coincide with one
+ * that sorted. Every weight is distinct.
+ */
+const TERMS: WordCloudPoint[] = [
+  { x: 'neural', y: 128 },
+  { x: 'machine', y: 412 },
+  { x: 'gradient', y: 57 },
+  { x: 'tensor', y: 233 },
+];
+
+/** The same terms heaviest first — what navigation should walk. */
+const BY_WEIGHT = ['machine', 'tensor', 'neural', 'gradient'];
+
+/**
+ * Create a minimal word cloud layer for model-only tests.
+ * @param data The terms the layer carries
+ * @returns Word cloud layer definition
+ */
+function createLayer(data: WordCloudPoint[]): MaidrLayer {
+  return {
+    id: 'test-word-cloud-layer',
+    type: TraceType.WORD_CLOUD,
+    title: 'Terms in the abstracts',
+    axes: { x: { label: 'Term' }, y: { label: 'Occurrences' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: WordCloudTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a trace and place the cursor on one term.
+ * @param col Term to land on
+ * @param data The terms the layer carries
+ * @returns The positioned trace
+ */
+function at(col: number, data: WordCloudPoint[] = TERMS): WordCloudTrace {
+  const trace = TraceFactory.create(createLayer(data)) as WordCloudTrace;
+  trace.moveToIndex(0, col);
+  return trace;
+}
+
+describe('word cloud registration', () => {
+  test('the factory builds a WordCloudTrace', () => {
+    expect(TraceFactory.create(createLayer(TERMS))).toBeInstanceOf(WordCloudTrace);
+  });
+
+  test('announces itself as a word cloud', () => {
+    expect(at(0).description.chartType).toBe('Word Cloud');
+  });
+
+  test('is a single row of terms, with no second dimension', () => {
+    expect(at(0).moveOnce('DOWNWARD')).toBe(false);
+  });
+});
+
+describe('reading a term', () => {
+  test('walks the terms heaviest first, not as authored', () => {
+    // A cloud's layout is chosen to pack glyphs, so authored order is
+    // arbitrary; weight order is the only sequence the chart is read for.
+    const walked = TERMS.map((_, col) => nonEmptyState(at(col)).text.main.value);
+
+    expect(walked).toEqual(BY_WEIGHT);
+  });
+
+  test('announces the weight alongside the term', () => {
+    // The number the chart encodes as glyph size and prints nowhere. Without
+    // it the reader gets the terms and no way to tell which is heaviest.
+    const { text } = nonEmptyState(at(0));
+
+    expect(text.main.value).toBe('machine');
+    expect(text.cross.value).toBe(412);
+  });
+
+  test('keeps ties in their authored order', () => {
+    // A stable sort matters here: an unstable one would let the same chart
+    // read two different ways between runs.
+    const tied: WordCloudPoint[] = [
+      { x: 'alpha', y: 10 },
+      { x: 'beta', y: 10 },
+      { x: 'gamma', y: 10 },
+    ];
+    const walked = tied.map((_, col) =>
+      nonEmptyState(at(col, tied)).text.main.value);
+
+    expect(walked).toEqual(['alpha', 'beta', 'gamma']);
+  });
+});
+
+describe('audio', () => {
+  test('pitches the weight, scaled across the cloud', () => {
+    const heaviest = nonEmptyState(at(0)).audio;
+    const lightest = nonEmptyState(at(3)).audio;
+
+    expect(heaviest.freq.raw).toBe(412);
+    expect(heaviest.freq.min).toBe(57);
+    expect(heaviest.freq.max).toBe(412);
+    expect(Number(lightest.freq.raw)).toBeLessThan(Number(heaviest.freq.raw));
+  });
+
+  test('pans across the terms', () => {
+    const { audio } = nonEmptyState(at(2));
+
+    expect(audio.panning.x).toBe(2);
+    expect(audio.panning.rows).toBe(1);
+    expect(audio.panning.cols).toBe(4);
+  });
+});
+
+describe('braille', () => {
+  test('renders one row of weights in the navigated order', () => {
+    const { braille } = nonEmptyState(at(1));
+
+    expect(braille.empty).toBe(false);
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+    expect(braille.values).toEqual([[412, 233, 128, 57]]);
+    expect(braille.col).toBe(1);
+  });
+});
+
+describe('extrema navigation', () => {
+  test('offers the heaviest and lightest terms', () => {
+    const targets = at(0).getExtremaTargets();
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({ type: 'max', value: 412, pointIndex: 0 });
+    expect(targets[1]).toMatchObject({ type: 'min', value: 57, pointIndex: 3 });
+  });
+
+  test('moves the cursor to a chosen target', () => {
+    // The base `navigateToExtrema` throws when `supportsExtrema` is set, so a
+    // trace advertising extrema without this is worse than one that does not.
+    const trace = at(0);
+    const [, lightest] = trace.getExtremaTargets();
+
+    trace.navigateToExtrema(lightest);
+
+    expect(nonEmptyState(trace).text.main.value).toBe('gradient');
+  });
+
+  test('offers one target when every term weighs the same', () => {
+    const tied: WordCloudPoint[] = [{ x: 'a', y: 5 }, { x: 'b', y: 5 }];
+
+    expect(at(0, tied).getExtremaTargets()).toHaveLength(1);
+  });
+});
+
+describe('description', () => {
+  test('names the heaviest and lightest terms', () => {
+    // What a cloud is drawn to answer at a glance, and what a reader walking
+    // term by term would otherwise have to hold in their head.
+    const { stats } = at(0).description;
+
+    expect(stats).toContainEqual({ label: 'Heaviest term', value: 'machine (412)' });
+    expect(stats).toContainEqual({ label: 'Lightest term', value: 'gradient (57)' });
+  });
+
+  test('reports the corpus size', () => {
+    const { stats } = at(0).description;
+
+    expect(stats).toContainEqual({ label: 'Number of terms', value: 4 });
+    expect(stats).toContainEqual({ label: 'Total weight', value: 830 });
+  });
+
+  test('tabulates the terms in weight order', () => {
+    const { dataTable } = at(0).description;
+
+    expect(dataTable.headers).toEqual(['Term', 'Occurrences']);
+    expect(dataTable.rows[0]).toEqual(['machine', 412]);
+    expect(dataTable.rows[3]).toEqual(['gradient', 57]);
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -43,6 +43,8 @@ describe('resolveOrientation', () => {
     // A waterfall is navigated one column per step whichever way the bars
     // are drawn, so there is no main and cross axis to swap.
     TraceType.WATERFALL,
+    // Terms are packed, not laid along an axis, and are walked by weight.
+    TraceType.WORD_CLOUD,
   ];
 
   test('answers for every trace type', () => {


### PR DESCRIPTION
Closes #796.

A word cloud is the canonical chart that carries real data while being readable only by eye: each term's weight is drawn as glyph size and written down nowhere on the page. Structurally it's a categorical label and a magnitude, so the reading is a term and its number — "machine, 412" — which is the whole of what the chart encodes and none of what it draws.

## The one part that isn't free

The issue estimated this as "nearly free — it *is* a sorted bar chart". The announcement, the braille and the audio genuinely are. **Navigating in weight order is not**, and it's the reason this extends `AbstractTrace` rather than `AbstractBarPlot`.

`AbstractBarPlot` resolves its highlight elements in **document order** (`Svg.selectAllElements`) inside its own constructor, and pairs `elements[i]` with `points[i]`. It also declares `highlightValues` as `readonly`. So a subclass can neither:

- reassign `highlightValues` after `super()` — it's `readonly` to the declaring class, nor
- permute inside a `mapToSvgElements` override — that override runs *during* `super()`, before any subclass field holding the permutation exists.

Sorting the points there would **announce one term and highlight another**. And nothing in the model would catch it: the text, the audio and the braille would all be correct. Owning the constructor keeps the sort and the permutation together — `byDescendingWeight` returns each term with the index it was authored at, and the resolved elements are reordered by exactly that.

## The test that proves it

The example authors its glyphs in **packing order**, which is what a cloud layout produces and what encodes nothing — `machine` is drawn *second* but is the heaviest term:

```
document order: neural, machine, gradient, tensor, embedding
weight order:   machine, tensor, neural, embedding, gradient
```

A spec asserts the fixture's two orders differ, so the suite can't silently degrade into one that would pass with the sort removed. Then the highlight spec arrows to the first term and checks the highlighted clone's text:

```ts
expect(announcement).toContain('machine');
await expect(page.locator('[id^="maidr-highlight"]').first()).toHaveText('machine');
```

MAIDR highlights by inserting a clone of the drawn element, so the clone's text *is* the glyph lit up on screen. Without the permutation this announces `machine` and highlights `neural`. It passes.

## Registration

All six places from `.claude/rules/model.md`, plus docs:

| # | Place | |
|---|---|---|
| 1 | `TraceType.WORD_CLOUD` + `WordCloudPoint` + data union | ✅ |
| 2 | `src/model/wordCloud.ts` | ✅ |
| 3 | `TraceFactory.create()` case | ✅ |
| 4 | `CHART_TYPE_LABEL` (total record) | ✅ |
| 5 | `IS_ORIENTED` — `false` | ✅ |
| 6 | Braille encoder — `BarBrailleEncoder` | ✅ |
| 7 | `docs/BRAILLE.md` | ✅ |

`IS_ORIENTED` is `false`: terms are packed into a rectangle, not laid along an axis, and are walked by weight regardless — there's no main/cross axis to swap, same as a pie. `test/util/orientation.test.ts` caught the omission before I did, as designed.

Extrema navigation offers the heaviest and lightest terms (implemented rather than merely advertised — the base `navigateToExtrema` throws precisely when `supportsExtrema` is set), collapsing to one target when every weight is equal.

## Verification actually run

| Step | Result |
|---|---|
| `npm test` | **2050 passed** (was 2032) + **73 passed** |
| `npx playwright test wordcloud.spec.ts` | **7 passed**, including the highlight assertion |
| `npm run type-check` | clean |
| `npm run lint:fix` | clean |
| `npm run build` | clean |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_