### PR TITLE
fix(text): render a section's case as authored wherever it is announced

### DIFF
--- a/src/command/describe.ts
+++ b/src/command/describe.ts
@@ -800,6 +800,11 @@ export class AnnouncePositionCommand extends AnnounceCommand {
   /**
    * Announces position for boxplots with section information.
    * Uses braille state which normalizes box position regardless of orientation.
+   *
+   * The section is rendered as it was authored, the same as
+   * {@link TextService} renders it for the per-point announcement (#830).
+   * Lower-casing it here meant a reader who pressed the position key heard
+   * "in minimum" for the section that had just announced itself as "Minimum".
    */
   private announceBoxplotPosition(state: NonEmptyTraceState): void {
     const section = state.text.section || '';
@@ -813,15 +818,20 @@ export class AnnouncePositionCommand extends AnnounceCommand {
 
     if (this.textService.isTerse() || this.textService.isOff()) {
       const percent = totalBoxes > 1 ? Math.round((boxIndex / (totalBoxes - 1)) * 100) : 0;
-      this.textViewModel.update(`${percent}%, ${section.toLowerCase()}`);
+      this.textViewModel.update(`${percent}%, ${section}`);
     } else {
-      this.textViewModel.update(`Position is ${position} of ${totalBoxes} in ${section.toLowerCase()}`);
+      this.textViewModel.update(`Position is ${position} of ${totalBoxes} in ${section}`);
     }
   }
 
   /**
    * Announces position for candlestick charts with component information.
    * Uses braille state to get correct candle position.
+   *
+   * Verbatim for the same reason as {@link announceBoxplotPosition}. A
+   * candlestick's sections are authored in lower case already, so this reads
+   * the same either way today -- but the section belongs to the trace, and
+   * the one place that decides its case should not be here.
    */
   private announceCandlestickPosition(state: NonEmptyTraceState): void {
     const section = state.text.section || '';
@@ -835,9 +845,9 @@ export class AnnouncePositionCommand extends AnnounceCommand {
 
     if (this.textService.isTerse() || this.textService.isOff()) {
       const percent = totalCandles > 1 ? Math.round((candleIndex / (totalCandles - 1)) * 100) : 0;
-      this.textViewModel.update(`${percent}%, ${section.toLowerCase()}`);
+      this.textViewModel.update(`${percent}%, ${section}`);
     } else {
-      this.textViewModel.update(`Position is ${position} of ${totalCandles}, ${section.toLowerCase()}`);
+      this.textViewModel.update(`Position is ${position} of ${totalCandles}, ${section}`);
     }
   }
 

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -518,11 +518,11 @@ export class TextService implements Observer<PlotState>, Disposable {
       const formattedMainValue = this.formatSingleValue(state.main.value as number | string, mainAxisType);
       if (outliers.length === 0) {
         // No outliers
-        return `${state.main.label} is ${formattedMainValue}, no ${state.section.toLowerCase()} for ${label}`;
+        return `${state.main.label} is ${formattedMainValue}, no ${state.section} for ${label}`;
       } else {
         // Outlier values present
         const verb = outliers.length === 1 ? 'is' : 'are';
-        return `${state.main.label} is ${formattedMainValue}, ${state.section.toLowerCase()} for ${label} ${verb} ${outlierStr}`;
+        return `${state.main.label} is ${formattedMainValue}, ${state.section} for ${label} ${verb} ${outlierStr}`;
       }
     }
 
@@ -530,7 +530,14 @@ export class TextService implements Observer<PlotState>, Disposable {
     if (state.section !== undefined) {
       if (this.announcesSectionBeforeLabel(state)) {
         const label = state.cross.label;
-        verbose.push(Constant.COMMA_SPACE, state.section!.toLowerCase(), Constant.SPACE, label);
+        // Verbatim, as terse renders it. Lower-casing here meant the same
+        // point announced two different ways depending on the mode, and the
+        // difference was in a label that came from neither the user nor the
+        // data. It also destroyed case a producer chose: a dumbbell's end
+        // names and a ridgeline's group names are authored strings, so
+        // `Control` became `control` in one mode and stayed `Control` in the
+        // other.
+        verbose.push(Constant.COMMA_SPACE, state.section!, Constant.SPACE, label);
       } else {
         // For candlestick plots: "section cross.label" (e.g., "high Price")
         verbose.push(Constant.COMMA_SPACE, state.section!, Constant.SPACE, state.cross.label);
@@ -656,9 +663,9 @@ export class TextService implements Observer<PlotState>, Disposable {
       const outlierStr = `[${formattedOutliers.join(', ')}]`;
       const formattedMainValue = this.formatSingleValue(state.main.value as number | string, mainAxisType);
       if (outliers.length === 0) {
-        return `${formattedMainValue}, no ${state.section.toLowerCase()}`;
+        return `${formattedMainValue}, no ${state.section}`;
       } else {
-        return `${formattedMainValue}, ${outliers.length} ${state.section.toLowerCase()} ${outlierStr}`;
+        return `${formattedMainValue}, ${outliers.length} ${state.section} ${outlierStr}`;
       }
     }
 

--- a/test/command/announce-position.test.ts
+++ b/test/command/announce-position.test.ts
@@ -3,9 +3,12 @@ import type { AudioService } from '@service/audio';
 import type { DisplayService } from '@service/display';
 import type { TextService } from '@service/text';
 import type { TextViewModel } from '@state/viewModel/textViewModel';
+import type { BoxPoint, CandlestickPoint } from '@type/grammar';
 import type { PlotState } from '@type/state';
 import { AnnouncePositionCommand } from '@command/describe';
 import { describe, expect, jest, test } from '@jest/globals';
+import { CANDLESTICK_SECTIONS } from '@model/candlestick';
+import { TraceFactory } from '@model/factory';
 import { TraceType } from '@type/grammar';
 
 interface MultilineOptions {
@@ -419,5 +422,137 @@ describe('AnnouncePositionCommand on multi-series radar plots', () => {
     const announced = jest.mocked(textViewModel.update).mock.calls[0][0] as string;
     expect(announced).toContain('Series 1 of 3');
     expect(announced).not.toContain('Line');
+  });
+});
+
+/**
+ * A real box trace's state, so the section string under test is the one the
+ * trace actually reports rather than one the fixture invented.
+ *
+ * The point of these cases is that two announcements about the same position
+ * name the section the same way, and a hand-written `section` would let the
+ * fixture decide the thing being asserted.
+ *
+ * @param section Row index -- the section, in `BoxplotSection` order
+ * @param box Column index -- which distribution
+ * @returns The trace's state with the cursor there
+ */
+function boxTraceState(section: number, box: number): PlotState {
+  const trace = TraceFactory.create({
+    id: 'position-box',
+    type: TraceType.BOX,
+    title: 'Sepal width',
+    axes: { x: { label: 'Species' }, y: { label: 'Value' } },
+    data: [
+      {
+        z: 'Setosa',
+        lowerOutliers: [1.1],
+        min: 2,
+        q1: 3,
+        q2: 4,
+        q3: 5,
+        max: 6,
+        upperOutliers: [9.4],
+      },
+      {
+        z: 'Virginica',
+        lowerOutliers: [],
+        min: 4,
+        q1: 5,
+        q2: 6,
+        q3: 7,
+        max: 8,
+        upperOutliers: [],
+      },
+    ] as BoxPoint[],
+  });
+  trace.moveToIndex(section, box);
+
+  return trace.state as PlotState;
+}
+
+/**
+ * A real candlestick trace's state, for the sections authored in lower case.
+ *
+ * @param section Row index, in `CANDLESTICK_SECTIONS` order
+ * @param candle Column index
+ * @returns The trace's state with the cursor there
+ */
+function candlestickTraceState(section: number, candle: number): PlotState {
+  const trace = TraceFactory.create({
+    id: 'position-candle',
+    type: TraceType.CANDLESTICK,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: [
+      { value: '2026-01-01', open: 10, high: 15, low: 9, close: 14, volume: 100, trend: 'Bull', volatility: 6 },
+      { value: '2026-01-02', open: 14, high: 18, low: 13, close: 17, volume: 120, trend: 'Bull', volatility: 5 },
+      { value: '2026-01-03', open: 17, high: 19, low: 12, close: 13, volume: 90, trend: 'Bear', volatility: 7 },
+    ] as CandlestickPoint[],
+  });
+  trace.moveToIndex(section, candle);
+
+  return trace.state as PlotState;
+}
+
+/**
+ * The section the trace reports at this position.
+ * @param state A non-empty trace state
+ * @returns The section string
+ */
+function sectionOf(state: PlotState): string {
+  return (state as unknown as { text: { section?: string } }).text.section ?? '';
+}
+
+describe('AnnouncePositionCommand names a section as the trace authored it', () => {
+  // The per-point announcement renders `section` verbatim (#830). This command
+  // lower-cased it, so pressing the position key on a box plot answered
+  // "in minimum" about the section that had just called itself "Minimum" --
+  // the same defect #830 describes, one code path further along.
+
+  test('keeps a box section verbatim in verbose', () => {
+    const state = boxTraceState(1, 1);
+    const { command, textViewModel } = createCommand(state);
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('Position is 2 of 2 in Minimum');
+  });
+
+  test('keeps a box section verbatim in terse', () => {
+    const state = boxTraceState(1, 1);
+    const { command, textViewModel } = createCommand(state, 'terse');
+
+    command.execute();
+
+    expect(textViewModel.update).toHaveBeenCalledWith('100%, Minimum');
+  });
+
+  test('announces whatever the trace reports, for every box section', () => {
+    // The contract rather than one string: this command does not get to
+    // decide the case of a label it did not author. Outliers are the section
+    // whose label is two words, so it is the one a re-cased reading garbles
+    // most visibly.
+    for (const row of [0, 1, 2, 6]) {
+      const state = boxTraceState(row, 0);
+      const { command, textViewModel } = createCommand(state);
+
+      command.execute();
+
+      const announced = jest.mocked(textViewModel.update).mock.calls[0][0] as string;
+      expect(sectionOf(state)).not.toBe('');
+      expect(announced).toContain(sectionOf(state));
+    }
+  });
+
+  test('leaves a candlestick section alone, which authors its own in lower case', () => {
+    // The same expression guarded both traces, and this one reads identically
+    // either way -- so it is the case that shows nothing else moved.
+    const state = candlestickTraceState(CANDLESTICK_SECTIONS.indexOf('close'), 1);
+    const { command, textViewModel } = createCommand(state);
+
+    command.execute();
+
+    expect(sectionOf(state)).toBe('close');
+    expect(textViewModel.update).toHaveBeenCalledWith('Position is 2 of 3, close');
   });
 });

--- a/test/service/sectionCase.test.ts
+++ b/test/service/sectionCase.test.ts
@@ -1,0 +1,156 @@
+import type { BoxTrace } from '@model/box';
+import type { DumbbellTrace } from '@model/dumbbell';
+import type { BoxPoint, DumbbellData, MaidrLayer } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { NotificationService } from '@service/notification';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/** One distribution, with outliers on both ends. */
+const BOX: BoxPoint[] = [
+  {
+    z: 'Setosa',
+    lowerOutliers: [1.1],
+    min: 2,
+    q1: 3,
+    q2: 4,
+    q3: 5,
+    max: 6,
+    upperOutliers: [9.4],
+  },
+];
+
+/**
+ * Two ends whose names the producer chose, with case that means something.
+ *
+ * `Control` and `Q1 2024` are the kind of strings a dumbbell actually carries.
+ * Lower-casing them is not a formatting preference -- it destroys a
+ * distinction the data made.
+ */
+const PAIRS: DumbbellData = {
+  startLabel: 'Control',
+  endLabel: 'Q1 2024',
+  points: [{ x: 'Alpha', start: 10, end: 25 }],
+};
+
+/**
+ * What a reader actually hears at one position, in one mode.
+ *
+ * The defect lives in how the text service *renders* `state.section`, so the
+ * assertion has to be on the sentence rather than on the trace's state.
+ *
+ * @param layer The layer to build
+ * @param at Where to put the cursor
+ * @param mode The verbosity to read in
+ * @returns The announcement
+ */
+function announcementAt(
+  layer: MaidrLayer,
+  at: [number, number],
+  mode: 'verbose' | 'terse',
+): string {
+  const trace = TraceFactory.create(layer) as BoxTrace | DumbbellTrace;
+  trace.moveToIndex(at[0], at[1]);
+
+  const notification = new NotificationService();
+  const text = new TextService(notification);
+  const heard: string[] = [];
+  text.onChange(event => heard.push(String(event.value)));
+  (text as unknown as { mode: string }).mode = mode;
+  text.update(trace.state);
+
+  return heard[heard.length - 1];
+}
+
+/**
+ * A box layer over the fixture above.
+ * @returns The layer
+ */
+function boxLayer(): MaidrLayer {
+  return {
+    id: 'section-case-box',
+    type: TraceType.BOX,
+    title: 'Sepal width',
+    axes: { x: { label: 'Species' }, y: { label: 'Value' } },
+    data: BOX,
+  };
+}
+
+/**
+ * A dumbbell layer whose end names carry producer-chosen case.
+ * @returns The layer
+ */
+function dumbbellLayer(): MaidrLayer {
+  return {
+    id: 'section-case-dumbbell',
+    type: TraceType.DUMBBELL,
+    title: 'Change',
+    axes: { x: { label: 'Group' }, y: { label: 'Score' } },
+    data: PAIRS,
+  };
+}
+
+/**
+ * Both readings of one position.
+ *
+ * @param layer The layer to build
+ * @param at Where to put the cursor
+ * @returns The verbose and terse announcements
+ */
+function bothModes(layer: MaidrLayer, at: [number, number]): [string, string] {
+  return [
+    announcementAt(layer, at, 'verbose'),
+    announcementAt(layer, at, 'terse'),
+  ];
+}
+
+describe('a section reads the same way in both modes', () => {
+  test('a box plot section keeps its case in verbose, as terse already did', () => {
+    // Verbose lower-cased and terse did not, so toggling T changed the
+    // capitalisation of a label that came from neither the user nor the data.
+    // Row is the section and column the distribution, so row 1 is Minimum.
+    const [verbose, terse] = bothModes(boxLayer(), [1, 0]);
+
+    expect(verbose).toContain('Minimum');
+    expect(verbose).not.toContain('minimum');
+    expect(terse).toContain('Minimum');
+  });
+
+  test('an outlier section reads the same way in both modes', () => {
+    // The outlier branch lower-cased on both sides, so the two agreed with
+    // each other and disagreed with every other section. Now all of them
+    // render the label as it was authored.
+    const [verbose, terse] = bothModes(boxLayer(), [0, 0]);
+
+    expect(verbose).toContain('Lower outlier(s)');
+    expect(terse).toContain('Lower outlier(s)');
+  });
+
+  test('a producer-supplied name is announced as the producer wrote it', () => {
+    // The reason this is worth changing rather than documenting. A dumbbell's
+    // end names are authored strings, and a ridgeline's group names are too.
+    const [verbose, terse] = bothModes(dumbbellLayer(), [0, 0]);
+
+    expect(verbose).toContain('Control');
+    expect(verbose).not.toContain('control,');
+    expect(terse).toContain('Control');
+  });
+
+  test('a name whose case carries meaning survives both modes', () => {
+    // `Q1 2024` is not a preference about capitalisation; lower-casing it
+    // makes a different string.
+    const [verbose, terse] = bothModes(dumbbellLayer(), [1, 0]);
+
+    expect(verbose).toContain('Q1 2024');
+    expect(terse).toContain('Q1 2024');
+  });
+
+  test('a lower-case section is left alone, so nothing else moved', () => {
+    // Error bar, waterfall and survival all author their sections in lower
+    // case already. Dropping the lower-casing must not have capitalised them.
+    const [verbose] = bothModes(boxLayer(), [2, 0]);
+
+    expect(verbose).toContain('25%');
+  });
+});


### PR DESCRIPTION
Closes #830. Takes **option 1** — dropping the `.toLowerCase()` — which the issue identified as the smallest and probably right choice.

## The defect

`formatVerboseTraceText` lower-cased `state.section`; `formatTerseTraceText` rendered it verbatim. The same point read `minimum Value is 3.2` in one mode and `Minimum 3.2` in the other, so toggling `T` changed the capitalisation of a label that came from neither the user nor the data.

## Why it is worth changing rather than documenting

When the issue was filed, one trace put a producer-supplied string in `section`. **There are now two**: a dumbbell's end names and a ridgeline's group names are both authored strings.

- A chart's `Control` was announced as `control` in verbose and `Control` in terse.
- `Q1 2024` is not a preference about capitalisation — lower-casing it makes a *different string*.

Neither trace works around it in the model, and shouldn't: doing so would destroy a distinction the data carries in order to compensate for something the formatting layer chose to drop. There is a comment in `src/model/dumbbell.ts` pointing at this issue.

## Scope

Nine call sites in two files, all of the trace's `section`:

| File | Site | Was | Now |
|---|---|---|---|
| `src/service/text.ts` | verbose, section-before-label | lower-cased | verbatim |
| `src/service/text.ts` | verbose, outlier branch (×2) | lower-cased | verbatim |
| `src/service/text.ts` | terse, outlier branch (×2) | lower-cased | verbatim |
| `src/command/describe.ts` | box position, verbose + terse | lower-cased | verbatim |
| `src/command/describe.ts` | candlestick position, verbose + terse | lower-cased | verbatim (no-op today) |

The outlier branch lower-cased on *both* sides, so those two agreed with each other while disagreeing with every other section. Including them is what the issue asked for under "the same treatment for consistency."

**`describe.ts` was added after review flagged it, and it is not optional.** Before this PR, the box plot's verbose per-point reading also lower-cased, so the position key agreed with it. Fixing only `text.ts` would have moved the disagreement rather than closed it — and moved it somewhere harder to notice, since it would then be two different *keys* saying different things rather than two modes of one key. The two candlestick sites read identically either way (`CANDLESTICK_SECTIONS` is already lower case) and go with the other two anyway: the trace owns the case of its own label, and one of four sites deciding differently is how these drifted apart.

`state.z.value.toLowerCase()` is left alone — that is the candlestick trend, a different field with a different argument.

## The visible change, stated plainly

A box plot's **verbose** reading changes:

- `minimum Value is 3.2` → `Minimum Value is 3.2`
- `upper outlier(s) for Value is [...]` → `Upper outlier(s) for Value is [...]`

**Terse already said both of those that way**, so this is the two modes agreeing rather than a new wording. The position key changes in both modes — `Position is 2 of 2 in minimum` → `... in Minimum` — which is it agreeing with the reading the reader just heard. Nothing else moves: error bar, waterfall and survival author their sections in lower case already, and a test pins that.

## What I found running it

**No test asserted the old behaviour in either direction.** `npm test` and the full e2e suite — including both box plot specs — passed with the change and with it reverted. Nothing in `e2e_tests/` asserts either wording, for the per-point reading or the position key. The issue predicted this "wants a product call plus an e2e update"; the e2e update turns out not to exist, because the rendering was never pinned at all. That is precisely how the two modes drifted apart, and it means the change is safe in the narrow sense and unguarded in the important one.

So two test files cover it:

- **`test/service/sectionCase.test.ts`** (new) asserts the **rendered sentence** through `TextService` in both modes: the box section, the outlier section, a producer-supplied name, a name whose case carries meaning (`Q1 2024`), and one already-lower-case section to prove nothing else moved. Reverting the fix fails four of the five.
- **`test/command/announce-position.test.ts`** gains four cases built on **real traces** rather than hand-written state — a fixture that writes `section: 'Minimum'` itself would decide the thing under assertion. Reverting fails three of the four; the candlestick case passes either way on purpose, since it is the only honest way to cover a site whose behaviour genuinely does not change.

## Verification

- `npm test` — **2609 + 73 passed**, 185 suites
- `npx playwright test --project=chromium boxplotVertical boxplotHorizontal dumbbell ridgeline errorbar waterfall survival forest` — **91 passed**, every trace that sets a `section`
- `npx playwright test --project=chromium boxplotVertical boxplotHorizontal candlestick` — **50 passed**, after the `describe.ts` change
- `npm run type-check`, `npm run lint:fix`, `npm run build` — clean