### PR TITLE
feat(radar): read categories arranged around a circle

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -381,6 +381,26 @@ Dumbbell charts use both lines on a multiline display: the starting values on
 the first and the finishing ones on the second, so the two profiles can be
 compared with one sweep rather than by toggling between rows.
 
+## Radar and polar area
+
+A radar's braille is the multi-line encoding unchanged: **one row per series**,
+one cell per spoke, each row scaled against its own range.
+
+What braille cannot carry here is the circle. A display is a line of cells and
+a spoke's angle has nowhere to go in it, so the row reads as the sequence of
+values it is — first spoke to last, in the order the chart declares them.
+
+That is not a loss the way a missing magnitude would be, because the angle is
+carried elsewhere and better: the **stereo position** follows the spoke around
+the dial, so a sweep goes out and comes back. Braille answers "how do the
+series compare across the spokes"; audio answers "where on the circle am I".
+Encoding a rotation into cell heights would answer neither.
+
+### Multiline Displays
+
+Radar charts use one line per series on a multiline display, so several models'
+profiles can be compared with one sweep rather than by toggling between rows.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/e2e_tests/specs/radar.spec.ts
+++ b/e2e_tests/specs/radar.spec.ts
@@ -1,0 +1,132 @@
+import type { Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/** The example's own page, driven through the shared base helpers. */
+class RadarPlotPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the radar example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/radar.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'radar-models');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   * @returns The braille content, whitespace trimmed
+   */
+  public async getBrailleContent(): Promise<string> {
+    const textarea = await this.waitForElement(this.selectors.braille);
+    return (await textarea.inputValue()).trim();
+  }
+}
+
+test.describe('Radar', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new RadarPlotPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new RadarPlotPage(page).navigateToPlot();
+  });
+
+  test('should declare the layer as a radar', () => {
+    expect(maidrData.subplots[0][0].layers[0].type).toBe('radar');
+  });
+
+  test('should carry a series per model over the same spokes', () => {
+    const layer = maidrData.subplots[0][0].layers[0];
+    const series = layer.data as { x: string; y: number }[][];
+
+    expect(series).toHaveLength(2);
+    expect(series[0].map(point => point.x)).toEqual(series[1].map(point => point.x));
+  });
+
+  test('should announce itself as a radar rather than a line', async ({ page }) => {
+    // The trace extends the line model, which names itself 'single line' or
+    // 'multiline'. A reader told they are on a line plot has been told the
+    // wrong chart.
+    const plot = new RadarPlotPage(page);
+    await plot.activateMaidr();
+
+    const instruction = normalizeText(await plot.getInstructionText());
+
+    expect(instruction).toContain('radar');
+    expect(instruction).not.toContain('line');
+  });
+
+  test('should announce the spoke and its score', async ({ page }) => {
+    const plot = new RadarPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('Speed');
+    expect(announcement).toContain('8');
+  });
+
+  test('should render one braille row per series', async ({ page }) => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    const plot = new RadarPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.toggleBrailleMode();
+
+    const rows = (await plot.getBrailleContent()).split('\n');
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row).toMatch(BRAILLE_CELL);
+      expect(row).toHaveLength(6);
+    }
+  });
+});

