### PR TITLE
feat(bump): sound first place as first place

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -472,6 +472,33 @@ rank the data does not support.
 Parallel coordinates use one line per observation on a multiline display, so
 several observations' profiles can be compared with one sweep rather than by
 toggling between rows.
+## Bump chart
+
+One row per competitor, one cell per period, each row scaled against its own
+range — the line encoding unchanged.
+
+**The cells rise with the rank number, not with the position.** A row that
+climbs the display is a competitor sliding *down* the table, because rank 1 is
+the best place and the smallest number. That is the opposite of what the pitch
+does, which inverts so first place is the highest note.
+
+The two disagree on purpose, and it is worth knowing which is which. Audio is
+given a direction to invert — the trace hands the service its bounds the other
+way round, and nothing else about the tone changes. Braille is given values,
+and the encoder maps a value to a dot height; inverting those would mean
+emitting `n + 1 - rank` in place of the rank, so the display would carry
+numbers the chart does not contain and every other reading of the same state
+would disagree with it.
+
+So the display stays literal: a low row is a good run, and the announcement and
+the pitch both say so in words and in tone. What braille adds is the *shape* —
+a row that stays flat held its place all season, and two rows that cross swapped
+positions, which is legible by touch whichever way the dots run.
+
+### Multiline Displays
+
+Bump charts use one line per competitor on a multiline display, so a whole
+table's season can be felt at once rather than by toggling between rows.
 
 ## Multiline Braille Display Support
 

--- a/e2e_tests/specs/bump.spec.ts
+++ b/e2e_tests/specs/bump.spec.ts
@@ -1,0 +1,134 @@
+import type { Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/** The example's own page, driven through the shared base helpers. */
+class BumpPlotPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the bump chart example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/bump.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'bump-league');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   * @returns The braille content, whitespace trimmed
+   */
+  public async getBrailleContent(): Promise<string> {
+    const textarea = await this.waitForElement(this.selectors.braille);
+    return (await textarea.inputValue()).trim();
+  }
+}
+
+test.describe('Bump chart', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new BumpPlotPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new BumpPlotPage(page).navigateToPlot();
+  });
+
+  test('should declare the layer as a bump chart', () => {
+    expect(maidrData.subplots[0][0].layers[0].type).toBe('bump');
+  });
+
+  test('should carry one line per competitor over the same rounds', () => {
+    const layer = maidrData.subplots[0][0].layers[0];
+    const teams = layer.data as { x: string; y: number }[][];
+
+    expect(teams).toHaveLength(4);
+    for (const team of teams) {
+      expect(team.map(point => point.x)).toEqual(['R1', 'R2', 'R3', 'R4']);
+    }
+  });
+
+  test('should announce itself as a bump chart rather than a line', async ({ page }) => {
+    const plot = new BumpPlotPage(page);
+    await plot.activateMaidr();
+
+    expect(normalizeText(await plot.getInstructionText())).toContain('bump');
+  });
+
+  test('should announce the places moved alongside the rank', async ({ page }) => {
+    // The overtake is what the chart is drawn for, and it is not recoverable
+    // from hearing a sequence of ranks one at a time.
+    const plot = new BumpPlotPage(page);
+    await plot.activateMaidr();
+    // The first keypress establishes the entry position on R1, which has no
+    // previous round and so reports no move -- the second reaches R2, where
+    // Ash has dropped a place.
+    await plot.moveToNextDataPoint();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('R2');
+    expect(announcement).toContain('Places lost is 1');
+  });
+
+  test('should render one braille row per competitor', async ({ page }) => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    const plot = new BumpPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.toggleBrailleMode();
+
+    const rows = (await plot.getBrailleContent()).split('\n');
+
+    expect(rows).toHaveLength(4);
+    for (const row of rows) {
+      expect(row).toMatch(BRAILLE_CELL);
+      expect(row).toHaveLength(4);
+    }
+  });
+});

