### PR TITLE
feat(victory): support the chart types added since the pie chart

### DIFF
--- a/examples/victory/App.tsx
+++ b/examples/victory/App.tsx
@@ -4,11 +4,13 @@ import { AreaChartExample } from './examples/AreaChartExample';
 import { BarChartExample } from './examples/BarChartExample';
 import { BoxPlotExample } from './examples/BoxPlotExample';
 import { CandlestickExample } from './examples/CandlestickExample';
+import { DotPlotExample } from './examples/DotPlotExample';
 import { ErrorBarExample } from './examples/ErrorBarExample';
 import { HistogramExample } from './examples/HistogramExample';
 import { LineChartExample } from './examples/LineChartExample';
 import { MultiPanelExample } from './examples/MultiPanelExample';
 import { PolarAreaExample } from './examples/PolarAreaExample';
+import { PopulationPyramidExample } from './examples/PopulationPyramidExample';
 import { ScatterChartExample } from './examples/ScatterChartExample';
 import { StackedAreaExample } from './examples/StackedAreaExample';
 import { StackedBarExample } from './examples/StackedBarExample';
@@ -18,8 +20,10 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Bar Chart', component: BarChartExample },
   { name: 'Line Chart', component: LineChartExample },
   { name: 'Scatter Chart', component: ScatterChartExample },
+  { name: 'Dot Plot', component: DotPlotExample },
   { name: 'Area Chart', component: AreaChartExample },
   { name: 'Stacked Bar', component: StackedBarExample },
+  { name: 'Population Pyramid', component: PopulationPyramidExample },
   { name: 'Stacked Area', component: StackedAreaExample },
   { name: 'Histogram', component: HistogramExample },
   { name: 'Box Plot', component: BoxPlotExample },

--- a/examples/victory/App.tsx
+++ b/examples/victory/App.tsx
@@ -1,22 +1,32 @@
 import type { JSX } from 'react';
 import { useState } from 'react';
+import { AreaChartExample } from './examples/AreaChartExample';
 import { BarChartExample } from './examples/BarChartExample';
 import { BoxPlotExample } from './examples/BoxPlotExample';
 import { CandlestickExample } from './examples/CandlestickExample';
+import { ErrorBarExample } from './examples/ErrorBarExample';
 import { HistogramExample } from './examples/HistogramExample';
 import { LineChartExample } from './examples/LineChartExample';
 import { MultiPanelExample } from './examples/MultiPanelExample';
+import { PolarAreaExample } from './examples/PolarAreaExample';
 import { ScatterChartExample } from './examples/ScatterChartExample';
+import { StackedAreaExample } from './examples/StackedAreaExample';
 import { StackedBarExample } from './examples/StackedBarExample';
+import { WaterfallExample } from './examples/WaterfallExample';
 
 const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Bar Chart', component: BarChartExample },
   { name: 'Line Chart', component: LineChartExample },
   { name: 'Scatter Chart', component: ScatterChartExample },
+  { name: 'Area Chart', component: AreaChartExample },
   { name: 'Stacked Bar', component: StackedBarExample },
+  { name: 'Stacked Area', component: StackedAreaExample },
   { name: 'Histogram', component: HistogramExample },
   { name: 'Box Plot', component: BoxPlotExample },
   { name: 'Candlestick', component: CandlestickExample },
+  { name: 'Error Bar', component: ErrorBarExample },
+  { name: 'Waterfall', component: WaterfallExample },
+  { name: 'Polar Area', component: PolarAreaExample },
   { name: 'Multi-Panel', component: MultiPanelExample },
 ];
 

