### PR TITLE
feat(dumbbell): read a pair per category with the gap between them

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -354,6 +354,33 @@ quantities; they are announced in text instead, which is where a reader asking
 Gauges use a single-line representation. On multiline braille displays the
 measure appears on the first line and the remaining lines are unused.
 
+## Dumbbell
+
+A dumbbell's braille is **two rows** — the starting values and the finishing
+ones — one cell per category, with each row scaled against **its own** range.
+
+That per-row scaling is the same treatment a multi-line plot gets, and it is
+what makes the two rows comparable as *shapes*: the point of the chart is
+whether the second row's profile sits differently from the first, and a single
+shared range would flatten both toward the middle of the combined spread when
+the two ends occupy different parts of the value axis.
+
+The rows keep the chart's own order — start first, then end — rather than being
+sorted by magnitude. A dumbbell normally contains rises and falls at once, so
+sorting would put a declining row's finishing value on the line that holds
+every other row's start, and the reader would have no way to know which line
+they were feeling.
+
+The change itself is not encoded. It is what the text announcement carries at
+both ends of every row, and a third line of deltas would read as a third series
+rather than as the gap between the first two.
+
+### Multiline Displays
+
+Dumbbell charts use both lines on a multiline display: the starting values on
+the first and the finishing ones on the second, so the two profiles can be
+compared with one sweep rather than by toggling between rows.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/e2e_tests/page-objects/plots/dumbbell-page.ts
+++ b/e2e_tests/page-objects/plots/dumbbell-page.ts
@@ -1,0 +1,140 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TestConstants } from '../../utils/constants';
+import { DumbbellPlotError } from '../../utils/errors';
+import { BasePage } from '../base-page';
+
+/**
+ * Page object for the dumbbell chart page.
+ *
+ * Provides the interactions the dumbbell spec needs: reaching the example,
+ * activating MAIDR on it, and reading back the announcement, the braille
+ * output and the text-mode state.
+ */
+export class DumbbellPlotPage extends BasePage {
+  /**
+   * Selectors for various UI elements
+   */
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    info: `#${TestConstants.MAIDR_INFO_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    speedIndicator: `#${TestConstants.MAIDR_SPEED_INDICATOR}${TestConstants.DUMBBELL_ID}`,
+    svg: `svg`,
+    // The textarea's id ends with a React `useId()` suffix, so match on the
+    // stable prefix rather than the whole id.
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /**
+   * The ID of the dumbbell
+   */
+  private readonly plotId = TestConstants.DUMBBELL_ID;
+
+  /**
+   * Creates a new DumbbellPlotPage instance
+   * @param page - The Playwright page object
+   */
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Navigates to the dumbbell page
+   * @throws DumbbellPlotError if navigation fails
+   */
+  public async navigateToDumbbellPlot(): Promise<void> {
+    try {
+      await super.navigateTo('examples/dumbbell.html');
+      await super.verifyPlotLoaded(this.selectors.svg);
+    } catch (error) {
+      throw new DumbbellPlotError('Failed to navigate to dumbbell', { cause: error });
+    }
+  }
+
+  /**
+   * Activates MAIDR on the dumbbell
+   * @throws DumbbellPlotError if MAIDR cannot be activated
+   */
+  public override async activateMaidr(): Promise<void> {
+    try {
+      await super.activateMaidr(this.selectors.svg, this.plotId);
+    } catch (error) {
+      throw new DumbbellPlotError('Failed to activate MAIDR', { cause: error });
+    }
+  }
+
+  /**
+   * Gets the instruction text displayed by MAIDR
+   * @returns Promise resolving to the instruction text
+   * @throws DumbbellPlotError if instruction text cannot be retrieved
+   */
+  public override async getInstructionText(): Promise<string> {
+    try {
+      return await super.getInstructionText(this.selectors.notification);
+    } catch (error) {
+      throw new DumbbellPlotError('Failed to get instruction text', { cause: error });
+    }
+  }
+
+  /**
+   * Verifies the plot has loaded correctly
+   * @returns Promise resolving when verification is complete
+   * @throws DumbbellPlotError if plot is not loaded correctly
+   */
+  public override async verifyPlotLoaded(): Promise<void> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded');
+      await expect(this.page.locator(this.selectors.svg)).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      throw new DumbbellPlotError('Dumbbell failed to load correctly', { cause: error });
+    }
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   *
+   * Braille is the modality that fails silently for a new trace type — an
+   * unregistered encoder leaves the display blank while text and audio still
+   * work — so this returns the raw cell string for the spec to assert on.
+   * @returns Promise resolving to the braille content, whitespace trimmed
+   * @throws DumbbellPlotError if the braille display never appears
+   */
+  public async getBrailleContent(): Promise<string> {
+    try {
+      const textarea = await this.waitForElement(this.selectors.braille);
+      return (await textarea.inputValue()).trim();
+    } catch (error) {
+      throw new DumbbellPlotError('Failed to read the braille display', { cause: error });
+    }
+  }
+
+  /**
+   * Checks if text mode is active
+   * @param textMode - The text mode to check
+   * @returns Promise resolving to true if text mode is active, false otherwise
+   * @throws DumbbellPlotError if text mode status cannot be checked
+   */
+  public async isTextModeActive(textMode: string): Promise<boolean> {
+    try {
+      const modeMessages: Record<string, string> = {
+        [TestConstants.TEXT_MODE_TERSE]: TestConstants.TEXT_MODE_TERSE_MESSAGE,
+        [TestConstants.TEXT_MODE_VERBOSE]: TestConstants.TEXT_MODE_VERBOSE_MESSAGE,
+        [TestConstants.TEXT_MODE_OFF]: TestConstants.TEXT_MODE_OFF_MESSAGE,
+      };
+      return await super.isModeActive(
+        this.selectors.notification,
+        textMode,
+        modeMessages,
+      );
+    } catch (error) {
+      throw new DumbbellPlotError('Failed to check text mode status', { cause: error });
+    }
+  }
+}

