### PR TITLE
feat(frappe): support the chart types added since the pie chart

### DIFF
--- a/docs/frappe.md
+++ b/docs/frappe.md
@@ -80,7 +80,7 @@ Once the page loads, click on the chart (or Tab to it) and MAIDR activates with:
 The Frappe Charts adapter:
 
 1. **Reads data** - takes the chart's `{ labels, datasets }` and converts it to MAIDR's schema
-2. **Creates selectors** - generates CSS selectors (scoped to the chart container) for the Frappe SVG elements used in visual highlighting. Line and scatter traces highlight one element per point, so they target the per-point `<circle>` dots — keep `lineOptions.dotSize > 0`.
+2. **Creates selectors** - generates CSS selectors (scoped to the chart container) for the Frappe SVG elements used in visual highlighting. MAIDR highlights one element per data point, so every line-based chart — line, area, bump, scatter, dot — targets the per-point `<circle>` dots rather than the one `<path>` drawn for the whole series. Keep `lineOptions.dotSize > 0` and leave `hideDots` off.
 3. **Returns MAIDR config** - produces a complete `Maidr` object you set as the `maidr` attribute
 
 ### Wait for the chart to settle
@@ -98,16 +98,28 @@ The `activateMaidrWhenSettled` helper in the Quick Start handles this: it waits 
 | Bar | `'bar'` | `'bar'` |
 | Line | `'line'` | `'line'` |
 | Multi-line | `'line'` (multiple datasets) | `'line'` |
+| Area | `'line'` + `lineOptions: { regionFill: 1 }` | `'area'` (also inferred) |
+| Bump (rank over time) | `'line'` (one dataset per competitor) | `'bump'` |
 | Scatter | `'line'` + `lineOptions: { hideLine: 1 }` | `'scatter'` |
+| Dot plot | `'line'` + `lineOptions: { hideLine: 1 }` | `'dot'` |
+| Diverging bar | `'bar'` (two signed datasets) | `'diverging'` |
 | Mixed axis (bar + line) | `'axis-mixed'` | `'axis-mixed'` |
 | Pie | `'pie'` | `'pie'` |
 | Donut | `'donut'` | `'donut'` |
+
+The `chartType` names above are the **adapter's**, not Frappe's. Frappe draws several distinct statistical charts with the same `type: 'line'` or `type: 'bar'`, differing only in their options or in what the numbers mean — nothing a chart instance records — so naming the chart is how you tell MAIDR which one to announce.
 
 **Not supported:** Percentage charts (no MAIDR equivalent), and Frappe's calendar-style Heatmap (structurally unlike MAIDR's matrix heatmap).
 
 > **Pie note:** Frappe aggregates before it draws — it sums every dataset at each label, drops labels whose total is negative, and collapses everything past `maxSlices` (default 20) into one "Rest" wedge. The adapter reproduces that aggregation so each announced slice is the wedge it highlights. Pass the chart instance (not a plain `{ data }` object) when you override `maxSlices`, so the adapter can read it.
 
-> **Scatter note:** Frappe Charts v1.6.2 has no native `scatter` type. Render a dot plot with a line chart whose connecting line is hidden (`lineOptions: { hideLine: 1 }`); pass `chartType: 'scatter'` to the adapter so it is treated as a scatter plot. Frappe spaces x-axis labels evenly regardless of their numeric value, so use evenly spaced numeric labels.
+> **Area note:** `lineOptions.regionFill` is an instance field the adapter reads directly, so a chart passed as `chartType: 'line'` with the region filled is announced as an area chart anyway — you cannot mislabel one as the other. Pass `chartType: 'area'` when you hand the adapter a plain `{ data }` object, which has no instance to read. Several filled bands in one chart **overlap** in Frappe rather than stacking, so they stay independent series (`area`, never `stacked_area`). Keep `dotSize > 0`: the fill is one `<path>` for the whole series and cannot highlight individual points.
+
+> **Scatter / dot note:** Frappe Charts v1.6.2 has no native `scatter` type. Render either chart with a line chart whose connecting line is hidden (`lineOptions: { hideLine: 1, dotSize: 6 }`). Frappe places its marks at **evenly spaced label positions whatever the label holds**, so which of the two you have depends on the labels: numeric, evenly spaced labels are a scatter plot (`chartType: 'scatter'`), and category names are a Cleveland dot plot (`chartType: 'dot'`). Passing `'scatter'` with categorical labels is converted as a dot plot with a console warning, because `Number('Mon')` is `NaN` and a scatter layer built from those labels would have no x values at all.
+
+> **Bump note:** A bump chart is a multi-dataset line chart whose y values are **ranks** — one dataset per competitor, `1` = best. MAIDR inverts the pitch so first place is the highest note and announces the places gained or lost at each period, which is why the type has to be declared: nothing in the data distinguishes a rank from a magnitude. Emit the **true ranks**. Frappe v1.6.2 cannot invert or reverse an axis, so a rank chart it draws shows rank 1 at the *bottom*; pre-inverting the values to make the picture look right would make MAIDR announce the wrong ranks.
+
+> **Diverging note:** A diverging bar chart is two bar datasets with opposite signs, drawn either side of Frappe's zero line — negate the values of the series that should grow downwards and emit them signed, exactly as the chart draws them. MAIDR takes the magnitude for the pitch and names the side. The adapter throws unless the chart is exactly two datasets, one all-negative and one all-positive, rather than announce sides that are not there. Two limits are Frappe's: it has no horizontal bars, so the back-to-back population pyramid orientation is not drawable — only the vertical up/down form — and `barOptions: { stacked: 1 }` must **not** be used, because Frappe cumulates raw values and would stack the negative series onto the positive one.
 
 ## Code Examples
 
@@ -181,6 +193,123 @@ The `activateMaidrWhenSettled` helper in the Quick Start handles this: it waits 
     chartType: 'line',
     title: 'Monthly Product Sales',
     axes: { x: 'Month', y: 'Sales (thousands USD)' },
