### PR TITLE
fix(bar): stop a trace writing to the spec it was handed

### DIFF
--- a/src/model/bar.ts
+++ b/src/model/bar.ts
@@ -65,7 +65,19 @@ export abstract class AbstractBarPlot<T extends BarPoint> extends AbstractTrace 
   protected constructor(layer: MaidrLayer, points: T[][]) {
     super(layer);
 
-    this.points = points;
+    // A copy of the outer array, not the caller's own. Two things here write
+    // to it: `SegmentedTrace` appends a summary row, and `dispose()` truncates
+    // it to zero. Held by reference, both reach back into the `MaidrLayer.data`
+    // the caller passed in -- so building a figure twice from one spec (a React
+    // re-render with the same `data` prop, a `setData()` push, two subplots
+    // sharing a spec object) leaves the second figure reading a chart with a
+    // phantom series, and the sums compound with every rebuild. Disposing the
+    // first figure empties the spec outright.
+    //
+    // The rows themselves are never written to, so a shallow copy is the whole
+    // fix; copying every point as well would cost the largest charts real work
+    // for no benefit.
+    this.points = [...points];
     this.orientation = layer.orientation ?? Orientation.VERTICAL;
 
     this.barValues = points.map(row =>

--- a/test/model/barInputMutation.test.ts
+++ b/test/model/barInputMutation.test.ts
@@ -1,0 +1,132 @@
+import type { BarPoint, MaidrLayer, SegmentedPoint } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A bar trace must not write to the data it was handed.
+ *
+ * `AbstractBarPlot` held `MaidrLayer.data` by reference, and two things write
+ * to it: `SegmentedTrace` appends its summary row, and `dispose()` truncates
+ * the array to zero. Both reached back into the caller's spec.
+ *
+ * That is not a theoretical sharing problem. A `Maidr` spec is built once and
+ * used repeatedly by design -- React re-renders with the same `data` prop,
+ * `window.maidrLive.setData()` pushes a new figure over the old one, and a
+ * multi-panel figure can hand one spec object to more than one subplot. Every
+ * one of those routes builds a second trace over an array the first has
+ * already grown, so the chart gains a phantom series whose values compound:
+ * `[[3,5],[2,4]]` read three times became
+ * `[[3,5],[2,4],[5,9],[10,18],[20,36]]`.
+ *
+ * Nothing announced the extra series as fabricated. It navigated, sonified and
+ * announced exactly as a real one would.
+ */
+
+/** Two series over two categories, rebuilt from scratch for each test. */
+let stackedData: SegmentedPoint[][];
+let barData: BarPoint[];
+
+beforeEach(() => {
+  stackedData = [
+    [{ x: 'a', y: 3, z: 'A' }, { x: 'b', y: 5, z: 'A' }],
+    [{ x: 'a', y: 2, z: 'B' }, { x: 'b', y: 4, z: 'B' }],
+  ];
+  barData = [{ x: 'a', y: 3 }, { x: 'b', y: 5 }];
+});
+
+/**
+ * A layer over the shared stacked data.
+ * @param type Which of the segmented types to declare
+ * @returns The layer definition
+ */
+function stackedLayer(type: TraceType = TraceType.STACKED): MaidrLayer {
+  return {
+    id: 'layer',
+    type,
+    title: 'Sales',
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'X' }, y: { label: 'Y' }, z: { label: 'Series' } },
+    data: stackedData,
+  };
+}
+
+/**
+ * The value grid a trace is navigating, read through its braille state.
+ *
+ * Braille carries the whole grid, so it reports a fabricated row without the
+ * test reaching into a private field.
+ * @param trace The trace to read
+ * @param trace.state Its current state
+ * @returns One row of values per series
+ */
+function grid(trace: { state: unknown }): number[][] {
+  const state = trace.state as { empty: boolean; braille: { empty: boolean; values: unknown } };
+  if (state.empty || state.braille.empty) {
+    throw new Error('Expected a populated braille state');
+  }
+  return state.braille.values as number[][];
+}
+
+describe('a bar trace does not write to the spec it was given', () => {
+  test('building a stacked bar twice does not grow the data', () => {
+    TraceFactory.create(stackedLayer());
+    TraceFactory.create(stackedLayer());
+
+    expect(stackedData).toHaveLength(2);
+  });
+
+  test('the second figure reads the same chart as the first', () => {
+    // The failure this prevents: the second trace navigates a series the
+    // chart does not contain, sonified and announced like any other.
+    const first = grid(TraceFactory.create(stackedLayer()));
+    const second = grid(TraceFactory.create(stackedLayer()));
+
+    expect(second).toEqual(first);
+    // Two authored series plus the summary row the trace appends.
+    expect(second).toHaveLength(3);
+  });
+
+  test('a third build does not compound the sums', () => {
+    // The appended totals were themselves summed on the next build, so the
+    // phantom values grew geometrically rather than merely repeating.
+    TraceFactory.create(stackedLayer());
+    TraceFactory.create(stackedLayer());
+    const third = grid(TraceFactory.create(stackedLayer()));
+
+    expect(third).toEqual([[3, 5], [2, 4], [5, 9]]);
+  });
+
+  test('the normalized variant is affected the same way, and fixed the same way', () => {
+    TraceFactory.create(stackedLayer(TraceType.NORMALIZED));
+    TraceFactory.create(stackedLayer(TraceType.NORMALIZED));
+
+    expect(stackedData).toHaveLength(2);
+  });
+
+  test('disposing a trace does not empty the caller data', () => {
+    // `dispose()` truncates the array it holds, which is the other half of
+    // the same reference. A figure torn down on a route change took the
+    // spec's data with it, so re-mounting rendered an empty chart.
+    const trace = TraceFactory.create(stackedLayer());
+
+    trace.dispose();
+
+    expect(stackedData).toHaveLength(2);
+    expect(stackedData[0]).toHaveLength(2);
+  });
+
+  test('a plain bar layer survives disposal too', () => {
+    const trace = TraceFactory.create({
+      id: 'layer',
+      type: TraceType.BAR,
+      title: 'Sales',
+      axes: { x: { label: 'X' }, y: { label: 'Y' } },
+      data: barData,
+    });
+
+    trace.dispose();
+
+    expect(barData).toHaveLength(2);
+  });
+});

