### PR TITLE
feat(parallel): pitch every axis against itself

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -436,6 +436,42 @@ same half of it.
 
 Gantt charts use one line per lane on a multiline display, so several lanes'
 workloads can be compared with one sweep rather than by toggling between rows.
+## Parallel coordinates
+
+One row per observation, one cell per axis, each row scaled from 0 to 1.
+
+The scaling is the whole point, and it happens **before** the encoder sees the
+data. Every other multi-row trace hands the encoder raw values and lets it
+scale each row against that row's own extent, which is right when a row is one
+quantity sampled repeatedly. A parallel coordinates row is not: it holds one
+observation across every variable, so scaling it row-wise would compare a car's
+fuel economy against its own kerb weight, and the cell heights would encode
+which variable happens to use bigger numbers rather than anything about the
+car.
+
+So the trace normalizes first. Each cell is its value's position **on its own
+axis**, which is exactly what the pitch plays and what the chart draws. A row
+of the display is then that observation's profile across the variables, and two
+rows can be compared cell by cell:
+
+```
+⠉⠉⣀    high economy, high power, low weight
+⣀⣀⠉    low economy, low power, high weight
+```
+
+Two rows whose heights swap between adjacent cells are the crossing lines that
+mean negative correlation — the pattern the chart is drawn for, available by
+touch as well as by ear.
+
+An axis whose observations all share one value has no spread to place anything
+within, so every cell on it sits at the midpoint. Both extremes would claim a
+rank the data does not support.
+
+### Multiline Displays
+
+Parallel coordinates use one line per observation on a multiline display, so
+several observations' profiles can be compared with one sweep rather than by
+toggling between rows.
 
 ## Multiline Braille Display Support
 

--- a/e2e_tests/specs/parallel.spec.ts
+++ b/e2e_tests/specs/parallel.spec.ts
@@ -1,0 +1,135 @@
+import type { Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/** The example's own page, driven through the shared base helpers. */
+class ParallelPlotPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the parallel coordinates example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/parallel.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'parallel-cars');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   * @returns The braille content, whitespace trimmed
+   */
+  public async getBrailleContent(): Promise<string> {
+    const textarea = await this.waitForElement(this.selectors.braille);
+    return (await textarea.inputValue()).trim();
+  }
+}
+
+test.describe('Parallel coordinates', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new ParallelPlotPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new ParallelPlotPage(page).navigateToPlot();
+  });
+
+  test('should declare the layer as parallel coordinates', () => {
+    expect(maidrData.subplots[0][0].layers[0].type).toBe('parallel_coordinates');
+  });
+
+  test('should carry one observation per car over the same axes', () => {
+    const layer = maidrData.subplots[0][0].layers[0];
+    const observations = layer.data as { x: string; y: number }[][];
+
+    expect(observations).toHaveLength(4);
+    for (const observation of observations) {
+      expect(observation.map(point => point.x)).toEqual(['mpg', 'hp', 'weight']);
+    }
+  });
+
+  test('should announce itself as parallel coordinates rather than a line', async ({ page }) => {
+    // The trace extends the line model, which names itself 'single line' or
+    // 'multiline'. A reader told they are on a line plot has been told the
+    // wrong chart.
+    const plot = new ParallelPlotPage(page);
+    await plot.activateMaidr();
+
+    const instruction = normalizeText(await plot.getInstructionText());
+
+    expect(instruction).toContain('parallel coordinates');
+  });
+
+  test('should announce the axis and the raw value, not a normalized rank', async ({ page }) => {
+    // The pitch carries the position on the axis; the announcement has to
+    // carry the number, or the reader is told a rank they cannot act on.
+    const plot = new ParallelPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('mpg');
+    expect(announcement).toContain('33');
+  });
+
+  test('should render one braille row per observation', async ({ page }) => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    const plot = new ParallelPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.toggleBrailleMode();
+
+    const rows = (await plot.getBrailleContent()).split('\n');
+
+    expect(rows).toHaveLength(4);
+    for (const row of rows) {
+      expect(row).toMatch(BRAILLE_CELL);
+      expect(row).toHaveLength(3);
+    }
+  });
+});

