### PR TITLE
feat(funnel): give the ear the ratio it cannot compute

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -401,6 +401,33 @@ Encoding a rotation into cell heights would answer neither.
 Radar charts use one line per series on a multiline display, so several models'
 profiles can be compared with one sweep rather than by toggling between rows.
 
+## Funnel
+
+A single row of stage counts, scaled against that row's own range -- the bar
+encoding unchanged.
+
+**The cells carry the counts, not the retention the pitch carries.** The two
+deliberately answer different questions, and it is worth knowing which is
+which.
+
+The pitch takes the **ratio** between adjacent stages, because a ratio is what
+a listener cannot compute: two heights heard one at a time do not give a
+percentage, and on a raw scale the worst stage in a funnel is routinely not
+the biggest fall. Braille takes the **counts**, because a display can show a
+shape all at once and that shape *is* the funnel -- a wide first cell tapering
+to a narrow last one, with the steep steps legible as the cells where the dots
+drop several levels at once.
+
+So the ear is told how bad each step is and the fingers are shown what the
+whole thing looks like. Encoding the retention in the cells instead would put
+a near-full cell wherever a stage lost nobody, and the display would no longer
+narrow -- a funnel that reads as a rectangle.
+
+### Multiline Displays
+
+Funnel charts use a single-line representation. On multiline braille displays
+the funnel appears on the first line and the remaining lines are unused.
+
 ## Gantt, timeline and swimlane
 
 A gantt's braille is the multi-line encoding: **one row per lane**, one cell

--- a/e2e_tests/specs/funnel.spec.ts
+++ b/e2e_tests/specs/funnel.spec.ts
@@ -1,0 +1,137 @@
+import type { Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * Every braille cell MAIDR can emit lives in the Unicode braille block
+ * (U+2800 to U+28FF), so a display carrying anything else is not braille
+ * output.
+ */
+const BRAILLE_CELL = /^[\u2800-\u28FF]+$/;
+
+/** The example's own page, driven through the shared base helpers. */
+class FunnelPlotPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the funnel example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/funnel.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'funnel-checkout');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   * @returns The braille content, whitespace trimmed
+   */
+  public async getBrailleContent(): Promise<string> {
+    const textarea = await this.waitForElement(this.selectors.braille);
+    // Only the trailing newline is stripped, not the whitespace before it: a
+    // lane with nothing booked renders as an empty row, and trimming would
+    // delete it and leave the reader's line count one short of the chart's.
+    return (await textarea.inputValue()).replace(/\n$/, '');
+  }
+}
+
+test.describe('Funnel', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new FunnelPlotPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new FunnelPlotPage(page).navigateToPlot();
+  });
+
+  test('should declare the layer as a funnel', () => {
+    expect(maidrData.subplots[0][0].layers[0].type).toBe('funnel');
+  });
+
+  test('should carry the stages in the order they are walked', () => {
+    const stages = maidrData.subplots[0][0].layers[0].data as { x: string; y: number }[];
+
+    expect(stages.map(stage => stage.x))
+      .toEqual(['Visited', 'Signed up', 'Viewed cart', 'Purchased']);
+  });
+
+  test('should announce the retention alongside the count', async ({ page }) => {
+    // The drop-off is what the chart is read for, and it is a ratio a
+    // listener cannot take from two heights heard one at a time.
+    const plot = new FunnelPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('Signed up');
+    expect(announcement).toContain('2400');
+    expect(announcement).toContain('24.0%');
+  });
+
+  test('should claim no retention on the entry stage', async ({ page }) => {
+    // Nothing converted into it, so "100% retained" would report a
+    // conversion the chart never claimed, and "Entered is 10000, 100.0% of
+    // it" would say the same number twice.
+    const plot = new FunnelPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('10000');
+    expect(announcement).not.toContain('100.0%');
+    expect(announcement).not.toContain('Retained');
+  });
+
+  test('should render one braille row of stage counts', async ({ page }) => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    const plot = new FunnelPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.toggleBrailleMode();
+
+    const braille = await plot.getBrailleContent();
+
+    expect(braille).toMatch(BRAILLE_CELL);
+    expect(braille).toHaveLength(4);
+  });
+});

