### PR TITLE
feat(grammar): let a layer say which one it is

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -121,6 +121,9 @@ interface MaidrLayer {
   id: string;              // Unique layer identifier
   type: TraceType;         // Plot type (see TraceType enum)
   title?: string;          // Layer title
+  name?: string;           // What this layer is, e.g. 'Male' — announced on a
+                           // layer switch in place of the trace type, so two
+                           // layers of one kind can be told apart
   selectors?: string | string[]; // CSS selectors for SVG highlight elements
   orientation?: Orientation;     // 'vert' or 'horz' (for bar/box plots)
   axes?: {

--- a/e2e_tests/specs/errorbarGrouped.spec.ts
+++ b/e2e_tests/specs/errorbarGrouped.spec.ts
@@ -1,0 +1,117 @@
+import type { Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * A grouped error bar chart poses one question — do the two groups' intervals
+ * overlap at this category? — and answering it means reading both groups.
+ *
+ * They are separate layers, so the reader moves between them rather than
+ * arrowing. What makes that readable is each layer saying which group it is:
+ * without a name both announce "error_bar plot" and the reader hears two sets
+ * of numbers with nothing to attach them to.
+ */
+
+/** The example's own page, driven through the shared base helpers. */
+class GroupedErrorBarPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the grouped error bar example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/errorbar-grouped.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'errorbar-grouped');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /** Moves to the next layer. */
+  public async moveToNextLayer(): Promise<void> {
+    await this.pressKey(TestConstants.PAGE_UP_KEY, 'move to the next layer');
+  }
+}
+
+test.describe('Grouped error bar', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new GroupedErrorBarPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new GroupedErrorBarPage(page).navigateToPlot();
+  });
+
+  test('should carry two layers of the same kind in one subplot', () => {
+    // The shape the naming exists for. Two layers of *different* kinds are
+    // already told apart by their types.
+    const { layers } = maidrData.subplots[0][0];
+
+    expect(layers).toHaveLength(2);
+    expect(layers.map(layer => layer.type)).toEqual(['error_bar', 'error_bar']);
+    expect(layers.map(layer => layer.name)).toEqual(['Male', 'Female']);
+  });
+
+  test('should name each layer on the way in', async ({ page }) => {
+    const plot = new GroupedErrorBarPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.moveToNextLayer();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    // The group, not "error_bar plot".
+    expect(announcement).toContain('Female');
+    expect(announcement).not.toContain('error_bar plot');
+  });
+
+  test('should land on the same category in the other layer', async ({ page }) => {
+    // What makes the two comparable: the switch keeps the reader's position,
+    // so the intervals announced either side of it are the same category's.
+    const plot = new GroupedErrorBarPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const before = normalizeText(await plot.getInstructionText());
+    await plot.moveToNextLayer();
+    const after = normalizeText(await plot.getInstructionText());
+
+    expect(before).toContain('Thur');
+    expect(after).toContain('Thur');
+    // Same category, different group, different reading.
+    expect(before).toContain('18.7');
+    expect(after).toContain('16.7');
+  });
+});