--- a/test/model/barInputMutation.test.ts
+++ b/test/model/barInputMutation.test.ts
@@ -97,12 +97,18 @@ describe('a bar trace does not write to the spec it was given', () => {
     expect(third).toEqual([[3, 5], [2, 4], [5, 9]]);
   });
 
-  test('the normalized variant is affected the same way, and fixed the same way', () => {
-    TraceFactory.create(stackedLayer(TraceType.NORMALIZED));
-    TraceFactory.create(stackedLayer(TraceType.NORMALIZED));
+  test.each([TraceType.NORMALIZED, TraceType.DODGED])(
+    'the %s variant is affected the same way, and fixed the same way',
+    (type) => {
+      // All three segmented types route to the same class, so naming them
+      // individually is what makes "every type that shares this code path"
+      // a checked claim rather than an inferred one.
+      TraceFactory.create(stackedLayer(type));
+      TraceFactory.create(stackedLayer(type));
 
-    expect(stackedData).toHaveLength(2);
-  });
+      expect(stackedData).toHaveLength(2);
+    },
+  );
 
   test('disposing a trace does not empty the caller data', () => {
     // `dispose()` truncates the array it holds, which is the other half of


### PR DESCRIPTION
Found while building #793. It affects shipped chart types — `stacked_bar` and `stacked_normalized_bar` — so it is split out rather than carried in with the feature.

## What happens

`AbstractBarPlot` held `MaidrLayer.data` by reference, and **two** things write to it:

- `SegmentedTrace` appends its summary row (`this.points.push(summaryPoints)`)
- `dispose()` truncates the array (`this.points.length = 0`)

Both reached back into the caller's spec. Building the same spec three times:

```
rows before      : 2
rows after one   : 3
rows after two   : 4
rows after three : 5
third barValues  : [[3,5],[2,4],[5,9],[10,18],[20,36]]
```

Two authored series became five. And the totals were themselves summed on the next pass, so the phantom values **compound geometrically** rather than merely repeating — `[5,9]` becomes `[10,18]` becomes `[20,36]`.

Nothing marked the extra series as fabricated. It navigated, it sonified, it announced, and it took its place in the description's series count exactly as a real one would.

## Why this is reachable, not theoretical

A `Maidr` spec is built once and used repeatedly *by design*:

- a React consumer re-rendering with the same `data` prop
- `window.maidrLive.setData()`, which pushes a new figure over the old one — the live-data path, where rebuilds are the point
- a multi-panel figure handing one spec object to more than one subplot

Every one of those routes builds a second trace over an array the first has already grown.

The `dispose()` half is the more visible one: tearing a figure down **empties the caller's data**, so re-mounting renders an empty chart from a spec that still looks intact in the console.

## The fix

```ts
this.points = [...points];
```

A copy of the outer array only. The rows themselves are never written to — the two writers append to and truncate the outer array — so copying every point would cost the largest charts real work for no benefit.

## Tests

`test/model/barInputMutation.test.ts` covers both writers across both segmented types and the plain bar. **5 of its 6 cases fail on the parent commit**; the sixth (plain bar disposal) passes there because `BarTrace` wraps its data in a fresh array before passing it up, which is why the bug was only ever visible on the segmented types.

The value grid is read through the trace's **braille state** rather than a private field, so the test reports a fabricated row the same way a user would encounter one.

## Verification

- `npm test` — **2156 + 73 passed**, 167 suites, none failing
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_