--- a/e2e_tests/specs/dumbbell.spec.ts
+++ b/e2e_tests/specs/dumbbell.spec.ts
@@ -1,0 +1,144 @@
+import type { DumbbellData, Maidr, MaidrLayer } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { DumbbellPlotPage } from '../page-objects/plots/dumbbell-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/**
+ * Reads the layer's pairs, failing loudly rather than returning undefined for
+ * a shape the example does not have.
+ * @param layer - The MAIDR layer carrying the pairs
+ * @returns The layer's dumbbell data
+ * @throws TypeError if the data is not a single dumbbell object
+ */
+function getPairs(layer: MaidrLayer | undefined): DumbbellData {
+  if (!layer?.data || Array.isArray(layer.data)) {
+    throw new TypeError('Dumbbell layer data is not a single object');
+  }
+
+  return layer.data as DumbbellData;
+}
+
+test.describe('Dumbbell', () => {
+  let maidrData: Maidr;
+  let dumbbellLayer: MaidrLayer;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const dumbbellPage = new DumbbellPlotPage(page);
+      await dumbbellPage.navigateToDumbbellPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+      dumbbellLayer = maidrData.subplots[0][0].layers[0];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Failed to extract MAIDR data:', errorMessage);
+      throw error;
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const dumbbellPage = new DumbbellPlotPage(page);
+    await dumbbellPage.navigateToDumbbellPlot();
+  });
+
+  test.describe('Basic Plot Functionality', () => {
+    test('should load the dumbbell with maidr data', async ({ page }) => {
+      const dumbbellPage = new DumbbellPlotPage(page);
+      await dumbbellPage.activateMaidr();
+      await dumbbellPage.verifyPlotLoaded();
+    });
+
+    test('should declare the layer as a dumbbell', () => {
+      expect(dumbbellLayer.type).toBe('dumbbell');
+    });
+
+    test('should carry both directions and an unchanged pair', () => {
+      // The fixture only proves anything if it holds all three cases the
+      // announcement distinguishes. A chart where everything rose would let a
+      // reading that ignored direction look right.
+      const { points } = getPairs(dumbbellLayer);
+      const changes = points.map(point => Number(point.end) - Number(point.start));
+
+      expect(changes.some(change => change > 0)).toBe(true);
+      expect(changes.some(change => change < 0)).toBe(true);
+      expect(changes.includes(0)).toBe(true);
+    });
+
+    test('should announce itself as a dumbbell', async ({ page }) => {
+      const dumbbellPage = new DumbbellPlotPage(page);
+      await dumbbellPage.activateMaidr();
+
+      const instructionText = await dumbbellPage.getInstructionText();
+      expect(normalizeText(instructionText)).toBe(
+        normalizeText(TestConstants.DUMBBELL_INSTRUCTION_TEXT),
+      );
+    });
+  });
+
+  test.describe('The Change Is The Message', () => {
+    test('should announce the change alongside the end under the cursor', async ({ page }) => {
+      // The reason this is a trace type. Without the change, a reader has to
+      // hold one number, navigate to the other and subtract by ear, on every
+      // row of the chart.
+      const dumbbellPage = new DumbbellPlotPage(page);
+      await dumbbellPage.activateMaidr();
+      await dumbbellPage.moveToNextDataPoint();
+
+      const announcement = normalizeText(await dumbbellPage.getInstructionText());
+
+      expect(announcement).toContain('Denmark');
+      // The chart's own name for the end, not "start".
+      expect(announcement).toContain('1990');
+      expect(announcement).toContain('71.2');
+      expect(announcement).toContain('Increase is 7.2');
+    });
+
+    test('should name a decline as a decrease', async ({ page }) => {
+      const dumbbellPage = new DumbbellPlotPage(page);
+      await dumbbellPage.activateMaidr();
+      await dumbbellPage.moveToNextDataPoint();
+      await dumbbellPage.moveToNextDataPoint();
+
+      const announcement = normalizeText(await dumbbellPage.getInstructionText());
+
+      expect(announcement).toContain('Latvia');
+      expect(announcement).toContain('Decrease is 5.1');
+    });
+  });
+
+  test.describe('Braille Output', () => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    test('should render one braille row per end', async ({ page }) => {
+      const dumbbellPage = new DumbbellPlotPage(page);
+      await dumbbellPage.activateMaidr();
+      await dumbbellPage.moveToNextDataPoint();
+      await dumbbellPage.toggleBrailleMode();
+
+      const braille = await dumbbellPage.getBrailleContent();
+      const rows = braille.split('\n');
+
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        expect(row).toMatch(BRAILLE_CELL);
+        expect(row).toHaveLength(getPairs(dumbbellLayer).points.length);
+      }
+    });
+  });
+});