--- a/examples/victory/examples/AreaChartExample.tsx
+++ b/examples/victory/examples/AreaChartExample.tsx
@@ -1,0 +1,32 @@
+import type { JSX } from 'react';
+import { VictoryArea, VictoryAxis, VictoryChart } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+const data = [
+  { x: 2018, y: 42 },
+  { x: 2019, y: 55 },
+  { x: 2020, y: 38 },
+  { x: 2021, y: 71 },
+  { x: 2022, y: 90 },
+  { x: 2023, y: 84 },
+];
+
+export function AreaChartExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Area Chart</h2>
+      <p>Area chart showing annual rainfall.</p>
+      <MaidrVictory
+        id="victory-area"
+        title="Annual Rainfall"
+        subtitle="2018–2023"
+      >
+        <VictoryChart domainPadding={{ y: 24 }}>
+          <VictoryAxis label="Year" />
+          <VictoryAxis dependentAxis label="Rainfall (cm)" />
+          <VictoryArea data={data} />
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/examples/victory/examples/DotPlotExample.tsx
+++ b/examples/victory/examples/DotPlotExample.tsx
@@ -1,0 +1,38 @@
+import type { JSX } from 'react';
+import { VictoryAxis, VictoryChart, VictoryScatter } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+// A Cleveland dot plot is a `VictoryScatter` whose x values name categories
+// rather than measure a position. One magnitude per named category is what a
+// bar chart is, drawn as a point, and MAIDR reads it as one.
+const data = [
+  { x: 'Finland', y: 7.8 },
+  { x: 'Denmark', y: 7.6 },
+  { x: 'Iceland', y: 7.5 },
+  { x: 'Sweden', y: 7.3 },
+  { x: 'Netherlands', y: 7.4 },
+  { x: 'Norway', y: 7.3 },
+];
+
+export function DotPlotExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Dot Plot</h2>
+      <p>
+        Life satisfaction by country, one dot per country. The categories are
+        announced by name rather than by position.
+      </p>
+      <MaidrVictory
+        id="victory-dot"
+        title="Life Satisfaction"
+        subtitle="Score out of 10"
+      >
+        <VictoryChart domainPadding={24}>
+          <VictoryAxis label="Country" style={{ tickLabels: { fontSize: 8 } }} />
+          <VictoryAxis dependentAxis label="Score" />
+          <VictoryScatter data={data} size={5} />
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/examples/victory/examples/ErrorBarExample.tsx
+++ b/examples/victory/examples/ErrorBarExample.tsx
@@ -1,0 +1,35 @@
+import type { JSX } from 'react';
+import { VictoryAxis, VictoryChart, VictoryErrorBar } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+// Victory's `errorY` is a distance from the estimate, either symmetric (a
+// number) or asymmetric (`[plus, minus]`). MAIDR announces absolute bounds.
+const data = [
+  { x: 'Control', y: 4.2, errorY: 0.6 },
+  { x: 'Low dose', y: 5.1, errorY: 0.9 },
+  { x: 'Mid dose', y: 6.4, errorY: [1.2, 0.7] },
+  { x: 'High dose', y: 6.9, errorY: 1.4 },
+];
+
+export function ErrorBarExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Error Bar</h2>
+      <p>
+        Group means with 95% confidence intervals. Up and down move between the
+        lower bound, the estimate and the upper bound at one sample.
+      </p>
+      <MaidrVictory
+        id="victory-error-bar"
+        title="Response by Dose"
+        subtitle="Mean with 95% CI"
+      >
+        <VictoryChart domainPadding={40}>
+          <VictoryAxis label="Group" />
+          <VictoryAxis dependentAxis label="Response (mmol/L)" />
+          <VictoryErrorBar data={data} />
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/examples/victory/examples/PolarAreaExample.tsx
+++ b/examples/victory/examples/PolarAreaExample.tsx
@@ -1,0 +1,36 @@
+import type { JSX } from 'react';
+import { VictoryBar, VictoryChart, VictoryPolarAxis } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+// A `VictoryBar` inside a `<VictoryChart polar>` draws a coxcomb: each value
+// is a wedge whose radius is its magnitude. MAIDR pans by the wedge's angle
+// rather than by its column, so the sweep goes out and back around the circle.
+const data = [
+  { x: 'N', y: 18 },
+  { x: 'NE', y: 12 },
+  { x: 'E', y: 7 },
+  { x: 'SE', y: 9 },
+  { x: 'S', y: 15 },
+  { x: 'SW', y: 22 },
+  { x: 'W', y: 27 },
+  { x: 'NW', y: 21 },
+];
+
+export function PolarAreaExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Polar Area</h2>
+      <p>Wind rose showing hours of wind from each compass direction.</p>
+      <MaidrVictory
+        id="victory-polar-area"
+        title="Wind by Direction"
+        subtitle="Hours per week"
+      >
+        <VictoryChart polar>
+          <VictoryPolarAxis />
+          <VictoryBar data={data} />
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/examples/victory/examples/PopulationPyramidExample.tsx
+++ b/examples/victory/examples/PopulationPyramidExample.tsx
@@ -1,0 +1,51 @@
+import type { JSX } from 'react';
+import { VictoryAxis, VictoryBar, VictoryChart, VictoryStack } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+// A population pyramid is a `VictoryStack` of two bar series with one of them
+// signed negative, drawn horizontally so the two sides grow left and right.
+// The sign is a direction rather than a magnitude, and MAIDR reads it as one:
+// the pitch carries the size and the announcement names the side.
+const men = [
+  { x: '0-14', y: -1200 },
+  { x: '15-29', y: -1150 },
+  { x: '30-44', y: -1080 },
+  { x: '45-59', y: -990 },
+  { x: '60-74', y: -720 },
+  { x: '75+', y: -310 },
+];
+
+const women = [
+  { x: '0-14', y: 1140 },
+  { x: '15-29', y: 1100 },
+  { x: '30-44', y: 1060 },
+  { x: '45-59', y: 1010 },
+  { x: '60-74', y: 830 },
+  { x: '75+', y: 520 },
+];
+
+export function PopulationPyramidExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Population Pyramid</h2>
+      <p>
+        Population by age band and sex. Each bar announces its size and which
+        side it points to, and the summary row reports which side is ahead.
+      </p>
+      <MaidrVictory
+        id="victory-pyramid"
+        title="Population by Age Band"
+        subtitle="People, thousands"
+      >
+        <VictoryChart horizontal domainPadding={16}>
+          <VictoryAxis label="Age band" />
+          <VictoryAxis dependentAxis label="People (thousands)" tickFormat={t => Math.abs(t)} />
+          <VictoryStack>
+            <VictoryBar name="Men" data={men} />
+            <VictoryBar name="Women" data={women} />
+          </VictoryStack>
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/examples/victory/examples/StackedAreaExample.tsx
+++ b/examples/victory/examples/StackedAreaExample.tsx
@@ -1,0 +1,51 @@
+import type { JSX } from 'react';
+import { VictoryArea, VictoryAxis, VictoryChart, VictoryStack } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+const solar = [
+  { x: 2019, y: 12 },
+  { x: 2020, y: 18 },
+  { x: 2021, y: 27 },
+  { x: 2022, y: 34 },
+];
+
+const wind = [
+  { x: 2019, y: 30 },
+  { x: 2020, y: 33 },
+  { x: 2021, y: 35 },
+  { x: 2022, y: 41 },
+];
+
+const hydro = [
+  { x: 2019, y: 21 },
+  { x: 2020, y: 20 },
+  { x: 2021, y: 22 },
+  { x: 2022, y: 19 },
+];
+
+export function StackedAreaExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Stacked Area</h2>
+      <p>
+        Stacked area chart of renewable generation by source. Each band is
+        announced with its own value and its share of the column total.
+      </p>
+      <MaidrVictory
+        id="victory-stacked-area"
+        title="Renewable Generation by Source"
+        subtitle="2019–2022"
+      >
+        <VictoryChart domainPadding={{ y: 24 }}>
+          <VictoryAxis label="Year" />
+          <VictoryAxis dependentAxis label="Generation (TWh)" />
+          <VictoryStack>
+            <VictoryArea name="Solar" data={solar} />
+            <VictoryArea name="Wind" data={wind} />
+            <VictoryArea name="Hydro" data={hydro} />
+          </VictoryStack>
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/examples/victory/examples/WaterfallExample.tsx
+++ b/examples/victory/examples/WaterfallExample.tsx
@@ -1,0 +1,38 @@
+import type { JSX } from 'react';
+import { VictoryAxis, VictoryBar, VictoryChart } from 'victory';
+import { MaidrVictory } from '../../../src/adapters/victory/MaidrVictory';
+
+// A waterfall is a `VictoryBar` whose bars float on a per-datum `y0`, each one
+// starting where the last one ended. The opening and closing bars rest on the
+// baseline, which is what marks them as totals rather than contributions.
+const data = [
+  { x: 'Opening', y0: 0, y: 1200 },
+  { x: 'New sales', y0: 1200, y: 1750 },
+  { x: 'Renewals', y0: 1750, y: 2010 },
+  { x: 'Churn', y0: 2010, y: 1680 },
+  { x: 'Refunds', y0: 1680, y: 1595 },
+  { x: 'Closing', y0: 0, y: 1595 },
+];
+
+export function WaterfallExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Waterfall</h2>
+      <p>
+        Revenue bridge from opening to closing balance. Each step announces its
+        contribution and the running total it produced.
+      </p>
+      <MaidrVictory
+        id="victory-waterfall"
+        title="Revenue Bridge"
+        subtitle="FY2024, thousands of dollars"
+      >
+        <VictoryChart domainPadding={24}>
+          <VictoryAxis label="Step" style={{ tickLabels: { fontSize: 9 } }} />
+          <VictoryAxis dependentAxis label="Revenue ($000)" />
+          <VictoryBar data={data} />
+        </VictoryChart>
+      </MaidrVictory>
+    </div>
+  );
+}

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -646,6 +646,23 @@ function extractErrorBarData(
 const WATERFALL_BASELINE = 0;
 
 /**
+ * How far a step may miss the previous step's end and still count as chained.
+ *
+ * The chain test is what separates a waterfall from a range bar, so it has to
+ * stay tight — but a running total built by arithmetic (percentages, divided
+ * quantities) lands a fraction of a ULP off the value it was accumulated from,
+ * and an exact comparison would demote such a chart to a plain bar chart with
+ * nothing reported. This tolerance is far below any spacing a reader could
+ * perceive and far above float drift.
+ */
+const WATERFALL_CHAIN_EPSILON = 1e-9;
+
+/** Whether two waterfall bounds meet, allowing for float drift. */
+function meets(a: number, b: number): boolean {
+  return Math.abs(a - b) <= WATERFALL_CHAIN_EPSILON;
+}
+
+/**
  * Extracts data from a VictoryBar whose bars float on a per-datum `y0`.
  *
  * `y0` is an ordinary Victory accessor prop, so a floating bar is native
@@ -681,16 +698,16 @@ function extractWaterfallData(
   if (steps.some(s => !Number.isFinite(s.start) || !Number.isFinite(s.end)))
     return null;
 
-  const floats = steps.some(s => s.start !== WATERFALL_BASELINE);
+  const floats = steps.some(s => !meets(s.start, WATERFALL_BASELINE));
   const chains = steps.every((s, i) =>
-    i === 0 || s.start === WATERFALL_BASELINE || s.start === steps[i - 1].end);
+    i === 0 || meets(s.start, WATERFALL_BASELINE) || meets(s.start, steps[i - 1].end));
   if (!floats || !chains)
     return null;
 
   const points: WaterfallPoint[] = steps.map(({ x, start, end }) => {
     const delta = end - start;
     let kind: WaterfallKind = delta < 0 ? 'decrease' : 'increase';
-    if (start === WATERFALL_BASELINE)
+    if (meets(start, WATERFALL_BASELINE))
       kind = 'total';
     return { x, start, end, delta, kind };
   });

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -283,7 +283,31 @@ function extractPolarAreaData(
 }
 
 /**
+ * Whether every datum's x names a category rather than measuring a position.
+ *
+ * This is Victory's own test: `Data.createStringMap` puts a datum on the
+ * category scale when `typeof value === 'string'`, whatever the string spells,
+ * so `'2024'` is a category to Victory exactly as `'Denmark'` is.
+ *
+ * @param rawData - The component's `data`, already validated
+ * @param getX    - The component's resolved x accessor
+ * @returns True when the chart is drawn against categories
+ */
+function hasCategoricalX(
+  rawData: Record<string, unknown>[],
+  getX: (d: Record<string, unknown>) => unknown,
+): boolean {
+  return rawData.every(d => typeof getX(d) === 'string');
+}
+
+/**
  * Extracts data from a VictoryScatter element.
+ *
+ * A scatter drawn over categories is a Cleveland dot plot: one magnitude per
+ * named category, which is what a bar chart is, drawn as a point. Reading it
+ * as a bivariate scatter would coerce every category name to a number and
+ * announce a chart of `NaN` positions, so the two are separated here — by the
+ * data, since the component is the same either way.
  */
 function extractScatterData(
   props: Record<string, unknown>,
@@ -294,6 +318,16 @@ function extractScatterData(
 
   const getX = resolveAccessor(props.x, 'x');
   const getY = resolveAccessor(props.y, 'y');
+
+  if (hasCategoricalX(rawData, getX)) {
+    const points: BarPoint[] = rawData.map(d => ({
+      x: getX(d) as string,
+      y: getY(d) as number | string,
+    }));
+
+    return { data: { kind: 'dot', points }, count: rawData.length };
+  }
+
   const points: ScatterPoint[] = rawData.map(d => ({
     x: Number(getX(d)),
     y: Number(getY(d)),
@@ -859,13 +893,58 @@ function extractStackedAreaLayer(
 }
 
 /**
+ * Which way one side of a candidate diverging chart grows.
+ *
+ * `SegmentedPoint.y` is typed `number | string` and the extractor below passes
+ * the accessor result through as Victory handed it over, so the value is
+ * coerced here before its sign is read. A side that reaches neither way (every
+ * bar zero) or both ways is not a side of a diverging chart.
+ *
+ * @param points - One series of the stack
+ * @returns The direction it grows, or null when it does not grow one way
+ */
+function growthDirection(points: SegmentedPoint[]): 'up' | 'down' | null {
+  const values = points.map(point => Number(point.y));
+  if (values.some(value => !Number.isFinite(value)))
+    return null;
+  if (values.every(value => value <= 0) && values.some(value => value < 0))
+    return 'down';
+  if (values.every(value => value >= 0) && values.some(value => value > 0))
+    return 'up';
+  return null;
+}
+
+/**
+ * Whether a stack's series are the two sides of a diverging chart.
+ *
+ * A population pyramid is drawn in Victory as a stack of two bar series with
+ * one of them signed negative — the same construct as an ordinary stacked bar,
+ * so the values are the only thing that tells them apart. The signal is the
+ * sign: exactly two series, one drawn entirely at or below the baseline and
+ * the other entirely at or above it, each reaching past it at least once. A
+ * stack whose bands all grow the same way is a stack.
+ *
+ * @param series - The extracted series, in children order
+ * @returns True when the two sides diverge across a shared baseline
+ */
+function isDivergingPair(series: SegmentedPoint[][]): boolean {
+  if (series.length !== 2)
+    return false;
+
+  const [first, second] = series.map(growthDirection);
+  return first !== null && second !== null && first !== second;
+}
+
+/**
  * Extracts a layer from a VictoryStack container.
  *
  * The stack's children decide what it is: `VictoryBar` children make a
  * segmented (stacked) bar, where each child becomes one series (row) of
  * `SegmentedPoint[][]`, and `VictoryArea` children make a stacked area, whose
  * bands are read as a line grid instead. A stack mixing the two is read as a
- * bar stack, which is what its bars draw.
+ * bar stack, which is what its bars draw. Two bar series signed against each
+ * other are not stacked on one another at all — they are the two sides of a
+ * diverging chart, and are emitted as one.
  */
 function extractSegmentedLayer(
   containerElement: ReactElement,
@@ -910,11 +989,32 @@ function extractSegmentedLayer(
     return null;
 
   const traceType: VictoryComponentType = containerType;
+  const diverging = isDivergingPair(series);
+
+  // The sides are emitted in the order Victory paints them, which is the
+  // reverse of the order they are declared in (`VictoryStack` reverses its
+  // children so the topmost band paints last). A stacked bar's highlight is
+  // resolved from one flat selector, which the DOM answers in document order,
+  // so declaration order would put every highlight on the opposite side —
+  // silent and visual-only, since the announcement never goes through the
+  // element mapping.
+  //
+  // Only safe here because a diverging chart's sides sit either side of a
+  // baseline rather than on top of one another: there is no stacking order to
+  // preserve, and `DivergingTrace` resolves which side is which by reading the
+  // values rather than by index. A true stack's row order **is** meaningful,
+  // which is why it is left alone.
+  if (diverging) {
+    series.reverse();
+    legend.reverse();
+  }
 
   return {
     id: layerId,
     victoryType: traceType,
-    data: { kind: 'segmented', points: series },
+    data: diverging
+      ? { kind: 'diverging', points: series }
+      : { kind: 'segmented', points: series },
     xAxisLabel: axisLabels.x,
     yAxisLabel: axisLabels.y,
     dataCount: totalElements,
@@ -1205,6 +1305,15 @@ export function toMaidrLayer(
         data: data.points,
       };
 
+    case 'dot':
+      return {
+        id: layer.id,
+        type: TraceType.DOT,
+        axes,
+        selectors: selector,
+        data: data.points,
+      };
+
     case 'errorBar':
       return {
         id: layer.id,
@@ -1271,6 +1380,19 @@ export function toMaidrLayer(
         id: layer.id,
         type: TraceType.STACKED,
         axes,
+        selectors: selector,
+        data: data.points,
+      };
+
+    case 'diverging':
+      return {
+        id: layer.id,
+        type: TraceType.DIVERGING,
+        axes,
+        // The values stay signed as the chart draws them. `DivergingTrace`
+        // reads the sign as the side a bar points to and pitches the
+        // magnitude, so stripping it here would leave the left-hand series
+        // indistinguishable from the right.
         selectors: selector,
         data: data.points,
       };

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -5,6 +5,7 @@ import type {
   CandlestickPoint,
   CandlestickSelector,
   CandlestickTrend,
+  ErrorBarPoint,
   HistogramPoint,
   LinePoint,
   MaidrLayer,
@@ -12,6 +13,8 @@ import type {
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
+  WaterfallKind,
+  WaterfallPoint,
 } from '@type/grammar';
 import type { ReactElement, ReactNode } from 'react';
 import type {
@@ -68,14 +71,27 @@ function getVictoryDisplayName(type: unknown): string | null {
  */
 function isDataComponent(name: string): name is VictoryComponentType {
   return (
-    name === 'VictoryBar'
+    name === 'VictoryArea'
+    || name === 'VictoryBar'
     || name === 'VictoryLine'
     || name === 'VictoryScatter'
     || name === 'VictoryBoxPlot'
     || name === 'VictoryCandlestick'
+    || name === 'VictoryErrorBar'
     || name === 'VictoryHistogram'
     || name === 'VictoryPie'
   );
+}
+
+/**
+ * Whether a data component is drawn around a circle rather than along an axis.
+ *
+ * `polar` is declared either on the component itself or on the enclosing
+ * `<VictoryChart polar>`, which passes it down to every child. A child that
+ * sets `polar={false}` opts back out, so an explicit own prop always wins.
+ */
+function isPolarComponent(props: Record<string, unknown>, chartPolar: boolean): boolean {
+  return typeof props.polar === 'boolean' ? props.polar : chartPolar;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,21 +203,36 @@ function stepDirectionOf(interpolation: unknown): StepDirection | undefined {
 }
 
 /**
- * Extracts data from a VictoryLine element.
+ * Reads a component's `data` prop as one series of {@link LinePoint}s, or
+ * `null` when there is no usable data.
+ *
+ * Shared by every line-shaped layer — line, step, area, stacked area band,
+ * polar area — because Victory draws them all from the same `data` prop under
+ * the same `x`/`y` accessor convention. What differs between them is the mark,
+ * which the layer's `kind` records, not the values.
  */
-function extractLineData(
-  props: Record<string, unknown>,
-): { data: VictoryLayerData; count: number } | null {
+function readLinePoints(props: Record<string, unknown>): LinePoint[] | null {
   const rawData = props.data;
   if (!validateRawData(rawData))
     return null;
 
   const getX = resolveAccessor(props.x, 'x');
   const getY = resolveAccessor(props.y, 'y');
-  const points: LinePoint[] = rawData.map(d => ({
+  return rawData.map(d => ({
     x: getX(d) as number | string,
     y: Number(getY(d)),
   }));
+}
+
+/**
+ * Extracts data from a VictoryLine element.
+ */
+function extractLineData(
+  props: Record<string, unknown>,
+): { data: VictoryLayerData; count: number } | null {
+  const points = readLinePoints(props);
+  if (!points)
+    return null;
 
   const stepDirection = stepDirectionOf(props.interpolation);
 
@@ -211,8 +242,44 @@ function extractLineData(
       points: [points],
       ...(stepDirection ? { stepDirection } : {}),
     },
-    count: rawData.length,
+    count: points.length,
   };
+}
+
+/**
+ * Extracts data from a VictoryArea element.
+ *
+ * An area is a line with the region down to the baseline filled in, and
+ * Victory draws it from the same props, so the values are read exactly as a
+ * line's are. A `polar` area is a radar outline instead, which MAIDR reads
+ * differently — that case is handled by the caller.
+ */
+function extractAreaData(
+  props: Record<string, unknown>,
+): { data: VictoryLayerData; count: number } | null {
+  const points = readLinePoints(props);
+  if (!points)
+    return null;
+
+  return { data: { kind: 'area', points: [points] }, count: points.length };
+}
+
+/**
+ * Extracts data from a `polar` VictoryBar element — a coxcomb, whose wedges
+ * radiate from the centre with the value as the radius.
+ *
+ * The payload is a single-series line grid because that is what MAIDR's radar
+ * family navigates: one column per spoke, with the spoke angles derived by the
+ * trace itself.
+ */
+function extractPolarAreaData(
+  props: Record<string, unknown>,
+): { data: VictoryLayerData; count: number } | null {
+  const points = readLinePoints(props);
+  if (!points)
+    return null;
+
+  return { data: { kind: 'polarArea', points: [points] }, count: points.length };
 }
 
 /**
@@ -452,6 +519,151 @@ function binByEdges(values: number[], rawEdges: unknown[]): HistogramBin[] | nul
   return bins;
 }
 
+// ---------------------------------------------------------------------------
+// Error bars
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads one side of a Victory error value as a distance from the estimate.
+ *
+ * Victory treats `0` as "draw no whisker on this side" rather than as a
+ * zero-length one (victory-errorbar/src/helper-methods), and so does this:
+ * a bound that coincides with the estimate is not a bound the chart drew.
+ * A missing or non-finite value is no error either.
+ *
+ * @param value - One side of a datum's error, as Victory received it
+ * @returns The distance from the estimate, or undefined for no whisker
+ */
+function errorDelta(value: unknown): number | undefined {
+  const delta = Number(value);
+  return Number.isFinite(delta) && delta !== 0 ? Math.abs(delta) : undefined;
+}
+
+/**
+ * Splits a Victory error value into its upper and lower distances.
+ *
+ * Victory accepts either a scalar — one symmetric error drawn on both sides —
+ * or a `[plus, minus]` pair for an asymmetric interval.
+ *
+ * @param error - A datum's `errorY`, as Victory received it
+ * @returns The distances above and below the estimate
+ */
+function readErrorDeltas(error: unknown): { plus?: number; minus?: number } {
+  if (Array.isArray(error)) {
+    return { plus: errorDelta(error[0]), minus: errorDelta(error[1]) };
+  }
+  const symmetric = errorDelta(error);
+  return { plus: symmetric, minus: symmetric };
+}
+
+/**
+ * Extracts data from a VictoryErrorBar element.
+ *
+ * Victory's error is a **delta** from the estimate while MAIDR's
+ * {@link ErrorBarPoint} fixes **absolute** bounds, so the conversion is the
+ * point of this extractor. Each side is emitted independently: a one-sided
+ * interval is a real chart, and `ErrorBarTrace` drops the row for a bound no
+ * point carries rather than announcing silence.
+ *
+ * Only `errorY` is read. A `errorX`-only chart draws its interval along the
+ * category axis, which is a different layer orientation rather than a
+ * different delta, and reading it as a vertical interval would put every
+ * bound on the wrong axis — so such a layer is left unconverted.
+ */
+function extractErrorBarData(
+  props: Record<string, unknown>,
+): { data: VictoryLayerData; count: number } | null {
+  const rawData = props.data;
+  if (!validateRawData(rawData))
+    return null;
+
+  const getX = resolveAccessor(props.x, 'x');
+  const getY = resolveAccessor(props.y, 'y');
+  const getErrorY = resolveAccessor(props.errorY, 'errorY');
+
+  const points: ErrorBarPoint[] = rawData.map((d) => {
+    const y = Number(getY(d));
+    const { plus, minus } = readErrorDeltas(getErrorY(d));
+    return {
+      x: getX(d) as number | string,
+      y,
+      ...(minus === undefined ? {} : { yMin: y - minus }),
+      ...(plus === undefined ? {} : { yMax: y + plus }),
+    };
+  });
+
+  // A layer that draws no interval anywhere is not an interval chart. Calling
+  // it one promises the reader bounds that no navigation can reach.
+  const hasInterval = points.some(p => p.yMin !== undefined || p.yMax !== undefined);
+  if (!hasInterval)
+    return null;
+
+  return { data: { kind: 'errorBar', points }, count: points.length };
+}
+
+// ---------------------------------------------------------------------------
+// Waterfall
+// ---------------------------------------------------------------------------
+
+/**
+ * The value a waterfall step is measured against — a bar sitting here restates
+ * the running total rather than contributing to it.
+ */
+const WATERFALL_BASELINE = 0;
+
+/**
+ * Extracts data from a VictoryBar whose bars float on a per-datum `y0`.
+ *
+ * `y0` is an ordinary Victory accessor prop, so a floating bar is native
+ * rather than a hack — but a floating bar alone is not yet a waterfall: a
+ * range bar and a gantt row are drawn the same way, and the adapter cannot
+ * tell those apart from the values. What it can check is whether the bars
+ * **chain**, each one starting where the last one ended, which is the
+ * defining property of a waterfall and something a range chart does not have.
+ * Bars resting on the baseline are exempt from the chain, since those restate
+ * the running total (the opening and closing bars, and any subtotal drawn
+ * along the way) instead of continuing it.
+ *
+ * Returns `null` when the bars are flat or unchained, so the caller falls back
+ * to reading them as an ordinary bar chart.
+ */
+function extractWaterfallData(
+  props: Record<string, unknown>,
+): { data: VictoryLayerData; count: number } | null {
+  const rawData = props.data;
+  if (!validateRawData(rawData))
+    return null;
+
+  const getX = resolveAccessor(props.x, 'x');
+  const getY = resolveAccessor(props.y, 'y');
+  const getY0 = resolveAccessor(props.y0, 'y0');
+
+  const steps = rawData.map(d => ({
+    x: getX(d) as number | string,
+    start: Number(getY0(d) ?? WATERFALL_BASELINE),
+    end: Number(getY(d)),
+  }));
+
+  if (steps.some(s => !Number.isFinite(s.start) || !Number.isFinite(s.end)))
+    return null;
+
+  const floats = steps.some(s => s.start !== WATERFALL_BASELINE);
+  const chains = steps.every((s, i) =>
+    i === 0 || s.start === WATERFALL_BASELINE || s.start === steps[i - 1].end);
+  if (!floats || !chains)
+    return null;
+
+  const points: WaterfallPoint[] = steps.map(({ x, start, end }) => {
+    const delta = end - start;
+    let kind: WaterfallKind = delta < 0 ? 'decrease' : 'increase';
+    if (start === WATERFALL_BASELINE)
+      kind = 'total';
+    return { x, start, end, delta, kind };
+  });
+
+  return { data: { kind: 'waterfall', points }, count: points.length };
+}
+
 /**
  * Converts a single Victory data component into a {@link VictoryLayerInfo}.
  */
@@ -459,18 +671,32 @@ function extractLayerFromElement(
   element: ReactElement,
   layerId: string,
   axisLabels: { x?: string; y?: string },
+  chartPolar: boolean,
 ): VictoryLayerInfo | null {
   const name = getVictoryDisplayName(element.type);
   if (!name || !isDataComponent(name))
     return null;
 
   const props = element.props as Record<string, unknown>;
+  const polar = isPolarComponent(props, chartPolar);
 
   let extracted: { data: VictoryLayerData; count: number } | null = null;
 
   switch (name) {
+    case 'VictoryArea':
+      extracted = extractAreaData(props);
+      break;
     case 'VictoryBar':
-      extracted = extractBarData(props);
+      // Two components' worth of chart types come out of `VictoryBar`: drawn
+      // polar it is a coxcomb, and floating on a chaining `y0` it is a
+      // waterfall. Both fall back to a plain bar when the data does not
+      // support the reading.
+      extracted = polar
+        ? extractPolarAreaData(props)
+        : extractWaterfallData(props) ?? extractBarData(props);
+      break;
+    case 'VictoryErrorBar':
+      extracted = extractErrorBarData(props);
       break;
     case 'VictoryLine':
       extracted = extractLineData(props);
@@ -509,11 +735,137 @@ function extractLayerFromElement(
 // Stacked bar extraction
 // ---------------------------------------------------------------------------
 
+/** One data child of a `VictoryStack`, with the name its band is announced under. */
+interface StackChild {
+  /** The Victory component drawing this band. */
+  name: 'VictoryArea' | 'VictoryBar';
+  /** The child's props, already known to carry usable `data`. */
+  props: Record<string, unknown>;
+  /** The band's series name, from the child's `name` prop or its position. */
+  seriesName: string;
+  /** Number of data elements this band contributes. */
+  count: number;
+}
+
 /**
- * Extracts a segmented (stacked) bar layer from a VictoryStack container.
+ * Collects the stackable data children of a `VictoryStack`, in children order.
  *
- * Each child VictoryBar becomes one series (row) in the resulting
- * `SegmentedPoint[][]` data.
+ * Only the two components Victory actually stacks into a readable layer are
+ * kept — everything else in the container (labels, a shared tooltip) draws no
+ * band and would only shift the series numbering.
+ */
+function collectStackChildren(children: ReactNode): StackChild[] {
+  const collected: StackChild[] = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child))
+      return;
+    const name = getVictoryDisplayName(child.type);
+    if (name !== 'VictoryBar' && name !== 'VictoryArea')
+      return;
+
+    const props = child.props as Record<string, unknown>;
+    if (!validateRawData(props.data))
+      return;
+
+    collected.push({
+      name,
+      props,
+      seriesName: (props.name as string) ?? `Series ${collected.length + 1}`,
+      count: props.data.length,
+    });
+  });
+
+  return collected;
+}
+
+/**
+ * Whether a stack's bands are shares of one whole.
+ *
+ * Victory has no `normalize` prop — unlike Vega-Lite's `stack: 'normalize'`
+ * there is nothing declarative to read — so the only evidence is arithmetic:
+ * every column adds up to the same whole. Both conventions authors use are
+ * accepted, percentages out of 100 and fractions of 1.
+ *
+ * Deliberately narrow. Two or more bands and two or more columns are required,
+ * because a single column summing to 100 says nothing, and the tolerance is
+ * half a percent so that a stack which merely passes through 100 somewhere is
+ * not swept up. A genuine unnormalized stack whose every column lands on the
+ * whole would still be misread; that is the residual cost of a library that
+ * does not state it.
+ *
+ * @param series - The extracted bands
+ * @returns True when every column sums to a common whole
+ */
+function isNormalizedStack(series: LinePoint[][]): boolean {
+  if (series.length < 2)
+    return false;
+
+  const totals = new Map<string, number>();
+  for (const band of series) {
+    for (const point of band) {
+      if (!Number.isFinite(point.y))
+        return false;
+      totals.set(String(point.x), (totals.get(String(point.x)) ?? 0) + point.y);
+    }
+  }
+  if (totals.size < 2)
+    return false;
+
+  const columns = Array.from(totals.values());
+  return [1, 100].some(whole =>
+    columns.every(total => Math.abs(total - whole) <= whole * 0.005));
+}
+
+/**
+ * Extracts a stacked-area layer from a VictoryStack of VictoryArea children.
+ *
+ * Each band keeps its **own** value rather than the running edge Victory
+ * paints it at: `VictoryStack` accumulates through `_y0` at render time only,
+ * and MAIDR's area trace deliberately computes the total itself from the
+ * series it is handed, so accumulating here would double it.
+ */
+function extractStackedAreaLayer(
+  children: StackChild[],
+  layerId: string,
+  axisLabels: { x?: string; y?: string },
+): VictoryLayerInfo | null {
+  const series: LinePoint[][] = [];
+  const legend: string[] = [];
+  let totalElements = 0;
+
+  for (const { props, seriesName, count } of children) {
+    const points = readLinePoints(props);
+    if (!points)
+      continue;
+
+    series.push(points.map(point => ({ ...point, z: seriesName })));
+    legend.push(seriesName);
+    totalElements += count;
+  }
+
+  if (series.length === 0)
+    return null;
+
+  return {
+    id: layerId,
+    victoryType: 'VictoryStack',
+    data: { kind: 'stackedArea', points: series, normalized: isNormalizedStack(series) },
+    xAxisLabel: axisLabels.x,
+    yAxisLabel: axisLabels.y,
+    dataCount: totalElements,
+    legend,
+  };
+}
+
+/**
+ * Extracts a layer from a VictoryStack container.
+ *
+ * The stack's children decide what it is: `VictoryBar` children make a
+ * segmented (stacked) bar, where each child becomes one series (row) of
+ * `SegmentedPoint[][]`, and `VictoryArea` children make a stacked area, whose
+ * bands are read as a line grid instead. A stack mixing the two is read as a
+ * bar stack, which is what its bars draw.
  */
 function extractSegmentedLayer(
   containerElement: ReactElement,
@@ -522,36 +874,37 @@ function extractSegmentedLayer(
   axisLabels: { x?: string; y?: string },
 ): VictoryLayerInfo | null {
   const containerProps = containerElement.props as { children?: ReactNode };
+  const children = collectStackChildren(containerProps.children);
+  if (children.length === 0)
+    return null;
+
+  if (children.every(child => child.name === 'VictoryArea')) {
+    return extractStackedAreaLayer(children, layerId, axisLabels);
+  }
+
   const series: SegmentedPoint[][] = [];
   const legend: string[] = [];
   let totalElements = 0;
 
-  Children.forEach(containerProps.children, (child) => {
-    if (!isValidElement(child))
-      return;
-    const name = getVictoryDisplayName(child.type);
+  for (const { name, props, seriesName, count } of children) {
     if (name !== 'VictoryBar')
-      return;
+      continue;
 
-    const props = child.props as Record<string, unknown>;
     const rawData = props.data;
     if (!validateRawData(rawData))
-      return;
+      continue;
 
     const getX = resolveAccessor(props.x, 'x');
     const getY = resolveAccessor(props.y, 'y');
-    const seriesName = (props.name as string) ?? `Series ${series.length + 1}`;
 
-    const points: SegmentedPoint[] = rawData.map(d => ({
+    series.push(rawData.map(d => ({
       x: getX(d) as string | number,
       y: getY(d) as number | string,
       z: seriesName,
-    }));
-
-    series.push(points);
+    })));
     legend.push(seriesName);
-    totalElements += rawData.length;
-  });
+    totalElements += count;
+  }
 
   if (series.length === 0)
     return null;
@@ -579,11 +932,16 @@ function extractSegmentedLayer(
  * Handles individual data components (e.g. `<VictoryScatter>`) and
  * `<VictoryStack>` for stacked bar charts. Layer ids are produced by
  * `makeId`, called with the layer's local index among the collected layers.
+ *
+ * `chartPolar` carries the enclosing `<VictoryChart polar>` down to the data
+ * components, which is where Victory itself applies it: a child inherits the
+ * chart's `polar` unless it declares its own.
  */
 function collectDataLayers(
   childNodes: ReactNode,
   axisLabels: { x?: string; y?: string },
   makeId: (localIndex: number) => string,
+  chartPolar = false,
 ): VictoryLayerInfo[] {
   const layers: VictoryLayerInfo[] = [];
 
@@ -604,7 +962,7 @@ function collectDataLayers(
     }
 
     // Individual data components
-    const layer = extractLayerFromElement(child, makeId(layers.length), axisLabels);
+    const layer = extractLayerFromElement(child, makeId(layers.length), axisLabels, chartPolar);
     if (layer)
       layers.push(layer);
   });
@@ -631,9 +989,14 @@ export function extractVictoryLayers(children: ReactNode): VictoryLayerInfo[] {
     const name = getVictoryDisplayName(child.type);
 
     if (name === 'VictoryChart') {
-      const chartProps = child.props as { children?: ReactNode };
+      const chartProps = child.props as { children?: ReactNode; polar?: boolean };
       const axisLabels = extractAxisLabels(chartProps.children);
-      layers.push(...collectDataLayers(chartProps.children, axisLabels, n => String(layers.length + n)));
+      layers.push(...collectDataLayers(
+        chartProps.children,
+        axisLabels,
+        n => String(layers.length + n),
+        chartProps.polar === true,
+      ));
     } else {
       layers.push(...collectDataLayers(child, {}, n => String(layers.length + n)));
     }
@@ -699,10 +1062,15 @@ export function extractVictorySubplots(children: ReactNode): VictorySubplotInfo[
   }
 
   return charts.map(({ element, svgIndex }, panelIndex) => {
-    const chartProps = element.props as { children?: ReactNode; title?: string };
+    const chartProps = element.props as { children?: ReactNode; title?: string; polar?: boolean };
     const axisLabels = extractAxisLabels(chartProps.children);
     return {
-      layers: collectDataLayers(chartProps.children, axisLabels, n => `${panelIndex}_${n}`),
+      layers: collectDataLayers(
+        chartProps.children,
+        axisLabels,
+        n => `${panelIndex}_${n}`,
+        chartProps.polar === true,
+      ),
       title: typeof chartProps.title === 'string' ? chartProps.title : undefined,
       svgIndex,
     };
@@ -741,6 +1109,28 @@ export function computeSubplotGrid<T>(panels: T[], layout?: VictoryPanelLayout):
 // ---------------------------------------------------------------------------
 
 /**
+ * Normalises a tagged selector into the per-series array the line family
+ * expects — one entry per row of the layer's `LinePoint[][]`.
+ *
+ * A single-series layer is tagged with one selector string and a multi-band
+ * one with an array already; both have to arrive as an array, because
+ * `LineTrace` compares the selector count against its series count and would
+ * otherwise measure the length of a string.
+ *
+ * @param selector - The selector produced by the DOM tagging pass
+ * @returns One selector per series, or undefined when nothing was tagged
+ */
+function toSeriesSelectors(
+  selector?: string | string[] | BoxSelector[] | CandlestickSelector,
+): string[] | undefined {
+  if (typeof selector === 'string')
+    return [selector];
+  if (Array.isArray(selector) && selector.every(one => typeof one === 'string'))
+    return selector;
+  return undefined;
+}
+
+/**
  * Converts a {@link VictoryLayerInfo} into the MAIDR {@link MaidrLayer}
  * schema.
  *
@@ -750,7 +1140,7 @@ export function computeSubplotGrid<T>(panels: T[], layout?: VictoryPanelLayout):
  */
 export function toMaidrLayer(
   layer: VictoryLayerInfo,
-  selector?: string | BoxSelector[] | CandlestickSelector,
+  selector?: string | string[] | BoxSelector[] | CandlestickSelector,
 ): MaidrLayer {
   const axes: MaidrLayer['axes'] = {
     x: layer.xAxisLabel ? { label: layer.xAxisLabel } : undefined,
@@ -779,10 +1169,55 @@ export function toMaidrLayer(
         data: data.points,
       };
 
+    case 'area':
+      return {
+        id: layer.id,
+        type: TraceType.AREA,
+        axes,
+        selectors: toSeriesSelectors(selector),
+        data: data.points,
+      };
+
+    case 'stackedArea':
+      return {
+        id: layer.id,
+        type: data.normalized ? TraceType.NORMALIZED_AREA : TraceType.STACKED_AREA,
+        axes,
+        selectors: toSeriesSelectors(selector),
+        data: data.points,
+      };
+
+    case 'polarArea':
+      return {
+        id: layer.id,
+        type: TraceType.POLAR_AREA,
+        axes,
+        selectors: toSeriesSelectors(selector),
+        data: data.points,
+      };
+
     case 'scatter':
       return {
         id: layer.id,
         type: TraceType.SCATTER,
+        axes,
+        selectors: selector,
+        data: data.points,
+      };
+
+    case 'errorBar':
+      return {
+        id: layer.id,
+        type: TraceType.ERROR_BAR,
+        axes,
+        selectors: selector,
+        data: data.points,
+      };
+
+    case 'waterfall':
+      return {
+        id: layer.id,
+        type: TraceType.WATERFALL,
         axes,
         selectors: selector,
         data: data.points,

--- a/src/adapters/victory/selectors.ts
+++ b/src/adapters/victory/selectors.ts
@@ -171,9 +171,28 @@ export function tagLayerElements(
   claimed: Set<Element>,
   scope: string,
   panelIndex: number | null = null,
-): string | BoxSelector[] | CandlestickSelector | undefined {
+): string | string[] | BoxSelector[] | CandlestickSelector | undefined {
   const attrName = victoryAttr(panelIndex, String(layerIndex));
-  const { victoryType } = layer;
+  const { victoryType, data } = layer;
+
+  // What was extracted decides the DOM shape before the component name does:
+  // one Victory component can draw more than one chart type (a polar
+  // VictoryBar is a coxcomb of wedges, a VictoryStack of areas is bands
+  // rather than one mark per datum), and the marks differ accordingly.
+  if (data.kind === 'area') {
+    // Victory's Area primitive renders the same single <path
+    // role="presentation"> its Line primitive does, closed along the baseline.
+    return tagLineElements(svg, layer, attrName, claimed, scope);
+  }
+  if (data.kind === 'stackedArea') {
+    return tagStackedAreaElements(svg, data.points.length, attrName, claimed, scope);
+  }
+  if (data.kind === 'errorBar') {
+    return tagErrorBarElements(svg, layer.dataCount, attrName, claimed, scope);
+  }
+  if (data.kind === 'polarArea') {
+    return tagPolarWedgeElements(svg, layer.dataCount, attrName, claimed, scope);
+  }
 
   // Line charts: single <path> representing the full series.
   if (victoryType === 'VictoryLine') {
@@ -194,7 +213,8 @@ export function tagLayerElements(
   }
 
   // Discrete-element charts: one <path role="presentation"> per data point.
-  // VictoryBar, VictoryHistogram, VictoryScatter, VictoryStack, and VictoryPie
+  // VictoryBar (plain or waterfall), VictoryHistogram, VictoryScatter,
+  // VictoryStack, and VictoryPie
   // all render their data points as <path> elements — Victory's Bar primitive
   // renders a <path> (with arc commands for corner radius), never a <rect>,
   // and its Slice primitive renders the d3-shape arc path for one wedge.
@@ -297,6 +317,168 @@ function tagLineElements(
   const fallback = candidates[0];
   fallback.setAttribute(attrName, '');
   claimed.add(fallback);
+  return `${scope}[${attrName}]`;
+}
+
+// ---------------------------------------------------------------------------
+// Area
+// ---------------------------------------------------------------------------
+
+/**
+ * Tags the band `<path>`s of a stacked-area layer — one selector per band.
+ *
+ * `VictoryStack` reverses the render order of its children so the topmost band
+ * paints last, which puts the bands in the DOM back to front. The emitted
+ * selectors are ordered to match the extracted bands instead, since an area
+ * trace reads its series in the order the payload lists them and would
+ * otherwise highlight one band while announcing another.
+ *
+ * @param svg       - The panel's root svg element
+ * @param bandCount - Number of bands the layer extracted
+ * @param attrName  - The layer's tracking attribute name
+ * @param claimed   - Elements already claimed by prior layers of this panel
+ * @param scope     - Per-chart (and per-panel) CSS scope prefix
+ * @returns One selector per band, or undefined when the bands were not found
+ */
+function tagStackedAreaElements(
+  svg: SVGElement,
+  bandCount: number,
+  attrName: string,
+  claimed: Set<Element>,
+  scope: string,
+): string[] | undefined {
+  const candidates = Array.from(
+    svg.querySelectorAll('path[role="presentation"]'),
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el));
+
+  if (candidates.length < bandCount) {
+    return undefined;
+  }
+
+  const paths = candidates.slice(0, bandCount);
+  const selectors: string[] = [];
+
+  for (let band = 0; band < bandCount; band++) {
+    const element = paths[bandCount - 1 - band];
+    const bandAttr = `${attrName}-band-${band}`;
+    element.setAttribute(attrName, '');
+    element.setAttribute(bandAttr, '');
+    claimed.add(element);
+    selectors.push(`${scope}[${bandAttr}]`);
+  }
+
+  return selectors;
+}
+
+// ---------------------------------------------------------------------------
+// Polar
+// ---------------------------------------------------------------------------
+
+/**
+ * Tags the wedge `<path>`s of a polar `VictoryBar` layer.
+ *
+ * A polar chart's axis is itself a `<path role="presentation">` — a circle
+ * drawn from two arcs — and it renders before or after the marks depending on
+ * where the axis component sits among the chart's children, so the plain
+ * "first N presentation paths" rule can hand back the axis as data. Victory
+ * translates every polar mark to the chart origin and leaves the axis
+ * untransformed, which tells the two apart whichever order they arrive in.
+ *
+ * @param svg       - The panel's root svg element
+ * @param dataCount - Number of wedges the layer extracted
+ * @param attrName  - The layer's tracking attribute name
+ * @param claimed   - Elements already claimed by prior layers of this panel
+ * @param scope     - Per-chart (and per-panel) CSS scope prefix
+ * @returns A CSS selector matching the wedges, or undefined when not found
+ */
+function tagPolarWedgeElements(
+  svg: SVGElement,
+  dataCount: number,
+  attrName: string,
+  claimed: Set<Element>,
+  scope: string,
+): string | undefined {
+  const candidates = Array.from(
+    svg.querySelectorAll('path[role="presentation"][transform]'),
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el));
+
+  const matched = candidates.slice(0, dataCount);
+  if (matched.length !== dataCount) {
+    return undefined;
+  }
+
+  for (const element of matched) {
+    element.setAttribute(attrName, '');
+    claimed.add(element);
+  }
+
+  return `${scope}[${attrName}]`;
+}
+
+// ---------------------------------------------------------------------------
+// Error bar
+// ---------------------------------------------------------------------------
+
+/**
+ * Tags one whisker `<line>` per sample of a VictoryErrorBar layer.
+ *
+ * Victory draws each sample as a `<g>` holding up to four `<line>`s: two caps
+ * (`data-type="border-*"`) and two whiskers running out from the estimate
+ * (`data-type="cross-*"`). Nothing else in a Victory svg carries `data-type`,
+ * so it is what separates these from an axis rule or a box plot's whiskers,
+ * and grouping by the parent `<g>` recovers one group per sample.
+ *
+ * One element per sample is exactly what MAIDR's error bar trace asks for: it
+ * highlights the same element for the estimate and for both bounds, because a
+ * chart draws one whip per sample rather than one mark per bound. The first
+ * whisker is the one tagged; the rest of the sample's lines are claimed so a
+ * sibling layer that classifies bare `<line>`s cannot pick them up.
+ *
+ * @param svg       - The panel's root svg element
+ * @param dataCount - Number of samples the layer extracted
+ * @param attrName  - The layer's tracking attribute name
+ * @param claimed   - Elements already claimed by prior layers of this panel
+ * @param scope     - Per-chart (and per-panel) CSS scope prefix
+ * @returns A CSS selector matching one whisker per sample, or undefined
+ */
+function tagErrorBarElements(
+  svg: SVGElement,
+  dataCount: number,
+  attrName: string,
+  claimed: Set<Element>,
+  scope: string,
+): string | undefined {
+  const whiskers = Array.from(
+    svg.querySelectorAll('line[data-type^="cross-"]'),
+  ).filter(el => !claimed.has(el) && !isMaidrOwned(el));
+
+  // Map preserves insertion order, so the samples come out in document order.
+  const bySample = new Map<Element, Element[]>();
+  for (const whisker of whiskers) {
+    const group = whisker.parentElement;
+    if (!group) {
+      continue;
+    }
+    const bucket = bySample.get(group);
+    if (bucket) {
+      bucket.push(whisker);
+    } else {
+      bySample.set(group, [whisker]);
+    }
+  }
+
+  const samples = Array.from(bySample.entries()).slice(0, dataCount);
+  if (samples.length !== dataCount) {
+    return undefined;
+  }
+
+  for (const [group, groupWhiskers] of samples) {
+    groupWhiskers[0].setAttribute(attrName, '');
+    for (const line of Array.from(group.querySelectorAll('line'))) {
+      claimed.add(line);
+    }
+  }
+
   return `${scope}[${attrName}]`;
 }
 

--- a/src/adapters/victory/selectors.ts
+++ b/src/adapters/victory/selectors.ts
@@ -213,8 +213,8 @@ export function tagLayerElements(
   }
 
   // Discrete-element charts: one <path role="presentation"> per data point.
-  // VictoryBar (plain or waterfall), VictoryHistogram, VictoryScatter,
-  // VictoryStack, and VictoryPie
+  // VictoryBar (plain or waterfall), VictoryHistogram, VictoryScatter (plain
+  // or dot plot), VictoryStack (stacked or diverging), and VictoryPie
   // all render their data points as <path> elements — Victory's Bar primitive
   // renders a <path> (with arc commands for corner radius), never a <rect>,
   // and its Slice primitive renders the d3-shape arc path for one wedge.
@@ -253,7 +253,11 @@ function tagDiscreteElements(
     // they expose no x/y or cx/cy. Stamp cx/cy from the path centre so MAIDR's
     // ScatterTrace.groupSvgElements (which groups points by cx/cy) can locate
     // them. Ignored by SVG path rendering; inherited by the highlight clones.
-    if (layer.victoryType === 'VictoryScatter') {
+    //
+    // Keyed on what was extracted rather than on the component: a `VictoryScatter`
+    // over categories is a dot plot, read by the bar trace, which locates its
+    // marks by position in the selector's result and needs no coordinates.
+    if (layer.data.kind === 'scatter') {
       stampPathCenter(el);
     }
   }

--- a/src/adapters/victory/types.ts
+++ b/src/adapters/victory/types.ts
@@ -2,12 +2,14 @@ import type {
   BarPoint,
   BoxPoint,
   CandlestickPoint,
+  ErrorBarPoint,
   HistogramPoint,
   LinePoint,
   PiePoint,
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
+  WaterfallPoint,
 } from '@type/grammar';
 import type { ReactNode } from 'react';
 
@@ -61,11 +63,13 @@ export type MaidrVictoryProps = VictoryAdapterConfig;
  * individual data components) that maps to a stacked bar chart.
  */
 export type VictoryComponentType
-  = | 'VictoryBar'
+  = | 'VictoryArea'
+    | 'VictoryBar'
     | 'VictoryLine'
     | 'VictoryScatter'
     | 'VictoryBoxPlot'
     | 'VictoryCandlestick'
+    | 'VictoryErrorBar'
     | 'VictoryHistogram'
     | 'VictoryPie'
     | 'VictoryStack';
@@ -84,7 +88,26 @@ export type VictoryLayerData
      * a staircase, making the layer a step rather than a line.
      */
     | { kind: 'line'; points: LinePoint[][]; stepDirection?: StepDirection }
+    /**
+     * A `VictoryArea` — a line whose region down to the baseline is filled.
+     * The fill is what the chart is called rather than a second magnitude, so
+     * the payload is a line's.
+     */
+    | { kind: 'area'; points: LinePoint[][] }
+    /**
+     * A `VictoryStack` of `VictoryArea` children, one row per band. Each
+     * band carries its own untransformed value; the running total is the
+     * trace's to compute. `normalized` marks a stack whose columns are shares
+     * of a common whole.
+     */
+    | { kind: 'stackedArea'; points: LinePoint[][]; normalized: boolean }
+    /** A `VictoryBar` drawn `polar` — values as wedges around a circle. */
+    | { kind: 'polarArea'; points: LinePoint[][] }
     | { kind: 'scatter'; points: ScatterPoint[] }
+    /** A `VictoryErrorBar`, with Victory's error deltas resolved to bounds. */
+    | { kind: 'errorBar'; points: ErrorBarPoint[] }
+    /** A `VictoryBar` whose bars float between a per-datum `y0` and `y`. */
+    | { kind: 'waterfall'; points: WaterfallPoint[] }
     | { kind: 'box'; points: BoxPoint[] }
     | { kind: 'candlestick'; points: CandlestickPoint[] }
     | { kind: 'histogram'; points: HistogramPoint[] }

--- a/src/adapters/victory/types.ts
+++ b/src/adapters/victory/types.ts
@@ -104,6 +104,12 @@ export type VictoryLayerData
     /** A `VictoryBar` drawn `polar` — values as wedges around a circle. */
     | { kind: 'polarArea'; points: LinePoint[][] }
     | { kind: 'scatter'; points: ScatterPoint[] }
+    /**
+     * A `VictoryScatter` whose x values name categories — a Cleveland dot
+     * plot. One magnitude per category is what a reader navigates, so the
+     * payload is a bar's rather than a scatter's.
+     */
+    | { kind: 'dot'; points: BarPoint[] }
     /** A `VictoryErrorBar`, with Victory's error deltas resolved to bounds. */
     | { kind: 'errorBar'; points: ErrorBarPoint[] }
     /** A `VictoryBar` whose bars float between a per-datum `y0` and `y`. */
@@ -113,7 +119,13 @@ export type VictoryLayerData
     | { kind: 'histogram'; points: HistogramPoint[] }
     /** A `VictoryPie` (or a doughnut — the same component with an `innerRadius`). */
     | { kind: 'pie'; points: PiePoint[] }
-    | { kind: 'segmented'; points: SegmentedPoint[][] };
+    | { kind: 'segmented'; points: SegmentedPoint[][] }
+    /**
+     * A `VictoryStack` of two `VictoryBar` children signed against each other
+     * — a population pyramid. The values stay signed as the chart draws them,
+     * and the two sides are listed in the order Victory paints them.
+     */
+    | { kind: 'diverging'; points: SegmentedPoint[][] };
 
 /**
  * Intermediate representation of a Victory data layer before conversion

--- a/test/adapters/victory/converters.test.ts
+++ b/test/adapters/victory/converters.test.ts
@@ -32,7 +32,9 @@ function stub(displayName: string): VictoryStub {
 
 const VictoryChart = stub('VictoryChart');
 const VictoryAxis = stub('VictoryAxis');
+const VictoryArea = stub('VictoryArea');
 const VictoryBar = stub('VictoryBar');
+const VictoryErrorBar = stub('VictoryErrorBar');
 const VictoryLine = stub('VictoryLine');
 const VictoryScatter = stub('VictoryScatter');
 const VictoryStack = stub('VictoryStack');
@@ -423,5 +425,324 @@ describe('toMaidrLayer', () => {
 
     expect(layer.type).toBe(TraceType.STACKED);
     expect(layer.selectors).toBeUndefined();
+  });
+});
+
+describe('area', () => {
+  it('converts a VictoryArea to an area layer of line points', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryArea, { data: lineData })),
+    );
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-0]');
+
+    expect(info.victoryType).toBe('VictoryArea');
+    expect(layer.type).toBe(TraceType.AREA);
+    expect(layer.data).toEqual([[{ x: 1, y: 10 }, { x: 2, y: 20 }]]);
+    // A line-shaped trace counts its selectors against its series, so a single
+    // series has to arrive as a one-entry array rather than as a bare string.
+    expect(layer.selectors).toEqual(['#mv [data-maidr-victory-0]']);
+  });
+
+  it('reads area accessors declared as prop keys', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryArea, {
+        data: [{ year: 2020, sales: '5' }],
+        x: 'year',
+        y: 'sales',
+      }),
+    );
+
+    expect(toMaidrLayer(info).data).toEqual([[{ x: 2020, y: 5 }]]);
+  });
+
+  it('ignores interpolation, which names the curve rather than the chart', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryArea, { data: lineData, interpolation: 'stepAfter' })),
+    );
+
+    const layer = toMaidrLayer(info);
+
+    expect(layer.type).toBe(TraceType.AREA);
+    expect(layer.stepDirection).toBeUndefined();
+  });
+});
+
+describe('stacked area', () => {
+  const bands = [
+    { name: 'Solar', data: [{ x: 2020, y: 1 }, { x: 2021, y: 2 }] },
+    { name: 'Wind', data: [{ x: 2020, y: 3 }, { x: 2021, y: 4 }] },
+  ];
+
+  function areaStack(children: { name: string; data: unknown[] }[]): ReactNode {
+    return chart(
+      {},
+      createElement(
+        VictoryStack,
+        {},
+        ...children.map(({ name, data }) => createElement(VictoryArea, { key: name, name, data })),
+      ),
+    );
+  }
+
+  it('converts a stack of areas to bands carrying their own values', () => {
+    const [info] = extractVictoryLayers(areaStack(bands));
+
+    const layer = toMaidrLayer(info, ['#mv [band-0]', '#mv [band-1]']);
+
+    expect(info.victoryType).toBe('VictoryStack');
+    expect(info.legend).toEqual(['Solar', 'Wind']);
+    expect(layer.type).toBe(TraceType.STACKED_AREA);
+    // Each band keeps its own magnitude: the running total is the trace's to
+    // compute, and pre-accumulating here would double it.
+    expect(layer.data).toEqual([
+      [{ x: 2020, y: 1, z: 'Solar' }, { x: 2021, y: 2, z: 'Solar' }],
+      [{ x: 2020, y: 3, z: 'Wind' }, { x: 2021, y: 4, z: 'Wind' }],
+    ]);
+    expect(layer.selectors).toEqual(['#mv [band-0]', '#mv [band-1]']);
+  });
+
+  it('names unnamed bands by position', () => {
+    const [info] = extractVictoryLayers(
+      chart(
+        {},
+        createElement(
+          VictoryStack,
+          {},
+          createElement(VictoryArea, { key: 'a', data: bands[0].data }),
+          createElement(VictoryArea, { key: 'b', data: bands[1].data }),
+        ),
+      ),
+    );
+
+    expect(info.legend).toEqual(['Series 1', 'Series 2']);
+  });
+
+  it('keeps a stack of bars a stacked bar', () => {
+    const [info] = extractVictoryLayers(
+      chart(
+        {},
+        createElement(
+          VictoryStack,
+          {},
+          createElement(VictoryBar, { name: 'S1', data: barData }),
+          createElement(VictoryBar, { name: 'S2', data: barData }),
+        ),
+      ),
+    );
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.STACKED);
+  });
+
+  it('reads a stack whose every column sums to 100 as normalized', () => {
+    const [info] = extractVictoryLayers(areaStack([
+      { name: 'A', data: [{ x: 2020, y: 60 }, { x: 2021, y: 30 }] },
+      { name: 'B', data: [{ x: 2020, y: 40 }, { x: 2021, y: 70 }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.NORMALIZED_AREA);
+  });
+
+  it('reads a stack whose every column sums to 1 as normalized', () => {
+    const [info] = extractVictoryLayers(areaStack([
+      { name: 'A', data: [{ x: 2020, y: 0.25 }, { x: 2021, y: 0.5 }] },
+      { name: 'B', data: [{ x: 2020, y: 0.75 }, { x: 2021, y: 0.5 }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.NORMALIZED_AREA);
+  });
+
+  it('leaves a stack whose columns differ unnormalized', () => {
+    const [info] = extractVictoryLayers(areaStack([
+      { name: 'A', data: [{ x: 2020, y: 60 }, { x: 2021, y: 30 }] },
+      { name: 'B', data: [{ x: 2020, y: 40 }, { x: 2021, y: 50 }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.STACKED_AREA);
+  });
+
+  it('does not call a single column normalized on one total alone', () => {
+    const [info] = extractVictoryLayers(areaStack([
+      { name: 'A', data: [{ x: 2020, y: 60 }] },
+      { name: 'B', data: [{ x: 2020, y: 40 }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.STACKED_AREA);
+  });
+});
+
+describe('error bar', () => {
+  it('converts a symmetric errorY delta into absolute bounds', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryErrorBar, {
+        data: [{ x: 1, y: 10, errorY: 2 }, { x: 2, y: 20, errorY: 0.5 }],
+      })),
+    );
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-0]');
+
+    expect(info.victoryType).toBe('VictoryErrorBar');
+    expect(layer.type).toBe(TraceType.ERROR_BAR);
+    expect(layer.data).toEqual([
+      { x: 1, y: 10, yMin: 8, yMax: 12 },
+      { x: 2, y: 20, yMin: 19.5, yMax: 20.5 },
+    ]);
+    expect(layer.selectors).toBe('#mv [data-maidr-victory-0]');
+  });
+
+  it('reads an asymmetric [plus, minus] error', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryErrorBar, { data: [{ x: 1, y: 10, errorY: [3, 1] }] }),
+    );
+
+    expect(toMaidrLayer(info).data).toEqual([{ x: 1, y: 10, yMin: 9, yMax: 13 }]);
+  });
+
+  it('leaves a one-sided interval one-sided rather than mirroring it', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryErrorBar, { data: [{ x: 1, y: 10, errorY: [3, 0] }] }),
+    );
+
+    // Victory draws no whisker for a zero error, so neither does MAIDR: the
+    // trace drops the lower row instead of announcing a bound at the estimate.
+    expect(toMaidrLayer(info).data).toEqual([{ x: 1, y: 10, yMax: 13 }]);
+  });
+
+  it('keeps a sample whose own error is missing', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryErrorBar, {
+        data: [{ x: 1, y: 10, errorY: 2 }, { x: 2, y: 20 }],
+      }),
+    );
+
+    expect(toMaidrLayer(info).data).toEqual([
+      { x: 1, y: 10, yMin: 8, yMax: 12 },
+      { x: 2, y: 20 },
+    ]);
+  });
+
+  it('reads an errorY accessor declared as a prop key', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryErrorBar, {
+        data: [{ x: 1, y: 10, sd: 2 }],
+        errorY: 'sd',
+      }),
+    );
+
+    expect(toMaidrLayer(info).data).toEqual([{ x: 1, y: 10, yMin: 8, yMax: 12 }]);
+  });
+
+  it('drops a layer that draws no interval at all', () => {
+    const layers = extractVictoryLayers(
+      createElement(VictoryErrorBar, { data: [{ x: 1, y: 10 }, { x: 2, y: 20 }] }),
+    );
+
+    expect(layers).toHaveLength(0);
+  });
+});
+
+describe('waterfall', () => {
+  const steps = [
+    { x: 'Open', y: 100, y0: 0 },
+    { x: 'Sales', y: 160, y0: 100 },
+    { x: 'Costs', y: 130, y0: 160 },
+    { x: 'Close', y: 130, y0: 0 },
+  ];
+
+  it('converts chaining floating bars into waterfall steps', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryBar, { data: steps })),
+    );
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-0]');
+
+    expect(layer.type).toBe(TraceType.WATERFALL);
+    expect(layer.data).toEqual([
+      { x: 'Open', start: 0, end: 100, delta: 100, kind: 'total' },
+      { x: 'Sales', start: 100, end: 160, delta: 60, kind: 'increase' },
+      { x: 'Costs', start: 160, end: 130, delta: -30, kind: 'decrease' },
+      { x: 'Close', start: 0, end: 130, delta: 130, kind: 'total' },
+    ]);
+    // Bars are one <path> per datum either way, so the discrete tagging path
+    // is reused unchanged.
+    expect(layer.selectors).toBe('#mv [data-maidr-victory-0]');
+  });
+
+  it('keeps an ordinary bar chart a bar chart', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryBar, { data: barData })),
+    );
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.BAR);
+  });
+
+  it('keeps unchained floating bars a bar chart', () => {
+    // A range bar and a gantt row float the same way a waterfall step does;
+    // without the chain there is nothing to tell them apart, so the adapter
+    // does not guess.
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryBar, {
+        data: [{ x: 'A', y: 5, y0: 1 }, { x: 'B', y: 9, y0: 6 }],
+      })),
+    );
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.BAR);
+  });
+
+  it('reads a y0 accessor declared as a prop key', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryBar, {
+        data: [{ x: 'A', end: 10, begin: 0 }, { x: 'B', end: 4, begin: 10 }],
+        y: 'end',
+        y0: 'begin',
+      }),
+    );
+
+    expect(toMaidrLayer(info).data).toEqual([
+      { x: 'A', start: 0, end: 10, delta: 10, kind: 'total' },
+      { x: 'B', start: 10, end: 4, delta: -6, kind: 'decrease' },
+    ]);
+  });
+});
+
+describe('polar area', () => {
+  const wedges = [{ x: 'N', y: 3 }, { x: 'E', y: 5 }, { x: 'S', y: 2 }];
+
+  it('reads a polar VictoryBar inside a polar chart as a polar area', () => {
+    const [info] = extractVictoryLayers(
+      chart({ polar: true }, createElement(VictoryBar, { data: wedges })),
+    );
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-0]');
+
+    expect(layer.type).toBe(TraceType.POLAR_AREA);
+    expect(layer.data).toEqual([[{ x: 'N', y: 3 }, { x: 'E', y: 5 }, { x: 'S', y: 2 }]]);
+    expect(layer.selectors).toEqual(['#mv [data-maidr-victory-0]']);
+  });
+
+  it('reads a polar prop on the bar itself', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryBar, { data: wedges, polar: true }),
+    );
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.POLAR_AREA);
+  });
+
+  it('lets a child opt back out of an enclosing polar chart', () => {
+    const [info] = extractVictoryLayers(
+      chart({ polar: true }, createElement(VictoryBar, { data: wedges, polar: false })),
+    );
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.BAR);
+  });
+
+  it('carries the chart polar flag into each panel of a multi-panel figure', () => {
+    const subplots = extractVictorySubplots([
+      chart({ key: 'a', polar: true }, createElement(VictoryBar, { data: wedges })),
+      chart({ key: 'b' }, createElement(VictoryBar, { data: barData })),
+    ]);
+
+    expect(toMaidrLayer(subplots[0].layers[0]).type).toBe(TraceType.POLAR_AREA);
+    expect(toMaidrLayer(subplots[1].layers[0]).type).toBe(TraceType.BAR);
   });
 });

--- a/test/adapters/victory/converters.test.ts
+++ b/test/adapters/victory/converters.test.ts
@@ -676,6 +676,27 @@ describe('waterfall', () => {
     expect(toMaidrLayer(info).type).toBe(TraceType.BAR);
   });
 
+  it('reads a chain the caller accumulated in floating point', () => {
+    // A chart that knows its deltas and its running totals derives each bar's
+    // foot as `end - delta`, which misses the previous bar's end by a ULP or
+    // so. Requiring the two to be bit-identical would demote a real waterfall
+    // to a bar chart over a difference no reader could perceive.
+    const deltas = [0.1, 0.2, 0.3];
+    let total = 0;
+    const running = deltas.map((delta, i) => {
+      total += delta;
+      return { x: `Step ${i}`, y: total, y0: total - delta };
+    });
+    // The premise of the test: the chain does not survive an exact comparison.
+    expect(running[1].y0).not.toBe(running[0].y);
+
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryBar, { data: running })),
+    );
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.WATERFALL);
+  });
+
   it('keeps unchained floating bars a bar chart', () => {
     // A range bar and a gantt row float the same way a waterfall step does;
     // without the chain there is nothing to tell them apart, so the adapter

--- a/test/adapters/victory/converters.test.ts
+++ b/test/adapters/victory/converters.test.ts
@@ -746,3 +746,171 @@ describe('polar area', () => {
     expect(toMaidrLayer(subplots[1].layers[0]).type).toBe(TraceType.BAR);
   });
 });
+
+describe('dot plot', () => {
+  const dotData = [
+    { x: 'Denmark', y: 7.6 },
+    { x: 'Finland', y: 7.8 },
+    { x: 'Iceland', y: 7.5 },
+  ];
+
+  it('reads a scatter over categories as a dot plot of bar points', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryScatter, { data: dotData })),
+    );
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-0]');
+
+    expect(info.victoryType).toBe('VictoryScatter');
+    expect(layer.type).toBe(TraceType.DOT);
+    // Read as a bivariate scatter every one of these x values coerces to NaN,
+    // which is what the category branch exists to prevent.
+    expect(layer.data).toEqual(dotData);
+    expect(layer.selectors).toBe('#mv [data-maidr-victory-0]');
+  });
+
+  it('keeps a numeric scatter a scatter', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryScatter, { data: scatterData })),
+    );
+
+    const layer = toMaidrLayer(info);
+
+    expect(layer.type).toBe(TraceType.SCATTER);
+    expect(layer.data).toEqual([{ x: 1, y: 2 }, { x: 3, y: 4 }]);
+  });
+
+  it('keeps a scatter whose x values are only partly categorical a scatter', () => {
+    const [info] = extractVictoryLayers(
+      chart({}, createElement(VictoryScatter, { data: [{ x: 'A', y: 1 }, { x: 2, y: 3 }] })),
+    );
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.SCATTER);
+  });
+
+  it('treats a numeric-looking string as the category Victory draws it as', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryScatter, { data: [{ x: '2023', y: 4 }, { x: '2024', y: 6 }] }),
+    );
+
+    const layer = toMaidrLayer(info);
+
+    expect(layer.type).toBe(TraceType.DOT);
+    expect(layer.data).toEqual([{ x: '2023', y: 4 }, { x: '2024', y: 6 }]);
+  });
+
+  it('reads dot accessors declared as prop keys', () => {
+    const [info] = extractVictoryLayers(
+      createElement(VictoryScatter, {
+        data: [{ country: 'Denmark', score: 7.6 }],
+        x: 'country',
+        y: 'score',
+      }),
+    );
+
+    const layer = toMaidrLayer(info);
+
+    expect(layer.type).toBe(TraceType.DOT);
+    expect(layer.data).toEqual([{ x: 'Denmark', y: 7.6 }]);
+  });
+});
+
+describe('diverging bar', () => {
+  const men = [{ x: '0-14', y: -1200 }, { x: '15-29', y: -1150 }];
+  const women = [{ x: '0-14', y: 1140 }, { x: '15-29', y: 1100 }];
+
+  function barStack(children: { name: string; data: unknown[] }[]): ReactNode {
+    return chart(
+      {},
+      createElement(
+        VictoryStack,
+        {},
+        ...children.map(({ name, data }) => createElement(VictoryBar, { key: name, name, data })),
+      ),
+    );
+  }
+
+  it('reads two oppositely signed bar series as a diverging chart', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'Men', data: men },
+      { name: 'Women', data: women },
+    ]));
+
+    const layer = toMaidrLayer(info, '#mv [data-maidr-victory-0]');
+
+    expect(info.victoryType).toBe('VictoryStack');
+    expect(layer.type).toBe(TraceType.DIVERGING);
+    expect(layer.selectors).toBe('#mv [data-maidr-victory-0]');
+  });
+
+  it('keeps the values signed as the chart draws them', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'Men', data: men },
+      { name: 'Women', data: women },
+    ]));
+
+    // The sign is the side a bar points to, and the trace reads it as one.
+    expect(toMaidrLayer(info).data).toEqual([
+      [{ x: '0-14', y: 1140, z: 'Women' }, { x: '15-29', y: 1100, z: 'Women' }],
+      [{ x: '0-14', y: -1200, z: 'Men' }, { x: '15-29', y: -1150, z: 'Men' }],
+    ]);
+  });
+
+  it('lists the sides in the order VictoryStack paints them', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'Men', data: men },
+      { name: 'Women', data: women },
+    ]));
+
+    // `VictoryStack` reverses its children, and the highlight resolves one
+    // flat selector in document order, so the last-declared side is the first
+    // one the payload lists.
+    expect(info.legend).toEqual(['Women', 'Men']);
+  });
+
+  it('reads the sign of a value Victory was handed as a string', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'Men', data: [{ x: '0-14', y: '-1200' }] },
+      { name: 'Women', data: [{ x: '0-14', y: '1140' }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.DIVERGING);
+  });
+
+  it('keeps a stack whose series both grow upwards a stacked bar', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'S1', data: barData },
+      { name: 'S2', data: barData },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.STACKED);
+  });
+
+  it('keeps a three-series stack a stacked bar', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'Men', data: men },
+      { name: 'Women', data: women },
+      { name: 'Unstated', data: [{ x: '0-14', y: 10 }, { x: '15-29', y: 12 }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.STACKED);
+  });
+
+  it('does not call a side that never leaves the baseline a side', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'Men', data: men },
+      { name: 'Women', data: [{ x: '0-14', y: 0 }, { x: '15-29', y: 0 }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.STACKED);
+  });
+
+  it('keeps a stack whose values are not numbers a stacked bar', () => {
+    const [info] = extractVictoryLayers(barStack([
+      { name: 'Men', data: men },
+      { name: 'Women', data: [{ x: '0-14', y: 'high' }, { x: '15-29', y: 'low' }] },
+    ]));
+
+    expect(toMaidrLayer(info).type).toBe(TraceType.STACKED);
+  });
+});

--- a/test/adapters/victory/renderedDom.test.ts
+++ b/test/adapters/victory/renderedDom.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tagging checked against the markup Victory really renders.
+ *
+ * The other two suites build their DOM by hand, which keeps them fast but
+ * also means they only ever assert what this adapter already believes about
+ * Victory. Every selector strategy in `selectors.ts` is a claim about
+ * somebody else's markup — that an area is one `<path role="presentation">`,
+ * that `VictoryStack` paints its bands back to front, that only an error bar's
+ * lines carry `data-type`, that a polar axis is the one presentation path
+ * without a `transform` — and a hand-built fixture cannot falsify any of them.
+ *
+ * So this suite renders the real components and runs the real extraction and
+ * tagging over the result. It is the file that fails when a Victory upgrade
+ * changes the markup, which is the failure that would otherwise reach a reader
+ * as a chart that announces correctly and highlights nothing.
+ */
+
+import type { MaidrLayer } from '@type/grammar';
+import type { ReactElement } from 'react';
+import { extractVictoryLayers, toMaidrLayer } from '@adapters/victory/converters';
+import { tagLayerElements } from '@adapters/victory/selectors';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  VictoryArea,
+  VictoryBar,
+  VictoryChart,
+  VictoryErrorBar,
+  VictoryPolarAxis,
+  VictoryStack,
+} from 'victory';
+
+const SCOPE = '#mv ';
+
+/**
+ * Renders `children`, extracts its layers, and tags the rendered svg — the
+ * same three steps `useVictoryAdapter` performs on mount.
+ */
+function renderAndTag(children: ReactElement): { doc: Document; layers: MaidrLayer[] } {
+  const dom = new JSDOM(
+    `<!doctype html><body><div id="mv">${renderToStaticMarkup(children)}</div></body>`,
+  );
+  const doc = dom.window.document as unknown as Document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+  const claimed = new Set<Element>();
+  const layers = extractVictoryLayers(children).map((layer, index) =>
+    toMaidrLayer(layer, tagLayerElements(svg, layer, index, claimed, SCOPE)));
+
+  return { doc, layers };
+}
+
+/** Resolves a layer's selectors the way the model does, one series at a time. */
+function resolveSeries(doc: Document, layer: MaidrLayer): Element[][] {
+  const selectors = layer.selectors as string[];
+  return selectors.map(selector => Array.from(doc.querySelectorAll(selector)));
+}
+
+describe('victory area', () => {
+  it('tags the one path an area renders', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      null,
+      createElement(VictoryArea, { data: [{ x: 1, y: 2 }, { x: 2, y: 3 }, { x: 3, y: 5 }] }),
+    ));
+
+    expect(layers[0].type).toBe(TraceType.AREA);
+    expect(resolveSeries(doc, layers[0])).toEqual([[expect.anything()]]);
+  });
+});
+
+describe('victory stacked area', () => {
+  it('binds band 0 to the bottom band despite the reversed render order', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      null,
+      createElement(
+        VictoryStack,
+        null,
+        createElement(VictoryArea, { key: 'a', name: 'Solar', data: [{ x: 1, y: 2 }, { x: 2, y: 3 }] }),
+        createElement(VictoryArea, { key: 'b', name: 'Wind', data: [{ x: 1, y: 1 }, { x: 2, y: 4 }] }),
+      ),
+    ));
+
+    expect(layers[0].type).toBe(TraceType.STACKED_AREA);
+    const [solar, wind] = resolveSeries(doc, layers[0]);
+    expect(solar).toHaveLength(1);
+    expect(wind).toHaveLength(1);
+
+    // The bottom band's top edge is drawn at the first series' own values, the
+    // upper band's at the running total, so the y of the first vertex says
+    // which band each selector actually found. `VictoryStack` paints the
+    // topmost band first, so getting this backwards is the live risk.
+    expect(firstVertexY(solar[0])).toBeGreaterThan(firstVertexY(wind[0]));
+  });
+
+  /** The y of a path's initial moveto — smaller is higher up the chart. */
+  function firstVertexY(path: Element): number {
+    const match = (path.getAttribute('d') ?? '').match(/M\s*-?[\d.]+[,\s]+(-?[\d.]+)/);
+    return match ? Number.parseFloat(match[1]) : Number.NaN;
+  }
+});
+
+describe('victory error bar', () => {
+  it('tags exactly one whisker per sample', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      null,
+      createElement(VictoryErrorBar, {
+        data: [
+          { x: 1, y: 2, errorY: 0.5 },
+          { x: 2, y: 3, errorY: [0.4, 0.2] },
+          { x: 3, y: 5, errorY: 0.3 },
+        ],
+      }),
+    ));
+
+    expect(layers[0].type).toBe(TraceType.ERROR_BAR);
+    // One element per sample is the trace's contract; any other count and it
+    // discards the highlight for the whole layer.
+    expect(doc.querySelectorAll(layers[0].selectors as string)).toHaveLength(3);
+  });
+});
+
+describe('victory waterfall', () => {
+  it('tags one bar per step', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      null,
+      createElement(VictoryBar, {
+        data: [
+          { x: 'Open', y: 100, y0: 0 },
+          { x: 'Sales', y: 160, y0: 100 },
+          { x: 'Costs', y: 130, y0: 160 },
+        ],
+      }),
+    ));
+
+    expect(layers[0].type).toBe(TraceType.WATERFALL);
+    expect(doc.querySelectorAll(layers[0].selectors as string)).toHaveLength(3);
+  });
+});
+
+describe('victory polar area', () => {
+  it('tags the wedges and never the polar axis', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      { polar: true },
+      createElement(VictoryPolarAxis, { key: 'axis' }),
+      createElement(VictoryBar, { key: 'bar', data: [{ x: 1, y: 2 }, { x: 2, y: 3 }, { x: 3, y: 5 }] }),
+    ));
+
+    expect(layers[0].type).toBe(TraceType.POLAR_AREA);
+    const [wedges] = resolveSeries(doc, layers[0]);
+    expect(wedges).toHaveLength(3);
+    // The axis is a presentation path too; the origin translate is what tells
+    // a mark from it.
+    expect(wedges.every(wedge => wedge.hasAttribute('transform'))).toBe(true);
+  });
+});

--- a/test/adapters/victory/renderedDom.test.ts
+++ b/test/adapters/victory/renderedDom.test.ts
@@ -15,7 +15,7 @@
  * as a chart that announces correctly and highlights nothing.
  */
 
-import type { MaidrLayer } from '@type/grammar';
+import type { ErrorBarPoint, MaidrLayer } from '@type/grammar';
 import type { ReactElement } from 'react';
 import { extractVictoryLayers, toMaidrLayer } from '@adapters/victory/converters';
 import { tagLayerElements } from '@adapters/victory/selectors';
@@ -124,6 +124,57 @@ describe('victory error bar', () => {
     // discards the highlight for the whole layer.
     expect(doc.querySelectorAll(layers[0].selectors as string)).toHaveLength(3);
   });
+
+  it('puts an asymmetric bound on the side victory drew it', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      null,
+      createElement(VictoryErrorBar, {
+        data: [
+          { x: 1, y: 2, errorY: [0.4, 0.2] },
+          { x: 2, y: 3, errorY: 0.3 },
+          { x: 3, y: 5, errorY: 0.3 },
+        ],
+      }),
+    ));
+
+    const points = layers[0].data as ErrorBarPoint[];
+    const [asymmetric, symmetric] = Array
+      .from(doc.querySelectorAll(layers[0].selectors as string))
+      .map(whiskerExtent);
+
+    // Reading `errorY: [a, b]` as `[minus, plus]` instead of `[plus, minus]`
+    // would swap yMin and yMax on every asymmetric sample and still satisfy
+    // every count- and shape-based assertion, so the only test that can
+    // falsify the mapping is one against the pixels Victory produced.
+    // Two sample centres one data unit apart calibrate the y scale; screen y
+    // grows downward, so the higher value sits at the smaller y.
+    const pxPerUnit = (asymmetric.centre - symmetric.centre)
+      / (points[1].y - points[0].y);
+
+    expect(asymmetric.centre - asymmetric.top)
+      .toBeCloseTo(pxPerUnit * ((points[0].yMax ?? Number.NaN) - points[0].y), 6);
+    expect(asymmetric.bottom - asymmetric.centre)
+      .toBeCloseTo(pxPerUnit * (points[0].y - (points[0].yMin ?? Number.NaN)), 6);
+  });
+
+  /**
+   * The screen-space span of one whisker, read off the four lines Victory
+   * renders per sample. Its `data-type` names ignore the y axis pointing down
+   * — `border-bottom` is the upper cap — so the sides are taken by geometry.
+   */
+  function whiskerExtent(cross: Element): { centre: number; top: number; bottom: number } {
+    const lines = Array.from((cross.parentElement as Element).querySelectorAll('line'));
+    const ys = lines.flatMap(line => [
+      Number(line.getAttribute('y1')),
+      Number(line.getAttribute('y2')),
+    ]);
+    return {
+      centre: Number(cross.getAttribute('y1')),
+      top: Math.min(...ys),
+      bottom: Math.max(...ys),
+    };
+  }
 });
 
 describe('victory waterfall', () => {

--- a/test/adapters/victory/renderedDom.test.ts
+++ b/test/adapters/victory/renderedDom.test.ts
@@ -30,6 +30,7 @@ import {
   VictoryChart,
   VictoryErrorBar,
   VictoryPolarAxis,
+  VictoryScatter,
   VictoryStack,
 } from 'victory';
 
@@ -160,4 +161,72 @@ describe('victory polar area', () => {
     // a mark from it.
     expect(wedges.every(wedge => wedge.hasAttribute('transform'))).toBe(true);
   });
+});
+
+describe('victory dot plot', () => {
+  it('tags one mark per category', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      { domainPadding: 20 },
+      createElement(VictoryScatter, {
+        data: [{ x: 'Denmark', y: 7.6 }, { x: 'Finland', y: 7.8 }, { x: 'Iceland', y: 7.5 }],
+      }),
+    ));
+
+    expect(layers[0].type).toBe(TraceType.DOT);
+    expect(doc.querySelectorAll(layers[0].selectors as string)).toHaveLength(3);
+    // The category names survive: read as a bivariate scatter every x would
+    // have coerced to NaN.
+    expect(layers[0].data).toEqual([
+      { x: 'Denmark', y: 7.6 },
+      { x: 'Finland', y: 7.8 },
+      { x: 'Iceland', y: 7.5 },
+    ]);
+  });
+});
+
+describe('victory diverging bar', () => {
+  it('lists the sides in the order the bars are painted', () => {
+    const { doc, layers } = renderAndTag(createElement(
+      VictoryChart,
+      null,
+      createElement(
+        VictoryStack,
+        null,
+        createElement(VictoryBar, {
+          key: 'men',
+          name: 'Men',
+          data: [{ x: '0-14', y: -1200 }, { x: '15-29', y: -1150 }],
+        }),
+        createElement(VictoryBar, {
+          key: 'women',
+          name: 'Women',
+          data: [{ x: '0-14', y: 1140 }, { x: '15-29', y: 1100 }],
+        }),
+      ),
+    ));
+
+    expect(layers[0].type).toBe(TraceType.DIVERGING);
+
+    const bars = Array.from(doc.querySelectorAll(layers[0].selectors as string));
+    expect(bars).toHaveLength(4);
+
+    // `SegmentedTrace` splits one flat selector's result across the sides in
+    // payload order, and the DOM answers it in document order — so the side
+    // the payload lists first has to be the side Victory painted first.
+    // `VictoryStack` paints its children back to front, which makes that the
+    // last-declared one: Women, drawn above the baseline.
+    const [first, second] = layers[0].data as { y: number }[][];
+    expect(first[0].y).toBeGreaterThan(0);
+    expect(second[0].y).toBeLessThan(0);
+    expect(barCenterY(bars[0])).toBeLessThan(barCenterY(bars[2]));
+  });
+
+  /** The vertical midpoint of a Victory bar `<path>`; smaller is higher up. */
+  function barCenterY(bar: Element): number {
+    const ys = Array.from((bar.getAttribute('d') ?? '').matchAll(/[\s,](-?[\d.]+)\s*(?:[a-z]|$)/gi))
+      .map(match => Number.parseFloat(match[1]))
+      .filter(y => Number.isFinite(y));
+    return (Math.min(...ys) + Math.max(...ys)) / 2;
+  }
 });