--- a/examples/funnel.html
+++ b/examples/funnel.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Funnel Chart Example — Checkout Funnel</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        The number a reader wants from a funnel is not the one it plots. A
+        funnel is read for its drop-offs, and a drop-off is a ratio between
+        adjacent bars - which a listener cannot take by ear from two heights
+        heard one at a time.
+
+        This chart is built so the raw scale and the retention disagree.
+        Visited to Signed up loses three quarters of the axis and keeps 24%.
+        Viewed cart to Purchased loses only a fifth of the axis and keeps
+        4.3%. The second is the catastrophe; the first is the ordinary top of
+        a funnel. Pitched by count, they are heard the wrong way round.
+
+        So the pitch carries the retention and the announcement carries the
+        count, the retention and the share of everyone who entered. Ratios go
+        to the ear because ratios are what it cannot compute.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="800pt" height="432pt" viewBox="0 0 800 432" version="1.1"
+        id="funnel-checkout" maidr='{&#10;  &quot;id&quot;: &quot;funnel-checkout&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;funnel-checkout-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;funnel-checkout-layer&quot;,&#10;            &quot;type&quot;: &quot;funnel&quot;,&#10;            &quot;title&quot;: &quot;Checkout Funnel&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Stage&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;People&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;funnel-bars&#x27;] &gt; rect&quot;,&#10;            &quot;data&quot;: [&#10;              {&#10;                &quot;x&quot;: &quot;Visited&quot;,&#10;                &quot;y&quot;: 10000&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Signed up&quot;,&#10;                &quot;y&quot;: 2400&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Viewed cart&quot;,&#10;                &quot;y&quot;: 2300&#10;              },&#10;              {&#10;                &quot;x&quot;: &quot;Purchased&quot;,&#10;                &quot;y&quot;: 100&#10;              }&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 800 432  L 800 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="funnel-bars">
+          <rect x="120.0" y="110" width="560.0" height="48" style="fill: #4c72b0" />
+          <rect x="332.8" y="172" width="134.4" height="48" style="fill: #4c72b0" />
+          <rect x="335.6" y="234" width="128.8" height="48" style="fill: #4c72b0" />
+          <rect x="397.0" y="296" width="6.0" height="48" style="fill: #4c72b0" />
+            </g>
+            <g id="stage-labels">
+          <text x="400" y="139.0" style="font: 13px sans-serif; text-anchor: middle; fill: #ffffff">Visited</text>
+          <text x="700.0" y="139.0" style="font: 12px sans-serif; text-anchor: start">10,000</text>
+          <text x="400" y="201.0" style="font: 13px sans-serif; text-anchor: middle; fill: #ffffff">Signed up</text>
+          <text x="700.0" y="201.0" style="font: 12px sans-serif; text-anchor: start">2,400</text>
+          <text x="400" y="263.0" style="font: 13px sans-serif; text-anchor: middle; fill: #ffffff">Viewed cart</text>
+          <text x="700.0" y="263.0" style="font: 12px sans-serif; text-anchor: start">2,300</text>
+          <text x="400" y="325.0" style="font: 13px sans-serif; text-anchor: middle; fill: #ffffff">Purchased</text>
+          <text x="700.0" y="325.0" style="font: 12px sans-serif; text-anchor: start">100</text>
+            </g>
+            <g id="chart-title">
+              <text x="400" y="60" style="font: 16px sans-serif; text-anchor: middle">Checkout Funnel</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -63,6 +63,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.DUMBBELL]: 'Dumbbell Chart',
   [TraceType.ERROR_BAR]: 'Error Bar Chart',
   [TraceType.GANTT]: 'Gantt Chart',
+  [TraceType.FUNNEL]: 'Funnel Chart',
   [TraceType.GAUGE]: 'Gauge',
   [TraceType.HEATMAP]: 'Heatmap',
   [TraceType.HISTOGRAM]: 'Histogram',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -7,6 +7,7 @@ import { BoxTrace } from './box';
 import { Candlestick } from './candlestick';
 import { DumbbellTrace } from './dumbbell';
 import { ErrorBarTrace } from './errorBar';
+import { FunnelTrace } from './funnel';
 import { GanttTrace } from './gantt';
 import { GaugeTrace } from './gauge';
 import { Heatmap } from './heatmap';