+  });
+</script>
+```
+
+### Area Chart
+
+```html
+<div id="area-chart"></div>
+<script>
+  const data = {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    datasets: [{ name: 'Rainfall', values: [42, 55, 71, 63, 48, 30] }],
+  };
+  // regionFill: 1 fills the band between the line and the baseline. The
+  // adapter reads it off the instance, so `chartType: 'line'` is announced as
+  // an area chart too — pass 'area' when handing over a plain { data } object.
+  const chart = new frappe.Chart('#area-chart', {
+    data,
+    type: 'line',
+    height: 400,
+    lineOptions: { regionFill: 1, dotSize: 5 },
+  });
+
+  activateMaidrWhenSettled(document.querySelector('#area-chart'), {
+    chartType: 'area',
+    title: 'Monthly Rainfall',
+    axes: { x: 'Month', y: 'Rainfall (mm)' },
+  });
+</script>
+```
+
+### Bump Chart (Rank Over Time)
+
+```html
+<div id="bump-chart"></div>
+<script>
+  // The values are RANKS, 1 = best. Emit them as ranks: MAIDR inverts the
+  // pitch itself, and Frappe cannot reverse an axis, so the drawn chart shows
+  // rank 1 at the bottom while the announcements stay correct.
+  const data = {
+    labels: ['Week 1', 'Week 2', 'Week 3', 'Week 4'],
+    datasets: [
+      { name: 'Alpha', values: [1, 2, 2, 1] },
+      { name: 'Beta', values: [2, 1, 3, 3] },
+      { name: 'Gamma', values: [3, 3, 1, 2] },
+    ],
+  };
+  const chart = new frappe.Chart('#bump-chart', {
+    data,
+    type: 'line',
+    height: 400,
+    lineOptions: { dotSize: 6 },
+  });
+
+  activateMaidrWhenSettled(document.querySelector('#bump-chart'), {
+    chartType: 'bump',
+    title: 'Weekly League Standings',
+    axes: { x: 'Week', y: 'Rank' },
+  });
+</script>
+```
+
+### Dot Plot
+
+```html
+<div id="dot-chart"></div>
+<script>
+  const data = {
+    labels: ['North', 'South', 'East', 'West', 'Central'],
+    datasets: [{ name: 'Sales', values: [64, 41, 78, 55, 92] }],
+  };
+  // Same rendering as the scatter plot below — a line chart with the line
+  // hidden. The labels are what tells the two apart: category names place one
+  // mark per category, which is a dot plot.
+  const chart = new frappe.Chart('#dot-chart', {
+    data,
+    type: 'line',
+    height: 400,
+    lineOptions: { hideLine: 1, dotSize: 8 },
+  });
+
+  activateMaidrWhenSettled(document.querySelector('#dot-chart'), {
+    chartType: 'dot',
+    title: 'Sales by Region',
+    axes: { x: 'Region', y: 'Sales (thousands USD)' },
+  });
+</script>
+```
+
+### Diverging Bar Chart
+
+```html
+<div id="diverging-chart"></div>
+<script>
+  // Two datasets with opposite signs. The downward series is NEGATIVE: MAIDR
+  // takes the magnitude for the pitch and names the side, so stripping the
+  // sign would leave it nothing to name the sides with. Do not set
+  // barOptions.stacked — Frappe cumulates raw values and would stack the
+  // negative series onto the positive one.
+  const data = {
+    labels: ['0-14', '15-29', '30-44', '45-59', '60-74', '75+'],
+    datasets: [
+      { name: 'Men', values: [-1200, -1150, -1080, -990, -720, -310] },
+      { name: 'Women', values: [1140, 1100, 1060, 1010, 830, 520] },
+    ],
+  };
+  const chart = new frappe.Chart('#diverging-chart', {
+    data,
+    type: 'bar',
+    height: 420,
+    colors: ['#4c72b0', '#c44e52'],
+  });
+
+  activateMaidrWhenSettled(document.querySelector('#diverging-chart'), {
+    chartType: 'diverging',
+    title: 'Population by Age Band',
+    axes: { x: 'Age band', y: 'People, thousands', z: 'Sex' },
   });
 </script>
 ```
@@ -308,9 +437,9 @@ The adapter accepts a `FrappeChartAdapterOptions` object:
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `chartType` | `'bar' \| 'line' \| 'scatter' \| 'axis-mixed'` | Yes | The Frappe chart type. Multi-line uses `'line'`. |
+| `chartType` | `'bar' \| 'line' \| 'area' \| 'bump' \| 'scatter' \| 'dot' \| 'diverging' \| 'axis-mixed' \| 'pie' \| 'donut'` | Yes | Which chart you drew (see [Supported Chart Types](#supported-chart-types)). Multi-line uses `'line'`. |
 | `title` | `string` | No | Chart title for accessibility announcements |
-| `axes` | `{ x?: string; y?: string }` | No | Axis labels |
+| `axes` | `{ x?: string; y?: string; z?: string }` | No | Axis labels. `z` names the dimension the series themselves vary along (the two sides of a `'diverging'` chart, say) and is ignored by the types that have no third dimension. |
 | `id` | `string` | No | Unique ID for the MAIDR instance (defaults to the container's `id`) |
 
 ## Using with npm/Bundlers

--- a/examples/frappe-area.html
+++ b/examples/frappe-area.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frappe Charts Area - MAIDR Example</title>
+    <!-- Frappe Charts v1.6.2 - the adapter's CSS selectors are specific to this
+         version. If upgrading, verify SVG class names match. -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.umd.js"
+      integrity="sha384-JQa9VKO4+ZAEaRWDOmQM5LPHQTv8t9B4y8kBn36iar33TxUZByrYAa3o+PsU7hYk"
+      crossorigin="anonymous"
+    ></script>
+    <!-- MAIDR core + Frappe Charts adapter -->
+    <script src="../dist/maidr.js"></script>
+    <script src="../dist/frappe.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Frappe Charts Area Chart with MAIDR</h1>
+      <p id="error" hidden>
+        Failed to load Frappe Charts from CDN. Please check your internet
+        connection.
+      </p>
+      <div id="chart"></div>
+    </main>
+
+    <script>
+      // Surface an error if Frappe Charts failed to load from CDN; otherwise
+      // build the chart and hand it to the MAIDR adapter.
+      const errorEl = document.getElementById('error');
+      if (typeof frappe === 'undefined') {
+        if (errorEl) {
+          errorEl.hidden = false;
+        }
+      } else {
+        const data = {
+          labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          datasets: [
+            {
+              name: 'Rainfall',
+              values: [42, 55, 71, 63, 48, 30],
+            },
+          ],
+        };
+
+        // regionFill fills the band between the line and the baseline, which is
+        // Frappe's own area-chart look. dotSize > 0 renders the per-point
+        // <circle> dots the adapter highlights - the fill is a single <path>
+        // for the whole series and cannot stand in for individual points.
+        const chart = new frappe.Chart('#chart', {
+          title: 'Monthly Rainfall',
+          data: data,
+          type: 'line',
+          height: 400,
+          colors: ['#7cd6fd'],
+          lineOptions: {
+            regionFill: 1,
+            dotSize: 5,
+          },
+        });
+
+        // The adapter reads `lineOptions.regionFill` off the chart instance, so
+        // passing chartType: 'line' here would be announced as an area chart
+        // too. Naming it 'area' keeps the intent readable, and is required when
+        // handing the adapter a plain { data } object with no instance to read.
+        //
+        // Frappe runs an entrance animation and re-creates the SVG nodes once it
+        // finishes. Wait until the chart DOM stops mutating before handing it to
+        // MAIDR, so MAIDR captures the final, stable elements for highlighting.
+        activateMaidrWhenSettled(document.querySelector('#chart'), {
+          chartType: 'area',
+          title: 'Monthly Rainfall',
+          axes: { x: 'Month', y: 'Rainfall (mm)' },
+        });
+
+        function activateMaidrWhenSettled(container, options) {
+          if (!container.querySelector('svg.frappe-chart')) {
+            requestAnimationFrame(() => activateMaidrWhenSettled(container, options));
+            return;
+          }
+          let settleTimer;
+          const observer = new MutationObserver(scheduleSettle);
+          function scheduleSettle() {
+            clearTimeout(settleTimer);
+            settleTimer = setTimeout(finish, 300);
+          }
+          function finish() {
+            observer.disconnect();
+            const maidr = maidrFrappe.createMaidrFromFrappeChart(chart, container, options);
+            container.setAttribute('maidr', JSON.stringify(maidr));
+          }
+          observer.observe(container, { childList: true, subtree: true, attributes: true });
+          scheduleSettle();
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/examples/frappe-bump.html
+++ b/examples/frappe-bump.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frappe Charts Bump - MAIDR Example</title>
+    <!-- Frappe Charts v1.6.2 - the adapter's CSS selectors are specific to this
+         version. If upgrading, verify SVG class names match. -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.umd.js"
+      integrity="sha384-JQa9VKO4+ZAEaRWDOmQM5LPHQTv8t9B4y8kBn36iar33TxUZByrYAa3o+PsU7hYk"
+      crossorigin="anonymous"
+    ></script>
+    <!-- MAIDR core + Frappe Charts adapter -->
+    <script src="../dist/maidr.js"></script>
+    <script src="../dist/frappe.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Frappe Charts Bump Chart with MAIDR</h1>
+      <p id="error" hidden>
+        Failed to load Frappe Charts from CDN. Please check your internet
+        connection.
+      </p>
+      <div id="chart"></div>
+    </main>
+
+    <script>
+      // Surface an error if Frappe Charts failed to load from CDN; otherwise
+      // build the chart and hand it to the MAIDR adapter.
+      const errorEl = document.getElementById('error');
+      if (typeof frappe === 'undefined') {
+        if (errorEl) {
+          errorEl.hidden = false;
+        }
+      } else {
+        // The values are RANKS, 1 = best, not magnitudes. Emit them as ranks:
+        // MAIDR inverts the pitch itself so first place is the highest note, and
+        // announces the places gained or lost at each week. Frappe v1.6.2 cannot
+        // reverse an axis, so the DRAWN chart shows rank 1 at the bottom -
+        // pre-inverting the values to fix the picture would make every
+        // announcement report the wrong rank.
+        const data = {
+          labels: ['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Week 5'],
+          datasets: [
+            {
+              name: 'Alpha',
+              values: [1, 2, 2, 1, 1],
+            },
+            {
+              name: 'Beta',
+              values: [2, 1, 3, 3, 2],
+            },
+            {
+              name: 'Gamma',
+              values: [3, 3, 1, 2, 3],
+            },
+          ],
+        };
+
+        // dotSize > 0 renders per-point <circle> dots, which the adapter's line
+        // selector targets for highlighting.
+        const chart = new frappe.Chart('#chart', {
+          title: 'Weekly League Standings',
+          data: data,
+          type: 'line',
+          height: 400,
+          colors: ['#7cd6fd', '#e44c55', '#5e64ff'],
+          lineOptions: {
+            dotSize: 6,
+          },
+        });
+
+        // Nothing in Frappe's data distinguishes a rank from a magnitude, so the
+        // chart type has to be declared. The adapter emits one selector per
+        // competitor plus a legend from the dataset names.
+        //
+        // Frappe runs an entrance animation and re-creates the SVG nodes once it
+        // finishes. Wait until the chart DOM stops mutating before handing it to
+        // MAIDR, so MAIDR captures the final, stable elements for highlighting.
+        activateMaidrWhenSettled(document.querySelector('#chart'), {
+          chartType: 'bump',
+          title: 'Weekly League Standings',
+          axes: { x: 'Week', y: 'Rank' },
+        });
+
+        function activateMaidrWhenSettled(container, options) {
+          if (!container.querySelector('svg.frappe-chart')) {
+            requestAnimationFrame(() => activateMaidrWhenSettled(container, options));
+            return;
+          }
+          let settleTimer;
+          const observer = new MutationObserver(scheduleSettle);
+          function scheduleSettle() {
+            clearTimeout(settleTimer);
+            settleTimer = setTimeout(finish, 300);
+          }
+          function finish() {
+            observer.disconnect();
+            const maidr = maidrFrappe.createMaidrFromFrappeChart(chart, container, options);
+            container.setAttribute('maidr', JSON.stringify(maidr));
+          }
+          observer.observe(container, { childList: true, subtree: true, attributes: true });
+          scheduleSettle();
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/examples/frappe-diverging.html
+++ b/examples/frappe-diverging.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frappe Charts Diverging Bar - MAIDR Example</title>
+    <!-- Frappe Charts v1.6.2 - the adapter's CSS selectors are specific to this
+         version. If upgrading, verify SVG class names match. -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.umd.js"
+      integrity="sha384-JQa9VKO4+ZAEaRWDOmQM5LPHQTv8t9B4y8kBn36iar33TxUZByrYAa3o+PsU7hYk"
+      crossorigin="anonymous"
+    ></script>
+    <!-- MAIDR core + Frappe Charts adapter -->
+    <script src="../dist/maidr.js"></script>
+    <script src="../dist/frappe.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Frappe Charts Diverging Bar Chart with MAIDR</h1>
+      <p id="error" hidden>
+        Failed to load Frappe Charts from CDN. Please check your internet
+        connection.
+      </p>
+      <div id="chart"></div>
+    </main>
+
+    <script>
+      // Surface an error if Frappe Charts failed to load from CDN; otherwise
+      // build the chart and hand it to the MAIDR adapter.
+      const errorEl = document.getElementById('error');
+      if (typeof frappe === 'undefined') {
+        if (errorEl) {
+          errorEl.hidden = false;
+        }
+      } else {
+        // Two datasets with opposite signs, drawn either side of Frappe's zero
+        // line. The downward series is NEGATIVE and is emitted that way: MAIDR
+        // takes the magnitude for the pitch and names the side, so stripping the
+        // sign would leave it nothing to name the sides with.
+        //
+        // Do NOT set barOptions.stacked here - Frappe cumulates raw values, so it
+        // would stack the negative series onto the positive one.
+        const data = {
+          labels: ['0-14', '15-29', '30-44', '45-59', '60-74', '75+'],
+          datasets: [
+            {
+              name: 'Men',
+              values: [-1200, -1150, -1080, -990, -720, -310],
+            },
+            {
+              name: 'Women',
+              values: [1140, 1100, 1060, 1010, 830, 520],
+            },
+          ],
+        };
+
+        // Frappe has no horizontal bars, so the classic back-to-back population
+        // pyramid is not drawable - only this vertical up/down form.
+        const chart = new frappe.Chart('#chart', {
+          title: 'Population by Age Band',
+          data: data,
+          type: 'bar',
+          height: 420,
+          colors: ['#4c72b0', '#c44e52'],
+        });
+
+        // The adapter validates the shape and throws unless the chart really is
+        // two sides, rather than announce sides that are not there. `axes.z`
+        // names what the two series vary along.
+        //
+        // Frappe runs an entrance animation and re-creates the SVG nodes once it
+        // finishes. Wait until the chart DOM stops mutating before handing it to
+        // MAIDR, so MAIDR captures the final, stable elements for highlighting.
+        activateMaidrWhenSettled(document.querySelector('#chart'), {
+          chartType: 'diverging',
+          title: 'Population by Age Band',
+          axes: { x: 'Age band', y: 'People, thousands', z: 'Sex' },
+        });
+
+        function activateMaidrWhenSettled(container, options) {
+          if (!container.querySelector('svg.frappe-chart')) {
+            requestAnimationFrame(() => activateMaidrWhenSettled(container, options));
+            return;
+          }
+          let settleTimer;
+          const observer = new MutationObserver(scheduleSettle);
+          function scheduleSettle() {
+            clearTimeout(settleTimer);
+            settleTimer = setTimeout(finish, 300);
+          }
+          function finish() {
+            observer.disconnect();
+            const maidr = maidrFrappe.createMaidrFromFrappeChart(chart, container, options);
+            container.setAttribute('maidr', JSON.stringify(maidr));
+          }
+          observer.observe(container, { childList: true, subtree: true, attributes: true });
+          scheduleSettle();
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/examples/frappe-dot.html
+++ b/examples/frappe-dot.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frappe Charts Dot Plot - MAIDR Example</title>
+    <!-- Frappe Charts v1.6.2 - the adapter's CSS selectors are specific to this
+         version. If upgrading, verify SVG class names match. -->
+    <script
+      src="https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.umd.js"
+      integrity="sha384-JQa9VKO4+ZAEaRWDOmQM5LPHQTv8t9B4y8kBn36iar33TxUZByrYAa3o+PsU7hYk"
+      crossorigin="anonymous"
+    ></script>
+    <!-- MAIDR core + Frappe Charts adapter -->
+    <script src="../dist/maidr.js"></script>
+    <script src="../dist/frappe.js"></script>
+  </head>
+
+  <body>
+    <main>
+      <h1>Frappe Charts Dot Plot with MAIDR</h1>
+      <p id="error" hidden>
+        Failed to load Frappe Charts from CDN. Please check your internet
+        connection.
+      </p>
+      <div id="chart"></div>
+    </main>
+
+    <script>
+      // Surface an error if Frappe Charts failed to load from CDN; otherwise
+      // build the chart and hand it to the MAIDR adapter.
+      const errorEl = document.getElementById('error');
+      if (typeof frappe === 'undefined') {
+        if (errorEl) {
+          errorEl.hidden = false;
+        }
+      } else {
+        const data = {
+          labels: ['North', 'South', 'East', 'West', 'Central'],
+          datasets: [
+            {
+              name: 'Sales',
+              values: [64, 41, 78, 55, 92],
+            },
+          ],
+        };
+
+        // Frappe v1.6.2 has no native dot-plot type; a line chart with the line
+        // hidden renders only the dots. This is the same rendering the adapter
+        // calls 'scatter' - the labels are what tell the two apart. Frappe places
+        // its marks at evenly spaced label positions whatever the label holds, so
+        // category names give one mark per category, which is a dot plot.
+        const chart = new frappe.Chart('#chart', {
+          title: 'Sales by Region',
+          data: data,
+          type: 'line',
+          height: 400,
+          colors: ['#743ee2'],
+          lineOptions: {
+            hideLine: 1,
+            dotSize: 8,
+          },
+        });
+
+        // Frappe runs an entrance animation and re-creates the SVG nodes once it
+        // finishes. Wait until the chart DOM stops mutating before handing it to
+        // MAIDR, so MAIDR captures the final, stable elements for highlighting.
+        activateMaidrWhenSettled(document.querySelector('#chart'), {
+          chartType: 'dot',
+          title: 'Sales by Region',
+          axes: { x: 'Region', y: 'Sales (thousands USD)' },
+        });
+
+        function activateMaidrWhenSettled(container, options) {
+          if (!container.querySelector('svg.frappe-chart')) {
+            requestAnimationFrame(() => activateMaidrWhenSettled(container, options));
+            return;
+          }
+          let settleTimer;
+          const observer = new MutationObserver(scheduleSettle);
+          function scheduleSettle() {
+            clearTimeout(settleTimer);
+            settleTimer = setTimeout(finish, 300);
+          }
+          function finish() {
+            observer.disconnect();
+            const maidr = maidrFrappe.createMaidrFromFrappeChart(chart, container, options);
+            container.setAttribute('maidr', JSON.stringify(maidr));
+          }
+          observer.observe(container, { childList: true, subtree: true, attributes: true });
+          scheduleSettle();
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/src/adapters/frappe/converters.ts
+++ b/src/adapters/frappe/converters.ts
@@ -450,7 +450,7 @@ function buildLineLayer(
   data: FrappeData,
   containerId: string,
   options: FrappeChartAdapterOptions,
-  type: TraceType.AREA | TraceType.BUMP | TraceType.LINE = TraceType.LINE,
+  type: TraceType.AREA | TraceType.BUMP | TraceType.LINE,
 ): MaidrLayer {
   const multiLine = data.datasets.length > 1;
 

--- a/src/adapters/frappe/converters.ts
+++ b/src/adapters/frappe/converters.ts
@@ -20,10 +20,12 @@ import type {
   MaidrSubplot,
   PiePoint,
   ScatterPoint,
+  SegmentedPoint,
 } from '@type/grammar';
-import type { FrappeChart, FrappeChartType, FrappeData, FrappePanel } from './types';
+import type { FrappeChart, FrappeChartType, FrappeData, FrappeDataset, FrappePanel } from './types';
 import { Orientation, TraceType } from '@type/grammar';
 import {
+  barSelector,
   barSelectorForDataset,
   ensureContainerId,
   lineSelector,
@@ -46,13 +48,19 @@ export interface FrappeChartAdapterOptions {
   /** Chart title. */
   title?: string;
   /**
-   * The Frappe chart type. Required because the chart instance does not expose
-   * its own type in a stable way. Multi-line charts use `'line'` (the adapter
-   * auto-detects multiple datasets).
+   * Which chart was drawn, in the adapter's own names — see
+   * {@link FrappeChartType}. Required because a chart instance does not expose
+   * its type in a stable way, and because Frappe draws several distinct
+   * statistical charts with the same `type`. Multi-line charts use `'line'`
+   * (the adapter auto-detects multiple datasets).
    */
   chartType: FrappeChartType;
-  /** Axis labels. */
-  axes?: { x?: string; y?: string };
+  /**
+   * Axis labels. `z` names the dimension the series themselves vary along —
+   * the two sides of a `'diverging'` chart, for instance — and is ignored by
+   * the types that have no third dimension.
+   */
+  axes?: { x?: string; y?: string; z?: string };
 }
 
 /**
@@ -206,18 +214,35 @@ export function createMaidrFromFrappeCharts(
 // ---------------------------------------------------------------------------
 
 /**
+ * The chart types whose layer belongs to the multi-line family: several series
+ * read independently over one shared set of categories. Multiple datasets of
+ * one of these get a selector per series plus a subplot legend naming them.
+ */
+const LINE_FAMILY_TYPES: ReadonlySet<FrappeChartType> = new Set<FrappeChartType>([
+  'area',
+  'bump',
+  'line',
+]);
+
+/**
  * Options for {@link buildSubplot}.
  */
 interface BuildSubplotOptions {
   /** The panel's Frappe chart type. */
   chartType: FrappeChartType;
   /** Axis labels for the panel's layers. */
-  axes?: { x?: string; y?: string };
+  axes?: { x?: string; y?: string; z?: string };
   /**
    * The chart's `maxSlices` setting, read from the instance. Pie / donut only
    * — see {@link buildPieLayer}.
    */
   maxSlices?: number;
+  /**
+   * The chart's `lineOptions.regionFill` setting, read from the instance. Line
+   * charts only — it fills the band between the line and the baseline, which
+   * makes the chart an area chart. See {@link buildLayers}.
+   */
+  regionFill?: boolean;
   /**
    * Panel display name. MAIDR has no subplot-level title field — the FIRST
    * layer's `title` is the panel's display name in subplot summaries, so this
@@ -253,16 +278,26 @@ function buildSubplot(
   const layers = buildLayers(data, container.id, {
     ...options,
     maxSlices: chart.config?.maxSlices,
+    regionFill: Boolean(chart.lineOptions?.regionFill),
   });
   if (options.panelTitle && layers.length > 0) {
     layers[0] = { ...layers[0], title: options.panelTitle };
   }
 
-  const isMultiLine = options.chartType === 'line' && data.datasets.length > 1;
+  const isMultiLine = LINE_FAMILY_TYPES.has(options.chartType) && data.datasets.length > 1;
   return {
-    ...(isMultiLine ? { legend: data.datasets.map((d, i) => d.name ?? `Series ${i + 1}`) } : {}),
+    ...(isMultiLine ? { legend: data.datasets.map(seriesName) } : {}),
     layers,
   };
+}
+
+/**
+ * What a series is called where the grammar needs a name and the author gave
+ * none — a legend entry, or a `SegmentedPoint.z`. Positional rather than
+ * empty, so two unnamed series stay tellable apart.
+ */
+function seriesName(dataset: FrappeDataset, index: number): string {
+  return dataset.name ?? `Series ${index + 1}`;
 }
 
 /**
@@ -316,9 +351,39 @@ function buildLayers(
     case 'bar':
       return [buildBarLayer(data, containerId, options)];
     case 'line':
-      return [buildLineLayer(data, containerId, options)];
+      // A line whose region is filled is an area chart. The setting is an
+      // instance field Frappe keeps verbatim, so reading it is more reliable
+      // than asking the author to name the chart twice — and an author who
+      // passes `chartType: 'area'` for a plain `{ data }` object, which has no
+      // instance to read, lands on the same layer.
+      return [buildLineLayer(
+        data,
+        containerId,
+        options,
+        options.regionFill ? TraceType.AREA : TraceType.LINE,
+      )];
+    case 'area':
+      return [buildLineLayer(data, containerId, options, TraceType.AREA)];
+    case 'bump':
+      return [buildLineLayer(data, containerId, options, TraceType.BUMP)];
     case 'scatter':
-      return [buildScatterLayer(data, containerId, options)];
+      // Frappe places its marks at evenly spaced label positions whatever the
+      // label holds, so a 'scatter' over category names is a dot plot rather
+      // than a scatter plot — and `Number('Mon')` is `NaN`, which would leave
+      // the layer with no x values at all.
+      if (hasNumericLabels(data)) {
+        return [buildScatterLayer(data, containerId, options)];
+      }
+      console.warn(
+        '[maidr/frappe] Chart type \'scatter\' has non-numeric labels, which Frappe '
+        + 'spaces evenly as categories rather than placing at their x values. '
+        + 'Converting as a dot plot; pass chartType: \'dot\' to say so directly.',
+      );
+      return [buildDotLayer(data, containerId, options)];
+    case 'dot':
+      return [buildDotLayer(data, containerId, options)];
+    case 'diverging':
+      return [buildDivergingLayer(data, containerId, options)];
     case 'axis-mixed':
       return buildMixedLayers(data, containerId, options);
     case 'pie':
@@ -327,7 +392,8 @@ function buildLayers(
     default:
       throw new Error(
         `Unsupported Frappe chart type: ${options.chartType as string}. `
-        + 'Supported types: bar, line, scatter, axis-mixed, pie, donut.',
+        + 'Supported types: bar, line, area, bump, scatter, dot, diverging, '
+        + 'axis-mixed, pie, donut.',
       );
   }
 }
@@ -365,10 +431,26 @@ function buildBarLayer(
   };
 }
 
+/**
+ * Builds the layer for the multi-line family — line, area and bump charts.
+ *
+ * All three are the same geometry converted the same way: one inner array per
+ * dataset, the dataset's name carried on every point, and one selector per
+ * `.dataset-{i}` group. What differs is only what the chart *is*, which the
+ * caller resolves and passes in, so a reader is told whether they are hearing
+ * a line, a filled band, or a table of ranks.
+ *
+ * @param data        - The chart's labels and datasets
+ * @param containerId - The chart container's id, for scoping the selectors
+ * @param options     - Adapter options, for the axis labels
+ * @param type        - Which of the three this chart is
+ * @returns The converted layer
+ */
 function buildLineLayer(
   data: FrappeData,
   containerId: string,
   options: FrappeChartAdapterOptions,
+  type: TraceType.AREA | TraceType.BUMP | TraceType.LINE = TraceType.LINE,
 ): MaidrLayer {
   const multiLine = data.datasets.length > 1;
 
@@ -389,7 +471,7 @@ function buildLineLayer(
 
   return {
     id: nextId('layer'),
-    type: TraceType.LINE,
+    type,
     selectors,
     axes: buildAxes(options),
     data: lines,
@@ -413,6 +495,153 @@ function buildScatterLayer(
     selectors: scatterSelector(containerId),
     axes: buildAxes(options),
     data: points,
+  };
+}
+
+/**
+ * Whether every label is a number Frappe's marks could be placed at.
+ *
+ * A blank label counts as categorical: `Number('')` is `0`, so a chart with
+ * one would otherwise be converted as a scatter plot with a point at the
+ * origin that the chart never drew.
+ */
+function hasNumericLabels(data: FrappeData): boolean {
+  return data.labels.every((label) => {
+    if (typeof label === 'number') {
+      return Number.isFinite(label);
+    }
+    return label.trim() !== '' && Number.isFinite(Number(label));
+  });
+}
+
+/**
+ * Builds the layer for a dot plot — a line chart whose connecting line is
+ * hidden (`lineOptions: { hideLine: 1 }`), drawn over categories.
+ *
+ * This is the same rendering the adapter calls `'scatter'`, converted the
+ * other way. Frappe spaces its labels evenly whatever they hold, so a chart
+ * over category names places a mark *per category* rather than at an x value:
+ * one category and one value per point, which is what a bar chart carries and
+ * what `TraceType.DOT` reads. The marks are the `<circle>` dots of the line
+ * dataset group, which is where the highlight goes.
+ */
+function buildDotLayer(
+  data: FrappeData,
+  containerId: string,
+  options: FrappeChartAdapterOptions,
+): MaidrLayer {
+  // Only the first dataset is converted, so scope the selector to its own
+  // `.dataset-0` group: the broad line selector would match every group's
+  // dots and the core drops all highlighting on the count mismatch.
+  if (data.datasets.length > 1) {
+    console.warn(
+      `[maidr/frappe] Dot plot has ${data.datasets.length} datasets; only the `
+      + 'first is converted. Multi-series dot plots are not yet supported.',
+    );
+  }
+
+  const dataset = data.datasets[0];
+  const points: BarPoint[] = data.labels.map((label, i) => ({
+    x: label,
+    y: dataset.values[i],
+  }));
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.DOT,
+    orientation: Orientation.VERTICAL,
+    selectors: lineSelectorForDataset(containerId, 0),
+    axes: buildAxes(options),
+    data: points,
+  };
+}
+
+/** Which way a series grows, read off its values rather than its position. */
+type SeriesSide = 'flat' | 'mixed' | 'negative' | 'positive';
+
+/**
+ * Reads which side of the zero line a series is drawn on.
+ *
+ * Zeros and gaps are skipped: a band with nobody in it says nothing about the
+ * side its series is on, and counting it would make an otherwise clean chart
+ * look mixed.
+ */
+function sideOf(values: number[]): SeriesSide {
+  let side: SeriesSide = 'flat';
+  for (const value of values) {
+    if (!Number.isFinite(value) || value === 0) {
+      continue;
+    }
+    const here: SeriesSide = value > 0 ? 'positive' : 'negative';
+    if (side === 'flat') {
+      side = here;
+    } else if (side !== here) {
+      return 'mixed';
+    }
+  }
+  return side;
+}
+
+/**
+ * Builds the layer for a diverging bar chart — two signed bar series drawn
+ * either side of Frappe's zero line, one growing down and one growing up.
+ *
+ * The values are emitted **as the chart draws them**, sign and all: the
+ * downward series is negative. `DivergingTrace` takes the magnitude for the
+ * pitch and names the side in the announcement, so a producer that stripped
+ * the sign would leave it nothing to name the sides with.
+ *
+ * Shape is validated rather than assumed. A layer built from three series, or
+ * from two that grow the same way, would still sonify — it would just describe
+ * a chart with sides that are not there, which is worse than refusing, since
+ * the sign is the one clue the announcement deliberately removes.
+ *
+ * @throws When the chart is not two series with opposite signs.
+ */
+function buildDivergingLayer(
+  data: FrappeData,
+  containerId: string,
+  options: FrappeChartAdapterOptions,
+): MaidrLayer {
+  if (data.datasets.length !== 2) {
+    throw new Error(
+      '[maidr/frappe] A diverging chart needs exactly two datasets, one drawn '
+      + `below the zero line and one above; got ${data.datasets.length}.`,
+    );
+  }
+
+  const sides = data.datasets.map(dataset => sideOf(dataset.values));
+  if (!sides.includes('negative') || !sides.includes('positive')) {
+    throw new Error(
+      '[maidr/frappe] A diverging chart\'s two datasets must have opposite signs '
+      + `(one all-negative, one all-positive); got ${sides.join(' and ')}. `
+      + 'Negate the values of the series that should grow downwards.',
+    );
+  }
+
+  const sideValues: SegmentedPoint[][] = data.datasets.map((dataset, index) =>
+    data.labels.map((label, i) => ({
+      x: label,
+      y: dataset.values[i],
+      z: seriesName(dataset, index),
+    })),
+  );
+
+  return {
+    id: nextId('layer'),
+    type: TraceType.DIVERGING,
+    // Frappe has no horizontal bars, so the classic back-to-back population
+    // pyramid is not drawable — only the vertical up/down form, whose
+    // magnitude is on `y`.
+    orientation: Orientation.VERTICAL,
+    // A segmented trace maps ONE selector across every series, so this is the
+    // broad all-groups selector rather than the per-dataset one the bar and
+    // line layers use. Frappe appends dataset 0's rects and then dataset 1's,
+    // which is the series-major order `order: 'row'` names.
+    selectors: barSelector(containerId),
+    domMapping: { order: 'row' },
+    axes: buildAxes(options),
+    data: sideValues,
   };
 }
 
@@ -561,8 +790,8 @@ function round4(value: number): number {
 function buildAxes(
   options: FrappeChartAdapterOptions,
   fallbacks?: { x: string; y: string },
-): { x?: AxisConfig; y?: AxisConfig } {
-  const axes: { x?: AxisConfig; y?: AxisConfig } = {};
+): { x?: AxisConfig; y?: AxisConfig; z?: AxisConfig } {
+  const axes: { x?: AxisConfig; y?: AxisConfig; z?: AxisConfig } = {};
   const x = options.axes?.x ?? fallbacks?.x;
   const y = options.axes?.y ?? fallbacks?.y;
   if (x) {
@@ -570,6 +799,12 @@ function buildAxes(
   }
   if (y) {
     axes.y = { label: y };
+  }
+  // No fallback: a `z` names the dimension the series vary along, and only the
+  // types that have one ever read it. Naming it for the rest would put a third
+  // label into an announcement that has nothing to attach it to.
+  if (options.axes?.z) {
+    axes.z = { label: options.axes.z };
   }
   return axes;
 }

--- a/src/adapters/frappe/selectors.ts
+++ b/src/adapters/frappe/selectors.ts
@@ -10,13 +10,17 @@
  *   Bars:    <rect class="bar"> inside <g class="dataset-units dataset-bars dataset-{i}">
  *   Lines:   <path class="line-graph-path"> + one <circle> per data point, inside
  *            <g class="dataset-units dataset-line dataset-{i}">
- *   Points:  <circle> inside <g class="dataset-units dataset-line dataset-{i}">  (scatter reuses the line group)
+ *   Areas:   the line group again, plus a <path class="region-fill"> under it
+ *            (`lineOptions.regionFill`)
+ *   Points:  <circle> inside <g class="dataset-units dataset-line dataset-{i}">  (scatter and dot reuse the line group)
  *   Pie:     <path class="pie-path"> inside <g class="pie-slices">
  *   Donut:   <path class="donut-path"> inside <g class="donut-slices">
  *
  * For line traces MAIDR highlights one element per data point, so the line
- * selectors target the per-point `<circle>` dots (not the single `<path>`).
- * This requires the Frappe chart to render dots (`lineOptions.dotSize > 0`).
+ * selectors target the per-point `<circle>` dots — never the single
+ * `path.line-graph-path` or `path.region-fill`, which are one element for the
+ * whole series. This requires the Frappe chart to render dots
+ * (`lineOptions.dotSize > 0`, and no `hideDots`).
  *
  * Every selector is scoped to the container element's `id` so that charts
  * elsewhere on the same page are never matched.
@@ -56,7 +60,14 @@ export function ensureContainerId(container: HTMLElement): void {
   }
 }
 
-/** Scoped selector for all bar rects (single or stacked bar groups). */
+/**
+ * Scoped selector for every dataset group's bar rects, in the order Frappe
+ * appends them (dataset 0's rects, then dataset 1's, …).
+ *
+ * The segmented bar family — a diverging chart here — maps ONE selector across
+ * all of its series and splits the match by `domMapping`, so it needs the
+ * broad selector rather than the per-dataset one below.
+ */
 export function barSelector(containerId: string): string {
   return `#${containerId} svg.frappe-chart .dataset-units.dataset-bars rect.bar`;
 }

