### PR TITLE
feat(ridgeline): compare distributions at the value the reader chose

### DIFF
--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -574,6 +574,46 @@ row while falling on the other.
 Diverging charts use one line per side on a multiline display, plus the
 balance, so the two sides can be compared with one sweep.
 
+## Ridgeline (joy plot)
+
+One row per group, one cell per sample of its density curve — the line
+encoding, which is what a density curve is.
+
+**Every row is scaled against the chart's peak rather than its own.** This is
+the one place a ridgeline's braille differs from a violin's, and it is
+deliberate: the chart exists so a reader can ask which distribution is tallest
+and where. Scaled per row, a group holding a tenth of another's density would
+fill its cells just as high, and the display would show a dozen equally tall
+ridges — the exact reading the chart is drawn to prevent.
+
+The floor is zero rather than the smallest density measured anywhere. A density
+of zero is a real reading — nobody in that group had that value — so it belongs
+at the bottom of the range and not somewhere above it.
+
+**The baseline offset has no representation here, and needs none.** The stagger
+that separates the curves on screen is presentation; it is not in the data and
+it is not in the display. What the fingers get is each group's shape, aligned
+row against row, which is the comparison the offset exists to make possible
+visually.
+
+```
+Group   Cells
+2019    ⠄⠆⠖⠶⣶⣶⠶⠖⠆⠄
+2021    ⠄⠆⠖⠖⠶⠶⠖⠖⠆⠄
+2023    ⠂⠆⠖⠶⣿⣿⠶⠖⠆⠂
+```
+
+The 2021 cohort's row never reaches the top because that cohort's curve never
+reaches the chart's peak — it is more spread out, so its density is lower
+everywhere. A per-row scale would have hidden that by filling its middle cells
+as high as everyone else's.
+
+### Multiline Displays
+
+Ridgelines use one line per group on a multiline display, so a reader can sweep
+across the groups at a fixed position and feel the modes march along the axis,
+or fail to — which is the finding the chart is drawn for.
+
 ## Multiline Braille Display Support
 
 By leveraging the two-dimensional nature of multiline braille displays, MAIDR can represent multiple lines of a plot simultaneously, allowing users to perceive the distribution of values across all lines at once. This is particularly beneficial for plots with multiple groups or categories, such as grouped boxplots or line plots with multiple lines, and it also applies to scatter plot grid navigation.

--- a/e2e_tests/specs/ridgeline.spec.ts
+++ b/e2e_tests/specs/ridgeline.spec.ts
@@ -1,0 +1,150 @@
+import type { Maidr } from '../../src/type/grammar';
+import { expect, test } from '@playwright/test';
+import { BasePage } from '../page-objects/base-page';
+import { TestConstants } from '../utils/constants';
+import { extractMaidrData } from '../utils/maidr-data';
+import { normalizeText } from '../utils/text';
+
+/**
+ * A braille row is cells, and may carry spaces where a curve is flat against
+ * the chart's floor.
+ */
+const BRAILLE_ROW = /^[\u2800-\u28FF ]+$/;
+/** At least one real cell, so a blank display is not mistaken for output. */
+const BRAILLE_CELL_ANYWHERE = /[\u2801-\u28FF]/;
+
+/** The example's own page, driven through the shared base helpers. */
+class RidgelinePlotPage extends BasePage {
+  protected override readonly selectors = {
+    notification: `#${TestConstants.MAIDR_NOTIFICATION_CONTAINER} ${TestConstants.PARAGRAPH}`,
+    svg: `svg`,
+    braille: `textarea[id^="${TestConstants.BRAILLE_TEXTAREA}"]`,
+    helpModal: TestConstants.MAIDR_HELP_MODAL,
+    helpModalTitle: TestConstants.MAIDR_HELP_MODAL_TITLE,
+    helpModalClose: TestConstants.HELP_MENU_CLOSE_BUTTON,
+    settingsModal: TestConstants.MAIDR_SETTINGS_MODAL,
+    chatModal: TestConstants.MAIDR_CHAT_MODAL,
+  };
+
+  /** Navigates to the ridgeline example. */
+  public async navigateToPlot(): Promise<void> {
+    await super.navigateTo('examples/ridgeline.html');
+    await super.verifyPlotLoaded(this.selectors.svg);
+  }
+
+  /** Activates MAIDR on the chart. */
+  public override async activateMaidr(): Promise<void> {
+    await super.activateMaidr(this.selectors.svg, 'ridgeline-delivery');
+  }
+
+  /**
+   * Reads the announcement currently on screen.
+   * @returns The announcement text
+   */
+  public override async getInstructionText(): Promise<string> {
+    return super.getInstructionText(this.selectors.notification);
+  }
+
+  /**
+   * Reads the current contents of the braille display.
+   * @returns The braille content, trailing newline removed
+   */
+  public async getBrailleContent(): Promise<string> {
+    const textarea = await this.waitForElement(this.selectors.braille);
+    return (await textarea.inputValue()).replace(/\n$/, '');
+  }
+}
+
+test.describe('Ridgeline', () => {
+  let maidrData: Maidr;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      const plot = new RidgelinePlotPage(page);
+      await plot.navigateToPlot();
+      await page.waitForSelector(`svg`, { timeout: 10000 });
+
+      maidrData = await extractMaidrData(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await new RidgelinePlotPage(page).navigateToPlot();
+  });
+
+  test('should declare the layer as a ridgeline', () => {
+    expect(maidrData.subplots[0][0].layers[0].type).toBe('ridgeline');
+  });
+
+  test('should carry no baseline offset in the data', async () => {
+    // The offset is drawn, not measured. A layer that carried it would
+    // announce a cohort's days shifted by wherever its curve was placed --
+    // the one number a reader has no way to correct for.
+    const groups = maidrData.subplots[0][0].layers[0].data as { y: number }[][];
+
+    expect(groups).toHaveLength(3);
+    // Every cohort's days sit on the same axis, overlapping as the chart
+    // draws them overlapping. Offsets would separate them into disjoint runs.
+    const lows = groups.map(row => Math.min(...row.map(point => point.y)));
+    const highs = groups.map(row => Math.max(...row.map(point => point.y)));
+
+    expect(lows[1]).toBeLessThan(highs[0]);
+    expect(lows[2]).toBeLessThan(highs[1]);
+  });
+
+  test('should announce the cohort, the day and the density', async ({ page }) => {
+    const plot = new RidgelinePlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const announcement = normalizeText(await plot.getInstructionText());
+
+    expect(announcement).toContain('2019');
+    expect(announcement).toContain('Days');
+  });
+
+  test('should stay on the same day when it moves between cohorts', async ({ page }) => {
+    // The comparison the chart exists for, and the one a listener cannot make
+    // by holding a number across a dozen groups. The cohorts are sampled on
+    // different grids, so a move by index would land on a different day and
+    // say nothing about it.
+    const plot = new RidgelinePlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+
+    const dayOf = (text: string): string => {
+      const match = /Days is ([\d.-]+)/.exec(text);
+      return match === null ? '' : match[1];
+    };
+
+    const before = dayOf(normalizeText(await plot.getInstructionText()));
+    expect(before).not.toBe('');
+
+    await plot.moveToDataPointAbove();
+    await plot.moveToDataPointBelow();
+
+    expect(dayOf(normalizeText(await plot.getInstructionText()))).toBe(before);
+  });
+
+  test('should render one braille row per cohort', async ({ page }) => {
+    // An unregistered braille encoder is the one registration failure that is
+    // silent: the display stays blank while text and audio keep working.
+    const plot = new RidgelinePlotPage(page);
+    await plot.activateMaidr();
+    await plot.moveToNextDataPoint();
+    await plot.toggleBrailleMode();
+
+    const rows = (await plot.getBrailleContent()).split('\n');
+
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row).toMatch(BRAILLE_ROW);
+      expect(row).toMatch(BRAILLE_CELL_ANYWHERE);
+    }
+  });
+});

