### PR TITLE
feat(diverging): read a population pyramid by size and side

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -549,6 +549,31 @@ positions, which is legible by touch whichever way the dots run.
 Bump charts use one line per competitor on a multiline display, so a whole
 table's season can be felt at once rather than by toggling between rows.
 
+## Diverging bar and population pyramid
+
+One row per side plus the balance row, one cell per category -- the bar
+encoding unchanged.
+
+**The cells encode the signed value, so a left-hand row reads low across its
+whole length.** That is the opposite of what the pitch does, which takes the
+magnitude so a bar of the same size sounds the same on either side.
+
+The two disagree on purpose. Audio is given a direction to invert and nothing
+else about the tone changes. Braille is given values, and the encoder maps a
+value to a dot height; flipping the left side's sign before encoding would put
+numbers in the display that the chart does not contain, and every other reading
+of the same state would then contradict it.
+
+So the display stays literal, and what it adds is the *silhouette*: the two
+sides read as a low band and a high band, and the taper of a pyramid -- wide at
+the young bands, narrow at the old -- is legible as a run of dots rising on one
+row while falling on the other.
+
+### Multiline Displays
+
+Diverging charts use one line per side on a multiline display, plus the
+balance, so the two sides can be compared with one sweep.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/e2e_tests/specs/pyramid.spec.ts
+++ b/e2e_tests/specs/pyramid.spec.ts
@@ -1,0 +1,123 @@
+import type { Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/** The example's own page, driven through the shared base helpers. */
+class PyramidPlotPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the population pyramid example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/pyramid.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'pyramid-population');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   * @returns The braille content, whitespace trimmed
+   */
+  public async getBrailleContent(): Promise<string> {
+    const textarea = await this.waitForElement(this.selectors.braille);
+    return (await textarea.inputValue()).trim();
+  }
+}
+
+test.describe('Population pyramid', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new PyramidPlotPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new PyramidPlotPage(page).navigateToPlot();
+  });
+
+  test('should declare the layer as a diverging bar', () => {
+    expect(maidrData.subplots[0][0].layers[0].type).toBe('diverging_bar');
+  });
+
+  test('should carry the left-hand side signed, as the chart draws it', () => {
+    // A horizontal bar layer carries its value on `x` and its category on
+    // `y`, which is the pair `toBarValue` reads.
+    const sides = maidrData.subplots[0][0].layers[0].data as { x: number; y: string }[][];
+
+    expect(sides).toHaveLength(2);
+    expect(sides[0].every(point => point.x < 0)).toBe(true);
+    expect(sides[1].every(point => point.x > 0)).toBe(true);
+  });
+
+  test('should announce a left-hand bar by size and side, not by a minus sign', async ({ page }) => {
+    // Pitched and announced as a signed value, the biggest bar on the left is
+    // the lowest note and the smallest number in the chart.
+    const plot = new PyramidPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('Men');
+    expect(announcement).toContain('1200');
+    expect(announcement).not.toContain('-1200');
+  });
+
+  test('should render one braille row per side plus the balance', async ({ page }) => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    const plot = new PyramidPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.toggleBrailleMode();
+
+    const rows = (await plot.getBrailleContent()).split('\n');
+
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row).toMatch(BRAILLE_CELL);
+    }
+  });
+});

--- a/e2e_tests/specs/pyramid.spec.ts
+++ b/e2e_tests/specs/pyramid.spec.ts
@@ -104,6 +104,31 @@ test.describe('Population pyramid', () => {
     expect(announcement).not.toContain('-1200');
   });
 