--- a/src/adapters/frappe/types.ts
+++ b/src/adapters/frappe/types.ts
@@ -46,15 +46,46 @@ export interface FrappeChart {
    * in which case Frappe's own default (20) is assumed.
    */
   config?: { maxSlices?: number };
+  /**
+   * The chart's line rendering options, an instance field on Frappe's
+   * `AxisChart` rather than part of `config`. Only `regionFill` is read: it is
+   * what fills the band between the line and the baseline, which makes the
+   * chart an area chart rather than a line chart, and reading it here means an
+   * author cannot mislabel one as the other. Absent on a plain `{ data }`
+   * object — pass `chartType: 'area'` in that case.
+   */
+  lineOptions?: { regionFill?: number };
 }
 
 /**
- * Frappe Charts chart-type strings the adapter can convert.
+ * Chart-type strings the adapter can convert.
  *
- * Frappe additionally supports `percentage` and a calendar-style `heatmap`;
- * those have no clean MAIDR equivalent and are not supported by this adapter.
+ * These are the **adapter's** names, not Frappe's own `type` strings. Frappe
+ * v1.6.2 draws only `bar`, `line`, `axis-mixed`, `pie`, `donut`, `percentage`
+ * and a calendar `heatmap`; several distinct statistical charts are all drawn
+ * with `type: 'line'` or `type: 'bar'` and differ only in their options or in
+ * what the numbers mean, which no chart instance records. Naming them here is
+ * how the author says which chart they drew, so MAIDR announces that one:
+ *
+ * - `'scatter'` / `'dot'` — `type: 'line'` with `lineOptions.hideLine`
+ * - `'area'` — `type: 'line'` with `lineOptions.regionFill` (also inferred)
+ * - `'bump'` — a multi-dataset `type: 'line'` chart whose y values are ranks
+ * - `'diverging'` — a two-dataset `type: 'bar'` chart with signed values
+ *
+ * `percentage` and the calendar-style `heatmap` have no clean MAIDR equivalent
+ * and are not supported.
  */
