### PR TITLE
feat(hexbin): keep a vertical walk over the x it started from

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -105,6 +105,28 @@ Multiline braille displays represent grouped boxplots, such as horizontal boxplo
 
 Single-line braille displays represent grouped boxplots by allowing users to navigate vertically between groups using the up and down arrow keys. As the user navigates, the braille representation updates to show the boxplot for the current group, enabling users to explore each group's distribution one at a time.
 
+## Hexbin
+
+One row per lattice row, one cell per bin, using the heatmap encoding above —
+because read as a lattice of cells each carrying a count, that is what a
+hexbin is.
+
+**The stagger has no representation here, and needs none.** A hex lattice
+offsets alternate rows by half a cell, and a braille display is a line of
+cells with nowhere to put half of one. What survives intact is the thing the
+chart is drawn for: the density pattern, as a run of cells that rises towards
+the cloud and falls away from it, with the empty margins reading as spaces.
+
+Where the offset *does* matter is navigation rather than encoding — moving up
+or down lands between two bins, so the trace keeps the reader over the x they
+started from rather than stepping by index. A display shows the whole row at
+once and never has to make that choice.
+
+### Multiline Displays
+
+Hexbin plots use one line per lattice row on a multiline display, so the shape
+of the cloud can be felt at once rather than row by row.
+
 ## Scatter plot
 
 In the Braille representation of a scatter plot, the encoding is performed only for the line layer (layer 2). Stand alone scatterplots without a line layer are not represented in braille.

--- a/e2e_tests/specs/hexbin.spec.ts
+++ b/e2e_tests/specs/hexbin.spec.ts
@@ -1,0 +1,154 @@
+import type { HexbinPoint, Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * A braille row of a sparse lattice: cells from the Unicode braille block
+ * (U+2800 to U+28FF), and spaces where a bin held nothing.
+ *
+ * The heatmap encoding this reuses renders an empty cell as a space, and on a
+ * hexbin that is most of the margin around the cloud -- so a row of pure
+ * braille would be the wrong assertion, not a stricter one.
+ */
+const BRAILLE_ROW = /^[\u2800-\u28FF ]+$/;
+
+/** At least one real cell, so an all-space row is not mistaken for output. */
+const BRAILLE_CELL_ANYWHERE = /[\u2800-\u28FF]/;
+
+/** The example's own page, driven through the shared base helpers. */
+class HexbinPlotPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the hexbin example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/hexbin.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'hexbin-density');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   * @returns The braille content, whitespace trimmed
+   */
+  public async getBrailleContent(): Promise<string> {
+    const textarea = await this.waitForElement(this.selectors.braille);
+    // Only the trailing newline is stripped, not the whitespace before it: a
+    // lane with nothing booked renders as an empty row, and trimming would
+    // delete it and leave the reader's line count one short of the chart's.
+    return (await textarea.inputValue()).replace(/\n$/, '');
+  }
+}
+
+test.describe('Hexbin', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new HexbinPlotPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new HexbinPlotPage(page).navigateToPlot();
+  });
+
+  test('should declare the layer as a hexbin', () => {
+    expect(maidrData.subplots[0][0].layers[0].type).toBe('hexbin');
+  });
+
+  test('should carry a staggered lattice', () => {
+    // The offset is the whole difficulty: alternate rows sit half a cell
+    // across, which is what lets the hexagons tessellate.
+    const rows = maidrData.subplots[0][0].layers[0].data as HexbinPoint[][];
+
+    expect(Number(rows[1][0].x) - Number(rows[0][0].x)).toBeCloseTo(0.5);
+    expect(rows[0].length).not.toBe(rows[1].length);
+  });
+
+  test('should announce a bin by its centre and count', async ({ page }) => {
+    // On a staggered lattice a column index is not a location, so it is not
+    // what the announcement gives.
+    const plot = new HexbinPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('Count');
+    expect(announcement).not.toContain('column');
+  });
+
+  test('should keep a vertical walk over the same x', async ({ page }) => {
+    // Two rows up and two rows back down has to return to where it started.
+    // Choosing the nearer bin relative to the one being left would drift
+    // half a cell per row and announce a real bin with a real count the
+    // whole way, so nothing but this check would notice.
+    const plot = new HexbinPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    const start = normalizeText(await plot.getInstructionText());
+
+    await plot.moveToDataPointAbove();
+    await plot.moveToDataPointAbove();
+    await plot.moveToDataPointBelow();
+    await plot.moveToDataPointBelow();
+
+    expect(normalizeText(await plot.getInstructionText())).toBe(start);
+  });
+
+  test('should render one braille row per lattice row', async ({ page }) => {
+    // Braille is the modality that fails silently for a new trace type: an
+    // unregistered encoder leaves the display blank while text and audio keep
+    // working, so nothing else in the suite would catch it.
+    const plot = new HexbinPlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.toggleBrailleMode();
+
+    const rows = (await plot.getBrailleContent()).split('\n');
+
+    // Five lattice rows, and every one of them real braille rather than the
+    // blank an unregistered encoder leaves behind. Spaces are admitted
+    // alongside the cells: an empty bin has no density to encode, and the
+    // heatmap encoding this reuses renders one as a space -- which on a
+    // hexbin is most of the margin around the cloud.
+    expect(rows).toHaveLength(5);
+    for (const row of rows) {
+      expect(row).toMatch(BRAILLE_ROW);
+      expect(row).toMatch(BRAILLE_CELL_ANYWHERE);
+    }
+  });
+});