--- a/examples/parallel.html
+++ b/examples/parallel.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Parallel Coordinates Example — Car Characteristics</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        The axes here measure different things on purpose. Weight runs in
+        thousands and economy in tens, so a chart sonified against one range
+        for the layer would put every economy figure at the bottom of the
+        register and every weight at the top - the reader would hear the
+        units rather than the data.
+
+        Pitched against its own axis, each note says where that car sits on
+        that variable. Arrow along the Honda and it is high, high, low; along
+        the Muscle Coupe and it is low, low, high. Those two crossing between
+        mpg and hp is negative correlation, which a sighted reader sees at a
+        glance and which is otherwise inaudible.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="parallel-cars" maidr='{&#10;  &quot;id&quot;: &quot;parallel-cars&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;parallel-cars-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;parallel-cars-layer&quot;,&#10;            &quot;type&quot;: &quot;parallel_coordinates&quot;,&#10;            &quot;title&quot;: &quot;Car Characteristics&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Variable&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Value&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;parallel-lines&#x27;] &gt; polyline&quot;,&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;mpg&quot;,&#10;                  &quot;y&quot;: 33,&#10;                  &quot;z&quot;: &quot;Honda Civic&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;hp&quot;,&#10;                  &quot;y&quot;: 65,&#10;                  &quot;z&quot;: &quot;Honda Civic&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;weight&quot;,&#10;                  &quot;y&quot;: 1800,&#10;                  &quot;z&quot;: &quot;Honda Civic&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;mpg&quot;,&#10;                  &quot;y&quot;: 21,&#10;                  &quot;z&quot;: &quot;Ford Sedan&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;hp&quot;,&#10;                  &quot;y&quot;: 110,&#10;                  &quot;z&quot;: &quot;Ford Sedan&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;weight&quot;,&#10;                  &quot;y&quot;: 2600,&#10;                  &quot;z&quot;: &quot;Ford Sedan&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;mpg&quot;,&#10;                  &quot;y&quot;: 15,&#10;                  &quot;z&quot;: &quot;Muscle Coupe&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;hp&quot;,&#10;                  &quot;y&quot;: 230,&#10;                  &quot;z&quot;: &quot;Muscle Coupe&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;weight&quot;,&#10;                  &quot;y&quot;: 3200,&#10;                  &quot;z&quot;: &quot;Muscle Coupe&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;mpg&quot;,&#10;                  &quot;y&quot;: 27,&#10;                  &quot;z&quot;: &quot;Compact Wagon&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;hp&quot;,&#10;                  &quot;y&quot;: 88,&#10;                  &quot;z&quot;: &quot;Compact Wagon&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;weight&quot;,&#10;                  &quot;y&quot;: 2100,&#10;                  &quot;z&quot;: &quot;Compact Wagon&quot;&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="parallel-axes">
+          <line x1="180" y1="90" x2="180" y2="320" style="stroke: #8c8c8c; stroke-width: 2" />
+          <text x="180" y="350" style="font: 14px sans-serif; text-anchor: middle">mpg</text>
+          <text x="170" y="325" style="font: 11px sans-serif; text-anchor: end">15</text>
+          <text x="170" y="95" style="font: 11px sans-serif; text-anchor: end">33</text>
+          <line x1="420" y1="90" x2="420" y2="320" style="stroke: #8c8c8c; stroke-width: 2" />
+          <text x="420" y="350" style="font: 14px sans-serif; text-anchor: middle">hp</text>
+          <text x="410" y="325" style="font: 11px sans-serif; text-anchor: end">65</text>
+          <text x="410" y="95" style="font: 11px sans-serif; text-anchor: end">230</text>
+          <line x1="660" y1="90" x2="660" y2="320" style="stroke: #8c8c8c; stroke-width: 2" />
+          <text x="660" y="350" style="font: 14px sans-serif; text-anchor: middle">weight</text>
+          <text x="650" y="325" style="font: 11px sans-serif; text-anchor: end">1800</text>
+          <text x="650" y="95" style="font: 11px sans-serif; text-anchor: end">3200</text>
+            </g>
+            <g id="parallel-lines">
+          <polyline points="180,90.0 420,320.0 660,320.0" fill="none" style="stroke: #4c72b0; stroke-width: 3" />
+          <polyline points="180,243.3 420,257.3 660,188.6" fill="none" style="stroke: #dd8452; stroke-width: 3" />
+          <polyline points="180,320.0 420,90.0 660,90.0" fill="none" style="stroke: #55a868; stroke-width: 3" />
+          <polyline points="180,166.7 420,287.9 660,270.7" fill="none" style="stroke: #c44e52; stroke-width: 3" />
+            </g>
+            <g id="chart-title">
+              <text x="420" y="60" style="font: 16px sans-serif; text-anchor: middle">Car Characteristics</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -698,7 +698,8 @@ export class AnnouncePositionCommand extends AnnounceCommand {
       (traceType === TraceType.LINE
         || traceType === TraceType.STEP
         || traceType === TraceType.RADAR
-        || traceType === TraceType.POLAR_AREA)
+        || traceType === TraceType.POLAR_AREA
+        || traceType === TraceType.PARALLEL)
       && state.groupCount
       && state.groupCount > 1
     ) {
@@ -716,7 +717,9 @@ export class AnnouncePositionCommand extends AnnounceCommand {
         // Without this the announcement falls through to the generic 2-D one
         // -- "column 3 of 4, row 2 of 2" -- which drops the series name a
         // reader needs to know which outline they are tracing.
-        traceType === TraceType.LINE ? 'Line' : 'Series',
+        traceType === TraceType.LINE
+          ? 'Line'
+          : traceType === TraceType.PARALLEL ? 'Observation' : 'Series',
       );
     } else if (traceType === TraceType.SCATTER) {
       // Scatter plot: use x/y for column/row position, but don't include 'Position' as it sounds weird

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -69,6 +69,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.LINE]: 'Line Chart',
   [TraceType.NORMALIZED]: 'Normalized Stacked Bar Chart',
   [TraceType.NORMALIZED_AREA]: 'Normalized Stacked Area Chart',