--- a/test/adapters/victory/selectors.test.ts
+++ b/test/adapters/victory/selectors.test.ts
@@ -694,3 +694,80 @@ describe('tagLayerElements: polar area', () => {
       .toBeUndefined();
   });
 });
+
+describe('tagLayerElements: dot plot', () => {
+  function dotLayer(count: number): VictoryLayerInfo {
+    const points: BarPoint[] = Array.from({ length: count }, (_, i) => ({ x: `c${i}`, y: i }));
+    return {
+      id: '0',
+      victoryType: 'VictoryScatter',
+      data: { kind: 'dot', points },
+      dataCount: count,
+    };
+  }
+
+  it('tags one mark per category', () => {
+    const { doc, svg } = buildSvg();
+    const marks = [0, 1, 2].map(i => appendPath(doc, svg, { d: `M ${i * 40}, 100 a 3,3 0 1,0 -6,0` }));
+
+    const selector = tagLayerElements(svg, dotLayer(3), 0, new Set(), '#mv-test ');
+
+    expect(selector).toBe('#mv-test [data-maidr-victory-0]');
+    expect(marks.every(mark => mark.hasAttribute('data-maidr-victory-0'))).toBe(true);
+  });
+
+  it('leaves the scatter cx/cy stamp off a dot plot', () => {
+    const { doc, svg } = buildSvg();
+    const marks = [0, 1].map(i => appendPath(doc, svg, { d: `M ${i * 40}, 100 a 3,3 0 1,0 -6,0` }));
+
+    tagLayerElements(svg, dotLayer(2), 0, new Set(), '#mv-test ');
+
+    // The stamp exists for ScatterTrace, which groups its points by cx/cy. A
+    // dot plot is read by the bar trace, which locates its marks by position
+    // in the selector's result.
+    expect(marks.some(mark => mark.hasAttribute('cx'))).toBe(false);
+  });
+
+  it('still stamps cx/cy on a bivariate scatter', () => {
+    const { doc, svg } = buildSvg();
+    const mark = appendPath(doc, svg, { d: 'M 74, 226 a 3,3 0 1,0 -6,0' });
+    const layer: VictoryLayerInfo = {
+      id: '0',
+      victoryType: 'VictoryScatter',
+      data: { kind: 'scatter', points: [{ x: 1, y: 2 }] },
+      dataCount: 1,
+    };
+
+    tagLayerElements(svg, layer, 0, new Set(), '#mv-test ');
+
+    expect(mark.getAttribute('cx')).toBe('74');
+    expect(mark.getAttribute('cy')).toBe('226');
+  });
+});
+
+describe('tagLayerElements: diverging bar', () => {
+  it('tags every bar of both sides under one selector', () => {
+    const { doc, svg } = buildSvg();
+    const bars = [0, 1, 2, 3].map(i => appendPath(doc, svg, { d: `M ${i * 40}, 150 L ${i * 40}, 60 z` }));
+    const layer: VictoryLayerInfo = {
+      id: '0',
+      victoryType: 'VictoryStack',
+      data: {
+        kind: 'diverging',
+        points: [
+          [{ x: '0-14', y: 1140, z: 'Women' }, { x: '15-29', y: 1100, z: 'Women' }],
+          [{ x: '0-14', y: -1200, z: 'Men' }, { x: '15-29', y: -1150, z: 'Men' }],
+        ],
+      },
+      dataCount: 4,
+      legend: ['Women', 'Men'],
+    };
+
+    const selector = tagLayerElements(svg, layer, 0, new Set(), '#mv-test ');
+
+    // `SegmentedTrace` resolves one flat selector and splits the result across
+    // the sides itself, so every bar of both sides carries the same tag.
+    expect(selector).toBe('#mv-test [data-maidr-victory-0]');
+    expect(bars.every(bar => bar.hasAttribute('data-maidr-victory-0'))).toBe(true);
+  });
+});