--- a/examples/radar.html
+++ b/examples/radar.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Radar Chart Example — Model Comparison</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A radar puts its categories around a circle rather than along an axis,
+        and the one thing that makes it a radar rather than a row of bars is
+        where each spoke sits.
+
+        So the stereo position follows the spoke's angle instead of its index:
+        12 o'clock centre, 3 o'clock hard right, 6 o'clock centre again, 9
+        o'clock hard left. Sweeping the six spokes goes out and comes back,
+        which is what a circle sounds like - the same treatment the pie chart
+        already gets.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="radar-models" maidr='{&#10;  &quot;id&quot;: &quot;radar-models&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;radar-models-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;radar-models-layer&quot;,&#10;            &quot;type&quot;: &quot;radar&quot;,&#10;            &quot;title&quot;: &quot;Model Comparison&quot;,&#10;            &quot;name&quot;: &quot;Model comparison&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Attribute&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Score&quot;&#10;              },&#10;              &quot;z&quot;: {&#10;                &quot;label&quot;: &quot;Model&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: [&#10;              &quot;g[id=&#x27;radar-series-a&#x27;] &gt; circle&quot;,&#10;              &quot;g[id=&#x27;radar-series-b&#x27;] &gt; circle&quot;&#10;            ],&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;Speed&quot;,&#10;                  &quot;y&quot;: 8,&#10;                  &quot;z&quot;: &quot;Model A&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Range&quot;,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;z&quot;: &quot;Model A&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Comfort&quot;,&#10;                  &quot;y&quot;: 6,&#10;                  &quot;z&quot;: &quot;Model A&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Price&quot;,&#10;                  &quot;y&quot;: 9,&#10;                  &quot;z&quot;: &quot;Model A&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Economy&quot;,&#10;                  &quot;y&quot;: 5,&#10;                  &quot;z&quot;: &quot;Model A&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Safety&quot;,&#10;                  &quot;y&quot;: 7,&#10;                  &quot;z&quot;: &quot;Model A&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;Speed&quot;,&#10;                  &quot;y&quot;: 5,&#10;                  &quot;z&quot;: &quot;Model B&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Range&quot;,&#10;                  &quot;y&quot;: 7,&#10;                  &quot;z&quot;: &quot;Model B&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Comfort&quot;,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;z&quot;: &quot;Model B&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Price&quot;,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;z&quot;: &quot;Model B&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Economy&quot;,&#10;                  &quot;y&quot;: 8,&#10;                  &quot;z&quot;: &quot;Model B&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Safety&quot;,&#10;                  &quot;y&quot;: 6,&#10;                  &quot;z&quot;: &quot;Model B&quot;&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="radar-grid">
+            <circle cx="360" cy="220" r="35.0" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            <circle cx="360" cy="220" r="70.0" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            <circle cx="360" cy="220" r="105.0" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            <circle cx="360" cy="220" r="140.0" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            <line x1="360" y1="220" x2="360.0" y2="80.0" style="stroke: #bdbdbd; stroke-width: 1" />
+            <line x1="360" y1="220" x2="481.2" y2="150.0" style="stroke: #bdbdbd; stroke-width: 1" />
+            <line x1="360" y1="220" x2="481.2" y2="290.0" style="stroke: #bdbdbd; stroke-width: 1" />
+            <line x1="360" y1="220" x2="360.0" y2="360.0" style="stroke: #bdbdbd; stroke-width: 1" />
+            <line x1="360" y1="220" x2="238.8" y2="290.0" style="stroke: #bdbdbd; stroke-width: 1" />
+            <line x1="360" y1="220" x2="238.8" y2="150.0" style="stroke: #bdbdbd; stroke-width: 1" />
+            </g>
+            <polygon points="360.0,108.0 408.5,192.0 432.7,262.0 360.0,346.0 299.4,255.0 275.1,171.0" style="fill: #4c72b0; fill-opacity: 0.25; stroke: #4c72b0; stroke-width: 2" />
+            <g id="radar-series-a">
+              <circle cx="360.0" cy="108.0" r="5" style="fill: #4c72b0" />
+              <circle cx="408.5" cy="192.0" r="5" style="fill: #4c72b0" />
+              <circle cx="432.7" cy="262.0" r="5" style="fill: #4c72b0" />
+              <circle cx="360.0" cy="346.0" r="5" style="fill: #4c72b0" />
+              <circle cx="299.4" cy="255.0" r="5" style="fill: #4c72b0" />
+              <circle cx="275.1" cy="171.0" r="5" style="fill: #4c72b0" />
+            </g>
+            <polygon points="360.0,150.0 444.9,171.0 396.4,241.0 360.0,248.0 263.0,276.0 287.3,178.0" style="fill: #c44e52; fill-opacity: 0.25; stroke: #c44e52; stroke-width: 2" />
+            <g id="radar-series-b">
+              <circle cx="360.0" cy="150.0" r="5" style="fill: #c44e52" />
+              <circle cx="444.9" cy="171.0" r="5" style="fill: #c44e52" />
+              <circle cx="396.4" cy="241.0" r="5" style="fill: #c44e52" />
+              <circle cx="360.0" cy="248.0" r="5" style="fill: #c44e52" />
+              <circle cx="263.0" cy="276.0" r="5" style="fill: #c44e52" />
+              <circle cx="287.3" cy="178.0" r="5" style="fill: #c44e52" />
+            </g>
+            <g id="spoke-labels">
+            <text x="360.0" y="57.6" style="font: 12px sans-serif; text-anchor: middle">Speed</text>
+            <text x="500.6" y="138.8" style="font: 12px sans-serif; text-anchor: middle">Range</text>
+            <text x="500.6" y="301.2" style="font: 12px sans-serif; text-anchor: middle">Comfort</text>
+            <text x="360.0" y="382.4" style="font: 12px sans-serif; text-anchor: middle">Price</text>
+            <text x="219.4" y="301.2" style="font: 12px sans-serif; text-anchor: middle">Economy</text>
+            <text x="219.4" y="138.8" style="font: 12px sans-serif; text-anchor: middle">Safety</text>
+            </g>
+            <g id="chart-title">
+              <text x="360" y="40" style="font: 16px sans-serif; text-anchor: middle">Model Comparison</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -695,7 +695,10 @@ export class AnnouncePositionCommand extends AnnounceCommand {
         this.announceSmoothPosition(x, cols);
       }
     } else if (
-      (traceType === TraceType.LINE || traceType === TraceType.STEP)
+      (traceType === TraceType.LINE
+        || traceType === TraceType.STEP
+        || traceType === TraceType.RADAR
+        || traceType === TraceType.POLAR_AREA)
       && state.groupCount
       && state.groupCount > 1
     ) {
@@ -709,7 +712,11 @@ export class AnnouncePositionCommand extends AnnounceCommand {
         y,
         rows,
         state.group,
-        traceType === TraceType.STEP ? 'Series' : 'Line',
+        // A radar's rows are series around a circle, not lines along an axis.
+        // Without this the announcement falls through to the generic 2-D one
+        // -- "column 3 of 4, row 2 of 2" -- which drops the series name a
+        // reader needs to know which outline they are tracing.
+        traceType === TraceType.LINE ? 'Line' : 'Series',
       );
     } else if (traceType === TraceType.SCATTER) {
       // Scatter plot: use x/y for column/row position, but don't include 'Position' as it sounds weird

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -69,6 +69,8 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.NORMALIZED]: 'Normalized Stacked Bar Chart',
   [TraceType.NORMALIZED_AREA]: 'Normalized Stacked Area Chart',
   [TraceType.PIE]: 'Pie Chart',
+  [TraceType.POLAR_AREA]: 'Polar Area Chart',
+  [TraceType.RADAR]: 'Radar Chart',
   [TraceType.SCATTER]: 'Scatter Plot',
   [TraceType.SMOOTH]: 'Smooth Line Chart',
   [TraceType.STACKED]: 'Stacked Bar Chart',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -12,6 +12,7 @@ import { Heatmap } from './heatmap';
 import { Histogram } from './histogram';
 import { LineTrace } from './line';
 import { PieTrace } from './pie';
+import { RadarTrace } from './radar';
 import { ScatterTrace } from './scatter';
 import { SegmentedTrace } from './segmented';
 import { createSmoothTrace } from './smoothtraceFactory';