--- a/examples/errorbar-grouped.html
+++ b/examples/errorbar-grouped.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Grouped Error Bar Example — Average Total Bill by Day and Sex</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A grouped error bar chart poses one question: do the two groups'
+        intervals overlap at this category? Answering it means reading both
+        groups, and the two are separate layers - PageUp and PageDown move
+        between them, landing on the same category each time.
+
+        Which is why each layer carries a `name`. Without one the switch
+        announces "Layer 1 of 2: error_bar plot" for both, and the reader hears
+        two sets of numbers with nothing to say which group either belongs to -
+        exactly what the legend tells a sighted reader at a glance.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="errorbar-grouped" maidr='{&#10;  &quot;id&quot;: &quot;errorbar-grouped&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;errorbar-grouped-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;errorbar-grouped-male&quot;,&#10;            &quot;type&quot;: &quot;error_bar&quot;,&#10;            &quot;title&quot;: &quot;Average Total Bill by Day&quot;,&#10;            &quot;name&quot;: &quot;Male&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Day&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Total bill (USD)&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;errorbar-grouped-male-whips&#x27;] &gt; line&quot;,&#10;            &quot;data&quot;: [&#10;              {&#10;                &quot;x&quot;: &quot;Thur&quot;,&#10;                &quot;y&quot;: 18.7,&#10;                &quot;yMin&quot;: 16.1,&#10;                &quot;yMax&quot;: 21.7&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Fri&quot;,&#10;                &quot;y&quot;: 19.9,&#10;                &quot;yMin&quot;: 14.6,&#10;                &quot;yMax&quot;: 26.0&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Sat&quot;,&#10;                &quot;y&quot;: 20.8,&#10;                &quot;yMin&quot;: 18.2,&#10;                &quot;yMax&quot;: 23.3&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Sun&quot;,&#10;                &quot;y&quot;: 21.9,&#10;                &quot;yMin&quot;: 19.4,&#10;                &quot;yMax&quot;: 24.2&#10;              }&#10;            ]&#10;          },&#10;          {&#10;            &quot;id&quot;: &quot;errorbar-grouped-female&quot;,&#10;            &quot;type&quot;: &quot;error_bar&quot;,&#10;            &quot;title&quot;: &quot;Average Total Bill by Day&quot;,&#10;            &quot;name&quot;: &quot;Female&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Day&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Total bill (USD)&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;errorbar-grouped-female-whips&#x27;] &gt; line&quot;,&#10;            &quot;data&quot;: [&#10;              {&#10;                &quot;x&quot;: &quot;Thur&quot;,&#10;                &quot;y&quot;: 16.7,&#10;                &quot;yMin&quot;: 14.2,&#10;                &quot;yMax&quot;: 19.5&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Fri&quot;,&#10;                &quot;y&quot;: 14.1,&#10;                &quot;yMin&quot;: 11.4,&#10;                &quot;yMax&quot;: 16.9&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Sat&quot;,&#10;                &quot;y&quot;: 19.7,&#10;                &quot;yMin&quot;: 16.6,&#10;                &quot;yMax&quot;: 22.8&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Sun&quot;,&#10;                &quot;y&quot;: 19.9,&#10;                &quot;yMin&quot;: 16.3,&#10;                &quot;yMax&quot;: 23.3&#10;              }&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="errorbar-grouped-male-whips">
+              <line x1="170" y1="255.3" x2="170" y2="177.5" style="stroke: #4c72b0; stroke-width: 3" />
+              <line x1="310" y1="276.1" x2="310" y2="117.8" style="stroke: #4c72b0; stroke-width: 3" />
+              <line x1="450" y1="226.1" x2="450" y2="155.3" style="stroke: #4c72b0; stroke-width: 3" />
+              <line x1="590" y1="209.4" x2="590" y2="142.8" style="stroke: #4c72b0; stroke-width: 3" />
+            </g>
+            <g id="errorbar-grouped-male-dots">
+            <circle cx="170" cy="219.2" r="6" style="fill: #4c72b0" />
+            <circle cx="310" cy="202.5" r="6" style="fill: #4c72b0" />
+            <circle cx="450" cy="190.0" r="6" style="fill: #4c72b0" />
+            <circle cx="590" cy="174.7" r="6" style="fill: #4c72b0" />
+            </g>
+            <g id="errorbar-grouped-female-whips">
+              <line x1="190" y1="281.7" x2="190" y2="208.1" style="stroke: #c44e52; stroke-width: 3" />
+              <line x1="330" y1="320.6" x2="330" y2="244.2" style="stroke: #c44e52; stroke-width: 3" />
+              <line x1="470" y1="248.3" x2="470" y2="162.2" style="stroke: #c44e52; stroke-width: 3" />
+              <line x1="610" y1="252.5" x2="610" y2="155.3" style="stroke: #c44e52; stroke-width: 3" />
+            </g>
+            <g id="errorbar-grouped-female-dots">
+            <circle cx="190" cy="246.9" r="6" style="fill: #c44e52" />
+            <circle cx="330" cy="283.1" r="6" style="fill: #c44e52" />
+            <circle cx="470" cy="205.3" r="6" style="fill: #c44e52" />
+            <circle cx="610" cy="202.5" r="6" style="fill: #c44e52" />
+            </g>
+            <g id="axis_x">
+              <text x="180" y="368" style="font: 12px sans-serif; text-anchor: middle">Thur</text>
+              <text x="320" y="368" style="font: 12px sans-serif; text-anchor: middle">Fri</text>
+              <text x="460" y="368" style="font: 12px sans-serif; text-anchor: middle">Sat</text>
+              <text x="600" y="368" style="font: 12px sans-serif; text-anchor: middle">Sun</text>
+              <text x="390" y="395" style="font: 13px sans-serif; text-anchor: middle">Day</text>
+            </g>
+            <g id="axis_y">
+              <text x="160" y="344.0" style="font: 12px sans-serif; text-anchor: end">10</text>
+              <text x="160" y="274.6" style="font: 12px sans-serif; text-anchor: end">15</text>
+              <text x="160" y="205.1" style="font: 12px sans-serif; text-anchor: end">20</text>
+              <text x="160" y="135.7" style="font: 12px sans-serif; text-anchor: end">25</text>
+            </g>
+            <g id="chart-title">
+              <text x="390" y="60" style="font: 16px sans-serif; text-anchor: middle">Average Total Bill by Day and Sex</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -391,6 +391,8 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
   protected readonly id: string;
   protected readonly type: TraceType;
   protected readonly title: string;
