### PR TITLE
feat(plotly): support the chart types added since the pie chart

### DIFF
--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -78,6 +78,14 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Funnel | `type: 'funnel'` | [Funnel chart](examples.html) |
 | Waterfall | `type: 'waterfall'` | [Waterfall chart](examples.html) |
 | Error Bars | `error_y` or `error_x` on a scatter or bar trace | [Error bars](examples.html) |
+| Sunburst | `type: 'sunburst'` | [Sunburst](examples.html) |
+| Icicle | `type: 'icicle'` | [Icicle](examples.html) |
+| Treemap | `type: 'treemap'` | [Treemap](examples.html) |
+| Sankey | `type: 'sankey'` | [Sankey](examples.html) |
+| Gauge / Bullet | `type: 'indicator'` with `gauge` in `mode` | [Gauge](examples.html) |
+| Radar | `type: 'scatterpolar'` | [Radar](examples.html) |
+| Polar Area / Rose | `type: 'barpolar'` | [Polar area](examples.html) |
+| Parallel Coordinates | `type: 'parcoords'` | [Parallel coordinates](examples.html) |
 | Subplots / Facets | multiple `xaxis`/`yaxis` pairs, `layout.grid`, or Plotly Express facets | [Subplots](examples.html) |
 
 **Notes on chart-type detection:**
