### PR TITLE
feat(recharts): support the chart types added since the pie chart

### DIFF
--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -137,6 +137,11 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'stacked_bar'` | `<Bar stackId="...">` | Stacked bar chart (multiple `yKeys`) |
 | `'dodged_bar'` | Multiple `<Bar>` | Grouped/side-by-side bar chart (multiple `yKeys`) |
 | `'normalized_bar'` | `<Bar stackId="...">` | 100% stacked bar chart (multiple `yKeys`) |
+| `'diverging_bar'` | `<BarChart stackOffset="sign">` | Population pyramid / Likert: two sides of a shared baseline (exactly two `yKeys`) |
+| `'waterfall'` | `<Bar>` with a `[start, end]` `dataKey` | A total carried through signed contributions (`waterfallConfig`) |
+| `'dumbbell'` | `<Bar>` with a `[start, end]` `dataKey` | Two values compared per category (exactly two `yKeys`) |
+| `'gantt'` | `<BarChart layout="vertical">` + floating `<Bar>` | Intervals laid out in lanes (`ganttConfig`) |
+| `'gauge'` | `<RadialBarChart>` + `<RadialBar>` | One measure against a range (`gaugeConfig`) |
 | `'dot'` | `<Scatter>` | Cleveland dot plot: one point per category |
 | `'lollipop'` | `<Bar barSize={2}>` + `<Scatter>` | Lollipop chart: a stem and a head |
 | `'funnel'` | `<FunnelChart>` + `<Funnel>` | Funnel chart: a population shrinking across ordered stages |
@@ -155,6 +160,8 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'forest'` | `<ScatterChart layout="vertical">` + `<ErrorBar direction="x">` | Forest plot (`errorConfig` + `forestConfig`) |
 | `'pie'` | `<Pie>` | Pie chart (a doughnut is a `<Pie>` with an `innerRadius`) |
 | `'alluvial'` | `<Sankey>` | Weighted flow between nodes (`flowConfig`) |
+| `'treemap'` | `<Treemap>` | A hierarchy laid out as nested area (nested `data`) |
+| `'sunburst'` | `<SunburstChart>` | The same hierarchy drawn as rings (nested `data`) |
 
 ## Data Examples by Chart Type
 
