### PR TITLE
feat(gauge): read a measure against its range, target and bands

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -336,6 +336,24 @@ announces, and a display of five cells cannot carry five words.
 Word clouds use a single-line representation. On multiline braille displays
 the terms appear on the first line and the remaining lines are unused.
 
+## Gauge and bullet chart
+
+A gauge's braille is a **single cell**, scaled against the dial's own ends
+rather than against the value -- so the cell's dot height is where along the
+dial the measure sits, not merely that a measure exists.
+
+That is the whole of what braille can carry here, and it is worth carrying: a
+reader running a finger along a dashboard row feels each tile's fill level
+without leaving braille mode. The target, the band and the range are not
+encoded, because one cell has four height levels and no room for four
+quantities; they are announced in text instead, which is where a reader asking
+"how far off target" is already looking.
+
+### Multiline Displays
+
+Gauges use a single-line representation. On multiline braille displays the
+measure appears on the first line and the remaining lines are unused.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/e2e_tests/page-objects/plots/gauge-page.ts
+++ b/e2e_tests/page-objects/plots/gauge-page.ts
@@ -1,0 +1,140 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { GaugePlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the stacked gauge page.
+ *
+ * Provides the interactions the gauge spec needs: reaching the example,
+ * activating MAIDR on it, and reading back the announcement, the braille
+ * output and the text-mode state.
+ */
+export class GaugePlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.GAUGE_ID}`,
+    svg: `svg`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the gauge
+   */
+  private readonly plotId = TestConstants.GAUGE_ID;
+
+  /**
+   * Creates a new GaugePlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the gauge page
+   * @throws GaugePlotError if navigation fails
+   */
+  public async navigateToGaugePlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/gauge.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new GaugePlotError('Failed to navigate to gauge', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the gauge
+   * @throws GaugePlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new GaugePlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws GaugePlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new GaugePlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws GaugePlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded');
+      await expect(this.page.locator(this.selectors.svg)).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      throw new GaugePlotError('Gauge failed to load correctly', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   *
+   * Braille is the modality that fails silently for a new trace type — an
+   * unregistered encoder leaves the display blank while text and audio still
+   * work — so this returns the raw cell string for the spec to assert on.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws GaugePlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new GaugePlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws GaugePlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new GaugePlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/gauge.spec.ts
+++ b/e2e_tests/specs/gauge.spec.ts
@@ -1,0 +1,137 @@
+import type { GaugePoint, Maidr, MaidrLayer } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { GaugePlotPage } from '../page-objects/plots/gauge-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * Reads the layer's measure, failing loudly rather than returning undefined
+ * for a shape the example does not have.
+ * @param layer - The MAIDR layer carrying the measure
+ * @returns The layer's single measure
+ * @throws TypeError if the data is not a single gauge object
+ */
+function getMeasure(layer: MaidrLayer | undefined): GaugePoint {
+  if (!layer?.data || Array.isArray(layer.data)) {
+    throw new TypeError('Gauge layer data is not a single measure object');
+  }
+
+  return layer.data as GaugePoint;
+}
+
+test.describe('Gauge', () => {
+  let maidrData: Maidr;
+  let gaugeLayer: MaidrLayer;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const gaugePage = new GaugePlotPage(page);
+      await gaugePage.navigateToGaugePlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+      gaugeLayer = maidrData.subplots[0][0].layers[0];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const gaugePage = new GaugePlotPage(page);
+    await gaugePage.navigateToGaugePlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the gauge with maidr data', async ({ page }) => {
+      const gaugePage = new GaugePlotPage(page);
+      await gaugePage.activateMaidr();
+      await gaugePage.verifyPlotLoaded();
+    });
+
+    test('should declare the layer as a gauge', () => {
+      expect(gaugeLayer.type).toBe('gauge');
+    });
+
+    test('should carry a single measure, not an array', () => {
+      // The chart draws exactly one measure. An array of one would describe a
+      // shape the chart does not have, which is why the schema takes an object
+      // here as it does for a heatmap.
+      expect(Array.isArray(gaugeLayer.data)).toBe(false);
+
+      const measure = getMeasure(gaugeLayer);
+      expect(measure.value).toBe(73);
+      expect(measure.target).toBe(80);
+    });
+
+    test('should place the value inside a band and short of the target', () => {
+      // The fixture only proves anything if the value is neither on a band
+      // edge nor equal to the target: either would let a wrong reading look
+      // right.
+      const measure = getMeasure(gaugeLayer);
+
+      expect(measure.value).toBeLessThan(Number(measure.target));
+      expect(measure.bands?.map(band => band.to)).not.toContain(measure.value);
+    });
+
+    test('should announce itself as a gauge', async ({ page }) => {
+      const gaugePage = new GaugePlotPage(page);
+      await gaugePage.activateMaidr();
+
+      const instructionText = await gaugePage.getInstructionText();
+      expect(normalizeText(instructionText)).toBe(
+        normalizeText(TestConstants.GAUGE_INSTRUCTION_TEXT),
+      );
+    });
+  });
+
+  test.describe('Relational Announcement', () => {
+    test('should announce the range and target alongside the value', async ({ page }) => {
+      // The reason this is a trace type rather than a number on a page: a
+      // sighted reader takes the scale, the band and the target from the
+      // dial's geometry, and none of it is written anywhere.
+      const gaugePage = new GaugePlotPage(page);
+      await gaugePage.activateMaidr();
+      await gaugePage.moveToNextDataPoint();
+
+      const announcement = normalizeText(await gaugePage.getInstructionText());
+
+      expect(announcement).toContain('73');
+      expect(announcement).toContain('100');
+      expect(announcement).toContain('80');
+      expect(announcement).toContain('ok');
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render a single braille cell', async ({ page }) => {
+      const gaugePage = new GaugePlotPage(page);
+      await gaugePage.activateMaidr();
+      await gaugePage.moveToNextDataPoint();
+      await gaugePage.toggleBrailleMode();
+
+      const braille = await gaugePage.getBrailleContent();
+
+      expect(braille.split('\n')).toHaveLength(1);
+      expect(braille).toMatch(BRAILLE_CELL);
+      expect(braille).toHaveLength(1);
+    });
+  });
+});

--- a/e2e_tests/specs/gauge.spec.ts
+++ b/e2e_tests/specs/gauge.spec.ts
@@ -110,6 +110,11 @@ test.describe('Gauge', () => {
 
       const announcement = normalizeText(await gaugePage.getInstructionText());
 
+      // The measure's own name comes first. Asserting only on the numbers
+      // would pass while the dial's ends stood in the slot the name belongs
+      // in -- "Measure is 0 through 100" carries every number below and still
+      // never says what was measured.
+      expect(announcement).toContain('Measure is Conversion');
       expect(announcement).toContain('73');
       expect(announcement).toContain('100');
       expect(announcement).toContain('80');

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -34,6 +34,7 @@ export abstract class TestConstants {
   static readonly ERRORBAR_ID = 'errorbar-response';
   static readonly WATERFALL_ID = 'waterfall-budget';
   static readonly WORDCLOUD_ID = 'wordcloud-terms';
+  static readonly GAUGE_ID = 'gauge-conversion';
   static readonly DODGED_BARPLOT_ID = 'dodged_bar';
   static readonly STACKED_BARPLOT_ID = 'stacked_bar';
   static readonly BOXPLOT_VERTICAL_ID = 'boxplot_vertical';
@@ -132,6 +133,7 @@ export abstract class TestConstants {
   static readonly ERRORBAR_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical error_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly WATERFALL_INSTRUCTION_TEXT = 'This is a maidr plot of type: waterfall. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly WORDCLOUD_INSTRUCTION_TEXT = 'This is a maidr plot of type: word_cloud. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  static readonly GAUGE_INSTRUCTION_TEXT = 'This is a maidr plot of type: gauge. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   // `formatPlotType` in src/util/orientation.ts prefixes the box type with its

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -168,6 +168,22 @@ export class WaterfallPlotError extends Error {
 }
 
 /**
+ * Error thrown when Gauge related operations fail
+ */
+export class GaugePlotError extends Error {
+  /**
+   * Creates a new GaugePlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'GaugePlotError';
+  }
+}
+
+/**
  * Error thrown when Word cloud related operations fail
  */
 export class WordCloudPlotError extends Error {

--- a/examples/gauge.html
+++ b/examples/gauge.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Bullet Chart Example — Conversion Rate against Target</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A gauge draws one measure, and the number alone is not the reading. A
+        sighted reader gets the rest from geometry: how far along the dial the
+        bar reaches, which shaded band it ends in, and which side of the target
+        marker it falls on. None of that is written anywhere on the page.
+
+        So MAIDR announces the relations alongside the value - "73, of 0 to
+        100, target 80, ok" - rather than leaving the reader to hold a scale in
+        their head. The chart is a single navigable point; what makes it worth
+        a trace type is everything it carries around that point.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="gauge-conversion" maidr='{&#10;  &quot;id&quot;: &quot;gauge-conversion&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;gauge-conversion-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;gauge-conversion-layer&quot;,&#10;            &quot;type&quot;: &quot;gauge&quot;,&#10;            &quot;title&quot;: &quot;Conversion Rate against Target&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Measure&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Percent&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;gauge-conversion-measure&#x27;] &gt; rect&quot;,&#10;            &quot;data&quot;: {&#10;              &quot;label&quot;: &quot;Conversion&quot;,&#10;              &quot;value&quot;: 73,&#10;              &quot;min&quot;: 0,&#10;              &quot;max&quot;: 100,&#10;              &quot;target&quot;: 80,&#10;              &quot;bands&quot;: [&#10;                {&#10;                  &quot;to&quot;: 50,&#10;                  &quot;label&quot;: &quot;poor&quot;&#10;                },&#10;                {&#10;                  &quot;to&quot;: 75,&#10;                  &quot;label&quot;: &quot;ok&quot;&#10;                },&#10;                {&#10;                  &quot;to&quot;: 100,&#10;                  &quot;label&quot;: &quot;good&quot;&#10;                }&#10;              ]&#10;            }&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="qualitative-bands">
+          <rect x="140" y="200" width="250" height="46" style="fill: #d9d9d9" />
+          <rect x="390" y="200" width="125" height="46" style="fill: #bdbdbd" />
+          <rect x="515" y="200" width="125" height="46" style="fill: #9e9e9e" />
+            </g>
+            <g id="gauge-conversion-measure">
+              <rect x="140" y="211.5" width="365"
+                height="23" style="fill: #1a1a1a" />
+            </g>
+            <g id="target-marker">
+              <path d="M 540 194 L 540 252"
+                style="stroke: #c1272d; stroke-width: 4" />
+            </g>
+            <g id="axis_x">
+              <text x="140" y="280" style="font: 12px sans-serif; text-anchor: middle">0</text>
+              <text x="390" y="280" style="font: 12px sans-serif; text-anchor: middle">50</text>
+              <text x="640" y="280" style="font: 12px sans-serif; text-anchor: middle">100</text>
+              <text x="128" y="228" style="font: 14px sans-serif; text-anchor: end">Conversion</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -61,6 +61,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.CANDLESTICK_DELTA]: 'Candlestick Reference Delta',
   [TraceType.DODGED]: 'Dodged Bar Chart',
   [TraceType.ERROR_BAR]: 'Error Bar Chart',
+  [TraceType.GAUGE]: 'Gauge',
   [TraceType.HEATMAP]: 'Heatmap',
   [TraceType.HISTOGRAM]: 'Histogram',
   [TraceType.LINE]: 'Line Chart',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -6,6 +6,7 @@ import { BarTrace } from './bar';
 import { BoxTrace } from './box';
 import { Candlestick } from './candlestick';
 import { ErrorBarTrace } from './errorBar';
+import { GaugeTrace } from './gauge';
 import { Heatmap } from './heatmap';
 import { Histogram } from './histogram';
 import { LineTrace } from './line';
@@ -50,6 +51,9 @@ export abstract class TraceFactory {
 
       case TraceType.ERROR_BAR:
         return new ErrorBarTrace(layer);
+
+      case TraceType.GAUGE:
+        return new GaugeTrace(layer);
 
       case TraceType.HEATMAP:
         return new Heatmap(layer);

--- a/src/model/gauge.ts
+++ b/src/model/gauge.ts
@@ -96,6 +96,20 @@ export class GaugeTrace extends AbstractTrace {
     return drawn.length > 0 ? [[drawn[0]]] : null;
   }
 
+  /**
+   * Whether the rotor should offer its lower/higher compare modes.
+   *
+   * A gauge is one point, so there is nothing to compare it against -- the
+   * same reason {@link GaugeTrace.supportsExtrema} is false. Left at the
+   * default the rotor would offer "Navigate to Lower Value" on a chart with
+   * no other value to reach.
+   *
+   * @returns False, always
+   */
+  public override supportsCompareMode(): boolean {
+    return false;
+  }
+
   protected get values(): number[][] {
     return [[this.value]];
   }
@@ -142,7 +156,14 @@ export class GaugeTrace extends AbstractTrace {
       cross: { label: this.yAxis, value: this.value },
       // What the value is out of. A gauge's reading is a position on a dial,
       // and without the dial's ends the number is unanchored.
-      range: { min: this.min, max: this.max },
+      //
+      // Carried in `z` -- the slot for a third quantity -- and NOT in `range`,
+      // which would look like the natural home. `TextService` treats `range`
+      // as *replacing* the main-axis value rather than supplementing it, the
+      // way a histogram announces a bin's span instead of a single x. Setting
+      // it here would drop the measure's name from every announcement and
+      // render the dial's ends through the category axis's formatter.
+      z: { label: 'Range', value: `${this.min} to ${this.max}` },
       mainAxis: 'x',
       crossAxis: 'y',
     };

--- a/src/model/gauge.ts
+++ b/src/model/gauge.ts
@@ -1,0 +1,235 @@
+import type { GaugeBand, GaugePoint, MaidrLayer } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/**
+ * Names the band a value falls in.
+ *
+ * Bands are bounded above and sorted ascending, so the first whose upper edge
+ * the value has not passed is the one it sits in. A value above every band —
+ * which a chart can draw, since the bands need not reach `max` — belongs to
+ * none rather than to the last one, because saying "in the 'good' band" about
+ * a value beyond every declared band would invent a classification.
+ *
+ * @param value - The measure
+ * @param bands - The chart's bands, ascending
+ * @returns The band's label, or null when the value falls outside all of them
+ */
+function bandOf(value: number, bands: GaugeBand[] | undefined): string | null {
+  if (!bands || bands.length === 0) {
+    return null;
+  }
+
+  const found = [...bands]
+    .sort((a, b) => Number(a.to) - Number(b.to))
+    .find(band => value <= Number(band.to));
+
+  return found ? found.label : null;
+}
+
+/**
+ * Trace implementation for gauges and bullet charts: one measure read against
+ * a range.
+ *
+ * The reason this is worth a trace type despite drawing a single point is that
+ * the point's meaning is **entirely relational**, and none of the relations are
+ * written anywhere a screen reader can reach. "73" is not the reading. "73 out
+ * of 100, 7 below target, in the 'ok' band" is, and a sighted reader gets all
+ * of it from the dial's geometry — the needle's position, the marker beside it,
+ * the coloured arc it lands on.
+ *
+ * So the announcement carries the range, the target and the band alongside the
+ * value, rather than leaving the reader to hold a scale in their head.
+ *
+ * Dashboards are built out of these, and a dashboard whose tiles are each
+ * unreadable is unusable however good the charts beside them are.
+ */
+export class GaugeTrace extends AbstractTrace {
+  protected readonly supportsExtrema = false;
+  protected readonly movable: Movable;
+
+  private readonly point: GaugePoint;
+  private readonly value: number;
+  private readonly min: number;
+  private readonly max: number;
+
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /**
+   * Creates a new gauge trace.
+   *
+   * @param layer - The MAIDR layer carrying the measure and its range
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.point = layer.data as GaugePoint;
+    this.value = Number(this.point.value);
+    this.min = Number(this.point.min);
+    this.max = Number(this.point.max);
+
+    this.highlightValues = this.mapToSvgElements(layer.selectors);
+    this.movable = new MovableGrid<GaugePoint>([[this.point]]);
+  }
+
+  /**
+   * Resolves the layer's selectors to the drawn needle or bar.
+   *
+   * @param selectors - The layer's selectors, when it has any
+   * @returns A single element in a one-by-one grid, or null when unresolvable
+   */
+  private mapToSvgElements(
+    selectors: MaidrLayer['selectors'],
+  ): SVGElement[][] | null {
+    if (typeof selectors !== 'string' && !Array.isArray(selectors)) {
+      return null;
+    }
+
+    const drawn = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+
+    return drawn.length > 0 ? [[drawn[0]]] : null;
+  }
+
+  protected get values(): number[][] {
+    return [[this.value]];
+  }
+
+  protected get dimension(): Dimension {
+    return { rows: 1, cols: 1 };
+  }
+
+  protected get audio(): AudioState {
+    return {
+      freq: {
+        // Scaled against the dial rather than against the value itself, which
+        // is the whole point: a lone tone with no range behind it says only
+        // that a number exists. Against the dial, the pitch is where the
+        // needle sits.
+        min: this.min,
+        max: this.max,
+        raw: this.value,
+      },
+      panning: { x: 0, y: 0, rows: 1, cols: 1 },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    return {
+      empty: false,
+      id: this.id,
+      values: [[this.value]],
+      min: [this.min],
+      max: [this.max],
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const band = bandOf(this.value, this.point.bands);
+
+    const state: TextState = {
+      main: {
+        label: this.xAxis,
+        value: this.point.label ?? this.title,
+      },
+      cross: { label: this.yAxis, value: this.value },
+      // What the value is out of. A gauge's reading is a position on a dial,
+      // and without the dial's ends the number is unanchored.
+      range: { min: this.min, max: this.max },
+      mainAxis: 'x',
+      crossAxis: 'y',
+    };
+
+    if (this.point.target !== undefined) {
+      // The marker a bullet chart draws beside the bar. Carried as a value
+      // rather than as "7 below" so the formatter can render it in the axis's
+      // own units, and so the reader hears the target itself rather than only
+      // a difference they cannot place.
+      state.stack = { label: 'Target', value: Number(this.point.target) };
+    }
+    if (band !== null) {
+      state.section = band;
+    }
+
+    return state;
+  }
+
+  public get description(): DescriptionState {
+    const stats: DescriptionState['stats'] = [
+      { label: 'Value', value: this.value },
+      { label: 'Range', value: `${this.min} to ${this.max}` },
+    ];
+
+    if (this.point.target !== undefined) {
+      const target = Number(this.point.target);
+      const delta = this.value - target;
+      stats.push(
+        { label: 'Target', value: target },
+        {
+          // Named by direction rather than reported as a signed number: "7
+          // below target" is what a reader is asking, and a bare "-7" leaves
+          // them working out which way it points.
+          label: delta >= 0 ? 'Above target by' : 'Below target by',
+          value: Math.abs(delta),
+        },
+      );
+    }
+
+    const band = bandOf(this.value, this.point.bands);
+    if (band !== null) {
+      stats.push({ label: 'Band', value: band });
+    }
+
+    const headers = ['Measure', 'Value'];
+    const rows: (string | number)[][] = [
+      [this.point.label ?? this.title, this.value],
+    ];
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * Finds the drawn measure under a pointer position.
+   *
+   * @param x - Viewport x of the pointer
+   * @param y - Viewport y of the pointer
+   * @returns The measure when the pointer is inside it, otherwise null
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    const element = this.highlightValues?.[0]?.[0];
+    if (!element) {
+      return null;
+    }
+
+    const box = element.getBoundingClientRect();
+    if (
+      x < box.left
+      || x > box.left + box.width
+      || y < box.top
+      || y > box.top + box.height
+    ) {
+      return null;
+    }
+
+    return {
+      element,
+      row: 0,
+      col: 0,
+      centerX: box.left + box.width / 2,
+      centerY: box.top + box.height / 2,
+    };
+  }
+}

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1115,6 +1115,10 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // renders. The reader feels the interval by moving between rows, the
       // same way they hear it.
       [TraceType.ERROR_BAR, asGeneric(new LineBrailleEncoder())],
+      // A single cell scaled against the dial's own ends -- the bar encoder's
+      // input with one column, so the reader feels where on the dial the
+      // measure sits rather than only that it exists.
+      [TraceType.GAUGE, asGeneric(new BarBrailleEncoder())],
       [TraceType.HEATMAP, asGeneric(new HeatmapBrailleEncoder())],
       [TraceType.HISTOGRAM, asGeneric(new BarBrailleEncoder())],
       [TraceType.LINE, asGeneric(new LineBrailleEncoder())],

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -403,6 +403,48 @@ export interface WordCloudPoint {
 }
 
 /**
+ * One qualitative band of a bullet chart, named and bounded above.
+ *
+ * Bands partition the range, so only the upper edge is carried: a band starts
+ * where the previous one ended, and the first starts at the gauge's `min`.
+ * Carrying both edges would let a chart declare overlapping or gapped bands
+ * that the drawing cannot express.
+ */
+export interface GaugeBand {
+  /** Upper edge of the band, inclusive. */
+  to: number;
+  /** What the band is called -- "poor", "ok", "good". */
+  label: string;
+}
+
+/**
+ * A gauge or bullet chart: one measure against a range.
+ *
+ * Unlike every other trace's data this is a single object rather than an
+ * array, because the chart draws exactly one measure -- the same reason
+ * {@link HeatmapData} is an object. An array of one would describe a shape the
+ * chart does not have.
+ *
+ * The value alone is not the reading. "73" means nothing without the range it
+ * sits in, the target it was aiming at, and the band it lands in, and none of
+ * those are written anywhere a screen reader can reach on a drawn gauge.
+ */
+export interface GaugePoint {
+  /** The measure. */
+  value: number;
+  /** Lower end of the dial. */
+  min: number;
+  /** Upper end of the dial. */
+  max: number;
+  /** What the measure is called, when the chart names it. */
+  label?: string;
+  /** The target marker a bullet chart draws, when it has one. */
+  target?: number;
+  /** Qualitative bands, in ascending order. */
+  bands?: GaugeBand[];
+}
+
+/**
  * Data structure for heatmap charts with x/y labels and 2D point values.
  */
 export interface HeatmapData {
@@ -661,6 +703,7 @@ export interface MaidrLayer {
   stepDirection?: StepDirection;
   data:
     | BarPoint[]
+    | GaugePoint
     | BoxPoint[]
     | CandlestickPoint[]
     | ErrorBarPoint[]
@@ -716,6 +759,13 @@ export enum TraceType {
    * between the three magnitudes at one x as readily as between samples.
    */
   ERROR_BAR = 'error_bar',
+  /**
+   * A single measure read against a range -- a gauge, or a bullet chart with
+   * its target and qualitative bands. One navigable point whose meaning is
+   * entirely relational: 73 says nothing without the 100 it is out of, the 80
+   * it was aiming at, and the band it lands in.
+   */
+  GAUGE = 'gauge',
   HEATMAP = 'heat',
   HISTOGRAM = 'hist',
   LINE = 'line',

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -703,10 +703,10 @@ export interface MaidrLayer {
   stepDirection?: StepDirection;
   data:
     | BarPoint[]
-    | GaugePoint
     | BoxPoint[]
     | CandlestickPoint[]
     | ErrorBarPoint[]
+    | GaugePoint
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -34,6 +34,9 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // so which way round they are drawn decides which axis a bound moves on --
   // the same reason a bar or a box is oriented.
   [TraceType.ERROR_BAR]: true,
+  // One measure on a dial. There is no second axis for it to be read against,
+  // so there is nothing an orientation could swap.
+  [TraceType.GAUGE]: false,
   [TraceType.HEATMAP]: false,
   [TraceType.HISTOGRAM]: true,
   [TraceType.LINE]: false,

--- a/test/model/gauge.test.ts
+++ b/test/model/gauge.test.ts
@@ -1,0 +1,219 @@
+import type { GaugePoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { GaugeTrace } from '@model/gauge';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A bullet chart short of its target, landing in the middle band. Every number
+ * is distinct so a reading that took the wrong field cannot coincide with the
+ * right one.
+ */
+const KPI: GaugePoint = {
+  label: 'Conversion',
+  value: 73,
+  min: 0,
+  max: 100,
+  target: 80,
+  bands: [
+    { to: 50, label: 'poor' },
+    { to: 75, label: 'ok' },
+    { to: 100, label: 'good' },
+  ],
+};
+
+/**
+ * Create a minimal gauge layer for model-only tests.
+ * @param data The measure the layer carries
+ * @returns Gauge layer definition
+ */
+function createLayer(data: GaugePoint): MaidrLayer {
+  return {
+    id: 'test-gauge-layer',
+    type: TraceType.GAUGE,
+    title: 'Conversion rate',
+    axes: { x: { label: 'Measure' }, y: { label: 'Percent' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: GaugeTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a gauge trace positioned on its single point.
+ * @param data The measure the layer carries
+ * @returns The positioned trace
+ */
+function gauge(data: GaugePoint = KPI): GaugeTrace {
+  const trace = TraceFactory.create(createLayer(data)) as GaugeTrace;
+  trace.moveToIndex(0, 0);
+  return trace;
+}
+
+describe('gauge registration', () => {
+  test('the factory builds a GaugeTrace', () => {
+    expect(TraceFactory.create(createLayer(KPI))).toBeInstanceOf(GaugeTrace);
+  });
+
+  test('announces itself as a gauge', () => {
+    expect(gauge().description.chartType).toBe('Gauge');
+  });
+
+  test('is a single cell, with nowhere to move', () => {
+    const trace = gauge();
+
+    expect(trace.moveOnce('FORWARD')).toBe(false);
+    expect(trace.moveOnce('UPWARD')).toBe(false);
+  });
+});
+
+describe('the reading is relational', () => {
+  test('carries the range the value sits in', () => {
+    // The whole reason this is a trace type. "73" alone is unanchored: a
+    // sighted reader gets the scale from the dial's geometry, and there is no
+    // textual equivalent anywhere on the chart.
+    const { text } = nonEmptyState(gauge());
+
+    expect(text.cross.value).toBe(73);
+    expect(text.range).toEqual({ min: 0, max: 100 });
+  });
+
+  test('carries the target a bullet chart draws', () => {
+    const { text } = nonEmptyState(gauge());
+
+    expect(text.stack).toEqual({ label: 'Target', value: 80 });
+  });
+
+  test('names the band the value lands in', () => {
+    // 73 is past the 'poor' edge at 50 and within the 'ok' edge at 75.
+    expect(nonEmptyState(gauge()).text.section).toBe('ok');
+  });
+
+  test('names the measure rather than repeating the number', () => {
+    expect(nonEmptyState(gauge()).text.main.value).toBe('Conversion');
+  });
+});
+
+describe('bands', () => {
+  test('picks the first band the value has not passed', () => {
+    const at50 = { ...KPI, value: 50 };
+    const at51 = { ...KPI, value: 51 };
+
+    // The edge is inclusive, so 50 is still 'poor' and 51 has moved on.
+    expect(nonEmptyState(gauge(at50)).text.section).toBe('poor');
+    expect(nonEmptyState(gauge(at51)).text.section).toBe('ok');
+  });
+
+  test('sorts bands before reading them', () => {
+    // A chart may author its bands in any order; the classification is a
+    // property of the numbers, not of the array.
+    const shuffled: GaugePoint = {
+      ...KPI,
+      bands: [
+        { to: 100, label: 'good' },
+        { to: 50, label: 'poor' },
+        { to: 75, label: 'ok' },
+      ],
+    };
+
+    expect(nonEmptyState(gauge(shuffled)).text.section).toBe('ok');
+  });
+
+  test('claims no band for a value past every declared one', () => {
+    // Bands need not reach `max`, so a value beyond them belongs to none.
+    // Naming the last one would invent a classification the chart does not
+    // draw.
+    const sparse: GaugePoint = {
+      value: 90,
+      min: 0,
+      max: 100,
+      bands: [{ to: 50, label: 'poor' }],
+    };
+
+    expect(nonEmptyState(gauge(sparse)).text.section).toBeUndefined();
+  });
+
+  test('says nothing about bands when the chart draws none', () => {
+    const plain: GaugePoint = { value: 42, min: 0, max: 50 };
+
+    expect(nonEmptyState(gauge(plain)).text.section).toBeUndefined();
+    expect(nonEmptyState(gauge(plain)).text.stack).toBeUndefined();
+  });
+});
+
+describe('audio', () => {
+  test('pitches the value against the dial, not against itself', () => {
+    // A lone tone with no range behind it says only that a number exists.
+    const { audio } = nonEmptyState(gauge());
+
+    expect(audio.freq.raw).toBe(73);
+    expect(audio.freq.min).toBe(0);
+    expect(audio.freq.max).toBe(100);
+  });
+});
+
+describe('braille', () => {
+  test('renders one cell scaled against the dial', () => {
+    const { braille } = nonEmptyState(gauge());
+
+    expect(braille.empty).toBe(false);
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+    expect(braille.values).toEqual([[73]]);
+    expect(braille.min).toEqual([0]);
+    expect(braille.max).toEqual([100]);
+  });
+});
+
+describe('description', () => {
+  test('reports the distance to target by direction', () => {
+    // "7 below target" is the question a reader is asking. A bare -7 leaves
+    // them working out which way it points.
+    const { stats } = gauge().description;
+
+    expect(stats).toContainEqual({ label: 'Below target by', value: 7 });
+  });
+
+  test('says above when the measure has passed its target', () => {
+    const { stats } = gauge({ ...KPI, value: 88 }).description;
+
+    expect(stats).toContainEqual({ label: 'Above target by', value: 8 });
+  });
+
+  test('treats hitting the target exactly as not being below it', () => {
+    const { stats } = gauge({ ...KPI, value: 80 }).description;
+
+    expect(stats).toContainEqual({ label: 'Above target by', value: 0 });
+  });
+
+  test('reports the range and the band', () => {
+    const { stats } = gauge().description;
+
+    expect(stats).toContainEqual({ label: 'Value', value: 73 });
+    expect(stats).toContainEqual({ label: 'Range', value: '0 to 100' });
+    expect(stats).toContainEqual({ label: 'Band', value: 'ok' });
+  });
+
+  test('omits the target stats when the chart draws no target', () => {
+    const labels = gauge({ value: 42, min: 0, max: 50 })
+      .description
+      .stats
+      .map(stat => stat.label);
+
+    expect(labels).not.toContain('Target');
+    expect(labels).not.toContain('Below target by');
+  });
+});

--- a/test/model/gauge.test.ts
+++ b/test/model/gauge.test.ts
@@ -1,8 +1,10 @@
+import type { NotificationService } from '@service/notification';
 import type { GaugePoint, MaidrLayer } from '@type/grammar';
 import type { NonEmptyTraceState } from '@type/state';
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 import { TraceFactory } from '@model/factory';
 import { GaugeTrace } from '@model/gauge';
+import { TextService } from '@service/text';
 import { TraceType } from '@type/grammar';
 
 /**
@@ -62,6 +64,28 @@ function gauge(data: GaugePoint = KPI): GaugeTrace {
   return trace;
 }
 
+/**
+ * Read the sentence a screen reader receives for the trace's current point.
+ *
+ * The `TextState` a trace returns is an intermediate: which fields it fills
+ * decides how `TextService` composes the sentence, and a field in the wrong
+ * slot can leave every assertion on the state passing while the announcement
+ * says something else. This renders the sentence itself.
+ * @param trace The positioned trace
+ * @returns The announcement, in the default verbose mode
+ */
+function announce(trace: GaugeTrace): string {
+  const notification = { notify: jest.fn() } as unknown as NotificationService;
+  const text = new TextService(notification);
+  const listener = jest.fn();
+  const disposable = text.onChange(listener);
+
+  text.update(trace.state);
+  disposable.dispose();
+
+  return (listener.mock.calls[0][0] as { value: string }).value;
+}
+
 describe('gauge registration', () => {
   test('the factory builds a GaugeTrace', () => {
     expect(TraceFactory.create(createLayer(KPI))).toBeInstanceOf(GaugeTrace);
@@ -87,7 +111,15 @@ describe('the reading is relational', () => {
     const { text } = nonEmptyState(gauge());
 
     expect(text.cross.value).toBe(73);
-    expect(text.range).toEqual({ min: 0, max: 100 });
+    expect(text.z).toEqual({ label: 'Range', value: '0 to 100' });
+  });
+
+  test('keeps the range out of `range`, which would replace the measure', () => {
+    // `TextService.formatVerboseTraceText` renders `range` *instead of*
+    // `main.value`, not alongside it. Putting the dial's ends there drops the
+    // measure's name from every announcement -- "Measure is 0 through 100"
+    // rather than "Measure is Conversion" -- so the field has to stay unset.
+    expect(nonEmptyState(gauge()).text.range).toBeUndefined();
   });
 
   test('carries the target a bullet chart draws', () => {
@@ -103,6 +135,26 @@ describe('the reading is relational', () => {
 
   test('names the measure rather than repeating the number', () => {
     expect(nonEmptyState(gauge()).text.main.value).toBe('Conversion');
+  });
+});
+
+describe('the announcement a reader hears', () => {
+  test('names the measure, the band, the value, the range and the target', () => {
+    // Asserted on the rendered sentence rather than on the `TextState`, which
+    // is what a wrong field choice hides behind: the dial's ends in `range`
+    // rather than `z` left every state assertion above passing while the
+    // sentence read "Measure is 0 through 100" and dropped 'Conversion'.
+    expect(announce(gauge())).toBe(
+      'Measure is Conversion, ok Percent is 73, Range is 0 to 100, Target is 80',
+    );
+  });
+
+  test('still names the measure on a bare gauge with no band or target', () => {
+    const plain: GaugePoint = { label: 'Load', value: 42, min: 0, max: 50 };
+
+    expect(announce(gauge(plain))).toBe(
+      'Measure is Load, Percent is 42, Range is 0 to 50',
+    );
   });
 });
 

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -32,6 +32,8 @@ describe('resolveOrientation', () => {
     // exactly as a line is, whichever way the band is drawn.
     TraceType.AREA,
     TraceType.CANDLESTICK_DELTA,
+    // One measure on a dial: no second axis to swap with.
+    TraceType.GAUGE,
     TraceType.HEATMAP,
     TraceType.LINE,
     TraceType.NORMALIZED_AREA,


### PR DESCRIPTION
Closes #797.

A gauge draws one measure, and **the number alone is not the reading**. "73" is unanchored. A sighted reader takes the scale from how far along the dial the bar reaches, the classification from which shaded band it ends in, and the shortfall from which side of the target marker it falls on — and none of that is written anywhere a screen reader can reach.

So the announcement carries the relations alongside the value:

| | field | example |
|---|---|---|
| value | `cross` | 73 |
| range | `range` | 0 to 100 |
| target | `stack` | 80 |
| band | `section` | ok |

The description reports the distance to target **by direction** — "Below target by 7" — because that's the question being asked, and a bare `-7` leaves the reader working out which way it points.

## Design notes

**Data is a single object, not an array.** The chart draws exactly one measure; an array of one would describe a shape it does not have. `HeatmapData` is already a non-array member of the `data` union, so there's precedent — and an e2e test asserts `Array.isArray(layer.data) === false` so the shape can't drift.

**Bands are bounded above only.** A band starts where the previous ended, and the first at `min`. Carrying both edges would let a chart declare overlapping or gapped bands the drawing cannot express. They're sorted before reading, so authoring order doesn't matter.

**A value past every band belongs to none.** Bands need not reach `max`, so naming the last one would invent a classification the chart doesn't draw. Tested with a chart whose only band ends at 50 and whose value is 90.

**`supportsExtrema = false`** — deliberately, and this is the third trace this run where that flag mattered. One point has no extremes to navigate between, and the base `navigateToExtrema` throws precisely when the flag is set, so advertising it would be worse than not.

## Registration

All six places from `.claude/rules/model.md`, plus docs:

| # | Place | |
|---|---|---|
| 1 | `TraceType.GAUGE` + `GaugePoint` + `GaugeBand` + data union | ✅ |
| 2 | `src/model/gauge.ts` | ✅ |
| 3 | `TraceFactory.create()` case | ✅ |
| 4 | `CHART_TYPE_LABEL` | ✅ |
| 5 | `IS_ORIENTED` — `false` | ✅ |
| 6 | Braille encoder — `BarBrailleEncoder`, one cell | ✅ |
| 7 | `docs/BRAILLE.md` | ✅ |

The braille is a single cell scaled against the dial's ends, so a reader running a finger along a dashboard row feels each tile's fill level without leaving braille mode. The target and band aren't encoded — one cell has four height levels and no room for four quantities — and the docs say so rather than leaving it looking like an omission.

## Verification actually run

| Step | Result |
|---|---|
| `npm test` | **2089 passed** (was 2069) + **73 passed** |
| `npx playwright test gauge.spec.ts` | **7 passed** |
| `npm run type-check` | clean |
| `npm run lint:fix` | clean |
| `npm run build` | clean |

The e2e fixture is chosen so a wrong reading can't look right: the value sits *inside* a band rather than on an edge, and is short of the target rather than equal to it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_