-export type FrappeChartType = 'axis-mixed' | 'bar' | 'donut' | 'line' | 'pie' | 'scatter';
+export type FrappeChartType
+  = | 'area'
+    | 'axis-mixed'
+    | 'bar'
+    | 'bump'
+    | 'diverging'
+    | 'donut'
+    | 'dot'
+    | 'line'
+    | 'pie'
+    | 'scatter';
 
 /**
  * One panel of a multi-panel (small-multiples) figure built from several
@@ -75,5 +106,5 @@ export interface FrappePanel {
   /** Panel display name, announced when navigating between subplots. */
   title?: string;
   /** Axis labels for this panel. */
-  axes?: { x?: string; y?: string };
+  axes?: { x?: string; y?: string; z?: string };
 }

--- a/test/adapters/frappe/converters.test.ts
+++ b/test/adapters/frappe/converters.test.ts
@@ -1,7 +1,8 @@
-import type { FrappeChart, FrappePanel } from '@adapters/frappe/types';
-import type { BarPoint, MaidrLayer, PiePoint } from '@type/grammar';
+import type { FrappeChart, FrappeChartType, FrappePanel } from '@adapters/frappe/types';
+import type { BarPoint, LinePoint, MaidrLayer, PiePoint, ScatterPoint, SegmentedPoint } from '@type/grammar';
 import { createMaidrFromFrappeChart, createMaidrFromFrappeCharts } from '@adapters/frappe/converters';