@@ -777,6 +784,234 @@ const links = [
 
 MAIDR reads this as a graph rather than a grid: following a ribbon is the primary move, and arrow keys step between a node and the flows that leave or arrive at it. Highlighting pairs each flow with the `<path class="recharts-sankey-link">` at the same position, so the `links` array order is the order the ribbons are announced in.
 
+### Diverging Bar Chart (Population Pyramid)
+
+Two series drawn back to back across a shared category axis. Declare **exactly two `yKeys`, the left-hand side first**, and give the left side **negative** values — the same numbers `<BarChart stackOffset="sign">` needs:
+
+```tsx
+const data = [
+  { band: '0-9', men: -2_100_000, women: 2_000_000 },
+  { band: '10-19', men: -1_900_000, women: 1_850_000 },
+];
+
+<MaidrRecharts
+  id="pyramid-example"
+  title="Population by Age Band"
+  data={data}
+  chartType="diverging_bar"
+  xKey="band"
+  yKeys={['men', 'women']}
+  fillKeys={['Men', 'Women']}
+  orientation={Orientation.HORIZONTAL}
+  xLabel="Age band"
+  yLabel="People"
+>
+  <BarChart width={600} height={400} layout="vertical" stackOffset="sign" data={data}>
+    <XAxis type="number" />
+    <YAxis type="category" dataKey="band" />
+    <Bar dataKey="men" stackId="sides" fill="#8884d8" />
+    <Bar dataKey="women" stackId="sides" fill="#82ca9d" />
+  </BarChart>
+</MaidrRecharts>
+```
+
+The sign is read as the **side**, not the magnitude: MAIDR pitches the size of the bar and announces which way it points, so the biggest bar on the left is not heard as the lowest note on the chart. It also announces the **balance** — what one side has over the other — at every band, which is the subtraction a pyramid is drawn back to back to support.
+
+Order matters twice. The sides are read in **declaration order**, so the `yKeys` must run left then right, and the `<Bar>` elements must be declared in that same order for highlighting to land on the right one. Declared with a single `yKey` the layer falls back to a plain bar chart, since a pyramid with one side is not one.
+
+### Waterfall Chart
+
+The single `yKeys` entry names each step's **contribution**; the adapter accumulates the running totals, because a waterfall bar floats between the total before the step and the total after it and neither number is in the data.
+
+```tsx
+const data = [
+  { step: 'Opening', change: 1200, restates: true },
+  { step: 'New sales', change: 450 },
+  { step: 'Churn', change: -180 },
+  { step: 'Upsell', change: 90 },
+  { step: 'Closing', restates: true },
+];
+
+<MaidrRecharts
+  id="waterfall-example"
+  title="Revenue Bridge"
+  data={data}
+  chartType="waterfall"
+  xKey="step"
+  yKeys={['change']}
+  waterfallConfig={{ totalKey: 'restates' }}
+  xLabel="Step"
+  yLabel="Revenue ($k)"
+>
+  <BarChart width={600} height={350} data={steps}>
+    <XAxis dataKey="x" />
+    <YAxis />
+    <Bar dataKey={(step) => [step.start, step.end]} fill="#8884d8" />
+  </BarChart>
+</MaidrRecharts>
+```
+
+A row flagged by `totalKey` (or listed in `totalIndices`, for data with no flag column) **restates** the running total rather than changing it — an opening balance, a subtotal, a closing balance. It sits on the baseline, and it need carry no number of its own: the `Closing` row above restates whatever the steps came to. `kindKey` names the kind outright when the data already holds it.
+
+Draw the chart from a **floating bar** — a `<Bar>` whose `dataKey` returns a `[start, end]` pair — and it renders exactly one rectangle per step, which is what the default selector targets. Those are the same totals the adapter computes, so read them back off the layer instead of accumulating twice:
+
+```tsx
+const maidrData = useRechartsAdapter(config);
+const steps = maidrData.subplots[0][0].layers[0].data as WaterfallPoint[];
+```
+
+The other recipe — a transparent offset `<Bar>` stacked under a visible one — draws **two** rectangles per step, and the default selector matches both. Give the visible bar a `className` and pass the narrowed selector as `selectorOverride`:
+
+```tsx
+<Bar dataKey="base" stackId="w" fill="transparent" />
+<Bar dataKey="change" stackId="w" className="wf-delta" />
+// selectorOverride: '.wf-delta .recharts-bar-rectangle .recharts-rectangle'
+```
+
+### Dumbbell Chart
+
+Two values compared at each category, joined by a segment. Two `yKeys`, the starting end first, and `fillKeys` names them:
+
+```tsx
+const data = [
+  { country: 'Japan', then: 78.9, now: 84.6 },
+  { country: 'Russia', then: 69.2, now: 68.9 },
+];
+
+<MaidrRecharts
+  id="dumbbell-example"
+  title="Life Expectancy, 1990 against 2020"
+  data={data}
+  chartType="dumbbell"
+  xKey="country"
+  yKeys={['then', 'now']}
+  fillKeys={['1990', '2020']}
+  xLabel="Country"
+  yLabel="Years"
+>
+  <BarChart width={600} height={350} data={data}>
+    <XAxis dataKey="country" />
+    <YAxis />
+    <Bar dataKey={(row) => [row.then, row.now]} fill="#8884d8" />
+  </BarChart>
+</MaidrRecharts>
+```
+
+The two names are the content of the comparison. Announced as "start" and "end", a chart of life expectancy in 1990 against 2020 tells a reader which dot they are on and not which year it is — which is the one thing the legend gives a sighted reader for free. MAIDR derives the change rather than taking it from the data, so a row that declined (Russia, above) is announced as a decrease without anything extra declared.
+
+Highlighting pairs one element with each **row**, not with each dot: a chart draws one connector per row, so both ends highlight the same element. A dumbbell drawn as a `<ScatterChart>` with two `<Scatter>`s draws two symbols per row instead and needs a `selectorOverride` naming the connector shape.
+
+### Gantt Chart
+
+One data row is one interval: `xKey` names its lane and the two `yKeys` its start and end, both as positions on the same numeric axis.
+
+```tsx
+const data = [
+  { task: 'Design', from: 0, to: 5, phase: 'Wireframes' },
+  { task: 'Build', from: 3, to: 12, phase: 'Alpha' },
+  { task: 'Build', from: 14, to: 18, phase: 'Beta' },
+];
+
+<MaidrRecharts
+  id="gantt-example"
+  title="Release Plan"
+  data={data}
+  chartType="gantt"
+  xKey="task"
+  yKeys={['from', 'to']}
+  ganttConfig={{ lanes: ['Design', 'Build', 'Launch'], labelKey: 'phase', unit: 'days' }}
+  xLabel="Task"
+  yLabel="Day"
+>
+  <BarChart width={600} height={350} layout="vertical" data={data}>
+    <XAxis type="number" />
+    <YAxis type="category" dataKey="task" />
+    <Bar dataKey={(row) => [row.from, row.to]} fill="#8884d8" />
+  </BarChart>
+</MaidrRecharts>
+```
+
+Declare `lanes` so that a lane with **nothing booked still exists** — `Launch` above holds no row, and nothing booked is a real statement about a schedule that a list grouped by task cannot make. A lane a row names but the list omits is appended rather than dropped. `unit` names what a unit of the axis is; without it the length of an interval is announced as a bare number.
+
+Dates have to arrive as **epoch milliseconds**: a `Date` is not a position on a numeric axis.
+
+MAIDR puts the interval's length on pitch and its start on stereo position, so two lanes whose work lines up sound like they line up. That is the overlap question answered by ear, and it is the reason a gantt gets a trace type rather than being read as a table.
+
+Highlighting needs the rows **grouped by lane, in the lane order** — Recharts draws one rectangle per row in row order, while the payload is walked lane by lane. The adapter checks this and turns highlighting off for the layer when the rows interleave lanes, rather than highlighting somebody else's task.
+
+### Gauge Chart
+
+One measure read against a range. The data holds a single row; everything else the reading needs is author knowledge and arrives through `gaugeConfig`, which is therefore required:
+
+```tsx
+const data = [{ measure: 'NPS', score: 73 }];
+
+<MaidrRecharts
+  id="gauge-example"
+  title="Net Promoter Score"
+  data={data}
+  chartType="gauge"
+  xKey="measure"
+  yKeys={['score']}
+  gaugeConfig={{
+    min: 0,
+    max: 100,
+    target: 80,
+    bands: [{ to: 40, label: 'poor' }, { to: 70, label: 'ok' }, { to: 100, label: 'good' }],
+  }}
+>
+  <RadialBarChart
+    width={400} height={250}
+    innerRadius={80} outerRadius={140}
+    startAngle={180} endAngle={0}
+    data={data}
+  >
+    <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+    <RadialBar dataKey="score" fill="#8884d8" background />
+  </RadialBarChart>
+</MaidrRecharts>
+```
+
+"73" is not the reading. "73 out of 100, 7 below target, in the 'ok' band" is, and a sighted reader gets all of it from the dial's geometry — the needle's position, the marker beside it, the coloured arc it lands on. None of that is written anywhere a screen reader can reach, and none of it is inferable from a `<RadialBar>`, so the range mirrors the chart's `domain` and the target and bands are declared.
+
+Bands are **ascending and bounded above only**: a band starts where the previous one ended, and the first starts at `min`. A value above every band belongs to none rather than to the last one. There is deliberately no default range — a guessed maximum misreports the one number the chart draws.
+
+### Treemap and Sunburst
+
+Both draw the same hierarchy, and both take the **nested** `{ name, children }` data Recharts itself is given rather than the adapter's usual flat rows. `xKey` is the `<Treemap nameKey>` and the single `yKeys` entry its `dataKey`:
+
+```tsx
+const nodes = [
+  { name: 'Europe', children: [{ name: 'France', people: 67.4 }, { name: 'Spain', people: 47.4 }] },
+  { name: 'Asia', children: [{ name: 'Japan', people: 125.1 }, { name: 'Nepal', people: 30.0 }] },
+];
+
+<MaidrRecharts
+  id="treemap-example"
+  title="Population by Region"
+  data={nodes}
+  chartType="treemap"
+  xKey="name"
+  yKeys={['people']}
+>
+  <Treemap width={600} height={350} data={nodes} dataKey="people" nameKey="name" />
+</MaidrRecharts>
+```
+
+A sunburst is the same config with `chartType="sunburst"`. Its Recharts component takes a single root object, and it draws that root's **children** — so pass the children here, and the declared nodes are then exactly the drawn ones:
+
+```tsx
+<MaidrRecharts id="sunburst-example" data={nodes} chartType="sunburst" xKey="name" yKeys={['people']}>
+  <SunburstChart width={400} height={400} data={{ name: 'World', children: nodes }} dataKey="people" />
+</MaidrRecharts>
+```
+
+MAIDR navigates the tree **as a tree**, on arrow keys that already exist: up returns to the parent, down enters the first child, left and right walk the siblings. Each node is announced with its exact share of its parent — the comparison the rectangles are drawn to support and the one the eye estimates worst.
+
+A node with children gets no value of its own, because Recharts computes an interior node's value as the sum of its children and ignores any value declared on it. MAIDR derives interior totals the same way.
+
+Highlighting relies on both components drawing their nodes in depth-first pre-order, which they do. The treemap selector deliberately skips the **synthetic root** rectangle Recharts wraps the data array in — it is one element more than there are nodes, and a count mismatch turns highlighting off entirely. A `<Treemap type="nest">`, or one given a custom `content`, draws something else and needs `selectorOverride`.
+
 ### Composed Chart (Bar + Line)
 
 Use `layers` mode to mix different chart types in a single chart:
@@ -905,6 +1140,11 @@ type RechartsChartType =
   | 'stacked_bar'
   | 'dodged_bar'
   | 'normalized_bar'
+  | 'diverging_bar'
+  | 'waterfall'
+  | 'dumbbell'
+  | 'gantt'
+  | 'gauge'
   | 'dot'
   | 'lollipop'
   | 'funnel'
@@ -922,7 +1162,9 @@ type RechartsChartType =
   | 'error_bar'
   | 'forest'
   | 'pie'
-  | 'alluvial';
+  | 'alluvial'
+  | 'treemap'
+  | 'sunburst';
 ```
 
 ### `RechartsLayerConfig`
@@ -1017,6 +1259,38 @@ interface SurvivalCurveConfig {
   yMinKeys?: string[];      // Keys for the lower confidence band, 1:1 with yKeys
   yMaxKeys?: string[];      // Keys for the upper confidence band, 1:1 with yKeys
   stepDirection?: StepDirection; // Where the curve jumps (defaults to 'hv')
+}
+```
+
+### `WaterfallStepConfig`
+
+```typescript
+interface WaterfallStepConfig {
+  totalKey?: string;      // Key whose truthy value marks a row as restating the total
+  totalIndices?: number[]; // Indices of the restating rows, for data with no flag column
+  kindKey?: string;       // Key holding 'increase' | 'decrease' | 'total' outright
+}
+```
+
+### `GanttChartConfig`
+
+```typescript
+interface GanttChartConfig {
+  lanes?: (string | number)[]; // The lanes in draw order — declare them to keep empty ones
+  labelKey?: string;           // Key naming an individual interval within its lane
+  unit?: string;               // What a unit of the axis is called ('days', 'hours')
+}
+```
+
+### `GaugeDialConfig`
+
+```typescript
+interface GaugeDialConfig {
+  min: number;         // Lower end of the dial — no default
+  max: number;         // Upper end of the dial — no default
+  target?: number;     // The target marker a bullet chart draws
+  bands?: GaugeBand[]; // Qualitative bands, ascending, upper edges only
+  label?: string;      // What the measure is called (defaults to the xKey value)
 }
 ```
 

--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -78,6 +78,11 @@ function AccessibleBarChart() {
 | `orientation` | `Orientation` | No | Bar orientation. Defaults to vertical. |
 | `fillKeys` | `string[]` | No | Display names for series in stacked/dodged/normalized charts. Maps 1:1 with `yKeys`. |
 | `binConfig` | `HistogramBinConfig` | Histogram only | Bin range configuration for histograms. |
+| `flowConfig` | `FlowLinkConfig` | Alluvial only | Target key and the `nodes` half of the `<Sankey>` data. |
+| `volcanoConfig` | `VolcanoPointConfig` | Volcano/Manhattan | Point labels, chromosome key and the significance/effect cutoffs. |
+| `errorConfig` | `ErrorIntervalConfig` | Error bar/forest | Which field holds the interval, as an offset or as absolute bounds. |
+| `forestConfig` | `ForestPlotConfig` | Forest only | Study weights, the pooled row, and the null line. |
+| `survivalConfig` | `SurvivalCurveConfig` | Survival only | Per-arm censoring and confidence band keys, and the step direction. |
 | `selectorOverride` | `string` | No | Custom CSS selector for SVG highlighting (see Advanced section). |
 
 ## Configuration Modes
@@ -134,6 +139,7 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'normalized_bar'` | `<Bar stackId="...">` | 100% stacked bar chart (multiple `yKeys`) |
 | `'dot'` | `<Scatter>` | Cleveland dot plot: one point per category |
 | `'lollipop'` | `<Bar barSize={2}>` + `<Scatter>` | Lollipop chart: a stem and a head |
+| `'funnel'` | `<FunnelChart>` + `<Funnel>` | Funnel chart: a population shrinking across ordered stages |
 | `'histogram'` | `<Bar>` | Histogram with bin ranges (requires `binConfig`) |
 | `'line'` | `<Line>` | Line chart |
 | `'area'` | `<Area>` | Area chart |
@@ -141,8 +147,14 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'normalized_area'` | `<AreaChart stackOffset="expand">` | 100% stacked area chart (multiple `yKeys`) |
 | `'radar'` | `<RadarChart>` + `<Radar>` | Radar/spider chart |
 | `'bump'` | `<LineChart>` + `<YAxis reversed>` | Bump chart: rank over time |
+| `'survival'` | `<Line type="stepAfter">` | Kaplan-Meier curve (optional `survivalConfig`) |
 | `'scatter'` | `<Scatter>` | Scatter/point plot |
+| `'volcano'` | `<ScatterChart>` + `<Scatter>` | Volcano plot: effect size against significance (`volcanoConfig`) |
+| `'manhattan'` | `<ScatterChart>` + `<Scatter>` | Manhattan plot: genomic position against significance (`volcanoConfig`) |
+| `'error_bar'` | `<ErrorBar>` inside `<Bar>`/`<Line>`/`<Scatter>` | An estimate with its interval (`errorConfig`) |
+| `'forest'` | `<ScatterChart layout="vertical">` + `<ErrorBar direction="x">` | Forest plot (`errorConfig` + `forestConfig`) |
 | `'pie'` | `<Pie>` | Pie chart (a doughnut is a `<Pie>` with an `innerRadius`) |
+| `'alluvial'` | `<Sankey>` | Weighted flow between nodes (`flowConfig`) |
 
 ## Data Examples by Chart Type
 
@@ -285,6 +297,40 @@ A lollipop has no Recharts primitive; compose a thin `<Bar>` stem with a `<Scatt
 ```
 
 Highlighting targets the head (`.recharts-scatter-symbol .recharts-symbols`), not the stem, because the head is where the value is read off. If you draw the lollipop with a custom `<Bar>` shape that renders its own dot, pass a `selectorOverride` pointing at that element instead.
+
+### Funnel Chart
+
+`xKey` is the stage label and the single `yKeys` entry its count, in the order the stages are drawn:
+
+```tsx
+const data = [
+  { stage: 'Visited', users: 10000 },
+  { stage: 'Signed up', users: 2400 },
+  { stage: 'Activated', users: 2300 },
+  { stage: 'Paid', users: 100 },
+];
+
+<MaidrRecharts
+  id="funnel-example"
+  title="Signup Funnel"
+  data={data}
+  chartType="funnel"
+  xKey="stage"
+  yKeys={['users']}
+  xLabel="Stage"
+  yLabel="Users"
+>
+  <FunnelChart width={600} height={350}>
+    <Funnel dataKey="users" nameKey="stage" data={data} fill="#8884d8">
+      <LabelList position="right" dataKey="stage" />
+    </Funnel>
+  </FunnelChart>
+</MaidrRecharts>
+```
+
+Pass the counts, never a pre-computed ratio. MAIDR sonifies the **retention** — what fraction of the previous stage survived — because that is the number a funnel is read for and the one a listener cannot take by ear from two heights heard one at a time: 2,300 to 100 keeps 4% while 10,000 to 2,400 keeps 24%, and on a raw scale the second sounds like the bigger fall.
+
+A funnel is never given an `orientation`. `FunnelTrace` is a bar trace, and a horizontal bar reads its category off `y`, so a leaked `orientation` would have every stage announced by its count.
 
 ### Histogram
 
@@ -471,6 +517,44 @@ const data = [
 
 > **Warning:** MAIDR inverts the pitch for a bump chart so rank 1 is the highest note, and announces the places gained or lost since the previous period. Declaring a chart of *values* as `'bump'` therefore sonifies it upside down — every rise heard as a fall. The adapter cannot tell the two apart, so this one is on you.
 
+### Survival Curve
+
+A Kaplan-Meier curve is a `<Line type="stepAfter">`. One `yKeys` entry per arm, and the per-arm keys in `survivalConfig` line up with it the way `fillKeys` does:
+
+```tsx
+const data = [
+  { months: 0, treated: 1.0, control: 1.0, treatedCensored: false },
+  { months: 6, treated: 0.88, control: 0.74, treatedCensored: true },
+  { months: 12, treated: 0.77, control: 0.52, treatedCensored: false },
+];
+
+<MaidrRecharts
+  id="survival-example"
+  title="Overall Survival"
+  data={data}
+  chartType="survival"
+  xKey="months"
+  yKeys={['treated', 'control']}
+  fillKeys={['Treatment', 'Control']}
+  survivalConfig={{ censoredKeys: ['treatedCensored'] }}
+  xLabel="Months"
+  yLabel="Survival probability"
+>
+  <LineChart width={600} height={350} data={data}>
+    <XAxis dataKey="months" />
+    <YAxis domain={[0, 1]} />
+    <Line type="stepAfter" dataKey="treated" stroke="#8884d8" dot />
+    <Line type="stepAfter" dataKey="control" stroke="#82ca9d" dot />
+  </LineChart>
+</MaidrRecharts>
+```
+
+Censoring is not an event: the curve does not step at a censored time, which is exactly why a reader has to be told about it — a flat tail backed by two hundred subjects and one backed by three are indistinguishable otherwise. MAIDR offers a rotor mode that jumps between the censored times.
+
+The layer declares `stepDirection: 'hv'`, which is what `type="stepAfter"` draws. Set `survivalConfig.stepDirection` to `'vh'` for a curve drawn with `type="stepBefore"`.
+
+Add a confidence band with `yMinKeys`/`yMaxKeys`; the bounds are absolute positions on the value axis, not offsets.
+
 ### Scatter Chart
 
 ```tsx
@@ -498,6 +582,138 @@ const data = [
   </ScatterChart>
 </MaidrRecharts>
 ```
+
+### Volcano and Manhattan Plots
+
+Both are scatters read almost entirely through a threshold, and both need two things a Recharts `<Scatter>` does not hold: what each point *is*, and where the cutoffs are.
+
+```tsx
+const data = [
+  { gene: 'TP53', log2fc: 2.4, negLog10P: 14.1 },
+  { gene: 'MYC', log2fc: -0.3, negLog10P: 0.8 },
+];
+
+<MaidrRecharts
+  id="volcano-example"
+  title="Differential Expression"
+  data={data}
+  chartType="volcano"
+  xKey="log2fc"
+  yKeys={['negLog10P']}
+  volcanoConfig={{ labelKey: 'gene', significance: 1.3, effect: 1 }}
+  xLabel="log2 fold change"
+  yLabel="-log10(p)"
+>
+  <ScatterChart width={600} height={350}>
+    <XAxis dataKey="log2fc" type="number" />
+    <YAxis dataKey="negLog10P" type="number" />
+    <ReferenceLine y={1.3} strokeDasharray="4 4" />
+    <Scatter data={data} fill="#8884d8" />
+  </ScatterChart>
+</MaidrRecharts>
+```
+
+There is no default cutoff, deliberately: -log10(p) puts the line at 1.3 for p < 0.05 and at 7.3 for genome-wide significance, and a guessed line sorts every point on the figure onto the wrong side silently. A **raw p axis runs the other way** and must declare `significanceDirection: 'below'` — fixed to `above` it would select exactly the points that failed to reach significance and announce them as the result.
+
+A Manhattan plot uses `chartType="manhattan"` with the same config, plus `groupKey` for the chromosome. Point `xKey` at the **per-chromosome position, not the cumulative offset the chart plots**: the offset keeps the chromosomes side by side on screen, and "position 249,388,120" answers nothing a reader asked.
+
+```tsx
+<MaidrRecharts
+  id="manhattan-example"
+  data={data}
+  chartType="manhattan"
+  xKey="bp"                   // announced
+  yKeys={['negLog10P']}
+  volcanoConfig={{ labelKey: 'snp', groupKey: 'chr', significance: 7.3 }}
+>
+  <ScatterChart width={600} height={350}>
+    <XAxis dataKey="cumulative" type="number" tick={false} />  {/* drawn */}
+    <YAxis dataKey="negLog10P" type="number" />
+    <Scatter data={data} fill="#8884d8" />
+  </ScatterChart>
+</MaidrRecharts>
+```
+
+A chart drawn as one `<Scatter>` per chromosome still emits a single MAIDR layer, so list the points in the order the `<Scatter>` elements are declared — highlighting pairs marks to points by index.
+
+### Error Bars
+
+MAIDR fixes the interval as **absolute positions on the value axis**, while Recharts' `<ErrorBar dataKey>` points at an **offset** from the estimate. Declare whichever your data holds:
+
+```tsx
+const data = [
+  { treatment: 'Control', mean: 4.2, sd: 0.6 },
+  { treatment: 'Nitrogen', mean: 5.5, sd: 0.5 },
+];
+
+<MaidrRecharts
+  id="error-bar-example"
+  title="Yield by Treatment"
+  data={data}
+  chartType="error_bar"
+  xKey="treatment"
+  yKeys={['mean']}
+  errorConfig={{ errorKey: 'sd' }}    // an offset, as <ErrorBar> reads it
+  xLabel="Treatment"
+  yLabel="Yield (t/ha)"
+>
+  <BarChart width={600} height={350} data={data}>
+    <XAxis dataKey="treatment" />
+    <YAxis />
+    <Bar dataKey="mean" fill="#8884d8">
+      <ErrorBar dataKey="sd" direction="y" />
+    </Bar>
+  </BarChart>
+</MaidrRecharts>
+```
+
+- `errorKey` — the field the `<ErrorBar>` uses. A number is a symmetric offset; a `[lower, upper]` pair is an asymmetric one. The adapter resolves both to `y - lower` / `y + upper`, the same arithmetic Recharts does to place the whiskers.
+- `yMinKey` / `yMaxKey` — absolute bounds, used as-is. These win when both are declared.
+
+The bounds are independently optional: a one-sided interval is a real chart, and a missing half is left off rather than defaulted to the estimate.
+
+Highlighting targets the whiskers, because the estimate's own mark may be a bar, a line dot or a scatter symbol depending on what you nested the `<ErrorBar>` in — pass the host's selector as `selectorOverride` to highlight that instead. Note that Recharts draws **no whisker at all** for a sample whose error value is zero or missing; MAIDR then sees fewer marks than samples and turns highlighting off for the layer rather than mis-aligning it.
+
+### Forest Plot
+
+A forest plot is an error bar chart on a categorical row axis, plus the two things that make it a meta-analysis:
+
+```tsx
+const studies = [
+  { study: 'Silva 2018', or: 0.62, lower: 0.41, upper: 0.94, weight: 0.12 },
+  { study: 'Okafor 2022', or: 1.71, lower: 1.22, upper: 2.40, weight: 0.55 },
+  { study: 'Pooled', or: 1.28, lower: 1.02, upper: 1.61, pooled: true },
+];
+
+<MaidrRecharts
+  id="forest-example"
+  title="Effect of the intervention"
+  data={studies}
+  chartType="forest"
+  xKey="study"
+  yKeys={['or']}
+  orientation={Orientation.HORIZONTAL}
+  errorConfig={{ yMinKey: 'lower', yMaxKey: 'upper' }}
+  forestConfig={{ weightKey: 'weight', pooledKey: 'pooled', nullValue: 1 }}
+  xLabel="Study"
+  yLabel="Odds ratio"
+>
+  <ScatterChart width={600} height={350} layout="vertical" margin={{ left: 80 }}>
+    <XAxis dataKey="or" type="number" />
+    <YAxis dataKey="study" type="category" width={80} />
+    <ReferenceLine x={1} />
+    <Scatter data={drawn} fill="#8884d8">
+      <ErrorBar dataKey="offsets" direction="x" />
+    </Scatter>
+  </ScatterChart>
+</MaidrRecharts>
+```
+
+- `nullValue` is the `<ReferenceLine>` the chart draws — 1 for a ratio measure, 0 for a difference. Whether a study's interval crosses it *is that study's result*, so MAIDR announces the crossing. There is no default: guessing 0 for a ratio chart would report every study as not crossing, since odds ratios are all positive. Omit it and the reading keeps the estimate, the interval and the weight, and makes no claim about significance.
+- `weightKey` is how much the study contributed, as a fraction of one. A forest plot encodes it as marker *area*, which no reader is otherwise told — two studies whose intervals look alike can contribute wholly differently.
+- The pooled summary is marked by `pooledKey` (a flag column) or `pooledIndex` (its row). It is not one more study, and announcing it as one invites a reader to count it among them.
+
+Row order is the drawn order, with the pooled row wherever the chart puts it. Keep the `orientation` horizontal: the rows are studies and the values run across.
 
 ### Pie Chart
 
@@ -529,6 +745,37 @@ const data = [
 Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Fruit is Apples, Units is 30, Percentage is 30.0%". Adding an `innerRadius` makes it a doughnut, which reads identically.
 
 > Recharts draws no sector at all for a slice whose value is `0` (its start and end angles are both zero). MAIDR then sees fewer elements than slices and turns highlighting off for the layer rather than index-aligning the wrong wedges; audio, text, and braille still cover every slice.
+
+### Alluvial Diagram
+
+An alluvial is a `<Sankey>` whose node set repeats at each stage. Pass the `links` half of the Sankey data as `data`, and the `nodes` half through `flowConfig`:
+
+```tsx
+const nodes = [{ name: 'Free (Q1)' }, { name: 'Paid (Q1)' }, { name: 'Free (Q2)' }, { name: 'Paid (Q2)' }];
+const links = [
+  { source: 0, target: 2, value: 420 },
+  { source: 0, target: 3, value: 130 },
+  { source: 1, target: 3, value: 260 },
+];
+
+<MaidrRecharts
+  id="alluvial-example"
+  title="Cohort Movement"
+  data={links}
+  chartType="alluvial"
+  xKey="source"
+  yKeys={['value']}
+  flowConfig={{ targetKey: 'target', nodes }}
+  xLabel="Stage"
+  yLabel="Accounts"
+>
+  <Sankey width={600} height={350} data={{ nodes, links }} link={{ stroke: '#8884d8' }} />
+</MaidrRecharts>
+```
+
+`xKey` names the source field and the single `yKeys` entry the magnitude, so only the target needs a key of its own. Recharts addresses nodes by their index in the `nodes` array; the adapter resolves those indices back to names, because "flow from 1 to 3" names neither end. Links that already carry node names work without `nodes`.
+
+MAIDR reads this as a graph rather than a grid: following a ribbon is the primary move, and arrow keys step between a node and the flows that leave or arrive at it. Highlighting pairs each flow with the `<path class="recharts-sankey-link">` at the same position, so the `links` array order is the order the ribbons are announced in.
 
 ### Composed Chart (Bar + Line)
 
@@ -642,6 +889,11 @@ import {
   type RechartsLayerConfig,    // Layer config for composed mode
   type RechartsSubplotConfig,  // Panel config for subplot mode
   type HistogramBinConfig,     // Histogram bin configuration
+  type FlowLinkConfig,         // Alluvial link/node configuration
+  type VolcanoPointConfig,     // Volcano and Manhattan labels and cutoffs
+  type ErrorIntervalConfig,    // Error bar / forest interval configuration
+  type ForestPlotConfig,       // Forest plot weights, pooled row and null line
+  type SurvivalCurveConfig,    // Survival censoring and confidence band keys
 } from 'maidr/recharts';
 ```
 
@@ -655,6 +907,7 @@ type RechartsChartType =
   | 'normalized_bar'
   | 'dot'
   | 'lollipop'
+  | 'funnel'
   | 'histogram'
   | 'line'
   | 'area'
@@ -662,8 +915,14 @@ type RechartsChartType =
   | 'normalized_area'
   | 'radar'
   | 'bump'
+  | 'survival'
   | 'scatter'
-  | 'pie';
+  | 'volcano'
+  | 'manhattan'
+  | 'error_bar'
+  | 'forest'
+  | 'pie'
+  | 'alluvial';
 ```
 
 ### `RechartsLayerConfig`
@@ -704,6 +963,60 @@ interface HistogramBinConfig {
   xMaxKey: string;   // Key for upper bin edge
   yMinKey?: string;  // Key for minimum count (defaults to 0)
   yMaxKey?: string;  // Key for maximum count (defaults to yKey value)
+}
+```
+
+### `FlowLinkConfig`
+
+```typescript
+interface FlowLinkConfig {
+  targetKey: string;                 // Key for the node the flow arrives at
+  nodes?: Record<string, unknown>[]; // The `nodes` half of the <Sankey> data
+  nodeNameKey?: string;              // Key for a node's name (defaults to 'name')
+}
+```
+
+### `VolcanoPointConfig`
+
+```typescript
+interface VolcanoPointConfig {
+  labelKey?: string;      // Key for what the point is (gene, SNP, probe)
+  groupKey?: string;      // Key for the region it belongs to (chromosome)
+  significance?: number;  // Cutoff on the y axis — no default
+  significanceDirection?: 'above' | 'below'; // Which side is significant (default 'above')
+  effect?: number;        // Cutoff on |x|
+}
+```
+
+### `ErrorIntervalConfig`
+
+```typescript
+interface ErrorIntervalConfig {
+  errorKey?: string;  // Key the <ErrorBar dataKey> points at — an OFFSET
+  yMinKey?: string;   // Key for the absolute lower bound (wins over errorKey)
+  yMaxKey?: string;   // Key for the absolute upper bound (wins over errorKey)
+}
+```
+
+### `ForestPlotConfig`
+
+```typescript
+interface ForestPlotConfig {
+  weightKey?: string;   // Key for the study's weight, as a fraction of one
+  pooledKey?: string;   // Key whose truthy value marks the pooled summary row
+  pooledIndex?: number; // Index of the pooled row, for data with no flag column
+  nullValue?: number;   // The value that means "no effect" — no default
+}
+```
+
+### `SurvivalCurveConfig`
+
+```typescript
+interface SurvivalCurveConfig {
+  censoredKeys?: string[];  // Keys marking censored times, 1:1 with yKeys
+  yMinKeys?: string[];      // Keys for the lower confidence band, 1:1 with yKeys
+  yMaxKeys?: string[];      // Keys for the upper confidence band, 1:1 with yKeys
+  stepDirection?: StepDirection; // Where the curve jumps (defaults to 'hv')
 }
 ```
 

--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -151,6 +151,7 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'stacked_area'` | `<Area stackId="...">` | Stacked area chart (multiple `yKeys`) |
 | `'normalized_area'` | `<AreaChart stackOffset="expand">` | 100% stacked area chart (multiple `yKeys`) |
 | `'radar'` | `<RadarChart>` + `<Radar>` | Radar/spider chart |
+| `'polar_area'` | `<Pie>` with equal angles and a per-datum `outerRadius` | Coxcomb/rose chart: a radar drawn as wedges |
 | `'bump'` | `<LineChart>` + `<YAxis reversed>` | Bump chart: rank over time |
 | `'survival'` | `<Line type="stepAfter">` | Kaplan-Meier curve (optional `survivalConfig`) |
 | `'scatter'` | `<Scatter>` | Scatter/point plot |
@@ -160,8 +161,10 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'forest'` | `<ScatterChart layout="vertical">` + `<ErrorBar direction="x">` | Forest plot (`errorConfig` + `forestConfig`) |
 | `'pie'` | `<Pie>` | Pie chart (a doughnut is a `<Pie>` with an `innerRadius`) |
 | `'alluvial'` | `<Sankey>` | Weighted flow between nodes (`flowConfig`) |
+| `'sankey'` | `<Sankey>` | The same flow drawn as a left-to-right budget (`flowConfig`) |
 | `'treemap'` | `<Treemap>` | A hierarchy laid out as nested area (nested `data`) |
 | `'sunburst'` | `<SunburstChart>` | The same hierarchy drawn as rings (nested `data`) |
+| `'icicle'` | `<BarChart layout="vertical">` + floating `<Bar>` | The same hierarchy drawn as depth-ordered bands (nested `data`) |
 
 ## Data Examples by Chart Type
 
@@ -492,6 +495,45 @@ const data = [
 
 MAIDR pans each spoke to its position around the circle — 12 o'clock centre, 3 o'clock hard right, 6 o'clock centre again — so a radar sounds like a circle rather than a row of bars.
 
+### Polar Area (Coxcomb) Chart
+
+A coxcomb, rose or Nightingale chart is a radar drawn as **wedges**: the same categories around the same circle, with the value as the radius rather than as a point on an outline. Recharts draws it as a `<Pie>` whose slices are all the same angle and whose `outerRadius` is a function of the datum:
+
+```tsx
+const data = [
+  { month: 'Jan', deaths: 120, slice: 1 },
+  { month: 'Feb', deaths: 84, slice: 1 },
+  { month: 'Mar', deaths: 61, slice: 1 },
+];
+
+<MaidrRecharts
+  id="coxcomb-example"
+  title="Deaths by Month"
+  data={data}
+  chartType="polar_area"
+  xKey="month"
+  yKeys={['deaths']}
+  xLabel="Month"
+  yLabel="Deaths"
+>
+  <PieChart width={400} height={400}>
+    <Pie
+      data={data}
+      dataKey="slice"
+      nameKey="month"
+      outerRadius={d => 40 + d.deaths}
+      fill="#8884d8"
+    />
+  </PieChart>
+</MaidrRecharts>
+```
+
+Note which field goes where. The `<Pie dataKey>` is the constant that makes every wedge the same **angle**; `yKeys` names the measure, which is the **radius**. Point `yKeys` at the pie's `dataKey` and every spoke announces the same number.
+
+MAIDR reads this exactly as it reads a radar — the two differ in the mark, not in what a reader navigates — so each wedge is panned to its position around the circle. Highlighting targets the pie's sectors, and carries the pie's one caveat: Recharts draws no sector at all for a zero-value slice, and a count mismatch turns highlighting off for the layer while audio, text and braille still describe every spoke.
+
+A `<RadialBarChart>` is **not** this chart. It puts the categories on concentric rings and encodes the value as the sweep angle, which is a different figure with a different reading.
+
 ### Bump Chart
 
 A bump chart is rank over time: a `<LineChart>` with `<YAxis reversed>` so rank 1 sits at the top. Each `yKey` holds the competitor's **rank** in that period, never the underlying value:
@@ -753,9 +795,9 @@ Left and Right move between slices; Up and Down are out of bounds, since a pie i
 
 > Recharts draws no sector at all for a slice whose value is `0` (its start and end angles are both zero). MAIDR then sees fewer elements than slices and turns highlighting off for the layer rather than index-aligning the wrong wedges; audio, text, and braille still cover every slice.
 
-### Alluvial Diagram
+### Alluvial and Sankey Diagrams
 
-An alluvial is a `<Sankey>` whose node set repeats at each stage. Pass the `links` half of the Sankey data as `data`, and the `nodes` half through `flowConfig`:
+An alluvial is a `<Sankey>` whose node set repeats at each stage; a Sankey proper is one left-to-right budget of ribbons that split and rejoin. Both are the same weighted graph and take the same config — pass the `links` half of the Sankey data as `data`, and the `nodes` half through `flowConfig`:
 
 ```tsx
 const nodes = [{ name: 'Free (Q1)' }, { name: 'Paid (Q1)' }, { name: 'Free (Q2)' }, { name: 'Paid (Q2)' }];
@@ -782,7 +824,9 @@ const links = [
 
 `xKey` names the source field and the single `yKeys` entry the magnitude, so only the target needs a key of its own. Recharts addresses nodes by their index in the `nodes` array; the adapter resolves those indices back to names, because "flow from 1 to 3" names neither end. Links that already carry node names work without `nodes`.
 
-MAIDR reads this as a graph rather than a grid: following a ribbon is the primary move, and arrow keys step between a node and the flows that leave or arrive at it. Highlighting pairs each flow with the `<path class="recharts-sankey-link">` at the same position, so the `links` array order is the order the ribbons are announced in.
+Set `chartType="sankey"` for the budget reading. Nothing else changes: the payload, the config and the selector are identical, and which of the two a figure is is a fact about the data — whether a node reappears at each stage — rather than anything the adapter emits.
+
+MAIDR reads both as a graph rather than a grid: following a ribbon is the primary move, and arrow keys step between a node and the flows that leave or arrive at it. Highlighting pairs each flow with the `<path class="recharts-sankey-link">` at the same position, so the `links` array order is the order the ribbons are announced in.
 
 ### Diverging Bar Chart (Population Pyramid)
 
@@ -976,9 +1020,9 @@ const data = [{ measure: 'NPS', score: 73 }];
 
 Bands are **ascending and bounded above only**: a band starts where the previous one ended, and the first starts at `min`. A value above every band belongs to none rather than to the last one. There is deliberately no default range — a guessed maximum misreports the one number the chart draws.
 
-### Treemap and Sunburst
+### Treemap, Sunburst and Icicle
 
-Both draw the same hierarchy, and both take the **nested** `{ name, children }` data Recharts itself is given rather than the adapter's usual flat rows. `xKey` is the `<Treemap nameKey>` and the single `yKeys` entry its `dataKey`:
+All three draw the same hierarchy, and all three take the **nested** `{ name, children }` data Recharts itself is given rather than the adapter's usual flat rows. `xKey` is the `<Treemap nameKey>` and the single `yKeys` entry its `dataKey`:
 
 ```tsx
 const nodes = [
@@ -1011,6 +1055,30 @@ MAIDR navigates the tree **as a tree**, on arrow keys that already exist: up ret
 A node with children gets no value of its own, because Recharts computes an interior node's value as the sum of its children and ignores any value declared on it. MAIDR derives interior totals the same way.
 
 Highlighting relies on both components drawing their nodes in depth-first pre-order, which they do. The treemap selector deliberately skips the **synthetic root** rectangle Recharts wraps the data array in — it is one element more than there are nodes, and a count mismatch turns highlighting off entirely. A `<Treemap type="nest">`, or one given a custom `content`, draws something else and needs `selectorOverride`.
+
+An icicle takes the same config again, with `chartType="icicle"`. Recharts has no icicle component, so the bands are drawn the way a gantt's intervals are: a `<BarChart layout="vertical">` whose lane is the node's **depth** and whose `<Bar>` returns the band's `[start, end]` span. One rectangle per row, and the rows must be the tree flattened **depth-first pre-order** — the order the adapter emits its nodes in, so that row *i* is node *i*:
+
+```tsx
+// The same `nodes` tree, flattened the way the adapter flattens it.
+const bands = [
+  { name: 'Europe', depth: '0', from: 0, to: 240 },
+  { name: 'France', depth: '1', from: 0, to: 67.4 },
+  { name: 'Spain', depth: '1', from: 67.4, to: 114.8 },
+  { name: 'Asia', depth: '0', from: 240, to: 395 },
+  { name: 'Japan', depth: '1', from: 240, to: 365.1 },
+  { name: 'Nepal', depth: '1', from: 365.1, to: 395.1 },
+];
+
+<MaidrRecharts id="icicle-example" data={nodes} chartType="icicle" xKey="name" yKeys={['people']}>
+  <BarChart width={600} height={300} layout="vertical" data={bands}>
+    <XAxis type="number" />
+    <YAxis type="category" dataKey="depth" />
+    <Bar dataKey={row => [row.from, row.to]} fill="#8884d8" />
+  </BarChart>
+</MaidrRecharts>
+```
+
+Built the other obvious way — one stacked `<Bar>` per depth level — the rectangles come out series-major rather than depth-first, which is not the order the nodes are in. Such a chart needs `selectorOverride`.
 
 ### Composed Chart (Bar + Line)
 
@@ -1154,6 +1222,7 @@ type RechartsChartType =
   | 'stacked_area'
   | 'normalized_area'
   | 'radar'
+  | 'polar_area'
   | 'bump'
   | 'survival'
   | 'scatter'
@@ -1163,8 +1232,10 @@ type RechartsChartType =
   | 'forest'
   | 'pie'
   | 'alluvial'
+  | 'sankey'
   | 'treemap'
-  | 'sunburst';
+  | 'sunburst'
+  | 'icicle';
 ```
 
 ### `RechartsLayerConfig`

--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -132,8 +132,15 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'stacked_bar'` | `<Bar stackId="...">` | Stacked bar chart (multiple `yKeys`) |
 | `'dodged_bar'` | Multiple `<Bar>` | Grouped/side-by-side bar chart (multiple `yKeys`) |
 | `'normalized_bar'` | `<Bar stackId="...">` | 100% stacked bar chart (multiple `yKeys`) |
+| `'dot'` | `<Scatter>` | Cleveland dot plot: one point per category |
+| `'lollipop'` | `<Bar barSize={2}>` + `<Scatter>` | Lollipop chart: a stem and a head |
 | `'histogram'` | `<Bar>` | Histogram with bin ranges (requires `binConfig`) |
 | `'line'` | `<Line>` | Line chart |
+| `'area'` | `<Area>` | Area chart |
+| `'stacked_area'` | `<Area stackId="...">` | Stacked area chart (multiple `yKeys`) |
+| `'normalized_area'` | `<AreaChart stackOffset="expand">` | 100% stacked area chart (multiple `yKeys`) |
+| `'radar'` | `<RadarChart>` + `<Radar>` | Radar/spider chart |
+| `'bump'` | `<LineChart>` + `<YAxis reversed>` | Bump chart: rank over time |
 | `'scatter'` | `<Scatter>` | Scatter/point plot |
 | `'pie'` | `<Pie>` | Pie chart (a doughnut is a `<Pie>` with an `innerRadius`) |
 
@@ -224,6 +231,61 @@ const data = [
 </MaidrRecharts>
 ```
 
+### Dot Plot and Lollipop Chart
+
+Both read exactly as a bar chart does — one category, one magnitude — and take the same config. What differs is the mark, and therefore what MAIDR highlights.
+
+A Cleveland dot plot is a `<Scatter>` against a category axis:
+
+```tsx
+const data = [
+  { role: 'Nurse', pay: 62 },
+  { role: 'Teacher', pay: 54 },
+  { role: 'Engineer', pay: 88 },
+];
+
+<MaidrRecharts
+  id="dot-example"
+  title="Median Pay by Role"
+  data={data}
+  chartType="dot"
+  xKey="role"
+  yKeys={['pay']}
+  xLabel="Role"
+  yLabel="Median pay ($k)"
+>
+  <ScatterChart width={600} height={350}>
+    <XAxis dataKey="role" type="category" allowDuplicatedCategory={false} />
+    <YAxis dataKey="pay" type="number" />
+    <Scatter data={data} fill="#8884d8" />
+  </ScatterChart>
+</MaidrRecharts>
+```
+
+A lollipop has no Recharts primitive; compose a thin `<Bar>` stem with a `<Scatter>` head:
+
+```tsx
+<MaidrRecharts
+  id="lollipop-example"
+  title="Market Share by Country"
+  data={data}
+  chartType="lollipop"
+  xKey="country"
+  yKeys={['share']}
+  xLabel="Country"
+  yLabel="Share (%)"
+>
+  <ComposedChart width={600} height={350} data={data}>
+    <XAxis dataKey="country" />
+    <YAxis />
+    <Bar dataKey="share" barSize={2} fill="#8884d8" />
+    <Scatter dataKey="share" fill="#8884d8" />
+  </ComposedChart>
+</MaidrRecharts>
+```
+
+Highlighting targets the head (`.recharts-scatter-symbol .recharts-symbols`), not the stem, because the head is where the value is read off. If you draw the lollipop with a custom `<Bar>` shape that renders its own dot, pass a `selectorOverride` pointing at that element instead.
+
 ### Histogram
 
 Requires `binConfig` to specify which data keys contain the bin edges:
@@ -284,6 +346,130 @@ const data = [
 ```
 
 > **Tip:** Always include `dot` on the `<Line>` component. MAIDR uses the rendered dot elements for visual highlighting during keyboard navigation.
+
+### Area Chart
+
+```tsx
+const data = [
+  { month: 'Jan', mm: 80 },
+  { month: 'Feb', mm: 65 },
+  { month: 'Mar', mm: 90 },
+];
+
+<MaidrRecharts
+  id="area-example"
+  title="Monthly Rainfall"
+  data={data}
+  chartType="area"
+  xKey="month"
+  yKeys={['mm']}
+  xLabel="Month"
+  yLabel="Rainfall (mm)"
+>
+  <AreaChart width={600} height={350} data={data}>
+    <XAxis dataKey="month" />
+    <YAxis />
+    <Area type="monotone" dataKey="mm" stroke="#8884d8" fill="#8884d8" dot />
+  </AreaChart>
+</MaidrRecharts>
+```
+
+> **Tip:** As with `<Line>`, include `dot` on the `<Area>`. The filled band is a single path with nothing per sample to highlight, so the dots are the only marks MAIDR can align to the data.
+
+### Stacked and 100% Stacked Area
+
+Use `stacked_area` for `<Area stackId="...">` and `normalized_area` when the chart also sets `stackOffset="expand"`. Pass each band's **own** value — not the accumulated top edge, and not the expanded fraction. MAIDR sums the series itself to announce the running total and each point's share of it:
+
+```tsx
+const data = [
+  { month: 'Jan', organic: 40, paid: 20 },
+  { month: 'Feb', organic: 55, paid: 15 },
+];
+
+<MaidrRecharts
+  id="stacked-area-example"
+  title="Sessions by Source"
+  data={data}
+  chartType="stacked_area"
+  xKey="month"
+  yKeys={['organic', 'paid']}
+  xLabel="Month"
+  yLabel="Sessions"
+>
+  <AreaChart width={600} height={350} data={data}>
+    <XAxis dataKey="month" />
+    <YAxis />
+    <Area type="monotone" dataKey="organic" stackId="a" stroke="#8884d8" fill="#8884d8" dot />
+    <Area type="monotone" dataKey="paid" stackId="a" stroke="#82ca9d" fill="#82ca9d" dot />
+  </AreaChart>
+</MaidrRecharts>
+```
+
+A stacked area declared over a single `yKey` falls back to `'area'`: one band is not stacked against anything, and announcing a total equal to the point's own value on every sample is noise rather than information.
+
+### Radar Chart
+
+`xKey` is the `<PolarAngleAxis dataKey>` (the spoke) and each entry in `yKeys` is one `<Radar>`:
+
+```tsx
+const data = [
+  { attribute: 'Speed', alice: 90, bob: 70 },
+  { attribute: 'Power', alice: 60, bob: 85 },
+  { attribute: 'Stamina', alice: 75, bob: 80 },
+];
+
+<MaidrRecharts
+  id="radar-example"
+  title="Player Attributes"
+  data={data}
+  chartType="radar"
+  xKey="attribute"
+  yKeys={['alice', 'bob']}
+  xLabel="Attribute"
+  yLabel="Rating"
+>
+  <RadarChart width={500} height={400} data={data}>
+    <PolarGrid />
+    <PolarAngleAxis dataKey="attribute" />
+    <Radar dataKey="alice" stroke="#8884d8" fill="#8884d8" fillOpacity={0.4} dot />
+    <Radar dataKey="bob" stroke="#82ca9d" fill="#82ca9d" fillOpacity={0.4} dot />
+  </RadarChart>
+</MaidrRecharts>
+```
+
+MAIDR pans each spoke to its position around the circle — 12 o'clock centre, 3 o'clock hard right, 6 o'clock centre again — so a radar sounds like a circle rather than a row of bars.
+
+### Bump Chart
+
+A bump chart is rank over time: a `<LineChart>` with `<YAxis reversed>` so rank 1 sits at the top. Each `yKey` holds the competitor's **rank** in that period, never the underlying value:
+
+```tsx
+const data = [
+  { matchday: 1, arsenal: 3, chelsea: 1 },
+  { matchday: 2, arsenal: 1, chelsea: 2 },
+  { matchday: 3, arsenal: 1, chelsea: 3 },
+];
+
+<MaidrRecharts
+  id="bump-example"
+  title="League Position by Matchday"
+  data={data}
+  chartType="bump"
+  xKey="matchday"
+  yKeys={['arsenal', 'chelsea']}
+  xLabel="Matchday"
+  yLabel="Position"
+>
+  <LineChart width={600} height={350} data={data}>
+    <XAxis dataKey="matchday" />
+    <YAxis reversed allowDecimals={false} />
+    <Line type="linear" dataKey="arsenal" stroke="#8884d8" dot />
+    <Line type="linear" dataKey="chelsea" stroke="#82ca9d" dot />
+  </LineChart>
+</MaidrRecharts>
+```
+
+> **Warning:** MAIDR inverts the pitch for a bump chart so rank 1 is the highest note, and announces the places gained or lost since the previous period. Declaring a chart of *values* as `'bump'` therefore sonifies it upside down — every rise heard as a fall. The adapter cannot tell the two apart, so this one is on you.
 
 ### Scatter Chart
 
@@ -467,8 +653,15 @@ type RechartsChartType =
   | 'stacked_bar'
   | 'dodged_bar'
   | 'normalized_bar'
+  | 'dot'
+  | 'lollipop'
   | 'histogram'
   | 'line'
+  | 'area'
+  | 'stacked_area'
+  | 'normalized_area'
+  | 'radar'
+  | 'bump'
   | 'scatter'
   | 'pie';
 ```

--- a/examples/recharts/App.tsx
+++ b/examples/recharts/App.tsx
@@ -6,6 +6,7 @@ import { DodgedBarExample } from './examples/DodgedBarExample';
 import { NormalizedBarExample } from './examples/NormalizedBarExample';
 import { DotPlotExample } from './examples/DotPlotExample';
 import { LollipopExample } from './examples/LollipopExample';
+import { FunnelChartExample } from './examples/FunnelChartExample';
 import { HistogramExample } from './examples/HistogramExample';
 import { LineChartExample } from './examples/LineChartExample';
 import { AreaChartExample } from './examples/AreaChartExample';
@@ -13,7 +14,13 @@ import { StackedAreaExample } from './examples/StackedAreaExample';
 import { NormalizedAreaExample } from './examples/NormalizedAreaExample';
 import { RadarChartExample } from './examples/RadarChartExample';
 import { BumpChartExample } from './examples/BumpChartExample';
+import { SurvivalCurveExample } from './examples/SurvivalCurveExample';
 import { ScatterChartExample } from './examples/ScatterChartExample';
+import { VolcanoPlotExample } from './examples/VolcanoPlotExample';
+import { ManhattanPlotExample } from './examples/ManhattanPlotExample';
+import { ErrorBarExample } from './examples/ErrorBarExample';
+import { ForestPlotExample } from './examples/ForestPlotExample';
+import { AlluvialExample } from './examples/AlluvialExample';
 import { ComposedChartExample } from './examples/ComposedChartExample';
 import { FacetExample } from './examples/FacetExample';
 
@@ -24,6 +31,7 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Normalized Bar', component: NormalizedBarExample },
   { name: 'Dot Plot', component: DotPlotExample },
   { name: 'Lollipop', component: LollipopExample },
+  { name: 'Funnel', component: FunnelChartExample },
   { name: 'Histogram', component: HistogramExample },
   { name: 'Line Chart', component: LineChartExample },
   { name: 'Area Chart', component: AreaChartExample },
@@ -31,7 +39,13 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Normalized Area', component: NormalizedAreaExample },
   { name: 'Radar Chart', component: RadarChartExample },
   { name: 'Bump Chart', component: BumpChartExample },
+  { name: 'Survival Curve', component: SurvivalCurveExample },
   { name: 'Scatter Chart', component: ScatterChartExample },
+  { name: 'Volcano Plot', component: VolcanoPlotExample },
+  { name: 'Manhattan Plot', component: ManhattanPlotExample },
+  { name: 'Error Bars', component: ErrorBarExample },
+  { name: 'Forest Plot', component: ForestPlotExample },
+  { name: 'Alluvial', component: AlluvialExample },
   { name: 'Composed Chart', component: ComposedChartExample },
   { name: 'Faceted (Multi-Panel)', component: FacetExample },
 ];

--- a/examples/recharts/App.tsx
+++ b/examples/recharts/App.tsx
@@ -18,6 +18,7 @@ import { AreaChartExample } from './examples/AreaChartExample';
 import { StackedAreaExample } from './examples/StackedAreaExample';
 import { NormalizedAreaExample } from './examples/NormalizedAreaExample';
 import { RadarChartExample } from './examples/RadarChartExample';
+import { PolarAreaExample } from './examples/PolarAreaExample';
 import { BumpChartExample } from './examples/BumpChartExample';
 import { SurvivalCurveExample } from './examples/SurvivalCurveExample';
 import { ScatterChartExample } from './examples/ScatterChartExample';
@@ -26,8 +27,10 @@ import { ManhattanPlotExample } from './examples/ManhattanPlotExample';
 import { ErrorBarExample } from './examples/ErrorBarExample';
 import { ForestPlotExample } from './examples/ForestPlotExample';
 import { AlluvialExample } from './examples/AlluvialExample';
+import { SankeyExample } from './examples/SankeyExample';
 import { TreemapExample } from './examples/TreemapExample';
 import { SunburstExample } from './examples/SunburstExample';
+import { IcicleExample } from './examples/IcicleExample';
 import { ComposedChartExample } from './examples/ComposedChartExample';
 import { FacetExample } from './examples/FacetExample';
 
@@ -50,6 +53,7 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Stacked Area', component: StackedAreaExample },
   { name: 'Normalized Area', component: NormalizedAreaExample },
   { name: 'Radar Chart', component: RadarChartExample },
+  { name: 'Polar Area', component: PolarAreaExample },
   { name: 'Bump Chart', component: BumpChartExample },
   { name: 'Survival Curve', component: SurvivalCurveExample },
   { name: 'Scatter Chart', component: ScatterChartExample },
@@ -58,8 +62,10 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Error Bars', component: ErrorBarExample },
   { name: 'Forest Plot', component: ForestPlotExample },
   { name: 'Alluvial', component: AlluvialExample },
+  { name: 'Sankey', component: SankeyExample },
   { name: 'Treemap', component: TreemapExample },
   { name: 'Sunburst', component: SunburstExample },
+  { name: 'Icicle', component: IcicleExample },
   { name: 'Composed Chart', component: ComposedChartExample },
   { name: 'Faceted (Multi-Panel)', component: FacetExample },
 ];

--- a/examples/recharts/App.tsx
+++ b/examples/recharts/App.tsx
@@ -4,6 +4,11 @@ import { BarChartExample } from './examples/BarChartExample';
 import { StackedBarExample } from './examples/StackedBarExample';
 import { DodgedBarExample } from './examples/DodgedBarExample';
 import { NormalizedBarExample } from './examples/NormalizedBarExample';
+import { DivergingBarExample } from './examples/DivergingBarExample';
+import { WaterfallExample } from './examples/WaterfallExample';
+import { DumbbellExample } from './examples/DumbbellExample';
+import { GanttExample } from './examples/GanttExample';
+import { GaugeExample } from './examples/GaugeExample';
 import { DotPlotExample } from './examples/DotPlotExample';
 import { LollipopExample } from './examples/LollipopExample';
 import { FunnelChartExample } from './examples/FunnelChartExample';
@@ -21,6 +26,8 @@ import { ManhattanPlotExample } from './examples/ManhattanPlotExample';
 import { ErrorBarExample } from './examples/ErrorBarExample';
 import { ForestPlotExample } from './examples/ForestPlotExample';
 import { AlluvialExample } from './examples/AlluvialExample';
+import { TreemapExample } from './examples/TreemapExample';
+import { SunburstExample } from './examples/SunburstExample';
 import { ComposedChartExample } from './examples/ComposedChartExample';
 import { FacetExample } from './examples/FacetExample';
 
@@ -29,6 +36,11 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Stacked Bar', component: StackedBarExample },
   { name: 'Dodged Bar', component: DodgedBarExample },
   { name: 'Normalized Bar', component: NormalizedBarExample },
+  { name: 'Diverging Bar', component: DivergingBarExample },
+  { name: 'Waterfall', component: WaterfallExample },
+  { name: 'Dumbbell', component: DumbbellExample },
+  { name: 'Gantt', component: GanttExample },
+  { name: 'Gauge', component: GaugeExample },
   { name: 'Dot Plot', component: DotPlotExample },
   { name: 'Lollipop', component: LollipopExample },
   { name: 'Funnel', component: FunnelChartExample },
@@ -46,6 +58,8 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Error Bars', component: ErrorBarExample },
   { name: 'Forest Plot', component: ForestPlotExample },
   { name: 'Alluvial', component: AlluvialExample },
+  { name: 'Treemap', component: TreemapExample },
+  { name: 'Sunburst', component: SunburstExample },
   { name: 'Composed Chart', component: ComposedChartExample },
   { name: 'Faceted (Multi-Panel)', component: FacetExample },
 ];

--- a/examples/recharts/App.tsx
+++ b/examples/recharts/App.tsx
@@ -4,8 +4,15 @@ import { BarChartExample } from './examples/BarChartExample';
 import { StackedBarExample } from './examples/StackedBarExample';
 import { DodgedBarExample } from './examples/DodgedBarExample';
 import { NormalizedBarExample } from './examples/NormalizedBarExample';
+import { DotPlotExample } from './examples/DotPlotExample';
+import { LollipopExample } from './examples/LollipopExample';
 import { HistogramExample } from './examples/HistogramExample';
 import { LineChartExample } from './examples/LineChartExample';
+import { AreaChartExample } from './examples/AreaChartExample';
+import { StackedAreaExample } from './examples/StackedAreaExample';
+import { NormalizedAreaExample } from './examples/NormalizedAreaExample';
+import { RadarChartExample } from './examples/RadarChartExample';
+import { BumpChartExample } from './examples/BumpChartExample';
 import { ScatterChartExample } from './examples/ScatterChartExample';
 import { ComposedChartExample } from './examples/ComposedChartExample';
 import { FacetExample } from './examples/FacetExample';
@@ -15,8 +22,15 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Stacked Bar', component: StackedBarExample },
   { name: 'Dodged Bar', component: DodgedBarExample },
   { name: 'Normalized Bar', component: NormalizedBarExample },
+  { name: 'Dot Plot', component: DotPlotExample },
+  { name: 'Lollipop', component: LollipopExample },
   { name: 'Histogram', component: HistogramExample },
   { name: 'Line Chart', component: LineChartExample },
+  { name: 'Area Chart', component: AreaChartExample },
+  { name: 'Stacked Area', component: StackedAreaExample },
+  { name: 'Normalized Area', component: NormalizedAreaExample },
+  { name: 'Radar Chart', component: RadarChartExample },
+  { name: 'Bump Chart', component: BumpChartExample },
   { name: 'Scatter Chart', component: ScatterChartExample },
   { name: 'Composed Chart', component: ComposedChartExample },
   { name: 'Faceted (Multi-Panel)', component: FacetExample },

--- a/examples/recharts/examples/AlluvialExample.tsx
+++ b/examples/recharts/examples/AlluvialExample.tsx
@@ -1,0 +1,58 @@
+import type { JSX } from 'react';
+import { Sankey, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// The same node set repeats at each stage, which is what makes this an
+// alluvial rather than a sankey: the diagram tracks one cohort moving between
+// the same states over time.
+const nodes = [
+  { name: 'Free (Q1)' },
+  { name: 'Paid (Q1)' },
+  { name: 'Free (Q2)' },
+  { name: 'Paid (Q2)' },
+  { name: 'Churned (Q2)' },
+];
+
+const links = [
+  { source: 0, target: 2, value: 420 },
+  { source: 0, target: 3, value: 130 },
+  { source: 0, target: 4, value: 90 },
+  { source: 1, target: 3, value: 260 },
+  { source: 1, target: 4, value: 40 },
+];
+
+export function AlluvialExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Alluvial Diagram</h2>
+      <p>
+        Cohort movement between plans, quarter over quarter. Following a ribbon
+        is the primary move: MAIDR navigates the graph rather than a grid, so
+        arrow keys step between a node and the flows that leave it.
+      </p>
+      <MaidrRecharts
+        id="alluvial-example"
+        title="Cohort Movement"
+        subtitle="Q1 to Q2"
+        data={links}
+        chartType="alluvial"
+        xKey="source"
+        yKeys={['value']}
+        flowConfig={{ targetKey: 'target', nodes }}
+        xLabel="Stage"
+        yLabel="Accounts"
+      >
+        <Sankey
+          width={600}
+          height={350}
+          data={{ nodes, links }}
+          nodePadding={40}
+          margin={{ top: 10, right: 120, bottom: 10, left: 10 }}
+          link={{ stroke: '#8884d8' }}
+        >
+          <Tooltip />
+        </Sankey>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/AreaChartExample.tsx
+++ b/examples/recharts/examples/AreaChartExample.tsx
@@ -1,0 +1,49 @@
+import type { JSX } from 'react';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [
+  { month: 'Jan', mm: 80 },
+  { month: 'Feb', mm: 65 },
+  { month: 'Mar', mm: 90 },
+  { month: 'Apr', mm: 120 },
+  { month: 'May', mm: 145 },
+  { month: 'Jun', mm: 60 },
+  { month: 'Jul', mm: 35 },
+  { month: 'Aug', mm: 40 },
+  { month: 'Sep', mm: 75 },
+  { month: 'Oct', mm: 110 },
+  { month: 'Nov', mm: 130 },
+  { month: 'Dec', mm: 95 },
+];
+
+export function AreaChartExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Area Chart</h2>
+      <p>Area chart showing monthly rainfall over a year.</p>
+      <MaidrRecharts
+        id="area-example"
+        title="Monthly Rainfall"
+        subtitle="2024"
+        data={data}
+        chartType="area"
+        xKey="month"
+        yKeys={['mm']}
+        xLabel="Month"
+        yLabel="Rainfall (mm)"
+      >
+        <AreaChart width={600} height={350} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          {/* `dot` is required: the filled band is one path, so the dots are
+              the only marks MAIDR can align to the data for highlighting. */}
+          <Area type="monotone" dataKey="mm" stroke="#8884d8" fill="#8884d8" name="Rainfall" dot />
+        </AreaChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/BumpChartExample.tsx
+++ b/examples/recharts/examples/BumpChartExample.tsx
@@ -1,0 +1,46 @@
+import type { JSX } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// Ranks, not points: 1 is top of the table. MAIDR inverts the pitch so first
+// place is the highest note and announces the places gained or lost.
+const data = [
+  { matchday: 1, arsenal: 3, chelsea: 1, everton: 2 },
+  { matchday: 2, arsenal: 1, chelsea: 2, everton: 3 },
+  { matchday: 3, arsenal: 1, chelsea: 3, everton: 2 },
+  { matchday: 4, arsenal: 2, chelsea: 3, everton: 1 },
+  { matchday: 5, arsenal: 1, chelsea: 2, everton: 3 },
+  { matchday: 6, arsenal: 2, chelsea: 1, everton: 3 },
+];
+
+export function BumpChartExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Bump Chart</h2>
+      <p>Bump chart showing how three clubs move up and down the table.</p>
+      <MaidrRecharts
+        id="bump-example"
+        title="League Position by Matchday"
+        subtitle="Rank 1 is top of the table"
+        data={data}
+        chartType="bump"
+        xKey="matchday"
+        yKeys={['arsenal', 'chelsea', 'everton']}
+        xLabel="Matchday"
+        yLabel="Position"
+      >
+        <LineChart width={600} height={350} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="matchday" />
+          {/* `reversed` puts rank 1 at the top, where a table reader expects it. */}
+          <YAxis reversed allowDecimals={false} domain={[1, 3]} />
+          <Tooltip />
+          <Legend />
+          <Line type="linear" dataKey="arsenal" stroke="#8884d8" name="Arsenal" dot />
+          <Line type="linear" dataKey="chelsea" stroke="#82ca9d" name="Chelsea" dot />
+          <Line type="linear" dataKey="everton" stroke="#ffc658" name="Everton" dot />
+        </LineChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/DivergingBarExample.tsx
+++ b/examples/recharts/examples/DivergingBarExample.tsx
@@ -1,0 +1,55 @@
+import type { JSX } from 'react';
+import { Bar, BarChart, CartesianGrid, Legend, Tooltip, XAxis, YAxis } from 'recharts';
+import { Orientation } from '../../../src/type/grammar';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// The left-hand side carries NEGATIVE values, which is what
+// `stackOffset="sign"` draws back to back — and what MAIDR reads as the side
+// rather than as the magnitude.
+const data = [
+  { band: '0-9', men: -2_140_000, women: 2_040_000 },
+  { band: '10-19', men: -2_020_000, women: 1_930_000 },
+  { band: '20-29', men: -1_880_000, women: 1_910_000 },
+  { band: '30-39', men: -1_760_000, women: 1_820_000 },
+  { band: '40-49', men: -1_540_000, women: 1_610_000 },
+  { band: '50-59', men: -1_290_000, women: 1_400_000 },
+];
+
+export function DivergingBarExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Diverging Bar Chart</h2>
+      <p>
+        A population pyramid. The sign is a <strong>direction</strong>, not a
+        magnitude: MAIDR pitches the size of the bar and announces which side
+        it points to, so the largest cohort on the left is not heard as the
+        smallest note on the chart. Each band also announces the{' '}
+        <strong>balance</strong> — what one side has over the other — which is
+        the subtraction the two sides are drawn back to back to support.
+      </p>
+      <MaidrRecharts
+        id="diverging-example"
+        title="Population by Age Band"
+        subtitle="Men and women"
+        data={data}
+        chartType="diverging_bar"
+        xKey="band"
+        yKeys={['men', 'women']}
+        fillKeys={['Men', 'Women']}
+        orientation={Orientation.HORIZONTAL}
+        xLabel="Age band"
+        yLabel="People"
+      >
+        <BarChart width={600} height={400} layout="vertical" stackOffset="sign" data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" />
+          <YAxis type="category" dataKey="band" />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="men" name="Men" stackId="sides" fill="#8884d8" isAnimationActive={false} />
+          <Bar dataKey="women" name="Women" stackId="sides" fill="#82ca9d" isAnimationActive={false} />
+        </BarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/DotPlotExample.tsx
+++ b/examples/recharts/examples/DotPlotExample.tsx
@@ -1,0 +1,40 @@
+import type { JSX } from 'react';
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [
+  { role: 'Nurse', pay: 62 },
+  { role: 'Teacher', pay: 54 },
+  { role: 'Engineer', pay: 88 },
+  { role: 'Designer', pay: 71 },
+  { role: 'Analyst', pay: 66 },
+  { role: 'Technician', pay: 49 },
+];
+
+export function DotPlotExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Dot Plot</h2>
+      <p>Cleveland dot plot showing median pay by role.</p>
+      <MaidrRecharts
+        id="dot-example"
+        title="Median Pay by Role"
+        subtitle="Cleveland dot plot"
+        data={data}
+        chartType="dot"
+        xKey="role"
+        yKeys={['pay']}
+        xLabel="Role"
+        yLabel="Median pay ($k)"
+      >
+        <ScatterChart width={600} height={350}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="role" type="category" allowDuplicatedCategory={false} />
+          <YAxis dataKey="pay" type="number" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <Scatter name="Median pay" data={data} fill="#8884d8" />
+        </ScatterChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/DumbbellExample.tsx
+++ b/examples/recharts/examples/DumbbellExample.tsx
@@ -1,0 +1,52 @@
+import type { JSX } from 'react';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [
+  { country: 'Japan', then: 78.9, now: 84.6 },
+  { country: 'Spain', then: 76.9, now: 83.2 },
+  { country: 'Korea', then: 71.7, now: 83.5 },
+  { country: 'United States', then: 75.3, now: 77.3 },
+  { country: 'Russia', then: 69.2, now: 68.9 },
+];
+
+/** The pair a floating `<Bar>` draws a connector between. */
+function span(row: unknown): [number, number] {
+  const point = row as { then: number; now: number };
+  return [point.then, point.now];
+}
+
+export function DumbbellExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Dumbbell Chart</h2>
+      <p>
+        Life expectancy in 1990 against 2020. The two ends are named through{' '}
+        <code>fillKeys</code>, and those names are the whole content of the
+        comparison — announced as &quot;start&quot; and &quot;end&quot;, a
+        reader is told which dot they are on and not which year it is. MAIDR
+        derives the change rather than reading it, so Russia is announced as a
+        decrease without anything extra declared.
+      </p>
+      <MaidrRecharts
+        id="dumbbell-example"
+        title="Life Expectancy, 1990 against 2020"
+        data={data}
+        chartType="dumbbell"
+        xKey="country"
+        yKeys={['then', 'now']}
+        fillKeys={['1990', '2020']}
+        xLabel="Country"
+        yLabel="Years"
+      >
+        <BarChart width={600} height={350} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="country" />
+          <YAxis domain={[60, 90]} />
+          <Tooltip />
+          <Bar dataKey={span} barSize={6} fill="#8884d8" isAnimationActive={false} />
+        </BarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/ErrorBarExample.tsx
+++ b/examples/recharts/examples/ErrorBarExample.tsx
@@ -1,0 +1,49 @@
+import type { JSX } from 'react';
+import { BarChart, Bar, ErrorBar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// `sd` is what the <ErrorBar dataKey> points at, so it is an OFFSET from the
+// mean. MAIDR fixes the interval as absolute positions on the value axis and
+// the adapter converts, which is why `errorConfig.errorKey` names the same
+// field the chart does rather than a pair of bounds.
+const data = [
+  { treatment: 'Control', mean: 4.2, sd: 0.6 },
+  { treatment: 'Nitrogen', mean: 5.5, sd: 0.5 },
+  { treatment: 'Phosphate', mean: 5.0, sd: 0.7 },
+  { treatment: 'Both', mean: 6.4, sd: 0.4 },
+];
+
+export function ErrorBarExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Error Bars</h2>
+      <p>
+        Mean yield with one standard deviation. Up and down move between the
+        lower bound, the estimate and the upper bound; left and right move
+        between treatments.
+      </p>
+      <MaidrRecharts
+        id="error-bar-example"
+        title="Yield by Treatment"
+        subtitle="Mean ± 1 SD"
+        data={data}
+        chartType="error_bar"
+        xKey="treatment"
+        yKeys={['mean']}
+        errorConfig={{ errorKey: 'sd' }}
+        xLabel="Treatment"
+        yLabel="Yield (t/ha)"
+      >
+        <BarChart width={600} height={350} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="treatment" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="mean" fill="#8884d8" isAnimationActive={false}>
+            <ErrorBar dataKey="sd" direction="y" width={6} stroke="#333" />
+          </Bar>
+        </BarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/ForestPlotExample.tsx
+++ b/examples/recharts/examples/ForestPlotExample.tsx
@@ -1,0 +1,59 @@
+import type { JSX } from 'react';
+import { ScatterChart, Scatter, ErrorBar, XAxis, YAxis, CartesianGrid, ReferenceLine, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+import { Orientation } from '../../../src/type/grammar';
+
+// The bounds here are ABSOLUTE (a confidence interval, not an offset), so the
+// config declares yMinKey/yMaxKey. The `lo`/`hi` offsets below are what the
+// Recharts <ErrorBar> needs, computed from the same numbers.
+const studies = [
+  { study: 'Silva 2018', or: 0.62, lower: 0.41, upper: 0.94, weight: 0.12 },
+  { study: 'Nguyen 2020', or: 1.34, lower: 0.98, upper: 1.83, weight: 0.08 },
+  { study: 'Okafor 2022', or: 1.71, lower: 1.22, upper: 2.40, weight: 0.55 },
+  { study: 'Haddad 2023', or: 1.05, lower: 0.60, upper: 1.84, weight: 0.25 },
+  { study: 'Pooled', or: 1.28, lower: 1.02, upper: 1.61, pooled: true },
+];
+
+const drawn = studies.map(row => ({
+  ...row,
+  offsets: [row.or - row.lower, row.upper - row.or] as [number, number],
+}));
+
+export function ForestPlotExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Forest Plot</h2>
+      <p>
+        A meta-analysis of four studies with the pooled summary last. MAIDR
+        announces whether each interval crosses the null line at 1, and the
+        weight each study carried — a magnitude a forest plot encodes as marker
+        area and a reader is otherwise never told.
+      </p>
+      <MaidrRecharts
+        id="forest-example"
+        title="Effect of the intervention"
+        subtitle="Odds ratio, random effects"
+        data={studies}
+        chartType="forest"
+        xKey="study"
+        yKeys={['or']}
+        orientation={Orientation.HORIZONTAL}
+        errorConfig={{ yMinKey: 'lower', yMaxKey: 'upper' }}
+        forestConfig={{ weightKey: 'weight', pooledKey: 'pooled', nullValue: 1 }}
+        xLabel="Study"
+        yLabel="Odds ratio"
+      >
+        <ScatterChart width={600} height={350} layout="vertical" margin={{ left: 80 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="or" type="number" domain={[0, 3]} name="Odds ratio" />
+          <YAxis dataKey="study" type="category" width={80} />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <ReferenceLine x={1} stroke="#333" />
+          <Scatter data={drawn} fill="#8884d8" isAnimationActive={false}>
+            <ErrorBar dataKey="offsets" direction="x" width={6} stroke="#333" />
+          </Scatter>
+        </ScatterChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/FunnelChartExample.tsx
+++ b/examples/recharts/examples/FunnelChartExample.tsx
@@ -1,0 +1,43 @@
+import type { JSX } from 'react';
+import { FunnelChart, Funnel, LabelList, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [
+  { stage: 'Visited', users: 10000 },
+  { stage: 'Signed up', users: 2400 },
+  { stage: 'Activated', users: 2300 },
+  { stage: 'Invited a teammate', users: 780 },
+  { stage: 'Paid', users: 100 },
+];
+
+export function FunnelChartExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Funnel Chart</h2>
+      <p>
+        Signup funnel. MAIDR sonifies the <strong>retention</strong> — what
+        fraction of the previous stage survived — rather than the raw count,
+        because the worst stage is rarely the biggest fall: 2,300 to 100 keeps
+        4% while 10,000 to 2,400 keeps 24%.
+      </p>
+      <MaidrRecharts
+        id="funnel-example"
+        title="Signup Funnel"
+        subtitle="Last 30 days"
+        data={data}
+        chartType="funnel"
+        xKey="stage"
+        yKeys={['users']}
+        xLabel="Stage"
+        yLabel="Users"
+      >
+        <FunnelChart width={600} height={350}>
+          <Tooltip />
+          <Funnel dataKey="users" nameKey="stage" data={data} fill="#8884d8" isAnimationActive={false}>
+            <LabelList position="right" fill="#333" dataKey="stage" />
+          </Funnel>
+        </FunnelChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/GanttExample.tsx
+++ b/examples/recharts/examples/GanttExample.tsx
@@ -1,0 +1,60 @@
+import type { JSX } from 'react';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// One row per interval, GROUPED BY LANE: Recharts draws one rectangle per row
+// in row order while the payload is walked lane by lane, and the adapter turns
+// highlighting off rather than mis-aligning it when the two disagree.
+const data = [
+  { task: 'Discovery', from: 0, to: 6, phase: 'Interviews' },
+  { task: 'Design', from: 4, to: 11, phase: 'Wireframes' },
+  { task: 'Design', from: 13, to: 16, phase: 'Visual' },
+  { task: 'Build', from: 10, to: 24, phase: 'Alpha' },
+  { task: 'Build', from: 26, to: 32, phase: 'Beta' },
+];
+
+/** The interval a floating `<Bar>` draws. */
+function span(row: unknown): [number, number] {
+  const interval = row as { from: number; to: number };
+  return [interval.from, interval.to];
+}
+
+export function GanttExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Gantt Chart</h2>
+      <p>
+        An interval is not a bar: it has two numbers and no baseline, so its
+        length is a difference a reader has to be told. MAIDR puts the length
+        on pitch and the start on stereo position, which makes two lanes whose
+        work overlaps <em>sound</em> like they overlap. <strong>Launch</strong>{' '}
+        is declared but holds nothing — an empty lane is a real statement about
+        a schedule, and it is navigable for that reason.
+      </p>
+      <MaidrRecharts
+        id="gantt-example"
+        title="Release Plan"
+        subtitle="Working days from kickoff"
+        data={data}
+        chartType="gantt"
+        xKey="task"
+        yKeys={['from', 'to']}
+        ganttConfig={{
+          lanes: ['Discovery', 'Design', 'Build', 'Launch'],
+          labelKey: 'phase',
+          unit: 'days',
+        }}
+        xLabel="Task"
+        yLabel="Day"
+      >
+        <BarChart width={600} height={350} layout="vertical" data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" domain={[0, 36]} />
+          <YAxis type="category" dataKey="task" width={90} />
+          <Tooltip />
+          <Bar dataKey={span} fill="#8884d8" isAnimationActive={false} />
+        </BarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/GaugeExample.tsx
+++ b/examples/recharts/examples/GaugeExample.tsx
@@ -1,0 +1,53 @@
+import type { JSX } from 'react';
+import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [{ measure: 'Net Promoter Score', score: 73 }];
+
+export function GaugeExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Gauge Chart</h2>
+      <p>
+        &quot;73&quot; is not the reading. &quot;73 out of 100, 7 below target,
+        in the &lsquo;good&rsquo; band&quot; is — and a sighted reader gets all
+        of it from the dial&apos;s geometry. None of it is written anywhere a
+        screen reader can reach, and none of it is inferable from a{' '}
+        <code>&lt;RadialBar&gt;</code>, so the range, the target and the bands
+        are declared through <code>gaugeConfig</code>.
+      </p>
+      <MaidrRecharts
+        id="gauge-example"
+        title="Net Promoter Score"
+        subtitle="Q3"
+        data={data}
+        chartType="gauge"
+        xKey="measure"
+        yKeys={['score']}
+        gaugeConfig={{
+          min: 0,
+          max: 100,
+          target: 80,
+          bands: [
+            { to: 40, label: 'poor' },
+            { to: 70, label: 'ok' },
+            { to: 100, label: 'good' },
+          ],
+        }}
+      >
+        <RadialBarChart
+          width={400}
+          height={260}
+          innerRadius={90}
+          outerRadius={150}
+          startAngle={180}
+          endAngle={0}
+          data={data}
+        >
+          <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+          <RadialBar dataKey="score" fill="#8884d8" background isAnimationActive={false} />
+        </RadialBarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/IcicleExample.tsx
+++ b/examples/recharts/examples/IcicleExample.tsx
@@ -1,0 +1,121 @@
+import type { JSX } from 'react';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// A type alias rather than an interface: only the former gets the implicit
+// index signature that lets it stand in for the adapter's `data` rows.
+type ChannelNode = {
+  name: string;
+  sessions?: number;
+  children?: ChannelNode[];
+};
+
+// The hierarchy the adapter is given — the same nested shape a treemap or a
+// sunburst takes. An interior node declares no value of its own: it is the sum
+// of its children, and MAIDR derives it the way the layout does.
+const nodes: ChannelNode[] = [
+  {
+    name: 'Direct',
+    children: [
+      { name: 'Bookmarks', sessions: 1840 },
+      { name: 'Typed', sessions: 920 },
+    ],
+  },
+  {
+    name: 'Search',
+    children: [
+      { name: 'Organic', sessions: 3400 },
+      { name: 'Paid', sessions: 1100 },
+    ],
+  },
+  {
+    name: 'Referral',
+    children: [
+      { name: 'Newsletters', sessions: 640 },
+      { name: 'Partners', sessions: 380 },
+    ],
+  },
+];
+
+/** One band of the icicle: a node's span at its own depth. */
+interface Band {
+  name: string;
+  depth: string;
+  from: number;
+  to: number;
+}
+
+/** A node's own value, or the sum of its children's — the layout's rule. */
+function total(node: ChannelNode): number {
+  return node.children
+    ? node.children.reduce((sum, child) => sum + total(child), 0)
+    : (node.sessions ?? 0);
+}
+
+/**
+ * Lays the tree out as bands, DEPTH-FIRST PRE-ORDER.
+ *
+ * Recharts has no icicle, so the chart is a `<BarChart layout="vertical">` of
+ * floating bars and draws one rectangle per row in row order. That order has
+ * to be the order the adapter flattens the same tree in, or row i is not
+ * node i and highlighting lands on somebody else's band.
+ *
+ * @param level - The siblings at this depth
+ * @param depth - How far down they sit; the chart's lane
+ * @param start - Where the first of them begins on the value axis
+ * @returns The bands, in the order they must be declared
+ */
+function toBands(level: ChannelNode[], depth = 0, start = 0): Band[] {
+  const bands: Band[] = [];
+  let from = start;
+
+  for (const node of level) {
+    const to = from + total(node);
+    bands.push({ name: node.name, depth: String(depth), from, to });
+    if (node.children) {
+      bands.push(...toBands(node.children, depth + 1, from));
+    }
+    from = to;
+  }
+
+  return bands;
+}
+
+const bands = toBands(nodes);
+
+/** The span a floating `<Bar>` draws. */
+function span(row: unknown): [number, number] {
+  const band = row as Band;
+  return [band.from, band.to];
+}
+
+export function IcicleExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Icicle Chart</h2>
+      <p>
+        The same hierarchy a treemap draws, laid out as depth-ordered bands.
+        MAIDR navigates it <strong>as a tree</strong> on the arrow keys that
+        already exist — up returns to the parent, down enters the first child,
+        left and right walk the siblings — and announces each node with its
+        exact share of its parent.
+      </p>
+      <MaidrRecharts
+        id="icicle-example"
+        title="Sessions by Channel"
+        data={nodes}
+        chartType="icicle"
+        xKey="name"
+        yKeys={['sessions']}
+      >
+        <BarChart width={600} height={300} layout="vertical" data={bands}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" />
+          <YAxis type="category" dataKey="depth" width={40} />
+          <Tooltip />
+          <Bar dataKey={span} fill="#8884d8" isAnimationActive={false} />
+        </BarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/LollipopExample.tsx
+++ b/examples/recharts/examples/LollipopExample.tsx
@@ -1,0 +1,42 @@
+import type { JSX } from 'react';
+import { ComposedChart, Bar, Scatter, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [
+  { country: 'Japan', share: 12 },
+  { country: 'Brazil', share: 8 },
+  { country: 'Germany', share: 15 },
+  { country: 'India', share: 21 },
+  { country: 'Canada', share: 6 },
+];
+
+export function LollipopExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Lollipop Chart</h2>
+      <p>Lollipop chart showing market share by country.</p>
+      <MaidrRecharts
+        id="lollipop-example"
+        title="Market Share by Country"
+        subtitle="Stem and head"
+        data={data}
+        chartType="lollipop"
+        xKey="country"
+        yKeys={['share']}
+        xLabel="Country"
+        yLabel="Share (%)"
+      >
+        <ComposedChart width={600} height={350} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="country" />
+          <YAxis />
+          <Tooltip />
+          {/* A thin bar is the stem; the scatter is the head, and the head is
+              what MAIDR highlights — it is where the value is read off. */}
+          <Bar dataKey="share" barSize={2} fill="#8884d8" />
+          <Scatter dataKey="share" fill="#8884d8" />
+        </ComposedChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/ManhattanPlotExample.tsx
+++ b/examples/recharts/examples/ManhattanPlotExample.tsx
@@ -1,0 +1,50 @@
+import type { JSX } from 'react';
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, ReferenceLine, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// `cumulative` is what the chart PLOTS — a running genomic offset that keeps
+// the chromosomes side by side — while `bp` is the position worth ANNOUNCING.
+// "Position 249,388,120" answers a question nobody asked, so `xKey` points at
+// the per-chromosome position and the chromosome travels as `groupKey`.
+const data = [
+  { snp: 'rs1042522', chr: '1', bp: 154_300, cumulative: 154_300, negLog10P: 9.2 },
+  { snp: 'rs2234693', chr: '1', bp: 890_450, cumulative: 890_450, negLog10P: 2.4 },
+  { snp: 'rs1801133', chr: '2', bp: 88_120, cumulative: 249_388_120, negLog10P: 3.1 },
+  { snp: 'rs4988235', chr: '2', bp: 610_775, cumulative: 249_910_775, negLog10P: 11.6 },
+  { snp: 'rs6265', chr: '3', bp: 271_390, cumulative: 492_671_390, negLog10P: 1.8 },
+  { snp: 'rs17822931', chr: '3', bp: 733_004, cumulative: 493_133_004, negLog10P: 7.9 },
+];
+
+export function ManhattanPlotExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Manhattan Plot</h2>
+      <p>
+        A genome-wide association scan. MAIDR announces the SNP and its
+        chromosome alongside the coordinates, and sorts every point against the
+        genome-wide significance line at 7.3.
+      </p>
+      <MaidrRecharts
+        id="manhattan-example"
+        title="Genome-Wide Association"
+        subtitle="-log10(p) by position"
+        data={data}
+        chartType="manhattan"
+        xKey="bp"
+        yKeys={['negLog10P']}
+        volcanoConfig={{ labelKey: 'snp', groupKey: 'chr', significance: 7.3 }}
+        xLabel="Position"
+        yLabel="-log10(p)"
+      >
+        <ScatterChart width={600} height={350}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="cumulative" type="number" name="Genomic position" tick={false} />
+          <YAxis dataKey="negLog10P" type="number" name="-log10(p)" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <ReferenceLine y={7.3} stroke="#999" strokeDasharray="4 4" />
+          <Scatter data={data} fill="#8884d8" />
+        </ScatterChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/NormalizedAreaExample.tsx
+++ b/examples/recharts/examples/NormalizedAreaExample.tsx
@@ -1,0 +1,43 @@
+import type { JSX } from 'react';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// Raw counts, not the fractions `stackOffset="expand"` renders: MAIDR derives
+// each band's share from the values it is given.
+const data = [
+  { quarter: 'Q1', desktop: 5200, mobile: 3100, tablet: 700 },
+  { quarter: 'Q2', desktop: 4800, mobile: 3900, tablet: 800 },
+  { quarter: 'Q3', desktop: 4300, mobile: 4600, tablet: 900 },
+  { quarter: 'Q4', desktop: 3900, mobile: 5400, tablet: 850 },
+];
+
+export function NormalizedAreaExample(): JSX.Element {
+  return (
+    <div>
+      <h2>100% Stacked Area Chart</h2>
+      <p>Normalized area chart showing the share of visits by device.</p>
+      <MaidrRecharts
+        id="normalized-area-example"
+        title="Visit Share by Device"
+        subtitle="100% stacked"
+        data={data}
+        chartType="normalized_area"
+        xKey="quarter"
+        yKeys={['desktop', 'mobile', 'tablet']}
+        xLabel="Quarter"
+        yLabel="Visits"
+      >
+        <AreaChart width={600} height={350} data={data} stackOffset="expand">
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="quarter" />
+          <YAxis tickFormatter={value => `${Math.round(value * 100)}%`} />
+          <Tooltip />
+          <Legend />
+          <Area type="monotone" dataKey="desktop" stackId="a" stroke="#8884d8" fill="#8884d8" name="Desktop" dot />
+          <Area type="monotone" dataKey="mobile" stackId="a" stroke="#82ca9d" fill="#82ca9d" name="Mobile" dot />
+          <Area type="monotone" dataKey="tablet" stackId="a" stroke="#ffc658" fill="#ffc658" name="Tablet" dot />
+        </AreaChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/PolarAreaExample.tsx
+++ b/examples/recharts/examples/PolarAreaExample.tsx
@@ -1,0 +1,53 @@
+import type { JSX } from 'react';
+import { Pie, PieChart, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// `slice` is the constant that makes every wedge the same ANGLE; `deaths` is
+// the measure, and it is the RADIUS. Pointing `yKeys` at the pie's own
+// `dataKey` would announce 1 on every spoke.
+const data = [
+  { month: 'Jan', deaths: 120, slice: 1 },
+  { month: 'Feb', deaths: 84, slice: 1 },
+  { month: 'Mar', deaths: 61, slice: 1 },
+  { month: 'Apr', deaths: 39, slice: 1 },
+  { month: 'May', deaths: 27, slice: 1 },
+  { month: 'Jun', deaths: 18, slice: 1 },
+];
+
+export function PolarAreaExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Polar Area (Coxcomb) Chart</h2>
+      <p>
+        A radar drawn as wedges: the same categories around the same circle,
+        with the value as the radius. MAIDR reads it exactly as it reads a
+        radar — the two differ in the mark, not in what a reader navigates — so
+        each wedge is panned to its position around the dial and a sweep goes
+        out and comes back rather than running left to right.
+      </p>
+      <MaidrRecharts
+        id="coxcomb-example"
+        title="Deaths by Month"
+        subtitle="First half of the campaign"
+        data={data}
+        chartType="polar_area"
+        xKey="month"
+        yKeys={['deaths']}
+        xLabel="Month"
+        yLabel="Deaths"
+      >
+        <PieChart width={420} height={420}>
+          <Pie
+            data={data}
+            dataKey="slice"
+            nameKey="month"
+            outerRadius={(row: { deaths: number }) => 40 + row.deaths}
+            fill="#8884d8"
+            isAnimationActive={false}
+          />
+          <Tooltip />
+        </PieChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/RadarChartExample.tsx
+++ b/examples/recharts/examples/RadarChartExample.tsx
@@ -1,0 +1,43 @@
+import type { JSX } from 'react';
+import { RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Tooltip, Legend } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [
+  { attribute: 'Speed', alice: 90, bob: 70 },
+  { attribute: 'Power', alice: 60, bob: 85 },
+  { attribute: 'Stamina', alice: 75, bob: 80 },
+  { attribute: 'Accuracy', alice: 85, bob: 55 },
+  { attribute: 'Defence', alice: 50, bob: 90 },
+  { attribute: 'Vision', alice: 80, bob: 65 },
+];
+
+export function RadarChartExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Radar Chart</h2>
+      <p>Radar chart comparing two players across six attributes.</p>
+      <MaidrRecharts
+        id="radar-example"
+        title="Player Attributes"
+        subtitle="Alice vs Bob"
+        data={data}
+        chartType="radar"
+        xKey="attribute"
+        yKeys={['alice', 'bob']}
+        xLabel="Attribute"
+        yLabel="Rating"
+      >
+        <RadarChart width={500} height={400} data={data}>
+          <PolarGrid />
+          {/* `xKey` is this axis' dataKey — the spoke each value sits on. */}
+          <PolarAngleAxis dataKey="attribute" />
+          <PolarRadiusAxis angle={30} domain={[0, 100]} />
+          <Tooltip />
+          <Legend />
+          <Radar dataKey="alice" stroke="#8884d8" fill="#8884d8" fillOpacity={0.4} name="Alice" dot />
+          <Radar dataKey="bob" stroke="#82ca9d" fill="#82ca9d" fillOpacity={0.4} name="Bob" dot />
+        </RadarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/SankeyExample.tsx
+++ b/examples/recharts/examples/SankeyExample.tsx
@@ -1,0 +1,63 @@
+import type { JSX } from 'react';
+import { Sankey, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// Each node appears once, and the ribbons carry one budget from left to
+// right — that is what makes this a sankey rather than an alluvial, where the
+// same node set repeats at every stage.
+const nodes = [
+  { name: 'Crude oil' },
+  { name: 'Natural gas' },
+  { name: 'Refining' },
+  { name: 'Power' },
+  { name: 'Transport' },
+  { name: 'Losses' },
+];
+
+const links = [
+  { source: 0, target: 2, value: 520 },
+  { source: 1, target: 3, value: 310 },
+  { source: 2, target: 4, value: 410 },
+  { source: 2, target: 5, value: 110 },
+  { source: 3, target: 4, value: 90 },
+  { source: 3, target: 5, value: 220 },
+];
+
+export function SankeyExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Sankey Diagram</h2>
+      <p>
+        Where a quantity goes, drawn as ribbons whose width is the magnitude.
+        MAIDR navigates the graph rather than a grid: following a ribbon is the
+        primary move, and arrow keys step between a node and the flows that
+        arrive at or leave it. The ribbons are announced in the order the{' '}
+        <code>links</code> array declares them, which is the order they are
+        highlighted in too.
+      </p>
+      <MaidrRecharts
+        id="sankey-example"
+        title="Primary Energy Flow"
+        subtitle="Petajoules"
+        data={links}
+        chartType="sankey"
+        xKey="source"
+        yKeys={['value']}
+        flowConfig={{ targetKey: 'target', nodes }}
+        xLabel="Stage"
+        yLabel="Energy (PJ)"
+      >
+        <Sankey
+          width={600}
+          height={350}
+          data={{ nodes, links }}
+          nodePadding={30}
+          margin={{ top: 10, right: 120, bottom: 10, left: 10 }}
+          link={{ stroke: '#82ca9d' }}
+        >
+          <Tooltip />
+        </Sankey>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/StackedAreaExample.tsx
+++ b/examples/recharts/examples/StackedAreaExample.tsx
@@ -1,0 +1,45 @@
+import type { JSX } from 'react';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// Each band's OWN value, never the accumulated top edge: MAIDR sums the
+// series itself to announce the running total and each point's share of it.
+const data = [
+  { month: 'Jan', organic: 4000, paid: 2400, referral: 1800 },
+  { month: 'Feb', organic: 4200, paid: 2100, referral: 1900 },
+  { month: 'Mar', organic: 3800, paid: 2800, referral: 2200 },
+  { month: 'Apr', organic: 4600, paid: 3200, referral: 2000 },
+  { month: 'May', organic: 5100, paid: 2900, referral: 2400 },
+  { month: 'Jun', organic: 5400, paid: 3600, referral: 2600 },
+];
+
+export function StackedAreaExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Stacked Area Chart</h2>
+      <p>Stacked area chart showing sessions by acquisition source.</p>
+      <MaidrRecharts
+        id="stacked-area-example"
+        title="Sessions by Source"
+        subtitle="Stacked view"
+        data={data}
+        chartType="stacked_area"
+        xKey="month"
+        yKeys={['organic', 'paid', 'referral']}
+        xLabel="Month"
+        yLabel="Sessions"
+      >
+        <AreaChart width={600} height={350} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Area type="monotone" dataKey="organic" stackId="a" stroke="#8884d8" fill="#8884d8" name="Organic" dot />
+          <Area type="monotone" dataKey="paid" stackId="a" stroke="#82ca9d" fill="#82ca9d" name="Paid" dot />
+          <Area type="monotone" dataKey="referral" stackId="a" stroke="#ffc658" fill="#ffc658" name="Referral" dot />
+        </AreaChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/SunburstExample.tsx
+++ b/examples/recharts/examples/SunburstExample.tsx
@@ -1,0 +1,57 @@
+import type { JSX } from 'react';
+import { SunburstChart } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const nodes = [
+  {
+    name: 'Direct',
+    children: [
+      { name: 'Bookmarks', sessions: 1840 },
+      { name: 'Typed', sessions: 920 },
+    ],
+  },
+  {
+    name: 'Search',
+    children: [
+      { name: 'Organic', sessions: 3400 },
+      { name: 'Paid', sessions: 1100 },
+    ],
+  },
+  {
+    name: 'Referral',
+    children: [
+      { name: 'Newsletters', sessions: 640 },
+      { name: 'Partners', sessions: 380 },
+    ],
+  },
+];
+
+export function SunburstExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Sunburst</h2>
+      <p>
+        The same hierarchy a treemap draws, laid out as rings. Recharts&apos;{' '}
+        <code>&lt;SunburstChart&gt;</code> takes a single root object and draws
+        that root&apos;s <strong>children</strong>, so those children are what
+        the adapter is given — the declared nodes are then exactly the drawn
+        ones, and highlighting lines up ring by ring.
+      </p>
+      <MaidrRecharts
+        id="sunburst-example"
+        title="Sessions by Channel"
+        data={nodes}
+        chartType="sunburst"
+        xKey="name"
+        yKeys={['sessions']}
+      >
+        <SunburstChart
+          width={420}
+          height={420}
+          data={{ name: 'All traffic', children: nodes }}
+          dataKey="sessions"
+        />
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/SurvivalCurveExample.tsx
+++ b/examples/recharts/examples/SurvivalCurveExample.tsx
@@ -1,0 +1,56 @@
+import type { JSX } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// A censored time is a subject who left the study without the event
+// happening. The curve does not step there, which is exactly why a reader has
+// to be told: a flat tail backed by two hundred subjects and one backed by
+// three look identical.
+const data = [
+  { months: 0, treated: 1.0, control: 1.0, treatedCensored: false },
+  { months: 3, treated: 0.94, control: 0.88, treatedCensored: false },
+  { months: 6, treated: 0.88, control: 0.74, treatedCensored: true },
+  { months: 9, treated: 0.81, control: 0.61, treatedCensored: false },
+  { months: 12, treated: 0.77, control: 0.52, treatedCensored: true },
+  { months: 18, treated: 0.71, control: 0.44, treatedCensored: false },
+  { months: 24, treated: 0.68, control: 0.39, treatedCensored: false },
+];
+
+export function SurvivalCurveExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Survival Curve</h2>
+      <p>
+        Kaplan-Meier curves for two arms, drawn with
+        {' '}
+        <code>type="stepAfter"</code>
+        {' '}
+        — survival holds until an event drops it. Use the rotor to jump between
+        the censored times.
+      </p>
+      <MaidrRecharts
+        id="survival-example"
+        title="Overall Survival"
+        subtitle="Treated versus control"
+        data={data}
+        chartType="survival"
+        xKey="months"
+        yKeys={['treated', 'control']}
+        fillKeys={['Treatment', 'Control']}
+        survivalConfig={{ censoredKeys: ['treatedCensored'] }}
+        xLabel="Months since randomisation"
+        yLabel="Survival probability"
+      >
+        <LineChart width={600} height={350} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="months" />
+          <YAxis domain={[0, 1]} />
+          <Tooltip />
+          <Legend />
+          <Line type="stepAfter" dataKey="treated" stroke="#8884d8" name="Treatment" dot />
+          <Line type="stepAfter" dataKey="control" stroke="#82ca9d" name="Control" dot />
+        </LineChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/TreemapExample.tsx
+++ b/examples/recharts/examples/TreemapExample.tsx
@@ -1,0 +1,67 @@
+import type { JSX } from 'react';
+import { Treemap } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// Nested `{ name, children }` — the data Recharts itself is given, not the
+// adapter's usual flat rows. Interior nodes carry no value: Recharts computes
+// theirs as the sum of their children, and so does MAIDR.
+const nodes = [
+  {
+    name: 'Europe',
+    children: [
+      { name: 'Germany', people: 83.2 },
+      { name: 'France', people: 67.4 },
+      { name: 'Spain', people: 47.4 },
+    ],
+  },
+  {
+    name: 'Asia',
+    children: [
+      { name: 'Japan', people: 125.1 },
+      { name: 'Vietnam', people: 97.5 },
+      { name: 'Nepal', people: 30.0 },
+    ],
+  },
+  {
+    name: 'Americas',
+    children: [
+      { name: 'Canada', people: 38.2 },
+      { name: 'Peru', people: 33.7 },
+    ],
+  },
+];
+
+export function TreemapExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Treemap</h2>
+      <p>
+        The tree navigates <strong>as a tree</strong>, on the arrow keys that
+        already exist: up returns to the parent, down enters the first child,
+        left and right walk the siblings. Each node is announced with its exact
+        share of its parent — the comparison the rectangles are drawn to
+        support, and the one the eye estimates worst.
+      </p>
+      <MaidrRecharts
+        id="treemap-example"
+        title="Population by Region"
+        subtitle="Millions"
+        data={nodes}
+        chartType="treemap"
+        xKey="name"
+        yKeys={['people']}
+      >
+        <Treemap
+          width={600}
+          height={350}
+          data={nodes}
+          dataKey="people"
+          nameKey="name"
+          stroke="#fff"
+          fill="#8884d8"
+          isAnimationActive={false}
+        />
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/VolcanoPlotExample.tsx
+++ b/examples/recharts/examples/VolcanoPlotExample.tsx
@@ -1,0 +1,50 @@
+import type { JSX } from 'react';
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, ReferenceLine, Tooltip } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const data = [
+  { gene: 'TP53', log2fc: 2.4, negLog10P: 14.1 },
+  { gene: 'EGFR', log2fc: 1.9, negLog10P: 6.4 },
+  { gene: 'BRCA1', log2fc: -2.1, negLog10P: 8.7 },
+  { gene: 'MYC', log2fc: -0.3, negLog10P: 0.8 },
+  { gene: 'KRAS', log2fc: 0.6, negLog10P: 1.1 },
+  { gene: 'PTEN', log2fc: -1.4, negLog10P: 4.2 },
+  { gene: 'ACTB', log2fc: 0.1, negLog10P: 0.2 },
+];
+
+export function VolcanoPlotExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Volcano Plot</h2>
+      <p>
+        Differential expression. The labels are the payload here — a reader
+        told only "x is 2.4, y is 14.1" has been handed the two numbers they
+        can already see the shape of, and withheld the gene.
+      </p>
+      <MaidrRecharts
+        id="volcano-example"
+        title="Differential Expression"
+        subtitle="Tumour versus normal"
+        data={data}
+        chartType="volcano"
+        xKey="log2fc"
+        yKeys={['negLog10P']}
+        volcanoConfig={{ labelKey: 'gene', significance: 1.3, effect: 1 }}
+        xLabel="log2 fold change"
+        yLabel="-log10(p)"
+      >
+        <ScatterChart width={600} height={350}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="log2fc" type="number" name="log2 fold change" />
+          <YAxis dataKey="negLog10P" type="number" name="-log10(p)" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          {/* The same cutoffs declared to MAIDR, drawn for sighted readers. */}
+          <ReferenceLine y={1.3} stroke="#999" strokeDasharray="4 4" />
+          <ReferenceLine x={1} stroke="#999" strokeDasharray="4 4" />
+          <ReferenceLine x={-1} stroke="#999" strokeDasharray="4 4" />
+          <Scatter data={data} fill="#8884d8" />
+        </ScatterChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/WaterfallExample.tsx
+++ b/examples/recharts/examples/WaterfallExample.tsx
@@ -1,0 +1,65 @@
+import type { JSX } from 'react';
+import type { WaterfallPoint } from '../../../src/type/grammar';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import { useRechartsAdapter } from '../../../src/adapters/recharts/useRechartsAdapter';
+import { Maidr } from '../../../src/maidr-component';
+
+const data = [
+  { step: 'Opening ARR', change: 1200, restates: true },
+  { step: 'New business', change: 450 },
+  { step: 'Expansion', change: 180 },
+  { step: 'Contraction', change: -95 },
+  { step: 'Churn', change: -210 },
+  { step: 'Closing ARR', restates: true },
+];
+
+const config = {
+  id: 'waterfall-example',
+  title: 'ARR Bridge',
+  subtitle: 'FY24',
+  data,
+  chartType: 'waterfall' as const,
+  xKey: 'step',
+  yKeys: ['change'],
+  waterfallConfig: { totalKey: 'restates' },
+  xLabel: 'Step',
+  yLabel: 'ARR ($k)',
+};
+
+export function WaterfallExample(): JSX.Element {
+  const maidrData = useRechartsAdapter(config);
+  // The adapter accumulates the running totals, which is exactly what a
+  // floating <Bar> needs — so the chart is drawn from them rather than
+  // accumulating a second time and risking a chart that disagrees with its
+  // own description.
+  const steps = maidrData.subplots[0][0].layers[0].data as WaterfallPoint[];
+
+  return (
+    <div>
+      <h2>Waterfall Chart</h2>
+      <p>
+        A step carries two numbers a bar chart would conflate: the{' '}
+        <strong>contribution</strong> it made and the <strong>running total</strong>{' '}
+        it produced. MAIDR sonifies the contribution — the totals of a
+        waterfall drift within a narrow band, so pitching those would squash
+        every step into one tone — and announces the total alongside it.
+      </p>
+      <Maidr data={maidrData}>
+        <BarChart width={600} height={350} data={steps}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="x" />
+          <YAxis />
+          <Tooltip />
+          <Bar
+            dataKey={(step: unknown) => {
+              const point = step as WaterfallPoint;
+              return [point.start, point.end];
+            }}
+            fill="#8884d8"
+            isAnimationActive={false}
+          />
+        </BarChart>
+      </Maidr>
+    </div>
+  );
+}

--- a/src/adapters/recharts/MaidrRecharts.tsx
+++ b/src/adapters/recharts/MaidrRecharts.tsx
@@ -124,6 +124,11 @@ export function MaidrRecharts({
   orientation,
   fillKeys,
   binConfig,
+  flowConfig,
+  volcanoConfig,
+  errorConfig,
+  forestConfig,
+  survivalConfig,
   selectorOverride,
   children,
 }: MaidrRechartsProps): JSX.Element {
@@ -145,9 +150,14 @@ export function MaidrRecharts({
       orientation,
       fillKeys,
       binConfig,
+      flowConfig,
+      volcanoConfig,
+      errorConfig,
+      forestConfig,
+      survivalConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, selectorOverride],
   );
 
   return (

--- a/src/adapters/recharts/MaidrRecharts.tsx
+++ b/src/adapters/recharts/MaidrRecharts.tsx
@@ -129,6 +129,9 @@ export function MaidrRecharts({
   errorConfig,
   forestConfig,
   survivalConfig,
+  waterfallConfig,
+  ganttConfig,
+  gaugeConfig,
   selectorOverride,
   children,
 }: MaidrRechartsProps): JSX.Element {
@@ -155,9 +158,12 @@ export function MaidrRecharts({
       errorConfig,
       forestConfig,
       survivalConfig,
+      waterfallConfig,
+      ganttConfig,
+      gaugeConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, selectorOverride],
   );
 
   return (

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -12,10 +12,18 @@
  *   SegmentedPoint[][]  = [[{ x, y, fill }, ...], ...]  (stacked/dodged/normalized)
  *   HistogramPoint[]    = [{ x, y, xMin, xMax, yMin, yMax }, ...]
  *   PiePoint[]          = [{ x, y }, ...]                (flat, one per slice)
+ *   ErrorBarPoint[]     = [{ x, y, yMin?, yMax? }, ...]  (bounds are ABSOLUTE)
+ *   ForestPoint[]       = [{ x, y, yMin?, yMax?, weight?, pooled? }, ...]
+ *   VolcanoPoint[]      = [{ x, y, label?, group? }, ...]
+ *   SurvivalPoint[][]   = [[{ x, y, censored?, yMin?, yMax? }, ...], ...]
+ *   FlowPoint[]         = [{ source, target, value }, ...]
  */
 
 import type {
   BarPoint,
+  ErrorBarPoint,
+  FlowPoint,
+  ForestPoint,
   HistogramPoint,
   LinePoint,
   Maidr,
@@ -24,6 +32,8 @@ import type {
   PiePoint,
   ScatterPoint,
   SegmentedPoint,
+  SurvivalPoint,
+  VolcanoPoint,
 } from '@type/grammar';
 import type { RechartsAdapterConfig, RechartsChartType, RechartsLayerConfig, RechartsSubplotConfig } from './types';
 import { cssEscape } from '@adapters/shared/selectorUtil';
@@ -153,6 +163,14 @@ function buildPanelSubplot(
     orientation: panel.orientation ?? config.orientation,
     fillKeys: panel.fillKeys ?? config.fillKeys,
     binConfig: panel.binConfig ?? config.binConfig,
+    // The per-type configs name FIELDS and declare CUTOFFS, both of which the
+    // panels of a facet grid share by construction — every panel plots the
+    // same columns of a split data set — so they have no per-panel override.
+    flowConfig: config.flowConfig,
+    volcanoConfig: config.volcanoConfig,
+    errorConfig: config.errorConfig,
+    forestConfig: config.forestConfig,
+    survivalConfig: config.survivalConfig,
     selectorOverride: panel.selectorOverride,
   };
 
@@ -215,6 +233,13 @@ function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): 
     return [buildHistogramLayer(data, xKey, yKeys[0], chartType, xLabel, yLabel, orientation, config.binConfig, selectorOverride, config.id, panelScope)];
   }
 
+  // Survival: one layer of SurvivalPoint[][] whether the figure draws one arm
+  // or several. The censoring marks and the confidence band ride on the
+  // points, and the plain line builders have nowhere to put them.
+  if (chartType === 'survival') {
+    return [buildSurvivalLayer(data, xKey, yKeys, chartType, xLabel, yLabel, fillKeys, config.survivalConfig, selectorOverride, config.id, panelScope)];
+  }
+
   // Line with multiple series: single layer with 2D LinePoint[][] data
   if (isLineType(chartType) && hasMultipleSeries) {
     return [buildMultiSeriesLineLayer(data, xKey, yKeys, chartType, xLabel, yLabel, selectorOverride)];
@@ -226,12 +251,13 @@ function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): 
   return yKeys.map((yKey, index) => {
     const seriesIndex = hasMultipleSeries ? index : undefined;
     const selector = selectorOverride ?? getRechartsSelector(chartType, seriesIndex, config.id, panelScope);
-    const layerData = convertData(chartType, data, xKey, yKey);
+    const layerData = convertData(chartType, data, xKey, yKey, config);
 
     return {
       id: String(index),
       type: maidrType,
       title: hasMultipleSeries ? (fillKeys?.[index] ?? yKey) : undefined,
+      ...layerOptions(chartType, config),
       // LineTrace expects selectors as string[] (one per series), not a single string
       selectors: isLineType(chartType) ? (selector ? [selector] : undefined) : selector,
       orientation: layerOrientation(chartType, orientation),
@@ -375,6 +401,62 @@ function buildMultiSeriesLineLayer(
 }
 
 /**
+ * Builds a single survival layer with one SurvivalPoint[] row per arm.
+ *
+ * `stepDirection` is emitted because Recharts draws these curves with
+ * `<Line type="stepAfter">` — survival holds until an event drops it, which
+ * is exactly the `hv` convention — and a reader told which way the curve
+ * jumps knows whether the value they hear covers the interval before the time
+ * or after it.
+ */
+function buildSurvivalLayer(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKeys: string[],
+  chartType: RechartsChartType,
+  xLabel?: string,
+  yLabel?: string,
+  fillKeys?: string[],
+  survivalConfig?: RechartsAdapterConfig['survivalConfig'],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  const hasMultipleArms = yKeys.length > 1;
+  const survivalData: SurvivalPoint[][] = yKeys.map((yKey, arm) =>
+    convertToSurvivalRow(
+      data,
+      xKey,
+      yKey,
+      survivalConfig,
+      arm,
+      // A single-arm curve has nothing to be distinguished from, so it goes
+      // unnamed the way a single-series line does.
+      hasMultipleArms ? (fillKeys?.[arm] ?? yKey) : undefined,
+    ),
+  );
+
+  // Same honest degrade as the other multi-series line families: CSS cannot
+  // tell one <Line> from another, so highlighting is off unless the consumer
+  // named the arms with their own classes.
+  const selector = selectorOverride
+    ?? getRechartsSelector(chartType, hasMultipleArms ? 0 : undefined, chartId, panelScope);
+
+  return {
+    id: '0',
+    type: TraceType.SURVIVAL,
+    // A SurvivalTrace is a LineTrace: one selector per arm, never a bare string.
+    selectors: selector ? yKeys.map(() => selector) : undefined,
+    stepDirection: survivalConfig?.stepDirection ?? 'hv',
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+    },
+    data: survivalData,
+  };
+}
+
+/**
  * Builds layers for composed mode (mixed chart types via layers config).
  */
 function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
@@ -406,12 +488,13 @@ function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string)
 
     const maidrType = toTraceType(chartType);
     const selector = selectorOverride ?? getRechartsSelector(chartType, seriesIndex, config.id, panelScope);
-    const layerData = convertData(chartType, data, xKey, yKey);
+    const layerData = convertData(chartType, data, xKey, yKey, config);
 
     return {
       id: String(index),
       type: maidrType,
       title: name,
+      ...layerOptions(chartType, config),
       // LineTrace expects selectors as string[] (one per series), not a single string
       selectors: isLineType(chartType) ? (selector ? [selector] : undefined) : selector,
       orientation: layerOrientation(chartType, orientation),
@@ -426,19 +509,27 @@ function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string)
 
 /**
  * Converts Recharts data for a single series into the appropriate MAIDR format.
+ *
+ * `config` is read only by the types whose payload carries more than a
+ * coordinate pair — the flow's node names, the volcano's labels, the
+ * interval's bounds — each of which names its fields in its own sub-config.
  */
 function convertData(
   chartType: RechartsChartType,
   data: Record<string, unknown>[],
   xKey: string,
   yKey: string,
-): BarPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] {
+  config: RechartsAdapterConfig,
+): BarPoint[] | ErrorBarPoint[] | FlowPoint[] | ForestPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] | SurvivalPoint[][] | VolcanoPoint[] {
   switch (chartType) {
     // A dot plot and a lollipop carry a bar's data — one category, one
-    // magnitude — and differ only in the mark drawn for it.
+    // magnitude — and differ only in the mark drawn for it. So does a funnel:
+    // the retention and the share it is read for are ratios MAIDR derives
+    // from the counts, never numbers the adapter hands it.
     case 'bar':
     case 'dot':
     case 'lollipop':
+    case 'funnel':
       return convertToBarPoints(data, xKey, yKey);
     // The area, radar and bump families are all read as a line is: one value
     // per sample. What the stacking, the circle and the rank change is how
@@ -450,8 +541,23 @@ function convertData(
     case 'radar':
     case 'bump':
       return convertToLinePoints(data, xKey, yKey);
+    // A composed chart carries one curve per layer, so it reads the first
+    // entry of each per-arm key array.
+    case 'survival':
+      return [convertToSurvivalRow(data, xKey, yKey, config.survivalConfig, 0)];
     case 'scatter':
       return convertToScatterPoints(data, xKey, yKey);
+    // Both are scatters read through a threshold, and differ only in what the
+    // x axis means — effect size against genomic position.
+    case 'volcano':
+    case 'manhattan':
+      return convertToVolcanoPoints(data, xKey, yKey, config.volcanoConfig);
+    case 'error_bar':
+      return convertToErrorBarPoints(data, xKey, yKey, config.errorConfig);
+    case 'forest':
+      return convertToForestPoints(data, xKey, yKey, config.errorConfig, config.forestConfig);
+    case 'alluvial':
+      return convertToFlowPoints(data, xKey, yKey, config.flowConfig);
     case 'pie':
       return convertToPiePoints(data, xKey, yKey);
     // Stacked/dodged/normalized/histogram handled by dedicated builders
@@ -529,6 +635,229 @@ function convertToScatterPoints(
 }
 
 /**
+ * Converts data to VolcanoPoint[] format — a scatter plus what the point is.
+ *
+ * On a Manhattan plot `xKey` should name the position that gets ANNOUNCED,
+ * which is rarely the one that gets plotted: the drawn x is usually a
+ * cumulative genomic offset running across every chromosome, and "position
+ * 1,431,900,204" answers nothing. Point it at the per-chromosome position and
+ * declare the chromosome as `groupKey`.
+ */
+function convertToVolcanoPoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  volcanoConfig?: RechartsAdapterConfig['volcanoConfig'],
+): VolcanoPoint[] {
+  const { labelKey, groupKey } = volcanoConfig ?? {};
+
+  return data.map((item) => {
+    const point: VolcanoPoint = {
+      x: toNumber(item[xKey]),
+      y: toNumber(item[yKey]),
+    };
+    const label = labelKey === undefined ? undefined : toText(item[labelKey]);
+    if (label !== undefined) {
+      point.label = label;
+    }
+    const group = groupKey === undefined ? undefined : toText(item[groupKey]);
+    if (group !== undefined) {
+      point.group = group;
+    }
+    return point;
+  });
+}
+
+/**
+ * Converts data to ErrorBarPoint[] format.
+ */
+function convertToErrorBarPoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  errorConfig?: RechartsAdapterConfig['errorConfig'],
+): ErrorBarPoint[] {
+  return data.map(item => toErrorBarPoint(item, xKey, yKey, errorConfig));
+}
+
+/**
+ * Converts data to ForestPoint[] format — an interval per study, plus the two
+ * things that make the figure a forest plot rather than a row of intervals.
+ *
+ * Row order is the drawn order, so the pooled summary is wherever the chart
+ * puts it: flagged by `pooledKey`, or named by `pooledIndex` for data that
+ * carries no flag column.
+ */
+function convertToForestPoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  errorConfig?: RechartsAdapterConfig['errorConfig'],
+  forestConfig?: RechartsAdapterConfig['forestConfig'],
+): ForestPoint[] {
+  const { weightKey, pooledKey, pooledIndex } = forestConfig ?? {};
+
+  return data.map((item, index) => {
+    const point: ForestPoint = toErrorBarPoint(item, xKey, yKey, errorConfig);
+    const weight = weightKey === undefined ? undefined : toOptionalNumber(item[weightKey]);
+    if (weight !== undefined) {
+      point.weight = weight;
+    }
+    if ((pooledKey !== undefined && Boolean(item[pooledKey])) || index === pooledIndex) {
+      point.pooled = true;
+    }
+    return point;
+  });
+}
+
+/**
+ * Converts one row into an estimate with its interval.
+ *
+ * The bounds are ABSOLUTE positions on the value axis, while Recharts'
+ * `<ErrorBar dataKey>` points at an OFFSET from the estimate, so an offset is
+ * resolved against `y` here — `y - lower`, `y + upper`, the same arithmetic
+ * `ErrorBar.js` does to place the whiskers. Absolute keys win when both are
+ * declared: they need no arithmetic and cannot be misread as offsets.
+ *
+ * The bounds are independently optional. A one-sided interval is a real
+ * chart, and dropping the point for want of its other half would lose the
+ * estimate too, so a missing bound is left off rather than defaulted to `y`.
+ */
+function toErrorBarPoint(
+  item: Record<string, unknown>,
+  xKey: string,
+  yKey: string,
+  errorConfig?: RechartsAdapterConfig['errorConfig'],
+): ErrorBarPoint {
+  const y = toNumber(item[yKey]);
+  const point: ErrorBarPoint = { x: item[xKey] as string | number, y };
+
+  const { errorKey, yMinKey, yMaxKey } = errorConfig ?? {};
+  const error = errorKey === undefined ? undefined : item[errorKey];
+  // A [lower, upper] pair is an asymmetric interval; a bare number is a
+  // symmetric one applied to both sides. Recharts reads the field the same way.
+  const [lower, upper] = Array.isArray(error)
+    ? [toOptionalNumber(error[0]), toOptionalNumber(error[1])]
+    : [toOptionalNumber(error), toOptionalNumber(error)];
+
+  const yMin = yMinKey === undefined
+    ? (lower === undefined ? undefined : y - lower)
+    : toOptionalNumber(item[yMinKey]);
+  const yMax = yMaxKey === undefined
+    ? (upper === undefined ? undefined : y + upper)
+    : toOptionalNumber(item[yMaxKey]);
+
+  if (yMin !== undefined) {
+    point.yMin = yMin;
+  }
+  if (yMax !== undefined) {
+    point.yMax = yMax;
+  }
+  return point;
+}
+
+/**
+ * Converts data to one arm of a survival curve.
+ *
+ * @param data - The Recharts data array
+ * @param xKey - Key holding the time
+ * @param yKey - Key holding this arm's survival probability
+ * @param survivalConfig - Per-arm censoring and confidence band keys
+ * @param arm - Which arm this is; indexes the per-arm key arrays
+ * @param seriesName - Arm display name, when the figure draws more than one
+ * @returns One arm's points, in the order the curve is walked
+ */
+function convertToSurvivalRow(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  survivalConfig?: RechartsAdapterConfig['survivalConfig'],
+  arm: number = 0,
+  seriesName?: string,
+): SurvivalPoint[] {
+  const censoredKey = survivalConfig?.censoredKeys?.[arm];
+  const yMinKey = survivalConfig?.yMinKeys?.[arm];
+  const yMaxKey = survivalConfig?.yMaxKeys?.[arm];
+
+  return data.map((item) => {
+    const point: SurvivalPoint = {
+      x: toLineX(item[xKey]),
+      y: toNumber(item[yKey]),
+    };
+    if (seriesName !== undefined) {
+      point.z = seriesName;
+    }
+    // Only a censored time is marked. An uncensored one says nothing, and a
+    // `censored: false` on every ordinary point is a claim the data never made.
+    if (censoredKey !== undefined && Boolean(item[censoredKey])) {
+      point.censored = true;
+    }
+    const yMin = yMinKey === undefined ? undefined : toOptionalNumber(item[yMinKey]);
+    if (yMin !== undefined) {
+      point.yMin = yMin;
+    }
+    const yMax = yMaxKey === undefined ? undefined : toOptionalNumber(item[yMaxKey]);
+    if (yMax !== undefined) {
+      point.yMax = yMax;
+    }
+    return point;
+  });
+}
+
+/**
+ * Converts data to FlowPoint[] format — one weighted flow per link.
+ *
+ * The `data` array is the `links` half of what Recharts' `<Sankey>` is given,
+ * so `xKey` names the source field and `yKey` the magnitude. Recharts
+ * addresses nodes by their index in the `nodes` array, and an index is not
+ * something to announce — "flow from 3 to 7" names neither end — so the
+ * indices are resolved back to node names whenever `flowConfig.nodes` is
+ * declared. Links that already carry names pass through untouched.
+ */
+function convertToFlowPoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  flowConfig?: RechartsAdapterConfig['flowConfig'],
+): FlowPoint[] {
+  if (!flowConfig) {
+    throw new Error('RechartsAdapter: flowConfig with a targetKey is required when chartType is "alluvial"');
+  }
+
+  const { targetKey, nodes, nodeNameKey } = flowConfig;
+  return data.map(item => ({
+    source: resolveFlowNode(item[xKey], nodes, nodeNameKey),
+    target: resolveFlowNode(item[targetKey], nodes, nodeNameKey),
+    value: toNumber(item[yKey]),
+  }));
+}
+
+/**
+ * Resolves one end of a flow to the node it names.
+ *
+ * A numeric end is a position in the `nodes` array, exactly as Recharts reads
+ * it. Anything else — a name the links carry themselves — is already the
+ * answer, and an index with no node list behind it stays a number rather than
+ * becoming a made-up label.
+ */
+function resolveFlowNode(
+  value: unknown,
+  nodes?: Record<string, unknown>[],
+  nodeNameKey: string = 'name',
+): string | number {
+  if (typeof value === 'number' && nodes) {
+    const name = toText(nodes[value]?.[nodeNameKey]);
+    if (name !== undefined) {
+      return name;
+    }
+  }
+  if (typeof value === 'number' || typeof value === 'string') {
+    return value;
+  }
+  return String(value);
+}
+
+/**
  * Returns true if the chart type produces bar-like visuals that benefit from orientation.
  */
 function isBarType(chartType: RechartsChartType): boolean {
@@ -547,13 +876,18 @@ function isBarType(chartType: RechartsChartType): boolean {
  * Bar-like layers default to vertical. A pie and a radar are never oriented —
  * their marks sit around a circle rather than along an axis — so a config-level
  * `orientation` (meaningful for the other layers of a composed chart) must not
- * leak onto one.
+ * leak onto one. Neither is a flow diagram, whose marks run between nodes.
+ *
+ * A funnel is left out for a different reason: `FunnelTrace` is a `BarTrace`,
+ * and a horizontal bar carries its category in `y` rather than `x`. The
+ * adapter always emits the stage label as `x`, so a leaked `HORIZONTAL` would
+ * have every stage announced by its count.
  */
 function layerOrientation(
   chartType: RechartsChartType,
   orientation?: Orientation,
 ): Orientation | undefined {
-  if (chartType === 'pie' || chartType === 'radar') {
+  if (chartType === 'pie' || chartType === 'radar' || chartType === 'funnel' || chartType === 'alluvial') {
     return undefined;
   }
   return orientation ?? (isBarType(chartType) ? Orientation.VERTICAL : undefined);
@@ -579,16 +913,52 @@ function isStackedAreaType(chartType: RechartsChartType): boolean {
 /**
  * Returns true if the chart type maps to a line-like MAIDR type.
  *
- * The whole area family, radar and bump belong here: every one of them is a
- * `LineTrace` subclass in the model, so each expects `LinePoint[][]` data and
- * `selectors` as a `string[]` rather than a bare string.
+ * The whole area family, radar, bump and survival belong here: every one of
+ * them is a `LineTrace` subclass in the model, so each expects `LinePoint[][]`
+ * data and `selectors` as a `string[]` rather than a bare string.
  */
 function isLineType(chartType: RechartsChartType): boolean {
   return chartType === 'line'
     || chartType === 'area'
     || isStackedAreaType(chartType)
     || chartType === 'radar'
-    || chartType === 'bump';
+    || chartType === 'bump'
+    || chartType === 'survival';
+}
+
+/**
+ * Returns the display options a layer of `chartType` carries beyond its data.
+ *
+ * Every one of these is author knowledge rather than Recharts state: a
+ * `<Scatter>` does not know which of its points are significant, and a
+ * `<ReferenceLine x={1}>` does not say that 1 is what "no effect" means. So
+ * each arrives through the adapter config, and is emitted only when declared —
+ * MAIDR substitutes no default for any of them, and a guessed cutoff sorts
+ * every point on the figure onto the wrong side silently.
+ */
+function layerOptions(
+  chartType: RechartsChartType,
+  config: RechartsAdapterConfig,
+): Partial<MaidrLayer> {
+  switch (chartType) {
+    case 'volcano':
+    case 'manhattan': {
+      const { significance, significanceDirection, effect } = config.volcanoConfig ?? {};
+      if (significance === undefined && significanceDirection === undefined && effect === undefined) {
+        return {};
+      }
+      return { thresholdOptions: { significance, significanceDirection, effect } };
+    }
+    case 'forest': {
+      const nullValue = config.forestConfig?.nullValue;
+      return nullValue === undefined ? {} : { forestOptions: { nullValue } };
+    }
+    case 'survival':
+      // Only reachable from composed mode; buildSurvivalLayer sets its own.
+      return { stepDirection: config.survivalConfig?.stepDirection ?? 'hv' };
+    default:
+      return {};
+  }
 }
 
 /**
@@ -630,6 +1000,8 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.DOT;
     case 'lollipop':
       return TraceType.LOLLIPOP;
+    case 'funnel':
+      return TraceType.FUNNEL;
     case 'histogram':
       return TraceType.HISTOGRAM;
     case 'line':
@@ -644,10 +1016,22 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.RADAR;
     case 'bump':
       return TraceType.BUMP;
+    case 'survival':
+      return TraceType.SURVIVAL;
     case 'scatter':
       return TraceType.SCATTER;
+    case 'volcano':
+      return TraceType.VOLCANO;
+    case 'manhattan':
+      return TraceType.MANHATTAN;
+    case 'error_bar':
+      return TraceType.ERROR_BAR;
+    case 'forest':
+      return TraceType.FOREST;
     case 'pie':
       return TraceType.PIE;
+    case 'alluvial':
+      return TraceType.ALLUVIAL;
   }
 }
 
@@ -664,6 +1048,41 @@ function toLineX(value: unknown): number | string {
   if (typeof value === 'string')
     return value;
   return 0;
+}
+
+/**
+ * Converts a value to a number, or to nothing.
+ *
+ * Unlike {@link toNumber} an absent value stays absent rather than becoming
+ * 0, because every caller here feeds an OPTIONAL field: a missing bound, a
+ * missing weight. Substituting 0 would draw an interval the chart never had
+ * and give a study a weight of none.
+ */
+function toOptionalNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const num = Number(value);
+    return Number.isNaN(num) ? undefined : num;
+  }
+  return undefined;
+}
+
+/**
+ * Converts a value to display text, or to nothing.
+ *
+ * Only strings and numbers become text: a label is something the author wrote
+ * down, and `[object Object]` announced as a gene name is worse than silence.
+ */
+function toText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value === '' ? undefined : value;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return undefined;
 }
 
 /**

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -754,12 +754,14 @@ function convertData(
       return convertToBarPoints(data, xKey, yKey);
     // The area, radar and bump families are all read as a line is: one value
     // per sample. What the stacking, the circle and the rank change is how
-    // the model announces them, not what the adapter has to emit.
+    // the model announces them, not what the adapter has to emit. A polar area
+    // is a radar whose spokes are drawn as wedges, so it lands here too.
     case 'line':
     case 'area':
     case 'stacked_area':
     case 'normalized_area':
     case 'radar':
+    case 'polar_area':
     case 'bump':
       return convertToLinePoints(data, xKey, yKey);
     // A composed chart carries one curve per layer, so it reads the first
@@ -777,14 +779,19 @@ function convertData(
       return convertToErrorBarPoints(data, xKey, yKey, config.errorConfig);
     case 'forest':
       return convertToForestPoints(data, xKey, yKey, config.errorConfig, config.forestConfig);
+    // Both are the same weighted graph: a `<Sankey>` of links between nodes.
+    // Whether the node set repeats at each stage is what tells the two apart,
+    // and that is a fact about the data rather than about the payload.
     case 'alluvial':
+    case 'sankey':
       return convertToFlowPoints(data, xKey, yKey, config.flowConfig);
     case 'waterfall':
       return convertToWaterfallPoints(data, xKey, yKey, config.waterfallConfig);
-    // A treemap and a sunburst are the same hierarchy, and differ only in
-    // whether it is drawn as area or as rings.
+    // A treemap, a sunburst and an icicle are the same hierarchy, and differ
+    // only in whether it is drawn as nested area, as rings or as bands.
     case 'treemap':
     case 'sunburst':
+    case 'icicle':
       return convertToTreemapPoints(data, xKey, yKey);
     case 'pie':
       return convertToPiePoints(data, xKey, yKey);
@@ -1164,7 +1171,7 @@ function convertToFlowPoints(
   flowConfig?: RechartsAdapterConfig['flowConfig'],
 ): FlowPoint[] {
   if (!flowConfig) {
-    throw new Error('RechartsAdapter: flowConfig with a targetKey is required when chartType is "alluvial"');
+    throw new Error('RechartsAdapter: flowConfig with a targetKey is required when chartType is "alluvial" or "sankey"');
   }
 
   const { targetKey, nodes, nodeNameKey } = flowConfig;
@@ -1219,11 +1226,13 @@ function isBarType(chartType: RechartsChartType): boolean {
 /**
  * Returns the orientation to emit for a layer of the given chart type.
  *
- * Bar-like layers default to vertical. A pie and a radar are never oriented —
- * their marks sit around a circle rather than along an axis — so a config-level
- * `orientation` (meaningful for the other layers of a composed chart) must not
- * leak onto one. Neither is a flow diagram, whose marks run between nodes, a
- * hierarchy, a gauge, or a waterfall, whose steps march one way only.
+ * Bar-like layers default to vertical. A pie, a radar and a polar area are
+ * never oriented — their marks sit around a circle rather than along an axis —
+ * so a config-level `orientation` (meaningful for the other layers of a
+ * composed chart) must not leak onto one. Neither is a flow diagram, whose
+ * marks run between nodes, a hierarchy, a gauge, or a waterfall, whose steps
+ * march one way only. An icicle is a hierarchy however it happens to be drawn:
+ * the bars are the layout it was given, not an axis a reader walks.
  *
  * A funnel is left out for a different reason: `FunnelTrace` is a `BarTrace`,
  * and a horizontal bar carries its category in `y` rather than `x`. The
@@ -1241,12 +1250,15 @@ function layerOrientation(
   switch (chartType) {
     case 'pie':
     case 'radar':
+    case 'polar_area':
     case 'funnel':
     case 'alluvial':
+    case 'sankey':
     case 'gauge':
     case 'waterfall':
     case 'treemap':
     case 'sunburst':
+    case 'icicle':
       return undefined;
     case 'gantt':
       return orientation ?? Orientation.HORIZONTAL;
@@ -1281,15 +1293,17 @@ function isStackedAreaType(chartType: RechartsChartType): boolean {
 /**
  * Returns true if the chart type maps to a line-like MAIDR type.
  *
- * The whole area family, radar, bump and survival belong here: every one of
- * them is a `LineTrace` subclass in the model, so each expects `LinePoint[][]`
- * data and `selectors` as a `string[]` rather than a bare string.
+ * The whole area family, radar, polar area, bump and survival belong here:
+ * every one of them is a `LineTrace` subclass in the model, so each expects
+ * `LinePoint[][]` data and `selectors` as a `string[]` rather than a bare
+ * string.
  */
 function isLineType(chartType: RechartsChartType): boolean {
   return chartType === 'line'
     || chartType === 'area'
     || isStackedAreaType(chartType)
     || chartType === 'radar'
+    || chartType === 'polar_area'
     || chartType === 'bump'
     || chartType === 'survival';
 }
@@ -1382,6 +1396,8 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.TREEMAP;
     case 'sunburst':
       return TraceType.SUNBURST;
+    case 'icicle':
+      return TraceType.ICICLE;
     case 'dot':
       return TraceType.DOT;
     case 'lollipop':
@@ -1400,6 +1416,8 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.NORMALIZED_AREA;
     case 'radar':
       return TraceType.RADAR;
+    case 'polar_area':
+      return TraceType.POLAR_AREA;
     case 'bump':
       return TraceType.BUMP;
     case 'survival':
@@ -1418,6 +1436,8 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.PIE;
     case 'alluvial':
       return TraceType.ALLUVIAL;
+    case 'sankey':
+      return TraceType.SANKEY;
   }
 }
 

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -220,11 +220,7 @@ function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): 
     return [buildMultiSeriesLineLayer(data, xKey, yKeys, chartType, xLabel, yLabel, selectorOverride)];
   }
 
-  // Determine the MAIDR trace type. For segmented bar types with a single yKey,
-  // fall back to BAR since a single series is not segmented.
-  const maidrType = (isSegmentedBarType(chartType) && !hasMultipleSeries)
-    ? TraceType.BAR
-    : toTraceType(chartType);
+  const maidrType = toLayerTraceType(chartType, hasMultipleSeries);
 
   // Simple single-series or multiple separate layers
   return yKeys.map((yKey, index) => {
@@ -438,9 +434,21 @@ function convertData(
   yKey: string,
 ): BarPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] {
   switch (chartType) {
+    // A dot plot and a lollipop carry a bar's data — one category, one
+    // magnitude — and differ only in the mark drawn for it.
     case 'bar':
+    case 'dot':
+    case 'lollipop':
       return convertToBarPoints(data, xKey, yKey);
+    // The area, radar and bump families are all read as a line is: one value
+    // per sample. What the stacking, the circle and the rank change is how
+    // the model announces them, not what the adapter has to emit.
     case 'line':
+    case 'area':
+    case 'stacked_area':
+    case 'normalized_area':
+    case 'radar':
+    case 'bump':
       return convertToLinePoints(data, xKey, yKey);
     case 'scatter':
       return convertToScatterPoints(data, xKey, yKey);
@@ -528,21 +536,24 @@ function isBarType(chartType: RechartsChartType): boolean {
     || chartType === 'stacked_bar'
     || chartType === 'dodged_bar'
     || chartType === 'normalized_bar'
+    || chartType === 'dot'
+    || chartType === 'lollipop'
     || chartType === 'histogram';
 }
 
 /**
  * Returns the orientation to emit for a layer of the given chart type.
  *
- * Bar-like layers default to vertical. A pie is never oriented — its slices sit
- * around a circle rather than along an axis — so a config-level `orientation`
- * (meaningful for the other layers of a composed chart) must not leak onto one.
+ * Bar-like layers default to vertical. A pie and a radar are never oriented —
+ * their marks sit around a circle rather than along an axis — so a config-level
+ * `orientation` (meaningful for the other layers of a composed chart) must not
+ * leak onto one.
  */
 function layerOrientation(
   chartType: RechartsChartType,
   orientation?: Orientation,
 ): Orientation | undefined {
-  if (chartType === 'pie') {
+  if (chartType === 'pie' || chartType === 'radar') {
     return undefined;
   }
   return orientation ?? (isBarType(chartType) ? Orientation.VERTICAL : undefined);
@@ -558,10 +569,48 @@ function isSegmentedBarType(chartType: RechartsChartType): boolean {
 }
 
 /**
+ * Returns true if the chart type maps to a stacked area MAIDR type.
+ */
+function isStackedAreaType(chartType: RechartsChartType): boolean {
+  return chartType === 'stacked_area'
+    || chartType === 'normalized_area';
+}
+
+/**
  * Returns true if the chart type maps to a line-like MAIDR type.
+ *
+ * The whole area family, radar and bump belong here: every one of them is a
+ * `LineTrace` subclass in the model, so each expects `LinePoint[][]` data and
+ * `selectors` as a `string[]` rather than a bare string.
  */
 function isLineType(chartType: RechartsChartType): boolean {
-  return chartType === 'line';
+  return chartType === 'line'
+    || chartType === 'area'
+    || isStackedAreaType(chartType)
+    || chartType === 'radar'
+    || chartType === 'bump';
+}
+
+/**
+ * Returns the MAIDR trace type for a simple-mode layer of `chartType`.
+ *
+ * A stacked type declared over a single yKey is not stacked at all — there is
+ * no second series to stack it against — so it falls back to its unstacked
+ * base: BAR for the bar family, AREA for the area family. Left as declared,
+ * a stacked bar would be handed a one-row `SegmentedPoint[][]`, and a stacked
+ * area would announce a running total equal to its own value and a 100% share
+ * at every single point.
+ */
+function toLayerTraceType(chartType: RechartsChartType, hasMultipleSeries: boolean): TraceType {
+  if (!hasMultipleSeries) {
+    if (isSegmentedBarType(chartType)) {
+      return TraceType.BAR;
+    }
+    if (isStackedAreaType(chartType)) {
+      return TraceType.AREA;
+    }
+  }
+  return toTraceType(chartType);
 }
 
 /**
@@ -577,10 +626,24 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.DODGED;
     case 'normalized_bar':
       return TraceType.NORMALIZED;
+    case 'dot':
+      return TraceType.DOT;
+    case 'lollipop':
+      return TraceType.LOLLIPOP;
     case 'histogram':
       return TraceType.HISTOGRAM;
     case 'line':
       return TraceType.LINE;
+    case 'area':
+      return TraceType.AREA;
+    case 'stacked_area':
+      return TraceType.STACKED_AREA;
+    case 'normalized_area':
+      return TraceType.NORMALIZED_AREA;
+    case 'radar':
+      return TraceType.RADAR;
+    case 'bump':
+      return TraceType.BUMP;
     case 'scatter':
       return TraceType.SCATTER;
     case 'pie':

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -17,13 +17,23 @@
  *   VolcanoPoint[]      = [{ x, y, label?, group? }, ...]
  *   SurvivalPoint[][]   = [[{ x, y, censored?, yMin?, yMax? }, ...], ...]
  *   FlowPoint[]         = [{ source, target, value }, ...]
+ *   WaterfallPoint[]    = [{ x, start, end, delta, kind }, ...]  (ABSOLUTE totals)
+ *   TreemapPoint[]      = [{ x, y?, path? }, ...]        (depth-first pre-order)
+ *   GaugePoint          = { value, min, max, ... }       (a single OBJECT)
+ *   GanttData           = { points: [[{ x, start, end }]], lanes?, unit? }
+ *   DumbbellData        = { points: [{ x, start, end }], startLabel?, endLabel? }
  */
 
 import type {
   BarPoint,
+  DumbbellData,
+  DumbbellPoint,
   ErrorBarPoint,
   FlowPoint,
   ForestPoint,
+  GanttData,
+  GanttPoint,
+  GaugePoint,
   HistogramPoint,
   LinePoint,
   Maidr,
@@ -33,7 +43,10 @@ import type {
   ScatterPoint,
   SegmentedPoint,
   SurvivalPoint,
+  TreemapPoint,
   VolcanoPoint,
+  WaterfallKind,
+  WaterfallPoint,
 } from '@type/grammar';
 import type { RechartsAdapterConfig, RechartsChartType, RechartsLayerConfig, RechartsSubplotConfig } from './types';
 import { cssEscape } from '@adapters/shared/selectorUtil';
@@ -171,6 +184,9 @@ function buildPanelSubplot(
     errorConfig: config.errorConfig,
     forestConfig: config.forestConfig,
     survivalConfig: config.survivalConfig,
+    waterfallConfig: config.waterfallConfig,
+    ganttConfig: config.ganttConfig,
+    gaugeConfig: config.gaugeConfig,
     selectorOverride: panel.selectorOverride,
   };
 
@@ -238,6 +254,20 @@ function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): 
   // points, and the plain line builders have nowhere to put them.
   if (chartType === 'survival') {
     return [buildSurvivalLayer(data, xKey, yKeys, chartType, xLabel, yLabel, fillKeys, config.survivalConfig, selectorOverride, config.id, panelScope)];
+  }
+
+  // A gauge, a gantt and a dumbbell each carry ONE payload for the whole
+  // layer — an object, or a grid grouped by something other than a series —
+  // so none of them fits the yKeys.map() loop below, which builds one layer
+  // per series out of one array each.
+  if (chartType === 'gauge') {
+    return [buildGaugeLayer(data, xKey, yKeys[0], chartType, xLabel, yLabel, config.gaugeConfig, selectorOverride, config.id, panelScope)];
+  }
+  if (chartType === 'gantt') {
+    return [buildGanttLayer(data, xKey, yKeys, chartType, xLabel, yLabel, orientation, config.ganttConfig, selectorOverride, config.id, panelScope)];
+  }
+  if (chartType === 'dumbbell') {
+    return [buildDumbbellLayer(data, xKey, yKeys, chartType, xLabel, yLabel, orientation, fillKeys, selectorOverride, config.id, panelScope)];
   }
 
   // Line with multiple series: single layer with 2D LinePoint[][] data
@@ -457,6 +487,197 @@ function buildSurvivalLayer(
 }
 
 /**
+ * Builds a single gauge layer whose data is one {@link GaugePoint} object.
+ *
+ * The value is the only part of the reading the chart holds. The range is the
+ * `<PolarAngleAxis domain>`, and the target and the bands are drawn as arcs
+ * and markers that carry no value at all, so all of them arrive through
+ * `gaugeConfig` — which is therefore required rather than optional.
+ */
+function buildGaugeLayer(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  chartType: RechartsChartType,
+  xLabel?: string,
+  yLabel?: string,
+  gaugeConfig?: RechartsAdapterConfig['gaugeConfig'],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  if (!gaugeConfig) {
+    throw new Error('RechartsAdapter: gaugeConfig with min and max is required when chartType is "gauge"');
+  }
+  const row = data[0];
+  if (!row) {
+    throw new Error('RechartsAdapter: a gauge needs one data row holding its measure');
+  }
+
+  const { min, max, target, bands, label } = gaugeConfig;
+  const point: GaugePoint = { value: toNumber(row[yKey]), min, max };
+  // A gauge names its measure the way every other type names a category: out
+  // of `xKey`, unless the config says otherwise.
+  const name = label ?? toText(row[xKey]);
+  if (name !== undefined) {
+    point.label = name;
+  }
+  if (target !== undefined) {
+    point.target = target;
+  }
+  if (bands !== undefined) {
+    point.bands = bands;
+  }
+
+  return {
+    id: '0',
+    type: TraceType.GAUGE,
+    selectors: selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope),
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+    },
+    data: point,
+  };
+}
+
+/**
+ * Builds a single gantt layer whose data is one {@link GanttData} object.
+ *
+ * One data row is one interval, and the payload is nested BY LANE so that a
+ * lane with nothing booked still exists — which is why the lane list comes
+ * from the config rather than from the rows, since an empty lane appears in
+ * no row.
+ */
+function buildGanttLayer(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKeys: string[],
+  chartType: RechartsChartType,
+  xLabel?: string,
+  yLabel?: string,
+  orientation?: Orientation,
+  ganttConfig?: RechartsAdapterConfig['ganttConfig'],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  if (yKeys.length < 2) {
+    throw new Error('RechartsAdapter: chartType "gantt" needs two yKeys — the interval\'s start and its end');
+  }
+
+  const lanes = ganttConfig?.lanes ? [...ganttConfig.lanes] : [];
+  const grouped: GanttPoint[][] = lanes.map(() => []);
+  // The order the rows land in, so the selectors can be checked against the
+  // order the marks are drawn in.
+  const drawnOrder: number[] = [];
+
+  for (const item of data) {
+    const lane = (item[xKey] ?? '') as string | number;
+    let laneIndex = lanes.indexOf(lane);
+    if (laneIndex === -1) {
+      // A lane a row names but the config omits. Appended rather than dropped:
+      // losing an interval is worse than a lane list in an unexpected order.
+      laneIndex = lanes.push(lane) - 1;
+      grouped.push([]);
+    }
+
+    const point: GanttPoint = {
+      x: lane,
+      start: toNumber(item[yKeys[0]]),
+      end: toNumber(item[yKeys[1]]),
+    };
+    const label = ganttConfig?.labelKey === undefined
+      ? undefined
+      : toText(item[ganttConfig.labelKey]);
+    if (label !== undefined) {
+      point.label = label;
+    }
+    grouped[laneIndex].push(point);
+    drawnOrder.push(laneIndex);
+  }
+
+  const payload: GanttData = { points: grouped };
+  if (lanes.length > 0) {
+    payload.lanes = lanes;
+  }
+  if (ganttConfig?.unit !== undefined) {
+    payload.unit = ganttConfig.unit;
+  }
+
+  // `GanttTrace` walks its selectors lane by lane, while Recharts draws one
+  // rectangle per row in row order. The two agree only when the rows are
+  // already grouped by lane, so a chart that interleaves them gets no
+  // highlighting rather than a highlight on somebody else's task.
+  const groupedInOrder = drawnOrder.every((lane, i) => i === 0 || lane >= drawnOrder[i - 1]);
+  const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope);
+
+  return {
+    id: '0',
+    type: TraceType.GANTT,
+    selectors: groupedInOrder ? selector : undefined,
+    orientation: layerOrientation(chartType, orientation),
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+    },
+    data: payload,
+  };
+}
+
+/**
+ * Builds a single dumbbell layer whose data is one {@link DumbbellData}
+ * object.
+ *
+ * The two `yKeys` are the two ends, in the order the chart compares them, and
+ * `fillKeys` names them — those names are the content of the comparison, and
+ * the chart writes them down only in its legend.
+ */
+function buildDumbbellLayer(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKeys: string[],
+  chartType: RechartsChartType,
+  xLabel?: string,
+  yLabel?: string,
+  orientation?: Orientation,
+  fillKeys?: string[],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  if (yKeys.length < 2) {
+    throw new Error('RechartsAdapter: chartType "dumbbell" needs two yKeys — the starting end and the finishing one');
+  }
+
+  const points: DumbbellPoint[] = data.map(item => ({
+    x: item[xKey] as string | number,
+    start: toNumber(item[yKeys[0]]),
+    end: toNumber(item[yKeys[1]]),
+  }));
+
+  const payload: DumbbellData = { points };
+  if (fillKeys?.[0] !== undefined) {
+    payload.startLabel = fillKeys[0];
+  }
+  if (fillKeys?.[1] !== undefined) {
+    payload.endLabel = fillKeys[1];
+  }
+
+  return {
+    id: '0',
+    type: TraceType.DUMBBELL,
+    selectors: selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope),
+    orientation: layerOrientation(chartType, orientation),
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+    },
+    data: payload,
+  };
+}
+
+/**
  * Builds layers for composed mode (mixed chart types via layers config).
  */
 function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
@@ -520,7 +741,7 @@ function convertData(
   xKey: string,
   yKey: string,
   config: RechartsAdapterConfig,
-): BarPoint[] | ErrorBarPoint[] | FlowPoint[] | ForestPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] | SurvivalPoint[][] | VolcanoPoint[] {
+): BarPoint[] | ErrorBarPoint[] | FlowPoint[] | ForestPoint[] | LinePoint[][] | PiePoint[] | ScatterPoint[] | SurvivalPoint[][] | TreemapPoint[] | VolcanoPoint[] | WaterfallPoint[] {
   switch (chartType) {
     // A dot plot and a lollipop carry a bar's data — one category, one
     // magnitude — and differ only in the mark drawn for it. So does a funnel:
@@ -558,12 +779,27 @@ function convertData(
       return convertToForestPoints(data, xKey, yKey, config.errorConfig, config.forestConfig);
     case 'alluvial':
       return convertToFlowPoints(data, xKey, yKey, config.flowConfig);
+    case 'waterfall':
+      return convertToWaterfallPoints(data, xKey, yKey, config.waterfallConfig);
+    // A treemap and a sunburst are the same hierarchy, and differ only in
+    // whether it is drawn as area or as rings.
+    case 'treemap':
+    case 'sunburst':
+      return convertToTreemapPoints(data, xKey, yKey);
     case 'pie':
       return convertToPiePoints(data, xKey, yKey);
-    // Stacked/dodged/normalized/histogram handled by dedicated builders
+    // Whole-chart types: their payload describes the figure rather than a
+    // series, so there is nothing for them to be a layer OF. Only composed
+    // mode reaches this — simple mode routes each to its own builder.
+    case 'gauge':
+    case 'gantt':
+    case 'dumbbell':
+      throw new Error(`RechartsAdapter: chartType "${chartType}" describes a whole chart and cannot be a layer of a composed one`);
+    // Stacked/dodged/normalized/diverging/histogram handled by dedicated builders
     case 'stacked_bar':
     case 'dodged_bar':
     case 'normalized_bar':
+    case 'diverging_bar':
     case 'histogram':
       return convertToBarPoints(data, xKey, yKey);
   }
@@ -805,6 +1041,113 @@ function convertToSurvivalRow(
 }
 
 /**
+ * Converts data to WaterfallPoint[] format — one step per row, carrying both
+ * the contribution it made and the running total it produced.
+ *
+ * `yKey` names the CONTRIBUTION, which is the number a waterfall's data
+ * actually holds; the totals a reader needs are accumulated here, because
+ * `WaterfallPoint.start`/`end` are absolute positions on the value axis and
+ * a bar that floats has neither of them written down.
+ *
+ * A step that RESTATES the total rather than changing it — an opening
+ * balance, a subtotal, a closing balance — sits on the baseline, so it runs
+ * from zero to the total it declares, and the running total continues from
+ * there. Such a row need carry no value of its own: a "Closing" row with no
+ * number restates what the steps came to, which is the whole point of drawing
+ * it.
+ */
+function convertToWaterfallPoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+  waterfallConfig?: RechartsAdapterConfig['waterfallConfig'],
+): WaterfallPoint[] {
+  const { totalKey, totalIndices, kindKey } = waterfallConfig ?? {};
+
+  let running = 0;
+  return data.map((item, index) => {
+    const declared = toOptionalNumber(item[yKey]);
+    const kindText = kindKey === undefined ? undefined : toText(item[kindKey]);
+    const restates = kindText === 'total'
+      || (kindKey === undefined
+        && ((totalKey !== undefined && Boolean(item[totalKey]))
+          || totalIndices?.includes(index) === true));
+
+    const start = restates ? 0 : running;
+    const end = restates ? (declared ?? running) : running + (declared ?? 0);
+    running = end;
+
+    const delta = end - start;
+    let kind: WaterfallKind = delta < 0 ? 'decrease' : 'increase';
+    if (restates) {
+      kind = 'total';
+    } else if (kindText === 'increase' || kindText === 'decrease') {
+      kind = kindText;
+    }
+
+    return { x: item[xKey] as string | number, start, end, delta, kind };
+  });
+}
+
+/**
+ * Converts nested Recharts hierarchy data to TreemapPoint[] format.
+ *
+ * `data` here is not the adapter's usual flat rows: `<Treemap>` and
+ * `<SunburstChart>` both take a tree of `{ [nameKey], children }` objects, so
+ * the tree is flattened depth-first in PRE-ORDER — the order both components
+ * draw their nodes in, and therefore the order the highlight selectors resolve
+ * in.
+ *
+ * A node with children gets no `y`. Recharts computes an interior node's value
+ * as the sum of its children and ignores any value declared on it
+ * (`computeNode` in `Treemap.js`), so passing a declared one through would
+ * announce a magnitude the chart did not draw — and MAIDR keeps a declared
+ * value in preference to the sum precisely because it trusts the producer.
+ *
+ * @param data - The top-level nodes, as the chart itself is given them
+ * @param xKey - Key holding a node's name (the `<Treemap nameKey>`)
+ * @param yKey - Key holding a leaf's magnitude (the `<Treemap dataKey>`)
+ * @returns Every node, depth-first pre-order, each with its ancestors named
+ */
+function convertToTreemapPoints(
+  data: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+): TreemapPoint[] {
+  const points: TreemapPoint[] = [];
+
+  /**
+   * Emits one level of the tree, then each node's own children.
+   *
+   * @param nodes - The siblings at this level
+   * @param path - Their ancestors, root first
+   */
+  function walk(nodes: Record<string, unknown>[], path: (string | number)[]): void {
+    for (const node of nodes) {
+      const name = (node[xKey] ?? '') as string | number;
+      const children = Array.isArray(node.children)
+        ? node.children as Record<string, unknown>[]
+        : [];
+
+      const point: TreemapPoint = { x: name };
+      if (path.length > 0) {
+        point.path = [...path];
+      }
+      const value = children.length > 0 ? undefined : toOptionalNumber(node[yKey]);
+      if (value !== undefined) {
+        point.y = value;
+      }
+      points.push(point);
+
+      walk(children, [...path, name]);
+    }
+  }
+
+  walk(data, []);
+  return points;
+}
+
+/**
  * Converts data to FlowPoint[] format — one weighted flow per link.
  *
  * The `data` array is the `links` half of what Recharts' `<Sankey>` is given,
@@ -865,9 +1208,12 @@ function isBarType(chartType: RechartsChartType): boolean {
     || chartType === 'stacked_bar'
     || chartType === 'dodged_bar'
     || chartType === 'normalized_bar'
+    || chartType === 'diverging_bar'
     || chartType === 'dot'
     || chartType === 'lollipop'
-    || chartType === 'histogram';
+    || chartType === 'histogram'
+    || chartType === 'gantt'
+    || chartType === 'dumbbell';
 }
 
 /**
@@ -876,30 +1222,52 @@ function isBarType(chartType: RechartsChartType): boolean {
  * Bar-like layers default to vertical. A pie and a radar are never oriented —
  * their marks sit around a circle rather than along an axis — so a config-level
  * `orientation` (meaningful for the other layers of a composed chart) must not
- * leak onto one. Neither is a flow diagram, whose marks run between nodes.
+ * leak onto one. Neither is a flow diagram, whose marks run between nodes, a
+ * hierarchy, a gauge, or a waterfall, whose steps march one way only.
  *
  * A funnel is left out for a different reason: `FunnelTrace` is a `BarTrace`,
  * and a horizontal bar carries its category in `y` rather than `x`. The
  * adapter always emits the stage label as `x`, so a leaked `HORIZONTAL` would
  * have every stage announced by its count.
+ *
+ * A gantt is the one type that defaults the other way. Its bars run left to
+ * right, which puts the axis on x and the lanes on y — the `<BarChart
+ * layout="vertical">` recipe, and what `GanttTrace` calls horizontal.
  */
 function layerOrientation(
   chartType: RechartsChartType,
   orientation?: Orientation,
 ): Orientation | undefined {
-  if (chartType === 'pie' || chartType === 'radar' || chartType === 'funnel' || chartType === 'alluvial') {
-    return undefined;
+  switch (chartType) {
+    case 'pie':
+    case 'radar':
+    case 'funnel':
+    case 'alluvial':
+    case 'gauge':
+    case 'waterfall':
+    case 'treemap':
+    case 'sunburst':
+      return undefined;
+    case 'gantt':
+      return orientation ?? Orientation.HORIZONTAL;
+    default:
+      return orientation ?? (isBarType(chartType) ? Orientation.VERTICAL : undefined);
   }
-  return orientation ?? (isBarType(chartType) ? Orientation.VERTICAL : undefined);
 }
 
 /**
  * Returns true if the chart type maps to a segmented bar MAIDR type.
+ *
+ * A diverging bar belongs here even though its two sides sit either side of a
+ * baseline rather than on top of one another: `DivergingTrace` is a
+ * `SegmentedTrace`, so it reads the same `SegmentedPoint[][]` payload, one row
+ * per side in the order the sides are DECLARED.
  */
 function isSegmentedBarType(chartType: RechartsChartType): boolean {
   return chartType === 'stacked_bar'
     || chartType === 'dodged_bar'
-    || chartType === 'normalized_bar';
+    || chartType === 'normalized_bar'
+    || chartType === 'diverging_bar';
 }
 
 /**
@@ -970,6 +1338,10 @@ function layerOptions(
  * a stacked bar would be handed a one-row `SegmentedPoint[][]`, and a stacked
  * area would announce a running total equal to its own value and a 100% share
  * at every single point.
+ *
+ * The same holds for a diverging bar, which has no side to diverge from when
+ * only one is declared — and whose balance row would then report every
+ * category's own value as the gap between the two sides.
  */
 function toLayerTraceType(chartType: RechartsChartType, hasMultipleSeries: boolean): TraceType {
   if (!hasMultipleSeries) {
@@ -996,6 +1368,20 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.DODGED;
     case 'normalized_bar':
       return TraceType.NORMALIZED;
+    case 'diverging_bar':
+      return TraceType.DIVERGING;
+    case 'waterfall':
+      return TraceType.WATERFALL;
+    case 'dumbbell':
+      return TraceType.DUMBBELL;
+    case 'gantt':
+      return TraceType.GANTT;
+    case 'gauge':
+      return TraceType.GAUGE;
+    case 'treemap':
+      return TraceType.TREEMAP;
+    case 'sunburst':
+      return TraceType.SUNBURST;
     case 'dot':
       return TraceType.DOT;
     case 'lollipop':

--- a/src/adapters/recharts/index.ts
+++ b/src/adapters/recharts/index.ts
@@ -15,6 +15,8 @@ export type {
   ErrorIntervalConfig,
   FlowLinkConfig,
   ForestPlotConfig,
+  GanttChartConfig,
+  GaugeDialConfig,
   HistogramBinConfig,
   MaidrRechartsProps,
   RechartsAdapterConfig,
@@ -23,5 +25,6 @@ export type {
   RechartsSubplotConfig,
   SurvivalCurveConfig,
   VolcanoPointConfig,
+  WaterfallStepConfig,
 } from './types';
 export { useRechartsAdapter } from './useRechartsAdapter';

--- a/src/adapters/recharts/index.ts
+++ b/src/adapters/recharts/index.ts
@@ -12,11 +12,16 @@ export { convertRechartsToMaidr, normalizeRechartsSubplotGrid } from './converte
 export { MaidrRecharts } from './MaidrRecharts';
 export { getPanelClassName, getRechartsSelector } from './selectors';
 export type {
+  ErrorIntervalConfig,
+  FlowLinkConfig,
+  ForestPlotConfig,
   HistogramBinConfig,
   MaidrRechartsProps,
   RechartsAdapterConfig,
   RechartsChartType,
   RechartsLayerConfig,
   RechartsSubplotConfig,
+  SurvivalCurveConfig,
+  VolcanoPointConfig,
 } from './types';
 export { useRechartsAdapter } from './useRechartsAdapter';

--- a/src/adapters/recharts/selectors.ts
+++ b/src/adapters/recharts/selectors.ts
@@ -34,22 +34,29 @@
  *   per-sample element to highlight, so the dots are the only index-aligned
  *   marks either chart has.
  *
- * Floating BarChart (waterfall, gantt, dumbbell):
+ * Floating BarChart (waterfall, gantt, dumbbell, icicle):
  *   g.recharts-bar-rectangle > path.recharts-rectangle
  *   [target: .recharts-bar-rectangle .recharts-rectangle]
  *
- *   None of the three is a Recharts primitive, and all three draw the same
+ *   None of the four is a Recharts primitive, and all four draw the same
  *   thing: a bar that does not start at the baseline. Recharts renders one
  *   for a `<Bar>` whose `dataKey` returns a `[start, end]` pair, which gives
  *   exactly one rectangle per row — the waterfall's floating step, the gantt's
- *   interval, the dumbbell's connector — so the ordinary bar selector already
- *   fits.
+ *   interval, the dumbbell's connector, the icicle's band — so the ordinary
+ *   bar selector already fits.
  *
- *   The other recipe for all three is a transparent offset `<Bar>` stacked
- *   under a visible one, and it does NOT: two `<Bar>`s draw two rectangles per
- *   row, and this selector matches the invisible one as well. Such a chart
- *   puts a `className` on the visible `<Bar>` and passes the narrowed selector
- *   as `selectorOverride`.
+ *   An icicle carries the one extra condition, since its rows are a flattened
+ *   tree rather than the chart's own data: they must be flattened in the same
+ *   depth-first pre-order the adapter emits its nodes in, so that row i is
+ *   node i. A chart built the other obvious way — one stacked `<Bar>` per
+ *   depth level — draws its rectangles series-major instead, which is not that
+ *   order, and needs `selectorOverride`.
+ *
+ *   The other recipe for all of them is a transparent offset `<Bar>` stacked
+ *   under a visible one, and it does NOT work: two `<Bar>`s draw two
+ *   rectangles per row, and this selector matches the invisible one as well.
+ *   Such a chart puts a `className` on the visible `<Bar>` and passes the
+ *   narrowed selector as `selectorOverride`.
  *
  * RadialBarChart (gauge):
  *   g.recharts-radial-bar-sectors > g > path.recharts-radial-bar-sector
@@ -119,15 +126,16 @@
  *   so its marks are the scatter symbols — the square whose area carries the
  *   study's weight — and it targets those instead.
  *
- * Sankey:
+ * Sankey (alluvial, sankey):
  *   g.recharts-sankey-links > path.recharts-sankey-link
  *   [target: .recharts-sankey-links .recharts-sankey-link]
  *
  *   One path per link in declared order, which is the order a flow layer's
  *   selectors have to be in: the trace sorts its edge lists by value the
  *   moment it builds them, and carries each edge's declared position with it.
+ *   Both types are drawn by the same component, so both target the same links.
  *
- * PieChart:
+ * PieChart (pie, polar area):
  *   g.recharts-pie > g.recharts-pie-sector > path.recharts-sector
  *   [target: .recharts-pie-sector .recharts-sector]
  *
@@ -136,6 +144,10 @@
  *   data. The `.recharts-pie-sector` parent scope matters here: the pie's
  *   label lines (`<path class="recharts-curve">`) and, in an active-shape
  *   chart, the enlarged active sector live under `.recharts-pie` too.
+ *
+ *   A coxcomb is a `<Pie>` whose slices are all the same angle and whose
+ *   `outerRadius` is a function of the datum, so its wedges are these same
+ *   sectors, one per spoke.
  *
  *   One exception is out of the adapter's hands: Recharts renders no sector at
  *   all for a zero-value slice (`Pie.js` drops sectors whose start and end
@@ -248,8 +260,8 @@ export function getRechartsSelector(
  */
 function baseRechartsSelector(chartType: RechartsChartType): string | undefined {
   switch (chartType) {
-    // A waterfall step, a gantt interval and a dumbbell connector are drawn by
-    // a `<Bar>` too — one floating rectangle per row.
+    // A waterfall step, a gantt interval, a dumbbell connector and an icicle
+    // band are drawn by a `<Bar>` too — one floating rectangle per row.
     case 'bar':
     case 'stacked_bar':
     case 'dodged_bar':
@@ -259,6 +271,7 @@ function baseRechartsSelector(chartType: RechartsChartType): string | undefined 
     case 'waterfall':
     case 'gantt':
     case 'dumbbell':
+    case 'icicle':
       return '.recharts-bar-rectangle .recharts-rectangle';
     case 'gauge':
       return '.recharts-radial-bar-sectors .recharts-radial-bar-sector';
@@ -291,9 +304,13 @@ function baseRechartsSelector(chartType: RechartsChartType): string | undefined 
       return '.recharts-funnel-trapezoid .recharts-trapezoid';
     case 'error_bar':
       return '.recharts-errorBars .recharts-errorBar';
+    // Both are a `<Sankey>`, so both highlight its ribbons.
     case 'alluvial':
+    case 'sankey':
       return '.recharts-sankey-links .recharts-sankey-link';
+    // A coxcomb is a `<Pie>` of equal-angle slices, so its wedges are sectors.
     case 'pie':
+    case 'polar_area':
       return '.recharts-pie-sector .recharts-sector';
   }
 }

--- a/src/adapters/recharts/selectors.ts
+++ b/src/adapters/recharts/selectors.ts
@@ -34,6 +34,55 @@
  *   per-sample element to highlight, so the dots are the only index-aligned
  *   marks either chart has.
  *
+ * Floating BarChart (waterfall, gantt, dumbbell):
+ *   g.recharts-bar-rectangle > path.recharts-rectangle
+ *   [target: .recharts-bar-rectangle .recharts-rectangle]
+ *
+ *   None of the three is a Recharts primitive, and all three draw the same
+ *   thing: a bar that does not start at the baseline. Recharts renders one
+ *   for a `<Bar>` whose `dataKey` returns a `[start, end]` pair, which gives
+ *   exactly one rectangle per row — the waterfall's floating step, the gantt's
+ *   interval, the dumbbell's connector — so the ordinary bar selector already
+ *   fits.
+ *
+ *   The other recipe for all three is a transparent offset `<Bar>` stacked
+ *   under a visible one, and it does NOT: two `<Bar>`s draw two rectangles per
+ *   row, and this selector matches the invisible one as well. Such a chart
+ *   puts a `className` on the visible `<Bar>` and passes the narrowed selector
+ *   as `selectorOverride`.
+ *
+ * RadialBarChart (gauge):
+ *   g.recharts-radial-bar-sectors > g > path.recharts-radial-bar-sector
+ *   [target: .recharts-radial-bar-sectors .recharts-radial-bar-sector]
+ *
+ *   A gauge draws exactly one measure, so one sector is what the trace wants.
+ *
+ * Treemap:
+ *   g.recharts-treemap-depth-N > g.recharts-layer > g > path.recharts-rectangle
+ *   [target: the same, for every depth EXCEPT 0]
+ *
+ *   Recharts wraps the `data` array in a synthetic root node and draws it as a
+ *   full-plot rectangle at depth 0, which is one more rectangle than the
+ *   layer declares nodes — and `TreemapTrace` withdraws highlighting entirely
+ *   on a count mismatch. Hence the `:not(.recharts-treemap-depth-0)`. The
+ *   remaining rectangles come out in document order, which for a tree drawn
+ *   as nested `<Layer>`s is depth-first pre-order: the same order the adapter
+ *   flattens the nested data in.
+ *
+ *   The `> g > g >` chain picks a node's OWN rectangle rather than its
+ *   descendants', since a child's `<Layer>` is a sibling of its parent's
+ *   rectangle. A `<Treemap type="nest">` or one given a custom `content`
+ *   draws something else and needs `selectorOverride`.
+ *
+ * SunburstChart:
+ *   g.recharts-sunburst > g > path.recharts-sector
+ *   [target: .recharts-sunburst .recharts-sector]
+ *
+ *   One sector per node in depth-first pre-order, and no sector for the root:
+ *   `SunburstChart` renders `data.children`. That is why the adapter is given
+ *   those children rather than the root — the declared nodes are then exactly
+ *   the drawn ones.
+ *
  * ScatterChart:
  *   g.recharts-scatter > g.recharts-scatter-symbol > path.recharts-symbols
  *   [target: .recharts-scatter-symbol .recharts-symbols]
@@ -199,12 +248,24 @@ export function getRechartsSelector(
  */
 function baseRechartsSelector(chartType: RechartsChartType): string | undefined {
   switch (chartType) {
+    // A waterfall step, a gantt interval and a dumbbell connector are drawn by
+    // a `<Bar>` too — one floating rectangle per row.
     case 'bar':
     case 'stacked_bar':
     case 'dodged_bar':
     case 'normalized_bar':
+    case 'diverging_bar':
     case 'histogram':
+    case 'waterfall':
+    case 'gantt':
+    case 'dumbbell':
       return '.recharts-bar-rectangle .recharts-rectangle';
+    case 'gauge':
+      return '.recharts-radial-bar-sectors .recharts-radial-bar-sector';
+    case 'treemap':
+      return 'g[class*="recharts-treemap-depth-"]:not(.recharts-treemap-depth-0) > g > g > path.recharts-rectangle';
+    case 'sunburst':
+      return '.recharts-sunburst .recharts-sector';
     // A bump chart is a <LineChart> of ranks and a survival curve a
     // <LineChart> of step segments, so both draw line dots.
     case 'line':

--- a/src/adapters/recharts/selectors.ts
+++ b/src/adapters/recharts/selectors.ts
@@ -19,9 +19,30 @@
  *   The element-based approach in LineTrace picks up individual dots directly
  *   (similar to how BarTrace uses individual rect elements).
  *
+ * AreaChart:
+ *   g.recharts-area > g.recharts-area-dots > circle.recharts-area-dot
+ *   [target: .recharts-area-dots .recharts-area-dot]
+ *
+ * RadarChart:
+ *   g.recharts-radar > g.recharts-radar-dots > circle.recharts-radar-dot
+ *   [target: .recharts-radar-dots .recharts-radar-dot]
+ *
+ *   Areas and radars carry the line's caveat, because they share its `Dots`
+ *   component: it renders nothing unless the consumer sets `dot` on the
+ *   `<Area>`/`<Radar>` (the sole exception being a series of exactly one
+ *   point). The filled band and the polygon outline are single paths with no
+ *   per-sample element to highlight, so the dots are the only index-aligned
+ *   marks either chart has.
+ *
  * ScatterChart:
  *   g.recharts-scatter > g.recharts-scatter-symbol > path.recharts-symbols
  *   [target: .recharts-scatter-symbol .recharts-symbols]
+ *
+ *   A Cleveland dot plot is a `<Scatter>` against a category axis, and a
+ *   lollipop is a `<Scatter>` head over a thin `<Bar>` stem, so both target
+ *   the symbols. The head is highlighted rather than the stem: it is where
+ *   the value is read off, and a lollipop drawn without one (a custom `<Bar>`
+ *   shape carrying its own dot) needs `selectorOverride` anyway.
  *
  * PieChart:
  *   g.recharts-pie > g.recharts-pie-sector > path.recharts-sector
@@ -150,9 +171,19 @@ function baseRechartsSelector(chartType: RechartsChartType): string | undefined 
     case 'normalized_bar':
     case 'histogram':
       return '.recharts-bar-rectangle .recharts-rectangle';
+    // A bump chart is a <LineChart> of ranks, so its marks are line dots too.
     case 'line':
+    case 'bump':
       return '.recharts-line-dots .recharts-line-dot';
+    case 'area':
+    case 'stacked_area':
+    case 'normalized_area':
+      return '.recharts-area-dots .recharts-area-dot';
+    case 'radar':
+      return '.recharts-radar-dots .recharts-radar-dot';
     case 'scatter':
+    case 'dot':
+    case 'lollipop':
       return '.recharts-scatter-symbol .recharts-symbols';
     case 'pie':
       return '.recharts-pie-sector .recharts-sector';

--- a/src/adapters/recharts/selectors.ts
+++ b/src/adapters/recharts/selectors.ts
@@ -44,6 +44,40 @@
  *   the value is read off, and a lollipop drawn without one (a custom `<Bar>`
  *   shape carrying its own dot) needs `selectorOverride` anyway.
  *
+ * FunnelChart:
+ *   g.recharts-trapezoids > g.recharts-funnel-trapezoid > g > path.recharts-trapezoid
+ *   [target: .recharts-funnel-trapezoid .recharts-trapezoid]
+ *
+ *   One trapezoid per stage, in the order the stages are declared, so the
+ *   funnel's drawn order and its data order are the same thing.
+ *
+ * ErrorBar (inside a Bar/Line/Scatter):
+ *   g.recharts-errorBars > g.recharts-errorBar > line
+ *   [target: .recharts-errorBars .recharts-errorBar]
+ *
+ *   The whiskers rather than the host mark: an `<ErrorBar>` is the only
+ *   element the adapter knows a chart of this type draws, since the estimate
+ *   itself may be a bar, a line dot or a scatter symbol depending on what the
+ *   author nested it in. A chart that would rather highlight its host mark
+ *   passes that selector as `selectorOverride`.
+ *
+ *   Recharts renders NO whisker for a sample whose error value is zero or
+ *   missing (`ErrorBar.js` returns null before drawing). The trace sees fewer
+ *   elements than samples and turns highlighting off for the layer rather
+ *   than mis-aligning it, the same way a zero-value pie slice behaves.
+ *
+ *   A forest plot is drawn as a `<ScatterChart>` with `<ErrorBar direction="x">`,
+ *   so its marks are the scatter symbols — the square whose area carries the
+ *   study's weight — and it targets those instead.
+ *
+ * Sankey:
+ *   g.recharts-sankey-links > path.recharts-sankey-link
+ *   [target: .recharts-sankey-links .recharts-sankey-link]
+ *
+ *   One path per link in declared order, which is the order a flow layer's
+ *   selectors have to be in: the trace sorts its edge lists by value the
+ *   moment it builds them, and carries each edge's declared position with it.
+ *
  * PieChart:
  *   g.recharts-pie > g.recharts-pie-sector > path.recharts-sector
  *   [target: .recharts-pie-sector .recharts-sector]
@@ -171,9 +205,11 @@ function baseRechartsSelector(chartType: RechartsChartType): string | undefined 
     case 'normalized_bar':
     case 'histogram':
       return '.recharts-bar-rectangle .recharts-rectangle';
-    // A bump chart is a <LineChart> of ranks, so its marks are line dots too.
+    // A bump chart is a <LineChart> of ranks and a survival curve a
+    // <LineChart> of step segments, so both draw line dots.
     case 'line':
     case 'bump':
+    case 'survival':
       return '.recharts-line-dots .recharts-line-dot';
     case 'area':
     case 'stacked_area':
@@ -181,10 +217,21 @@ function baseRechartsSelector(chartType: RechartsChartType): string | undefined 
       return '.recharts-area-dots .recharts-area-dot';
     case 'radar':
       return '.recharts-radar-dots .recharts-radar-dot';
+    // A volcano and a Manhattan plot are literally scatters, and a forest plot
+    // is a <ScatterChart> whose symbols carry the study weights.
     case 'scatter':
     case 'dot':
     case 'lollipop':
+    case 'volcano':
+    case 'manhattan':
+    case 'forest':
       return '.recharts-scatter-symbol .recharts-symbols';
+    case 'funnel':
+      return '.recharts-funnel-trapezoid .recharts-trapezoid';
+    case 'error_bar':
+      return '.recharts-errorBars .recharts-errorBar';
+    case 'alluvial':
+      return '.recharts-sankey-links .recharts-sankey-link';
     case 'pie':
       return '.recharts-pie-sector .recharts-sector';
   }

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -15,8 +15,22 @@ import type { Orientation } from '@type/grammar';
  * - `'stacked_bar'` → `TraceType.STACKED` — Stacked bar chart (Recharts `<Bar stackId="...">`)
  * - `'dodged_bar'` → `TraceType.DODGED` — Grouped/dodged bar chart (multiple `<Bar>` without stackId)
  * - `'normalized_bar'` → `TraceType.NORMALIZED` — Stacked normalized (100%) bar chart
+ * - `'dot'` → `TraceType.DOT` — Cleveland dot plot: one point per category,
+ *   drawn with `<Scatter>` against a category axis
+ * - `'lollipop'` → `TraceType.LOLLIPOP` — Lollipop chart: a `<ComposedChart>`
+ *   of a thin `<Bar>` stem plus a `<Scatter>` head. Read exactly as a bar is —
+ *   the stem is the mark, not extra data
  * - `'histogram'` → `TraceType.HISTOGRAM` — Histogram rendered as bar chart with bin ranges
  * - `'line'` → `TraceType.LINE` — Line chart
+ * - `'area'` → `TraceType.AREA` — Area chart (Recharts `<Area>`); the fill is
+ *   decoration, so the data is a line's
+ * - `'stacked_area'` → `TraceType.STACKED_AREA` — Stacked area chart
+ *   (`<Area stackId="...">`, multiple `yKeys`)
+ * - `'normalized_area'` → `TraceType.NORMALIZED_AREA` — 100% stacked area
+ *   (`<AreaChart stackOffset="expand">`, multiple `yKeys`)
+ * - `'radar'` → `TraceType.RADAR` — Radar/spider chart (`<RadarChart>` + `<Radar>`)
+ * - `'bump'` → `TraceType.BUMP` — Bump chart: rank over time, drawn as a
+ *   `<LineChart>` with `<YAxis reversed>`
  * - `'scatter'` → `TraceType.SCATTER` — Scatter/point plot
  * - `'pie'` → `TraceType.PIE` — Pie/doughnut chart (Recharts `<Pie>`); a
  *   doughnut is a pie with an `innerRadius`, which changes nothing about the
@@ -27,8 +41,15 @@ export type RechartsChartType
     | 'stacked_bar'
     | 'dodged_bar'
     | 'normalized_bar'
+    | 'dot'
+    | 'lollipop'
     | 'histogram'
     | 'line'
+    | 'area'
+    | 'stacked_area'
+    | 'normalized_area'
+    | 'radar'
+    | 'bump'
     | 'scatter'
     | 'pie';
 
@@ -169,6 +190,39 @@ export interface RechartsSubplotConfig {
  *   binConfig: { xMinKey: 'xMin', xMaxKey: 'xMax' },
  *   xLabel: 'Score',
  *   yLabel: 'Frequency',
+ * };
+ * ```
+ *
+ * @example Stacked area chart
+ * ```typescript
+ * // Pass each band's OWN value, not the accumulated edge — MAIDR sums the
+ * // series to get the running total it announces.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'traffic-chart',
+ *   title: 'Traffic by Source',
+ *   data: [{ month: 'Jan', organic: 40, paid: 20 }],
+ *   chartType: 'stacked_area',
+ *   xKey: 'month',
+ *   yKeys: ['organic', 'paid'],
+ *   xLabel: 'Month',
+ *   yLabel: 'Sessions',
+ * };
+ * ```
+ *
+ * @example Bump chart
+ * ```typescript
+ * // Each yKey holds the competitor's RANK in that period (1 is best), not
+ * // the underlying value. MAIDR inverts the pitch so rank 1 is the highest
+ * // note; handing it values instead would sonify the chart upside down.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'table-chart',
+ *   title: 'League Position by Matchday',
+ *   data: [{ matchday: 1, arsenal: 3, chelsea: 1 }],
+ *   chartType: 'bump',
+ *   xKey: 'matchday',
+ *   yKeys: ['arsenal', 'chelsea'],
+ *   xLabel: 'Matchday',
+ *   yLabel: 'Position',
  * };
  * ```
  *

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -47,6 +47,11 @@ import type { GaugeBand, Orientation, StepDirection } from '@type/grammar';
  * - `'normalized_area'` → `TraceType.NORMALIZED_AREA` — 100% stacked area
  *   (`<AreaChart stackOffset="expand">`, multiple `yKeys`)
  * - `'radar'` → `TraceType.RADAR` — Radar/spider chart (`<RadarChart>` + `<Radar>`)
+ * - `'polar_area'` → `TraceType.POLAR_AREA` — Coxcomb or rose chart: the same
+ *   spokes a radar has, drawn as wedges whose radius is the value. A `<Pie>`
+ *   with equal-angle slices and a per-datum `outerRadius`, NOT a
+ *   `<RadialBarChart>` — that one puts the categories on rings and encodes the
+ *   value as angle, which is a different chart
  * - `'bump'` → `TraceType.BUMP` — Bump chart: rank over time, drawn as a
  *   `<LineChart>` with `<YAxis reversed>`
  * - `'survival'` → `TraceType.SURVIVAL` — Kaplan-Meier curve: a
@@ -66,12 +71,19 @@ import type { GaugeBand, Orientation, StepDirection } from '@type/grammar';
  *   data, so both use this type
  * - `'alluvial'` → `TraceType.ALLUVIAL` — Weighted flow between nodes drawn
  *   as a `<Sankey>` whose node set repeats at each stage
+ * - `'sankey'` → `TraceType.SANKEY` — The same weighted flow drawn as a
+ *   left-to-right budget: one `<Sankey>`, one node set, ribbons that split and
+ *   rejoin. Same data and same {@link FlowLinkConfig} as `'alluvial'`
  * - `'treemap'` → `TraceType.TREEMAP` — A hierarchy laid out as nested area
  *   (`<Treemap>`). `data` is the nested `{ name, children }` array the
  *   component itself is given, not the adapter's usual flat rows
  * - `'sunburst'` → `TraceType.SUNBURST` — The same hierarchy drawn as rings
  *   (`<SunburstChart>`). `data` is the root's `children`, since the sunburst
  *   draws every node except the root
+ * - `'icicle'` → `TraceType.ICICLE` — The same hierarchy drawn as
+ *   depth-ordered bands. Recharts has no icicle component, so it is built as a
+ *   `<BarChart layout="vertical">` of floating bars — one row per node, the
+ *   lane its depth — exactly the recipe `'gantt'` uses
  */
 export type RechartsChartType
   = | 'bar'
@@ -92,6 +104,7 @@ export type RechartsChartType
     | 'stacked_area'
     | 'normalized_area'
     | 'radar'
+    | 'polar_area'
     | 'bump'
     | 'survival'
     | 'scatter'
@@ -101,8 +114,10 @@ export type RechartsChartType
     | 'forest'
     | 'pie'
     | 'alluvial'
+    | 'sankey'
     | 'treemap'
-    | 'sunburst';
+    | 'sunburst'
+    | 'icicle';
 
 /**
  * A single data series/layer configuration for composed charts.
@@ -133,8 +148,8 @@ export interface HistogramBinConfig {
 }
 
 /**
- * Configuration for a flow (alluvial) diagram.
- * Required when `chartType` is `'alluvial'`.
+ * Configuration for a flow diagram.
+ * Required when `chartType` is `'alluvial'` or `'sankey'`.
  *
  * The `data` array is the `links` half of what Recharts' `<Sankey>` is given:
  * one row per flow. `xKey` names the field holding the source node and the
@@ -516,6 +531,24 @@ export interface RechartsSubplotConfig {
  * };
  * ```
  *
+ * @example Polar area (coxcomb) chart
+ * ```typescript
+ * // The payload is a radar's — one value per spoke — because that is what a
+ * // reader navigates either way. The `<Pie>` drawing it takes its ANGLE from
+ * // a constant field so every wedge is the same width, and its RADIUS from
+ * // the measure, which is the field named here.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'nightingale-chart',
+ *   title: 'Deaths by Month',
+ *   data: [{ month: 'Jan', deaths: 120, slice: 1 }, { month: 'Feb', deaths: 84, slice: 1 }],
+ *   chartType: 'polar_area',
+ *   xKey: 'month',
+ *   yKeys: ['deaths'],
+ *   xLabel: 'Month',
+ *   yLabel: 'Deaths',
+ * };
+ * ```
+ *
  * @example Survival curve
  * ```typescript
  * // One `yKeys` entry per arm, and the per-arm keys line up with it the way
@@ -590,10 +623,13 @@ export interface RechartsSubplotConfig {
  * };
  * ```
  *
- * @example Alluvial (flow) diagram
+ * @example Alluvial or Sankey diagram
  * ```typescript
  * // `data` is the `links` half of what <Sankey> is given; `flowConfig.nodes`
  * // is the other half, and resolves the indices the links carry into names.
+ * // `'sankey'` takes exactly this config: the two differ in whether the node
+ * // set repeats at each stage, which is a fact about the data rather than
+ * // anything the adapter emits.
  * const config: RechartsAdapterConfig = {
  *   id: 'flow-chart',
  *   title: 'Cohort Movement',
@@ -706,13 +742,14 @@ export interface RechartsSubplotConfig {
  * };
  * ```
  *
- * @example Treemap / sunburst
+ * @example Treemap / sunburst / icicle
  * ```typescript
  * // `data` is the nested array Recharts is given, not the adapter's usual
  * // flat rows. `xKey` is the `<Treemap nameKey>` and the single `yKeys`
  * // entry its `dataKey`; children live under `children`, as Recharts
  * // requires. A `<SunburstChart data={{ name: 'World', children }}>` passes
- * // that same `children` array here, since it draws every node but the root.
+ * // that same `children` array here, since it draws every node but the root,
+ * // and an `'icicle'` takes the same nested array again.
  * const config: RechartsAdapterConfig = {
  *   id: 'regions-chart',
  *   title: 'Population by Region',
@@ -870,7 +907,7 @@ export interface RechartsAdapterConfig {
 
   /**
    * Flow link configuration.
-   * Required when `chartType` is `'alluvial'`.
+   * Required when `chartType` is `'alluvial'` or `'sankey'`.
    */
   flowConfig?: FlowLinkConfig;
 

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -5,7 +5,7 @@
  * and SVG structure into MAIDR's accessible format.
  */
 
-import type { Orientation, StepDirection } from '@type/grammar';
+import type { GaugeBand, Orientation, StepDirection } from '@type/grammar';
 
 /**
  * Recharts chart types supported by the adapter.
@@ -15,6 +15,21 @@ import type { Orientation, StepDirection } from '@type/grammar';
  * - `'stacked_bar'` → `TraceType.STACKED` — Stacked bar chart (Recharts `<Bar stackId="...">`)
  * - `'dodged_bar'` → `TraceType.DODGED` — Grouped/dodged bar chart (multiple `<Bar>` without stackId)
  * - `'normalized_bar'` → `TraceType.NORMALIZED` — Stacked normalized (100%) bar chart
+ * - `'diverging_bar'` → `TraceType.DIVERGING` — Population pyramid or Likert
+ *   scale: exactly two `yKeys` drawn back to back with
+ *   `<BarChart stackOffset="sign">`, the left-hand one holding NEGATIVE values
+ * - `'waterfall'` → `TraceType.WATERFALL` — A starting value carried to an
+ *   ending one through signed contributions. The single `yKeys` entry holds
+ *   each step's contribution and the adapter accumulates the running totals;
+ *   see {@link WaterfallStepConfig}
+ * - `'dumbbell'` → `TraceType.DUMBBELL` — Two values compared at each
+ *   category, joined by a segment. Exactly two `yKeys` — the starting end
+ *   first — named for the reader by `fillKeys`
+ * - `'gantt'` → `TraceType.GANTT` — Intervals laid out along a shared axis,
+ *   one row per interval: `xKey` names the lane and the two `yKeys` its start
+ *   and end; see {@link GanttChartConfig}
+ * - `'gauge'` → `TraceType.GAUGE` — One measure read against a range, drawn
+ *   as a half-dial `<RadialBarChart>`; see {@link GaugeDialConfig}
  * - `'dot'` → `TraceType.DOT` — Cleveland dot plot: one point per category,
  *   drawn with `<Scatter>` against a category axis
  * - `'lollipop'` → `TraceType.LOLLIPOP` — Lollipop chart: a `<ComposedChart>`
@@ -51,12 +66,23 @@ import type { Orientation, StepDirection } from '@type/grammar';
  *   data, so both use this type
  * - `'alluvial'` → `TraceType.ALLUVIAL` — Weighted flow between nodes drawn
  *   as a `<Sankey>` whose node set repeats at each stage
+ * - `'treemap'` → `TraceType.TREEMAP` — A hierarchy laid out as nested area
+ *   (`<Treemap>`). `data` is the nested `{ name, children }` array the
+ *   component itself is given, not the adapter's usual flat rows
+ * - `'sunburst'` → `TraceType.SUNBURST` — The same hierarchy drawn as rings
+ *   (`<SunburstChart>`). `data` is the root's `children`, since the sunburst
+ *   draws every node except the root
  */
 export type RechartsChartType
   = | 'bar'
     | 'stacked_bar'
     | 'dodged_bar'
     | 'normalized_bar'
+    | 'diverging_bar'
+    | 'waterfall'
+    | 'dumbbell'
+    | 'gantt'
+    | 'gauge'
     | 'dot'
     | 'lollipop'
     | 'funnel'
@@ -74,7 +100,9 @@ export type RechartsChartType
     | 'error_bar'
     | 'forest'
     | 'pie'
-    | 'alluvial';
+    | 'alluvial'
+    | 'treemap'
+    | 'sunburst';
 
 /**
  * A single data series/layer configuration for composed charts.
@@ -241,6 +269,106 @@ export interface SurvivalCurveConfig {
    * with `type="stepBefore"`.
    */
   stepDirection?: StepDirection;
+}
+
+/**
+ * Configuration for waterfall charts.
+ * Optional when `chartType` is `'waterfall'`.
+ *
+ * The single `yKeys` entry names each step's CONTRIBUTION, and the adapter
+ * accumulates the running totals MAIDR announces — a waterfall bar floats
+ * between the total before the step and the total after it, and neither
+ * number is in the data. This config only says which rows are *not*
+ * contributions: an opening balance, a subtotal, a closing balance.
+ */
+export interface WaterfallStepConfig {
+  /**
+   * Key whose truthy value marks a row as restating the running total rather
+   * than changing it. Such a row sits on the baseline instead of floating,
+   * and a reader told a subtotal "rose by 950" would hear a contribution the
+   * chart never made.
+   *
+   * A restating row's own value becomes the new running total. When it has
+   * none, the accumulated total is used, so a "Closing" row need carry no
+   * number of its own.
+   */
+  totalKey?: string;
+  /**
+   * Indices of the restating rows, for data that carries no flag column.
+   * A waterfall usually opens and closes on one, so this is commonly
+   * `[0, data.length - 1]`.
+   */
+  totalIndices?: number[];
+  /**
+   * Key holding the step kind outright — `'increase'`, `'decrease'` or
+   * `'total'`. Takes precedence over both fields above; without any of the
+   * three, a step is read from the sign of its contribution.
+   */
+  kindKey?: string;
+}
+
+/**
+ * Configuration for gantt charts, timelines and swimlane diagrams.
+ * Optional when `chartType` is `'gantt'`.
+ *
+ * One data row is one interval: `xKey` names its lane and the two `yKeys`
+ * entries its start and end, both as positions on the same numeric axis.
+ * Dates therefore have to arrive as epoch milliseconds — a `Date` is not a
+ * position, and a length in milliseconds needs {@link unit} to read as one.
+ */
+export interface GanttChartConfig {
+  /**
+   * The lanes, in the order the chart draws them.
+   *
+   * Declared rather than derived so an EMPTY lane survives: nothing booked is
+   * a real statement about a schedule, and a lane with no rows cannot name
+   * itself. A lane a row names but this list omits is appended at the end
+   * rather than dropped.
+   */
+  lanes?: (string | number)[];
+  /**
+   * Key holding what an individual interval is called, when its lane is not
+   * already its name. A lane commonly holds several — a resource booked
+   * twice, a phase that pauses — and without this they are announced by
+   * position alone.
+   */
+  labelKey?: string;
+  /**
+   * What a unit of the axis is called: `'days'`, `'hours'`, `'weeks'`.
+   * The length of an interval is the fact a gantt exists to carry, and a bare
+   * number does not carry it.
+   */
+  unit?: string;
+}
+
+/**
+ * Configuration for gauge and bullet charts.
+ * Required when `chartType` is `'gauge'`.
+ *
+ * The value comes from the one data row, but nothing else on a gauge does:
+ * a `<RadialBarChart>` holds a magnitude and an angle, while the reading is
+ * "73 out of 100, 7 below target, in the 'ok' band". The range mirrors the
+ * chart's own domain and the rest is author knowledge, so all of it arrives
+ * here — there is deliberately no default range, since a guessed maximum
+ * misreports the one number the chart draws.
+ */
+export interface GaugeDialConfig {
+  /** Lower end of the dial — the `<PolarAngleAxis domain>` floor. */
+  min: number;
+  /** Upper end of the dial — the `<PolarAngleAxis domain>` ceiling. */
+  max: number;
+  /** The target marker a bullet chart draws, when it has one. */
+  target?: number;
+  /**
+   * Qualitative bands, ascending and bounded above only: a band starts where
+   * the previous one ended, and the first starts at {@link min}.
+   */
+  bands?: GaugeBand[];
+  /**
+   * What the measure is called. Defaults to the data row's `xKey` value, the
+   * way every other chart type takes its category label from `xKey`.
+   */
+  label?: string;
 }
 
 /**
@@ -479,6 +607,125 @@ export interface RechartsSubplotConfig {
  * };
  * ```
  *
+ * @example Diverging bar chart (population pyramid)
+ * ```typescript
+ * // Exactly two yKeys, the LEFT-hand side first and holding NEGATIVE values —
+ * // the sign is the side, and MAIDR pitches the magnitude so the biggest bar
+ * // on the left is not heard as the smallest note on the chart.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'pyramid-chart',
+ *   title: 'Population by Age Band',
+ *   data: [{ band: '0-9', men: -2_100_000, women: 2_000_000 }],
+ *   chartType: 'diverging_bar',
+ *   xKey: 'band',
+ *   yKeys: ['men', 'women'],
+ *   fillKeys: ['Men', 'Women'],
+ *   orientation: Orientation.HORIZONTAL,
+ *   xLabel: 'Age band',
+ *   yLabel: 'People',
+ * };
+ * ```
+ *
+ * @example Waterfall chart
+ * ```typescript
+ * // The yKey holds each step's CONTRIBUTION; the adapter accumulates the
+ * // running totals, because a waterfall bar floats between the total before
+ * // the step and the total after it and neither number is in the data.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'bridge-chart',
+ *   title: 'Revenue Bridge',
+ *   data: [
+ *     { step: 'Opening', change: 1200, restates: true },
+ *     { step: 'New sales', change: 450 },
+ *     { step: 'Churn', change: -180 },
+ *     { step: 'Closing', restates: true },
+ *   ],
+ *   chartType: 'waterfall',
+ *   xKey: 'step',
+ *   yKeys: ['change'],
+ *   waterfallConfig: { totalKey: 'restates' },
+ *   xLabel: 'Step',
+ *   yLabel: 'Revenue ($k)',
+ * };
+ * ```
+ *
+ * @example Dumbbell chart
+ * ```typescript
+ * // Two yKeys, the starting end first, and `fillKeys` names them: those
+ * // names are what the comparison is about, and the legend is where a
+ * // sighted reader gets them.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'life-chart',
+ *   title: 'Life Expectancy, 1990 against 2020',
+ *   data: [{ country: 'Japan', then: 78.9, now: 84.6 }],
+ *   chartType: 'dumbbell',
+ *   xKey: 'country',
+ *   yKeys: ['then', 'now'],
+ *   fillKeys: ['1990', '2020'],
+ *   xLabel: 'Country',
+ *   yLabel: 'Years',
+ * };
+ * ```
+ *
+ * @example Gantt chart
+ * ```typescript
+ * // One row per interval: `xKey` is its lane and the two `yKeys` its start
+ * // and end. Declare `lanes` so a lane with nothing booked still exists —
+ * // an empty row is a real statement about a schedule.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'plan-chart',
+ *   title: 'Release Plan',
+ *   data: [{ task: 'Design', from: 0, to: 5 }, { task: 'Build', from: 3, to: 12 }],
+ *   chartType: 'gantt',
+ *   xKey: 'task',
+ *   yKeys: ['from', 'to'],
+ *   ganttConfig: { lanes: ['Design', 'Build', 'Launch'], unit: 'days' },
+ *   xLabel: 'Task',
+ *   yLabel: 'Day',
+ * };
+ * ```
+ *
+ * @example Gauge chart
+ * ```typescript
+ * // One data row, and everything the reading needs beyond its value comes
+ * // from the config: "73" is not the reading, "73 out of 100, 7 below
+ * // target, in the 'ok' band" is.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'nps-chart',
+ *   title: 'Net Promoter Score',
+ *   data: [{ measure: 'NPS', score: 73 }],
+ *   chartType: 'gauge',
+ *   xKey: 'measure',
+ *   yKeys: ['score'],
+ *   gaugeConfig: {
+ *     min: 0,
+ *     max: 100,
+ *     target: 80,
+ *     bands: [{ to: 40, label: 'poor' }, { to: 70, label: 'ok' }, { to: 100, label: 'good' }],
+ *   },
+ * };
+ * ```
+ *
+ * @example Treemap / sunburst
+ * ```typescript
+ * // `data` is the nested array Recharts is given, not the adapter's usual
+ * // flat rows. `xKey` is the `<Treemap nameKey>` and the single `yKeys`
+ * // entry its `dataKey`; children live under `children`, as Recharts
+ * // requires. A `<SunburstChart data={{ name: 'World', children }}>` passes
+ * // that same `children` array here, since it draws every node but the root.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'regions-chart',
+ *   title: 'Population by Region',
+ *   data: [
+ *     { name: 'Europe', children: [{ name: 'France', people: 67.4 }] },
+ *     { name: 'Asia', children: [{ name: 'Japan', people: 125.1 }] },
+ *   ],
+ *   chartType: 'treemap',
+ *   xKey: 'name',
+ *   yKeys: ['people'],
+ * };
+ * ```
+ *
  * @example Pie chart
  * ```typescript
  * // `xKey` is the Recharts `<Pie nameKey>` (the slice label) and the single
@@ -604,9 +851,14 @@ export interface RechartsAdapterConfig {
   orientation?: Orientation;
 
   /**
-   * Display names for each series in stacked/dodged/normalized bar charts.
-   * Maps 1:1 with `yKeys` — the i-th fillKey names the i-th yKey.
+   * Display names for each series in stacked/dodged/normalized/diverging bar
+   * charts. Maps 1:1 with `yKeys` — the i-th fillKey names the i-th yKey.
    * When omitted, the yKey strings are used as fill labels.
+   *
+   * A dumbbell reads them as the names of its two ends. They are the content
+   * of that comparison: announced as "start" and "end", a chart of life
+   * expectancy in 1990 against 2020 tells the reader which dot they are on
+   * and not which year it is.
    */
   fillKeys?: string[];
 
@@ -645,6 +897,24 @@ export interface RechartsAdapterConfig {
    * Used when `chartType` is `'survival'`.
    */
   survivalConfig?: SurvivalCurveConfig;
+
+  /**
+   * Waterfall step configuration.
+   * Used when `chartType` is `'waterfall'`.
+   */
+  waterfallConfig?: WaterfallStepConfig;
+
+  /**
+   * Gantt lane configuration.
+   * Used when `chartType` is `'gantt'`.
+   */
+  ganttConfig?: GanttChartConfig;
+
+  /**
+   * Gauge range, target and bands.
+   * Required when `chartType` is `'gauge'`.
+   */
+  gaugeConfig?: GaugeDialConfig;
 
   /**
    * Custom CSS selector override for SVG highlighting.

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -5,7 +5,7 @@
  * and SVG structure into MAIDR's accessible format.
  */
 
-import type { Orientation } from '@type/grammar';
+import type { Orientation, StepDirection } from '@type/grammar';
 
 /**
  * Recharts chart types supported by the adapter.
@@ -20,6 +20,9 @@ import type { Orientation } from '@type/grammar';
  * - `'lollipop'` → `TraceType.LOLLIPOP` — Lollipop chart: a `<ComposedChart>`
  *   of a thin `<Bar>` stem plus a `<Scatter>` head. Read exactly as a bar is —
  *   the stem is the mark, not extra data
+ * - `'funnel'` → `TraceType.FUNNEL` — Funnel chart (`<FunnelChart>` + `<Funnel>`):
+ *   a population shrinking across ordered stages. The counts are a bar's data;
+ *   MAIDR derives the retention and share it announces from them
  * - `'histogram'` → `TraceType.HISTOGRAM` — Histogram rendered as bar chart with bin ranges
  * - `'line'` → `TraceType.LINE` — Line chart
  * - `'area'` → `TraceType.AREA` — Area chart (Recharts `<Area>`); the fill is
@@ -31,10 +34,23 @@ import type { Orientation } from '@type/grammar';
  * - `'radar'` → `TraceType.RADAR` — Radar/spider chart (`<RadarChart>` + `<Radar>`)
  * - `'bump'` → `TraceType.BUMP` — Bump chart: rank over time, drawn as a
  *   `<LineChart>` with `<YAxis reversed>`
+ * - `'survival'` → `TraceType.SURVIVAL` — Kaplan-Meier curve: a
+ *   `<Line type="stepAfter">` plus the censoring marks and confidence band
+ *   declared through {@link SurvivalCurveConfig}
  * - `'scatter'` → `TraceType.SCATTER` — Scatter/point plot
+ * - `'volcano'` → `TraceType.VOLCANO` — Volcano plot: effect size against
+ *   significance, read through the cutoffs in {@link VolcanoPointConfig}
+ * - `'manhattan'` → `TraceType.MANHATTAN` — Manhattan plot: genomic position
+ *   against significance. Same payload and config as `'volcano'`
+ * - `'error_bar'` → `TraceType.ERROR_BAR` — An estimate with the interval
+ *   drawn around it (`<ErrorBar>` inside a `<Bar>`/`<Line>`/`<Scatter>`)
+ * - `'forest'` → `TraceType.FOREST` — Forest plot: one interval per study
+ *   against a shared null line, with the pooled summary last
  * - `'pie'` → `TraceType.PIE` — Pie/doughnut chart (Recharts `<Pie>`); a
  *   doughnut is a pie with an `innerRadius`, which changes nothing about the
  *   data, so both use this type
+ * - `'alluvial'` → `TraceType.ALLUVIAL` — Weighted flow between nodes drawn
+ *   as a `<Sankey>` whose node set repeats at each stage
  */
 export type RechartsChartType
   = | 'bar'
@@ -43,6 +59,7 @@ export type RechartsChartType
     | 'normalized_bar'
     | 'dot'
     | 'lollipop'
+    | 'funnel'
     | 'histogram'
     | 'line'
     | 'area'
@@ -50,8 +67,14 @@ export type RechartsChartType
     | 'normalized_area'
     | 'radar'
     | 'bump'
+    | 'survival'
     | 'scatter'
-    | 'pie';
+    | 'volcano'
+    | 'manhattan'
+    | 'error_bar'
+    | 'forest'
+    | 'pie'
+    | 'alluvial';
 
 /**
  * A single data series/layer configuration for composed charts.
@@ -79,6 +102,145 @@ export interface HistogramBinConfig {
   yMinKey?: string;
   /** Key in data objects for the maximum count. Defaults to the yKey value. */
   yMaxKey?: string;
+}
+
+/**
+ * Configuration for a flow (alluvial) diagram.
+ * Required when `chartType` is `'alluvial'`.
+ *
+ * The `data` array is the `links` half of what Recharts' `<Sankey>` is given:
+ * one row per flow. `xKey` names the field holding the source node and the
+ * single `yKeys` entry the field holding the magnitude, so only the target
+ * needs a key of its own.
+ */
+export interface FlowLinkConfig {
+  /** Key in link objects for the node the flow arrives at. */
+  targetKey: string;
+  /**
+   * The `nodes` half of the `<Sankey>` data, used to resolve the numeric
+   * indices Recharts links carry into node names.
+   *
+   * Recharts addresses nodes by their position in this array, and an index is
+   * not something to announce — "flow from 3 to 7" names neither end. Omit it
+   * only when the links already carry node names.
+   */
+  nodes?: Record<string, unknown>[];
+  /** Key in node objects for the node's name. Mirrors `<Sankey nameKey>`, and defaults to `'name'`. */
+  nodeNameKey?: string;
+}
+
+/**
+ * Configuration for volcano and Manhattan plots.
+ * Optional when `chartType` is `'volcano'` or `'manhattan'`.
+ *
+ * None of this is inferable from a Recharts `<Scatter>`: the component holds
+ * coordinates, and these charts are read for identity and for which side of a
+ * cutoff a point falls on. Both arrive from the author or not at all.
+ */
+export interface VolcanoPointConfig {
+  /** Key holding what the point *is* — a gene, a SNP, a probe. */
+  labelKey?: string;
+  /** Key holding the region the point belongs to — a chromosome. */
+  groupKey?: string;
+  /**
+   * The significance cutoff on the y axis.
+   *
+   * There is no default: -log10(p) puts the line at 1.3 for p < 0.05 and at
+   * 7.3 for genome-wide significance, and a guessed line sorts every point
+   * onto the wrong side silently.
+   */
+  significance?: number;
+  /**
+   * Which side of the cutoff is the significant one. Defaults to `'above'`,
+   * which is right for the transformed axes these charts usually carry.
+   * A raw p axis runs the other way and must declare `'below'`.
+   */
+  significanceDirection?: 'above' | 'below';
+  /** The effect-size cutoff, applied to the magnitude of x. */
+  effect?: number;
+}
+
+/**
+ * Configuration for the interval drawn around an estimate.
+ * Used when `chartType` is `'error_bar'` or `'forest'`.
+ *
+ * MAIDR fixes the interval as ABSOLUTE positions on the value axis, while
+ * Recharts' `<ErrorBar dataKey>` points at an OFFSET from the estimate. Both
+ * are accepted here and normalised to absolutes: declare `errorKey` for the
+ * Recharts field, or `yMinKey`/`yMaxKey` when the data already holds bounds.
+ */
+export interface ErrorIntervalConfig {
+  /**
+   * Key holding the interval as an offset from the estimate — the field a
+   * `<ErrorBar dataKey>` points at. A number is a symmetric offset; a
+   * `[lower, upper]` pair is an asymmetric one, exactly as Recharts reads it.
+   */
+  errorKey?: string;
+  /** Key holding the absolute lower bound. Takes precedence over `errorKey`. */
+  yMinKey?: string;
+  /** Key holding the absolute upper bound. Takes precedence over `errorKey`. */
+  yMaxKey?: string;
+}
+
+/**
+ * Configuration for forest plots.
+ * Optional when `chartType` is `'forest'`, but a forest plot that declares no
+ * `nullValue` gets no claim about significance — see {@link nullValue}.
+ */
+export interface ForestPlotConfig {
+  /**
+   * Key holding the study's weight in the pooled estimate, as a fraction of
+   * one. A forest plot encodes this as marker area, which no reader is
+   * otherwise told: two studies whose intervals look alike can contribute
+   * wholly differently to the result.
+   */
+  weightKey?: string;
+  /** Key whose truthy value marks a row as the pooled summary rather than a study. */
+  pooledKey?: string;
+  /**
+   * Index of the pooled summary row, for data that carries no flag column.
+   * A meta-analysis draws the pooled row last, so this is usually
+   * `data.length - 1`.
+   */
+  pooledIndex?: number;
+  /**
+   * The value that means "no effect" — 1 for a ratio measure, 0 for a
+   * difference. It is the `<ReferenceLine>` the chart draws, and whether a
+   * study's interval crosses it is that study's result.
+   *
+   * There is deliberately no default: guessing 0 for a ratio chart reports
+   * every study as not crossing, since odds ratios are all positive.
+   */
+  nullValue?: number;
+}
+
+/**
+ * Configuration for Kaplan-Meier survival curves.
+ * Optional when `chartType` is `'survival'`.
+ *
+ * The key arrays map 1:1 with `yKeys` — the i-th entry belongs to the i-th
+ * arm — the same way `fillKeys` names the i-th series.
+ */
+export interface SurvivalCurveConfig {
+  /**
+   * Keys whose truthy value marks a censored time, one per arm.
+   *
+   * Censoring is not an event: the curve does not step there. A reader who
+   * cannot tell a censored time from an ordinary one cannot tell a flat tail
+   * backed by two hundred subjects from one backed by three.
+   */
+  censoredKeys?: string[];
+  /** Keys for the lower bound of the confidence band, one per arm. */
+  yMinKeys?: string[];
+  /** Keys for the upper bound of the confidence band, one per arm. */
+  yMaxKeys?: string[];
+  /**
+   * Where the curve jumps between times. Defaults to `'hv'`, which is what
+   * `<Line type="stepAfter">` draws and what a Kaplan-Meier curve means:
+   * survival holds until an event drops it. Declare `'vh'` for a curve drawn
+   * with `type="stepBefore"`.
+   */
+  stepDirection?: StepDirection;
 }
 
 /**
@@ -226,6 +388,97 @@ export interface RechartsSubplotConfig {
  * };
  * ```
  *
+ * @example Survival curve
+ * ```typescript
+ * // One `yKeys` entry per arm, and the per-arm keys line up with it the way
+ * // `fillKeys` does. Censoring marks a time where a subject left the study
+ * // without the event happening — the curve does not step there.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'km-chart',
+ *   title: 'Overall Survival',
+ *   data: [{ months: 0, treated: 1, treatedCensored: false }],
+ *   chartType: 'survival',
+ *   xKey: 'months',
+ *   yKeys: ['treated'],
+ *   survivalConfig: { censoredKeys: ['treatedCensored'] },
+ *   xLabel: 'Months',
+ *   yLabel: 'Survival probability',
+ * };
+ * ```
+ *
+ * @example Error bars
+ * ```typescript
+ * // `errorKey` is the field the Recharts `<ErrorBar dataKey>` points at, so
+ * // it holds an OFFSET; the adapter turns it into the absolute bounds MAIDR
+ * // announces. Data that already holds bounds uses yMinKey/yMaxKey instead.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'yield-chart',
+ *   title: 'Yield by Treatment',
+ *   data: [{ treatment: 'Control', mean: 4.2, sd: 0.6 }],
+ *   chartType: 'error_bar',
+ *   xKey: 'treatment',
+ *   yKeys: ['mean'],
+ *   errorConfig: { errorKey: 'sd' },
+ *   xLabel: 'Treatment',
+ *   yLabel: 'Yield (t/ha)',
+ * };
+ * ```
+ *
+ * @example Forest plot
+ * ```typescript
+ * // `nullValue` is the <ReferenceLine> the chart draws: 1 for a ratio, 0 for
+ * // a difference. Without it MAIDR reports the estimate, the interval and the
+ * // weight, and makes no claim about significance.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'meta-chart',
+ *   title: 'Effect of the intervention',
+ *   data: [{ study: 'Silva 2018', or: 0.62, lo: 0.41, hi: 0.94, weight: 0.12 }],
+ *   chartType: 'forest',
+ *   xKey: 'study',
+ *   yKeys: ['or'],
+ *   orientation: Orientation.HORIZONTAL,
+ *   errorConfig: { yMinKey: 'lo', yMaxKey: 'hi' },
+ *   forestConfig: { weightKey: 'weight', pooledKey: 'pooled', nullValue: 1 },
+ *   xLabel: 'Study',
+ *   yLabel: 'Odds ratio',
+ * };
+ * ```
+ *
+ * @example Volcano plot
+ * ```typescript
+ * // The labels are the payload on these charts — a reader told "x is 2.3,
+ * // y is 14.1" has been given the two numbers they can already see the shape
+ * // of, and withheld the gene they came for.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'volcano-chart',
+ *   title: 'Differential Expression',
+ *   data: [{ gene: 'TP53', log2fc: 2.4, negLog10P: 14.1 }],
+ *   chartType: 'volcano',
+ *   xKey: 'log2fc',
+ *   yKeys: ['negLog10P'],
+ *   volcanoConfig: { labelKey: 'gene', significance: 1.3, effect: 1 },
+ *   xLabel: 'log2 fold change',
+ *   yLabel: '-log10(p)',
+ * };
+ * ```
+ *
+ * @example Alluvial (flow) diagram
+ * ```typescript
+ * // `data` is the `links` half of what <Sankey> is given; `flowConfig.nodes`
+ * // is the other half, and resolves the indices the links carry into names.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'flow-chart',
+ *   title: 'Cohort Movement',
+ *   data: [{ source: 0, target: 2, value: 34 }],
+ *   chartType: 'alluvial',
+ *   xKey: 'source',
+ *   yKeys: ['value'],
+ *   flowConfig: { targetKey: 'target', nodes: [{ name: 'Free' }, { name: 'Paid' }] },
+ *   xLabel: 'Stage',
+ *   yLabel: 'Users',
+ * };
+ * ```
+ *
  * @example Pie chart
  * ```typescript
  * // `xKey` is the Recharts `<Pie nameKey>` (the slice label) and the single
@@ -362,6 +615,36 @@ export interface RechartsAdapterConfig {
    * Required when `chartType` is `'histogram'`.
    */
   binConfig?: HistogramBinConfig;
+
+  /**
+   * Flow link configuration.
+   * Required when `chartType` is `'alluvial'`.
+   */
+  flowConfig?: FlowLinkConfig;
+
+  /**
+   * Point labels and cutoffs for a volcano or Manhattan plot.
+   * Used when `chartType` is `'volcano'` or `'manhattan'`.
+   */
+  volcanoConfig?: VolcanoPointConfig;
+
+  /**
+   * Interval configuration.
+   * Used when `chartType` is `'error_bar'` or `'forest'`.
+   */
+  errorConfig?: ErrorIntervalConfig;
+
+  /**
+   * Forest plot configuration.
+   * Used when `chartType` is `'forest'`.
+   */
+  forestConfig?: ForestPlotConfig;
+
+  /**
+   * Survival curve configuration.
+   * Used when `chartType` is `'survival'`.
+   */
+  survivalConfig?: SurvivalCurveConfig;
 
   /**
    * Custom CSS selector override for SVG highlighting.

--- a/src/adapters/recharts/useRechartsAdapter.ts
+++ b/src/adapters/recharts/useRechartsAdapter.ts
@@ -79,6 +79,11 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
     orientation,
     fillKeys,
     binConfig,
+    flowConfig,
+    volcanoConfig,
+    errorConfig,
+    forestConfig,
+    survivalConfig,
     selectorOverride,
   } = config;
 
@@ -100,8 +105,13 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
       orientation,
       fillKeys,
       binConfig,
+      flowConfig,
+      volcanoConfig,
+      errorConfig,
+      forestConfig,
+      survivalConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, selectorOverride],
   );
 }

--- a/src/adapters/recharts/useRechartsAdapter.ts
+++ b/src/adapters/recharts/useRechartsAdapter.ts
@@ -84,6 +84,9 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
     errorConfig,
     forestConfig,
     survivalConfig,
+    waterfallConfig,
+    ganttConfig,
+    gaugeConfig,
     selectorOverride,
   } = config;
 
@@ -110,8 +113,11 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
       errorConfig,
       forestConfig,
       survivalConfig,
+      waterfallConfig,
+      ganttConfig,
+      gaugeConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, selectorOverride],
   );
 }

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -540,7 +540,7 @@ describe('convertRechartsToMaidr', () => {
     });
   });
 
-  describe('treemap and sunburst', () => {
+  describe('treemap, sunburst and icicle', () => {
     const hierarchyConfig: RechartsAdapterConfig = {
       id: 'regions',
       title: 'Population by Region',
@@ -600,6 +600,33 @@ describe('convertRechartsToMaidr', () => {
       expect(layer.data).toEqual(
         convertRechartsToMaidr(hierarchyConfig).subplots[0][0].layers[0].data,
       );
+    });
+
+    it('reads an icicle as the same hierarchy, drawn as floating bands', () => {
+      const result = convertRechartsToMaidr({ ...hierarchyConfig, chartType: 'icicle' });
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.ICICLE);
+      // Recharts draws no icicle, so the bands are floating `<Bar>`
+      // rectangles — one per row, the same recipe a gantt uses.
+      expect(layer.selectors).toBe(
+        '#maidr-article-regions .recharts-bar-rectangle .recharts-rectangle',
+      );
+      expect(layer.data).toEqual(
+        convertRechartsToMaidr(hierarchyConfig).subplots[0][0].layers[0].data,
+      );
+    });
+
+    it('never orients an icicle, however its bands happen to run', () => {
+      const layer = convertRechartsToMaidr({
+        ...hierarchyConfig,
+        chartType: 'icicle',
+        orientation: Orientation.HORIZONTAL,
+      }).subplots[0][0].layers[0];
+
+      // The bars are the layout the tree was given, not an axis a reader
+      // walks: an icicle is navigated as the hierarchy it is.
+      expect(layer.orientation).toBeUndefined();
     });
   });
 
@@ -1048,6 +1075,58 @@ describe('convertRechartsToMaidr', () => {
     });
   });
 
+  describe('polar area chart', () => {
+    const polarConfig: RechartsAdapterConfig = {
+      id: 'nightingale',
+      title: 'Deaths by Month',
+      data: [
+        { month: 'Jan', deaths: 120 },
+        { month: 'Feb', deaths: 84 },
+        { month: 'Mar', deaths: 61 },
+      ],
+      chartType: 'polar_area',
+      xKey: 'month',
+      yKeys: ['deaths'],
+      xLabel: 'Month',
+      yLabel: 'Deaths',
+    };
+
+    it('converts a coxcomb to a radar\'s payload — one value per spoke', () => {
+      const layer = convertRechartsToMaidr(polarConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.POLAR_AREA);
+
+      // Wedges rather than an outline is what the chart looks like; a reader
+      // navigates the same spokes either way, so the data is a line's.
+      const data = layer.data as LinePoint[][];
+      expect(data).toEqual([[
+        { x: 'Jan', y: 120 },
+        { x: 'Feb', y: 84 },
+        { x: 'Mar', y: 61 },
+      ]]);
+    });
+
+    it('targets the pie sectors that draw the wedges', () => {
+      const layer = convertRechartsToMaidr(polarConfig).subplots[0][0].layers[0];
+
+      // A `RadarTrace` is a `LineTrace`, so the selector is a list even for
+      // the single series a coxcomb draws.
+      expect(layer.selectors).toEqual([
+        '#maidr-article-nightingale .recharts-pie-sector .recharts-sector',
+      ]);
+    });
+
+    it('never emits an orientation, even when the config sets one', () => {
+      const layer = convertRechartsToMaidr({
+        ...polarConfig,
+        orientation: Orientation.HORIZONTAL,
+      }).subplots[0][0].layers[0];
+
+      // Wedges sit around a circle, not along an axis — same as a radar.
+      expect(layer.orientation).toBeUndefined();
+    });
+  });
+
   describe('bump chart', () => {
     const bumpConfig: RechartsAdapterConfig = {
       id: 'bump',
@@ -1470,7 +1549,7 @@ describe('convertRechartsToMaidr', () => {
     });
   });
 
-  describe('alluvial diagram', () => {
+  describe('alluvial and sankey diagrams', () => {
     const nodes = [
       { name: 'Free' },
       { name: 'Trial' },
@@ -1542,6 +1621,31 @@ describe('convertRechartsToMaidr', () => {
     it('throws when the flow config is missing', () => {
       expect(() => convertRechartsToMaidr({
         ...alluvialConfig,
+        flowConfig: undefined,
+      })).toThrow('RechartsAdapter');
+    });
+
+    it('reads a sankey as the same weighted graph, drawn as one budget', () => {
+      const result = convertRechartsToMaidr({ ...alluvialConfig, chartType: 'sankey' });
+
+      const sankey = result.subplots[0][0].layers[0];
+
+      expect(sankey.type).toBe(TraceType.SANKEY);
+      // Whether the node set repeats at each stage is what tells the two
+      // apart, and that is a fact about the data rather than the payload.
+      expect(sankey.data).toEqual(
+        convertRechartsToMaidr(alluvialConfig).subplots[0][0].layers[0].data,
+      );
+      expect(sankey.selectors).toBe(
+        '#maidr-article-flow .recharts-sankey-links .recharts-sankey-link',
+      );
+      expect(sankey.orientation).toBeUndefined();
+    });
+
+    it('throws for a sankey with no flow config either', () => {
+      expect(() => convertRechartsToMaidr({
+        ...alluvialConfig,
+        chartType: 'sankey',
         flowConfig: undefined,
       })).toThrow('RechartsAdapter');
     });

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -1,5 +1,5 @@
 import type { RechartsAdapterConfig } from '@adapters/recharts/types';
-import type { BarPoint, ErrorBarPoint, FlowPoint, ForestPoint, HistogramPoint, LinePoint, PiePoint, ScatterPoint, SegmentedPoint, SurvivalPoint, VolcanoPoint } from '@type/grammar';
+import type { BarPoint, DumbbellData, ErrorBarPoint, FlowPoint, ForestPoint, GanttData, GaugePoint, HistogramPoint, LinePoint, PiePoint, ScatterPoint, SegmentedPoint, SurvivalPoint, TreemapPoint, VolcanoPoint, WaterfallPoint } from '@type/grammar';
 import { convertRechartsToMaidr } from '@adapters/recharts/converters';
 import { Orientation, TraceType } from '@type/grammar';
 
@@ -196,6 +196,410 @@ describe('convertRechartsToMaidr', () => {
 
       const result = convertRechartsToMaidr(config);
       expect(result.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+    });
+  });
+
+  describe('diverging bar chart', () => {
+    const pyramidConfig: RechartsAdapterConfig = {
+      id: 'pyramid',
+      title: 'Population by Age Band',
+      data: [
+        { band: '0-9', men: -2100, women: 2000 },
+        { band: '10-19', men: -1900, women: 1850 },
+      ],
+      chartType: 'diverging_bar',
+      xKey: 'band',
+      yKeys: ['men', 'women'],
+      fillKeys: ['Men', 'Women'],
+      orientation: Orientation.HORIZONTAL,
+      xLabel: 'Age band',
+      yLabel: 'People',
+    };
+
+    it('produces DIVERGING trace type with the bar selector', () => {
+      const result = convertRechartsToMaidr(pyramidConfig);
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.DIVERGING);
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      expect(layer.selectors).toBe('#maidr-article-pyramid .recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('keeps the sides in declaration order, signs and all', () => {
+      const result = convertRechartsToMaidr(pyramidConfig);
+
+      // DivergingTrace reads the sides in DECLARATION order rather than the
+      // reversed stacking order, and reads the sign as the SIDE — so the left
+      // side must stay first and stay negative.
+      const data = result.subplots[0][0].layers[0].data as SegmentedPoint[][];
+      expect(data).toHaveLength(2);
+      expect(data[0][0]).toEqual({ x: '0-9', y: -2100, z: 'Men' });
+      expect(data[1][0]).toEqual({ x: '0-9', y: 2000, z: 'Women' });
+    });
+
+    it('falls back to BAR type when only one side is declared', () => {
+      const result = convertRechartsToMaidr({
+        ...pyramidConfig,
+        yKeys: ['men'],
+        fillKeys: undefined,
+      });
+
+      expect(result.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+    });
+  });
+
+  describe('waterfall chart', () => {
+    const bridgeConfig: RechartsAdapterConfig = {
+      id: 'bridge',
+      title: 'Revenue Bridge',
+      data: [
+        { step: 'Opening', change: 1200, restates: true },
+        { step: 'New sales', change: 450 },
+        { step: 'Churn', change: -180 },
+        { step: 'Closing', restates: true },
+      ],
+      chartType: 'waterfall',
+      xKey: 'step',
+      yKeys: ['change'],
+      waterfallConfig: { totalKey: 'restates' },
+      xLabel: 'Step',
+      yLabel: 'Revenue',
+    };
+
+    it('accumulates the running totals into absolute positions', () => {
+      const result = convertRechartsToMaidr(bridgeConfig);
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.WATERFALL);
+      expect(layer.selectors).toBe('#maidr-article-bridge .recharts-bar-rectangle .recharts-rectangle');
+
+      const data = layer.data as WaterfallPoint[];
+      expect(data[1]).toEqual({ x: 'New sales', start: 1200, end: 1650, delta: 450, kind: 'increase' });
+      expect(data[2]).toEqual({ x: 'Churn', start: 1650, end: 1470, delta: -180, kind: 'decrease' });
+    });
+
+    it('sits a restating step on the baseline', () => {
+      const result = convertRechartsToMaidr(bridgeConfig);
+      const data = result.subplots[0][0].layers[0].data as WaterfallPoint[];
+
+      // The opening declares its own total; the closing carries no number and
+      // restates what the steps came to.
+      expect(data[0]).toEqual({ x: 'Opening', start: 0, end: 1200, delta: 1200, kind: 'total' });
+      expect(data[3]).toEqual({ x: 'Closing', start: 0, end: 1470, delta: 1470, kind: 'total' });
+    });
+
+    it('marks restating steps by index when the data carries no flag', () => {
+      const result = convertRechartsToMaidr({
+        ...bridgeConfig,
+        data: [
+          { step: 'Opening', change: 1200 },
+          { step: 'New sales', change: 450 },
+        ],
+        waterfallConfig: { totalIndices: [0] },
+      });
+
+      const data = result.subplots[0][0].layers[0].data as WaterfallPoint[];
+      expect(data[0].kind).toBe('total');
+      expect(data[1].kind).toBe('increase');
+    });
+
+    it('reads the kind outright when the data names it', () => {
+      const result = convertRechartsToMaidr({
+        ...bridgeConfig,
+        data: [
+          { step: 'Opening', change: 1200, how: 'total' },
+          { step: 'Rebate', change: 0, how: 'decrease' },
+        ],
+        waterfallConfig: { kindKey: 'how' },
+      });
+
+      const data = result.subplots[0][0].layers[0].data as WaterfallPoint[];
+      expect(data[0].kind).toBe('total');
+      // A zero-width step reads from the sign as an increase; the declared
+      // kind is what the chart drew.
+      expect(data[1].kind).toBe('decrease');
+    });
+
+    it('carries no orientation', () => {
+      const result = convertRechartsToMaidr({
+        ...bridgeConfig,
+        orientation: Orientation.HORIZONTAL,
+      });
+
+      expect(result.subplots[0][0].layers[0].orientation).toBeUndefined();
+    });
+  });
+
+  describe('dumbbell chart', () => {
+    const dumbbellConfig: RechartsAdapterConfig = {
+      id: 'life',
+      title: 'Life Expectancy',
+      data: [
+        { country: 'Japan', then: 78.9, now: 84.6 },
+        { country: 'Russia', then: 69.2, now: 68.9 },
+      ],
+      chartType: 'dumbbell',
+      xKey: 'country',
+      yKeys: ['then', 'now'],
+      fillKeys: ['1990', '2020'],
+      xLabel: 'Country',
+      yLabel: 'Years',
+    };
+
+    it('produces a DumbbellData object rather than an array', () => {
+      const result = convertRechartsToMaidr(dumbbellConfig);
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.DUMBBELL);
+      expect(layer.selectors).toBe('#maidr-article-life .recharts-bar-rectangle .recharts-rectangle');
+
+      const data = layer.data as DumbbellData;
+      expect(Array.isArray(data)).toBe(false);
+      expect(data.points).toHaveLength(2);
+      // Both directions in one chart: Russia's end sits below its start.
+      expect(data.points[0]).toEqual({ x: 'Japan', start: 78.9, end: 84.6 });
+      expect(data.points[1]).toEqual({ x: 'Russia', start: 69.2, end: 68.9 });
+    });
+
+    it('names the two ends from fillKeys', () => {
+      const result = convertRechartsToMaidr(dumbbellConfig);
+      const data = result.subplots[0][0].layers[0].data as DumbbellData;
+
+      expect(data.startLabel).toBe('1990');
+      expect(data.endLabel).toBe('2020');
+    });
+
+    it('leaves the ends unnamed when fillKeys is omitted', () => {
+      const result = convertRechartsToMaidr({ ...dumbbellConfig, fillKeys: undefined });
+      const data = result.subplots[0][0].layers[0].data as DumbbellData;
+
+      expect(data.startLabel).toBeUndefined();
+      expect(data.endLabel).toBeUndefined();
+    });
+
+    it('throws when only one end is declared', () => {
+      expect(() => convertRechartsToMaidr({
+        ...dumbbellConfig,
+        yKeys: ['then'],
+      })).toThrow('RechartsAdapter');
+    });
+  });
+
+  describe('gantt chart', () => {
+    const planConfig: RechartsAdapterConfig = {
+      id: 'plan',
+      title: 'Release Plan',
+      data: [
+        { task: 'Design', from: 0, to: 5, phase: 'Wireframes' },
+        { task: 'Build', from: 3, to: 12, phase: 'Alpha' },
+        { task: 'Build', from: 14, to: 18, phase: 'Beta' },
+      ],
+      chartType: 'gantt',
+      xKey: 'task',
+      yKeys: ['from', 'to'],
+      ganttConfig: { lanes: ['Design', 'Build', 'Launch'], labelKey: 'phase', unit: 'days' },
+      xLabel: 'Task',
+      yLabel: 'Day',
+    };
+
+    it('nests the intervals by lane and keeps the empty lane', () => {
+      const result = convertRechartsToMaidr(planConfig);
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.GANTT);
+      // A gantt's bars run left to right, which puts the lanes on y.
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+
+      const data = layer.data as GanttData;
+      expect(data.points).toHaveLength(3);
+      expect(data.points[0]).toEqual([{ x: 'Design', start: 0, end: 5, label: 'Wireframes' }]);
+      expect(data.points[1]).toHaveLength(2);
+      // Nothing booked in Launch — the row exists so the schedule can say so.
+      expect(data.points[2]).toEqual([]);
+      expect(data.lanes).toEqual(['Design', 'Build', 'Launch']);
+      expect(data.unit).toBe('days');
+    });
+
+    it('highlights when the rows are already grouped by lane', () => {
+      const result = convertRechartsToMaidr(planConfig);
+
+      expect(result.subplots[0][0].layers[0].selectors)
+        .toBe('#maidr-article-plan .recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('drops the selector when the rows interleave lanes', () => {
+      // Recharts draws one rectangle per ROW while GanttTrace walks its
+      // selectors lane by lane, so interleaved rows would highlight the wrong
+      // task rather than none.
+      const result = convertRechartsToMaidr({
+        ...planConfig,
+        data: [
+          { task: 'Design', from: 0, to: 5 },
+          { task: 'Build', from: 3, to: 12 },
+          { task: 'Design', from: 8, to: 9 },
+        ],
+      });
+
+      expect(result.subplots[0][0].layers[0].selectors).toBeUndefined();
+    });
+
+    it('derives the lanes from the data when none are declared', () => {
+      const result = convertRechartsToMaidr({
+        ...planConfig,
+        ganttConfig: undefined,
+      });
+
+      const data = result.subplots[0][0].layers[0].data as GanttData;
+      expect(data.lanes).toEqual(['Design', 'Build']);
+      expect(data.unit).toBeUndefined();
+      expect(data.points[0][0].label).toBeUndefined();
+    });
+
+    it('appends a lane the data names but the config omits', () => {
+      const result = convertRechartsToMaidr({
+        ...planConfig,
+        ganttConfig: { lanes: ['Design'] },
+      });
+
+      const data = result.subplots[0][0].layers[0].data as GanttData;
+      expect(data.lanes).toEqual(['Design', 'Build']);
+      expect(data.points[1]).toHaveLength(2);
+    });
+
+    it('throws when only one end of the interval is declared', () => {
+      expect(() => convertRechartsToMaidr({
+        ...planConfig,
+        yKeys: ['from'],
+      })).toThrow('RechartsAdapter');
+    });
+  });
+
+  describe('gauge chart', () => {
+    const gaugeConfig: RechartsAdapterConfig = {
+      id: 'nps',
+      title: 'Net Promoter Score',
+      data: [{ measure: 'NPS', score: 73 }],
+      chartType: 'gauge',
+      xKey: 'measure',
+      yKeys: ['score'],
+      gaugeConfig: {
+        min: 0,
+        max: 100,
+        target: 80,
+        bands: [{ to: 40, label: 'poor' }, { to: 70, label: 'ok' }, { to: 100, label: 'good' }],
+      },
+    };
+
+    it('produces a single GaugePoint object with its range', () => {
+      const result = convertRechartsToMaidr(gaugeConfig);
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.GAUGE);
+      expect(layer.selectors)
+        .toBe('#maidr-article-nps .recharts-radial-bar-sectors .recharts-radial-bar-sector');
+      expect(layer.orientation).toBeUndefined();
+
+      const data = layer.data as GaugePoint;
+      expect(Array.isArray(data)).toBe(false);
+      expect(data).toEqual({
+        value: 73,
+        min: 0,
+        max: 100,
+        label: 'NPS',
+        target: 80,
+        bands: [{ to: 40, label: 'poor' }, { to: 70, label: 'ok' }, { to: 100, label: 'good' }],
+      });
+    });
+
+    it('omits the target and bands the chart does not declare', () => {
+      const result = convertRechartsToMaidr({
+        ...gaugeConfig,
+        gaugeConfig: { min: 0, max: 100 },
+      });
+
+      const data = result.subplots[0][0].layers[0].data as GaugePoint;
+      expect(data.target).toBeUndefined();
+      expect(data.bands).toBeUndefined();
+    });
+
+    it('prefers a declared label over the xKey value', () => {
+      const result = convertRechartsToMaidr({
+        ...gaugeConfig,
+        gaugeConfig: { min: 0, max: 100, label: 'Promoter score' },
+      });
+
+      const data = result.subplots[0][0].layers[0].data as GaugePoint;
+      expect(data.label).toBe('Promoter score');
+    });
+
+    it('throws when the range is not declared', () => {
+      expect(() => convertRechartsToMaidr({
+        ...gaugeConfig,
+        gaugeConfig: undefined,
+      })).toThrow('RechartsAdapter');
+    });
+  });
+
+  describe('treemap and sunburst', () => {
+    const hierarchyConfig: RechartsAdapterConfig = {
+      id: 'regions',
+      title: 'Population by Region',
+      data: [
+        {
+          name: 'Europe',
+          people: 999,
+          children: [{ name: 'France', people: 67.4 }, { name: 'Spain', people: 47.4 }],
+        },
+        { name: 'Oceania', children: [{ name: 'Fiji', people: 0.9 }] },
+      ],
+      chartType: 'treemap',
+      xKey: 'name',
+      yKeys: ['people'],
+    };
+
+    it('flattens the hierarchy depth-first, ancestors named', () => {
+      const result = convertRechartsToMaidr(hierarchyConfig);
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.TREEMAP);
+
+      const data = layer.data as TreemapPoint[];
+      expect(data).toEqual([
+        { x: 'Europe' },
+        { x: 'France', path: ['Europe'], y: 67.4 },
+        { x: 'Spain', path: ['Europe'], y: 47.4 },
+        { x: 'Oceania' },
+        { x: 'Fiji', path: ['Oceania'], y: 0.9 },
+      ]);
+    });
+
+    it('drops an interior node\'s declared value', () => {
+      // Recharts computes an interior node's value as the sum of its children
+      // and ignores any value declared on it, so passing Europe's 999 through
+      // would announce a magnitude the chart never drew.
+      const result = convertRechartsToMaidr(hierarchyConfig);
+      const data = result.subplots[0][0].layers[0].data as TreemapPoint[];
+
+      expect(data[0].y).toBeUndefined();
+    });
+
+    it('targets the treemap rectangles below the synthetic root', () => {
+      const result = convertRechartsToMaidr(hierarchyConfig);
+
+      expect(result.subplots[0][0].layers[0].selectors).toBe(
+        '#maidr-article-regions g[class*="recharts-treemap-depth-"]:not(.recharts-treemap-depth-0) > g > g > path.recharts-rectangle',
+      );
+    });
+
+    it('reads a sunburst as the same hierarchy, drawn as sectors', () => {
+      const result = convertRechartsToMaidr({ ...hierarchyConfig, chartType: 'sunburst' });
+
+      const layer = result.subplots[0][0].layers[0];
+      expect(layer.type).toBe(TraceType.SUNBURST);
+      expect(layer.selectors).toBe('#maidr-article-regions .recharts-sunburst .recharts-sector');
+      expect(layer.data).toEqual(
+        convertRechartsToMaidr(hierarchyConfig).subplots[0][0].layers[0].data,
+      );
     });
   });
 

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -1,5 +1,5 @@
 import type { RechartsAdapterConfig } from '@adapters/recharts/types';
-import type { BarPoint, HistogramPoint, LinePoint, PiePoint, ScatterPoint, SegmentedPoint } from '@type/grammar';
+import type { BarPoint, ErrorBarPoint, FlowPoint, ForestPoint, HistogramPoint, LinePoint, PiePoint, ScatterPoint, SegmentedPoint, SurvivalPoint, VolcanoPoint } from '@type/grammar';
 import { convertRechartsToMaidr } from '@adapters/recharts/converters';
 import { Orientation, TraceType } from '@type/grammar';
 
@@ -279,6 +279,61 @@ describe('convertRechartsToMaidr', () => {
       expect(layer.selectors).toBe(
         '#maidr-article-lollipop .recharts-scatter-symbol .recharts-symbols',
       );
+    });
+  });
+
+  describe('funnel chart', () => {
+    const funnelConfig: RechartsAdapterConfig = {
+      id: 'funnel',
+      title: 'Signup Funnel',
+      data: [
+        { stage: 'Visited', users: 10000 },
+        { stage: 'Signed up', users: 2400 },
+        { stage: 'Activated', users: 2300 },
+        { stage: 'Paid', users: 100 },
+      ],
+      chartType: 'funnel',
+      xKey: 'stage',
+      yKeys: ['users'],
+      xLabel: 'Stage',
+      yLabel: 'Users',
+    };
+
+    it('converts the stage counts to BarPoint[] in draw order', () => {
+      const layer = convertRechartsToMaidr(funnelConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.FUNNEL);
+
+      // The counts, untouched: FunnelTrace computes the retention and the
+      // share it announces from them, so a pre-computed ratio here would be
+      // a second source of truth for the same numbers.
+      const data = layer.data as BarPoint[];
+      expect(data).toEqual([
+        { x: 'Visited', y: 10000 },
+        { x: 'Signed up', y: 2400 },
+        { x: 'Activated', y: 2300 },
+        { x: 'Paid', y: 100 },
+      ]);
+    });
+
+    it('targets the funnel trapezoids', () => {
+      const layer = convertRechartsToMaidr(funnelConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe(
+        '#maidr-article-funnel .recharts-funnel-trapezoid .recharts-trapezoid',
+      );
+    });
+
+    it('never emits an orientation, even when the config declares one', () => {
+      const layer = convertRechartsToMaidr({
+        ...funnelConfig,
+        orientation: Orientation.HORIZONTAL,
+      }).subplots[0][0].layers[0];
+
+      // FunnelTrace is a BarTrace, and a horizontal bar reads its category
+      // off `y`. The stage label is always emitted as `x`, so a leaked
+      // HORIZONTAL would have every stage announced by its count.
+      expect(layer.orientation).toBeUndefined();
     });
   });
 
@@ -638,6 +693,105 @@ describe('convertRechartsToMaidr', () => {
     });
   });
 
+  describe('survival curve', () => {
+    const survivalConfig: RechartsAdapterConfig = {
+      id: 'km',
+      title: 'Overall Survival',
+      data: [
+        { months: 0, treated: 1, control: 1, treatedCensored: false },
+        { months: 6, treated: 0.88, control: 0.74, treatedCensored: true },
+        { months: 12, treated: 0.71, control: 0.52, treatedCensored: false },
+      ],
+      chartType: 'survival',
+      xKey: 'months',
+      yKeys: ['treated'],
+      survivalConfig: { censoredKeys: ['treatedCensored'] },
+      xLabel: 'Months',
+      yLabel: 'Survival probability',
+    };
+
+    it('marks only the censored times', () => {
+      const layer = convertRechartsToMaidr(survivalConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.SURVIVAL);
+
+      // An ordinary time carries no flag at all: `censored: false` on every
+      // other point is a claim the data never made.
+      const data = layer.data as SurvivalPoint[][];
+      expect(data).toEqual([[
+        { x: 0, y: 1 },
+        { x: 6, y: 0.88, censored: true },
+        { x: 12, y: 0.71 },
+      ]]);
+    });
+
+    it('carries the confidence band as absolute bounds', () => {
+      const layer = convertRechartsToMaidr({
+        ...survivalConfig,
+        data: [
+          { months: 0, treated: 1, lo: 1, hi: 1 },
+          { months: 6, treated: 0.88, lo: 0.79, hi: 0.97 },
+        ],
+        survivalConfig: { yMinKeys: ['lo'], yMaxKeys: ['hi'] },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as SurvivalPoint[][];
+      expect(data[0][1]).toEqual({ x: 6, y: 0.88, yMin: 0.79, yMax: 0.97 });
+    });
+
+    it('declares the step direction Recharts draws', () => {
+      const layer = convertRechartsToMaidr(survivalConfig).subplots[0][0].layers[0];
+
+      // <Line type="stepAfter"> holds the value until the next time, then
+      // jumps — which is exactly what a Kaplan-Meier curve means.
+      expect(layer.stepDirection).toBe('hv');
+
+      const stepBefore = convertRechartsToMaidr({
+        ...survivalConfig,
+        survivalConfig: { stepDirection: 'vh' },
+      }).subplots[0][0].layers[0];
+      expect(stepBefore.stepDirection).toBe('vh');
+    });
+
+    it('targets the line dots for a single arm', () => {
+      const layer = convertRechartsToMaidr(survivalConfig).subplots[0][0].layers[0];
+
+      // A SurvivalTrace is a LineTrace: selectors are a string[], one per arm.
+      expect(layer.selectors).toEqual([
+        '#maidr-article-km .recharts-line-dots .recharts-line-dot',
+      ]);
+    });
+
+    it('builds one row per arm, named, with highlighting off', () => {
+      const layer = convertRechartsToMaidr({
+        ...survivalConfig,
+        yKeys: ['treated', 'control'],
+        fillKeys: ['Treatment', 'Control'],
+        survivalConfig: { censoredKeys: ['treatedCensored'] },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as SurvivalPoint[][];
+      expect(data).toHaveLength(2);
+      expect(data[0][1]).toEqual({ x: 6, y: 0.88, z: 'Treatment', censored: true });
+      // The second arm declares no censoring key of its own, so it gets none.
+      expect(data[1][1]).toEqual({ x: 6, y: 0.74, z: 'Control' });
+      expect(layer.selectors).toBeUndefined();
+    });
+
+    it('splats a selectorOverride across the arms', () => {
+      const layer = convertRechartsToMaidr({
+        ...survivalConfig,
+        yKeys: ['treated', 'control'],
+        selectorOverride: '.km .recharts-line-dot',
+      }).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toEqual([
+        '.km .recharts-line-dot',
+        '.km .recharts-line-dot',
+      ]);
+    });
+  });
+
   describe('scatter chart', () => {
     it('converts scatter data to ScatterPoint[]', () => {
       const config: RechartsAdapterConfig = {
@@ -659,6 +813,333 @@ describe('convertRechartsToMaidr', () => {
       const data = layer.data as ScatterPoint[];
       expect(data).toHaveLength(2);
       expect(data[0]).toEqual({ x: 1, y: 10 });
+    });
+  });
+
+  describe('volcano plot', () => {
+    const volcanoConfig: RechartsAdapterConfig = {
+      id: 'volcano',
+      title: 'Differential Expression',
+      data: [
+        { gene: 'TP53', log2fc: 2.4, negLog10P: 14.1 },
+        { gene: 'MYC', log2fc: -0.3, negLog10P: 0.8 },
+      ],
+      chartType: 'volcano',
+      xKey: 'log2fc',
+      yKeys: ['negLog10P'],
+      volcanoConfig: { labelKey: 'gene', significance: 1.3, effect: 1 },
+      xLabel: 'log2 fold change',
+      yLabel: '-log10(p)',
+    };
+
+    it('carries the point labels alongside the coordinates', () => {
+      const layer = convertRechartsToMaidr(volcanoConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.VOLCANO);
+
+      const data = layer.data as VolcanoPoint[];
+      expect(data).toEqual([
+        { x: 2.4, y: 14.1, label: 'TP53' },
+        { x: -0.3, y: 0.8, label: 'MYC' },
+      ]);
+    });
+
+    it('emits the declared cutoffs as thresholdOptions', () => {
+      const layer = convertRechartsToMaidr(volcanoConfig).subplots[0][0].layers[0];
+
+      expect(layer.thresholdOptions).toEqual({ significance: 1.3, effect: 1 });
+    });
+
+    it('omits thresholdOptions entirely when no cutoff is declared', () => {
+      const layer = convertRechartsToMaidr({
+        ...volcanoConfig,
+        volcanoConfig: { labelKey: 'gene' },
+      }).subplots[0][0].layers[0];
+
+      // A guessed cutoff sorts every point onto the wrong side silently, so
+      // an undeclared one stays undeclared.
+      expect(layer.thresholdOptions).toBeUndefined();
+    });
+
+    it('targets the scatter symbols', () => {
+      const layer = convertRechartsToMaidr(volcanoConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe(
+        '#maidr-article-volcano .recharts-scatter-symbol .recharts-symbols',
+      );
+    });
+  });
+
+  describe('manhattan plot', () => {
+    const manhattanConfig: RechartsAdapterConfig = {
+      id: 'gwas',
+      title: 'Genome-Wide Association',
+      data: [
+        { snp: 'rs1234', chr: '1', bp: 154_300, cumulative: 154_300, negLog10P: 9.2 },
+        { snp: 'rs5678', chr: '2', bp: 88_120, cumulative: 249_388_120, negLog10P: 3.1 },
+      ],
+      chartType: 'manhattan',
+      // The per-chromosome position, NOT the cumulative offset the chart
+      // plots: "position 249,388,120" answers nothing a reader asked.
+      xKey: 'bp',
+      yKeys: ['negLog10P'],
+      volcanoConfig: { labelKey: 'snp', groupKey: 'chr', significance: 7.3 },
+      xLabel: 'Position',
+      yLabel: '-log10(p)',
+    };
+
+    it('carries the SNP and its chromosome', () => {
+      const layer = convertRechartsToMaidr(manhattanConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.MANHATTAN);
+
+      const data = layer.data as VolcanoPoint[];
+      expect(data).toEqual([
+        { x: 154_300, y: 9.2, label: 'rs1234', group: '1' },
+        { x: 88_120, y: 3.1, label: 'rs5678', group: '2' },
+      ]);
+    });
+
+    it('emits the genome-wide significance line', () => {
+      const layer = convertRechartsToMaidr(manhattanConfig).subplots[0][0].layers[0];
+
+      expect(layer.thresholdOptions?.significance).toBe(7.3);
+    });
+  });
+
+  describe('error bars', () => {
+    const errorConfig: RechartsAdapterConfig = {
+      id: 'yield',
+      title: 'Yield by Treatment',
+      data: [
+        { treatment: 'Control', mean: 4.2, sd: 0.6 },
+        { treatment: 'Nitrogen', mean: 5.5, sd: 0.5 },
+      ],
+      chartType: 'error_bar',
+      xKey: 'treatment',
+      yKeys: ['mean'],
+      errorConfig: { errorKey: 'sd' },
+      xLabel: 'Treatment',
+      yLabel: 'Yield (t/ha)',
+    };
+
+    it('resolves a symmetric offset to absolute bounds', () => {
+      const layer = convertRechartsToMaidr(errorConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.ERROR_BAR);
+
+      // <ErrorBar dataKey="sd"> is an offset; ErrorBarPoint fixes absolute
+      // positions on the value axis, which is the same arithmetic Recharts
+      // does to place the whiskers.
+      const data = layer.data as ErrorBarPoint[];
+      expect(data).toEqual([
+        { x: 'Control', y: 4.2, yMin: 3.6, yMax: 4.8 },
+        { x: 'Nitrogen', y: 5.5, yMin: 5, yMax: 6 },
+      ]);
+    });
+
+    it('reads a [lower, upper] pair as an asymmetric offset', () => {
+      const layer = convertRechartsToMaidr({
+        ...errorConfig,
+        data: [{ treatment: 'Control', mean: 10, err: [2, 5] }],
+        errorConfig: { errorKey: 'err' },
+      }).subplots[0][0].layers[0];
+
+      // Recharts reads the field the same way: value - low, value + high.
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0]).toEqual({ x: 'Control', y: 10, yMin: 8, yMax: 15 });
+    });
+
+    it('takes absolute bounds straight from the data when declared', () => {
+      const layer = convertRechartsToMaidr({
+        ...errorConfig,
+        data: [{ treatment: 'Control', mean: 4.2, lo: 3.1, hi: 5.0 }],
+        errorConfig: { yMinKey: 'lo', yMaxKey: 'hi' },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0]).toEqual({ x: 'Control', y: 4.2, yMin: 3.1, yMax: 5.0 });
+    });
+
+    it('keeps a one-sided interval one-sided', () => {
+      const layer = convertRechartsToMaidr({
+        ...errorConfig,
+        data: [{ treatment: 'Control', mean: 4.2, hi: 5.0 }],
+        errorConfig: { yMaxKey: 'hi' },
+      }).subplots[0][0].layers[0];
+
+      // An upper bound with no lower is a real chart, and defaulting the
+      // missing half to the estimate would draw an interval nobody measured.
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0]).toEqual({ x: 'Control', y: 4.2, yMax: 5.0 });
+    });
+
+    it('drops both bounds when the interval is missing', () => {
+      const layer = convertRechartsToMaidr({
+        ...errorConfig,
+        data: [{ treatment: 'Control', mean: 4.2, sd: null }],
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as ErrorBarPoint[];
+      expect(data[0]).toEqual({ x: 'Control', y: 4.2 });
+    });
+
+    it('targets the whiskers', () => {
+      const layer = convertRechartsToMaidr(errorConfig).subplots[0][0].layers[0];
+
+      // The estimate's own mark could be a bar, a line dot or a scatter
+      // symbol depending on what the author nested the <ErrorBar> in; the
+      // whiskers are the one element a chart of this type always draws.
+      expect(layer.selectors).toBe(
+        '#maidr-article-yield .recharts-errorBars .recharts-errorBar',
+      );
+    });
+  });
+
+  describe('forest plot', () => {
+    const forestConfig: RechartsAdapterConfig = {
+      id: 'meta',
+      title: 'Effect of the intervention',
+      data: [
+        { study: 'Silva 2018', or: 0.62, lo: 0.41, hi: 0.94, weight: 0.12 },
+        { study: 'Okafor 2022', or: 1.71, lo: 1.22, hi: 2.40, weight: 0.55 },
+        { study: 'Pooled', or: 1.28, lo: 1.02, hi: 1.61, summary: true },
+      ],
+      chartType: 'forest',
+      xKey: 'study',
+      yKeys: ['or'],
+      orientation: Orientation.HORIZONTAL,
+      errorConfig: { yMinKey: 'lo', yMaxKey: 'hi' },
+      forestConfig: { weightKey: 'weight', pooledKey: 'summary', nullValue: 1 },
+      xLabel: 'Study',
+      yLabel: 'Odds ratio',
+    };
+
+    it('converts the studies with their weights and the pooled row', () => {
+      const layer = convertRechartsToMaidr(forestConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.FOREST);
+
+      const data = layer.data as ForestPoint[];
+      expect(data).toEqual([
+        { x: 'Silva 2018', y: 0.62, yMin: 0.41, yMax: 0.94, weight: 0.12 },
+        { x: 'Okafor 2022', y: 1.71, yMin: 1.22, yMax: 2.40, weight: 0.55 },
+        { x: 'Pooled', y: 1.28, yMin: 1.02, yMax: 1.61, pooled: true },
+      ]);
+    });
+
+    it('finds the pooled row by index when the data carries no flag', () => {
+      const layer = convertRechartsToMaidr({
+        ...forestConfig,
+        forestConfig: { weightKey: 'weight', pooledIndex: 2, nullValue: 1 },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as ForestPoint[];
+      expect(data[1].pooled).toBeUndefined();
+      expect(data[2].pooled).toBe(true);
+    });
+
+    it('emits the null line and keeps the row axis horizontal', () => {
+      const layer = convertRechartsToMaidr(forestConfig).subplots[0][0].layers[0];
+
+      expect(layer.forestOptions).toEqual({ nullValue: 1 });
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    });
+
+    it('omits forestOptions when no null value is declared', () => {
+      const layer = convertRechartsToMaidr({
+        ...forestConfig,
+        forestConfig: { weightKey: 'weight' },
+      }).subplots[0][0].layers[0];
+
+      // Guessing 0 for a ratio measure reports every study as not crossing,
+      // since odds ratios are all positive.
+      expect(layer.forestOptions).toBeUndefined();
+    });
+
+    it('targets the scatter symbols', () => {
+      const layer = convertRechartsToMaidr(forestConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe(
+        '#maidr-article-meta .recharts-scatter-symbol .recharts-symbols',
+      );
+    });
+  });
+
+  describe('alluvial diagram', () => {
+    const nodes = [
+      { name: 'Free' },
+      { name: 'Trial' },
+      { name: 'Paid' },
+      { name: 'Churned' },
+    ];
+
+    const alluvialConfig: RechartsAdapterConfig = {
+      id: 'flow',
+      title: 'Cohort Movement',
+      data: [
+        { source: 0, target: 1, value: 34 },
+        { source: 1, target: 2, value: 21 },
+        { source: 1, target: 3, value: 13 },
+      ],
+      chartType: 'alluvial',
+      xKey: 'source',
+      yKeys: ['value'],
+      flowConfig: { targetKey: 'target', nodes },
+      xLabel: 'Stage',
+      yLabel: 'Users',
+    };
+
+    it('resolves the node indices Recharts links carry into names', () => {
+      const layer = convertRechartsToMaidr(alluvialConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.ALLUVIAL);
+
+      // "flow from 1 to 3" names neither end, and the index is a fact about
+      // the nodes array rather than about the data.
+      const data = layer.data as FlowPoint[];
+      expect(data).toEqual([
+        { source: 'Free', target: 'Trial', value: 34 },
+        { source: 'Trial', target: 'Paid', value: 21 },
+        { source: 'Trial', target: 'Churned', value: 13 },
+      ]);
+    });
+
+    it('passes links that already name their ends through untouched', () => {
+      const layer = convertRechartsToMaidr({
+        ...alluvialConfig,
+        data: [{ source: 'Free', target: 'Paid', value: 8 }],
+        flowConfig: { targetKey: 'target' },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as FlowPoint[];
+      expect(data).toEqual([{ source: 'Free', target: 'Paid', value: 8 }]);
+    });
+
+    it('keeps an index with no node list behind it as a number', () => {
+      const layer = convertRechartsToMaidr({
+        ...alluvialConfig,
+        flowConfig: { targetKey: 'target' },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as FlowPoint[];
+      expect(data[0]).toEqual({ source: 0, target: 1, value: 34 });
+    });
+
+    it('targets the sankey links in declared order', () => {
+      const layer = convertRechartsToMaidr(alluvialConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe(
+        '#maidr-article-flow .recharts-sankey-links .recharts-sankey-link',
+      );
+      expect(layer.orientation).toBeUndefined();
+    });
+
+    it('throws when the flow config is missing', () => {
+      expect(() => convertRechartsToMaidr({
+        ...alluvialConfig,
+        flowConfig: undefined,
+      })).toThrow('RechartsAdapter');
     });
   });
 

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -199,6 +199,89 @@ describe('convertRechartsToMaidr', () => {
     });
   });
 
+  describe('dot plot', () => {
+    const dotConfig: RechartsAdapterConfig = {
+      id: 'dot',
+      title: 'Median Pay by Role',
+      data: [
+        { role: 'Nurse', pay: 62 },
+        { role: 'Teacher', pay: 54 },
+      ],
+      chartType: 'dot',
+      xKey: 'role',
+      yKeys: ['pay'],
+      xLabel: 'Role',
+      yLabel: 'Median pay ($k)',
+    };
+
+    it('converts dot data to BarPoint[] with the category x kept as a string', () => {
+      const layer = convertRechartsToMaidr(dotConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.DOT);
+
+      // BarPoint, not ScatterPoint: a Cleveland dot plot's x is a category
+      // label, which the scatter converter would coerce to 0.
+      const data = layer.data as BarPoint[];
+      expect(data).toEqual([
+        { x: 'Nurse', y: 62 },
+        { x: 'Teacher', y: 54 },
+      ]);
+    });
+
+    it('targets the scatter symbols', () => {
+      const layer = convertRechartsToMaidr(dotConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe(
+        '#maidr-article-dot .recharts-scatter-symbol .recharts-symbols',
+      );
+    });
+
+    it('emits an orientation, defaulting to vertical', () => {
+      const vertical = convertRechartsToMaidr(dotConfig).subplots[0][0].layers[0];
+      expect(vertical.orientation).toBe(Orientation.VERTICAL);
+
+      const horizontal = convertRechartsToMaidr({
+        ...dotConfig,
+        orientation: Orientation.HORIZONTAL,
+      }).subplots[0][0].layers[0];
+      expect(horizontal.orientation).toBe(Orientation.HORIZONTAL);
+    });
+  });
+
+  describe('lollipop chart', () => {
+    const lollipopConfig: RechartsAdapterConfig = {
+      id: 'lollipop',
+      data: [
+        { country: 'Japan', share: 12 },
+        { country: 'Brazil', share: 8 },
+      ],
+      chartType: 'lollipop',
+      xKey: 'country',
+      yKeys: ['share'],
+    };
+
+    it('converts lollipop data to BarPoint[]', () => {
+      const layer = convertRechartsToMaidr(lollipopConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.LOLLIPOP);
+      expect(layer.orientation).toBe(Orientation.VERTICAL);
+
+      const data = layer.data as BarPoint[];
+      expect(data).toEqual([
+        { x: 'Japan', y: 12 },
+        { x: 'Brazil', y: 8 },
+      ]);
+    });
+
+    it('targets the scatter head rather than the bar stem', () => {
+      const layer = convertRechartsToMaidr(lollipopConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe(
+        '#maidr-article-lollipop .recharts-scatter-symbol .recharts-symbols',
+      );
+    });
+  });
+
   describe('histogram', () => {
     it('converts histogram data with bin config', () => {
       const config: RechartsAdapterConfig = {
@@ -345,6 +428,216 @@ describe('convertRechartsToMaidr', () => {
     });
   });
 
+  describe('area chart', () => {
+    const areaConfig: RechartsAdapterConfig = {
+      id: 'area',
+      title: 'Rainfall',
+      data: [
+        { month: 'Jan', mm: 80 },
+        { month: 'Feb', mm: 65 },
+      ],
+      chartType: 'area',
+      xKey: 'month',
+      yKeys: ['mm'],
+      xLabel: 'Month',
+      yLabel: 'Rainfall (mm)',
+    };
+
+    it('converts single series area data to LinePoint[][]', () => {
+      const layer = convertRechartsToMaidr(areaConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.AREA);
+
+      const data = layer.data as LinePoint[][];
+      expect(data).toEqual([[
+        { x: 'Jan', y: 80 },
+        { x: 'Feb', y: 65 },
+      ]]);
+    });
+
+    it('targets the area dots, as a string[] like every line-family layer', () => {
+      const layer = convertRechartsToMaidr(areaConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toEqual([
+        '#maidr-article-area .recharts-area-dots .recharts-area-dot',
+      ]);
+    });
+
+    it('converts multi-series area data to one row per series', () => {
+      const layer = convertRechartsToMaidr({
+        ...areaConfig,
+        data: [{ month: 'Jan', organic: 40, paid: 20 }],
+        yKeys: ['organic', 'paid'],
+      }).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.AREA);
+
+      const data = layer.data as LinePoint[][];
+      expect(data).toEqual([
+        [{ x: 'Jan', y: 40, z: 'organic' }],
+        [{ x: 'Jan', y: 20, z: 'paid' }],
+      ]);
+    });
+  });
+
+  describe('stacked area chart', () => {
+    const stackedAreaConfig: RechartsAdapterConfig = {
+      id: 'stacked-area',
+      data: [
+        { month: 'Jan', organic: 40, paid: 20 },
+        { month: 'Feb', organic: 55, paid: 15 },
+      ],
+      chartType: 'stacked_area',
+      xKey: 'month',
+      yKeys: ['organic', 'paid'],
+    };
+
+    it('passes each band\'s own value, never the accumulated edge', () => {
+      const layer = convertRechartsToMaidr(stackedAreaConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.STACKED_AREA);
+
+      // AreaTrace sums the series itself, so the second band carries 20/15
+      // rather than the 60/70 the chart draws its top edge at.
+      const data = layer.data as LinePoint[][];
+      expect(data).toEqual([
+        [{ x: 'Jan', y: 40, z: 'organic' }, { x: 'Feb', y: 55, z: 'organic' }],
+        [{ x: 'Jan', y: 20, z: 'paid' }, { x: 'Feb', y: 15, z: 'paid' }],
+      ]);
+    });
+
+    it('produces NORMALIZED_AREA for a 100% stacked area', () => {
+      const layer = convertRechartsToMaidr({
+        ...stackedAreaConfig,
+        chartType: 'normalized_area',
+      }).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.NORMALIZED_AREA);
+
+      // Raw values, not the expanded fractions Recharts renders.
+      const data = layer.data as LinePoint[][];
+      expect(data[0][0]).toEqual({ x: 'Jan', y: 40, z: 'organic' });
+    });
+
+    it('falls back to AREA when a stacked area has a single yKey', () => {
+      const layer = convertRechartsToMaidr({
+        ...stackedAreaConfig,
+        yKeys: ['organic'],
+      }).subplots[0][0].layers[0];
+
+      // One band is not stacked against anything: as STACKED_AREA every point
+      // would announce a total equal to its own value and a 100% share.
+      expect(layer.type).toBe(TraceType.AREA);
+    });
+
+    it('falls back to AREA when a normalized area has a single yKey', () => {
+      const layer = convertRechartsToMaidr({
+        ...stackedAreaConfig,
+        chartType: 'normalized_area',
+        yKeys: ['organic'],
+      }).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.AREA);
+    });
+  });
+
+  describe('radar chart', () => {
+    const radarConfig: RechartsAdapterConfig = {
+      id: 'radar',
+      title: 'Player Attributes',
+      data: [
+        { attribute: 'Speed', alice: 90, bob: 70 },
+        { attribute: 'Power', alice: 60, bob: 85 },
+      ],
+      chartType: 'radar',
+      xKey: 'attribute',
+      yKeys: ['alice', 'bob'],
+    };
+
+    it('converts radar data to one row per series and one column per spoke', () => {
+      const layer = convertRechartsToMaidr(radarConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.RADAR);
+
+      const data = layer.data as LinePoint[][];
+      expect(data).toEqual([
+        [{ x: 'Speed', y: 90, z: 'alice' }, { x: 'Power', y: 60, z: 'alice' }],
+        [{ x: 'Speed', y: 70, z: 'bob' }, { x: 'Power', y: 85, z: 'bob' }],
+      ]);
+    });
+
+    it('targets the radar dots for a single series', () => {
+      const layer = convertRechartsToMaidr({
+        ...radarConfig,
+        yKeys: ['alice'],
+      }).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toEqual([
+        '#maidr-article-radar .recharts-radar-dots .recharts-radar-dot',
+      ]);
+    });
+
+    it('never emits an orientation, even when the config sets one', () => {
+      const layer = convertRechartsToMaidr({
+        ...radarConfig,
+        yKeys: ['alice'],
+        orientation: Orientation.HORIZONTAL,
+      }).subplots[0][0].layers[0];
+
+      // Spokes sit around a circle, not along an axis — same as a pie.
+      expect(layer.orientation).toBeUndefined();
+    });
+  });
+
+  describe('bump chart', () => {
+    const bumpConfig: RechartsAdapterConfig = {
+      id: 'bump',
+      title: 'League Position by Matchday',
+      data: [
+        { matchday: 1, arsenal: 3, chelsea: 1 },
+        { matchday: 2, arsenal: 1, chelsea: 2 },
+      ],
+      chartType: 'bump',
+      xKey: 'matchday',
+      yKeys: ['arsenal', 'chelsea'],
+      xLabel: 'Matchday',
+      yLabel: 'Position',
+    };
+
+    it('passes the ranks through verbatim, one row per competitor', () => {
+      const layer = convertRechartsToMaidr(bumpConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.BUMP);
+
+      // BumpTrace derives the best/worst rank and the per-period moves from
+      // these numbers, so the adapter must not pre-compute either.
+      const data = layer.data as LinePoint[][];
+      expect(data).toEqual([
+        [{ x: 1, y: 3, z: 'arsenal' }, { x: 2, y: 1, z: 'arsenal' }],
+        [{ x: 1, y: 1, z: 'chelsea' }, { x: 2, y: 2, z: 'chelsea' }],
+      ]);
+    });
+
+    it('targets the line dots for a single series', () => {
+      const layer = convertRechartsToMaidr({
+        ...bumpConfig,
+        yKeys: ['arsenal'],
+      }).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toEqual([
+        '#maidr-article-bump .recharts-line-dots .recharts-line-dot',
+      ]);
+    });
+
+    it('omits selectors for a multi-series bump chart', () => {
+      const layer = convertRechartsToMaidr(bumpConfig).subplots[0][0].layers[0];
+
+      // The line-family limitation: CSS cannot pick one competitor's dots
+      // out of the surface, so highlighting degrades rather than misaligns.
+      expect(layer.selectors).toBeUndefined();
+    });
+  });
+
   describe('scatter chart', () => {
     it('converts scatter data to ScatterPoint[]', () => {
       const config: RechartsAdapterConfig = {
@@ -452,6 +745,26 @@ describe('convertRechartsToMaidr', () => {
       expect(layers[0].title).toBe('Revenue');
       expect(layers[1].type).toBe(TraceType.LINE);
       expect(layers[1].title).toBe('Trend');
+    });
+
+    it('wraps an area layer\'s selector in an array, as it does a line\'s', () => {
+      const config: RechartsAdapterConfig = {
+        id: 'composed-area',
+        data: [{ month: 'Jan', revenue: 100, budget: 90 }],
+        xKey: 'month',
+        layers: [
+          { yKey: 'revenue', chartType: 'bar', name: 'Revenue' },
+          { yKey: 'budget', chartType: 'area', name: 'Budget' },
+        ],
+      };
+
+      const layers = convertRechartsToMaidr(config).subplots[0][0].layers;
+
+      expect(layers[1].type).toBe(TraceType.AREA);
+      expect(layers[1].selectors).toEqual([
+        '#maidr-article-composed-area .recharts-area-dots .recharts-area-dot',
+      ]);
+      expect(layers[1].data).toEqual([[{ x: 'Jan', y: 90 }]]);
     });
 
     it('returns undefined selectors for multiple same-type layers', () => {

--- a/test/adapters/recharts/markDom.test.ts
+++ b/test/adapters/recharts/markDom.test.ts
@@ -15,7 +15,7 @@
  * two disagree.
  */
 
-import type { Maidr } from '@type/grammar';
+import type { Maidr, WaterfallPoint } from '@type/grammar';
 import type { ReactElement } from 'react';
 import type { Root } from 'react-dom/client';
 import { convertRechartsToMaidr } from '@adapters/recharts/converters';
@@ -51,6 +51,42 @@ const survivalData = [
   { months: 6, treated: 0.88, censored: true },
   { months: 12, treated: 0.71, censored: false },
 ];
+
+const pyramidData = [
+  { band: '0-9', men: -2100, women: 2000 },
+  { band: '10-19', men: -1900, women: 1850 },
+  { band: '20-29', men: -1750, women: 1820 },
+];
+
+// A waterfall, a gantt and a dumbbell are all drawn as FLOATING bars: a
+// `<Bar>` whose dataKey returns a [start, end] pair, which is one rectangle
+// per row rather than the two a transparent-base stack would draw.
+const bridgeData = [
+  { step: 'Opening', change: 1200, restates: true },
+  { step: 'New sales', change: 450 },
+  { step: 'Churn', change: -180 },
+  { step: 'Closing', restates: true },
+];
+
+const planData = [
+  { task: 'Design', from: 0, to: 5 },
+  { task: 'Build', from: 3, to: 12 },
+  { task: 'Build', from: 14, to: 18 },
+];
+
+const lifeData = [
+  { country: 'Japan', then: 78.9, now: 84.6 },
+  { country: 'Russia', then: 69.2, now: 68.9 },
+];
+
+const gaugeData = [{ measure: 'NPS', score: 73 }];
+
+const hierarchyData = [
+  { name: 'Europe', children: [{ name: 'France', people: 67.4 }, { name: 'Spain', people: 47.4 }] },
+  { name: 'Oceania', children: [{ name: 'Fiji', people: 0.9 }] },
+];
+/** Every node of {@link hierarchyData}, which is what both charts draw. */
+const hierarchyNodes = 5;
 
 const flowNodes = [{ name: 'Free' }, { name: 'Trial' }, { name: 'Paid' }, { name: 'Churned' }];
 const flowLinks = [
@@ -99,6 +135,60 @@ const configs = {
     yKeys: ['value'],
     flowConfig: { targetKey: 'target', nodes: flowNodes },
   },
+  diverging: {
+    id: 'diverging-dom',
+    data: pyramidData,
+    chartType: 'diverging_bar' as const,
+    xKey: 'band',
+    yKeys: ['men', 'women'],
+    fillKeys: ['Men', 'Women'],
+  },
+  waterfall: {
+    id: 'waterfall-dom',
+    data: bridgeData,
+    chartType: 'waterfall' as const,
+    xKey: 'step',
+    yKeys: ['change'],
+    waterfallConfig: { totalKey: 'restates' },
+  },
+  gantt: {
+    id: 'gantt-dom',
+    data: planData,
+    chartType: 'gantt' as const,
+    xKey: 'task',
+    yKeys: ['from', 'to'],
+    ganttConfig: { lanes: ['Design', 'Build', 'Launch'], unit: 'days' },
+  },
+  dumbbell: {
+    id: 'dumbbell-dom',
+    data: lifeData,
+    chartType: 'dumbbell' as const,
+    xKey: 'country',
+    yKeys: ['then', 'now'],
+    fillKeys: ['1990', '2020'],
+  },
+  gauge: {
+    id: 'gauge-dom',
+    data: gaugeData,
+    chartType: 'gauge' as const,
+    xKey: 'measure',
+    yKeys: ['score'],
+    gaugeConfig: { min: 0, max: 100, target: 80 },
+  },
+  treemap: {
+    id: 'treemap-dom',
+    data: hierarchyData,
+    chartType: 'treemap' as const,
+    xKey: 'name',
+    yKeys: ['people'],
+  },
+  sunburst: {
+    id: 'sunburst-dom',
+    data: hierarchyData,
+    chartType: 'sunburst' as const,
+    xKey: 'name',
+    yKeys: ['people'],
+  },
 };
 
 interface MutableGlobals {
@@ -116,6 +206,24 @@ const maidr: Record<keyof typeof configs, Maidr> = {} as Record<keyof typeof con
 
 function defineGlobal(key: keyof MutableGlobals, value: unknown): void {
   Object.defineProperty(globals, key, { value, configurable: true, writable: true });
+}
+
+/**
+ * A `<Bar dataKey>` that reads a row's span rather than a magnitude.
+ *
+ * Recharts draws a bar returning a `[start, end]` pair floating between the
+ * two, which is how a waterfall step, a gantt interval and a dumbbell
+ * connector each come out as ONE rectangle per row.
+ *
+ * @param startKey - Field holding where the bar begins
+ * @param endKey - Field holding where it ends
+ * @returns A dataKey accessor Recharts accepts
+ */
+function floatingSpan(startKey: string, endKey: string): (obj: unknown) => [number, number] {
+  return (obj) => {
+    const row = obj as Record<string, unknown>;
+    return [Number(row[startKey]), Number(row[endKey])];
+  };
 }
 
 /** The first (or only) selector the layer declares. */
@@ -156,9 +264,13 @@ beforeAll(async () => {
     FunnelChart,
     Line,
     LineChart,
+    RadialBar,
+    RadialBarChart,
     Sankey,
     Scatter,
     ScatterChart,
+    SunburstChart,
+    Treemap,
     XAxis,
     YAxis,
   } = await import('recharts');
@@ -171,6 +283,11 @@ beforeAll(async () => {
   for (const [name, config] of Object.entries(configs)) {
     maidr[name as keyof typeof configs] = convertRechartsToMaidr(config);
   }
+
+  // The waterfall's running totals are what the adapter computes and what the
+  // floating `<Bar>` needs, so the chart is drawn from the layer's own steps —
+  // which is the recipe the docs give a consumer.
+  const waterfallSteps = maidr.waterfall.subplots[0][0].layers[0].data as WaterfallPoint[];
 
   root = createRoot(document.getElementById('root') as HTMLElement);
   await act(async () => {
@@ -212,6 +329,56 @@ beforeAll(async () => {
         height: 300,
         data: { nodes: flowNodes, links: flowLinks },
       })),
+      wrap(configs.diverging, createElement(
+        BarChart,
+        { width: 320, height: 220, layout: 'vertical', stackOffset: 'sign', data: pyramidData },
+        createElement(XAxis, { type: 'number' }),
+        createElement(YAxis, { type: 'category', dataKey: 'band' }),
+        createElement(Bar, { dataKey: 'men', stackId: 'sides', isAnimationActive: false }),
+        createElement(Bar, { dataKey: 'women', stackId: 'sides', isAnimationActive: false }),
+      )),
+      wrap(configs.waterfall, createElement(
+        BarChart,
+        { width: 320, height: 220, data: waterfallSteps },
+        createElement(XAxis, { dataKey: 'x' }),
+        createElement(YAxis, {}),
+        createElement(Bar, { dataKey: floatingSpan('start', 'end'), isAnimationActive: false }),
+      )),
+      wrap(configs.gantt, createElement(
+        BarChart,
+        { width: 320, height: 220, layout: 'vertical', data: planData },
+        createElement(XAxis, { type: 'number' }),
+        createElement(YAxis, { type: 'category', dataKey: 'task' }),
+        createElement(Bar, { dataKey: floatingSpan('from', 'to'), isAnimationActive: false }),
+      )),
+      wrap(configs.dumbbell, createElement(
+        BarChart,
+        { width: 320, height: 220, data: lifeData },
+        createElement(XAxis, { dataKey: 'country' }),
+        createElement(YAxis, {}),
+        createElement(Bar, { dataKey: floatingSpan('then', 'now'), isAnimationActive: false }),
+      )),
+      wrap(configs.gauge, createElement(
+        RadialBarChart,
+        { width: 320, height: 220, innerRadius: 60, outerRadius: 100, startAngle: 180, endAngle: 0, data: gaugeData },
+        createElement(RadialBar, { dataKey: 'score', isAnimationActive: false }),
+      )),
+      wrap(configs.treemap, createElement(Treemap, {
+        width: 320,
+        height: 220,
+        data: hierarchyData,
+        dataKey: 'people',
+        nameKey: 'name',
+        isAnimationActive: false,
+      })),
+      wrap(configs.sunburst, createElement(SunburstChart, {
+        width: 320,
+        height: 320,
+        // The sunburst draws `data.children`, which is why the adapter is
+        // given those children rather than this root.
+        data: { name: 'World', children: hierarchyData },
+        dataKey: 'people',
+      })),
     ));
   });
 });
@@ -252,6 +419,54 @@ describe('recharts rendered mark contract', () => {
     // FlowTrace addresses its selector list by each flow's DECLARED position,
     // so the DOM order has to be the links array's order.
     expect(links).toHaveLength(flowLinks.length);
+  });
+
+  it('matches one rectangle per side per band on a diverging bar', () => {
+    // A `SegmentedTrace` maps [side][category], so both sides' rectangles are
+    // wanted — one `<Bar>` draws all of one side's, then the next draws the
+    // other's, which is the declaration order the diverging payload is in.
+    expect(document.querySelectorAll(firstSelector(maidr.diverging)))
+      .toHaveLength(pyramidData.length * 2);
+  });
+
+  it('matches one floating rectangle per waterfall step', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.waterfall)))
+      .toHaveLength(bridgeData.length);
+  });
+
+  it('matches one rectangle per gantt interval, lane order and all', () => {
+    // `GanttTrace` walks its selectors lane by lane, so the count must be the
+    // interval total rather than the lane count — the empty lane draws nothing.
+    expect(document.querySelectorAll(firstSelector(maidr.gantt)))
+      .toHaveLength(planData.length);
+  });
+
+  it('matches one connector per dumbbell row', () => {
+    // One element per ROW, not per dot: `DumbbellTrace` highlights the same
+    // connector from both ends rather than inventing elements the chart never
+    // drew.
+    expect(document.querySelectorAll(firstSelector(maidr.dumbbell)))
+      .toHaveLength(lifeData.length);
+  });
+
+  it('matches the single sector a gauge draws', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.gauge))).toHaveLength(1);
+  });
+
+  it('matches one treemap rectangle per node, excluding the synthetic root', () => {
+    // Recharts wraps the data array in a root node and draws it full-plot,
+    // which is one rectangle more than the layer declares nodes — and
+    // `TreemapTrace` withdraws highlighting entirely on a count mismatch.
+    const nodes = document.querySelectorAll(firstSelector(maidr.treemap));
+
+    expect(nodes).toHaveLength(hierarchyNodes);
+    expect([...nodes].map(node => node.getAttribute('name')))
+      .toEqual(['Europe', 'France', 'Spain', 'Oceania', 'Fiji']);
+  });
+
+  it('matches one sunburst sector per node, in depth-first order', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.sunburst)))
+      .toHaveLength(hierarchyNodes);
   });
 
   it('scopes every selector to its own chart', () => {

--- a/test/adapters/recharts/markDom.test.ts
+++ b/test/adapters/recharts/markDom.test.ts
@@ -95,6 +95,24 @@ const flowLinks = [
   { source: 1, target: 3, value: 13 },
 ];
 
+// A coxcomb is a `<Pie>` whose angles are all equal — hence the constant
+// `slice` field its dataKey reads — and whose radius is the measure.
+const coxcombData = [
+  { month: 'Jan', deaths: 120, slice: 1 },
+  { month: 'Feb', deaths: 84, slice: 1 },
+  { month: 'Mar', deaths: 61, slice: 1 },
+];
+
+// An icicle's bands are floating bars over a depth lane, one row per node, so
+// the rows have to be the flattened tree in the order the adapter emits it.
+const icicleBands = [
+  { name: 'Europe', depth: '0', from: 0, to: 100 },
+  { name: 'France', depth: '1', from: 0, to: 59 },
+  { name: 'Spain', depth: '1', from: 59, to: 100 },
+  { name: 'Oceania', depth: '0', from: 100, to: 101 },
+  { name: 'Fiji', depth: '1', from: 100, to: 101 },
+];
+
 const configs = {
   funnel: {
     id: 'funnel-dom',
@@ -189,6 +207,28 @@ const configs = {
     xKey: 'name',
     yKeys: ['people'],
   },
+  icicle: {
+    id: 'icicle-dom',
+    data: hierarchyData,
+    chartType: 'icicle' as const,
+    xKey: 'name',
+    yKeys: ['people'],
+  },
+  sankey: {
+    id: 'sankey-dom',
+    data: flowLinks,
+    chartType: 'sankey' as const,
+    xKey: 'source',
+    yKeys: ['value'],
+    flowConfig: { targetKey: 'target', nodes: flowNodes },
+  },
+  polarArea: {
+    id: 'polar-dom',
+    data: coxcombData,
+    chartType: 'polar_area' as const,
+    xKey: 'month',
+    yKeys: ['deaths'],
+  },
 };
 
 interface MutableGlobals {
@@ -264,6 +304,8 @@ beforeAll(async () => {
     FunnelChart,
     Line,
     LineChart,
+    Pie,
+    PieChart,
     RadialBar,
     RadialBarChart,
     Sankey,
@@ -379,6 +421,31 @@ beforeAll(async () => {
         data: { name: 'World', children: hierarchyData },
         dataKey: 'people',
       })),
+      wrap(configs.icicle, createElement(
+        BarChart,
+        { width: 320, height: 220, layout: 'vertical', data: icicleBands },
+        createElement(XAxis, { type: 'number' }),
+        createElement(YAxis, { type: 'category', dataKey: 'depth' }),
+        createElement(Bar, { dataKey: floatingSpan('from', 'to'), isAnimationActive: false }),
+      )),
+      wrap(configs.sankey, createElement(Sankey, {
+        width: 480,
+        height: 300,
+        data: { nodes: flowNodes, links: flowLinks },
+      })),
+      wrap(configs.polarArea, createElement(
+        PieChart,
+        { width: 320, height: 320 },
+        createElement(Pie, {
+          data: coxcombData,
+          // Equal angles come from the constant field; the measure is the
+          // RADIUS, which is what makes the pie a coxcomb.
+          dataKey: 'slice',
+          nameKey: 'month',
+          outerRadius: (row: unknown) => Number((row as { deaths: number }).deaths),
+          isAnimationActive: false,
+        }),
+      )),
     ));
   });
 });
@@ -467,6 +534,25 @@ describe('recharts rendered mark contract', () => {
   it('matches one sunburst sector per node, in depth-first order', () => {
     expect(document.querySelectorAll(firstSelector(maidr.sunburst)))
       .toHaveLength(hierarchyNodes);
+  });
+
+  it('matches one floating band per icicle node', () => {
+    // Recharts draws no icicle, so it is a `<BarChart layout="vertical">` of
+    // floating bars over a depth lane. One rectangle per ROW, which is why
+    // the rows have to be the tree flattened depth-first pre-order — the
+    // order the adapter emits its nodes in.
+    expect(document.querySelectorAll(firstSelector(maidr.icicle)))
+      .toHaveLength(hierarchyNodes);
+  });
+
+  it('matches one ribbon per sankey flow, in the order the links were declared', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.sankey)))
+      .toHaveLength(flowLinks.length);
+  });
+
+  it('matches one pie sector per polar area spoke', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.polarArea)))
+      .toHaveLength(coxcombData.length);
   });
 
   it('scopes every selector to its own chart', () => {

--- a/test/adapters/recharts/markDom.test.ts
+++ b/test/adapters/recharts/markDom.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Verifies that the highlight selectors this adapter emits actually resolve,
+ * in the DOM Recharts really renders, to one element per data point.
+ *
+ * A trace type that sonifies but does not highlight is not finished, and the
+ * class names are the one part of an adapter that no amount of unit testing
+ * of the converters can confirm: they are Recharts' own, they differ per
+ * component, and they change between versions. These tests mount the real
+ * charts in jsdom and count the marks each emitted selector picks up, so a
+ * renamed class or a wrongly nested scope fails here rather than silently
+ * turning highlighting off in a user's chart.
+ *
+ * The count is what matters: every trace in the model maps its selector's
+ * matches to its samples BY INDEX, and refuses to highlight at all when the
+ * two disagree.
+ */
+
+import type { Maidr } from '@type/grammar';
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import { convertRechartsToMaidr } from '@adapters/recharts/converters';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+
+// MaidrApp only mounts after focus-in (contextValue starts null), so it never
+// renders in these tests — mock it away to keep its ESM-only dependencies
+// (react-markdown et al.) out of the ts-jest CJS transform.
+jest.mock('@ui/App', () => ({ MaidrApp: () => null }));
+
+const funnelData = [
+  { stage: 'Visited', users: 10000 },
+  { stage: 'Signed up', users: 2400 },
+  { stage: 'Activated', users: 2300 },
+  { stage: 'Paid', users: 100 },
+];
+
+const errorData = [
+  { treatment: 'Control', mean: 4.2, sd: 0.6 },
+  { treatment: 'Nitrogen', mean: 5.5, sd: 0.5 },
+  { treatment: 'Phosphate', mean: 5, sd: 0.7 },
+];
+
+const volcanoData = [
+  { gene: 'TP53', log2fc: 2.4, negLog10P: 14.1 },
+  { gene: 'MYC', log2fc: -0.3, negLog10P: 0.8 },
+  { gene: 'EGFR', log2fc: 1.9, negLog10P: 6.4 },
+];
+
+const survivalData = [
+  { months: 0, treated: 1, censored: false },
+  { months: 6, treated: 0.88, censored: true },
+  { months: 12, treated: 0.71, censored: false },
+];
+
+const flowNodes = [{ name: 'Free' }, { name: 'Trial' }, { name: 'Paid' }, { name: 'Churned' }];
+const flowLinks = [
+  { source: 0, target: 1, value: 34 },
+  { source: 1, target: 2, value: 21 },
+  { source: 1, target: 3, value: 13 },
+];
+
+const configs = {
+  funnel: {
+    id: 'funnel-dom',
+    data: funnelData,
+    chartType: 'funnel' as const,
+    xKey: 'stage',
+    yKeys: ['users'],
+  },
+  errorBar: {
+    id: 'error-dom',
+    data: errorData,
+    chartType: 'error_bar' as const,
+    xKey: 'treatment',
+    yKeys: ['mean'],
+    errorConfig: { errorKey: 'sd' },
+  },
+  volcano: {
+    id: 'volcano-dom',
+    data: volcanoData,
+    chartType: 'volcano' as const,
+    xKey: 'log2fc',
+    yKeys: ['negLog10P'],
+    volcanoConfig: { labelKey: 'gene', significance: 1.3 },
+  },
+  survival: {
+    id: 'survival-dom',
+    data: survivalData,
+    chartType: 'survival' as const,
+    xKey: 'months',
+    yKeys: ['treated'],
+    survivalConfig: { censoredKeys: ['censored'] },
+  },
+  alluvial: {
+    id: 'alluvial-dom',
+    data: flowLinks,
+    chartType: 'alluvial' as const,
+    xKey: 'source',
+    yKeys: ['value'],
+    flowConfig: { targetKey: 'target', nodes: flowNodes },
+  },
+};
+
+interface MutableGlobals {
+  window?: unknown;
+  document?: unknown;
+  navigator?: unknown;
+  ResizeObserver?: unknown;
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+}
+
+const globals = globalThis as unknown as MutableGlobals;
+const saved: MutableGlobals = {};
+let root: Root | null = null;
+const maidr: Record<keyof typeof configs, Maidr> = {} as Record<keyof typeof configs, Maidr>;
+
+function defineGlobal(key: keyof MutableGlobals, value: unknown): void {
+  Object.defineProperty(globals, key, { value, configurable: true, writable: true });
+}
+
+/** The first (or only) selector the layer declares. */
+function firstSelector(figure: Maidr): string {
+  const { selectors } = figure.subplots[0][0].layers[0];
+  return Array.isArray(selectors) ? selectors[0] as string : selectors as string;
+}
+
+beforeAll(async () => {
+  saved.window = globals.window;
+  saved.document = globals.document;
+  saved.navigator = globals.navigator;
+  saved.ResizeObserver = globals.ResizeObserver;
+  saved.IS_REACT_ACT_ENVIRONMENT = globals.IS_REACT_ACT_ENVIRONMENT;
+
+  const dom = new JSDOM(
+    '<!doctype html><body><div id="root"></div></body>',
+    { pretendToBeVisual: true },
+  );
+  defineGlobal('window', dom.window);
+  defineGlobal('document', dom.window.document);
+  defineGlobal('navigator', dom.window.navigator);
+  defineGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  class ResizeObserverStub {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  defineGlobal('ResizeObserver', ResizeObserverStub);
+
+  const { createElement, act } = await import('react');
+  const { createRoot } = await import('react-dom/client');
+  const {
+    Bar,
+    BarChart,
+    ErrorBar,
+    Funnel,
+    FunnelChart,
+    Line,
+    LineChart,
+    Sankey,
+    Scatter,
+    ScatterChart,
+    XAxis,
+    YAxis,
+  } = await import('recharts');
+  const { MaidrRecharts } = await import('@adapters/recharts/MaidrRecharts');
+
+  function wrap(config: (typeof configs)[keyof typeof configs], chart: ReactElement): ReactElement {
+    return createElement(MaidrRecharts, { ...config, children: null }, chart);
+  }
+
+  for (const [name, config] of Object.entries(configs)) {
+    maidr[name as keyof typeof configs] = convertRechartsToMaidr(config);
+  }
+
+  root = createRoot(document.getElementById('root') as HTMLElement);
+  await act(async () => {
+    root?.render(createElement(
+      'div',
+      null,
+      wrap(configs.funnel, createElement(
+        FunnelChart,
+        { width: 320, height: 260 },
+        createElement(Funnel, { dataKey: 'users', data: funnelData, isAnimationActive: false }),
+      )),
+      wrap(configs.errorBar, createElement(
+        BarChart,
+        { width: 320, height: 220, data: errorData },
+        createElement(XAxis, { dataKey: 'treatment' }),
+        createElement(YAxis, {}),
+        createElement(
+          Bar,
+          { dataKey: 'mean', isAnimationActive: false },
+          createElement(ErrorBar, { dataKey: 'sd', direction: 'y', isAnimationActive: false }),
+        ),
+      )),
+      wrap(configs.volcano, createElement(
+        ScatterChart,
+        { width: 320, height: 220 },
+        createElement(XAxis, { dataKey: 'log2fc', type: 'number' }),
+        createElement(YAxis, { dataKey: 'negLog10P', type: 'number' }),
+        createElement(Scatter, { data: volcanoData, isAnimationActive: false }),
+      )),
+      wrap(configs.survival, createElement(
+        LineChart,
+        { width: 320, height: 220, data: survivalData },
+        createElement(XAxis, { dataKey: 'months' }),
+        createElement(YAxis, {}),
+        createElement(Line, { type: 'stepAfter', dataKey: 'treated', dot: true, isAnimationActive: false }),
+      )),
+      wrap(configs.alluvial, createElement(Sankey, {
+        width: 480,
+        height: 300,
+        data: { nodes: flowNodes, links: flowLinks },
+      })),
+    ));
+  });
+});
+
+afterAll(async () => {
+  if (root) {
+    const { act } = await import('react');
+    await act(async () => root?.unmount());
+    root = null;
+  }
+  defineGlobal('window', saved.window);
+  defineGlobal('document', saved.document);
+  defineGlobal('navigator', saved.navigator);
+  defineGlobal('ResizeObserver', saved.ResizeObserver);
+  defineGlobal('IS_REACT_ACT_ENVIRONMENT', saved.IS_REACT_ACT_ENVIRONMENT);
+});
+
+describe('recharts rendered mark contract', () => {
+  it('matches one trapezoid per funnel stage', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.funnel))).toHaveLength(funnelData.length);
+  });
+
+  it('matches one whisker group per error bar sample', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.errorBar))).toHaveLength(errorData.length);
+  });
+
+  it('matches one symbol per volcano point', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.volcano))).toHaveLength(volcanoData.length);
+  });
+
+  it('matches one dot per survival time', () => {
+    expect(document.querySelectorAll(firstSelector(maidr.survival))).toHaveLength(survivalData.length);
+  });
+
+  it('matches one path per flow, in the order the links were declared', () => {
+    const links = document.querySelectorAll(firstSelector(maidr.alluvial));
+
+    // FlowTrace addresses its selector list by each flow's DECLARED position,
+    // so the DOM order has to be the links array's order.
+    expect(links).toHaveLength(flowLinks.length);
+  });
+
+  it('scopes every selector to its own chart', () => {
+    // Each figure's marks are wrapped in its own `#maidr-article-<id>`, so
+    // the five charts on this page cannot highlight one another's elements.
+    for (const figure of Object.values(maidr)) {
+      const selector = firstSelector(figure);
+      expect(selector.startsWith(`#maidr-article-${figure.id}`)).toBe(true);
+    }
+  });
+});

--- a/test/adapters/recharts/selectors.test.ts
+++ b/test/adapters/recharts/selectors.test.ts
@@ -52,6 +52,33 @@ describe('getRechartsSelector', () => {
       expect(getRechartsSelector('lollipop')).toBe('.recharts-scatter-symbol .recharts-symbols');
     });
 
+    it('returns scoped line dot selector for survival type', () => {
+      // A Kaplan-Meier curve is a <Line type="stepAfter">, so it draws line dots.
+      expect(getRechartsSelector('survival')).toBe('.recharts-line-dots .recharts-line-dot');
+    });
+
+    it('returns scoped scatter symbol selector for volcano, manhattan and forest types', () => {
+      // The first two are literally scatters; a forest plot is a
+      // <ScatterChart> whose symbols carry the study weights.
+      expect(getRechartsSelector('volcano')).toBe('.recharts-scatter-symbol .recharts-symbols');
+      expect(getRechartsSelector('manhattan')).toBe('.recharts-scatter-symbol .recharts-symbols');
+      expect(getRechartsSelector('forest')).toBe('.recharts-scatter-symbol .recharts-symbols');
+    });
+
+    it('returns scoped trapezoid selector for funnel type', () => {
+      expect(getRechartsSelector('funnel')).toBe('.recharts-funnel-trapezoid .recharts-trapezoid');
+    });
+
+    it('returns scoped whisker selector for error_bar type', () => {
+      // The whiskers, not the host mark: the estimate may be drawn by a bar,
+      // a line dot or a scatter symbol, and only the author knows which.
+      expect(getRechartsSelector('error_bar')).toBe('.recharts-errorBars .recharts-errorBar');
+    });
+
+    it('returns scoped sankey link selector for alluvial type', () => {
+      expect(getRechartsSelector('alluvial')).toBe('.recharts-sankey-links .recharts-sankey-link');
+    });
+
     it('returns scoped pie sector selector for pie type', () => {
       expect(getRechartsSelector('pie')).toBe('.recharts-pie-sector .recharts-sector');
     });

--- a/test/adapters/recharts/selectors.test.ts
+++ b/test/adapters/recharts/selectors.test.ts
@@ -75,12 +75,17 @@ describe('getRechartsSelector', () => {
       expect(getRechartsSelector('error_bar')).toBe('.recharts-errorBars .recharts-errorBar');
     });
 
-    it('returns scoped sankey link selector for alluvial type', () => {
+    it('returns scoped sankey link selector for alluvial and sankey types', () => {
+      // Both are drawn by the same `<Sankey>`, so both highlight its ribbons.
       expect(getRechartsSelector('alluvial')).toBe('.recharts-sankey-links .recharts-sankey-link');
+      expect(getRechartsSelector('sankey')).toBe('.recharts-sankey-links .recharts-sankey-link');
     });
 
-    it('returns scoped pie sector selector for pie type', () => {
+    it('returns scoped pie sector selector for pie and polar_area types', () => {
+      // A coxcomb is a `<Pie>` of equal-angle slices with a per-datum radius,
+      // so its wedges are the same sectors a pie's slices are.
       expect(getRechartsSelector('pie')).toBe('.recharts-pie-sector .recharts-sector');
+      expect(getRechartsSelector('polar_area')).toBe('.recharts-pie-sector .recharts-sector');
     });
 
     it('returns scoped bar rectangle selector for diverging_bar type', () => {
@@ -88,11 +93,13 @@ describe('getRechartsSelector', () => {
     });
 
     it('returns scoped bar rectangle selector for the floating-bar types', () => {
-      // A waterfall step, a gantt interval and a dumbbell connector are each
-      // one `<Bar>` rectangle that does not start at the baseline.
+      // A waterfall step, a gantt interval, a dumbbell connector and an icicle
+      // band are each one `<Bar>` rectangle that does not start at the
+      // baseline. Recharts draws no icicle of its own, so that is the recipe.
       expect(getRechartsSelector('waterfall')).toBe('.recharts-bar-rectangle .recharts-rectangle');
       expect(getRechartsSelector('gantt')).toBe('.recharts-bar-rectangle .recharts-rectangle');
       expect(getRechartsSelector('dumbbell')).toBe('.recharts-bar-rectangle .recharts-rectangle');
+      expect(getRechartsSelector('icicle')).toBe('.recharts-bar-rectangle .recharts-rectangle');
     });
 
     it('returns scoped radial bar sector selector for gauge type', () => {

--- a/test/adapters/recharts/selectors.test.ts
+++ b/test/adapters/recharts/selectors.test.ts
@@ -82,6 +82,34 @@ describe('getRechartsSelector', () => {
     it('returns scoped pie sector selector for pie type', () => {
       expect(getRechartsSelector('pie')).toBe('.recharts-pie-sector .recharts-sector');
     });
+
+    it('returns scoped bar rectangle selector for diverging_bar type', () => {
+      expect(getRechartsSelector('diverging_bar')).toBe('.recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('returns scoped bar rectangle selector for the floating-bar types', () => {
+      // A waterfall step, a gantt interval and a dumbbell connector are each
+      // one `<Bar>` rectangle that does not start at the baseline.
+      expect(getRechartsSelector('waterfall')).toBe('.recharts-bar-rectangle .recharts-rectangle');
+      expect(getRechartsSelector('gantt')).toBe('.recharts-bar-rectangle .recharts-rectangle');
+      expect(getRechartsSelector('dumbbell')).toBe('.recharts-bar-rectangle .recharts-rectangle');
+    });
+
+    it('returns scoped radial bar sector selector for gauge type', () => {
+      expect(getRechartsSelector('gauge')).toBe('.recharts-radial-bar-sectors .recharts-radial-bar-sector');
+    });
+
+    it('excludes the synthetic root rectangle for treemap type', () => {
+      // Recharts wraps the data array in a root node and draws it full-plot;
+      // counting it would be one element more than the layer has nodes.
+      expect(getRechartsSelector('treemap')).toBe(
+        'g[class*="recharts-treemap-depth-"]:not(.recharts-treemap-depth-0) > g > g > path.recharts-rectangle',
+      );
+    });
+
+    it('returns scoped sunburst sector selector for sunburst type', () => {
+      expect(getRechartsSelector('sunburst')).toBe('.recharts-sunburst .recharts-sector');
+    });
   });
 
   describe('multi-series (with seriesIndex)', () => {

--- a/test/adapters/recharts/selectors.test.ts
+++ b/test/adapters/recharts/selectors.test.ts
@@ -26,8 +26,30 @@ describe('getRechartsSelector', () => {
       expect(getRechartsSelector('line')).toBe('.recharts-line-dots .recharts-line-dot');
     });
 
+    it('returns scoped area dot selector for the whole area family', () => {
+      expect(getRechartsSelector('area')).toBe('.recharts-area-dots .recharts-area-dot');
+      expect(getRechartsSelector('stacked_area')).toBe('.recharts-area-dots .recharts-area-dot');
+      expect(getRechartsSelector('normalized_area')).toBe('.recharts-area-dots .recharts-area-dot');
+    });
+
+    it('returns scoped radar dot selector for radar type', () => {
+      expect(getRechartsSelector('radar')).toBe('.recharts-radar-dots .recharts-radar-dot');
+    });
+
+    it('returns scoped line dot selector for bump type', () => {
+      // A bump chart is a <LineChart> of ranks, so it draws line dots.
+      expect(getRechartsSelector('bump')).toBe('.recharts-line-dots .recharts-line-dot');
+    });
+
     it('returns scoped scatter symbol selector for scatter type', () => {
       expect(getRechartsSelector('scatter')).toBe('.recharts-scatter-symbol .recharts-symbols');
+    });
+
+    it('returns scoped scatter symbol selector for dot and lollipop types', () => {
+      // Both are drawn with <Scatter>; the lollipop's stem <Bar> is not the
+      // mark a reader takes the value off.
+      expect(getRechartsSelector('dot')).toBe('.recharts-scatter-symbol .recharts-symbols');
+      expect(getRechartsSelector('lollipop')).toBe('.recharts-scatter-symbol .recharts-symbols');
     });
 
     it('returns scoped pie sector selector for pie type', () => {


### PR DESCRIPTION
## Description

The Recharts adapter has recognised eight chart types since it was written — bar, stacked bar, dodged bar, normalized bar, histogram, line, scatter and pie. MAIDR's grammar has grown a long way past that, and every trace type this pull request adds was already fully implemented in the core: the models, the sonification, the text and braille output all exist and are unchanged here. What was missing was the declaration that lets a Recharts author reach them.

This extends `RechartsChartType` with **24 further types** and wires each one end to end: payload conversion into the exact shape `src/type/grammar.ts` specifies, a highlight selector built from Recharts' own class names, a runnable example, and documentation. No file outside `src/adapters/recharts/`, `test/adapters/recharts/`, `examples/` and `docs/` is touched.

Accessibility is the acceptance bar, not sonification alone. `test/adapters/recharts/markDom.test.ts` is new for this reason: it mounts the real Recharts components in jsdom and asserts that each type's selector resolves to exactly one mark per data point — the funnel trapezoids, the whisker groups, the scatter symbols, the line dots, the sankey ribbons, the floating bar rectangles, the radial sectors. A type that sonifies but does not highlight would fail that test rather than ship.

## Related Issues

Closes #863

## Changes Made

### Trace types added (24)

Grouped by the converter they reuse or introduce.

**Reuse the bar converter (`BarPoint[]`)**

- `'dot'` — Cleveland dot plot, a `<Scatter>` against a category axis
- `'lollipop'` — a `<ComposedChart>` of a thin `<Bar>` stem plus a `<Scatter>` head; the stem is the mark, not extra data
- `'funnel'` — `<FunnelChart>` + `<Funnel>`. The counts are passed through untouched and `FunnelTrace` derives the retention it announces, because retention is the number a funnel is read for and the one a listener cannot take by ear from two heights heard separately

**Join the line family (`LinePoint[][]`)**

- `'area'` — the fill is what the mark looks like, not a second magnitude, so the data is a line's
- `'stacked_area'` — `<Area stackId="...">`. Declared over a single `yKey` it falls back to `AREA`, mirroring how the bar family downgrades to `BAR`: one band is not stacked against anything, and announcing a total equal to the point's own value on every sample is noise
- `'normalized_area'` — `<AreaChart stackOffset="expand">`
- `'radar'` — `<RadarChart>` + `<Radar>`
- `'polar_area'` — a coxcomb/rose: the radar's spokes drawn as `<Pie>` wedges with equal angles and a per-datum `outerRadius`, so it carries the radar payload and the pie's sectors
- `'bump'` — rank over time, a `<LineChart>` with `<YAxis reversed>`

**Carry payload a coordinate pair cannot, through a new sub-config**

- `'survival'` — Kaplan-Meier, a `<Line type="stepAfter">` plus censoring marks and confidence band (`survivalConfig`)
- `'volcano'` and `'manhattan'` — effect size or genomic position against significance; point identity, region and cutoffs (`volcanoConfig`)
- `'error_bar'` — `<ErrorBar>` inside a `<Bar>`/`<Line>`/`<Scatter>` (`errorConfig`)
- `'forest'` — one interval per study against a shared null line, pooled summary last (`forestConfig`)
- `'alluvial'` and `'sankey'` — weighted flow through a `<Sankey>` (`flowConfig`). The two share payload, config and selector; they differ in whether the node set repeats at each stage, which the data says rather than the adapter
- `'diverging_bar'` — two `yKeys` back to back with `<BarChart stackOffset="sign">`
- `'waterfall'` — signed contributions carried to a running total (`waterfallConfig`)
- `'gantt'` — intervals per lane (`ganttConfig`)
- `'gauge'` — one measure against a range as a half-dial `<RadialBarChart>` (`gaugeConfig`)
- `'dumbbell'` — two values per category joined by a segment
- `'treemap'` and `'icicle'` — a hierarchy as nested area or as spans
- `'sunburst'` — the same hierarchy as rings

### Conversions that decide correctness

- **Error bar bounds.** Recharts' `<ErrorBar dataKey>` points at an *offset* from the estimate while `ErrorBarPoint` fixes *absolute* positions on the value axis. `errorKey` is resolved against `y` — a number or a `[lower, upper]` pair, the same arithmetic `ErrorBar.js` does — while `yMinKey`/`yMaxKey` pass through untouched. The two bounds stay independently optional: a one-sided interval is a real chart.
- **Waterfall totals.** The data holds contributions; `WaterfallPoint` holds absolute start and end positions. The running totals are accumulated in the converter, with a restating row (opening balance, subtotal, closing balance) sitting on the baseline and falling back to the accumulated total when it carries no number of its own.
- **Hierarchy flattening.** Treemap, sunburst and icicle data is flattened depth-first in pre-order so row *i* is node *i*, dropping an interior node's declared value because Recharts computes one from the children and ignores it. Order and magnitudes then match what the chart actually drew.
- **Non-uniform payloads.** `GaugePoint` is a single object, `GanttData` nests its intervals by lane, and `DumbbellData` wraps its rows with the names of the two ends — none of them one array per `yKey`. Those three get dedicated builders alongside histogram and survival rather than passing through the `yKeys.map()` loop.

### Highlighting

Every added type gets a selector derived from Recharts' own class names, and two need more than a class:

- the treemap selector skips the synthetic root rectangle Recharts wraps the data array in, which would otherwise be one element more than there are nodes and turn highlighting off entirely;
- the gantt withdraws its own selector when the rows interleave lanes, because Recharts draws in row order while `GanttTrace` walks lane by lane, and a wrong highlight is worse than none.

Sunburst excludes the root because `SunburstChart` renders `data.children`.

### Reuse over new configuration

Where an existing idiom already said the thing, it is reused rather than duplicated: a dumbbell's and a gantt's two positions are its two `yKeys`, and a dumbbell's end labels are its `fillKeys` — the names a legend gives a sighted reader for free. Only what Recharts genuinely cannot know becomes a new sub-config: `waterfallConfig` marks the rows that restate the running total, `ganttConfig` declares the lanes so an empty one survives, and `gaugeConfig` carries the range, target and bands a `<RadialBar>` holds nowhere.

### Examples and docs

24 new example components under `examples/recharts/examples/`, one per added type, registered in `examples/recharts/App.tsx`. `docs/recharts.md` grows by roughly 850 lines: a section per type with the data shape, the config, the Recharts markup that renders the marks the default selector expects, and the recipes that do not (the transparent-offset waterfall needs a `selectorOverride`, and a chart of values declared as `'bump'` sonifies upside down — the adapter cannot tell rank from value).

### Trace types NOT added, and why

**No Recharts primitive draws them.** The library has no component for these marks, so there is nothing for a selector to target and no data an adapter could read off the chart:

- `box`, `boxen`, `violin_box`, `violin_kde` — no box or violin primitive
- `heat`, `hexbin`, `mosaic` — no cell-grid primitive
- `contour`, `choropleth` — no scalar-field or geographic primitive
- `chord`, `network` — no graph-layout primitive
- `parallel_coordinates`, `ridgeline` — no multi-axis or offset-density primitive
- `word_cloud` — no text-layout primitive
- `candlestick` — no OHLC primitive

**Not an adapter concern.** `candlestick_delta` is never declared in MAIDR JSON; the core creates it at runtime from a candlestick layer.

**Drawable in Recharts, not declared here.** `step` (`<Line type="stepAfter">`) and `smooth` (`<Line type="monotone">`) are `<Line>` curve variants Recharts renders today. This change does not add declarations for them, so an author still reaches them as `'line'` and loses the announcement that says which curve it is. They are the obvious next batch; no core change is needed for either.

No core change was required for anything in this pull request, and none was made.

## Checklist

- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

Two boxes are left unticked deliberately. `CONTRIBUTING.md` was not read as part of this work, and the manual pass in `ManualTestingProcess.md` — a screen reader driven through each new chart in a browser — was not performed. The automated gate below did run in full and is green; it is not a substitute for that manual pass, and the examples are there so a reviewer can do it.

## Additional Notes

Verification run on this branch, in order, from a clean tree:

| Step | Result |
| --- | --- |
| `npm run lint:fix` | clean, no files rewritten |
| `npm run type-check` | clean (`tsc --noEmit` and `tsc -p tsconfig.ci.json`) |
| `npm run build` | all 12 adapter bundles built |
| `npm test` | 188/188 suites, 2731/2731 tests (unit + component), 7/7 suites and 73/73 tests (ESM) |

Nothing failed, so no fix commits were needed on top of the four feature commits. `npm run e2e` was not run — it is outside the gate for this change and needs browsers this environment does not have.

Review suggestion: the two conversions worth checking against the Recharts source are the `<ErrorBar>` offset-to-absolute arithmetic in `src/adapters/recharts/converters.ts` and the waterfall total accumulation, since both restate numbers the chart holds only implicitly. `test/adapters/recharts/markDom.test.ts` is the file to read for the highlighting claims — it is the proof, not a description of one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_