@@ -125,6 +133,49 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   bar's height, which is what the pitch follows) and the running total it
   produced (the bar's position). Steps whose `measure` is `total` or `absolute`
   are announced as totals, so a subtotal is not mistaken for a contribution.
+
+- A sunburst, an icicle and a treemap are one tree drawn three ways, so MAIDR
+  reads all three the same: the hierarchy navigates *as a hierarchy* on the
+  arrow keys that already exist — up to the parent, down to the first child,
+  left and right between siblings — and each node announces its share of its
+  parent. Plotly stratifies `labels`/`parents` into a tree and, unless the
+  trace sets `sort: false`, reorders every node's children largest first, so
+  the adapter walks the tree Plotly computed rather than the arrays as written.
+  A hierarchy Plotly has not computed yet is still read out, in the authored
+  order, but without selectors — sector *k* is then not slice *k*.
+
+- A sankey names both ends of every flow. Plotly stores them as indices into
+  `node.label`, so the adapter resolves them back to the labels: "34 from Coal
+  to Electricity" is the reading and "34 from 0 to 1" is not. The nodes are
+  derived from the flows, so nothing is emitted for them separately. Flows
+  Plotly drops before drawing — a non-positive value, an endpoint that is not a
+  node — are dropped here too, since a ribbon nothing draws would still put a
+  node in the graph.
+
+- An `indicator` trace is a gauge only when it draws one. Without `gauge` in
+  its `mode` it is a number set in text, which a screen reader already reaches,
+  so it is skipped rather than announced twice. A gauge's `gauge.threshold.value`
+  becomes the target; `delta.reference` stands in when there is no threshold,
+  except when it equals the measure, which is the value Plotly defaults it to
+  and not a target anyone set. Plotly's steps carry a range and a colour but no
+  name, so the qualitative bands are announced only when the author named every
+  step — an invented "band 2" would say nothing the numbers do not.
+
+- A polar trace has no axis pair either: `scatterpolar` and `barpolar` name a
+  `subplot` (`polar`, `polar2`, …) and are positioned by `layout.polar.domain`,
+  so each polar subplot becomes its own MAIDR panel. Both read as spokes and
+  values, the way a multi-line chart reads as samples and values, and the
+  circle is carried in the panning rather than in the payload. Plotly's schema
+  has no title for the angular axis, so the spokes are named `Spoke`; the
+  radial axis title is read when there is one.
+
+- A `parcoords` layer is transposed on the way in: Plotly stores a column of
+  values per axis, and MAIDR reads a row per observation. The pitch is scaled
+  per axis rather than for the layer, since the columns are different
+  quantities and one range for all of them would sonify the units instead of
+  the data. Plotly draws these lines to a canvas rather than to SVG, so the
+  layer carries no selectors — audio, text, braille, and navigation all work,
+  visual highlighting alone does not.
 
 - Plotly sorts pie slices by descending value unless the trace sets
   `sort: false`, so the authored order is not necessarily the drawn order. The
@@ -454,7 +505,7 @@ For the full list, see the [Keyboard Controls](docs/CONTROLS.html) reference.
 | Data source | Manual JSON schema | Manual JSON schema | Auto-extracted from Plotly |
 | SVG selectors | Manual CSS selectors | Manual CSS selectors | Auto-generated |
 | Configuration | Required | Required | Zero configuration |
-| Chart types | All MAIDR types | All MAIDR types | 15 Plotly types |
+| Chart types | All MAIDR types | All MAIDR types | 23 Plotly types |
 | Dynamic charts | Manual init | React lifecycle | Auto-detected |
 
 ## Python and R Binders

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -72,6 +72,12 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Pie | `type: 'pie'` | [Pie chart](examples.html) |
 | Grouped Bar | `barmode: 'group'` + multiple bar traces | [Grouped bar](examples.html) |
 | Stacked Bar | `barmode: 'stack'` + multiple bar traces | [Stacked bar](examples.html) |
+| Area | `type: 'scatter'`, `fill: 'tozeroy' \| 'tozerox' \| 'toself'` | [Area chart](examples.html) |
+| Stacked Area | `type: 'scatter'` + `stackgroup` | [Stacked area](examples.html) |
+| 100% Stacked Area | `stackgroup` + `groupnorm: 'percent' \| 'fraction'` | [Normalized area](examples.html) |
+| Funnel | `type: 'funnel'` | [Funnel chart](examples.html) |
+| Waterfall | `type: 'waterfall'` | [Waterfall chart](examples.html) |
+| Error Bars | `error_y` or `error_x` on a scatter or bar trace | [Error bars](examples.html) |
 | Subplots / Facets | multiple `xaxis`/`yaxis` pairs, `layout.grid`, or Plotly Express facets | [Subplots](examples.html) |
 
 **Notes on chart-type detection:**
@@ -90,6 +96,35 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   whichever cartesian panel happens to use the first axis pair. `axes.x` and
   `axes.y` are named `Label` and `Value`, since there is no drawn axis title to
   read them from. A doughnut (`hole`) is the same trace and reads identically.
+
+- A filled scatter is an area chart. Naming a `stackgroup` makes it a stacked
+  one, and adding `groupnorm` makes that a 100% stacked one; each stack group
+  in a panel becomes its own layer, so two independent stacks are never merged
+  into a running total neither of them draws. The layer carries each band's
+  **own** value rather than the running edge Plotly draws it at — MAIDR derives
+  the totals and each band's share of them — except under `groupnorm`, where
+  the rescaled heights Plotly drew are read from its calculated data so the
+  announced number matches the percentage axis. A filled trace whose
+  `line.shape` is step-wise stays a step chart: with nothing accumulating, the
+  fill is decoration and the staircase convention is the part worth announcing.
+
+- Error bars are a modifier rather than a trace type, so a scatter or bar trace
+  whose `error_y` (or `error_x`) is visible becomes an error-bar layer instead
+  of a scatter, line, or bar one. The interval is what such a chart is drawn to
+  show, and a scatter reading announces the estimate and drops it. MAIDR reads
+  the absolute bounds Plotly resolved for each sample, whichever way they were
+  declared — `array`, `percent`, `constant`, or `sqrt` — and navigates them as
+  three rows: lower bound, value, upper bound.
+
+- A funnel is read as a bar chart whose order means something: the pitch
+  carries the **retention** between adjacent stages rather than the count,
+  since the drop-off is what a funnel is read for and a ratio is what a
+  listener cannot take by ear. The counts are announced alongside it.
+
+- A waterfall step carries both numbers the bar draws: the contribution (the
+  bar's height, which is what the pitch follows) and the running total it
+  produced (the bar's position). Steps whose `measure` is `total` or `absolute`
+  are announced as totals, so a subtotal is not mistaken for a contribution.
 
 - Plotly sorts pie slices by descending value unless the trace sets
   `sort: false`, so the authored order is not necessarily the drawn order. The
@@ -419,7 +454,7 @@ For the full list, see the [Keyboard Controls](docs/CONTROLS.html) reference.
 | Data source | Manual JSON schema | Manual JSON schema | Auto-extracted from Plotly |
 | SVG selectors | Manual CSS selectors | Manual CSS selectors | Auto-generated |
 | Configuration | Required | Required | Zero configuration |
-| Chart types | All MAIDR types | All MAIDR types | 9 Plotly types |
+| Chart types | All MAIDR types | All MAIDR types | 15 Plotly types |
 | Dynamic charts | Manual init | React lifecycle | Auto-detected |
 
 ## Python and R Binders

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -86,6 +86,12 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Radar | `type: 'scatterpolar'` | [Radar](examples.html) |
 | Polar Area / Rose | `type: 'barpolar'` | [Polar area](examples.html) |
 | Parallel Coordinates | `type: 'parcoords'` | [Parallel coordinates](examples.html) |
+| Ridgeline | `type: 'violin'` with `side: 'positive'` | [Ridgeline](examples.html) |
+| Gantt / Timeline | horizontal `bar` traces with a `base` array on a date axis | [Gantt chart](examples.html) |
+| Diverging Bar / Pyramid | `barmode: 'relative'` + bar traces with opposed signs | [Population pyramid](examples.html) |
+| Dot Plot | `type: 'scatter'`, `mode: 'markers'`, one marker per category | [Dot plot](examples.html) |
+| Word Cloud | `type: 'scatter'`, `mode: 'text'`, array `textfont.size` | [Word cloud](examples.html) |
+| Choropleth | `type: 'choropleth'` | [Choropleth map](examples.html) |
 | Subplots / Facets | multiple `xaxis`/`yaxis` pairs, `layout.grid`, or Plotly Express facets | [Subplots](examples.html) |
 
 **Notes on chart-type detection:**
@@ -505,7 +511,7 @@ For the full list, see the [Keyboard Controls](docs/CONTROLS.html) reference.
 | Data source | Manual JSON schema | Manual JSON schema | Auto-extracted from Plotly |
 | SVG selectors | Manual CSS selectors | Manual CSS selectors | Auto-generated |
 | Configuration | Required | Required | Zero configuration |
-| Chart types | All MAIDR types | All MAIDR types | 23 Plotly types |
+| Chart types | All MAIDR types | All MAIDR types | 29 Plotly types |
 | Dynamic charts | Manual init | React lifecycle | Auto-detected |
 
 ## Python and R Binders

--- a/examples/plotly-area.html
+++ b/examples/plotly-area.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Area Charts - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Area Charts</h1>
+    <p>
+      Three filled plotly.js charts auto-detected by MAIDR. Click on a chart and
+      use arrow keys to navigate; up and down move between series. On the
+      stacked charts each point is announced with the running total of the
+      column it sits in and its share of that total, which is the number the
+      band heights are drawn to compare.
+    </p>
+
+    <h2>Filled bands, independent of one another (<code>fill</code>)</h2>
+    <div id="area" style="width: 700px; height: 400px"></div>
+
+    <h2>Bands stacked on one another (<code>stackgroup</code>)</h2>
+    <div id="stacked-area" style="width: 700px; height: 400px"></div>
+
+    <h2>Bands as shares of a common total (<code>groupnorm</code>)</h2>
+    <div id="normalized-area" style="width: 700px; height: 400px"></div>
+
+    <script>
+      // Quarterly revenue by region. The stacked charts read the same numbers;
+      // only how plotly lays the bands out differs.
+      var quarters = ['Q1', 'Q2', 'Q3', 'Q4'];
+      var east = [120, 80, 140, 160];
+      var west = [90, 70, 60, 110];
+
+      function series(name, values, extra) {
+        var trace = {
+          x: quarters,
+          y: values,
+          mode: 'lines',
+          type: 'scatter',
+          name: name
+        };
+        for (var key in extra) {
+          trace[key] = extra[key];
+        }
+        return trace;
+      }
+
+      function areaChart(divId, title, extra) {
+        Plotly.newPlot(
+          divId,
+          [series('East', east, extra), series('West', west, extra)],
+          {
+            title: { text: title },
+            xaxis: { title: { text: 'Quarter' } },
+            yaxis: { title: { text: 'Revenue' } }
+          }
+        );
+      }
+
+      areaChart('area', 'Revenue by region', { fill: 'tozeroy' });
+      areaChart('stacked-area', 'Revenue by region (stacked)', {
+        stackgroup: 'one'
+      });
+      areaChart('normalized-area', 'Revenue by region (share)', {
+        stackgroup: 'one',
+        groupnorm: 'percent'
+      });
+    </script>
+  </body>
+</html>

--- a/examples/plotly-choropleth.html
+++ b/examples/plotly-choropleth.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Choropleth Map - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Choropleth Map</h1>
+    <p>
+      A plotly.js <code>choropleth</code> trace auto-detected by MAIDR. Read as
+      a bar chart whose categories happen to be places, a map loses everything
+      spatial, so the regions are laid out by the centroid plotly resolved for
+      each one while projecting it: the arrows move north, south, east and west
+      rather than along a list, and the panning follows the longitude. The
+      shaded quantity takes its name from the colorbar, which is the only place
+      a map names it.
+    </p>
+
+    <div id="choropleth" style="width: 800px; height: 500px"></div>
+
+    <script>
+      Plotly.newPlot(
+        'choropleth',
+        [
+          {
+            type: 'choropleth',
+            locationmode: 'ISO-3',
+            locations: ['FRA', 'DEU', 'ESP', 'ITA', 'POL', 'SWE', 'GRC'],
+            text: ['France', 'Germany', 'Spain', 'Italy', 'Poland', 'Sweden', 'Greece'],
+            z: [67.4, 84.4, 47.6, 58.9, 36.8, 10.5, 10.4],
+            colorscale: 'Blues',
+            colorbar: { title: { text: 'Population (millions)' } }
+          }
+        ],
+        {
+          title: { text: 'Population by country' },
+          geo: { scope: 'europe', showframe: false }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-diverging.html
+++ b/examples/plotly-diverging.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Population Pyramid - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Population Pyramid</h1>
+    <p>
+      Two bar traces with signed values under <code>barmode: 'relative'</code> —
+      the standard plotly idiom for a population pyramid or a Likert scale.
+      MAIDR reads the opposed signs as what they are: a direction rather than a
+      magnitude. The pitch takes the size of each bar and the announcement names
+      the side, so the larger cohort is the higher note whichever way it points,
+      and the summary row down each category is the balance between the two
+      sides rather than a total.
+    </p>
+
+    <div id="pyramid" style="width: 760px; height: 500px"></div>
+
+    <script>
+      const bands = ['0-9', '10-19', '20-29', '30-39', '40-49', '50-59', '60+'];
+      const men = [3.1, 3.4, 4.0, 3.8, 3.5, 3.0, 3.9];
+      const women = [2.9, 3.2, 3.9, 3.9, 3.6, 3.2, 4.8];
+
+      Plotly.newPlot(
+        'pyramid',
+        [
+          {
+            type: 'bar',
+            orientation: 'h',
+            name: 'Men',
+            y: bands,
+            x: men.map(value => -value),
+            marker: { color: '#4C78A8' }
+          },
+          {
+            type: 'bar',
+            orientation: 'h',
+            name: 'Women',
+            y: bands,
+            x: women,
+            marker: { color: '#E45756' }
+          }
+        ],
+        {
+          title: { text: 'Population by age band' },
+          barmode: 'relative',
+          xaxis: { title: { text: 'Millions' }, tickformat: '+' },
+          yaxis: { title: { text: 'Age band' } }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-dot.html
+++ b/examples/plotly-dot.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Dot Plot - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Dot Plot</h1>
+    <p>
+      A Cleveland dot plot: a <code>scatter</code> trace in markers mode with
+      one marker per category. MAIDR announces it as the chart the author drew
+      rather than as a scatter — a dot plot is a bar chart with a dot where the
+      bar would be, so a reader navigates one category and one value, and the
+      category is a name rather than a coordinate. Two markers on one category
+      would make it a scatter again, and it is left as one.
+    </p>
+
+    <div id="dot" style="width: 720px; height: 420px"></div>
+
+    <script>
+      Plotly.newPlot(
+        'dot',
+        [
+          {
+            type: 'scatter',
+            mode: 'markers',
+            y: ['Chicago', 'Boston', 'Denver', 'Austin', 'Seattle', 'Phoenix'],
+            x: [2100, 2850, 1780, 1650, 2400, 1490],
+            marker: { size: 14, color: '#4C78A8' },
+            name: 'Median rent'
+          }
+        ],
+        {
+          title: { text: 'Median rent by city' },
+          xaxis: { title: { text: 'US dollars per month' } },
+          yaxis: { title: { text: 'City' } },
+          showlegend: false
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-errorbar.html
+++ b/examples/plotly-errorbar.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Error Bars - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Error Bars</h1>
+    <p>
+      Plotly.js traces carrying <code>error_y</code> / <code>error_x</code>,
+      auto-detected by MAIDR as interval charts rather than as a scatter or a
+      bar chart. Click on a chart and use arrow keys: left and right walk the
+      samples, up and down walk the lower bound, the estimate and the upper
+      bound at one sample — so whether two intervals overlap can be traced by
+      ear.
+    </p>
+
+    <h2>An estimate with its interval (<code>error_y</code> on a scatter)</h2>
+    <div id="pointrange" style="width: 700px; height: 400px"></div>
+
+    <h2>Group means with standard errors (<code>error_y</code> on bars)</h2>
+    <div id="bar-errors" style="width: 700px; height: 400px"></div>
+
+    <h2>Horizontal intervals (<code>error_x</code>)</h2>
+    <div id="horizontal-errors" style="width: 700px; height: 400px"></div>
+
+    <script>
+      var doses = [0, 10, 20, 30, 40];
+      var response = [2.1, 3.4, 4.2, 4.6, 4.7];
+      var responseError = [0.3, 0.4, 0.35, 0.5, 0.45];
+
+      Plotly.newPlot(
+        'pointrange',
+        [
+          {
+            type: 'scatter',
+            mode: 'markers',
+            x: doses,
+            y: response,
+            error_y: { type: 'data', array: responseError, visible: true },
+            name: 'Response'
+          }
+        ],
+        {
+          title: { text: 'Dose response, with 95% intervals' },
+          xaxis: { title: { text: 'Dose (mg)' } },
+          yaxis: { title: { text: 'Response' } }
+        }
+      );
+
+      Plotly.newPlot(
+        'bar-errors',
+        [
+          {
+            type: 'bar',
+            x: ['Control', 'Low', 'High'],
+            y: [12.4, 15.1, 19.8],
+            error_y: { type: 'data', array: [1.1, 1.4, 2.2], visible: true },
+            name: 'Mean yield'
+          }
+        ],
+        {
+          title: { text: 'Mean yield by treatment' },
+          xaxis: { title: { text: 'Treatment' } },
+          yaxis: { title: { text: 'Yield' } }
+        }
+      );
+
+      Plotly.newPlot(
+        'horizontal-errors',
+        [
+          {
+            type: 'scatter',
+            mode: 'markers',
+            y: ['Study A', 'Study B', 'Study C', 'Study D'],
+            x: [1.24, 0.86, 1.05, 1.42],
+            // Asymmetric, which is the ordinary shape of a ratio interval.
+            error_x: {
+              type: 'data',
+              symmetric: false,
+              array: [0.31, 0.22, 0.18, 0.46],
+              arrayminus: [0.24, 0.19, 0.17, 0.38],
+              visible: true
+            },
+            name: 'Odds ratio'
+          }
+        ],
+        {
+          title: { text: 'Odds ratio by study' },
+          xaxis: { title: { text: 'Odds ratio' } },
+          yaxis: { title: { text: 'Study' } }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-funnel.html
+++ b/examples/plotly-funnel.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Funnel Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Funnel Chart</h1>
+    <p>
+      A plotly.js <code>funnel</code> trace auto-detected by MAIDR. Click on the
+      chart and use arrow keys to walk the stages. The pitch carries the
+      <em>retention</em> between adjacent stages rather than the count: the
+      worst stage of a funnel is rarely the biggest fall in absolute numbers,
+      and a listener given raw heights hears the two the wrong way round.
+    </p>
+
+    <div id="funnel" style="width: 700px; height: 450px"></div>
+
+    <script>
+      // A checkout funnel. 2,300 to 100 is a far worse stage than 10,000 to
+      // 2,400, and only the ratios say so.
+      Plotly.newPlot(
+        'funnel',
+        [
+          {
+            type: 'funnel',
+            y: [
+              'Visited',
+              'Viewed a product',
+              'Added to basket',
+              'Started checkout',
+              'Purchased'
+            ],
+            x: [10000, 2400, 2300, 900, 100],
+            name: 'Visitors'
+          }
+        ],
+        {
+          title: { text: 'Checkout funnel' },
+          xaxis: { title: { text: 'Visitors' } },
+          yaxis: { title: { text: 'Stage' } }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-gantt.html
+++ b/examples/plotly-gantt.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Gantt Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Gantt Chart</h1>
+    <p>
+      Plotly has no gantt trace: a schedule is drawn as horizontal bars whose
+      <code>base</code> array floats each one onto a date axis, which is what
+      <code>plotly.express.timeline</code> emits. MAIDR reads that back as
+      intervals rather than as bars — an interval has two positions and no
+      baseline, so its length is a difference a reader has to be told. The
+      pitch carries the length and the stereo position carries the start,
+      mapped along the whole axis, so two tasks that line up sound like they
+      line up and a lane whose work happens late sounds late.
+    </p>
+
+    <div id="gantt" style="width: 800px; height: 420px"></div>
+
+    <script>
+      const day = 86400000;
+      const start = date => Date.parse(date + 'T00:00:00Z');
+      const tasks = [
+        { lane: 'Research', from: '2024-03-01', to: '2024-03-12' },
+        { lane: 'Design', from: '2024-03-08', to: '2024-03-22' },
+        { lane: 'Build', from: '2024-03-18', to: '2024-04-19' },
+        { lane: 'Build', from: '2024-04-24', to: '2024-05-06' },
+        { lane: 'Launch', from: '2024-05-06', to: '2024-05-13' }
+      ];
+
+      Plotly.newPlot(
+        'gantt',
+        [
+          {
+            type: 'bar',
+            orientation: 'h',
+            y: tasks.map(task => task.lane),
+            base: tasks.map(task => task.from),
+            x: tasks.map(task => start(task.to) - start(task.from)),
+            marker: { color: '#4C78A8' }
+          }
+        ],
+        {
+          title: { text: 'Release schedule' },
+          xaxis: { type: 'date', title: { text: 'Date' } },
+          yaxis: { title: { text: 'Phase' }, autorange: 'reversed' },
+          showlegend: false
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-gauge.html
+++ b/examples/plotly-gauge.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Gauge Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Gauge Chart</h1>
+    <p>
+      A plotly.js <code>indicator</code> trace with a <code>gauge</code>,
+      auto-detected by MAIDR. A gauge's number means nothing on its own: "73"
+      is not the reading, "73 out of 100, 7 below target, in the 'ok' band" is,
+      and a sighted reader gets all of it from the dial's geometry. So the
+      announcement carries the range, the target and the band alongside the
+      value. Plotly's steps carry no name of their own, so the bands are read
+      out only when the chart names them — as this one does.
+    </p>
+
+    <div id="gauge" style="width: 600px; height: 450px"></div>
+
+    <script>
+      Plotly.newPlot(
+        'gauge',
+        [
+          {
+            type: 'indicator',
+            mode: 'gauge+number+delta',
+            value: 73,
+            title: { text: 'Conversion' },
+            delta: { reference: 80 },
+            gauge: {
+              shape: 'angular',
+              axis: { range: [0, 100] },
+              threshold: { value: 80, line: { color: 'red', width: 3 } },
+              steps: [
+                { range: [0, 50], color: '#e6e6e6', name: 'poor' },
+                { range: [50, 75], color: '#cccccc', name: 'ok' },
+                { range: [75, 100], color: '#b3b3b3', name: 'good' }
+              ]
+            }
+          }
+        ],
+        { title: { text: 'Conversion rate against target' } }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-parallel.html
+++ b/examples/plotly-parallel.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Parallel Coordinates - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Parallel Coordinates</h1>
+    <p>
+      A plotly.js <code>parcoords</code> trace auto-detected by MAIDR. The
+      columns here are not one scale — miles per gallon beside horsepower
+      beside weight — so the pitch is scaled per axis rather than for the layer.
+      Arrowing along one car hears it high here and low there; arrowing down a
+      column hears the cars ranked on that variable; and two cars whose pitches
+      swap between adjacent axes are the crossing lines that mean negative
+      correlation. Plotly draws these lines to a canvas rather than to SVG, so
+      the layer sonifies and reads out but has no visual highlight.
+    </p>
+
+    <div id="parallel" style="width: 800px; height: 480px"></div>
+
+    <script>
+      Plotly.newPlot(
+        'parallel',
+        [
+          {
+            type: 'parcoords',
+            dimensions: [
+              { label: 'Miles per gallon', values: [33, 21, 15, 27, 18] },
+              { label: 'Horsepower', values: [65, 110, 230, 95, 150] },
+              { label: 'Weight (lb)', values: [1800, 2600, 3200, 2200, 2900] },
+              { label: 'Cylinders', values: [4, 6, 8, 4, 6] }
+            ]
+          }
+        ],
+        { title: { text: 'Car characteristics' } }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-radar.html
+++ b/examples/plotly-radar.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Radar Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Radar Chart</h1>
+    <p>
+      A plotly.js <code>scatterpolar</code> trace auto-detected by MAIDR. The
+      data navigates exactly as a multi-line chart does — a spoke is a column
+      and a series is a row — and what the circle adds is carried in the
+      panning: the sweep goes out and back, 12 o'clock at centre, 3 o'clock
+      hard right, 9 o'clock hard left, so a radar does not sound like a row of
+      bars. A <code>barpolar</code> trace (a rose or coxcomb chart) reads the
+      same way and is announced as a polar area.
+    </p>
+
+    <div id="radar" style="width: 650px; height: 550px"></div>
+
+    <script>
+      const spokes = ['Speed', 'Range', 'Comfort', 'Price', 'Economy', 'Safety'];
+
+      Plotly.newPlot(
+        'radar',
+        [
+          {
+            type: 'scatterpolar',
+            mode: 'lines+markers',
+            r: [8, 4, 6, 9, 5, 7],
+            theta: spokes,
+            fill: 'toself',
+            name: 'Model A'
+          },
+          {
+            type: 'scatterpolar',
+            mode: 'lines+markers',
+            r: [5, 7, 3, 2, 8, 6],
+            theta: spokes,
+            fill: 'toself',
+            name: 'Model B'
+          }
+        ],
+        {
+          title: { text: 'Model comparison' },
+          polar: {
+            radialaxis: { visible: true, range: [0, 10], title: { text: 'Score' } }
+          }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-ridgeline.html
+++ b/examples/plotly-ridgeline.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Ridgeline Plot - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Ridgeline Plot</h1>
+    <p>
+      Plotly's own ridgeline recipe: horizontal <code>violin</code> traces with
+      <code>side: 'positive'</code>, widened so the halved curves overlap. MAIDR
+      emits one ridgeline layer rather than the violin pair, because the recipe
+      draws no inner box for a quartile summary to describe. Every group is
+      pitched against the tallest density anywhere on the chart, so the ridges
+      can be compared — and moving between groups holds the value the reader is
+      on rather than the column index, since the curves need not share a grid.
+    </p>
+
+    <div id="ridgeline" style="width: 760px; height: 520px"></div>
+
+    <script>
+      const groups = ['2019', '2020', '2021', '2022', '2023'];
+      // A different centre and spread per year, so the ridges have shapes to
+      // compare rather than the same curve five times.
+      const sample = (centre, spread) =>
+        Array.from({ length: 400 }, () => {
+          const u = Math.random();
+          const v = Math.random();
+          const z = Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+          return centre + spread * z;
+        });
+
+      Plotly.newPlot(
+        'ridgeline',
+        groups.map((year, i) => ({
+          type: 'violin',
+          name: year,
+          x: sample(20 + i * 3, 4 + i),
+          orientation: 'h',
+          side: 'positive',
+          width: 3,
+          points: false,
+          meanline: { visible: false }
+        })),
+        {
+          title: { text: 'Delivery time by year' },
+          xaxis: { title: { text: 'Days' }, zeroline: false },
+          yaxis: { title: { text: 'Year' } },
+          showlegend: false
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-sankey.html
+++ b/examples/plotly-sankey.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Sankey Diagram - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Sankey Diagram</h1>
+    <p>
+      A plotly.js <code>sankey</code> trace auto-detected by MAIDR. Following a
+      ribbon is the primary move and it is on the keys that already exist:
+      right follows the largest flow out of the current node, left follows the
+      largest flow in, and up and down walk the other nodes stacked in the same
+      column. Plotly names the ends of each flow by index; MAIDR resolves them
+      back to the node labels, because "34 from Coal to Electricity" is the
+      reading and "34 from 0 to 1" is not.
+    </p>
+
+    <div id="sankey" style="width: 800px; height: 500px"></div>
+
+    <script>
+      // A small energy balance, in petajoules.
+      Plotly.newPlot(
+        'sankey',
+        [
+          {
+            type: 'sankey',
+            node: {
+              label: [
+                'Coal',
+                'Gas',
+                'Wind',
+                'Electricity',
+                'Heat',
+                'Losses',
+                'Households',
+                'Industry'
+              ],
+              pad: 18,
+              thickness: 18
+            },
+            link: {
+              source: [0, 0, 1, 1, 2, 3, 3, 3, 4, 4],
+              target: [3, 5, 3, 4, 3, 5, 6, 7, 6, 7],
+              value: [34, 22, 26, 14, 18, 12, 30, 36, 6, 8]
+            }
+          }
+        ],
+        { title: { text: 'Energy flow' } }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-sunburst.html
+++ b/examples/plotly-sunburst.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Sunburst Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Sunburst Chart</h1>
+    <p>
+      A plotly.js <code>sunburst</code> trace auto-detected by MAIDR. The tree
+      navigates as a tree, on the arrow keys that already exist: up returns to
+      the parent, down enters the first child, and left and right walk the
+      siblings inside one parent. Each node announces its exact share of its
+      parent — the comparison the rings are drawn to support and the one the
+      eye estimates worst. A <code>treemap</code> or an <code>icicle</code>
+      trace with the same attributes reads identically; only the name changes.
+    </p>
+
+    <div id="sunburst" style="width: 700px; height: 550px"></div>
+
+    <script>
+      // World population, in millions. Interior nodes are declared so their
+      // own totals are announced rather than derived.
+      Plotly.newPlot(
+        'sunburst',
+        [
+          {
+            type: 'sunburst',
+            labels: [
+              'World',
+              'Asia',
+              'Africa',
+              'Europe',
+              'China',
+              'India',
+              'Indonesia',
+              'Nigeria',
+              'Ethiopia',
+              'Germany',
+              'France'
+            ],
+            parents: [
+              '',
+              'World',
+              'World',
+              'World',
+              'Asia',
+              'Asia',
+              'Asia',
+              'Africa',
+              'Africa',
+              'Europe',
+              'Europe'
+            ],
+            values: [4000, 3131, 546, 152, 1425, 1428, 278, 224, 322, 84, 68],
+            branchvalues: 'total'
+          }
+        ],
+        { title: { text: 'World population by region, millions' } }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-waterfall.html
+++ b/examples/plotly-waterfall.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Waterfall Chart - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Waterfall Chart</h1>
+    <p>
+      A plotly.js <code>waterfall</code> trace auto-detected by MAIDR. Click on
+      the chart and use arrow keys to walk the steps. Each step announces both
+      numbers the bar draws — the contribution it made, which is what the pitch
+      follows, and the running total it produced — and says whether it added,
+      subtracted, or restated the total.
+    </p>
+
+    <div id="waterfall" style="width: 700px; height: 450px"></div>
+
+    <script>
+      // A profit bridge: an opening balance, four contributions, and a closing
+      // total. `measure` is what tells plotly (and MAIDR) which bars sit on
+      // the baseline rather than floating.
+      Plotly.newPlot(
+        'waterfall',
+        [
+          {
+            type: 'waterfall',
+            x: [
+              'Opening',
+              'Product sales',
+              'Services',
+              'Returns',
+              'Operating costs',
+              'Closing'
+            ],
+            y: [1200, 950, 340, -180, -620, 0],
+            measure: [
+              'absolute',
+              'relative',
+              'relative',
+              'relative',
+              'relative',
+              'total'
+            ],
+            name: 'Profit'
+          }
+        ],
+        {
+          title: { text: 'Profit bridge, FY2024 (thousands)' },
+          xaxis: { title: { text: 'Step' } },
+          yaxis: { title: { text: 'Profit' } }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-wordcloud.html
+++ b/examples/plotly-wordcloud.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Word Cloud - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Word Cloud</h1>
+    <p>
+      Plotly has no word-cloud trace: the documented recipe is a
+      <code>scatter</code> in text mode whose <code>textfont.size</code> is an
+      array, one glyph size per term. That per-term size is what MAIDR detects.
+      The layout of a cloud carries nothing — the coordinates are chosen to pack
+      glyphs, not to encode anything — so the terms are walked in weight order
+      instead, and the weight itself is taken from <code>customdata</code> where
+      the author put the real counts there, as below, rather than from the glyph
+      size that stands in for them.
+    </p>
+
+    <div id="wordcloud" style="width: 760px; height: 460px"></div>
+
+    <script>
+      const terms = [
+        { word: 'sonification', count: 412, x: 2.1, y: 3.4 },
+        { word: 'braille', count: 310, x: 4.6, y: 2.2 },
+        { word: 'navigation', count: 268, x: 1.3, y: 1.5 },
+        { word: 'audio', count: 190, x: 3.8, y: 4.1 },
+        { word: 'highlight', count: 122, x: 5.2, y: 3.1 },
+        { word: 'subplot', count: 74, x: 2.9, y: 0.8 },
+        { word: 'rotor', count: 41, x: 4.9, y: 1.1 }
+      ];
+
+      Plotly.newPlot(
+        'wordcloud',
+        [
+          {
+            type: 'scatter',
+            mode: 'text',
+            x: terms.map(term => term.x),
+            y: terms.map(term => term.y),
+            text: terms.map(term => term.word),
+            customdata: terms.map(term => term.count),
+            textfont: { size: terms.map(term => 10 + term.count / 12) }
+          }
+        ],
+        {
+          title: { text: 'Terms in the issue tracker' },
+          xaxis: { visible: false, range: [0, 6] },
+          yaxis: { visible: false, range: [0, 5] },
+          showlegend: false
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -1791,25 +1791,30 @@ function extractGanttLayer(
 
   const scale = ganttUnit(intervals);
   const lanes = ganttLanes(posAxis, intervals);
+  const rowByLane = new Map(lanes.map((lane, row) => [lane, row]));
   const points: GanttPoint[][] = lanes.map(() => []);
-  const selectors: string[] = [];
+  // The layer's selectors are one flat list read row by row, so each row
+  // collects its own and they are joined once the intervals are placed.
+  const rowSelectors: string[][] = lanes.map(() => []);
   const prefix = subplotCssPrefix(barTraces[0].trace.xaxis, barTraces[0].trace.yaxis);
 
-  for (let row = 0; row < lanes.length; row++) {
-    for (const interval of intervals) {
-      if (interval.lane !== lanes[row])
-        continue;
-      points[row].push({
-        x: interval.lane,
-        // Divided into the announced unit so the LENGTH reads in it. The axis
-        // format below turns the same number back into the date it names, so
-        // both halves of an interval stay readable.
-        start: interval.start / (scale?.ms ?? 1),
-        end: interval.end / (scale?.ms ?? 1),
-      });
-      selectors.push(barPointSelector(prefix, interval.tracePosition, interval.pointIndex));
-    }
+  for (const interval of intervals) {
+    const row = rowByLane.get(interval.lane);
+    if (row === undefined)
+      continue;
+    points[row].push({
+      x: interval.lane,
+      // Divided into the announced unit so the LENGTH reads in it. The axis
+      // format below turns the same number back into the date it names, so
+      // both halves of an interval stay readable.
+      start: interval.start / (scale?.ms ?? 1),
+      end: interval.end / (scale?.ms ?? 1),
+    });
+    rowSelectors[row].push(
+      barPointSelector(prefix, interval.tracePosition, interval.pointIndex),
+    );
   }
+  const selectors = rowSelectors.flat();
 
   // Positions are scaled milliseconds, which no reader wants read out. The
   // format takes them back to the instant they name — as a date alone for a
@@ -3160,6 +3165,23 @@ function ancestorLabels(
 }
 
 /**
+ * Whether the trace draws only part of the tree it declared.
+ *
+ * `maxdepth` stops the layout after that many levels below its entry point,
+ * and `level` moves the entry point to a sector partway down — either way,
+ * plotly puts fewer slices on the page than the tree has nodes. `-1` is
+ * plotly's own "all of it" and trims nothing.
+ *
+ * @param trace - The resolved plotly trace
+ * @returns True when plotly drew a subset of the computed tree
+ */
+function isTrimmedHierarchy(trace: PlotlyTrace): boolean {
+  const depth = trace.maxdepth;
+  return (typeof depth === 'number' && depth > 0)
+    || (trace.level !== undefined && trace.level !== '');
+}
+
+/**
  * Builds a sunburst, icicle or treemap layer.
  *
  * One extractor for all three because plotly gives them one attribute set and
@@ -3193,7 +3215,12 @@ function extractHierarchyLayer(
     // is not the drawn one, so a layer built from the trace's own arrays goes
     // out without selectors. No highlight at all beats one that lands on a
     // neighbouring sector while the text announces this one.
-    selectors: drawn ? selectors : undefined,
+    //
+    // A trimmed tree is withheld for the same reason. `maxdepth` and `level`
+    // narrow what plotly draws without narrowing what it computed, so the walk
+    // still yields every node while only some have a `g.slice` on the page —
+    // and sector k would then be some other sector's slice.
+    selectors: drawn && !isTrimmedHierarchy(trace) ? selectors : undefined,
     axes: {
       x: { label: HIERARCHY_LABEL_AXIS },
       y: { label: HIERARCHY_VALUE_AXIS },
@@ -3222,9 +3249,13 @@ const SANKEY_VALUE_AXIS = 'Value';
  * declared labels (one plotly generated for a `node.groups` entry) falls back
  * to its index, which at least identifies it consistently across the flows
  * that touch it.
+ *
+ * `null` is admitted because `typeof null` is `'object'`: a hole in an
+ * authored `link.source` array would otherwise be read as a node and have its
+ * label taken off nothing.
  */
 function sankeyEndpoint(
-  end: number | PlotlySankeyNode | undefined,
+  end: number | PlotlySankeyNode | null | undefined,
   labels: (number | string)[],
 ): string | number {
   if (end !== null && typeof end === 'object') {

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -15,6 +15,9 @@ import type {
   BoxSelector,
   CandlestickPoint,
   ErrorBarPoint,
+  FlowPoint,
+  GaugeBand,
+  GaugePoint,
   HeatmapData,
   HistogramPoint,
   LinePoint,
@@ -25,6 +28,7 @@ import type {
   ScatterPoint,
   SegmentedPoint,
   StepDirection,
+  TreemapPoint,
   ViolinKdePoint,
   WaterfallKind,
   WaterfallPoint,
@@ -36,11 +40,20 @@ import type {
   PlotlyErrorBar,
   PlotlyFullLayout,
   PlotlyGraphDiv,
+  PlotlyHierarchyNode,
   PlotlyLayout,
+  PlotlyPolarLayout,
+  PlotlySankeyNode,
   PlotlyTrace,
+  PolarSeries,
 } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
-import { errorBarAxis, generatePlotlySelectors, subplotCssPrefix } from './selectors';
+import {
+  errorBarAxis,
+  generatePlotlySelectors,
+  polarSeriesSelectors,
+  subplotCssPrefix,
+} from './selectors';
 
 // Monotonic counter for generating unique IDs when the graph div has no id.
 let plotlyIdCounter = 0;
@@ -319,6 +332,42 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
     case 'waterfall':
       return TraceType.WATERFALL;
 
+    // One tree, three layouts. MAIDR reads all three as the same hierarchy —
+    // only the emitted type differs, and the sunburst's angular panning is
+    // the one thing that reads it.
+    case 'sunburst':
+      return TraceType.SUNBURST;
+
+    case 'icicle':
+      return TraceType.ICICLE;
+
+    case 'treemap':
+      return TraceType.TREEMAP;
+
+    case 'sankey':
+      return TraceType.SANKEY;
+
+    // An indicator is a gauge only when it draws one. Without `gauge` it is a
+    // number (and maybe a delta) set in text, which a screen reader already
+    // reaches — there is no mark, no scale and nothing to sonify.
+    case 'indicator':
+      if (trace.gauge)
+        return TraceType.GAUGE;
+      console.warn('[maidr] Plotly indicator has no gauge to read. Skipping.');
+      return null;
+
+    // A radar and a polar area differ in the mark alone: both are values on
+    // named spokes, and MAIDR navigates them identically.
+    case 'scatterpolar':
+    case 'scatterpolargl':
+      return TraceType.RADAR;
+
+    case 'barpolar':
+      return TraceType.POLAR_AREA;
+
+    case 'parcoords':
+      return TraceType.PARALLEL;
+
     default:
       console.warn(`[maidr] Unsupported plotly trace type: "${type}". Skipping.`);
       return null;
@@ -423,13 +472,45 @@ interface SubplotGroup {
   yAxisId: string;
   /**
    * Where the panel sits on the paper, when it is not an axis pair that says
-   * so. Only a pie sets this — see {@link groupTracesBySubplot}.
+   * so. Every domain-positioned trace sets this — see
+   * {@link groupTracesBySubplot}.
    */
   domain?: { x: DomainInterval; y: DomainInterval };
+  /**
+   * The polar subplot the panel is, when it is one (`polar`, `polar2`, …).
+   * Its domain lives on the layout rather than on the trace, so unlike the
+   * domain-positioned types it is resolved later, where the layout is in hand.
+   */
+  polarId?: string;
   traces: PlotlyTrace[];
   calcdata: PlotlyCalcData[][];
   traceIndices: number[];
 }
+
+/**
+ * The trace types plotly positions by their own `domain` rather than by an
+ * axis pair. Each is a panel of its own: they carry no `xaxis`/`yaxis`, so
+ * falling through to the `'x'`/`'y'` defaults would file them under whichever
+ * cartesian panel happens to use the first axis pair, giving them that
+ * panel's axis labels and putting two unrelated charts in one subplot.
+ */
+const DOMAIN_POSITIONED_TYPES = new Set([
+  'pie',
+  'sunburst',
+  'icicle',
+  'treemap',
+  'sankey',
+  'indicator',
+  'parcoords',
+]);
+
+/**
+ * The trace types plotly draws on a polar subplot. They have the same problem
+ * the domain-positioned types do, with one difference: several of them share
+ * a subplot, and the subplot — named on `trace.subplot` — is what keys the
+ * panel, exactly as an axis pair does for a cartesian trace.
+ */
+const POLAR_TYPES = new Set(['scatterpolar', 'scatterpolargl', 'barpolar']);
 
 /** A trace within a subplot group, keyed to its calcdata and its global index. */
 interface TraceEntry {
@@ -455,22 +536,24 @@ function groupTracesBySubplot(
     if (trace.visible === false || trace.visible === 'legendonly')
       continue;
 
-    // A pie has no axes: plotly positions it by its own `domain` instead, and
-    // `trace.xaxis`/`trace.yaxis` are unset. Falling through to the 'x'/'y'
-    // defaults below would file it under the cartesian panel that happens to
-    // use the first axis pair, giving it that panel's axis labels and putting
-    // two unrelated charts in one subplot. Each pie is its own panel, keyed by
-    // its trace index and positioned from its own domain.
-    const isPie = trace.type === 'pie';
-    const xAxisId = isPie ? '' : (trace.xaxis ?? 'x');
-    const yAxisId = isPie ? '' : (trace.yaxis ?? 'y');
-    const key = isPie ? `pie${i}` : `${xAxisId}${yAxisId}`;
+    // A domain-positioned trace is its own panel, keyed by its trace index and
+    // positioned from its own domain; a polar trace shares a panel with every
+    // other trace on the same polar subplot. Neither has an axis pair, so both
+    // leave the axis ids blank.
+    const type = trace.type ?? 'scatter';
+    const isDomain = DOMAIN_POSITIONED_TYPES.has(type);
+    const polarId = POLAR_TYPES.has(type) ? (trace.subplot ?? 'polar') : undefined;
+    const positioned = isDomain || polarId !== undefined;
+    const xAxisId = positioned ? '' : (trace.xaxis ?? 'x');
+    const yAxisId = positioned ? '' : (trace.yaxis ?? 'y');
+    const key = isDomain ? `domain${i}` : (polarId ?? `${xAxisId}${yAxisId}`);
 
     if (!map.has(key)) {
       map.set(key, {
         xAxisId,
         yAxisId,
-        ...(isPie ? { domain: readTraceDomain(trace) } : {}),
+        ...(isDomain ? { domain: readTraceDomain(trace) } : {}),
+        ...(polarId === undefined ? {} : { polarId }),
         traces: [],
         calcdata: [],
         traceIndices: [],
@@ -558,6 +641,10 @@ function buildSubplotLayers(
   const boxTraces: TraceEntry[] = [];
   const barTraces: TraceEntry[] = [];
   const violinTraces: TraceEntry[] = [];
+  // Spokes on a polar subplot, read as a multi-series layer the way lines are.
+  // The two marks are kept apart because a layer announces one of them.
+  const radarTraces: TraceEntry[] = [];
+  const polarAreaTraces: TraceEntry[] = [];
   const otherTraces: TraceEntry[] = [];
 
   for (let i = 0; i < group.traces.length; i++) {
@@ -599,6 +686,10 @@ function buildSubplotLayers(
       barTraces.push(entry);
     } else if (entry.maidrType === TraceType.VIOLIN_KDE) {
       violinTraces.push(entry);
+    } else if (entry.maidrType === TraceType.RADAR) {
+      radarTraces.push(entry);
+    } else if (entry.maidrType === TraceType.POLAR_AREA) {
+      polarAreaTraces.push(entry);
     } else {
       otherTraces.push(entry);
     }
@@ -658,6 +749,19 @@ function buildSubplotLayers(
   // and one KDE layer.
   if (violinTraces.length > 0) {
     layers.push(...extractViolinLayers(violinTraces, group, layout, xLabel, yLabel));
+  }
+
+  // One layer per mark on the polar subplot: the spokes are shared, but a
+  // layer announces itself as a radar or as a polar area, not as both.
+  for (const [type, traces] of [
+    [TraceType.RADAR, radarTraces],
+    [TraceType.POLAR_AREA, polarAreaTraces],
+  ] as const) {
+    if (traces.length === 0)
+      continue;
+    const layer = extractPolarLayer(traces, type, group, layout);
+    if (layer)
+      layers.push(layer);
   }
 
   // Build bar layers: grouped/stacked/normalized for multiple bar traces.
@@ -729,10 +833,12 @@ function arrangePanelsIntoGrid(
 ): PositionedPanel[][] | null {
   const positioned: PositionedPanel[] = [];
   for (const panel of panels) {
-    // A pie panel carries its own domain (it has no axes to read one from);
+    // A domain-positioned panel carries its own domain and a polar one names
+    // the layout entry holding it (neither has axes to read one from);
     // everything else takes it from the axis pair it was grouped by.
-    const xDomain = panel.group.domain?.x ?? readAxisDomain(getAxis(layout, panel.group.xAxisId));
-    const yDomain = panel.group.domain?.y ?? readAxisDomain(getAxis(layout, panel.group.yAxisId));
+    const own = panel.group.domain ?? readPolarDomain(layout, panel.group.polarId);
+    const xDomain = own?.x ?? readAxisDomain(getAxis(layout, panel.group.xAxisId));
+    const yDomain = own?.y ?? readAxisDomain(getAxis(layout, panel.group.yAxisId));
     if (!xDomain || !yDomain)
       return null;
     positioned.push({ ...panel, xDomain, yDomain });
@@ -813,10 +919,27 @@ function containsValue(interval: DomainInterval, value: number): boolean {
  * that have no axes. Returns `undefined` unless BOTH sides are usable — half a
  * domain cannot place a panel in a grid.
  */
-function readTraceDomain(trace: PlotlyTrace): { x: DomainInterval; y: DomainInterval } | undefined {
-  const x = readInterval(trace.domain?.x);
-  const y = readInterval(trace.domain?.y);
+function readTraceDomain(
+  holder: { domain?: { x?: [number, number]; y?: [number, number] } },
+): { x: DomainInterval; y: DomainInterval } | undefined {
+  const x = readInterval(holder.domain?.x);
+  const y = readInterval(holder.domain?.y);
   return x && y ? { x, y } : undefined;
+}
+
+/**
+ * Reads a polar subplot's paper domain. Plotly keeps it on the layout entry
+ * the traces name rather than on the traces themselves, so it is resolved here
+ * rather than while they are grouped.
+ */
+function readPolarDomain(
+  layout: PlotlyFullLayout,
+  polarId: string | undefined,
+): { x: DomainInterval; y: DomainInterval } | undefined {
+  const polar = polarId === undefined
+    ? undefined
+    : (layout[polarId] as PlotlyPolarLayout | undefined);
+  return polar ? readTraceDomain(polar) : undefined;
 }
 
 function readAxisDomain(axis: PlotlyAxis | undefined): DomainInterval | null {
@@ -1168,10 +1291,25 @@ function extractLayer(
     case TraceType.CANDLESTICK:
       return extractCandlestickLayer(trace, id, title, selectors, axes);
 
-    // `axes` is deliberately not passed on: a pie group has no axis ids, so it
-    // is always empty, and the pie names its own two dimensions.
+    // `axes` is deliberately not passed on to any of these: they are drawn on
+    // panels with no axis ids, so it is always empty, and each names its own
+    // two dimensions the way the pie does.
     case TraceType.PIE:
       return extractPieLayer(trace, calcdata, id, title, selectors);
+
+    case TraceType.SUNBURST:
+    case TraceType.ICICLE:
+    case TraceType.TREEMAP:
+      return extractHierarchyLayer(trace, maidrType, calcdata, id, title, selectors);
+
+    case TraceType.SANKEY:
+      return extractSankeyLayer(trace, calcdata, id, title, selectors);
+
+    case TraceType.GAUGE:
+      return extractGaugeLayer(trace, id, title, selectors);
+
+    case TraceType.PARALLEL:
+      return extractParallelLayer(trace, id, title);
 
     default:
       return null;
@@ -1469,6 +1607,83 @@ function normalizedBandHeights(
   }
 
   return heights.length === trace.y?.length ? heights : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Polar (radar, polar area)
+// ---------------------------------------------------------------------------
+
+/**
+ * What a polar layer calls its two dimensions.
+ *
+ * The radial axis can be titled and usually is, so its name is read off the
+ * layout; plotly's schema has no title for the ANGULAR axis at all, so the
+ * spokes are named generically — the pie's reasoning for `Label`/`Value`,
+ * applied to a chart whose categories run round a circle instead.
+ */
+const POLAR_SPOKE_AXIS = 'Spoke';
+const POLAR_VALUE_AXIS = 'Value';
+
+/**
+ * Builds one layer from every radar (or polar area) trace on a polar subplot.
+ *
+ * The payload is a multi-line layer's — a spoke is a column and a trace is a
+ * row — because that is exactly what `RadarTrace` reads. Plotly names the two
+ * coordinates `theta` and `r` rather than `x` and `y`, which is the only
+ * difference from {@link extractMultiLineLayer}, and the reason this does not
+ * reuse it.
+ */
+function extractPolarLayer(
+  entries: TraceEntry[],
+  type: TraceType.RADAR | TraceType.POLAR_AREA,
+  group: SubplotGroup,
+  layout: PlotlyFullLayout,
+): MaidrLayer | null {
+  const data: LinePoint[][] = [];
+  const series: PolarSeries[] = [];
+
+  for (let position = 0; position < entries.length; position++) {
+    const trace = entries[position].trace;
+    const theta = trace.theta;
+    const r = trace.r;
+    if (!theta || !r)
+      continue;
+
+    const len = Math.min(theta.length, r.length);
+    const spokes: LinePoint[] = [];
+    const seriesName = trace.name ?? `Series ${data.length + 1}`;
+    for (let i = 0; i < len; i++) {
+      // Plotly leaves a spoke off the outline where the value is missing, and
+      // `Number(null)` is a finite 0 that would be drawn at the centre.
+      if (r[i] == null || !Number.isFinite(Number(r[i])))
+        continue;
+      spokes.push({ x: theta[i], y: Number(r[i]), z: seriesName });
+    }
+
+    if (spokes.length === 0)
+      continue;
+    data.push(spokes);
+    series.push({ trace, position });
+  }
+
+  if (data.length === 0)
+    return null;
+
+  const subplotId = group.polarId ?? 'polar';
+  const polar = layout[subplotId] as PlotlyPolarLayout | undefined;
+  const radialLabel = extractAxisLabel(polar?.radialaxis, layout);
+
+  return {
+    id: String(entries[0].globalIdx),
+    type,
+    title: series.length === 1 ? series[0].trace.name : undefined,
+    selectors: polarSeriesSelectors(series, subplotId, type === TraceType.POLAR_AREA),
+    axes: {
+      x: { label: POLAR_SPOKE_AXIS },
+      y: { label: radialLabel ?? POLAR_VALUE_AXIS },
+    },
+    data,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -2067,6 +2282,497 @@ function extractPieLayer(
     axes: {
       x: { label: PIE_LABEL_AXIS },
       y: { label: PIE_VALUE_AXIS },
+    },
+    data,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hierarchy (sunburst, icicle, treemap)
+// ---------------------------------------------------------------------------
+
+/**
+ * What a hierarchy layer calls its two dimensions.
+ *
+ * Plotly gives these traces no axes to take a name from — a sector's name and
+ * its magnitude are the whole chart — so they are named the way a pie's are.
+ */
+const HIERARCHY_LABEL_AXIS = 'Label';
+const HIERARCHY_VALUE_AXIS = 'Value';
+
+/** One sector as the layer needs it: its name, its magnitude and its ancestry. */
+interface HierarchySector {
+  label: string;
+  /** The magnitude, or undefined when the trace declared none for this sector. */
+  value: number | undefined;
+  /** The names of its ancestors, root first, excluding itself. */
+  path: string[];
+}
+
+/**
+ * Reads the sectors out of the tree plotly computed, in the order it drew them.
+ *
+ * calcdata is the only source that describes the hierarchy as it was drawn.
+ * Plotly stratifies the `labels`/`parents` pair into a tree, sums it, and —
+ * unless a trace turns `sort` off — reorders every node's children largest
+ * first, so the authored order is not the drawn order. It then draws the tree
+ * a level at a time, which is what this walk reproduces: the `g.slice` groups
+ * sit in exactly this order, and that is what the layer's
+ * sector-k-is-slice-k selector contract needs.
+ *
+ * A tree whose root plotly synthesised to stand in front of several top-level
+ * sectors is refused outright. The stand-in is nameless, the three layouts
+ * disagree over whether it is drawn at all, and a sector list that is off by
+ * one against the slices would highlight a neighbour for the whole chart.
+ *
+ * @param calcdata - What plotly computed for the trace
+ * @returns The drawn sectors, or null when plotly has not computed the trace
+ */
+function drawnHierarchySectors(calcdata: PlotlyCalcData[]): HierarchySector[] | null {
+  const root = calcdata[0]?.hierarchy;
+  if (!root || root.data?.data?.hasMultipleRoots) {
+    return null;
+  }
+
+  const sectors: HierarchySector[] = [];
+  let level: { node: PlotlyHierarchyNode; path: string[] }[] = [{ node: root, path: [] }];
+
+  while (level.length > 0) {
+    const next: { node: PlotlyHierarchyNode; path: string[] }[] = [];
+    for (const { node, path } of level) {
+      const label = node.data?.data?.label;
+      if (label === undefined) {
+        return null;
+      }
+      const value = Number(node.value);
+      sectors.push({
+        label,
+        value: Number.isFinite(value) ? value : undefined,
+        path,
+      });
+
+      const childPath = [...path, label];
+      for (const child of node.children ?? []) {
+        next.push({ node: child, path: childPath });
+      }
+    }
+    level = next;
+  }
+
+  return sectors.length > 0 ? sectors : null;
+}
+
+/**
+ * Reads the sectors from the trace's own arrays, as the author wrote them.
+ *
+ * The fallback for a chart captured before plotly computed it. A sector is
+ * addressed by its id where the trace has one and by its label otherwise,
+ * which is how plotly resolves the `parents` entries against it.
+ */
+function authoredHierarchySectors(trace: PlotlyTrace): HierarchySector[] {
+  const labels = trace.labels ?? [];
+  const parents = trace.parents ?? [];
+  const values = trace.values ?? [];
+  const ids = trace.ids;
+
+  const len = Math.min(labels.length, parents.length);
+  const labelByKey = new Map<string, string>();
+  const parentByKey = new Map<string, string>();
+  for (let i = 0; i < len; i++) {
+    const key = String(ids?.[i] ?? labels[i]);
+    labelByKey.set(key, String(labels[i]));
+    parentByKey.set(key, String(parents[i] ?? ''));
+  }
+
+  const sectors: HierarchySector[] = [];
+  for (let i = 0; i < len; i++) {
+    // A sector plotly would not size is one it declared no magnitude for, and
+    // `Number(null)` is a finite 0 that would be announced as one.
+    const declared = values[i];
+    const value = declared == null ? Number.NaN : Number(declared);
+    sectors.push({
+      label: String(labels[i]),
+      value: Number.isFinite(value) ? value : undefined,
+      path: ancestorLabels(String(ids?.[i] ?? labels[i]), labelByKey, parentByKey),
+    });
+  }
+  return sectors;
+}
+
+/**
+ * Names a sector's ancestors, root first.
+ *
+ * The walk stops on a key it has already seen: a `parents` array is authored
+ * by hand and can name a cycle, which plotly refuses to draw at all and which
+ * would otherwise spin here.
+ */
+function ancestorLabels(
+  key: string,
+  labelByKey: Map<string, string>,
+  parentByKey: Map<string, string>,
+): string[] {
+  const path: string[] = [];
+  const seen = new Set<string>([key]);
+
+  let current = parentByKey.get(key) ?? '';
+  while (current !== '' && !seen.has(current)) {
+    const label = labelByKey.get(current);
+    if (label === undefined) {
+      break;
+    }
+    seen.add(current);
+    path.unshift(label);
+    current = parentByKey.get(current) ?? '';
+  }
+  return path;
+}
+
+/**
+ * Builds a sunburst, icicle or treemap layer.
+ *
+ * One extractor for all three because plotly gives them one attribute set and
+ * MAIDR gives them one trace: the tree is the chart, and the layout is only
+ * how it was drawn. Only the emitted type differs.
+ */
+function extractHierarchyLayer(
+  trace: PlotlyTrace,
+  type: TraceType.SUNBURST | TraceType.ICICLE | TraceType.TREEMAP,
+  calcdata: PlotlyCalcData[],
+  id: string,
+  title: string | undefined,
+  selectors: string | undefined,
+): MaidrLayer | null {
+  const drawn = drawnHierarchySectors(calcdata);
+  const sectors = drawn ?? authoredHierarchySectors(trace);
+  if (sectors.length === 0)
+    return null;
+
+  const data: TreemapPoint[] = sectors.map(sector => ({
+    x: sector.label,
+    ...(sector.value === undefined ? {} : { y: sector.value }),
+    ...(sector.path.length > 0 ? { path: sector.path } : {}),
+  }));
+
+  return {
+    id,
+    type,
+    title,
+    // The wedge contract a pie is under, applied to slices: the authored order
+    // is not the drawn one, so a layer built from the trace's own arrays goes
+    // out without selectors. No highlight at all beats one that lands on a
+    // neighbouring sector while the text announces this one.
+    selectors: drawn ? selectors : undefined,
+    axes: {
+      x: { label: HIERARCHY_LABEL_AXIS },
+      y: { label: HIERARCHY_VALUE_AXIS },
+    },
+    data,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sankey
+// ---------------------------------------------------------------------------
+
+/**
+ * What a sankey layer calls its two dimensions. Plotly titles neither, and a
+ * flow diagram's dimensions are the same on both sides of every ribbon.
+ */
+const SANKEY_NODE_AXIS = 'Node';
+const SANKEY_VALUE_AXIS = 'Value';
+
+/**
+ * Names one end of a flow.
+ *
+ * A trace authors its ends as INDICES into `node.label`, and plotly's layout
+ * pass replaces each index with the node object itself — so which of the two
+ * arrives here depends on whether the chart has been drawn. A node beyond the
+ * declared labels (one plotly generated for a `node.groups` entry) falls back
+ * to its index, which at least identifies it consistently across the flows
+ * that touch it.
+ */
+function sankeyEndpoint(
+  end: number | PlotlySankeyNode | undefined,
+  labels: (number | string)[],
+): string | number {
+  if (end !== null && typeof end === 'object') {
+    return end.label ?? end.pointNumber ?? '';
+  }
+  const index = Number(end);
+  return labels[index] ?? index;
+}
+
+/**
+ * Reads the flows out of what plotly computed, in the order it drew the
+ * ribbons.
+ *
+ * Plotly's calc drops every flow it will not draw — a non-positive value, an
+ * endpoint that is not a node, both ends inside one group — and keeps the
+ * rest in the order they were authored. What survives is exactly the ribbons
+ * in the DOM, which is what the layer's flow-k-is-ribbon-k contract needs.
+ *
+ * @param calcdata - What plotly computed for the trace
+ * @param trace    - The resolved plotly trace, which names the nodes
+ * @returns The drawn flows, or null when plotly has not computed the trace
+ */
+function drawnFlows(calcdata: PlotlyCalcData[], trace: PlotlyTrace): FlowPoint[] | null {
+  const links = calcdata[0]?._links;
+  const labels = trace.node?.label ?? [];
+  if (!links || links.length === 0) {
+    return null;
+  }
+
+  const flows: FlowPoint[] = [];
+  for (const link of links) {
+    const value = Number(link.value);
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    flows.push({
+      source: sankeyEndpoint(link.source, labels),
+      target: sankeyEndpoint(link.target, labels),
+      value,
+    });
+  }
+  return flows;
+}
+
+/**
+ * Reads the flows from the trace's own arrays, as the author wrote them.
+ *
+ * The fallback for a chart captured before plotly computed it. A flow with
+ * nothing running through it is dropped here as well, because plotly drops it
+ * too and a zero-weight edge would put a node in the graph that the chart
+ * does not draw.
+ */
+function authoredFlows(trace: PlotlyTrace): FlowPoint[] {
+  const sources = trace.link?.source ?? [];
+  const targets = trace.link?.target ?? [];
+  const values = trace.link?.value ?? [];
+  const labels = trace.node?.label ?? [];
+
+  const len = Math.min(sources.length, targets.length, values.length);
+  const flows: FlowPoint[] = [];
+  for (let i = 0; i < len; i++) {
+    const value = Number(values[i]);
+    if (!Number.isFinite(value) || value <= 0)
+      continue;
+    flows.push({
+      source: sankeyEndpoint(sources[i], labels),
+      target: sankeyEndpoint(targets[i], labels),
+      value,
+    });
+  }
+  return flows;
+}
+
+function extractSankeyLayer(
+  trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
+  id: string,
+  title: string | undefined,
+  selectors: string | undefined,
+): MaidrLayer | null {
+  const drawn = drawnFlows(calcdata, trace);
+  const flows = drawn ?? authoredFlows(trace);
+  if (flows.length === 0)
+    return null;
+
+  return {
+    id,
+    type: TraceType.SANKEY,
+    title,
+    // Selectors only for the drawn set, for the reason a pie's are withheld:
+    // the ribbons are matched to the flows by position, and a list rebuilt
+    // from the trace's own arrays cannot promise plotly kept them all.
+    selectors: drawn ? selectors : undefined,
+    axes: {
+      x: { label: SANKEY_NODE_AXIS },
+      y: { label: SANKEY_VALUE_AXIS },
+    },
+    data: flows,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Gauge
+// ---------------------------------------------------------------------------
+
+/**
+ * What a gauge layer calls its two dimensions: the measure it names and the
+ * number it reads. Plotly titles neither.
+ */
+const GAUGE_MEASURE_AXIS = 'Measure';
+const GAUGE_VALUE_AXIS = 'Value';
+
+/**
+ * The target a gauge was aiming at, when it drew one.
+ *
+ * `threshold.value` is the marker plotly draws on the dial, and it is the
+ * target proper. `delta.reference` is the number an indicator computes its
+ * delta against, which is the same thing whenever the author set it — but
+ * plotly DEFAULTS it to the measure, and "0 above target" is not a reading, so
+ * a reference equal to the value is treated as the absent one it is.
+ *
+ * Plotly resolves an unset `threshold.value` to the boolean `false`, which
+ * `Number` would happily turn into a target of zero. Hence the type test.
+ */
+function gaugeTarget(trace: PlotlyTrace): number | undefined {
+  const threshold = trace.gauge?.threshold?.value;
+  if (typeof threshold === 'number' && Number.isFinite(threshold)) {
+    return threshold;
+  }
+
+  const reference = trace.delta?.reference;
+  if (typeof reference === 'number' && Number.isFinite(reference) && reference !== trace.value) {
+    return reference;
+  }
+  return undefined;
+}
+
+/**
+ * The qualitative bands a bullet chart declared, ascending.
+ *
+ * Plotly's steps carry a range and a colour; a NAME is optional and usually
+ * absent, because the colour is what a sighted reader goes by. A band with no
+ * name has no honest label, and "band 2" says nothing a reader could not work
+ * out from the numbers — so an unnamed step withdraws the bands entirely
+ * rather than having one invented for it.
+ */
+function gaugeBands(trace: PlotlyTrace): GaugeBand[] | undefined {
+  const steps = trace.gauge?.steps;
+  if (!steps || steps.length === 0) {
+    return undefined;
+  }
+
+  const bands: GaugeBand[] = [];
+  for (const step of steps) {
+    const to = Number(step.range?.[1]);
+    if (!step.name || !Number.isFinite(to)) {
+      return undefined;
+    }
+    bands.push({ to, label: step.name });
+  }
+  return bands.sort((a, b) => a.to - b.to);
+}
+
+function extractGaugeLayer(
+  trace: PlotlyTrace,
+  id: string,
+  title: string | undefined,
+  selectors: string | undefined,
+): MaidrLayer | null {
+  // Read as a number rather than coerced to one: an absent measure is the
+  // `undefined` plotly leaves, and `Number(null)` would be a finite zero the
+  // chart never drew.
+  const value = trace.value;
+  const range = trace.gauge?.axis?.range;
+  if (typeof value !== 'number' || !Number.isFinite(value) || !range || range.length < 2)
+    return null;
+
+  const min = Number(range[0]);
+  const max = Number(range[1]);
+  if (!Number.isFinite(min) || !Number.isFinite(max))
+    return null;
+
+  const point: GaugePoint = { value, min, max };
+
+  // The indicator's own title, which is what a gauge tile is captioned with.
+  // Unlike an axis title it has no placeholder to guard against: plotly
+  // resolves an unset one to the empty string.
+  const label = extractTextOrObject(trace.title);
+  if (label)
+    point.label = label;
+
+  const target = gaugeTarget(trace);
+  if (target !== undefined)
+    point.target = target;
+
+  const bands = gaugeBands(trace);
+  if (bands)
+    point.bands = bands;
+
+  return {
+    id,
+    type: TraceType.GAUGE,
+    title,
+    selectors,
+    axes: {
+      x: { label: GAUGE_MEASURE_AXIS },
+      y: { label: GAUGE_VALUE_AXIS },
+    },
+    // A single object rather than an array: a gauge draws exactly one measure.
+    data: point,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parallel coordinates
+// ---------------------------------------------------------------------------
+
+/**
+ * What a parallel-coordinates layer calls its two dimensions. Each axis names
+ * itself in the x of every point, so the layer's own x names what those are.
+ */
+const PARALLEL_VARIABLE_AXIS = 'Variable';
+const PARALLEL_VALUE_AXIS = 'Value';
+
+/**
+ * Builds a parallel-coordinates layer.
+ *
+ * `ParallelTrace` reads one ROW PER OBSERVATION and one column per axis;
+ * plotly stores the transpose, a `values` column per dimension, so the grid is
+ * turned over here. Every observation crosses every axis, which is what makes
+ * the transpose safe: a dimension shorter than the rest describes fewer
+ * observations than the chart drew, and reading past its end would invent
+ * values, so the row count is the shortest column.
+ *
+ * No selectors: plotly draws parcoords lines to a canvas rather than to SVG,
+ * so there is nothing per-observation to highlight. The layer still sonifies,
+ * navigates and reads out, which is the whole chart bar the visual cue.
+ */
+function extractParallelLayer(
+  trace: PlotlyTrace,
+  id: string,
+  title: string | undefined,
+): MaidrLayer | null {
+  // A hidden dimension is not an axis on the chart, so it is not a column.
+  const dimensions = (trace.dimensions ?? []).filter(dimension => dimension.visible !== false);
+  if (dimensions.length === 0)
+    return null;
+
+  const rows = dimensions.reduce(
+    (shortest, dimension) => Math.min(shortest, dimension.values?.length ?? 0),
+    Infinity,
+  );
+  if (!Number.isFinite(rows) || rows === 0)
+    return null;
+
+  const data: LinePoint[][] = [];
+  for (let row = 0; row < rows; row++) {
+    const observation: LinePoint[] = [];
+    for (const dimension of dimensions) {
+      const value = Number(dimension.values?.[row]);
+      // A gap on one axis is a break in the line rather than a value, and the
+      // per-axis extents this trace scales its pitch by must not see it.
+      if (dimension.values?.[row] == null || !Number.isFinite(value))
+        continue;
+      observation.push({ x: dimension.label ?? '', y: value });
+    }
+    if (observation.length > 0)
+      data.push(observation);
+  }
+
+  if (data.length === 0)
+    return null;
+
+  return {
+    id,
+    type: TraceType.PARALLEL,
+    title,
+    axes: {
+      x: { label: PARALLEL_VARIABLE_AXIS },
+      y: { label: PARALLEL_VALUE_AXIS },
     },
     data,
   };

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -14,8 +14,11 @@ import type {
   BoxPoint,
   BoxSelector,
   CandlestickPoint,
+  ChoroplethPoint,
   ErrorBarPoint,
   FlowPoint,
+  GanttData,
+  GanttPoint,
   GaugeBand,
   GaugePoint,
   HeatmapData,
@@ -32,6 +35,7 @@ import type {
   ViolinKdePoint,
   WaterfallKind,
   WaterfallPoint,
+  WordCloudPoint,
 } from '../../type/grammar';
 import type {
   PlotlyAnnotation,
@@ -49,6 +53,8 @@ import type {
 } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 import {
+  barPointSelector,
+  choroplethRegionSelectors,
   errorBarAxis,
   generatePlotlySelectors,
   polarSeriesSelectors,
@@ -368,6 +374,12 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
     case 'parcoords':
       return TraceType.PARALLEL;
 
+    // Only the SVG choropleth. `choroplethmapbox` and `choroplethmap` draw
+    // their regions into a WebGL canvas, so there is no element per region to
+    // highlight and nothing the adapter could scope a selector to.
+    case 'choropleth':
+      return TraceType.CHOROPLETH;
+
     default:
       console.warn(`[maidr] Unsupported plotly trace type: "${type}". Skipping.`);
       return null;
@@ -387,6 +399,11 @@ function mapScatterMode(trace: PlotlyTrace): TraceType {
   const mode = trace.mode;
   if (!mode)
     return TraceType.SCATTER;
+  // Ahead of the mark tests, because a cloud is drawn with no mark at all: its
+  // terms ARE the text, and read as a scatter it would announce the packing
+  // coordinates plotly was handed to lay the glyphs out with.
+  if (wordCloudWeights(trace) !== null)
+    return TraceType.WORD_CLOUD;
   // When both lines and markers exist, prefer LINE for navigational context.
   if (mode.includes('lines')) {
     // A staircase keeps its step reading even when it is filled: with nothing
@@ -398,7 +415,58 @@ function mapScatterMode(trace: PlotlyTrace): TraceType {
   }
   if (isFilled(trace.fill))
     return TraceType.AREA;
+  // A marker per category, with no category drawn twice, is a Cleveland dot
+  // plot: the same category-and-value pairing a bar chart draws, with a dot in
+  // place of the bar. A scatter reading would announce the category as a
+  // coordinate and offer a grid walk over a single row of them.
+  if (mode.includes('markers') && dotCategoryAxis(trace) !== null)
+    return TraceType.DOT;
   return TraceType.SCATTER;
+}
+
+/**
+ * Which axis of a markers-only scatter is the category axis of a dot plot, or
+ * `null` when the trace is not one.
+ *
+ * Read off the data rather than off the resolved axis, which is not in hand
+ * here and which an author can set to `category` for a chart that is nothing
+ * of the kind. The test is deliberately narrow: every position on one axis is
+ * a distinct label, and every value on the other is a number. One label drawn
+ * twice means the chart is comparing points within a category rather than
+ * naming it once, which is a scatter — so the ambiguous case stays a scatter,
+ * as it is announced today.
+ *
+ * @param trace - The resolved plotly trace
+ * @returns `'x'`, `'y'`, or null when this is not a dot plot
+ */
+function dotCategoryAxis(trace: PlotlyTrace): 'x' | 'y' | null {
+  if (isDistinctLabels(trace.x) && isMagnitudes(trace.y))
+    return 'x';
+  if (isDistinctLabels(trace.y) && isMagnitudes(trace.x))
+    return 'y';
+  return null;
+}
+
+/** Whether a column is a non-empty run of labels, none of them repeated. */
+function isDistinctLabels(values: (number | string)[] | undefined): boolean {
+  if (!values || values.length === 0)
+    return false;
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string' || value === '')
+      return false;
+    if (seen.has(value))
+      return false;
+    seen.add(value);
+  }
+  return true;
+}
+
+/** Whether a column is a non-empty run of numbers, parallel to the labels. */
+function isMagnitudes(values: (number | string)[] | undefined): boolean {
+  if (!values || values.length === 0)
+    return false;
+  return values.every(value => value != null && Number.isFinite(Number(value)));
 }
 
 /**
@@ -477,11 +545,11 @@ interface SubplotGroup {
    */
   domain?: { x: DomainInterval; y: DomainInterval };
   /**
-   * The polar subplot the panel is, when it is one (`polar`, `polar2`, …).
-   * Its domain lives on the layout rather than on the trace, so unlike the
+   * The named subplot the panel is, when it is one (`polar`, `polar2`, `geo`,
+   * …). Its domain lives on the layout rather than on the trace, so unlike the
    * domain-positioned types it is resolved later, where the layout is in hand.
    */
-  polarId?: string;
+  subplotId?: string;
   traces: PlotlyTrace[];
   calcdata: PlotlyCalcData[][];
   traceIndices: number[];
@@ -512,6 +580,13 @@ const DOMAIN_POSITIONED_TYPES = new Set([
  */
 const POLAR_TYPES = new Set(['scatterpolar', 'scatterpolargl', 'barpolar']);
 
+/**
+ * The trace types plotly draws on a geo subplot. They are keyed the way the
+ * polar types are — by the subplot named on the trace — and their domain
+ * likewise lives on the layout entry rather than on the trace.
+ */
+const GEO_TYPES = new Set(['choropleth', 'scattergeo']);
+
 /** A trace within a subplot group, keyed to its calcdata and its global index. */
 interface TraceEntry {
   trace: PlotlyTrace;
@@ -537,23 +612,27 @@ function groupTracesBySubplot(
       continue;
 
     // A domain-positioned trace is its own panel, keyed by its trace index and
-    // positioned from its own domain; a polar trace shares a panel with every
-    // other trace on the same polar subplot. Neither has an axis pair, so both
-    // leave the axis ids blank.
+    // positioned from its own domain; a polar or geo trace shares a panel with
+    // every other trace on the same named subplot. Neither has an axis pair,
+    // so both leave the axis ids blank.
     const type = trace.type ?? 'scatter';
     const isDomain = DOMAIN_POSITIONED_TYPES.has(type);
-    const polarId = POLAR_TYPES.has(type) ? (trace.subplot ?? 'polar') : undefined;
-    const positioned = isDomain || polarId !== undefined;
+    const subplotId = POLAR_TYPES.has(type)
+      ? (trace.subplot ?? 'polar')
+      : GEO_TYPES.has(type)
+        ? (trace.geo ?? 'geo')
+        : undefined;
+    const positioned = isDomain || subplotId !== undefined;
     const xAxisId = positioned ? '' : (trace.xaxis ?? 'x');
     const yAxisId = positioned ? '' : (trace.yaxis ?? 'y');
-    const key = isDomain ? `domain${i}` : (polarId ?? `${xAxisId}${yAxisId}`);
+    const key = isDomain ? `domain${i}` : (subplotId ?? `${xAxisId}${yAxisId}`);
 
     if (!map.has(key)) {
       map.set(key, {
         xAxisId,
         yAxisId,
         ...(isDomain ? { domain: readTraceDomain(trace) } : {}),
-        ...(polarId === undefined ? {} : { polarId }),
+        ...(subplotId === undefined ? {} : { subplotId }),
         traces: [],
         calcdata: [],
         traceIndices: [],
@@ -746,9 +825,16 @@ function buildSubplotLayers(
   }
 
   // Build the violin pair: every violin in the subplot shares one box layer
-  // and one KDE layer.
+  // and one KDE layer. Halved and overlapped, the same traces are plotly's
+  // ridgeline, which is one layer rather than two.
   if (violinTraces.length > 0) {
-    layers.push(...extractViolinLayers(violinTraces, group, layout, xLabel, yLabel));
+    if (isRidgeline(violinTraces)) {
+      const layer = extractRidgelineLayer(violinTraces, group, layout, xLabel, yLabel);
+      if (layer)
+        layers.push(layer);
+    } else {
+      layers.push(...extractViolinLayers(violinTraces, group, layout, xLabel, yLabel));
+    }
   }
 
   // One layer per mark on the polar subplot: the spokes are shared, but a
@@ -764,8 +850,17 @@ function buildSubplotLayers(
       layers.push(layer);
   }
 
+  // A schedule reaches plotly as bars floated onto a time axis, so it has to
+  // be recognised before the bar shapes are: read as bars, the intervals would
+  // announce their durations as magnitudes measured from nothing.
+  const ganttLayer = isGanttPanel(barTraces, group, layout)
+    ? extractGanttLayer(barTraces, group, layout, xLabel, yLabel)
+    : null;
+
   // Build bar layers: grouped/stacked/normalized for multiple bar traces.
-  if (barTraces.length > 1) {
+  if (ganttLayer) {
+    layers.push(ganttLayer);
+  } else if (barTraces.length > 1) {
     const barmode = layout.barmode ?? 'group';
     const barnorm = layout.barnorm ?? '';
 
@@ -774,9 +869,14 @@ function buildSubplotLayers(
       if (layer)
         layers.push(layer);
     } else if (barmode === 'stack' || barmode === 'relative') {
+      // A pyramid is stacked the same way and drawn the same way; what tells
+      // the two apart is that its sides grow in opposite directions from the
+      // baseline, which is the sign of the values themselves.
       const type = barnorm === 'percent' || barnorm === 'fraction'
         ? TraceType.NORMALIZED
-        : TraceType.STACKED;
+        : divergingSides(barTraces)
+          ? TraceType.DIVERGING
+          : TraceType.STACKED;
       const layer = extractSegmentedBarLayer(barTraces, group, type, xLabel, yLabel, gd);
       if (layer)
         layers.push(layer);
@@ -836,7 +936,7 @@ function arrangePanelsIntoGrid(
     // A domain-positioned panel carries its own domain and a polar one names
     // the layout entry holding it (neither has axes to read one from);
     // everything else takes it from the axis pair it was grouped by.
-    const own = panel.group.domain ?? readPolarDomain(layout, panel.group.polarId);
+    const own = panel.group.domain ?? readSubplotDomain(layout, panel.group.subplotId);
     const xDomain = own?.x ?? readAxisDomain(getAxis(layout, panel.group.xAxisId));
     const yDomain = own?.y ?? readAxisDomain(getAxis(layout, panel.group.yAxisId));
     if (!xDomain || !yDomain)
@@ -928,18 +1028,18 @@ function readTraceDomain(
 }
 
 /**
- * Reads a polar subplot's paper domain. Plotly keeps it on the layout entry
- * the traces name rather than on the traces themselves, so it is resolved here
- * rather than while they are grouped.
+ * Reads a named subplot's paper domain — a polar dial, a geo map. Plotly keeps
+ * it on the layout entry the traces name rather than on the traces themselves,
+ * so it is resolved here rather than while they are grouped.
  */
-function readPolarDomain(
+function readSubplotDomain(
   layout: PlotlyFullLayout,
-  polarId: string | undefined,
+  subplotId: string | undefined,
 ): { x: DomainInterval; y: DomainInterval } | undefined {
-  const polar = polarId === undefined
+  const subplot = subplotId === undefined
     ? undefined
-    : (layout[polarId] as PlotlyPolarLayout | undefined);
-  return polar ? readTraceDomain(polar) : undefined;
+    : (layout[subplotId] as PlotlyPolarLayout | undefined);
+  return subplot ? readTraceDomain(subplot) : undefined;
 }
 
 function readAxisDomain(axis: PlotlyAxis | undefined): DomainInterval | null {
@@ -1270,6 +1370,18 @@ function extractLayer(
     case TraceType.BAR:
       return extractBarLayer(trace, calcdata, TraceType.BAR, id, title, selectors, axes);
 
+    // A dot plot is a bar chart drawn with dots, and MAIDR reads it as one.
+    // Its calcdata is a scatter's and carries no bar size, so the marks are
+    // the authored values — which is what the chart put on the axis.
+    case TraceType.DOT:
+      return extractBarLayer(trace, [], TraceType.DOT, id, title, selectors, axes, dotCategoryAxis(trace) === 'y');
+
+    case TraceType.WORD_CLOUD:
+      return extractWordCloudLayer(trace, id, title, selectors);
+
+    case TraceType.CHOROPLETH:
+      return extractChoroplethLayer(trace, calcdata, id, title, traceIndex, gd);
+
     // A funnel is a bar chart whose order means something: same points, same
     // orientation handling, and the retention between stages is derived by
     // the trace rather than carried in the payload.
@@ -1432,18 +1544,21 @@ function barPoint(
 function extractBarLayer(
   trace: PlotlyTrace,
   calcdata: PlotlyCalcData[],
-  type: TraceType.BAR | TraceType.FUNNEL,
+  type: TraceType.BAR | TraceType.FUNNEL | TraceType.DOT,
   id: string,
   title: string | undefined,
   selectors: string | undefined,
   axes: MaidrLayer['axes'],
+  horizontal?: boolean,
 ): MaidrLayer | null {
   const x = trace.x;
   const y = trace.y;
   if (!x || !y)
     return null;
 
-  const isHorizontal = trace.orientation === 'h';
+  // A scatter has no `orientation`, so a dot plot says which way it lies by
+  // which of its axes holds the categories.
+  const isHorizontal = horizontal ?? trace.orientation === 'h';
   const len = Math.min(x.length, y.length);
   const data: BarPoint[] = [];
 
@@ -1461,6 +1576,424 @@ function extractBarLayer(
     selectors,
     axes,
     ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
+    data,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Gantt
+// ---------------------------------------------------------------------------
+
+/**
+ * The units a schedule is read in, coarsest first, with the milliseconds a
+ * plotly date axis measures in.
+ *
+ * A date axis puts every position and every duration in milliseconds, and a
+ * task announced as lasting 1,209,600,000 has not been announced. The coarsest
+ * unit that still gives the shortest interval a whole number of its own is the
+ * one a reader would use to describe the chart.
+ */
+const GANTT_UNITS: { unit: string; ms: number }[] = [
+  { unit: 'days', ms: 86400000 },
+  { unit: 'hours', ms: 3600000 },
+  { unit: 'minutes', ms: 60000 },
+  { unit: 'seconds', ms: 1000 },
+];
+
+/** One interval, before it is grouped into the lane it belongs to. */
+interface GanttInterval {
+  /** The lane, as the position axis names it. */
+  lane: string;
+  /** Where it begins, in milliseconds. */
+  start: number;
+  /** Where it ends, in milliseconds. */
+  end: number;
+  /** Which of the panel's bar-layer traces drew it, and which of its points. */
+  tracePosition: number;
+  pointIndex: number;
+}
+
+/**
+ * Whether the panel's bar traces are a schedule rather than a bar chart.
+ *
+ * Plotly has no gantt trace: `plotly.express.timeline` and
+ * `figure_factory.create_gantt` both emit horizontal bars whose `base` array
+ * floats each one onto a date axis, with the DURATION in `x`. All three
+ * conditions are required together — a horizontal bar chart with a shared
+ * numeric base is a floating bar chart, not a timeline — and every bar trace
+ * on the panel has to be one, since a schedule shares its lanes across the
+ * traces and half a schedule cannot be laid out.
+ *
+ * @param barTraces - The panel's bar traces
+ * @param group     - The panel they were grouped into
+ * @param layout    - The resolved layout, which types the axes
+ * @returns True when the panel draws intervals
+ */
+function isGanttPanel(
+  barTraces: TraceEntry[],
+  group: SubplotGroup,
+  layout: PlotlyFullLayout,
+): boolean {
+  if (barTraces.length === 0 || getAxis(layout, group.xAxisId)?.type !== 'date')
+    return false;
+  return barTraces.every(
+    ({ trace }) => trace.orientation === 'h' && Array.isArray(trace.base),
+  );
+}
+
+/**
+ * Reads one interval's ends.
+ *
+ * Plotly resolved both while positioning the bar: `cd.b` is the base it was
+ * floated onto and `cd.s` the duration it runs for, both already converted to
+ * the axis's own milliseconds. Without calcdata the authored pair is parsed
+ * the way plotly's own `d2c` would, so a chart captured before it was
+ * positioned still reads.
+ *
+ * @param cd       - The calcdata entry for this bar
+ * @param base     - What the trace declared as its start
+ * @param duration - What the trace declared as its length
+ * @returns The two ends in milliseconds, or null when neither source resolves
+ */
+function ganttEnds(
+  cd: PlotlyCalcData | undefined,
+  base: number | string | undefined,
+  duration: number | string | undefined,
+): { start: number; end: number } | null {
+  if (typeof cd?.b === 'number' && Number.isFinite(cd.b)
+    && typeof cd?.s === 'number' && Number.isFinite(cd.s)) {
+    return { start: cd.b, end: cd.b + cd.s };
+  }
+
+  const start = ganttInstant(base);
+  const length = duration == null ? Number.NaN : Number(duration);
+  if (start === null || !Number.isFinite(length))
+    return null;
+  return { start, end: start + length };
+}
+
+/**
+ * Parses an authored instant into milliseconds.
+ *
+ * A date axis accepts both what plotly.py sends — an ISO string — and the
+ * epoch milliseconds a hand-written figure may use, so both are admitted.
+ *
+ * @param value - The authored start of an interval
+ * @returns Milliseconds, or null when the value is not an instant
+ */
+function ganttInstant(value: number | string | undefined): number | null {
+  if (value == null)
+    return null;
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * The unit the intervals are announced in, and the milliseconds in one of it.
+ *
+ * @param intervals - Every interval on the panel
+ * @returns The unit, or undefined when nothing lasts a whole second
+ */
+function ganttUnit(intervals: GanttInterval[]): { unit: string; ms: number } | undefined {
+  const shortest = shortestInterval(intervals);
+  return GANTT_UNITS.find(candidate => shortest >= candidate.ms);
+}
+
+/**
+ * The shortest interval on the panel, ignoring the milestones a schedule marks
+ * with a zero-length bar — those would drive every unit down to milliseconds
+ * while saying nothing about how long the work takes.
+ *
+ * @param intervals - Every interval on the panel
+ * @returns Its length in milliseconds, or 0 when nothing has one
+ */
+function shortestInterval(intervals: GanttInterval[]): number {
+  const lengths = intervals
+    .map(interval => interval.end - interval.start)
+    .filter(length => Number.isFinite(length) && length > 0);
+  return lengths.length === 0 ? 0 : Math.min(...lengths);
+}
+
+/**
+ * The lanes the schedule is drawn on, in visual order from the top.
+ *
+ * Taken from the axis rather than from the intervals so a lane with nothing
+ * booked survives — an empty row is a real statement about a schedule, and
+ * {@link GanttData} is nested to be able to make it. Plotly stacks categories
+ * upwards from index 0, so the drawn order is the reverse of the declared one
+ * unless the axis was reversed, which is what `plotly.express.timeline` does
+ * to put the first task at the top.
+ *
+ * @param axis      - The position axis, when the layout has one
+ * @param intervals - The intervals, for a panel whose lanes are not categories
+ * @returns The lane names, top first
+ */
+function ganttLanes(axis: PlotlyAxis | undefined, intervals: GanttInterval[]): string[] {
+  const categories = axis?._categories;
+  if (categories && categories.length > 0) {
+    const names = categories.map(String);
+    const reversed = Array.isArray(axis?.range) && Number(axis.range[0]) > Number(axis.range[1]);
+    return reversed ? names : names.reverse();
+  }
+  // No category axis to read: the lanes are whichever positions were drawn,
+  // first seen first, and nothing is claimed about lanes that hold nothing.
+  return [...new Set(intervals.map(interval => interval.lane))];
+}
+
+/**
+ * Builds the schedule layer from every bar trace on the panel.
+ *
+ * The intervals are regrouped by lane rather than by trace, because a lane is
+ * what a reader navigates: `plotly.express.timeline` splits one schedule into
+ * a trace per colour, so a resource booked twice in two colours is two traces
+ * to plotly and one row here.
+ *
+ * @param barTraces - The panel's bar traces, all of them intervals
+ * @param group     - The panel they were grouped into
+ * @param layout    - The resolved layout
+ * @param xLabel    - The time axis's name
+ * @param yLabel    - The lane axis's name
+ * @returns The layer, or null when nothing resolved
+ */
+function extractGanttLayer(
+  barTraces: TraceEntry[],
+  group: SubplotGroup,
+  layout: PlotlyFullLayout,
+  xLabel: string | undefined,
+  yLabel: string | undefined,
+): MaidrLayer | null {
+  const posAxis = getAxis(layout, group.yAxisId);
+  const intervals: GanttInterval[] = [];
+
+  for (const { trace, calcIdx } of barTraces) {
+    const cds = group.calcdata[calcIdx] ?? [];
+    const positions = trace.y ?? [];
+    const bases = Array.isArray(trace.base) ? trace.base : [];
+    const durations = trace.x ?? [];
+    // Plotly draws a bar per calc entry whether or not it resolved, so the
+    // position within the trace is what the selector counts by — dropping an
+    // interval must not shift the ones after it.
+    const tracePosition = barLayerPosition(group, calcIdx);
+
+    for (let i = 0; i < positions.length; i++) {
+      const ends = ganttEnds(cds[i], bases[i], durations[i]);
+      const lane = resolveAxisCategory(cds[i]?.p ?? positions[i], posAxis);
+      if (!ends || lane === undefined)
+        continue;
+      intervals.push({ lane, ...ends, tracePosition, pointIndex: i });
+    }
+  }
+
+  if (intervals.length === 0)
+    return null;
+
+  const scale = ganttUnit(intervals);
+  const lanes = ganttLanes(posAxis, intervals);
+  const points: GanttPoint[][] = lanes.map(() => []);
+  const selectors: string[] = [];
+  const prefix = subplotCssPrefix(barTraces[0].trace.xaxis, barTraces[0].trace.yaxis);
+
+  for (let row = 0; row < lanes.length; row++) {
+    for (const interval of intervals) {
+      if (interval.lane !== lanes[row])
+        continue;
+      points[row].push({
+        x: interval.lane,
+        // Divided into the announced unit so the LENGTH reads in it. The axis
+        // format below turns the same number back into the date it names, so
+        // both halves of an interval stay readable.
+        start: interval.start / (scale?.ms ?? 1),
+        end: interval.end / (scale?.ms ?? 1),
+      });
+      selectors.push(barPointSelector(prefix, interval.tracePosition, interval.pointIndex));
+    }
+  }
+
+  // Positions are scaled milliseconds, which no reader wants read out. The
+  // format takes them back to the instant they name — as a date alone for a
+  // schedule measured in days, where the time of day is always midnight.
+  const rendered = scale?.unit === 'days' ? 'toLocaleDateString' : 'toLocaleString';
+  const axes: MaidrLayer['axes'] = {
+    x: {
+      ...(xLabel ? { label: xLabel } : {}),
+      format: { function: `return new Date(value * ${scale?.ms ?? 1}).${rendered}();` },
+    },
+  };
+  if (yLabel)
+    axes.y = { label: yLabel };
+
+  const data: GanttData = {
+    points,
+    lanes,
+    ...(scale ? { unit: scale.unit } : {}),
+  };
+
+  return {
+    id: String(barTraces[0].globalIdx),
+    type: TraceType.GANTT,
+    selectors,
+    axes,
+    // The lanes run down the page and the axis across it, which is what a
+    // gantt's `orientation` says — the grid stays lanes-by-intervals either
+    // way, and the trace uses this to name its two axes the right way round.
+    orientation: Orientation.HORIZONTAL,
+    data,
+  };
+}
+
+/**
+ * Where a trace sits among the ones plotly draws into the panel's bar layer.
+ *
+ * Histograms share bar's renderer and therefore its layer, so they are counted
+ * too: a histogram drawn before a schedule's bars shifts every group after it.
+ *
+ * @param group   - The panel the traces were grouped into
+ * @param calcIdx - The trace's index within that panel
+ * @returns Its position among the panel's bar-layer traces
+ */
+function barLayerPosition(group: SubplotGroup, calcIdx: number): number {
+  let position = 0;
+  for (let i = 0; i < calcIdx; i++) {
+    const type = group.traces[i].type;
+    if (type === 'bar' || type === 'histogram')
+      position++;
+  }
+  return position;
+}
+
+/**
+ * Names a categorical coordinate.
+ *
+ * Plotly stores a category as its index on the axis and keeps the labels in
+ * `_categories`, so a position is only a name once the axis is in hand. A
+ * position that is already a string is one plotly has not indexed yet, which
+ * happens before the chart is drawn.
+ *
+ * @param pos  - The coordinate, as an index or as the label itself
+ * @param axis - The axis it is measured on
+ * @returns The category name, or undefined when there is none
+ */
+function resolveAxisCategory(
+  pos: number | string | undefined,
+  axis: PlotlyAxis | undefined,
+): string | undefined {
+  if (typeof pos === 'string')
+    return pos;
+  if (pos === undefined)
+    return undefined;
+
+  const categories = axis?._categories;
+  if (categories && pos >= 0 && pos < categories.length)
+    return String(categories[pos]);
+  return String(pos);
+}
+
+// ---------------------------------------------------------------------------
+// Word cloud
+// ---------------------------------------------------------------------------
+
+/**
+ * The weight behind each term of a word cloud, or null when the trace is not
+ * one.
+ *
+ * Plotly has no word cloud. Its documented recipe is a text-mode scatter whose
+ * `textfont.size` is an ARRAY — a per-term glyph size is the whole chart, and
+ * it is what tells one apart from an ordinary annotated scatter.
+ *
+ * The weight is the honest difficulty here. The only magnitude the trace is
+ * obliged to carry is the size in pixels, which many recipes set to the count
+ * itself but some set to a rescaled version of it. So a real weight is taken
+ * wherever the author put one — `customdata`, then a numeric `hovertext`,
+ * which are the two places plotly carries a per-point number it does not draw
+ * — and the glyph size stands in otherwise. The size ranks the terms
+ * correctly either way, which is what the reading is walked in.
+ *
+ * @param trace - The resolved plotly trace
+ * @returns One weight per term, or null when this is not a word cloud
+ */
+function wordCloudWeights(trace: PlotlyTrace): number[] | null {
+  const sizes = trace.textfont?.size;
+  const terms = trace.text;
+  if (
+    !trace.mode?.includes('text')
+    || !Array.isArray(terms)
+    || !Array.isArray(sizes)
+  ) {
+    return null;
+  }
+
+  const len = Math.min(terms.length, sizes.length);
+  if (len === 0)
+    return null;
+
+  const declared = declaredWeights(trace, len);
+  const weights: number[] = [];
+  for (let i = 0; i < len; i++) {
+    const weight = declared?.[i] ?? Number(sizes[i]);
+    if (!Number.isFinite(weight))
+      return null;
+    weights.push(weight);
+  }
+  return weights;
+}
+
+/**
+ * The per-term numbers the author carried alongside the glyphs, when they did.
+ *
+ * Taken whole or not at all: a column that is numeric for some terms and not
+ * for others is not the weights, and mixing it with the glyph sizes would put
+ * two different quantities on one axis.
+ *
+ * @param trace - The resolved plotly trace
+ * @param len   - How many terms the cloud draws
+ * @returns The weights, or undefined when neither carrier holds them
+ */
+function declaredWeights(trace: PlotlyTrace, len: number): number[] | undefined {
+  for (const carrier of [trace.customdata, trace.hovertext]) {
+    if (!Array.isArray(carrier) || carrier.length < len)
+      continue;
+    const values = carrier.slice(0, len).map(entry => Number(entry));
+    if (values.every(value => Number.isFinite(value)))
+      return values;
+  }
+  return undefined;
+}
+
+/**
+ * What a word cloud calls its two dimensions. The layout carries nothing, so
+ * the axes plotly gives the trace name the packing coordinates rather than the
+ * chart — they are deliberately not read.
+ */
+const WORD_CLOUD_TERM_AXIS = 'Term';
+const WORD_CLOUD_WEIGHT_AXIS = 'Weight';
+
+function extractWordCloudLayer(
+  trace: PlotlyTrace,
+  id: string,
+  title: string | undefined,
+  selectors: string | undefined,
+): MaidrLayer | null {
+  const weights = wordCloudWeights(trace);
+  const terms = trace.text;
+  if (!weights || !Array.isArray(terms))
+    return null;
+
+  const data: WordCloudPoint[] = weights.map((weight, i) => ({
+    x: String(terms[i]),
+    y: weight,
+  }));
+
+  return {
+    id,
+    type: TraceType.WORD_CLOUD,
+    title,
+    selectors,
+    axes: {
+      x: { label: WORD_CLOUD_TERM_AXIS },
+      y: { label: WORD_CLOUD_WEIGHT_AXIS },
+    },
     data,
   };
 }
@@ -1669,7 +2202,7 @@ function extractPolarLayer(
   if (data.length === 0)
     return null;
 
-  const subplotId = group.polarId ?? 'polar';
+  const subplotId = group.subplotId ?? 'polar';
   const polar = layout[subplotId] as PlotlyPolarLayout | undefined;
   const radialLabel = extractAxisLabel(polar?.radialaxis, layout);
 
@@ -1901,6 +2434,81 @@ function extractViolinLayers(
 }
 
 /**
+ * Whether the subplot's violins are plotly's ridgeline.
+ *
+ * A ridgeline is drawn by halving the curves — `side: 'positive'` — and
+ * widening them so they overlap, which is plotly's own documented recipe and
+ * the only thing on the trace that distinguishes one. Every violin has to be
+ * halved: a chart mixing halved and whole violins is comparing two things and
+ * is not a ridgeline.
+ *
+ * @param violinTraces - The subplot's violin traces
+ * @returns True when the panel is a ridgeline
+ */
+function isRidgeline(violinTraces: TraceEntry[]): boolean {
+  return violinTraces.every(({ trace }) => trace.side === 'positive');
+}
+
+/**
+ * What a ridgeline layer calls its dimensions.
+ *
+ * `RidgelineTrace` announces the sample's place on the value axis against the
+ * layer's x and the density against its z, so the value axis's own name goes
+ * on x whichever way plotly drew the curves. Plotly titles no density axis —
+ * the offset baseline is not one — so it is named for what it is.
+ */
+const RIDGELINE_DENSITY_AXIS = 'Density';
+
+/**
+ * Builds the ridgeline layer from the subplot's halved violins.
+ *
+ * The payload is the KDE layer's — plotly computed the same `cd.density`
+ * samples either way — and what differs is that a ridgeline is ONE layer: the
+ * recipe draws no inner box, so the quartile summary the violin pair opens
+ * with would describe marks that are not on the chart.
+ *
+ * Curves are emitted top first. `RidgelineTrace` reverses nothing, and plotly
+ * stacks its categories upwards from the bottom of the position axis, so a
+ * horizontal ridgeline's own order is the reverse of the reading one.
+ */
+function extractRidgelineLayer(
+  violinTraces: TraceEntry[],
+  group: SubplotGroup,
+  layout: PlotlyFullLayout,
+  xLabel: string | undefined,
+  yLabel: string | undefined,
+): MaidrLayer | null {
+  const isHorizontal = violinTraces[0].trace.orientation === 'h';
+  const posAxis = getAxis(layout, isHorizontal ? group.yAxisId : group.xAxisId);
+
+  const violins = collectViolins(violinTraces, group, posAxis);
+  if (violins.length === 0)
+    return null;
+  if (isHorizontal)
+    violins.reverse();
+
+  const data: ViolinKdePoint[][] = violins.map(({ label, cd }) =>
+    (cd.density ?? []).map(sample => ({ x: label, y: sample.t, density: sample.v })),
+  );
+
+  // The value axis is plotly's x on a horizontal ridgeline, which is where the
+  // trace reads it from; a vertical one has the two exchanged.
+  const axes: MaidrLayer['axes'] = {};
+  const valueLabel = isHorizontal ? xLabel : yLabel;
+  if (valueLabel)
+    axes.x = { label: valueLabel };
+  axes.z = { label: RIDGELINE_DENSITY_AXIS };
+
+  return {
+    id: `${violinTraces[0].globalIdx}-ridgeline`,
+    type: TraceType.RIDGELINE,
+    selectors: violins.map(violin => violin.kdeSelector),
+    axes,
+    data,
+  };
+}
+
+/**
  * Flattens the subplot's violin traces into one violin per calcdata entry,
  * in the order plotly renders them, and builds each one's selectors.
  *
@@ -1976,26 +2584,11 @@ function resolveViolinLabel(
   posAxis: PlotlyAxis | undefined,
   violinsInTrace: number,
 ): string {
-  const category = resolveViolinCategory(cd.pos, posAxis);
+  const category = resolveAxisCategory(cd.pos, posAxis);
   if (violinsInTrace > 1 && category) {
     return trace.name ? `${trace.name}, ${category}` : category;
   }
   return trace.name ?? category ?? '';
-}
-
-function resolveViolinCategory(
-  pos: number | string | undefined,
-  posAxis: PlotlyAxis | undefined,
-): string | undefined {
-  if (typeof pos === 'string')
-    return pos;
-  if (pos === undefined)
-    return undefined;
-
-  const categories = posAxis?._categories;
-  if (categories && pos >= 0 && pos < categories.length)
-    return String(categories[pos]);
-  return String(pos);
 }
 
 /**
@@ -2150,22 +2743,26 @@ function extractHeatmapLayer(
   axes: MaidrLayer['axes'],
   gd: PlotlyGraphDiv,
 ): MaidrLayer | null {
-  if (!trace.z || trace.z.length === 0)
+  // A heatmap's `z` is the grid of cells. The same attribute carries a flat
+  // column on a choropleth, which is a different trace type and a different
+  // extractor — so a grid is what it is not being one.
+  const grid = Array.isArray(trace.z?.[0]) ? (trace.z as number[][]) : undefined;
+  if (!grid || grid.length === 0)
     return null;
 
-  const numCols = trace.z[0]?.length ?? 0;
-  const numRows = trace.z.length;
+  const numCols = grid[0]?.length ?? 0;
+  const numRows = grid.length;
   if (numCols === 0)
     return null;
 
   // Ensure labels match z dimensions (trim if Plotly provides extras).
-  const xLabels = trace.x ? trace.x.slice(0, numCols).map(String) : trace.z[0].map((_, i) => String(i));
-  const yLabels = trace.y ? trace.y.slice(0, numRows).map(String) : trace.z.map((_, i) => String(i));
+  const xLabels = trace.x ? trace.x.slice(0, numCols).map(String) : grid[0].map((_, i) => String(i));
+  const yLabels = trace.y ? trace.y.slice(0, numRows).map(String) : grid.map((_, i) => String(i));
 
   const data: HeatmapData = {
     x: xLabels,
     y: yLabels,
-    points: trace.z,
+    points: grid,
   };
 
   // Set the z axis label for z-values from the colorbar title, or default.
@@ -2187,6 +2784,141 @@ function extractHeatmapLayer(
  */
 function extractColorbarTitle(trace: PlotlyTrace, layout: PlotlyLayout | undefined): string | undefined {
   return extractGivenTitle(trace.colorbar?.title, layout);
+}
+
+// ---------------------------------------------------------------------------
+// Choropleth
+// ---------------------------------------------------------------------------
+
+/**
+ * What a choropleth layer calls its two dimensions. A map has no axes to take
+ * a name from; the shaded quantity usually names itself on the colorbar, and
+ * the regions are named for what they are.
+ */
+const CHOROPLETH_REGION_AXIS = 'Region';
+const CHOROPLETH_VALUE_AXIS = 'Value';
+
+/** One region as the layer needs it, keyed to the shape plotly drew for it. */
+interface ChoroplethRegion {
+  name: string | number;
+  value: number;
+  /** The centroid plotly resolved, when the map has been drawn. */
+  ct?: [number, number];
+  /** Its position in the trace's own arrays, which is the shape's position. */
+  index: number;
+}
+
+/**
+ * Names one region.
+ *
+ * `locations` addresses the region rather than naming it: on a world map it is
+ * usually an ISO code, and with `locationmode: 'geojson-id'` it is whatever key
+ * the feature collection uses — `01`, `06`. Plotly draws no labels either, so
+ * the name a sighted reader is given is the text the author attached, and it
+ * is preferred wherever there is one.
+ *
+ * @param trace - The resolved plotly trace
+ * @param index - Which region
+ * @returns The name to announce it by
+ */
+function regionName(trace: PlotlyTrace, index: number): string | number {
+  for (const carrier of [trace.hovertext, trace.text]) {
+    const entry = Array.isArray(carrier) ? carrier[index] : undefined;
+    if (typeof entry === 'string' && entry !== '')
+      return entry;
+  }
+  return trace.locations?.[index] ?? index;
+}
+
+/**
+ * Reads the regions plotly shaded, keeping each one's own position.
+ *
+ * A region whose value is missing, or whose name matched no feature on the
+ * map, is dropped rather than shaded at zero — plotly leaves its path in the
+ * DOM with no shape at all, which is why the position is carried rather than
+ * recounted: the regions that survive still have to line up with the shapes.
+ *
+ * The centroid is plotly's own `ct`, copied off the resolved feature while the
+ * map was projected, and it is what turns a region list into a map: without a
+ * longitude and a latitude there is no north, no gradient and no neighbouring
+ * region to move to.
+ *
+ * @param trace    - The resolved plotly trace
+ * @param calcdata - What plotly computed for it
+ * @returns The regions, in the order the trace declared them
+ */
+function drawnRegions(trace: PlotlyTrace, calcdata: PlotlyCalcData[]): ChoroplethRegion[] {
+  const values = (trace.z ?? []) as (number | string)[];
+  const len = Math.max(values.length, trace.locations?.length ?? 0);
+
+  const regions: ChoroplethRegion[] = [];
+  for (let index = 0; index < len; index++) {
+    const cd = calcdata[index];
+    // Plotly's own calc marks an unusable region by nulling its location, and
+    // `Number(null)` is a finite zero that would be shaded as a real reading.
+    const raw = cd && 'z' in cd ? cd.z : values[index];
+    if (raw == null || (cd && cd.loc === null))
+      continue;
+    const value = Number(raw);
+    if (!Number.isFinite(value))
+      continue;
+
+    const centroid = cd?.ct;
+    regions.push({
+      name: regionName(trace, index),
+      value,
+      ...(isLonLat(centroid) ? { ct: centroid } : {}),
+      index,
+    });
+  }
+  return regions;
+}
+
+/** Whether plotly resolved a usable `[lon, lat]` pair for a region. */
+function isLonLat(ct: [number, number] | undefined): ct is [number, number] {
+  return Array.isArray(ct) && ct.length >= 2
+    && Number.isFinite(Number(ct[0])) && Number.isFinite(Number(ct[1]));
+}
+
+/**
+ * Builds a choropleth layer.
+ *
+ * `neighbors` is deliberately never emitted: plotly holds each region's
+ * polygons but nothing that says which regions share a border, and the
+ * grammar asks for silence rather than a guess — two regions can have near
+ * centroids and no shared border at all.
+ */
+function extractChoroplethLayer(
+  trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
+  id: string,
+  title: string | undefined,
+  traceIndex: number,
+  gd: PlotlyGraphDiv,
+): MaidrLayer | null {
+  const regions = drawnRegions(trace, calcdata);
+  if (regions.length === 0)
+    return null;
+
+  const data: ChoroplethPoint[] = regions.map(region => ({
+    x: region.name,
+    y: region.value,
+    ...(region.ct ? { lon: Number(region.ct[0]), lat: Number(region.ct[1]) } : {}),
+  }));
+
+  const valueLabel = extractColorbarTitle(trace, gd._fullLayout ?? gd.layout);
+
+  return {
+    id,
+    type: TraceType.CHOROPLETH,
+    title,
+    selectors: choroplethRegionSelectors(gd, traceIndex, regions.map(region => region.index)),
+    axes: {
+      x: { label: CHOROPLETH_REGION_AXIS },
+      y: { label: valueLabel ?? CHOROPLETH_VALUE_AXIS },
+    },
+    data,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -3244,6 +3976,46 @@ function extractErrorBarLayer(
 // ---------------------------------------------------------------------------
 // Segmented bars (dodged / stacked / normalized)
 // ---------------------------------------------------------------------------
+
+/**
+ * Whether the panel's bar traces are two sides of one baseline.
+ *
+ * A population pyramid, and a Likert scale split around a neutral midpoint,
+ * are authored the same way: the values on one side are negated so the bars
+ * grow the other way, and `barmode` stacks them from a shared zero. What makes
+ * it a pyramid rather than a stack is exactly that — one series growing left
+ * and another growing right — so it is read off the signs of the values.
+ *
+ * Every series has to keep to one side. A series that crosses the baseline is
+ * not a side of anything, and announcing the chart as diverging would promise
+ * a direction per series that it does not have.
+ *
+ * @param barTraces - The panel's bar traces
+ * @returns True when the panel draws two opposed sides
+ */
+function divergingSides(barTraces: TraceEntry[]): boolean {
+  let growsUp = false;
+  let growsDown = false;
+
+  for (const { trace } of barTraces) {
+    const values = (trace.orientation === 'h' ? trace.x : trace.y) ?? [];
+    const numbers = values
+      .filter(value => value != null)
+      .map(Number)
+      .filter(value => Number.isFinite(value) && value !== 0);
+    if (numbers.length === 0)
+      continue;
+
+    const positive = numbers.every(value => value > 0);
+    const negative = numbers.every(value => value < 0);
+    if (!positive && !negative)
+      return false;
+    growsUp = growsUp || positive;
+    growsDown = growsDown || negative;
+  }
+
+  return growsUp && growsDown;
+}
 
 /**
  * Combines multiple plotly bar traces into a single MAIDR segmented bar layer.

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -14,6 +14,7 @@ import type {
   BoxPoint,
   BoxSelector,
   CandlestickPoint,
+  ErrorBarPoint,
   HeatmapData,
   HistogramPoint,
   LinePoint,
@@ -25,18 +26,21 @@ import type {
   SegmentedPoint,
   StepDirection,
   ViolinKdePoint,
+  WaterfallKind,
+  WaterfallPoint,
 } from '../../type/grammar';
 import type {
   PlotlyAnnotation,
   PlotlyAxis,
   PlotlyCalcData,
+  PlotlyErrorBar,
   PlotlyFullLayout,
   PlotlyGraphDiv,
   PlotlyLayout,
   PlotlyTrace,
 } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
-import { generatePlotlySelectors, subplotCssPrefix } from './selectors';
+import { errorBarAxis, generatePlotlySelectors, subplotCssPrefix } from './selectors';
 
 // Monotonic counter for generating unique IDs when the graph div has no id.
 let plotlyIdCounter = 0;
@@ -257,11 +261,28 @@ function extractAxisGridConfig(
 // ---------------------------------------------------------------------------
 
 /**
+ * The trace types plotly draws error bars on top of. It is a modifier rather
+ * than a trace type of its own, so it has to be recognised before the type
+ * itself: a scatter with intervals is an error-bar chart, not a scatter that
+ * happens to have whiskers, and reading it as a scatter announces the
+ * estimate and drops the uncertainty the chart was drawn to show.
+ *
+ * A histogram is deliberately absent even though plotly will draw error bars
+ * on one: its counts are computed rather than authored, and the layer is
+ * already built from bins that carry no per-bin interval.
+ */
+const ERROR_BAR_TRACE_TYPES = new Set(['scatter', 'scattergl', 'bar']);
+
+/**
  * Maps a plotly.js trace type + mode to a MAIDR TraceType.
  * Returns `null` for unsupported types.
  */
 function mapTraceType(trace: PlotlyTrace): TraceType | null {
   const type = trace.type ?? 'scatter';
+
+  if (ERROR_BAR_TRACE_TYPES.has(type) && errorBarAxis(trace) !== null) {
+    return TraceType.ERROR_BAR;
+  }
 
   switch (type) {
     case 'scatter':
@@ -292,6 +313,12 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
     case 'pie':
       return TraceType.PIE;
 
+    case 'funnel':
+      return TraceType.FUNNEL;
+
+    case 'waterfall':
+      return TraceType.WATERFALL;
+
     default:
       console.warn(`[maidr] Unsupported plotly trace type: "${type}". Skipping.`);
       return null;
@@ -299,15 +326,49 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
 }
 
 function mapScatterMode(trace: PlotlyTrace): TraceType {
+  // A stacked scatter IS plotly's area chart: naming a `stackgroup` is how one
+  // is authored, and plotly turns the fill on itself. The mode does not enter
+  // into it — the accumulation is the payload either way.
+  if (trace.stackgroup) {
+    return isNormalizedStack(trace.groupnorm)
+      ? TraceType.NORMALIZED_AREA
+      : TraceType.STACKED_AREA;
+  }
+
   const mode = trace.mode;
   if (!mode)
     return TraceType.SCATTER;
   // When both lines and markers exist, prefer LINE for navigational context.
-  if (mode.includes('lines'))
-    return isStepShape(trace.line?.shape) ? TraceType.STEP : TraceType.LINE;
-  if (mode.includes('markers'))
-    return TraceType.SCATTER;
+  if (mode.includes('lines')) {
+    // A staircase keeps its step reading even when it is filled: with nothing
+    // accumulating, AREA would trade the announced convention for a fill that
+    // is decoration.
+    if (isStepShape(trace.line?.shape))
+      return TraceType.STEP;
+    return isFilled(trace.fill) ? TraceType.AREA : TraceType.LINE;
+  }
+  if (isFilled(trace.fill))
+    return TraceType.AREA;
   return TraceType.SCATTER;
+}
+
+/**
+ * Whether plotly fills the region under (or around) this trace.
+ *
+ * Plotly resolves an unfilled trace to the literal string `'none'` rather
+ * than leaving the attribute off, so the absent case has to be spelled out
+ * alongside it.
+ */
+function isFilled(fill: string | undefined): boolean {
+  return fill !== undefined && fill !== '' && fill !== 'none';
+}
+
+/**
+ * Whether a stack group's bands were rescaled to a common total — the direct
+ * analogue of the `barnorm` test that splits STACKED from NORMALIZED.
+ */
+function isNormalizedStack(groupnorm: string | undefined): boolean {
+  return groupnorm === 'percent' || groupnorm === 'fraction';
 }
 
 /**
@@ -487,6 +548,13 @@ function buildSubplotLayers(
   // with a `vh` one would describe one of them wrongly. Keyed by direction,
   // with '' for the shapes that report none, so those stay together too.
   const stepTraces = new Map<StepDirection | '', TraceEntry[]>();
+  // Independent bands over shared axes, read as a multi-series layer the way
+  // plain lines are — the fill is what they look like, not a second magnitude.
+  const areaTraces: TraceEntry[] = [];
+  // Stacked bands, keyed by the group they stack in, for the reason step
+  // traces are keyed by direction: two stacks drawn on one panel have two
+  // running totals, and merging them would announce a total nothing drew.
+  const stackedAreaTraces = new Map<string, TraceEntry[]>();
   const boxTraces: TraceEntry[] = [];
   const barTraces: TraceEntry[] = [];
   const violinTraces: TraceEntry[] = [];
@@ -512,6 +580,19 @@ function buildSubplotLayers(
       } else {
         stepTraces.set(key, [entry]);
       }
+    } else if (entry.maidrType === TraceType.AREA) {
+      areaTraces.push(entry);
+    } else if (
+      entry.maidrType === TraceType.STACKED_AREA
+      || entry.maidrType === TraceType.NORMALIZED_AREA
+    ) {
+      const key = trace.stackgroup ?? '';
+      const bucket = stackedAreaTraces.get(key);
+      if (bucket) {
+        bucket.push(entry);
+      } else {
+        stackedAreaTraces.set(key, [entry]);
+      }
     } else if (entry.maidrType === TraceType.BOX) {
       boxTraces.push(entry);
     } else if (entry.maidrType === TraceType.BAR) {
@@ -536,6 +617,32 @@ function buildSubplotLayers(
       type: TraceType.STEP,
       stepDirection: direction === '' ? undefined : direction,
     });
+    if (layer)
+      layers.push(layer);
+  }
+
+  // Unstacked areas share one layer, the way unstacked lines do.
+  if (areaTraces.length > 0) {
+    const layer = extractMultiLineLayer(areaTraces, xLabel, yLabel, gd, {
+      type: TraceType.AREA,
+    });
+    if (layer)
+      layers.push(layer);
+  }
+
+  // One layer per stack group. Every trace in a group shares its `groupnorm`,
+  // so the first one settles whether the layer is stacked or normalized.
+  for (const [, traces] of stackedAreaTraces) {
+    const type = traces[0].maidrType === TraceType.NORMALIZED_AREA
+      ? TraceType.NORMALIZED_AREA
+      : TraceType.STACKED_AREA;
+    const bands = type === TraceType.NORMALIZED_AREA
+      ? traces.map(entry => ({
+          ...entry,
+          values: normalizedBandHeights(entry.trace, group.calcdata[entry.calcIdx] ?? []),
+        }))
+      : traces;
+    const layer = extractMultiLineLayer(bands, xLabel, yLabel, gd, { type });
     if (layer)
       layers.push(layer);
   }
@@ -1038,7 +1145,19 @@ function extractLayer(
       return extractScatterLayer(trace, id, title, selectors, axes, gd);
 
     case TraceType.BAR:
-      return extractBarLayer(trace, calcdata, id, title, selectors, axes);
+      return extractBarLayer(trace, calcdata, TraceType.BAR, id, title, selectors, axes);
+
+    // A funnel is a bar chart whose order means something: same points, same
+    // orientation handling, and the retention between stages is derived by
+    // the trace rather than carried in the payload.
+    case TraceType.FUNNEL:
+      return extractBarLayer(trace, calcdata, TraceType.FUNNEL, id, title, selectors, axes);
+
+    case TraceType.WATERFALL:
+      return extractWaterfallLayer(trace, calcdata, id, title, selectors, axes);
+
+    case TraceType.ERROR_BAR:
+      return extractErrorBarLayer(trace, calcdata, id, title, selectors, axes);
 
     case TraceType.HEATMAP:
       return extractHeatmapLayer(trace, id, title, selectors, axes, gd);
@@ -1168,9 +1287,14 @@ function barPoint(
     : { x, y: drawn ?? y };
 }
 
+/**
+ * Builds a bar-shaped layer: a plain bar, or a funnel, which plotly draws
+ * through the same renderer and describes with the same calcdata.
+ */
 function extractBarLayer(
   trace: PlotlyTrace,
   calcdata: PlotlyCalcData[],
+  type: TraceType.BAR | TraceType.FUNNEL,
   id: string,
   title: string | undefined,
   selectors: string | undefined,
@@ -1194,7 +1318,7 @@ function extractBarLayer(
 
   return {
     id,
-    type: TraceType.BAR,
+    type,
     title,
     selectors,
     axes,
@@ -1207,27 +1331,52 @@ function extractBarLayer(
 // Line (multi-series)
 // ---------------------------------------------------------------------------
 
+/** One trace of a line-shaped layer, with the values to read off it. */
+interface LineTraceEntry {
+  trace: PlotlyTrace;
+  calcIdx: number;
+  globalIdx: number;
+  /**
+   * Magnitudes to announce instead of the trace's own `y`, parallel to it.
+   * Only a normalized stack needs this: plotly rescaled the bands it drew and
+   * the authored numbers are no longer what is on the axis.
+   */
+  values?: number[];
+}
+
 /**
- * Builds one line-shaped layer from every line (or step) trace in a subplot.
+ * How a line-shaped layer is emitted: the type it announces, and — for a
+ * staircase — which convention it jumps by. Absent means a plain line.
+ */
+interface LineVariant {
+  type: TraceType;
+  stepDirection?: StepDirection;
+}
+
+/**
+ * Builds one line-shaped layer from every line (step, or area) trace in a
+ * subplot.
  *
- * Step traces reuse this because their point shape is identical — plotly
- * varies only how the segments between samples are drawn, not the samples
- * themselves — so `step` differs from `line` here by its layer type and the
- * convention it announces.
+ * Step and area traces reuse this because their point shape is identical —
+ * plotly varies only how the segments between samples are drawn and whether
+ * the region under them is filled, not the samples themselves — so they
+ * differ from a line here by their layer type and, for a step, the convention
+ * it announces. A stacked area emits each band's OWN value, which is what
+ * `AreaTrace` accumulates the running totals from.
  */
 function extractMultiLineLayer(
-  lineTraces: { trace: PlotlyTrace; calcIdx: number; globalIdx: number }[],
+  lineTraces: LineTraceEntry[],
   xLabel: string | undefined,
   yLabel: string | undefined,
   gd: PlotlyGraphDiv,
-  step?: { type: TraceType.STEP; stepDirection?: StepDirection },
+  variant?: LineVariant,
 ): MaidrLayer | null {
   const data: LinePoint[][] = [];
   const legend: string[] = [];
 
-  for (const { trace } of lineTraces) {
+  for (const { trace, values } of lineTraces) {
     const x = trace.x;
-    const y = trace.y;
+    const y = values ?? trace.y;
     if (!x || !y)
       continue;
 
@@ -1262,23 +1411,64 @@ function extractMultiLineLayer(
   if (yLabel)
     axes.y = { label: yLabel };
 
+  const type = variant?.type ?? TraceType.LINE;
+
   // All line traces in the same subplot share the same unscoped selector
   // (e.g. `.subplot.xy .trace.scatter .point`), so any trace index works here.
-  const selectors = generatePlotlySelectors(
-    step?.type ?? TraceType.LINE,
-    lineTraces[0].globalIdx,
-    gd,
-  );
+  const selectors = generatePlotlySelectors(type, lineTraces[0].globalIdx, gd);
 
   return {
     id: String(lineTraces[0].globalIdx),
-    type: step?.type ?? TraceType.LINE,
+    type,
     title: legend.length === 1 ? legend[0] : undefined,
     selectors,
     axes,
-    ...(step?.stepDirection ? { stepDirection: step.stepDirection } : {}),
+    ...(variant?.stepDirection ? { stepDirection: variant.stepDirection } : {}),
     data,
   };
+}
+
+/**
+ * The band heights plotly drew for one trace of a normalized stack.
+ *
+ * `groupnorm` rescales every band so the stack sums to 100 (or to 1), and the
+ * axis a reader is on shows the rescaled figure. Plotly keeps each band's own
+ * rescaled height on `cd.sNorm`; `cd.y` is deliberately not used, because for
+ * a stacked scatter that is the RUNNING TOTAL rather than the band, and
+ * feeding it back to a trace that accumulates the bands itself would count
+ * every series twice.
+ *
+ * Stacking interleaves the positions of every trace in the group, so a trace
+ * that skipped one gets a blank spliced into its calcdata (`cd.i === null`).
+ * Those are not samples this trace authored — dropping them lines the rest up
+ * with the trace's own arrays, and a count that still disagrees means the
+ * calcdata does not describe these samples and the raw values are the honest
+ * fallback.
+ *
+ * @param trace - The resolved plotly trace
+ * @param calcdata - What plotly computed for it
+ * @returns One height per authored sample, or undefined when unavailable
+ */
+function normalizedBandHeights(
+  trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
+): number[] | undefined {
+  // A horizontal stack carries its bands on x, where the layer wants its
+  // positions; the raw arrays already sit the right way round for that.
+  if (trace.orientation === 'h' || calcdata.length === 0) {
+    return undefined;
+  }
+
+  const heights: number[] = [];
+  for (const cd of calcdata) {
+    if (cd.i === null)
+      continue;
+    if (typeof cd.sNorm !== 'number' || !Number.isFinite(cd.sNorm))
+      return undefined;
+    heights.push(cd.sNorm);
+  }
+
+  return heights.length === trace.y?.length ? heights : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -2001,6 +2191,346 @@ function extractCandlestickLayer(
     title,
     selectors,
     axes,
+    data,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Waterfall
+// ---------------------------------------------------------------------------
+
+/**
+ * The `measure` values that mark a step restating the running total rather
+ * than contributing to it. Plotly accepts both the words and their initials.
+ */
+const WATERFALL_TOTAL_MEASURES = new Set(['total', 't', 'absolute', 'a']);
+
+/** A measure that resets the running total to the step's own amount. */
+const WATERFALL_ABSOLUTE_MEASURES = new Set(['absolute', 'a']);
+
+/** One step as the layer needs it, before its label is attached. */
+interface WaterfallStep {
+  start: number;
+  end: number;
+  delta: number;
+  kind: WaterfallKind;
+}
+
+/**
+ * Names what a step did to the running total.
+ *
+ * A zero-sized relative step is an increase rather than a decrease, matching
+ * plotly's own `dir`, which reserves `decreasing` for a negative amount.
+ */
+function waterfallKind(isSum: boolean, delta: number): WaterfallKind {
+  if (isSum)
+    return 'total';
+  return delta < 0 ? 'decrease' : 'increase';
+}
+
+/**
+ * Reads one step out of what plotly computed for it.
+ *
+ * This is the arithmetic plotly's own hover does: the running total after the
+ * step is `cd.v` — the trace's base plus everything accumulated so far — and
+ * the contribution is the step's authored amount `cd.rawS`. A total's
+ * contribution is the whole total it restates, which is what leaves it
+ * sitting on the baseline rather than floating like the steps around it.
+ *
+ * `cd.s` is deliberately not read: for a relative step it already holds the
+ * accumulated total, so taking it for the contribution would announce the
+ * running total twice and never the change.
+ *
+ * @param cd - The calcdata entry for this step, when plotly has computed one
+ * @returns The step, or null when calcdata cannot describe it
+ */
+function calcWaterfallStep(cd: PlotlyCalcData | undefined): WaterfallStep | null {
+  if (!cd || typeof cd.v !== 'number' || !Number.isFinite(cd.v)) {
+    return null;
+  }
+
+  const end = cd.v;
+  const isSum = cd.isSum === true;
+  if (!isSum && (typeof cd.rawS !== 'number' || !Number.isFinite(cd.rawS))) {
+    return null;
+  }
+
+  const delta = isSum ? end : (cd.rawS as number);
+  return { start: end - delta, end, delta, kind: waterfallKind(isSum, delta) };
+}
+
+/**
+ * Accumulates the steps from what the author wrote, for a chart captured
+ * before plotly computed it.
+ *
+ * Mirrors plotly's own calc so the two agree: a relative step adds its amount
+ * to the running total, an absolute one replaces it, and a total leaves it
+ * alone while restating it as a bar from the baseline.
+ *
+ * @param sizes - The value-axis amounts, in step order
+ * @param measures - What each step does, `relative` where it says nothing
+ * @param base - The value-axis offset the trace is measured from
+ * @returns One step per amount
+ */
+function authoredWaterfallSteps(
+  sizes: (number | string)[],
+  measures: string[] | undefined,
+  base: number,
+): WaterfallStep[] {
+  const steps: WaterfallStep[] = [];
+  let running = 0;
+
+  for (let i = 0; i < sizes.length; i++) {
+    const parsed = Number(sizes[i]);
+    const amount = Number.isFinite(parsed) ? parsed : 0;
+    const measure = measures?.[i] ?? 'relative';
+    const isSum = WATERFALL_TOTAL_MEASURES.has(measure);
+
+    if (WATERFALL_ABSOLUTE_MEASURES.has(measure)) {
+      running = amount;
+    } else if (!isSum) {
+      running += amount;
+    }
+
+    const end = base + running;
+    const delta = isSum ? end : amount;
+    steps.push({ start: end - delta, end, delta, kind: waterfallKind(isSum, delta) });
+  }
+
+  return steps;
+}
+
+function extractWaterfallLayer(
+  trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
+  id: string,
+  title: string | undefined,
+  selectors: string | undefined,
+  axes: MaidrLayer['axes'],
+): MaidrLayer | null {
+  const isHorizontal = trace.orientation === 'h';
+  const positions = isHorizontal ? trace.y : trace.x;
+  const sizes = isHorizontal ? trace.x : trace.y;
+  if (!positions || !sizes)
+    return null;
+
+  const parsedBase = Number(trace.base);
+  const base = Number.isFinite(parsedBase) ? parsedBase : 0;
+  const authored = authoredWaterfallSteps(sizes, trace.measure, base);
+
+  const len = Math.min(positions.length, sizes.length);
+  const data: WaterfallPoint[] = [];
+  for (let i = 0; i < len; i++) {
+    const step = calcWaterfallStep(calcdata[i]) ?? authored[i];
+    data.push({
+      x: positions[i] as number | string,
+      start: step.start,
+      end: step.end,
+      delta: step.delta,
+      kind: step.kind,
+    });
+  }
+
+  if (data.length === 0)
+    return null;
+
+  return {
+    id,
+    type: TraceType.WATERFALL,
+    title,
+    selectors,
+    // `WaterfallTrace` names the step with the layer's x axis and the
+    // contribution with its y axis whichever way plotly drew the bars — the
+    // sequence navigates the same either way, so it has no orientation to
+    // read. On a horizontal waterfall those are plotly's y and x, so the
+    // labels are swapped into the layer rather than announced crossed over.
+    axes: isHorizontal ? swappedAxes(axes) : axes,
+    data,
+  };
+}
+
+/**
+ * Exchanges a layer's x and y axis labels, for a trace whose navigation has
+ * no orientation of its own.
+ */
+function swappedAxes(axes: MaidrLayer['axes']): MaidrLayer['axes'] {
+  const swapped: MaidrLayer['axes'] = {};
+  if (axes?.y)
+    swapped.x = axes.y;
+  if (axes?.x)
+    swapped.y = axes.x;
+  return swapped;
+}
+
+// ---------------------------------------------------------------------------
+// Error bars
+// ---------------------------------------------------------------------------
+
+/** A sample's interval, either side of which the chart may leave undrawn. */
+interface ErrorBounds {
+  min?: number;
+  max?: number;
+}
+
+/**
+ * Reads the bounds plotly resolved for one sample.
+ *
+ * Plotly's errorbar calc turns every flavour of `error_y` — arrays,
+ * percentages, square roots — into the two absolute positions it will draw
+ * the whip between, and stores them per sample as `ys`/`yh` (`xs`/`xh` for
+ * horizontal intervals). Those are exactly what {@link ErrorBarPoint} wants,
+ * so nothing is recomputed here.
+ *
+ * @param cd - The calcdata entry for this sample
+ * @param axis - The axis the interval is drawn on
+ * @returns The bounds, or null when plotly resolved none
+ */
+function calcErrorBounds(
+  cd: PlotlyCalcData | undefined,
+  axis: 'x' | 'y',
+): ErrorBounds | null {
+  if (!cd)
+    return null;
+
+  const low = axis === 'y' ? cd.ys : cd.xs;
+  const high = axis === 'y' ? cd.yh : cd.xh;
+  if (!Number.isFinite(low) && !Number.isFinite(high))
+    return null;
+
+  return {
+    ...(Number.isFinite(low) ? { min: low } : {}),
+    ...(Number.isFinite(high) ? { max: high } : {}),
+  };
+}
+
+/**
+ * The magnitudes an error-bar container declares at one sample, below and
+ * above the estimate.
+ *
+ * Mirrors plotly's own `computeError`, for the chart captured before it ran.
+ *
+ * @param options - The trace's `error_x`/`error_y` container
+ * @param value - The estimate the interval is drawn around
+ * @param index - Which sample this is, for the per-sample arrays
+ * @returns `[below, above]`, or null when the container declares nothing
+ */
+function errorMagnitudes(
+  options: PlotlyErrorBar,
+  value: number,
+  index: number,
+): [number, number] | null {
+  // Only `data` reads a second array; the scalar types repeat their single
+  // magnitude unless the trace declared the other side separately.
+  const separate = options.symmetric === false;
+
+  switch (options.type) {
+    case 'data': {
+      const above = Number(options.array?.[index]);
+      return [separate ? Number(options.arrayminus?.[index]) : above, above];
+    }
+    case 'constant': {
+      const above = Math.abs(Number(options.value));
+      return [separate ? Math.abs(Number(options.valueminus)) : above, above];
+    }
+    case 'percent': {
+      const above = Math.abs(value * Number(options.value) / 100);
+      return [separate ? Math.abs(value * Number(options.valueminus) / 100) : above, above];
+    }
+    case 'sqrt': {
+      const magnitude = Math.sqrt(Math.abs(value));
+      return [magnitude, magnitude];
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Turns the declared magnitudes into the absolute bounds the grammar fixes.
+ */
+function authoredErrorBounds(
+  options: PlotlyErrorBar,
+  value: number,
+  index: number,
+): ErrorBounds | null {
+  const magnitudes = errorMagnitudes(options, value, index);
+  if (!magnitudes)
+    return null;
+
+  const [below, above] = magnitudes;
+  if (!Number.isFinite(below) && !Number.isFinite(above))
+    return null;
+
+  return {
+    ...(Number.isFinite(below) ? { min: value - below } : {}),
+    ...(Number.isFinite(above) ? { max: value + above } : {}),
+  };
+}
+
+/**
+ * Builds the interval layer for a scatter or bar trace drawn with error bars.
+ *
+ * A horizontal interval is the same shape with the axes exchanged: the
+ * estimate and its bounds come off plotly's x and the sample labels off its
+ * y, which is what `orientation` tells the trace so it announces each against
+ * the right axis.
+ *
+ * Samples plotly would not draw are dropped rather than emitted at zero. That
+ * also keeps the points lined up with the whips in the DOM, which plotly
+ * leaves out for exactly the same samples.
+ */
+function extractErrorBarLayer(
+  trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
+  id: string,
+  title: string | undefined,
+  selectors: string | undefined,
+  axes: MaidrLayer['axes'],
+): MaidrLayer | null {
+  const axis = errorBarAxis(trace);
+  if (axis === null)
+    return null;
+
+  const isHorizontal = axis === 'x';
+  const positions = isHorizontal ? trace.y : trace.x;
+  const values = isHorizontal ? trace.x : trace.y;
+  const options = (isHorizontal ? trace.error_x : trace.error_y) ?? {};
+  if (!positions || !values)
+    return null;
+
+  const len = Math.min(positions.length, values.length);
+  const data: ErrorBarPoint[] = [];
+
+  for (let i = 0; i < len; i++) {
+    // The explicit null gap goes first: `Number(null)` is 0, which is finite
+    // and would be announced as an estimate of zero the chart never drew.
+    if (positions[i] == null || values[i] == null)
+      continue;
+    const value = Number(values[i]);
+    if (!Number.isFinite(value))
+      continue;
+
+    const bounds = calcErrorBounds(calcdata[i], axis)
+      ?? authoredErrorBounds(options, value, i);
+
+    data.push({
+      x: positions[i] as number | string,
+      y: value,
+      ...(bounds?.min !== undefined ? { yMin: bounds.min } : {}),
+      ...(bounds?.max !== undefined ? { yMax: bounds.max } : {}),
+    });
+  }
+
+  if (data.length === 0)
+    return null;
+
+  return {
+    id,
+    type: TraceType.ERROR_BAR,
+    title,
+    selectors,
+    axes,
+    ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
     data,
   };
 }

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -54,11 +54,15 @@ export function generatePlotlySelectors(
     case TraceType.SCATTER:
       return `${prefix}.trace.scatter .point`;
 
+    // A pyramid is among these: it is a stacked bar chart whose two sides grow
+    // opposite ways, drawn through the same renderer, so its bars are the same
+    // elements in the same trace-by-trace order.
     case TraceType.BAR:
     case TraceType.HISTOGRAM:
     case TraceType.DODGED:
     case TraceType.STACKED:
     case TraceType.NORMALIZED:
+    case TraceType.DIVERGING:
       return `${prefix}.trace.bars .point > path`;
 
     // A step trace is a scatter trace plotly drew as a staircase, and an area
@@ -80,6 +84,18 @@ export function generatePlotlySelectors(
 
     case TraceType.WATERFALL:
       return `${prefix}.waterfalllayer .trace.bars .point > path`;
+
+    // A dot plot is a scatter with one marker per category, so its marks are
+    // scatter markers — but a bar-shaped layer pairs its selector with its own
+    // points alone, so this one is scoped to the single trace it describes
+    // rather than to every scatter on the panel.
+    case TraceType.DOT:
+      return scatterTraceScope(prefix, traceData, '.point');
+
+    // A word cloud is a scatter drawn as text: the glyph is the mark, and it
+    // is the only thing on the panel that carries the term.
+    case TraceType.WORD_CLOUD:
+      return scatterTraceScope(prefix, traceData, 'g.textpoint > text');
 
     case TraceType.ERROR_BAR:
       return errorBarSelector(prefix, traceData);
@@ -146,6 +162,95 @@ function lineSelector(prefix: string, mode?: string): string | undefined {
   }
   // Lines-only mode: no per-point SVG elements to highlight.
   return undefined;
+}
+
+/**
+ * Scopes a selector to one scatter trace's own marks.
+ *
+ * The subplot prefix alone matches every scatter on the panel, which is what
+ * the line and scatter layers want — they describe all of them. A layer built
+ * from a single trace needs its own marks and nothing else, and the uid class
+ * plotly hangs on each `g.trace` is the only thing that names one: the group
+ * order inside `.scatterlayer` is the fill z-order plotly sorted them into,
+ * not the order of `_fullData`, so counting siblings would pick the wrong one.
+ *
+ * A uid that is not a usable class name — plotly generates safe ones, but an
+ * author may set `uid` to anything — withdraws the selector rather than
+ * emitting one that would silently match nothing.
+ *
+ * @param prefix - The subplot prefix the trace is drawn in
+ * @param trace  - The resolved plotly trace
+ * @param marks  - The selector for the marks within the trace's group
+ * @returns The scoped selector, or undefined when the trace cannot be named
+ */
+function scatterTraceScope(
+  prefix: string,
+  trace: PlotlyTrace | undefined,
+  marks: string,
+): string | undefined {
+  const uid = trace?.uid;
+  if (!uid || !/^[\w-]+$/.test(uid)) {
+    return undefined;
+  }
+  return `${prefix}.scatterlayer g.trace.trace${uid} ${marks}`;
+}
+
+/**
+ * The bar plotly drew for one point of one bar-family trace.
+ *
+ * Bars are addressed individually — rather than through the one selector the
+ * bar layers share — wherever a layer regroups its points into rows that are
+ * not the traces plotly drew. A schedule does exactly that: its lanes are
+ * categories, and the intervals in one lane may come from several traces.
+ *
+ * @param prefix        - The subplot prefix the trace is drawn in
+ * @param tracePosition - Its position among the panel's bar-layer traces
+ * @param pointIndex    - Which of that trace's points, in calc order
+ * @returns The selector for that one bar's path
+ */
+export function barPointSelector(
+  prefix: string,
+  tracePosition: number,
+  pointIndex: number,
+): string {
+  return `${prefix}.barlayer > g.trace.bars:nth-of-type(${tracePosition + 1})`
+    + ` > g.points > g.point:nth-of-type(${pointIndex + 1}) > path`;
+}
+
+/**
+ * Choropleth selectors: one region at a time, in the order the trace declared
+ * them.
+ *
+ * Plotly draws a path per calc entry — including the entries it resolved to no
+ * region at all, which stay in the DOM with no shape — so a region is
+ * addressed by its own position rather than by counting the ones before it.
+ * That keeps the pairing right for a map whose data has holes, which is the
+ * ordinary case: a value the source had nothing for is still a row.
+ *
+ * The trace's group is counted within its own geo subplot, since plotly hangs
+ * no uid class on these groups either.
+ *
+ * @param gd         - The plotly graph div
+ * @param traceIndex - The global index of the choropleth trace
+ * @param indices    - The calc index of each region the layer emitted
+ * @returns One selector per region
+ */
+export function choroplethRegionSelectors(
+  gd: PlotlyGraphDiv,
+  traceIndex: number,
+  indices: number[],
+): string[] {
+  const geoId = gd._fullData?.[traceIndex]?.geo ?? 'geo';
+  const position = drawnBefore(
+    gd,
+    traceIndex,
+    'choropleth',
+    trace => (trace.geo ?? 'geo') === geoId,
+  ) + 1;
+  const group = `.geolayer > g.geo.${geoId} > g.backplot > g.choroplethlayer`
+    + ` > g.trace.choropleth:nth-of-type(${position})`;
+  return indices.map(index =>
+    `${group} > path.choroplethlocation:nth-of-type(${index + 1})`);
 }
 
 /**
@@ -237,14 +342,26 @@ function isDrawnPie(trace: PlotlyTrace | undefined): boolean {
  * @param gd         - The plotly graph div
  * @param traceIndex - The global index of the trace being selected
  * @param type       - The plotly trace type sharing the layer
+ * @param sameLayer  - Narrows the count to the traces sharing one layer, for a
+ *                     family drawn once per subplot rather than once per paper
  * @returns How many traces of that type plotly drew before this one
  */
-function drawnBefore(gd: PlotlyGraphDiv, traceIndex: number, type: string): number {
+function drawnBefore(
+  gd: PlotlyGraphDiv,
+  traceIndex: number,
+  type: string,
+  sameLayer?: (trace: PlotlyTrace) => boolean,
+): number {
   const traces = gd._fullData ?? [];
   let count = 0;
   for (let i = 0; i < traceIndex; i++) {
     const trace = traces[i];
-    if (trace?.type === type && trace.visible !== false && trace.visible !== 'legendonly') {
+    if (
+      trace?.type === type
+      && trace.visible !== false
+      && trace.visible !== 'legendonly'
+      && (sameLayer === undefined || sameLayer(trace))
+    ) {
       count++;
     }
   }

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -15,8 +15,21 @@
  * py-maidr's proven approach.
  */
 
-import type { PlotlyGraphDiv, PlotlyTrace } from './types';
+import type { PlotlyGraphDiv, PlotlyTrace, PolarSeries } from './types';
 import { TraceType } from '../../type/grammar';
+
+/**
+ * Sankey selector: every ribbon plotly drew, in the order the flows were
+ * authored.
+ *
+ * Unscoped by trace, because plotly appends each sankey's `g.sankey` straight
+ * onto the paper beside groups of every other kind — there is no layer to
+ * count within, the way `.pielayer` lets a pie be counted. A page with two
+ * sankeys therefore matches both traces' ribbons, and `FlowTrace` withdraws
+ * the highlight on the count mismatch that produces. That is the intended
+ * outcome: the alternative is lighting up another chart's ribbon.
+ */
+const SANKEY_LINK_SELECTOR = '.sankey .sankey-links > path.sankey-link';
 
 /**
  * Generates CSS selectors for a given trace type and index.
@@ -83,6 +96,20 @@ export function generatePlotlySelectors(
 
     case TraceType.PIE:
       return pieSelector(plotlyGd, traceIndex);
+
+    // The three hierarchy layouts. Plotly draws each into a layer of its own
+    // and gives every sector the same `g.slice > path.surface`, so they differ
+    // only in which layer is scoped to.
+    case TraceType.SUNBURST:
+    case TraceType.ICICLE:
+    case TraceType.TREEMAP:
+      return hierarchySelector(plotlyGd, traceIndex);
+
+    case TraceType.SANKEY:
+      return SANKEY_LINK_SELECTOR;
+
+    case TraceType.GAUGE:
+      return gaugeSelector(plotlyGd, traceIndex);
 
     default:
       return undefined;
@@ -198,4 +225,113 @@ function isDrawnPie(trace: PlotlyTrace | undefined): boolean {
   return trace?.type === 'pie'
     && trace.visible !== false
     && trace.visible !== 'legendonly';
+}
+
+/**
+ * How many traces of one plotly type were drawn before the given one.
+ *
+ * The pie's counting problem, generalised: every trace positioned by its own
+ * domain shares one layer with its siblings and carries no class of its own,
+ * so its position among the drawn ones is the only thing that picks it out.
+ *
+ * @param gd         - The plotly graph div
+ * @param traceIndex - The global index of the trace being selected
+ * @param type       - The plotly trace type sharing the layer
+ * @returns How many traces of that type plotly drew before this one
+ */
+function drawnBefore(gd: PlotlyGraphDiv, traceIndex: number, type: string): number {
+  const traces = gd._fullData ?? [];
+  let count = 0;
+  for (let i = 0; i < traceIndex; i++) {
+    const trace = traces[i];
+    if (trace?.type === type && trace.visible !== false && trace.visible !== 'legendonly') {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Hierarchy selector: every sector of one sunburst, icicle or treemap, in the
+ * order plotly drew them.
+ *
+ * All three draw into `.{type}layer`, one `g.trace.{type}` per trace, and give
+ * each sector a `g.slice` holding the `path.surface` that is the drawn shape.
+ * A treemap's breadcrumb bar is deliberately not matched: its ancestors are
+ * `g.pathbar` groups rather than slices, and they repeat nodes the reader has
+ * already been given.
+ *
+ * The layer is counted through the same trick {@link pieSelector} uses, and
+ * for the same reason — plotly hangs no uid class on these groups either.
+ */
+function hierarchySelector(gd: PlotlyGraphDiv, traceIndex: number): string | undefined {
+  const type = gd._fullData?.[traceIndex]?.type;
+  if (!type) {
+    return undefined;
+  }
+  const position = drawnBefore(gd, traceIndex, type) + 1;
+  return `.${type}layer > g.trace.${type}:nth-of-type(${position}) g.slice > path.surface`;
+}
+
+/**
+ * Gauge selector: the bar plotly fills to the measure.
+ *
+ * The two shapes draw it differently — an angular dial fills an arc, a bullet
+ * fills a rectangle — and each is the one element on the tile whose extent is
+ * the reading, which is what a highlight should land on. The surrounding
+ * background arc, the step bands and the threshold line are all context the
+ * value is read against rather than the value itself.
+ */
+function gaugeSelector(gd: PlotlyGraphDiv, traceIndex: number): string {
+  const trace = gd._fullData?.[traceIndex];
+  const position = drawnBefore(gd, traceIndex, 'indicator') + 1;
+  const bar = trace?.gauge?.shape === 'bullet'
+    ? 'g.value-bullet > rect'
+    : 'g.value-arc > path';
+  return `.indicatorlayer > g.trace:nth-of-type(${position}) ${bar}`;
+}
+
+/**
+ * Polar selectors: one per series, which is what a line-shaped layer needs.
+ *
+ * `LineTrace` pairs its series with its selectors by position, so a single
+ * selector covering the whole layer would resolve to nothing on a chart with
+ * more than one series. Plotly gives every scatter group a `trace{uid}`
+ * compound class, so each series can be named directly; barpolar's groups
+ * carry no uid and are counted within the subplot's `g.barlayer` instead.
+ *
+ * A uid that is not a usable class name — plotly generates safe ones, but an
+ * author may set `uid` to anything — withdraws the whole list rather than
+ * emitting a selector that would silently match nothing.
+ *
+ * @param series    - The layer's series, each with its position among the subplot's traces
+ * @param subplotId - The polar subplot they are drawn on (`polar`, `polar2`, …)
+ * @param isBar     - Whether these are barpolar traces rather than scatterpolar
+ * @returns One selector per series, or undefined when none can be built
+ */
+export function polarSeriesSelectors(
+  series: PolarSeries[],
+  subplotId: string,
+  isBar: boolean,
+): string[] | undefined {
+  const prefix = `.polarlayer > g.${subplotId} > g.frontplot`;
+
+  if (isBar) {
+    // Counted by the trace's position among the subplot's barpolar traces
+    // rather than among the layer's series: plotly draws a group for a trace
+    // whose values were all unusable too, so a dropped series still shifts
+    // every group after it.
+    return series.map(one =>
+      `${prefix} > g.barlayer > g.trace:nth-of-type(${one.position + 1}) g.point > path`);
+  }
+
+  const selectors: string[] = [];
+  for (const { trace } of series) {
+    const uid = trace.uid;
+    if (!uid || !/^[\w-]+$/.test(uid)) {
+      return undefined;
+    }
+    selectors.push(`${prefix} > g.scatterlayer > g.trace.trace${uid} .point`);
+  }
+  return selectors;
 }

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -48,11 +48,28 @@ export function generatePlotlySelectors(
     case TraceType.NORMALIZED:
       return `${prefix}.trace.bars .point > path`;
 
-    // A step trace is a scatter trace plotly drew as a staircase, so its
-    // markers — when it has any — are the same `.point` elements.
+    // A step trace is a scatter trace plotly drew as a staircase, and an area
+    // is one it filled in underneath, so their markers — when they have any —
+    // are the same `.point` elements.
     case TraceType.LINE:
     case TraceType.STEP:
+    case TraceType.AREA:
+    case TraceType.STACKED_AREA:
+    case TraceType.NORMALIZED_AREA:
       return lineSelector(prefix, traceData?.mode);
+
+    // Funnel and waterfall are bar-like: plotly draws both through the bar
+    // renderer, down to the `trace bars` group class. Only the layer they sit
+    // in differs, and scoping by it keeps them apart from an actual bar trace
+    // sharing the panel.
+    case TraceType.FUNNEL:
+      return `${prefix}.funnellayer .trace.bars .point > path`;
+
+    case TraceType.WATERFALL:
+      return `${prefix}.waterfalllayer .trace.bars .point > path`;
+
+    case TraceType.ERROR_BAR:
+      return errorBarSelector(prefix, traceData);
 
     case TraceType.BOX:
       return `${prefix}.trace.boxes .point > path`;
@@ -102,6 +119,53 @@ function lineSelector(prefix: string, mode?: string): string | undefined {
   }
   // Lines-only mode: no per-point SVG elements to highlight.
   return undefined;
+}
+
+/**
+ * Which axis carries a trace's error bars, or `null` when it draws none.
+ *
+ * Plotly resolves an `error_x`/`error_y` container onto every trace that
+ * could carry one, so the `visible` flag — not the container's presence — is
+ * what says a chart drew intervals. A trace with both gets its vertical ones
+ * read: a MAIDR error-bar layer carries one interval per sample, and the
+ * vertical is the one a reader means by "the error bar".
+ *
+ * Lives here, beside the selector, because the two must agree: reading the
+ * y bounds while highlighting `path.xerror` would announce one interval and
+ * light up another.
+ *
+ * @param trace - The resolved plotly trace
+ * @returns `'y'`, `'x'`, or null when neither axis draws an interval
+ */
+export function errorBarAxis(trace: PlotlyTrace): 'x' | 'y' | null {
+  if (trace.error_y?.visible === true)
+    return 'y';
+  if (trace.error_x?.visible === true)
+    return 'x';
+  return null;
+}
+
+/**
+ * Error-bar selector: the whip drawn at each sample.
+ *
+ * The `g.errorbar` group around it would be the tidier target — plotly emits
+ * exactly one per sample, whether or not the sample got a whip — but the
+ * whisker inside carries its own inline stroke, so a highlight clone of the
+ * group would be recoloured on the group and repaint identically to the
+ * original. The path itself is what can actually be seen highlighted.
+ *
+ * Plotly puts a bar-like trace's error bars straight into the trace group and
+ * a scatter's into an `errorbars` group of their own, drawn under the line.
+ */
+function errorBarSelector(prefix: string, trace: PlotlyTrace | undefined): string | undefined {
+  const axis = trace ? errorBarAxis(trace) : null;
+  if (axis === null) {
+    return undefined;
+  }
+  const group = trace?.type === 'bar'
+    ? `${prefix}.trace.bars`
+    : `${prefix}.trace.scatter .errorbars`;
+  return `${group} > g.errorbar > path.${axis}error`;
 }
 
 /**

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -98,7 +98,7 @@ export function generatePlotlySelectors(
       return scatterTraceScope(prefix, traceData, 'g.textpoint > text');
 
     case TraceType.ERROR_BAR:
-      return errorBarSelector(prefix, traceData);
+      return errorBarSelector(prefix, plotlyGd, traceIndex);
 
     case TraceType.BOX:
       return `${prefix}.trace.boxes .point > path`;
@@ -288,16 +288,72 @@ export function errorBarAxis(trace: PlotlyTrace): 'x' | 'y' | null {
  *
  * Plotly puts a bar-like trace's error bars straight into the trace group and
  * a scatter's into an `errorbars` group of their own, drawn under the line.
+ *
+ * Both are scoped to the one trace the layer describes rather than to the
+ * panel. Two traces carrying intervals on one subplot is an ordinary chart —
+ * a measurement against its control — and a panel-wide selector would give
+ * both layers every whip on the panel. `ErrorBarTrace` withholds highlighting
+ * outright when the elements do not match its samples, so the visual modality
+ * would go silently missing for both.
+ *
+ * @param prefix     - The subplot prefix the trace is drawn in
+ * @param gd         - The plotly graph div
+ * @param traceIndex - The global index of the trace carrying the intervals
+ * @returns The selector, or undefined when the trace draws no intervals
  */
-function errorBarSelector(prefix: string, trace: PlotlyTrace | undefined): string | undefined {
+function errorBarSelector(
+  prefix: string,
+  gd: PlotlyGraphDiv,
+  traceIndex: number,
+): string | undefined {
+  const trace = gd._fullData?.[traceIndex];
   const axis = trace ? errorBarAxis(trace) : null;
-  if (axis === null) {
+  if (!trace || axis === null) {
     return undefined;
   }
-  const group = trace?.type === 'bar'
-    ? `${prefix}.trace.bars`
-    : `${prefix}.trace.scatter .errorbars`;
-  return `${group} > g.errorbar > path.${axis}error`;
+  const whip = `g.errorbar > path.${axis}error`;
+  if (trace.type === 'bar') {
+    // Bar groups carry no uid class, so the trace is named by its position
+    // among the panel's bar-layer traces — the count {@link barPointSelector}
+    // is under, and histograms share that layer.
+    const position = barLayerPosition(gd, traceIndex, trace) + 1;
+    return `${prefix}.barlayer > g.trace.bars:nth-of-type(${position}) > ${whip}`;
+  }
+  return scatterTraceScope(prefix, trace, `.errorbars > ${whip}`);
+}
+
+/**
+ * A bar-family trace's position among the ones plotly drew into its panel's
+ * `barlayer`, which is what a `nth-of-type` selector counts by.
+ *
+ * Histograms are counted too: plotly draws them through the bar renderer and
+ * into the same layer, so one sitting before this trace shifts its group.
+ *
+ * @param gd         - The plotly graph div
+ * @param traceIndex - The global index of the trace being selected
+ * @param trace      - That trace, whose axes name the panel
+ * @returns How many bar-layer traces plotly drew before it on that panel
+ */
+function barLayerPosition(
+  gd: PlotlyGraphDiv,
+  traceIndex: number,
+  trace: PlotlyTrace,
+): number {
+  const traces = gd._fullData ?? [];
+  let position = 0;
+  for (let i = 0; i < traceIndex; i++) {
+    const other = traces[i];
+    if (
+      (other?.type === 'bar' || other?.type === 'histogram')
+      && other.visible !== false
+      && other.visible !== 'legendonly'
+      && (other.xaxis ?? 'x') === (trace.xaxis ?? 'x')
+      && (other.yaxis ?? 'y') === (trace.yaxis ?? 'y')
+    ) {
+      position++;
+    }
+  }
+  return position;
 }
 
 /**

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -77,11 +77,55 @@ export interface PlotlyTrace {
   close?: number[];
   // Histogram-specific
   xbins?: { start?: number; end?: number; size?: number };
-  // Pie-specific
+  // Pie-specific, and shared with the hierarchy traces below, which name and
+  // size their sectors through the same two arrays.
   /** Slice labels, in the order the trace was authored. */
   labels?: (number | string)[];
   /** Slice magnitudes, parallel to {@link labels}. */
   values?: (number | string)[];
+  // Hierarchy traces (sunburst, icicle, treemap)
+  /**
+   * Each sector's parent, parallel to {@link labels}. An empty string means
+   * the sector sits at the root. Plotly matches these against `ids` when a
+   * trace has them and against `labels` otherwise.
+   */
+  parents?: (number | string)[];
+  /** Sector ids, for a hierarchy whose labels repeat. Parallel to {@link labels}. */
+  ids?: (number | string)[];
+  // Sankey-specific
+  /** The nodes the flows run between. */
+  node?: { label?: (number | string)[]; groups?: number[][] };
+  /**
+   * The flows themselves, held as three parallel arrays. `source` and
+   * `target` are INDICES into {@link node}'s labels rather than the names a
+   * MAIDR flow carries.
+   */
+  link?: { source?: number[]; target?: number[]; value?: number[] };
+  // Indicator-specific (gauge and bullet charts)
+  /** The measure a gauge draws. */
+  value?: number;
+  /** What the measure is called. Only the indicator traces carry one. */
+  title?: { text?: string } | string;
+  /** The dial. Present only when `mode` includes `gauge`. */
+  gauge?: PlotlyGauge;
+  /** The comparison an indicator draws its delta against. */
+  delta?: { reference?: number };
+  // Polar-specific (scatterpolar, barpolar)
+  /**
+   * Which polar subplot the trace is drawn on (`polar`, `polar2`, …). Polar
+   * traces carry this instead of an `xaxis`/`yaxis` pair.
+   */
+  subplot?: string;
+  /** Radial coordinates — the magnitude on each spoke. */
+  r?: (number | string)[];
+  /** Angular coordinates — which spoke each value sits on. */
+  theta?: (number | string)[];
+  // Parallel-coordinates-specific
+  /**
+   * One entry per axis, each carrying the whole column of observations.
+   * Plotly stores the transpose of the row-per-observation grid MAIDR reads.
+   */
+  dimensions?: PlotlyDimension[];
   /**
    * Whether plotly reorders the slices largest-first before drawing them.
    * Defaults to true, so the authored order is NOT the drawn order unless a
@@ -96,6 +140,95 @@ export interface PlotlyTrace {
   domain?: { x?: [number, number]; y?: [number, number] };
   // Heatmap colorbar
   colorbar?: { title?: { text?: string } | string };
+}
+
+/**
+ * The dial an indicator trace draws, as plotly resolves it.
+ *
+ * Only present when the trace's `mode` includes `gauge`; a `number`-only
+ * indicator is a text tile with no dial and no container here.
+ */
+export interface PlotlyGauge {
+  /** `angular` (the default dial) or `bullet` (a horizontal bar). */
+  shape?: 'angular' | 'bullet';
+  /** The dial's ends, on `axis.range`. */
+  axis?: { range?: [number, number] };
+  /**
+   * The coloured arcs behind the bar. Plotly resolves `range` and `color` for
+   * every step; `name` only when the author wrote one.
+   */
+  steps?: { range?: [number, number]; name?: string }[];
+  /**
+   * The target line. Plotly resolves `value` to the boolean `false` when the
+   * author set none, which is why it is not simply coerced to a number.
+   */
+  threshold?: { value?: number | false };
+}
+
+/**
+ * One series of a polar layer, together with where its trace sits among the
+ * subplot's traces of that kind — which is what a selector counts by.
+ */
+export interface PolarSeries {
+  trace: PlotlyTrace;
+  position: number;
+}
+
+/** One axis of a parallel-coordinates trace, with its whole column of values. */
+export interface PlotlyDimension {
+  label?: string;
+  values?: (number | string)[];
+  /** False for an axis the author hid, which plotly then does not draw. */
+  visible?: boolean;
+}
+
+/**
+ * One node of a drawn sankey, as its calcdata holds it.
+ *
+ * `pointNumber` is the node's index in the trace's own `node.label` array;
+ * `label` is the name plotly resolved for it.
+ */
+export interface PlotlySankeyNode {
+  pointNumber?: number;
+  label?: number | string;
+}
+
+/**
+ * One flow of a drawn sankey.
+ *
+ * The ends start out as indices, exactly as the trace authored them, and the
+ * layout pass REPLACES them with the node objects themselves — so a link read
+ * off a rendered chart carries objects and one read before layout carries
+ * numbers. Both are admitted here because both are reachable.
+ */
+export interface PlotlySankeyLink {
+  source?: number | PlotlySankeyNode;
+  target?: number | PlotlySankeyNode;
+  value?: number;
+}
+
+/**
+ * One node of the tree a hierarchy trace was drawn from, as plotly's calc
+ * leaves it on the first calcdata entry.
+ *
+ * `data.data` is the calc entry for the sector — the double hop is d3's: the
+ * hierarchy wraps the stratified node, which wraps what plotly computed.
+ */
+export interface PlotlyHierarchyNode {
+  children?: PlotlyHierarchyNode[];
+  parent?: PlotlyHierarchyNode | null;
+  /** The magnitude d3 resolved, which is the one the sector was drawn at. */
+  value?: number;
+  data?: { data?: PlotlySector };
+}
+
+/** What plotly computed for one sector of a hierarchy trace. */
+export interface PlotlySector {
+  /** Index into the trace's own arrays; absent on a root plotly synthesised. */
+  i?: number;
+  label?: string;
+  /** Set on the stand-in root plotly adds when several sectors claim the top. */
+  hasMultipleRoots?: boolean;
 }
 
 /**
@@ -270,10 +403,32 @@ export interface PlotlyCalcData {
   v?: number;
   /** Slice label. */
   label?: number | string;
+  // Hierarchy traces: plotly stashes the whole tree on the first entry
+  /** The stratified, sorted tree the sectors were drawn from. */
+  hierarchy?: PlotlyHierarchyNode;
+  // Sankey: plotly stashes the whole graph on the first entry
+  /** The flows plotly kept, in the order it drew the ribbons. */
+  _links?: PlotlySankeyLink[];
+  // Polar
+  /** Radial coordinate (scatterpolar). */
+  r?: number;
+  /** Angular coordinate (scatterpolar). */
+  theta?: number | string;
   // Heatmap
   z?: number[][];
   trace?: PlotlyTrace;
   [key: string]: unknown;
+}
+
+/**
+ * One polar subplot's layout. Polar traces name theirs on `trace.subplot`,
+ * and it is what says where the subplot sits on the paper — polar has no
+ * axis pair with a domain to read one from.
+ */
+export interface PlotlyPolarLayout {
+  domain?: { x?: [number, number]; y?: [number, number] };
+  radialaxis?: PlotlyAxis;
+  angularaxis?: PlotlyAxis;
 }
 
 export interface PlotlyDensitySample {

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -23,12 +23,41 @@ export interface PlotlyTrace {
    * piecewise-constant staircase.
    */
   line?: { shape?: string };
+  /**
+   * What the trace fills towards: `tozeroy`, `tonexty`, `toself`, … Plotly
+   * resolves an unfilled trace to the string `'none'` rather than dropping
+   * the attribute, so a filled trace is any other non-empty value.
+   */
+  fill?: string;
+  /**
+   * The stack this trace belongs to. Plotly stacks scatter traces that name
+   * the same group, drawing them as an area chart whose bands sit on one
+   * another; an empty or absent value means the trace stands alone.
+   */
+  stackgroup?: string;
+  /**
+   * How a stack group is rescaled: `percent` makes each column sum to 100,
+   * `fraction` to 1. Empty or absent leaves the bands at their own totals.
+   */
+  groupnorm?: string;
   x?: (number | string)[];
   y?: (number | string)[];
   z?: number[][];
   xaxis?: string;
   yaxis?: string;
   orientation?: 'v' | 'h';
+  /** Value-axis offset every bar-like size is measured from. */
+  base?: number;
+  // Waterfall-specific
+  /**
+   * What each step does to the running total: `relative` contributes,
+   * `total` restates it, `absolute` resets it. Parallel to the position
+   * array, and `relative` where it says nothing.
+   */
+  measure?: string[];
+  // Error bars, which any scatter or bar trace may carry
+  error_x?: PlotlyErrorBar;
+  error_y?: PlotlyErrorBar;
   // Box-specific
   q1?: number[];
   median?: number[];
@@ -67,6 +96,30 @@ export interface PlotlyTrace {
   domain?: { x?: [number, number]; y?: [number, number] };
   // Heatmap colorbar
   colorbar?: { title?: { text?: string } | string };
+}
+
+/**
+ * The interval drawn around each sample on one axis.
+ *
+ * Plotly resolves `visible` for every trace that could carry error bars, so a
+ * trace without them has `visible: false` rather than no container at all —
+ * which is what makes the flag the reliable test. The magnitudes below are
+ * what `type` selects between; plotly turns them into absolute bounds during
+ * calc, and they are only read here when it has not.
+ */
+export interface PlotlyErrorBar {
+  visible?: boolean;
+  type?: 'data' | 'percent' | 'constant' | 'sqrt';
+  /** False when the two sides are given separately. */
+  symmetric?: boolean;
+  /** Per-sample magnitudes, for `type: 'data'`. */
+  array?: number[];
+  /** Per-sample magnitudes below the estimate, when not symmetric. */
+  arrayminus?: number[];
+  /** Single magnitude, for `percent` and `constant`. */
+  value?: number;
+  /** Single magnitude below the estimate, when not symmetric. */
+  valueminus?: number;
 }
 
 export interface PlotlyLayout {
@@ -164,9 +217,30 @@ export interface PlotlyCalcData {
   x?: number;
   y?: number;
   p?: number | string; // position (bar, box)
-  s?: number; // size/value (bar)
+  s?: number; // size/value (bar); running total after the step (waterfall)
   s0?: number;
   s1?: number;
+  /**
+   * Index into the trace's own arrays, and `null` for a sample plotly
+   * inserted rather than the author writing it — the positions a stacked
+   * scatter borrows from the other traces in its stack.
+   */
+  i?: number | null;
+  // Stacked scatter (area)
+  /** This band's own size after `groupnorm` rescaled the stack. */
+  sNorm?: number;
+  // Waterfall calc data
+  /** The step's authored contribution, before it was accumulated. */
+  rawS?: number;
+  /** Whether the step restates the running total rather than changing it. */
+  isSum?: boolean;
+  /** Base the bar is measured from, set while plotly positions the group. */
+  b?: number;
+  // Error bars: the bounds plotly resolved per sample, on each axis
+  xs?: number;
+  xh?: number;
+  ys?: number;
+  yh?: number;
   // Box calc data
   pos?: number | string;
   min?: number;
@@ -189,7 +263,10 @@ export interface PlotlyCalcData {
   /** Per-trace calc metadata; plotly stores it on the first entry of a trace. */
   t?: PlotlyCalcMeta;
   // Pie calc data
-  /** Slice magnitude, after plotly dropped the values it would not draw. */
+  /**
+   * Slice magnitude, after plotly dropped the values it would not draw. A
+   * waterfall keeps the running total the step produced here instead.
+   */
   v?: number;
   /** Slice label. */
   label?: number | string;

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -42,12 +42,36 @@ export interface PlotlyTrace {
   groupnorm?: string;
   x?: (number | string)[];
   y?: (number | string)[];
-  z?: number[][];
+  /**
+   * A heatmap's grid of magnitudes — and a choropleth's flat column of them,
+   * which is the same attribute carrying one value per region rather than one
+   * per cell.
+   */
+  z?: number[][] | (number | string)[];
   xaxis?: string;
   yaxis?: string;
   orientation?: 'v' | 'h';
-  /** Value-axis offset every bar-like size is measured from. */
-  base?: number;
+  /**
+   * Value-axis offset every bar-like size is measured from. An ARRAY floats
+   * each bar from its own offset, which is how a schedule is drawn: the bar
+   * starts at `base[i]` and runs for the duration in `x[i]`.
+   */
+  base?: number | (number | string)[];
+  /**
+   * Text drawn at, or associated with, each point. A word cloud is a scatter
+   * whose terms live here, and a choropleth names its regions here when the
+   * locations themselves are codes.
+   */
+  text?: (number | string)[] | string;
+  /** Hover-only text. Plotly.py's `hover_name` resolves to this. */
+  hovertext?: (number | string)[] | string;
+  /**
+   * Glyph styling for the text marks. An ARRAY of sizes is what makes a text
+   * scatter a word cloud: the size is per term rather than per trace.
+   */
+  textfont?: { size?: number | number[] };
+  /** Author-supplied values carried through to hover templates and events. */
+  customdata?: unknown[];
   // Waterfall-specific
   /**
    * What each step does to the running total: `relative` contributes,
@@ -66,6 +90,12 @@ export interface PlotlyTrace {
   upperfence?: number[];
   mean?: number[];
   // Violin-specific
+  /**
+   * Which half of each violin is drawn. `positive` is plotly's own ridgeline
+   * recipe: the curves are halved so they can overlap without hiding one
+   * another.
+   */
+  side?: 'both' | 'positive' | 'negative';
   /** Inner box overlay. Plotly draws `path.box` only when `visible` is true. */
   box?: { visible?: boolean };
   /** Mean line overlay drawn across the violin. */
@@ -120,6 +150,17 @@ export interface PlotlyTrace {
   r?: (number | string)[];
   /** Angular coordinates — which spoke each value sits on. */
   theta?: (number | string)[];
+  // Choropleth-specific
+  /**
+   * Which geo subplot the trace is drawn on (`geo`, `geo2`, …). A choropleth
+   * carries this instead of an `xaxis`/`yaxis` pair.
+   */
+  geo?: string;
+  /**
+   * The regions shaded, named the way `locationmode` addresses them — an ISO
+   * code, a state name, a GeoJSON feature id. Parallel to the values in `z`.
+   */
+  locations?: (number | string)[];
   // Parallel-coordinates-specific
   /**
    * One entry per axis, each carrying the whole column of observations.
@@ -409,13 +450,23 @@ export interface PlotlyCalcData {
   // Sankey: plotly stashes the whole graph on the first entry
   /** The flows plotly kept, in the order it drew the ribbons. */
   _links?: PlotlySankeyLink[];
+  // Choropleth
+  /** The region this entry shades, as the trace addressed it. */
+  loc?: number | string | null;
+  /**
+   * The region's centroid as `[lon, lat]` in degrees, copied off the
+   * topojson/GeoJSON feature plotly resolved the region to. Present only once
+   * the map has been drawn.
+   */
+  ct?: [number, number];
   // Polar
   /** Radial coordinate (scatterpolar). */
   r?: number;
   /** Angular coordinate (scatterpolar). */
   theta?: number | string;
-  // Heatmap
-  z?: number[][];
+  // Heatmap, and choropleth — where the same field is one region's magnitude
+  // rather than a grid of them.
+  z?: number[][] | number;
   trace?: PlotlyTrace;
   [key: string]: unknown;
 }

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -122,6 +122,10 @@ export interface PlotlyTrace {
   parents?: (number | string)[];
   /** Sector ids, for a hierarchy whose labels repeat. Parallel to {@link labels}. */
   ids?: (number | string)[];
+  /** How many levels below the entry point are drawn; `-1` for all of them. */
+  maxdepth?: number;
+  /** The sector the layout is entered at, drawing that subtree alone. */
+  level?: number | string;
   // Sankey-specific
   /** The nodes the flows run between. */
   node?: { label?: (number | string)[]; groups?: number[][] };

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,5 +1,5 @@
-import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
-import type { BarPoint, BoxPoint, BoxSelector, ErrorBarPoint, LinePoint, MaidrLayer, PiePoint, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
+import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyHierarchyNode, PlotlyTrace } from '@adapters/plotly/types';
+import type { BarPoint, BoxPoint, BoxSelector, ErrorBarPoint, GaugePoint, LinePoint, MaidrLayer, PiePoint, SegmentedPoint, TreemapPoint, ViolinKdePoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
@@ -125,7 +125,7 @@ describe('plotly extractor', () => {
     it('warns once for a trace type MAIDR has no equivalent for', () => {
       const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const gd = createGraphDiv({
-        traces: [{ type: 'sunburst', y: [1, 2, 3] }],
+        traces: [{ type: 'scatter3d', y: [1, 2, 3] }],
         layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
       });
 
@@ -1726,6 +1726,94 @@ describe('plotly extractor', () => {
         expect(figure.state).toMatchObject({ empty: false });
       });
     });
+
+    it('constructs a navigable trace for each of the domain-positioned types', () => {
+      const gd = createGraphDiv({
+        traces: [
+          {
+            type: 'sunburst',
+            labels: ['World', 'Asia', 'Europe'],
+            parents: ['', 'World', 'World'],
+            values: [100, 60, 40],
+            domain: { x: [0, 0.45], y: [0.575, 1] },
+            name: 'Population',
+          },
+          {
+            type: 'sankey',
+            node: { label: ['Coal', 'Electricity', 'Losses'] },
+            link: { source: [0, 0, 1], target: [1, 2, 2], value: [34, 8, 12] },
+            domain: { x: [0.55, 1], y: [0.575, 1] },
+            name: 'Energy',
+          },
+          {
+            type: 'indicator',
+            mode: 'gauge+number',
+            value: 73,
+            title: { text: 'Conversion' },
+            gauge: { shape: 'angular', axis: { range: [0, 100] } },
+            domain: { x: [0, 0.45], y: [0, 0.425] },
+          },
+          {
+            type: 'parcoords',
+            dimensions: [
+              { label: 'mpg', values: [33, 21] },
+              { label: 'hp', values: [65, 110] },
+            ],
+            domain: { x: [0.55, 1], y: [0, 0.425] },
+          },
+        ],
+        layout: {},
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        // Every payload is one the core's factory recognises and can build a
+        // trace from — the emitted shapes, not just the emitted type names.
+        expect(figure.getSubplotSummaries().map(summary => summary.traceTypes)).toEqual([
+          ['sunburst'],
+          ['sankey'],
+          ['gauge'],
+          ['parallel_coordinates'],
+        ]);
+        expect(figure.state).toMatchObject({ empty: false });
+      });
+    });
+
+    it('a plotly polar chart reaches the core as a radar trace', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'scatterpolar',
+          mode: 'lines+markers',
+          subplot: 'polar',
+          uid: 'aaa111',
+          theta: ['Speed', 'Range', 'Comfort'],
+          r: [8, 4, 6],
+          name: 'Model A',
+        }],
+        layout: {
+          polar: {
+            domain: { x: [0, 1], y: [0, 1] },
+            radialaxis: { title: { text: 'Score' } },
+          },
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.RADAR]);
+        expect(figure.state).toMatchObject({ empty: false });
+      });
+    });
   });
 
   describe('segmented bars', () => {
@@ -2570,6 +2658,609 @@ describe('plotly extractor', () => {
       }));
 
       expect((layer.data as ErrorBarPoint[]).map(point => point.x)).toEqual(['A', 'C']);
+    });
+  });
+
+  describe('hierarchy traces', () => {
+    const DOMAIN = { x: [0, 1] as [number, number], y: [0, 1] as [number, number] };
+
+    /** A tree as an author thinks of it, before plotly stratifies one. */
+    interface TreeSpec {
+      label: string;
+      value?: number;
+      children?: TreeSpec[];
+    }
+
+    /**
+     * Builds the tree plotly stashes on the first calcdata entry: a d3
+     * hierarchy whose nodes wrap the sector calc data two levels down, with
+     * every node's children already sorted the way plotly sorts them.
+     */
+    function hierarchyNode(spec: TreeSpec, parent: PlotlyHierarchyNode | null = null): PlotlyHierarchyNode {
+      const node: PlotlyHierarchyNode = {
+        parent,
+        value: spec.value,
+        data: { data: { label: spec.label } },
+      };
+      node.children = spec.children?.map(child => hierarchyNode(child, node));
+      return node;
+    }
+
+    /** The tree every case below is drawn from, largest child first. */
+    const WORLD: TreeSpec = {
+      label: 'World',
+      value: 100,
+      children: [
+        {
+          label: 'Asia',
+          value: 60,
+          children: [
+            { label: 'China', value: 35 },
+            { label: 'India', value: 25 },
+          ],
+        },
+        { label: 'Europe', value: 40, children: [{ label: 'France', value: 40 }] },
+      ],
+    };
+
+    function hierarchyTrace(type: string, overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type,
+        labels: ['World', 'Asia', 'Europe', 'China', 'India', 'France'],
+        parents: ['', 'World', 'World', 'Asia', 'Asia', 'Europe'],
+        values: [100, 60, 40, 35, 25, 40],
+        domain: DOMAIN,
+        ...overrides,
+      };
+    }
+
+    function hierarchyLayer(type: string, options: {
+      trace?: Partial<PlotlyTrace>;
+      calcdata?: PlotlyCalcData[][];
+    } = {}): MaidrLayer {
+      const gd = createGraphDiv({
+        traces: [hierarchyTrace(type, options.trace)],
+        layout: {},
+        calcdata: options.calcdata,
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it('reads the sectors in the order plotly drew them, deepest level last', () => {
+      const layer = hierarchyLayer('sunburst', {
+        calcdata: [[{ hierarchy: hierarchyNode(WORLD) }]],
+      });
+
+      expect(layer.type).toBe(TraceType.SUNBURST);
+      // Level order, not the authored order: plotly draws the tree a level at
+      // a time, and the `g.slice` groups sit in that order.
+      expect((layer.data as TreemapPoint[]).map(point => point.x)).toEqual([
+        'World',
+        'Asia',
+        'Europe',
+        'China',
+        'India',
+        'France',
+      ]);
+    });
+
+    it('names each sector\'s ancestors root first, excluding itself', () => {
+      const layer = hierarchyLayer('sunburst', {
+        calcdata: [[{ hierarchy: hierarchyNode(WORLD) }]],
+      });
+
+      const data = layer.data as TreemapPoint[];
+      expect(data[0]).toEqual({ x: 'World', y: 100 });
+      expect(data[1]).toEqual({ x: 'Asia', y: 60, path: ['World'] });
+      expect(data[3]).toEqual({ x: 'China', y: 35, path: ['World', 'Asia'] });
+    });
+
+    it.each([
+      ['sunburst', TraceType.SUNBURST],
+      ['icicle', TraceType.ICICLE],
+      ['treemap', TraceType.TREEMAP],
+    ])('binds a %s to its own layer and its own slices', (type, expected) => {
+      const layer = hierarchyLayer(type, {
+        calcdata: [[{ hierarchy: hierarchyNode(WORLD) }]],
+      });
+
+      expect(layer.type).toBe(expected);
+      expect(layer.selectors).toBe(
+        `.${type}layer > g.trace.${type}:nth-of-type(1) g.slice > path.surface`,
+      );
+      expect(layer.axes?.x?.label).toBe('Label');
+      expect(layer.axes?.y?.label).toBe('Value');
+    });
+
+    it('falls back to the authored arrays and withholds selectors when nothing was computed', () => {
+      const layer = hierarchyLayer('treemap');
+
+      // Authored order this time, which is not the drawn order — so no
+      // highlight rather than one landing on a neighbouring rectangle.
+      expect((layer.data as TreemapPoint[]).map(point => point.x)).toEqual([
+        'World',
+        'Asia',
+        'Europe',
+        'China',
+        'India',
+        'France',
+      ]);
+      expect((layer.data as TreemapPoint[])[5]).toEqual({
+        x: 'France',
+        y: 40,
+        path: ['World', 'Europe'],
+      });
+      expect(layer.selectors).toBeUndefined();
+    });
+
+    it('resolves an authored path through ids when the labels repeat', () => {
+      const layer = hierarchyLayer('treemap', {
+        trace: {
+          labels: ['Sales', 'North', 'North'],
+          ids: ['sales', 'sales/north', 'ops/north'],
+          parents: ['', 'sales', 'sales'],
+          values: [10, 6, 4],
+        },
+      });
+
+      const data = layer.data as TreemapPoint[];
+      expect(data[1]).toEqual({ x: 'North', y: 6, path: ['Sales'] });
+      expect(data[2]).toEqual({ x: 'North', y: 4, path: ['Sales'] });
+    });
+
+    it('refuses the drawn order for a forest plotly gave a stand-in root', () => {
+      const forest = hierarchyNode({
+        label: '',
+        children: [{ label: 'Asia', value: 60 }, { label: 'Europe', value: 40 }],
+      });
+      forest.data = { data: { label: '', hasMultipleRoots: true } };
+
+      const layer = hierarchyLayer('sunburst', { calcdata: [[{ hierarchy: forest }]] });
+
+      // The three layouts disagree over whether the stand-in is drawn, so the
+      // sector list cannot be lined up with the slices at all.
+      expect(layer.selectors).toBeUndefined();
+      expect((layer.data as TreemapPoint[])[0].x).toBe('World');
+    });
+
+    it('keeps a sunburst out of the cartesian panel beside it', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'Counts' },
+          hierarchyTrace('sunburst', { domain: { x: [0.55, 1], y: [0, 1] } }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 0.45], title: { text: 'Day' } },
+          yaxis: { domain: [0, 1], title: { text: 'Count' } },
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots[0]).toHaveLength(2);
+      const [bars, sunburst] = maidr!.subplots[0];
+      expect(bars.layers[0].type).toBe(TraceType.BAR);
+      expect(sunburst.layers[0].type).toBe(TraceType.SUNBURST);
+      // Not the bar panel's axis names.
+      expect(sunburst.layers[0].axes?.x?.label).toBe('Label');
+    });
+  });
+
+  describe('sankey traces', () => {
+    const NODES = { label: ['Coal', 'Electricity', 'Losses'] };
+
+    function sankeyTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'sankey',
+        node: NODES,
+        link: { source: [0, 0, 1], target: [1, 2, 2], value: [34, 8, 12] },
+        domain: { x: [0, 1], y: [0, 1] },
+        name: 'Energy',
+        ...overrides,
+      };
+    }
+
+    function sankeyLayer(options: {
+      trace?: Partial<PlotlyTrace>;
+      calcdata?: PlotlyCalcData[][];
+    } = {}): MaidrLayer {
+      const gd = createGraphDiv({
+        traces: [sankeyTrace(options.trace)],
+        layout: {},
+        calcdata: options.calcdata,
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('names both ends of every flow plotly kept', () => {
+      const layer = sankeyLayer({
+        calcdata: [[{
+          _links: [
+            { source: 0, target: 1, value: 34 },
+            { source: 0, target: 2, value: 8 },
+            { source: 1, target: 2, value: 12 },
+          ],
+        }]],
+      });
+
+      expect(layer.type).toBe(TraceType.SANKEY);
+      expect(layer.data).toEqual([
+        { source: 'Coal', target: 'Electricity', value: 34 },
+        { source: 'Coal', target: 'Losses', value: 8 },
+        { source: 'Electricity', target: 'Losses', value: 12 },
+      ]);
+      expect(layer.selectors).toBe('.sankey .sankey-links > path.sankey-link');
+    });
+
+    it('reads the node objects the layout pass leaves on the links', () => {
+      const layer = sankeyLayer({
+        calcdata: [[{
+          _links: [
+            { source: { pointNumber: 0, label: 'Coal' }, target: { pointNumber: 1, label: 'Electricity' }, value: 34 },
+          ],
+        }]],
+      });
+
+      expect(layer.data).toEqual([{ source: 'Coal', target: 'Electricity', value: 34 }]);
+    });
+
+    it('falls back to the authored links, dropping the ones plotly would not draw', () => {
+      const layer = sankeyLayer({
+        trace: { link: { source: [0, 0, 1], target: [1, 2, 2], value: [34, 0, 12] } },
+      });
+
+      // The zero-weight flow is not a ribbon, and keeping it would put an
+      // edge in the graph that nothing on screen corresponds to.
+      expect(layer.data).toEqual([
+        { source: 'Coal', target: 'Electricity', value: 34 },
+        { source: 'Electricity', target: 'Losses', value: 12 },
+      ]);
+      expect(layer.selectors).toBeUndefined();
+    });
+
+    it('falls back to the index for a node the trace never named', () => {
+      const layer = sankeyLayer({
+        trace: { node: { label: ['Coal'] } },
+      });
+
+      expect(layer.data).toEqual([
+        { source: 'Coal', target: 1, value: 34 },
+        { source: 'Coal', target: 2, value: 8 },
+        { source: 1, target: 2, value: 12 },
+      ]);
+    });
+  });
+
+  describe('indicator traces', () => {
+    function gaugeTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'indicator',
+        mode: 'gauge+number',
+        value: 73,
+        title: { text: 'Conversion' },
+        gauge: { shape: 'angular', axis: { range: [0, 100] } },
+        domain: { x: [0, 1], y: [0, 1] },
+        ...overrides,
+      };
+    }
+
+    function gaugeLayer(overrides: Partial<PlotlyTrace> = {}): MaidrLayer {
+      const gd = createGraphDiv({ traces: [gaugeTrace(overrides)], layout: {} });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('reads the measure against the dial it was drawn on', () => {
+      const layer = gaugeLayer();
+
+      expect(layer.type).toBe(TraceType.GAUGE);
+      // A single object, not an array of one: the chart draws one measure.
+      expect(layer.data).toEqual({ value: 73, min: 0, max: 100, label: 'Conversion' });
+      expect(layer.selectors)
+        .toBe('.indicatorlayer > g.trace:nth-of-type(1) g.value-arc > path');
+    });
+
+    it('highlights the filled rectangle of a bullet chart instead of an arc', () => {
+      const layer = gaugeLayer({
+        gauge: { shape: 'bullet', axis: { range: [0, 100] } },
+      });
+
+      expect(layer.selectors)
+        .toBe('.indicatorlayer > g.trace:nth-of-type(1) g.value-bullet > rect');
+    });
+
+    it('takes the threshold line as the target', () => {
+      const layer = gaugeLayer({
+        gauge: { shape: 'angular', axis: { range: [0, 100] }, threshold: { value: 80 } },
+      });
+
+      expect((layer.data as GaugePoint).target).toBe(80);
+    });
+
+    it('ignores the threshold plotly resolves to false, and a self-referencing delta', () => {
+      const layer = gaugeLayer({
+        mode: 'gauge+number+delta',
+        gauge: { shape: 'angular', axis: { range: [0, 100] }, threshold: { value: false } },
+        // Plotly defaults `delta.reference` to the measure itself, and
+        // "0 above target" is not a reading.
+        delta: { reference: 73 },
+      });
+
+      expect((layer.data as GaugePoint).target).toBeUndefined();
+    });
+
+    it('falls back to the delta reference the author really set', () => {
+      const layer = gaugeLayer({
+        mode: 'gauge+number+delta',
+        delta: { reference: 65 },
+      });
+
+      expect((layer.data as GaugePoint).target).toBe(65);
+    });
+
+    it('carries the qualitative bands the author named, ascending', () => {
+      const layer = gaugeLayer({
+        gauge: {
+          shape: 'angular',
+          axis: { range: [0, 100] },
+          steps: [
+            { range: [75, 100], name: 'good' },
+            { range: [0, 50], name: 'poor' },
+            { range: [50, 75], name: 'ok' },
+          ],
+        },
+      });
+
+      expect((layer.data as GaugePoint).bands).toEqual([
+        { to: 50, label: 'poor' },
+        { to: 75, label: 'ok' },
+        { to: 100, label: 'good' },
+      ]);
+    });
+
+    it('withholds the bands entirely when a step went unnamed', () => {
+      const layer = gaugeLayer({
+        gauge: {
+          shape: 'angular',
+          axis: { range: [0, 100] },
+          steps: [{ range: [0, 50], name: 'poor' }, { range: [50, 100] }],
+        },
+      });
+
+      // Colour is what a sighted reader goes by, and there is no honest name
+      // to give the second band.
+      expect((layer.data as GaugePoint).bands).toBeUndefined();
+    });
+
+    it('skips an indicator that draws no gauge', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'indicator',
+          mode: 'number+delta',
+          value: 73,
+          domain: { x: [0, 1], y: [0, 1] },
+        }],
+        layout: {},
+      });
+
+      try {
+        expect(extractPlotlyData(gd)).toBeNull();
+        const skipped = warn.mock.calls.filter(([message]) =>
+          String(message).includes('no gauge to read'),
+        );
+        expect(skipped).toHaveLength(1);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe('polar traces', () => {
+    const POLAR_LAYOUT: PlotlyFullLayout = {
+      polar: {
+        domain: { x: [0, 1], y: [0, 1] },
+        radialaxis: { title: { text: 'Score' } },
+      },
+    };
+
+    function polarLayer(traces: PlotlyTrace[], layout: PlotlyFullLayout = POLAR_LAYOUT): MaidrLayer {
+      const gd = createGraphDiv({ traces, layout });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it('reads a scatterpolar as a radar, one row per series', () => {
+      const layer = polarLayer([
+        {
+          type: 'scatterpolar',
+          mode: 'lines+markers',
+          subplot: 'polar',
+          uid: 'aaa111',
+          theta: ['Speed', 'Range', 'Comfort'],
+          r: [8, 4, 6],
+          name: 'Model A',
+        },
+        {
+          type: 'scatterpolar',
+          mode: 'lines+markers',
+          subplot: 'polar',
+          uid: 'bbb222',
+          theta: ['Speed', 'Range', 'Comfort'],
+          r: [5, 7, 3],
+          name: 'Model B',
+        },
+      ]);
+
+      expect(layer.type).toBe(TraceType.RADAR);
+      const data = layer.data as LinePoint[][];
+      expect(data).toHaveLength(2);
+      expect(data[0][0]).toEqual({ x: 'Speed', y: 8, z: 'Model A' });
+      expect(data[1][2]).toEqual({ x: 'Comfort', y: 3, z: 'Model B' });
+      // The radial axis is the only one plotly lets an author title.
+      expect(layer.axes?.y?.label).toBe('Score');
+      expect(layer.axes?.x?.label).toBe('Spoke');
+    });
+
+    it('names each radar series by its own uid class', () => {
+      const layer = polarLayer([
+        {
+          type: 'scatterpolar',
+          mode: 'markers',
+          subplot: 'polar',
+          uid: 'aaa111',
+          theta: ['Speed'],
+          r: [8],
+        },
+        {
+          type: 'scatterpolar',
+          mode: 'markers',
+          subplot: 'polar',
+          uid: 'bbb222',
+          theta: ['Speed'],
+          r: [5],
+        },
+      ]);
+
+      // One selector per series, which is what a line-shaped layer pairs by
+      // position — a single selector for the layer would resolve to nothing.
+      expect(layer.selectors).toEqual([
+        '.polarlayer > g.polar > g.frontplot > g.scatterlayer > g.trace.traceaaa111 .point',
+        '.polarlayer > g.polar > g.frontplot > g.scatterlayer > g.trace.tracebbb222 .point',
+      ]);
+    });
+
+    it('reads a barpolar as a polar area, counted within the subplot bar layer', () => {
+      const layer = polarLayer([{
+        type: 'barpolar',
+        subplot: 'polar2',
+        theta: ['N', 'E', 'S', 'W'],
+        r: [12, 9, 4, 7],
+        name: 'Wind',
+      }], {
+        polar2: { domain: { x: [0, 1], y: [0, 1] } },
+      });
+
+      expect(layer.type).toBe(TraceType.POLAR_AREA);
+      expect(layer.title).toBe('Wind');
+      expect(layer.selectors).toEqual([
+        '.polarlayer > g.polar2 > g.frontplot > g.barlayer > g.trace:nth-of-type(1) g.point > path',
+      ]);
+      // No radial title on this subplot, so the magnitude keeps its generic name.
+      expect(layer.axes?.y?.label).toBe('Value');
+    });
+
+    it('drops a spoke with no value rather than drawing it at the centre', () => {
+      const layer = polarLayer([{
+        type: 'scatterpolar',
+        mode: 'markers',
+        subplot: 'polar',
+        uid: 'aaa111',
+        theta: ['Speed', 'Range', 'Comfort'],
+        r: [8, null as unknown as number, 6],
+      }]);
+
+      expect((layer.data as LinePoint[][])[0].map(point => point.x))
+        .toEqual(['Speed', 'Comfort']);
+    });
+
+    it('keeps a polar subplot apart from the cartesian panel beside it', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'Counts' },
+          {
+            type: 'scatterpolar',
+            mode: 'markers',
+            subplot: 'polar',
+            uid: 'aaa111',
+            theta: ['N'],
+            r: [3],
+            name: 'Wind',
+          },
+        ],
+        layout: {
+          xaxis: { domain: [0, 0.45] },
+          yaxis: { domain: [0, 1] },
+          polar: { domain: { x: [0.55, 1], y: [0, 1] } },
+        },
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots[0]).toHaveLength(2);
+      expect(maidr!.subplots[0].map(panel => panel.layers[0].type))
+        .toEqual([TraceType.BAR, TraceType.RADAR]);
+    });
+  });
+
+  describe('parallel coordinates traces', () => {
+    function parcoordsLayer(overrides: Partial<PlotlyTrace> = {}): MaidrLayer {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'parcoords',
+          domain: { x: [0, 1], y: [0, 1] },
+          dimensions: [
+            { label: 'mpg', values: [33, 21, 15] },
+            { label: 'hp', values: [65, 110, 230] },
+            { label: 'weight', values: [1800, 2600, 3200] },
+          ],
+          ...overrides,
+        }],
+        layout: {},
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('turns plotly\'s column-per-axis store into a row per observation', () => {
+      const layer = parcoordsLayer();
+
+      expect(layer.type).toBe(TraceType.PARALLEL);
+      const data = layer.data as LinePoint[][];
+      expect(data).toHaveLength(3);
+      expect(data[0]).toEqual([
+        { x: 'mpg', y: 33 },
+        { x: 'hp', y: 65 },
+        { x: 'weight', y: 1800 },
+      ]);
+      expect(data[2][2]).toEqual({ x: 'weight', y: 3200 });
+    });
+
+    it('emits no selectors, because plotly draws the lines to a canvas', () => {
+      expect(parcoordsLayer().selectors).toBeUndefined();
+    });
+
+    it('leaves out an axis the author hid', () => {
+      const layer = parcoordsLayer({
+        dimensions: [
+          { label: 'mpg', values: [33, 21] },
+          { label: 'hp', values: [65, 110], visible: false },
+        ],
+      });
+
+      expect((layer.data as LinePoint[][])[0]).toEqual([{ x: 'mpg', y: 33 }]);
+    });
+
+    it('reads no further than the shortest column reaches', () => {
+      const layer = parcoordsLayer({
+        dimensions: [
+          { label: 'mpg', values: [33, 21, 15] },
+          { label: 'hp', values: [65, 110] },
+        ],
+      });
+
+      expect(layer.data as LinePoint[][]).toHaveLength(2);
     });
   });
 });

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -2586,19 +2586,22 @@ describe('plotly extractor', () => {
         layout: SINGLE_PANEL,
         // As plotly leaves it: `v` is the total after the step, `rawS` the
         // authored contribution, `s` the accumulated size it draws with.
+        // The amounts deliberately disagree with the trace's own arrays, so
+        // falling back to `authoredWaterfallSteps` fails this outright rather
+        // than passing on identical numbers.
         calcdata: [[
-          { p: 0, s: 1000, rawS: 1000, isSum: true, v: 1000 },
-          { p: 1, s: 1400, rawS: 400, isSum: false, v: 1400 },
-          { p: 2, s: 1250, rawS: -150, isSum: false, v: 1250 },
-          { p: 3, s: 1250, rawS: 0, isSum: true, v: 1250 },
+          { p: 0, s: 1100, rawS: 1100, isSum: true, v: 1100 },
+          { p: 1, s: 1500, rawS: 400, isSum: false, v: 1500 },
+          { p: 2, s: 1300, rawS: -200, isSum: false, v: 1300 },
+          { p: 3, s: 1300, rawS: 0, isSum: true, v: 1300 },
         ]],
       }));
 
       expect(layer.data).toEqual([
-        { x: 'Opening', start: 0, end: 1000, delta: 1000, kind: 'total' },
-        { x: 'Sales', start: 1000, end: 1400, delta: 400, kind: 'increase' },
-        { x: 'Returns', start: 1400, end: 1250, delta: -150, kind: 'decrease' },
-        { x: 'Closing', start: 0, end: 1250, delta: 1250, kind: 'total' },
+        { x: 'Opening', start: 0, end: 1100, delta: 1100, kind: 'total' },
+        { x: 'Sales', start: 1100, end: 1500, delta: 400, kind: 'increase' },
+        { x: 'Returns', start: 1500, end: 1300, delta: -200, kind: 'decrease' },
+        { x: 'Closing', start: 0, end: 1300, delta: 1300, kind: 'total' },
       ]);
     });
 
@@ -2664,6 +2667,7 @@ describe('plotly extractor', () => {
       return {
         type: 'scatter',
         mode: 'markers',
+        uid: 'trt',
         x: ['A', 'B'],
         y: [4.2, 5.1],
         error_y: { visible: true, type: 'data', array: [0.4, 0.3] },
@@ -2760,6 +2764,7 @@ describe('plotly extractor', () => {
         traces: [{
           type: 'scatter',
           mode: 'markers',
+          uid: 'study',
           y: ['Study A', 'Study B'],
           x: [1.2, 0.8],
           error_x: { visible: true, type: 'data', array: [0.3, 0.2] },
@@ -2773,8 +2778,9 @@ describe('plotly extractor', () => {
       expect(data[0].y).toBe(1.2);
       expect(data[0].yMin).toBeCloseTo(0.9, 10);
       expect(data[0].yMax).toBeCloseTo(1.5, 10);
-      expect(layer.selectors)
-        .toBe('.subplot.xy .trace.scatter .errorbars > g.errorbar > path.xerror');
+      expect(layer.selectors).toBe(
+        '.subplot.xy .scatterlayer g.trace.tracestudy .errorbars > g.errorbar > path.xerror',
+      );
     });
 
     it('highlights the whip a bar trace hangs off its own group', () => {
@@ -2784,7 +2790,49 @@ describe('plotly extractor', () => {
       }));
 
       expect(layer.type).toBe(TraceType.ERROR_BAR);
-      expect(layer.selectors).toBe('.subplot.xy .trace.bars > g.errorbar > path.yerror');
+      expect(layer.selectors).toBe(
+        '.subplot.xy .barlayer > g.trace.bars:nth-of-type(1) > g.errorbar > path.yerror',
+      );
+    });
+
+    it('scopes each of two traces on one panel to its own whips', () => {
+      const gd = createGraphDiv({
+        traces: [
+          errorTrace({ uid: 'ctl', name: 'Control' }),
+          errorTrace({ uid: 'trt', name: 'Treatment' }),
+        ],
+        layout: SINGLE_PANEL,
+      });
+
+      const layers = extractPlotlyData(gd)!.subplots[0][0].layers;
+      expect(layers).toHaveLength(2);
+      // A panel-wide selector would hand both layers every whip on the panel,
+      // and `ErrorBarTrace` drops the highlight outright on a count mismatch.
+      expect(layers[0].selectors).toBe(
+        '.subplot.xy .scatterlayer g.trace.tracectl .errorbars > g.errorbar > path.yerror',
+      );
+      expect(layers[1].selectors).toBe(
+        '.subplot.xy .scatterlayer g.trace.tracetrt .errorbars > g.errorbar > path.yerror',
+      );
+    });
+
+    it('counts the bar traces drawn before one carrying intervals', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: ['A', 'B'], y: [1, 2] },
+          { type: 'bar', x: ['A', 'B'], y: [3, 4], visible: 'legendonly' },
+          errorTrace({ type: 'bar', mode: undefined }),
+        ],
+        layout: SINGLE_PANEL,
+      });
+
+      const layers = extractPlotlyData(gd)!.subplots[0][0].layers;
+      const errorLayer = layers.find(layer => layer.type === TraceType.ERROR_BAR);
+      // The hidden trace gets no group in the layer, so it must not shift the
+      // count; the drawn one before it must.
+      expect(errorLayer?.selectors).toBe(
+        '.subplot.xy .barlayer > g.trace.bars:nth-of-type(2) > g.errorbar > path.yerror',
+      );
     });
 
     it('drops a sample plotly drew no estimate for, as it drew no whip', () => {
@@ -2842,9 +2890,12 @@ describe('plotly extractor', () => {
     function hierarchyTrace(type: string, overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
       return {
         type,
-        labels: ['World', 'Asia', 'Europe', 'China', 'India', 'France'],
+        // Authored smallest first at both levels, which is NOT how plotly
+        // draws it: its calc sorts each node's children largest first. The two
+        // orders differing is what lets the drawn-order test discriminate.
+        labels: ['World', 'Europe', 'Asia', 'India', 'China', 'France'],
         parents: ['', 'World', 'World', 'Asia', 'Asia', 'Europe'],
-        values: [100, 60, 40, 35, 25, 40],
+        values: [100, 40, 60, 25, 35, 40],
         domain: DOMAIN,
         ...overrides,
       };
@@ -2873,7 +2924,9 @@ describe('plotly extractor', () => {
 
       expect(layer.type).toBe(TraceType.SUNBURST);
       // Level order, not the authored order: plotly draws the tree a level at
-      // a time, and the `g.slice` groups sit in that order.
+      // a time, and the `g.slice` groups sit in that order. The trace authored
+      // each level's siblings the other way round, so this is the computed
+      // tree's order and could not have come from the trace's own arrays.
       expect((layer.data as TreemapPoint[]).map(point => point.x)).toEqual([
         'World',
         'Asia',
@@ -2919,10 +2972,10 @@ describe('plotly extractor', () => {
       // highlight rather than one landing on a neighbouring rectangle.
       expect((layer.data as TreemapPoint[]).map(point => point.x)).toEqual([
         'World',
-        'Asia',
         'Europe',
-        'China',
+        'Asia',
         'India',
+        'China',
         'France',
       ]);
       expect((layer.data as TreemapPoint[])[5]).toEqual({
@@ -2931,6 +2984,32 @@ describe('plotly extractor', () => {
         path: ['World', 'Europe'],
       });
       expect(layer.selectors).toBeUndefined();
+    });
+
+    it.each([
+      ['maxdepth', { maxdepth: 2 }],
+      ['level', { level: 'Asia' }],
+    ])('withholds selectors when %s trims what plotly drew', (_name, trace) => {
+      const layer = hierarchyLayer('sunburst', {
+        trace,
+        calcdata: [[{ hierarchy: hierarchyNode(WORLD) }]],
+      });
+
+      // Plotly computed the whole tree and drew part of it, so sector k is no
+      // longer slice k — no highlight beats one landing on another sector.
+      expect((layer.data as TreemapPoint[])).toHaveLength(6);
+      expect(layer.selectors).toBeUndefined();
+    });
+
+    it('keeps the selectors when maxdepth asks for the whole tree', () => {
+      const layer = hierarchyLayer('sunburst', {
+        trace: { maxdepth: -1 },
+        calcdata: [[{ hierarchy: hierarchyNode(WORLD) }]],
+      });
+
+      expect(layer.selectors).toBe(
+        '.sunburstlayer > g.trace.sunburst:nth-of-type(1) g.slice > path.surface',
+      );
     });
 
     it('resolves an authored path through ids when the labels repeat', () => {
@@ -3623,7 +3702,7 @@ describe('plotly extractor', () => {
       ];
     }
 
-    function barLayer(traces: PlotlyTrace[]): MaidrLayer {
+    function barLayer(traces: PlotlyTrace[], calcdata?: PlotlyCalcData[][]): MaidrLayer {
       const gd = createGraphDiv({
         traces,
         layout: {
@@ -3631,6 +3710,7 @@ describe('plotly extractor', () => {
           xaxis: { domain: [0, 1], title: { text: 'Population' } },
           yaxis: { domain: [0, 1], title: { text: 'Age band' } },
         },
+        calcdata,
       });
       const maidr = extractPlotlyData(gd);
       expect(maidr).not.toBeNull();
@@ -3648,6 +3728,20 @@ describe('plotly extractor', () => {
       expect(data[0][0]).toEqual({ x: -5, y: '0-9', z: 'Male' });
       expect(data[1][1]).toEqual({ x: 6, y: '10-19', z: 'Female' });
       expect(layer.selectors).toBe('.subplot.xy .trace.bars .point > path');
+    });
+
+    it('keeps the sign of the size plotly computed for each bar', () => {
+      // The calc sizes deliberately differ from the authored ones, so reading
+      // `cd.s` — signed, not made absolute — is what this asserts.
+      const layer = barLayer(pyramidTraces([-5, -7], [5, 6]), [
+        [{ p: 0, s: -4 }, { p: 1, s: -8 }],
+        [{ p: 0, s: 4.5 }, { p: 1, s: 6.5 }],
+      ]);
+
+      const data = layer.data as SegmentedPoint[][];
+      expect(data[0][0]).toEqual({ x: -4, y: '0-9', z: 'Male' });
+      expect(data[0][1]).toEqual({ x: -8, y: '10-19', z: 'Male' });
+      expect(data[1][0]).toEqual({ x: 4.5, y: '0-9', z: 'Female' });
     });
 
     it('leaves a stack whose series grow the same way alone', () => {

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,10 +1,10 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyTrace } from '@adapters/plotly/types';
-import type { BarPoint, BoxPoint, BoxSelector, MaidrLayer, PiePoint, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, BoxSelector, ErrorBarPoint, LinePoint, MaidrLayer, PiePoint, SegmentedPoint, ViolinKdePoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
 import { Figure } from '@model/plot';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 import { resolveSubplotLayout } from '@util/subplotLayout';
 import { JSDOM } from 'jsdom';
 
@@ -1651,6 +1651,81 @@ describe('plotly extractor', () => {
         expect(figure.state).toMatchObject({ empty: false });
       });
     });
+
+    it('constructs a navigable trace for each of the bar-like and banded types', () => {
+      const gd = createGraphDiv({
+        traces: [
+          {
+            type: 'waterfall',
+            x: ['Opening', 'Sales', 'Closing'],
+            y: [1000, 400, 0],
+            measure: ['absolute', 'relative', 'total'],
+            name: 'Revenue',
+          },
+          {
+            type: 'funnel',
+            orientation: 'h',
+            y: ['Visited', 'Purchased'],
+            x: [10000, 100],
+            name: 'Conversion',
+            xaxis: 'x2',
+            yaxis: 'y2',
+          },
+          {
+            type: 'scatter',
+            mode: 'markers',
+            x: [1, 2],
+            y: [4.2, 5.1],
+            error_y: { visible: true, type: 'data', array: [0.4, 0.3] },
+            name: 'Treatment',
+            xaxis: 'x3',
+            yaxis: 'y3',
+          },
+          {
+            type: 'scatter',
+            mode: 'lines',
+            x: ['Q1', 'Q2'],
+            y: [120, 80],
+            fill: 'tozeroy',
+            stackgroup: 'one',
+            name: 'East',
+            xaxis: 'x4',
+            yaxis: 'y4',
+          },
+          {
+            type: 'scatter',
+            mode: 'lines',
+            x: ['Q1', 'Q2'],
+            y: [90, 70],
+            fill: 'tonexty',
+            stackgroup: 'one',
+            name: 'West',
+            xaxis: 'x4',
+            yaxis: 'y4',
+          },
+        ],
+        layout: twoByTwoLayout(),
+        bgRects: TWO_BY_TWO_RECTS,
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        // Every payload is one the core's factory recognises and can build a
+        // trace from — the emitted shapes, not just the emitted type names.
+        expect(figure.getSubplotSummaries().map(summary => summary.traceTypes)).toEqual([
+          ['waterfall'],
+          ['funnel'],
+          ['error_bar'],
+          ['stacked_area'],
+        ]);
+        expect(figure.state).toMatchObject({ empty: false });
+      });
+    });
   });
 
   describe('segmented bars', () => {
@@ -1934,6 +2009,567 @@ describe('plotly extractor', () => {
       expect(data[1][2].y).toBeNull();
       // Category labels still come from the trace, so they survive the gaps.
       expect(data[0].map(point => point.x)).toEqual(quarters);
+    });
+  });
+
+  describe('area traces', () => {
+    const SINGLE_PANEL = {
+      xaxis: { domain: [0, 1] as [number, number] },
+      yaxis: { domain: [0, 1] as [number, number] },
+    };
+
+    function areaTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'scatter',
+        mode: 'lines',
+        x: ['Q1', 'Q2'],
+        y: [120, 80],
+        fill: 'tozeroy',
+        ...overrides,
+      };
+    }
+
+    function layersOf(gd: PlotlyGraphDiv): MaidrLayer[] {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers;
+    }
+
+    it('binds a filled scatter as an area layer, shaped like a line', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [areaTrace({ name: 'East' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.AREA);
+      expect(layers[0].data).toEqual([[
+        { x: 'Q1', y: 120, z: 'East' },
+        { x: 'Q2', y: 80, z: 'East' },
+      ]]);
+    });
+
+    it('leaves an unfilled scatter a line', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [areaTrace({ fill: 'none' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers[0].type).toBe(TraceType.LINE);
+    });
+
+    it('keeps a filled staircase a step, whose convention still describes it', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [areaTrace({ line: { shape: 'hv' } })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers[0].type).toBe(TraceType.STEP);
+      expect(layers[0].stepDirection).toBe('hv');
+    });
+
+    it('merges independent bands into one multi-series area layer', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          areaTrace({ name: 'East' }),
+          areaTrace({ name: 'West', y: [90, 70] }),
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.AREA);
+      expect(layers[0].data).toHaveLength(2);
+    });
+
+    it('binds a stackgroup as a stacked area carrying each band\'s own value', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          areaTrace({ name: 'East', stackgroup: 'one' }),
+          areaTrace({ name: 'West', y: [90, 70], stackgroup: 'one' }),
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.STACKED_AREA);
+      // Not the running total (210/150): AreaTrace accumulates the bands
+      // itself, and pre-accumulated values would be counted twice.
+      expect(layers[0].data).toEqual([
+        [{ x: 'Q1', y: 120, z: 'East' }, { x: 'Q2', y: 80, z: 'East' }],
+        [{ x: 'Q1', y: 90, z: 'West' }, { x: 'Q2', y: 70, z: 'West' }],
+      ]);
+    });
+
+    it('keeps two stack groups apart, so neither invents the other\'s total', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          areaTrace({ name: 'East', stackgroup: 'sales' }),
+          areaTrace({ name: 'North', y: [5, 6], stackgroup: 'costs' }),
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers.map(layer => layer.type)).toEqual([
+        TraceType.STACKED_AREA,
+        TraceType.STACKED_AREA,
+      ]);
+      expect(layers.map(layer => (layer.data as unknown[]).length)).toEqual([1, 1]);
+    });
+
+    it('binds a normalized stackgroup as its own type', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          areaTrace({ name: 'East', stackgroup: 'one', groupnorm: 'percent' }),
+          areaTrace({ name: 'West', y: [90, 70], stackgroup: 'one', groupnorm: 'percent' }),
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.NORMALIZED_AREA);
+    });
+
+    it('announces the rescaled band heights plotly drew for a normalized stack', () => {
+      const gd = createGraphDiv({
+        traces: [
+          areaTrace({ name: 'East', stackgroup: 'one', groupnorm: 'percent' }),
+          areaTrace({ name: 'West', y: [90, 70], stackgroup: 'one', groupnorm: 'percent' }),
+        ],
+        layout: SINGLE_PANEL,
+        // As plotly leaves it: `sNorm` is the band's own rescaled height and
+        // `y` the running top of the stack.
+        calcdata: [
+          [
+            { x: 0, s: 120, sNorm: 100 * 120 / 210, y: 100 * 120 / 210 },
+            { x: 1, s: 80, sNorm: 100 * 80 / 150, y: 100 * 80 / 150 },
+          ],
+          [
+            { x: 0, s: 90, sNorm: 100 * 90 / 210, y: 100 },
+            { x: 1, s: 70, sNorm: 100 * 70 / 150, y: 100 },
+          ],
+        ],
+      });
+
+      const data = layersOf(gd)[0].data as LinePoint[][];
+
+      expect(data[0][0].y).toBeCloseTo(57.142857, 5);
+      expect(data[1][0].y).toBeCloseTo(42.857143, 5);
+      expect(data[0][1].y).toBeCloseTo(53.333333, 5);
+      expect(data[1][1].y).toBeCloseTo(46.666667, 5);
+    });
+
+    it('drops the positions plotly interleaved into a stack from another band', () => {
+      const gd = createGraphDiv({
+        traces: [
+          areaTrace({ name: 'East', stackgroup: 'one', groupnorm: 'percent' }),
+          // West has nothing at Q2, so plotly splices a blank into its
+          // calcdata to line the two bands up.
+          areaTrace({ name: 'West', x: ['Q1'], y: [90], stackgroup: 'one', groupnorm: 'percent' }),
+        ],
+        layout: SINGLE_PANEL,
+        calcdata: [
+          [
+            { x: 0, sNorm: 100 * 120 / 210 },
+            { x: 1, sNorm: 100 },
+          ],
+          [
+            { x: 0, sNorm: 100 * 90 / 210 },
+            { x: 1, i: null, s: 0, sNorm: 0 },
+          ],
+        ],
+      });
+
+      const data = layersOf(gd)[0].data as LinePoint[][];
+
+      // West keeps its one authored sample; the interleaved blank is not one.
+      expect(data[1]).toHaveLength(1);
+      expect(data[1][0].y).toBeCloseTo(42.857143, 5);
+    });
+
+    it('falls back to the authored values when plotly computed no calcdata', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [areaTrace({ name: 'East', stackgroup: 'one', groupnorm: 'percent' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers[0].data).toEqual([[
+        { x: 'Q1', y: 120, z: 'East' },
+        { x: 'Q2', y: 80, z: 'East' },
+      ]]);
+    });
+
+    it('highlights the markers of an area drawn with them', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [areaTrace({ mode: 'lines+markers', stackgroup: 'one' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers[0].selectors).toBe('.subplot.xy .trace.scatter .point');
+    });
+
+    it('leaves a lines-only area unhighlighted, as it leaves a line', () => {
+      const layers = layersOf(createGraphDiv({
+        traces: [areaTrace()],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layers[0].selectors).toBeUndefined();
+    });
+
+    it('does not warn about an area trace, which is supported', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        extractPlotlyData(createGraphDiv({
+          traces: [areaTrace({ stackgroup: 'one' })],
+          layout: SINGLE_PANEL,
+        }));
+
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe('funnel traces', () => {
+    const SINGLE_PANEL = {
+      xaxis: { title: { text: 'Users' }, domain: [0, 1] as [number, number] },
+      yaxis: { title: { text: 'Stage' }, domain: [0, 1] as [number, number] },
+    };
+
+    /** The default funnel shape: counts on x, stages on y, drawn sideways. */
+    function funnelTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'funnel',
+        orientation: 'h',
+        y: ['Visited', 'Signed up', 'Purchased'],
+        x: [10000, 2400, 100],
+        name: 'Conversion',
+        ...overrides,
+      };
+    }
+
+    function onlyLayer(gd: PlotlyGraphDiv): MaidrLayer {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it('binds a funnel trace as a funnel layer, in the authored stage order', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [funnelTrace()],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.FUNNEL);
+      expect(layer.title).toBe('Conversion');
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      // The count sits on the axis it was drawn against, which is where
+      // AbstractBarPlot reads a horizontal bar's value from.
+      expect(layer.data).toEqual([
+        { x: 10000, y: 'Visited' },
+        { x: 2400, y: 'Signed up' },
+        { x: 100, y: 'Purchased' },
+      ]);
+      expect(layer.axes?.x?.label).toBe('Users');
+      expect(layer.axes?.y?.label).toBe('Stage');
+    });
+
+    it('prefers the size plotly computed over the authored one', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [funnelTrace()],
+        layout: SINGLE_PANEL,
+        calcdata: [[{ p: 0, s: 9000 }, { p: 1, s: 2400 }, { p: 2, s: 100 }]],
+      }));
+
+      expect((layer.data as BarPoint[])[0].x).toBe(9000);
+    });
+
+    it('scopes the highlight to the funnel layer, not to a neighbouring bar', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [funnelTrace()],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.selectors).toBe('.subplot.xy .funnellayer .trace.bars .point > path');
+    });
+
+    it('keeps a vertical funnel on the value axis it was drawn against', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [funnelTrace({
+          orientation: 'v',
+          x: ['Visited', 'Signed up'],
+          y: [10000, 2400],
+        })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.orientation).toBeUndefined();
+      expect(layer.data).toEqual([
+        { x: 'Visited', y: 10000 },
+        { x: 'Signed up', y: 2400 },
+      ]);
+    });
+  });
+
+  describe('waterfall traces', () => {
+    const SINGLE_PANEL = {
+      xaxis: { title: { text: 'Step' }, domain: [0, 1] as [number, number] },
+      yaxis: { title: { text: 'Amount' }, domain: [0, 1] as [number, number] },
+    };
+
+    function waterfallTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'waterfall',
+        x: ['Opening', 'Sales', 'Returns', 'Closing'],
+        y: [1000, 400, -150, 0],
+        measure: ['absolute', 'relative', 'relative', 'total'],
+        name: 'Revenue',
+        ...overrides,
+      };
+    }
+
+    function onlyLayer(gd: PlotlyGraphDiv): MaidrLayer {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it('accumulates the authored steps when plotly computed no calcdata', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [waterfallTrace()],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.WATERFALL);
+      expect(layer.title).toBe('Revenue');
+      expect(layer.data).toEqual([
+        { x: 'Opening', start: 0, end: 1000, delta: 1000, kind: 'total' },
+        { x: 'Sales', start: 1000, end: 1400, delta: 400, kind: 'increase' },
+        { x: 'Returns', start: 1400, end: 1250, delta: -150, kind: 'decrease' },
+        { x: 'Closing', start: 0, end: 1250, delta: 1250, kind: 'total' },
+      ]);
+    });
+
+    it('reads the running totals plotly computed in preference to its own', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [waterfallTrace()],
+        layout: SINGLE_PANEL,
+        // As plotly leaves it: `v` is the total after the step, `rawS` the
+        // authored contribution, `s` the accumulated size it draws with.
+        calcdata: [[
+          { p: 0, s: 1000, rawS: 1000, isSum: true, v: 1000 },
+          { p: 1, s: 1400, rawS: 400, isSum: false, v: 1400 },
+          { p: 2, s: 1250, rawS: -150, isSum: false, v: 1250 },
+          { p: 3, s: 1250, rawS: 0, isSum: true, v: 1250 },
+        ]],
+      }));
+
+      expect(layer.data).toEqual([
+        { x: 'Opening', start: 0, end: 1000, delta: 1000, kind: 'total' },
+        { x: 'Sales', start: 1000, end: 1400, delta: 400, kind: 'increase' },
+        { x: 'Returns', start: 1400, end: 1250, delta: -150, kind: 'decrease' },
+        { x: 'Closing', start: 0, end: 1250, delta: 1250, kind: 'total' },
+      ]);
+    });
+
+    it('measures the steps from the trace base', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [waterfallTrace({
+          x: ['Sales'],
+          y: [400],
+          measure: ['relative'],
+          base: 500,
+        })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.data).toEqual([
+        { x: 'Sales', start: 500, end: 900, delta: 400, kind: 'increase' },
+      ]);
+    });
+
+    it('swaps the axis labels of a horizontal waterfall, which reads them fixed', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [waterfallTrace({
+          orientation: 'h',
+          y: ['Opening', 'Sales'],
+          x: [1000, 400],
+          measure: ['absolute', 'relative'],
+        })],
+        // Drawn sideways, so plotly's x carries the amounts and its y the
+        // steps — the opposite of how the layer has to name them.
+        layout: {
+          xaxis: { title: { text: 'Amount' }, domain: [0, 1] },
+          yaxis: { title: { text: 'Step' }, domain: [0, 1] },
+        },
+      }));
+
+      // WaterfallTrace names the step with the layer's x axis and the
+      // contribution with its y axis, whichever way plotly drew the bars.
+      expect(layer.axes?.x?.label).toBe('Step');
+      expect(layer.axes?.y?.label).toBe('Amount');
+      expect(layer.data).toEqual([
+        { x: 'Opening', start: 0, end: 1000, delta: 1000, kind: 'total' },
+        { x: 'Sales', start: 1000, end: 1400, delta: 400, kind: 'increase' },
+      ]);
+    });
+
+    it('scopes the highlight to the waterfall layer', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [waterfallTrace()],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.selectors).toBe('.subplot.xy .waterfalllayer .trace.bars .point > path');
+    });
+  });
+
+  describe('error bar traces', () => {
+    const SINGLE_PANEL = {
+      xaxis: { title: { text: 'Group' }, domain: [0, 1] as [number, number] },
+      yaxis: { title: { text: 'Mean' }, domain: [0, 1] as [number, number] },
+    };
+
+    function errorTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'scatter',
+        mode: 'markers',
+        x: ['A', 'B'],
+        y: [4.2, 5.1],
+        error_y: { visible: true, type: 'data', array: [0.4, 0.3] },
+        name: 'Treatment',
+        ...overrides,
+      };
+    }
+
+    function onlyLayer(gd: PlotlyGraphDiv): MaidrLayer {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it('binds a scatter carrying intervals as an error bar layer', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [errorTrace()],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.ERROR_BAR);
+      expect(layer.title).toBe('Treatment');
+      expect(layer.orientation).toBeUndefined();
+      // Absolute bounds, not the offsets the trace declared.
+      const data = layer.data as ErrorBarPoint[];
+      expect(data.map(point => point.x)).toEqual(['A', 'B']);
+      expect(data[0].yMin).toBeCloseTo(3.8, 10);
+      expect(data[0].yMax).toBeCloseTo(4.6, 10);
+      expect(data[1].yMin).toBeCloseTo(4.8, 10);
+      expect(data[1].yMax).toBeCloseTo(5.4, 10);
+    });
+
+    it('leaves a scatter whose intervals plotly turned off a scatter', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [errorTrace({
+          x: [1, 2],
+          error_y: { visible: false, type: 'data', array: [0.4, 0.3] },
+        })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.SCATTER);
+    });
+
+    it('prefers the bounds plotly resolved over recomputing them', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [errorTrace({ error_y: { visible: true, type: 'sqrt' } })],
+        layout: SINGLE_PANEL,
+        calcdata: [[
+          { x: 0, y: 4.2, ys: 2.15, yh: 6.25 },
+          { x: 1, y: 5.1, ys: 2.84, yh: 7.36 },
+        ]],
+      }));
+
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0]).toEqual({ x: 'A', y: 4.2, yMin: 2.15, yMax: 6.25 });
+      expect(data[1]).toEqual({ x: 'B', y: 5.1, yMin: 2.84, yMax: 7.36 });
+    });
+
+    it('reads the two sides separately when the trace declared them so', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [errorTrace({
+          error_y: {
+            visible: true,
+            type: 'data',
+            symmetric: false,
+            array: [0.4, 0.3],
+            arrayminus: [0.1, 0.2],
+          },
+        })],
+        layout: SINGLE_PANEL,
+      }));
+
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0].yMin).toBeCloseTo(4.1, 10);
+      expect(data[0].yMax).toBeCloseTo(4.6, 10);
+    });
+
+    it('resolves a percentage interval against each estimate', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [errorTrace({ error_y: { visible: true, type: 'percent', value: 10 } })],
+        layout: SINGLE_PANEL,
+      }));
+
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0].yMin).toBeCloseTo(3.78, 10);
+      expect(data[0].yMax).toBeCloseTo(4.62, 10);
+    });
+
+    it('reads a horizontal interval off the axis it was drawn on', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [{
+          type: 'scatter',
+          mode: 'markers',
+          y: ['Study A', 'Study B'],
+          x: [1.2, 0.8],
+          error_x: { visible: true, type: 'data', array: [0.3, 0.2] },
+        }],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0].x).toBe('Study A');
+      expect(data[0].y).toBe(1.2);
+      expect(data[0].yMin).toBeCloseTo(0.9, 10);
+      expect(data[0].yMax).toBeCloseTo(1.5, 10);
+      expect(layer.selectors)
+        .toBe('.subplot.xy .trace.scatter .errorbars > g.errorbar > path.xerror');
+    });
+
+    it('highlights the whip a bar trace hangs off its own group', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [errorTrace({ type: 'bar', mode: undefined })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.ERROR_BAR);
+      expect(layer.selectors).toBe('.subplot.xy .trace.bars > g.errorbar > path.yerror');
+    });
+
+    it('drops a sample plotly drew no estimate for, as it drew no whip', () => {
+      const layer = onlyLayer(createGraphDiv({
+        traces: [errorTrace({ x: ['A', 'B', 'C'], y: [4.2, null as unknown as number, 5.1] })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect((layer.data as ErrorBarPoint[]).map(point => point.x)).toEqual(['A', 'C']);
     });
   });
 });

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,5 +1,5 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyHierarchyNode, PlotlyTrace } from '@adapters/plotly/types';
-import type { BarPoint, BoxPoint, BoxSelector, ErrorBarPoint, GaugePoint, LinePoint, MaidrLayer, PiePoint, SegmentedPoint, TreemapPoint, ViolinKdePoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, BoxSelector, ChoroplethPoint, ErrorBarPoint, GanttData, GaugePoint, LinePoint, MaidrLayer, PiePoint, SegmentedPoint, TreemapPoint, ViolinKdePoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
@@ -1784,6 +1784,142 @@ describe('plotly extractor', () => {
       });
     });
 
+    it('constructs a navigable trace for each of the derived cartesian types', () => {
+      const day = 86400000;
+      const march = Date.UTC(2024, 2, 1);
+      const gd = createGraphDiv({
+        traces: [
+          {
+            type: 'bar',
+            orientation: 'h',
+            base: [march],
+            x: [4 * day],
+            y: ['Design'],
+            name: 'Team A',
+          },
+          {
+            type: 'bar',
+            orientation: 'h',
+            y: ['0-9'],
+            x: [-5],
+            name: 'Male',
+            xaxis: 'x2',
+            yaxis: 'y2',
+          },
+          {
+            type: 'bar',
+            orientation: 'h',
+            y: ['0-9'],
+            x: [5],
+            name: 'Female',
+            xaxis: 'x2',
+            yaxis: 'y2',
+          },
+          {
+            type: 'scatter',
+            mode: 'markers',
+            uid: 'dot1',
+            x: ['Chicago', 'Boston'],
+            y: [21, 17],
+            xaxis: 'x3',
+            yaxis: 'y3',
+          },
+          {
+            type: 'scatter',
+            mode: 'text',
+            uid: 'wc1',
+            x: [1, 2],
+            y: [2, 1],
+            text: ['sonification', 'braille'],
+            textfont: { size: [44, 18] },
+            xaxis: 'x4',
+            yaxis: 'y4',
+          },
+        ],
+        layout: twoByTwoLayout({
+          barmode: 'relative',
+          xaxis: { domain: [0, 0.45], type: 'date' },
+          yaxis: { domain: [0.575, 1], _categories: ['Design'] },
+        }),
+        bgRects: TWO_BY_TWO_RECTS,
+        calcdata: [[{ p: 0, s: 4 * day, b: march }]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        // Every payload is one the core's factory recognises and can build a
+        // trace from — the emitted shapes, not just the emitted type names.
+        expect(figure.getSubplotSummaries().map(summary => summary.traceTypes)).toEqual([
+          ['gantt'],
+          ['diverging_bar'],
+          ['dot'],
+          ['word_cloud'],
+        ]);
+        expect(figure.state).toMatchObject({ empty: false });
+      });
+    });
+
+    it('a plotly choropleth reaches the core as a map of regions', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'choropleth',
+          locations: ['FRA', 'DEU'],
+          z: [10, 20],
+          name: 'Europe',
+        }],
+        layout: { geo: { domain: { x: [0, 1], y: [0, 1] } } },
+        calcdata: [[
+          { loc: 'FRA', z: 10, ct: [2.2, 46.2] },
+          { loc: 'DEU', z: 20, ct: [10.4, 51.1] },
+        ]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.CHOROPLETH]);
+        expect(figure.state).toMatchObject({ empty: false });
+      });
+    });
+
+    it('a plotly ridgeline reaches the core as one layer of curves', () => {
+      const density = [
+        { v: 0.1, t: 1 },
+        { v: 0.4, t: 3 },
+      ];
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'violin', orientation: 'h', side: 'positive', x: [1, 3], name: 'A' },
+          { type: 'violin', orientation: 'h', side: 'positive', x: [2, 4], name: 'B' },
+        ],
+        layout: {
+          xaxis: { domain: [0, 1], title: { text: 'Score' } },
+          yaxis: { domain: [0, 1], _categories: ['A', 'B'] },
+        },
+        calcdata: [[{ pos: 0, density }], [{ pos: 1, density }]],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+
+      withDomGlobals(gd, () => {
+        const figure = new Figure(maidr!);
+        figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+        expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.RIDGELINE]);
+        expect(figure.state).toMatchObject({ empty: false });
+      });
+    });
+
     it('a plotly polar chart reaches the core as a radar trace', () => {
       const gd = createGraphDiv({
         traces: [{
@@ -3261,6 +3397,508 @@ describe('plotly extractor', () => {
       });
 
       expect(layer.data as LinePoint[][]).toHaveLength(2);
+    });
+  });
+  describe('ridgeline traces', () => {
+    /** One halved violin, with the KDE samples plotly computed for it. */
+    function ridgeCalc(pos: number): PlotlyCalcData {
+      return {
+        pos,
+        min: 1,
+        q1: 2,
+        med: 3,
+        q3: 4,
+        max: 9,
+        density: [
+          { v: 0.1, t: 1 },
+          { v: 0.4, t: 3 },
+          { v: 0.05, t: 9 },
+        ],
+      };
+    }
+
+    /** Plotly's own ridgeline recipe: horizontal violins, positive half only. */
+    function ridgeTraces(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace[] {
+      return [
+        { type: 'violin', orientation: 'h', side: 'positive', x: [1, 3, 9], name: 'A', ...overrides },
+        { type: 'violin', orientation: 'h', side: 'positive', x: [2, 4, 8], name: 'B', ...overrides },
+      ];
+    }
+
+    const RIDGE_LAYOUT: PlotlyFullLayout = {
+      xaxis: { domain: [0, 1], title: { text: 'Score' } },
+      yaxis: { domain: [0, 1], title: { text: 'Group' }, _categories: ['A', 'B'] },
+    };
+
+    function ridgeLayers(traces: PlotlyTrace[] = ridgeTraces()): MaidrLayer[] {
+      const gd = createGraphDiv({
+        traces,
+        layout: RIDGE_LAYOUT,
+        calcdata: [[ridgeCalc(0)], [ridgeCalc(1)]],
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers;
+    }
+
+    it('emits one ridgeline layer in place of the violin pair', () => {
+      const layers = ridgeLayers();
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.RIDGELINE);
+    });
+
+    it('reads plotly\'s density samples, curves top first', () => {
+      const data = ridgeLayers()[0].data as ViolinKdePoint[][];
+
+      // The last trace is drawn at the top of a horizontal position axis, and
+      // the ridgeline trace reverses nothing of its own.
+      expect(data.map(curve => curve[0].x)).toEqual(['B', 'A']);
+      expect(data[0][1]).toEqual({ x: 'B', y: 3, density: 0.4 });
+    });
+
+    it('names the value axis and the density, one selector per curve', () => {
+      const layer = ridgeLayers()[0];
+
+      expect(layer.axes?.x?.label).toBe('Score');
+      expect(layer.axes?.z?.label).toBe('Density');
+      expect(layer.selectors).toEqual([
+        '.subplot.xy .violinlayer > g:nth-child(2) > path.violin:nth-child(1)',
+        '.subplot.xy .violinlayer > g:nth-child(1) > path.violin:nth-child(1)',
+      ]);
+    });
+
+    it('keeps the violin pair when only some of the violins are halved', () => {
+      const layers = ridgeLayers([
+        { type: 'violin', orientation: 'h', side: 'positive', x: [1, 3, 9], name: 'A' },
+        { type: 'violin', orientation: 'h', x: [2, 4, 8], name: 'B' },
+      ]);
+
+      expect(layers.map(layer => layer.type)).toEqual([
+        TraceType.VIOLIN_BOX,
+        TraceType.VIOLIN_KDE,
+      ]);
+    });
+  });
+
+  describe('gantt traces', () => {
+    const DAY = 86400000;
+    const MARCH_1 = Date.UTC(2024, 2, 1);
+
+    /** A timeline as `plotly.express.timeline` emits one: bars floated on dates. */
+    function timelineTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'bar',
+        orientation: 'h',
+        base: [MARCH_1, MARCH_1 + 4 * DAY],
+        x: [4 * DAY, 6 * DAY],
+        y: ['Design', 'Build'],
+        name: 'Team A',
+        ...overrides,
+      };
+    }
+
+    /**
+     * The lane axis as plotly resolves it for a timeline: categories, with the
+     * range reversed so the first task sits at the top.
+     */
+    function timelineLayout(extra: Partial<PlotlyFullLayout> = {}): PlotlyFullLayout {
+      return {
+        xaxis: { domain: [0, 1], type: 'date', title: { text: 'Date' } },
+        yaxis: {
+          domain: [0, 1],
+          type: 'category',
+          title: { text: 'Task' },
+          _categories: ['Design', 'Build', 'Ship'],
+          range: [2.5, -0.5],
+        },
+        ...extra,
+      };
+    }
+
+    function ganttLayer(
+      traces: PlotlyTrace[] = [timelineTrace()],
+      calcdata?: PlotlyCalcData[][],
+    ): MaidrLayer {
+      const gd = createGraphDiv({
+        traces,
+        layout: timelineLayout(),
+        calcdata: calcdata ?? [[
+          { p: 0, s: 4 * DAY, b: MARCH_1 },
+          { p: 1, s: 6 * DAY, b: MARCH_1 + 4 * DAY },
+        ]],
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers).toHaveLength(1);
+      return layers[0];
+    }
+
+    it('reads the intervals plotly floated onto the date axis', () => {
+      const layer = ganttLayer();
+
+      expect(layer.type).toBe(TraceType.GANTT);
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      const data = layer.data as GanttData;
+      // Scaled into the unit the lengths are announced in, so a task reads as
+      // four days rather than as 345,600,000.
+      expect(data.points[0]).toEqual([
+        { x: 'Design', start: MARCH_1 / DAY, end: MARCH_1 / DAY + 4 },
+      ]);
+      expect(data.unit).toBe('days');
+    });
+
+    it('keeps a lane nothing was booked in', () => {
+      const data = ganttLayer().data as GanttData;
+
+      expect(data.lanes).toEqual(['Design', 'Build', 'Ship']);
+      expect(data.points[2]).toEqual([]);
+    });
+
+    it('takes the axis format back to the instant the position names', () => {
+      const format = ganttLayer().axes?.x?.format;
+
+      expect(format?.function).toContain('new Date(value * 86400000)');
+      // eslint-disable-next-line no-new-func
+      const render = new Function('value', format!.function!) as (v: number) => string;
+      expect(render(MARCH_1 / DAY)).toContain('2024');
+    });
+
+    it('addresses each interval by its own bar', () => {
+      expect(ganttLayer().selectors).toEqual([
+        '.subplot.xy .barlayer > g.trace.bars:nth-of-type(1) > g.points > g.point:nth-of-type(1) > path',
+        '.subplot.xy .barlayer > g.trace.bars:nth-of-type(1) > g.points > g.point:nth-of-type(2) > path',
+      ]);
+    });
+
+    it('merges the traces plotly.express splits a schedule into by colour', () => {
+      const layer = ganttLayer(
+        [
+          timelineTrace({ base: [MARCH_1], x: [4 * DAY], y: ['Design'], name: 'Alice' }),
+          timelineTrace({ base: [MARCH_1 + 4 * DAY], x: [6 * DAY], y: ['Design'], name: 'Bob' }),
+        ],
+        [
+          [{ p: 0, s: 4 * DAY, b: MARCH_1 }],
+          [{ p: 0, s: 6 * DAY, b: MARCH_1 + 4 * DAY }],
+        ],
+      );
+
+      const data = layer.data as GanttData;
+      expect(data.points[0]).toHaveLength(2);
+      expect(layer.selectors).toEqual([
+        '.subplot.xy .barlayer > g.trace.bars:nth-of-type(1) > g.points > g.point:nth-of-type(1) > path',
+        '.subplot.xy .barlayer > g.trace.bars:nth-of-type(2) > g.points > g.point:nth-of-type(1) > path',
+      ]);
+    });
+
+    it('parses the dates plotly.py writes as strings when calcdata is absent', () => {
+      const layer = ganttLayer(
+        [timelineTrace({ base: ['2024-03-01T00:00:00Z'], x: [2 * DAY], y: ['Design'] })],
+        [],
+      );
+
+      const data = layer.data as GanttData;
+      expect(data.points[0][0].start).toBe(MARCH_1 / DAY);
+      expect(data.points[0][0].end).toBe(MARCH_1 / DAY + 2);
+    });
+
+    it('leaves a horizontal bar chart with no base a bar chart', () => {
+      const gd = createGraphDiv({
+        traces: [{ type: 'bar', orientation: 'h', x: [4, 6], y: ['Design', 'Build'] }],
+        layout: timelineLayout(),
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+    });
+  });
+
+  describe('diverging bars', () => {
+    function pyramidTraces(left: number[], right: number[]): PlotlyTrace[] {
+      return [
+        { type: 'bar', orientation: 'h', y: ['0-9', '10-19'], x: left, name: 'Male' },
+        { type: 'bar', orientation: 'h', y: ['0-9', '10-19'], x: right, name: 'Female' },
+      ];
+    }
+
+    function barLayer(traces: PlotlyTrace[]): MaidrLayer {
+      const gd = createGraphDiv({
+        traces,
+        layout: {
+          barmode: 'relative',
+          xaxis: { domain: [0, 1], title: { text: 'Population' } },
+          yaxis: { domain: [0, 1], title: { text: 'Age band' } },
+        },
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('reads two opposed sides as a pyramid, keeping the signs', () => {
+      const layer = barLayer(pyramidTraces([-5, -7], [5, 6]));
+
+      expect(layer.type).toBe(TraceType.DIVERGING);
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      const data = layer.data as SegmentedPoint[][];
+      // The sign is the side rather than a magnitude, and the trace reads it
+      // as one — so it must survive into the payload.
+      expect(data[0][0]).toEqual({ x: -5, y: '0-9', z: 'Male' });
+      expect(data[1][1]).toEqual({ x: 6, y: '10-19', z: 'Female' });
+      expect(layer.selectors).toBe('.subplot.xy .trace.bars .point > path');
+    });
+
+    it('leaves a stack whose series grow the same way alone', () => {
+      expect(barLayer(pyramidTraces([5, 7], [5, 6])).type).toBe(TraceType.STACKED);
+    });
+
+    it('leaves a series that crosses the baseline alone', () => {
+      expect(barLayer(pyramidTraces([-5, 7], [5, 6])).type).toBe(TraceType.STACKED);
+    });
+  });
+
+  describe('dot plots', () => {
+    function dotLayer(overrides: Partial<PlotlyTrace> = {}): MaidrLayer {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'scatter',
+          mode: 'markers',
+          uid: 'abc123',
+          x: ['Chicago', 'Boston', 'Denver'],
+          y: [21, 17, 24],
+          name: 'Median rent',
+          ...overrides,
+        }],
+        layout: {
+          xaxis: { domain: [0, 1], title: { text: 'City' } },
+          yaxis: { domain: [0, 1], title: { text: 'Rent' } },
+        },
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('reads one marker per category as a dot plot', () => {
+      const layer = dotLayer();
+
+      expect(layer.type).toBe(TraceType.DOT);
+      expect(layer.orientation).toBeUndefined();
+      expect(layer.data as BarPoint[]).toEqual([
+        { x: 'Chicago', y: 21 },
+        { x: 'Boston', y: 17 },
+        { x: 'Denver', y: 24 },
+      ]);
+    });
+
+    it('reads the categories off whichever axis carries them', () => {
+      const layer = dotLayer({ x: [21, 17], y: ['Chicago', 'Boston'] });
+
+      expect(layer.type).toBe(TraceType.DOT);
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      expect(layer.data as BarPoint[]).toEqual([
+        { x: 21, y: 'Chicago' },
+        { x: 17, y: 'Boston' },
+      ]);
+    });
+
+    it('scopes the highlight to the trace\'s own markers', () => {
+      // The subplot prefix alone would take in every scatter on the panel,
+      // and a bar-shaped layer pairs its selector with its own points.
+      expect(dotLayer().selectors)
+        .toBe('.subplot.xy .scatterlayer g.trace.traceabc123 .point');
+    });
+
+    it('leaves a scatter that draws a category twice alone', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'scatter',
+          mode: 'markers',
+          uid: 'abc123',
+          x: ['Chicago', 'Chicago', 'Boston'],
+          y: [21, 19, 17],
+        }],
+        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
+      });
+
+      // Still a scatter — and a scatter of labels has no numeric coordinates
+      // to emit, which is what it already did before dot plots were read.
+      expect(extractPlotlyData(gd)).toBeNull();
+    });
+  });
+
+  describe('word clouds', () => {
+    function cloudLayer(overrides: Partial<PlotlyTrace> = {}): MaidrLayer {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'scatter',
+          mode: 'text',
+          uid: 'wc1',
+          x: [3, 1, 2],
+          y: [2, 1, 3],
+          text: ['sonification', 'braille', 'audio'],
+          textfont: { size: [44, 18, 30] },
+          name: 'Terms',
+          ...overrides,
+        }],
+        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('reads a text scatter with per-term glyph sizes as a cloud', () => {
+      const layer = cloudLayer();
+
+      expect(layer.type).toBe(TraceType.WORD_CLOUD);
+      expect(layer.data).toEqual([
+        { x: 'sonification', y: 44 },
+        { x: 'braille', y: 18 },
+        { x: 'audio', y: 30 },
+      ]);
+      expect(layer.axes?.x?.label).toBe('Term');
+      expect(layer.axes?.y?.label).toBe('Weight');
+    });
+
+    it('prefers a weight the author carried over the glyph size', () => {
+      const layer = cloudLayer({ customdata: [1200, 300, 640] });
+
+      expect((layer.data as { y: number }[]).map(point => point.y))
+        .toEqual([1200, 300, 640]);
+    });
+
+    it('highlights the glyph, which is the only mark the cloud draws', () => {
+      expect(cloudLayer().selectors)
+        .toBe('.subplot.xy .scatterlayer g.trace.tracewc1 g.textpoint > text');
+    });
+
+    it('leaves a text scatter with one glyph size a scatter', () => {
+      const gd = createGraphDiv({
+        traces: [{
+          type: 'scatter',
+          mode: 'markers+text',
+          uid: 'wc1',
+          x: [1, 2],
+          y: [3, 4],
+          text: ['a', 'b'],
+          textfont: { size: 12 },
+        }],
+        layout: { xaxis: { domain: [0, 1] }, yaxis: { domain: [0, 1] } },
+      });
+
+      expect(extractPlotlyData(gd)!.subplots[0][0].layers[0].type)
+        .toBe(TraceType.SCATTER);
+    });
+  });
+
+  describe('choropleth traces', () => {
+    function choroplethTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'choropleth',
+        locations: ['FRA', 'DEU', 'ITA'],
+        z: [10, 20, 30],
+        text: ['France', 'Germany', 'Italy'],
+        colorbar: { title: { text: 'GDP' } },
+        name: 'Europe',
+        ...overrides,
+      };
+    }
+
+    /** What plotly leaves once the map has been projected. */
+    function choroplethCalc(): PlotlyCalcData[] {
+      return [
+        { loc: 'FRA', z: 10, ct: [2.2, 46.2] },
+        { loc: 'DEU', z: 20, ct: [10.4, 51.1] },
+        { loc: 'ITA', z: 30, ct: [12.6, 42.8] },
+      ];
+    }
+
+    function choroplethLayer(
+      trace: PlotlyTrace = choroplethTrace(),
+      calcdata: PlotlyCalcData[] = choroplethCalc(),
+    ): MaidrLayer {
+      const gd = createGraphDiv({
+        traces: [trace],
+        layout: { geo: { domain: { x: [0, 1], y: [0, 1] } } },
+        calcdata: [calcdata],
+      });
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('reads the regions with the centroids plotly resolved for them', () => {
+      const layer = choroplethLayer();
+
+      expect(layer.type).toBe(TraceType.CHOROPLETH);
+      expect(layer.data as ChoroplethPoint[]).toEqual([
+        { x: 'France', y: 10, lon: 2.2, lat: 46.2 },
+        { x: 'Germany', y: 20, lon: 10.4, lat: 51.1 },
+        { x: 'Italy', y: 30, lon: 12.6, lat: 42.8 },
+      ]);
+      // The colorbar is the only place a choropleth names its magnitude.
+      expect(layer.axes?.y?.label).toBe('GDP');
+      expect(layer.axes?.x?.label).toBe('Region');
+    });
+
+    it('falls back to the location code when nothing names the region', () => {
+      const layer = choroplethLayer(choroplethTrace({ text: undefined }));
+
+      expect((layer.data as ChoroplethPoint[]).map(point => point.x))
+        .toEqual(['FRA', 'DEU', 'ITA']);
+    });
+
+    it('leaves the centroid off a map plotly has not projected', () => {
+      const layer = choroplethLayer(choroplethTrace(), []);
+
+      expect(layer.data as ChoroplethPoint[]).toEqual([
+        { x: 'France', y: 10 },
+        { x: 'Germany', y: 20 },
+        { x: 'Italy', y: 30 },
+      ]);
+    });
+
+    it('drops a region plotly could not shade, keeping the others\' shapes', () => {
+      const layer = choroplethLayer(choroplethTrace(), [
+        { loc: 'FRA', z: 10, ct: [2.2, 46.2] },
+        { loc: null, z: undefined },
+        { loc: 'ITA', z: 30, ct: [12.6, 42.8] },
+      ]);
+
+      expect((layer.data as ChoroplethPoint[]).map(point => point.x))
+        .toEqual(['France', 'Italy']);
+      // The dropped region keeps its own path in the DOM, so the ones after it
+      // are still addressed by their own position.
+      expect(layer.selectors).toEqual([
+        '.geolayer > g.geo.geo > g.backplot > g.choroplethlayer > g.trace.choropleth:nth-of-type(1) > path.choroplethlocation:nth-of-type(1)',
+        '.geolayer > g.geo.geo > g.backplot > g.choroplethlayer > g.trace.choropleth:nth-of-type(1) > path.choroplethlocation:nth-of-type(3)',
+      ]);
+    });
+
+    it('keeps a geo subplot apart from the cartesian panel beside it', () => {
+      const gd = createGraphDiv({
+        traces: [
+          { type: 'bar', x: ['a', 'b'], y: [1, 2], name: 'Counts' },
+          choroplethTrace({ geo: 'geo2' }),
+        ],
+        layout: {
+          xaxis: { domain: [0, 0.45] },
+          yaxis: { domain: [0, 1] },
+          geo2: { domain: { x: [0.55, 1], y: [0, 1] } },
+        },
+        calcdata: [[], choroplethCalc()],
+      });
+
+      const maidr = extractPlotlyData(gd);
+
+      expect(maidr!.subplots[0]).toHaveLength(2);
+      expect(maidr!.subplots[0].map(panel => panel.layers[0].type))
+        .toEqual([TraceType.BAR, TraceType.CHOROPLETH]);
+      expect(maidr!.subplots[0][1].layers[0].selectors)
+        .toEqual(expect.arrayContaining([expect.stringContaining('g.geo.geo2')]));
     });
   });
 });


### PR DESCRIPTION
## Description

The `plotly` adapter had not kept up with the trace types MAIDR core gained
since the pie chart: of the types in scope it emitted none, so a chart
plotly.js draws perfectly well was either dropped from the figure or announced
as the wrong chart.

This adds **20 of the 21 in-scope trace types**, taking the adapter from 9 to
29 recognised Plotly constructs. The work is adapter-local — detection,
payload construction and highlight selectors only. No file under `src/model/`,
`src/service/`, `src/state/`, `src/ui/`, `src/command/` or `src/type/grammar.ts`
is touched; the core already supported every payload emitted here.

Each type is wired end to end in the same change: detection, the grammar
payload, **and** the CSS selector path. A type that sonifies but does not
highlight was not counted as done.

## Related Issues

Closes #861

## Changes Made

### Trace types added (20)

| TraceType | Detected from |
|---|---|
| `AREA` | `scatter` with `fill` other than `none`, no `stackgroup` |
| `STACKED_AREA` | `scatter` with `stackgroup` |
| `NORMALIZED_AREA` | `stackgroup` + `groupnorm: 'percent' \| 'fraction'` |
| `FUNNEL` | `type: 'funnel'` |
| `WATERFALL` | `type: 'waterfall'` |
| `ERROR_BAR` | visible `error_y` / `error_x` on a scatter or bar trace |
| `SUNBURST` | `type: 'sunburst'` |
| `ICICLE` | `type: 'icicle'` |
| `TREEMAP` | `type: 'treemap'` |
| `SANKEY` | `type: 'sankey'` |
| `GAUGE` | `type: 'indicator'` with `gauge` in `mode` |
| `RADAR` | `type: 'scatterpolar'` |
| `POLAR_AREA` | `type: 'barpolar'` |
| `PARALLEL` | `type: 'parcoords'` |
| `RIDGELINE` | `violin` traces with `side: 'positive'` |
| `GANTT` | horizontal `bar` traces with a `base` array on a date axis |
| `DIVERGING` | `barmode: 'relative'` + bar traces with opposed signs |
| `DOT` | `scatter`, `mode: 'markers'`, one marker per category |
| `WORD_CLOUD` | `scatter`, `mode: 'text'`, array `textfont.size` |
| `CHOROPLETH` | `type: 'choropleth'` |

### Trace types NOT added

- **`ALLUVIAL`** (`parcats`) — skipped. Two blockers, both verified against
  upstream. (1) `traces/parcats/calc.js` models a path as a full
  N-dimensional `categoryInds` tuple keyed across *all* dimensions plus
  colour, not as pairwise flows; deriving `FlowPoint`s would mean inventing a
  pairwise re-aggregation rather than reading what Plotly computed, against
  the adapter's calcdata-first convention. (2) `FlowPoint` keys its nodes by
  *label* and has no id field, so the same category label recurring in several
  dimensions (`"Yes"` under both `Survived` and `Smoker`) would fold into one
  node and produce a cyclic graph with wrong totals. Stage-qualifying the
  names, as the issue suggests, makes the node labels an adapter invention
  rather than the chart's own text. Additionally `traces/parcats/parcats.js`
  draws one `path.path` per whole path across every dimension, so there is no
  DOM element per pairwise flow to attach a highlight to.

The following were declared out of scope by the issue itself and are not
attempted here: `CONTOUR` and `MOSAIC` (deferred to a follow-up), and
`BOXEN` / `CHORD` / `HEXBIN` (not renderable by plotly.js).

`choroplethmapbox`, `choroplethmap`, `scattergeo` and the 3D traces continue
to warn as unsupported — they draw to a WebGL canvas with no element per
region, so there is nothing to highlight.

### Shared machinery

- `groupTracesBySubplot` generalised from the one hand-written pie exception
  into a panel-key + domain resolver. Domain-positioned types
  (`DOMAIN_POSITIONED_TYPES`) and subplot-keyed families (`POLAR_TYPES`,
  `GEO_TYPES`) are now one set entry plus a `mapTraceType` case.
- `extractMultiLineLayer` made generic over the line family; `extractBarLayer`
  parameterised by emitted type; new `extractHierarchyLayer` shared by
  sunburst / icicle / treemap.
- `drawnBefore`, `scatterTraceScope`, `polarSeriesSelectors`,
  `barPointSelector` in `selectors.ts` for the layers Plotly hangs no uid
  class on.

### Docs and examples

- `docs/plotly.md` support matrix extended, per-type detection notes added,
  and the type count updated 9 → 29.
- 15 new `examples/plotly-*.html` files, one per new chart family.

### Tests

175 unit tests under `test/adapters/plotly/`, including `core-model
integration` cases that round-trip the emitted payloads through a real
`Figure` so the payload *shape*, not just the type string, is checked against
what `TraceFactory` can build.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is left unticked deliberately: `ManualTestingProcess.md`
is not present in the repo, and plotly.js is not a dependency (the examples
load it from a CDN), so no rendered-chart pass was performed. The automated
gate below is green.

## Additional Notes

### Verification method

Because plotly.js is not in `node_modules`, every behavioural claim was checked
against the upstream source over the network rather than against the issue
spec. That caught several spec claims that would have shipped bugs:

- Waterfall does **not** get `s0`/`s1` from its own calc — those arrive later
  from bar's `setGroupPositions` as pixel-layout helpers. The authority is
  `traces/waterfall/hover.js`; reading `cd.s` for the contribution announces
  the running total twice.
- For stacked/normalized area, `calcdata[i][j].y` is the **cumulative** value,
  not the band — feeding it to `AreaTrace` double-counts every series.
- For diverging bars, `cd.s` keeps the signed authored size (contrary to the
  spec), so the existing segmented-bar extractor works unchanged.
- Emitting a hierarchy in authored order would have misaligned every
  highlight, since Plotly re-sorts children by value; the adapter walks the
  computed tree instead.

### Known limitations

- A **lines-only area or line** trace gets no highlight, matching existing
  LINE/STEP behaviour — `lineSelector` returns a selector only when the trace
  has markers. Fixing it properly means per-segment path parsing that breaks
  on gapped series, and would touch LINE/STEP too; worth its own change.
- `parcoords` draws to canvas, so the layer carries no selectors — audio,
  text, braille and navigation work, visual highlighting does not.
- A hierarchy authored with `ids` **and** duplicate sibling labels collapses,
  because the grammar keys the tree by label path. A grammar limitation, not
  an adapter one.
- `trace.node.groups` on a sankey generates nodes past `node.label`, which
  fall back to their index as a name.
- A gantt whose bar traces carry `ids` gets d3-keyed groups that can reorder
  on update and desynchronise the selectors (first render is fine). Its axis
  formatter uses `new Function`, which a strict-CSP page refuses —
  `FormatUtil.resolveFormat` catches that and falls back, so positions then
  read as scaled numbers rather than dates. A panel mixing a schedule with an
  ordinary bar chart stays a bar chart.
- Gauge qualitative bands are emitted only when the author named every step,
  since Plotly's steps carry a range and colour but no required name — an
  invented "band 2" would say nothing the numbers do not.

### Gate

`npm run lint:fix`, `npm run type-check` (both tsconfigs), `npm run build` and
`npm test` all pass; `npm run sync:copilot:check` reports in sync. Full suite:
187 suites / 2711 tests plus the ESM project's 7 suites / 73 tests, all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_