--- a/examples/hexbin.html
+++ b/examples/hexbin.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Hexbin Example — Point Density</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        Read as a lattice of cells each carrying a count, a hexbin is a
+        heatmap - and navigation, braille and pitch all transfer on those
+        terms. The one real difference is that the rows are offset by half a
+        cell, which is what lets the hexagons tessellate.
+
+        That means a column index is not a position: bin 3 of one row and bin
+        3 of the next sit at different x. And it means a bin has no neighbour
+        directly above it - it has two, exactly equidistant. Choosing between
+        them relative to the bin being left would choose the same way every
+        time, so a walk up a tall lattice would drift half a cell per row and
+        slide off the feature it was following, announcing a real bin with a
+        real count at every step.
+
+        So a vertical move measures against where the reader STARTED, the way
+        a text editor keeps a desired column while arrowing past short lines,
+        and the announcement gives the bin's centre rather than its indices.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1"
+        id="hexbin-density" maidr='{&#10;  &quot;id&quot;: &quot;hexbin-density&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;hexbin-density-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;hexbin-density-layer&quot;,&#10;            &quot;type&quot;: &quot;hexbin&quot;,&#10;            &quot;title&quot;: &quot;Point Density&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;X&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Y&quot;&#10;              },&#10;              &quot;z&quot;: {&#10;                &quot;label&quot;: &quot;Count&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;hexbin-cells&#x27;] &gt; polygon&quot;,&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: 0.0,&#10;                  &quot;y&quot;: 0,&#10;                  &quot;count&quot;: 0&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1.0,&#10;                  &quot;y&quot;: 0,&#10;                  &quot;count&quot;: 0&#10;                },&#10;                {&#10;                  &quot;x&quot;: 2.0,&#10;                  &quot;y&quot;: 0,&#10;                  &quot;count&quot;: 2&#10;                },&#10;                {&#10;                  &quot;x&quot;: 3.0,&#10;                  &quot;y&quot;: 0,&#10;                  &quot;count&quot;: 4&#10;                },&#10;                {&#10;                  &quot;x&quot;: 4.0,&#10;                  &quot;y&quot;: 0,&#10;                  &quot;count&quot;: 3&#10;                },&#10;                {&#10;                  &quot;x&quot;: 5.0,&#10;                  &quot;y&quot;: 0,&#10;                  &quot;count&quot;: 1&#10;                },&#10;                {&#10;                  &quot;x&quot;: 6.0,&#10;                  &quot;y&quot;: 0,&#10;                  &quot;count&quot;: 0&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: 0.5,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;count&quot;: 1&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1.5,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;count&quot;: 4&#10;                },&#10;                {&#10;                  &quot;x&quot;: 2.5,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;count&quot;: 13&#10;                },&#10;                {&#10;                  &quot;x&quot;: 3.5,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;count&quot;: 16&#10;                },&#10;                {&#10;                  &quot;x&quot;: 4.5,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;count&quot;: 7&#10;                },&#10;                {&#10;                  &quot;x&quot;: 5.5,&#10;                  &quot;y&quot;: 1,&#10;                  &quot;count&quot;: 1&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: 0.0,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;count&quot;: 0&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1.0,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;count&quot;: 3&#10;                },&#10;                {&#10;                  &quot;x&quot;: 2.0,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;count&quot;: 14&#10;                },&#10;                {&#10;                  &quot;x&quot;: 3.0,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;count&quot;: 27&#10;                },&#10;                {&#10;                  &quot;x&quot;: 4.0,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;count&quot;: 21&#10;                },&#10;                {&#10;                  &quot;x&quot;: 5.0,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;count&quot;: 6&#10;                },&#10;                {&#10;                  &quot;x&quot;: 6.0,&#10;                  &quot;y&quot;: 2,&#10;                  &quot;count&quot;: 1&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: 0.5,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;count&quot;: 1&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1.5,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;count&quot;: 5&#10;                },&#10;                {&#10;                  &quot;x&quot;: 2.5,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;count&quot;: 16&#10;                },&#10;                {&#10;                  &quot;x&quot;: 3.5,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;count&quot;: 19&#10;                },&#10;                {&#10;                  &quot;x&quot;: 4.5,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;count&quot;: 9&#10;                },&#10;                {&#10;                  &quot;x&quot;: 5.5,&#10;                  &quot;y&quot;: 3,&#10;                  &quot;count&quot;: 2&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: 0.0,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;count&quot;: 0&#10;                },&#10;                {&#10;                  &quot;x&quot;: 1.0,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;count&quot;: 1&#10;                },&#10;                {&#10;                  &quot;x&quot;: 2.0,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;count&quot;: 3&#10;                },&#10;                {&#10;                  &quot;x&quot;: 3.0,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;count&quot;: 5&#10;                },&#10;                {&#10;                  &quot;x&quot;: 4.0,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;count&quot;: 4&#10;                },&#10;                {&#10;                  &quot;x&quot;: 5.0,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;count&quot;: 1&#10;                },&#10;                {&#10;                  &quot;x&quot;: 6.0,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;count&quot;: 0&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="hexbin-cells">
+          <polygon points="209.4,313.0 209.4,347.0 180.0,364.0 150.6,347.0 150.6,313.0 180.0,296.0" style="fill: rgb(240,245,250); stroke: #ffffff" />
+          <polygon points="268.3,313.0 268.3,347.0 238.9,364.0 209.4,347.0 209.4,313.0 238.9,296.0" style="fill: rgb(240,245,250); stroke: #ffffff" />
+          <polygon points="327.2,313.0 327.2,347.0 297.8,364.0 268.3,347.0 268.3,313.0 297.8,296.0" style="fill: rgb(225,235,245); stroke: #ffffff" />
+          <polygon points="386.1,313.0 386.1,347.0 356.7,364.0 327.2,347.0 327.2,313.0 356.7,296.0" style="fill: rgb(210,225,241); stroke: #ffffff" />
+          <polygon points="445.0,313.0 445.0,347.0 415.6,364.0 386.1,347.0 386.1,313.0 415.6,296.0" style="fill: rgb(217,230,243); stroke: #ffffff" />
+          <polygon points="503.9,313.0 503.9,347.0 474.4,364.0 445.0,347.0 445.0,313.0 474.4,296.0" style="fill: rgb(232,240,247); stroke: #ffffff" />
+          <polygon points="562.8,313.0 562.8,347.0 533.3,364.0 503.9,347.0 503.9,313.0 533.3,296.0" style="fill: rgb(240,245,250); stroke: #ffffff" />
+          <polygon points="238.9,262.0 238.9,296.0 209.4,313.0 180.0,296.0 180.0,262.0 209.4,245.0" style="fill: rgb(232,240,247); stroke: #ffffff" />
+          <polygon points="297.8,262.0 297.8,296.0 268.3,313.0 238.9,296.0 238.9,262.0 268.3,245.0" style="fill: rgb(210,225,241); stroke: #ffffff" />
+          <polygon points="356.7,262.0 356.7,296.0 327.2,313.0 297.8,296.0 297.8,262.0 327.2,245.0" style="fill: rgb(143,182,221); stroke: #ffffff" />
+          <polygon points="415.6,262.0 415.6,296.0 386.1,313.0 356.7,296.0 356.7,262.0 386.1,245.0" style="fill: rgb(121,167,214); stroke: #ffffff" />
+          <polygon points="474.4,262.0 474.4,296.0 445.0,313.0 415.6,296.0 415.6,262.0 445.0,245.0" style="fill: rgb(188,211,234); stroke: #ffffff" />
+          <polygon points="533.3,262.0 533.3,296.0 503.9,313.0 474.4,296.0 474.4,262.0 503.9,245.0" style="fill: rgb(232,240,247); stroke: #ffffff" />
+          <polygon points="209.4,211.0 209.4,245.0 180.0,262.0 150.6,245.0 150.6,211.0 180.0,194.0" style="fill: rgb(240,245,250); stroke: #ffffff" />
+          <polygon points="268.3,211.0 268.3,245.0 238.9,262.0 209.4,245.0 209.4,211.0 238.9,194.0" style="fill: rgb(217,230,243); stroke: #ffffff" />
+          <polygon points="327.2,211.0 327.2,245.0 297.8,262.0 268.3,245.0 268.3,211.0 297.8,194.0" style="fill: rgb(136,177,218); stroke: #ffffff" />
+          <polygon points="386.1,211.0 386.1,245.0 356.7,262.0 327.2,245.0 327.2,211.0 356.7,194.0" style="fill: rgb(40,115,190); stroke: #ffffff" />
+          <polygon points="445.0,211.0 445.0,245.0 415.6,262.0 386.1,245.0 386.1,211.0 415.6,194.0" style="fill: rgb(84,143,203); stroke: #ffffff" />
+          <polygon points="503.9,211.0 503.9,245.0 474.4,262.0 445.0,245.0 445.0,211.0 474.4,194.0" style="fill: rgb(195,216,236); stroke: #ffffff" />
+          <polygon points="562.8,211.0 562.8,245.0 533.3,262.0 503.9,245.0 503.9,211.0 533.3,194.0" style="fill: rgb(232,240,247); stroke: #ffffff" />
+          <polygon points="238.9,160.0 238.9,194.0 209.4,211.0 180.0,194.0 180.0,160.0 209.4,143.0" style="fill: rgb(232,240,247); stroke: #ffffff" />
+          <polygon points="297.8,160.0 297.8,194.0 268.3,211.0 238.9,194.0 238.9,160.0 268.3,143.0" style="fill: rgb(202,220,238); stroke: #ffffff" />
+          <polygon points="356.7,160.0 356.7,194.0 327.2,211.0 297.8,194.0 297.8,160.0 327.2,143.0" style="fill: rgb(121,167,214); stroke: #ffffff" />
+          <polygon points="415.6,160.0 415.6,194.0 386.1,211.0 356.7,194.0 356.7,160.0 386.1,143.0" style="fill: rgb(99,153,207); stroke: #ffffff" />
+          <polygon points="474.4,160.0 474.4,194.0 445.0,211.0 415.6,194.0 415.6,160.0 445.0,143.0" style="fill: rgb(173,201,230); stroke: #ffffff" />
+          <polygon points="533.3,160.0 533.3,194.0 503.9,211.0 474.4,194.0 474.4,160.0 503.9,143.0" style="fill: rgb(225,235,245); stroke: #ffffff" />
+          <polygon points="209.4,109.0 209.4,143.0 180.0,160.0 150.6,143.0 150.6,109.0 180.0,92.0" style="fill: rgb(240,245,250); stroke: #ffffff" />
+          <polygon points="268.3,109.0 268.3,143.0 238.9,160.0 209.4,143.0 209.4,109.0 238.9,92.0" style="fill: rgb(232,240,247); stroke: #ffffff" />
+          <polygon points="327.2,109.0 327.2,143.0 297.8,160.0 268.3,143.0 268.3,109.0 297.8,92.0" style="fill: rgb(217,230,243); stroke: #ffffff" />
+          <polygon points="386.1,109.0 386.1,143.0 356.7,160.0 327.2,143.0 327.2,109.0 356.7,92.0" style="fill: rgb(202,220,238); stroke: #ffffff" />
+          <polygon points="445.0,109.0 445.0,143.0 415.6,160.0 386.1,143.0 386.1,109.0 415.6,92.0" style="fill: rgb(210,225,241); stroke: #ffffff" />
+          <polygon points="503.9,109.0 503.9,143.0 474.4,160.0 445.0,143.0 445.0,109.0 474.4,92.0" style="fill: rgb(232,240,247); stroke: #ffffff" />
+          <polygon points="562.8,109.0 562.8,143.0 533.3,160.0 503.9,143.0 503.9,109.0 533.3,92.0" style="fill: rgb(240,245,250); stroke: #ffffff" />
+            </g>
+            <g id="chart-title">
+              <text x="400" y="50" style="font: 16px sans-serif; text-anchor: middle">Point Density</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -65,6 +65,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.GANTT]: 'Gantt Chart',
   [TraceType.GAUGE]: 'Gauge',
   [TraceType.HEATMAP]: 'Heatmap',