-import { TraceType } from '@type/grammar';
+import { afterAll, beforeEach, jest } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
 import { JSDOM } from 'jsdom';
 
 /** A minimal chart stub — the adapter only reads `chart.data`. */
@@ -26,6 +27,26 @@ function makeDom(count: number): { wrapper: HTMLElement; containers: HTMLElement
     containers.push(container);
   }
   return { wrapper, containers };
+}
+
+/**
+ * Converts one chart and returns its only layer, with the container id pinned
+ * to `chart` so the expected selector strings can be written out in full.
+ */
+function onlyLayer(
+  chart: FrappeChart,
+  chartType: FrappeChartType,
+  axes?: { x?: string; y?: string; z?: string },
+): MaidrLayer {
+  const { containers } = makeDom(1);
+  containers[0].id = 'chart';
+  const maidr = createMaidrFromFrappeChart(chart, containers[0], {
+    chartType,
+    ...(axes ? { axes } : {}),
+  });
+  const layers = maidr.subplots[0][0].layers;
+  expect(layers).toHaveLength(1);
+  return layers[0];
 }
 
 function panel(container: HTMLElement, title?: string, values?: number[]): FrappePanel {
@@ -80,6 +101,301 @@ describe('createMaidrFromFrappeChart (single chart)', () => {
     expect(maidr.id).toBe(container.id);
     expect(maidr.subplots[0][0].layers[0].selectors)
       .toBe(`#${container.id} svg.frappe-chart .dataset-units.dataset-bars.dataset-0 rect.bar`);
+  });
+});
+
+describe('createMaidrFromFrappeChart (area)', () => {
+  /** Two series over the same months, as an overlapping area chart is built. */
+  const twoSeries: FrappeChart = {
+    data: {
+      labels: ['Jan', 'Feb'],
+      datasets: [
+        { name: 'Product A', values: [18, 40] },
+        { name: 'Product B', values: [36, 20] },
+      ],
+    },
+  };
+
+  it('emits an area layer whose selector matches the line group dots', () => {
+    const layer = onlyLayer(makeChart(), 'area', { x: 'Month', y: 'Revenue' });
+
+    expect(layer.type).toBe(TraceType.AREA);
+    // The region fill is one <path> for the whole series, so the highlight
+    // targets the per-point dots exactly as a line layer does.
+    expect(layer.selectors)
+      .toEqual(['#chart svg.frappe-chart .dataset-units.dataset-line circle']);
+    expect(layer.axes).toEqual({ x: { label: 'Month' }, y: { label: 'Revenue' } });
+    expect(layer.data as LinePoint[][]).toEqual([[
+      { x: 'A', y: 10, z: 'Series' },
+      { x: 'B', y: 20, z: 'Series' },
+      { x: 'C', y: 30, z: 'Series' },
+    ]]);
+  });
+
+  it('reads regionFill off the chart instance, so a line chart cannot be mislabelled', () => {
+    const layer = onlyLayer({ ...makeChart(), lineOptions: { regionFill: 1 } }, 'line');
+
+    expect(layer.type).toBe(TraceType.AREA);
+  });
+
+  it('stays a line layer when the instance does not fill the region', () => {
+    const layer = onlyLayer({ ...makeChart(), lineOptions: {} }, 'line');
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('scopes one selector per series and emits a legend for overlapping bands', () => {
+    const { containers } = makeDom(1);
+    containers[0].id = 'chart';
+
+    const maidr = createMaidrFromFrappeChart(twoSeries, containers[0], { chartType: 'area' });
+    const subplot = maidr.subplots[0][0];
+
+    // Plain AREA bands overlap rather than stack, so the two series are read
+    // independently — the multi-line treatment, not a STACKED_AREA one.
+    expect(subplot.legend).toEqual(['Product A', 'Product B']);
+    expect(subplot.layers[0].selectors).toEqual([
+      '#chart svg.frappe-chart .dataset-units.dataset-line.dataset-0 circle',
+      '#chart svg.frappe-chart .dataset-units.dataset-line.dataset-1 circle',
+    ]);
+  });
+});
+
+describe('createMaidrFromFrappeChart (bump)', () => {
+  /** A three-period table of ranks, 1 = best, as Frappe would be handed it. */
+  const ranks: FrappeChart = {
+    data: {
+      labels: ['Week 1', 'Week 2', 'Week 3'],
+      datasets: [
+        { name: 'Alpha', values: [1, 2, 1] },
+        { name: 'Beta', values: [2, 1, 3] },
+        { name: 'Gamma', values: [3, 3, 2] },
+      ],
+    },
+  };
+
+  it('emits a bump layer with one selector per competitor', () => {
+    const { containers } = makeDom(1);
+    containers[0].id = 'chart';
+
+    const maidr = createMaidrFromFrappeChart(ranks, containers[0], {
+      chartType: 'bump',
+      axes: { x: 'Week', y: 'Rank' },
+    });
+    const subplot = maidr.subplots[0][0];
+    const layer = subplot.layers[0];
+
+    expect(layer.type).toBe(TraceType.BUMP);
+    expect(subplot.legend).toEqual(['Alpha', 'Beta', 'Gamma']);
+    expect(layer.selectors).toEqual([
+      '#chart svg.frappe-chart .dataset-units.dataset-line.dataset-0 circle',
+      '#chart svg.frappe-chart .dataset-units.dataset-line.dataset-1 circle',
+      '#chart svg.frappe-chart .dataset-units.dataset-line.dataset-2 circle',
+    ]);
+  });
+
+  it('emits the true rank, leaving the inversion to the trace', () => {
+    const layer = onlyLayer(ranks, 'bump');
+
+    // Frappe cannot reverse an axis, so a rank chart it draws puts rank 1 at
+    // the bottom. The values must still be the ranks themselves: BumpTrace
+    // inverts the pitch, and pre-inverted values would announce wrong ranks.
+    expect((layer.data as LinePoint[][])[1]).toEqual([
+      { x: 'Week 1', y: 2, z: 'Beta' },
+      { x: 'Week 2', y: 1, z: 'Beta' },
+      { x: 'Week 3', y: 3, z: 'Beta' },
+    ]);
+  });
+});
+
+describe('createMaidrFromFrappeChart (dot)', () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    warn.mockClear();
+  });
+
+  afterAll(() => {
+    warn.mockRestore();
+  });
+
+  it('emits a category/value dot layer highlighting the first dataset\'s dots', () => {
+    const layer = onlyLayer(makeChart(), 'dot', { x: 'Region', y: 'Sales' });
+
+    expect(layer.type).toBe(TraceType.DOT);
+    expect(layer.orientation).toBe(Orientation.VERTICAL);
+    expect(layer.selectors)
+      .toBe('#chart svg.frappe-chart .dataset-units.dataset-line.dataset-0 circle');
+    expect(layer.axes).toEqual({ x: { label: 'Region' }, y: { label: 'Sales' } });
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'A', y: 10 },
+      { x: 'B', y: 20 },
+      { x: 'C', y: 30 },
+    ]);
+  });
+
+  it('converts a scatter over category labels as a dot plot instead', () => {
+    const layer = onlyLayer(makeChart(), 'scatter');
+
+    // `Number('A')` is NaN, so a scatter layer built from these labels would
+    // have no x values at all — and Frappe spaces the marks evenly anyway.
+    expect(layer.type).toBe(TraceType.DOT);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'A', y: 10 },
+      { x: 'B', y: 20 },
+      { x: 'C', y: 30 },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a scatter over numeric labels a scatter plot', () => {
+    const layer = onlyLayer(
+      { data: { labels: [10, 20, 30], datasets: [{ name: 'Temp', values: [22, 25, 28] }] } },
+      'scatter',
+    );
+
+    expect(layer.type).toBe(TraceType.SCATTER);
+    expect(layer.data as ScatterPoint[]).toEqual([
+      { x: 10, y: 22 },
+      { x: 20, y: 25 },
+      { x: 30, y: 28 },
+    ]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('treats a blank label as a category rather than as zero', () => {
+    const layer = onlyLayer(
+      { data: { labels: ['1', ' ', '3'], datasets: [{ values: [4, 5, 6] }] } },
+      'scatter',
+    );
+
+    expect(layer.type).toBe(TraceType.DOT);
+  });
+
+  it('warns that only the first dataset of a multi-series dot plot is converted', () => {
+    onlyLayer(
+      {
+        data: {
+          labels: ['A', 'B'],
+          datasets: [{ name: 'One', values: [1, 2] }, { name: 'Two', values: [3, 4] }],
+        },
+      },
+      'dot',
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('2 datasets');
+  });
+});
+
+describe('createMaidrFromFrappeChart (diverging)', () => {
+  /** Men drawn below the zero line, women above, as Frappe renders them. */
+  const pyramid: FrappeChart = {
+    data: {
+      labels: ['0-14', '15-29'],
+      datasets: [
+        { name: 'Men', values: [-1200, -1150] },
+        { name: 'Women', values: [1140, 1100] },
+      ],
+    },
+  };
+
+  it('emits both sides as one segmented layer, signed as the chart draws them', () => {
+    const layer = onlyLayer(pyramid, 'diverging', {
+      x: 'Age band',
+      y: 'People, thousands',
+      z: 'Sex',
+    });
+
+    expect(layer.type).toBe(TraceType.DIVERGING);
+    expect(layer.orientation).toBe(Orientation.VERTICAL);
+    expect(layer.axes).toEqual({
+      x: { label: 'Age band' },
+      y: { label: 'People, thousands' },
+      z: { label: 'Sex' },
+    });
+    // The sign is a direction, not a magnitude: DivergingTrace takes the size
+    // for the pitch and names the side, so stripping it here would leave it
+    // nothing to name the sides with.
+    expect(layer.data as SegmentedPoint[][]).toEqual([
+      [
+        { x: '0-14', y: -1200, z: 'Men' },
+        { x: '15-29', y: -1150, z: 'Men' },
+      ],
+      [
+        { x: '0-14', y: 1140, z: 'Women' },
+        { x: '15-29', y: 1100, z: 'Women' },
+      ],
+    ]);
+  });
+
+  it('maps one broad selector across both dataset groups in series-major order', () => {
+    const layer = onlyLayer(pyramid, 'diverging');
+
+    // A segmented trace takes ONE selector and splits the match itself, so
+    // this is the all-groups selector; Frappe appends dataset 0's rects and
+    // then dataset 1's, which is what `order: 'row'` names.
+    expect(layer.selectors)
+      .toBe('#chart svg.frappe-chart .dataset-units.dataset-bars rect.bar');
+    expect(layer.domMapping).toEqual({ order: 'row' });
+  });
+
+  it('names an unnamed side by its position so the two stay tellable apart', () => {
+    const layer = onlyLayer(
+      { data: { labels: ['A'], datasets: [{ values: [-1] }, { values: [2] }] } },
+      'diverging',
+    );
+
+    expect((layer.data as SegmentedPoint[][]).map(side => side[0].z))
+      .toEqual(['Series 1', 'Series 2']);
+  });
+
+  it('ignores zeros and gaps when reading which side a series is on', () => {
+    const layer = onlyLayer(
+      {
+        data: {
+          labels: ['A', 'B'],
+          datasets: [
+            { name: 'Down', values: [0, -5] },
+            { name: 'Up', values: [3, 0] },
+          ],
+        },
+      },
+      'diverging',
+    );
+
+    expect(layer.type).toBe(TraceType.DIVERGING);
+  });
+
+  it('refuses a chart that is not two sided', () => {
+    expect(() => onlyLayer(makeChart(), 'diverging')).toThrow('exactly two datasets');
+  });
+
+  it('refuses two series that grow the same way', () => {
+    expect(() => onlyLayer(
+      {
+        data: {
+          labels: ['A'],
+          datasets: [{ name: 'One', values: [1] }, { name: 'Two', values: [2] }],
+        },
+      },
+      'diverging',
+    )).toThrow('opposite signs');
+  });
+
+  it('refuses a series that crosses the zero line, which has no side', () => {
+    expect(() => onlyLayer(
+      {
+        data: {
+          labels: ['A', 'B'],
+          datasets: [
+            { name: 'Mixed', values: [-1, 2] },
+            { name: 'Up', values: [3, 4] },
+          ],
+        },
+      },
+      'diverging',
+    )).toThrow('opposite signs');
   });
 });
 

--- a/test/adapters/frappe/selectorResolution.test.ts
+++ b/test/adapters/frappe/selectorResolution.test.ts
@@ -1,0 +1,169 @@
+import type { FrappeChart, FrappeChartType } from '@adapters/frappe/types';
+import type { MaidrLayer } from '@type/grammar';
+import { createMaidrFromFrappeChart } from '@adapters/frappe/converters';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+/**
+ * Contract test for the highlight path of the newer chart types.
+ *
+ * A layer that sonifies but highlights nothing is not accessible, and the only
+ * thing standing between the two is whether the emitted selector resolves —
+ * against the real Frappe v1.6.2 SVG shape — to exactly one element per data
+ * point, in the order the points were emitted in. Both halves fail silently at
+ * runtime: `AbstractBarPlot.mapToSvgElements` returns null on a count
+ * mismatch, and a mis-ordered match highlights the wrong mark while every
+ * announcement stays correct.
+ *
+ * jsdom implements neither `SVGRectElement` nor `SVGPathElement`, so the
+ * traces' own element mapping cannot be exercised here — that is what the
+ * Playwright specs are for. What this pins is the part the adapter owns: the
+ * selector string, and the DOM order it relies on.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const globals = globalThis as unknown as { document?: Document };
+let savedDocument: Document | undefined;
+let dom: JSDOM;
+
+beforeEach(() => {
+  savedDocument = globals.document;
+  dom = new JSDOM('<!doctype html><body><div id="chart"></div></body>');
+  globals.document = dom.window.document as Document;
+});
+
+afterEach(() => {
+  globals.document = savedDocument;
+});
+
+/**
+ * Builds the Frappe v1.6.2 SVG for a chart: one
+ * `g.dataset-units.dataset-{bars|line}.dataset-{i}` group per dataset, in
+ * dataset order, holding one mark per label.
+ *
+ * Line groups also carry the whole-series `path.line-graph-path` and, for an
+ * area chart, the `path.region-fill` beneath it — both single elements the
+ * selectors must NOT pick up, since one path cannot highlight N points.
+ */
+function render(chart: FrappeChart, marks: 'bars' | 'line'): HTMLElement {
+  const container = document.getElementById('chart') as HTMLElement;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'frappe-chart chart');
+  container.appendChild(svg);
+
+  chart.data.datasets.forEach((dataset, index) => {
+    const group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', `dataset-units dataset-${marks} dataset-${index}`);
+    svg.appendChild(group);
+
+    if (marks === 'line') {
+      const region = document.createElementNS(SVG_NS, 'path');
+      region.setAttribute('class', 'region-fill');
+      group.appendChild(region);
+      const line = document.createElementNS(SVG_NS, 'path');
+      line.setAttribute('class', 'line-graph-path');
+      group.appendChild(line);
+    }
+
+    dataset.values.forEach((value) => {
+      const mark = marks === 'bars'
+        ? document.createElementNS(SVG_NS, 'rect')
+        : document.createElementNS(SVG_NS, 'circle');
+      if (marks === 'bars') {
+        mark.setAttribute('class', 'bar mini');
+      }
+      // Tags each mark with the datum it was drawn for, so the assertions can
+      // say which point each matched element belongs to.
+      mark.setAttribute('data-value', String(value));
+      group.appendChild(mark);
+    });
+  });
+
+  return container;
+}
+
+function convert(chart: FrappeChart, chartType: FrappeChartType): MaidrLayer {
+  const container = document.getElementById('chart') as HTMLElement;
+  const maidr = createMaidrFromFrappeChart(chart, container, { chartType });
+  return maidr.subplots[0][0].layers[0];
+}
+
+/** The `data-value` of every element the selector matches, in DOM order. */
+function matched(selector: string): string[] {
+  return Array.from(document.querySelectorAll(selector))
+    .map(element => element.getAttribute('data-value') ?? '');
+}
+
+describe('frappe layer selectors against the rendered SVG', () => {
+  it('gives an area chart one dot per point per band, never the fill path', () => {
+    const chart: FrappeChart = {
+      data: {
+        labels: ['Jan', 'Feb', 'Mar'],
+        datasets: [
+          { name: 'A', values: [1, 2, 3] },
+          { name: 'B', values: [4, 5, 6] },
+        ],
+      },
+    };
+    render(chart, 'line');
+
+    const selectors = convert(chart, 'area').selectors as string[];
+
+    expect(selectors).toHaveLength(2);
+    expect(matched(selectors[0])).toEqual(['1', '2', '3']);
+    expect(matched(selectors[1])).toEqual(['4', '5', '6']);
+  });
+
+  it('gives a bump chart one dot per period per competitor', () => {
+    const chart: FrappeChart = {
+      data: {
+        labels: ['W1', 'W2'],
+        datasets: [
+          { name: 'Alpha', values: [1, 2] },
+          { name: 'Beta', values: [2, 1] },
+        ],
+      },
+    };
+    render(chart, 'line');
+
+    const selectors = convert(chart, 'bump').selectors as string[];
+
+    expect(matched(selectors[0])).toEqual(['1', '2']);
+    expect(matched(selectors[1])).toEqual(['2', '1']);
+  });
+
+  it('gives a dot plot one dot per category, scoped to the converted dataset', () => {
+    const chart: FrappeChart = {
+      data: {
+        labels: ['North', 'South'],
+        datasets: [{ name: 'Sales', values: [7, 8] }],
+      },
+    };
+    render(chart, 'line');
+
+    expect(matched(convert(chart, 'dot').selectors as string)).toEqual(['7', '8']);
+  });
+
+  it('gives a diverging chart every group\'s bars, series-major as domMapping declares', () => {
+    const chart: FrappeChart = {
+      data: {
+        labels: ['0-14', '15-29'],
+        datasets: [
+          { name: 'Men', values: [-1200, -1150] },
+          { name: 'Women', values: [1140, 1100] },
+        ],
+      },
+    };
+    render(chart, 'bars');
+
+    const layer = convert(chart, 'diverging');
+
+    // One element per point across BOTH sides — the segmented trace splits
+    // this single match itself — and `order: 'row'` is only correct because
+    // Frappe appends dataset 0's rects before dataset 1's.
+    expect(layer.domMapping).toEqual({ order: 'row' });
+    expect(matched(layer.selectors as string))
+      .toEqual(['-1200', '-1150', '1140', '1100']);
+  });
+});


