### PR TITLE
feat(chartjs): support the chart types added since the pie chart

### DIFF
--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -72,15 +72,36 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Bar | `'bar'` (one dataset) | — | [Bar chart](examples.html) |
 | Stacked Bar | `'bar'` with `scales.x.stacked` / `scales.y.stacked` | — | [Stacked bar](examples.html) |
 | Dodged Bar | `'bar'` with multiple datasets (no stacking) | — | [Dodged bar](examples.html) |
+| Diverging Bar | stacked `'bar'` with one series negated | — | [Diverging bar](examples.html) |
+| Gantt / Range Bar | `'bar'` with `[start, end]` data | — | [Gantt chart](examples.html) |
+| Waterfall | `'bar'` with chained `[start, end]` data | — | [Waterfall](examples.html) |
 | Line | `'line'` | — | [Line chart](examples.html) |
 | Step | `'line'` with `stepped` on the dataset (or `elements.line`) | — | [Line chart](examples.html) |
+| Area | `'line'` with `fill` | — | [Line chart](examples.html) |
+| Stacked Area | `'line'` with `fill` and a stacked value scale | — | [Line chart](examples.html) |
+| Normalized Area | stacked area whose categories all total 100 (or 1) | — | [Line chart](examples.html) |
+| Bump | `'line'` with `scales.y.reverse` and ranked values | — | [Bump chart](examples.html) |
 | Scatter | `'scatter'` | — | [Scatter plot](examples.html) |
+| Radar | `'radar'` | — | [Radar chart](examples.html) |
+| Polar Area | `'polarArea'` | — | [Radar chart](examples.html) |
 | Box Plot | `'boxplot'` | `@sgratzl/chartjs-chart-boxplot` | [Box plot](examples.html) |
 | Candlestick | `'candlestick'` | `chartjs-chart-financial` + a date adapter | [Candlestick](examples.html) |
 | Heatmap | `'matrix'` | `chartjs-chart-matrix` | [Heatmap](examples.html) |
 | Pie / Doughnut | `'pie'`, `'doughnut'` | — | [Pie chart](examples.html) |
 
 > **Pie note:** a pie has no Chart.js scales, so there is no axis title to read. `axes.x` and `axes.y` default to `Category` and `Value`; set `plugins.maidr.axes` to name what the slice labels and their values actually mean. Multiple datasets are concentric rings, not slices of one circle — each becomes its own MAIDR layer with its own total and percentages, and Page Up / Page Down move between them.
+
+> **Radar note:** a radar and a polar area are drawn against a single radial `r` scale, so `axes.y` reads `scales.r.title.text` and `axes.x` defaults to `Category` — set `plugins.maidr.axes` to name what the spokes and their magnitudes mean. Both are read as a multi-series layer, one row per dataset and one column per spoke, with each spoke's stereo position following its angle rather than its index.
+
+### Charts Chart.js Does Not Declare
+
+Chart.js has no configuration for a waterfall, a bump chart, a normalized area or a diverging bar — each is a recipe built out of a plain bar or line chart — so MAIDR reads them off the **values**. Each test is deliberately strict, because announcing a chart as something it is not is worse than announcing it plainly:
+
+- **Waterfall** — one series of `[start, end]` bars on the default vertical index axis where each step begins where the previous one ended. Bars that sit on the baseline (`start` of `0`) are read as the opening, closing or a subtotal. Unchained intervals are read as a gantt instead.
+- **Gantt** — any other `[start, end]` bar chart. `indexAxis: 'y'` is the ordinary schedule, one lane per label; several datasets put several intervals in the same lane, each named by its dataset label. A lane whose entry is `null` stays a navigable row with nothing booked. Bounds may be numbers or `Date`s; on a `type: 'time'` scale MAIDR announces both ends as dates and measures lengths in milliseconds, so set `plugins.maidr.unit` when the schedule reads in days or sprints.
+- **Normalized area** — two or more stacked, filled line datasets whose every category totals the same whole (100 or 1, within half a percent so rounded shares still count).
+- **Bump** — a line chart with `scales.y.reverse` whose values at every period are a permutation of `1..N` across the series. The reversed axis alone is not enough; the permutation is what makes the rank reading safe.
+- **Diverging bar** — a stacked bar chart whose datasets each sit wholly on one side of the baseline, with both sides occupied. The values stay signed: MAIDR pitches the magnitude and announces the side.
 
 ## Code Examples
 

--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -75,12 +75,15 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Diverging Bar | stacked `'bar'` with one series negated | — | [Diverging bar](examples.html) |
 | Gantt / Range Bar | `'bar'` with `[start, end]` data | — | [Gantt chart](examples.html) |
 | Waterfall | `'bar'` with chained `[start, end]` data | — | [Waterfall](examples.html) |
+| Dumbbell | horizontal `'bar'` with `[start, end]` data and `plugins.maidr.traceType` | — | [Dumbbell](examples.html) |
 | Line | `'line'` | — | [Line chart](examples.html) |
 | Step | `'line'` with `stepped` on the dataset (or `elements.line`) | — | [Line chart](examples.html) |
 | Area | `'line'` with `fill` | — | [Line chart](examples.html) |
 | Stacked Area | `'line'` with `fill` and a stacked value scale | — | [Line chart](examples.html) |
 | Normalized Area | stacked area whose categories all total 100 (or 1) | — | [Line chart](examples.html) |
 | Bump | `'line'` with `scales.y.reverse` and ranked values | — | [Bump chart](examples.html) |
+| Dot Plot | `'line'` with `showLine: false` on a category axis | — | [Dot plot](examples.html) |
+| Survival | `'line'` with `stepped` and `plugins.maidr.traceType` | — | [Survival curve](examples.html) |
 | Scatter | `'scatter'` | — | [Scatter plot](examples.html) |
 | Radar | `'radar'` | — | [Radar chart](examples.html) |
 | Polar Area | `'polarArea'` | — | [Radar chart](examples.html) |
@@ -88,6 +91,7 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Candlestick | `'candlestick'` | `chartjs-chart-financial` + a date adapter | [Candlestick](examples.html) |
 | Heatmap | `'matrix'` | `chartjs-chart-matrix` | [Heatmap](examples.html) |
 | Pie / Doughnut | `'pie'`, `'doughnut'` | — | [Pie chart](examples.html) |
+| Gauge | `'doughnut'` with `circumference` under 360 and two values | — | [Gauge](examples.html) |
 
 > **Pie note:** a pie has no Chart.js scales, so there is no axis title to read. `axes.x` and `axes.y` default to `Category` and `Value`; set `plugins.maidr.axes` to name what the slice labels and their values actually mean. Multiple datasets are concentric rings, not slices of one circle — each becomes its own MAIDR layer with its own total and percentages, and Page Up / Page Down move between them.
 
@@ -102,6 +106,16 @@ Chart.js has no configuration for a waterfall, a bump chart, a normalized area o
 - **Normalized area** — two or more stacked, filled line datasets whose every category totals the same whole (100 or 1, within half a percent so rounded shares still count).
 - **Bump** — a line chart with `scales.y.reverse` whose values at every period are a permutation of `1..N` across the series. The reversed axis alone is not enough; the permutation is what makes the rank reading safe.
 - **Diverging bar** — a stacked bar chart whose datasets each sit wholly on one side of the baseline, with both sides occupied. The values stay signed: MAIDR pitches the magnitude and announces the side.
+- **Dot plot** — a line chart whose every dataset sets `showLine: false` on a category axis. This one Chart.js does say outright: switching the line off is its own way of drawing a Cleveland dot plot. Unjoined points along a *linear* axis are a scatter plot drawn by the line controller, and stay one.
+- **Gauge** — a `doughnut` swept through less than the full circle (`circumference` under 360) whose single dataset holds exactly two values: the measure, and the rest of the dial drawn empty. The remainder is spent on the dial's `max` rather than announced as a second reading.
+
+### Charts Only the Page Can Declare
+
+Three readings are shape-identical to another recipe, so no test on the config or the values can reach them. Set `plugins.maidr.traceType` to say which figure the chart is; the declaration wins over every heuristic above, in both directions — declaring `pie` on a two-slice half-doughnut keeps it a pie, and declaring `gantt` on a chained bar chart keeps it a schedule.
+
+- **Dumbbell** (`traceType: 'dumbbell'`) — a horizontal floating bar chart, which is the same `[start, end]` datum a one-interval-per-lane gantt uses. `plugins.maidr.startLabel` and `endLabel` name the two ends ("1990", "2020"); without them the reader is told which dot they are on but not which year it is. Rows with no pair are skipped rather than kept as empty rows, unlike a gantt lane.
+- **Survival** (`traceType: 'survival'`) — a `stepped: 'after'` line, which is how every staircase is drawn. Chart.js ignores properties it does not know, so ride the two things a survival figure carries and a step chart does not on the points themselves: `{x, y, censored: true}` for a censoring mark and `{yMin, yMax}` for the confidence band. Each dataset is one arm, gathered into a single layer.
+- **Gauge** (`traceType: 'gauge'`) — for a dial the geometry above misses, and for the target and bands Chart.js records only as styling: `plugins.maidr.target` is the bullet marker and `plugins.maidr.bands` is a `[{ to, label }]` list in ascending order.
 
 ## Code Examples
 

--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -101,7 +101,7 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 
 Chart.js has no configuration for a waterfall, a bump chart, a normalized area or a diverging bar — each is a recipe built out of a plain bar or line chart — so MAIDR reads them off the **values**. Each test is deliberately strict, because announcing a chart as something it is not is worse than announcing it plainly:
 
-- **Waterfall** — one series of `[start, end]` bars on the default vertical index axis where each step begins where the previous one ended. Bars that sit on the baseline (`start` of `0`) are read as the opening, closing or a subtotal. Unchained intervals are read as a gantt instead.
+- **Waterfall** — one series of `[start, end]` bars on the default vertical index axis where each step begins where the previous one ended. Bars that sit on the baseline (`start` of `0`) are read as the opening, closing or a subtotal. Unchained intervals are read as a gantt instead. A waterfall is one running total, so only the first dataset is read — a chart with several series of intervals is a gantt.
 - **Gantt** — any other `[start, end]` bar chart. `indexAxis: 'y'` is the ordinary schedule, one lane per label; several datasets put several intervals in the same lane, each named by its dataset label. A lane whose entry is `null` stays a navigable row with nothing booked. Bounds may be numbers or `Date`s; on a `type: 'time'` scale MAIDR announces both ends as dates and measures lengths in milliseconds, so set `plugins.maidr.unit` when the schedule reads in days or sprints.
 - **Normalized area** — two or more stacked, filled line datasets whose every category totals the same whole (100 or 1, within half a percent so rounded shares still count).
 - **Bump** — a line chart with `scales.y.reverse` whose values at every period are a permutation of `1..N` across the series. The reversed axis alone is not enough; the permutation is what makes the rank reading safe.
@@ -113,7 +113,7 @@ Chart.js has no configuration for a waterfall, a bump chart, a normalized area o
 
 Three readings are shape-identical to another recipe, so no test on the config or the values can reach them. Set `plugins.maidr.traceType` to say which figure the chart is; the declaration wins over every heuristic above, in both directions — declaring `pie` on a two-slice half-doughnut keeps it a pie, and declaring `gantt` on a chained bar chart keeps it a schedule.
 
-- **Dumbbell** (`traceType: 'dumbbell'`) — a horizontal floating bar chart, which is the same `[start, end]` datum a one-interval-per-lane gantt uses. `plugins.maidr.startLabel` and `endLabel` name the two ends ("1990", "2020"); without them the reader is told which dot they are on but not which year it is. Rows with no pair are skipped rather than kept as empty rows, unlike a gantt lane.
+- **Dumbbell** (`traceType: 'dumbbell'`) — a horizontal floating bar chart, which is the same `[start, end]` datum a one-interval-per-lane gantt uses. `plugins.maidr.startLabel` and `endLabel` name the two ends ("1990", "2020"); without them the reader is told which dot they are on but not which year it is. Rows with no pair are skipped rather than kept as empty rows, unlike a gantt lane. A dumbbell is one pair per row, so only the first dataset is read — several intervals in the same row are a gantt.
 - **Survival** (`traceType: 'survival'`) — a `stepped: 'after'` line, which is how every staircase is drawn. Chart.js ignores properties it does not know, so ride the two things a survival figure carries and a step chart does not on the points themselves: `{x, y, censored: true}` for a censoring mark and `{yMin, yMax}` for the confidence band. Each dataset is one arm, gathered into a single layer.
 - **Gauge** (`traceType: 'gauge'`) — for a dial the geometry above misses, and for the target and bands Chart.js records only as styling: `plugins.maidr.target` is the bullet marker and `plugins.maidr.bands` is a `[{ to, label }]` list in ascending order.
 
@@ -524,7 +524,7 @@ For the full list, see the [Keyboard Controls](docs/CONTROLS.html) reference.
 | Data source | Manual JSON schema | Manual JSON schema | Auto-extracted from Chart.js |
 | Element addressing | Manual CSS selectors | Manual CSS selectors | Auto-generated from canvas elements |
 | Configuration | Required | Required | Zero configuration |