+  [TraceType.PARALLEL]: 'Parallel Coordinates Plot',
   [TraceType.PIE]: 'Pie Chart',
   [TraceType.POLAR_AREA]: 'Polar Area Chart',
   [TraceType.RADAR]: 'Radar Chart',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -12,6 +12,7 @@ import { GaugeTrace } from './gauge';
 import { Heatmap } from './heatmap';
 import { Histogram } from './histogram';
 import { LineTrace } from './line';
+import { ParallelTrace } from './parallel';
 import { PieTrace } from './pie';
 import { RadarTrace } from './radar';
 import { ScatterTrace } from './scatter';
@@ -72,6 +73,9 @@ export abstract class TraceFactory {
 
       case TraceType.LINE:
         return new LineTrace(layer);
+
+      case TraceType.PARALLEL:
+        return new ParallelTrace(layer);
 
       case TraceType.PIE:
         return new PieTrace(layer);

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -119,7 +119,22 @@ export class LineTrace extends AbstractTrace {
    * reach a label resolved here.
    */
   private get groupLabel(): string {
-    return named(this.layer.axes?.z?.label, TYPE);
+    return named(this.layer.axes?.z?.label, this.groupFallbackLabel);
+  }
+
+  /**
+   * What this chart calls one of its series, when the layer names no z axis.
+   *
+   * Overridable for the reason {@link LineTrace.seriesLabels} is: a subclass
+   * navigates the same grid but draws something else, and this label is
+   * announced literally beside the series' own name. A parallel coordinates
+   * plot that named its own noun everywhere else and then said "Group is
+   * Honda Civic" would use two words for one referent in a single sentence.
+   *
+   * @returns The fallback label
+   */
+  protected get groupFallbackLabel(): string {
+    return TYPE;
   }
 
   /**

--- a/src/model/parallel.ts
+++ b/src/model/parallel.ts
@@ -1,0 +1,203 @@
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { AudioState, BrailleState, DescriptionState, TraceState } from '@type/state';
+import { MathUtil } from '@util/math';
+import { LineTrace } from './line';
+
+/**
+ * Trace implementation for parallel coordinates plots.
+ *
+ * The data is a multi-line layer's: each observation is a row and each axis a
+ * column, so navigation, text and highlighting transfer unchanged. What is new
+ * is that **the columns are not one scale**. A line chart's columns are
+ * samples of one quantity; a parallel coordinates plot's columns are different
+ * quantities entirely -- miles per gallon beside horsepower beside weight --
+ * and nothing about them is comparable except each value's position within its
+ * own axis.
+ *
+ * That is the whole chart, and it is what the pitch has to carry. Sonifying
+ * against one range for the layer would put every axis measured in small
+ * numbers at the bottom of the register and every axis measured in large ones
+ * at the top, so a reader would hear the units rather than the data: a car
+ * with the best economy and the worst power would sound the same as a car with
+ * the worst of both.
+ *
+ * Scaled per axis, the pitch says where a value sits **on its own axis**, and
+ * the pattern the chart is drawn for becomes audible. A reader arrowing along
+ * one observation hears it high here and low there; arrowing down a column
+ * hears the observations ranked on that variable; and two observations whose
+ * pitches swap between adjacent axes are the crossing lines that mean negative
+ * correlation -- which is instantly visible and, until now, entirely
+ * inaudible.
+ */
+export class ParallelTrace extends LineTrace {
+  /** Per-axis extent, indexed by column rather than by row. */
+  private readonly axisMin: number[];
+  private readonly axisMax: number[];
+
+  /**
+   * Each value's position on its own axis, from 0 to 1.
+   *
+   * Held rather than recomputed because braille reads the whole grid on every
+   * move, and the extents it is computed from are fixed at construction.
+   */
+  private readonly normalized: number[][];
+
+  /**
+   * Creates a new parallel coordinates trace.
+   *
+   * @param layer - The MAIDR layer carrying the observations
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    const columns = this.lineValues.reduce(
+      (widest, row) => Math.max(widest, row.length),
+      0,
+    );
+
+    const perColumn = Array.from({ length: columns }, (_, column) =>
+      this.lineValues
+        .map(row => row[column])
+        .filter(value => value !== undefined));
+
+    this.axisMin = perColumn.map(values => MathUtil.safeMin(values));
+    this.axisMax = perColumn.map(values => MathUtil.safeMax(values));
+
+    this.normalized = this.lineValues.map(row =>
+      row.map((value, column) => this.positionOnAxis(value, column)));
+  }
+
+  /**
+   * Places a value within its own axis, from 0 (lowest) to 1 (highest).
+   *
+   * An axis whose observations all share one value has no spread to place
+   * anything within, so every value sits at the midpoint rather than at an
+   * end: 0 and 1 both claim an extreme the data does not have, and the
+   * midpoint is the honest reading of "nothing distinguishes these".
+   *
+   * @param value - The raw value
+   * @param column - Which axis it belongs to
+   * @returns Its position on that axis
+   */
+  private positionOnAxis(value: number, column: number): number {
+    const min = this.axisMin[column];
+    const max = this.axisMax[column];
+    if (!Number.isFinite(min) || !Number.isFinite(max) || max === min) {
+      return 0.5;
+    }
+    return (value - min) / (max - min);
+  }
+
+  protected override get audio(): AudioState {
+    const base = super.audio;
+
+    // `LineTrace` scales against the CURRENT ROW's extent, which is right for
+    // a series sampling one quantity and wrong here: a row spans every axis,
+    // so its extent is the range of a horsepower figure and a fuel-economy
+    // figure taken together, which is not a range of anything.
+    return {
+      ...base,
+      freq: {
+        ...base.freq,
+        min: this.axisMin[this.col],
+        max: this.axisMax[this.col],
+      },
+    };
+  }
+
+  protected override get braille(): BrailleState {
+    const base = super.braille;
+    if (base.empty) {
+      return base;
+    }
+
+    // The normalized grid, scaled 0 to 1 for every row, rather than the raw
+    // values. `LineBrailleEncoder` scales each row against that row's own
+    // extent, and a row here holds one observation across every axis -- so a
+    // car's economy would be scaled against its horsepower, and the cell
+    // heights would encode which axis happens to use bigger numbers.
+    //
+    // Normalizing first makes each cell its value's position on its own axis,
+    // which is what the pitch plays and what the chart draws. A row of the
+    // display is then one observation's profile across the variables, and two
+    // rows can be compared cell by cell.
+    return {
+      ...base,
+      values: this.normalized,
+      min: this.normalized.map(() => 0),
+      max: this.normalized.map(() => 1),
+    };
+  }
+
+  protected override get seriesLabels(): {
+    count: string;
+    perSeries: string;
+    names: string;
+    column: string;
+  } {
+    // Rendered literally by the description dialog, so the line's wording
+    // tells a reader they are on a chart with "lines" and "points per line".
+    return {
+      count: 'Number of observations',
+      perSeries: 'Axes per observation',
+      names: 'Observation names',
+      column: 'Observation',
+    };
+  }
+
+  public override get description(): DescriptionState {
+    const base = super.description;
+
+    // `LineTrace` reports one Min value and one Max value for the layer. Here
+    // those are the smallest and largest numbers anywhere in the chart, taken
+    // across axes that measure different things -- a figure with no referent,
+    // and the dialog is where a reader goes to learn what the axes are.
+    const stats = base.stats.filter(
+      stat => stat.label !== 'Min value' && stat.label !== 'Max value',
+    );
+
+    const axisNames = this.axisNames();
+    if (axisNames.length > 0) {
+      // The order is part of the chart: which variables sit next to each other
+      // decides which crossings are visible at all, and it is a choice the
+      // author made rather than a property of the data.
+      stats.push({ label: 'Axes, in order', value: axisNames.join(', ') });
+
+      for (const [column, name] of axisNames.entries()) {
+        stats.push({
+          label: name,
+          value: `${this.axisMin[column]} to ${this.axisMax[column]}`,
+        });
+      }
+    }
+
+    return { ...base, stats };
+  }
+
+  /**
+   * The axis names, in the order the chart draws them.
+   *
+   * Read from the longest observation rather than the first, so a chart whose
+   * rows run to different lengths still names every column a cursor can reach.
+   *
+   * @returns One name per axis
+   */
+  private axisNames(): string[] {
+    const widest = this.points.reduce(
+      (best: LinePoint[], row) => (row.length > best.length ? row : best),
+      [] as LinePoint[],
+    );
+    return widest.map(point => String(point.x));
+  }
+
+  public override get state(): TraceState {
+    const base = super.state;
+    if (base.empty) {
+      return base;
+    }
+
+    // `LineTrace` reports itself as a 'single line' or 'multiline' plot, which
+    // is what the instruction text and the layer-switch cue announce.
+    return { ...base, plotType: 'parallel coordinates' };
+  }
+}

--- a/src/model/parallel.ts
+++ b/src/model/parallel.ts
@@ -129,6 +129,13 @@ export class ParallelTrace extends LineTrace {
     };
   }
 
+  protected override get groupFallbackLabel(): string {
+    // Announced beside the series' own name on every move, so inheriting the
+    // line's "Group" puts two words for one referent in one sentence --
+    // "Observation 1 of 4, Group is Honda Civic".
+    return 'Observation';
+  }
+
   protected override get seriesLabels(): {
     count: string;
     perSeries: string;

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1131,6 +1131,11 @@ implements Observer<SubplotState | TraceState>, Disposable {
       [TraceType.HISTOGRAM, asGeneric(new BarBrailleEncoder())],
       [TraceType.LINE, asGeneric(new LineBrailleEncoder())],
       [TraceType.NORMALIZED, asGeneric(new BarBrailleEncoder())],
+      // A parallel coordinates trace normalizes its own values before they
+      // reach here -- each cell its position on its own axis -- precisely so
+      // the line encoder's per-row scaling is correct for it. Scaling a row
+      // of raw values would compare a horsepower figure to a fuel-economy one.
+      [TraceType.PARALLEL, asGeneric(new LineBrailleEncoder())],
       // A pie's braille state is a single row of slice magnitudes scaled
       // against that row's own range — the bar encoder's input exactly.
       [TraceType.PIE, asGeneric(new BarBrailleEncoder())],

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -923,6 +923,14 @@ export enum TraceType {
   NORMALIZED = 'stacked_normalized_bar',
   /** {@link TraceType.STACKED_AREA} whose bands are shares of a common total. */
   NORMALIZED_AREA = 'stacked_normalized_area',
+  /**
+   * One polyline per observation across several axes, one axis per variable.
+   * Navigated as a multi-line layer -- an observation per row, an axis per
+   * column -- with the one difference that decides the chart: every column is
+   * a different quantity, so a value is pitched against its OWN axis rather
+   * than against one range for the layer.
+   */
+  PARALLEL = 'parallel_coordinates',
   PIE = 'pie',
   /**
    * Categories arranged around a circle rather than along an axis, drawn as

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -48,6 +48,11 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   [TraceType.LINE]: false,
   [TraceType.NORMALIZED]: true,
   [TraceType.NORMALIZED_AREA]: false,
+  // The axes are the columns and the observations the rows, whichever way the
+  // axes are drawn -- a horizontal parallel coordinates plot still walks the
+  // same grid. There is no main and cross axis to swap, because every column
+  // is its own axis.
+  [TraceType.PARALLEL]: false,
   // Slices are arranged around a circle, not along an axis: there is no
   // orientation to declare and none to fall back to.
   [TraceType.PIE]: false,

--- a/test/model/parallel.test.ts
+++ b/test/model/parallel.test.ts
@@ -1,0 +1,265 @@
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { ParallelTrace } from '@model/parallel';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Three cars over three axes whose units are deliberately incomparable.
+ *
+ * `weight` is measured in thousands and `mpg` in tens, which is the situation
+ * that makes one scale for the layer wrong: against a single 21-to-3200 range,
+ * every economy figure sits at the very bottom and is inaudible.
+ *
+ * Within each axis the three cars rank differently -- car A is best on economy
+ * and worst on power, car C the reverse -- so a reading that lost the per-axis
+ * scaling cannot coincide with the right answer.
+ */
+const CARS: LinePoint[][] = [
+  [
+    { x: 'mpg', y: 33, z: 'car A' },
+    { x: 'hp', y: 65, z: 'car A' },
+    { x: 'weight', y: 1800, z: 'car A' },
+  ],
+  [
+    { x: 'mpg', y: 21, z: 'car B' },
+    { x: 'hp', y: 110, z: 'car B' },
+    { x: 'weight', y: 2600, z: 'car B' },
+  ],
+  [
+    { x: 'mpg', y: 15, z: 'car C' },
+    { x: 'hp', y: 230, z: 'car C' },
+    { x: 'weight', y: 3200, z: 'car C' },
+  ],
+];
+
+/**
+ * Create a minimal parallel coordinates layer for model-only tests.
+ * @param data The observations the layer carries
+ * @returns Parallel coordinates layer definition
+ */
+function createLayer(data: LinePoint[][] = CARS): MaidrLayer {
+  return {
+    id: 'test-parallel-layer',
+    type: TraceType.PARALLEL,
+    title: 'Car comparison',
+    axes: { x: { label: 'Variable' }, y: { label: 'Value' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: ParallelTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a parallel coordinates trace positioned on one axis of one observation.
+ * @param row Which observation
+ * @param col Which axis
+ * @param data The observations the layer carries
+ * @returns The positioned trace
+ */
+function parallel(row = 0, col = 0, data: LinePoint[][] = CARS): ParallelTrace {
+  const trace = TraceFactory.create(createLayer(data)) as ParallelTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+/**
+ * Where a state's pitch sits within the range it was given, 0 to 1.
+ *
+ * The service interpolates `raw` between `min` and `max`, so asserting on
+ * `raw` alone would pass for a trace that kept the wrong range -- and the
+ * range is the half this chart type gets right or wrong.
+ * @param state The trace state to read
+ * @returns The relative pitch
+ */
+function pitch(state: NonEmptyTraceState): number {
+  const { min, max, raw } = state.audio.freq;
+  return (Number(raw) - min) / (max - min);
+}
+
+/**
+ * The braille grid, narrowed to the numeric shape this trace emits.
+ *
+ * `BrailleState.values` is a union with the box plot's own point shape, so a
+ * bare index would not type-check.
+ * @param trace The trace to read
+ * @returns One row of normalized positions per observation
+ */
+function brailleGrid(trace: ParallelTrace): number[][] {
+  const { braille } = nonEmptyState(trace);
+  if (braille.empty) {
+    throw new Error('Expected a populated braille state');
+  }
+  const values = braille.values;
+  if (!Array.isArray(values[0])) {
+    throw new TypeError('Expected a grid of numbers');
+  }
+  return values as number[][];
+}
+
+describe('parallel coordinates registration', () => {
+  test('the factory builds a ParallelTrace', () => {
+    expect(TraceFactory.create(createLayer())).toBeInstanceOf(ParallelTrace);
+  });
+
+  test('announces itself as the chart it is', () => {
+    expect(parallel().description.chartType).toBe('Parallel Coordinates Plot');
+    expect(nonEmptyState(parallel()).plotType).toBe('parallel coordinates');
+  });
+
+  test('does not report itself as a line plot', () => {
+    expect(nonEmptyState(parallel()).plotType).not.toContain('line');
+  });
+});
+
+describe('every axis is pitched against itself', () => {
+  test('a value is scaled by its own axis, not by the layer', () => {
+    // car B on mpg: 21 within the 15-to-33 economy axis, not 21 within the
+    // 15-to-3200 range of every number in the chart.
+    const { audio } = nonEmptyState(parallel(1, 0));
+
+    expect(audio.freq.min).toBe(15);
+    expect(audio.freq.max).toBe(33);
+    expect(audio.freq.raw).toBe(21);
+  });
+
+  test('the same row gets a different range on a different axis', () => {
+    // The property `LineTrace` cannot have: its range is per row, so both of
+    // these would report the same pair.
+    const economy = nonEmptyState(parallel(1, 0)).audio.freq;
+    const weight = nonEmptyState(parallel(1, 2)).audio.freq;
+
+    expect([economy.min, economy.max]).toEqual([15, 33]);
+    expect([weight.min, weight.max]).toEqual([1800, 3200]);
+  });
+
+  test('the best on an axis sounds highest whatever the units', () => {
+    // Car A is the best on economy and the worst on weight, and its two
+    // pitches have to say so despite weight being measured in thousands.
+    expect(pitch(nonEmptyState(parallel(0, 0)))).toBeCloseTo(1);
+    expect(pitch(nonEmptyState(parallel(0, 2)))).toBeCloseTo(0);
+  });
+
+  test('crossing lines are audible as a swap in pitch', () => {
+    // The pattern the chart exists to show: between mpg and hp, car A goes
+    // from top to bottom and car C from bottom to top. Negative correlation,
+    // heard rather than seen.
+    const aEconomy = pitch(nonEmptyState(parallel(0, 0)));
+    const aPower = pitch(nonEmptyState(parallel(0, 1)));
+    const cEconomy = pitch(nonEmptyState(parallel(2, 0)));
+    const cPower = pitch(nonEmptyState(parallel(2, 1)));
+
+    expect(aEconomy).toBeGreaterThan(cEconomy);
+    expect(aPower).toBeLessThan(cPower);
+  });
+
+  test('an axis whose values are all equal pitches to the middle', () => {
+    // Nothing distinguishes the observations there, and either extreme would
+    // claim a rank the data does not support.
+    const flat: LinePoint[][] = [
+      [{ x: 'a', y: 5 }, { x: 'b', y: 1 }],
+      [{ x: 'a', y: 5 }, { x: 'b', y: 9 }],
+    ];
+    const { audio } = nonEmptyState(parallel(0, 0, flat));
+
+    expect(audio.freq.min).toBe(5);
+    expect(audio.freq.max).toBe(5);
+  });
+});
+
+describe('braille is a profile across the axes', () => {
+  test('carries each value normalized on its own axis', () => {
+    // Raw values would be scaled row-wise by the line encoder, comparing a
+    // car's economy against its own weight -- so the cell heights would
+    // encode which axis uses bigger numbers.
+    const grid = brailleGrid(parallel());
+
+    // Car A tops the economy axis and bottoms the weight one; car C reverses
+    // both, on axes whose raw numbers differ by two orders of magnitude.
+    expect(grid[0][0]).toBeCloseTo(1);
+    expect(grid[0][2]).toBeCloseTo(0);
+    expect(grid[2][0]).toBeCloseTo(0);
+    expect(grid[2][2]).toBeCloseTo(1);
+  });
+
+  test('scales every row against the same 0 to 1, not its own extent', () => {
+    const { braille } = nonEmptyState(parallel());
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+
+    expect(braille.min).toEqual([0, 0, 0]);
+    expect(braille.max).toEqual([1, 1, 1]);
+  });
+
+  test('one row per observation', () => {
+    expect(brailleGrid(parallel())).toHaveLength(3);
+  });
+});
+
+describe('the description says what the axes are', () => {
+  const read = (label: string): unknown =>
+    parallel().description.stats.find(stat => stat.label === label)?.value;
+
+  test('names the axes in the order the chart draws them', () => {
+    // The order is the author's choice and decides which crossings are
+    // visible at all, so it is part of the chart rather than of the data.
+    expect(read('Axes, in order')).toBe('mpg, hp, weight');
+  });
+
+  test('gives each axis its own range', () => {
+    expect(read('mpg')).toBe('15 to 33');
+    expect(read('hp')).toBe('65 to 230');
+    expect(read('weight')).toBe('1800 to 3200');
+  });
+
+  test('drops the layer-wide min and max, which measure nothing', () => {
+    // Inherited from the line trace, where one range is the chart. Here they
+    // would be the smallest and largest numbers across axes measuring
+    // different quantities -- 15 and 3200, a pair with no referent.
+    const labels = parallel().description.stats.map(stat => stat.label);
+
+    expect(labels).not.toContain('Min value');
+    expect(labels).not.toContain('Max value');
+  });
+
+  test('counts observations and axes, not lines and points', () => {
+    const labels = parallel().description.stats.map(stat => stat.label);
+
+    expect(labels).toContain('Number of observations');
+    expect(labels).toContain('Axes per observation');
+    expect(labels).not.toContain('Number of lines');
+  });
+});
+
+describe('navigation is the multi-line model', () => {
+  test('walks axes across and observations up', () => {
+    const trace = parallel();
+
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe('hp');
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.cross.value).toBe(110);
+  });
+
+  test('announces the axis name and the raw value, not the normalized one', () => {
+    // The pitch carries the position; the announcement has to carry the
+    // number, or the reader is told a rank they cannot act on.
+    const { text } = nonEmptyState(parallel(2, 2));
+
+    expect(text.main.value).toBe('weight');
+    expect(text.cross.value).toBe(3200);
+  });
+});

--- a/test/model/parallel.test.ts
+++ b/test/model/parallel.test.ts
@@ -244,6 +244,76 @@ describe('the description says what the axes are', () => {
   });
 });
 
+describe('one word per referent', () => {
+  test('names a series the way the rest of the chart names it', () => {
+    // The noun is announced beside the series' own name on every move, so
+    // inheriting the line's "Group" would say "Observation 1 of 4, Group is
+    // car A" -- two words for one thing in one sentence.
+    expect(nonEmptyState(parallel()).text.z)
+      .toEqual({ label: 'Observation', value: 'car A' });
+  });
+
+  test('a layer that names its own z axis still wins', () => {
+    // The fallback is a fallback. A producer who said what the series are
+    // called has said it, and the trace does not overrule them.
+    const layer: MaidrLayer = { ...createLayer(), axes: {
+      x: { label: 'Variable' },
+      y: { label: 'Value' },
+      z: { label: 'Model' },
+    } };
+    const trace = TraceFactory.create(layer) as ParallelTrace;
+    trace.moveToIndex(0, 0);
+
+    expect(nonEmptyState(trace).text.z?.label).toBe('Model');
+  });
+});
+
+describe('observations that do not all reach every axis', () => {
+  /** The third car was never measured for weight. */
+  const RAGGED: LinePoint[][] = [
+    [
+      { x: 'mpg', y: 33, z: 'car A' },
+      { x: 'hp', y: 65, z: 'car A' },
+      { x: 'weight', y: 1800, z: 'car A' },
+    ],
+    [
+      { x: 'mpg', y: 21, z: 'car B' },
+      { x: 'hp', y: 110, z: 'car B' },
+      { x: 'weight', y: 3200, z: 'car B' },
+    ],
+    [
+      { x: 'mpg', y: 15, z: 'car C' },
+      { x: 'hp', y: 230, z: 'car C' },
+    ],
+  ];
+
+  test('an axis is scaled by the observations that reached it', () => {
+    // The short row contributes to mpg and hp and not to weight, so weight's
+    // range must come from the two rows that have one.
+    const weight = nonEmptyState(parallel(0, 2, RAGGED)).audio.freq;
+    const economy = nonEmptyState(parallel(0, 0, RAGGED)).audio.freq;
+
+    expect([weight.min, weight.max]).toEqual([1800, 3200]);
+    expect([economy.min, economy.max]).toEqual([15, 33]);
+  });
+
+  test('the axes are named from the longest observation, not the first', () => {
+    // Reading the first row would work here by luck; reading the shortest
+    // would lose an axis a cursor can still reach.
+    const shortestFirst: LinePoint[][] = [RAGGED[2], RAGGED[0], RAGGED[1]];
+    const stats = parallel(0, 0, shortestFirst).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Axes, in order')?.value)
+      .toBe('mpg, hp, weight');
+  });
+
+  test('every axis a cursor can reach still has a range', () => {
+    const stats = parallel(0, 0, RAGGED).description.stats.map(s => s.label);
+
+    expect(stats).toContain('weight');
+  });
+});
+
 describe('navigation is the multi-line model', () => {
   test('walks axes across and observations up', () => {
     const trace = parallel();

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -45,6 +45,9 @@ describe('resolveOrientation', () => {
     TraceType.HEATMAP,
     TraceType.LINE,
     TraceType.NORMALIZED_AREA,
+    // Every column is its own axis, so there is no main and cross axis to
+    // swap -- a horizontal parallel coordinates plot walks the same grid.
+    TraceType.PARALLEL,
     TraceType.PIE,
     // Spokes sit around a circle rather than along an axis, so there is no
     // main and cross axis to swap -- the answer a pie already gives.


### PR DESCRIPTION
Closes #794.

## The cheap part, and the part that is the chart

#794 is right that the data is already the shape MAIDR navigates: an observation per row, an axis per column, which is a multi-line layer. Navigation, text, highlighting and the row/column model all transfer by extending `LineTrace`.

The part that does not transfer is the one that decides whether the chart is readable at all. **The columns are not one scale.** A line chart's columns are samples of one quantity; here they are different quantities entirely — miles per gallon beside horsepower beside kerb weight — and nothing about them is comparable except each value's position within its own axis.

`LineTrace` scales against the **current row's** extent. For a series sampling one quantity that is right. For a row that spans every variable, that extent is the range of a horsepower figure and a fuel-economy figure taken together, which is not a range of anything.

Sonified that way a reader hears the *units*, not the data:

| | mpg | hp | weight |
|---|---|---|---|
| Honda Civic | 33 | 65 | 1800 |
| Muscle Coupe | 15 | 230 | 3200 |

Against one 15-to-3200 range, every economy figure sits at the floor of the register and every weight at the ceiling — so the car with the best economy and the worst power sounds indistinguishable from the car with the worst of both.

Scaled per axis, the pitch says where a value sits **on its own axis**. Arrow along the Civic and it is high, high, low; along the Coupe and it is low, low, high. Those two swapping between `mpg` and `hp` is negative correlation, which a sighted reader sees at a glance and which #794 correctly calls "completely inaudible" today. `crossing lines are audible as a swap in pitch` is the test for it.

## Braille normalizes before the encoder sees it

Same reasoning, one layer down. `LineBrailleEncoder` scales each row against that row's own extent — so raw values here would compare a car's economy against its own kerb weight, and the cell heights would encode which variable happens to use bigger numbers.

So the trace normalizes first, and each cell is its value's position on its own axis:

```
⠉⠉⣀    high economy, high power, low weight
⣀⣀⠉    low economy, low power, high weight
```

Two rows whose heights swap between adjacent cells are the same crossing, available by touch. `docs/BRAILLE.md` carries the argument.

## Two smaller things

**Axis order is announced.** #794 asks for it, and it is a real property of the chart rather than of the data: which variables sit next to each other decides which crossings are visible at all, and that is the author's choice. The description reports `Axes, in order` plus each axis's own range.

**The layer-wide Min and Max are dropped.** Inherited from `LineTrace`, where one range *is* the chart. Here they would be the smallest and largest numbers anywhere across axes measuring different things — `15` and `3200`, a pair with no referent — and the description dialog is precisely where a reader goes to learn what the axes are.

**An axis whose values are all equal** places every value at the midpoint rather than at an end. 0 and 1 both claim an extreme the data does not have.

## Registration

All six sites plus the docs: `grammar.ts` (`TraceType.PARALLEL`, reusing `LinePoint[][]` — no new point shape needed, exactly as #794 predicted), `src/model/parallel.ts`, `factory.ts`, `CHART_TYPE_LABEL`, `IS_ORIENTED` (**false** — every column is its own axis, so there is no main and cross to swap), and the braille encoder map. `describe.ts` also gets the type in its multi-series branch, with `Observation` as the noun, so the position announcement keeps naming which observation is being traced instead of falling through to "column 3 of 4, row 2 of 3".

## Verification

- `npm test` — **2168 + 73 passed**, 167 suites, none failing
- `npx playwright test --project=chromium parallel` — **5 passed**
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_