### PR DESCRIPTION
## Description

The Frappe Charts adapter previously converted bar, line, multi-line, scatter, mixed-axis and pie/donut charts. This adds the statistical chart types MAIDR has gained since the pie work landed and that Frappe can actually draw: **area**, **bump**, **dot** and **diverging bar**.

Frappe v1.6.2 draws several distinct statistical charts with the *same* `type: 'line'` or `type: 'bar'` — they differ only in their options or in what the numbers mean, and nothing on the chart instance records which one the author intended. So the adapter's own `chartType` union (already distinct from Frappe's `type` strings, since it carried an invented `'scatter'`) grows to name them. This is adapter-local work: no core file was touched, and the existing traces already support every payload emitted here.

Every new layer both sonifies **and** highlights — the line-family types target the per-point `<circle>` dots, and the dot layer is scoped to its own `.dataset-0` group.

## Related Issues

Closes #866

## Changes Made

### Trace types added

| Trace | Adapter `chartType` | How it is detected |
|-------|--------------------|--------------------|
| `AREA` | `'area'` | Explicit, **and inferred** from `chart.lineOptions.regionFill` |
| `BUMP` | `'bump'` | Explicit — a multi-dataset line chart whose y values are ranks |
| `DOT` | `'dot'` | Explicit, **and** a `'scatter'` whose labels are categorical |
| `DIVERGING` | `'diverging'` | Explicit, validated as two opposite-signed datasets |