-| Chart types | All MAIDR types | All MAIDR types | 8 Chart.js types (incl. plugins) |
+| Chart types | All MAIDR types | All MAIDR types | [23 Chart.js types](#supported-chart-types) (incl. plugins) |
 | Dynamic charts | Manual init | React lifecycle | Auto-handled per chart |
 
 ## npm Installation (Optional)

--- a/examples/chartjs/bar-diverging.html
+++ b/examples/chartjs/bar-diverging.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Diverging Bar Chart Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Diverging Bar Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. The values arrive signed, so MAIDR pitches how large a cohort is and announces which side it is on; the summary row is the balance between the two sides rather than their sum.</p>
+
+    <div style="width: 700px; height: 450px">
+      <canvas id="pyramid-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // The population-pyramid recipe: an ordinary stacked bar chart with one
+      // side's values negated so the bars grow in opposite directions.
+      new Chart(document.getElementById('pyramid-chart'), {
+        type: 'bar',
+        data: {
+          labels: ['0-14', '15-29', '30-44', '45-59', '60-74', '75+'],
+          datasets: [
+            {
+              label: 'Men',
+              data: [-1820, -2140, -2260, -2050, -1480, -720],
+              backgroundColor: '#4682b4',
+            },
+            {
+              label: 'Women',
+              data: [1740, 2080, 2210, 2090, 1620, 1010],
+              backgroundColor: '#d2691e',
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          plugins: {
+            title: { display: true, text: 'Population by Age Band' },
+          },
+          scales: {
+            x: { stacked: true, title: { display: true, text: 'Thousands of people' } },
+            y: { stacked: true, title: { display: true, text: 'Age band' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/bump.html
+++ b/examples/chartjs/bump.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Bump Chart Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Bump Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. The y axis is a rank, so rank 1 is the highest note; each point announces the places gained or lost alongside the position.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="bump-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // The standard Chart.js bump recipe: a line chart with `reverse: true`
+      // so rank 1 sits at the top. MAIDR reads it as ranks because the values
+      // at every round are a permutation of 1..N across the teams.
+      new Chart(document.getElementById('bump-chart'), {
+        type: 'line',
+        data: {
+          labels: ['Round 1', 'Round 2', 'Round 3', 'Round 4', 'Round 5'],
+          datasets: [
+            { label: 'Arsenal', data: [1, 2, 2, 1, 1], borderColor: '#d62728' },
+            { label: 'Chelsea', data: [2, 1, 3, 3, 4], borderColor: '#1f77b4' },
+            { label: 'Spurs', data: [3, 4, 1, 2, 2], borderColor: '#2ca02c' },
+            { label: 'Fulham', data: [4, 3, 4, 4, 3], borderColor: '#8b4789' },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'League Table by Round' },
+          },
+          scales: {
+            x: { title: { display: true, text: 'Round' } },
+            y: {
+              title: { display: true, text: 'League position' },
+              reverse: true,
+              min: 1,
+              max: 4,
+              ticks: { stepSize: 1 },
+            },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/dot.html
+++ b/examples/chartjs/dot.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Dot Plot Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Dot Plot</h1>
+    <p>Click on a chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions. Page Up and Page Down move between the two series.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="dot-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // `showLine: false` is Chart.js's own way of drawing a Cleveland dot
+      // plot: the markers without the line that would join them.
+      new Chart(document.getElementById('dot-chart'), {
+        type: 'line',
+        data: {
+          labels: ['Chrome', 'Safari', 'Edge', 'Firefox', 'Opera'],
+          datasets: [
+            {
+              label: '2020',
+              data: [60, 25, 4, 8, 2],
+              showLine: false,
+              borderColor: '#8b8b8b',
+              backgroundColor: '#8b8b8b',
+              pointRadius: 6,
+            },
+            {
+              label: '2024',
+              data: [64, 19, 5, 6, 3],
+              showLine: false,
+              borderColor: '#1f77b4',
+              backgroundColor: '#1f77b4',
+              pointRadius: 6,
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Browser Share' },
+            maidr: { axes: { x: 'Browser', y: 'Share (%)' } },
+          },
+          scales: {
+            x: { title: { display: true, text: 'Browser' } },
+            y: { title: { display: true, text: 'Share (%)' }, beginAtZero: true },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/dumbbell.html
+++ b/examples/chartjs/dumbbell.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Dumbbell Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Dumbbell</h1>
+    <p>Click on a chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions. Up and Down move between the two ends of a row; Left and Right move between rows, and every position announces the change the row draws.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="dumbbell-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // A dumbbell is a horizontal floating bar: the connector between the two
+      // dots is the bar itself. That is the same datum a one-interval gantt
+      // uses, so `plugins.maidr.traceType` says which figure this is — and
+      // `startLabel` / `endLabel` name the two ends the legend cannot.
+      new Chart(document.getElementById('dumbbell-chart'), {
+        type: 'bar',
+        data: {
+          labels: ['Japan', 'Spain', 'Poland', 'Brazil', 'Chad'],
+          datasets: [
+            {
+              label: 'Life expectancy',
+              data: [
+                [78.9, 84.6],
+                [76.8, 83.4],
+                [70.9, 78.3],
+                [65.3, 75.9],
+                [50.6, 59.3],
+              ],
+              backgroundColor: '#4682b4',
+              barThickness: 6,
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          plugins: {
+            title: { display: true, text: 'Life Expectancy, 1990 vs 2020' },
+            legend: { display: false },
+            maidr: {
+              traceType: 'dumbbell',
+              startLabel: '1990',
+              endLabel: '2020',
+              axes: { x: 'Years', y: 'Country' },
+            },
+          },
+          scales: {
+            x: { title: { display: true, text: 'Years' } },
+            y: { title: { display: true, text: 'Country' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/gantt.html
+++ b/examples/chartjs/gantt.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Gantt Chart Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Gantt Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. Up and Down move between lanes, Left and Right between the intervals booked in one lane. Pitch carries how long an interval runs; stereo position carries when it starts, so two lanes whose work lines up sound like they line up.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="gantt-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // A Chart.js floating bar: each datum is [start, end] rather than a
+      // magnitude from the baseline, and `indexAxis: 'y'` puts the lanes on
+      // the category axis with the schedule running left to right.
+      new Chart(document.getElementById('gantt-chart'), {
+        type: 'bar',
+        data: {
+          labels: ['Research', 'Design', 'Build', 'Review', 'Ship'],
+          datasets: [
+            {
+              label: 'Phase',
+              data: [[0, 10], [8, 20], [18, 45], [42, 52], [52, 56]],
+              backgroundColor: '#4682b4',
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          plugins: {
+            title: { display: true, text: 'Project Schedule' },
+            // Chart.js states nowhere what one step of the axis measures, so
+            // a schedule read in days has to say so.
+            maidr: { unit: 'days' },
+          },
+          scales: {
+            x: { title: { display: true, text: 'Day of project' }, min: 0 },
+            y: { title: { display: true, text: 'Phase' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/gauge.html
+++ b/examples/chartjs/gauge.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Gauge Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Gauge</h1>
+    <p>Click on a chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions. A gauge is one measure, so the announcement carries the dial it sits on, the target it was aiming at, and the band it lands in.</p>
+
+    <div style="width: 500px; height: 300px">
+      <canvas id="gauge-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // A gauge is a doughnut swept through half the circle: the first value
+      // is the measure and the second is the rest of the dial, drawn empty.
+      new Chart(document.getElementById('gauge-chart'), {
+        type: 'doughnut',
+        data: {
+          labels: ['CPU utilisation', 'Headroom'],
+          datasets: [
+            {
+              data: [73, 27],
+              backgroundColor: ['#d2691e', '#e8e8e8'],
+              borderWidth: 0,
+            },
+          ],
+        },
+        options: {
+          circumference: 180,
+          rotation: 270,
+          cutout: '70%',
+          plugins: {
+            title: { display: true, text: 'CPU Utilisation' },
+            legend: { display: false },
+            // The target marker and the coloured bands are styling to
+            // Chart.js, so the page states them for the announcement.
+            maidr: {
+              target: 80,
+              bands: [
+                { to: 50, label: 'idle' },
+                { to: 85, label: 'ok' },
+                { to: 100, label: 'saturated' },
+              ],
+            },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/radar.html
+++ b/examples/chartjs/radar.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Radar Chart Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Radar and Polar Area</h1>
+    <p>Click on a chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions. A spoke's stereo position follows its angle, so sweeping a series goes out and comes back.</p>
+
+    <div style="width: 500px; height: 400px">
+      <canvas id="radar-chart"></canvas>
+    </div>
+
+    <div style="width: 500px; height: 400px">
+      <canvas id="polar-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      new Chart(document.getElementById('radar-chart'), {
+        type: 'radar',
+        data: {
+          labels: ['Speed', 'Handling', 'Range', 'Comfort', 'Economy'],
+          datasets: [
+            {
+              label: 'Model A',
+              data: [82, 74, 60, 91, 55],
+              borderColor: '#2ca02c',
+              backgroundColor: 'rgba(44, 160, 44, 0.2)',
+            },
+            {
+              label: 'Model B',
+              data: [61, 88, 79, 66, 84],
+              borderColor: '#1f77b4',
+              backgroundColor: 'rgba(31, 119, 180, 0.2)',
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Model Comparison' },
+            // A radar has no x or y scale, so name what the spokes and their
+            // magnitudes mean rather than letting MAIDR announce 'Category'.
+            maidr: { axes: { x: 'Attribute', y: 'Score' } },
+          },
+          scales: {
+            r: { title: { display: true, text: 'Score' }, min: 0, max: 100 },
+          },
+        },
+      });
+
+      new Chart(document.getElementById('polar-chart'), {
+        type: 'polarArea',
+        data: {
+          labels: ['North', 'East', 'South', 'West'],
+          datasets: [
+            {
+              label: 'Deliveries',
+              data: [42, 67, 31, 55],
+              backgroundColor: ['#4682b4', '#d2691e', '#6b8e23', '#8b4789'],
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Deliveries by Region' },
+            maidr: { axes: { x: 'Region', y: 'Deliveries' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/survival.html
+++ b/examples/chartjs/survival.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Survival Curve Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Survival Curve</h1>
+    <p>Click on a chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions. Up and Down move between the two arms, and the rotor offers the censored times as a navigation unit of their own.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="survival-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // A Kaplan-Meier curve is a `stepped: 'after'` line, and nothing in the
+      // config tells it from any other staircase — hence the declaration.
+      // Chart.js ignores properties it does not know, so the censoring marks
+      // and the confidence band ride on the points themselves.
+      new Chart(document.getElementById('survival-chart'), {
+        type: 'line',
+        data: {
+          datasets: [
+            {
+              label: 'Treatment',
+              data: [
+                { x: 0, y: 1.0, yMin: 1.0, yMax: 1.0 },
+                { x: 3, y: 0.94, yMin: 0.88, yMax: 1.0 },
+                { x: 6, y: 0.88, yMin: 0.79, yMax: 0.97 },
+                { x: 9, y: 0.88, yMin: 0.79, yMax: 0.97, censored: true },
+                { x: 14, y: 0.79, yMin: 0.68, yMax: 0.9 },
+                { x: 21, y: 0.71, yMin: 0.58, yMax: 0.84 },
+              ],
+              stepped: 'after',
+              borderColor: '#2ca02c',
+            },
+            {
+              label: 'Control',
+              data: [
+                { x: 0, y: 1.0, yMin: 1.0, yMax: 1.0 },
+                { x: 2, y: 0.9, yMin: 0.82, yMax: 0.98 },
+                { x: 5, y: 0.78, yMin: 0.67, yMax: 0.89 },
+                { x: 8, y: 0.61, yMin: 0.48, yMax: 0.74 },
+                { x: 12, y: 0.61, yMin: 0.48, yMax: 0.74, censored: true },
+                { x: 19, y: 0.44, yMin: 0.31, yMax: 0.57 },
+              ],
+              stepped: 'after',
+              borderColor: '#d62728',
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Overall Survival' },
+            maidr: { traceType: 'survival' },
+          },
+          scales: {
+            x: { type: 'linear', title: { display: true, text: 'Months' } },
+            y: {
+              title: { display: true, text: 'Survival probability' },
+              min: 0,
+              max: 1,
+            },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/waterfall.html
+++ b/examples/chartjs/waterfall.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Waterfall Chart Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Waterfall Chart</h1>
+    <p>Click on the chart and use arrow keys to navigate. Each step announces its contribution and the running total it produced; the opening, closing and any subtotal are announced as totals rather than as a change.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="waterfall-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // Chart.js's own waterfall recipe: floating bars whose every step begins
+      // where the previous one ended, with the opening and closing bars drawn
+      // from the baseline. That chaining is what tells MAIDR this is a running
+      // total rather than a set of intervals.
+      new Chart(document.getElementById('waterfall-chart'), {
+        type: 'bar',
+        data: {
+          labels: ['Opening', 'Product', 'Services', 'Refunds', 'Costs', 'Closing'],
+          datasets: [
+            {
+              label: 'Cash flow',
+              data: [[0, 420], [420, 610], [610, 700], [700, 655], [655, 540], [0, 540]],
+              backgroundColor: [
+                '#4682b4',
+                '#2ca02c',
+                '#2ca02c',
+                '#d62728',
+                '#d62728',
+                '#4682b4',
+              ],
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Quarterly Cash Flow' },
+          },
+          scales: {
+            x: { title: { display: true, text: 'Step' } },
+            y: { title: { display: true, text: 'USD (thousands)' }, beginAtZero: true },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -4,8 +4,9 @@
  *
  * Supported chart types (those with a genuine MAIDR trace-type equivalent):
  * - Native: bar (plain/stacked/dodged/diverging), floating bar (gantt,
- *   waterfall), line (plain, stepped, area, stacked and normalized area,
- *   bump), scatter, bubble, pie, doughnut, radar, polarArea
+ *   waterfall, dumbbell), line (plain, stepped, area, stacked and normalized
+ *   area, bump, dot, survival), scatter, bubble, pie, doughnut, gauge, radar,
+ *   polarArea
  * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap)
  *
  * Unsupported types (treemap, sankey, etc.) are rejected with an explicit
@@ -13,8 +14,8 @@
  * semantically equivalent trace for them.
  */
 
-import type { BarPoint, BoxPoint, CandlestickPoint, GanttData, GanttPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, WaterfallKind, WaterfallPoint } from '../../type/grammar';
-import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsRangeBound, MaidrPluginOptions } from './types';
+import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, WaterfallKind, WaterfallPoint } from '../../type/grammar';
+import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsPointValue, ChartJsRangeBound, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 
 // ---------------------------------------------------------------------------
@@ -550,7 +551,7 @@ function rangeBounds(value: [ChartJsRangeBound, ChartJsRangeBound]): [number, nu
   return [toRangeBound(value[0]) ?? 0, toRangeBound(value[1]) ?? 0];
 }
 
-export function isPointValue(v: ChartJsDataValue): v is { x: number; y: number; r?: number } {
+export function isPointValue(v: ChartJsDataValue): v is ChartJsPointValue {
   return v != null && typeof v === 'object' && 'x' in v && 'y' in v && !('o' in v) && !('v' in v) && !('median' in v);
 }
 
@@ -577,6 +578,20 @@ function formatCandlestickValue(value: unknown): string {
 
 export function isMatrixValue(v: ChartJsDataValue): v is { x: string | number; y: string | number; v: number } {
   return v != null && typeof v === 'object' && 'v' in v;
+}
+
+/**
+ * What the page's author declared the chart to be, if anything.
+ *
+ * The escape hatch for the figures Chart.js draws as a recipe: it wins over
+ * every heuristic below, and for the three readings no heuristic can reach —
+ * a survival curve, a dumbbell, a gauge — it is the only way in.
+ *
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns The declared trace type, or `undefined` when the page does not say
+ */
+function declaredType(pluginOptions?: MaidrPluginOptions): TraceType | undefined {
+  return pluginOptions?.traceType;
 }
 
 function isStacked(chart: ChartJsChart): boolean {
@@ -712,12 +727,20 @@ function isDivergingSplit(datasets: ChartJsDataset[]): boolean {
   return negativeSides > 0 && positiveSides > 0;
 }
 
+/**
+ * Builds a one-value-per-category layer from a single dataset.
+ *
+ * Serves the mark variants that differ only in what is drawn at the category:
+ * a bar, and the point a dot plot draws instead. `BarTrace` reads both, so the
+ * type is a parameter rather than a second copy of this.
+ */
 function singleDatasetToBarLayer(
   dataset: { label?: string; data: ChartJsDataValue[] },
   labels: (string | number)[],
   chart: ChartJsChart,
   pluginOptions?: MaidrPluginOptions,
   id: number = 0,
+  traceType: TraceType = TraceType.BAR,
 ): MaidrLayer {
   // Horizontal bars (`indexAxis: 'y'`) carry the value on X and the category on
   // Y, matching how `AbstractBarPlot` reads `barValues` for HORIZONTAL. Gap
@@ -736,7 +759,7 @@ function singleDatasetToBarLayer(
 
   return {
     id: String(id),
-    type: TraceType.BAR,
+    type: traceType,
     title: dataset.label,
     ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
     axes: {
@@ -839,9 +862,76 @@ function extractFloatingBarLayer(
   chart: ChartJsChart,
   pluginOptions?: MaidrPluginOptions,
 ): MaidrLayer {
-  return isWaterfallSequence(chart)
-    ? extractWaterfallLayer(chart, pluginOptions)
-    : extractGanttLayer(chart, pluginOptions);
+  // A dumbbell has no heuristic of its own on purpose. One interval per
+  // category on a horizontal axis is the same figure a one-lane-per-task gantt
+  // draws, down to the datum, so any test that read one as a dumbbell would
+  // read every schedule as one too. The author says which, or it stays a gantt.
+  switch (declaredType(pluginOptions)) {
+    case TraceType.DUMBBELL:
+      return extractDumbbellLayer(chart, pluginOptions);
+    case TraceType.WATERFALL:
+      return extractWaterfallLayer(chart, pluginOptions);
+    case TraceType.GANTT:
+      return extractGanttLayer(chart, pluginOptions);
+    default:
+      return isWaterfallSequence(chart)
+        ? extractWaterfallLayer(chart, pluginOptions)
+        : extractGanttLayer(chart, pluginOptions);
+  }
+}
+
+/**
+ * Extracts a declared dumbbell chart: one paired comparison per category.
+ *
+ * Chart.js draws it as a floating bar — the connector between the two dots is
+ * the bar itself — so the two ends arrive as the `[start, end]` pair every
+ * other floating bar uses. What it does not carry is what the ends *are*: the
+ * datum has no room for them and the chart has no legend for a single dataset,
+ * which is why they come from the plugin options and default to nothing rather
+ * than being guessed from the axis.
+ *
+ * @param chart - The chart to read
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns A single dumbbell layer
+ */
+function extractDumbbellLayer(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer {
+  const labels = chart.data.labels ?? [];
+  const dataset = chart.data.datasets[0];
+  // Rows with nothing to compare are skipped rather than kept as a gap: unlike
+  // a gantt lane, an empty dumbbell row has no pair and so no comparison to
+  // announce, and the trace's grid is a plain rows x ends rectangle.
+  const points: DumbbellPoint[] = [];
+  dataset.data.forEach((value, i) => {
+    if (!isRangeValue(value))
+      return;
+    const [start, end] = rangeBounds(value);
+    points.push({ x: labels[i] ?? i, start, end });
+  });
+
+  const data: DumbbellData = {
+    points,
+    ...(pluginOptions?.startLabel ? { startLabel: pluginOptions.startLabel } : {}),
+    ...(pluginOptions?.endLabel ? { endLabel: pluginOptions.endLabel } : {}),
+  };
+
+  // A dumbbell is normally drawn with its categories running down the page,
+  // which is Chart.js's `indexAxis: 'y'` — the same reading a gantt gives it.
+  const isHorizontal = chart.options.indexAxis === 'y';
+
+  return {
+    id: '0',
+    type: TraceType.DUMBBELL,
+    title: dataset.label,
+    ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
+    axes: {
+      x: { label: getAxisLabel(chart, 'x', pluginOptions) },
+      y: { label: getAxisLabel(chart, 'y', pluginOptions) },
+    },
+    data,
+  };
 }
 
 /**
@@ -1192,6 +1282,171 @@ function isBumpGroup(group: LineGroup, chart: ChartJsChart): boolean {
   return true;
 }
 
+/** Which scale a line chart's categories run along. */
+function categoryAxis(chart: ChartJsChart): AxisKind {
+  return chart.options.indexAxis === 'y' ? 'y' : 'x';
+}
+
+/** Whether a scale plots named categories rather than a continuum. */
+function isCategoryScale(chart: ChartJsChart, axisId: string): boolean {
+  const type = chart.options.scales?.[axisId]?.type;
+  // A line chart's category axis is what Chart.js gives it when the config
+  // names no type, which is how nearly every one of them is written.
+  return type === undefined || type === 'category';
+}
+
+/**
+ * Whether a line chart is a dot plot — the markers drawn without the line
+ * that would join them.
+ *
+ * Chart.js says this outright, which makes it one of the few recipes that
+ * needs no value heuristic: `showLine: false` is its own way of drawing a
+ * Cleveland dot plot, and a dataset's setting wins over the chart's default
+ * exactly as {@link stepDirectionOf} resolves `stepped`.
+ *
+ * The category axis has to be a category axis. Points with the line switched
+ * off along a continuum is a scatter plot drawn by the line controller, and it
+ * has two measured coordinates rather than a value per named category.
+ *
+ * @param chart - The chart to classify
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns True when the chart draws one value per category as a point
+ */
+function isDotPlot(chart: ChartJsChart, pluginOptions?: MaidrPluginOptions): boolean {
+  if (declaredType(pluginOptions) === TraceType.DOT)
+    return true;
+  if (!isCategoryScale(chart, categoryAxis(chart)))
+    return false;
+  return chart.data.datasets.every(
+    dataset => (dataset.showLine ?? chart.options.showLine) === false,
+  );
+}
+
+/**
+ * Extracts a dot plot as one layer per dataset.
+ *
+ * The payload is a bar layer's — a value per category, read by `BarTrace` —
+ * because that is what the chart holds; the dot is the mark it is drawn with.
+ * One layer per series rather than one layer of rows, so a two-series dot plot
+ * keeps each series' own range and its own highlight routing, the way
+ * {@link extractPieLayers} keeps a doughnut's rings apart.
+ *
+ * @param chart - The chart to read
+ * @param pluginOptions - Optional per-chart plugin options
+ * @param datasetIndices - Collects which dataset backs each emitted layer
+ * @returns One layer per dataset
+ */
+function extractDotLayers(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+  datasetIndices?: LocalDatasetIndices,
+): MaidrLayer[] {
+  const labels = chart.data.labels ?? [];
+  return chart.data.datasets.map((dataset, dsIdx) => {
+    // Each layer is backed by exactly one dataset, so say which: the caller's
+    // per-type default (all datasets, in order) would route every series'
+    // highlight to the first one.
+    datasetIndices?.set(String(dsIdx), [dsIdx]);
+    return singleDatasetToBarLayer(
+      dataset,
+      labels,
+      chart,
+      pluginOptions,
+      dsIdx,
+      TraceType.DOT,
+    );
+  });
+}
+
+/**
+ * The time a survival point sits at.
+ *
+ * A Kaplan-Meier curve is plotted against elapsed time rather than against a
+ * row of named categories, so its points are normally written as `{x, y}`
+ * objects with no `labels` array to index — the one place in this adapter a
+ * line point's own `x` has to be preferred over the category label.
+ *
+ * @param value - The raw dataset entry
+ * @param labels - The chart's category labels, when it has any
+ * @param i - The entry's position in the dataset
+ * @returns The point's position along the time axis
+ */
+function survivalTime(
+  value: ChartJsDataValue,
+  labels: (string | number)[],
+  i: number,
+): number | string {
+  return isPointValue(value) ? value.x : labels[i] ?? i;
+}
+
+/** A bound of a confidence band, when the point carries a usable one. */
+function bandBound(bound: number | undefined): number | undefined {
+  return typeof bound === 'number' && Number.isFinite(bound) ? bound : undefined;
+}
+
+/**
+ * Extracts a declared Kaplan-Meier curve as one layer, an arm per row.
+ *
+ * Nothing in a Chart.js config distinguishes a survival curve from any other
+ * staircase — it is a `stepped: 'after'` line — so this is only reached by
+ * declaration. What makes the declaration worth honouring is the rest of the
+ * figure: censoring marks and confidence bands are the two things a survival
+ * plot carries that a step chart does not, and Chart.js ignores unknown
+ * properties on a datum, so a page rides them on the points themselves as
+ * `{x, y, censored, yMin, yMax}` and they arrive here intact.
+ *
+ * @param chart - The chart to read
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns A single survival layer holding every arm
+ */
+function extractSurvivalLayer(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer {
+  const labels = chart.data.labels ?? [];
+
+  const arms: SurvivalPoint[][] = chart.data.datasets.map((dataset, dsIdx) => {
+    const curve: SurvivalPoint[] = [];
+    dataset.data.forEach((value, i) => {
+      const y = toFiniteNumber(value);
+      if (y === null)
+        return;
+      // The censoring mark and the band ride on the point itself, which is the
+      // only place a Chart.js datum leaves for a fact the config cannot state.
+      const marks = isPointValue(value) ? value : undefined;
+      const yMin = bandBound(marks?.yMin);
+      const yMax = bandBound(marks?.yMax);
+      curve.push({
+        x: survivalTime(value, labels, i),
+        y,
+        z: dataset.label ?? `Arm ${dsIdx + 1}`,
+        ...(marks?.censored === true ? { censored: true } : {}),
+        ...(yMin !== undefined ? { yMin } : {}),
+        ...(yMax !== undefined ? { yMax } : {}),
+      });
+    });
+    return curve;
+  });
+
+  // Every arm of one figure shares a convention, so the first dataset that
+  // states one states it for the layer; a curve drawn without `stepped` at all
+  // is still a step function and defaults to the 'after' KM curves are drawn as.
+  const direction = chart.data.datasets
+    .map(dataset => stepDirectionOf(dataset, chart))
+    .find(one => one !== undefined) ?? 'vh';
+
+  return {
+    id: '0',
+    type: TraceType.SURVIVAL,
+    stepDirection: direction,
+    axes: {
+      x: { label: getAxisLabel(chart, 'x', pluginOptions) },
+      y: { label: getAxisLabel(chart, 'y', pluginOptions) },
+    },
+    data: arms,
+  };
+}
+
 function extractLineLayers(
   chart: ChartJsChart,
   pluginOptions?: MaidrPluginOptions,
@@ -1213,6 +1468,16 @@ function extractLineLayers(
       data: [],
     }];
   }
+
+  // Both readings replace the layer rather than refine one, so they are
+  // settled before the datasets are bucketed by mark: a dot plot has no line
+  // to be stepped or filled, and a survival curve is one figure whose arms
+  // belong together whatever each dataset declares.
+  if (declaredType(pluginOptions) === TraceType.SURVIVAL)
+    return [extractSurvivalLayer(chart, pluginOptions)];
+
+  if (isDotPlot(chart, pluginOptions))
+    return extractDotLayers(chart, pluginOptions, datasetIndices);
 
   // Skip gap markers (`null` / `NaN`) so they are never sonified as a 0 tone;
   // the plugin re-derives the original Chart.js indices for highlight alignment.
@@ -1450,6 +1715,102 @@ function getPieAxes(pluginOptions?: MaidrPluginOptions): MaidrLayer['axes'] {
 }
 
 /**
+ * Whether a part-circle doughnut is a gauge rather than a part-circle pie.
+ *
+ * Chart.js has no gauge controller: the recipe is a doughnut swept through
+ * less than the full circle, with the measure as its first value and the rest
+ * of the dial as its second — the remainder is drawn only to leave the arc
+ * unfilled. Two values in one part-circle ring is that recipe, and it is the
+ * most a config can say.
+ *
+ * The honest limit: a half-pie of exactly two slices is drawn identically and
+ * would be read as a dial. That is what {@link MaidrPluginOptions.traceType}
+ * is for in both directions — declaring `gauge` reads a dial the heuristic
+ * misses, declaring `pie` keeps two slices two slices.
+ *
+ * @param chart - The chart to classify
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns True when the chart draws one measure against a dial
+ */
+function isGaugeDial(chart: ChartJsChart, pluginOptions?: MaidrPluginOptions): boolean {
+  const declared = declaredType(pluginOptions);
+  if (declared === TraceType.GAUGE)
+    return true;
+  if (declared !== undefined)
+    return false;
+
+  const circumference = chart.options.circumference;
+  if (typeof circumference !== 'number' || circumference >= 360)
+    return false;
+
+  const datasets = chart.data.datasets;
+  if (datasets.length !== 1 || datasets[0].data.length !== 2)
+    return false;
+  return datasets[0].data.every(value => toFiniteNumber(value) !== null);
+}
+
+/**
+ * Axis labels for a gauge layer.
+ *
+ * `GaugeTrace` announces the measure's name against `axes.x` and its value
+ * against `axes.y`, and a dial has no Chart.js scales to read either off, so
+ * name what the two positions mean the way {@link getPieAxes} does.
+ */
+function getGaugeAxes(pluginOptions?: MaidrPluginOptions): MaidrLayer['axes'] {
+  return {
+    x: { label: pluginOptions?.axes?.x ?? 'Measure' },
+    y: { label: pluginOptions?.axes?.y ?? 'Value' },
+  };
+}
+
+/**
+ * Extracts a doughnut gauge as its single measure.
+ *
+ * The payload is one object rather than an array, because the chart draws one
+ * measure: the second value is the unfilled remainder of the dial, not a
+ * second reading, so it is spent on `max` instead of being announced as a
+ * slice of its own.
+ *
+ * @param chart - The chart to read
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns A single gauge layer
+ */
+function extractGaugeLayer(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer {
+  const dataset = chart.data.datasets[0];
+  const label = chart.data.labels?.[0] ?? dataset.label;
+  const value = toFiniteNumber(dataset.data[0]) ?? 0;
+  // The dial is however far round the ring goes: the measure plus everything
+  // drawn empty after it. Summing rather than reading the second value keeps a
+  // ring that splits its remainder across several arcs on one honest total.
+  const max = dataset.data.reduce<number>(
+    (total, entry) => total + (toFiniteNumber(entry) ?? 0),
+    0,
+  );
+
+  const point: GaugePoint = {
+    value,
+    // A doughnut sweeps from nothing, so the dial starts at zero: an arc's
+    // length is its share of the ring and there is no other origin to read.
+    min: 0,
+    max,
+    ...(label !== undefined ? { label: String(label) } : {}),
+    ...(pluginOptions?.target !== undefined ? { target: pluginOptions.target } : {}),
+    ...(pluginOptions?.bands ? { bands: pluginOptions.bands } : {}),
+  };
+
+  return {
+    id: '0',
+    type: TraceType.GAUGE,
+    title: dataset.label,
+    axes: getGaugeAxes(pluginOptions),
+    data: point,
+  };
+}
+
+/**
  * Extracts one pie layer per dataset.
  *
  * Chart.js draws a second dataset as a concentric ring rather than as more
@@ -1463,6 +1824,11 @@ function extractPieLayers(
   pluginOptions?: MaidrPluginOptions,
   datasetIndices?: LocalDatasetIndices,
 ): MaidrLayer[] {
+  // A dial is the same ring drawn part way round, so it is settled here rather
+  // than in the dispatcher — the chart type is `doughnut` either way.
+  if (chart.data.datasets.length > 0 && isGaugeDial(chart, pluginOptions))
+    return [extractGaugeLayer(chart, pluginOptions)];
+
   const labels = chart.data.labels ?? [];
   const axes = getPieAxes(pluginOptions);
 

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -3,17 +3,18 @@
  * JSON schema format.
  *
  * Supported chart types (those with a genuine MAIDR trace-type equivalent):
- * - Native: bar (plain/stacked/dodged), line (plain or stepped), scatter,
- *   bubble, pie, doughnut
+ * - Native: bar (plain/stacked/dodged/diverging), floating bar (gantt,
+ *   waterfall), line (plain, stepped, area, stacked and normalized area,
+ *   bump), scatter, bubble, pie, doughnut, radar, polarArea
  * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap)
  *
- * Unsupported types (radar, polarArea, treemap, sankey, etc.) are rejected with
- * an explicit error rather than silently mapped to a bar chart, because MAIDR
- * has no semantically equivalent trace for them.
+ * Unsupported types (treemap, sankey, etc.) are rejected with an explicit
+ * error rather than silently mapped to a bar chart, because MAIDR has no
+ * semantically equivalent trace for them.
  */
 
-import type { BarPoint, BoxPoint, CandlestickPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection } from '../../type/grammar';
-import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, MaidrPluginOptions } from './types';
+import type { BarPoint, BoxPoint, CandlestickPoint, GanttData, GanttPoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, WaterfallKind, WaterfallPoint } from '../../type/grammar';
+import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsRangeBound, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 
 // ---------------------------------------------------------------------------
@@ -504,6 +505,51 @@ export function toFiniteNumber(value: ChartJsDataValue): number | null {
   return null;
 }
 
+/**
+ * The numeric position of one end of a floating bar.
+ *
+ * A `Date` is how Chart.js's own range-bar recipes write a bound on a time
+ * scale, and its epoch value is exactly what the scale plots it at, so the two
+ * forms are the same number to everything downstream.
+ *
+ * @param bound - One entry of a `[start, end]` tuple
+ * @returns The position, or `null` when the entry carries no usable one
+ */
+function toRangeBound(bound: ChartJsRangeBound): number | null {
+  const value = bound instanceof Date ? bound.valueOf() : bound;
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Whether a dataset entry is a floating bar — a `[start, end]` pair rather
+ * than a magnitude measured from the baseline.
+ *
+ * This is the shape Chart.js gantt lanes, range bars and waterfall steps are
+ * all written in, and the one {@link toFiniteNumber} cannot read: an array is
+ * an object with neither a `y` nor a `v`, so before this guard existed such a
+ * chart extracted as a bar layer holding no points at all.
+ *
+ * @param v - A raw Chart.js dataset value
+ * @returns True when the entry is a usable `[start, end]` pair
+ */
+export function isRangeValue(v: ChartJsDataValue): v is [ChartJsRangeBound, ChartJsRangeBound] {
+  return Array.isArray(v)
+    && v.length === 2
+    && toRangeBound(v[0]) !== null
+    && toRangeBound(v[1]) !== null;
+}
+
+/**
+ * The two ends of a floating bar, as positions on the value axis.
+ *
+ * @param value - An entry {@link isRangeValue} has accepted
+ * @returns Its start and end
+ */
+function rangeBounds(value: [ChartJsRangeBound, ChartJsRangeBound]): [number, number] {
+  // Both bounds are known good: nothing reaches here without `isRangeValue`.
+  return [toRangeBound(value[0]) ?? 0, toRangeBound(value[1]) ?? 0];
+}
+
 export function isPointValue(v: ChartJsDataValue): v is { x: number; y: number; r?: number } {
   return v != null && typeof v === 'object' && 'x' in v && 'y' in v && !('o' in v) && !('v' in v) && !('median' in v);
 }
@@ -569,6 +615,13 @@ function extractLayers(
     case 'pie':
     case 'doughnut':
       return extractPieLayers(chart, pluginOptions, datasetIndices);
+    // A radar joins its values into a closed outline and a polar area draws
+    // them as wedges; a reader navigates the same spokes either way, which is
+    // why `RadarTrace` serves both and the payload is identical.
+    case 'radar':
+      return extractRadarLayers(chart, TraceType.RADAR, pluginOptions);
+    case 'polarArea':
+      return extractRadarLayers(chart, TraceType.POLAR_AREA, pluginOptions);
     case 'boxplot':
       return extractBoxplotLayers(chart, pluginOptions);
     case 'candlestick':
@@ -579,8 +632,8 @@ function extractLayers(
     default:
       throw new Error(
         `MAIDR Chart.js adapter: unsupported chart type "${chartType}". `
-        + 'Supported types: bar, line, scatter, bubble, pie, doughnut, boxplot, '
-        + 'candlestick, ohlc, matrix.',
+        + 'Supported types: bar, line, scatter, bubble, pie, doughnut, radar, '
+        + 'polarArea, boxplot, candlestick, ohlc, matrix.',
       );
   }
 }
@@ -598,12 +651,65 @@ function extractBarLayers(
   if (data.datasets.length === 0)
     return [];
 
+  // Floating bars carry two positions rather than a magnitude, so they are
+  // neither a bar nor a segmented bar — checked before either.
+  if (data.datasets.some(dataset => dataset.data.some(isRangeValue)))
+    return [extractFloatingBarLayer(chart, pluginOptions)];
+
   if (data.datasets.length > 1) {
-    const traceType = isStacked(chart) ? TraceType.STACKED : TraceType.DODGED;
+    const traceType = isStacked(chart)
+      ? (isDivergingSplit(data.datasets) ? TraceType.DIVERGING : TraceType.STACKED)
+      : TraceType.DODGED;
     return extractSegmentedBarLayers(chart, pluginOptions, traceType);
   }
 
   return [singleDatasetToBarLayer(data.datasets[0], data.labels ?? [], chart, pluginOptions)];
+}
+
+/**
+ * Whether stacked datasets are drawn back to back around a shared baseline —
+ * a population pyramid, or a Likert scale split around its neutral point.
+ *
+ * Chart.js states nothing about this: the recipe is an ordinary stacked bar
+ * chart with one side's values negated, so the sign split *is* the signal.
+ * The test is deliberately strict — every dataset must sit wholly on one side,
+ * and both sides must be occupied — because a stacked chart that merely
+ * happens to contain a negative series is not two sides of anything, and
+ * announcing it as one would name a left and a right that the chart does not
+ * have.
+ *
+ * @param datasets - The chart's datasets
+ * @returns True when the datasets partition into a negative and a positive side
+ */
+function isDivergingSplit(datasets: ChartJsDataset[]): boolean {
+  let negativeSides = 0;
+  let positiveSides = 0;
+
+  for (const dataset of datasets) {
+    let hasNegative = false;
+    let hasPositive = false;
+    for (const value of dataset.data) {
+      const num = toFiniteNumber(value);
+      // Zero belongs to neither side: a category a series does not reach is
+      // written as 0 on both wings of a pyramid.
+      if (num === null || num === 0)
+        continue;
+      if (num < 0)
+        hasNegative = true;
+      else
+        hasPositive = true;
+    }
+    // A series that crosses the baseline is a series of signed values, not a
+    // side of a diverging chart.
+    if (hasNegative && hasPositive)
+      return false;
+    if (hasNegative)
+      negativeSides++;
+    if (hasPositive)
+      positiveSides++;
+  }
+
+  return negativeSides > 0 && positiveSides > 0;
 }
 
 function singleDatasetToBarLayer(
@@ -683,6 +789,203 @@ function extractSegmentedBarLayers(
       data: points,
     },
   ];
+}
+
+// ---------------------------------------------------------------------------
+// Floating bar extraction (gantt / waterfall)
+// ---------------------------------------------------------------------------
+
+/**
+ * Which of a floating bar chart's two readings it is.
+ *
+ * Chart.js draws a gantt chart, a range bar chart and a waterfall with the
+ * same `[start, end]` datum and says nothing to tell them apart, so the shape
+ * of the numbers has to. A waterfall is a chain: each step begins where the
+ * previous one ended, which is the whole point of the figure and something no
+ * schedule does by construction. Everything else is a set of intervals, which
+ * is a gantt.
+ *
+ * Only tested on the default vertical index axis, and only for a single
+ * series. A horizontal chart is a schedule drawn the ordinary way round, and a
+ * waterfall has one running total rather than several.
+ *
+ * @param chart - The chart the datasets belong to
+ * @returns True when the steps chain into a running total
+ */
+function isWaterfallSequence(chart: ChartJsChart): boolean {
+  if (chart.options.indexAxis === 'y' || chart.data.datasets.length !== 1)
+    return false;
+
+  const steps = chart.data.datasets[0].data.filter(isRangeValue).map(rangeBounds);
+  if (steps.length < 2)
+    return false;
+
+  // The opening, closing and subtotal bars sit on the baseline instead of
+  // floating, so they restate the total rather than continuing the chain and
+  // are skipped rather than counted as a break in it.
+  let links = 0;
+  for (let i = 1; i < steps.length; i++) {
+    const [start] = steps[i];
+    if (start === 0)
+      continue;
+    if (start !== steps[i - 1][1])
+      return false;
+    links++;
+  }
+  return links > 0;
+}
+
+function extractFloatingBarLayer(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer {
+  return isWaterfallSequence(chart)
+    ? extractWaterfallLayer(chart, pluginOptions)
+    : extractGanttLayer(chart, pluginOptions);
+}
+
+/**
+ * What a step does to the running total.
+ *
+ * A bar drawn from the baseline is the opening, the closing or a subtotal: it
+ * restates the total rather than contributing to it, and a reader told a
+ * subtotal "rose by 950" would be hearing a contribution the chart never made.
+ *
+ * @param start - The step's running total before
+ * @param end - Its running total after
+ * @returns Which kind of step it is
+ */
+function waterfallKind(start: number, end: number): WaterfallKind {
+  if (start === 0)
+    return 'total';
+  return end < start ? 'decrease' : 'increase';
+}
+
+function extractWaterfallLayer(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer {
+  const labels = chart.data.labels ?? [];
+  const points: WaterfallPoint[] = [];
+
+  chart.data.datasets[0].data.forEach((value, i) => {
+    if (!isRangeValue(value))
+      return;
+    const [start, end] = rangeBounds(value);
+    points.push({
+      x: labels[i] ?? i,
+      start,
+      end,
+      delta: end - start,
+      kind: waterfallKind(start, end),
+    });
+  });
+
+  return {
+    id: '0',
+    type: TraceType.WATERFALL,
+    title: chart.data.datasets[0].label,
+    axes: {
+      x: { label: getAxisLabel(chart, 'x', pluginOptions) },
+      y: { label: getAxisLabel(chart, 'y', pluginOptions) },
+    },
+    data: points,
+  };
+}
+
+/**
+ * What a unit of the interval axis measures.
+ *
+ * Only the page's author knows: a linear axis is bare numbers, and a time axis
+ * is parsed to epoch milliseconds however `time.unit` chooses to *display* it,
+ * so reading `time.unit` here would announce "5 days" for an interval of five
+ * milliseconds. A time scale therefore names the unit its numbers are actually
+ * in, and everything else names nothing rather than guessing.
+ *
+ * @param chart - The chart being read
+ * @param valueAxis - Which scale the intervals are plotted along
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns The unit, or `undefined` when the chart does not say
+ */
+function ganttUnit(
+  chart: ChartJsChart,
+  valueAxis: AxisKind,
+  pluginOptions?: MaidrPluginOptions,
+): string | undefined {
+  if (pluginOptions?.unit)
+    return pluginOptions.unit;
+  return isTimeScale(chart, valueAxis) ? 'milliseconds' : undefined;
+}
+
+/** Whether a scale plots instants rather than plain numbers. */
+function isTimeScale(chart: ChartJsChart, axisId: string): boolean {
+  const type = chart.options.scales?.[axisId]?.type;
+  return type === 'time' || type === 'timeseries';
+}
+
+function extractGanttLayer(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer {
+  const datasets = chart.data.datasets;
+  const labels = chart.data.labels ?? [];
+  // A gantt drawn the ordinary way runs its bars left to right, which is
+  // Chart.js's `indexAxis: 'y'`: the lanes are the category axis and the
+  // intervals run along x.
+  const isHorizontal = chart.options.indexAxis === 'y';
+  const valueAxis: AxisKind = isHorizontal ? 'x' : 'y';
+
+  const laneCount = Math.max(0, labels.length, ...datasets.map(ds => ds.data.length));
+  // One lane per category, holding whatever every dataset booked there. A
+  // second dataset is a second interval in the same lane — a resource booked
+  // twice, a phase that pauses and resumes — so it is named rather than left
+  // to be told apart by position.
+  const namesIntervals = datasets.length > 1;
+  const points: GanttPoint[][] = [];
+  for (let lane = 0; lane < laneCount; lane++) {
+    const intervals: GanttPoint[] = [];
+    for (const dataset of datasets) {
+      const value = dataset.data[lane];
+      if (!isRangeValue(value))
+        continue;
+      const [start, end] = rangeBounds(value);
+      intervals.push({
+        x: labels[lane] ?? lane,
+        start,
+        end,
+        ...(namesIntervals && dataset.label ? { label: dataset.label } : {}),
+      });
+    }
+    points.push(intervals);
+  }
+
+  const unit = ganttUnit(chart, valueAxis, pluginOptions);
+  const data: GanttData = {
+    points,
+    // Carried for the lanes that hold nothing: an empty lane is a real
+    // statement about a schedule and has no interval to name itself with.
+    lanes: Array.from({ length: laneCount }, (_, lane) => labels[lane] ?? lane),
+    ...(unit ? { unit } : {}),
+  };
+
+  // Epoch milliseconds are what a time scale parses its bounds to, and
+  // announcing one raw says nothing a reader can place, so the interval axis
+  // carries a date format that renders both ends of the span.
+  const intervalAxis = {
+    label: getAxisLabel(chart, valueAxis, pluginOptions),
+    ...(isTimeScale(chart, valueAxis) ? { format: { type: 'date' as const } } : {}),
+  };
+  const laneAxis = { label: getAxisLabel(chart, isHorizontal ? 'y' : 'x', pluginOptions) };
+
+  return {
+    id: '0',
+    type: TraceType.GANTT,
+    ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
+    axes: isHorizontal
+      ? { x: intervalAxis, y: laneAxis }
+      : { x: laneAxis, y: intervalAxis },
+    data,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -768,18 +1071,125 @@ interface LineGroup {
  * unstacked stepped band keeps STEP, because nothing accumulates and the
  * staircase is then the more specific reading.
  *
+ * The two readings that live below this one — a normalized band and a bump
+ * chart — are settled by the values rather than by the options, because
+ * Chart.js has no way to declare either.
+ *
  * @param group - The group to classify
+ * @param chart - The chart it belongs to, for its scales and datasets
  * @param stacked - Whether the chart's scales stack
  * @returns The trace type for the group's layer
  */
-function lineGroupType(group: LineGroup, stacked: boolean): TraceType {
+function lineGroupType(
+  group: LineGroup,
+  chart: ChartJsChart,
+  stacked: boolean,
+): TraceType {
   if (group.filled) {
     if (stacked) {
-      return TraceType.STACKED_AREA;
+      return isNormalizedGroup(group, chart.data.datasets)
+        ? TraceType.NORMALIZED_AREA
+        : TraceType.STACKED_AREA;
     }
     return group.direction === '' ? TraceType.AREA : TraceType.STEP;
   }
-  return group.direction === '' ? TraceType.LINE : TraceType.STEP;
+  if (group.direction !== '') {
+    return TraceType.STEP;
+  }
+  return isBumpGroup(group, chart) ? TraceType.BUMP : TraceType.LINE;
+}
+
+/** The totals a normalized chart's bands are shares of: percent, or unity. */
+const NORMALIZED_TOTALS = [100, 1] as const;
+
+/**
+ * How far a column's total may sit from the whole and still read as one.
+ *
+ * Relative, and loose enough to admit shares rounded for display: percentages
+ * rounded to whole numbers routinely sum to 99.8 or 100.2, and a chart is not
+ * less normalized for having been rounded.
+ */
+const NORMALIZED_TOLERANCE = 0.005;
+
+/**
+ * Whether a stacked band group is normalized — every category a share of one
+ * common total.
+ *
+ * Chart.js has no `stack: 'normalize'` mode of its own: the recipe is an
+ * ordinary stacked area whose values were turned into percentages before they
+ * were handed over, so the values are the only evidence there is. Two or more
+ * bands whose columns all sum to the same whole is that evidence.
+ *
+ * The honest limit: a normalized chart whose totals were rounded unevenly
+ * enough to drift past the tolerance reads as a plain stacked area, which
+ * announces the same numbers and only misses the "share of" framing.
+ *
+ * @param group - The band group to classify
+ * @param datasets - The chart's datasets, indexed by the group
+ * @returns True when every category totals the same whole
+ */
+function isNormalizedGroup(group: LineGroup, datasets: ChartJsDataset[]): boolean {
+  const bands = group.indices.map(dsIdx => datasets[dsIdx]?.data ?? []);
+  // One band is not a share of anything, and a single category totals its own
+  // value whatever that is — neither says the chart is normalized.
+  if (bands.length < 2)
+    return false;
+  const categories = Math.max(...bands.map(band => band.length));
+  if (categories < 2)
+    return false;
+
+  const columnTotals: number[] = [];
+  for (let i = 0; i < categories; i++) {
+    let total = 0;
+    for (const band of bands)
+      total += toFiniteNumber(band[i]) ?? 0;
+    columnTotals.push(total);
+  }
+
+  return NORMALIZED_TOTALS.some(whole =>
+    columnTotals.every(total => Math.abs(total - whole) <= whole * NORMALIZED_TOLERANCE),
+  );
+}
+
+/**
+ * Whether a plain line group is a bump chart — rank over time, one line per
+ * competitor.
+ *
+ * Chart.js's bump recipe is a line chart with `scales.y.reverse` so rank 1
+ * sits at the top, and a reversed axis alone is nowhere near enough to go on:
+ * plenty of charts reverse an axis without their values being ranks. What
+ * makes the reading safe is that at every period the values across the series
+ * are a permutation of 1..N — the defining property of a ranking, and one no
+ * ordinary value series satisfies by accident.
+ *
+ * @param group - The line group to classify
+ * @param chart - The chart it belongs to, for its scales and datasets
+ * @returns True when the group's values rank its series at every period
+ */
+function isBumpGroup(group: LineGroup, chart: ChartJsChart): boolean {
+  if (chart.options.scales?.y?.reverse !== true)
+    return false;
+
+  const series = group.indices.map(dsIdx => chart.data.datasets[dsIdx]?.data ?? []);
+  // A single competitor has no table to climb, and one period has no movement.
+  if (series.length < 2)
+    return false;
+  const periods = Math.max(...series.map(one => one.length));
+  if (periods < 2)
+    return false;
+
+  for (let i = 0; i < periods; i++) {
+    const held = new Set<number>();
+    for (const one of series) {
+      const rank = toFiniteNumber(one[i]);
+      if (rank === null || !Number.isInteger(rank) || rank < 1 || rank > series.length)
+        return false;
+      if (held.has(rank))
+        return false;
+      held.add(rank);
+    }
+  }
+  return true;
 }
 
 function extractLineLayers(
@@ -857,7 +1267,7 @@ function extractLineLayers(
   for (const group of ordered) {
     const id = String(layers.length);
     datasetIndices?.set(id, group.indices);
-    const type = lineGroupType(group, stacked);
+    const type = lineGroupType(group, chart, stacked);
     layers.push({
       id,
       type,
@@ -871,6 +1281,84 @@ function extractLineLayers(
   }
 
   return layers;
+}
+
+// ---------------------------------------------------------------------------
+// Radar / polar area chart extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Axis labels for a radar or polar area layer.
+ *
+ * Neither has an x or a y scale — they are drawn against a single radial `r`
+ * scale — so {@link getAxisLabel} would fall through to its `'X'`/`'Y'`
+ * default and announce an axis the chart does not have. Name what the two
+ * positions mean instead, the way {@link getPieAxes} does: `x` is what the
+ * spokes are, `y` is what their magnitudes measure, which is the one of the
+ * two Chart.js can actually title.
+ *
+ * @param chart - The chart being read
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns The layer's axes
+ */
+function getRadarAxes(
+  chart: ChartJsChart,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer['axes'] {
+  const radialTitle = chart.options.scales?.r?.title?.text;
+  return {
+    x: { label: pluginOptions?.axes?.x ?? 'Category' },
+    y: { label: pluginOptions?.axes?.y ?? radialTitle ?? 'Value' },
+  };
+}
+
+/**
+ * Extracts a radar or polar area chart as one multi-series layer.
+ *
+ * The payload is a line layer's — a row per dataset, a column per spoke —
+ * because that is what a reader navigates either way; what the circle adds is
+ * carried by `RadarTrace` in the panning rather than in the data. The line
+ * extractor is deliberately not reused for it: a radar dataset is very
+ * commonly `fill: true`, which would bucket it as an area band, and a radar
+ * has no stacking or step convention for those buckets to mean anything.
+ *
+ * @param chart - The chart to read
+ * @param traceType - Which of the two marks the chart draws
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns A single layer holding every series
+ */
+function extractRadarLayers(
+  chart: ChartJsChart,
+  traceType: TraceType,
+  pluginOptions?: MaidrPluginOptions,
+): MaidrLayer[] {
+  const labels = chart.data.labels ?? [];
+
+  // Gap markers (`null` / `NaN`) are skipped, as they are on a line, so a
+  // missing spoke is never sonified as a fabricated zero.
+  const points: LinePoint[][] = chart.data.datasets.map((dataset, dsIdx) => {
+    const spokes: LinePoint[] = [];
+    dataset.data.forEach((value, i) => {
+      const num = toFiniteNumber(value);
+      if (num === null)
+        return;
+      spokes.push({
+        x: labels[i] ?? i,
+        y: num,
+        z: dataset.label ?? `Series ${dsIdx + 1}`,
+      });
+    });
+    return spokes;
+  });
+
+  return [
+    {
+      id: '0',
+      type: traceType,
+      axes: getRadarAxes(chart, pluginOptions),
+      data: points,
+    },
+  ];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -8,10 +8,10 @@
  * highlight resolution O(1) and aligned with the original chart elements.
  */
 
-import type { HeatmapData, MaidrLayer } from '../../type/grammar';
-import type { ChartJsActiveElement, ChartJsChart, ChartJsDataValue } from './types';
+import type { GanttData, HeatmapData, MaidrLayer } from '../../type/grammar';
+import type { ChartJsActiveElement, ChartJsChart, ChartJsDataset, ChartJsDataValue } from './types';
 import { TraceType } from '../../type/grammar';
-import { isMatrixValue, isPointValue, toFiniteNumber } from './extractor';
+import { isMatrixValue, isPointValue, isRangeValue, toFiniteNumber } from './extractor';
 
 /**
  * Figure-unique layer id → original Chart.js dataset indices backing that
@@ -31,10 +31,17 @@ export interface TargetMaps {
   barLineIndices: Map<string, number[][]>;
   /** Heatmap: `heatmapIndices[layerId]` maps `"x\0y"` to the flat Chart.js element index. */
   heatmapIndices: Map<string, Map<string, number>>;
+  /** Gantt: `ganttTargets[layerId][lane][interval]` is the element drawing it. */
+  ganttTargets: Map<string, ChartJsActiveElement[][]>;
 }
 
 function isSegmentedType(type: string): boolean {
-  return type === TraceType.STACKED || type === TraceType.DODGED || type === TraceType.NORMALIZED;
+  return type === TraceType.STACKED
+    || type === TraceType.DODGED
+    || type === TraceType.NORMALIZED
+    // A diverging chart is a stacked one whose sides carry opposite signs, so
+    // it is drawn from the same grid of elements and indexes identically.
+    || type === TraceType.DIVERGING;
 }
 
 /**
@@ -49,6 +56,51 @@ function finiteIndices(data: ChartJsDataValue[]): number[] {
       indices.push(i);
   });
   return indices;
+}
+
+/**
+ * Original indices of a dataset's floating-bar entries, in dataset order.
+ * The same job {@link finiteIndices} does for a magnitude: a `[start, end]`
+ * pair is not a number, so the gap-skipping test has to be its own.
+ */
+function rangeIndices(data: ChartJsDataValue[]): number[] {
+  const indices: number[] = [];
+  data.forEach((value, i) => {
+    if (isRangeValue(value))
+      indices.push(i);
+  });
+  return indices;
+}
+
+/**
+ * Mirror the gantt extractor's lane walk to map a MAIDR (lane, interval)
+ * position onto the Chart.js element drawing it.
+ *
+ * A gantt is the one layer whose grid is transposed against Chart.js's own:
+ * MAIDR's row is the *category* (Chart.js's element index) and its column is
+ * which dataset booked that lane, so neither axis of the usual bar/line
+ * lookup applies and the pair is carried whole.
+ *
+ * @param datasets - The chart's datasets
+ * @param dsIndices - The dataset indices backing the layer, in chart order
+ * @param laneCount - How many lanes the emitted payload holds
+ * @returns One element per interval, lanes x intervals
+ */
+function buildGanttTargets(
+  datasets: ChartJsDataset[],
+  dsIndices: number[],
+  laneCount: number,
+): ChartJsActiveElement[][] {
+  const lanes: ChartJsActiveElement[][] = [];
+  for (let lane = 0; lane < laneCount; lane++) {
+    const intervals: ChartJsActiveElement[] = [];
+    for (const datasetIndex of dsIndices) {
+      if (isRangeValue(datasets[datasetIndex]?.data[lane] ?? null))
+        intervals.push({ datasetIndex, index: lane });
+    }
+    lanes.push(intervals);
+  }
+  return lanes;
 }
 
 /**
@@ -124,6 +176,7 @@ export function computeTargetMaps(
   const scatterBuckets = new Map<string, number[][]>();
   const barLineIndices = new Map<string, number[][]>();
   const heatmapIndices = new Map<string, Map<string, number>>();
+  const ganttTargets = new Map<string, ChartJsActiveElement[][]>();
   const datasets = chart.data.datasets;
 
   for (const layer of layers) {
@@ -142,13 +195,35 @@ export function computeTargetMaps(
         barLineIndices.set(layer.id, [finiteIndices(datasets[dsIdx]?.data ?? [])]);
         break;
       }
+      case TraceType.WATERFALL: {
+        // One series of floating bars: a single MAIDR row whose columns are
+        // the steps. Their entries are `[start, end]` pairs, so the finite
+        // test a magnitude uses would skip every one of them.
+        const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
+        barLineIndices.set(layer.id, [rangeIndices(datasets[dsIdx]?.data ?? [])]);
+        break;
+      }
+      case TraceType.GANTT: {
+        // Lanes come from the payload rather than the datasets so an empty
+        // lane keeps its row — the extractor emits one per category.
+        const lanes = (layer.data as GanttData).points.length;
+        const dsIndices = layerDatasetIndices.get(layer.id) ?? datasets.map((_, i) => i);
+        ganttTargets.set(layer.id, buildGanttTargets(datasets, dsIndices, lanes));
+        break;
+      }
       // A filled band is drawn from the same dataset a line is, one per
       // series, so it indexes identically — the fill changes the mark, not
-      // where a point lives. A staircase is the same again.
+      // where a point lives. A staircase is the same again, and so are the
+      // spokes of a radar and the ranks of a bump chart: one row per series,
+      // one column per position along it.
       case TraceType.LINE:
       case TraceType.AREA:
       case TraceType.STACKED_AREA:
-      case TraceType.STEP: {
+      case TraceType.NORMALIZED_AREA:
+      case TraceType.STEP:
+      case TraceType.BUMP:
+      case TraceType.RADAR:
+      case TraceType.POLAR_AREA: {
         // One MAIDR row per backing dataset, in MAIDR row order.
         const dsIndices = layerDatasetIndices.get(layer.id) ?? datasets.map((_, i) => i);
         barLineIndices.set(
@@ -167,7 +242,7 @@ export function computeTargetMaps(
     }
   }
 
-  return { scatterBuckets, barLineIndices, heatmapIndices };
+  return { scatterBuckets, barLineIndices, heatmapIndices, ganttTargets };
 }
 
 /**
@@ -202,6 +277,13 @@ export function resolveActiveTargets(
     return buckets[col].map(index => ({ datasetIndex, index }));
   }
 
+  // Gantt: MAIDR row = lane (the Chart.js element index), col = which dataset
+  // booked that lane. Both halves come from the prebuilt pair.
+  if (layer.type === TraceType.GANTT) {
+    const target = maps.ganttTargets.get(layer.id)?.[row]?.[col];
+    return target ? [target] : [];
+  }
+
   // Candlestick / OHLC: a single dataset of candles. MAIDR `col` selects the
   // candle; MAIDR `row` picks the OHLC field (volatility/open/high/low/close)
   // for audio/text and does NOT change which element to highlight.
@@ -224,8 +306,9 @@ export function resolveActiveTargets(
     return [{ datasetIndex: firstDatasetIndex(layerDatasetIndices, layer.id), index: flatIndex }];
   }
 
-  // Bar / line / pie: MAIDR row = dataset (always 0 for a pie, whose slices are
-  // one row), col = point (into the gap-skipped list). Map col back to the
+  // Bar / line / pie / waterfall: MAIDR row = dataset (always 0 for a pie,
+  // whose slices are one row, and for a waterfall's single chain of steps),
+  // col = point (into the gap-skipped list). Map col back to the
   // original Chart.js element index so highlights stay aligned when the dataset
   // contains gap markers.
   const indexMap = maps.barLineIndices.get(layer.id);

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -187,18 +187,24 @@ export function computeTargetMaps(
         break;
       }
       case TraceType.BAR:
+      case TraceType.DOT:
+      case TraceType.GAUGE:
       case TraceType.PIE: {
         // Single-dataset bar, or one pie/doughnut ring: a single MAIDR row
         // backed by the layer's own dataset. A pie's row is always 0 and its
-        // col is the slice, which is the same shape.
+        // col is the slice, which is the same shape — and so are a dot plot's
+        // one series of points and a gauge's single measure, whose only
+        // position is the ring's first arc.
         const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
         barLineIndices.set(layer.id, [finiteIndices(datasets[dsIdx]?.data ?? [])]);
         break;
       }
+      case TraceType.DUMBBELL:
       case TraceType.WATERFALL: {
         // One series of floating bars: a single MAIDR row whose columns are
-        // the steps. Their entries are `[start, end]` pairs, so the finite
-        // test a magnitude uses would skip every one of them.
+        // the steps, or the paired rows of a dumbbell. Their entries are
+        // `[start, end]` pairs, so the finite test a magnitude uses would skip
+        // every one of them.
         const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
         barLineIndices.set(layer.id, [rangeIndices(datasets[dsIdx]?.data ?? [])]);
         break;
@@ -214,13 +220,14 @@ export function computeTargetMaps(
       // A filled band is drawn from the same dataset a line is, one per
       // series, so it indexes identically — the fill changes the mark, not
       // where a point lives. A staircase is the same again, and so are the
-      // spokes of a radar and the ranks of a bump chart: one row per series,
-      // one column per position along it.
+      // spokes of a radar, the ranks of a bump chart and the arms of a
+      // survival curve: one row per series, one column per position along it.
       case TraceType.LINE:
       case TraceType.AREA:
       case TraceType.STACKED_AREA:
       case TraceType.NORMALIZED_AREA:
       case TraceType.STEP:
+      case TraceType.SURVIVAL:
       case TraceType.BUMP:
       case TraceType.RADAR:
       case TraceType.POLAR_AREA: {
@@ -282,6 +289,17 @@ export function resolveActiveTargets(
   if (layer.type === TraceType.GANTT) {
     const target = maps.ganttTargets.get(layer.id)?.[row]?.[col];
     return target ? [target] : [];
+  }
+
+  // Dumbbell: MAIDR row = which end of the pair, col = the category. Both ends
+  // are drawn by the one floating bar that connects them, so the row does not
+  // change what is highlighted — the same reading `DumbbellTrace` gives its own
+  // selectors, which repeat one element per category across the two ends.
+  if (layer.type === TraceType.DUMBBELL) {
+    const index = maps.barLineIndices.get(layer.id)?.[0]?.[col];
+    if (index === undefined)
+      return [];
+    return [{ datasetIndex: firstDatasetIndex(layerDatasetIndices, layer.id), index }];
   }
 
   // Candlestick / OHLC: a single dataset of candles. MAIDR `col` selects the

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -6,6 +6,8 @@
  * objects will satisfy these interfaces.
  */
 
+import type { GaugeBand, TraceType } from '../../type/grammar';
+
 /**
  * One end of a floating bar.
  *
@@ -16,6 +18,30 @@
  * equally be a category label.
  */
 export type ChartJsRangeBound = number | Date;
+
+/**
+ * A point-shaped datum: a scatter or bubble point, a line vertex on a
+ * continuum, one time of a survival curve.
+ *
+ * The three optional members after `r` are not Chart.js's. Chart.js passes
+ * unknown properties on a datum through untouched, which is how a page carries
+ * a fact its config has no field for — and a Kaplan-Meier curve has two of
+ * those, the censoring mark and the confidence band, neither of which is a
+ * position the chart draws. They are named here rather than read off an index
+ * signature so this stays a statement about what the adapter looks for.
+ */
+export interface ChartJsPointValue {
+  x: number;
+  y: number;
+  /** A bubble's radius: a third encoded variable. */
+  r?: number;
+  /** A subject left the study here without the event happening. */
+  censored?: boolean;
+  /** Lower bound of the confidence band at this point. */
+  yMin?: number;
+  /** Upper bound of the confidence band at this point. */
+  yMax?: number;
+}
 
 /**
  * Union of data value shapes found in Chart.js datasets.
@@ -30,7 +56,7 @@ export type ChartJsDataValue
      * this way.
      */
     | [ChartJsRangeBound, ChartJsRangeBound]
-    | { x: number; y: number; r?: number }
+    | ChartJsPointValue
     | { x: number | string; o: number; h: number; l: number; c: number }
     | {
       min: number;
@@ -86,6 +112,11 @@ export interface ChartJsDataset {
   backgroundColor?: string | string[];
   borderColor?: string | string[];
   /**
+   * Whether a line dataset joins its points. `false` draws the markers alone,
+   * which is Chart.js's own way of writing a dot plot.
+   */
+  showLine?: boolean;
+  /**
    * Step interpolation for a line dataset. `'before'` (and the legacy `true`)
    * hold the current value until the next x and jump there, `'after'` jumps at
    * the current x and holds the new value across, `'middle'` jumps midway.
@@ -115,6 +146,15 @@ export interface ChartJsOptions {
   indexAxis?: 'x' | 'y';
   scales?: Record<string, ChartJsScale>;
   plugins?: Record<string, unknown>;
+  /** Chart-wide `showLine`; a dataset's own setting wins over it. */
+  showLine?: boolean;
+  /**
+   * How much of the circle an arc chart sweeps, in degrees. Less than the full
+   * 360 is what turns a doughnut into a dial.
+   */
+  circumference?: number;
+  /** Where the sweep starts, in degrees clockwise from the top. */
+  rotation?: number;
   /** Chart-wide element defaults; a dataset's own setting wins over these. */
   elements?: {
     line?: {
@@ -222,6 +262,18 @@ export interface MaidrPluginOptions {
   /** Override axis labels. */
   axes?: { x?: string; y?: string; z?: string };
   /**
+   * What the chart actually is, when Chart.js cannot say.
+   *
+   * Several figures are drawn in Chart.js as a recipe rather than as a type of
+   * their own, and a few of those are shape-identical to another recipe: a
+   * Kaplan-Meier curve is a stepped line, a dumbbell is a horizontal floating
+   * bar exactly as a one-interval gantt is, and a gauge is a part-circle
+   * doughnut exactly as a half-pie is. Where the values cannot settle it — see
+   * the value heuristics in the extractor for the cases where they can — this
+   * is the author saying so, and it wins over every heuristic.
+   */
+  traceType?: TraceType;
+  /**
    * What one unit of a gantt chart's interval axis measures — "days",
    * "sprints", "hours".
    *
@@ -232,6 +284,28 @@ export interface MaidrPluginOptions {
    * inventing one.
    */
   unit?: string;
+  /**
+   * What a dumbbell's two ends are called — "1990" and "2020", "before" and
+   * "after".
+   *
+   * A dumbbell drawn as a floating bar carries one datum per row and no name
+   * for either end, so without these a reader is told which dot they are on
+   * ("start", "end") but not which year it is — the one thing the legend gives
+   * a sighted reader for free.
+   */
+  startLabel?: string;
+  endLabel?: string;
+  /**
+   * The target a bullet chart's marker sits at, and the qualitative bands its
+   * arc is coloured in.
+   *
+   * A doughnut gauge draws neither: the target is a second arc or a needle and
+   * the bands are background colours, and Chart.js records both as styling
+   * rather than as data. They are part of the reading — "7 below target, in
+   * the 'ok' band" — so the author supplies them here or they go unannounced.
+   */
+  target?: number;
+  bands?: GaugeBand[];
   /**
    * Outline color used for the DOM highlight overlay drawn on top of the
    * canvas during MAIDR navigation. Accepts any CSS color string.

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -7,12 +7,29 @@
  */
 
 /**
+ * One end of a floating bar.
+ *
+ * A number on a linear scale; a `Date` when the bar is drawn against a time
+ * scale, which is how Chart.js's own gantt and range-bar recipes write them.
+ * ISO date *strings* are also accepted by Chart.js there and are deliberately
+ * not read here — parsing one means guessing a calendar for a value that may
+ * equally be a category label.
+ */
+export type ChartJsRangeBound = number | Date;
+
+/**
  * Union of data value shapes found in Chart.js datasets.
  * Covers native chart types and popular plugins (boxplot, financial, matrix).
  */
 export type ChartJsDataValue
   = | number
     | null
+    /**
+     * A floating bar: `[start, end]` rather than a magnitude from the
+     * baseline. Chart.js draws gantt lanes, range bars and waterfall steps
+     * this way.
+     */
+    | [ChartJsRangeBound, ChartJsRangeBound]
     | { x: number; y: number; r?: number }
     | { x: number | string; o: number; h: number; l: number; c: number }
     | {
@@ -114,6 +131,14 @@ export interface ChartJsScale {
   title?: { text?: string; display?: boolean };
   type?: string;
   stacked?: boolean;
+  /**
+   * Whether the scale runs the other way (largest value at the origin end).
+   * A rank axis is the case that matters here: a bump chart reverses y so
+   * rank 1 sits at the top.
+   */
+  reverse?: boolean;
+  /** Time-scale options; `unit` names what one step of the axis measures. */
+  time?: { unit?: string };
   /** Which axis this scale belongs to; defaults from the scale id's first letter. */
   axis?: 'x' | 'y';
   /**
@@ -196,6 +221,17 @@ export interface MaidrPluginOptions {
   title?: string;
   /** Override axis labels. */
   axes?: { x?: string; y?: string; z?: string };
+  /**
+   * What one unit of a gantt chart's interval axis measures — "days",
+   * "sprints", "hours".
+   *
+   * The length of an interval is the fact a schedule is drawn to carry, and
+   * Chart.js states the unit nowhere: a linear axis is bare numbers, and a
+   * time axis is parsed to epoch milliseconds whatever `time.unit` displays.
+   * Absent, MAIDR announces a length without naming a unit rather than
+   * inventing one.
+   */
+  unit?: string;
   /**
    * Outline color used for the DOM highlight overlay drawn on top of the
    * canvas during MAIDR navigation. Accepts any CSS color string.

--- a/test/adapters/chartjs/divergingBar.test.ts
+++ b/test/adapters/chartjs/divergingBar.test.ts
@@ -1,0 +1,96 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions } from '@adapters/chartjs/types';
+import type { MaidrLayer, SegmentedPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal stacked bar chart for the extractor to read.
+ * @param datasets The datasets the chart carries
+ * @param options Chart options; defaults to the population-pyramid recipe
+ * @returns A chart object shaped the way the extractor expects
+ */
+function barChart(
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = { indexAxis: 'y', scales: { x: { stacked: true }, y: { stacked: true } } },
+): ChartJsChart {
+  const data: ChartJsData = { labels: ['0-14', '15-64', '65+'], datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type: 'bar' },
+    getDatasetMeta: () => ({ data: [], type: 'bar' }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart): MaidrLayer[] {
+  return extractChartData(chart).maidr.subplots[0][0].layers;
+}
+
+/** The pyramid's two sides: one series negated, one not. */
+const men: ChartJsDataset = { label: 'Men', data: [-30, -50, -20] };
+const women: ChartJsDataset = { label: 'Women', data: [28, 52, 26] };
+
+describe('chart.js diverging bar detection', () => {
+  it('reads a sign-split stacked chart as a diverging bar', () => {
+    const layers = layersOf(barChart([men, women]));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.DIVERGING);
+  });
+
+  it('carries the sign through rather than normalising it', () => {
+    // The sign is the side the bar points, and the trace reads it: pitching
+    // the magnitude and announcing the side is the whole difference between
+    // this and a stacked bar.
+    const points = layersOf(barChart([men, women]))[0].data as SegmentedPoint[][];
+
+    expect(points[0][1]).toEqual({ x: -50, y: '15-64', z: 'Men' });
+    expect(points[1][1]).toEqual({ x: 52, y: '15-64', z: 'Women' });
+  });
+
+  it('leaves an all-positive stacked chart a stacked bar', () => {
+    expect(layersOf(barChart([women, { label: 'Other', data: [1, 2, 3] }]))[0].type)
+      .toBe(TraceType.STACKED);
+  });
+
+  it('leaves a series that crosses the baseline a stacked bar', () => {
+    // A stacked chart that merely contains a negative value is not two sides
+    // of anything, and naming a left and a right would invent them.
+    const mixed: ChartJsDataset = { label: 'Net', data: [-5, 10, -2] };
+
+    expect(layersOf(barChart([mixed, women]))[0].type).toBe(TraceType.STACKED);
+  });
+
+  it('leaves an unstacked sign split a dodged bar', () => {
+    // Back to back is what stacking draws; side by side is a comparison of
+    // two series that happen to be signed.
+    const chart = barChart([men, women], { indexAxis: 'y' });
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.DODGED);
+  });
+
+  it('treats zero as belonging to neither side', () => {
+    // A category a side does not reach is written as 0 on both wings.
+    const chart = barChart([
+      { label: 'Men', data: [-30, 0, -20] },
+      { label: 'Women', data: [0, 52, 26] },
+    ]);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.DIVERGING);
+  });
+
+  it('routes highlighting by MAIDR row = dataset, col = category', () => {
+    const chart = barChart([men, women]);
+    const { maidr, layerDatasetIndices } = extractChartData(chart);
+    const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 1, 2))
+      .toEqual([{ datasetIndex: 1, index: 2 }]);
+  });
+});

--- a/test/adapters/chartjs/dotPlot.test.ts
+++ b/test/adapters/chartjs/dotPlot.test.ts
@@ -1,0 +1,158 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions } from '@adapters/chartjs/types';
+import type { BarPoint, MaidrLayer } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal line chart for the extractor to read.
+ * @param labels The category labels
+ * @param datasets The datasets the chart carries
+ * @param options Chart options, for `showLine` and the scales
+ * @returns A chart object shaped the way the extractor expects
+ */
+function lineChart(
+  labels: (string | number)[],
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  const data: ChartJsData = { labels, datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type: 'line' },
+    getDatasetMeta: () => ({ data: [], type: 'line' }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart): MaidrLayer[] {
+  return extractChartData(chart).maidr.subplots[0][0].layers;
+}
+
+describe('chart.js dot plot extraction', () => {
+  it('reads a line chart drawn without its line as a dot plot', () => {
+    const chart = lineChart(
+      ['Chrome', 'Safari', 'Edge'],
+      [{ label: 'Share', data: [64, 19, 5], showLine: false }],
+    );
+
+    const layers = layersOf(chart);
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.DOT);
+    // A value per category, the shape `BarTrace` reads — not the nested rows
+    // the line path emits.
+    expect(layers[0].data as BarPoint[]).toEqual([
+      { x: 'Chrome', y: 64 },
+      { x: 'Safari', y: 19 },
+      { x: 'Edge', y: 5 },
+    ]);
+  });
+
+  it('reads the chart-wide default when the dataset does not say', () => {
+    const chart = lineChart(
+      ['A', 'B'],
+      [{ data: [1, 2] }],
+      { showLine: false },
+    );
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.DOT);
+  });
+
+  it('lets a dataset switch its line back on', () => {
+    // A dataset's own setting wins over the chart's, the way `stepped` does,
+    // and one joined series means the chart is not a dot plot.
+    const chart = lineChart(
+      ['A', 'B'],
+      [{ data: [1, 2], showLine: true }, { data: [3, 4] }],
+      { showLine: false },
+    );
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.LINE);
+  });
+
+  it('leaves an ordinary line chart a line', () => {
+    const chart = lineChart(['A', 'B'], [{ data: [1, 2] }]);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.LINE);
+  });
+
+  it('does not read unjoined points on a continuum as a dot plot', () => {
+    // Points with the line switched off along a linear axis is a scatter
+    // drawn by the line controller: two measured coordinates, not a value per
+    // named category.
+    const chart = lineChart(
+      [],
+      [{ data: [{ x: 1, y: 2 }, { x: 3, y: 4 }], showLine: false }],
+      { scales: { x: { type: 'linear' } } },
+    );
+
+    expect(layersOf(chart)[0].type).not.toBe(TraceType.DOT);
+  });
+
+  it('keeps a horizontal dot plot horizontal', () => {
+    const chart = lineChart(
+      ['Chrome', 'Safari'],
+      [{ data: [64, 19], showLine: false }],
+      { indexAxis: 'y' },
+    );
+
+    const layer = layersOf(chart)[0];
+
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 64, y: 'Chrome' },
+      { x: 19, y: 'Safari' },
+    ]);
+  });
+
+  it('gives each series its own layer', () => {
+    const chart = lineChart(
+      ['Chrome', 'Safari'],
+      [
+        { label: '2020', data: [60, 25], showLine: false },
+        { label: '2024', data: [64, 19], showLine: false },
+      ],
+    );
+
+    const layers = layersOf(chart);
+
+    expect(layers.map(layer => layer.type)).toEqual([TraceType.DOT, TraceType.DOT]);
+    expect(layers.map(layer => layer.title)).toEqual(['2020', '2024']);
+  });
+
+  it('routes each series highlight to its own dataset', () => {
+    const chart = lineChart(
+      ['Chrome', 'Safari'],
+      [
+        { label: '2020', data: [60, 25], showLine: false },
+        { label: '2024', data: [64, 19], showLine: false },
+      ],
+    );
+    const { maidr, layerDatasetIndices } = extractChartData(chart);
+    const layers = maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '1', 0, 1))
+      .toEqual([{ datasetIndex: 1, index: 1 }]);
+  });
+
+  it('keeps a highlight aligned across a gap', () => {
+    const chart = lineChart(
+      ['A', 'B', 'C'],
+      [{ data: [1, null, 3], showLine: false }],
+    );
+    const { maidr, layerDatasetIndices } = extractChartData(chart);
+    const layers = maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    // The gap is skipped in the payload, so MAIDR's second column is the
+    // chart's third element.
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 0, 1))
+      .toEqual([{ datasetIndex: 0, index: 2 }]);
+  });
+});

--- a/test/adapters/chartjs/dumbbell.test.ts
+++ b/test/adapters/chartjs/dumbbell.test.ts
@@ -103,6 +103,31 @@ describe('chart.js dumbbell extraction', () => {
     expect(data.points.map(point => point.x)).toEqual(['Japan', 'Chad']);
   });
 
+  it('reads the first dataset only, and highlights the bar it read', () => {
+    // A dumbbell is one pair per row, so a second series of intervals is a
+    // gantt rather than a second pair. What matters is that extraction and
+    // highlighting agree on which dataset that is: reading dataset 0 while
+    // highlighting dataset 1 would put the outline on a bar the reader was
+    // never told about.
+    const chart = barChart(
+      ['Japan', 'Spain'],
+      [{ data: [[79, 84], [77, 83]] }, { data: [[60, 65], [61, 66]] }],
+      horizontal,
+    );
+    const { maidr, layerDatasetIndices } = extractChartData(chart, declared);
+    const layers = maidr.subplots[0][0].layers;
+
+    expect(layers).toHaveLength(1);
+    expect((layers[0].data as DumbbellData).points).toEqual([
+      { x: 'Japan', start: 79, end: 84 },
+      { x: 'Spain', start: 77, end: 83 },
+    ]);
+
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 0, 1))
+      .toEqual([{ datasetIndex: 0, index: 1 }]);
+  });
+
   it('highlights the connector whichever end the cursor is on', () => {
     const chart = barChart(
       ['Japan', 'Spain'],

--- a/test/adapters/chartjs/dumbbell.test.ts
+++ b/test/adapters/chartjs/dumbbell.test.ts
@@ -1,0 +1,137 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions, MaidrPluginOptions } from '@adapters/chartjs/types';
+import type { DumbbellData, MaidrLayer } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal floating-bar chart for the extractor to read.
+ * @param labels The category labels — the dumbbell's rows
+ * @param datasets The datasets the chart carries
+ * @param options Chart options, for `indexAxis` and the scales
+ * @returns A chart object shaped the way the extractor expects
+ */
+function barChart(
+  labels: (string | number)[],
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  const data: ChartJsData = { labels, datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type: 'bar' },
+    getDatasetMeta: () => ({ data: [], type: 'bar' }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart, pluginOptions?: MaidrPluginOptions): MaidrLayer[] {
+  return extractChartData(chart, pluginOptions).maidr.subplots[0][0].layers;
+}
+
+/** A dumbbell drawn the ordinary way: categories down the page. */
+const horizontal: ChartJsOptions = { indexAxis: 'y' };
+
+/** The declaration that makes a floating bar chart a paired comparison. */
+const declared: MaidrPluginOptions = { traceType: TraceType.DUMBBELL };
+
+describe('chart.js dumbbell extraction', () => {
+  it('reads a declared floating bar chart as a dumbbell', () => {
+    const chart = barChart(
+      ['Japan', 'Spain', 'Chad'],
+      [{ data: [[79, 84], [77, 83], [50, 55]] }],
+      horizontal,
+    );
+
+    const layers = layersOf(chart, declared);
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.DUMBBELL);
+    expect(layers[0].orientation).toBe(Orientation.HORIZONTAL);
+    // A single object carrying the rows, not a bare array: the names of the
+    // two ends belong to the chart rather than to any one row.
+    expect((layers[0].data as DumbbellData).points).toEqual([
+      { x: 'Japan', start: 79, end: 84 },
+      { x: 'Spain', start: 77, end: 83 },
+      { x: 'Chad', start: 50, end: 55 },
+    ]);
+  });
+
+  it('stays a gantt when the page does not declare otherwise', () => {
+    // One interval per category on a horizontal axis is the figure a
+    // one-lane-per-task schedule draws, down to the datum. Reading it as a
+    // dumbbell unasked would rename every gantt in the wild.
+    const chart = barChart(['Japan', 'Spain'], [{ data: [[79, 84], [77, 83]] }], horizontal);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.GANTT);
+  });
+
+  it('names the two ends when the page says what they are', () => {
+    const chart = barChart(['Japan'], [{ data: [[79, 84]] }], horizontal);
+
+    const named = { ...declared, startLabel: '1990', endLabel: '2020' };
+    const data = layersOf(chart, named)[0].data as DumbbellData;
+
+    expect(data.startLabel).toBe('1990');
+    expect(data.endLabel).toBe('2020');
+  });
+
+  it('leaves the ends unnamed rather than guessing', () => {
+    const chart = barChart(['Japan'], [{ data: [[79, 84]] }], horizontal);
+
+    const data = layersOf(chart, declared)[0].data as DumbbellData;
+
+    expect(data.startLabel).toBeUndefined();
+    expect(data.endLabel).toBeUndefined();
+  });
+
+  it('skips a row with nothing to compare', () => {
+    // Unlike a gantt lane, an unpaired row has no comparison to announce, and
+    // the trace's grid is a plain rows-by-ends rectangle.
+    const chart = barChart(
+      ['Japan', 'Unknown', 'Chad'],
+      [{ data: [[79, 84], null, [50, 55]] }],
+      horizontal,
+    );
+
+    const data = layersOf(chart, declared)[0].data as DumbbellData;
+
+    expect(data.points.map(point => point.x)).toEqual(['Japan', 'Chad']);
+  });
+
+  it('highlights the connector whichever end the cursor is on', () => {
+    const chart = barChart(
+      ['Japan', 'Spain'],
+      [{ data: [[79, 84], [77, 83]] }],
+      horizontal,
+    );
+    const { maidr, layerDatasetIndices } = extractChartData(chart, declared);
+    const layers = maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+    const resolve = (row: number, col: number): unknown[] =>
+      resolveActiveTargets(layers, maps, layerDatasetIndices, '0', row, col);
+
+    // MAIDR row = which end of the pair; both are drawn by the one bar that
+    // connects them, so the row does not move the highlight.
+    expect(resolve(0, 1)).toEqual([{ datasetIndex: 0, index: 1 }]);
+    expect(resolve(1, 1)).toEqual([{ datasetIndex: 0, index: 1 }]);
+  });
+
+  it('keeps a highlight aligned across a skipped row', () => {
+    const chart = barChart(
+      ['Japan', 'Unknown', 'Chad'],
+      [{ data: [[79, 84], null, [50, 55]] }],
+      horizontal,
+    );
+    const { maidr, layerDatasetIndices } = extractChartData(chart, declared);
+    const layers = maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 0, 1))
+      .toEqual([{ datasetIndex: 0, index: 2 }]);
+  });
+});

--- a/test/adapters/chartjs/extractor.test.ts
+++ b/test/adapters/chartjs/extractor.test.ts
@@ -458,10 +458,10 @@ describe('chart.js extractor', () => {
     });
 
     it('still throws for unsupported chart types', () => {
-      // 'radar', not 'pie' — a pie is supported now, and a supported type here
-      // would assert nothing about the unsupported path.
+      // 'treemap', not 'radar' — a radar is supported now, and a supported
+      // type here would assert nothing about the unsupported path.
       const chart = createChart({
-        type: 'radar',
+        type: 'treemap',
         data: { datasets: [{ data: [1, 2] }] },
         options: {
           scales: { x: {}, y: { stack: 'demo' }, y2: { stack: 'demo' } },

--- a/test/adapters/chartjs/floatingBar.test.ts
+++ b/test/adapters/chartjs/floatingBar.test.ts
@@ -1,0 +1,269 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions } from '@adapters/chartjs/types';
+import type { GanttData, MaidrLayer, WaterfallPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal floating-bar chart for the extractor to read.
+ * @param labels The category labels — the lanes, or the waterfall's steps
+ * @param datasets The datasets the chart carries
+ * @param options Chart options, for `indexAxis` and the scales
+ * @returns A chart object shaped the way the extractor expects
+ */
+function barChart(
+  labels: (string | number)[],
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  const data: ChartJsData = { labels, datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type: 'bar' },
+    getDatasetMeta: () => ({ data: [], type: 'bar' }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart): MaidrLayer[] {
+  return extractChartData(chart).maidr.subplots[0][0].layers;
+}
+
+/** Resolve a MAIDR navigation position the way the plugin's nav bridge does. */
+function resolverFor(chart: ChartJsChart): (row: number, col: number) => unknown[] {
+  const { maidr, layerDatasetIndices } = extractChartData(chart);
+  const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+  const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+  return (row, col) =>
+    resolveActiveTargets(layers, maps, layerDatasetIndices, '0', row, col);
+}
+
+/** A horizontal schedule: lanes on the category axis, intervals along x. */
+const horizontal: ChartJsOptions = { indexAxis: 'y' };
+
+describe('chart.js floating bar extraction', () => {
+  describe('gantt', () => {
+    it('reads a horizontal floating bar chart as a gantt', () => {
+      const chart = barChart(
+        ['Design', 'Build', 'Ship'],
+        [{ label: 'Phase', data: [[0, 5], [5, 12], [12, 14]] }],
+        horizontal,
+      );
+
+      const layers = layersOf(chart);
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.GANTT);
+      expect(layers[0].orientation).toBe(Orientation.HORIZONTAL);
+      const data = layers[0].data as GanttData;
+      expect(data.points).toEqual([
+        [{ x: 'Design', start: 0, end: 5 }],
+        [{ x: 'Build', start: 5, end: 12 }],
+        [{ x: 'Ship', start: 12, end: 14 }],
+      ]);
+    });
+
+    it('used to lose every point of a floating bar chart', () => {
+      // Regression: an array entry is neither a number nor a `{y}` object, so
+      // before floating bars were read the chart extracted as a BAR layer
+      // holding no points at all — silently.
+      const layer = layersOf(barChart(['A'], [{ data: [[1, 2]] }], horizontal))[0];
+
+      expect(layer.type).not.toBe(TraceType.BAR);
+      expect((layer.data as GanttData).points.flat()).toHaveLength(1);
+    });
+
+    it('gathers a second dataset as a second interval in the same lane', () => {
+      const chart = barChart(
+        ['Alice', 'Bob'],
+        [
+          { label: 'Morning', data: [[9, 11], [9, 10]] },
+          { label: 'Afternoon', data: [[14, 17], [13, 15]] },
+        ],
+        horizontal,
+      );
+
+      const data = layersOf(chart)[0].data as GanttData;
+
+      expect(data.points[0]).toEqual([
+        { x: 'Alice', start: 9, end: 11, label: 'Morning' },
+        { x: 'Alice', start: 14, end: 17, label: 'Afternoon' },
+      ]);
+    });
+
+    it('keeps an empty lane as a row and names it', () => {
+      // The nested shape exists precisely so a lane with nothing booked is a
+      // row a reader can navigate onto and be told about.
+      const chart = barChart(
+        ['Design', 'Idle', 'Ship'],
+        [{ data: [[0, 5], null, [12, 14]] }],
+        horizontal,
+      );
+
+      const data = layersOf(chart)[0].data as GanttData;
+
+      expect(data.points).toHaveLength(3);
+      expect(data.points[1]).toEqual([]);
+      expect(data.lanes).toEqual(['Design', 'Idle', 'Ship']);
+    });
+
+    it('reads Date bounds as the instants the time scale plots them at', () => {
+      const start = new Date('2024-01-01T00:00:00Z');
+      const end = new Date('2024-01-08T00:00:00Z');
+      const chart = barChart(['Design'], [{ data: [[start, end]] }], {
+        indexAxis: 'y',
+        scales: { x: { type: 'time', time: { unit: 'day' } } },
+      });
+
+      const layer = layersOf(chart)[0];
+      const data = layer.data as GanttData;
+
+      expect(data.points[0][0]).toEqual({
+        x: 'Design',
+        start: start.valueOf(),
+        end: end.valueOf(),
+      });
+      // Epoch milliseconds are what the bounds actually are, and what the
+      // announced length is measured in — `time.unit` only says how the axis
+      // is labelled.
+      expect(data.unit).toBe('milliseconds');
+      expect(layer.axes?.x?.format).toEqual({ type: 'date' });
+    });
+
+    it('names no unit on a plain linear axis', () => {
+      const chart = barChart(['Design'], [{ data: [[0, 5]] }], horizontal);
+
+      expect((layersOf(chart)[0].data as GanttData).unit).toBeUndefined();
+    });
+
+    it('lets the plugin name what the axis measures', () => {
+      const chart = barChart(['Design'], [{ data: [[0, 5]] }], horizontal);
+
+      const layers = extractChartData(chart, { unit: 'sprints' })
+        .maidr
+        .subplots[0][0]
+        .layers;
+
+      expect((layers[0].data as GanttData).unit).toBe('sprints');
+    });
+
+    it('reads a vertical range bar chart as a gantt too', () => {
+      // Intervals along the value axis with one lane per category is what a
+      // gantt is, whichever way round the chart is drawn.
+      const chart = barChart(['Mon', 'Tue'], [{ data: [[3, 9], [5, 11]] }]);
+
+      const layer = layersOf(chart)[0];
+
+      expect(layer.type).toBe(TraceType.GANTT);
+      expect(layer.orientation).toBeUndefined();
+    });
+  });
+
+  describe('waterfall', () => {
+    it('reads chained floating bars as a waterfall', () => {
+      const chart = barChart(
+        ['Open', 'Sales', 'Costs', 'Close'],
+        [{ data: [[0, 100], [100, 150], [150, 120], [0, 120]] }],
+      );
+
+      const layers = layersOf(chart);
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.WATERFALL);
+      expect(layers[0].data as WaterfallPoint[]).toEqual([
+        { x: 'Open', start: 0, end: 100, delta: 100, kind: 'total' },
+        { x: 'Sales', start: 100, end: 150, delta: 50, kind: 'increase' },
+        { x: 'Costs', start: 150, end: 120, delta: -30, kind: 'decrease' },
+        { x: 'Close', start: 0, end: 120, delta: 120, kind: 'total' },
+      ]);
+    });
+
+    it('reads a subtotal drawn mid-chart as a total', () => {
+      const chart = barChart(
+        ['Open', 'Sales', 'Subtotal', 'Costs'],
+        [{ data: [[0, 100], [100, 150], [0, 150], [150, 130]] }],
+      );
+
+      const points = layersOf(chart)[0].data as WaterfallPoint[];
+
+      expect(points.map(point => point.kind))
+        .toEqual(['total', 'increase', 'total', 'decrease']);
+    });
+
+    it('does not read unchained intervals as a waterfall', () => {
+      // A schedule whose tasks happen to sit on one axis is not a running
+      // total, and announcing a contribution the chart never made is the
+      // failure this guard exists to prevent.
+      const chart = barChart(['A', 'B'], [{ data: [[1, 3], [7, 9]] }]);
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.GANTT);
+    });
+
+    it('does not read a horizontal chart as a waterfall', () => {
+      const chart = barChart(
+        ['Open', 'Sales'],
+        [{ data: [[0, 100], [100, 150]] }],
+        horizontal,
+      );
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.GANTT);
+    });
+
+    it('does not read several chained series as one waterfall', () => {
+      // A waterfall carries one running total; two series are two schedules.
+      const chart = barChart(['A', 'B'], [
+        { label: 'One', data: [[0, 10], [10, 20]] },
+        { label: 'Two', data: [[0, 5], [5, 8]] },
+      ]);
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.GANTT);
+    });
+  });
+
+  describe('highlighting', () => {
+    it('maps a gantt lane and interval onto the dataset that booked it', () => {
+      const chart = barChart(
+        ['Alice', 'Bob'],
+        [
+          { label: 'Morning', data: [[9, 11], [9, 10]] },
+          { label: 'Afternoon', data: [[14, 17], [13, 15]] },
+        ],
+        horizontal,
+      );
+
+      const resolve = resolverFor(chart);
+
+      // MAIDR row = lane (Chart.js element index), col = which dataset.
+      expect(resolve(0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
+      expect(resolve(0, 1)).toEqual([{ datasetIndex: 1, index: 0 }]);
+      expect(resolve(1, 1)).toEqual([{ datasetIndex: 1, index: 1 }]);
+    });
+
+    it('highlights nothing on an empty lane', () => {
+      const chart = barChart(
+        ['Design', 'Idle'],
+        [{ data: [[0, 5], null] }],
+        horizontal,
+      );
+
+      const resolve = resolverFor(chart);
+
+      expect(resolve(1, 0)).toEqual([]);
+    });
+
+    it('maps a waterfall step to its bar', () => {
+      const chart = barChart(
+        ['Open', 'Sales', 'Costs'],
+        [{ data: [[0, 100], [100, 150], [150, 120]] }],
+      );
+
+      const resolve = resolverFor(chart);
+
+      expect(resolve(0, 2)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    });
+  });
+});

--- a/test/adapters/chartjs/gauge.test.ts
+++ b/test/adapters/chartjs/gauge.test.ts
@@ -1,0 +1,129 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions } from '@adapters/chartjs/types';
+import type { GaugePoint, MaidrLayer, PiePoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal arc chart for the extractor to read.
+ * @param labels The slice labels — on a dial, the measure's name
+ * @param datasets The datasets the chart carries
+ * @param options Chart options, for the sweep geometry
+ * @returns A chart object shaped the way the extractor expects
+ */
+function doughnut(
+  labels: (string | number)[],
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  const data: ChartJsData = { labels, datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type: 'doughnut' },
+    getDatasetMeta: () => ({ data: [], type: 'doughnut' }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart, pluginOptions?: Parameters<typeof extractChartData>[1]): MaidrLayer[] {
+  return extractChartData(chart, pluginOptions).maidr.subplots[0][0].layers;
+}
+
+/** The half-circle sweep the doughnut-gauge recipe is drawn with. */
+const dial: ChartJsOptions = { circumference: 180, rotation: 270 };
+
+describe('chart.js gauge extraction', () => {
+  it('reads a part-circle two-value doughnut as a gauge', () => {
+    const chart = doughnut(['CPU'], [{ data: [73, 27] }], dial);
+
+    const layers = layersOf(chart);
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.GAUGE);
+    // A single object, not an array: the chart draws one measure.
+    expect(layers[0].data as GaugePoint).toEqual({
+      value: 73,
+      min: 0,
+      max: 100,
+      label: 'CPU',
+    });
+  });
+
+  it('spends the remainder on the dial rather than announcing it', () => {
+    // The second arc is drawn empty to leave the ring unfilled, so reading it
+    // as a slice would announce a measure the chart does not have.
+    const point = layersOf(doughnut(['Used'], [{ data: [30, 70] }], dial))[0].data as GaugePoint;
+
+    expect(point.value).toBe(30);
+    expect(point.max).toBe(100);
+  });
+
+  it('leaves a full-circle doughnut a pie', () => {
+    const chart = doughnut(['Yes', 'No'], [{ data: [73, 27] }]);
+
+    const layer = layersOf(chart)[0];
+
+    expect(layer.type).toBe(TraceType.PIE);
+    expect(layer.data as PiePoint[]).toHaveLength(2);
+  });
+
+  it('leaves a part-circle pie of several slices alone', () => {
+    const chart = doughnut(['A', 'B', 'C'], [{ data: [10, 20, 30] }], dial);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.PIE);
+  });
+
+  it('lets the page declare a dial the geometry does not show', () => {
+    const chart = doughnut(['Score'], [{ data: [8, 2] }]);
+
+    const layer = layersOf(chart, { traceType: TraceType.GAUGE })[0];
+
+    expect(layer.type).toBe(TraceType.GAUGE);
+    expect((layer.data as GaugePoint).max).toBe(10);
+  });
+
+  it('lets the page keep two slices two slices', () => {
+    // A half-pie of exactly two slices is drawn identically to a dial, so the
+    // declaration has to work in both directions.
+    const chart = doughnut(['Yes', 'No'], [{ data: [73, 27] }], dial);
+
+    expect(layersOf(chart, { traceType: TraceType.PIE })[0].type).toBe(TraceType.PIE);
+  });
+
+  it('carries the target and bands the chart draws as styling', () => {
+    const chart = doughnut(['CPU'], [{ data: [73, 27] }], dial);
+
+    const point = layersOf(chart, {
+      target: 80,
+      bands: [{ to: 50, label: 'idle' }, { to: 90, label: 'ok' }],
+    })[0].data as GaugePoint;
+
+    expect(point.target).toBe(80);
+    expect(point.bands).toEqual([{ to: 50, label: 'idle' }, { to: 90, label: 'ok' }]);
+  });
+
+  it('names what the dial measures', () => {
+    const layer = layersOf(doughnut(['CPU'], [{ data: [73, 27] }], dial))[0];
+
+    // A dial has no scales, so the fallback would announce an axis it does
+    // not have.
+    expect(layer.axes?.x?.label).toBe('Measure');
+    expect(layer.axes?.y?.label).toBe('Value');
+  });
+
+  it('highlights the arc the measure is drawn as', () => {
+    const chart = doughnut(['CPU'], [{ data: [73, 27] }], dial);
+    const { maidr, layerDatasetIndices } = extractChartData(chart);
+    const layers = maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    // The gauge is one position, and it is the ring's first arc — never the
+    // remainder drawn beside it.
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 0, 0))
+      .toEqual([{ datasetIndex: 0, index: 0 }]);
+  });
+});

--- a/test/adapters/chartjs/lineVariants.test.ts
+++ b/test/adapters/chartjs/lineVariants.test.ts
@@ -1,0 +1,186 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions } from '@adapters/chartjs/types';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal line chart for the extractor to read.
+ * @param datasets The datasets the chart carries
+ * @param options Chart options, for scale stacking and reversal
+ * @returns A chart object shaped the way the extractor expects
+ */
+function lineChart(
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  const data: ChartJsData = { labels: ['Q1', 'Q2', 'Q3', 'Q4'], datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type: 'line' },
+    getDatasetMeta: () => ({ data: [], type: 'line' }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart): MaidrLayer[] {
+  return extractChartData(chart).maidr.subplots[0][0].layers;
+}
+
+const stackedScales: ChartJsOptions = { scales: { x: {}, y: { stacked: true } } };
+const rankScales: ChartJsOptions = { scales: { x: {}, y: { reverse: true } } };
+
+/** A filled band, which is what a stacked area chart is made of. */
+function band(label: string, data: number[]): ChartJsDataset {
+  return { label, data, fill: 'origin' };
+}
+
+describe('chart.js normalized area detection', () => {
+  it('reads bands whose categories all total 100 as a normalized area', () => {
+    const chart = lineChart([
+      band('Mobile', [60, 55, 50, 45]),
+      band('Desktop', [40, 45, 50, 55]),
+    ], stackedScales);
+
+    const layers = layersOf(chart);
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.NORMALIZED_AREA);
+    // The payload is a stacked area's; only the reading changes.
+    expect(layers[0].data).toHaveLength(2);
+  });
+
+  it('reads unit shares the same way', () => {
+    const chart = lineChart([
+      band('Mobile', [0.6, 0.55, 0.5, 0.45]),
+      band('Desktop', [0.4, 0.45, 0.5, 0.55]),
+    ], stackedScales);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.NORMALIZED_AREA);
+  });
+
+  it('tolerates shares rounded for display', () => {
+    // Percentages rounded to whole numbers routinely miss 100 by a fraction,
+    // and a chart is not less normalized for having been rounded.
+    const chart = lineChart([
+      band('Mobile', [60, 55, 50, 45]),
+      band('Desktop', [40, 45, 50, 55.2]),
+    ], stackedScales);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.NORMALIZED_AREA);
+  });
+
+  it('leaves bands with varying totals a stacked area', () => {
+    const chart = lineChart([
+      band('Mobile', [60, 55, 50, 45]),
+      band('Desktop', [40, 60, 80, 100]),
+    ], stackedScales);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.STACKED_AREA);
+  });
+
+  it('leaves a single band a stacked area even at a constant 100', () => {
+    // One band is not a share of anything.
+    const chart = lineChart([band('Only', [100, 100, 100, 100])], stackedScales);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.STACKED_AREA);
+  });
+
+  it('leaves unstacked bands an area', () => {
+    const chart = lineChart([
+      band('Mobile', [60, 55, 50, 45]),
+      band('Desktop', [40, 45, 50, 55]),
+    ]);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.AREA);
+  });
+
+  it('routes a normalized band row to its own dataset', () => {
+    const chart = lineChart([
+      band('Mobile', [60, 55, 50, 45]),
+      band('Desktop', [40, 45, 50, 55]),
+    ], stackedScales);
+    const { maidr, layerDatasetIndices } = extractChartData(chart);
+    const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 1, 3))
+      .toEqual([{ datasetIndex: 1, index: 3 }]);
+  });
+});
+
+describe('chart.js bump chart detection', () => {
+  /** Three competitors, each period a permutation of 1..3. */
+  const table: ChartJsDataset[] = [
+    { label: 'Arsenal', data: [1, 2, 2, 1] },
+    { label: 'Chelsea', data: [2, 1, 3, 3] },
+    { label: 'Spurs', data: [3, 3, 1, 2] },
+  ];
+
+  it('reads a reversed rank axis with permuted values as a bump chart', () => {
+    const layers = layersOf(lineChart(table, rankScales));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.BUMP);
+    // A multi-line payload, unchanged: the ranks are the y values.
+    const points = layers[0].data as LinePoint[][];
+    expect(points).toHaveLength(3);
+    expect(points[2][2]).toEqual({ x: 'Q3', y: 1, z: 'Spurs' });
+  });
+
+  it('leaves a reversed axis alone when the values are not ranks', () => {
+    // A reversed axis is common enough on its own; the permutation test is
+    // what makes the reading safe.
+    const chart = lineChart([
+      { label: 'A', data: [10, 20, 30, 40] },
+      { label: 'B', data: [15, 25, 35, 45] },
+    ], rankScales);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.LINE);
+  });
+
+  it('leaves ranks on an un-reversed axis a line', () => {
+    // Without the reversal the chart draws rank 1 at the bottom, which is not
+    // a bump chart however the numbers look.
+    expect(layersOf(lineChart(table))[0].type).toBe(TraceType.LINE);
+  });
+
+  it('rejects a period where two competitors hold the same rank', () => {
+    const tied: ChartJsDataset[] = [
+      { label: 'A', data: [1, 1, 1, 1] },
+      { label: 'B', data: [1, 2, 2, 2] },
+      { label: 'C', data: [3, 3, 3, 3] },
+    ];
+
+    expect(layersOf(lineChart(tied, rankScales))[0].type).toBe(TraceType.LINE);
+  });
+
+  it('rejects ranks outside the field of competitors', () => {
+    const chart = lineChart([
+      { label: 'A', data: [1, 1, 1, 1] },
+      { label: 'B', data: [5, 5, 5, 5] },
+    ], rankScales);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.LINE);
+  });
+
+  it('leaves a single reversed series a line', () => {
+    const chart = lineChart([{ label: 'Solo', data: [1, 1, 1, 1] }], rankScales);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.LINE);
+  });
+
+  it('routes a competitor row to its own dataset', () => {
+    const chart = lineChart(table, rankScales);
+    const { maidr, layerDatasetIndices } = extractChartData(chart);
+    const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 2, 1))
+      .toEqual([{ datasetIndex: 2, index: 1 }]);
+  });
+});

--- a/test/adapters/chartjs/radar.test.ts
+++ b/test/adapters/chartjs/radar.test.ts
@@ -1,0 +1,156 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions } from '@adapters/chartjs/types';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal radar-family chart for the extractor to read.
+ * @param type The Chart.js controller name — 'radar' or 'polarArea'
+ * @param datasets The datasets the chart carries
+ * @param options Chart options, for the radial scale and plugin overrides
+ * @returns A chart object shaped the way the extractor expects
+ */
+function radarChart(
+  type: string,
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  const data: ChartJsData = { labels: ['Speed', 'Power', 'Range'], datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type },
+    getDatasetMeta: () => ({ data: [], type }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart): MaidrLayer[] {
+  return extractChartData(chart).maidr.subplots[0][0].layers;
+}
+
+/** Resolve a MAIDR navigation position the way the plugin's nav bridge does. */
+function resolverFor(chart: ChartJsChart): (row: number, col: number) => unknown[] {
+  const { maidr, layerDatasetIndices } = extractChartData(chart);
+  const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+  const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+  return (row, col) =>
+    resolveActiveTargets(layers, maps, layerDatasetIndices, '0', row, col);
+}
+
+describe('chart.js radar and polar area extraction', () => {
+  it('reads a radar as one layer with a row per series and a column per spoke', () => {
+    const layers = layersOf(radarChart('radar', [
+      { label: 'Model A', data: [10, 20, 30] },
+      { label: 'Model B', data: [15, 5, 25] },
+    ]));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.RADAR);
+    const points = layers[0].data as LinePoint[][];
+    expect(points).toHaveLength(2);
+    expect(points[0]).toEqual([
+      { x: 'Speed', y: 10, z: 'Model A' },
+      { x: 'Power', y: 20, z: 'Model A' },
+      { x: 'Range', y: 30, z: 'Model A' },
+    ]);
+    expect(points[1][1]).toEqual({ x: 'Power', y: 5, z: 'Model B' });
+  });
+
+  it('reads a polar area as its own type on the same payload', () => {
+    // POLAR_AREA and RADAR share a trace: the two differ in the mark, not in
+    // what a reader navigates, so only the declared type changes.
+    const layers = layersOf(radarChart('polarArea', [{ label: 'Share', data: [1, 2, 3] }]));
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.POLAR_AREA);
+    expect(layers[0].data).toHaveLength(1);
+  });
+
+  it('keeps a filled radar dataset a radar', () => {
+    // A radar dataset is very commonly `fill: true`; routing it through the
+    // line extractor would bucket it as an area band instead.
+    expect(layersOf(radarChart('radar', [{ label: 'Model A', data: [1, 2, 3], fill: true }]))[0].type)
+      .toBe(TraceType.RADAR);
+  });
+
+  it('names the positions rather than announcing absent x and y axes', () => {
+    // A radar has no x or y scale, so the extractor's `'X'`/`'Y'` fallback
+    // would name axes the chart does not have.
+    const axes = layersOf(radarChart('radar', [{ data: [1, 2, 3] }]))[0].axes;
+
+    expect(axes?.x?.label).toBe('Category');
+    expect(axes?.y?.label).toBe('Value');
+  });
+
+  it('reads the value axis label off the radial scale', () => {
+    const chart = radarChart('radar', [{ data: [1, 2, 3] }], {
+      scales: { r: { title: { text: 'Score' } } },
+    });
+
+    expect(layersOf(chart)[0].axes?.y?.label).toBe('Score');
+  });
+
+  it('lets the plugin axes override the radial title', () => {
+    const chart = radarChart('radar', [{ data: [1, 2, 3] }], {
+      scales: { r: { title: { text: 'Score' } } },
+    });
+
+    const layers = extractChartData(chart, { axes: { x: 'Attribute', y: 'Rating' } })
+      .maidr
+      .subplots[0][0]
+      .layers;
+
+    expect(layers[0].axes?.x?.label).toBe('Attribute');
+    expect(layers[0].axes?.y?.label).toBe('Rating');
+  });
+
+  it('skips gap markers rather than sonifying them as zeros', () => {
+    const points = layersOf(radarChart('radar', [{ label: 'A', data: [10, null, 30] }]))[0]
+      .data as LinePoint[][];
+
+    expect(points[0]).toHaveLength(2);
+    expect(points[0][1]).toEqual({ x: 'Range', y: 30, z: 'A' });
+  });
+
+  it('falls back to a positional series name when a dataset has no label', () => {
+    const points = layersOf(radarChart('radar', [{ data: [1, 2, 3] }]))[0].data as LinePoint[][];
+
+    expect(points[0][0].z).toBe('Series 1');
+  });
+
+  describe('highlighting', () => {
+    it('routes each series row to its own dataset', () => {
+      const chart = radarChart('radar', [
+        { label: 'Model A', data: [10, 20, 30] },
+        { label: 'Model B', data: [15, 5, 25] },
+      ]);
+
+      const resolve = resolverFor(chart);
+
+      expect(resolve(1, 2)).toEqual([{ datasetIndex: 1, index: 2 }]);
+    });
+
+    it('maps a column back past a skipped gap', () => {
+      const chart = radarChart('radar', [{ label: 'A', data: [10, null, 30] }]);
+
+      const resolve = resolverFor(chart);
+
+      // Column 1 is the second spoke that survived extraction, which Chart.js
+      // still draws at element index 2.
+      expect(resolve(0, 1)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    });
+
+    it('highlights a polar area wedge by slice index', () => {
+      const chart = radarChart('polarArea', [{ label: 'Share', data: [1, 2, 3] }]);
+
+      const resolve = resolverFor(chart);
+
+      expect(resolve(0, 2)).toEqual([{ datasetIndex: 0, index: 2 }]);
+    });
+  });
+});

--- a/test/adapters/chartjs/survival.test.ts
+++ b/test/adapters/chartjs/survival.test.ts
@@ -1,0 +1,138 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions, MaidrPluginOptions } from '@adapters/chartjs/types';
+import type { MaidrLayer, SurvivalPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal line chart for the extractor to read.
+ * @param datasets The datasets the chart carries
+ * @param options Chart options, for the scales
+ * @param labels The category labels, when the curve is drawn against them
+ * @returns A chart object shaped the way the extractor expects
+ */
+function lineChart(
+  datasets: ChartJsDataset[],
+  options: ChartJsOptions = {},
+  labels: (string | number)[] = [],
+): ChartJsChart {
+  const data: ChartJsData = { labels, datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type: 'line' },
+    getDatasetMeta: () => ({ data: [], type: 'line' }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart, pluginOptions?: MaidrPluginOptions): MaidrLayer[] {
+  return extractChartData(chart, pluginOptions).maidr.subplots[0][0].layers;
+}
+
+/** The declaration that makes a staircase a Kaplan-Meier curve. */
+const declared: MaidrPluginOptions = { traceType: TraceType.SURVIVAL };
+
+/** A curve plotted against elapsed time, as Chart.js draws one. */
+const timeAxis: ChartJsOptions = { scales: { x: { type: 'linear' } } };
+
+describe('chart.js survival extraction', () => {
+  it('reads a declared stepped line as a survival curve', () => {
+    const chart = lineChart([{
+      label: 'Treatment',
+      data: [{ x: 0, y: 1 }, { x: 6, y: 0.82 }, { x: 12, y: 0.61 }],
+      stepped: 'after',
+    }], timeAxis);
+
+    const layers = layersOf(chart, declared);
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.SURVIVAL);
+    // 'after' jumps at the current x and holds the new value across.
+    expect(layers[0].stepDirection).toBe('vh');
+    expect(layers[0].data as SurvivalPoint[][]).toEqual([[
+      { x: 0, y: 1, z: 'Treatment' },
+      { x: 6, y: 0.82, z: 'Treatment' },
+      { x: 12, y: 0.61, z: 'Treatment' },
+    ]]);
+  });
+
+  it('stays a step chart when the page does not declare otherwise', () => {
+    // Nothing in a Chart.js config tells a survival curve from any other
+    // staircase, so the automatic reading is the one it can defend.
+    const chart = lineChart([{ data: [1, 0.8, 0.6], stepped: 'after' }]);
+
+    expect(layersOf(chart)[0].type).toBe(TraceType.STEP);
+  });
+
+  it('reads the censoring marks the page rides on its points', () => {
+    // Chart.js ignores properties it does not know, so a censored time is
+    // written on the datum itself and arrives intact.
+    const chart = lineChart([{
+      data: [
+        { x: 0, y: 1 },
+        { x: 4, y: 0.9, censored: true },
+        { x: 9, y: 0.7 },
+      ],
+      stepped: 'after',
+    }], timeAxis);
+
+    const arms = layersOf(chart, declared)[0].data as SurvivalPoint[][];
+
+    expect(arms[0].map(point => point.censored)).toEqual([undefined, true, undefined]);
+  });
+
+  it('reads a confidence band written on the points', () => {
+    const chart = lineChart([{
+      data: [{ x: 0, y: 1, yMin: 1, yMax: 1 }, { x: 6, y: 0.8, yMin: 0.7, yMax: 0.9 }],
+      stepped: 'after',
+    }], timeAxis);
+
+    const arms = layersOf(chart, declared)[0].data as SurvivalPoint[][];
+
+    expect(arms[0][1]).toEqual({ x: 6, y: 0.8, z: 'Arm 1', yMin: 0.7, yMax: 0.9 });
+  });
+
+  it('gathers every arm into one layer', () => {
+    // The arms of a survival figure belong together whatever each dataset
+    // declares — they are the comparison the chart is drawn to make.
+    const chart = lineChart([
+      { label: 'Treatment', data: [{ x: 0, y: 1 }, { x: 6, y: 0.9 }], stepped: 'after' },
+      { label: 'Control', data: [{ x: 0, y: 1 }, { x: 6, y: 0.7 }] },
+    ], timeAxis);
+
+    const layers = layersOf(chart, declared);
+
+    expect(layers).toHaveLength(1);
+    expect((layers[0].data as SurvivalPoint[][])).toHaveLength(2);
+  });
+
+  it('reads a curve drawn against category labels', () => {
+    const chart = lineChart(
+      [{ label: 'Arm A', data: [1, 0.8], stepped: 'after' }],
+      {},
+      ['0', '6'],
+    );
+
+    const arms = layersOf(chart, declared)[0].data as SurvivalPoint[][];
+
+    expect(arms[0].map(point => point.x)).toEqual(['0', '6']);
+  });
+
+  it('maps an arm and a time onto the point drawing it', () => {
+    const chart = lineChart([
+      { label: 'Treatment', data: [{ x: 0, y: 1 }, { x: 6, y: 0.9 }], stepped: 'after' },
+      { label: 'Control', data: [{ x: 0, y: 1 }, { x: 6, y: 0.7 }], stepped: 'after' },
+    ], timeAxis);
+    const { maidr, layerDatasetIndices } = extractChartData(chart, declared);
+    const layers = maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+
+    // One row per arm, one column per time along it.
+    expect(resolveActiveTargets(layers, maps, layerDatasetIndices, '0', 1, 1))
+      .toEqual([{ datasetIndex: 1, index: 1 }]);
+  });
+});

--- a/test/adapters/chartjs/traceConstruction.test.ts
+++ b/test/adapters/chartjs/traceConstruction.test.ts
@@ -1,4 +1,4 @@
-import type { ChartJsChart, ChartJsData, ChartJsOptions } from '@adapters/chartjs/types';
+import type { ChartJsChart, ChartJsData, ChartJsOptions, MaidrPluginOptions } from '@adapters/chartjs/types';
 import type { TraceState } from '@type/state';
 import { extractChartData } from '@adapters/chartjs/extractor';
 import { TraceFactory } from '@model/factory';
@@ -29,8 +29,13 @@ function createChart(
 }
 
 /** The state the chart's single layer announces at the given position. */
-function stateAt(chart: ChartJsChart, row: number, col: number): TraceState {
-  const layer = extractChartData(chart).maidr.subplots[0][0].layers[0];
+function stateAt(
+  chart: ChartJsChart,
+  row: number,
+  col: number,
+  pluginOptions?: MaidrPluginOptions,
+): TraceState {
+  const layer = extractChartData(chart, pluginOptions).maidr.subplots[0][0].layers[0];
   return TraceFactory.create(layer).getStateAt(row, col);
 }
 
@@ -167,5 +172,89 @@ describe('chart.js payloads the core can build a trace from', () => {
     // Rank 1 is the best position, so the pitch is handed over inverted.
     expect(state.audio.freq.raw).toBe(1);
     expect(state.audio.freq.min).toBeGreaterThan(state.audio.freq.max);
+  });
+
+  it('builds a gauge trace', () => {
+    const chart = createChart('doughnut', {
+      labels: ['CPU'],
+      datasets: [{ data: [73, 27] }],
+    }, { circumference: 180, rotation: 270 });
+
+    const state = stateAt(chart, 0, 0, { target: 80 });
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.GAUGE);
+    // The dial, not the number: the pitch is where the needle sits on it.
+    expect(state.audio.freq.min).toBe(0);
+    expect(state.audio.freq.max).toBe(100);
+    expect(state.text.z).toEqual({ label: 'Range', value: '0 to 100' });
+    expect(state.text.stack).toEqual({ label: 'Target', value: 80 });
+  });
+
+  it('builds a dot plot trace', () => {
+    const chart = createChart('line', {
+      labels: ['Chrome', 'Safari', 'Edge'],
+      datasets: [{ label: 'Share', data: [64, 19, 5], showLine: false }],
+    });
+
+    const state = stateAt(chart, 0, 1);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.DOT);
+    expect(state.text.main.value).toBe('Safari');
+    expect(state.text.cross.value).toBe(19);
+  });
+
+  it('builds a dumbbell trace', () => {
+    const chart = createChart('bar', {
+      labels: ['Japan', 'Spain'],
+      datasets: [{ data: [[79, 84], [77, 83]] }],
+    }, { indexAxis: 'y' });
+
+    const declared: MaidrPluginOptions = {
+      traceType: TraceType.DUMBBELL,
+      startLabel: '1990',
+      endLabel: '2020',
+    };
+    const state = stateAt(chart, 1, 0, declared);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.DUMBBELL);
+    // Which dot the cursor is on, in the chart's own words — and the gap,
+    // which is the finding the reader cannot recover one end at a time.
+    expect(state.text.section).toBe('2020');
+    expect(state.text.stack).toEqual({ label: 'Increase', value: 5 });
+  });
+
+  it('builds a survival trace', () => {
+    const chart = createChart('line', {
+      datasets: [{
+        label: 'Treatment',
+        data: [
+          { x: 0, y: 1 },
+          { x: 4, y: 0.9, censored: true },
+          { x: 9, y: 0.7 },
+        ],
+        stepped: 'after',
+      }],
+    }, { scales: { x: { type: 'linear' } } });
+
+    const state = stateAt(chart, 0, 1, { traceType: TraceType.SURVIVAL });
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    // A survival curve is a step chart, but it is not *a* step chart to a
+    // reader, and the type is one of the few places they learn what it is.
+    expect(state.plotType).toBe('survival');
+    // The curve does not step at a censored time, so nothing else in the
+    // announcement distinguishes it from the time before.
+    expect(state.text.section).toBe('censored');
   });
 });

--- a/test/adapters/chartjs/traceConstruction.test.ts
+++ b/test/adapters/chartjs/traceConstruction.test.ts
@@ -1,0 +1,171 @@
+import type { ChartJsChart, ChartJsData, ChartJsOptions } from '@adapters/chartjs/types';
+import type { TraceState } from '@type/state';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A trace type is only reached if the core can build a trace from what the
+ * adapter emitted, and a payload of the wrong shape fails there rather than in
+ * extraction — at the moment a reader opens the chart. These build the trace
+ * the factory builds and read the state a first arrow key would announce,
+ * which is what exercises the audio, braille and text channels.
+ */
+
+function createChart(
+  type: string,
+  data: ChartJsData,
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type },
+    getDatasetMeta: () => ({ data: [], type }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The state the chart's single layer announces at the given position. */
+function stateAt(chart: ChartJsChart, row: number, col: number): TraceState {
+  const layer = extractChartData(chart).maidr.subplots[0][0].layers[0];
+  return TraceFactory.create(layer).getStateAt(row, col);
+}
+
+describe('chart.js payloads the core can build a trace from', () => {
+  it('builds a radar trace', () => {
+    const chart = createChart('radar', {
+      labels: ['Speed', 'Power', 'Range'],
+      datasets: [
+        { label: 'A', data: [10, 20, 30] },
+        { label: 'B', data: [15, 5, 25] },
+      ],
+    });
+
+    const state = stateAt(chart, 1, 2);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.RADAR);
+    expect(state.text.main).toEqual({ label: 'Category', value: 'Range' });
+    expect(state.text.cross).toEqual({ label: 'Value', value: 25 });
+  });
+
+  it('builds a polar area trace', () => {
+    const chart = createChart('polarArea', {
+      labels: ['Speed', 'Power', 'Range'],
+      datasets: [{ label: 'Share', data: [10, 20, 30] }],
+    });
+
+    const state = stateAt(chart, 0, 1);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.POLAR_AREA);
+    expect(state.text.cross.value).toBe(20);
+  });
+
+  it('builds a gantt trace, empty lane and all', () => {
+    const chart = createChart('bar', {
+      labels: ['Design', 'Idle', 'Ship'],
+      datasets: [{ label: 'Phase', data: [[0, 5], null, [12, 14]] }],
+    }, { indexAxis: 'y' });
+
+    const state = stateAt(chart, 2, 0);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.GANTT);
+    // The span, not a magnitude: a gantt announces both ends of the interval.
+    expect(state.text.crossRange).toEqual({ min: 12, max: 14 });
+    expect(state.text.z).toEqual({ label: 'Length', value: 2 });
+
+    // The lane a reader can navigate onto and be told nothing about is the
+    // row the nested payload exists to express.
+    const idle = stateAt(chart, 1, 0);
+    expect(idle.empty).toBe(false);
+    if (idle.empty)
+      return;
+    expect(idle.text.main.value).toBe('Idle');
+  });
+
+  it('builds a waterfall trace', () => {
+    const chart = createChart('bar', {
+      labels: ['Open', 'Sales', 'Costs', 'Close'],
+      datasets: [{ data: [[0, 100], [100, 150], [150, 120], [0, 120]] }],
+    });
+
+    const state = stateAt(chart, 0, 2);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.WATERFALL);
+    // The contribution is what a waterfall step is read for.
+    expect(state.audio.freq.raw).toBe(-30);
+  });
+
+  it('builds a diverging bar trace', () => {
+    const chart = createChart('bar', {
+      labels: ['0-14', '15-64', '65+'],
+      datasets: [
+        { label: 'Men', data: [-30, -50, -20] },
+        { label: 'Women', data: [28, 52, 26] },
+      ],
+    }, { indexAxis: 'y', scales: { x: { stacked: true }, y: { stacked: true } } });
+
+    const state = stateAt(chart, 0, 1);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.DIVERGING);
+    // The pitch takes the magnitude; the sign is announced as a side rather
+    // than sounding like the smallest bar on the chart.
+    expect(state.audio.freq.raw).toBe(50);
+  });
+
+  it('builds a normalized area trace', () => {
+    const chart = createChart('line', {
+      labels: ['Q1', 'Q2', 'Q3'],
+      datasets: [
+        { label: 'Mobile', data: [60, 55, 50], fill: 'origin' },
+        { label: 'Desktop', data: [40, 45, 50], fill: 'origin' },
+      ],
+    }, { scales: { x: {}, y: { stacked: true } } });
+
+    const state = stateAt(chart, 1, 2);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.NORMALIZED_AREA);
+    expect(state.text.cross.value).toBe(50);
+  });
+
+  it('builds a bump trace', () => {
+    const chart = createChart('line', {
+      labels: ['Q1', 'Q2', 'Q3'],
+      datasets: [
+        { label: 'Arsenal', data: [1, 2, 2] },
+        { label: 'Chelsea', data: [2, 1, 3] },
+        { label: 'Spurs', data: [3, 3, 1] },
+      ],
+    }, { scales: { x: {}, y: { reverse: true } } });
+
+    const state = stateAt(chart, 2, 2);
+
+    expect(state.empty).toBe(false);
+    if (state.empty)
+      return;
+    expect(state.traceType).toBe(TraceType.BUMP);
+    // Rank 1 is the best position, so the pitch is handed over inverted.
+    expect(state.audio.freq.raw).toBe(1);
+    expect(state.audio.freq.min).toBeGreaterThan(state.audio.freq.max);
+  });
+});


### PR DESCRIPTION
## Description

The Chart.js adapter had fallen behind MAIDR core: of the trace types added since the pie chart it emitted only `AREA` and `STACKED_AREA`. Charts Chart.js draws perfectly well were either announced as the wrong figure or dropped from the figure entirely — which for a screen-reader user is worse than no support at all.

This adds all 11 in-scope trace types from #860. It is adapter-local: nothing under `src/model/`, `src/service/`, `src/state/`, `src/ui/`, `src/command/` or `src/type/grammar.ts` is touched, because the core already supports every one of these payloads.

It also fixes a live correctness bug found along the way. `toFiniteNumber` returned `null` for an array, so **every Chart.js floating-bar chart extracted as a `BAR` layer with zero points** — silently, with no warning. The `isRangeValue` guard that gantt, waterfall and dumbbell are built on fixes that on its own.

## Related Issues

Closes #860

## Changes Made

### Trace types added (11 of 11 in scope)

| Trace type | How it is detected |
|---|---|
| `RADAR` | native `type: 'radar'` — previously an explicit rejection |
| `POLAR_AREA` | native `type: 'polarArea'` — previously an explicit rejection |
| `GANTT` | `[start, end]` bar data that does not chain; one lane per label |
| `WATERFALL` | one series of `[start, end]` bars on a vertical index axis where each step begins where the last ended |
| `DIVERGING` | stacked bars whose datasets each sit wholly on one side of the baseline, both sides occupied |
| `NORMALIZED_AREA` | stacked filled lines whose every category totals the same whole (100 or 1) |
| `BUMP` | `scales.y.reverse` **and** values at every period a permutation of `1..N` |
| `GAUGE` | `doughnut` with `circumference` under 360 and exactly two finite values, or declared |
| `DOT` | every dataset `showLine: false` on a **category** axis |
| `DUMBBELL` | declared — shape-identical to a one-interval-per-lane gantt |
| `SURVIVAL` | declared — a `stepped` line is how every staircase is drawn |

Highlight was wired in the same change as detection for each, per the acceptance criteria: `computeTargetMaps` gained the DOT/GAUGE and SURVIVAL/BUMP/RADAR/POLAR_AREA cases, `DUMBBELL` got its own `resolveActiveTargets` branch (its rows are the two ends of one drawn element, so the row must not reach `rowDatasetIndex`), and gantt needed a dedicated `ganttTargets` map because its grid is transposed against Chart.js's — MAIDR row = lane, MAIDR column = which dataset booked it.

### Supporting groundwork

- `plugins.maidr.traceType` — the author declaration the issue called the unlock. Read through one helper and consulted in exactly three places. A declaration wins over every heuristic **in both directions**: declaring `pie` on a two-slice half-doughnut keeps it a pie.
- `plugins.maidr` also gained `unit` (gantt interval axis), `startLabel`/`endLabel` (dumbbell ends), and `target`/`bands` (gauge).
- New `ChartJsPointValue` with `censored`, `yMin`, `yMax`. This was forced, not cosmetic — TS excess-property checking made a datum carrying survival extras unrepresentable in the adapter's own types even though Chart.js passes them through.

### Trace types deliberately NOT added

- **`VOLCANO`** — deferred by #860 itself. Indistinguishable from any scatter; needs a `thresholdOptions` passthrough on top of the declaration.
- **`MANHATTAN`** — same situation and same consumer class as VOLCANO; needs the same `thresholdOptions` work plus a per-point label preserved through scatter extraction.
- **The 19 types Chart.js cannot draw** — ALLUVIAL, CHORD, SANKEY, NETWORK, TREEMAP, SUNBURST, ICICLE, CHOROPLETH, HEXBIN, CONTOUR, MOSAIC, PARALLEL, ERROR_BAR, FOREST, BOXEN, RIDGELINE, FUNNEL, LOLLIPOP, WORD_CLOUD. Either no controller exists, or the controller lives in a plugin this repo does not depend on, or the data Chart.js carries genuinely lacks the semantics (a mosaic's per-bar widths, a contour's level values, a ridgeline's offsets). LOLLIPOP costs nothing today: it already reads correctly as BAR.

### Two places the issue's plan was corrected

- The issue said the radar payload "is exactly what `extractLineLayers` already builds". Radar datasets are very commonly `fill: true`, and that path buckets by (stepDirection, filled) — it would have emitted an AREA layer. A dedicated `extractRadarLayers` was written instead, with a test pinning it.
- The issue offered "x scale kind (time ⇒ gantt, linear ⇒ dumbbell)" as an alternative to declaring a dumbbell. That would have been a regression: every real gantt on a numeric week or sprint axis is linear. Implemented as declaration-only.
- Gantt `unit` announces `'milliseconds'` on a time scale — which is what `end - start` actually is — rather than `time.unit`, which is a *display* unit and would have announced "5 days" for a five-millisecond span.

### Tests, docs and examples

- 9 new test files plus `traceConstruction.test.ts`, which builds each type through `TraceFactory` and asserts `getStateAt(row, col)` — it catches payload-shape errors extraction-only assertions miss.
- `docs/chartjs.md`: the support table was stale (it listed neither Area nor Stacked Area despite both being emitted); every new type is now in it, plus sections on the value heuristics and on the declaration-only readings.
- 9 new example pages under `examples/chartjs/`.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is left unticked deliberately: the automated gate below passes in full, but no manual browser pass was done against the new example pages, and `ManualTestingProcess.md` is not present in the repo.

## Additional Notes

**Gate — all green.** `npm run lint:fix` (no changes produced), `npm run type-check`, `npm run build`, `npm test` (2709 unit/component + 73 ESM, 0 failures). Also verified against the rest of CI: `npm run lint`, `npm run docs`, `npm run build:preview` and `npm run sync:copilot:check` all pass. `npm run e2e` was not run locally.

**One follow-up needed outside this diff's scope.** The 9 new example pages ship to the site — the examples folder is copied wholesale — but they are not linked from the gallery index, whose Chart.js list is hardcoded in `scripts/build-site.js` (~line 421). Rows are needed for `chartjs/radar.html`, `gantt.html`, `waterfall.html`, `bump.html`, `bar-diverging.html`, `gauge.html`, `dot.html`, `dumbbell.html` and `survival.html`. That file sits outside the adapter and was left alone rather than edited opportunistically.

**Known limits, stated plainly.** The normalized-area, bump, diverging and waterfall readings are value heuristics — Chart.js declares none of these — so each is deliberately strict and each has `plugins.maidr.traceType` as an escape hatch in both directions. A normalized chart whose totals were rounded unevenly beyond half a percent will read as a plain stacked area. Mixed charts remain a pre-existing latent trap: dispatch is still on `chart.config.type`, and `ChartJsDataset.type` is still never read — this change does not deepen that assumption, but it does not fix it either.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_