--- a/test/adapters/victory/selectors.test.ts
+++ b/test/adapters/victory/selectors.test.ts
@@ -460,3 +460,237 @@ describe('buildVictorySubplots', () => {
     expect(subplots[0][1].layers[0].selectors).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Post-pie trace types
+// ---------------------------------------------------------------------------
+
+/** An empty jsdom container with one `<svg role="img">` panel inside it. */
+function buildSvg(): { container: HTMLElement; doc: Document; svg: SVGElement } {
+  const dom = new JSDOM('<!doctype html><body><div id="mv-test"></div></body>');
+  const doc = dom.window.document as Document;
+  const container = doc.getElementById('mv-test') as HTMLElement;
+  const wrapper = doc.createElement('div');
+  const svg = doc.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('role', 'img');
+  wrapper.appendChild(svg);
+  container.appendChild(wrapper);
+  return { container, doc, svg };
+}
+
+/** Appends a `<path role="presentation">` with the given attributes. */
+function appendPath(
+  doc: Document,
+  parent: Element,
+  attrs: Record<string, string>,
+): Element {
+  const path = doc.createElementNS(SVG_NS, 'path');
+  path.setAttribute('role', 'presentation');
+  for (const [name, value] of Object.entries(attrs)) {
+    path.setAttribute(name, value);
+  }
+  parent.appendChild(path);
+  return path;
+}
+
+describe('tagLayerElements: area', () => {
+  it('tags the single area path, the way it does a line', () => {
+    const { doc, svg } = buildSvg();
+    // Victory's Area primitive closes the line back along the baseline, so the
+    // path carries twice the vertices plus the closing point.
+    appendPath(doc, svg, { d: 'M50,170L225,130L400,50L400,250L225,250L50,250Z' });
+    const layer: VictoryLayerInfo = {
+      id: '0',
+      victoryType: 'VictoryArea',
+      data: { kind: 'area', points: [[{ x: 1, y: 2 }, { x: 2, y: 3 }, { x: 3, y: 5 }]] },
+      dataCount: 3,
+    };
+
+    const selector = tagLayerElements(svg, layer, 0, new Set(), '#mv-test ');
+
+    expect(selector).toBe('#mv-test [data-maidr-victory-0]');
+    expect(svg.querySelectorAll('[data-maidr-victory-0]')).toHaveLength(1);
+  });
+});
+
+describe('tagLayerElements: stacked area', () => {
+  function stackedAreaLayer(bandCount: number): VictoryLayerInfo {
+    const points = Array.from({ length: bandCount }, (_, band) => [
+      { x: 2020, y: band + 1, z: `S${band}` },
+    ]);
+    return {
+      id: '0',
+      victoryType: 'VictoryStack',
+      data: { kind: 'stackedArea', points, normalized: false },
+      dataCount: bandCount,
+    };
+  }
+
+  it('maps bands to paths back to front, matching VictoryStack render order', () => {
+    const { container, doc, svg } = buildSvg();
+    // VictoryStack reverses its children so the topmost band paints last: the
+    // first path in the DOM is the LAST band of the payload.
+    const top = appendPath(doc, svg, { d: 'M0,0L1,1' });
+    const bottom = appendPath(doc, svg, { d: 'M0,2L1,3' });
+
+    const selectors = tagLayerElements(svg, stackedAreaLayer(2), 0, new Set(), '#mv-test ');
+
+    expect(selectors).toEqual([
+      '#mv-test [data-maidr-victory-0-band-0]',
+      '#mv-test [data-maidr-victory-0-band-1]',
+    ]);
+    expect(bottom.hasAttribute('data-maidr-victory-0-band-0')).toBe(true);
+    expect(top.hasAttribute('data-maidr-victory-0-band-1')).toBe(true);
+    // One selector per band, each resolving to exactly one path.
+    for (const selector of selectors as string[]) {
+      expect(container.ownerDocument.querySelectorAll(selector)).toHaveLength(1);
+    }
+  });
+
+  it('clears band tags along with the layer tag', () => {
+    const { container, doc, svg } = buildSvg();
+    appendPath(doc, svg, { d: 'M0,0L1,1' });
+    appendPath(doc, svg, { d: 'M0,2L1,3' });
+
+    tagLayerElements(svg, stackedAreaLayer(2), 0, new Set(), '#mv-test ');
+    expect(getTaggedElements(container)).toHaveLength(2);
+
+    clearTaggedElements(container);
+
+    expect(getTaggedElements(container)).toHaveLength(0);
+    expect(container.querySelectorAll('[data-maidr-victory-0-band-0]')).toHaveLength(0);
+  });
+
+  it('gives up when the stack rendered fewer paths than bands', () => {
+    const { doc, svg } = buildSvg();
+    appendPath(doc, svg, { d: 'M0,0L1,1' });
+
+    expect(tagLayerElements(svg, stackedAreaLayer(2), 0, new Set(), '#mv-test '))
+      .toBeUndefined();
+  });
+});
+
+describe('tagLayerElements: error bar', () => {
+  /**
+   * Builds the DOM VictoryErrorBar renders: one `<g>` per sample holding two
+   * cap lines and two whisker lines, each marked with Victory's `data-type`.
+   */
+  function buildErrorBars(sampleCount: number): { container: HTMLElement; svg: SVGElement } {
+    const { container, doc, svg } = buildSvg();
+    const outer = doc.createElementNS(SVG_NS, 'g');
+    outer.setAttribute('role', 'presentation');
+    svg.appendChild(outer);
+
+    for (let i = 0; i < sampleCount; i++) {
+      const group = doc.createElementNS(SVG_NS, 'g');
+      group.setAttribute('role', 'presentation');
+      for (const type of ['border-bottom', 'border-top', 'cross-bottom', 'cross-top']) {
+        const line = doc.createElementNS(SVG_NS, 'line');
+        line.setAttribute('role', 'presentation');
+        line.setAttribute('data-type', type);
+        group.appendChild(line);
+      }
+      outer.appendChild(group);
+    }
+    return { container, svg };
+  }
+
+  function errorBarLayer(sampleCount: number): VictoryLayerInfo {
+    return {
+      id: '0',
+      victoryType: 'VictoryErrorBar',
+      data: {
+        kind: 'errorBar',
+        points: Array.from({ length: sampleCount }, (_, i) => ({ x: i, y: i, yMin: i - 1, yMax: i + 1 })),
+      },
+      dataCount: sampleCount,
+    };
+  }
+
+  it('tags exactly one whisker per sample', () => {
+    const { container, svg } = buildErrorBars(3);
+
+    const selector = tagLayerElements(svg, errorBarLayer(3), 0, new Set(), '#mv-test ');
+
+    expect(selector).toBe('#mv-test [data-maidr-victory-0]');
+    // The trace requires one element per sample: any more and it drops the
+    // highlight entirely.
+    expect(container.ownerDocument.querySelectorAll(selector as string)).toHaveLength(3);
+    for (const group of Array.from(svg.querySelectorAll('g > g'))) {
+      expect(group.querySelectorAll('[data-maidr-victory-0]')).toHaveLength(1);
+    }
+  });
+
+  it('never tags a cap line', () => {
+    const { svg } = buildErrorBars(2);
+
+    tagLayerElements(svg, errorBarLayer(2), 0, new Set(), '#mv-test ');
+
+    const tagged = Array.from(svg.querySelectorAll('[data-maidr-victory-0]'));
+    expect(tagged.every(el => el.getAttribute('data-type')?.startsWith('cross-'))).toBe(true);
+  });
+
+  it('claims every line of a sample so a sibling layer cannot reuse them', () => {
+    const { svg } = buildErrorBars(2);
+    const claimed = new Set<Element>();
+
+    tagLayerElements(svg, errorBarLayer(2), 0, claimed, '#mv-test ');
+
+    expect(claimed.size).toBe(8);
+  });
+
+  it('ignores lines with no data-type, which belong to axes and box plots', () => {
+    const { doc, svg } = buildSvg();
+    const group = doc.createElementNS(SVG_NS, 'g');
+    const bare = doc.createElementNS(SVG_NS, 'line');
+    bare.setAttribute('role', 'presentation');
+    group.appendChild(bare);
+    svg.appendChild(group);
+
+    expect(tagLayerElements(svg, errorBarLayer(1), 0, new Set(), '#mv-test '))
+      .toBeUndefined();
+  });
+});
+
+describe('tagLayerElements: polar area', () => {
+  function polarAreaLayer(wedgeCount: number): VictoryLayerInfo {
+    return {
+      id: '0',
+      victoryType: 'VictoryBar',
+      data: {
+        kind: 'polarArea',
+        points: [Array.from({ length: wedgeCount }, (_, i) => ({ x: i, y: i + 1 }))],
+      },
+      dataCount: wedgeCount,
+    };
+  }
+
+  it.each([
+    ['before', true],
+    ['after', false],
+  ])('skips the polar axis path rendered %s the wedges', (_position, axisFirst) => {
+    const { doc, svg } = buildSvg();
+    // The polar axis is a role="presentation" path too, but Victory leaves it
+    // untransformed while every polar mark is translated to the chart origin.
+    const addAxis = (): Element =>
+      appendPath(doc, svg, { d: 'M 325, 150 A 100, 100, 0, 0, 0, 125, 150' });
+    const axis = axisFirst ? addAxis() : null;
+    const wedges = [0, 1, 2].map(i =>
+      appendPath(doc, svg, { d: `M ${i},0 A 1,1,0,0,0,0,0 L 0,0 z`, transform: 'translate(225, 150)' }));
+    const trailingAxis = axis ?? addAxis();
+
+    const selector = tagLayerElements(svg, polarAreaLayer(3), 0, new Set(), '#mv-test ');
+
+    expect(selector).toBe('#mv-test [data-maidr-victory-0]');
+    expect(wedges.every(w => w.hasAttribute('data-maidr-victory-0'))).toBe(true);
+    expect(trailingAxis.hasAttribute('data-maidr-victory-0')).toBe(false);
+  });
+
+  it('gives up rather than tag too few wedges', () => {
+    const { doc, svg } = buildSvg();
+    appendPath(doc, svg, { d: 'M 0,0 z', transform: 'translate(225, 150)' });
+
+    expect(tagLayerElements(svg, polarAreaLayer(3), 0, new Set(), '#mv-test '))
+      .toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The Victory adapter emitted nine trace types, all of them pre-dating the pie chart. Charts that Victory draws perfectly well were therefore either dropped from the figure or announced as the wrong chart — which for a screen-reader user is worse than no support at all.

This teaches the adapter eight of the nine trace types listed as in scope, along with the detection, the payload conversion and the highlight tagging for each. Two structural changes make room for them:

- **Dispatch is now data-driven, not component-driven.** One Victory component can produce several trace types — `VictoryBar` is a bar, a waterfall or a coxcomb depending on its props and its values — so `tagLayerElements` switches on `layer.data.kind` first and only falls through to the old `victoryType` branches. The component name no longer decides the DOM shape.
- **`polar` is threaded from `VictoryChart` down to its children**, the way Victory passes it internally. A child's own `polar` prop wins, so `polar={false}` opts back out.

Everything is adapter-local: no model, service, command, state, ui or `grammar.ts` change.

## Related Issues

Closes #864

## Changes Made

### Trace types added (8)

| TraceType | Detected from | Notes |
|---|---|---|
| `AREA` | `VictoryArea` | Read exactly as a line; Victory draws both from the same props. |
| `STACKED_AREA` | `VictoryStack` of `VictoryArea` children | One band per child, each carrying its own **untransformed** value — `AreaTrace` computes the running total itself. |
| `NORMALIZED_AREA` | such a stack whose columns sum to a common whole | Victory has no normalize prop, so the evidence is arithmetic. Deliberately narrow: ≥2 bands, ≥2 columns, every column total within 0.5% of 1 or 100. |
| `ERROR_BAR` | `VictoryErrorBar` | Converts Victory's error **deltas** to the absolute bounds the schema fixes, one side at a time so a one-sided interval survives. |
| `POLAR_AREA` | `VictoryBar` drawn polar | A coxcomb, emitted as the single-series line grid the radar trace reads. |
| `WATERFALL` | `VictoryBar` floating on a per-datum `y0` | Gated on the bars chaining (`y0[i+1] === y[i]`), baseline-resting bars exempt as totals. |
| `DOT` | `VictoryScatter` over a categorical x | Doubles as a bug fix — see below. |
| `DIVERGING` | `VictoryStack` of two oppositely-signed bar series | A population pyramid. Values stay signed as the chart draws them. |

### Trace types NOT added, with the reason

- **`RADAR`** — the only in-scope type skipped. A radar is several sibling `VictoryLine`/`VictoryArea` series coalesced into one multi-row layer, and the adapter has no sibling-coalescing step (each sibling stays its own layer; the Vega-Lite `coalesceSiblingLineLayers` is the in-repo precedent for what is missing). The polar plumbing this needs is now in place, so what remains is the coalescing. Until then a polar line or area still reads as `LINE`/`AREA` — the same behaviour as before this PR, not a regression.
- **`GANTT` / `DUMBBELL`** — the issue lists these as drawable but not detectable, and implementing `WATERFALL` confirms why: all three are the same floating-`y0` bar. Chaining is the only checkable signal, and only a waterfall has it. An unchained floating bar deliberately falls back to `BAR` rather than guessing.
- **`FOREST`** — composable on top of `ERROR_BAR`, but `ForestPoint.weight` and `isSummary` have no Victory-side source.
- **`GAUGE`, `MOSAIC`, `LOLLIPOP`, `BUMP`, `SURVIVAL`, `VOLCANO`/`MANHATTAN`, `RIDGELINE`, `PARALLEL`** — as analysed in the issue: Victory can be contrived into drawing them, but the props carry no signal that separates them from a type the adapter already emits, or the author has already applied the transform the trace must not receive.
- **The 13 types Victory cannot render** (`ALLUVIAL`, `CHORD`, `SANKEY`, `NETWORK`, `TREEMAP`, `ICICLE`, `SUNBURST`, `CHOROPLETH`, `CONTOUR`, `HEXBIN`, `WORD_CLOUD`, `BOXEN`, `FUNNEL`) — no corresponding primitive or layout in the library.

### Bug fixed along the way

`extractScatterData` coerced x with `Number()`, so a **categorical `VictoryScatter` produced `NaN` on every point and sonified as garbage**. Categorical is now decided by Victory's own test (a datum goes on the category scale when its x is a string), and such a layer becomes a `DOT`.

### Highlighting

Every type above is tagged as well as detected. The two that needed real work:

- **Stacked area** — `VictoryStack` reverses render order, so band *i* of the payload is path *(N-1-i)* in the DOM. Band selectors are inverted to match, and each band gets a distinct attribute so `LineTrace` maps them positionally instead of falling into `selectNthElement`.
- **Error bar** — `VictoryErrorBar` renders `<line>` elements, not the `<path role="presentation">` the discrete tagger looks for, so the whiskers are grouped by their parent `<g>` to reach the one-element-per-sample `ErrorBarTrace` requires exactly.

### Tests and examples

- `test/adapters/victory/converters.test.ts` and `selectors.test.ts` extended for every new type.
- New `test/adapters/victory/renderedDom.test.ts` renders the real Victory components and tags the result, so the DOM assumptions are checked against the library rather than against a hand-built fragment.
- New examples under `examples/victory/examples/`, registered in `App.tsx`: area, stacked area, error bar, polar area, waterfall, dot plot, population pyramid.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

Note on the unticked boxes: the automated suite passes in full (`lint:fix`, `type-check`, `build`, `test` — 2677 unit + 73 ESM tests green) and the new examples build, but the `ManualTestingProcess.md` walkthrough with a screen reader was not performed, so that box is left unticked rather than claimed. No prose documentation was changed; the new behaviour is documented in code comments and in the examples.

## Additional Notes

Two things worth a reviewer's attention, both deliberate:

**1. `NORMALIZED_AREA` is a heuristic.** Victory has no declarative normalize flag (`grep normalize|percent` over `victory-stack` returns nothing), so a genuine unnormalized stack whose columns happen to sum to 1.0 would be mislabelled. The tolerance is tight on purpose. If that is not acceptable, the alternative is an author-supplied opt-in prop.

**2. A latent core bug this PR does not fix.** Plain `STACKED` is mis-highlighted today, independently of this work: `VictoryStack` reverses render order, and `SegmentedTrace.mapToSvgElements` takes one flat `string` selector, resolves it in document order and maps row-major — so a stack of two bar series binds series 0 to series 1's paths. `DIVERGING` sidesteps this because `DivergingTrace` resolves which side is which by reading values rather than by index, so this PR emits its sides in Victory's paint order. A true stack's row order is semantic, so the adapter cannot fix it by reordering; it needs either `SegmentedTrace` to consume `string[][]` (the grammar already allows it) or a `domMapping.seriesDirection`. Out of scope here — happy to file it as a separate issue.

Also unchanged: `<VictoryChart horizontal>` is still ignored. That is correct for the payload (Victory's `horizontal` flips the drawing, not the data), but it means highlight pan geometry is never orientation-aware. A `VictoryErrorBar` carrying only `errorX` is dropped rather than read as a vertical interval on the wrong axis.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_