### PR TITLE
ci: notify py-maidr of a release alongside r-maidr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,26 +71,28 @@ jobs:
         if: steps.semantic-release.outputs.new_release == 'true'
         run: npm publish --access public --provenance
 
-      # r-maidr ships a copy of this package's built bundle, and refreshes it
-      # from npm. Left to itself it discovers a release on a daily poll, so a
-      # fix can sit unread by users for up to a day after it is published.
-      # Telling it directly closes that gap to minutes.
+      # Both language bindings ship a copy of this package's built bundle and
+      # refresh it from npm. Left to themselves they discover a release on
+      # their own cadence, so a fix can sit unread for a day or longer.
+      # Telling them directly closes that gap to minutes.
       #
-      # Deliberately after the publish step and gated on it: the receiver
-      # fetches the tarball straight from the registry, so announcing before
-      # the package is actually there would just make it fail.
+      # Deliberately after the publish step and gated on it: the receivers
+      # fetch the tarball straight from the registry, so announcing before
+      # the package is actually there would just make them fail.
       #
-      # py-maidr is not notified, and that is not an oversight. It bundles
-      # upstream at *its own* release time so each py-maidr release pins the
-      # version it was tested against, rather than tracking upstream
-      # continuously. Pinging it would work against that design.
+      # What each does with the news is its own call, not this step's.
+      # r-maidr commits the refreshed bundle to `main`, and `main` is what it
+      # ships, because CRAN submissions are manual. py-maidr also commits to
+      # `main`, but as a `chore:`, which by design does not cut a PyPI
+      # release: its release workflow re-resolves upstream when a release is
+      # actually cut, so the news reaches its users then rather than now.
       #
       # continue-on-error, because the release is the thing that matters
-      # here. A missed ping costs at most a day -- r-maidr keeps its
-      # scheduled refresh precisely as the backstop for this step failing --
-      # whereas a red release job costs a manual re-run of a publish that
-      # already happened.
-      - name: Tell r-maidr the new version is on npm
+      # here. A missed ping costs a binding some currency -- each keeps its
+      # own refresh path as the backstop for this step failing -- whereas a
+      # red release job costs a manual re-run of a publish that already
+      # happened.
+      - name: Tell the language bindings the new version is on npm
         if: steps.semantic-release.outputs.new_release == 'true'
         continue-on-error: true
         env:
@@ -99,15 +101,33 @@ jobs:
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "DOWNSTREAM_DISPATCH_TOKEN is not configured."
-            echo "r-maidr will pick v${VERSION} up on its next scheduled refresh."
+            echo "The bindings will pick v${VERSION} up on their own schedules."
             exit 0
           fi
+
           # jq builds the body so the version reaches JSON as data rather
           # than as text spliced into a quoted string.
-          jq -n --arg version "$VERSION" \
-            '{event_type: "maidr-released", client_payload: {version: $version}}' \
-            | gh api repos/xability/r-maidr/dispatches --input -
-          echo "Notified r-maidr of v${VERSION}."
+          BODY=$(jq -n --arg version "$VERSION" \
+            '{event_type: "maidr-released", client_payload: {version: $version}}')
+
+          # Each binding is notified independently. Looping with the whole run
+          # gated on the first call would let one repository being unreachable
+          # decide whether the other ever hears about the release, which is
+          # exactly the coupling this step exists to avoid.
+          missed=0
+          for repo in xability/r-maidr xability/py-maidr; do
+            if printf '%s' "$BODY" | gh api "repos/$repo/dispatches" --input -; then
+              echo "Notified $repo of v${VERSION}."
+            else
+              echo "Could not notify $repo of v${VERSION}."
+              missed=1
+            fi
+          done
+
+          # Reported as a step failure so a silently expired or under-scoped
+          # token is visible in the run, while continue-on-error keeps it from
+          # touching a release that has already happened.
+          exit "$missed"
 
       - name: Upload npm logs on failure
         if: failure()


### PR DESCRIPTION
# Pull Request

## Description

Sending half of a two-repo change. The receiving half is xability/py-maidr#355. Extends the notification added in #787, which currently reaches r-maidr only.

py-maidr ships the same built bundle r-maidr does, but only ever moved it at its own release time, so between releases its `main` carried whatever upstream version the last release happened to pin.

## Related Issues

No issue — a follow-on from #787, which shipped the r-maidr half and proved the mechanism on `v4.1.0`.

## Changes Made

- The notify step now loops over both `xability/r-maidr` and `xability/py-maidr`, and is renamed to match.
- **Each is notified independently.** Under the Actions default `bash -e`, a chained call would let the first repository being unreachable decide whether the second ever hears about the release — exactly the coupling this step exists to avoid. Each result is reported individually.
- **The step exits non-zero if either was missed**, so a silently expired or under-scoped token is visible in the run rather than being swallowed. `continue-on-error` keeps that from touching a release that has already happened.
- The block comment is rewritten: it previously explained why py-maidr was *not* notified, which is now the opposite of what the code does.

What each binding does with the news stays its own decision, and the comment now says so:

| binding | on receiving | reaches users |
|---|---|---|
| r-maidr | commits the refresh to `main` | promptly — `main` is what it ships, CRAN submissions being manual |
| py-maidr | commits it as a `chore:` | on its next release — by design, a bundle refresh does not cut a PyPI release |

## Screenshots (if applicable)

Not applicable — CI-only change.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable — not applicable; there is no harness for workflow YAML beyond `actionlint`, which runs in CI and passes.

## Additional Notes

**The token needs its scope widened.** `DOWNSTREAM_DISPATCH_TOKEN` currently reaches `xability/r-maidr`; it now also needs write access to `xability/py-maidr`. If it is left scoped to r-maidr alone, that half keeps working and the py-maidr call is reported as missed in the run rather than failing silently — the failure is visible and bounded, not hidden.

**Verification.** `actionlint` passes. The loop's failure isolation — the property the rewrite hinges on — was exercised under `bash -e` with a stubbed `gh`:

| case | result |
|---|---|
| both calls succeed | both reported notified, step exits 0 |
| py-maidr's call fails | r-maidr still notified, py-maidr reported missed, step exits 1 |

The second row is the one that matters: without the per-call `if`, `bash -e` would have aborted the step before r-maidr's result was even printed if the ordering were reversed.

Ordering note: py-maidr#355 should land first, since `repository_dispatch` only triggers the workflow file as it exists on the receiver's default branch. Merging this first is harmless — the dispatch would simply find nothing listening.

For context, #787's mechanism worked end to end on its first live run: `v4.1.0` published at 17:58:18, r-maidr's refresh committed at 17:58:32.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_