+  /** What this layer is, when the producer named it. See `MaidrLayer.name`. */
+  protected readonly name: string | undefined;
 
   protected readonly xAxis: string;
   protected readonly yAxis: string;
@@ -407,6 +409,10 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
     this.id = layer.id;
     this.type = layer.type;
     this.title = layer.title ?? DEFAULT_SUBPLOT_TITLE;
+    // Undefined rather than defaulted: the announcement falls back to naming
+    // the trace type, which is the better answer for a figure whose layers
+    // differ in kind, and a default here would replace it with a placeholder.
+    this.name = layer.name?.trim() || undefined;
 
     this.xAxis = named(layer.axes?.x?.label, DEFAULT_X_AXIS);
     this.yAxis = named(layer.axes?.y?.label, DEFAULT_Y_AXIS);
@@ -465,6 +471,7 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
       traceType: this.type,
       plotType: this.type, // Default to traceType for other plot types
       title: this.title,
+      name: this.name,
       xAxis: this.xAxis,
       yAxis: this.yAxis,
       z: this.z,

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -1,7 +1,7 @@
 import type { Disposable } from '@type/disposable';
 import type { Event } from '@type/event';
 import type { Observer } from '@type/observable';
-import type { PlotState, TextState, TraceState } from '@type/state';
+import type { NonEmptyTraceState, PlotState, TextState, TraceState } from '@type/state';
 import type { AxisType, FormatterService } from './formatter';
 import type { NotificationService } from './notification';
 import { focusedSubplotTitle } from '@model/plot';