@@ -58,6 +59,9 @@ export abstract class TraceFactory {
 
       case TraceType.ERROR_BAR:
         return new ErrorBarTrace(layer);
+
+      case TraceType.FUNNEL:
+        return new FunnelTrace(layer);
 
       case TraceType.GANTT:
         return new GanttTrace(layer);

--- a/src/model/funnel.ts
+++ b/src/model/funnel.ts
@@ -1,0 +1,201 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { AudioState, DescriptionState, TextState, TraceState } from '@type/state';
+import { BarTrace, isMeasured } from './bar';
+
+/**
+ * Formats a fraction as a percentage, to one decimal place.
+ *
+ * One decimal because a funnel's interesting numbers are often small: a stage
+ * converting at 0.4% and one converting at 0.9% are more than twice apart, and
+ * rounding both to "0%" would report them as identical.
+ *
+ * @param fraction - A fraction, where 1 is everything
+ * @returns The percentage, as text
+ */
+function asPercent(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+/**
+ * Trace implementation for funnel charts -- a population shrinking across
+ * ordered stages.
+ *
+ * Structurally a bar chart whose order is meaningful, so navigation, braille
+ * and highlighting transfer. What is different is that **the number a reader
+ * wants is not the one the chart plots.** A funnel is read for its drop-offs:
+ * which stage loses people, and how badly. That is a ratio between adjacent
+ * bars, and a listener cannot take a ratio by ear from two heights heard one
+ * at a time.
+ *
+ * So the pitch carries the **retention** -- what fraction of the previous
+ * stage survived -- rather than the count. On a raw scale the worst stage in a
+ * funnel is routinely not the biggest fall: going from 10,000 to 2,400 drops
+ * three quarters of the range and keeps 24%, while 2,300 to 100 drops only a
+ * fifth of the range and keeps **4%**. The second is the catastrophe and the
+ * first is the ordinary top of a funnel, and a reader listening to absolute
+ * heights hears them the other way round.
+ *
+ * The count is not lost -- it is announced, alongside the retention and the
+ * share of the population that entered. Ratios are what the ear is given,
+ * because ratios are what it cannot compute.
+ */
+export class FunnelTrace extends BarTrace {
+  /** Each stage's count, in the order the funnel is walked. */
+  private readonly counts: number[];
+
+  /**
+   * What fraction of the previous stage reached each one.
+   *
+   * The first stage is 1: nothing converted into it, and it kept all of
+   * itself. That is an artifact of there being no previous stage rather than a
+   * measurement, which is why the announcement says "first stage" there
+   * instead of "100% retained" -- a reader told the latter would hear a
+   * perfect conversion the chart never claimed.
+   */
+  private readonly retention: number[];
+
+  /** What fraction of the first stage reached each one. */
+  private readonly share: number[];
+
+  /**
+   * Creates a new funnel trace.
+   *
+   * @param layer - The MAIDR layer carrying the stages
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.counts = this.barValues[0] ?? [];
+
+    const entered = this.counts[0];
+    this.share = this.counts.map(count =>
+      FunnelTrace.ratio(count, entered));
+    this.retention = this.counts.map((count, stage) =>
+      (stage === 0 ? 1 : FunnelTrace.ratio(count, this.counts[stage - 1])));
+  }
+
+  /**
+   * One count against another, guarded.
+   *
+   * A stage that measured nothing has no ratio to report, and a stage
+   * following an empty one has nothing to be a fraction of -- dividing would
+   * hand the audio a non-finite frequency and the announcement an infinity.
+   * Both answer `NaN`, which is how this codebase already says a value is
+   * absent: the pitch sounds it as a gap and the text reads it as "missing".
+   *
+   * @param count - The stage's own count
+   * @param against - The count it is measured against
+   * @returns The fraction, or NaN when there is none
+   */
+  private static ratio(count: number, against: number): number {
+    if (!isMeasured(count) || !isMeasured(against) || against === 0) {
+      return Number.NaN;
+    }
+    return count / against;
+  }
+
+  protected override get audio(): AudioState {
+    const base = super.audio;
+
+    // Zero to one, and the retention against it. The parent pitches the count
+    // against the chart's own range, where the top of a funnel dominates and
+    // every later stage is squeezed into the bottom of the register -- so the
+    // stages a reader is listening for are the ones the scale flattens.
+    return {
+      ...base,
+      freq: { min: 0, max: 1, raw: this.retention[this.col] },
+    };
+  }
+
+  protected override get text(): TextState {
+    const base = super.text;
+    const stage = this.col;
+
+    if (stage === 0) {
+      // The entry stage carries neither. Nothing converted into it, so a
+      // retention would report a conversion the chart never claimed; and it
+      // IS the population that entered, so "Entered is 10000, 100.0% of it"
+      // says the same number twice and calls one of them a share.
+      //
+      // Saying nothing is also the signal: every other stage announces a
+      // retention, so the stage that does not is the one the funnel starts
+      // at. The description names it too, for a reader who arrived by rotor
+      // rather than by walking.
+      return base;
+    }
+
+    return {
+      ...base,
+      // What fraction of the previous stage got here.
+      z: { label: 'Retained', value: asPercent(this.retention[stage]) },
+      // The population that entered, with this stage's share of it. Renders as
+      // ", Entered is 10000, 24.0% of it" -- the cumulative view, which the
+      // per-stage retention does not give and which a reader would otherwise
+      // have to multiply out across every stage they had passed.
+      stack: {
+        label: 'Entered',
+        value: this.counts[0],
+        share: this.share[stage],
+      },
+    };
+  }
+
+  public override get description(): DescriptionState {
+    const base = super.description;
+    const stats = [...base.stats];
+
+    const entry = this.points[0]?.[0]?.x;
+    if (entry !== undefined) {
+      stats.push({ label: 'Entry stage', value: entry });
+    }
+
+    if (this.counts.length > 1) {
+      const overall = this.share[this.share.length - 1];
+      if (Number.isFinite(overall)) {
+        stats.push({ label: 'Overall conversion', value: asPercent(overall) });
+      }
+
+      const worst = this.worstStage();
+      if (worst !== null) {
+        // The finding. A funnel is drawn to locate the stage that loses
+        // people, and it is the one thing a reader cannot assemble from a
+        // sequence of counts without dividing each by the one before it.
+        stats.push({
+          label: 'Steepest drop',
+          value: `${this.points[0][worst].x}, ${asPercent(this.retention[worst])} retained`,
+        });
+      }
+    }
+
+    return { ...base, stats };
+  }
+
+  /**
+   * The stage that kept the smallest share of the one before it.
+   *
+   * Skips the first, which has no previous stage to have lost anyone from.
+   *
+   * @returns The stage index, or null when no stage has a measured retention
+   */
+  private worstStage(): number | null {
+    let worst: number | null = null;
+    for (let stage = 1; stage < this.retention.length; stage++) {
+      if (!Number.isFinite(this.retention[stage])) {
+        continue;
+      }
+      if (worst === null || this.retention[stage] < this.retention[worst]) {
+        worst = stage;
+      }
+    }
+    return worst;
+  }
+
+  public override get state(): TraceState {
+    const base = super.state;
+    if (base.empty) {
+      return base;
+    }
+
+    return { ...base, plotType: 'funnel' };
+  }
+}

--- a/src/model/funnel.ts
+++ b/src/model/funnel.ts
@@ -1,5 +1,6 @@
 import type { MaidrLayer } from '@type/grammar';
 import type { AudioState, DescriptionState, TextState, TraceState } from '@type/state';
+import { Orientation } from '@type/grammar';
 import { BarTrace, isMeasured } from './bar';
 
 /**
@@ -140,11 +141,34 @@ export class FunnelTrace extends BarTrace {
     };
   }
 
+  /**
+   * What a stage is called.
+   *
+   * Which field holds the name depends on how the funnel is drawn: a
+   * horizontal bar layer carries its magnitude on `x` and its category on
+   * `y`, and a funnel is drawn top to bottom at least as often as left to
+   * right. The parent's `text` getter already resolves this for the
+   * announcement; the description is the other place a stage is named, and it
+   * has to resolve it the same way or it reports the **count** where the
+   * name belongs -- in the one summary a reader consults precisely to find
+   * out where the funnel starts and where it breaks.
+   *
+   * @param stage - Which stage
+   * @returns Its name, or undefined when the stage does not exist
+   */
+  private stageNameAt(stage: number): number | string | undefined {
+    const point = this.points[0]?.[stage];
+    if (point === undefined) {
+      return undefined;
+    }
+    return this.orientation === Orientation.VERTICAL ? point.x : point.y;
+  }
+
   public override get description(): DescriptionState {
     const base = super.description;
     const stats = [...base.stats];
 
-    const entry = this.points[0]?.[0]?.x;
+    const entry = this.stageNameAt(0);
     if (entry !== undefined) {
       stats.push({ label: 'Entry stage', value: entry });
     }
@@ -162,7 +186,7 @@ export class FunnelTrace extends BarTrace {
         // sequence of counts without dividing each by the one before it.
         stats.push({
           label: 'Steepest drop',
-          value: `${this.points[0][worst].x}, ${asPercent(this.retention[worst])} retained`,
+          value: `${this.stageNameAt(worst)}, ${asPercent(this.retention[worst])} retained`,
         });
       }
     }

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1123,6 +1123,12 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // so a fortnight and three weeks become the same dot. Exact about how
       // long beats approximate about when.
       [TraceType.GANTT, asGeneric(new LineBrailleEncoder())],
+      // A single row of stage counts scaled against that row's own range --
+      // the bar encoder's input exactly. The cells carry the COUNTS, not the
+      // retention the pitch carries, and `docs/BRAILLE.md` says why: the
+      // counts are the funnel's silhouette, which is what a display can show
+      // and a tone cannot.
+      [TraceType.FUNNEL, asGeneric(new BarBrailleEncoder())],
       // A single cell scaled against the dial's own ends -- the bar encoder's
       // input with one column, so the reader feels where on the dial the
       // measure sits rather than only that it exists.

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -916,6 +916,14 @@ export enum TraceType {
    * sweep left to right with the axis, so later is audibly later.
    */
   GANTT = 'gantt',
+  /**
+   * A population shrinking across ordered stages. Navigated as a
+   * {@link TraceType.BAR} layer is, with the one difference that decides
+   * whether the chart is readable: the number a reader wants is the
+   * **retention** between adjacent stages, not the count, so that is what the
+   * pitch carries. The counts are announced alongside it.
+   */
+  FUNNEL = 'funnel',
   GAUGE = 'gauge',
   HEATMAP = 'heat',
   HISTOGRAM = 'hist',

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -40,6 +40,11 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // bar or a box is oriented. A timeline drawn down the page is the ordinary
   // alternative, not an exotic one.
   [TraceType.GANTT]: true,
+  // A funnel is drawn top to bottom as often as left to right, and the stages
+  // run along one axis with the counts on the other either way -- so which
+  // axis a bar's length lies on depends on how it was drawn, exactly as it
+  // does for the bar chart this extends.
+  [TraceType.FUNNEL]: true,
   // One measure on a dial. There is no second axis for it to be read against,
   // so there is nothing an orientation could swap.
   [TraceType.GAUGE]: false,

--- a/test/model/funnel.test.ts
+++ b/test/model/funnel.test.ts
@@ -3,7 +3,7 @@ import type { NonEmptyTraceState } from '@type/state';
 import { describe, expect, test } from '@jest/globals';
 import { TraceFactory } from '@model/factory';
 import { FunnelTrace } from '@model/funnel';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 
 /**
  * Four stages, arranged so the raw scale and the retention disagree.
@@ -26,15 +26,32 @@ const STAGES: BarPoint[] = [
  * @param data The stages the layer carries
  * @returns Funnel layer definition
  */
-function createLayer(data: BarPoint[] = STAGES): MaidrLayer {
+function createLayer(
+  data: BarPoint[] = STAGES,
+  orientation: Orientation = Orientation.VERTICAL,
+): MaidrLayer {
   return {
     id: 'test-funnel-layer',
     type: TraceType.FUNNEL,
     title: 'Checkout funnel',
+    orientation,
     axes: { x: { label: 'Stage' }, y: { label: 'People' } },
     data,
   };
 }
+
+/**
+ * The same four stages a funnel drawn top to bottom carries.
+ *
+ * A horizontal bar layer puts the magnitude on `x` and the category on `y`,
+ * which is the pair the parent reads. A funnel is drawn this way at least as
+ * often as the other, so it is the arrangement where reading a fixed field
+ * is wrong.
+ */
+const HORIZONTAL_STAGES: BarPoint[] = STAGES.map(point => ({
+  x: point.y,
+  y: point.x,
+}));
 
 /**
  * Read the trace's current state, asserting it is a populated one.
@@ -203,5 +220,35 @@ describe('the description locates the drop', () => {
     const stats = funnel(0, [{ x: 'only', y: 5 }]).description.stats;
 
     expect(stats.find(stat => stat.label === 'Steepest drop')).toBeUndefined();
+  });
+});
+
+describe('a funnel drawn top to bottom', () => {
+  /**
+   * Build a horizontally oriented funnel.
+   * @returns The trace
+   */
+  function horizontal(): FunnelTrace {
+    return TraceFactory.create(
+      createLayer(HORIZONTAL_STAGES, Orientation.HORIZONTAL),
+    ) as FunnelTrace;
+  }
+
+  test('names the entry stage rather than counting it', () => {
+    // Read off a fixed field, this reports 10000 -- the count where the name
+    // belongs, in the one summary a reader consults to find out where the
+    // funnel starts.
+    const stats = horizontal().description.stats;
+    const read = (label: string): unknown =>
+      stats.find(stat => stat.label === label)?.value;
+
+    expect(read('Entry stage')).toBe('Visited');
+  });
+
+  test('names the stage that loses the most people', () => {
+    const stats = horizontal().description.stats;
+    const worst = stats.find(stat => stat.label === 'Steepest drop')?.value;
+
+    expect(worst).toBe('Purchased, 4.3% retained');
   });
 });

--- a/test/model/funnel.test.ts
+++ b/test/model/funnel.test.ts
@@ -1,0 +1,207 @@
+import type { BarPoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { FunnelTrace } from '@model/funnel';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Four stages, arranged so the raw scale and the retention disagree.
+ *
+ * `Visited -> Signed up` loses three quarters of the axis and keeps 24%.
+ * `Viewed -> Purchased` loses a fifth of the axis and keeps **4%**. The second
+ * is the catastrophe and the first is the ordinary top of a funnel, so a
+ * reading that pitched the counts hears them the wrong way round -- which is
+ * the whole reason this is a type of its own.
+ */
+const STAGES: BarPoint[] = [
+  { x: 'Visited', y: 10000 },
+  { x: 'Signed up', y: 2400 },
+  { x: 'Viewed', y: 2300 },
+  { x: 'Purchased', y: 100 },
+];
+
+/**
+ * Create a minimal funnel layer for model-only tests.
+ * @param data The stages the layer carries
+ * @returns Funnel layer definition
+ */
+function createLayer(data: BarPoint[] = STAGES): MaidrLayer {
+  return {
+    id: 'test-funnel-layer',
+    type: TraceType.FUNNEL,
+    title: 'Checkout funnel',
+    axes: { x: { label: 'Stage' }, y: { label: 'People' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: FunnelTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a funnel trace positioned on one stage.
+ * @param col Which stage
+ * @param data The stages the layer carries
+ * @returns The positioned trace
+ */
+function funnel(col = 0, data: BarPoint[] = STAGES): FunnelTrace {
+  const trace = TraceFactory.create(createLayer(data)) as FunnelTrace;
+  trace.moveToIndex(0, col);
+  return trace;
+}
+
+/**
+ * Where a state's pitch sits within the range it was given, 0 to 1.
+ * @param state The trace state to read
+ * @returns The relative pitch
+ */
+function pitch(state: NonEmptyTraceState): number {
+  const { min, max, raw } = state.audio.freq;
+  return (Number(raw) - min) / (max - min);
+}
+
+describe('funnel registration', () => {
+  test('the factory builds a FunnelTrace', () => {
+    expect(TraceFactory.create(createLayer())).toBeInstanceOf(FunnelTrace);
+  });
+
+  test('announces itself as the chart it is', () => {
+    expect(funnel().description.chartType).toBe('Funnel Chart');
+    expect(nonEmptyState(funnel()).plotType).toBe('funnel');
+  });
+});
+
+describe('the ear gets the ratio, because the ear cannot take a ratio', () => {
+  test('the pitch is the retention, not the count', () => {
+    // Signed up keeps 24% of Visited.
+    const { audio } = nonEmptyState(funnel(1));
+
+    expect(audio.freq.raw).toBeCloseTo(0.24);
+    expect(audio.freq.min).toBe(0);
+    expect(audio.freq.max).toBe(1);
+  });
+
+  test('the worst stage is the lowest note, which the counts would not give', () => {
+    // Purchased keeps 4% and is the catastrophe; Signed up keeps 24% and is
+    // the ordinary top of a funnel. On the raw scale the fall into Signed up
+    // is three times the fall into Purchased -- so pitching counts reports
+    // the healthy stage as the worse one.
+    const signedUp = pitch(nonEmptyState(funnel(1)));
+    const purchased = pitch(nonEmptyState(funnel(3)));
+
+    expect(purchased).toBeLessThan(signedUp);
+
+    // And the counts really do disagree, so the assertion above is not a
+    // coincidence of this fixture.
+    const counts = STAGES.map(stage => Number(stage.y));
+    const rawFallIntoSignedUp = counts[0] - counts[1];
+    const rawFallIntoPurchased = counts[2] - counts[3];
+    expect(rawFallIntoSignedUp).toBeGreaterThan(rawFallIntoPurchased);
+  });
+
+  test('a stage that lost nobody sounds like one', () => {
+    // Viewed keeps 95.8% of Signed up, which has to be near the top of the
+    // register rather than near the bottom where its count sits.
+    expect(pitch(nonEmptyState(funnel(2)))).toBeGreaterThan(0.9);
+  });
+});
+
+describe('the announcement keeps the count', () => {
+  test('gives the stage, the count, the retention and the share', () => {
+    const { text } = nonEmptyState(funnel(1));
+
+    expect(text.main.value).toBe('Signed up');
+    expect(text.cross.value).toBe(2400);
+    expect(text.z).toEqual({ label: 'Retained', value: '24.0%' });
+    expect(text.stack?.label).toBe('Entered');
+    expect(text.stack?.value).toBe(10000);
+    expect(text.stack?.share).toBeCloseTo(0.24);
+  });
+
+  test('the entry stage claims neither a retention nor a share', () => {
+    // "100% retained" would report a conversion the chart never claimed --
+    // nothing converted into the first stage -- and "Entered is 10000, 100.0%
+    // of it" says the same number twice while calling one of them a share.
+    const { text } = nonEmptyState(funnel(0));
+
+    expect(text.z).toBeUndefined();
+    expect(text.stack).toBeUndefined();
+    // The count itself is still there.
+    expect(text.cross.value).toBe(10000);
+  });
+
+  test('the description names the entry stage, since the announcement does not', () => {
+    // Silence is the signal when walking the funnel, but a reader who
+    // arrived by rotor has nothing to have contrasted it against.
+    const stats = funnel().description.stats;
+
+    expect(stats.find(stat => stat.label === 'Entry stage')?.value)
+      .toBe('Visited');
+  });
+
+  test('the share is cumulative, which the retention alone does not give', () => {
+    // Viewed keeps 95.8% of the stage before it but only 23% of everyone who
+    // entered, and a reader would otherwise have to multiply out every stage
+    // they had passed.
+    const { text } = nonEmptyState(funnel(2));
+
+    expect(text.z?.value).toBe('95.8%');
+    expect(text.stack?.share).toBeCloseTo(0.23);
+  });
+});
+
+describe('a stage that measured nothing', () => {
+  test('reports no ratio rather than an infinity', () => {
+    // Dividing by an empty stage would hand the audio a non-finite frequency
+    // and the announcement an infinity.
+    const withZero: BarPoint[] = [
+      { x: 'a', y: 100 },
+      { x: 'b', y: 0 },
+      { x: 'c', y: 0 },
+    ];
+    const { audio } = nonEmptyState(funnel(2, withZero));
+
+    expect(Number.isNaN(Number(audio.freq.raw))).toBe(true);
+  });
+
+  test('a zero stage is a real reading of zero retention, not a gap', () => {
+    const withZero: BarPoint[] = [
+      { x: 'a', y: 100 },
+      { x: 'b', y: 0 },
+    ];
+
+    expect(nonEmptyState(funnel(1, withZero)).audio.freq.raw).toBe(0);
+  });
+});
+
+describe('the description locates the drop', () => {
+  const read = (label: string): unknown =>
+    funnel().description.stats.find(stat => stat.label === label)?.value;
+
+  test('names the steepest drop by retention, not by size', () => {
+    // The one thing a reader cannot assemble from a sequence of counts
+    // without dividing each by the one before it.
+    expect(read('Steepest drop')).toBe('Purchased, 4.3% retained');
+  });
+
+  test('reports the overall conversion', () => {
+    expect(read('Overall conversion')).toBe('1.0%');
+  });
+
+  test('says nothing about a drop on a single-stage funnel', () => {
+    const stats = funnel(0, [{ x: 'only', y: 5 }]).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Steepest drop')).toBeUndefined();
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -19,6 +19,9 @@ describe('resolveOrientation', () => {
     // drawn decides which axis an interval's ends move on. A timeline drawn
     // down the page is the ordinary alternative, not an exotic one.
     TraceType.GANTT,
+    // A funnel is drawn top to bottom as often as left to right, and the
+    // stages run along one axis with the counts on the other either way.
+    TraceType.FUNNEL,
     TraceType.HISTOGRAM,
     TraceType.NORMALIZED,
     TraceType.STACKED,


### PR DESCRIPTION
Closes #791.

## The number a reader wants is not the one the chart plots

#791 puts it exactly: "the value the reader actually wants is rarely the raw count — it is the drop." A drop-off is a **ratio between adjacent bars**, and a ratio is precisely what a listener cannot take from two heights heard one at a time.

So the pitch carries the retention. The case for it is stronger than "nicer": on a raw scale the worst stage in a funnel is routinely **not** the biggest fall.

| step | falls | keeps |
|---|---|---|
| Visited → Signed up | 7,600 — three quarters of the axis | **24%** |
| Viewed cart → Purchased | 2,200 — a fifth of the axis | **4.3%** |

The second is the catastrophe; the first is the ordinary top of a funnel. A reader listening to absolute heights hears them the other way round, and the shipped example is built so they genuinely disagree — `the worst stage is the lowest note, which the counts would not give` asserts both halves, including that the raw falls really do rank the other way, so the test cannot pass by coincidence of fixture.

## The count is not lost

Each stage announces the count, the retention, **and** its share of everyone who entered:

> Stage is Signed up, People is 2400, Retained is 24.0%, Entered is 10000, 24.0% of it

The share is the cumulative view the per-stage ratio does not give, and which a reader would otherwise have to multiply out across every stage they had passed. It uses `TextState.stack`'s existing `share` field, which renders as "N% of it" — the same slot a stacked area uses for its running total.

## The entry stage claims neither, and that took two passes

My first version reported the entry stage as `Stage is first` with `Entered is 10000, 100.0% of it`. The e2e caught two problems in one line:

- **`Stage` labelled two different things** — the x-axis label and the z value — in a single sentence. The inverse of the "two words for one referent" defect flagged on #835.
- **"100.0% of it" was vacuous.** The entry stage *is* the population that entered, so that says one number twice and calls one of them a share. And "100% retained" reports a conversion the chart never claimed: nothing converted into the first stage.

Both are gone. The entry stage announces its name and its count and nothing else, and **its silence is the signal** — every other stage carries a retention, so the one that does not is where the funnel starts. The description names it as `Entry stage` for a reader who arrived by rotor rather than by walking.

## Braille keeps the counts

Deliberately not matching the pitch, and `docs/BRAILLE.md` says why. The counts *are* the funnel's silhouette — wide first cell tapering to a narrow last one, with the steep steps legible as the cells where the dots drop several levels at once. Encoding retention instead would put a near-full cell wherever a stage lost nobody, and the display would stop narrowing: a funnel that reads as a rectangle.

The ear is told how bad each step is; the fingers are shown what the whole thing looks like.

## Empty stages

A stage following an empty one has nothing to be a fraction of. Dividing would hand the audio a non-finite frequency and the announcement an infinity, so it answers `NaN` — how this codebase already says a value is absent. A stage that measured **zero** after a non-empty one is a real reading of zero retention, not a gap, and is pitched at the floor rather than sounded as missing.

## Registration

All six sites plus the docs. `IS_ORIENTED` is **true**, for the same reason the bar chart it extends is — a funnel is drawn top-to-bottom as often as left-to-right.

## Verification

- `npm test` — **2204 + 73 passed**, 170 suites, none failing
- `npx playwright test --project=chromium funnel` — **5 passed**
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_