### PR TITLE
fix(scatter): let autoplay sweep the points inside an entered grid cell

### DIFF
--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -820,6 +820,14 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
         cols: this.xValues.length,
       };
     }
+    if (this.isInGridCellMode) {
+      // Autoplay divides its duration budget by these, so a cell traversal
+      // must be paced over the cell's points, not the grid's cells.
+      return {
+        rows: 1,
+        cols: Math.max(1, this.cellXPoints.length),
+      };
+    }
     if (this.isInGridMode) {
       return {
         rows: this.numGridRows,
@@ -921,6 +929,23 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
    * from before the mode was entered.
    */
   protected override get outOfBoundsState(): TraceEmptyState {
+    // Inside a cell the cursor is cellPointIndex, so the bounds chime has to
+    // pan there — the grid branch below would place it at the cell's position
+    // in the grid instead, on the wrong side of the plot.
+    if (this.isInGridCellMode && this.cellXPoints.length > 0) {
+      return {
+        empty: true,
+        type: 'trace',
+        traceType: this.type,
+        audio: {
+          y: 0,
+          x: this.cellPointIndex,
+          rows: 1,
+          cols: Math.max(1, this.cellXPoints.length),
+        },
+      };
+    }
+
     // Use grid position when in grid mode for correct panning
     if (this.isInGridMode && this.gridCells) {
       return {
@@ -1028,6 +1053,13 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       return true;
     }
 
+    // Cell mode sits inside grid mode, so it has to be tested first: the grid
+    // branch below moves the cell *selection*, which is not what the user is
+    // navigating once they have pressed Enter into a cell.
+    if (this.isInGridCellMode) {
+      return this.moveOnceInGridCellMode(direction);
+    }
+
     // Handle grid mode navigation (used by autoplay and direct calls)
     if (this.isInGridMode && this.gridCells) {
       return this.moveOnceInGridMode(direction);
@@ -1100,6 +1132,33 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
    * @param direction - The movement direction
    * @returns True if movement was successful, false if at boundary
    */
+  /**
+   * Handles movement inside an entered grid cell, mapping directions to the
+   * cell's own point cursor. Only left/right are meaningful — a cell's points
+   * are walked as one horizontal list — so up/down report out of bounds
+   * rather than falling through and moving the grid selection underneath a
+   * user who believes they are still inside the cell.
+   *
+   * Used by autoplay, which drives movement through moveOnce; manual arrows
+   * reach the same moveCellPoint* methods through their own commands. Those
+   * methods notify observers or report bounds themselves.
+   * @param direction - The movement direction
+   * @returns True if movement was successful, false at a boundary
+   */
+  private moveOnceInGridCellMode(direction: MovableDirection): boolean {
+    switch (direction) {
+      case 'FORWARD':
+        return this.moveCellPointRight();
+      case 'BACKWARD':
+        return this.moveCellPointLeft();
+      case 'UPWARD':
+      case 'DOWNWARD':
+      default:
+        this.notifyOutOfBounds();
+        return false;
+    }
+  }
+
   private moveOnceInGridMode(direction: MovableDirection): boolean {
     let moved = false;
     switch (direction) {
@@ -1232,6 +1291,20 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       return target === 'FORWARD' || target === 'UPWARD'
         ? this.intersectionStackIndex < stackLength - 1
         : this.intersectionStackIndex > 0;
+    }
+
+    // Check grid cell boundaries. Autoplay gates on this before every step,
+    // so it has to describe the cell's point list rather than the grid the
+    // cell sits in. Horizontal-only, matching moveOnceInGridCellMode.
+    if (this.isInGridCellMode) {
+      switch (target) {
+        case 'FORWARD':
+          return this.cellPointIndex < this.cellXPoints.length - 1;
+        case 'BACKWARD':
+          return this.cellPointIndex > 0;
+        default:
+          return false;
+      }
     }
 
     // Check grid mode boundaries

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1128,11 +1128,6 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
   }
 
   /**
-   * Handles movement in grid mode, mapping directions to grid cell navigation.
-   * @param direction - The movement direction
-   * @returns True if movement was successful, false if at boundary
-   */
-  /**
    * Handles movement inside an entered grid cell, mapping directions to the
    * cell's own point cursor. Only left/right are meaningful — a cell's points
    * are walked as one horizontal list — so up/down report out of bounds
@@ -1159,6 +1154,13 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
     }
   }
 
+  /**
+   * Handles movement in grid mode, mapping directions to grid cell selection.
+   * Only reached when the user is browsing the grid itself; once they have
+   * pressed Enter into a cell, {@link moveOnceInGridCellMode} takes over.
+   * @param direction - The movement direction
+   * @returns True if movement was successful, false if at boundary
+   */
   private moveOnceInGridMode(direction: MovableDirection): boolean {
     let moved = false;
     switch (direction) {

--- a/src/service/keybinding.ts
+++ b/src/service/keybinding.ts
@@ -392,6 +392,16 @@ const GRID_CELL_KEYMAP = {
   GRID_CELL_MOVE_LEFT: key('left', 'Navigate Left in Cell', { showInHelp: false }),
   GRID_CELL_MOVE_RIGHT: key('right', 'Navigate Right in Cell', { showInHelp: false }),
   EXIT_GRID_CELL: key('esc', 'Exit Grid Cell', { showInHelp: false }),
+
+  // Sweeping a dense cell is the whole reason for entering one, so autoplay
+  // has to be reachable here. Horizontal only: a cell's points are one list,
+  // and up/down are not bound above either.
+  AUTOPLAY_FORWARD: key(`${Platform.ctrl}+shift+right`, 'Autoplay Forward', { helpKey: `${Platform.ctrl} + shift + right` }),
+  AUTOPLAY_BACKWARD: key(`${Platform.ctrl}+shift+left`, 'Autoplay Backward', { helpKey: `${Platform.ctrl} + shift + left` }),
+  STOP_AUTOPLAY: key(`${Platform.ctrl}, left, right`, 'Stop Autoplay', { helpKey: `${Platform.ctrl}` }),
+  SPEED_UP_AUTOPLAY: key(`.`, 'Speed Up Autoplay', { helpKey: '. (period)' }),
+  SPEED_DOWN_AUTOPLAY: key(`,`, 'Speed Down Autoplay', { helpKey: ', (comma)' }),
+  RESET_AUTOPLAY_SPEED: key(`/`, 'Reset Autoplay Speed', { helpKey: '/ (slash)' }),
 } as const;
 
 /**

--- a/test/model/scatterGridCellAutoplay.test.ts
+++ b/test/model/scatterGridCellAutoplay.test.ts
@@ -122,12 +122,13 @@ describe('autoplay inside an entered grid cell', () => {
     const trace = traceInsideCell();
     const update = jest.fn();
     trace.addObserver({ update });
+    const before = trace.getGridPosition();
 
     expect(trace.moveOnce('UPWARD')).toBe(false);
 
     expect(update).toHaveBeenCalledTimes(1);
     expect(update.mock.calls[0][0]).toMatchObject({ empty: true });
-    expect(trace.getGridPosition()).toEqual(trace.getGridPosition());
+    expect(trace.getGridPosition()).toEqual(before);
     expect(trace.isInCellMode()).toBe(true);
   });
 });

--- a/test/model/scatterGridCellAutoplay.test.ts
+++ b/test/model/scatterGridCellAutoplay.test.ts
@@ -1,0 +1,155 @@
+import type { Scope } from '@type/event';
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import { describe, expect, jest, test } from '@jest/globals';
+import { ScatterTrace } from '@model/scatter';
+import { SCOPED_KEYMAP } from '@service/keybinding';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A scatter layer carrying the six axis values `resolveGridConfig` requires,
+ * so the trace advertises grid mode and a cell can be entered.
+ */
+function gridScatterLayer(data: ScatterPoint[]): MaidrLayer {
+  return {
+    id: 'grid-cell-autoplay-layer',
+    type: TraceType.SCATTER,
+    title: 'Grid cell autoplay',
+    axes: {
+      x: { label: 'X', min: 0, max: 4, tickStep: 2 },
+      y: { label: 'Y', min: 0, max: 4, tickStep: 2 },
+    },
+    data,
+  };
+}
+
+/** A trace sitting inside a cell that holds three points at distinct x. */
+function traceInsideCell(): ScatterTrace {
+  const trace = new ScatterTrace(gridScatterLayer([
+    { x: 0.5, y: 0.5 },
+    { x: 1.0, y: 0.7 },
+    { x: 1.5, y: 0.9 },
+    { x: 3, y: 3 },
+  ]));
+  trace.isInitialEntry = false;
+  trace.setGridMode(true);
+  expect(trace.enterGridCell()).toBe(true);
+  expect(trace.getCellPointCount()).toBe(3);
+  return trace;
+}
+
+describe('autoplay inside an entered grid cell', () => {
+  // Autoplay drives movement through context.moveOnce / isMovable rather than
+  // the cell's own commands, so both have to know the cursor is the cell's
+  // point index — not the grid selection the cell sits in.
+
+  test('moveOnce walks the cell points and bounds at the last one', () => {
+    const trace = traceInsideCell();
+
+    expect(trace.getCellPointIndex()).toBe(0);
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.getCellPointIndex()).toBe(1);
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.getCellPointIndex()).toBe(2);
+
+    expect(trace.moveOnce('FORWARD')).toBe(false);
+    expect(trace.getCellPointIndex()).toBe(2);
+  });
+
+  test('moveOnce leaves the grid selection alone while inside a cell', () => {
+    // The defect: the grid branch ran first, so an autoplay step moved the
+    // cell *selection* while the user believed they were inside one — with no
+    // announcement that the context had changed under them.
+    const trace = traceInsideCell();
+    const before = trace.getGridPosition();
+
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    expect(trace.getGridPosition()).toEqual(before);
+    expect(trace.isInCellMode()).toBe(true);
+  });
+
+  test('isMovable describes the cell, and never allows vertical movement', () => {
+    const trace = traceInsideCell();
+
+    expect(trace.isMovable('BACKWARD')).toBe(false); // at the first point
+    expect(trace.isMovable('FORWARD')).toBe(true);
+    expect(trace.isMovable('UPWARD')).toBe(false);
+    expect(trace.isMovable('DOWNWARD')).toBe(false);
+
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    expect(trace.isMovable('FORWARD')).toBe(false); // at the last point
+    expect(trace.isMovable('BACKWARD')).toBe(true);
+  });
+
+  test('autoplay is paced over the cell points, not the grid cells', () => {
+    // AutoplayService divides its duration budget by these counts. Reporting
+    // the 2x2 grid would pace a three-point sweep against two steps.
+    const trace = traceInsideCell();
+    const state = trace.state;
+    if (state.empty || state.type !== 'trace') {
+      throw new Error('expected a populated trace state');
+    }
+
+    expect(state.autoplay.FORWARD).toBe(3);
+    expect(state.autoplay.BACKWARD).toBe(3);
+  });
+
+  test('the boundary chime pans at the cell cursor, not at the cell in the grid', () => {
+    const trace = traceInsideCell();
+    const update = jest.fn();
+    trace.addObserver({ update });
+
+    while (trace.isMovable('FORWARD')) {
+      trace.moveOnce('FORWARD');
+    }
+    update.mockClear();
+
+    expect(trace.moveOnce('FORWARD')).toBe(false);
+
+    const bounds = update.mock.calls[0][0] as {
+      empty: boolean;
+      audio: { x: number; cols: number };
+    };
+    expect(bounds.empty).toBe(true);
+    expect(bounds.audio.x).toBe(2); // the last point in the cell
+    expect(bounds.audio.cols).toBe(3);
+  });
+
+  test('vertical movement inside a cell reports out of bounds rather than moving', () => {
+    const trace = traceInsideCell();
+    const update = jest.fn();
+    trace.addObserver({ update });
+
+    expect(trace.moveOnce('UPWARD')).toBe(false);
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][0]).toMatchObject({ empty: true });
+    expect(trace.getGridPosition()).toEqual(trace.getGridPosition());
+    expect(trace.isInCellMode()).toBe(true);
+  });
+});
+
+describe('grid cell keyboard scope', () => {
+  test('binds autoplay, so a dense cell can be swept rather than stepped', () => {
+    // Entering a cell switches the scope to GRID_CELL. A key bound only in
+    // TRACE does nothing there, which is why Ctrl+Shift+arrow was silent.
+    const keymap = SCOPED_KEYMAP['GRID_CELL' as Scope] as Record<string, unknown>;
+
+    expect(keymap).toHaveProperty('AUTOPLAY_FORWARD');
+    expect(keymap).toHaveProperty('AUTOPLAY_BACKWARD');
+    expect(keymap).toHaveProperty('STOP_AUTOPLAY');
+    expect(keymap).toHaveProperty('SPEED_UP_AUTOPLAY');
+    expect(keymap).toHaveProperty('SPEED_DOWN_AUTOPLAY');
+    expect(keymap).toHaveProperty('RESET_AUTOPLAY_SPEED');
+  });
+
+  test('does not bind vertical autoplay, matching the cell\'s horizontal navigation', () => {
+    const keymap = SCOPED_KEYMAP['GRID_CELL' as Scope] as Record<string, unknown>;
+
+    expect(keymap).not.toHaveProperty('AUTOPLAY_UPWARD');
+    expect(keymap).not.toHaveProperty('AUTOPLAY_DOWNWARD');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Fixes the third item @soundaryakp1999 reported on #617 — pressing <kbd>Enter</kbd> into a grid cell and finding autoplay dead. It turned out to be two defects stacked, both predating #619.

## Related Issues

Fixes #824

## Changes Made

### 1. The autoplay keys were never bound in the grid-cell scope

`Context.enterGridCell()` switches the keyboard scope to `Scope.GRID_CELL`, and that keymap bound three keys:

```ts
const GRID_CELL_KEYMAP = {
  GRID_CELL_MOVE_LEFT: key('left', …),
  GRID_CELL_MOVE_RIGHT: key('right', …),
  EXIT_GRID_CELL: key('esc', …),
} as const;
```

No `AUTOPLAY_*`, no `STOP_AUTOPLAY`, no speed keys — so <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>arrow</kbd> was unbound and nothing happened. Now bound, horizontally only: a cell's points are one list, and up/down aren't bound for manual movement either.

### 2. Binding it alone would have been worse than the silence

`moveOnce` and `isMovable` both branch on `isInGridMode` without ever checking `isInGridCellMode`, and `moveOnceInGridMode` dispatches only to `moveGridRight`/`moveGridLeft`/`moveGridUp`/`moveGridDown`. So autoplay would have walked the cell **selection** while the user believed they were inside one — silently changing what the arrow keys mean afterwards, with no announcement that the context had moved.

Both now test cell mode ahead of the grid branch and drive `moveCellPointRight`/`moveCellPointLeft`. Vertical movement reports out of bounds instead of falling through.

### 3. Pacing and the closing chime

- `dimension` reports the cell's point count in cell mode, so `AutoplayService` divides its duration budget by the points actually being played rather than by the grid's cells.
- `outOfBoundsState` pans at `cellPointIndex`, so the end-of-sweep chime lands where the last tone did instead of at the cell's position in the grid — the same correction #823 made for point and intersection mode.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Accessibility

Sweeping is the point of entering a dense cell — without it a blind user has to step every point by hand to learn what is in there. Defect 2 was the more dangerous of the two: moving the grid cursor while the user believes they are inside a cell desynchronises the mental model with nothing announced to correct it.

### Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass — **2126 tests, 161 suites, 0 failures**.

8 tests added in `test/model/scatterGridCellAutoplay.test.ts`. 7 of the 8 fail with the fix reverted (verified); the eighth asserts that vertical autoplay stays *unbound*, which holds either way and is there to keep the horizontal-only contract from drifting.

---
_Generated by [Claude Code](https://claude.ai/code/session_018bssjSyAmytuMCVtFgYEQ6)_