@@ -214,14 +214,7 @@ export class TextService implements Observer<PlotState>, Disposable {
     // Set currentLayerId for formatting
     this.currentLayerId = state.layerId;
 
-    // The layer's own name when it has one, and the trace type otherwise.
-    // A subplot whose layers are the same kind of thing -- one per hue level
-    // -- is announced identically at every layer without this, so the reader
-    // hears two sets of numbers and never learns which series each belongs
-    // to. A figure whose layers differ in kind is better served by the type,
-    // which is why this falls back to it rather than to a placeholder.
-    const identity = state.name ?? `${state.plotType || state.traceType} plot`;
-    let announcement = `Layer ${state.index} of ${state.size}: ${identity}`;
+    let announcement = `Layer ${state.index} of ${state.size}: ${TextService.layerIdentity(state)}`;
     if (state.text) {
       const parts: string[] = [];
 
@@ -424,9 +417,31 @@ export class TextService implements Observer<PlotState>, Disposable {
    * @returns Formatted subplot description text
    */
   private formatSubplotText(index: number, size: number, traceType: string, traceState?: TraceState): string {
-    // Use plotType if available, otherwise fall back to traceType
-    const type = traceState && !traceState.empty ? traceState.plotType : traceType;
-    return `Layer ${index} of ${size}: ${type} plot`;
+    const identity = traceState && !traceState.empty
+      ? TextService.layerIdentity(traceState)
+      : `${traceType} plot`;
+    return `Layer ${index} of ${size}: ${identity}`;
+  }
+
+  /**
+   * Names a layer for an announcement: what it is, or failing that, its kind.
+   *
+   * A subplot whose layers are the same kind of thing -- one per hue level of
+   * a grouped chart -- reads identically at every layer without the name, so
+   * the reader hears two sets of numbers and never learns which series each
+   * belongs to. A figure whose layers differ in kind is better served by the
+   * type, which is why this falls back to it rather than to a placeholder.
+   *
+   * Shared by both announcement sites rather than written twice. They compose
+   * the same sentence from different states, and the reason to make that
+   * explicit is that duplicated formatting is exactly how the two would come
+   * to disagree about the same layer.
+   *
+   * @param state - The trace state of the layer being announced
+   * @returns The layer's name, or a phrase naming its type
+   */
+  private static layerIdentity(state: NonEmptyTraceState): string {
+    return state.name ?? `${state.plotType || state.traceType} plot`;
   }
 
   /**

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -214,7 +214,14 @@ export class TextService implements Observer<PlotState>, Disposable {
     // Set currentLayerId for formatting
     this.currentLayerId = state.layerId;
 
-    let announcement = `Layer ${state.index} of ${state.size}: ${state.plotType || state.traceType} plot`;
+    // The layer's own name when it has one, and the trace type otherwise.
+    // A subplot whose layers are the same kind of thing -- one per hue level
+    // -- is announced identically at every layer without this, so the reader
+    // hears two sets of numbers and never learns which series each belongs
+    // to. A figure whose layers differ in kind is better served by the type,
+    // which is why this falls back to it rather than to a placeholder.
+    const identity = state.name ?? `${state.plotType || state.traceType} plot`;
+    let announcement = `Layer ${state.index} of ${state.size}: ${identity}`;
     if (state.text) {
       const parts: string[] = [];
 

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -677,6 +677,25 @@ export interface MaidrLayer {
   id: string;
   type: TraceType;
   title?: string;
+  /**
+   * What this layer is, when a subplot's layers are the same kind of thing.
+   *
+   * Announced on a layer switch in place of the trace type. Without it, two
+   * layers of one type are indistinguishable — a hue-split error bar chart
+   * announces "Layer 1 of 2: error_bar plot" and then "Layer 2 of 2:
+   * error_bar plot", so a reader hears two different sets of numbers and is
+   * never told that the first is Male and the second Female, which is the
+   * whole content of the split and what a legend gives a sighted reader for
+   * free.
+   *
+   * Distinct from `title`, which names the *chart* rather than the layer:
+   * producers put the figure's title there for every layer of a figure, so it
+   * cannot say which layer this is.
+   *
+   * @example
+   * name: 'Male'
+   */
+  name?: string;
   selectors?: string | string[] | string[][] | BoxSelector[] | CandlestickSelector;
   orientation?: Orientation;
   /**

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -81,6 +81,12 @@ export type TraceState
       traceType: TraceType;
       plotType: string;
       title: string;
+      /**
+       * What this layer is, when the producer named it — see
+       * {@link MaidrLayer.name}. Announced on a layer switch in place of the
+       * trace type, which cannot tell two layers of one kind apart.
+       */
+      name?: string;
       xAxis: string;
       yAxis: string;
       z: string;

--- a/test/service/layerName.test.ts
+++ b/test/service/layerName.test.ts
@@ -1,0 +1,116 @@
+import type { NotificationService } from '@service/notification';
+import type { ErrorBarPoint, MaidrLayer } from '@type/grammar';
+import type { LayerSwitchTraceState, NonEmptyTraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { ErrorBarTrace } from '@model/errorBar';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * How a subplot's layers are told apart when the reader switches between them.
+ *
+ * The switch announcement was built from the trace *type*, which answers the
+ * question only when the layers differ in kind. The case it does not answer is
+ * the one a grouped chart produces: a hue split emits one layer per level, so
+ * every layer is an `error_bar` and every announcement reads the same. The
+ * reader hears two different sets of numbers and is never told which series
+ * each belongs to -- the whole content of the split, and what the legend gives
+ * a sighted reader for free.
+ */
+
+/** Minimal NotificationService stub whose notify is a jest mock. */
+function createMockNotificationService(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+const POINTS: ErrorBarPoint[] = [
+  { x: 'Sat', y: 20.4, yMin: 18.5, yMax: 22.5 },
+  { x: 'Sun', y: 21.4, yMin: 19.5, yMax: 23.3 },
+];
+
+/**
+ * Build an error bar layer, named or not.
+ * @param name What the layer is, when the producer said
+ * @returns The layer definition
+ */
+function layerOf(name?: string): MaidrLayer {
+  return {
+    id: name ?? 'unnamed',
+    type: TraceType.ERROR_BAR,
+    // The figure's title, which every layer of a figure carries and which
+    // therefore cannot say which layer this is.
+    title: 'Total bill by day',
+    name,
+    axes: { x: { label: 'Day' }, y: { label: 'Total bill' } },
+    data: POINTS,
+  };
+}
+
+/**
+ * Announce a layer switch onto a trace, as the navigation service does.
+ * @param name What the layer is, when the producer said
+ * @param index Which layer this is, one-based
+ * @param size How many layers the subplot holds
+ * @returns The announcement the notification service received
+ */
+function announceSwitch(name: string | undefined, index = 1, size = 2): string {
+  const trace = new ErrorBarTrace(layerOf(name));
+  trace.moveToIndex(1, 0);
+
+  const notification = createMockNotificationService();
+  const text = new TextService(notification);
+
+  const state: LayerSwitchTraceState = {
+    ...(trace.state as NonEmptyTraceState),
+    isLayerSwitch: true,
+    index,
+    size,
+  };
+  text.update(state);
+
+  return (notification.notify as jest.Mock).mock.calls[0][0] as string;
+}
+
+describe('announcing which layer the reader landed on', () => {
+  test('names the layer when the producer named it', () => {
+    expect(announceSwitch('Male')).toContain('Layer 1 of 2: Male');
+  });
+
+  test('tells two layers of one kind apart', () => {
+    // The case the trace type cannot answer, and the reason the field exists.
+    const first = announceSwitch('Male', 1, 2);
+    const second = announceSwitch('Female', 2, 2);
+
+    expect(first).not.toBe(second);
+    expect(first).toContain('Male');
+    expect(second).toContain('Female');
+  });
+
+  test('falls back to the trace type when the layer has no name', () => {
+    // A figure whose layers differ in kind is better served by the type than
+    // by a placeholder, so the existing wording is what an unnamed layer keeps.
+    expect(announceSwitch(undefined)).toContain('Layer 1 of 2: error_bar plot');
+  });
+
+  test('does not mistake the figure title for the layer', () => {
+    // Producers put the figure's title on every layer, so preferring it would
+    // announce the same string for each -- the bug this replaces, in a new
+    // costume.
+    expect(announceSwitch(undefined)).not.toContain('Total bill by day');
+  });
+
+  test('treats a blank name as no name', () => {
+    // A producer emitting an empty string for a layer it could not name should
+    // get the type, not "Layer 1 of 2: ".
+    expect(announceSwitch('   ')).toContain('Layer 1 of 2: error_bar plot');
+  });
+
+  test('still announces where in the data the reader is', () => {
+    // The name replaces the type, not the position: a switch lands on the same
+    // point in the new layer, and saying so is what makes the two comparable.
+    const announcement = announceSwitch('Male');
+
+    expect(announcement).toContain('Day is Sat');
+    expect(announcement).toContain('20.4');
+  });
+});


### PR DESCRIPTION
Closes #828.

## The problem, restated after checking it

I opened #828 believing the flat `ErrorBarPoint[]` was what blocked grouped uncertainty. **It is not.** Multiple layers per subplot already work — `examples/violin.html` puts two in one subplot, and py-maidr's `_merge_plots_by_subplot_position` already groups every plot registered at the same `(row, col)` into one subplot's `layers`. A binding could emit one `error_bar` layer per hue level today.

What it could not do is make them tellable apart. `src/service/text.ts:217` built the announcement from the **trace type**:

```
Layer 1 of 2: error_bar plot at Day is Sat, Total bill is 20.4
Layer 2 of 2: error_bar plot at Day is Sat, Total bill is 19.7
```

The reader hears two different sets of numbers and is never told that the first is Male and the second Female — the whole content of the split, and what a legend gives a sighted reader at a glance. #828 is rewritten with the corrected framing.

## The change

`MaidrLayer.name` — what *this layer* is — announced in place of the trace type. A layer without one keeps the current wording.

```
Layer 1 of 2: Male at Day is Thur, Total bill is 18.7
Layer 2 of 2: Female at Day is Thur, Total bill is 16.7
```

**Deliberately not `title`.** It looks like the natural home and is the trap: producers put the *figure's* title there for every layer of a figure — py-maidr emits the figure title or `""` — so preferring it would announce the same string at each layer. That is the same bug in a new costume, and a regression for every existing multi-layer figure including `examples/violin.html`.

**Falls back to the type, not to a placeholder.** A figure whose layers genuinely differ in kind (`violin_box` + `violin_kde`) is better served by the type than by "Layer 1 of 2:" with nothing after it. A blank or whitespace-only name is treated as absent for the same reason.

## Why this is the piece worth doing

Grouped uncertainty is the case where reading an interval matters *most* — whether two group means differ is answered by whether their intervals overlap, and a grouped error bar chart poses that comparison once per category. Three bindings are currently unable to describe it:

- **py-maidr** — `sns.pointplot(..., hue=...)` (xability/py-maidr#352) drops its intervals; `sns.barplot(..., hue=...)` the same
- **r-maidr** — `geom_errorbar` with a `colour`/`fill` aesthetic

All three were waiting on a way to say *which series a layer is*, not on a way to carry two series in one.

## `examples/errorbar-grouped.html`

New, and the point of it is that the feature is demonstrable rather than theoretical: two `error_bar` layers in one subplot, one per sex, `PageUp`/`PageDown` between them. The e2e drives exactly the reading the chart exists for — switch layers at one category and hear both groups' intervals for it:

| | Thur |
|---|---|
| Male | 18.7, 16.1 to 21.7 |
| Female | 16.7, 14.2 to 19.5 |

## What is deliberately not here

Arrowing *between* series rather than switching layers — sketch (3) in #828, where the series become rows of one trace. That is the better reading for the overlap question, since it makes the comparison a keypress rather than a mode change, and it is a real design change: the error bar grid is currently sections × samples and series would have to become a third axis or be flattened into the rows. It can land later without invalidating this.

## Verification actually run

| Step | Result |
|---|---|
| `npm test` | **2127 passed** (was 2121) + **73 passed** |
| `npx playwright test --project=chromium errorbarGrouped` | **3 passed** |
| `npm run type-check` | clean |
| `npm run lint:fix` | clean |
| `npm run build` | clean |

Six unit tests cover the naming, the fallback, the blank-name case, and — the one that pins the trap — that the figure title is *not* what gets announced.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_