+  [TraceType.HEXBIN]: 'Hexbin Plot',
   [TraceType.HISTOGRAM]: 'Histogram',
   [TraceType.LINE]: 'Line Chart',
   [TraceType.NORMALIZED]: 'Normalized Stacked Bar Chart',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -10,6 +10,7 @@ import { ErrorBarTrace } from './errorBar';
 import { GanttTrace } from './gantt';
 import { GaugeTrace } from './gauge';
 import { Heatmap } from './heatmap';
+import { HexbinTrace } from './hexbin';
 import { Histogram } from './histogram';
 import { LineTrace } from './line';
 import { ParallelTrace } from './parallel';
@@ -67,6 +68,9 @@ export abstract class TraceFactory {
 
       case TraceType.HEATMAP:
         return new Heatmap(layer);
+
+      case TraceType.HEXBIN:
+        return new HexbinTrace(layer);
 
       case TraceType.HISTOGRAM:
         return new Histogram(layer);

--- a/src/model/hexbin.ts
+++ b/src/model/hexbin.ts
@@ -1,0 +1,363 @@
+import type { HexbinPoint, MaidrLayer } from '@type/grammar';
+import type { Movable, MovableDirection } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { MathUtil } from '@util/math';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/**
+ * Trace implementation for hexbin (hexagonal binning) plots.
+ *
+ * Hexagonal binning is the standard answer to an overplotted scatter: bin the
+ * points into hexagons and encode the count as fill. Read as a lattice of
+ * cells each carrying a count, that is a heatmap -- and the navigation,
+ * braille and pitch all transfer on those terms.
+ *
+ * **The one real difference is that the rows are offset.** A hex lattice
+ * staggers alternate rows by half a cell, which is what lets the hexagons
+ * tessellate, and it means a column index does not identify a position: bin 3
+ * of one row and bin 3 of the next sit at different x. Moving left or right is
+ * unaffected, but moving up or down lands *between* two bins, and something
+ * has to decide which one takes focus.
+ *
+ * This trace picks the bin whose centre is nearest in x. Nearest to *where the
+ * reader started*, though, not to the bin they are leaving: a stagger means
+ * the two candidates above any bin are exactly equidistant, so choosing
+ * relative to the current one means choosing the same way every time, and half
+ * a cell of drift per row accumulates into the very slide this is meant to
+ * prevent. See {@link HexbinTrace.anchorX}.
+ *
+ * Getting it wrong is silent, which is why it is worth the mechanism: a cursor
+ * walking off the feature it was following announces a real bin with a real
+ * count at every step, and a column index -- the one thing that would give it
+ * away -- is exactly what this trace does not announce.
+ *
+ * So the announcement gives the bin's **centre**, not its indices. On a
+ * staggered lattice "row 4, column 3" is not a location a reader can hold on
+ * to or compare with anything.
+ */
+export class HexbinTrace extends AbstractTrace {
+  protected readonly supportsExtrema = false;
+  protected readonly movable: Movable;
+
+  private readonly bins: HexbinPoint[][];
+  private readonly counts: number[][];
+
+  private readonly min: number;
+  private readonly max: number;
+
+  /**
+   * The x the reader is tracking down a column, or null before they start.
+   *
+   * A hex lattice offsets alternate rows by half a cell, so a bin has no
+   * neighbour directly above it -- it has two, equidistant. Choosing between
+   * them relative to the *current* bin means choosing the same way every
+   * time, and half a cell of drift per row accumulates into exactly the slide
+   * off the feature this navigation exists to prevent: from x = 2 a walk up
+   * two rows lands on x = 0.
+   *
+   * So the choice is made against where the reader *was* when they started
+   * moving vertically, and reset the moment they move sideways. This is the
+   * "desired column" a text editor keeps while arrowing past short lines, for
+   * the same reason and with the same effect.
+   */
+  private anchorX: number | null = null;
+
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /**
+   * Creates a new hexbin trace.
+   *
+   * @param layer - The MAIDR layer carrying the lattice
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.bins = layer.data as HexbinPoint[][];
+    this.counts = this.bins.map(row => row.map(bin => Number(bin.count)));
+
+    const bounds = MathUtil.minMax(this.counts.flat().filter(Number.isFinite));
+    this.min = bounds.min;
+    this.max = bounds.max;
+
+    this.highlightValues = this.mapToSvgElements(layer.selectors);
+    this.movable = new MovableGrid<number>(this.counts);
+  }
+
+  /**
+   * Resolves the layer's selectors to one element per bin.
+   *
+   * Withdrawn unless the count matches exactly. A hexbin routinely omits the
+   * empty cells from the DOM -- there is nothing to draw -- so a selector
+   * list that has slipped by one highlights a neighbouring bin for the rest
+   * of the lattice, which on a staggered grid is not even a neighbour in the
+   * direction a reader would guess.
+   *
+   * @param selectors - The layer's selectors, when it has any
+   * @returns Elements shaped rows x bins, or null when unresolvable
+   */
+  private mapToSvgElements(
+    selectors?: MaidrLayer['selectors'],
+  ): SVGElement[][] | null {
+    if (typeof selectors !== 'string' && !Array.isArray(selectors)) {
+      return null;
+    }
+
+    const flat = typeof selectors === 'string'
+      ? Svg.selectAllElements(selectors)
+      : (selectors as string[]).flatMap(one => Svg.selectAllElements(one));
+
+    if (flat.length !== this.bins.flat().length) {
+      return null;
+    }
+
+    let taken = 0;
+    return this.bins.map(row => flat.slice(taken, taken += row.length));
+  }
+
+  protected get values(): number[][] {
+    return this.counts;
+  }
+
+  protected get dimension(): Dimension {
+    return {
+      rows: this.counts.length,
+      cols: this.counts.reduce((widest, row) => Math.max(widest, row.length), 0),
+    };
+  }
+
+  /**
+   * Moves the cursor, keeping a vertical move over the same x.
+   *
+   * A horizontal move is the grid's own: within a row, the index is the
+   * position. A vertical one is not, because the rows are staggered -- so the
+   * row is stepped and the column re-chosen as whichever bin's centre is
+   * nearest the one being left.
+   *
+   * @param direction - Which way to move
+   * @returns True if the cursor moved
+   */
+  public override moveOnce(direction: MovableDirection): boolean {
+    if (direction !== 'UPWARD' && direction !== 'DOWNWARD') {
+      // A sideways move is where the reader chooses a new column to track.
+      const moved = super.moveOnce(direction);
+      if (moved) {
+        this.anchorX = null;
+      }
+      return moved;
+    }
+
+    const targetRow = this.row + (direction === 'UPWARD' ? 1 : -1);
+    const row = this.bins[targetRow];
+    if (row === undefined || row.length === 0) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+
+    const anchor = this.anchorX ?? this.currentX();
+    if (anchor === null) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+
+    const moved = this.moveToIndex(targetRow, HexbinTrace.nearestByX(row, anchor));
+    if (moved) {
+      // Set after the move, since moveToIndex clears it: the anchor has to
+      // survive the whole vertical walk, and only a sideways move ends it.
+      this.anchorX = anchor;
+    }
+    return moved;
+  }
+
+  public override moveToIndex(row: number, col: number): boolean {
+    const moved = super.moveToIndex(row, col);
+    if (moved) {
+      // An explicit jump is a new starting point, not a continuation of a
+      // vertical walk.
+      this.anchorX = null;
+    }
+    return moved;
+  }
+
+  /**
+   * The x centre of the bin under the cursor.
+   *
+   * @returns The centre, or null when the cursor is not on a bin
+   */
+  private currentX(): number | null {
+    const x = this.bins[this.row]?.[this.col]?.x;
+    return x === undefined ? null : Number(x);
+  }
+
+  /**
+   * The bin in a row whose centre is closest to a given x.
+   *
+   * Ties take the earlier bin. A reader stepping up and then straight back
+   * down has to land where they started, and a tie broken by "whichever the
+   * scan reached last" would depend on the direction of travel.
+   *
+   * @param row - The row to search
+   * @param x - The x centre to stay closest to
+   * @returns The index of the nearest bin
+   */
+  private static nearestByX(row: HexbinPoint[], x: number): number {
+    let best = 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (let index = 0; index < row.length; index++) {
+      const distance = Math.abs(Number(row[index].x) - x);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = index;
+      }
+    }
+    return best;
+  }
+
+  protected get audio(): AudioState {
+    return {
+      freq: {
+        min: this.min,
+        max: this.max,
+        raw: this.counts[this.row]?.[this.col] ?? Number.NaN,
+      },
+      panning: {
+        x: this.col,
+        y: this.row,
+        rows: this.counts.length,
+        cols: this.counts[this.row]?.length ?? 1,
+      },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    // The counts, one row per lattice row -- the heatmap encoding, which is
+    // what this is. The stagger has no representation here and needs none: a
+    // display is a line of cells and half a cell of offset has nowhere to go
+    // in it, while the density pattern the chart is drawn for survives
+    // intact.
+    return {
+      empty: false,
+      id: this.id,
+      values: this.counts,
+      min: this.counts.map(() => this.min),
+      max: this.counts.map(() => this.max),
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const bin = this.bins[this.row]?.[this.col];
+
+    return {
+      // The bin's centre, not its indices. On a staggered lattice a column
+      // index is not a location: bin 3 of one row and bin 3 of the next sit
+      // at different x, so "column 3" is not something a reader can hold on
+      // to or compare between rows.
+      main: { label: this.xAxis, value: bin?.x ?? Number.NaN },
+      cross: { label: this.yAxis, value: bin?.y ?? Number.NaN },
+      z: { label: this.z, value: this.counts[this.row]?.[this.col] ?? Number.NaN },
+    };
+  }
+
+  public get description(): DescriptionState {
+    const flat = this.counts.flat().filter(Number.isFinite);
+    const occupied = flat.filter(count => count > 0);
+    const total = occupied.reduce((sum, count) => sum + count, 0);
+
+    const stats: DescriptionState['stats'] = [
+      { label: 'Number of bins', value: flat.length },
+      // How many bins hold anything is the shape of the cloud: a scatter
+      // spread evenly fills most of its lattice, and a tight one leaves most
+      // of it empty. That is not recoverable from the counts alone without
+      // walking every cell.
+      { label: 'Occupied bins', value: occupied.length },
+      { label: 'Total points', value: total },
+    ];
+
+    if (occupied.length > 0) {
+      stats.push(
+        { label: 'Min count', value: MathUtil.safeMin(occupied) },
+        { label: 'Max count', value: this.max },
+      );
+
+      const densest = this.densestBin();
+      if (densest !== null) {
+        stats.push({
+          label: 'Densest bin',
+          value: `${this.xAxis} ${densest.x}, ${this.yAxis} ${densest.y}`,
+        });
+      }
+    }
+
+    const headers = [this.xAxis, this.yAxis, this.z];
+    const rows: (string | number)[][] = this.bins.flatMap((row, y) =>
+      row.map((bin, x) => [bin.x, bin.y, this.counts[y][x]]));
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * The centre of the bin holding the most points.
+   *
+   * Named by its coordinates rather than its indices, for the reason the
+   * announcement is: on a staggered lattice the indices do not locate it.
+   *
+   * @returns The densest bin's centre, or null when the lattice is empty
+   */
+  private densestBin(): { x: number | string; y: number | string } | null {
+    let best: HexbinPoint | null = null;
+    for (const [y, row] of this.bins.entries()) {
+      for (const [x, bin] of row.entries()) {
+        const count = this.counts[y][x];
+        if (!Number.isFinite(count)) {
+          continue;
+        }
+        if (best === null || count > Number(best.count)) {
+          best = bin;
+        }
+      }
+    }
+    return best === null ? null : { x: best.x, y: best.y };
+  }
+
+  /**
+   * Finds the bin whose drawn hexagon is nearest a pointer position.
+   *
+   * @param x - Horizontal pointer position
+   * @param y - Vertical pointer position
+   * @returns The nearest bin, or null when nothing is resolvable
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    const elements = this.highlightValues;
+    if (!elements) {
+      return null;
+    }
+
+    let nearest: NearestPoint | null = null;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+
+    for (let row = 0; row < elements.length; row++) {
+      for (let col = 0; col < elements[row].length; col++) {
+        const box = elements[row][col].getBoundingClientRect();
+        const centerX = box.left + box.width / 2;
+        const centerY = box.top + box.height / 2;
+        const distance = (centerX - x) ** 2 + (centerY - y) ** 2;
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearest = { element: elements[row][col], row, col, centerX, centerY };
+        }
+      }
+    }
+
+    return nearest;
+  }
+}

--- a/src/model/hexbin.ts
+++ b/src/model/hexbin.ts
@@ -149,6 +149,15 @@ export class HexbinTrace extends AbstractTrace {
       return moved;
     }
 
+    if (this.isInitialEntry) {
+      // The first arrow press enters the grid rather than stepping through
+      // it, and that convention lives in MovableGrid. Skipping it made the
+      // very first keypress either report out of bounds (DOWNWARD off row 0)
+      // or skip row 0 entirely (UPWARD), and seed the anchor from a bin the
+      // reader was never told about.
+      return super.moveOnce(direction);
+    }
+
     const targetRow = this.row + (direction === 'UPWARD' ? 1 : -1);
     const row = this.bins[targetRow];
     if (row === undefined || row.length === 0) {
@@ -166,6 +175,60 @@ export class HexbinTrace extends AbstractTrace {
     if (moved) {
       // Set after the move, since moveToIndex clears it: the anchor has to
       // survive the whole vertical walk, and only a sideways move ends it.
+      this.anchorX = anchor;
+    }
+    return moved;
+  }
+
+  /**
+   * Jumps to the far row, staying over the x the cursor is on.
+   *
+   * A vertical extreme is a vertical move, so it has the same problem: the
+   * base grid carries the *column index* into the far row, and on a stagger
+   * an index is not a position. On a sparse lattice -- and a hexbin is
+   * sparse, since an empty bin is not drawn -- the rows do not even hold the
+   * same number of bins, so the index lands wherever the clamp puts it.
+   *
+   * This is reachable from Ctrl+Up and Ctrl+Down, which are bound
+   * unconditionally rather than gated on `supportsExtrema`: that flag gates
+   * the statistical extrema menu, not the grid-edge jump.
+   *
+   * A horizontal extreme is the grid's own -- within a row, the index is the
+   * position -- and ends the vertical walk the same way a horizontal step
+   * does.
+   *
+   * @param direction - Which edge to jump to
+   * @returns True if the cursor moved
+   */
+  public override moveToExtreme(direction: MovableDirection): boolean {
+    if (direction !== 'UPWARD' && direction !== 'DOWNWARD') {
+      const moved = super.moveToExtreme(direction);
+      if (moved) {
+        this.anchorX = null;
+      }
+      return moved;
+    }
+
+    if (this.isInitialEntry) {
+      return super.moveToExtreme(direction);
+    }
+
+    const targetRow = direction === 'UPWARD' ? this.bins.length - 1 : 0;
+    const row = this.bins[targetRow];
+    const anchor = this.anchorX ?? this.currentX();
+    if (row === undefined || row.length === 0 || anchor === null) {
+      return super.moveToExtreme(direction);
+    }
+
+    const moved = this.moveToIndex(targetRow, HexbinTrace.nearestByX(row, anchor));
+    if (moved) {
+      // The anchor survives, as it does across an ordinary vertical step. A
+      // jump to the far row is still part of one vertical excursion, and the
+      // column the reader chose is still the one they chose -- where they
+      // land is forced by whatever the far row happens to hold, which on a
+      // sparse lattice can be most of the field away. Dropping the anchor
+      // here would make the next step resume from a bin the lattice picked
+      // rather than from the one they did.
       this.anchorX = anchor;
     }
     return moved;

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1128,6 +1128,10 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // measure sits rather than only that it exists.
       [TraceType.GAUGE, asGeneric(new BarBrailleEncoder())],
       [TraceType.HEATMAP, asGeneric(new HeatmapBrailleEncoder())],
+      // A lattice of counts, which is the heatmap encoder's input. The
+      // stagger has no representation here and needs none: a display is a
+      // line of cells and half a cell of offset has nowhere to go in it.
+      [TraceType.HEXBIN, asGeneric(new HeatmapBrailleEncoder())],
       [TraceType.HISTOGRAM, asGeneric(new BarBrailleEncoder())],
       [TraceType.LINE, asGeneric(new LineBrailleEncoder())],
       [TraceType.NORMALIZED, asGeneric(new BarBrailleEncoder())],

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -569,6 +569,23 @@ export interface HeatmapData {
 }
 
 /**
+ * One hexagonal bin: where its centre is, and how many points fell in it.
+ *
+ * The centre is carried per bin rather than derived from a lattice origin and
+ * a cell size, because a hex lattice staggers alternate rows by half a cell --
+ * so a bin's index does not give its position, and a consumer reconstructing
+ * one would have to know which rows a particular library chose to offset.
+ */
+export interface HexbinPoint {
+  /** The bin's centre along the x axis. */
+  x: number | string;
+  /** The bin's centre along the y axis. */
+  y: number | string;
+  /** How many points fell in it. */
+  count: number;
+}
+
+/**
  * Data point for histograms extending bar points with bin ranges.
  */
 export interface HistogramPoint extends BarPoint {
@@ -844,6 +861,7 @@ export interface MaidrLayer {
     | GanttData
     | GaugePoint
     | HeatmapData
+    | HexbinPoint[][]
     | HistogramPoint[]
     | LinePoint[][]
     | PiePoint[]
@@ -918,6 +936,16 @@ export enum TraceType {
   GANTT = 'gantt',
   GAUGE = 'gauge',
   HEATMAP = 'heat',
+  /**
+   * Hexagonal binning: the standard answer to an overplotted scatter. Read as
+   * a lattice of cells each carrying a count, which is a {@link
+   * TraceType.HEATMAP} -- with the one difference that decides its
+   * navigation: a hex lattice staggers alternate rows, so a column index does
+   * not identify a position. A vertical move keeps the bin whose centre is
+   * nearest in x, and the announcement gives the centre rather than the
+   * indices.
+   */
+  HEXBIN = 'hexbin',
   HISTOGRAM = 'hist',
   LINE = 'line',
   NORMALIZED = 'stacked_normalized_bar',

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -44,6 +44,9 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // so there is nothing an orientation could swap.
   [TraceType.GAUGE]: false,
   [TraceType.HEATMAP]: false,
+  // A lattice of bins over two continuous axes, navigated by row and bin
+  // whichever way round the axes are -- the same answer a heatmap gives.
+  [TraceType.HEXBIN]: false,
   [TraceType.HISTOGRAM]: true,
   [TraceType.LINE]: false,
   [TraceType.NORMALIZED]: true,

--- a/test/model/hexbin.test.ts
+++ b/test/model/hexbin.test.ts
@@ -194,3 +194,98 @@ describe('the description says what the cloud looks like', () => {
     expect(read('Max count')).toBe(12);
   });
 });
+
+describe('the first keypress enters the lattice', () => {
+  /**
+   * A trace nobody has navigated yet.
+   * @returns The trace
+   */
+  function fresh(): HexbinTrace {
+    return TraceFactory.create(createLayer()) as HexbinTrace;
+  }
+
+  test('a first press downward lands rather than falling off', () => {
+    // The vertical branch computed row -1 from row 0 and reported out of
+    // bounds, so a reader whose first key was Down heard the edge tone on a
+    // chart they had not entered.
+    const trace = fresh();
+
+    expect(trace.moveOnce('DOWNWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.z?.value).toBe(3);
+  });
+
+  test('a first press upward lands on the first bin, not the second row', () => {
+    // Stepping straight to row 1 skips row 0 entirely and seeds the anchor
+    // from a bin the reader was never told about.
+    const trace = fresh();
+
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.z?.value).toBe(3);
+  });
+});
+
+describe('a jump to the far row keeps the x too', () => {
+  /**
+   * A sparse lattice, which is what a hexbin is: an empty bin is not drawn,
+   * so the rows hold different numbers of bins at different offsets. A
+   * strongly diagonal cloud gives exactly this -- the bottom row occupies
+   * the right of the field and the top row the left.
+   *
+   * Row 0 is the bottom, since UPWARD increments the row.
+   */
+  const SPARSE: HexbinPoint[][] = [
+    [
+      { x: 8, y: 0, count: 41 },
+      { x: 10, y: 0, count: 42 },
+    ],
+    [
+      { x: 1, y: 1, count: 11 },
+      { x: 5, y: 1, count: 15 },
+    ],
+    [
+      { x: 0, y: 2, count: 1 },
+      { x: 2, y: 2, count: 2 },
+      { x: 4, y: 2, count: 3 },
+    ],
+  ];
+
+  test('lands under the bin it left, not at its index', () => {
+    // Ctrl+Down from x = 4. The base grid carries the column index into the
+    // far row, and index 2 clamps to the last bin there -- x = 10, the wrong
+    // end of a row that does not reach x = 4 at all.
+    const trace = hexbin(2, 2, SPARSE);
+
+    expect(trace.moveToExtreme('DOWNWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe(8);
+  });
+
+  test('keeps the column the reader chose, not the one the lattice forced', () => {
+    // A jump is still part of one vertical excursion. Where it lands is
+    // decided by whatever the far row holds -- here x = 8, most of the field
+    // from the x = 0 the reader picked -- so resuming from the landing bin
+    // would strand them there.
+    const trace = hexbin(2, 0, SPARSE);
+    trace.moveOnce('DOWNWARD');
+    trace.moveToExtreme('DOWNWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe(8);
+
+    trace.moveOnce('UPWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe(1);
+  });
+
+  test('a horizontal extreme ends the vertical walk', () => {
+    // Choosing a new column is what ends it, whether by one step or by a
+    // jump to the end of the row.
+    const trace = hexbin(2, 0, SPARSE);
+    trace.moveOnce('DOWNWARD');
+    trace.moveToExtreme('FORWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe(5);
+
+    trace.moveOnce('UPWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe(4);
+  });
+});

--- a/test/model/hexbin.test.ts
+++ b/test/model/hexbin.test.ts
@@ -1,0 +1,196 @@
+import type { HexbinPoint, MaidrLayer } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { HexbinTrace } from '@model/hexbin';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Three staggered rows, offset by half a cell as a hex lattice is.
+ *
+ * Row 0 and row 2 sit at x = 0, 2, 4; row 1 sits at x = 1, 3. That is the
+ * whole difficulty: bin 1 of row 0 is at x = 2 while bin 1 of row 1 is at
+ * x = 3, so a vertical move by index drifts sideways.
+ *
+ * The counts are distinct so a drifted cursor announces a different number
+ * rather than coincidentally the right one.
+ */
+const LATTICE: HexbinPoint[][] = [
+  [
+    { x: 0, y: 0, count: 3 },
+    { x: 2, y: 0, count: 9 },
+    { x: 4, y: 0, count: 1 },
+  ],
+  [
+    { x: 1, y: 1, count: 5 },
+    { x: 3, y: 1, count: 12 },
+  ],
+  [
+    { x: 0, y: 2, count: 0 },
+    { x: 2, y: 2, count: 7 },
+    { x: 4, y: 2, count: 2 },
+  ],
+];
+
+/**
+ * Create a minimal hexbin layer for model-only tests.
+ * @param data The lattice the layer carries
+ * @returns Hexbin layer definition
+ */
+function createLayer(data: HexbinPoint[][] = LATTICE): MaidrLayer {
+  return {
+    id: 'test-hexbin-layer',
+    type: TraceType.HEXBIN,
+    title: 'Density',
+    axes: { x: { label: 'X' }, y: { label: 'Y' }, z: { label: 'Count' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: HexbinTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a hexbin trace positioned on one bin.
+ * @param row Which lattice row
+ * @param col Which bin within it
+ * @param data The lattice the layer carries
+ * @returns The positioned trace
+ */
+function hexbin(
+  row = 0,
+  col = 0,
+  data: HexbinPoint[][] = LATTICE,
+): HexbinTrace {
+  const trace = TraceFactory.create(createLayer(data)) as HexbinTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+describe('hexbin registration', () => {
+  test('the factory builds a HexbinTrace', () => {
+    expect(TraceFactory.create(createLayer())).toBeInstanceOf(HexbinTrace);
+  });
+
+  test('announces itself as the chart it is', () => {
+    expect(hexbin().description.chartType).toBe('Hexbin Plot');
+  });
+});
+
+describe('a vertical move stays over the same x', () => {
+  test('lands on the nearest bin, not the same index', () => {
+    // From x = 2 in row 0, the nearest bin in row 1 is x = 1 or x = 3 -- both
+    // one away, and the tie takes the earlier. By index it would be x = 3.
+    const trace = hexbin(0, 1);
+
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe(1);
+  });
+
+  test('does not drift over repeated moves', () => {
+    // The failure a column index produces on a tall lattice: the cursor
+    // slides off the feature it was following, half a cell per row, and
+    // nothing in the announcement says so.
+    const trace = hexbin(0, 1);
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('UPWARD');
+
+    // Back to x = 2, where it started, rather than x = 4.
+    expect(nonEmptyState(trace).text.main.value).toBe(2);
+    expect(nonEmptyState(trace).text.z?.value).toBe(7);
+  });
+
+  test('stepping up and straight back down returns to the start', () => {
+    // The tie-breaking rule exists for this: broken by "whichever the scan
+    // reached last" it would depend on the direction of travel.
+    const trace = hexbin(0, 1);
+    const before = nonEmptyState(trace).text.main.value;
+
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('DOWNWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe(before);
+  });
+
+  test('a move to a shorter row still lands inside it', () => {
+    // Row 1 has two bins and row 0 has three, so index 2 does not exist
+    // there. By index this is out of bounds; by nearest x it is a real bin.
+    const trace = hexbin(0, 2);
+
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe(3);
+  });
+
+  test('reports the bound at the edge of the lattice', () => {
+    expect(hexbin(2, 0).moveOnce('UPWARD')).toBe(false);
+    expect(hexbin(0, 0).moveOnce('DOWNWARD')).toBe(false);
+  });
+
+  test('a horizontal move is still the grid\'s own', () => {
+    const trace = hexbin(0, 0);
+
+    expect(trace.moveOnce('FORWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.main.value).toBe(2);
+  });
+});
+
+describe('a bin is announced by its centre', () => {
+  test('gives the centre and the count, not a row and column', () => {
+    // On a staggered lattice "column 1" is not a location: bin 1 of one row
+    // and bin 1 of the next sit at different x.
+    const { text } = nonEmptyState(hexbin(1, 1));
+
+    expect(text.main.value).toBe(3);
+    expect(text.cross.value).toBe(1);
+    expect(text.z).toEqual({ label: 'Count', value: 12 });
+  });
+});
+
+describe('the pitch is the count across the whole lattice', () => {
+  test('one scale, so two bins of the same count sound the same', () => {
+    const dense = nonEmptyState(hexbin(1, 1)).audio.freq;
+    const sparse = nonEmptyState(hexbin(0, 2)).audio.freq;
+
+    expect([dense.min, dense.max]).toEqual([sparse.min, sparse.max]);
+    expect(dense.raw).toBe(12);
+    expect(sparse.raw).toBe(1);
+  });
+});
+
+describe('the description says what the cloud looks like', () => {
+  const read = (label: string): unknown =>
+    hexbin().description.stats.find(stat => stat.label === label)?.value;
+
+  test('counts the bins that hold anything, not just the bins', () => {
+    // A scatter spread evenly fills most of its lattice and a tight one
+    // leaves most of it empty, which is not recoverable from the counts
+    // without walking every cell.
+    expect(read('Number of bins')).toBe(8);
+    expect(read('Occupied bins')).toBe(7);
+  });
+
+  test('reports the total points binned', () => {
+    expect(read('Total points')).toBe(39);
+  });
+
+  test('names the densest bin by its centre', () => {
+    expect(read('Densest bin')).toBe('X 3, Y 1');
+  });
+
+  test('the min count ignores the empty bins', () => {
+    // Counting an empty bin as the minimum would report a density the
+    // occupied part of the chart does not have.
+    expect(read('Min count')).toBe(1);
+    expect(read('Max count')).toBe(12);
+  });
+});

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -43,6 +43,8 @@ describe('resolveOrientation', () => {
     // One measure on a dial: no second axis to swap with.
     TraceType.GAUGE,
     TraceType.HEATMAP,
+    // A lattice of bins over two continuous axes, the same as a heatmap.
+    TraceType.HEXBIN,
     TraceType.LINE,
     TraceType.NORMALIZED_AREA,
     // Every column is its own axis, so there is no main and cross axis to


### PR DESCRIPTION
Closes #799. This is the last open item in tier A of #814.

## Mostly a heatmap, as #799 says

Read as a lattice of cells each carrying a count, a hexbin **is** a heatmap — so the grid navigation, the pitch, and `HeatmapBrailleEncoder` all transfer unchanged. The work is confined to the lattice indexing, exactly as the issue predicted.

## The stagger, and the part that took two attempts

A hex lattice offsets alternate rows by half a cell — that is what lets the hexagons tessellate. Two consequences:

**A column index is not a position.** Bin 3 of one row and bin 3 of the next sit at different x. So the announcement gives the bin's **centre**, per #799.

**A bin has no neighbour directly above it.** It has two, and they are *exactly* equidistant. My first implementation chose the nearer bin relative to the bin being left, which — because the two candidates always tie — means choosing the same way every time. The drift test caught it immediately:

```
from x = 2, two rows up  →  x = 1  →  x = 0
```

Half a cell per row, accumulating, which is precisely the slide the feature exists to prevent.

So the choice is made against **where the reader started**, held in an anchor and reset the moment they move sideways. That is the "desired column" a text editor keeps while arrowing past short lines — same problem, same solution. Now `2 → 1 → 2`, and stepping up and straight back down returns to where it started.

**Getting this wrong is silent**, which is what earns the mechanism. A drifting cursor announces a real bin with a real count at every step; the one thing that would give it away is a column index, and a column index is exactly what this trace does not announce.

## Smaller decisions

- **`min` count ignores empty bins.** A hexbin is mostly empty margin; reporting `0` as the minimum count would describe a density the occupied part of the chart does not have.
- **`Occupied bins` is reported alongside `Number of bins`.** A scatter spread evenly fills most of its lattice and a tight one leaves most of it empty — the shape of the cloud, not recoverable from the counts without walking every cell.
- **The densest bin is named by its centre**, for the same reason the announcement is.
- **Selectors are withdrawn on a count mismatch.** A hexbin routinely omits empty cells from the DOM, so a list off by one highlights a bin that is not even a neighbour in the direction a reader would guess.
- **Ragged rows are handled**: a move to a shorter row still lands inside it, where an index-based move would be out of bounds.

## Braille

`HeatmapBrailleEncoder`, unchanged. The stagger has no representation and needs none: a display is a line of cells with nowhere to put half of one. Empty bins render as spaces — so the e2e asserts a row of *cells and spaces* with at least one real cell, rather than pure braille, which would have been the wrong assertion rather than a stricter one.

## Verification

- `npm test` — **2203 + 73 passed**, 170 suites, none failing
- `npx playwright test --project=chromium hexbin` — **5 passed**, including a keyboard walk two rows up and two back down asserting the announcement is identical
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_