Notes on each:

- **Area** is additionally inferred from `lineOptions.regionFill`, an instance field Frappe keeps verbatim (`AxisChart.js:17`), so a filled chart passed as `chartType: 'line'` is still announced as an area chart — an author cannot mislabel one. Several filled bands *overlap* in Frappe rather than stacking, so they stay independent `area` series, never `stacked_area`.
- **Bump** shares the line payload; only the announced type differs, which is what flips MAIDR's pitch so rank 1 is the highest note. `buildLineLayer` gained a 4th `type` parameter over the `AREA | BUMP | LINE` union rather than forking the builder.
- **Dot** vs scatter is decided by the labels, because Frappe spaces its marks evenly whatever the label holds. A `chartType: 'scatter'` over categorical labels is converted as a dot plot with a `console.warn`, since `Number('Mon')` is `NaN` and a scatter layer built from those labels would have had no x values at all. A blank label counts as categorical, because `Number('')` is `0` and would otherwise plant a phantom point at the origin.
- **Diverging** throws (rather than warns) unless the chart really is exactly two datasets with opposite signs — `DivergingTrace` strips the sign from its announcement, so a mis-shaped chart would name sides that do not exist. It uses the broad all-groups bar selector plus `domMapping: { order: 'row' }`, which is the series-major order Frappe appends its dataset groups in (`AxisChart.js:340`).