--- a/examples/ridgeline.html
+++ b/examples/ridgeline.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Ridgeline Plot Example — Delivery Time by Cohort</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A ridgeline stacks one density curve per group along a shared value
+        axis, offset down the page so the shapes can be compared.
+
+        The offset is presentation. It exists so the curves do not sit on top
+        of one another, and it says nothing about any cohort -- so the layer
+        carries each curve on its own terms, the day it was measured at and
+        the density there, and never the baseline it was drawn from. The
+        drawn paths below apply the offset; the data does not contain it.
+
+        The three cohorts are sampled on DIFFERENT grids, which is what a
+        density estimated over each cohort's own range produces. That is why
+        moving between them holds the value rather than the index: stepping
+        by index would land at a different day, announcing a real density at
+        a real place with nothing to say it had moved.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="760pt" height="400pt" viewBox="0 0 760 400" version="1.1"
+        id="ridgeline-delivery" maidr='{&#10;  &quot;id&quot;: &quot;ridgeline-delivery&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;ridgeline-delivery-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;ridgeline-delivery-layer&quot;,&#10;            &quot;type&quot;: &quot;ridgeline&quot;,&#10;            &quot;title&quot;: &quot;Delivery Time by Cohort&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Days&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Cohort&quot;&#10;              },&#10;              &quot;z&quot;: {&#10;                &quot;label&quot;: &quot;Cohort&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;ridgeline-curves&#x27;] &gt; path&quot;,&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 18.6,&#10;                  &quot;density&quot;: 0.00507&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 21.2,&#10;                  &quot;density&quot;: 0.01062&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 23.7,&#10;                  &quot;density&quot;: 0.01944&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 26.3,&#10;                  &quot;density&quot;: 0.03112&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 28.9,&#10;                  &quot;density&quot;: 0.04355&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 31.4,&#10;                  &quot;density&quot;: 0.05329&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 34.0,&#10;                  &quot;density&quot;: 0.05699&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 36.6,&#10;                  &quot;density&quot;: 0.05329&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 39.1,&#10;                  &quot;density&quot;: 0.04355&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 41.7,&#10;                  &quot;density&quot;: 0.03112&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 44.3,&#10;                  &quot;density&quot;: 0.01944&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 46.8,&#10;                  &quot;density&quot;: 0.01062&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 49.4,&#10;                  &quot;density&quot;: 0.00507&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 20.1,&#10;                  &quot;density&quot;: 0.00373&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 23.6,&#10;                  &quot;density&quot;: 0.00782&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 27.1,&#10;                  &quot;density&quot;: 0.01432&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 30.6,&#10;                  &quot;density&quot;: 0.02293&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 34.0,&#10;                  &quot;density&quot;: 0.03209&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 37.5,&#10;                  &quot;density&quot;: 0.03926&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 41.0,&#10;                  &quot;density&quot;: 0.04199&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 44.5,&#10;                  &quot;density&quot;: 0.03926&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 48.0,&#10;                  &quot;density&quot;: 0.03209&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 51.5,&#10;                  &quot;density&quot;: 0.02293&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 54.9,&#10;                  &quot;density&quot;: 0.01432&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 58.4,&#10;                  &quot;density&quot;: 0.00782&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 61.9,&#10;                  &quot;density&quot;: 0.00373&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 38.8,&#10;                  &quot;density&quot;: 0.00591&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 41.0,&#10;                  &quot;density&quot;: 0.01239&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 43.2,&#10;                  &quot;density&quot;: 0.02268&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 45.4,&#10;                  &quot;density&quot;: 0.03631&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 47.6,&#10;                  &quot;density&quot;: 0.05081&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 49.8,&#10;                  &quot;density&quot;: 0.06217&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 52.0,&#10;                  &quot;density&quot;: 0.06649&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 54.2,&#10;                  &quot;density&quot;: 0.06217&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 56.4,&#10;                  &quot;density&quot;: 0.05081&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 58.6,&#10;                  &quot;density&quot;: 0.03631&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 60.8,&#10;                  &quot;density&quot;: 0.02268&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 63.0,&#10;                  &quot;density&quot;: 0.01239&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 65.2,&#10;                  &quot;density&quot;: 0.00591&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 400  L 760 400  L 760 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="ridgeline-curves">
+          <path d="M 158.8,330.0 L 158.8,322.8 L 179.6,314.8 L 199.6,302.2 L 220.4,285.5 L 241.2,267.8 L 261.2,253.9 L 282.0,248.6 L 302.8,253.9 L 322.8,267.8 L 343.6,285.5 L 364.4,302.2 L 384.4,314.8 L 405.2,322.8 L 405.2,330.0 Z" style="fill: #4c72b0; fill-opacity: 0.75; stroke: #333" />
+          <path d="M 170.8,250.0 L 170.8,244.7 L 198.8,238.8 L 226.8,229.5 L 254.8,217.2 L 282.0,204.2 L 310.0,193.9 L 338.0,190.0 L 366.0,193.9 L 394.0,204.2 L 422.0,217.2 L 449.2,229.5 L 477.2,238.8 L 505.2,244.7 L 505.2,250.0 Z" style="fill: #55a868; fill-opacity: 0.75; stroke: #333" />
+          <path d="M 320.4,170.0 L 320.4,161.6 L 338.0,152.3 L 355.6,137.6 L 373.2,118.1 L 390.8,97.4 L 408.4,81.2 L 426.0,75.0 L 443.6,81.2 L 461.2,97.4 L 478.8,118.1 L 496.4,137.6 L 514.0,152.3 L 531.6,161.6 L 531.6,170.0 Z" style="fill: #c44e52; fill-opacity: 0.75; stroke: #333" />
+            </g>
+            <g id="axis_y">
+          <text x="80" y="334" style="font: 13px sans-serif; text-anchor: end">2019</text>
+          <text x="80" y="254" style="font: 13px sans-serif; text-anchor: end">2021</text>
+          <text x="80" y="174" style="font: 13px sans-serif; text-anchor: end">2023</text>
+            </g>
+            <g id="axis_x">
+          <text x="170" y="368" style="font: 12px sans-serif; text-anchor: middle">20</text>
+          <text x="250" y="368" style="font: 12px sans-serif; text-anchor: middle">30</text>
+          <text x="330" y="368" style="font: 12px sans-serif; text-anchor: middle">40</text>
+          <text x="410" y="368" style="font: 12px sans-serif; text-anchor: middle">50</text>
+          <text x="490" y="368" style="font: 12px sans-serif; text-anchor: middle">60</text>
+              <text x="330" y="392" style="font: 13px sans-serif; text-anchor: middle">Days</text>
+            </g>
+            <g id="chart-title">
+              <text x="380" y="45" style="font: 16px sans-serif; text-anchor: middle">Delivery Time by Cohort</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -77,6 +77,7 @@ const CHART_TYPE_LABEL: Record<TraceType, string> = {
   [TraceType.PIE]: 'Pie Chart',
   [TraceType.POLAR_AREA]: 'Polar Area Chart',
   [TraceType.RADAR]: 'Radar Chart',
+  [TraceType.RIDGELINE]: 'Ridgeline Plot',
   [TraceType.SCATTER]: 'Scatter Plot',
   [TraceType.SMOOTH]: 'Smooth Line Chart',
   [TraceType.STACKED]: 'Stacked Bar Chart',

--- a/src/model/factory.ts
+++ b/src/model/factory.ts
@@ -19,6 +19,7 @@ import { LineTrace } from './line';
 import { ParallelTrace } from './parallel';
 import { PieTrace } from './pie';
 import { RadarTrace } from './radar';
+import { RidgelineTrace } from './ridgeline';
 import { ScatterTrace } from './scatter';
 import { SegmentedTrace } from './segmented';
 import { createSmoothTrace } from './smoothtraceFactory';
@@ -102,6 +103,9 @@ export abstract class TraceFactory {
       case TraceType.POLAR_AREA:
       case TraceType.RADAR:
         return new RadarTrace(layer);
+
+      case TraceType.RIDGELINE:
+        return new RidgelineTrace(layer);
 
       case TraceType.SCATTER:
         return new ScatterTrace(layer);

--- a/src/model/ridgeline.ts
+++ b/src/model/ridgeline.ts
@@ -1,0 +1,400 @@
+import type { MaidrLayer, ViolinKdePoint } from '@type/grammar';
+import type { Movable, MovableDirection } from '@type/movable';
+import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
+import type { Dimension, NearestPoint } from './abstract';
+import { MathUtil } from '@util/math';
+import { Svg } from '@util/svg';
+import { AbstractTrace } from './abstract';
+import { MovableGrid } from './movable';
+
+/**
+ * Trace implementation for ridgeline (joy) plots.
+ *
+ * One density curve per group along a shared value axis, the curves offset
+ * down the page so their shapes can be compared. `ggridges`, Plotly's
+ * ridgelines and the seaborn recipes all draw it.
+ *
+ * **The offset is not data.** A ridgeline's vertical stagger exists so the
+ * curves do not sit on top of one another; it says nothing about any group. A
+ * layer therefore carries each group's curve on its own terms -- the value it
+ * was measured at and the density there -- and never the baseline it happened
+ * to be drawn from. This is the same rule the area layer follows: read what
+ * the chart is *of*, not where it was put.
+ *
+ * Two things follow, and they are what make this a type rather than a
+ * {@link ViolinKdeTrace} with a different layout.
+ *
+ * **Every group is pitched against the whole chart.** The violin trace pitches
+ * from a reference curve and uses the current group only for volume, which
+ * suits a chart drawn to compare each violin against a first one. A ridgeline
+ * is drawn so a reader can ask which distribution is tallest, and where --
+ * a question that needs one scale across all of them. Scaled per row, every
+ * group's own peak would be the highest note it can make and the chart would
+ * report a dozen equally tall ridges.
+ *
+ * **Moving between groups holds the value.** Comparing at a fixed point on the
+ * value axis is what the chart is *for*, and it is the comparison a listener
+ * cannot make by holding a number in their head across a dozen groups. Groups
+ * are not obliged to share a sample grid -- a KDE evaluated over each group's
+ * own range does not -- so stepping to the next ridge by *index* lands at a
+ * different value, silently: every sample is a real density at a real place,
+ * and nothing in the announcement would give it away except the value itself,
+ * which is what changed.
+ */
+export class RidgelineTrace extends AbstractTrace {
+  protected readonly supportsExtrema = false;
+  protected readonly movable: Movable;
+
+  private readonly points: ViolinKdePoint[][];
+  private readonly densities: number[][];
+  private readonly positions: number[][];
+
+  /** Highest density anywhere, so one scale serves every group. */
+  private readonly peak: number;
+
+  /**
+   * The value the reader is tracking across groups, or null before they start.
+   *
+   * Groups need not share a sample grid, so an index does not name a place on
+   * the value axis. Holding the value the reader chose -- rather than
+   * re-deriving it from whichever sample each ridge happened to offer -- is
+   * what keeps a walk down the groups a comparison instead of a drift. The
+   * hexbin trace holds an x for the same reason; this holds a value.
+   */
+  private anchor: number | null = null;
+
+  protected readonly highlightValues: SVGElement[][] | null;
+
+  /**
+   * Creates a new ridgeline trace.
+   *
+   * @param layer - The MAIDR layer carrying one curve per group
+   */
+  public constructor(layer: MaidrLayer) {
+    super(layer);
+
+    this.points = layer.data as ViolinKdePoint[][];
+    this.densities = this.points.map(row =>
+      row.map(point => Number(point.density ?? point.width ?? 0)),
+    );
+    this.positions = this.points.map(row => row.map(point => Number(point.y)));
+
+    this.peak = MathUtil.safeMax(this.densities.flat().filter(Number.isFinite));
+
+    this.highlightValues = this.mapToSvgElements(layer.selectors);
+    this.movable = new MovableGrid<ViolinKdePoint>(this.points);
+  }
+
+  /**
+   * Resolves the layer's selectors to one element per group.
+   *
+   * A ridgeline is drawn as one filled path per group, not one element per
+   * sample, so every sample of a group highlights that group's curve --
+   * honest about what was drawn rather than inventing per-sample elements.
+   * Withdrawn unless the count matches the number of groups exactly: a list
+   * off by one lights a neighbouring ridge for the rest of the chart, and the
+   * curves overlap, so which one is lit is not obvious even to a sighted
+   * reader looking at it.
+   *
+   * @param selectors - The layer's selectors, when it has any
+   * @returns Elements shaped groups x samples, or null when unresolvable
+   */
+  private mapToSvgElements(
+    selectors?: MaidrLayer['selectors'],
+  ): SVGElement[][] | null {
+    if (typeof selectors === 'string') {
+      return this.pairWith(Svg.selectAllElements(selectors));
+    }
+    if (!Array.isArray(selectors)
+      || !selectors.every(one => typeof one === 'string')) {
+      return null;
+    }
+    return this.pairWith(selectors.flatMap(one => Svg.selectAllElements(one)));
+  }
+
+  /**
+   * Pairs resolved elements with the curves, one element per group.
+   *
+   * @param flat - The elements the selectors resolved to
+   * @returns Elements shaped groups x samples, or null on a count mismatch
+   */
+  private pairWith(flat: SVGElement[]): SVGElement[][] | null {
+    if (flat.length !== this.points.length) {
+      return null;
+    }
+    return this.points.map((row, group) => row.map(() => flat[group]));
+  }
+
+  protected get values(): number[][] {
+    return this.densities;
+  }
+
+  protected get dimension(): Dimension {
+    return {
+      rows: this.points.length,
+      cols: this.points.reduce((widest, row) => Math.max(widest, row.length), 0),
+    };
+  }
+
+  /**
+   * Moves the cursor, holding the value when it changes group.
+   *
+   * Along a curve the index *is* the position, so a horizontal move is the
+   * grid's own and ends whatever comparison was in progress. Between groups
+   * the index is not a position, because two groups need not share a sample
+   * grid -- so the group is stepped and the sample re-chosen as whichever
+   * sits nearest the value the reader is holding.
+   *
+   * @param direction - Which way to move
+   * @returns True if the cursor moved
+   */
+  public override moveOnce(direction: MovableDirection): boolean {
+    if (direction !== 'UPWARD' && direction !== 'DOWNWARD') {
+      const moved = super.moveOnce(direction);
+      if (moved) {
+        // Choosing a new place on the value axis is what ends a comparison.
+        this.anchor = null;
+      }
+      return moved;
+    }
+
+    if (this.isInitialEntry) {
+      // The first arrow press enters the grid rather than stepping through it.
+      return super.moveOnce(direction);
+    }
+
+    const targetGroup = this.row + (direction === 'UPWARD' ? 1 : -1);
+    const row = this.positions[targetGroup];
+    if (row === undefined || row.length === 0) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+
+    const held = this.anchor ?? this.currentValue();
+    if (held === null) {
+      this.notifyOutOfBounds();
+      return false;
+    }
+
+    const moved = this.moveToIndex(targetGroup, RidgelineTrace.nearestTo(row, held));
+    if (moved) {
+      // Set after the move, since moveToIndex clears it: the value has to
+      // survive the whole walk down the groups.
+      this.anchor = held;
+    }
+    return moved;
+  }
+
+  public override moveToIndex(row: number, col: number): boolean {
+    const moved = super.moveToIndex(row, col);
+    if (moved) {
+      // An explicit jump is a new starting point, not a continuation.
+      this.anchor = null;
+    }
+    return moved;
+  }
+
+  /**
+   * The value under the cursor.
+   *
+   * @returns The value, or null when the cursor is not on a sample
+   */
+  private currentValue(): number | null {
+    const value = this.positions[this.row]?.[this.col];
+    return value === undefined || !Number.isFinite(value) ? null : value;
+  }
+
+  /**
+   * The sample in a curve closest to a given value.
+   *
+   * Ties take the earlier sample, so a reader stepping down and straight back
+   * up lands where they started rather than somewhere that depends on the
+   * direction of travel.
+   *
+   * @param row - The curve to search
+   * @param value - The value to stay closest to
+   * @returns The index of the nearest sample
+   */
+  private static nearestTo(row: number[], value: number): number {
+    let best = 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (let index = 0; index < row.length; index++) {
+      const distance = Math.abs(row[index] - value);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = index;
+      }
+    }
+    return best;
+  }
+
+  /**
+   * What a group is called.
+   *
+   * @param group - Which curve
+   * @returns Its name
+   */
+  private groupNameAt(group: number): string {
+    const authored = this.points[group]?.[0]?.x;
+    return typeof authored === 'string' && authored !== ''
+      ? authored
+      : `Group ${group + 1}`;
+  }
+
+  protected get audio(): AudioState {
+    const density = this.densities[this.row]?.[this.col];
+
+    return {
+      freq: {
+        // Zero to the chart's peak, not this group's. A ridgeline is drawn to
+        // be read across its groups, and a per-group scale would make every
+        // ridge's own summit the top of the register -- so a group holding a
+        // tenth of another's density would sound exactly as tall.
+        min: 0,
+        max: this.peak,
+        raw: density === undefined ? Number.NaN : density,
+      },
+      panning: {
+        x: this.col,
+        y: this.row,
+        rows: this.points.length,
+        cols: this.points[this.row]?.length ?? 1,
+      },
+    };
+  }
+
+  protected get braille(): BrailleState {
+    // One row per group, every row against the chart's range for the reason
+    // the pitch is: a row of full cells should mean a dense group, not merely
+    // the densest part of a sparse one.
+    return {
+      empty: false,
+      id: this.id,
+      values: this.densities,
+      min: this.densities.map(() => 0),
+      max: this.densities.map(() => this.peak),
+      row: this.row,
+      col: this.col,
+    };
+  }
+
+  protected get text(): TextState {
+    const point = this.points[this.row]?.[this.col];
+    const density = this.densities[this.row]?.[this.col];
+
+    return {
+      main: { label: this.xAxis, value: point === undefined ? Number.NaN : Number(point.y) },
+      cross: { label: this.z, value: density === undefined ? Number.NaN : density },
+      section: this.groupNameAt(this.row),
+    };
+  }
+
+  public get description(): DescriptionState {
+    const stats: DescriptionState['stats'] = [
+      { label: 'Number of groups', value: this.points.length },
+      { label: 'Groups', value: this.points.map((_, i) => this.groupNameAt(i)).join(', ') },
+    ];
+
+    // Where each group peaks, which is the ridgeline's headline finding: the
+    // chart is drawn so a reader can see the modes march across the axis, or
+    // fail to. Reading it by ear otherwise means walking every sample of
+    // every group and holding a dozen maxima in mind.
+    const modes = this.points
+      .map((_, group) => ({ group, mode: this.modeOf(group) }))
+      .filter((entry): entry is { group: number; mode: number } => entry.mode !== null);
+
+    if (modes.length > 0) {
+      stats.push({
+        label: 'Peak of each group',
+        value: modes
+          .map(({ group, mode }) => `${this.groupNameAt(group)} at ${mode}`)
+          .join(', '),
+      });
+
+      // Two groups whose peaks sit at the same place have the same typical
+      // value however different their spread, and a reader comparing shapes
+      // wants to know which it is.
+      const widest = modes.reduce((a, b) => (a.mode > b.mode ? a : b));
+      const narrowest = modes.reduce((a, b) => (a.mode < b.mode ? a : b));
+      if (widest.mode !== narrowest.mode) {
+        stats.push({
+          label: 'Peaks span',
+          value: `${narrowest.mode} to ${widest.mode}`,
+        });
+      }
+    }
+
+    const headers = [this.z, this.xAxis, 'Density'];
+    const rows: (string | number)[][] = this.points.flatMap((row, group) =>
+      row.map((point, col) => [
+        this.groupNameAt(group),
+        Number(point.y),
+        this.densities[group][col],
+      ]));
+
+    return {
+      chartType: this.getChartTypeLabel(),
+      title: this.title,
+      axes: this.getDescriptionAxes(),
+      stats,
+      dataTable: { headers, rows },
+    };
+  }
+
+  /**
+   * The value at which a group's density is highest.
+   *
+   * @param group - Which curve
+   * @returns The modal value, or null when the curve carries no density
+   */
+  private modeOf(group: number): number | null {
+    const densities = this.densities[group];
+    const positions = this.positions[group];
+    if (densities === undefined || densities.length === 0) {
+      return null;
+    }
+
+    let best: number | null = null;
+    let bestDensity = Number.NEGATIVE_INFINITY;
+    for (let index = 0; index < densities.length; index++) {
+      const density = densities[index];
+      if (Number.isFinite(density) && density > bestDensity) {
+        bestDensity = density;
+        best = positions[index];
+      }
+    }
+    return best === null || !Number.isFinite(best) ? null : best;
+  }
+
+  /**
+   * Finds the group whose drawn curve is nearest a pointer position.
+   *
+   * @param x - Horizontal pointer position
+   * @param y - Vertical pointer position
+   * @returns The nearest sample, or null when nothing is resolvable
+   */
+  protected findNearestPoint(x: number, y: number): NearestPoint | null {
+    const elements = this.highlightValues;
+    if (!elements) {
+      return null;
+    }
+
+    let nearest: NearestPoint | null = null;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+
+    for (let row = 0; row < elements.length; row++) {
+      for (let col = 0; col < elements[row].length; col++) {
+        const box = elements[row][col].getBoundingClientRect();
+        const centerX = box.left + box.width / 2;
+        const centerY = box.top + box.height / 2;
+        const distance = (centerX - x) ** 2 + (centerY - y) ** 2;
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearest = { element: elements[row][col], row, col, centerX, centerY };
+        }
+      }
+    }
+
+    return nearest;
+  }
+}