+  test('should light up the bar it just announced, not the one across the axis', async ({ page }) => {
+    // The assertion no model-level test can make, and the failure it guards
+    // is silent and visual-only: the element mapping is the one path audio,
+    // text and braille do not go through, so a swapped mapping announces
+    // every bar correctly while lighting the opposite one.
+    //
+    // The clone is recoloured, so the fill cannot tell the two sides apart --
+    // but it keeps the geometry, and on a mirrored baseline that is exactly
+    // what says which side of the axis a bar is on. Men grow left from the
+    // centre and so start at x = 184; women grow right and start at x = 400.
+    const plot = new PyramidPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    expect(normalizeText(await plot.getInstructionText())).toContain('Men');
+    await expect(page.locator('[id^="maidr-highlight"]').first())
+      .toHaveAttribute('x', '184.0');
+
+    await plot.moveToDataPointAbove();
+
+    expect(normalizeText(await plot.getInstructionText())).toContain('Women');
+    await expect(page.locator('[id^="maidr-highlight"]').first())
+      .toHaveAttribute('x', '400');
+  });
+
   test('should render one braille row per side plus the balance', async ({ page }) => {
     // Braille is the modality that fails silently for a new trace type: an
     // unregistered encoder leaves the display blank while text and audio keep

--- a/examples/pyramid.html
+++ b/examples/pyramid.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Population Pyramid Example — Population by Age Band</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        The left-hand values are negative, because that is what a chart with a
+        mirrored baseline draws. The sign is a direction, not a magnitude:
+        pitched as a signed value the biggest bar on the left becomes the
+        lowest note on the chart, so a cohort of 1,200,000 men would sound
+        smaller than a cohort of 310,000 women and the pyramid would be heard
+        as sagging on one side.
+
+        Here the pitch takes the size and the announcement names the side,
+        which is how a sighted reader takes it in: length from the bar, side
+        from which way it points.
+
+        The third row is the balance. Because the values arrive signed, a sum
+        down a category is already the comparison the chart is drawn to make -
+        so it is renamed rather than recomputed, and it announces which side
+        is ahead instead of a total that came out negative. In the youngest
+        bands men lead; from 45 on, women do.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="800pt" height="432pt" viewBox="0 0 800 432" version="1.1"
+        id="pyramid-population" maidr='{&#10;  &quot;id&quot;: &quot;pyramid-population&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;pyramid-population-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;pyramid-population-layer&quot;,&#10;            &quot;type&quot;: &quot;diverging_bar&quot;,&#10;            &quot;title&quot;: &quot;Population by Age Band&quot;,&#10;            &quot;orientation&quot;: &quot;horz&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;People, thousands&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Age band&quot;&#10;              },&#10;              &quot;z&quot;: {&#10;                &quot;label&quot;: &quot;Sex&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;pyramid-bars&#x27;] &gt; rect&quot;,&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: -1200,&#10;                  &quot;y&quot;: &quot;0-14&quot;,&#10;                  &quot;z&quot;: &quot;Men&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: -1150,&#10;                  &quot;y&quot;: &quot;15-29&quot;,&#10;                  &quot;z&quot;: &quot;Men&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: -1080,&#10;                  &quot;y&quot;: &quot;30-44&quot;,&#10;                  &quot;z&quot;: &quot;Men&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: -990,&#10;                  &quot;y&quot;: &quot;45-59&quot;,&#10;                  &quot;z&quot;: &quot;Men&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: -720,&#10;                  &quot;y&quot;: &quot;60-74&quot;,&#10;                  &quot;z&quot;: &quot;Men&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: -310,&#10;                  &quot;y&quot;: &quot;75+&quot;,&#10;                  &quot;z&quot;: &quot;Men&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: 1140,&#10;                  &quot;y&quot;: &quot;0-14&quot;,&#10;                  &quot;z&quot;: &quot;Women&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1100,&#10;                  &quot;y&quot;: &quot;15-29&quot;,&#10;                  &quot;z&quot;: &quot;Women&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1060,&#10;                  &quot;y&quot;: &quot;30-44&quot;,&#10;                  &quot;z&quot;: &quot;Women&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1010,&#10;                  &quot;y&quot;: &quot;45-59&quot;,&#10;                  &quot;z&quot;: &quot;Women&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: 830,&#10;                  &quot;y&quot;: &quot;60-74&quot;,&#10;                  &quot;z&quot;: &quot;Women&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: 520,&#10;                  &quot;y&quot;: &quot;75+&quot;,&#10;                  &quot;z&quot;: &quot;Women&quot;&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 800 432  L 800 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="pyramid-bars">
+          <rect x="184.0" y="100" width="216.0" height="32" style="fill: #4c72b0" />
+          <rect x="400" y="100" width="205.2" height="32" style="fill: #c44e52" />
+          <rect x="193.0" y="140" width="207.0" height="32" style="fill: #4c72b0" />
+          <rect x="400" y="140" width="198.0" height="32" style="fill: #c44e52" />
+          <rect x="205.6" y="180" width="194.4" height="32" style="fill: #4c72b0" />
+          <rect x="400" y="180" width="190.8" height="32" style="fill: #c44e52" />
+          <rect x="221.8" y="220" width="178.2" height="32" style="fill: #4c72b0" />
+          <rect x="400" y="220" width="181.8" height="32" style="fill: #c44e52" />
+          <rect x="270.4" y="260" width="129.6" height="32" style="fill: #4c72b0" />
+          <rect x="400" y="260" width="149.4" height="32" style="fill: #c44e52" />
+          <rect x="344.2" y="300" width="55.8" height="32" style="fill: #4c72b0" />
+          <rect x="400" y="300" width="93.6" height="32" style="fill: #c44e52" />
+            </g>
+            <g id="axis_y">
+          <text x="400" y="148" style="font: 11px sans-serif; text-anchor: middle">0-14</text>
+          <text x="400" y="188" style="font: 11px sans-serif; text-anchor: middle">15-29</text>
+          <text x="400" y="228" style="font: 11px sans-serif; text-anchor: middle">30-44</text>
+          <text x="400" y="268" style="font: 11px sans-serif; text-anchor: middle">45-59</text>
+          <text x="400" y="308" style="font: 11px sans-serif; text-anchor: middle">60-74</text>
+          <text x="400" y="348" style="font: 11px sans-serif; text-anchor: middle">75+</text>
+            </g>
+            <g id="legend">
+              <text x="200" y="80" style="font: 13px sans-serif; text-anchor: middle">Men</text>
+              <text x="600" y="80" style="font: 13px sans-serif; text-anchor: middle">Women</text>
+            </g>
+            <g id="chart-title">
+              <text x="400" y="50" style="font: 16px sans-serif; text-anchor: middle">Population by Age Band</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -60,6 +60,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.BOX]: 'Box Plot',
   [TraceType.CANDLESTICK]: 'Candlestick Chart',
   [TraceType.CANDLESTICK_DELTA]: 'Candlestick Reference Delta',
+  [TraceType.DIVERGING]: 'Diverging Bar Chart',
   [TraceType.DODGED]: 'Dodged Bar Chart',
   [TraceType.DUMBBELL]: 'Dumbbell Chart',
   [TraceType.ERROR_BAR]: 'Error Bar Chart',

--- a/src/model/diverging.ts
+++ b/src/model/diverging.ts
@@ -44,14 +44,40 @@ export class DivergingTrace extends SegmentedTrace {
   public constructor(layer: MaidrLayer) {
     super(layer);
 
-    // Computed over every row INCLUDING the balance row the parent appends,
-    // so a category whose balance exceeds either side's own bar still lands
-    // inside the register rather than off the top of it.
+    // Over every row, balance included. On a well-formed two-sided chart the
+    // balance can never raise this -- one side is negative and the other
+    // positive, so |left + right| never exceeds the larger of the two -- but
+    // taking the flat rather than slicing the balance off keeps the reading
+    // inside the register for a chart that is shaped otherwise, at no cost.
     const magnitudes = this.barValues
       .flat()
       .filter(isMeasured)
       .map(value => Math.abs(value));
     this.widest = magnitudes.length > 0 ? MathUtil.safeMax(magnitudes) : 0;
+  }
+
+  /**
+   * A diverging chart's sides are drawn in the order they are declared.
+   *
+   * `SegmentedTrace` defaults to reverse because a stacked bar's producers
+   * draw its segments bottom-up. A diverging chart is not stacked -- the two
+   * sides sit either side of a baseline rather than on top of one another --
+   * so there is no stacking order to inherit, and a producer emits the left
+   * bar then the right one, which is the order the data declares them in.
+   *
+   * The first example authored for this type got it wrong by following that
+   * natural order, which is the evidence: an author who has to know about the
+   * stacked bar's convention to draw a pyramid will not know about it. The
+   * failure is silent and visual-only -- audio, text and braille never go
+   * through the element mapping, so every announcement stays correct while
+   * the highlight sits on the opposite bar.
+   *
+   * `domMapping.groupDirection` still overrides this in either direction.
+   *
+   * @returns True unless the layer asks for the reverse
+   */
+  protected override get groupsRunForward(): boolean {
+    return this.layer.domMapping?.groupDirection !== 'reverse';
   }
 
   /**
@@ -62,6 +88,49 @@ export class DivergingTrace extends SegmentedTrace {
    */
   private isBalanceRow(row: number): boolean {
     return row === this.barValues.length - 1;
+  }
+
+  /**
+   * Which row grows in a given direction.
+   *
+   * Resolved by reading the values rather than by index. Nothing obliges a
+   * producer to declare the left-hand side first, and a fixed index names the
+   * **wrong winner** for a chart that declares the right-hand side first --
+   * a fluent, confident sentence with the two sides swapped, which on this
+   * trace is the worst available failure: the sign is the one clue the
+   * announcement deliberately removes, so a reader has nothing left to check
+   * it against.
+   *
+   * @param positive - True for the side that grows right
+   * @returns The row, or null when no side grows that way
+   */
+  private sideGrowing(positive: boolean): number | null {
+    for (let row = 0; row < this.barValues.length - 1; row++) {
+      const measured = this.barValues[row]?.find(
+        value => isMeasured(value) && value !== 0,
+      );
+      if (measured !== undefined && (measured > 0) === positive) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Whether the chart is the two-sided one the balance reading assumes.
+   *
+   * "X ahead" is a comparison between exactly two sides. Nothing in the
+   * grammar holds a diverging layer to two, and a chart with three would get
+   * a winner named out of a sum that is not a two-way difference -- so a
+   * chart that is not two-sided keeps the segmented bar's plain summary,
+   * which stays true whatever the shape.
+   *
+   * @returns True when there are exactly two sides, one growing each way
+   */
+  private get isTwoSided(): boolean {
+    return this.barValues.length - 1 === 2
+      && this.sideGrowing(true) !== null
+      && this.sideGrowing(false) !== null;
   }
 
   protected override get audio(): AudioState {
@@ -101,16 +170,22 @@ export class DivergingTrace extends SegmentedTrace {
     });
 
     if (this.isBalanceRow(this.row)) {
+      if (!this.isTwoSided) {
+        // Not a two-way difference, so it is a sum and says so.
+        return base;
+      }
+
       // Which side is ahead, and by how much. Signed, the same number reads as
       // a total that came out negative -- and on the balance row a minus sign
       // is not a smaller number, it is the other side winning.
+      const ahead = this.sideGrowing(value > 0);
       return {
         ...sized(base),
         z: {
           label: BALANCE,
-          value: magnitude === 0
+          value: magnitude === 0 || ahead === null
             ? 'level'
-            : `${this.sideNameAt(value > 0 ? 1 : 0)} ahead`,
+            : `${this.sideNameAt(ahead)} ahead`,
         },
       };
     }

--- a/src/model/diverging.ts
+++ b/src/model/diverging.ts
@@ -1,0 +1,168 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { AudioState, DescriptionState, TextState, TraceState } from '@type/state';
+import { MathUtil } from '@util/math';
+import { isMeasured } from './bar';
+import { SegmentedTrace } from './segmented';
+
+/** What the summary row is called, in place of the segmented bar's "Sum". */
+const BALANCE = 'Balance';
+
+/**
+ * Trace implementation for population pyramids and diverging bar charts.
+ *
+ * Two series drawn back to back across a shared category axis, one growing
+ * left and one growing right -- a population pyramid by age band, or a Likert
+ * scale split around a neutral midpoint. The category navigation is the
+ * segmented bar's, so what is new is entirely in how a signed value is read.
+ *
+ * **The sign is a direction, not a magnitude.** A producer emits the values
+ * as the chart draws them, so the left-hand series is negative. Pitched that
+ * way, the biggest bar on the left becomes the lowest note on the chart: a
+ * cohort of two million men sounds smaller than a cohort of ten thousand
+ * women, and the pyramid is heard as a chart that sags on one side. The pitch
+ * takes the magnitude and the announcement names the side, which is how a
+ * sighted reader takes it in -- length from the bar, side from which way it
+ * points.
+ *
+ * **The balance is the finding.** A pyramid is drawn back to back so the two
+ * sides can be compared at a glance, and that comparison is a subtraction a
+ * listener cannot do by ear across every band. Because the values arrive
+ * signed, the summary row the segmented bar already builds -- the sum down a
+ * category -- *is* that comparison: `(-left) + right` is what one side has
+ * over the other. It is renamed rather than recomputed, since "Sum is
+ * -40,000" invites a reader to hear a total that came out negative.
+ */
+export class DivergingTrace extends SegmentedTrace {
+  /** Largest magnitude anywhere in the chart, ignoring which side it is on. */
+  private readonly widest: number;
+
+  /**
+   * Creates a new diverging bar trace.
+   *
+   * @param layer - The MAIDR layer carrying the two sides
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    // Computed over every row INCLUDING the balance row the parent appends,
+    // so a category whose balance exceeds either side's own bar still lands
+    // inside the register rather than off the top of it.
+    const magnitudes = this.barValues
+      .flat()
+      .filter(isMeasured)
+      .map(value => Math.abs(value));
+    this.widest = magnitudes.length > 0 ? MathUtil.safeMax(magnitudes) : 0;
+  }
+
+  /**
+   * Renames the summary row the segmented bar builds.
+   *
+   * @param row - Which row
+   * @returns True when it is the appended summary
+   */
+  private isBalanceRow(row: number): boolean {
+    return row === this.barValues.length - 1;
+  }
+
+  protected override get audio(): AudioState {
+    const base = super.audio;
+    const value = this.barValues[this.row][this.col];
+
+    // Zero to widest, and the magnitude against it. The parent scales from the
+    // chart's minimum, which on a diverging chart is the largest left-hand bar
+    // -- so the left series would occupy the bottom of the register in reverse
+    // order and the right series the top, and neither side's bars would be
+    // comparable with the other's by ear.
+    return {
+      ...base,
+      freq: {
+        min: 0,
+        max: this.widest,
+        raw: isMeasured(value) ? Math.abs(value) : value,
+      },
+    };
+  }
+
+  protected override get text(): TextState {
+    const base = super.text;
+    const value = this.barValues[this.row][this.col];
+    if (!isMeasured(value)) {
+      return base;
+    }
+
+    const side = this.sideNameAt(this.row);
+    const magnitude = Math.abs(value);
+    // `cross` carries the bar's length in BOTH orientations -- the parent
+    // swaps which point field feeds it, not which half of the announcement it
+    // is -- so there is one slot to replace rather than two.
+    const sized = (state: TextState): TextState => ({
+      ...state,
+      cross: { ...state.cross, value: magnitude },
+    });
+
+    if (this.isBalanceRow(this.row)) {
+      // Which side is ahead, and by how much. Signed, the same number reads as
+      // a total that came out negative -- and on the balance row a minus sign
+      // is not a smaller number, it is the other side winning.
+      return {
+        ...sized(base),
+        z: {
+          label: BALANCE,
+          value: magnitude === 0
+            ? 'level'
+            : `${this.sideNameAt(value > 0 ? 1 : 0)} ahead`,
+        },
+      };
+    }
+
+    // The bar's own size. A reader hearing "-1,240,000" has to strip a sign
+    // that says which side they are on, which the label beside it already
+    // said.
+    return { ...sized(base), z: { label: this.z, value: side } };
+  }
+
+  /**
+   * What one side of the chart is called.
+   *
+   * The series' own name, which every segment carries. Falls back to the
+   * direction it grows, so an unnamed chart still says which way a bar points
+   * rather than leaving the sign as the only clue -- and the sign is exactly
+   * what this trace removes from the announcement.
+   *
+   * @param row - Which series
+   * @returns Its name
+   */
+  private sideNameAt(row: number): string {
+    const authored = this.points[row]?.[0]?.z;
+    if (authored !== undefined && authored !== null && String(authored) !== '') {
+      return String(authored);
+    }
+    const measured = this.barValues[row]?.find(isMeasured) ?? 0;
+    return measured < 0 ? 'left' : 'right';
+  }
+
+  public override get description(): DescriptionState {
+    const base = super.description;
+    const stats = [...base.stats];
+
+    // One total per side, which is the number a pyramid is captioned with and
+    // the one a reader cannot accumulate by ear across twenty age bands.
+    for (let row = 0; row < this.barValues.length - 1; row++) {
+      const total = this.barValues[row]
+        .filter(isMeasured)
+        .reduce((sum, value) => sum + Math.abs(value), 0);
+      stats.push({ label: `${this.sideNameAt(row)} total`, value: total });
+    }
+
+    return { ...base, stats };
+  }
+
+  public override get state(): TraceState {
+    const base = super.state;
+    if (base.empty) {
+      return base;
+    }
+
+    return { ...base, plotType: 'diverging bar' };
+  }
+}

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -6,6 +6,7 @@ import { BarTrace } from './bar';
 import { BoxTrace } from './box';
 import { BumpTrace } from './bump';
 import { Candlestick } from './candlestick';
+import { DivergingTrace } from './diverging';
 import { DumbbellTrace } from './dumbbell';
 import { ErrorBarTrace } from './errorBar';
 import { FunnelTrace } from './funnel';
@@ -64,6 +65,9 @@ export abstract class TraceFactory {
 
       case TraceType.ERROR_BAR:
         return new ErrorBarTrace(layer);
+
+      case TraceType.DIVERGING:
+        return new DivergingTrace(layer);
 
       case TraceType.FUNNEL:
         return new FunnelTrace(layer);

--- a/src/model/segmented.ts
+++ b/src/model/segmented.ts
@@ -294,6 +294,24 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     };
   }
 
+  /**
+   * Whether a category's DOM elements run in the order the series are declared.
+   *
+   * A stacked bar's producers draw its segments bottom-up, so the first
+   * element of a category is the *last* series -- which is why the default is
+   * reverse, and has been since this was called `domOrder`.
+   *
+   * A subclass whose chart is not stacked has no such convention to inherit,
+   * and overriding this is how it says so. `domMapping.groupDirection`
+   * overrides either answer, so a producer that draws the other way round can
+   * still declare it.
+   *
+   * @returns True when a category's first element is its first series
+   */
+  protected get groupsRunForward(): boolean {
+    return this.layer.domMapping?.groupDirection === 'forward';
+  }
+
   protected override mapToSvgElements(selector?: string): SVGElement[][] | null {
     if (!selector) {
       return null;
@@ -312,7 +330,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
     const skipZeros = domElements.length < totalExpected;
 
     const isRowMajor = this.layer.domMapping?.order === 'row';
-    const isForward = this.layer.domMapping?.groupDirection === 'forward';
+    const isForward = this.groupsRunForward;
 
     const svgElements = new Array<Array<SVGElement>>();
     if (domElements[0] instanceof SVGPathElement) {
@@ -381,7 +399,7 @@ export class SegmentedTrace extends AbstractBarPlot<SegmentedPoint> {
       }
 
       const isRowMajor = this.layer.domMapping?.order === 'row';
-      const isForward = this.layer.domMapping?.groupDirection === 'forward';
+      const isForward = this.groupsRunForward;
 
       if (isRowMajor) {
         // Row-major DOM order: DOM elements are [series0-all-cats, series1-all-cats, ...]

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1116,6 +1116,12 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // The virtual delta layer reuses the candlestick encoding: height maps
       // |delta| and the 'Bear' trend adds dot 8 for below-line points.
       [TraceType.CANDLESTICK_DELTA, asGeneric(new CandlestickBrailleEncoder())],
+      // A diverging chart's rows are the two sides and its columns the shared
+      // categories, which is the bar encoder's input. The cells encode the
+      // SIGNED value, so a left-hand row reads low across its whole length --
+      // the inversion the pitch applies has no equivalent here, and
+      // `docs/BRAILLE.md` says so, because a reader cannot tell from the dots.
+      [TraceType.DIVERGING, asGeneric(new BarBrailleEncoder())],
       [TraceType.DODGED, asGeneric(new BarBrailleEncoder())],
       // One row per section — a profile of lower bounds, of estimates, of
       // upper bounds — which is the per-row height profile the line encoder

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -917,6 +917,16 @@ export enum TraceType {
    * to pick the reference line).
    */
   CANDLESTICK_DELTA = 'candlestick_delta',
+  /**
+   * Two series drawn back to back across a shared category axis, one growing
+   * left and one growing right -- a population pyramid, or a Likert scale
+   * split around a neutral midpoint. Navigated as a
+   * {@link TraceType.STACKED} layer is, with the one difference that decides
+   * whether it reads correctly: the values arrive **signed**, and the sign is
+   * a direction rather than a magnitude, so the pitch takes the size and the
+   * announcement names the side.
+   */
+  DIVERGING = 'diverging_bar',
   DODGED = 'dodged_bar',
   /**
    * Two values per category joined by a segment -- before and after, two

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -33,6 +33,12 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // is drawn, so there is no main and cross axis to swap -- the answer a line
   // already gives.
   [TraceType.BUMP]: false,
+  // A population pyramid is drawn with its categories running down the page
+  // and a Likert chart with them across it, and the sides grow along the
+  // other axis either way -- so which axis a bar's length lies on depends on
+  // which way it was drawn, exactly as it does for the stacked bar this
+  // extends.
+  [TraceType.DIVERGING]: true,
   [TraceType.DODGED]: true,
   // The interval runs along the value axis and the samples along the other,
   // so which way round they are drawn decides which axis a bound moves on --

--- a/test/model/diverging.test.ts
+++ b/test/model/diverging.test.ts
@@ -1,0 +1,246 @@
+import type { MaidrLayer, SegmentedPoint } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { DivergingTrace } from '@model/diverging';
+import { TraceFactory } from '@model/factory';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Three age bands, men left and women right, as the chart draws them.
+ *
+ * The left-hand values are negative because that is what a producer emits for
+ * a chart with a mirrored baseline. Every magnitude is distinct and the
+ * largest bar is on the *left*, which is the arrangement that exposes a
+ * reading that took the sign for a magnitude: the biggest bar would be the
+ * lowest note.
+ *
+ * Band `45-64` is the one where the two sides differ, so a balance of zero and
+ * a balance in either direction are all present.
+ */
+const BANDS: SegmentedPoint[][] = [
+  [
+    { x: '0-24', y: -1200, z: 'Men' },
+    { x: '25-44', y: -900, z: 'Men' },
+    { x: '45-64', y: -700, z: 'Men' },
+  ],
+  [
+    { x: '0-24', y: 1200, z: 'Women' },
+    { x: '25-44', y: 950, z: 'Women' },
+    { x: '45-64', y: 800, z: 'Women' },
+  ],
+];
+
+/**
+ * Create a minimal diverging bar layer for model-only tests.
+ * @param data The sides the layer carries
+ * @returns Diverging bar layer definition
+ */
+function createLayer(data: SegmentedPoint[][] = BANDS): MaidrLayer {
+  return {
+    id: 'test-diverging-layer',
+    type: TraceType.DIVERGING,
+    title: 'Population by age band',
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Age band' }, y: { label: 'People' }, z: { label: 'Sex' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: DivergingTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a diverging trace positioned on one band of one side.
+ * @param row Which side; the last row is the balance the parent appends
+ * @param col Which band
+ * @param data The sides the layer carries
+ * @returns The positioned trace
+ */
+function diverging(
+  row = 0,
+  col = 0,
+  data: SegmentedPoint[][] = BANDS,
+): DivergingTrace {
+  const trace = TraceFactory.create(createLayer(data)) as DivergingTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+/**
+ * Where a state's pitch sits within the range it was given, 0 to 1.
+ * @param state The trace state to read
+ * @returns The relative pitch
+ */
+function pitch(state: NonEmptyTraceState): number {
+  const { min, max, raw } = state.audio.freq;
+  return (Number(raw) - min) / (max - min);
+}
+
+describe('diverging registration', () => {
+  test('the factory builds a DivergingTrace', () => {
+    expect(TraceFactory.create(createLayer())).toBeInstanceOf(DivergingTrace);
+  });
+
+  test('announces itself as the chart it is', () => {
+    expect(diverging().description.chartType).toBe('Diverging Bar Chart');
+    expect(nonEmptyState(diverging()).plotType).toBe('diverging bar');
+  });
+});
+
+describe('the sign is a direction, not a magnitude', () => {
+  test('a left-hand bar is pitched by its size', () => {
+    // The largest bar in the chart is on the left. Pitched as a signed value
+    // it would be the LOWEST note -- a cohort of 1,200 men sounding smaller
+    // than a cohort of 800 women.
+    const { audio } = nonEmptyState(diverging(0, 0));
+
+    expect(audio.freq.raw).toBe(1200);
+    expect(audio.freq.min).toBe(0);
+  });
+
+  test('equal cohorts on opposite sides sound the same', () => {
+    // Band `0-24` has 1,200 either way, and the two have to be
+    // indistinguishable by pitch or the chart cannot be compared across its
+    // own baseline.
+    expect(pitch(nonEmptyState(diverging(0, 0))))
+      .toBeCloseTo(pitch(nonEmptyState(diverging(1, 0))));
+  });
+
+  test('a bigger bar is a higher note whichever side it is on', () => {
+    const bigLeft = pitch(nonEmptyState(diverging(0, 0)));
+    const smallLeft = pitch(nonEmptyState(diverging(0, 2)));
+    const smallRight = pitch(nonEmptyState(diverging(1, 2)));
+
+    expect(bigLeft).toBeGreaterThan(smallLeft);
+    expect(smallRight).toBeGreaterThan(smallLeft);
+  });
+
+  test('the announcement gives the size and the side, not a minus sign', () => {
+    // A reader hearing "-1200" has to strip a sign that says which side they
+    // are on, which the label beside it already said.
+    const { text } = nonEmptyState(diverging(0, 0));
+
+    expect(text.cross.value).toBe(1200);
+    expect(text.z).toEqual({ label: 'Sex', value: 'Men' });
+  });
+
+  test('an unnamed side is named by the way it grows', () => {
+    // Better than leaving the sign as the only clue, which is exactly what
+    // this trace removes from the announcement.
+    const unnamed: SegmentedPoint[][] = [
+      [{ x: 'a', y: -5, z: '' }, { x: 'b', y: -3, z: '' }],
+      [{ x: 'a', y: 4, z: '' }, { x: 'b', y: 6, z: '' }],
+    ];
+
+    expect(nonEmptyState(diverging(0, 0, unnamed)).text.z?.value).toBe('left');
+    expect(nonEmptyState(diverging(1, 0, unnamed)).text.z?.value).toBe('right');
+  });
+});
+
+describe('a chart drawn with its bands down the page', () => {
+  /**
+   * The same pyramid, horizontal. A bar layer carries its value on `x` and
+   * its category on `y` when the orientation is horizontal -- the pair
+   * `toBarValue` reads -- so the point fields swap, not the announcement.
+   */
+  const HORIZONTAL: SegmentedPoint[][] = BANDS.map(side =>
+    side.map(point => ({ x: point.y, y: point.x, z: point.z })));
+
+  /**
+   * Build a horizontal diverging trace.
+   * @param row Which side
+   * @param col Which band
+   * @returns The positioned trace
+   */
+  function horizontal(row: number, col: number): DivergingTrace {
+    const trace = TraceFactory.create({
+      ...createLayer(HORIZONTAL),
+      orientation: Orientation.HORIZONTAL,
+      axes: { x: { label: 'People' }, y: { label: 'Age band' }, z: { label: 'Sex' } },
+    }) as DivergingTrace;
+    trace.moveToIndex(row, col);
+    return trace;
+  }
+
+  test('still announces the size and the side rather than a sign', () => {
+    // The parent swaps which point field feeds `cross`, not which half of the
+    // announcement carries the length -- so there is one slot to replace, and
+    // this is the case that says whether the right one was chosen. A pyramid
+    // is ordinarily drawn this way up, so getting it wrong here would be the
+    // ordinary case rather than the exotic one.
+    const { text } = nonEmptyState(horizontal(0, 0));
+
+    expect(text.cross.label).toBe('People');
+    expect(text.cross.value).toBe(1200);
+    expect(text.main.value).toBe('0-24');
+    expect(text.z?.value).toBe('Men');
+  });
+
+  test('still pitches by size', () => {
+    const { audio } = nonEmptyState(horizontal(0, 0));
+
+    expect(audio.freq.raw).toBe(1200);
+    expect(audio.freq.min).toBe(0);
+  });
+});
+
+describe('the balance row says which side is ahead', () => {
+  /** The summary row the segmented bar appends, after the two sides. */
+  const BALANCE_ROW = 2;
+
+  test('names the side rather than reporting a signed total', () => {
+    // Band `25-44`: 950 women against 900 men, so the balance is +50.
+    // "Sum is 50" invites a reader to hear a total; the number is a lead.
+    const { text } = nonEmptyState(diverging(BALANCE_ROW, 1));
+
+    expect(text.cross.value).toBe(50);
+    expect(text.z).toEqual({ label: 'Balance', value: 'Women ahead' });
+  });
+
+  test('names the other side when it leads', () => {
+    const flipped: SegmentedPoint[][] = [
+      [{ x: 'a', y: -900, z: 'Men' }],
+      [{ x: 'a', y: 400, z: 'Women' }],
+    ];
+
+    // Row 2 is the balance the parent appends; rows 0 and 1 are the sides.
+    expect(nonEmptyState(diverging(2, 0, flipped)).text.z)
+      .toEqual({ label: 'Balance', value: 'Men ahead' });
+  });
+
+  test('says level rather than naming a winner at zero', () => {
+    // Band `0-24` is 1,200 either way.
+    expect(nonEmptyState(diverging(BALANCE_ROW, 0)).text.z)
+      .toEqual({ label: 'Balance', value: 'level' });
+  });
+
+  test('a balance is pitched by its size like any other bar', () => {
+    const { audio } = nonEmptyState(diverging(BALANCE_ROW, 1));
+
+    expect(audio.freq.raw).toBe(50);
+    expect(audio.freq.min).toBe(0);
+  });
+});
+
+describe('the description totals each side', () => {
+  test('reports a total per side, unsigned', () => {
+    // The number a pyramid is captioned with, and the one a reader cannot
+    // accumulate by ear across twenty age bands.
+    const stats = diverging().description.stats;
+    const read = (label: string): unknown =>
+      stats.find(stat => stat.label === label)?.value;
+
+    expect(read('Men total')).toBe(2800);
+    expect(read('Women total')).toBe(2950);
+  });
+});

--- a/test/model/diverging.test.ts
+++ b/test/model/diverging.test.ts
@@ -1,9 +1,10 @@
 import type { MaidrLayer, SegmentedPoint } from '@type/grammar';
 import type { NonEmptyTraceState } from '@type/state';
-import { describe, expect, test } from '@jest/globals';
+import { afterEach, describe, expect, test } from '@jest/globals';
 import { DivergingTrace } from '@model/diverging';
 import { TraceFactory } from '@model/factory';
 import { Orientation, TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
 
 /**
  * Three age bands, men left and women right, as the chart draws them.
@@ -218,6 +219,38 @@ describe('the balance row says which side is ahead', () => {
       .toEqual({ label: 'Balance', value: 'Men ahead' });
   });
 
+  test('names the leader by which way it grows, not by where it was declared', () => {
+    // The right-hand side declared FIRST. Reading the winner off a fixed row
+    // index announces "Women ahead" on a band where men lead by 500 -- the
+    // sentence a reader has no way to check, since the sign is exactly what
+    // this trace takes out of the announcement.
+    const rightFirst: SegmentedPoint[][] = [
+      [{ x: 'a', y: 400, z: 'Women' }],
+      [{ x: 'a', y: -900, z: 'Men' }],
+    ];
+
+    expect(nonEmptyState(diverging(2, 0, rightFirst)).text.z)
+      .toEqual({ label: 'Balance', value: 'Men ahead' });
+  });
+
+  test('keeps the plain summary when the chart is not two-sided', () => {
+    // "X ahead" is a comparison between two sides. A third makes the summary
+    // a sum again rather than a two-way difference, so it stays one: nothing
+    // in the grammar holds a diverging layer to two sides, and naming a
+    // winner out of a three-way total would be confidently wrong.
+    const threeSided: SegmentedPoint[][] = [
+      [{ x: 'a', y: -900, z: 'Against' }],
+      [{ x: 'a', y: 400, z: 'For' }],
+      [{ x: 'a', y: 200, z: 'Strongly for' }],
+    ];
+
+    const { text } = nonEmptyState(diverging(3, 0, threeSided));
+
+    expect(text.z).toEqual({ label: 'Sex', value: 'Sum' });
+    // Signed, too: on a sum a minus sign really is a smaller number.
+    expect(text.cross.value).toBe(-300);
+  });
+
   test('says level rather than naming a winner at zero', () => {
     // Band `0-24` is 1,200 either way.
     expect(nonEmptyState(diverging(BALANCE_ROW, 0)).text.z)
@@ -242,5 +275,102 @@ describe('the description totals each side', () => {
 
     expect(read('Men total')).toBe(2800);
     expect(read('Women total')).toBe(2950);
+  });
+});
+
+describe('the highlight lands on the bar the reader is on', () => {
+  /**
+   * Provision the globals `Svg.selectAllElements` and the rect branch touch.
+   *
+   * jsdom does not expose `SVGRectElement` as a distinct constructor, so it
+   * is aliased to `SVGElement` -- which is what makes `<rect>` nodes take the
+   * mapping branch under test.
+   *
+   * @param html - The document to install
+   */
+  function installDom(html: string): void {
+    const dom = new JSDOM(html);
+    const g = globalThis as unknown as Record<string, unknown>;
+    g.document = dom.window.document;
+    g.SVGElement = dom.window.SVGElement;
+    g.SVGRectElement = dom.window.SVGRectElement ?? dom.window.SVGElement;
+    g.SVGPathElement = dom.window.SVGPathElement ?? class SVGPathElementStub {};
+  }
+
+  afterEach(() => {
+    const g = globalThis as unknown as Record<string, unknown>;
+    delete g.document;
+    delete g.SVGElement;
+    delete g.SVGRectElement;
+    delete g.SVGPathElement;
+  });
+
+  /**
+   * Three bands drawn left bar then right bar, which is the order a producer
+   * emits them in: the sides in the order the data declares them.
+   *
+   * Each rect is tagged with the side it draws so a test can say which one
+   * the model picked, rather than asserting on an index that would be
+   * satisfied by either mapping.
+   *
+   * @returns The document source
+   */
+  function pyramidSvg(): string {
+    const bands = ['0-24', '25-44', '45-64'];
+    const rects = bands
+      .map(band => `<rect data-side="Men" data-band="${band}" />`
+        + `<rect data-side="Women" data-band="${band}" />`)
+      .join('');
+    return `<svg id="p"><g id="bars">${rects}</g></svg>`;
+  }
+
+  /**
+   * The elements the trace resolved, exposed for assertion.
+   *
+   * @param layer - The layer to build a trace from
+   * @returns One element per bar, shaped rows x categories
+   */
+  function highlightsOf(layer: MaidrLayer): SVGElement[][] | null {
+    const trace = new DivergingTrace(layer);
+    return (trace as unknown as { highlightValues: SVGElement[][] | null })
+      .highlightValues;
+  }
+
+  test('reads the sides in the order the data declares them', () => {
+    // The failure this guards is silent and visual-only: audio, text and
+    // braille never go through this path, so every announcement is correct
+    // while the highlight sits on the opposite bar.
+    installDom(pyramidSvg());
+
+    const highlights = highlightsOf({
+      ...createLayer(),
+      selectors: 'g[id=\'bars\'] > rect',
+    });
+
+    expect(highlights).not.toBeNull();
+    expect(highlights![0][0].getAttribute('data-side')).toBe('Men');
+    expect(highlights![1][0].getAttribute('data-side')).toBe('Women');
+    expect(highlights![0][2].getAttribute('data-band')).toBe('45-64');
+    expect(highlights![1][2].getAttribute('data-band')).toBe('45-64');
+  });
+
+  test('a producer that draws right-hand bars first can say so', () => {
+    // The reverse order is still reachable, just no longer the thing an
+    // author gets without asking for it.
+    const bands = ['0-24', '25-44', '45-64'];
+    installDom(`<svg id="p"><g id="bars">${bands
+      .map(band => `<rect data-side="Women" data-band="${band}" />`
+        + `<rect data-side="Men" data-band="${band}" />`)
+      .join('')}</g></svg>`);
+
+    const highlights = highlightsOf({
+      ...createLayer(),
+      selectors: 'g[id=\'bars\'] > rect',
+      domMapping: { order: 'column', groupDirection: 'reverse' },
+    });
+
+    expect(highlights).not.toBeNull();
+    expect(highlights![0][0].getAttribute('data-side')).toBe('Men');
+    expect(highlights![1][0].getAttribute('data-side')).toBe('Women');
   });
 });

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -7,6 +7,9 @@ describe('resolveOrientation', () => {
     TraceType.BAR,
     TraceType.BOX,
     TraceType.CANDLESTICK,
+    // A pyramid is drawn with its categories down the page and a Likert chart
+    // with them across it, and the sides grow along the other axis either way.
+    TraceType.DIVERGING,
     TraceType.DODGED,
     // A dumbbell is commonly drawn with its categories running down the page,
     // and the pair runs along the value axis either way -- so which axis a dot


### PR DESCRIPTION
Closes #793. Rebased onto current `main`; #837 is merged, so the "merge #837 first" note that was here is gone.

## The sign is a direction, not a magnitude

#793 names this exactly. A producer emits the values as the chart draws them, so the left-hand series is negative. Pitched that way, the biggest bar on the left becomes the **lowest note on the chart** — a cohort of 1,200,000 men sounds smaller than a cohort of 310,000 women, and the pyramid is heard as sagging on one side.

The pitch takes the magnitude and scales from **zero** rather than from the chart's minimum, which on a diverging chart is the largest left-hand bar. Left as-is, the left series would occupy the bottom of the register *in reverse order* and the right series the top, and neither side's bars would be comparable with the other's by ear. With the fix, equal cohorts on opposite sides are indistinguishable by pitch, which is the property the chart is drawn to be read for.

The announcement names the size and the side — `People is 1200, Sex is Men` — which is how a sighted reader takes it in: length from the bar, side from which way it points.

## The balance is the finding, and it is already there

Because the values arrive signed, the summary row `SegmentedTrace` already builds — the sum down a category — **is** the comparison the chart is drawn to make: `(-left) + right` is what one side has over the other.

So it is renamed rather than recomputed. `Sum is -40000` invites a reader to hear a total that came out negative; on this row a minus sign is not a smaller number, it is the other side winning. It announces `Balance is Men ahead`, or `level` at zero rather than naming a winner.

**Which side is ahead is resolved by reading which way the values grow, not by row index.** Nothing obliges a producer to declare the left-hand side first, and a fixed index names the wrong winner for a chart that declares the right-hand side first — a fluent, confident sentence with the two sides swapped. That is the worst failure available here, because the sign is the one clue this trace deliberately removes from the announcement.

A chart that is **not two-sided** keeps the segmented bar's plain `Sum`. "X ahead" is a comparison between exactly two sides, and nothing in the grammar holds a diverging layer to two.

## The highlight follows the reader

`SegmentedTrace` defaults a category's DOM elements to reverse order, because a stacked bar's producers draw its segments bottom-up. A diverging chart is not stacked — the two sides sit either side of a baseline — so a producer emits the left bar then the right one, in the order the data declares them.

The default is now a `groupsRunForward` hook that `DivergingTrace` overrides, rather than `domMapping` patched into the example. The evidence is that the first example authored for this type got it wrong by following the natural order: an author who has to know the stacked bar's convention in order to draw a pyramid will not know it. `domMapping.groupDirection` still overrides in both directions.

**The e2e assertion is the one that matters** — it fails without the fix while the other four pyramid specs pass either way, which is the shape of the defect: audio, text and braille never go through the element mapping, so every announcement stayed correct while the highlight lit the opposite bar.

## An unnamed side is named by the way it grows

`left` / `right` as a fallback, because the sign is exactly what this trace removes from the announcement — leaving an unnamed series with no way to say which half of the chart it is on would be worse than the signed reading it replaces.

## Two things the e2e caught that unit tests did not

**The example had `NaN` for every value.** A horizontal bar layer carries its value on `x` and its category on `y` — the pair `toBarValue` reads — and I authored the example with the vertical convention. Braille rendered blank rather than erroring.

**My first fix for that was wrong in the opposite direction.** Seeing `Age band is -1200`, I concluded the parent puts the value in `main` for a horizontal layer. It does not: the parent swaps *which point field feeds `cross`*, not which half of the announcement carries the length. Reverted, with a horizontal unit test so the ordinary way to draw a pyramid is covered where it should have been.

## Braille stays literal, and says so

The cells encode the **signed** value, so a left-hand row reads low across its whole length — the opposite of what the pitch does. Flipping the sign before encoding would put numbers in the display the chart does not contain. `docs/BRAILLE.md` states the disagreement, since a reader cannot tell from the dots; what braille adds is the silhouette.

## Registration

All six sites plus the docs. `IS_ORIENTED` is **true**, for the same reason the stacked bar it extends is.

## Verification

On the rebase onto current `main`:

- `npm test` — **2296 + 73 passed**, 167 suites
- `npx playwright test --project=chromium pyramid bump funnel hexbin` — **20 passed**
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)