### PR TITLE
ci: fail the actionlint download instead of checksumming the error page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,22 @@ jobs:
       # Pinned by version and checksum rather than piping the upstream install
       # script into bash, so a new actionlint release cannot turn an unrelated
       # PR red and the download is verified rather than trusted.
+      #
+      # `--fail` matters as much as the checksum does. Without it curl writes
+      # whatever the server returned -- an error page, a truncated body -- into
+      # the file and exits zero, and the *checksum* is then what fails. That
+      # reports a transient download problem as a hash mismatch on a pinned
+      # release, which is indistinguishable from the supply-chain attack this
+      # pinning exists to catch. `--retry-all-errors` covers the transient case
+      # so it stops reaching the checksum at all.
       - name: Install actionlint
         env:
           ACTIONLINT_VERSION: 1.7.7
           ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
         run: |
-          curl -sSLo actionlint.tar.gz \
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            --output actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check
           tar xzf actionlint.tar.gz actionlint


### PR DESCRIPTION
`Lint Workflows` went red on several open pull requests at once today, on branches that touch no workflow file. This is the cause, and it is worth fixing rather than re-running.

## What actually happened

```
sha256sum: WARNING: 1 computed checksum did NOT match
actionlint.tar.gz: FAILED
```

That reads as the pinned release having changed under us — which is exactly the supply-chain event the pinning exists to catch. **It is not what happened.** I fetched the pinned tarball and checked it:

```
023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  actionlint.tar.gz   ← downloaded
023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757                       ← pinned
```

Identical. Nothing about the release moved; the download failed.

## Why the failure wore the wrong clothes

`curl -sSLo file URL` has no `--fail`, so on an HTTP error curl **writes the error body into the file and exits zero**. The step then proceeds to the checksum, which of course does not match — so a network blip surfaces as a hash mismatch on a pinned artifact.

That is a bad failure mode on two counts. It is confusing when it happens, and it is corrosive over time: a checksum that cries wolf on flaky networks is one people learn to re-run past, which is the opposite of what a pinned-and-verified download is for.

## The fix

```diff
-          curl -sSLo actionlint.tar.gz \
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            --output actionlint.tar.gz \
```

- `--fail` exits non-zero on an HTTP error instead of saving the body, so a download failure reports itself as a download failure.
- `--retry-all-errors` covers the transient case so it stops reaching the checksum at all.

**The pin and the verification are unchanged.** This only stops a network failure from being reported as a security one.

## Verification

I downloaded actionlint 1.7.7 at the pinned checksum and ran it against this branch's workflows: **exit 0, no findings.** So the edited step both parses and passes its own linter.

The comment above the step now says why `--fail` matters alongside the checksum, since the existing comment explains the pinning but not this.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_