--- a/src/model/ridgeline.ts
+++ b/src/model/ridgeline.ts
@@ -185,6 +185,52 @@ export class RidgelineTrace extends AbstractTrace {
     return moved;
   }
 
+  /**
+   * Jumps to the first or last group, holding the value.
+   *
+   * A vertical extreme is a vertical move and has the same problem: the base
+   * grid carries the *column index* into the far group, and an index is not a
+   * place on the value axis when the groups do not share a sample grid. This
+   * is reachable from Ctrl+Up and Ctrl+Down, which are bound unconditionally
+   * rather than gated on `supportsExtrema` -- that flag gates the statistical
+   * extrema menu, not the grid-edge jump.
+   *
+   * A horizontal extreme is the grid's own -- within a curve the index is the
+   * position -- and ends the comparison the same way a horizontal step does.
+   *
+   * @param direction - Which edge to jump to
+   * @returns True if the cursor moved
+   */
+  public override moveToExtreme(direction: MovableDirection): boolean {
+    if (direction !== 'UPWARD' && direction !== 'DOWNWARD') {
+      const moved = super.moveToExtreme(direction);
+      if (moved) {
+        this.anchor = null;
+      }
+      return moved;
+    }
+
+    if (this.isInitialEntry) {
+      return super.moveToExtreme(direction);
+    }
+
+    const targetGroup = direction === 'UPWARD' ? this.positions.length - 1 : 0;
+    const row = this.positions[targetGroup];
+    const held = this.anchor ?? this.currentValue();
+    if (row === undefined || row.length === 0 || held === null) {
+      return super.moveToExtreme(direction);
+    }
+
+    const moved = this.moveToIndex(targetGroup, RidgelineTrace.nearestTo(row, held));
+    if (moved) {
+      // The value survives, as it does across an ordinary step: a jump to the
+      // far group is still one comparison, and where it lands is decided by
+      // whatever that group happens to have sampled.
+      this.anchor = held;
+    }
+    return moved;
+  }
+
   public override moveToIndex(row: number, col: number): boolean {
     const moved = super.moveToIndex(row, col);
     if (moved) {

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -1181,6 +1181,12 @@ implements Observer<SubplotState | TraceState>, Disposable {
       // A step chart's braille state is LineTrace's verbatim — a per-row
       // height profile — so the line encoder renders it correctly.
       [TraceType.STEP, asGeneric(new LineBrailleEncoder())],
+      // A density curve is a line, which is what the violin already reuses
+      // this for. What differs is the scaling, and that is decided in the
+      // trace: every group is rendered against the chart's peak rather than
+      // its own, so a row of full cells means a dense group and not merely
+      // the densest part of a sparse one. `docs/BRAILLE.md` says so.
+      [TraceType.RIDGELINE, asGeneric(new LineBrailleEncoder())],
       [TraceType.VIOLIN_KDE, asGeneric(new LineBrailleEncoder())],
       [TraceType.VIOLIN_BOX, asGeneric(new BoxBrailleEncoder())],
     ]);

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -1016,6 +1016,16 @@ export enum TraceType {
    * this is a type of its own rather than a line with a fill.
    */
   STACKED_AREA = 'stacked_area',
+  /**
+   * One density curve per group along a shared value axis, the curves offset
+   * down the page so their shapes can be compared. The offset is presentation
+   * -- it exists so the curves do not overlap illegibly -- so a layer carries
+   * each group's curve on its own terms and never the baseline it was drawn
+   * from. Reading it as a {@link TraceType.VIOLIN_KDE} pitches every group
+   * against a reference curve, which answers a different question than the
+   * one a ridgeline is drawn to ask.
+   */
+  RIDGELINE = 'ridgeline',
   STEP = 'step',
   VIOLIN_BOX = 'violin_box',
   VIOLIN_KDE = 'violin_kde',

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -1005,6 +1005,16 @@ export enum TraceType {
    * rather than its index, so a sweep goes out and comes back.
    */
   RADAR = 'radar',
+  /**
+   * One density curve per group along a shared value axis, the curves offset
+   * down the page so their shapes can be compared. The offset is presentation
+   * -- it exists so the curves do not overlap illegibly -- so a layer carries
+   * each group's curve on its own terms and never the baseline it was drawn
+   * from. Reading it as a {@link TraceType.VIOLIN_KDE} pitches every group
+   * against a reference curve, which answers a different question than the
+   * one a ridgeline is drawn to ask.
+   */
+  RIDGELINE = 'ridgeline',
   SCATTER = 'point',
   SMOOTH = 'smooth',
   STACKED = 'stacked_bar',
@@ -1016,16 +1026,6 @@ export enum TraceType {
    * this is a type of its own rather than a line with a fill.
    */
   STACKED_AREA = 'stacked_area',
-  /**
-   * One density curve per group along a shared value axis, the curves offset
-   * down the page so their shapes can be compared. The offset is presentation
-   * -- it exists so the curves do not overlap illegibly -- so a layer carries
-   * each group's curve on its own terms and never the baseline it was drawn
-   * from. Reading it as a {@link TraceType.VIOLIN_KDE} pitches every group
-   * against a reference curve, which answers a different question than the
-   * one a ridgeline is drawn to ask.
-   */
-  RIDGELINE = 'ridgeline',
   STEP = 'step',
   VIOLIN_BOX = 'violin_box',
   VIOLIN_KDE = 'violin_kde',

--- a/src/util/orientation.ts
+++ b/src/util/orientation.ts
@@ -78,6 +78,10 @@ const IS_ORIENTED: Record<TraceType, boolean> = {
   // and cross axis to swap -- the same answer a pie gives.
   [TraceType.POLAR_AREA]: false,
   [TraceType.RADAR]: false,
+  // The groups run one way and the value axis the other, and a ridgeline is
+  // drawn with its groups down the page as often as across it -- the same
+  // reason the violin it shares a point shape with is oriented.
+  [TraceType.RIDGELINE]: true,
   [TraceType.SCATTER]: false,
   [TraceType.SMOOTH]: false,
   [TraceType.STACKED]: true,

--- a/test/model/ridgeline.test.ts
+++ b/test/model/ridgeline.test.ts
@@ -1,0 +1,256 @@
+import type { MaidrLayer, ViolinKdePoint } from '@type/grammar';
+import type { NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { RidgelineTrace } from '@model/ridgeline';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Three groups sampled on *different* grids, which is what a KDE evaluated
+ * over each group's own range produces.
+ *
+ * The grids are chosen so index and value disagree: sample 1 of `early` sits
+ * at 20 while sample 1 of `late` sits at 60. A move between groups that
+ * carried the index would land forty units away and announce a real density
+ * at a real place, with nothing to say it had moved.
+ *
+ * The densities differ by an order of magnitude between groups, so a reading
+ * that scaled each group against its own peak would report them as equally
+ * tall.
+ */
+const GROUPS: ViolinKdePoint[][] = [
+  [
+    { x: 'early', y: 10, density: 0.02 },
+    { x: 'early', y: 20, density: 0.09 },
+    { x: 'early', y: 30, density: 0.01 },
+  ],
+  [
+    { x: 'middle', y: 30, density: 0.30 },
+    { x: 'middle', y: 45, density: 0.90 },
+    { x: 'middle', y: 60, density: 0.20 },
+  ],
+  [
+    { x: 'late', y: 50, density: 0.05 },
+    { x: 'late', y: 60, density: 0.11 },
+    { x: 'late', y: 70, density: 0.03 },
+  ],
+];
+
+/**
+ * Create a minimal ridgeline layer for model-only tests.
+ * @param data The groups the layer carries
+ * @returns Ridgeline layer definition
+ */
+function createLayer(data: ViolinKdePoint[][] = GROUPS): MaidrLayer {
+  return {
+    id: 'test-ridgeline-layer',
+    type: TraceType.RIDGELINE,
+    title: 'Delivery times by cohort',
+    axes: { x: { label: 'Days' }, y: { label: 'Cohort' }, z: { label: 'Cohort' } },
+    data,
+  };
+}
+
+/**
+ * Read the trace's current state, asserting it is a populated one.
+ * @param trace The trace to read
+ * @returns The non-empty trace state
+ */
+function nonEmptyState(trace: RidgelineTrace): NonEmptyTraceState {
+  const state = trace.state;
+  if (state.empty) {
+    throw new Error('Expected a non-empty trace state');
+  }
+  return state;
+}
+
+/**
+ * Build a ridgeline trace positioned on one sample of one group.
+ * @param row Which group
+ * @param col Which sample
+ * @param data The groups the layer carries
+ * @returns The positioned trace
+ */
+function ridgeline(
+  row = 0,
+  col = 0,
+  data: ViolinKdePoint[][] = GROUPS,
+): RidgelineTrace {
+  const trace = TraceFactory.create(createLayer(data)) as RidgelineTrace;
+  trace.moveToIndex(row, col);
+  return trace;
+}
+
+describe('ridgeline registration', () => {
+  test('the factory builds a RidgelineTrace', () => {
+    expect(TraceFactory.create(createLayer())).toBeInstanceOf(RidgelineTrace);
+  });
+
+  test('it names itself a ridgeline rather than a violin', () => {
+    expect(ridgeline().description.chartType).toBe('Ridgeline Plot');
+  });
+});
+
+describe('every group is pitched against the whole chart', () => {
+  test('a sparse group does not sound as tall as a dense one', () => {
+    // `early` peaks at 0.09 and `middle` at 0.90 -- an order of magnitude.
+    // Scaled per group, both peaks would be the top of the register and the
+    // chart would report a dozen equally tall ridges.
+    const early = nonEmptyState(ridgeline(0, 1)).audio.freq;
+    const middle = nonEmptyState(ridgeline(1, 1)).audio.freq;
+
+    expect(early.max).toBe(0.9);
+    expect(middle.max).toBe(0.9);
+    expect(early.raw).toBe(0.09);
+    expect(middle.raw).toBe(0.9);
+  });
+
+  test('the floor is zero, not the smallest density on the chart', () => {
+    // A density of zero is a real reading -- nobody in this group had that
+    // value -- so it belongs at the bottom of the register rather than
+    // wherever the sparsest sample that *was* measured happens to sit.
+    expect(nonEmptyState(ridgeline(0, 0)).audio.freq.min).toBe(0);
+  });
+
+  test('braille scales every row against the chart too', () => {
+    const { braille } = nonEmptyState(ridgeline(0, 0));
+    if (braille.empty) {
+      throw new Error('Expected a populated braille state');
+    }
+
+    expect(braille.min).toEqual([0, 0, 0]);
+    expect(braille.max).toEqual([0.9, 0.9, 0.9]);
+  });
+});
+
+describe('moving between groups holds the value', () => {
+  test('lands on the nearest sample, not the same index', () => {
+    // From `early` at 30 (index 2), the nearest sample in `middle` is 30
+    // (index 0) -- not index 2, which is 60.
+    const trace = ridgeline(0, 2);
+
+    expect(trace.moveOnce('UPWARD')).toBe(true);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.main.value).toBe(30);
+    expect(text.section).toBe('middle');
+  });
+
+  test('a walk across groups does not drift', () => {
+    // Three grids staggered so that holding the reader's value and
+    // re-deriving it at each ridge give different answers by the third
+    // group. A single step can only move by half a sample spacing, so the
+    // failure this guards needs a walk to show up at all -- which is exactly
+    // what makes it easy to miss.
+    //
+    //   chosen 10  ->  `b` has nothing nearer than 16
+    //                  `c`'s samples straddle: 5 is nearest to 10,
+    //                                          22 is nearest to 16
+    const staggered: ViolinKdePoint[][] = [
+      [
+        { x: 'a', y: 0, density: 0.1 },
+        { x: 'a', y: 10, density: 0.4 },
+        { x: 'a', y: 20, density: 0.2 },
+      ],
+      [
+        { x: 'b', y: 16, density: 0.5 },
+        { x: 'b', y: 30, density: 0.3 },
+        { x: 'b', y: 44, density: 0.1 },
+      ],
+      [
+        { x: 'c', y: 5, density: 0.2 },
+        { x: 'c', y: 22, density: 0.6 },
+      ],
+    ];
+
+    const trace = ridgeline(0, 1, staggered);
+    trace.moveOnce('UPWARD');
+    expect(nonEmptyState(trace).text.main.value).toBe(16);
+
+    trace.moveOnce('UPWARD');
+
+    expect(nonEmptyState(trace).text.section).toBe('c');
+    // 5, the sample nearest the 10 the reader chose. Re-deriving from the 16
+    // they were forced onto in `b` would give 22 -- twelve units from where
+    // they meant to be, announcing a real density at a real place.
+    expect(nonEmptyState(trace).text.main.value).toBe(5);
+  });
+
+  test('stepping across and straight back returns to the start', () => {
+    const trace = ridgeline(1, 1);
+    const start = nonEmptyState(trace).text.main.value;
+
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('DOWNWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe(start);
+  });
+
+  test('moving along a curve ends the comparison', () => {
+    // Choosing a new place on the value axis is what ends it, so the next
+    // move between groups measures from there.
+    const trace = ridgeline(0, 0);
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('DOWNWARD');
+
+    // Back in `early`, nearest to `middle`'s second sample (45) is 30.
+    expect(nonEmptyState(trace).text.main.value).toBe(30);
+  });
+
+  test('the first keypress enters the chart rather than falling off', () => {
+    const trace = TraceFactory.create(createLayer()) as RidgelineTrace;
+
+    expect(trace.moveOnce('DOWNWARD')).toBe(true);
+    expect(nonEmptyState(trace).text.section).toBe('early');
+  });
+});
+
+describe('the announcement names the group, the value and the density', () => {
+  test('carries all three', () => {
+    const { text } = nonEmptyState(ridgeline(1, 1));
+
+    expect(text.section).toBe('middle');
+    expect(text.main).toEqual({ label: 'Days', value: 45 });
+    expect(text.cross).toEqual({ label: 'Cohort', value: 0.9 });
+  });
+
+  test('names an unnamed group by its position', () => {
+    const unnamed: ViolinKdePoint[][] = [
+      [{ x: '', y: 1, density: 0.5 }],
+      [{ x: '', y: 2, density: 0.6 }],
+    ];
+
+    expect(nonEmptyState(ridgeline(1, 0, unnamed)).text.section).toBe('Group 2');
+  });
+});
+
+describe('the description reports where each group peaks', () => {
+  test('names the modal value of every group', () => {
+    // The ridgeline's headline finding: whether the modes march across the
+    // axis. A reader cannot assemble it without walking every sample of
+    // every group and holding a dozen maxima in mind.
+    const stats = ridgeline().description.stats;
+    const read = (label: string): unknown =>
+      stats.find(stat => stat.label === label)?.value;
+
+    expect(read('Peak of each group')).toBe(
+      'early at 20, middle at 45, late at 60',
+    );
+    expect(read('Peaks span')).toBe('20 to 60');
+    expect(read('Number of groups')).toBe(3);
+  });
+
+  test('withholds the span when every group peaks in the same place', () => {
+    // Naming a span of zero would report a finding the chart does not make.
+    const aligned: ViolinKdePoint[][] = [
+      [{ x: 'a', y: 5, density: 0.1 }, { x: 'a', y: 9, density: 0.9 }],
+      [{ x: 'b', y: 5, density: 0.2 }, { x: 'b', y: 9, density: 0.4 }],
+    ];
+    const stats = ridgeline(0, 0, aligned).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Peaks span')).toBeUndefined();
+    expect(stats.find(stat => stat.label === 'Peak of each group')?.value)
+      .toBe('a at 9, b at 9');
+  });
+});

--- a/test/model/ridgeline.test.ts
+++ b/test/model/ridgeline.test.ts
@@ -206,6 +206,87 @@ describe('moving between groups holds the value', () => {
   });
 });
 
+describe('a jump to the far group keeps the value too', () => {
+  /** Three grids staggered so index and value give different answers. */
+  const STAGGERED: ViolinKdePoint[][] = [
+    [
+      { x: 'a', y: 0, density: 0.1 },
+      { x: 'a', y: 10, density: 0.4 },
+      { x: 'a', y: 20, density: 0.2 },
+    ],
+    [
+      { x: 'b', y: 16, density: 0.5 },
+      { x: 'b', y: 30, density: 0.3 },
+      { x: 'b', y: 44, density: 0.1 },
+    ],
+    [
+      { x: 'c', y: 5, density: 0.2 },
+      { x: 'c', y: 22, density: 0.6 },
+    ],
+  ];
+
+  test('lands under the value it left, not at its index', () => {
+    // Ctrl+Up is a vertical move and has the vertical move's problem. The
+    // base grid carries the column index into the far group: index 1 of `c`
+    // is 22, twelve units from the 10 the reader was comparing at -- the
+    // drift this trace exists to prevent, reached by a different key.
+    const trace = ridgeline(0, 1, STAGGERED);
+
+    expect(trace.moveToExtreme('UPWARD')).toBe(true);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.section).toBe('c');
+    expect(text.main.value).toBe(5);
+  });
+
+  test('keeps the value the reader chose, not the one the group forced', () => {
+    // Where a jump lands is decided by whatever the far group sampled, so
+    // resuming from there would strand the reader at a value they never
+    // picked. `b` straddles the two candidates: nearest to the chosen 10 is
+    // 12, while nearest to the 5 that `c` forced is 2.
+    const straddling: ViolinKdePoint[][] = [
+      [
+        { x: 'a', y: 0, density: 0.1 },
+        { x: 'a', y: 10, density: 0.4 },
+        { x: 'a', y: 20, density: 0.2 },
+      ],
+      [
+        { x: 'b', y: 2, density: 0.3 },
+        { x: 'b', y: 12, density: 0.5 },
+      ],
+      [
+        { x: 'c', y: 5, density: 0.2 },
+        { x: 'c', y: 22, density: 0.6 },
+      ],
+    ];
+
+    const trace = ridgeline(0, 1, straddling);
+    trace.moveToExtreme('UPWARD');
+
+    expect(nonEmptyState(trace).text.section).toBe('c');
+    expect(nonEmptyState(trace).text.main.value).toBe(5);
+
+    trace.moveOnce('DOWNWARD');
+
+    expect(nonEmptyState(trace).text.section).toBe('b');
+    expect(nonEmptyState(trace).text.main.value).toBe(12);
+  });
+
+  test('a horizontal extreme ends the comparison', () => {
+    const trace = ridgeline(0, 0, STAGGERED);
+    trace.moveOnce('UPWARD');
+    trace.moveToExtreme('FORWARD');
+
+    expect(nonEmptyState(trace).text.main.value).toBe(44);
+
+    trace.moveOnce('DOWNWARD');
+
+    // Measured from the 44 the horizontal jump chose, not the 0 the vertical
+    // walk started from: `a`'s nearest to 44 is 20.
+    expect(nonEmptyState(trace).text.main.value).toBe(20);
+  });
+});
+
 describe('the announcement names the group, the value and the density', () => {
   test('carries all three', () => {
     const { text } = nonEmptyState(ridgeline(1, 1));

--- a/test/util/orientation.test.ts
+++ b/test/util/orientation.test.ts
@@ -27,6 +27,9 @@ describe('resolveOrientation', () => {
     TraceType.FUNNEL,
     TraceType.HISTOGRAM,
     TraceType.NORMALIZED,
+    // Groups run one way and the value axis the other, and a ridgeline is
+    // drawn with its groups down the page as often as across it.
+    TraceType.RIDGELINE,
     TraceType.STACKED,
     TraceType.VIOLIN_BOX,
     TraceType.VIOLIN_KDE,


### PR DESCRIPTION
Closes #803. First of tier B in #814.

## Mostly reuse, as the issue says

The issue is right that `ViolinKdeTrace` already models a KDE curve per group. `ViolinKdePoint` is reused **outright** — same `{x, y, density}` — and so are the grid navigation and the line braille encoder.

Two things differ enough to make this a type rather than a violin with a layout, and both are the kind of difference that produces a chart which sounds confident and says something false.

## 1 — every group is pitched against the whole chart

`ViolinKdeTrace` pitches from a **reference curve** (row 0) and uses the current group only for volume. That suits a chart drawn to compare each violin against a first one. A ridgeline is drawn so a reader can ask *which distribution is tallest, and where* — and that needs one scale across all of them.

| | scaled per group | scaled across the chart |
|---|---|---|
| a group peaking at 0.09 | top of the register | a fifth of the way up |
| a group peaking at 0.90 | top of the register | top of the register |

Per-group, the chart reports a dozen equally tall ridges. Braille does the same and for the same reason, so a row of full cells means a dense group and not merely the densest part of a sparse one.

**The floor is zero**, not the smallest density measured anywhere. A density of zero is a real reading — nobody in that group had that value — so it belongs at the bottom of the range rather than somewhere above it.

## 2 — moving between groups holds the value

Comparing at a fixed point on the value axis is what the chart is *for*, and it is exactly the comparison a listener cannot make by holding a number in their head across a dozen groups. Groups are **not obliged to share a sample grid** — a density estimated over each group's own range does not — so stepping by *index* lands at a different value, silently: every sample is a real density at a real place, and the only thing that would give it away is the value itself, which is what changed.

So the group is stepped and the sample re-chosen as whichever sits nearest the value the reader is holding.

**Holding it, rather than re-deriving it at each ridge.** This is the part worth the mechanism, and it is subtler than the hexbin's version of the same problem: there, the two candidates always tie, so re-deriving drifts immediately. Here a single step moves by at most half a sample spacing, so re-deriving *looks* correct — and accumulates only over a walk. My first fixture could not tell the two apart and passed either way; the one in the branch uses three staggered grids where the answers diverge by the third group:

```
reader chooses 10  →  b has nothing nearer than 16
                   →  c straddles: 5 is nearest to 10, 22 is nearest to 16
```

Twelve units from where they meant to be, announcing a real density at a real place. **The test fails when the anchor is removed.**

## 3 — the offset is not data

A ridgeline's vertical stagger exists so the curves do not sit on top of one another. It says nothing about any group, so the layer carries each curve on its own terms — the value it was measured at and the density there — and never the baseline it was drawn from. Same rule the area layer follows: read what the chart is *of*, not where it was put.

The e2e pins it from the other side: the emitted groups still **overlap** on the value axis, exactly as the chart draws them overlapping. An offset baked into the data would have separated them into disjoint runs.

## Smaller decisions

- **The description reports where each group peaks** (`2019 at 34, 2021 at 41, 2023 at 52`) and the span of those peaks. Whether the modes march across the axis is the ridgeline's headline finding, and a reader cannot assemble it without walking every sample of every group. The span is **withheld** when every group peaks in the same place, rather than reporting a range of zero.
- **Highlighting is one element per group**, repeated across its samples — a ridgeline is drawn as one filled path per group and does not emit a per-sample element to pair with. Selectors are withdrawn on a count mismatch: the curves overlap, so a list off by one lights a ridge that is not obviously wrong even to a sighted reader.
- **`supportsExtrema` is false.** "The largest value" on a density curve is its mode, which the description already names for every group.
- **The first keypress enters the chart** rather than stepping through it, delegating to `MovableGrid` — the gap found on #842 and worth not repeating.

## Registration

All six sites plus `docs/BRAILLE.md` — **and a seventh** the checklist does not name: `test/util/orientation.test.ts` keeps its own list of every type and asserts totality against `TraceType`. The suite caught it, which is the checklist working even where it is incomplete.

## Verification

- `npm test` — **2312 + 73 passed**, 168 suites
- `npx playwright test --project=chromium ridgeline violin` — **24 passed** (the violin suite included deliberately, since the point type is shared)
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean

Each mechanism was checked against the code it pins rather than assumed: reverting nearest-by-value fails 3 tests, and reverting the anchor fails the drift test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_