--- a/e2e_tests/utils/constants.ts
+++ b/e2e_tests/utils/constants.ts
@@ -34,6 +34,7 @@ export abstract class TestConstants {
   static readonly ERRORBAR_ID = 'errorbar-response';
   static readonly WATERFALL_ID = 'waterfall-budget';
   static readonly WORDCLOUD_ID = 'wordcloud-terms';
+  static readonly DUMBBELL_ID = 'dumbbell-life-expectancy';
   static readonly GAUGE_ID = 'gauge-conversion';
   static readonly DODGED_BARPLOT_ID = 'dodged_bar';
   static readonly STACKED_BARPLOT_ID = 'stacked_bar';
@@ -133,6 +134,10 @@ export abstract class TestConstants {
   static readonly ERRORBAR_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical error_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly WATERFALL_INSTRUCTION_TEXT = 'This is a maidr plot of type: waterfall. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly WORDCLOUD_INSTRUCTION_TEXT = 'This is a maidr plot of type: word_cloud. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+  // 'horizontal' because the trace is orientation-aware and the example draws
+  // its categories down the page, which is how a dumbbell is usually laid out.
+  static readonly DUMBBELL_INSTRUCTION_TEXT = 'This is a maidr plot of type: horizontal dumbbell. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
+
   static readonly GAUGE_INSTRUCTION_TEXT = 'This is a maidr plot of type: gauge. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly DODGED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical dodged_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';
   static readonly STACKED_BARPLOT_INSTRUCTION_TEXT = 'This is a maidr plot of type: vertical stacked_bar. Use Arrows to navigate data points. Toggle B for Braille, T for Text, S for Sonification, and R for Review mode.';

--- a/e2e_tests/utils/errors.ts
+++ b/e2e_tests/utils/errors.ts
@@ -170,6 +170,19 @@ export class WaterfallPlotError extends Error {
 /**
  * Error thrown when Gauge related operations fail
  */
+export class DumbbellPlotError extends Error {
+  /**
+   * Creates a new DumbbellPlotError
+   * @param message - Error message describing the issue
+   * @param options - Standard error options. Pass `{ cause }` so the
+   * original failure's message and stack stay attached to this one.
+   */
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'DumbbellPlotError';
+  }
+}
+
 export class GaugePlotError extends Error {
   /**
    * Creates a new GaugePlotError

--- a/examples/dumbbell.html
+++ b/examples/dumbbell.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Dumbbell Chart Example — Life Expectancy, 1990 against 2020</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A dumbbell is drawn to be read as a comparison. The segment between
+        each pair of dots is the finding - which countries gained, which lost,
+        and by how much - and it is the one thing a reader cannot recover from
+        hearing the two ends one at a time, because that means holding one
+        number while navigating to the other and subtracting by ear on every
+        row.
+
+        So the change travels with both ends: "Denmark, 1990 71.2, increase
+        7.2". Latvia is here to make sure a decline reads as a decline, and
+        Malta to make sure an unchanged pair is not announced as either.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="dumbbell-life-expectancy" maidr='{&#10;  &quot;id&quot;: &quot;dumbbell-life-expectancy&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;dumbbell-life-expectancy-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;dumbbell-life-expectancy-layer&quot;,&#10;            &quot;type&quot;: &quot;dumbbell&quot;,&#10;            &quot;title&quot;: &quot;Life Expectancy, 1990 against 2020&quot;,&#10;            &quot;orientation&quot;: &quot;horz&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Years&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Country&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;dumbbell-connectors&#x27;] &gt; line&quot;,&#10;            &quot;data&quot;: {&#10;              &quot;startLabel&quot;: &quot;1990&quot;,&#10;              &quot;endLabel&quot;: &quot;2020&quot;,&#10;              &quot;points&quot;: [&#10;                {&#10;                  &quot;x&quot;: &quot;Denmark&quot;,&#10;                  &quot;start&quot;: 71.2,&#10;                  &quot;end&quot;: 78.4&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Latvia&quot;,&#10;                  &quot;start&quot;: 74.6,&#10;                  &quot;end&quot;: 69.5&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Malta&quot;,&#10;                  &quot;start&quot;: 76.0,&#10;                  &quot;end&quot;: 76.0&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Poland&quot;,&#10;                  &quot;start&quot;: 70.9,&#10;                  &quot;end&quot;: 75.6&#10;                }&#10;              ]&#10;            }&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="dumbbell-connectors">
+          <line x1="308.0" y1="120" x2="596.0" y2="120" style="stroke: #8c8c8c; stroke-width: 6" />
+          <line x1="444.0" y1="190" x2="240.0" y2="190" style="stroke: #8c8c8c; stroke-width: 6" />
+          <line x1="500.0" y1="260" x2="500.0" y2="260" style="stroke: #8c8c8c; stroke-width: 6" />
+          <line x1="296.0" y1="330" x2="484.0" y2="330" style="stroke: #8c8c8c; stroke-width: 6" />
+            </g>
+            <g id="dumbbell-dots">
+          <circle cx="308.0" cy="120" r="9" style="fill: #4c72b0" />
+          <circle cx="596.0" cy="120" r="9" style="fill: #c44e52" />
+          <circle cx="444.0" cy="190" r="9" style="fill: #4c72b0" />
+          <circle cx="240.0" cy="190" r="9" style="fill: #c44e52" />
+          <circle cx="500.0" cy="260" r="9" style="fill: #4c72b0" />
+          <circle cx="500.0" cy="260" r="9" style="fill: #c44e52" />
+          <circle cx="296.0" cy="330" r="9" style="fill: #4c72b0" />
+          <circle cx="484.0" cy="330" r="9" style="fill: #c44e52" />
+            </g>
+            <g id="axis_y">
+          <text x="168" y="125" style="font: 14px sans-serif; text-anchor: end">Denmark</text>
+          <text x="168" y="195" style="font: 14px sans-serif; text-anchor: end">Latvia</text>
+          <text x="168" y="265" style="font: 14px sans-serif; text-anchor: end">Malta</text>
+          <text x="168" y="335" style="font: 14px sans-serif; text-anchor: end">Poland</text>
+            </g>
+            <g id="axis_x">
+          <text x="180.0" y="390" style="font: 12px sans-serif; text-anchor: middle">68</text>
+          <text x="300.0" y="390" style="font: 12px sans-serif; text-anchor: middle">71</text>
+          <text x="420.0" y="390" style="font: 12px sans-serif; text-anchor: middle">74</text>
+          <text x="540.0" y="390" style="font: 12px sans-serif; text-anchor: middle">77</text>
+          <text x="660.0" y="390" style="font: 12px sans-serif; text-anchor: middle">80</text>
+              <text x="420" y="415" style="font: 13px sans-serif; text-anchor: middle">Years</text>
+            </g>
+            <g id="chart-title">
+              <text x="420" y="60" style="font: 16px sans-serif; text-anchor: middle">Life Expectancy, 1990 against 2020</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -60,6 +60,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.CANDLESTICK]: 'Candlestick Chart',
   [TraceType.CANDLESTICK_DELTA]: 'Candlestick Reference Delta',
   [TraceType.DODGED]: 'Dodged Bar Chart',
+  [TraceType.DUMBBELL]: 'Dumbbell Chart',
   [TraceType.ERROR_BAR]: 'Error Bar Chart',
   [TraceType.GAUGE]: 'Gauge',
   [TraceType.HEATMAP]: 'Heatmap',

--- a/src/model/dumbbell.ts
+++ b/src/model/dumbbell.ts
@@ -1,0 +1,412 @@
+import type { ExtremaTarget } from '@type/extrema';
+import type { DumbbellData, DumbbellPoint, MaidrLayer } from '@type/grammar';
+import type { Movable } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { Orientation } from '@type/grammar';
+import { MathUtil } from '@util/math';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/**
+ * The two ends of a dumbbell, in the order the chart names them.
+ *
+ * Ordered by role rather than by magnitude, unlike {@link ErrorBarTrace}'s
+ * sections. A dumbbell's ends have no fixed order on the value axis -- a row
+ * showing a decline draws its end below its start, and a chart normally holds
+ * both directions at once -- so ordering rows by size would make row 0 mean
+ * "1990" in one column and "2020" in the next, and the label under the cursor
+ * would flip as the reader arrowed sideways.
+ */
+const ENDS = ['start', 'end'] as const;
+
+type End = (typeof ENDS)[number];
+
+/** Row the cursor enters on, and the one a pointer resolves to. */
+const START_ROW = 0;
+
+/**
+ * Strips binary floating-point noise from a subtracted magnitude.
+ *
+ * The change is derived, not authored: `78.4 - 71.2` is `7.199999999999996`
+ * in IEEE 754, and announcing that spells out sixteen digits of an artifact
+ * the chart does not contain.
+ *
+ * Twelve significant figures rather than a fixed number of decimals, because
+ * the decimals a chart needs depend on its scale -- rounding to two would
+ * report a change of 0.003 as no change at all, which is worse than the noise.
+ *
+ * @param value - A magnitude obtained by subtraction
+ * @returns The same magnitude without the trailing artifact
+ */
+function withoutFloatNoise(value: number): number {
+  return Number(value.toPrecision(12));
+}
+
+/**
+ * The change one row draws, from its starting value to its finishing one.
+ *
+ * @param point - The row to measure
+ * @returns The signed change
+ */
+function changeOf(point: DumbbellPoint): number {
+  return withoutFloatNoise(Number(point.end) - Number(point.start));
+}
+
+/**
+ * Trace implementation for dumbbell charts: two values per category, joined.
+ *
+ * A dumbbell is drawn to be read as a comparison, not as two numbers. The
+ * segment between the dots is the finding -- which countries gained, which
+ * lost, and by how much -- and it is the one thing a reader cannot recover
+ * from hearing the ends one at a time, because doing so means holding one
+ * number while navigating to the other and subtracting by ear across every
+ * row of the chart.
+ *
+ * So the change travels with both ends. A reader landing anywhere in a row
+ * hears what the row does, and the sighted reader's advantage -- seeing at a
+ * glance which segments are long and which way they point -- is available
+ * without the arithmetic.
+ *
+ * Navigation follows {@link ErrorBarTrace}: the ends are the grid's rows and
+ * the categories its columns, so up and down at one category walk the two
+ * values while left and right walk the categories.
+ */
+export class DumbbellTrace extends AbstractTrace {
+  protected readonly supportsExtrema = true;
+  protected readonly movable: Movable;
+
+  private readonly points: DumbbellPoint[];
+  private readonly endValues: number[][];
+  private readonly endLabels: Record<End, string>;
+  private readonly changes: number[];
+  private readonly orientation: Orientation;
+
+  private readonly min: number;
+  private readonly max: number;
+  private readonly perRowMin: number[];
+  private readonly perRowMax: number[];
+
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /**
+   * Creates a new dumbbell trace.
+   *
+   * @param layer - The MAIDR layer carrying the paired data
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    const data = layer.data as DumbbellData;
+    this.points = data.points;
+    this.orientation = layer.orientation ?? Orientation.VERTICAL;
+
+    // Defaulted rather than required, so a producer that has no names for the
+    // two ends emits a chart that still reads. "start" and "end" say less than
+    // "1990" and "2020", but they do say which dot the cursor is on, which is
+    // the minimum a paired chart has to convey.
+    this.endLabels = {
+      start: data.startLabel ?? 'start',
+      end: data.endLabel ?? 'end',
+    };
+
+    this.endValues = ENDS.map(end =>
+      this.points.map(point => Number(point[end])),
+    );
+    this.changes = this.points.map(changeOf);
+
+    const { min, max } = MathUtil.minMax(this.endValues.flat());
+    this.min = min;
+    this.max = max;
+    this.perRowMin = this.endValues.map(row => MathUtil.safeMin(row));
+    this.perRowMax = this.endValues.map(row => MathUtil.safeMax(row));
+
+    this.highlightValues = this.mapToSvgElements(layer.selectors);
+    this.movable = new MovableGrid<number>(this.endValues, { row: START_ROW });
+  }
+
+  /**
+   * Resolves the layer's selectors to one element per category, repeated
+   * across the two ends.
+   *
+   * A chart draws one connector per row, not one element per dot, so both
+   * ends of a column highlight the same element. Announcing a move between
+   * the ends while the highlight sits still is the honest rendering of that;
+   * the alternative is inventing elements the chart never drew.
+   *
+   * @param selectors - The layer's selectors, when it has any
+   * @returns Elements shaped ends x categories, or null when unresolvable
+   */
+  private mapToSvgElements(
+    selectors?: MaidrLayer['selectors'],
+  ): SVGElement[][] | null {
+    if (typeof selectors !== 'string' && !Array.isArray(selectors)) {
+      return null;
+    }
+
+    const flat = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+
+    if (flat.length !== this.points.length) {
+      return null;
+    }
+    return ENDS.map(() => flat);
+  }
+
+  protected get values(): number[][] {
+    return this.endValues;
+  }
+
+  protected get dimension(): Dimension {
+    // Orientation-independent, matching `ErrorBarTrace.dimension`: up and down
+    // walk the ends and left and right walk the categories in BOTH
+    // orientations, so rows must always be the end count. `AutoplayState` is
+    // keyed by direction, so conditioning this on orientation mis-paces
+    // autoplay and mis-clamps the `isMovable` bounds.
+    return { rows: ENDS.length, cols: this.points.length };
+  }
+
+  protected get audio(): AudioState {
+    return {
+      freq: {
+        // One scale across both rows, not per row: the two ends are the same
+        // quantity on the same axis, so the larger of a pair has to sound
+        // higher than the smaller. Per-row scaling would put both at the same
+        // pitch and erase the gap by ear -- which is the whole chart.
+        min: this.min,
+        max: this.max,
+        raw: this.endValues[this.row][this.col],
+      },
+      panning: {
+        // The grid stays ends-by-categories whichever way the chart is drawn,
+        // so panning has to swap here instead: stereo position tracks where a
+        // point sits on screen, and a dumbbell is commonly drawn with its
+        // categories running down the page rather than across it.
+        x: this.orientation === Orientation.HORIZONTAL ? this.row : this.col,
+        y: this.orientation === Orientation.HORIZONTAL ? this.col : this.row,
+        rows: ENDS.length,
+        cols: this.points.length,
+      },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    return {
+      empty: false,
+      id: this.id,
+      values: this.endValues,
+      min: this.perRowMin,
+      max: this.perRowMax,
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const point = this.points[this.col];
+    const change = this.changes[this.col];
+    const isHorizontal = this.orientation === Orientation.HORIZONTAL;
+
+    return {
+      main: { label: isHorizontal ? this.yAxis : this.xAxis, value: point.x },
+      cross: {
+        label: isHorizontal ? this.xAxis : this.yAxis,
+        value: this.endValues[this.row][this.col],
+      },
+      // Which of the two dots the cursor is on. Announced ahead of the axis
+      // label, and lower-cased on the way, by the same text service branch an
+      // error bar's bounds travel on -- so these are the chart's own names for
+      // its ends and are left in whatever case the producer wrote them.
+      section: this.endLabels[ENDS[this.row]],
+      // The gap, named by direction rather than signed. "Decrease is 3.1"
+      // needs no interpretation; "-3.1" asks the reader to hear a minus sign
+      // and work out which way it points, on every row of the chart.
+      stack: {
+        label: change > 0 ? 'Increase' : change < 0 ? 'Decrease' : 'Change',
+        value: Math.abs(change),
+      },
+      // Which real axis each value came from, so the formatter service picks
+      // the right per-axis format. It defaults to x/y when absent, which is
+      // silently wrong for a horizontal layer whose two axes format
+      // differently.
+      mainAxis: isHorizontal ? 'y' : 'x',
+      crossAxis: isHorizontal ? 'x' : 'y',
+    };
+  }
+
+  public get description(): DescriptionState {
+    const stats: DescriptionState['stats'] = [
+      { label: 'Number of pairs', value: this.points.length },
+      { label: 'Min value', value: this.min },
+      { label: 'Max value', value: this.max },
+    ];
+
+    const rises = this.changes.filter(change => change > 0).length;
+    const falls = this.changes.filter(change => change < 0).length;
+    if (rises > 0 || falls > 0) {
+      // The count each way is what a sighted reader takes from the shape of
+      // the chart before reading a single number, and it is not recoverable
+      // from the ranges above.
+      stats.push(
+        { label: 'Increased', value: rises },
+        { label: 'Decreased', value: falls },
+      );
+    }
+
+    const largest = this.extremeChange('max');
+    const smallest = this.extremeChange('min');
+    if (largest !== null) {
+      stats.push({
+        label: `Largest ${largest.change >= 0 ? 'increase' : 'decrease'}`,
+        value: `${this.points[largest.index].x}, ${Math.abs(largest.change)}`,
+      });
+    }
+    if (smallest !== null && smallest.index !== largest?.index) {
+      stats.push({
+        label: `Largest ${smallest.change >= 0 ? 'increase' : 'decrease'}`,
+        value: `${this.points[smallest.index].x}, ${Math.abs(smallest.change)}`,
+      });
+    }
+
+    const headers = [
+      this.xAxis,
+      this.endLabels.start,
+      this.endLabels.end,
+      'Change',
+    ];
+    const rows: (string | number)[][] = this.points.map((point, index) => [
+      point.x,
+      point.start,
+      point.end,
+      this.changes[index],
+    ]);
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * Returns the row whose change is furthest in one direction.
+   *
+   * @param kind - Whether to take the most positive or the most negative
+   * @returns The row and its change, or null when the chart has no rows
+   */
+  private extremeChange(
+    kind: 'max' | 'min',
+  ): { index: number; change: number } | null {
+    if (this.changes.length === 0) {
+      return null;
+    }
+
+    return this.changes
+      .map((change, index) => ({ change, index }))
+      .reduce((best, candidate) =>
+        (kind === 'max'
+          ? candidate.change > best.change
+          : candidate.change < best.change)
+          ? candidate
+          : best,
+      );
+  }
+
+  /**
+   * Offers the biggest mover in each direction as extrema targets.
+   *
+   * "Extreme" on a dumbbell is the largest change, not the largest value: the
+   * chart is drawn to show which rows moved and which way, and the tallest
+   * dot is a fact about the category rather than about the comparison. Ranking
+   * both under one menu would leave the reader unable to tell which sense they
+   * had just jumped to.
+   *
+   * Both land on the finishing end, where the change has completed.
+   *
+   * @returns The largest rise and the largest fall, when the chart has them
+   */
+  public override getExtremaTargets(): ExtremaTarget[] {
+    const largest = this.extremeChange('max');
+    const smallest = this.extremeChange('min');
+    if (largest === null || smallest === null) {
+      return [];
+    }
+
+    const targets: ExtremaTarget[] = [{
+      label: `Largest increase at ${this.points[largest.index].x}`,
+      value: largest.change,
+      pointIndex: largest.index,
+      segment: 'end',
+      type: 'max',
+      navigationType: 'point',
+      xValue: this.points[largest.index].x,
+    }];
+
+    // A chart that moved one way only, or one whose rows all moved equally,
+    // has a single extreme. Naming the same row as both would report a spread
+    // the chart does not have.
+    if (smallest.index !== largest.index) {
+      targets.push({
+        label: `Largest decrease at ${this.points[smallest.index].x}`,
+        value: smallest.change,
+        pointIndex: smallest.index,
+        segment: 'end',
+        type: 'min',
+        navigationType: 'point',
+        xValue: this.points[smallest.index].x,
+      });
+    }
+
+    return targets;
+  }
+
+  /**
+   * Moves the cursor to a chosen extrema target, on the finishing end.
+   *
+   * @param target - The extrema target to navigate to
+   */
+  public override navigateToExtrema(target: ExtremaTarget): void {
+    this.row = ENDS.indexOf('end');
+    this.col = target.pointIndex;
+    this.finalizeNavigation();
+  }
+
+  /**
+   * Finds the category whose drawn connector is nearest a pointer position.
+   *
+   * Resolves to the starting end rather than to whichever dot is closest.
+   * Neither end is privileged the way an error bar's estimate is, so the
+   * cursor lands where it would have entered, and the reader moves from there
+   * rather than from wherever the pointer happened to fall.
+   *
+   * @param x - Viewport x of the pointer
+   * @param y - Viewport y of the pointer
+   * @returns The nearest category, or null when nothing is resolvable
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    const elements = this.highlightValues?.[START_ROW];
+    if (!elements || elements.length === 0) {
+      return null;
+    }
+
+    let nearest: NearestPoint | null = null;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+
+    for (let col = 0; col < elements.length; col++) {
+      const box = elements[col].getBoundingClientRect();
+      const centerX = box.left + box.width / 2;
+      const centerY = box.top + box.height / 2;
+      const distance = (centerX - x) ** 2 + (centerY - y) ** 2;
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        nearest = { element: elements[col], row: START_ROW, col, centerX, centerY };
+      }
+    }
+
+    return nearest;
+  }
+}

--- a/src/model/dumbbell.ts
+++ b/src/model/dumbbell.ts
@@ -55,6 +55,35 @@ function changeOf(point: DumbbellPoint): number {
 }
 
 /**
+ * Names a ranked change, so the name matches the direction it actually has.
+ *
+ * The two extremes of a dumbbell are the most positive change and the most
+ * negative one, and neither is necessarily a rise or a fall. On a chart where
+ * every row declined, the most positive change is the row that fell *least* —
+ * calling that "largest increase" reports a rise the chart does not contain,
+ * and calling it "largest decrease" reports the wrong row as the biggest
+ * faller. It is the smallest decrease, and that is what it is called.
+ *
+ * This matters more here than the wording usually would: the label is what the
+ * "go to extrema" menu renders as its option text and its `aria-label`, so it
+ * is read out as a claim about the finding rather than shown beside the number
+ * that would correct it.
+ *
+ * @param kind - Which end of the ranking this change came from
+ * @param change - The signed change
+ * @returns How to name it
+ */
+function rankLabel(kind: 'max' | 'min', change: number): string {
+  if (change === 0) {
+    return 'No change';
+  }
+  if (kind === 'max') {
+    return change > 0 ? 'Largest increase' : 'Smallest decrease';
+  }
+  return change < 0 ? 'Largest decrease' : 'Smallest increase';
+}
+
+/**
  * Trace implementation for dumbbell charts: two values per category, joined.
  *
  * A dumbbell is drawn to be read as a comparison, not as two numbers. The
@@ -215,10 +244,16 @@ export class DumbbellTrace extends AbstractTrace {
         label: isHorizontal ? this.xAxis : this.yAxis,
         value: this.endValues[this.row][this.col],
       },
-      // Which of the two dots the cursor is on. Announced ahead of the axis
-      // label, and lower-cased on the way, by the same text service branch an
-      // error bar's bounds travel on -- so these are the chart's own names for
-      // its ends and are left in whatever case the producer wrote them.
+      // Which of the two dots the cursor is on. The chart's own name for the
+      // end, passed through as the producer wrote it.
+      //
+      // Verbose mode lower-cases it on the way out and terse mode does not, so
+      // a `startLabel` of "Control" is announced two ways depending on the
+      // text mode. That is `TextService`'s doing rather than this trace's --
+      // the same branch already lower-cases a box plot's "Minimum" -- and it
+      // is not corrected here, because lower-casing the label in the model to
+      // make the two agree would destroy a distinction ("Q1 2024") that the
+      // formatting layer, not the data, chose to drop. Tracked in #830.
       section: this.endLabels[ENDS[this.row]],
       // The gap, named by direction rather than signed. "Decrease is 3.1"
       // needs no interpretation; "-3.1" asks the reader to hear a minus sign
@@ -259,13 +294,13 @@ export class DumbbellTrace extends AbstractTrace {
     const smallest = this.extremeChange('min');
     if (largest !== null) {
       stats.push({
-        label: `Largest ${largest.change >= 0 ? 'increase' : 'decrease'}`,
+        label: rankLabel('max', largest.change),
         value: `${this.points[largest.index].x}, ${Math.abs(largest.change)}`,
       });
     }
     if (smallest !== null && smallest.index !== largest?.index) {
       stats.push({
-        label: `Largest ${smallest.change >= 0 ? 'increase' : 'decrease'}`,
+        label: rankLabel('min', smallest.change),
         value: `${this.points[smallest.index].x}, ${Math.abs(smallest.change)}`,
       });
     }
@@ -337,7 +372,7 @@ export class DumbbellTrace extends AbstractTrace {
     }
 
     const targets: ExtremaTarget[] = [{
-      label: `Largest increase at ${this.points[largest.index].x}`,
+      label: `${rankLabel('max', largest.change)} at ${this.points[largest.index].x}`,
       value: largest.change,
       pointIndex: largest.index,
       segment: 'end',
@@ -351,7 +386,7 @@ export class DumbbellTrace extends AbstractTrace {
     // the chart does not have.
     if (smallest.index !== largest.index) {
       targets.push({
-        label: `Largest decrease at ${this.points[smallest.index].x}`,
+        label: `${rankLabel('min', smallest.change)} at ${this.points[smallest.index].x}`,
         value: smallest.change,
         pointIndex: smallest.index,
         segment: 'end',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -5,6 +5,7 @@ import { AreaTrace } from './area';
 import { BarTrace } from './bar';
 import { BoxTrace } from './box';
 import { Candlestick } from './candlestick';
+import { DumbbellTrace } from './dumbbell';
 import { ErrorBarTrace } from './errorBar';
 import { GaugeTrace } from './gauge';
 import { Heatmap } from './heatmap';
@@ -48,6 +49,9 @@ export abstract class TraceFactory {
 
       case TraceType.CANDLESTICK:
         return new Candlestick(layer);
+
+      case TraceType.DUMBBELL:
+        return new DumbbellTrace(layer);
 
       case TraceType.ERROR_BAR:
         return new ErrorBarTrace(layer);

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1114,6 +1114,7 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // upper bounds — which is the per-row height profile the line encoder
       // renders. The reader feels the interval by moving between rows, the
       // same way they hear it.
+      [TraceType.DUMBBELL, asGeneric(new LineBrailleEncoder())],
       [TraceType.ERROR_BAR, asGeneric(new LineBrailleEncoder())],
       // A single cell scaled against the dial's own ends -- the bar encoder's
       // input with one column, so the reader feels where on the dial the

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -445,6 +445,51 @@ export interface GaugePoint {
 }
 
 /**
+ * One row of a dumbbell chart: a category and the pair of values compared at
+ * it.
+ *
+ * The pair is what the chart is for -- before and after, two groups, two
+ * years -- and the segment drawn between the dots is the comparison. Which of
+ * the two is larger is not fixed: a dumbbell showing a decline draws `end`
+ * below `start`, and a chart usually contains both directions at once.
+ *
+ * The change between them is deliberately absent, and derived instead. A
+ * drawn segment cannot disagree with the dots it joins, so an authored delta
+ * is a second source of truth for a quantity that already has one -- and the
+ * one a reader would be told is the one the chart did not draw.
+ */
+export interface DumbbellPoint {
+  /** Position along the category axis. */
+  x: number | string;
+  /** The value the segment starts at -- the earlier, or the reference, one. */
+  start: number;
+  /** The value the segment ends at. */
+  end: number;
+}
+
+/**
+ * A dumbbell chart: its rows, and what its two ends are called.
+ *
+ * An object rather than a bare array -- as {@link HeatmapData} and
+ * {@link GaugePoint} already are -- because the names of the two ends belong
+ * to the chart and not to any one row. Repeating them on every point would
+ * let a producer emit rows that disagree about what the chart is comparing.
+ *
+ * Those names are the content of the comparison. Announced as "start" and
+ * "end", a chart of life expectancy in 1990 against 2020 tells the reader
+ * which dot they are on and not which year it is, which is the one thing the
+ * legend gives a sighted reader for free.
+ */
+export interface DumbbellData {
+  /** The rows, in the order the chart draws them. */
+  points: DumbbellPoint[];
+  /** What the starting end is called -- "1990", "before", "control". */
+  startLabel?: string;
+  /** What the finishing end is called -- "2020", "after", "treatment". */
+  endLabel?: string;
+}
+
+/**
  * Data structure for heatmap charts with x/y labels and 2D point values.
  */
 export interface HeatmapData {
@@ -705,6 +750,7 @@ export interface MaidrLayer {
     | BarPoint[]
     | BoxPoint[]
     | CandlestickPoint[]
+    | DumbbellData
     | ErrorBarPoint[]
     | GaugePoint
     | HeatmapData
@@ -752,6 +798,13 @@ export enum TraceType {
    */
   CANDLESTICK_DELTA = 'candlestick_delta',
   DODGED = 'dodged_bar',
+  /**
+   * Two values per category joined by a segment -- before and after, two
+   * groups, two years. The gap is the message, so the trace announces the
+   * change alongside each end rather than leaving the reader to subtract two
+   * numbers they heard one at a time.
+   */
+  DUMBBELL = 'dumbbell',
   /**
    * An estimate with the interval drawn around it — an error bar, a
    * confidence interval, a point range. Navigated as a grid of

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -33,6 +33,7 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // The interval runs along the value axis and the samples along the other,
   // so which way round they are drawn decides which axis a bound moves on --
   // the same reason a bar or a box is oriented.
+  [TraceType.DUMBBELL]: true,
   [TraceType.ERROR_BAR]: true,
   // One measure on a dial. There is no second axis for it to be read against,
   // so there is nothing an orientation could swap.

--- a/test/model/dumbbell.test.ts
+++ b/test/model/dumbbell.test.ts
@@ -1,0 +1,346 @@
+import type { NotificationService } from '@service/notification';
+import type { DumbbellData, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { DumbbellTrace } from '@model/dumbbell';
+import { TraceFactory } from '@model/factory';
+import { TextService } from '@service/text';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Life expectancy in two years, for three countries. One row rises, one falls
+ * and one is unchanged, so the three directions the announcement distinguishes
+ * are all present -- and every number is distinct, so a reading that took the
+ * wrong end cannot coincide with the right one.
+ */
+const GAINS: DumbbellData = {
+  startLabel: '1990',
+  endLabel: '2020',
+  points: [
+    { x: 'Denmark', start: 71.2, end: 78.4 },
+    { x: 'Latvia', start: 74.6, end: 69.5 },
+    { x: 'Malta', start: 76.0, end: 76.0 },
+  ],
+};
+
+/**
+ * Create a minimal dumbbell layer for model-only tests.
+ * @param data The pairs the layer carries
+ * @param orientation Which way the chart is drawn
+ * @returns Dumbbell layer definition
+ */
+function createLayer(
+  data: DumbbellData,
+  orientation?: Orientation,
+): MaidrLayer {
+  return {
+    id: 'test-dumbbell-layer',
+    type: TraceType.DUMBBELL,
+    title: 'Life expectancy',
+    axes: { x: { label: 'Country' }, y: { label: 'Years' } },
+    orientation,
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: DumbbellTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a dumbbell trace positioned on one cell.
+ * @param row Which end
+ * @param col Which category
+ * @param data The pairs the layer carries
+ * @param orientation Which way the chart is drawn
+ * @returns The positioned trace
+ */
+function dumbbell(
+  row = 0,
+  col = 0,
+  data: DumbbellData = GAINS,
+  orientation?: Orientation,
+): DumbbellTrace {
+  const trace = TraceFactory.create(
+    createLayer(data, orientation),
+  ) as DumbbellTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+/**
+ * Read the sentence a screen reader receives for the trace's current cell.
+ *
+ * The `TextState` a trace returns is an intermediate: which fields it fills
+ * decides how `TextService` composes the sentence, so a field in the wrong
+ * slot can leave every assertion on the state passing while the announcement
+ * says something else.
+ * @param trace The positioned trace
+ * @returns The announcement, in the default verbose mode
+ */
+function announce(trace: DumbbellTrace): string {
+  const notification = { notify: jest.fn() } as unknown as NotificationService;
+  const text = new TextService(notification);
+  const listener = jest.fn();
+  const disposable = text.onChange(listener);
+
+  text.update(trace.state);
+  disposable.dispose();
+
+  return (listener.mock.calls[0][0] as { value: string }).value;
+}
+
+describe('dumbbell registration', () => {
+  test('the factory builds a DumbbellTrace', () => {
+    expect(TraceFactory.create(createLayer(GAINS))).toBeInstanceOf(DumbbellTrace);
+  });
+
+  test('announces itself as a dumbbell', () => {
+    expect(dumbbell().description.chartType).toBe('Dumbbell Chart');
+  });
+});
+
+describe('navigation', () => {
+  test('is two ends by however many categories', () => {
+    const trace = dumbbell();
+
+    // Down through both ends, then no further.
+    expect(trace.moveOnce('DOWNWARD')).toBe(false);
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+    expect(trace.moveOnce('UPWARD')).toBe(false);
+
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.moveOnce('FORWARD')).toBe(false);
+  });
+
+  test('enters on the starting end', () => {
+    // The chart's own order, so a reader arriving at a row hears where it
+    // began before hearing where it got to.
+    expect(nonEmptyState(dumbbell()).text.section).toBe('1990');
+  });
+
+  test('keeps the ends in role order rather than by size', () => {
+    // Latvia declined, so its finishing value is the *lower* of its pair.
+    // Ordering rows by magnitude would put it on the row that held Denmark's
+    // start, and the label under the cursor would flip mid-sweep.
+    const declining = nonEmptyState(dumbbell(1, 1));
+
+    expect(declining.text.section).toBe('2020');
+    expect(declining.text.cross.value).toBe(69.5);
+  });
+});
+
+describe('the change is the message', () => {
+  test('names a rise by direction rather than by sign', () => {
+    // "-3.1" asks the reader to hear a minus sign and work out which way it
+    // points, on every row of the chart.
+    expect(nonEmptyState(dumbbell(0, 0)).text.stack).toEqual({
+      label: 'Increase',
+      value: 7.2,
+    });
+  });
+
+  test('names a fall', () => {
+    expect(nonEmptyState(dumbbell(0, 1)).text.stack).toEqual({
+      label: 'Decrease',
+      value: 5.1,
+    });
+  });
+
+  test('says neither when the pair did not move', () => {
+    expect(nonEmptyState(dumbbell(0, 2)).text.stack).toEqual({
+      label: 'Change',
+      value: 0,
+    });
+  });
+
+  test('carries the change at both ends of a row', () => {
+    // A reader landing on either dot is asking the same question, and the one
+    // who entered at the finish should not have to walk back to hear it.
+    const start = nonEmptyState(dumbbell(0, 0)).text.stack;
+    const end = nonEmptyState(dumbbell(1, 0)).text.stack;
+
+    expect(end).toEqual(start);
+  });
+
+  test('does not spell out floating-point noise', () => {
+    // 78.4 - 71.2 is 7.199999999999996 in IEEE 754, and a screen reader reads
+    // every one of those digits.
+    expect(nonEmptyState(dumbbell(0, 0)).text.stack?.value).toBe(7.2);
+  });
+});
+
+describe('the announcement a reader hears', () => {
+  test('names the category, the end, its value and the change', () => {
+    // Asserted on the rendered sentence rather than on the `TextState`, since
+    // a field in the wrong slot leaves the state looking correct.
+    expect(announce(dumbbell(0, 0))).toBe(
+      'Country is Denmark, 1990 Years is 71.2, Increase is 7.2',
+    );
+  });
+
+  test('reads a decline the same way', () => {
+    expect(announce(dumbbell(1, 1))).toBe(
+      'Country is Latvia, 2020 Years is 69.5, Decrease is 5.1',
+    );
+  });
+
+  test('falls back to naming the ends when the chart does not', () => {
+    // Less than "1990" and "2020", but it still says which dot the cursor is
+    // on -- the minimum a paired chart has to convey.
+    const unnamed: DumbbellData = { points: GAINS.points };
+
+    expect(announce(dumbbell(0, 0, unnamed))).toBe(
+      'Country is Denmark, start Years is 71.2, Increase is 7.2',
+    );
+  });
+});
+
+describe('orientation', () => {
+  test('swaps the axis labels when the categories run down the page', () => {
+    const horizontal = nonEmptyState(dumbbell(0, 0, GAINS, Orientation.HORIZONTAL));
+
+    expect(horizontal.text.main.label).toBe('Years');
+    expect(horizontal.text.cross.label).toBe('Country');
+    // Which real axis each value came from, so the formatter service picks
+    // the right per-axis format.
+    expect(horizontal.text.mainAxis).toBe('y');
+    expect(horizontal.text.crossAxis).toBe('x');
+  });
+
+  test('keeps the grid ends-by-categories in both orientations', () => {
+    // `AutoplayState` is keyed by direction, so a transposed dimension
+    // mis-paces autoplay and mis-clamps the movement bounds.
+    const horizontal = dumbbell(0, 0, GAINS, Orientation.HORIZONTAL);
+
+    expect(horizontal.moveOnce('DOWNWARD')).toBe(false);
+    expect(horizontal.moveOnce('UPWARD')).toBe(true);
+    expect(horizontal.moveOnce('UPWARD')).toBe(false);
+  });
+
+  test('swaps the stereo position instead', () => {
+    // Panning tracks where a point sits on screen, and a horizontal chart's
+    // categories run down the page rather than across it.
+    const { audio } = nonEmptyState(dumbbell(1, 2, GAINS, Orientation.HORIZONTAL));
+
+    expect(audio.panning.x).toBe(1);
+    expect(audio.panning.y).toBe(2);
+  });
+});
+
+describe('audio', () => {
+  test('pitches both ends on one scale', () => {
+    // The two ends are the same quantity on the same axis, so the larger of a
+    // pair has to sound higher. Per-row scaling would put them at the same
+    // pitch and erase the gap by ear -- which is the whole chart.
+    const start = nonEmptyState(dumbbell(0, 0)).audio.freq;
+    const end = nonEmptyState(dumbbell(1, 0)).audio.freq;
+
+    expect(start.min).toBe(end.min);
+    expect(start.max).toBe(end.max);
+    // Denmark's pair spans 71.2 to 78.4, and the scale spans the whole chart:
+    // Latvia's 69.5 is the floor and Denmark's own 78.4 the ceiling.
+    expect(start.min).toBe(69.5);
+    expect(start.max).toBe(78.4);
+    expect(start.raw).toBe(71.2);
+    expect(end.raw).toBe(78.4);
+  });
+});
+
+describe('braille', () => {
+  test('renders one row per end', () => {
+    const { braille } = nonEmptyState(dumbbell());
+
+    expect(braille.empty).toBe(false);
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+    expect(braille.values).toEqual([
+      [71.2, 74.6, 76.0],
+      [78.4, 69.5, 76.0],
+    ]);
+    expect(braille.min).toEqual([71.2, 69.5]);
+    expect(braille.max).toEqual([76.0, 78.4]);
+  });
+});
+
+describe('extrema', () => {
+  test('ranks the biggest mover each way, not the biggest value', () => {
+    // The chart is drawn to show which rows moved and which way; the tallest
+    // dot is a fact about the category rather than about the comparison.
+    const targets = dumbbell().getExtremaTargets();
+
+    expect(targets.map(target => target.label)).toEqual([
+      'Largest increase at Denmark',
+      'Largest decrease at Latvia',
+    ]);
+  });
+
+  test('lands on the finishing end, where the change completed', () => {
+    // `supportsExtrema` is true, so the base implementation throws: a trace
+    // that advertises extrema without overriding both halves is worse than
+    // one that does not advertise them.
+    const trace = dumbbell();
+    const [increase] = trace.getExtremaTargets();
+
+    trace.navigateToExtrema(increase);
+
+    const state = nonEmptyState(trace);
+    expect(state.text.main.value).toBe('Denmark');
+    expect(state.text.section).toBe('2020');
+  });
+
+  test('offers one target when every row moved the same way', () => {
+    // Naming the same row as both extremes would report a spread the chart
+    // does not have.
+    const rising: DumbbellData = {
+      points: [
+        { x: 'a', start: 1, end: 2 },
+        { x: 'b', start: 1, end: 2 },
+      ],
+    };
+
+    expect(dumbbell(0, 0, rising).getExtremaTargets()).toHaveLength(1);
+  });
+});
+
+describe('description', () => {
+  test('counts the rows each way', () => {
+    // What a sighted reader takes from the shape of the chart before reading
+    // a single number.
+    const { stats } = dumbbell().description;
+
+    expect(stats).toContainEqual({ label: 'Increased', value: 1 });
+    expect(stats).toContainEqual({ label: 'Decreased', value: 1 });
+  });
+
+  test('names the biggest mover each way', () => {
+    const { stats } = dumbbell().description;
+
+    expect(stats).toContainEqual({
+      label: 'Largest increase',
+      value: 'Denmark, 7.2',
+    });
+    expect(stats).toContainEqual({
+      label: 'Largest decrease',
+      value: 'Latvia, 5.1',
+    });
+  });
+
+  test('heads the data table with the chart\'s own names for its ends', () => {
+    const { dataTable } = dumbbell().description;
+
+    expect(dataTable?.headers).toEqual(['Country', '1990', '2020', 'Change']);
+    expect(dataTable?.rows[1]).toEqual(['Latvia', 74.6, 69.5, -5.1]);
+  });
+});

--- a/test/model/dumbbell.test.ts
+++ b/test/model/dumbbell.test.ts
@@ -300,6 +300,38 @@ describe('extrema', () => {
     expect(state.text.section).toBe('2020');
   });
 
+  test('does not report a rise on a chart where everything fell', () => {
+    // `extremeChange('max')` takes the most *positive* change, which on an
+    // all-declining chart is the row that fell least. Naming that "largest
+    // increase" reports a rise the chart does not contain; naming it "largest
+    // decrease" reports the wrong row as the biggest faller.
+    //
+    // The label is what the go-to-extrema menu renders as its option text and
+    // its `aria-label`, so it is read out as a claim rather than shown beside
+    // the number that would correct it.
+    const allFalling: DumbbellData = {
+      points: [
+        { x: 'a', start: 10, end: 5 },
+        { x: 'b', start: 20, end: 1 },
+      ],
+    };
+
+    expect(dumbbell(0, 0, allFalling).getExtremaTargets().map(t => t.label))
+      .toEqual(['Smallest decrease at a', 'Largest decrease at b']);
+  });
+
+  test('does not report a fall on a chart where everything rose', () => {
+    const allRising: DumbbellData = {
+      points: [
+        { x: 'a', start: 1, end: 20 },
+        { x: 'b', start: 5, end: 10 },
+      ],
+    };
+
+    expect(dumbbell(0, 0, allRising).getExtremaTargets().map(t => t.label))
+      .toEqual(['Largest increase at a', 'Smallest increase at b']);
+  });
+
   test('offers one target when every row moved the same way', () => {
     // Naming the same row as both extremes would report a spread the chart
     // does not have.
@@ -335,6 +367,25 @@ describe('description', () => {
       label: 'Largest decrease',
       value: 'Latvia, 5.1',
     });
+  });
+
+  test('names them by the direction they have, not the one expected', () => {
+    // The same defect the extrema targets had: the most positive change on an
+    // all-declining chart is not an increase.
+    const allFalling: DumbbellData = {
+      points: [
+        { x: 'a', start: 10, end: 5 },
+        { x: 'b', start: 20, end: 1 },
+      ],
+    };
+    const labels = dumbbell(0, 0, allFalling)
+      .description
+      .stats
+      .map(stat => stat.label);
+
+    expect(labels).toContain('Smallest decrease');
+    expect(labels).toContain('Largest decrease');
+    expect(labels).not.toContain('Largest increase');
   });
 
   test('heads the data table with the chart\'s own names for its ends', () => {

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -8,6 +8,10 @@ describe('resolveOrientation', () => {
     TraceType.BOX,
     TraceType.CANDLESTICK,
     TraceType.DODGED,
+    // A dumbbell is commonly drawn with its categories running down the page,
+    // and the pair runs along the value axis either way -- so which axis a dot
+    // moves on depends on which way it was drawn.
+    TraceType.DUMBBELL,
     // The interval runs along the value axis and the samples along the other,
     // so which way round they are drawn decides which axis a bound moves on.
     TraceType.ERROR_BAR,


### PR DESCRIPTION
Addresses the dumbbell half of #792.

A dumbbell is drawn to be read as a **comparison**, not as two numbers. The segment between each pair of dots is the finding — which rows gained, which lost, and by how much — and it is the one thing a reader cannot recover from hearing the two ends one at a time, because that means holding one number while navigating to the other and subtracting by ear on **every row of the chart**.

So the change travels with both ends:

```
Country is Denmark, 1990 Years is 71.2, Increase is 7.2
Country is Latvia,  2020 Years is 69.5, Decrease is 5.1
```

## Design notes

**The change is derived, not authored.** A drawn segment cannot disagree with the dots it joins, so an authored `delta` would be a second source of truth for a quantity that already has one — and the one a reader would be told is the one the chart did not draw. (The issue's sketch carried it in the data; this is the one place I departed from it.)

**Named by direction rather than signed.** `Increase is 7.2` / `Decrease is 5.1` / `Change is 0`. A bare `-3.1` asks the reader to hear a minus sign and work out which way it points, on every row. The three cases are separately tested because a `delta >= 0` split would announce an unchanged pair as an increase of zero.

**Rows keep the chart's order, not magnitude order.** Unlike an error bar's `lower/value/upper`, a dumbbell's ends have no fixed order on the value axis — a declining row draws its end *below* its start, and a real chart holds both directions at once. Sorting rows by size would put Latvia's finish on the line that holds every other row's start, and the label under the cursor would flip as the reader arrowed sideways.

**The end names live on the layer, not on each point.** `DumbbellData` is an object — as `HeatmapData` and `GaugePoint` already are — so a producer cannot emit rows that disagree about what the chart is comparing. Those names are the content of the comparison: announced as "start" and "end", a chart of 1990 against 2020 tells the reader which dot they are on and not which year it is, which is exactly what the legend gives a sighted reader for free. They default, so a producer without them still emits a chart that reads.

**Extrema rank the biggest mover each way**, not the largest value — the chart is drawn to show which rows moved, and the tallest dot is a fact about the category rather than about the comparison. `supportsExtrema` is `true`, so **both** `getExtremaTargets` and `navigateToExtrema` are overridden; the base throws precisely when that flag is set.

**Braille is two rows, each scaled against its own range**, so the two profiles are comparable as shapes. A shared range would flatten both toward the middle of the combined spread when the ends occupy different parts of the value axis. This is the one trace so far that uses both lines of a multiline display for something.

## Registration

All six places from `.claude/rules/model.md`, plus docs:

| # | Place | |
|---|---|---|
| 1 | `TraceType.DUMBBELL` + `DumbbellPoint` + `DumbbellData` + data union | ✅ |
| 2 | `src/model/dumbbell.ts` | ✅ |
| 3 | `TraceFactory.create()` case | ✅ |
| 4 | `CHART_TYPE_LABEL` | ✅ |
| 5 | `IS_ORIENTED` — `true` | ✅ |
| 6 | Braille encoder — `LineBrailleEncoder`, two rows | ✅ |
| 7 | `docs/BRAILLE.md` | ✅ |

## Scope

**Dumbbell only.** #792 also asks for dot and lollipop charts, which it correctly describes as needing no new model — but each still costs six registration points, a grammar entry, an example and a spec, and neither carries a design question worth deciding alongside this one. Left open on #792 rather than bundled.

## Verification actually run

| Step | Result |
|---|---|
| `npm test` | **2118 passed** (was 2092) + **73 passed** |
| `npx playwright test --project=chromium dumbbell` | **7 passed** |
| `npm run type-check` | clean |
| `npm run lint:fix` | clean |
| `npm run build` | clean |

The e2e fixture holds a rise, a fall **and** an unchanged pair, and a test asserts it does — a chart where everything rose would let a reading that ignored direction look right. The example is drawn horizontally, which is how a dumbbell usually is, so the orientation path is exercised end to end rather than only in unit tests.

Two failures found this in development, both kept as tests: `test/util/orientation.test.ts` catches an unregistered type via its total-coverage assertion, and the e2e instruction text is `horizontal dumbbell` — the oriented-type prefix — which is correct behaviour my constant had wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_