--- a/examples/bump.html
+++ b/examples/bump.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Bump Chart Example — League Table by Round</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A rank is not a magnitude. Rank 1 is the best position and the
+        smallest number, so sonified as a magnitude the leader is the lowest
+        note on the chart - a team climbing the table would be heard falling,
+        on every move, with nothing to say the reading was upside down. The
+        pitch is inverted here, so first place is the highest note.
+
+        Ash starts top and finishes bottom while Cyan does the exact reverse,
+        so the inversion is audible on the first two arrow keys. Birch holds
+        second across the last two rounds, which is why "no change" is
+        announced rather than left silent: silence is what the first round
+        says, and the first round has nothing to compare against.
+
+        Alt+Shift+Up/Down reaches the rank-gained and rank-lost rotor units,
+        which jump between the rounds where something actually moved instead
+        of scanning every column.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="bump-league" maidr='{&#10;  &quot;id&quot;: &quot;bump-league&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;bump-league-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;bump-league-layer&quot;,&#10;            &quot;type&quot;: &quot;bump&quot;,&#10;            &quot;title&quot;: &quot;League Table by Round&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Round&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Rank&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;bump-lines&#x27;] &gt; polyline&quot;,&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;R1&quot;,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;z&quot;: &quot;Ash&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R2&quot;,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;z&quot;: &quot;Ash&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R3&quot;,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;z&quot;: &quot;Ash&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R4&quot;,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;z&quot;: &quot;Ash&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;R1&quot;,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;z&quot;: &quot;Birch&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R2&quot;,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;z&quot;: &quot;Birch&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R3&quot;,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;z&quot;: &quot;Birch&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R4&quot;,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;z&quot;: &quot;Birch&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;R1&quot;,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;z&quot;: &quot;Cedar&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R2&quot;,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;z&quot;: &quot;Cedar&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R3&quot;,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;z&quot;: &quot;Cedar&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R4&quot;,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;z&quot;: &quot;Cedar&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;R1&quot;,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;z&quot;: &quot;Cyan&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R2&quot;,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;z&quot;: &quot;Cyan&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R3&quot;,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;z&quot;: &quot;Cyan&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;R4&quot;,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;z&quot;: &quot;Cyan&quot;&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="bump-lines">
+          <polyline points="180,110 340,180 500,250 660,320" fill="none" style="stroke: #4c72b0; stroke-width: 3" />
+          <polyline points="180,180 340,250 500,180 660,180" fill="none" style="stroke: #dd8452; stroke-width: 3" />
+          <polyline points="180,250 340,110 500,320 660,250" fill="none" style="stroke: #55a868; stroke-width: 3" />
+          <polyline points="180,320 340,320 500,110 660,110" fill="none" style="stroke: #c44e52; stroke-width: 3" />
+            </g>
+            <g id="team-labels">
+          <text x="165" y="115" style="font: 13px sans-serif; text-anchor: end">Ash</text>
+          <text x="165" y="185" style="font: 13px sans-serif; text-anchor: end">Birch</text>
+          <text x="165" y="255" style="font: 13px sans-serif; text-anchor: end">Cedar</text>
+          <text x="165" y="325" style="font: 13px sans-serif; text-anchor: end">Cyan</text>
+            </g>
+            <g id="axis_x">
+          <text x="180" y="380" style="font: 13px sans-serif; text-anchor: middle">R1</text>
+          <text x="340" y="380" style="font: 13px sans-serif; text-anchor: middle">R2</text>
+          <text x="500" y="380" style="font: 13px sans-serif; text-anchor: middle">R3</text>
+          <text x="660" y="380" style="font: 13px sans-serif; text-anchor: middle">R4</text>
+              <text x="420" y="410" style="font: 13px sans-serif; text-anchor: middle">Round</text>
+            </g>
+            <g id="axis_y">
+          <text x="700" y="115" style="font: 12px sans-serif; text-anchor: start">1</text>
+          <text x="700" y="185" style="font: 12px sans-serif; text-anchor: start">2</text>
+          <text x="700" y="255" style="font: 12px sans-serif; text-anchor: start">3</text>
+          <text x="700" y="325" style="font: 12px sans-serif; text-anchor: start">4</text>
+            </g>
+            <g id="chart-title">
+              <text x="420" y="60" style="font: 16px sans-serif; text-anchor: middle">League Table by Round</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -699,7 +699,8 @@ export class AnnouncePositionCommand extends AnnounceCommand {
         || traceType === TraceType.STEP
         || traceType === TraceType.RADAR
         || traceType === TraceType.POLAR_AREA
-        || traceType === TraceType.PARALLEL)
+        || traceType === TraceType.PARALLEL
+        || traceType === TraceType.BUMP)
       && state.groupCount
       && state.groupCount > 1
     ) {
@@ -719,7 +720,9 @@ export class AnnouncePositionCommand extends AnnounceCommand {
         // reader needs to know which outline they are tracing.
         traceType === TraceType.LINE
           ? 'Line'
-          : traceType === TraceType.PARALLEL ? 'Observation' : 'Series',
+          : traceType === TraceType.PARALLEL
+            ? 'Observation'
+            : traceType === TraceType.BUMP ? 'Competitor' : 'Series',
       );
     } else if (traceType === TraceType.SCATTER) {
       // Scatter plot: use x/y for column/row position, but don't include 'Position' as it sounds weird

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -56,6 +56,7 @@ export function named(label: string | undefined, fallback: string): string {
 const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.AREA]: 'Area Chart',
   [TraceType.BAR]: 'Bar Chart',
+  [TraceType.BUMP]: 'Bump Chart',
   [TraceType.BOX]: 'Box Plot',
   [TraceType.CANDLESTICK]: 'Candlestick Chart',
   [TraceType.CANDLESTICK_DELTA]: 'Candlestick Reference Delta',

--- a/src/model/bump.ts
+++ b/src/model/bump.ts
@@ -1,6 +1,7 @@
 import type { RotorFilterUnit } from '@model/abstract';
 import type { MaidrLayer } from '@type/grammar';
 import type { AudioState, DescriptionState, TextState, TraceState } from '@type/state';
+import { MathUtil } from '@util/math';
 import { LineTrace } from './line';
 
 /**
@@ -61,6 +62,12 @@ export class BumpTrace extends LineTrace {
    */
   private readonly moves: (number | undefined)[][];
 
+  /** How many periods the longest competitor runs to. */
+  private readonly periods: number;
+
+  /** Cached rotor units; see the constructor for why they are precomputed. */
+  private readonly rotorUnits: readonly RotorFilterUnit[];
+
   /**
    * Creates a new bump trace.
    *
@@ -69,13 +76,33 @@ export class BumpTrace extends LineTrace {
   public constructor(layer: MaidrLayer) {
     super(layer);
 
-    const ranks = this.lineValues.flat();
-    this.bestRank = ranks.length > 0 ? Math.min(...ranks) : 1;
-    this.worstRank = ranks.length > 0 ? Math.max(...ranks) : 1;
+    // `MathUtil` rather than a spread into `Math.min`: the same helpers
+    // `LineTrace` uses per row, without the call-stack limit a spread carries
+    // on a large table and with one answer for an empty chart.
+    this.bestRank = MathUtil.minFrom2D(this.lineValues);
+    this.worstRank = MathUtil.maxFrom2D(this.lineValues);
+
+    // The longest competitor, not row 0's. A table where one competitor
+    // joined late is ragged, and reading row 0's length would take some other
+    // row's *middle* period for its last one -- reporting the wrong finisher
+    // and the wrong net move, quietly, since the comparison just fails rather
+    // than erroring.
+    this.periods = this.lineValues.reduce(
+      (longest, row) => Math.max(longest, row.length),
+      0,
+    );
 
     this.moves = this.lineValues.map(row =>
       row.map((rank, column) =>
         (column === 0 ? undefined : row[column - 1] - rank)));
+
+    // Precomputed, as `Candlestick` precomputes its trend units and for the
+    // same reason: the ranks are fixed at construction and the rotor service
+    // asks for this twice per keystroke.
+    this.rotorUnits = this.moves.some(row =>
+      row.some(move => move !== undefined && move !== 0))
+      ? RANK_ROTOR_UNITS
+      : [];
   }
 
   protected override get audio(): AudioState {
@@ -164,10 +191,9 @@ export class BumpTrace extends LineTrace {
       return best === null ? null : this.groupNameAt(best);
     };
 
-    const periods = this.lineValues[0]?.length ?? 0;
-    if (periods > 0) {
+    if (this.periods > 0) {
       const first = leaderAt(0);
-      const last = leaderAt(periods - 1);
+      const last = leaderAt(this.periods - 1);
       if (first !== null) {
         stats.push({ label: 'Led at the start', value: first });
       }
@@ -217,14 +243,16 @@ export class BumpTrace extends LineTrace {
   private extremeMover(
     direction: 'up' | 'down',
   ): { row: number; places: number } | null {
-    const periods = this.lineValues[0]?.length ?? 0;
-    if (this.lineValues.length === 0 || periods < 2) {
+    if (this.lineValues.length === 0 || this.periods < 2) {
       return null;
     }
 
     let best: { row: number; places: number } | null = null;
     for (const [row, ranks] of this.lineValues.entries()) {
-      const places = ranks[0] - ranks[periods - 1];
+      // A competitor's own last period, not the table's. One that joined late
+      // or dropped out has a shorter row, and reading past its end would
+      // compare its start against nothing.
+      const places = ranks[0] - ranks[ranks.length - 1];
       const moved = direction === 'up' ? places > 0 : places < 0;
       if (!moved) {
         continue;
@@ -255,9 +283,7 @@ export class BumpTrace extends LineTrace {
    * @returns The rank-change rotor units, or none
    */
   public override getRotorFilterUnits(): readonly RotorFilterUnit[] {
-    const hasMove = this.moves.some(row =>
-      row.some(move => move !== undefined && move !== 0));
-    return hasMove ? RANK_ROTOR_UNITS : [];
+    return this.rotorUnits;
   }
 
   /**

--- a/src/model/bump.ts
+++ b/src/model/bump.ts
@@ -1,0 +1,292 @@
+import type { RotorFilterUnit } from '@model/abstract';
+import type { MaidrLayer } from '@type/grammar';
+import type { AudioState, DescriptionState, TextState, TraceState } from '@type/state';
+import { LineTrace } from './line';
+
+/**
+ * Rotor units for jumping between the periods where a rank actually moved.
+ *
+ * A bump chart is read for its overtakes, and they are sparse: a twelve-team
+ * table over a season is mostly periods where nothing changed, so a reader
+ * scanning every column to find the three that matter spends the navigation on
+ * the uninteresting part. These are the candlestick's bullish/bearish filters
+ * applied to the event this chart is drawn for.
+ */
+const RANK_ROTOR_UNITS: readonly RotorFilterUnit[] = [
+  { key: 'gained', label: 'Rank gained', noun: 'rank gain' },
+  { key: 'lost', label: 'Rank lost', noun: 'rank loss' },
+];
+
+/**
+ * Trace implementation for bump charts -- rank over time, one line per
+ * competitor.
+ *
+ * Structurally a multi-line layer, so navigation, braille and highlighting
+ * transfer. What is different is that **the y axis is a rank**, and a rank is
+ * not a magnitude: it is inverted, bounded by the number of competitors, and
+ * meaningful only relative to the others in the same period.
+ *
+ * Two consequences, and both are the difference between a readable chart and a
+ * misleading one.
+ *
+ * **The pitch is inverted.** Rank 1 is the best position and the smallest
+ * number, so sonifying it as a magnitude makes the leader sound like the
+ * loser: a team climbing the table would be heard falling, on every move, with
+ * nothing to say the reading was upside down. The bounds are handed to the
+ * audio service the other way round, so first place is the highest note.
+ *
+ * **The change travels with the position.** What a reader wants from a bump
+ * chart is who overtook whom, and that is not recoverable from hearing a
+ * sequence of ranks one at a time -- it means holding the previous period's
+ * number while navigating to the next and subtracting by ear, for every
+ * competitor. So each point announces the places gained or lost alongside the
+ * rank, and the rotor can jump between the periods where something moved.
+ *
+ * A *slope graph* of values is not this: two points per series on a value axis
+ * is a line layer with two samples, which the line trace already reads
+ * correctly. What makes this a type of its own is the rank.
+ */
+export class BumpTrace extends LineTrace {
+  /** Best (numerically smallest) and worst rank anywhere in the chart. */
+  private readonly bestRank: number;
+  private readonly worstRank: number;
+
+  /**
+   * Places gained since the previous period, per competitor per period.
+   *
+   * Positive is an improvement -- a move towards rank 1 -- so the sign reads
+   * the way a reader means it rather than the way the numbers subtract.
+   * `undefined` in the first period, which has nothing to compare against and
+   * must not be reported as "no change".
+   */
+  private readonly moves: (number | undefined)[][];
+
+  /**
+   * Creates a new bump trace.
+   *
+   * @param layer - The MAIDR layer carrying the ranks
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    const ranks = this.lineValues.flat();
+    this.bestRank = ranks.length > 0 ? Math.min(...ranks) : 1;
+    this.worstRank = ranks.length > 0 ? Math.max(...ranks) : 1;
+
+    this.moves = this.lineValues.map(row =>
+      row.map((rank, column) =>
+        (column === 0 ? undefined : row[column - 1] - rank)));
+  }
+
+  protected override get audio(): AudioState {
+    const base = super.audio;
+
+    // Handed to the service the other way round, so `interpolate` maps the
+    // best rank to the top of the register. `LineTrace` would give the leader
+    // the lowest note it has, which is the reading a reader would have to
+    // consciously invert on every single move.
+    //
+    // Scaled across the whole chart rather than per row: every competitor is
+    // ranked in the same table, so their positions are comparable, and
+    // per-row bounds would make each competitor's own best period the highest
+    // note whether that was first place or eleventh.
+    return {
+      ...base,
+      freq: { ...base.freq, min: this.worstRank, max: this.bestRank },
+    };
+  }
+
+  protected override get text(): TextState {
+    const base = super.text;
+    const move = this.moves[this.row]?.[this.col];
+
+    if (move === undefined) {
+      // The first period has nothing to compare against. Saying "no change"
+      // would report a stability the chart does not claim.
+      return base;
+    }
+
+    // Named by direction rather than signed, for the reason the dumbbell
+    // gives: "Places gained is 2" needs no interpretation, while "-2" asks
+    // the reader to hear a minus sign and work out which way it points --
+    // on a rank axis, where the arithmetic already runs backwards.
+    return {
+      ...base,
+      stack: {
+        label: move > 0 ? 'Places gained' : move < 0 ? 'Places lost' : 'Change',
+        value: Math.abs(move),
+      },
+    };
+  }
+
+  protected override get seriesLabels(): {
+    count: string;
+    perSeries: string;
+    names: string;
+    column: string;
+  } {
+    return {
+      count: 'Number of competitors',
+      perSeries: 'Periods',
+      names: 'Competitor names',
+      column: 'Competitor',
+    };
+  }
+
+  public override get description(): DescriptionState {
+    const base = super.description;
+
+    // `LineTrace` reports Min value and Max value, which on a rank axis are
+    // "somebody came first" and "somebody came last" -- true of every bump
+    // chart ever drawn, and so worth nothing.
+    const stats = base.stats.filter(
+      stat => stat.label !== 'Min value' && stat.label !== 'Max value',
+    );
+
+    const leaderAt = (column: number): string | null => {
+      let best: number | null = null;
+      for (const [row, ranks] of this.lineValues.entries()) {
+        const rank = ranks[column];
+        if (rank === undefined) {
+          continue;
+        }
+        if (best === null || rank < this.lineValues[best][column]) {
+          best = row;
+        }
+      }
+      return best === null ? null : this.groupNameAt(best);
+    };
+
+    const periods = this.lineValues[0]?.length ?? 0;
+    if (periods > 0) {
+      const first = leaderAt(0);
+      const last = leaderAt(periods - 1);
+      if (first !== null) {
+        stats.push({ label: 'Led at the start', value: first });
+      }
+      if (last !== null) {
+        stats.push({ label: 'Led at the end', value: last });
+      }
+    }
+
+    // Both directions, not the larger of the two. They are different
+    // findings -- who came up and who went down -- and a chart whose biggest
+    // climb and biggest fall are the same size is the ordinary case rather
+    // than a rare one, since ranks are a permutation: somebody's gain is
+    // somebody else's loss. Reporting the winner of that tie would drop one
+    // of the two facts on exactly the charts where both are most obviously
+    // present.
+    const climber = this.extremeMover('up');
+    const faller = this.extremeMover('down');
+    if (climber !== null) {
+      stats.push({
+        label: 'Climbed furthest',
+        value: `${this.groupNameAt(climber.row)}, ${climber.places}`,
+      });
+    }
+    if (faller !== null) {
+      stats.push({
+        label: 'Fell furthest',
+        value: `${this.groupNameAt(faller.row)}, ${-faller.places}`,
+      });
+    }
+
+    return { ...base, stats };
+  }
+
+  /**
+   * The competitor who moved furthest in one direction over the whole chart.
+   *
+   * Answers null when nobody moved that way, rather than naming whoever moved
+   * least: "climbed furthest: Ash, 0 places" reports a rise on a chart where
+   * every rank fell.
+   *
+   * Ties take the first, as {@link DumbbellTrace} does -- somebody has to be
+   * named, and the earlier row is at least stable across renders.
+   *
+   * @param direction - Whether to find the biggest climb or the biggest fall
+   * @returns The row and its net places gained (negative for a fall), or null
+   */
+  private extremeMover(
+    direction: 'up' | 'down',
+  ): { row: number; places: number } | null {
+    const periods = this.lineValues[0]?.length ?? 0;
+    if (this.lineValues.length === 0 || periods < 2) {
+      return null;
+    }
+
+    let best: { row: number; places: number } | null = null;
+    for (const [row, ranks] of this.lineValues.entries()) {
+      const places = ranks[0] - ranks[periods - 1];
+      const moved = direction === 'up' ? places > 0 : places < 0;
+      if (!moved) {
+        continue;
+      }
+      if (best === null || Math.abs(places) > Math.abs(best.places)) {
+        best = { row, places };
+      }
+    }
+    return best;
+  }
+
+  public override get state(): TraceState {
+    const base = super.state;
+    if (base.empty) {
+      return base;
+    }
+
+    return { ...base, plotType: 'bump' };
+  }
+
+  /**
+   * Offers the two rank-change filters, when the chart has anything to filter.
+   *
+   * A chart with one period holds no moves at all, and offering a rotor unit
+   * that can never find anything is worse than not offering it: the reader
+   * cycles onto a mode whose only possible answer is "none found".
+   *
+   * @returns The rank-change rotor units, or none
+   */
+  public override getRotorFilterUnits(): readonly RotorFilterUnit[] {
+    const hasMove = this.moves.some(row =>
+      row.some(move => move !== undefined && move !== 0));
+    return hasMove ? RANK_ROTOR_UNITS : [];
+  }
+
+  /**
+   * Jumps to the next period where this competitor gained or lost places.
+   *
+   * Filtering runs along the period axis within the current competitor, which
+   * is the question the filter answers -- "when did *this* team move?" The
+   * rotor service handles up/down itself and only dispatches left/right here.
+   *
+   * @param key - Which direction of move to find ('gained' or 'lost')
+   * @param direction - Which way along the periods to search
+   * @returns True if a matching period was found and moved to
+   */
+  public override moveToRotorFilter(
+    key: string,
+    direction: 'left' | 'right',
+  ): boolean {
+    const row = this.moves[this.row];
+    if (row === undefined) {
+      this.notifyRotorBounds();
+      return false;
+    }
+
+    const step = direction === 'right' ? 1 : -1;
+    for (let col = this.col + step; col >= 0 && col < row.length; col += step) {
+      const move = row[col];
+      if (move === undefined || move === 0) {
+        continue;
+      }
+      if ((key === 'gained' && move > 0) || (key === 'lost' && move < 0)) {
+        this.moveToIndex(this.row, col);
+        return true;
+      }
+    }
+
+    this.notifyRotorBounds();
+    return false;
+  }
+}

--- a/src/model/bump.ts
+++ b/src/model/bump.ts
@@ -119,6 +119,13 @@ export class BumpTrace extends LineTrace {
     };
   }
 
