### PR TITLE
docs(testing): record the jest / jest-environment-jsdom major skew

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -129,6 +129,24 @@ import '@testing-library/jest-dom/jest-globals';
   lines — DefinitelyTyped has no release matching every jsdom major. Bumping
   one means checking `npm run type-check` still passes, or the break surfaces
   on an unrelated pull request.
+- **`jest` and `jest-environment-jsdom` are a major apart on purpose**: core on
+  29, the environment on 30, so `@jest/environment` resolves at two majors in
+  one tree. Nothing warns — `jest-environment-jsdom` does not peer-declare
+  `jest` at all, so npm has no constraint to check. It was the price of
+  clearing an advisory that reached the tree through `jest-environment-jsdom@29`'s
+  bundled `jsdom@20` (#760), and it bought a second win: 30.x bundles
+  `jsdom@26`, which dedupes with the `jsdom` devDependency instead of sitting
+  on two majors.
+
+  The failure mode is quiet, which is why it is written down. If a `jest` core
+  bump ever changes the environment interface, the dependency graph will not
+  object — it surfaces as confusing test failures rather than an install
+  error, and the natural response to *those* is the same bump that would fix
+  this, so the two are easy to conflate. Realigning means moving core to 30,
+  which needs `ts-jest` checked against the two-project setup below; do it when
+  `jest` is bumped for its own reasons, not for this. Tracked in #766, and
+  `test/scripts/jestMajorSkew.test.ts` fails if this note and the installed
+  versions stop agreeing in either direction.
 
 ## ESM tests
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -128,6 +128,24 @@ import '@testing-library/jest-dom/jest-globals';
   lines — DefinitelyTyped has no release matching every jsdom major. Bumping
   one means checking `npm run type-check` still passes, or the break surfaces
   on an unrelated pull request.
+- **`jest` and `jest-environment-jsdom` are a major apart on purpose**: core on
+  29, the environment on 30, so `@jest/environment` resolves at two majors in
+  one tree. Nothing warns — `jest-environment-jsdom` does not peer-declare
+  `jest` at all, so npm has no constraint to check. It was the price of
+  clearing an advisory that reached the tree through `jest-environment-jsdom@29`'s
+  bundled `jsdom@20` (#760), and it bought a second win: 30.x bundles
+  `jsdom@26`, which dedupes with the `jsdom` devDependency instead of sitting
+  on two majors.
+
+  The failure mode is quiet, which is why it is written down. If a `jest` core
+  bump ever changes the environment interface, the dependency graph will not
+  object — it surfaces as confusing test failures rather than an install
+  error, and the natural response to *those* is the same bump that would fix
+  this, so the two are easy to conflate. Realigning means moving core to 30,
+  which needs `ts-jest` checked against the two-project setup below; do it when
+  `jest` is bumped for its own reasons, not for this. Tracked in #766, and
+  `test/scripts/jestMajorSkew.test.ts` fails if this note and the installed
+  versions stop agreeing in either direction.
 
 ## ESM tests
 

--- a/test/scripts/jestMajorSkew.test.ts
+++ b/test/scripts/jestMajorSkew.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, test } from '@jest/globals';
+
+/**
+ * The Jest core and its jsdom environment run a major apart, deliberately.
+ *
+ * Nothing in the dependency graph says so: `jest-environment-jsdom` declares
+ * a peer on `canvas` and **not on `jest`**, so npm has no constraint to check
+ * and installs the combination silently. `@jest/environment` then resolves at
+ * two majors in one tree and the suites pass by observation rather than by any
+ * declared contract (#766).
+ *
+ * A note in `.claude/rules/testing.md` is the only thing standing between the
+ * next person bumping `jest` and a confusing afternoon — so this fails if the
+ * note and the installed versions stop agreeing, **in either direction**. Skew
+ * without the note is the state the issue describes; the note without the skew
+ * is a warning about a hazard that no longer exists, which is how a rules file
+ * starts being ignored.
+ */
+
+const ROOT = resolve(__dirname, '../..');
+const RULE = join(ROOT, '.claude/rules/testing.md');
+
+/**
+ * The installed major of a package.
+ *
+ * Read from the installed tree rather than from `package.json`'s range,
+ * because the range is what was asked for and this is about what arrived.
+ *
+ * @param name The package to look up
+ * @returns Its major version
+ */
+function installedMajor(name: string): number {
+  const manifest = join(ROOT, 'node_modules', name, 'package.json');
+  const { version } = JSON.parse(readFileSync(manifest, 'utf8')) as {
+    version: string;
+  };
+  const major = Number.parseInt(version.split('.')[0], 10);
+
+  expect(Number.isFinite(major)).toBe(true);
+  return major;
+}
+
+describe('the jest core and its jsdom environment', () => {
+  const core = installedMajor('jest');
+  const environment = installedMajor('jest-environment-jsdom');
+  const rule = readFileSync(RULE, 'utf8');
+
+  test('are both installed, so the comparison below means something', () => {
+    expect(core).toBeGreaterThan(0);
+    expect(environment).toBeGreaterThan(0);
+  });
+
+  test('have their skew written down while it exists', () => {
+    // The note names both packages in one sentence; matching on that rather
+    // than on a version keeps a routine bump from failing this for the wrong
+    // reason.
+    const documented = /`jest` and `jest-environment-jsdom` are a major apart/
+      .test(rule);
+
+    if (core === environment) {
+      expect(documented).toBe(false);
+    } else {
+      expect(documented).toBe(true);
+    }
+  });
+
+  test('point at the issue tracking the realignment', () => {
+    if (core === environment) {
+      return;
+    }
+
+    // Without the number the note is folklore: a reader has no way to find
+    // what was weighed, or to see that realigning is a `ts-jest` question
+    // rather than a version bump.
+    expect(rule).toContain('#766');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The Jest core runs on 29 and its jsdom environment on 30, so `@jest/environment` resolves at two majors in one tree:

```
node_modules/@jest/globals/node_modules/@jest/environment                  -> 29.7.0
node_modules/jest-environment-jsdom/node_modules/@jest/environment         -> 30.4.1
```

**Nothing warns.** `jest-environment-jsdom` peer-declares `canvas` and *not* `jest`, so npm has no constraint to check and installs the combination silently. The suites pass by observation rather than by any declared contract.

## Related Issues

Closes #766, taking the option that issue recommends: **document it now, realign when `jest` is bumped for its own reasons.** Moving core to 30 means checking `ts-jest` against this repo's two-project setup — `unit` compiles to CommonJS, `esm` to ESNext under `--experimental-vm-modules` — which is a piece of work rather than a version bump, and the skew is not currently causing a problem.

## Changes Made

A note in `.claude/rules/testing.md`, beside the existing `jsdom` / `@types/jsdom` one that already explains some of these track separate lines. It records what the skew *is*, that it was the price of clearing an advisory reaching the tree through `jest-environment-jsdom@29`'s bundled `jsdom@20` (#760), that it also bought a `jsdom` dedupe, and what realigning would actually cost.

The part worth having written down is the failure mode: if a `jest` core bump ever changes the environment interface, **the dependency graph will not object**. It surfaces as confusing test failures rather than an install error — and the natural response to *those* is the same bump that would fix this, so the two are easy to conflate.

`npm run sync:copilot` regenerates `.github/instructions/testing.instructions.md`, included here.

## Screenshots (if applicable)

n/a — a rules note and its test.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**A note nothing checks is a note that rots**, which is the whole reason the skew was undocumented in the first place. `test/scripts/jestMajorSkew.test.ts` reads the installed majors and fails if they and the note stop agreeing **in either direction**:

- skew without the note is the state #766 describes;
- **the note without the skew** is a warning about a hazard that no longer exists, which is how a rules file starts being ignored. So the day someone bumps `jest` to 30, this fails and tells them to delete the paragraph.

It also asserts the note carries the issue number — without it the paragraph is folklore, and a reader has no way to see what was weighed or that realigning is a `ts-jest` question.

Matching is on the sentence naming both packages rather than on a version, so a routine patch bump cannot fail it for the wrong reason.

**Verified it bites:** rewording the note's first clause fails the middle case and leaves the other two green.

| Gate | Result |
|---|---|
| `npm run lint:fix` | clean |
| `npm run type-check` | clean |
| `npm test` | **2621 + 73 passed**, 187 suites |
| `npm run sync:copilot:check` | in sync (11 files) |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_