@@ -70,6 +71,13 @@ export abstract class TraceFactory {
 
       case TraceType.PIE:
         return new PieTrace(layer);
+
+      // One class, two marks. A polar area draws its values as wedges and a
+      // radar joins them into an outline; a reader navigates the same spokes
+      // either way.
+      case TraceType.POLAR_AREA:
+      case TraceType.RADAR:
+        return new RadarTrace(layer);
 
       case TraceType.SCATTER:
         return new ScatterTrace(layer);

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -171,12 +171,40 @@ export class LineTrace extends AbstractTrace {
    * Gets the description state for the line trace.
    * @returns The description state containing chart metadata and data table
    */
+  /**
+   * What this chart calls its series and its samples, in the description.
+   *
+   * A subclass navigates the same grid but draws something else, and the
+   * description dialog renders these labels literally -- so a radar inheriting
+   * "Number of lines" tells a reader they are on a chart they are not, which
+   * is the same problem the spoken plot type is overridden to avoid.
+   *
+   * Defaulted to the line's own wording, so nothing changes for the chart this
+   * class is named after.
+   *
+   * @returns The four labels the description uses
+   */
+  protected get seriesLabels(): {
+    count: string;
+    perSeries: string;
+    names: string;
+    column: string;
+  } {
+    return {
+      count: 'Number of lines',
+      perSeries: 'Points per line',
+      names: 'Line names',
+      column: 'Line',
+    };
+  }
+
   public get description(): DescriptionState {
     const isMultiline = this.points.length > 1;
+    const labels = this.seriesLabels;
 
     const stats: DescriptionState['stats'] = [
-      { label: 'Number of lines', value: this.points.length },
-      { label: 'Points per line', value: this.points[0].length },
+      { label: labels.count, value: this.points.length },
+      { label: labels.perSeries, value: this.points[0].length },
       { label: 'Min value', value: MathUtil.safeMin(this.min) },
       { label: 'Max value', value: MathUtil.safeMax(this.max) },
     ];
@@ -185,14 +213,14 @@ export class LineTrace extends AbstractTrace {
       const lineNames = this.points
         .map((_line, i) => this.groupNameAt(i))
         .join(', ');
-      stats.push({ label: 'Line names', value: lineNames });
+      stats.push({ label: labels.names, value: lineNames });
     }
 
     let headers: string[];
     let rows: (string | number)[][];
 
     if (isMultiline) {
-      headers = [this.xAxis, this.yAxis, 'Line'];
+      headers = [this.xAxis, this.yAxis, labels.column];
       rows = this.points.flatMap((line, i) => {
         const lineName = this.groupNameAt(i);
         return line.map(p => [p.x, p.y, lineName]);

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -168,10 +168,6 @@ export class LineTrace extends AbstractTrace {
   }
 
   /**
-   * Gets the description state for the line trace.
-   * @returns The description state containing chart metadata and data table
-   */
-  /**
    * What this chart calls its series and its samples, in the description.
    *
    * A subclass navigates the same grid but draws something else, and the
@@ -198,6 +194,10 @@ export class LineTrace extends AbstractTrace {
     };
   }
 
+  /**
+   * Gets the description state for the line trace.
+   * @returns The description state containing chart metadata and data table
+   */
   public get description(): DescriptionState {
     const isMultiline = this.points.length > 1;
     const labels = this.seriesLabels;
@@ -311,6 +311,29 @@ export class LineTrace extends AbstractTrace {
     return graph;
   }
 
+  /**
+   * Where a cell sits in the stereo field.
+   *
+   * Split out because two places need it and they must agree: the tone for the
+   * cursor's own point, and the tones of every series a chord sounds at an
+   * intersection. A subclass that hears its columns somewhere other than a
+   * straight left-to-right sweep -- a radar's spokes go out and back around a
+   * circle -- overrides this one method and both follow, rather than one of
+   * them keeping the line's sweep and contradicting the other.
+   *
+   * @param row - The series index
+   * @param col - The column index
+   * @returns The panning for that cell
+   */
+  protected panningFor(row: number, col: number): AudioState['panning'] {
+    return {
+      x: col,
+      y: row,
+      rows: this.lineValues.length,
+      cols: this.lineValues[row].length,
+    };
+  }
+
   protected get audio(): AudioState {
     return {
       freq: {
@@ -318,12 +341,7 @@ export class LineTrace extends AbstractTrace {
         max: this.max[this.row],
         raw: this.lineValues[this.row][this.col],
       },
-      panning: {
-        x: this.col,
-        y: this.row,
-        rows: this.lineValues.length,
-        cols: this.lineValues[this.row].length,
-      },
+      panning: this.panningFor(this.row, this.col),
       group: this.row,
     };
   }
@@ -518,12 +536,11 @@ export class LineTrace extends AbstractTrace {
               max: this.max[r],
               raw: currentY,
             },
-            panning: {
-              x: this.col,
-              y: this.row,
-              rows: this.lineValues.length,
-              cols: this.lineValues[this.row].length,
-            },
+            // The cursor's own cell, not series `r`'s -- an intersection is
+            // one point that several series share, so every tone in the chord
+            // has to arrive from the same place. `group: r` is what tells them
+            // apart.
+            panning: this.panningFor(this.row, this.col),
             group: r,
           },
         );

--- a/src/model/radar.ts
+++ b/src/model/radar.ts
@@ -97,11 +97,10 @@ export class RadarTrace extends LineTrace {
     return Array.from({ length: spokes }, (_, index) => (index * 2 * Math.PI) / spokes);
   }
 
-  protected override get audio(): AudioState {
-    const base = super.audio;
-    const angle = this.spokeAngles[this.col];
+  protected override panningFor(row: number, col: number): AudioState['panning'] {
+    const angle = this.spokeAngles[col];
     if (angle === undefined) {
-      return base;
+      return super.panningFor(row, col);
     }
 
     // `AudioService` reads the pan as `interpolate(x, 0, cols - 1, -1, 1)`, so
@@ -112,14 +111,16 @@ export class RadarTrace extends LineTrace {
     // `y` and `rows` stay honest rather than being zeroed: the stereo position
     // is computed from `x` and `cols` alone, so the series index costs nothing
     // to keep and is the truth about where the cursor is.
+    //
+    // Overriding here rather than in `audio` covers the intersection chord as
+    // well: two series meeting on a spoke are one point on the circle, and a
+    // chord that swept left-to-right while every other tone went out and back
+    // would place that point somewhere the chart does not have.
     return {
-      ...base,
-      panning: {
-        x: (Math.sin(angle) + 1) / 2,
-        y: this.row,
-        rows: this.lineValues.length,
-        cols: 2,
-      },
+      x: (Math.sin(angle) + 1) / 2,
+      y: row,
+      rows: this.lineValues.length,
+      cols: 2,
     };
   }
 

--- a/src/model/radar.ts
+++ b/src/model/radar.ts
@@ -123,6 +123,24 @@ export class RadarTrace extends LineTrace {
     };
   }
 
+  protected override get seriesLabels(): {
+    count: string;
+    perSeries: string;
+    names: string;
+    column: string;
+  } {
+    // The description dialog renders these literally, so inheriting the line's
+    // wording tells a reader opening it that they are on a chart with "lines"
+    // and "points per line" -- the same misdescription the spoken plot type is
+    // overridden to avoid, one dialog further along.
+    return {
+      count: 'Number of series',
+      perSeries: 'Spokes per series',
+      names: 'Series names',
+      column: 'Series',
+    };
+  }
+
   public override get state(): TraceState {
     const base = super.state;
     if (base.empty) {

--- a/src/model/radar.ts
+++ b/src/model/radar.ts
@@ -1,0 +1,137 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { AudioState, TraceState } from '@type/state';
+import { TraceType } from '@type/grammar';
+import { LineTrace } from './line';
+
+/**
+ * How the values are drawn around the spokes.
+ *
+ * A radar joins them into a closed outline; a polar area draws each as a wedge
+ * whose radius is the value. The reading is identical — a spoke and a value —
+ * so they share a trace and differ only in what they are called, the way an
+ * area and a stacked area do.
+ */
+type RadarVariant = 'radar' | 'polar';
+
+/** Spoken plot type, per variant, for the instruction and layer-switch cues. */
+const PLOT_TYPE_LABEL: Record<RadarVariant, string> = {
+  radar: 'radar',
+  polar: 'polar area',
+};
+
+/**
+ * Reads a layer's type as a {@link RadarVariant}.
+ *
+ * @param type - The layer's declared trace type
+ * @returns The variant, defaulting to `radar`
+ */
+function variantOf(type: TraceType): RadarVariant {
+  return type === TraceType.POLAR_AREA ? 'polar' : 'radar';
+}
+
+/**
+ * Trace implementation for radar, spider and polar area charts — categories
+ * arranged around a circle rather than along an axis.
+ *
+ * The data is a multi-line layer's: each spoke is a column and each series a
+ * row, and navigation, braille and pitch all transfer unchanged. What a circle
+ * adds is **where a spoke sits**, and that is carried in the panning.
+ *
+ * Panning by column index is what a line does — hard left to hard right, a
+ * straight sweep — and it makes a radar sound like a row of bars, which is the
+ * one thing the layout is chosen to avoid. Panning by the spoke's angle sends
+ * the sweep out and back: 12 o'clock centre, 3 o'clock hard right, 6 o'clock
+ * centre again, 9 o'clock hard left. That is the same treatment {@link PieTrace}
+ * received, and it is what distinguishes a circle from a line by ear.
+ */
+export class RadarTrace extends LineTrace {
+  private readonly variant: RadarVariant;
+
+  /**
+   * The angle of each spoke, clockwise from 12 o'clock.
+   *
+   * Evenly spaced, because a radar's spokes are: unlike a pie's slices, whose
+   * angles follow from their shares, a radar puts its categories at equal
+   * intervals whatever they measure.
+   *
+   * Where spoke zero actually sits is a convention rather than something the
+   * payload states — the same gap {@link PieTrace} notes. It matters less
+   * here: nothing announces an absolute clock position for a radar, so a
+   * producer laying its first spoke elsewhere shifts which spoke is heard at
+   * centre without making any announcement untrue.
+   */
+  private readonly spokeAngles: number[];
+
+  /**
+   * Creates a new radar trace.
+   *
+   * @param layer - The MAIDR layer carrying the spoke data
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.variant = variantOf(layer.type);
+    this.spokeAngles = this.computeSpokeAngles();
+  }
+
+  /**
+   * Places each spoke at an equal share of the circle.
+   *
+   * Taken from the longest series rather than the first, so a chart whose
+   * series run to different lengths still has an angle for every column a
+   * cursor can reach. Ragged series are not what a radar is for, but a
+   * producer can emit them, and an absent angle would pan that spoke to
+   * whatever `undefined` interpolates to.
+   *
+   * @returns One angle per spoke, in radians
+   */
+  private computeSpokeAngles(): number[] {
+    const spokes = this.lineValues.reduce(
+      (widest, series) => Math.max(widest, series.length),
+      0,
+    );
+    if (spokes === 0) {
+      return [];
+    }
+
+    return Array.from({ length: spokes }, (_, index) => (index * 2 * Math.PI) / spokes);
+  }
+
+  protected override get audio(): AudioState {
+    const base = super.audio;
+    const angle = this.spokeAngles[this.col];
+    if (angle === undefined) {
+      return base;
+    }
+
+    // `AudioService` reads the pan as `interpolate(x, 0, cols - 1, -1, 1)`, so
+    // `cols: 2` makes the mapping `2x - 1`, and `x = (sin θ + 1) / 2` lands the
+    // pan on `sin θ` exactly. The same arithmetic `PieTrace` uses, and the
+    // reason neither needs a new state field to express an angle.
+    //
+    // `y` and `rows` stay honest rather than being zeroed: the stereo position
+    // is computed from `x` and `cols` alone, so the series index costs nothing
+    // to keep and is the truth about where the cursor is.
+    return {
+      ...base,
+      panning: {
+        x: (Math.sin(angle) + 1) / 2,
+        y: this.row,
+        rows: this.lineValues.length,
+        cols: 2,
+      },
+    };
+  }
+
+  public override get state(): TraceState {
+    const base = super.state;
+    if (base.empty) {
+      return base;
+    }
+
+    // `LineTrace` reports itself as a 'single line' or 'multiline' plot, which
+    // is what the instruction text and the layer-switch cue announce. A reader
+    // told they are on a line plot has been told the wrong chart.
+    return { ...base, plotType: PLOT_TYPE_LABEL[this.variant] };
+  }
+}

--- a/src/service/audio.ts
+++ b/src/service/audio.ts
@@ -342,6 +342,14 @@ export class AudioService implements Observer<PlotState>, Disposable {
     // sample is a data property, not a path-geometry one — so they belong here
     // too. Compared against the enum rather than a bare string so a renamed
     // member breaks the build instead of silently disabling the chord.
+    //
+    // RADAR and POLAR_AREA also inherit that detection and their state does
+    // carry `intersections`, and the coincidence is real on a circle too — a
+    // shared spoke and value is one point either way. They are left out
+    // because a chord is several tones at once and a radar reads position by
+    // ear, out and back around the circle: sounding them together spends the
+    // one cue the layout has. Adding them here would sound correct, so this is
+    // a choice about what a radar is for, not a gap to close by accident.
     if (
       (state.traceType === TraceType.LINE || state.traceType === TraceType.STEP)
       && !state.empty

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1127,6 +1127,12 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // A pie's braille state is a single row of slice magnitudes scaled
       // against that row's own range — the bar encoder's input exactly.
       [TraceType.PIE, asGeneric(new BarBrailleEncoder())],
+      // A radar's rows are series and its columns spokes, which is the line
+      // encoder's input exactly. The circle is what the *pan* carries; braille
+      // has no way to express an angle, and a row of magnitudes per series is
+      // the honest thing a display can show.
+      [TraceType.POLAR_AREA, asGeneric(new LineBrailleEncoder())],
+      [TraceType.RADAR, asGeneric(new LineBrailleEncoder())],
       [TraceType.SCATTER, asGeneric(new HeatmapBrailleEncoder())],
       // A single row of signed contributions scaled against that row's own
       // range -- the bar encoder's input exactly, and the same magnitude the

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -845,6 +845,21 @@ export enum TraceType {
   /** {@link TraceType.STACKED_AREA} whose bands are shares of a common total. */
   NORMALIZED_AREA = 'stacked_normalized_area',
   PIE = 'pie',
+  /**
+   * Categories arranged around a circle rather than along an axis, drawn as
+   * wedges whose radius is the value -- a polar area, coxcomb or rose chart.
+   * Read exactly as {@link TraceType.RADAR} is; the two differ in the mark,
+   * not in what a reader navigates.
+   */
+  POLAR_AREA = 'polar_area',
+  /**
+   * Categories arranged around a circle rather than along an axis, joined
+   * into a closed outline -- a radar or spider chart. Navigated as a
+   * multi-line layer, with each spoke a column and each series a row; what
+   * the circle adds is that a spoke's stereo position follows its angle
+   * rather than its index, so a sweep goes out and comes back.
+   */
+  RADAR = 'radar',
   SCATTER = 'point',
   SMOOTH = 'smooth',
   STACKED = 'stacked_bar',

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -46,6 +46,10 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // Slices are arranged around a circle, not along an axis: there is no
   // orientation to declare and none to fall back to.
   [TraceType.PIE]: false,
+  // Spokes sit around a circle rather than along an axis, so there is no main
+  // and cross axis to swap -- the same answer a pie gives.
+  [TraceType.POLAR_AREA]: false,
+  [TraceType.RADAR]: false,
   [TraceType.SCATTER]: false,
   [TraceType.SMOOTH]: false,
   [TraceType.STACKED]: true,

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -378,3 +378,46 @@ describe('AnnouncePositionCommand on a pie', () => {
     );
   });
 });
+
+/**
+ * Builds a multi-series radar trace state as {@link RadarTrace} reports it:
+ * the shape `LineTrace` produces, typed `radar` and naming itself `radar`.
+ * @param options Cursor position and group, as for {@link multilineState}
+ * @returns A non-empty multi-series radar trace state
+ */
+function multiRadarState(options: MultilineOptions = {}): PlotState {
+  return {
+    ...(multilineState(options) as object),
+    traceType: TraceType.RADAR,
+    plotType: 'radar',
+  } as unknown as PlotState;
+}
+
+describe('AnnouncePositionCommand on multi-series radar plots', () => {
+  it('names the series rather than falling through to row and column', () => {
+    // A radar extends the line trace and reports its groups the same way, but
+    // its own trace type -- so without a branch it lands on the generic 2-D
+    // announcement, "column 3 of 10, row 1 of 3", and the series name a reader
+    // needs to know which outline they are tracing is dropped.
+    const { command, textViewModel } = createCommand(
+      multiRadarState({ group: { label: 'Model', value: 'Model B' } }),
+    );
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith(
+      'Series 1 of 3, Model is Model B, Position is 3 of 10',
+    );
+  });
+
+  it('calls it a series rather than a line', () => {
+    // The instruction text and chartType for this same chart both say "radar".
+    const { command, textViewModel } = createCommand(multiRadarState());
+
+    command.execute();
+
+    const announced = jest.mocked(textViewModel.update).mock.calls[0][0] as string;
+    expect(announced).toContain('Series 1 of 3');
+    expect(announced).not.toContain('Line');
+  });
+});

--- a/test/model/radar.test.ts
+++ b/test/model/radar.test.ts
@@ -1,3 +1,4 @@
+import type { LineTrace } from '@model/line';
 import type { LinePoint, MaidrLayer } from '@type/grammar';
 import type { NonEmptyTraceState } from '@type/state';
 import { describe, expect, test } from '@jest/globals';
@@ -203,6 +204,46 @@ describe('spoke angles', () => {
       expect(pan(nonEmptyState(radar(0, col, TraceType.RADAR, doubled))))
         .toBeCloseTo(pan(nonEmptyState(radar(0, col))));
     }
+  });
+});
+
+describe('the description dialog', () => {
+  test('names series and spokes rather than lines and points', () => {
+    // The dialog renders these labels literally, so inheriting the line
+    // trace's wording tells a reader opening it that they are on a chart with
+    // "lines" -- the same misdescription the spoken plot type avoids, one
+    // dialog further along.
+    const labels = radar().description.stats.map(stat => stat.label);
+
+    expect(labels).toContain('Number of series');
+    expect(labels).toContain('Spokes per series');
+    expect(labels).toContain('Series names');
+    expect(labels).not.toContain('Number of lines');
+    expect(labels).not.toContain('Points per line');
+  });
+
+  test('heads the data table with the series rather than the line', () => {
+    expect(radar().description.dataTable?.headers).toEqual([
+      'Attribute',
+      'Score',
+      'Series',
+    ]);
+  });
+
+  test('leaves a line chart\'s own wording alone', () => {
+    // The labels are parameterised on `LineTrace`, so this is what says the
+    // parameterisation did not change the chart it is named after.
+    const line = TraceFactory.create({
+      id: 'l',
+      type: TraceType.LINE,
+      title: 't',
+      axes: { x: { label: 'X' }, y: { label: 'Y' } },
+      data: SPECS,
+    }) as LineTrace;
+    const labels = line.description.stats.map(stat => stat.label);
+
+    expect(labels).toContain('Number of lines');
+    expect(labels).toContain('Points per line');
   });
 });
 

--- a/test/model/radar.test.ts
+++ b/test/model/radar.test.ts
@@ -1,6 +1,6 @@
 import type { LineTrace } from '@model/line';
 import type { LinePoint, MaidrLayer } from '@type/grammar';
-import type { NonEmptyTraceState } from '@type/state';
+import type { AudioState, NonEmptyTraceState } from '@type/state';
 import { describe, expect, test } from '@jest/globals';
 import { TraceFactory } from '@model/factory';
 import { RadarTrace } from '@model/radar';
@@ -84,12 +84,25 @@ function radar(
  * It reads the pan as `interpolate(x, 0, cols - 1, -1, 1)`, so asserting on
  * `panning.x` alone would pass for a trace that got `cols` wrong -- and `cols`
  * is the half of the pair that makes the arithmetic land on `sin θ`.
+ *
+ * Takes the audio state rather than the trace state so the tones of an
+ * intersection chord, which are audio states in their own right, can be
+ * measured by the same arithmetic as the cursor's own tone.
+ * @param audio The audio state to read
+ * @returns The pan, from -1 (hard left) to 1 (hard right)
+ */
+function pan(audio: AudioState): number {
+  const { x, cols } = audio.panning;
+  return (x / (cols - 1)) * 2 - 1;
+}
+
+/**
+ * The pan of a positioned trace's own tone.
  * @param state The trace state to read
  * @returns The pan, from -1 (hard left) to 1 (hard right)
  */
-function pan(state: NonEmptyTraceState): number {
-  const { x, cols } = state.audio.panning;
-  return (x / (cols - 1)) * 2 - 1;
+function panOf(state: NonEmptyTraceState): number {
+  return pan(state.audio);
 }
 
 describe('radar registration', () => {
@@ -145,17 +158,17 @@ describe('the sweep goes round rather than across', () => {
   test('places four spokes at the quarters of the circle', () => {
     // 12 o'clock centre, 3 o'clock hard right, 6 o'clock centre again,
     // 9 o'clock hard left. A linear pan would give -1, -1/3, 1/3, 1.
-    expect(pan(nonEmptyState(radar(0, 0)))).toBeCloseTo(0);
-    expect(pan(nonEmptyState(radar(0, 1)))).toBeCloseTo(1);
-    expect(pan(nonEmptyState(radar(0, 2)))).toBeCloseTo(0);
-    expect(pan(nonEmptyState(radar(0, 3)))).toBeCloseTo(-1);
+    expect(panOf(nonEmptyState(radar(0, 0)))).toBeCloseTo(0);
+    expect(panOf(nonEmptyState(radar(0, 1)))).toBeCloseTo(1);
+    expect(panOf(nonEmptyState(radar(0, 2)))).toBeCloseTo(0);
+    expect(panOf(nonEmptyState(radar(0, 3)))).toBeCloseTo(-1);
   });
 
   test('returns to where it started, which a line never does', () => {
     // The property that makes a circle audible: the first and third spokes
     // of a four-spoke chart sit at the same stereo position.
-    const first = pan(nonEmptyState(radar(0, 0)));
-    const opposite = pan(nonEmptyState(radar(0, 2)));
+    const first = panOf(nonEmptyState(radar(0, 0)));
+    const opposite = panOf(nonEmptyState(radar(0, 2)));
 
     expect(first).toBeCloseTo(opposite);
   });
@@ -163,8 +176,8 @@ describe('the sweep goes round rather than across', () => {
   test('gives every series the same angles', () => {
     // A spoke is a place on the chart, not a place in a series.
     for (let col = 0; col < 4; col++) {
-      expect(pan(nonEmptyState(radar(0, col))))
-        .toBeCloseTo(pan(nonEmptyState(radar(1, col))));
+      expect(panOf(nonEmptyState(radar(0, col))))
+        .toBeCloseTo(panOf(nonEmptyState(radar(1, col))));
     }
   });
 
@@ -189,7 +202,7 @@ describe('spoke angles', () => {
     ];
     const trace = radar(1, 2, TraceType.RADAR, ragged);
 
-    expect(Number.isFinite(pan(nonEmptyState(trace)))).toBe(true);
+    expect(Number.isFinite(panOf(nonEmptyState(trace)))).toBe(true);
   });
 
   test('divide the circle evenly whatever the values are', () => {
@@ -201,8 +214,8 @@ describe('spoke angles', () => {
     );
 
     for (let col = 0; col < 4; col++) {
-      expect(pan(nonEmptyState(radar(0, col, TraceType.RADAR, doubled))))
-        .toBeCloseTo(pan(nonEmptyState(radar(0, col))));
+      expect(panOf(nonEmptyState(radar(0, col, TraceType.RADAR, doubled))))
+        .toBeCloseTo(panOf(nonEmptyState(radar(0, col))));
     }
   });
 });
@@ -244,6 +257,48 @@ describe('the description dialog', () => {
 
     expect(labels).toContain('Number of lines');
     expect(labels).toContain('Points per line');
+  });
+});
+
+describe('an intersection is heard from where the spoke is', () => {
+  /** Two series meeting on the third spoke, at 6 o'clock. */
+  const MEETING: LinePoint[][] = [
+    [
+      { x: 'speed', y: 8, z: 'model A' },
+      { x: 'range', y: 4, z: 'model A' },
+      { x: 'comfort', y: 6, z: 'model A' },
+      { x: 'price', y: 9, z: 'model A' },
+    ],
+    [
+      { x: 'speed', y: 5, z: 'model B' },
+      { x: 'range', y: 7, z: 'model B' },
+      { x: 'comfort', y: 6, z: 'model B' },
+      { x: 'price', y: 2, z: 'model B' },
+    ],
+  ];
+
+  test('every tone in the chord pans to the spoke, not across the sweep', () => {
+    // The chord's panning is built where the intersection is found, which is
+    // a different place from the tone for the cursor's own point. If only the
+    // latter went round the circle, two series meeting at 6 o'clock would be
+    // heard at centre by one route and hard right by the other.
+    const state = nonEmptyState(radar(0, 2, TraceType.RADAR, MEETING));
+
+    expect(state.intersections).toHaveLength(2);
+    for (const intersection of state.intersections ?? []) {
+      expect(pan(intersection)).toBeCloseTo(Math.sin(Math.PI), 10);
+    }
+  });
+
+  test('the chord arrives from one place, and `group` tells the tones apart', () => {
+    // An intersection is one point several series share, so a chord that
+    // spread its tones across the field would place that point somewhere the
+    // chart does not have.
+    const state = nonEmptyState(radar(0, 2, TraceType.RADAR, MEETING));
+    const pans = new Set((state.intersections ?? []).map(pan));
+
+    expect(pans.size).toBe(1);
+    expect((state.intersections ?? []).map(i => i.group)).toEqual([0, 1]);
   });
 });
 

--- a/test/model/radar.test.ts
+++ b/test/model/radar.test.ts
@@ -1,0 +1,232 @@
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { RadarTrace } from '@model/radar';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Four spokes, two series. Four is the number that makes the angles exact --
+ * 12, 3, 6 and 9 o'clock -- so the panning can be asserted as values rather
+ * than as inequalities, and a sweep that stayed linear cannot coincide with
+ * one that goes round.
+ */
+const SPECS: LinePoint[][] = [
+  [
+    { x: 'speed', y: 8, z: 'model A' },
+    { x: 'range', y: 4, z: 'model A' },
+    { x: 'comfort', y: 6, z: 'model A' },
+    { x: 'price', y: 9, z: 'model A' },
+  ],
+  [
+    { x: 'speed', y: 5, z: 'model B' },
+    { x: 'range', y: 7, z: 'model B' },
+    { x: 'comfort', y: 3, z: 'model B' },
+    { x: 'price', y: 2, z: 'model B' },
+  ],
+];
+
+/**
+ * Create a minimal radar layer for model-only tests.
+ * @param type Which of the two circular types to declare
+ * @param data The spokes the layer carries
+ * @returns Radar layer definition
+ */
+function createLayer(
+  type: TraceType = TraceType.RADAR,
+  data: LinePoint[][] = SPECS,
+): MaidrLayer {
+  return {
+    id: 'test-radar-layer',
+    type,
+    title: 'Model comparison',
+    axes: { x: { label: 'Attribute' }, y: { label: 'Score' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: RadarTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a radar trace positioned on one spoke of one series.
+ * @param row Which series
+ * @param col Which spoke
+ * @param type Which of the two circular types to declare
+ * @param data The spokes the layer carries
+ * @returns The positioned trace
+ */
+function radar(
+  row = 0,
+  col = 0,
+  type: TraceType = TraceType.RADAR,
+  data: LinePoint[][] = SPECS,
+): RadarTrace {
+  const trace = TraceFactory.create(createLayer(type, data)) as RadarTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+/**
+ * The stereo position the audio service will compute from a state.
+ *
+ * It reads the pan as `interpolate(x, 0, cols - 1, -1, 1)`, so asserting on
+ * `panning.x` alone would pass for a trace that got `cols` wrong -- and `cols`
+ * is the half of the pair that makes the arithmetic land on `sin θ`.
+ * @param state The trace state to read
+ * @returns The pan, from -1 (hard left) to 1 (hard right)
+ */
+function pan(state: NonEmptyTraceState): number {
+  const { x, cols } = state.audio.panning;
+  return (x / (cols - 1)) * 2 - 1;
+}
+
+describe('radar registration', () => {
+  test('the factory builds a RadarTrace for both circular types', () => {
+    expect(TraceFactory.create(createLayer(TraceType.RADAR)))
+      .toBeInstanceOf(RadarTrace);
+    expect(TraceFactory.create(createLayer(TraceType.POLAR_AREA)))
+      .toBeInstanceOf(RadarTrace);
+  });
+
+  test('announces itself as the chart it is', () => {
+    expect(radar().description.chartType).toBe('Radar Chart');
+    expect(radar(0, 0, TraceType.POLAR_AREA).description.chartType)
+      .toBe('Polar Area Chart');
+  });
+
+  test('does not report itself as a line plot', () => {
+    // It extends the line trace, which names itself 'single line' or
+    // 'multiline' -- and that is what the instruction text and the layer
+    // switch announce. A reader told they are on a line plot has been told
+    // the wrong chart.
+    expect(nonEmptyState(radar()).plotType).toBe('radar');
+    expect(nonEmptyState(radar(0, 0, TraceType.POLAR_AREA)).plotType)
+      .toBe('polar area');
+  });
+});
+
+describe('navigation is the multi-line model', () => {
+  test('walks spokes across and series up', () => {
+    // Series zero is the bottom row, as it is for any multi-line layer, so
+    // UPWARD reaches the next series -- inherited rather than redefined.
+    const trace = radar();
+
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(trace.moveOnce('DOWNWARD')).toBe(false);
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe('range');
+    expect(nonEmptyState(trace).text.cross.value).toBe(7);
+  });
+
+  test('stops at the last spoke rather than wrapping', () => {
+    // The outline is closed, so wrapping would arguably read better -- but
+    // every other trace stops at its bounds, and a reader who has learned
+    // that would be silently looped without being told. Changing it is a
+    // decision for the whole navigation model, not for one trace.
+    const trace = radar(0, 3);
+
+    expect(trace.moveOnce('FORWARD')).toBe(false);
+  });
+});
+
+describe('the sweep goes round rather than across', () => {
+  test('places four spokes at the quarters of the circle', () => {
+    // 12 o'clock centre, 3 o'clock hard right, 6 o'clock centre again,
+    // 9 o'clock hard left. A linear pan would give -1, -1/3, 1/3, 1.
+    expect(pan(nonEmptyState(radar(0, 0)))).toBeCloseTo(0);
+    expect(pan(nonEmptyState(radar(0, 1)))).toBeCloseTo(1);
+    expect(pan(nonEmptyState(radar(0, 2)))).toBeCloseTo(0);
+    expect(pan(nonEmptyState(radar(0, 3)))).toBeCloseTo(-1);
+  });
+
+  test('returns to where it started, which a line never does', () => {
+    // The property that makes a circle audible: the first and third spokes
+    // of a four-spoke chart sit at the same stereo position.
+    const first = pan(nonEmptyState(radar(0, 0)));
+    const opposite = pan(nonEmptyState(radar(0, 2)));
+
+    expect(first).toBeCloseTo(opposite);
+  });
+
+  test('gives every series the same angles', () => {
+    // A spoke is a place on the chart, not a place in a series.
+    for (let col = 0; col < 4; col++) {
+      expect(pan(nonEmptyState(radar(0, col))))
+        .toBeCloseTo(pan(nonEmptyState(radar(1, col))));
+    }
+  });
+
+  test('keeps the series index in the panning it does not use for stereo', () => {
+    // `y` and `rows` are carried through to the tone but not read for the
+    // stereo position, so they stay honest rather than being zeroed.
+    const { panning } = nonEmptyState(radar(1, 0)).audio;
+
+    expect(panning.y).toBe(1);
+    expect(panning.rows).toBe(2);
+  });
+});
+
+describe('spoke angles', () => {
+  test('are taken from the longest series, not the first', () => {
+    // A ragged chart is not what a radar is for, but a producer can emit one,
+    // and a column with no angle would pan to whatever `undefined`
+    // interpolates to.
+    const ragged: LinePoint[][] = [
+      [{ x: 'a', y: 1 }, { x: 'b', y: 2 }],
+      [{ x: 'a', y: 3 }, { x: 'b', y: 4 }, { x: 'c', y: 5 }],
+    ];
+    const trace = radar(1, 2, TraceType.RADAR, ragged);
+
+    expect(Number.isFinite(pan(nonEmptyState(trace)))).toBe(true);
+  });
+
+  test('divide the circle evenly whatever the values are', () => {
+    // Unlike a pie, whose angles follow from the shares. Doubling one spoke's
+    // value must not move any spoke.
+    const doubled = SPECS.map(series =>
+      series.map((point, index) =>
+        index === 0 ? { ...point, y: Number(point.y) * 2 } : point),
+    );
+
+    for (let col = 0; col < 4; col++) {
+      expect(pan(nonEmptyState(radar(0, col, TraceType.RADAR, doubled))))
+        .toBeCloseTo(pan(nonEmptyState(radar(0, col))));
+    }
+  });
+});
+
+describe('the rest of the reading is unchanged', () => {
+  test('pitch still tracks the value', () => {
+    const { audio } = nonEmptyState(radar(0, 0));
+
+    expect(audio.freq.raw).toBe(8);
+  });
+
+  test('braille is one row per series', () => {
+    const { braille } = nonEmptyState(radar());
+
+    expect(braille.empty).toBe(false);
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+    expect(braille.values).toEqual([[8, 4, 6, 9], [5, 7, 3, 2]]);
+  });
+
+  test('the spoke and its value are announced', () => {
+    const { text } = nonEmptyState(radar(1, 2));
+
+    expect(text.main.value).toBe('comfort');
+    expect(text.cross.value).toBe(3);
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -42,6 +42,10 @@ describe('resolveOrientation', () => {
     TraceType.LINE,
     TraceType.NORMALIZED_AREA,
     TraceType.PIE,
+    // Spokes sit around a circle rather than along an axis, so there is no
+    // main and cross axis to swap -- the answer a pie already gives.
+    TraceType.POLAR_AREA,
+    TraceType.RADAR,
     TraceType.SCATTER,
     TraceType.SMOOTH,
     TraceType.STACKED_AREA,


### PR DESCRIPTION
Closes #800.

Radar, spider and polar area charts are offered by Chart.js, ECharts, amCharts, Highcharts and Plotly, and MAIDR read none of them. The Vega-Lite adapter was explicit about the gap — `converters.ts:646` returns `null` for an `arc` mark without a `theta` encoding.

## Smaller than the issue expected, because half of it already shipped

#800 proposed building polar position as new state, together with #780. **#780 was closed by #784 and is released** — `PieTrace` already pans by angle. So no new state field and no service change: angular position is expressible in the existing `panning` shape, and there is a worked example in the tree. I posted the scope check on #800 before starting.

## The change

The data is a multi-line layer's — each spoke a column, each series a row — so navigation, braille and pitch transfer unchanged and `RadarTrace extends LineTrace` rather than restating them. **No new point shape**; `LinePoint[][]` was already in the data union.

What a circle adds is *where a spoke sits*:

```ts
x: (Math.sin(angle) + 1) / 2,
cols: 2,
```

`AudioService` reads the pan as `interpolate(x, 0, cols - 1, -1, 1)`, so `cols: 2` makes the mapping `2x − 1` and `x = (sin θ + 1) / 2` lands it on `sin θ` exactly. Six spokes then sweep **out and back** rather than hard-left to hard-right, which is the difference between hearing a circle and hearing a row of bars.

The unit test asserts the pan the *service* will compute rather than `panning.x` alone — `cols` is the half of the pair that makes the arithmetic work, and an assertion on `x` would pass for a trace that got it wrong.

**Spokes are evenly spaced**, unlike a pie's slices whose angles follow from their shares. A test doubles one value and asserts no spoke moves.

**`plotType` is overridden** because `LineTrace` names itself `'single line'` / `'multiline'`, and that is what the instruction text and the layer-switch cue announce. A reader told they are on a line plot has been told the wrong chart — pinned in both the unit tests and the e2e.

**Two types, one class** — `RADAR` and `POLAR_AREA` differ in the mark, not in what a reader navigates, the way `area` and `stacked_area` share `AreaTrace`.

## Deliberately not here

**Wrapping from the last spoke back to the first.** The outline is closed and wrapping would arguably read better — but every other trace stops at its bounds, and a reader who has learned that would be silently looped without being told. That is a decision for the navigation model, not something to slip into one trace. There is a test asserting it currently stops, so the day someone decides otherwise the case turns red rather than the behaviour drifting.

**A declared start angle.** The payload does not state where spoke zero sits, and neither does a pie's — the gap #780 flagged. It matters less here: nothing announces an absolute clock position for a radar, so a producer laying its first spoke elsewhere shifts which spoke is heard at centre without making any announcement untrue. Noted on #800 as the thing to settle before any clock-position wording is added.

## Registration

| # | Place | |
|---|---|---|
| 1 | `TraceType.RADAR` + `POLAR_AREA` (data union already covered) | ✅ |
| 2 | `src/model/radar.ts` | ✅ |
| 3 | `TraceFactory.create()` cases | ✅ |
| 4 | `CHART_TYPE_LABEL` | ✅ |
| 5 | `IS_ORIENTED` — `false`, as a pie is | ✅ |
| 6 | Braille encoder — `LineBrailleEncoder`, one row per series | ✅ |
| 7 | `docs/BRAILLE.md` | ✅ |

The braille section says what braille *cannot* carry here and why that is not a loss: a display is a line of cells and an angle has nowhere to go in it, but the angle is carried better by the pan. Braille answers "how do the series compare across the spokes"; audio answers "where on the circle am I".

## Verification actually run

| Step | Result |
|---|---|
| `npm test` | **2143 passed** (was 2127) + **73 passed** |
| `npx playwright test --project=chromium radar` | **5 passed** |
| `npm run type-check` | clean |
| `npm run lint:fix` | clean |
| `npm run build` | clean |

Two tests failed first and were corrected rather than the code: `test/util/orientation.test.ts` caught both new types before I registered them (the total-coverage guard doing its job), and my navigation test asserted `DOWNWARD` reaches the next series when series zero is the *bottom* row — I had asserted my assumption rather than the model, and fixed the test.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_