+  protected override get groupFallbackLabel(): string {
+    // Announced beside the competitor's own name on every move, so inheriting
+    // the line's "Group" puts two words for one referent in one sentence --
+    // "Competitor 1 of 4, Group is Ash".
+    return 'Competitor';
+  }
+
   protected override get seriesLabels(): {
     count: string;
     perSeries: string;

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -4,6 +4,7 @@ import { TraceType } from '@type/grammar';
 import { AreaTrace } from './area';
 import { BarTrace } from './bar';
 import { BoxTrace } from './box';
+import { BumpTrace } from './bump';
 import { Candlestick } from './candlestick';
 import { DumbbellTrace } from './dumbbell';
 import { ErrorBarTrace } from './errorBar';
@@ -49,6 +50,9 @@ export abstract class TraceFactory {
 
       case TraceType.BOX:
         return new BoxTrace(layer);
+
+      case TraceType.BUMP:
+        return new BumpTrace(layer);
 
       case TraceType.CANDLESTICK:
         return new Candlestick(layer);

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -127,9 +127,10 @@ export class LineTrace extends AbstractTrace {
    *
    * Overridable for the reason {@link LineTrace.seriesLabels} is: a subclass
    * navigates the same grid but draws something else, and this label is
-   * announced literally beside the series' own name. A parallel coordinates
-   * plot that named its own noun everywhere else and then said "Group is
-   * Honda Civic" would use two words for one referent in a single sentence.
+   * announced literally beside the series' own name. A chart that named its
+   * own noun everywhere else and then said "Group is Honda Civic" -- or
+   * "Group is Ash" -- would use two words for one referent in a single
+   * sentence.
    *
    * @returns The fallback label
    */

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -152,8 +152,14 @@ export class LineTrace extends AbstractTrace {
   /**
    * Human-readable name of a single line: the authored name when the spec
    * provides one, otherwise a positional fallback ("Line 2").
+   *
+   * Protected rather than private because a subclass naming a series in its
+   * own description -- which competitor led, which observation is an outlier
+   * -- has to name it the way every other announcement does, and reaching for
+   * `points[row][0].z` directly would skip the fallback and report
+   * `undefined` for an unnamed series.
    */
-  private groupNameAt(row: number): string {
+  protected groupNameAt(row: number): string {
     return this.authoredGroupNameAt(row) ?? `Line ${row + 1}`;
   }
 

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1105,6 +1105,13 @@ implements Observer<SubplotState | TraceState>, Disposable {
       [TraceType.STACKED_AREA, asGeneric(new LineBrailleEncoder())],
       [TraceType.BAR, asGeneric(new BarBrailleEncoder())],
       [TraceType.BOX, asGeneric(new BoxBrailleEncoder())],
+      // A bump chart's rows are competitors and its columns periods, which is
+      // the line encoder's input exactly. The cells rise with the rank NUMBER
+      // rather than with the position, so a table-topping run reads as a low
+      // row -- the inversion the pitch applies has no equivalent here, since
+      // the encoder is handed values and not a direction. `docs/BRAILLE.md`
+      // says so, because a reader cannot tell from the dots alone.
+      [TraceType.BUMP, asGeneric(new LineBrailleEncoder())],
       [TraceType.CANDLESTICK, asGeneric(new CandlestickBrailleEncoder())],
       // The virtual delta layer reuses the candlestick encoding: height maps
       // |delta| and the 'Bear' trend adds dot 8 for below-line points.

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -878,6 +878,18 @@ export enum TraceType {
    */
   AREA = 'area',
   BAR = 'bar',
+  /**
+   * Rank over time, one line per competitor -- a bump chart. Navigated as a
+   * multi-line layer, with the one difference that decides whether it reads
+   * correctly: the y axis is a *rank*, so rank 1 is the best position and the
+   * smallest number, and the pitch is inverted to match. Each point announces
+   * the places gained or lost alongside the rank, since the overtake is what
+   * the chart is drawn for.
+   *
+   * A slope graph of *values* is a {@link TraceType.LINE} layer with two
+   * samples, not this.
+   */
+  BUMP = 'bump',
   BOX = 'box',
   CANDLESTICK = 'candlestick',
   /**

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -29,6 +29,10 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // Built at runtime from a candlestick and a reference line, never declared
   // in the JSON; it is navigated by field and candle, not by an orientation.
   [TraceType.CANDLESTICK_DELTA]: false,
+  // Competitors are the rows and periods the columns whichever way the chart
+  // is drawn, so there is no main and cross axis to swap -- the answer a line
+  // already gives.
+  [TraceType.BUMP]: false,
   [TraceType.DODGED]: true,
   // The interval runs along the value axis and the samples along the other,
   // so which way round they are drawn decides which axis a bound moves on --

--- a/test/model/bump.test.ts
+++ b/test/model/bump.test.ts
@@ -106,6 +106,26 @@ describe('bump registration', () => {
   });
 });
 
+describe('one word per referent', () => {
+  test('names a competitor the way the rest of the chart names it', () => {
+    // The noun is announced beside the competitor's own name on every move,
+    // so inheriting the line's "Group" would say "Competitor 1 of 4, Group is
+    // Ash" -- two words for one thing in one sentence.
+    expect(nonEmptyState(bump()).text.z)
+      .toEqual({ label: 'Competitor', value: 'Ash' });
+  });
+
+  test('a layer that names its own z axis still wins', () => {
+    const trace = TraceFactory.create({
+      ...createLayer(),
+      axes: { x: { label: 'Round' }, y: { label: 'Rank' }, z: { label: 'Team' } },
+    }) as BumpTrace;
+    trace.moveToIndex(0, 0);
+
+    expect(nonEmptyState(trace).text.z?.label).toBe('Team');
+  });
+});
+
 describe('first place is the highest note', () => {
   test('the pitch runs opposite to the rank number', () => {
     // Rank 1 is the best position and the smallest number. Sonified as a

--- a/test/model/bump.test.ts
+++ b/test/model/bump.test.ts
@@ -238,6 +238,57 @@ describe('the rotor jumps between overtakes', () => {
   });
 });
 
+describe('a table where a competitor joined late or dropped out', () => {
+  /**
+   * Row 0 is the SHORT one, on purpose, and the answers genuinely differ.
+   *
+   * Reading the table's period count off row 0 takes R2 for the last round.
+   * At R2 Birch leads and has gained a place; at the real last round, R4,
+   * Cedar leads and Birch has gone backwards. So both the finisher and the
+   * biggest climber come out wrong -- quietly, since the comparison against a
+   * missing column just fails rather than erroring.
+   */
+  const RAGGED: LinePoint[][] = [
+    [
+      { x: 'R1', y: 1, z: 'Ash' },
+      { x: 'R2', y: 3, z: 'Ash' },
+    ],
+    [
+      { x: 'R1', y: 2, z: 'Birch' },
+      { x: 'R2', y: 1, z: 'Birch' },
+      { x: 'R3', y: 2, z: 'Birch' },
+      { x: 'R4', y: 3, z: 'Birch' },
+    ],
+    [
+      { x: 'R1', y: 3, z: 'Cedar' },
+      { x: 'R2', y: 2, z: 'Cedar' },
+      { x: 'R3', y: 1, z: 'Cedar' },
+      { x: 'R4', y: 1, z: 'Cedar' },
+    ],
+  ];
+
+  const read = (label: string): unknown =>
+    bump(0, 0, RAGGED).description.stats.find(stat => stat.label === label)?.value;
+
+  test('the last period is the table\'s longest, not row zero\'s', () => {
+    // Cedar leads at R4. Off row 0's length the leader is read at R2, where
+    // Birch led.
+    expect(read('Led at the end')).toBe('Cedar');
+  });
+
+  test('a net move is measured against a competitor\'s own last round', () => {
+    // Cedar goes 3rd to 1st over four rounds. Measured to R2 it has gained
+    // one place and Birch also one, so the tie would name Birch instead.
+    expect(read('Climbed furthest')).toBe('Cedar, 2');
+  });
+
+  test('a competitor who ran fewer rounds is measured over the rounds it ran', () => {
+    // Ash ran two and fell two places. Reading past the end of its row would
+    // compare its start against nothing.
+    expect(read('Fell furthest')).toBe('Ash, 2');
+  });
+});
+
 describe('the description says who moved', () => {
   const read = (label: string): unknown =>
     bump().description.stats.find(stat => stat.label === label)?.value;

--- a/test/model/bump.test.ts
+++ b/test/model/bump.test.ts
@@ -1,0 +1,269 @@
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { BumpTrace } from '@model/bump';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Four teams over four rounds.
+ *
+ * Ash starts first and finishes last while Cyan does the reverse, so a reading
+ * that lost the inversion cannot coincide with the right answer. Birch holds
+ * second throughout, which is the case a "no change" report has to distinguish
+ * from the first round's absence of one.
+ */
+const TABLE: LinePoint[][] = [
+  [
+    { x: 'R1', y: 1, z: 'Ash' },
+    { x: 'R2', y: 2, z: 'Ash' },
+    { x: 'R3', y: 3, z: 'Ash' },
+    { x: 'R4', y: 4, z: 'Ash' },
+  ],
+  [
+    { x: 'R1', y: 2, z: 'Birch' },
+    { x: 'R2', y: 3, z: 'Birch' },
+    { x: 'R3', y: 2, z: 'Birch' },
+    { x: 'R4', y: 2, z: 'Birch' },
+  ],
+  [
+    { x: 'R1', y: 3, z: 'Cedar' },
+    { x: 'R2', y: 1, z: 'Cedar' },
+    { x: 'R3', y: 4, z: 'Cedar' },
+    { x: 'R4', y: 3, z: 'Cedar' },
+  ],
+  [
+    { x: 'R1', y: 4, z: 'Cyan' },
+    { x: 'R2', y: 4, z: 'Cyan' },
+    { x: 'R3', y: 1, z: 'Cyan' },
+    { x: 'R4', y: 1, z: 'Cyan' },
+  ],
+];
+
+/**
+ * Create a minimal bump layer for model-only tests.
+ * @param data The competitors the layer carries
+ * @returns Bump layer definition
+ */
+function createLayer(data: LinePoint[][] = TABLE): MaidrLayer {
+  return {
+    id: 'test-bump-layer',
+    type: TraceType.BUMP,
+    title: 'League table',
+    axes: { x: { label: 'Round' }, y: { label: 'Rank' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: BumpTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a bump trace positioned on one round of one competitor.
+ * @param row Which competitor
+ * @param col Which round
+ * @param data The competitors the layer carries
+ * @returns The positioned trace
+ */
+function bump(row = 0, col = 0, data: LinePoint[][] = TABLE): BumpTrace {
+  const trace = TraceFactory.create(createLayer(data)) as BumpTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+/**
+ * The pitch the audio service will compute, from 0 (lowest) to 1 (highest).
+ *
+ * The service interpolates `raw` between `min` and `max`, and this chart hands
+ * it those the other way round -- so asserting on `raw` alone would pass for a
+ * trace that had not inverted anything.
+ * @param state The trace state to read
+ * @returns The relative pitch
+ */
+function pitch(state: NonEmptyTraceState): number {
+  const { min, max, raw } = state.audio.freq;
+  return (Number(raw) - min) / (max - min);
+}
+
+describe('bump registration', () => {
+  test('the factory builds a BumpTrace', () => {
+    expect(TraceFactory.create(createLayer())).toBeInstanceOf(BumpTrace);
+  });
+
+  test('announces itself as the chart it is', () => {
+    expect(bump().description.chartType).toBe('Bump Chart');
+    expect(nonEmptyState(bump()).plotType).toBe('bump');
+  });
+});
+
+describe('first place is the highest note', () => {
+  test('the pitch runs opposite to the rank number', () => {
+    // Rank 1 is the best position and the smallest number. Sonified as a
+    // magnitude, the leader would be the lowest note in the chart.
+    expect(pitch(nonEmptyState(bump(0, 0)))).toBeCloseTo(1);
+    expect(pitch(nonEmptyState(bump(3, 0)))).toBeCloseTo(0);
+  });
+
+  test('the bounds are handed over inverted', () => {
+    const { freq } = nonEmptyState(bump(0, 0)).audio;
+
+    expect(freq.min).toBe(4);
+    expect(freq.max).toBe(1);
+    expect(freq.raw).toBe(1);
+  });
+
+  test('a competitor falling down the table falls in pitch', () => {
+    // Ash goes 1st, 2nd, 3rd, 4th. Every step has to sound like a step down.
+    const rounds = [0, 1, 2, 3].map(col => pitch(nonEmptyState(bump(0, col))));
+
+    for (let i = 1; i < rounds.length; i++) {
+      expect(rounds[i]).toBeLessThan(rounds[i - 1]);
+    }
+  });
+
+  test('every competitor is scaled against the same table', () => {
+    // Per-row bounds would make each competitor's own best round the highest
+    // note, whether that was first place or fourth.
+    const ash = nonEmptyState(bump(0, 0)).audio.freq;
+    const cyan = nonEmptyState(bump(3, 0)).audio.freq;
+
+    expect([ash.min, ash.max]).toEqual([cyan.min, cyan.max]);
+  });
+});
+
+describe('the move travels with the rank', () => {
+  test('a gain is named a gain rather than signed', () => {
+    // Cedar goes 3rd to 1st between R1 and R2.
+    const { text } = nonEmptyState(bump(2, 1));
+
+    expect(text.cross.value).toBe(1);
+    expect(text.stack).toEqual({ label: 'Places gained', value: 2 });
+  });
+
+  test('a loss is named a loss', () => {
+    // Cedar goes 1st to 4th between R2 and R3.
+    expect(nonEmptyState(bump(2, 2)).text.stack)
+      .toEqual({ label: 'Places lost', value: 3 });
+  });
+
+  test('holding a position reports no change rather than staying silent', () => {
+    // Birch holds 2nd between R3 and R4. Silence here is indistinguishable
+    // from the first round, which has nothing to compare against at all.
+    expect(nonEmptyState(bump(1, 3)).text.stack)
+      .toEqual({ label: 'Change', value: 0 });
+  });
+
+  test('the first period reports no move, because there is none to report', () => {
+    // Saying "no change" would claim a stability the chart does not.
+    expect(nonEmptyState(bump(0, 0)).text.stack).toBeUndefined();
+  });
+});
+
+describe('the rotor jumps between overtakes', () => {
+  test('offers a gained and a lost unit', () => {
+    expect(bump().getRotorFilterUnits().map(unit => unit.key))
+      .toEqual(['gained', 'lost']);
+  });
+
+  test('offers nothing on a chart where no rank ever moved', () => {
+    // Cycling onto a mode whose only possible answer is "none found" is worse
+    // than not offering it.
+    const frozen: LinePoint[][] = [
+      [{ x: 'R1', y: 1 }, { x: 'R2', y: 1 }],
+      [{ x: 'R1', y: 2 }, { x: 'R2', y: 2 }],
+    ];
+
+    expect(bump(0, 0, frozen).getRotorFilterUnits()).toEqual([]);
+  });
+
+  test('skips the rounds where this competitor held its place', () => {
+    // Cyan holds 4th into R2, then gains 3 into R3. From R1 the next gain is
+    // R3, not R2.
+    const trace = bump(3, 0);
+
+    expect(trace.moveToRotorFilter('gained', 'right')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe('R3');
+  });
+
+  test('finds nothing past the last move and reports the bound', () => {
+    const trace = bump(3, 3);
+
+    expect(trace.moveToRotorFilter('gained', 'right')).toBe(false);
+  });
+
+  test('a loss filter does not stop on a gain', () => {
+    // Cedar gains into R2 and loses into R3. Asked for a loss from R1, it has
+    // to pass over the gain.
+    const trace = bump(2, 0);
+
+    expect(trace.moveToRotorFilter('lost', 'right')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe('R3');
+  });
+
+  test('searches backwards too', () => {
+    const trace = bump(0, 3);
+
+    expect(trace.moveToRotorFilter('lost', 'left')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe('R3');
+  });
+});
+
+describe('the description says who moved', () => {
+  const read = (label: string): unknown =>
+    bump().description.stats.find(stat => stat.label === label)?.value;
+
+  test('names the leader at each end', () => {
+    expect(read('Led at the start')).toBe('Ash');
+    expect(read('Led at the end')).toBe('Cyan');
+  });
+
+  test('names the biggest climb and the biggest fall separately', () => {
+    // Cyan goes 4th to 1st and Ash goes 1st to 4th, so the two are the same
+    // size -- which is the ordinary case, since ranks are a permutation and
+    // somebody's gain is somebody else's loss. Reporting only the larger
+    // would silently drop one of the two findings on exactly those charts.
+    expect(read('Climbed furthest')).toBe('Cyan, 3');
+    expect(read('Fell furthest')).toBe('Ash, 3');
+  });
+
+  test('reports no climb on a chart where every rank fell or held', () => {
+    // Naming whoever moved least would announce a rise the chart does not
+    // contain.
+    const sinking: LinePoint[][] = [
+      [{ x: 'R1', y: 1, z: 'Ash' }, { x: 'R2', y: 2, z: 'Ash' }],
+      [{ x: 'R1', y: 2, z: 'Birch' }, { x: 'R2', y: 2, z: 'Birch' }],
+    ];
+    const stats = bump(0, 0, sinking).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Climbed furthest')).toBeUndefined();
+    expect(stats.find(stat => stat.label === 'Fell furthest')?.value)
+      .toBe('Ash, 1');
+  });
+
+  test('drops the layer-wide min and max, which say nothing on a rank axis', () => {
+    // "Somebody came first and somebody came last" is true of every bump
+    // chart ever drawn.
+    const labels = bump().description.stats.map(stat => stat.label);
+
+    expect(labels).not.toContain('Min value');
+    expect(labels).not.toContain('Max value');
+  });
+
+  test('counts competitors and periods, not lines and points', () => {
+    const labels = bump().description.stats.map(stat => stat.label);
+
+    expect(labels).toContain('Number of competitors');
+    expect(labels).toContain('Periods');
+    expect(labels).not.toContain('Number of lines');
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -39,6 +39,9 @@ describe('resolveOrientation', () => {
     // An area trace is navigated along its series and then between series,
     // exactly as a line is, whichever way the band is drawn.
     TraceType.AREA,
+    // Competitors are the rows and periods the columns whichever way the
+    // chart is drawn -- the answer a line already gives.
+    TraceType.BUMP,
     TraceType.CANDLESTICK_DELTA,
     // One measure on a dial: no second axis to swap with.
     TraceType.GAUGE,


### PR DESCRIPTION
Closes #795.

## A rank is not a magnitude

Structurally a bump chart is a multi-line layer, so navigation, braille and highlighting transfer by extending `LineTrace`. The y axis is what makes it a type of its own: **rank 1 is the best position and the smallest number.**

Sonified as a magnitude, the leader is the lowest note on the chart. A team climbing the table is heard *falling*, on every move, with nothing anywhere in the output to say the reading is upside down — which is exactly the "actively misleading" case #795 names. The bounds go to the audio service the other way round (`min: worstRank, max: bestRank`), so `MathUtil.interpolate` maps first place to the top of the register.

Scaled across the whole table rather than per row, too. Every competitor is ranked in the same table, so their positions are comparable — and `LineTrace`'s per-row bounds would make each competitor's own best round the highest note whether that was first place or eleventh.

## The overtake travels with the position

What a reader wants from a bump chart is who overtook whom, and that is not recoverable from hearing a sequence of ranks one at a time: it means holding the previous period's number while navigating to the next and subtracting by ear, for every competitor.

So each point announces the move alongside the rank, named by direction rather than signed — the dumbbell's argument, which applies with extra force on an axis where the arithmetic already runs backwards:

| situation | announced |
|---|---|
| 3rd → 1st | `Places gained is 2` |
| 1st → 4th | `Places lost is 3` |
| held 2nd | `Change is 0` |
| first period | *nothing* |

The last two rows are a real distinction. Silence in the first period is honest — there is nothing to compare against — so "held its place" has to say something rather than also be silent, or the two become indistinguishable.

## Rotor units for the overtakes

#795 asks for this and it is the right call: overtakes are sparse. A twelve-team table over a season is mostly periods where nothing moved, so a reader scanning every column spends the navigation on the uninteresting part. `Rank gained` and `Rank lost` follow the candlestick's bullish/bearish precedent exactly, filtering along the period axis within the current competitor.

They are **withheld** on a chart where no rank ever moved. Cycling onto a mode whose only possible answer is "none found" is worse than not offering it.

## The description reports both directions

`Climbed furthest` and `Fell furthest` are separate entries, not the larger of the two. Ranks are a permutation, so somebody's gain is somebody else's loss and the two are commonly *the same size* — my own first draft took the larger and the test caught it naming only the fall. Reporting the winner of that tie would drop one of two distinct findings on precisely the charts where both are most clearly present. Each is withheld when nobody moved that way, rather than naming whoever moved least.

The inherited `Min value` / `Max value` are dropped: on a rank axis they say "somebody came first and somebody came last", true of every bump chart ever drawn.

## Braille stays literal, and says so

The encoder is given values, not a direction, so the cells rise with the rank *number* — a row climbing the display is a competitor sliding down the table, the opposite of what the pitch does. Inverting it would mean emitting `n + 1 - rank` in place of the rank, putting numbers in the display that the chart does not contain and that every other reading of the same state would contradict.

So the display stays literal and `docs/BRAILLE.md` states the disagreement outright, since a reader cannot tell from the dots alone. What braille adds is the *shape*: a flat row held its place all season, and two rows that cross swapped positions — legible by touch whichever way the dots run.

## Scope: slope graphs

#795 covers "slope graphs and bump charts". A slope graph of **values** is two points per series on a value axis — a line layer with two samples, which `LineTrace` already reads correctly, with nothing new needed. A slope graph of **ranks** is a two-period bump chart and is covered here. What makes this a type of its own is the rank, not the number of periods, so there is one type rather than two.

## Registration

All six sites plus the docs, plus `describe.ts`'s multi-series branch with `Competitor` as the noun. `groupNameAt` on `LineTrace` becomes `protected` — a subclass naming a series in its own description has to name it the way every other announcement does, and reaching for `points[row][0].z` directly would skip the fallback and report `undefined` for an unnamed series.

## Verification

- `npm test` — **2172 + 73 passed**, 167 suites, none failing
- `npx playwright test --project=chromium bump` — **5 passed**
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_