### Supporting changes

- `buildAxes` now emits `axes.z`; `FrappeChartAdapterOptions.axes` and `FrappePanel.axes` gained `z?: string`. Deliberately no fallback — only the types with a third dimension read it.
- New shared `seriesName(dataset, index)` helper (`dataset.name ?? \`Series N\``), used by both the multi-series legend and `SegmentedPoint.z`, which the grammar requires.
- `LINE_FAMILY_TYPES` drives the multi-series legend that used to be gated on `chartType === 'line'` alone.
- `barSelector(containerId)` gained a doc comment explaining the one-selector-plus-`domMapping` contract; the diverging layer is its first caller.
- Docs: `docs/frappe.md` gains a row per type in the supported table, a worked code example for each, and a caveat note per type.
- Examples: `examples/frappe-{area,bump,dot,diverging}.html`.
- Tests: `test/adapters/frappe/converters.test.ts` extended, plus a new `test/adapters/frappe/selectorResolution.test.ts`.

### Trace types deliberately NOT added

- **`DODGED` / `STACKED`** — out of scope for this change. Multi-dataset bar charts are still reduced to dataset 0 with a `console.warn`, exactly as before. The diverging work does build all the segmented plumbing these need (broad selector, `domMapping: { order: 'row' }`, `SegmentedPoint` construction), so this is the obvious next increment.
- **`HEATMAP`** — Frappe's only heatmap is a GitHub-style *calendar* heatmap, structurally unlike MAIDR's matrix heatmap. Not a payload mismatch that a converter can bridge.
- **`STACKED_AREA` / `NORMALIZED_AREA`** — Frappe overlaps filled regions rather than stacking them, so the drawn picture is not a stacked area chart and announcing it as one would be wrong.
- **Frappe's `percentage` chart** — no MAIDR trace is an equivalent.
- **`GAUGE`, `GANTT`, `DUMBBELL`, `CANDLESTICK`, `BOX`, `HISTOGRAM` and the rest of the grammar** — Frappe Charts v1.6.2 has no drawing primitive for any of them, so there is no chart to convert.

One limit is Frappe's, not MAIDR's, and is documented rather than faked: Frappe has **no horizontal bars**, so a diverging chart can only be the vertical up/down form — the back-to-back population-pyramid orientation is not drawable.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

On the third box: the automated suite is fully green (details below), but `ManualTestingProcess.md` does not exist in this repository and no manual screen-reader pass was run, so the box is left unticked rather than half-claimed. The four new example pages are the natural place for that manual pass.

## Additional Notes

**Gate results** — all green, no fixes were needed:

| Check | Result |
|-------|--------|
| `npm run lint:fix` | clean, no files modified |
| `npm run type-check` | clean (`tsc --noEmit` + `tsconfig.ci.json`) |
| `npm run build` | all 12 adapter bundles built |
| `npm test` | 188 suites / 2640 tests + 7 ESM suites / 73 tests, 0 failures |
| `npm run sync:copilot:check` | in sync (11 files) |

`src/adapters/frappe` sits at 96.96% statement coverage.

**Testing caveat worth knowing for review:** jsdom implements neither `SVGRectElement` nor `SVGPathElement`, and `SegmentedTrace.mapToSvgElements` branches on exactly those two `instanceof` checks — so a trace-level highlight test for any segmented type (diverging included) cannot run under jest here; it falls through both branches. The new `selectorResolution.test.ts` works around this by building a realistic Frappe SVG and asserting each emitted selector resolves to exactly one element per point, in the emitted order. Real end-to-end highlight verification for the segmented types belongs in Playwright.

**Known gap, outside this change's file scope:** `scripts/build-site.js` lists the frappe example pages in the docs-site nav. The four new `examples/frappe-*.html` pages work standalone but are not yet linked from the built site nav, and `scripts/` was out of scope here. Someone with that access should add the four entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_