### PR TITLE
feat(amcharts): support the chart types added since the pie chart

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -78,7 +78,10 @@ Series are classified by their amCharts class name and field configuration:
 - multiple `ColumnSeries` → **stacked**, **100%-stacked (normalized)**, or **dodged**, detected from each series' `stacked` flag and `valueYShow`/`valueXShow` setting
 - `ColumnSeries` with both X and Y category axes → **heatmap** (heat value read from the `value` field)
 - `ColumnSeries` on a value X axis with `openValueXField` bin edges → **histogram**
-- `LineSeries` (incl. smoothed/step variants) → **line**
+- `LineSeries` (incl. smoothed variants) → **line**, or **area** / **stacked area** / **100% stacked area** when its `fills` are visible
+- `StepLineSeries` → **step**
+- `RadarLineSeries` → **radar**; `RadarColumnSeries` → **polar area**
+- `am5percent.FunnelSeries` (and `PyramidSeries`, `PictorialStackedSeries`) → **funnel**
 
 ### Visual Highlighting
 
@@ -92,21 +95,31 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Dodged / Grouped Bar | multiple `ColumnSeries` | no `stacked` flag |
 | Stacked Bar | multiple `ColumnSeries` | `stacked: true` |
 | 100% Stacked (Normalized) | multiple `ColumnSeries` | `stacked: true` + `valueYShow: "valueYTotalPercent"` |
-| Line (single & multi-series) | `LineSeries` | line series class |
+| Line (single & multi-series) | `LineSeries` | line series class, no visible fill |
+| Area | `LineSeries` | visible `fills` template |
+| Stacked Area | multiple `LineSeries` | visible fills + `stacked: true` |
+| 100% Stacked Area | multiple `LineSeries` | visible fills + `stacked: true` + `valueYShow: "valueYTotalPercent"` |
 | Step (single & multi-series) | `StepLineSeries` | step-line series class |
 | Histogram | `ColumnSeries` | value X axis + `openValueXField` bin edges |
 | Heatmap | `ColumnSeries` | category X **and** category Y axes + `value` field |
 | Pie / Doughnut | `am5percent.PieSeries` | series class (requires `percent.js`) |
+| Funnel / Pyramid | `am5percent.FunnelSeries`, `PyramidSeries`, `PictorialStackedSeries` | series class (requires `percent.js`) |
+| Radar / Spider | `am5radar.RadarLineSeries` | series class (requires `radar.js`) |
+| Polar Area / Coxcomb | `am5radar.RadarColumnSeries` | series class (requires `radar.js`) |
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
 A `PieSeries` lives in amCharts' separate `percent.js` module and is bound to no axis, so `axes.x` and `axes.y` default to `Label` and `Value`; the `axisLabels` option overrides both. A doughnut is a `PieChart` with an `innerRadius` and reads identically. Slices with no category or no numeric value are skipped rather than counted as zero.
 
+A `FunnelSeries` lives in the same `percent.js` module, inside a `SlicedChart` rather than a `PieChart`, and is likewise bound to no axis — its dimensions default to `Stage` and `Value`. Its pyramid and pictorial-stack siblings carry the same ordered `category`/`value` stages and are read the same way.
+
+`RadarLineSeries` and `RadarColumnSeries` need `radar.js` on top of `xy.js`; a `RadarChart` extends `XYChart`, so the binder finds it with the rest.
+
 > Box plots, candlestick, scatter, violin, and smooth/regression layers are **not** supported by the amCharts binder. amCharts 5 has no dedicated scatter or box series, and there is no reliable runtime signal to distinguish a scatter (hidden-stroke `LineSeries`) from a normal line chart.
 
 ## Multi-Panel Charts
 
-Every `PieChart` in the root's container is a subplot too, on the same terms as the XYCharts below — a root holding a pie and a doughnut is one MAIDR figure with two panels.
+Every am5percent chart in the root's container — a `PieChart` or a `SlicedChart` — is a subplot too, on the same terms as the XYCharts below: a root holding a pie and a doughnut is one MAIDR figure with two panels.
 
 When one amCharts `Root` contains **multiple XYCharts** — amCharts' native multi-panel pattern (`root.container.set("layout", root.verticalLayout)` plus several `XYChart` children, or a `horizontalLayout`/`GridLayout`) — both `bindAmCharts` and `fromAmCharts` convert **each chart into its own MAIDR subplot**. The same applies to **am5stock `StockChart` panels** (`StockPanel` extends `XYChart`), which the binder finds by walking the root's container tree; scrollbar preview charts (`XYChartScrollbar`) are excluded.
 
@@ -236,6 +249,56 @@ maidrAmCharts.bindAmCharts(root, { axisLabels: { x: "Fruit", y: "Units sold" } }
 ```
 
 Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Fruit is Apples, Units sold is 30, Percentage is 26.1%".
+
+### Area / Stacked Area
+
+An area chart is a `LineSeries` whose `fills` template has been made visible — amCharts has no area series — so that fill is what the adapter reads. A line with no visible fill stays a line. Add `stacked: true` for a stacked area, and `valueYShow: "valueYTotalPercent"` (with `calculateTotals: true` on the value axis) for a 100% stack. A runnable page is at [`examples/amcharts-area.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-area.html).
+
+```js
+var series = chart.series.push(am5xy.LineSeries.new(root, {
+  name: "Search", xAxis: xAxis, yAxis: yAxis,
+  valueYField: "search", categoryXField: "quarter",
+  stacked: true, // omit for independent (overlapping) bands
+}));
+series.fills.template.setAll({ visible: true, fillOpacity: 0.4 });
+```
+
+Every area series of one chart merges into a **single** layer, and the stacking is read across the whole group: amCharts commonly sets `stacked` on the bands that sit *on* another one and leaves it off the bottom band, so splitting the group by that flag would strand the bottom band in a layer of its own. A stacked area announces two magnitudes per sample — the band's own value and the running total its top edge sits at — where a line reading collapses them to one.
+
+### Radar / Polar Area
+
+A `RadarChart` extends `XYChart`, so it is found like any other chart; its series classes are what identify it. `RadarLineSeries` becomes a radar layer (each spoke a column, each series a row), and `RadarColumnSeries` a polar area — the same values drawn as wedges. A spoke's stereo position follows its angle rather than its index, so sweeping the spokes goes out and comes back. A runnable page is at [`examples/amcharts-radar.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-radar.html).
+
+```js
+var chart = root.container.children.push(am5radar.RadarChart.new(root, {}));
+var xAxis = chart.xAxes.push(am5xy.CategoryAxis.new(root, {
+  categoryField: "attribute", renderer: am5radar.AxisRendererCircular.new(root, {}),
+}));
+var yAxis = chart.yAxes.push(am5xy.ValueAxis.new(root, {
+  renderer: am5radar.AxisRendererRadial.new(root, {}),
+}));
+chart.series.push(am5radar.RadarLineSeries.new(root, {
+  name: "Model A", xAxis: xAxis, yAxis: yAxis,
+  valueYField: "a", categoryXField: "attribute",
+}));
+```
+
+### Funnel / Pyramid
+
+A funnel lives in an `am5percent.SlicedChart`, not a `PieChart`, and takes no axes. The stages stay in data order, which is what the reading depends on: MAIDR pitches each stage against the **retention** from the one before it — the ratio a listener cannot compute from two heights heard one at a time — and announces the counts alongside. A runnable page is at [`examples/amcharts-funnel.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-funnel.html).
+
+```js
+var chart = root.container.children.push(am5percent.SlicedChart.new(root, {}));
+var series = chart.series.push(am5percent.FunnelSeries.new(root, {
+  name: "Checkout", valueField: "people", categoryField: "stage",
+}));
+series.data.setAll([
+  { stage: "Visited", people: 10000 }, { stage: "Signed up", people: 2400 },
+  { stage: "Viewed cart", people: 2300 }, { stage: "Purchased", people: 100 },
+]);
+
+maidrAmCharts.bindAmCharts(root, { axisLabels: { x: "Stage", y: "People" } });
+```
 
 ## Keyboard Controls
 

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -82,6 +82,9 @@ Series are classified by their amCharts class name and field configuration:
 - `StepLineSeries` → **step**
 - `RadarLineSeries` → **radar**; `RadarColumnSeries` → **polar area**
 - `am5percent.FunnelSeries` (and `PyramidSeries`, `PictorialStackedSeries`) → **funnel**
+- `ColumnSeries` with `openValueYField` on a category X axis → **waterfall** when the bars chain (each opens where the previous one closed), **dumbbell** when they do not
+- `ColumnSeries` with `openValueXField` on a category Y axis → **gantt**
+- `am5hierarchy.Treemap` → **treemap**; `am5hierarchy.Partition` → **icicle**
 
 ### Visual Highlighting
 
@@ -106,6 +109,11 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Funnel / Pyramid | `am5percent.FunnelSeries`, `PyramidSeries`, `PictorialStackedSeries` | series class (requires `percent.js`) |
 | Radar / Spider | `am5radar.RadarLineSeries` | series class (requires `radar.js`) |
 | Polar Area / Coxcomb | `am5radar.RadarColumnSeries` | series class (requires `radar.js`) |
+| Waterfall / Bridge | `ColumnSeries` | category X axis + `openValueYField`, bars chaining end-to-end |
+| Dumbbell / Barbell | `ColumnSeries` | category X axis + `openValueYField`, bars **not** chaining |
+| Gantt / Timeline | `ColumnSeries` | category Y axis + `openValueXField` (or `openDateXField`) |
+| Treemap | `am5hierarchy.Treemap` | series class (requires `hierarchy.js`) |
+| Icicle | `am5hierarchy.Partition` | series class (requires `hierarchy.js`) |
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
@@ -300,6 +308,74 @@ series.data.setAll([
 maidrAmCharts.bindAmCharts(root, { axisLabels: { x: "Stage", y: "People" } });
 ```
 
+### Waterfall / Dumbbell
+
+amCharts draws both with the same construct — a `ColumnSeries` whose bars float between `openValueY` and `valueY` — so the data decides which chart it is. A waterfall **chains**: each bar opens where the one before it closed, because the bars trace a single running total, and the bars that sit on the baseline are the opening, closing and subtotal steps. A dumbbell's pairs are independent, so the chain breaks at the second row of any real one. Both are runnable at [`examples/amcharts-floating-columns.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-floating-columns.html).
+
+```js
+// Waterfall: `open` continues the running total, 0 restates it.
+var series = chart.series.push(am5xy.ColumnSeries.new(root, {
+  name: "Budget", xAxis: xAxis, yAxis: yAxis,
+  categoryXField: "category", openValueYField: "open", valueYField: "value",
+}));
+series.data.setAll([
+  { category: "Opening", open: 0, value: 1200 },
+  { category: "Marketing", open: 1200, value: 950 },
+  { category: "Closing", open: 0, value: 950 },
+]);
+```
+
+A waterfall announces the contribution and the running total separately, because a bar chart would conflate them; the pitch follows the contribution, whose signed range is what makes the large movers audible.
+
+A dumbbell's finding is the change between the two ends, so it travels with both. amCharts names the *series*, not the two ends, so nothing on the chart says what they stand for — pass `dumbbellLabels` and MAIDR announces "Denmark, 1990 71.2, increase 7.2" instead of "start" and "end":
+
+```js
+maidrAmCharts.bindAmCharts(root, { dumbbellLabels: { start: "1990", end: "2020" } });
+```
+
+### Gantt / Timeline
+
+A schedule is floating columns on a category Y axis of lanes and a `DateAxis` of time. Pitch carries each interval's **length** and stereo position carries its **start**, mapped along the whole axis rather than by column index, so two lanes whose work overlaps sound like they overlap.
+
+```js
+var yAxis = chart.yAxes.push(am5xy.CategoryAxis.new(root, {
+  categoryField: "category", renderer: am5xy.AxisRendererY.new(root, { inversed: true }),
+}));
+// Declare every lane on the axis, including one with nothing booked.
+yAxis.data.setAll([{ category: "Design" }, { category: "Build" }, { category: "Launch" }]);
+
+var xAxis = chart.xAxes.push(am5xy.DateAxis.new(root, {
+  baseInterval: { timeUnit: "day", count: 1 }, renderer: am5xy.AxisRendererX.new(root, {}),
+}));
+var series = chart.series.push(am5xy.ColumnSeries.new(root, {
+  name: "Schedule", xAxis: xAxis, yAxis: yAxis,
+  categoryYField: "category", openValueXField: "start", valueXField: "end",
+}));
+```
+
+The lanes come from the **category axis**, not from the bars, so a lane with nothing booked survives — an empty lane is a real statement about a schedule and the only row a reader can navigate onto and be told nothing by, so MAIDR names it and reports the count up front.
+
+A `DateAxis` stores positions as epoch milliseconds, which no reader can hear a length in, so the adapter rescales them to the axis' own `baseInterval` time unit, measured from the earliest interval: a schedule reads as "day 0 to day 30, length 30 days". The absolute dates are dropped by that, and everything a schedule is drawn to answer — what overlaps what, what hands over to what, where the slack is — survives it. A plain `ValueAxis` is passed through untouched and named with no unit.
+
+### Treemap / Icicle
+
+An `am5hierarchy` layout is **not** a chart: it is a series pushed straight into a container, with no series list and no axes, so the adapter recognises the series itself and treats it as one panel. A treemap and an icicle (amCharts calls it a `Partition`) draw the same tree with different marks and are read identically — as a tree, not a grid: Left and Right move between siblings, Down steps into a node's children, Up returns to its parent. A runnable page is at [`examples/amcharts-treemap.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-treemap.html).
+
+```js
+var series = root.container.children.push(am5hierarchy.Treemap.new(root, {
+  name: "Population", valueField: "value", categoryField: "name", childDataField: "children",
+}));
+series.data.setAll([{
+  name: "World",
+  children: [
+    { name: "Asia", children: [{ name: "China", value: 1425 }, { name: "India", value: 1428 }] },
+    { name: "Africa", children: [{ name: "Nigeria", value: 224 }] },
+  ],
+}]);
+```
+
+The single root object amCharts requires is dropped: it is a container for the chart rather than a finding, and keeping it would add a level that always holds one node worth 100% of the total. A branch is emitted without a value unless it declares one of its own, so its total is derived from what is under it and cannot disagree with its own children.
+
 ## Keyboard Controls
 
 Once a chart is focused, use the standard MAIDR shortcuts:
@@ -334,7 +410,7 @@ const binding = bindAmCharts(root, { title: 'Sales by Day' });
 // later: binding.dispose();
 ```
 
-`bindAmCharts(root, options?)` finds every `XYChart` in `root.container` (one subplot per chart — see [Multi-Panel Charts](#multi-panel-charts)); `bindXYChart(chart, root, options?)` takes a chart you already hold. Options accept `title`, `subtitle`, `axisLabels: { x, y }`, plus `highlight` (default `true`) and `highlightColor`. Pass `{ highlight: false }` to mount the accessible UI without the overlay.
+`bindAmCharts(root, options?)` finds every `XYChart` in `root.container` (one subplot per chart — see [Multi-Panel Charts](#multi-panel-charts)); `bindXYChart(chart, root, options?)` takes a chart you already hold. Options accept `title`, `subtitle`, `axisLabels: { x, y }`, `dumbbellLabels: { start, end }`, plus `highlight` (default `true`) and `highlightColor`. Pass `{ highlight: false }` to mount the accessible UI without the overlay.
 
 For the data-only path (no highlighting), use `fromAmCharts(root, options?)` / `fromXYChart(chart, containerEl, options?)`, which return MAIDR JSON for the `maidr` attribute or `<Maidr data={...}>`.
 

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -85,6 +85,10 @@ Series are classified by their amCharts class name and field configuration:
 - `ColumnSeries` with `openValueYField` on a category X axis → **waterfall** when the bars chain (each opens where the previous one closed), **dumbbell** when they do not
 - `ColumnSeries` with `openValueXField` on a category Y axis → **gantt**
 - `am5hierarchy.Treemap` → **treemap**; `am5hierarchy.Partition` → **icicle**
+- two `ColumnSeries` on one category axis, one side's values all negative and the other's all positive → **diverging bar** (a population pyramid); any other unstacked group stays **dodged**
+- `LineSeries` with its stroke switched off and bullets pushed on, on a category axis → **dot** (a Cleveland dot plot)
+- `ColumnSeries` whose columns are narrowed to a hairline, with bullets → **lollipop**
+- `am5wc.WordCloud` → **word cloud**
 
 ### Visual Highlighting
 
@@ -114,6 +118,10 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Gantt / Timeline | `ColumnSeries` | category Y axis + `openValueXField` (or `openDateXField`) |
 | Treemap | `am5hierarchy.Treemap` | series class (requires `hierarchy.js`) |
 | Icicle | `am5hierarchy.Partition` | series class (requires `hierarchy.js`) |
+| Diverging Bar / Population Pyramid | two `ColumnSeries` | shared categories, one series entirely negative and the other entirely positive |
+| Dot Plot (Cleveland) | `LineSeries` | category axis + `strokes.template` hidden + bullets |
+| Lollipop | `ColumnSeries` | category axis + hairline `columns.template` width + bullets |
+| Word Cloud | `am5wc.WordCloud` | series class (requires `wc.js`) |
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
@@ -123,7 +131,7 @@ A `FunnelSeries` lives in the same `percent.js` module, inside a `SlicedChart` r
 
 `RadarLineSeries` and `RadarColumnSeries` need `radar.js` on top of `xy.js`; a `RadarChart` extends `XYChart`, so the binder finds it with the rest.
 
-> Box plots, candlestick, scatter, violin, and smooth/regression layers are **not** supported by the amCharts binder. amCharts 5 has no dedicated scatter or box series, and there is no reliable runtime signal to distinguish a scatter (hidden-stroke `LineSeries`) from a normal line chart.
+> Box plots, candlestick, violin, and smooth/regression layers are **not** supported by the amCharts binder. Neither is **scatter**: amCharts draws one as a hidden-stroke `LineSeries` with bullets, which is also how it draws a dot plot, and the only thing separating them is the axis — so a hidden-stroke series on a **category** axis is read as a dot plot and the same series on two **value** axes stays a line chart rather than being announced as a scatter MAIDR would then read as a dot plot.
 
 ## Multi-Panel Charts
 
@@ -375,6 +383,69 @@ series.data.setAll([{
 ```
 
 The single root object amCharts requires is dropped: it is a container for the chart rather than a finding, and keeping it would add a level that always holds one node worth 100% of the total. A branch is emitted without a value unless it declares one of its own, so its total is derived from what is under it and cannot disagree with its own children.
+
+### Diverging Bar / Population Pyramid
+
+A runnable page covering all three of the marks below is at [`examples/amcharts-marks.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-marks.html).
+
+amCharts has no diverging series: the chart is two ordinary `ColumnSeries` on one category axis with one side's values negated, which is otherwise the signature of a dodged bar chart. What separates them is the sign — one series entirely on each side of the baseline, over the same categories in the same order — and that is a statement about the data rather than about how it was drawn.
+
+```js
+var yAxis = chart.yAxes.push(am5xy.CategoryAxis.new(root, {
+  categoryField: "band", renderer: am5xy.AxisRendererY.new(root, {}),
+}));
+// One side negated, which is what draws it to the left of the baseline.
+var data = [{ band: "0-14", men: -1200, women: 1140 }, { band: "15-29", men: -1150, women: 1100 }];
+["men", "women"].forEach(function (field) {
+  var s = chart.series.push(am5xy.ColumnSeries.new(root, {
+    name: field, xAxis: xAxis, yAxis: yAxis, valueXField: field, categoryYField: "band",
+  }));
+  s.data.setAll(data);
+});
+```
+
+The values reach MAIDR **signed**, exactly as the chart drew them. The trace pitches the magnitude and announces the side, so the biggest bar on the left is the loudest note on the left rather than the lowest note on the chart, and the summary row is the balance between the two sides rather than a "sum" that came out negative. A group carrying a `stacked` flag is taken at its word and stays a stacked bar chart — a pyramid's sides sit either side of the baseline rather than on top of one another.
+
+### Dot Plot / Lollipop
+
+amCharts has no dot or lollipop series either. A Cleveland dot plot is a `LineSeries` with its stroke switched off and bullets pushed on; a lollipop is a `ColumnSeries` narrowed to a hairline with a bullet on the end. Both carry one category and one value per mark and are navigated exactly as a bar chart is — the type names the chart the author drew.
+
+```js
+// Dot plot: the line is switched off, so what is drawn is the points alone.
+var dots = chart.series.push(am5xy.LineSeries.new(root, {
+  name: "Response time", xAxis: xAxis, yAxis: yAxis, valueXField: "ms", categoryYField: "endpoint",
+}));
+dots.strokes.template.setAll({ strokeOpacity: 0 });
+dots.bullets.push(function () {
+  return am5.Bullet.new(root, { sprite: am5.Circle.new(root, { radius: 5, fill: dots.get("fill") }) });
+});
+
+// Lollipop: a hairline column with a bullet on the end.
+var stems = chart.series.push(am5xy.ColumnSeries.new(root, {
+  name: "Life expectancy", xAxis: xAxis, yAxis: yAxis, valueYField: "years", categoryXField: "country",
+}));
+stems.columns.template.setAll({ width: 2 });
+stems.bullets.push(function () {
+  return am5.Bullet.new(root, { sprite: am5.Circle.new(root, { radius: 6, fill: stems.get("fill") }) });
+});
+```
+
+Both probes require the bullets, because either half alone is something else: a strokeless line with no bullets draws nothing, a line with bullets **and** a stroke is a line chart with markers, and a narrow bar chart with no bullets is a narrow bar chart. A stem width declared as a `Percent` is read as an ordinary bar — a column half its cell wide is not a hairline however small the number reads.
+
+### Word Cloud
+
+An `am5wc.WordCloud` is a standalone series like an `am5hierarchy` layout: pushed straight into a container, with no chart around it, so the adapter recognises the series itself and treats it as one panel. It needs `wc.js` on top of `index.js`. A runnable page is at [`examples/amcharts-wordcloud.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-wordcloud.html).
+
+```js
+var series = root.container.children.push(am5wc.WordCloud.new(root, {
+  categoryField: "tag", valueField: "count",
+}));
+series.data.setAll([
+  { tag: "neural", count: 128 }, { tag: "machine", count: 412 }, { tag: "gradient", count: 57 },
+]);
+```
+
+A cloud's arrangement is chosen to pack glyphs and encodes nothing, so MAIDR walks the terms **heaviest first** rather than in layout order, and each term announces the weight the chart prints nowhere. The layer declares the terms in data order; the reading order is derived from the weights themselves, so it cannot disagree with them. The highlight box is drawn around the active term's glyph, rotated words included.
 
 ## Keyboard Controls
 

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -89,6 +89,7 @@ Series are classified by their amCharts class name and field configuration:
 - `LineSeries` with its stroke switched off and bullets pushed on, on a category axis → **dot** (a Cleveland dot plot)
 - `ColumnSeries` whose columns are narrowed to a hairline, with bullets → **lollipop**
 - `am5wc.WordCloud` → **word cloud**
+- `LineSeries` on a value axis whose renderer is `inversed`, carrying a genuine ranking → **bump** (rank over time); the `bump` option settles the cases the axis cannot
 
 ### Visual Highlighting
 
@@ -122,6 +123,7 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Dot Plot (Cleveland) | `LineSeries` | category axis + `strokes.template` hidden + bullets |
 | Lollipop | `ColumnSeries` | category axis + hairline `columns.template` width + bullets |
 | Word Cloud | `am5wc.WordCloud` | series class (requires `wc.js`) |
+| Bump (rank over time) | `LineSeries` | value axis renderer `inversed: true` **and** values that are a ranking; or the `bump` option |
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
@@ -447,6 +449,38 @@ series.data.setAll([
 
 A cloud's arrangement is chosen to pack glyphs and encodes nothing, so MAIDR walks the terms **heaviest first** rather than in layout order, and each term announces the weight the chart prints nowhere. The layer declares the terms in data order; the reading order is derived from the weights themselves, so it cannot disagree with them. The highlight box is drawn around the active term's glyph, rotated words included.
 
+### Bump (Rank Over Time)
+
+amCharts has no bump series: a rank table is ordinary `LineSeries` on a `ValueAxis` whose renderer is `inversed`, so that first place is drawn at the top. A runnable page is at [`examples/amcharts-bump.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-bump.html).
+
+```js
+var yAxis = chart.yAxes.push(am5xy.ValueAxis.new(root, {
+  min: 1, max: 4, strictMinMax: true,
+  renderer: am5xy.AxisRendererY.new(root, { inversed: true }),
+}));
+["ash", "birch", "cedar", "cyan"].forEach(function (field) {
+  var s = chart.series.push(am5xy.LineSeries.new(root, {
+    name: field, xAxis: xAxis, yAxis: yAxis, valueYField: field, categoryXField: "round",
+  }));
+  s.data.setAll(data); // one place per competitor per round: 1, 2, 3, 4
+});
+```
+
+**A rank is not a magnitude**, and that is the whole of what this type buys. Rank 1 is the best position and the smallest number, so read as a line chart the leader is sonified as the lowest note on the chart and a team climbing the table is heard *falling* — on every move, with nothing to say the reading was upside down. MAIDR's bump trace inverts the pitch so first place is the highest note, announces the places gained or lost alongside the rank (the overtake is what the chart is drawn for, and it is not recoverable from hearing ranks one at a time), and offers rank-gained / rank-lost rotor units that jump between the periods where something moved.
+
+An inversed axis alone does not make a bump chart — it is also how a plain chart counting down is drawn — so the adapter corroborates it against the values, which have to read as a ranking: whole places, no two competitors on the same place in the same period, and somebody in first. A chart drawn from the *middle* of a larger field (places 3 through 9 of twenty) fails that test and stays a line chart rather than being sonified against a rank range it does not carry.
+
+The `bump` option settles what amCharts leaves ambiguous:
+
+```js
+// The axis runs the ordinary way up, but the lines carry places.
+maidrAmCharts.bindAmCharts(root, { bump: true });
+// A chart of small integers that only looks like a ranking.
+maidrAmCharts.bindAmCharts(root, { bump: false });
+```
+
+`true` stands in for the inversed axis and no more: the values still have to read as a ranking, because the option applies to every panel of the figure and must not invert the pitch of a plain line chart in the next one. `false` suppresses the reading outright. A *slope graph* of values is not a bump chart — it is a line layer with two samples, which the line trace already reads correctly.
+
 ## Keyboard Controls
 
 Once a chart is focused, use the standard MAIDR shortcuts:
@@ -481,7 +515,7 @@ const binding = bindAmCharts(root, { title: 'Sales by Day' });
 // later: binding.dispose();
 ```
 
-`bindAmCharts(root, options?)` finds every `XYChart` in `root.container` (one subplot per chart — see [Multi-Panel Charts](#multi-panel-charts)); `bindXYChart(chart, root, options?)` takes a chart you already hold. Options accept `title`, `subtitle`, `axisLabels: { x, y }`, `dumbbellLabels: { start, end }`, plus `highlight` (default `true`) and `highlightColor`. Pass `{ highlight: false }` to mount the accessible UI without the overlay.
+`bindAmCharts(root, options?)` finds every `XYChart` in `root.container` (one subplot per chart — see [Multi-Panel Charts](#multi-panel-charts)); `bindXYChart(chart, root, options?)` takes a chart you already hold. Options accept `title`, `subtitle`, `axisLabels: { x, y }`, `dumbbellLabels: { start, end }`, `bump`, plus `highlight` (default `true`) and `highlightColor`. Pass `{ highlight: false }` to mount the accessible UI without the overlay.
 
 For the data-only path (no highlighting), use `fromAmCharts(root, options?)` / `fromXYChart(chart, containerEl, options?)`, which return MAIDR JSON for the `maidr` attribute or `<Maidr data={...}>`.
 

--- a/examples/amcharts-area.html
+++ b/examples/amcharts-area.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Area Charts</title>
+
+    <!-- 1. Load amCharts 5 (core + XY; an area is a filled LineSeries) -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 600px;
+        height: 380px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Area Charts</h1>
+    <p>
+      amCharts has no area series: an area chart is a <code>LineSeries</code>
+      whose <code>fills</code> template has been made visible. That fill is the
+      only runtime signal there is, so it is what the adapter reads — a line
+      with no visible fill stays a line.
+    </p>
+    <p>
+      A <strong>stacked</strong> area draws two magnitudes at every sample: the
+      band's own value, and the running total its top edge sits at. MAIDR
+      announces both, which is why the stacked variants are trace types of
+      their own rather than a line with a fill.
+    </p>
+
+    <h2>Area (independent bands)</h2>
+    <div id="area-chart" class="chart"></div>
+
+    <h2>Stacked area</h2>
+    <div id="stacked-area-chart" class="chart"></div>
+
+    <h2>100% stacked area</h2>
+    <p>
+      The same bands with <code>valueYShow: "valueYTotalPercent"</code>, so each
+      one is a share of a common total.
+    </p>
+    <div id="normalized-area-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      var TRAFFIC_DATA = [
+        { quarter: "Q1", direct: 120, search: 240, social: 60 },
+        { quarter: "Q2", direct: 140, search: 300, social: 110 },
+        { quarter: "Q3", direct: 190, search: 280, social: 180 },
+        { quarter: "Q4", direct: 230, search: 340, social: 260 },
+      ];
+
+      // Build one area chart into `elId`. `mode` is "plain", "stacked" or
+      // "normalized"; nothing else about the series changes.
+      function makeArea(elId, title, mode) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        chart.children.unshift(
+          am5.Label.new(root, { text: title, fontSize: 16, x: am5.p50, centerX: am5.p50 })
+        );
+
+        var xAxis = chart.xAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "quarter",
+            renderer: am5xy.AxisRendererX.new(root, {}),
+          })
+        );
+        xAxis.children.push(am5.Label.new(root, { text: "Quarter", x: am5.p50, centerX: am5.p50 }));
+
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, {
+            // A 100% stack needs the axis to compute the totals it is a share of.
+            calculateTotals: mode === "normalized",
+            renderer: am5xy.AxisRendererY.new(root, {}),
+          })
+        );
+        yAxis.children.unshift(
+          am5.Label.new(root, { text: "Visits", rotation: -90, y: am5.p50, centerX: am5.p50 })
+        );
+
+        function addBand(name, field) {
+          var series = chart.series.push(
+            am5xy.LineSeries.new(root, {
+              name: name,
+              xAxis: xAxis,
+              yAxis: yAxis,
+              valueYField: field,
+              categoryXField: "quarter",
+              stacked: mode !== "plain",
+              valueYShow: mode === "normalized" ? "valueYTotalPercent" : undefined,
+            })
+          );
+          // THIS is what makes it an area rather than a line, for amCharts and
+          // for MAIDR alike.
+          series.fills.template.setAll({ visible: true, fillOpacity: 0.4 });
+          series.data.setAll(TRAFFIC_DATA);
+        }
+
+        addBand("Direct", "direct");
+        addBand("Search", "search");
+        addBand("Social", "social");
+        xAxis.data.setAll(TRAFFIC_DATA);
+
+        register(root, { title: title, axisLabels: { x: "Quarter", y: "Visits" } });
+      }
+
+      makeArea("area-chart", "Site Visits by Channel", "plain");
+      makeArea("stacked-area-chart", "Site Visits by Channel, Stacked", "stacked");
+      makeArea("normalized-area-chart", "Share of Visits by Channel", "normalized");
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-bump.html
+++ b/examples/amcharts-bump.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Bump Chart</title>
+
+    <!-- 1. Load amCharts 5 (core + XY; a bump chart is line series on an
+         inversed value axis, so no extra module is needed) -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 700px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Bump Chart</h1>
+    <p>
+      A bump chart is rank over time: one line per competitor, plotted on a
+      value axis drawn upside down so first place sits at the top. amCharts has
+      no bump series — the chart is ordinary <code>LineSeries</code> and an
+      <code>AxisRendererY</code> with <code>inversed: true</code> — so the
+      adapter reads the inversion together with the values, which have to be a
+      genuine ranking: whole places, one competitor per place per round, and
+      somebody in first.
+    </p>
+    <p>
+      That distinction is the whole point. A rank is not a magnitude, so read as
+      a line chart the leader would be sonified as the <em>lowest</em> note on
+      the chart and a team climbing the table would be heard falling, on every
+      move, with nothing to say the reading was upside down. MAIDR's bump trace
+      inverts the pitch, announces the places gained or lost alongside the rank,
+      and offers rank-gained / rank-lost rotor units (Alt+Shift+Up/Down) that
+      jump between the rounds where something actually moved.
+    </p>
+
+    <h2>League table by round</h2>
+    <div id="bump-chart" class="chart"></div>
+
+    <h2>Market share position, declared rather than detected</h2>
+    <p>
+      The same chart drawn the right way up. Nothing about the numbers says
+      which way the axis runs, so the <code>bump: true</code> option is what
+      says these lines are places; the values still have to read as a ranking
+      before MAIDR announces them as one.
+    </p>
+    <div id="upright-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      // Ash starts top and finishes bottom while Cyan does the exact reverse,
+      // so the inverted pitch is audible on the first two arrow keys.
+      var LEAGUE_DATA = [
+        { round: "R1", ash: 1, birch: 2, cedar: 3, cyan: 4 },
+        { round: "R2", ash: 2, birch: 3, cedar: 1, cyan: 4 },
+        { round: "R3", ash: 3, birch: 2, cedar: 4, cyan: 1 },
+        { round: "R4", ash: 4, birch: 2, cedar: 3, cyan: 1 },
+      ];
+
+      var SHARE_DATA = [
+        { quarter: "Q1", north: 1, south: 2, east: 3 },
+        { quarter: "Q2", north: 2, south: 1, east: 3 },
+        { quarter: "Q3", north: 3, south: 1, east: 2 },
+        { quarter: "Q4", north: 2, south: 3, east: 1 },
+      ];
+
+      // A rank table: a category axis of periods, and a value axis whose
+      // renderer is inversed so rank 1 is drawn at the top. `min`/`max` keep
+      // the places on whole gridlines.
+      function makeRankChart(elId, title, categoryField, data, competitors, inversed) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        chart.children.unshift(
+          am5.Label.new(root, { text: title, fontSize: 16, x: am5.p50, centerX: am5.p50 })
+        );
+
+        var xAxis = chart.xAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: categoryField,
+            renderer: am5xy.AxisRendererX.new(root, {}),
+          })
+        );
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, {
+            min: 1,
+            max: competitors,
+            strictMinMax: true,
+            renderer: am5xy.AxisRendererY.new(root, { inversed: inversed }),
+          })
+        );
+        xAxis.data.setAll(data);
+
+        return { root: root, chart: chart, xAxis: xAxis, yAxis: yAxis };
+      }
+
+      // One line per competitor, with a bullet on each place so the highlight
+      // box has a mark to sit on.
+      function addCompetitor(built, name, field, categoryField, data) {
+        var series = built.chart.series.push(
+          am5xy.LineSeries.new(built.root, {
+            name: name,
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueYField: field,
+            categoryXField: categoryField,
+          })
+        );
+        series.bullets.push(function () {
+          return am5.Bullet.new(built.root, {
+            sprite: am5.Circle.new(built.root, {
+              radius: 5,
+              fill: series.get("fill"),
+            }),
+          });
+        });
+        series.data.setAll(data);
+      }
+
+      // Detected: the inversed axis and the places agree, so no option needed.
+      (function () {
+        var built = makeRankChart(
+          "bump-chart", "League Table by Round", "round", LEAGUE_DATA, 4, true
+        );
+        [["Ash", "ash"], ["Birch", "birch"], ["Cedar", "cedar"], ["Cyan", "cyan"]]
+          .forEach(function (pair) {
+            addCompetitor(built, pair[0], pair[1], "round", LEAGUE_DATA);
+          });
+        register(built.root, {
+          title: "League Table by Round",
+          axisLabels: { x: "Round", y: "Rank" },
+        });
+      })();
+
+      // Declared: the axis runs the ordinary way up, so the option is what
+      // says these lines carry places.
+      (function () {
+        var built = makeRankChart(
+          "upright-chart", "Market Share Position", "quarter", SHARE_DATA, 3, false
+        );
+        [["North", "north"], ["South", "south"], ["East", "east"]]
+          .forEach(function (pair) {
+            addCompetitor(built, pair[0], pair[1], "quarter", SHARE_DATA);
+          });
+        register(built.root, {
+          title: "Market Share Position",
+          axisLabels: { x: "Quarter", y: "Position" },
+          bump: true,
+        });
+      })();
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-floating-columns.html
+++ b/examples/amcharts-floating-columns.html
@@ -1,0 +1,273 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Floating-Column Charts</title>
+
+    <!-- 1. Load amCharts 5 (core + XY charts) -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 640px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Floating-Column Charts</h1>
+    <p>
+      amCharts draws three different charts with the same construct: a
+      <code>ColumnSeries</code> whose bars float between two values instead of
+      rising from a baseline. What the interval means is what makes them three
+      charts, and MAIDR reads each one as what it is.
+    </p>
+    <ul>
+      <li>
+        A <strong>waterfall</strong> chains — each bar opens where the one
+        before it closed — so it carries a contribution and a running total,
+        and the pitch follows the contribution.
+      </li>
+      <li>
+        A <strong>dumbbell</strong>'s pairs are independent, so the finding is
+        the change between the two ends. Up and Down walk the ends, Left and
+        Right the categories.
+      </li>
+      <li>
+        A <strong>gantt</strong>'s interval is a stretch of time. Pitch carries
+        the length and stereo position carries the start, so two tasks that
+        overlap sound like they overlap.
+      </li>
+    </ul>
+
+    <h2>Waterfall: quarterly budget bridge</h2>
+    <div id="waterfall-chart" class="chart"></div>
+
+    <h2>Dumbbell: life expectancy, 1990 against 2020</h2>
+    <div id="dumbbell-chart" class="chart"></div>
+
+    <h2>Gantt: project schedule</h2>
+    <div id="gantt-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      function makeChart(elId, title) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        chart.children.unshift(
+          am5.Label.new(root, { text: title, fontSize: 16, x: am5.p50, centerX: am5.p50 })
+        );
+        return { root: root, chart: chart };
+      }
+
+      // --- Waterfall ------------------------------------------------------
+      // The opening and closing bars sit on the baseline (open: 0); every other
+      // bar opens where the previous one closed. That chain is what tells the
+      // adapter this is a bridge and not a barbell.
+      (function () {
+        var built = makeChart("waterfall-chart", "Quarterly Budget Bridge");
+        var chart = built.chart;
+        var root = built.root;
+
+        var xAxis = chart.xAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "category",
+            renderer: am5xy.AxisRendererX.new(root, {}),
+          })
+        );
+        xAxis.children.push(am5.Label.new(root, { text: "Step", x: am5.p50, centerX: am5.p50 }));
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) })
+        );
+        yAxis.children.unshift(
+          am5.Label.new(root, { text: "Amount (thousands)", rotation: -90, y: am5.p50, centerX: am5.p50 })
+        );
+
+        var series = chart.series.push(
+          am5xy.ColumnSeries.new(root, {
+            name: "Budget",
+            xAxis: xAxis,
+            yAxis: yAxis,
+            categoryXField: "category",
+            openValueYField: "open",
+            valueYField: "value",
+          })
+        );
+
+        var data = [
+          { category: "Opening", open: 0, value: 1200 },
+          { category: "Marketing", open: 1200, value: 950 },
+          { category: "Sales", open: 950, value: 1430 },
+          { category: "Support", open: 1430, value: 1360 },
+          { category: "Closing", open: 0, value: 1360 },
+        ];
+        xAxis.data.setAll(data);
+        series.data.setAll(data);
+
+        register(root, { title: "Quarterly Budget Bridge" });
+      })();
+
+      // --- Dumbbell -------------------------------------------------------
+      // The same openValueY signature, but the pairs do not chain: row 2 opens
+      // at 74.6 while row 1 closed at 78.4, so this reads as a comparison.
+      (function () {
+        var built = makeChart("dumbbell-chart", "Life Expectancy, 1990 against 2020");
+        var chart = built.chart;
+        var root = built.root;
+
+        var xAxis = chart.xAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "category",
+            renderer: am5xy.AxisRendererX.new(root, {}),
+          })
+        );
+        xAxis.children.push(am5.Label.new(root, { text: "Country", x: am5.p50, centerX: am5.p50 }));
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) })
+        );
+        yAxis.children.unshift(
+          am5.Label.new(root, { text: "Years", rotation: -90, y: am5.p50, centerX: am5.p50 })
+        );
+
+        var series = chart.series.push(
+          am5xy.ColumnSeries.new(root, {
+            name: "Life expectancy",
+            xAxis: xAxis,
+            yAxis: yAxis,
+            categoryXField: "category",
+            openValueYField: "from",
+            valueYField: "to",
+          })
+        );
+        series.columns.template.setAll({ width: 3 });
+        // A dot at each end -- the mark that makes it a barbell on screen.
+        series.bullets.push(function () {
+          return am5.Bullet.new(root, {
+            locationY: 0,
+            sprite: am5.Circle.new(root, { radius: 7, fill: am5.color(0x4c72b0) }),
+          });
+        });
+        series.bullets.push(function () {
+          return am5.Bullet.new(root, {
+            locationY: 1,
+            sprite: am5.Circle.new(root, { radius: 7, fill: am5.color(0xc44e52) }),
+          });
+        });
+
+        var data = [
+          { category: "Denmark", from: 71.2, to: 78.4 },
+          { category: "Latvia", from: 74.6, to: 69.5 },
+          { category: "Malta", from: 76.0, to: 76.0 },
+          { category: "Poland", from: 70.9, to: 75.6 },
+        ];
+        xAxis.data.setAll(data);
+        series.data.setAll(data);
+
+        register(root, {
+          title: "Life Expectancy, 1990 against 2020",
+          // amCharts names the series, not the two ends of its columns, so the
+          // years have to be supplied. Drop this and MAIDR announces "start"
+          // and "end" instead.
+          dumbbellLabels: { start: "1990", end: "2020" },
+        });
+      })();
+
+      // --- Gantt ----------------------------------------------------------
+      // Lanes on the category Y axis, time on a DateAxis. The date axis' base
+      // interval is what names the unit MAIDR announces lengths in.
+      (function () {
+        var built = makeChart("gantt-chart", "Project Schedule");
+        var chart = built.chart;
+        var root = built.root;
+
+        var yAxis = chart.yAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "category",
+            renderer: am5xy.AxisRendererY.new(root, { inversed: true }),
+          })
+        );
+        // Every lane is declared on the axis, including the one with nothing
+        // booked -- an empty lane is a real statement about a schedule, and
+        // MAIDR reads the lanes from here so it survives.
+        yAxis.data.setAll([
+          { category: "Design" },
+          { category: "Build" },
+          { category: "Review" },
+          { category: "Launch" },
+        ]);
+
+        var xAxis = chart.xAxes.push(
+          am5xy.DateAxis.new(root, {
+            baseInterval: { timeUnit: "day", count: 1 },
+            renderer: am5xy.AxisRendererX.new(root, {}),
+          })
+        );
+        xAxis.children.push(am5.Label.new(root, { text: "Day", x: am5.p50, centerX: am5.p50 }));
+
+        var series = chart.series.push(
+          am5xy.ColumnSeries.new(root, {
+            name: "Schedule",
+            xAxis: xAxis,
+            yAxis: yAxis,
+            categoryYField: "category",
+            openValueXField: "start",
+            valueXField: "end",
+          })
+        );
+        series.data.processor = am5.DataProcessor.new(root, {
+          dateFields: ["start", "end"],
+          dateFormat: "yyyy-MM-dd",
+        });
+        series.data.setAll([
+          { category: "Design", start: "2024-01-01", end: "2024-01-31" },
+          { category: "Design", start: "2024-03-01", end: "2024-03-16" },
+          { category: "Build", start: "2024-01-31", end: "2024-04-10" },
+          { category: "Review", start: "2024-03-16", end: "2024-03-31" },
+        ]);
+
+        register(root, { title: "Project Schedule" });
+      })();
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-funnel.html
+++ b/examples/amcharts-funnel.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Funnel Chart</title>
+
+    <!-- 1. Load amCharts 5 (core + percent charts, where SlicedChart lives) -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/percent.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 600px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Funnel Chart</h1>
+    <p>
+      A funnel is a population shrinking across ordered stages, and the number
+      a reader wants is not the one the chart plots: it is the
+      <strong>retention</strong> between adjacent stages. That is a ratio, and
+      a listener cannot take a ratio by ear from two heights heard one at a
+      time — so the pitch carries the retention and the counts are announced
+      alongside it.
+    </p>
+    <p>
+      Left and Right move between stages. amCharts' pyramid and pictorial
+      stacked series carry the same ordered stages and read the same way.
+    </p>
+
+    <h2>Funnel: checkout</h2>
+    <div id="funnel-chart" class="chart"></div>
+
+    <h2>Pyramid: the same stages, drawn as a triangle</h2>
+    <div id="pyramid-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      var CHECKOUT_DATA = [
+        { stage: "Visited", people: 10000 },
+        { stage: "Signed up", people: 2400 },
+        { stage: "Viewed cart", people: 2300 },
+        { stage: "Purchased", people: 100 },
+      ];
+
+      // Build one sliced chart into `elId`. `seriesClass` is either
+      // am5percent.FunnelSeries or am5percent.PyramidSeries — the data, and
+      // everything MAIDR reads, are identical.
+      function makeSliced(elId, title, seriesClass) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5percent.SlicedChart.new(root, { layout: root.verticalLayout })
+        );
+        chart.children.unshift(
+          am5.Label.new(root, { text: title, fontSize: 16, x: am5.p50, centerX: am5.p50 })
+        );
+        var series = chart.series.push(
+          seriesClass.new(root, {
+            name: "Checkout",
+            valueField: "people",
+            categoryField: "stage",
+            alignLabels: false,
+          })
+        );
+        series.data.setAll(CHECKOUT_DATA);
+
+        register(root, {
+          title: title,
+          // A sliced chart is bound to no axis, so there is no axis title to
+          // extract. Drop these and the adapter falls back to "Stage" and
+          // "Value".
+          axisLabels: { x: "Stage", y: "People" },
+        });
+      }
+
+      makeSliced("funnel-chart", "Checkout Funnel", am5percent.FunnelSeries);
+      makeSliced("pyramid-chart", "Checkout Funnel, as a Pyramid", am5percent.PyramidSeries);
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-marks.html
+++ b/examples/amcharts-marks.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Pyramid, Dot Plot and Lollipop</title>
+
+    <!-- 1. Load amCharts 5 (core + XY). All three charts here are ordinary XY
+         charts: amCharts has no series class for any of them. -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 640px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Pyramid, Dot Plot and Lollipop</h1>
+    <p>
+      amCharts has no series class for any of these three, so each is an
+      ordinary XY series styled into the mark the author wanted. What the
+      adapter reads is therefore what the data says — a pyramid is two column
+      series on opposite sides of the baseline — or, where the data says
+      nothing, what the styling says: a hairline column with a bullet on the
+      end is a lollipop.
+    </p>
+
+    <h2>Population pyramid: two column series, one side negated</h2>
+    <div id="pyramid-chart" class="chart"></div>
+
+    <h2>Cleveland dot plot: a line series with its stroke switched off</h2>
+    <div id="dot-chart" class="chart"></div>
+
+    <h2>Lollipop: columns narrowed to a stem</h2>
+    <div id="lollipop-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      /** A chart with a category Y axis (bars lying on their side). */
+      function horizontalChart(elId, categories) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        var yAxis = chart.yAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "category",
+            renderer: am5xy.AxisRendererY.new(root, { inversed: true }),
+          })
+        );
+        yAxis.data.setAll(categories);
+        var xAxis = chart.xAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererX.new(root, {}) })
+        );
+        return { root: root, chart: chart, xAxis: xAxis, yAxis: yAxis };
+      }
+
+      // --- Population pyramid -------------------------------------------
+      // One side's values are negated, which is what draws it to the left of
+      // the baseline. MAIDR reads them signed: the pitch takes the size and
+      // the announcement names the side, and the summary row is the balance
+      // between the two rather than a "sum" that came out negative.
+      var PYRAMID = [
+        { category: "0-14", men: -1200, women: 1140 },
+        { category: "15-29", men: -1150, women: 1100 },
+        { category: "30-44", men: -1080, women: 1060 },
+        { category: "45-59", men: -990, women: 1010 },
+        { category: "60-74", men: -720, women: 830 },
+        { category: "75+", men: -310, women: 520 },
+      ];
+
+      (function () {
+        var built = horizontalChart("pyramid-chart", PYRAMID);
+        ["men", "women"].forEach(function (field) {
+          var series = built.chart.series.push(
+            am5xy.ColumnSeries.new(built.root, {
+              name: field === "men" ? "Men" : "Women",
+              xAxis: built.xAxis,
+              yAxis: built.yAxis,
+              valueXField: field,
+              categoryYField: "category",
+            })
+          );
+          series.data.setAll(PYRAMID);
+        });
+
+        register(built.root, {
+          title: "Population by Age Band",
+          axisLabels: { x: "People, thousands", y: "Age band" },
+        });
+      })();
+
+      // --- Cleveland dot plot -------------------------------------------
+      // A LineSeries with no stroke and bullets on it: what is drawn is the
+      // points alone. Both halves matter — with a stroke it would be a line
+      // chart with markers, and without the bullets it would draw nothing.
+      var RESPONSE = [
+        { category: "/search", ms: 412 },
+        { category: "/checkout", ms: 318 },
+        { category: "/profile", ms: 214 },
+        { category: "/health", ms: 96 },
+      ];
+
+      (function () {
+        var built = horizontalChart("dot-chart", RESPONSE);
+        var series = built.chart.series.push(
+          am5xy.LineSeries.new(built.root, {
+            name: "Median response time",
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueXField: "ms",
+            categoryYField: "category",
+          })
+        );
+        series.strokes.template.setAll({ strokeOpacity: 0 });
+        series.bullets.push(function () {
+          return am5.Bullet.new(built.root, {
+            sprite: am5.Circle.new(built.root, {
+              radius: 6,
+              fill: series.get("fill"),
+            }),
+          });
+        });
+        series.data.setAll(RESPONSE);
+
+        register(built.root, {
+          title: "Median Response Time by Endpoint",
+          axisLabels: { x: "Milliseconds", y: "Endpoint" },
+        });
+      })();
+
+      // --- Lollipop ------------------------------------------------------
+      // A column narrowed to a hairline with a bullet on the end. The width is
+      // the only signal there is, so the bullets are what keep a merely narrow
+      // bar chart from being read as one.
+      var LIFE = [
+        { category: "Norway", years: 84 },
+        { category: "Japan", years: 81 },
+        { category: "Chile", years: 74 },
+        { category: "India", years: 61 },
+        { category: "Nigeria", years: 53 },
+      ];
+
+      (function () {
+        var root = am5.Root.new("lollipop-chart");
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        var xAxis = chart.xAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "category",
+            renderer: am5xy.AxisRendererX.new(root, {}),
+          })
+        );
+        xAxis.data.setAll(LIFE);
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) })
+        );
+
+        var series = chart.series.push(
+          am5xy.ColumnSeries.new(root, {
+            name: "Life expectancy",
+            xAxis: xAxis,
+            yAxis: yAxis,
+            valueYField: "years",
+            categoryXField: "category",
+          })
+        );
+        series.columns.template.setAll({ width: 2 });
+        series.bullets.push(function () {
+          return am5.Bullet.new(root, {
+            sprite: am5.Circle.new(root, { radius: 7, fill: series.get("fill") }),
+          });
+        });
+        series.data.setAll(LIFE);
+
+        register(root, {
+          title: "Life Expectancy at Birth",
+          axisLabels: { x: "Country", y: "Years" },
+        });
+      })();
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-radar.html
+++ b/examples/amcharts-radar.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Radar and Polar Area Charts</title>
+
+    <!-- 1. Load amCharts 5 (core + XY + radar; a RadarChart extends XYChart) -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/radar.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 600px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Radar and Polar Area Charts</h1>
+    <p>
+      A radar puts its categories around a circle rather than along an axis,
+      and MAIDR reads it as a multi-line layer: each spoke is a column, each
+      series a row. What the circle adds is where a spoke <em>sits</em> — the
+      stereo position follows the spoke's angle instead of its index, so
+      sweeping the spokes goes out and comes back.
+    </p>
+    <p>
+      A polar area (coxcomb, rose) draws the same values as wedges instead of
+      an outline. It is read identically; only the mark differs.
+    </p>
+
+    <h2>Radar: model comparison</h2>
+    <div id="radar-chart" class="chart"></div>
+
+    <h2>Polar area: rainfall by month</h2>
+    <div id="polar-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      var MODEL_DATA = [
+        { attribute: "Speed", a: 8, b: 5 },
+        { attribute: "Range", a: 4, b: 7 },
+        { attribute: "Comfort", a: 6, b: 3 },
+        { attribute: "Price", a: 9, b: 2 },
+        { attribute: "Economy", a: 5, b: 8 },
+        { attribute: "Safety", a: 7, b: 6 },
+      ];
+
+      var RAINFALL_DATA = [
+        { month: "Jan", mm: 78 }, { month: "Feb", mm: 61 },
+        { month: "Mar", mm: 55 }, { month: "Apr", mm: 42 },
+        { month: "May", mm: 30 }, { month: "Jun", mm: 18 },
+        { month: "Jul", mm: 12 }, { month: "Aug", mm: 16 },
+        { month: "Sep", mm: 34 }, { month: "Oct", mm: 58 },
+        { month: "Nov", mm: 72 }, { month: "Dec", mm: 85 },
+      ];
+
+      // A RadarChart with a category axis around the circle and a value axis
+      // out along the radius. Both marks below share this setup.
+      function makeRadarChart(elId, title, categoryField, data) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5radar.RadarChart.new(root, { layout: root.verticalLayout })
+        );
+        chart.children.unshift(
+          am5.Label.new(root, { text: title, fontSize: 16, x: am5.p50, centerX: am5.p50 })
+        );
+
+        var xAxis = chart.xAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: categoryField,
+            renderer: am5radar.AxisRendererCircular.new(root, {}),
+          })
+        );
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, {
+            renderer: am5radar.AxisRendererRadial.new(root, {}),
+          })
+        );
+        xAxis.data.setAll(data);
+
+        return { root: root, chart: chart, xAxis: xAxis, yAxis: yAxis };
+      }
+
+      // Radar: one closed outline per model.
+      (function () {
+        var built = makeRadarChart(
+          "radar-chart", "Model Comparison", "attribute", MODEL_DATA
+        );
+        ["a", "b"].forEach(function (field, index) {
+          var series = built.chart.series.push(
+            am5radar.RadarLineSeries.new(built.root, {
+              name: "Model " + (index === 0 ? "A" : "B"),
+              xAxis: built.xAxis,
+              yAxis: built.yAxis,
+              valueYField: field,
+              categoryXField: "attribute",
+            })
+          );
+          series.data.setAll(MODEL_DATA);
+        });
+        register(built.root, {
+          title: "Model Comparison",
+          axisLabels: { x: "Attribute", y: "Score" },
+        });
+      })();
+
+      // Polar area: the same spokes drawn as wedges.
+      (function () {
+        var built = makeRadarChart(
+          "polar-chart", "Rainfall by Month", "month", RAINFALL_DATA
+        );
+        var series = built.chart.series.push(
+          am5radar.RadarColumnSeries.new(built.root, {
+            name: "Rainfall",
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueYField: "mm",
+            categoryXField: "month",
+          })
+        );
+        series.data.setAll(RAINFALL_DATA);
+        register(built.root, {
+          title: "Rainfall by Month",
+          axisLabels: { x: "Month", y: "Rainfall, mm" },
+        });
+      })();
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-treemap.html
+++ b/examples/amcharts-treemap.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Treemap and Icicle</title>
+
+    <!-- 1. Load amCharts 5 (core + hierarchy charts). A hierarchy layout is not
+         a chart: it is a series pushed straight into the root container. -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/hierarchy.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 640px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Treemap and Icicle</h1>
+    <p>
+      A treemap and an icicle draw the same tree with different marks — nested
+      rectangles against stacked bands — so MAIDR reads them the same way: as a
+      tree rather than as a grid. Left and Right move between siblings, Down
+      steps into a node's children, and Up returns to its parent.
+    </p>
+    <p>
+      Only the leaves carry a value here. Every branch total is derived from
+      what is under it, so the chart cannot report a parent that disagrees with
+      its own children.
+    </p>
+
+    <h2>Treemap: world population by region</h2>
+    <div id="treemap-chart" class="chart"></div>
+
+    <h2>Icicle: the same tree, drawn as bands</h2>
+    <div id="icicle-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      // amCharts hierarchy data is ONE root object whose `children` are the
+      // branches. The root is a container for the chart and not a finding, so
+      // MAIDR drops it and starts the reader at the regions.
+      var POPULATION = {
+        name: "World",
+        children: [
+          {
+            name: "Asia",
+            children: [
+              { name: "China", value: 1425 },
+              { name: "India", value: 1428 },
+              { name: "Indonesia", value: 278 },
+              { name: "Japan", value: 124 },
+            ],
+          },
+          {
+            name: "Africa",
+            children: [
+              { name: "Nigeria", value: 224 },
+              { name: "Ethiopia", value: 127 },
+              { name: "Egypt", value: 113 },
+            ],
+          },
+          {
+            name: "Europe",
+            children: [
+              { name: "Russia", value: 144 },
+              { name: "Germany", value: 83 },
+              { name: "France", value: 68 },
+            ],
+          },
+        ],
+      };
+
+      // Build one hierarchy layout into `elId`. `seriesClass` is either
+      // am5hierarchy.Treemap or am5hierarchy.Partition (amCharts' name for the
+      // icicle) — the data, and everything MAIDR reads, are identical.
+      function makeHierarchy(elId, title, seriesClass, extraSettings) {
+        var root = am5.Root.new(elId);
+        var container = root.container.children.push(
+          am5.Container.new(root, {
+            width: am5.percent(100),
+            height: am5.percent(100),
+            layout: root.verticalLayout,
+          })
+        );
+        var settings = {
+          name: "Population",
+          singleBranchOnly: false,
+          downDepth: 2,
+          initialDepth: 2,
+          topDepth: 1,
+          valueField: "value",
+          categoryField: "name",
+          childDataField: "children",
+        };
+        for (var key in (extraSettings || {})) {
+          settings[key] = extraSettings[key];
+        }
+        var series = container.children.push(seriesClass.new(root, settings));
+        series.data.setAll([POPULATION]);
+        series.set("selectedDataItem", series.dataItems[0]);
+
+        register(root, {
+          title: title,
+          // A tree is bound to no axis, so there is no axis title to extract.
+          // Drop these and the adapter falls back to "Node" and "Value".
+          axisLabels: { x: "Region", y: "Population, millions" },
+        });
+      }
+
+      makeHierarchy("treemap-chart", "World Population by Region", am5hierarchy.Treemap);
+      makeHierarchy(
+        "icicle-chart",
+        "World Population by Region, as an Icicle",
+        am5hierarchy.Partition,
+        { orientation: "vertical" }
+      );
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-wordcloud.html
+++ b/examples/amcharts-wordcloud.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Word Cloud</title>
+
+    <!-- 1. Load amCharts 5 (core + word cloud). Like a hierarchy layout, a word
+         cloud is not a chart: it is a series pushed straight into the root
+         container. -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/wc.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over the chart, so the core maidr.js
+         script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      .chart {
+        width: 640px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Word Cloud</h1>
+    <p>
+      A word cloud is the canonical chart that carries real data while being
+      readable only by eye: each term's weight is drawn as glyph size and
+      written down nowhere on the page. MAIDR announces the number alongside
+      the term.
+    </p>
+    <p>
+      The packing is chosen to fit glyphs into a rectangle and encodes nothing,
+      so the reader walks the terms <strong>heaviest first</strong> rather than
+      in layout order — and the highlight box follows onto the right glyph,
+      rotated words included.
+    </p>
+
+    <div id="wordcloud-chart" class="chart"></div>
+
+    <script>
+      var TERMS = [
+        { tag: "machine", count: 412 },
+        { tag: "tensor", count: 233 },
+        { tag: "neural", count: 128 },
+        { tag: "embedding", count: 96 },
+        { tag: "gradient", count: 57 },
+        { tag: "attention", count: 184 },
+        { tag: "transformer", count: 141 },
+        { tag: "corpus", count: 44 },
+      ];
+
+      var root = am5.Root.new("wordcloud-chart");
+      // The series goes straight into the root container: there is no chart
+      // object, which is why the adapter recognises the series itself and
+      // treats it as one panel.
+      var series = root.container.children.push(
+        am5wc.WordCloud.new(root, {
+          categoryField: "tag",
+          valueField: "count",
+          maxFontSize: am5.percent(20),
+          minFontSize: am5.percent(5),
+        })
+      );
+      series.data.setAll(TERMS);
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         via the `maidrAmCharts` UMD global. In production, prefer listening to
+         the series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      setTimeout(function () {
+        try {
+          maidrAmCharts.bindAmCharts(root, {
+            title: "Terms in the Abstracts",
+            // A cloud is bound to no axis; drop these and the adapter falls
+            // back to "Term" and "Weight".
+            axisLabels: { x: "Term", y: "Occurrences" },
+          });
+        } catch (err) {
+          console.error('MAIDR amCharts bind failed:', err);
+        }
+      }, 1500);
+    </script>
+  </body>
+</html>

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -25,6 +25,8 @@
 
 import type {
   BarPoint,
+  DumbbellData,
+  GanttData,
   HeatmapData,
   HistogramPoint,
   LinePoint,
@@ -33,6 +35,8 @@ import type {
   MaidrSubplot,
   PiePoint,
   SegmentedPoint,
+  TreemapPoint,
+  WaterfallPoint,
 } from '@type/grammar';
 import type {
   AmChart,
@@ -44,11 +48,16 @@ import { Orientation, TraceType } from '@type/grammar';
 import {
   classifySeriesKind,
   extractBarPoints,
+  extractDumbbellPoints,
+  extractGanttData,
   extractHeatmapData,
+  extractHierarchyPoints,
   extractHistogramPoints,
   extractLinePoints,
   extractPiePoints,
   extractSegmentedPoints,
+  extractWaterfallPoints,
+  HIERARCHY_CLASSES,
   readAxisLabel,
 } from './extractor';
 import { computeChartGrid } from './geometry';
@@ -303,6 +312,35 @@ function buildChartLayers(
         layers.push(buildFunnelLayer(series, data, options));
         break;
       }
+      case 'waterfall': {
+        const data = extractWaterfallPoints(series);
+        if (data.length === 0)
+          break;
+        layers.push(buildWaterfallLayer(series, data, xLabel, yLabel, containerEl));
+        break;
+      }
+      case 'dumbbell': {
+        const points = extractDumbbellPoints(series);
+        if (points.length === 0)
+          break;
+        layers.push(buildDumbbellLayer(series, points, xLabel, yLabel, containerEl, options));
+        break;
+      }
+      case 'gantt': {
+        const data = extractGanttData(series);
+        if (!data)
+          break;
+        layers.push(buildGanttLayer(series, data, xLabel, yLabel, containerEl));
+        break;
+      }
+      case 'treemap':
+      case 'icicle': {
+        const data = extractHierarchyPoints(series);
+        if (data.length === 0)
+          break;
+        layers.push(buildHierarchyLayer(series, kind, data, options));
+        break;
+      }
       default:
         // Skip unsupported series types.
         break;
@@ -442,6 +480,134 @@ function buildSegmentedLayer(
     ...(combinedSelector ? { selectors: combinedSelector } : {}),
     ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
     axes: { x: { label: xLabel }, y: { label: yLabel } },
+    data,
+  };
+}
+
+/**
+ * Builds the layer for one waterfall series.
+ *
+ * The columns keep the order amCharts drew them in, which is what the reading
+ * depends on: a bridge is a sequence, and each step is announced against the
+ * running total the step before it produced.
+ */
+function buildWaterfallLayer(
+  series: AmXYSeries,
+  data: WaterfallPoint[],
+  xLabel: string,
+  yLabel: string,
+  containerEl: HTMLElement,
+): MaidrLayer {
+  const selector = buildColumnSelector(series, containerEl);
+
+  return {
+    id: layerId(series),
+    type: TraceType.WATERFALL,
+    title: seriesName(series),
+    ...(selector ? { selectors: selector } : {}),
+    axes: { x: { label: xLabel }, y: { label: yLabel } },
+    data,
+  };
+}
+
+/**
+ * Builds the layer for one dumbbell series.
+ *
+ * The two ends are named from the binder options when they were supplied —
+ * see {@link AmChartsBinderOptions.dumbbellLabels} for why they cannot come
+ * off the chart.
+ */
+function buildDumbbellLayer(
+  series: AmXYSeries,
+  points: DumbbellData['points'],
+  xLabel: string,
+  yLabel: string,
+  containerEl: HTMLElement,
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  const selector = buildColumnSelector(series, containerEl);
+  const labels = options?.dumbbellLabels;
+
+  return {
+    id: layerId(series),
+    type: TraceType.DUMBBELL,
+    title: seriesName(series),
+    ...(selector ? { selectors: selector } : {}),
+    axes: { x: { label: xLabel }, y: { label: yLabel } },
+    data: {
+      points,
+      ...(labels?.start ? { startLabel: labels.start } : {}),
+      ...(labels?.end ? { endLabel: labels.end } : {}),
+    },
+  };
+}
+
+/**
+ * Builds the layer for one gantt series.
+ *
+ * Always horizontal: amCharts draws a schedule with the lanes on the category
+ * Y axis and time running left to right, which is what the detection matched
+ * on, so the announcement puts the lane on the main axis and the interval on
+ * the cross one.
+ */
+function buildGanttLayer(
+  series: AmXYSeries,
+  data: GanttData,
+  xLabel: string,
+  yLabel: string,
+  containerEl: HTMLElement,
+): MaidrLayer {
+  const selector = buildColumnSelector(series, containerEl);
+
+  return {
+    id: layerId(series),
+    type: TraceType.GANTT,
+    title: seriesName(series),
+    ...(selector ? { selectors: selector } : {}),
+    orientation: Orientation.HORIZONTAL,
+    axes: { x: { label: xLabel }, y: { label: yLabel } },
+    data,
+  };
+}
+
+/**
+ * What a hierarchy's two dimensions are called. A treemap is bound to no axis,
+ * so the chart-level fallback would name them `x` and `y` — after coordinates
+ * a tree does not have.
+ */
+const HIERARCHY_NODE_AXIS = 'Node';
+const HIERARCHY_VALUE_AXIS = 'Value';
+
+/** The trace type each hierarchy layout is announced as. */
+const HIERARCHY_TRACE_TYPES = {
+  treemap: TraceType.TREEMAP,
+  icicle: TraceType.ICICLE,
+} as const;
+
+/**
+ * Builds the layer for one am5hierarchy series — a treemap, or the icicle
+ * amCharts calls a `Partition`.
+ *
+ * The two draw the same tree with different marks, so they differ here only in
+ * which trace type they name; MAIDR navigates both as a tree either way.
+ *
+ * No `selectors`, for the reason a pie emits none — amCharts paints the nodes
+ * into a canvas. The binder's overlay highlights the active node's rectangle.
+ */
+function buildHierarchyLayer(
+  series: AmXYSeries,
+  kind: 'treemap' | 'icicle',
+  data: TreemapPoint[],
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  return {
+    id: layerId(series),
+    type: HIERARCHY_TRACE_TYPES[kind],
+    title: seriesName(series),
+    axes: {
+      x: { label: options?.axisLabels?.x ?? HIERARCHY_NODE_AXIS },
+      y: { label: options?.axisLabels?.y ?? HIERARCHY_VALUE_AXIS },
+    },
     data,
   };
 }
@@ -688,6 +854,11 @@ function collectCharts(node: unknown, found: AmChart[]): void {
       found.push(child);
       continue;
     }
+    const standalone = asStandalonePanel(child);
+    if (standalone) {
+      found.push(standalone);
+      continue;
+    }
     collectCharts(child, found);
   }
 }
@@ -733,6 +904,42 @@ function isPercentChartLike(candidate: unknown): candidate is AmChart {
   return typeof c.className === 'string'
     && PERCENT_CHART_CLASSES.has(c.className)
     && Boolean(c.series);
+}
+
+/**
+ * Wrap a standalone am5 series as the one-series panel it is.
+ *
+ * An am5hierarchy layout is not a chart: it is an `am5.Series` pushed straight
+ * into a container, with no `series` list, no axes and no plot area, so
+ * discovery would recurse past it into its own nodes. Recognising it by class
+ * name and wrapping it gives the rest of the adapter the shape it works in —
+ * one panel, one series — without widening the chart type for a chart that
+ * does not exist.
+ *
+ * The series stands in as its own plot container, which is exactly what it is:
+ * an am5 series IS a `Container`, so the panel it occupies is the box the
+ * series reports. That keeps highlight clipping and multi-panel grid layout
+ * working for it on the same reads every other panel uses.
+ *
+ * @returns The wrapped panel, or `null` for anything that is not one.
+ */
+function asStandalonePanel(candidate: unknown): AmChart | null {
+  if (candidate == null || typeof candidate !== 'object')
+    return null;
+
+  const series = candidate as AmXYSeries;
+  if (typeof series.className !== 'string' || !HIERARCHY_CLASSES.has(series.className))
+    return null;
+  if (!Array.isArray(series.dataItems))
+    return null;
+
+  return {
+    className: series.className,
+    uid: series.uid,
+    get: key => series.get(key),
+    series: { values: [series] },
+    plotContainer: series,
+  };
 }
 
 /**

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -57,6 +57,8 @@ import {
   extractPiePoints,
   extractSegmentedPoints,
   extractWaterfallPoints,
+  hasRankAxis,
+  holdsRanks,
   isDivergingPair,
   readAxisLabel,
   STANDALONE_SERIES_CLASSES,
@@ -257,10 +259,12 @@ function buildChartLayers(
     polar: emptyMergedSeries(),
   };
 
-  // Collect bar series for grouped handling (stacked/dodged/normalized), and
-  // area series for the stacking their merged layer's type has to report.
+  // Collect bar series for grouped handling (stacked/dodged/normalized), area
+  // series for the stacking their merged layer's type has to report, and line
+  // series for the question of whether they carry ranks.
   const barSeriesList: AmXYSeries[] = [];
   const areaSeriesList: AmXYSeries[] = [];
+  const lineSeriesList: AmXYSeries[] = [];
 
   for (const series of chart.series.values) {
     const kind = classifySeriesKind(series);
@@ -308,6 +312,8 @@ function buildChartLayers(
         collectSeries(merged[kind], series, points, containerEl);
         if (kind === 'area')
           areaSeriesList.push(series);
+        else if (kind === 'line')
+          lineSeriesList.push(series);
         break;
       }
       case 'pie': {
@@ -387,7 +393,7 @@ function buildChartLayers(
   // Merge each bucket of point series into a single layer of its own type.
   // The area bucket is the one that has to name its stacking, read from the
   // same per-series settings the bar path reads.
-  pushMerged(layers, merged.line, TraceType.LINE, xLabel, yLabel);
+  pushMerged(layers, merged.line, lineTraceType(lineSeriesList, options), xLabel, yLabel);
   pushMerged(layers, merged.step, TraceType.STEP, xLabel, yLabel);
   pushMerged(layers, merged.area, areaTraceType(areaSeriesList), xLabel, yLabel);
   pushMerged(layers, merged.radar, TraceType.RADAR, xLabel, yLabel);
@@ -407,6 +413,37 @@ function pushMerged(
   if (merged.data.length > 0) {
     layers.push(buildLineLayer(merged, type, xLabel, yLabel));
   }
+}
+
+/**
+ * The trace type a line layer reports: a bump chart when its lines carry ranks
+ * rather than magnitudes.
+ *
+ * A rank is not a magnitude — first place is the smallest number — so a bump
+ * chart read as a line chart sonifies the leader as the lowest note it has, and
+ * a team climbing the table is heard falling on every move. Getting this right
+ * is the whole of what the trace type buys, and getting it wrong inverts a
+ * reading that has nothing to say it is upside down, so both halves of the
+ * signature must agree: the axis has to be drawn as a rank axis, and the values
+ * have to be ranks. See {@link hasRankAxis} and {@link holdsRanks}.
+ *
+ * {@link AmChartsBinderOptions.bump} settles the case amCharts leaves
+ * ambiguous, and is asked in the order the two answers deserve — `false`
+ * suppresses the reading outright, while `true` stands in for the axis alone
+ * and still requires the data to be ranks. That asymmetry is deliberate: the
+ * option is figure-wide, so a `true` meant for one panel must not invert the
+ * pitch of a plain line chart in the next one.
+ */
+function lineTraceType(
+  lineSeriesList: AmXYSeries[],
+  options?: AmChartsBinderOptions,
+): MergedTraceType {
+  if (options?.bump === false || !holdsRanks(lineSeriesList))
+    return TraceType.LINE;
+
+  return options?.bump === true || hasRankAxis(lineSeriesList)
+    ? TraceType.BUMP
+    : TraceType.LINE;
 }
 
 /**
@@ -795,6 +832,7 @@ type MergedKind = 'line' | 'step' | 'area' | 'radar' | 'polar';
 /** The trace types those merged layers are emitted as. */
 type MergedTraceType
   = | TraceType.LINE
+    | TraceType.BUMP
     | TraceType.STEP
     | TraceType.AREA
     | TraceType.STACKED_AREA
@@ -805,6 +843,7 @@ type MergedTraceType
 /** Layer-id prefix per merged type, so an id still names what it holds. */
 const MERGED_ID_PREFIX: Record<MergedTraceType, string> = {
   [TraceType.LINE]: 'line',
+  [TraceType.BUMP]: 'bump',
   [TraceType.STEP]: 'step',
   [TraceType.AREA]: 'area',
   [TraceType.STACKED_AREA]: 'area',

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -57,8 +57,9 @@ import {
   extractPiePoints,
   extractSegmentedPoints,
   extractWaterfallPoints,
-  HIERARCHY_CLASSES,
+  isDivergingPair,
   readAxisLabel,
+  STANDALONE_SERIES_CLASSES,
 } from './extractor';
 import { computeChartGrid } from './geometry';
 import {
@@ -269,6 +270,19 @@ function buildChartLayers(
         barSeriesList.push(series);
         break;
       }
+      case 'dot':
+      case 'lollipop': {
+        // A dot plot and a lollipop hold a bar chart's categories and values;
+        // only the mark differs, so only the trace type does. They never join
+        // the bar list: a chart drawing both would otherwise have them read as
+        // two groups of one segmented chart.
+        const data = extractBarPoints(series);
+        if (data.length === 0)
+          break;
+        const type = kind === 'dot' ? TraceType.DOT : TraceType.LOLLIPOP;
+        layers.push(buildBarLayer(series, type, data, xLabel, yLabel, containerEl));
+        break;
+      }
       case 'histogram': {
         const data = extractHistogramPoints(series);
         if (data.length === 0)
@@ -341,6 +355,15 @@ function buildChartLayers(
         layers.push(buildHierarchyLayer(series, kind, data, options));
         break;
       }
+      case 'wordcloud': {
+        // A term carries the same category/value pair a pie slice does, so the
+        // same extraction serves both.
+        const data = extractPiePoints(series);
+        if (data.length === 0)
+          break;
+        layers.push(buildWordCloudLayer(series, data, options));
+        break;
+      }
       default:
         // Skip unsupported series types.
         break;
@@ -352,7 +375,7 @@ function buildChartLayers(
     const series = barSeriesList[0];
     const data = extractBarPoints(series);
     if (data.length > 0) {
-      layers.push(buildBarLayer(series, data, xLabel, yLabel, containerEl));
+      layers.push(buildBarLayer(series, TraceType.BAR, data, xLabel, yLabel, containerEl));
     }
   } else if (barSeriesList.length > 1) {
     const layer = buildSegmentedLayer(barSeriesList, xLabel, yLabel, containerEl);
@@ -411,8 +434,23 @@ function areaTraceType(areaSeriesList: AmXYSeries[]): MergedTraceType {
 // Layer builders
 // ---------------------------------------------------------------------------
 
+/**
+ * The trace types a bar chart's reading serves: the bar itself, and the two
+ * marks that hold one category and one value while drawing them differently.
+ */
+type MarkTraceType = TraceType.BAR | TraceType.DOT | TraceType.LOLLIPOP;
+
+/**
+ * Builds the layer for one bar-shaped series — a bar chart, a Cleveland dot
+ * plot, or a lollipop.
+ *
+ * All three carry one category and one value per mark and are navigated
+ * identically; the type names the chart the author drew, which is the whole of
+ * what a reader gains from the distinction.
+ */
 function buildBarLayer(
   series: AmXYSeries,
+  type: MarkTraceType,
   data: BarPoint[],
   xLabel: string,
   yLabel: string,
@@ -423,7 +461,7 @@ function buildBarLayer(
 
   return {
     id: layerId(series),
-    type: TraceType.BAR,
+    type,
     title: seriesName(series),
     ...(selector ? { selectors: selector } : {}),
     ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
@@ -449,7 +487,11 @@ function buildSegmentedLayer(
       traceType = TraceType.NORMALIZED;
       break;
     default:
-      traceType = TraceType.DODGED;
+      // Two series drawn back to back rather than side by side. Asked only of
+      // an unstacked group, because the two sides of a pyramid sit either side
+      // of the baseline rather than on top of one another — a stack that says
+      // it is stacked is taken at its word.
+      traceType = isDivergingPair(barSeriesList) ? TraceType.DIVERGING : TraceType.DODGED;
   }
 
   // Each series becomes one group (row) in the SegmentedPoint[][] grid.
@@ -696,6 +738,41 @@ function buildFunnelLayer(
   };
 }
 
+/**
+ * What a word cloud's two dimensions are called. A cloud is bound to no axis —
+ * its layout is chosen to pack glyphs and encodes nothing — so the chart-level
+ * fallback would name them after coordinates that carry no meaning at all.
+ */
+const WORD_CLOUD_TERM_AXIS = 'Term';
+const WORD_CLOUD_WEIGHT_AXIS = 'Weight';
+
+/**
+ * Builds the layer for one am5wc word cloud series.
+ *
+ * The terms stay in data order. MAIDR walks them heaviest first — the order a
+ * cloud is read for, since its arrangement carries nothing — and derives that
+ * from the weights themselves, so the layer declares what the chart declared.
+ *
+ * No `selectors`, for the reason a pie emits none — amCharts paints the glyphs
+ * into a canvas. The binder's overlay highlights the active term's label.
+ */
+function buildWordCloudLayer(
+  series: AmXYSeries,
+  data: PiePoint[],
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  return {
+    id: layerId(series),
+    type: TraceType.WORD_CLOUD,
+    title: seriesName(series),
+    axes: {
+      x: { label: options?.axisLabels?.x ?? WORD_CLOUD_TERM_AXIS },
+      y: { label: options?.axisLabels?.y ?? WORD_CLOUD_WEIGHT_AXIS },
+    },
+    data,
+  };
+}
+
 function buildHeatmapLayer(
   data: HeatmapData,
   xLabel: string,
@@ -909,12 +986,12 @@ function isPercentChartLike(candidate: unknown): candidate is AmChart {
 /**
  * Wrap a standalone am5 series as the one-series panel it is.
  *
- * An am5hierarchy layout is not a chart: it is an `am5.Series` pushed straight
- * into a container, with no `series` list, no axes and no plot area, so
- * discovery would recurse past it into its own nodes. Recognising it by class
- * name and wrapping it gives the rest of the adapter the shape it works in —
- * one panel, one series — without widening the chart type for a chart that
- * does not exist.
+ * An am5hierarchy layout and an am5wc word cloud are not charts: each is an
+ * `am5.Series` pushed straight into a container, with no `series` list, no
+ * axes and no plot area, so discovery would recurse past it into its own
+ * nodes. Recognising it by class name and wrapping it gives the rest of the
+ * adapter the shape it works in — one panel, one series — without widening the
+ * chart type for a chart that does not exist.
  *
  * The series stands in as its own plot container, which is exactly what it is:
  * an am5 series IS a `Container`, so the panel it occupies is the box the
@@ -928,7 +1005,7 @@ function asStandalonePanel(candidate: unknown): AmChart | null {
     return null;
 
   const series = candidate as AmXYSeries;
-  if (typeof series.className !== 'string' || !HIERARCHY_CLASSES.has(series.className))
+  if (typeof series.className !== 'string' || !STANDALONE_SERIES_CLASSES.has(series.className))
     return null;
   if (!Array.isArray(series.dataItems))
     return null;

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -2,8 +2,9 @@
  * Main adapter that converts an amCharts 5 chart into a MAIDR data object.
  *
  * Supports single charts and multi-panel roots: every `XYChart` found in the
- * root's container tree (including am5stock `StockPanel`s, which extend
- * `XYChart`) and every am5percent `PieChart` becomes one MAIDR subplot,
+ * root's container tree (including am5stock `StockPanel`s and am5radar
+ * `RadarChart`s, which extend `XYChart`) and every am5percent chart — a
+ * `PieChart` or a funnel's `SlicedChart` — becomes one MAIDR subplot,
  * arranged in a grid mirroring the on-screen layout with rows emitted
  * bottom-first (see {@link computeChartGrid}) so the core's UPWARD = row+1
  * mapping moves visually up.
@@ -83,7 +84,7 @@ export interface AmChartsConversion {
  * Convert an amCharts 5 {@link AmRoot} into a MAIDR data object.
  *
  * The function walks the root's container tree, collects every XY chart
- * (including am5stock `StockPanel`s) and every pie chart, and converts each
+ * (including am5stock `StockPanel`s) and every am5percent chart, and converts each
  * one into a MAIDR subplot. A single chart produces a 1x1 grid; multiple charts are arranged
  * in a grid mirroring their on-screen layout, rows ordered bottom-first so
  * that pressing Up moves to the visually upper panel.
@@ -235,14 +236,21 @@ function buildChartLayers(
   const yLabel = options?.axisLabels?.y ?? readAxisLabel(chart.yAxes?.values[0], 'y');
 
   const layers: MaidrLayer[] = [];
-  // Line and step series each merge into one layer of their own type. The
-  // points are extracted identically — amCharts varies only how it draws
-  // between them — so they differ here only in which bucket they land in.
-  const lineSeries = emptyMergedSeries();
-  const stepSeries = emptyMergedSeries();
+  // Line, step, area and radar series each merge into one layer of their own
+  // type. The points are extracted identically — amCharts varies only how it
+  // draws between them — so they differ here only in which bucket they land in.
+  const merged: Record<MergedKind, MergedSeries> = {
+    line: emptyMergedSeries(),
+    step: emptyMergedSeries(),
+    area: emptyMergedSeries(),
+    radar: emptyMergedSeries(),
+    polar: emptyMergedSeries(),
+  };
 
-  // Collect bar series for grouped handling (stacked/dodged/normalized).
+  // Collect bar series for grouped handling (stacked/dodged/normalized), and
+  // area series for the stacking their merged layer's type has to report.
   const barSeriesList: AmXYSeries[] = [];
+  const areaSeriesList: AmXYSeries[] = [];
 
   for (const series of chart.series.values) {
     const kind = classifySeriesKind(series);
@@ -267,11 +275,16 @@ function buildChartLayers(
         break;
       }
       case 'line':
-      case 'step': {
+      case 'step':
+      case 'area':
+      case 'radar':
+      case 'polar': {
         const points = extractLinePoints(series);
         if (points.length === 0)
           break;
-        collectSeries(kind === 'step' ? stepSeries : lineSeries, series, points, containerEl);
+        collectSeries(merged[kind], series, points, containerEl);
+        if (kind === 'area')
+          areaSeriesList.push(series);
         break;
       }
       case 'pie': {
@@ -279,6 +292,15 @@ function buildChartLayers(
         if (data.length === 0)
           break;
         layers.push(buildPieLayer(series, data, options));
+        break;
+      }
+      case 'funnel': {
+        // A funnel stage carries the same category/value pair a pie slice
+        // does, so the same extraction serves both.
+        const data = extractPiePoints(series);
+        if (data.length === 0)
+          break;
+        layers.push(buildFunnelLayer(series, data, options));
         break;
       }
       default:
@@ -301,16 +323,50 @@ function buildChartLayers(
     }
   }
 
-  // Merge all line series into a single multi-line layer, and likewise the
-  // step series into a step layer of their own.
-  if (lineSeries.data.length > 0) {
-    layers.push(buildLineLayer(lineSeries, TraceType.LINE, xLabel, yLabel));
-  }
-  if (stepSeries.data.length > 0) {
-    layers.push(buildLineLayer(stepSeries, TraceType.STEP, xLabel, yLabel));
-  }
+  // Merge each bucket of point series into a single layer of its own type.
+  // The area bucket is the one that has to name its stacking, read from the
+  // same per-series settings the bar path reads.
+  pushMerged(layers, merged.line, TraceType.LINE, xLabel, yLabel);
+  pushMerged(layers, merged.step, TraceType.STEP, xLabel, yLabel);
+  pushMerged(layers, merged.area, areaTraceType(areaSeriesList), xLabel, yLabel);
+  pushMerged(layers, merged.radar, TraceType.RADAR, xLabel, yLabel);
+  pushMerged(layers, merged.polar, TraceType.POLAR_AREA, xLabel, yLabel);
 
   return layers;
+}
+
+/** Append the merged layer for one bucket, unless the bucket stayed empty. */
+function pushMerged(
+  layers: MaidrLayer[],
+  merged: MergedSeries,
+  type: MergedTraceType,
+  xLabel: string,
+  yLabel: string,
+): void {
+  if (merged.data.length > 0) {
+    layers.push(buildLineLayer(merged, type, xLabel, yLabel));
+  }
+}
+
+/**
+ * The trace type an area layer reports, from how its bands are stacked.
+ *
+ * Every area series of one chart merges into a single layer, so the stacking
+ * is read across the whole group rather than per series: amCharts commonly
+ * sets `stacked` on the bands that sit ON another one and leaves it off the
+ * bottom band, and splitting the group by that flag would strand the bottom
+ * band in an unstacked layer of its own — announcing the one band a reader
+ * would compare the others against as a chart of its own.
+ */
+function areaTraceType(areaSeriesList: AmXYSeries[]): MergedTraceType {
+  switch (detectStackMode(areaSeriesList)) {
+    case 'normal':
+      return TraceType.STACKED_AREA;
+    case '100%':
+      return TraceType.NORMALIZED_AREA;
+    default:
+      return TraceType.AREA;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -442,6 +498,38 @@ function buildPieLayer(
   };
 }
 
+/**
+ * What a funnel's two dimensions are called. Like a pie, a sliced chart is
+ * bound to no axis, so the chart-level fallback would name them `x` and `y`.
+ */
+const FUNNEL_STAGE_AXIS = 'Stage';
+const FUNNEL_VALUE_AXIS = 'Value';
+
+/**
+ * Builds the layer for one am5percent funnel (or pyramid, or pictorial stack)
+ * series. The stages stay in data order, which is what the funnel's retention
+ * reading depends on: MAIDR pitches each stage against the one before it.
+ *
+ * No `selectors`, for the same reason a pie emits none — amCharts paints the
+ * stages into a canvas. The binder's overlay highlights the active stage.
+ */
+function buildFunnelLayer(
+  series: AmXYSeries,
+  data: BarPoint[],
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  return {
+    id: layerId(series),
+    type: TraceType.FUNNEL,
+    title: seriesName(series),
+    axes: {
+      x: { label: options?.axisLabels?.x ?? FUNNEL_STAGE_AXIS },
+      y: { label: options?.axisLabels?.y ?? FUNNEL_VALUE_AXIS },
+    },
+    data,
+  };
+}
+
 function buildHeatmapLayer(
   data: HeatmapData,
   xLabel: string,
@@ -454,6 +542,33 @@ function buildHeatmapLayer(
     data,
   };
 }
+
+/**
+ * Series kinds whose points are extracted identically and merged into one
+ * layer per kind — everything MAIDR reads as a grid of series by samples.
+ */
+type MergedKind = 'line' | 'step' | 'area' | 'radar' | 'polar';
+
+/** The trace types those merged layers are emitted as. */
+type MergedTraceType
+  = | TraceType.LINE
+    | TraceType.STEP
+    | TraceType.AREA
+    | TraceType.STACKED_AREA
+    | TraceType.NORMALIZED_AREA
+    | TraceType.RADAR
+    | TraceType.POLAR_AREA;
+
+/** Layer-id prefix per merged type, so an id still names what it holds. */
+const MERGED_ID_PREFIX: Record<MergedTraceType, string> = {
+  [TraceType.LINE]: 'line',
+  [TraceType.STEP]: 'step',
+  [TraceType.AREA]: 'area',
+  [TraceType.STACKED_AREA]: 'area',
+  [TraceType.NORMALIZED_AREA]: 'area',
+  [TraceType.RADAR]: 'radar',
+  [TraceType.POLAR_AREA]: 'polar',
+};
 
 /**
  * Series that merge into one layer, gathered as the chart is walked.
@@ -503,7 +618,7 @@ function collectSeries(
  */
 function buildLineLayer(
   merged: MergedSeries,
-  type: TraceType.LINE | TraceType.STEP,
+  type: MergedTraceType,
   xLabel: string,
   yLabel: string,
 ): MaidrLayer {
@@ -511,7 +626,7 @@ function buildLineLayer(
   const selectors = merged.selectors;
 
   return {
-    id: `${type === TraceType.STEP ? 'step' : 'line'}-${uid()}`,
+    id: `${MERGED_ID_PREFIX[type]}-${uid()}`,
     type,
     ...(title ? { title } : {}),
     ...(selectors && selectors.length > 0 ? { selectors } : {}),
@@ -569,7 +684,7 @@ function collectCharts(node: unknown, found: AmChart[]): void {
       // Never a panel; its child preview XYChart must not be found either.
       continue;
     }
-    if (isXYChartLike(child) || isPieChartLike(child)) {
+    if (isXYChartLike(child) || isPercentChartLike(child)) {
       found.push(child);
       continue;
     }
@@ -595,31 +710,44 @@ function isXYChartLike(candidate: unknown): candidate is AmChart {
 }
 
 /**
- * Duck-type check for an am5percent `PieChart`.
+ * Charts of the am5percent module: a `PieChart` and the `SlicedChart` that
+ * carries funnels, pyramids and pictorial stacks. Both are `SerialChart`s with
+ * a series list and no axes.
+ */
+const PERCENT_CHART_CLASSES = new Set([
+  'PieChart',
+  'SlicedChart',
+]);
+
+/**
+ * Duck-type check for an am5percent chart.
  *
- * A pie chart has a series list but no axes, which on its own is too weak a
+ * These charts have a series list but no axes, which on its own is too weak a
  * signature — plenty of am5 containers carry a `series` property of some kind.
  * The class name is what makes it specific, and am5 sets it on every entity.
  */
-function isPieChartLike(candidate: unknown): candidate is AmChart {
+function isPercentChartLike(candidate: unknown): candidate is AmChart {
   if (candidate == null || typeof candidate !== 'object')
     return false;
   const c = candidate as Partial<AmChart>;
-  return c.className === 'PieChart' && Boolean(c.series);
+  return typeof c.className === 'string'
+    && PERCENT_CHART_CLASSES.has(c.className)
+    && Boolean(c.series);
 }
 
 /**
- * Detect the stacking mode from a list of column series.
+ * Detect the stacking mode from a list of series that share a layer.
  *
  * In amCharts 5, stacking is a per-series setting, not an axis setting:
- * `series.get('stacked')` is `true` for stacked columns, and a 100%
- * (normalized) stack additionally sets `valueYShow` (or `valueXShow` for
+ * `series.get('stacked')` is `true` for a stacked column or area band, and a
+ * 100% (normalized) stack additionally sets `valueYShow` (or `valueXShow` for
  * horizontal columns) to `'valueYTotalPercent'` / `'valueXTotalPercent'`.
- * Series with no `stacked` flag render side-by-side (dodged).
+ * Columns with no `stacked` flag render side-by-side (dodged); area bands with
+ * none are independent overlapping bands.
  */
-function detectStackMode(barSeriesList: AmXYSeries[]): 'none' | 'normal' | '100%' {
+function detectStackMode(seriesList: AmXYSeries[]): 'none' | 'normal' | '100%' {
   let anyStacked = false;
-  for (const series of barSeriesList) {
+  for (const series of seriesList) {
     if (series.get('stacked') !== true)
       continue;
     anyStacked = true;

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -24,12 +24,11 @@
 import type { Maidr as MaidrData, NavigateCallback } from '@type/grammar';
 import type { JSX } from 'react';
 import type { Root as ReactRoot } from 'react-dom/client';
-import type { NavMap } from './navmap';
+import type { NavMap, SeriesGroups } from './navmap';
 import type {
   AmChart,
   AmChartsBinderOptions,
   AmRoot,
-  AmXYSeries,
 } from './types';
 import { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -125,10 +124,11 @@ function applyHighlight(
   // Clip the highlight to the OWNING panel's visible plot area; a column's
   // geometry can extend to the value=0 baseline beyond a clipped (min > 0)
   // axis, and in multi-panel roots it must not bleed into sibling panels.
-  // A pie panel has no plot container to read, so its rectangle comes from the
-  // wedges instead. The fallback is pie-only by construction — an XY chart's
-  // data items carry no `slice` — so an XY panel with no readable plot area
-  // still falls through to the suppression below.
+  // An am5percent panel (a pie, or a funnel's sliced chart) has no plot
+  // container to read, so its rectangle comes from the slices instead. The
+  // fallback is percent-only by construction — an XY chart's data items carry
+  // no `slice` — so an XY panel with no readable plot area still falls through
+  // to the suppression below.
   const chart = navMap.chartFor(event.layerId);
   const plotBounds = chart ? readPlotBounds(chart) ?? readSliceBounds(chart) : null;
 
@@ -184,54 +184,58 @@ function createHighlightCallback(
 // Series grouping (mirrors fromXYChart in adapter.ts)
 // ---------------------------------------------------------------------------
 
-function groupSeries(chart: AmChart): {
-  barSeriesList: AmXYSeries[];
-  lineSeriesList: AmXYSeries[];
-  stepSeriesList: AmXYSeries[];
-  histogramSeries: AmXYSeries[];
-  heatmapSeries: AmXYSeries[];
-  pieSeriesList: AmXYSeries[];
-} {
-  const barSeriesList: AmXYSeries[] = [];
-  const lineSeriesList: AmXYSeries[] = [];
-  const stepSeriesList: AmXYSeries[] = [];
-  const histogramSeries: AmXYSeries[] = [];
-  const heatmapSeries: AmXYSeries[] = [];
-  const pieSeriesList: AmXYSeries[] = [];
+function groupSeries(chart: AmChart): SeriesGroups {
+  const groups: SeriesGroups = {
+    barSeriesList: [],
+    lineSeriesList: [],
+    stepSeriesList: [],
+    areaSeriesList: [],
+    radarSeriesList: [],
+    polarSeriesList: [],
+    histogramSeries: [],
+    heatmapSeries: [],
+    pieSeriesList: [],
+    funnelSeriesList: [],
+  };
 
   for (const series of chart.series.values) {
     switch (classifySeriesKind(series)) {
       case 'bar':
-        barSeriesList.push(series);
+        groups.barSeriesList.push(series);
         break;
       case 'line':
-        lineSeriesList.push(series);
+        groups.lineSeriesList.push(series);
         break;
       case 'step':
-        stepSeriesList.push(series);
+        groups.stepSeriesList.push(series);
+        break;
+      case 'area':
+        groups.areaSeriesList.push(series);
+        break;
+      case 'radar':
+        groups.radarSeriesList.push(series);
+        break;
+      case 'polar':
+        groups.polarSeriesList.push(series);
         break;
       case 'histogram':
-        histogramSeries.push(series);
+        groups.histogramSeries.push(series);
         break;
       case 'heatmap':
-        heatmapSeries.push(series);
+        groups.heatmapSeries.push(series);
         break;
       case 'pie':
-        pieSeriesList.push(series);
+        groups.pieSeriesList.push(series);
+        break;
+      case 'funnel':
+        groups.funnelSeriesList.push(series);
         break;
       default:
         break;
     }
   }
 
-  return {
-    barSeriesList,
-    lineSeriesList,
-    stepSeriesList,
-    histogramSeries,
-    heatmapSeries,
-    pieSeriesList,
-  };
+  return groups;
 }
 
 // ---------------------------------------------------------------------------
@@ -293,7 +297,7 @@ function renderMaidr(maidrData: MaidrData, rootDom: HTMLElement): RenderResult |
 /**
  * Bind MAIDR to an amCharts 5 {@link AmRoot}, mounting the accessible UI and
  * (by default) a canvas highlight overlay. Finds every XYChart in the root's
- * container tree (including am5stock StockPanels) and every PieChart; each
+ * container tree (including am5stock StockPanels) and every am5percent chart; each
  * chart becomes one MAIDR subplot, navigable with the arrow keys.
  *
  * @throws If no supported chart is found in `root.container`, or if no chart

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -187,6 +187,8 @@ function createHighlightCallback(
 function groupSeries(chart: AmChart): SeriesGroups {
   const groups: SeriesGroups = {
     barSeriesList: [],
+    dotSeriesList: [],
+    lollipopSeriesList: [],
     lineSeriesList: [],
     stepSeriesList: [],
     areaSeriesList: [],
@@ -200,12 +202,22 @@ function groupSeries(chart: AmChart): SeriesGroups {
     dumbbellSeriesList: [],
     ganttSeriesList: [],
     hierarchySeriesList: [],
+    wordCloudSeriesList: [],
   };
 
   for (const series of chart.series.values) {
     switch (classifySeriesKind(series)) {
       case 'bar':
         groups.barSeriesList.push(series);
+        break;
+      // A dot and a lollipop read as a bar chart but are drawn with different
+      // marks, so the highlight measures different sprites and they keep
+      // buckets of their own.
+      case 'dot':
+        groups.dotSeriesList.push(series);
+        break;
+      case 'lollipop':
+        groups.lollipopSeriesList.push(series);
         break;
       case 'line':
         groups.lineSeriesList.push(series);
@@ -248,6 +260,9 @@ function groupSeries(chart: AmChart): SeriesGroups {
       case 'treemap':
       case 'icicle':
         groups.hierarchySeriesList.push(series);
+        break;
+      case 'wordcloud':
+        groups.wordCloudSeriesList.push(series);
         break;
       default:
         break;

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -219,6 +219,9 @@ function groupSeries(chart: AmChart): SeriesGroups {
       case 'lollipop':
         groups.lollipopSeriesList.push(series);
         break;
+      // A bump chart's competitors are line series too. Whether the layer they
+      // merge into is read as ranks is a property of the group, decided where
+      // the layer is built, so the highlight path has one bucket for both.
       case 'line':
         groups.lineSeriesList.push(series);
         break;

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -196,6 +196,10 @@ function groupSeries(chart: AmChart): SeriesGroups {
     heatmapSeries: [],
     pieSeriesList: [],
     funnelSeriesList: [],
+    waterfallSeriesList: [],
+    dumbbellSeriesList: [],
+    ganttSeriesList: [],
+    hierarchySeriesList: [],
   };
 
   for (const series of chart.series.values) {
@@ -229,6 +233,21 @@ function groupSeries(chart: AmChart): SeriesGroups {
         break;
       case 'funnel':
         groups.funnelSeriesList.push(series);
+        break;
+      case 'waterfall':
+        groups.waterfallSeriesList.push(series);
+        break;
+      case 'dumbbell':
+        groups.dumbbellSeriesList.push(series);
+        break;
+      case 'gantt':
+        groups.ganttSeriesList.push(series);
+        break;
+      // A treemap and an icicle draw one tree two ways; the highlight walks
+      // the same nodes either way, so they share a bucket.
+      case 'treemap':
+      case 'icicle':
+        groups.hierarchySeriesList.push(series);
         break;
       default:
         break;

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -5,11 +5,16 @@
 
 import type {
   BarPoint,
+  DumbbellPoint,
+  GanttData,
   HeatmapData,
   HistogramPoint,
   LinePoint,
   PiePoint,
   SegmentedPoint,
+  TreemapPoint,
+  WaterfallKind,
+  WaterfallPoint,
 } from '@type/grammar';
 import type { AmAxis, AmDataItem, AmXYSeries } from './types';
 
@@ -73,6 +78,86 @@ function hasVisibleFill(series: AmXYSeries): boolean {
   if (typeof opacity === 'number')
     return opacity > 0;
   return visible === true;
+}
+
+/**
+ * Where a floating column keeps its two ends.
+ *
+ * A column bound to a date axis may carry its ends as `Date`s under the
+ * `dateX` pair rather than as numbers under the `valueX` one, so both are
+ * tried in turn — the first key that holds anything wins.
+ */
+const OPEN_Y_KEYS = ['openValueY'];
+const VALUE_Y_KEYS = ['valueY'];
+const OPEN_X_KEYS = ['openValueX', 'openDateX'];
+const VALUE_X_KEYS = ['valueX', 'dateX'];
+
+/** One floating column: the category it sits at, and the interval it spans. */
+interface Span {
+  /** The live data item, which the highlight path resolves back to. */
+  item: AmDataItem;
+  category: string | number;
+  start: number;
+  end: number;
+}
+
+/**
+ * Read one end of a span, as a number, from the first key that holds a value.
+ *
+ * A date axis stores a `Date` where a value axis stores a number, and the two
+ * are the same position on the same axis — so the date is read as its
+ * timestamp rather than skipped.
+ */
+function readSpanEnd(item: AmDataItem, keys: readonly string[]): number | null {
+  for (const key of keys) {
+    const value = item.get(key);
+    if (value == null)
+      continue;
+    return toNumber(value instanceof Date ? value.getTime() : value);
+  }
+  return null;
+}
+
+/**
+ * Read every floating column of a series as a category and an interval.
+ *
+ * Shared by the three charts amCharts draws with `openValue*` columns — a
+ * waterfall, a dumbbell and a gantt — which differ in what the interval means
+ * and not in how it is stored. Items missing a category or either end are
+ * skipped, exactly as {@link extractBarPoints} skips them, so an index into
+ * the result keeps naming the column it addresses.
+ */
+function readSpans(
+  series: AmXYSeries,
+  categoryKey: string,
+  openKeys: readonly string[],
+  valueKeys: readonly string[],
+): Span[] {
+  const spans: Span[] = [];
+
+  for (const item of series.dataItems) {
+    const category = item.get(categoryKey);
+    const start = readSpanEnd(item, openKeys);
+    const end = readSpanEnd(item, valueKeys);
+
+    if (category == null || start == null || end == null)
+      continue;
+
+    spans.push({ item, category: toStringOrNumber(category), start, end });
+  }
+
+  return spans;
+}
+
+/**
+ * Strip binary floating-point noise from a magnitude obtained by subtraction.
+ *
+ * `MAIDR`'s own gantt trace does the same to the lengths it derives, for the
+ * same reason: `2.3 - 1.1` announces as `1.2000000000000002` otherwise, and a
+ * waterfall's contribution is the number the chart exists to report.
+ */
+function withoutFloatNoise(value: number): number {
+  return Number(value.toPrecision(12));
 }
 
 // ---------------------------------------------------------------------------
@@ -189,6 +274,248 @@ export function extractHistogramPoints(series: AmXYSeries): HistogramPoint[] {
   }
 
   return points;
+}
+
+// ---------------------------------------------------------------------------
+// Waterfall extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract {@link WaterfallPoint} data from a column series drawn as a bridge.
+ *
+ * The bar floats between the running total before the step and the total after
+ * it, which is the pair amCharts keeps in `openValueY` / `valueY`. Both are
+ * carried, plus the contribution between them: a bar chart would conflate the
+ * two, and "how big was this step" and "where did it leave us" are different
+ * questions.
+ */
+export function extractWaterfallPoints(series: AmXYSeries): WaterfallPoint[] {
+  return readSpans(series, 'categoryX', OPEN_Y_KEYS, VALUE_Y_KEYS).map((span) => {
+    const delta = withoutFloatNoise(span.end - span.start);
+    return {
+      x: span.category,
+      start: span.start,
+      end: span.end,
+      delta,
+      kind: waterfallKind(span.start, delta),
+    };
+  });
+}
+
+/**
+ * Whether a step moves the running total or restates it.
+ *
+ * A bar that sits on the baseline restates it — the opening bar, the closing
+ * bar, and any subtotal drawn along the way — which is the same signature
+ * {@link isWaterfallChain} reads when it decides a series is a bridge at all.
+ */
+function waterfallKind(start: number, delta: number): WaterfallKind {
+  if (start === 0)
+    return 'total';
+  return delta < 0 ? 'decrease' : 'increase';
+}
+
+// ---------------------------------------------------------------------------
+// Dumbbell extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract {@link DumbbellPoint} data from a column series drawn as a barbell.
+ *
+ * The same `openValueY` / `valueY` pair a waterfall uses, read as the two
+ * values compared at one category rather than as a running total: which of the
+ * two is larger is not fixed, and a chart usually holds both directions at
+ * once.
+ *
+ * The two ends are deliberately not named here. amCharts names the series, not
+ * the ends, so anything read off the chart would be a guess; the adapter takes
+ * them from an option instead, and the trace announces "start" and "end" when
+ * it has nothing better.
+ */
+export function extractDumbbellPoints(series: AmXYSeries): DumbbellPoint[] {
+  return readSpans(series, 'categoryX', OPEN_Y_KEYS, VALUE_Y_KEYS).map(span => ({
+    x: span.category,
+    start: span.start,
+    end: span.end,
+  }));
+}
+
+/**
+ * The live data items behind a vertical series of floating columns, in the
+ * order {@link extractWaterfallPoints} and {@link extractDumbbellPoints} emit
+ * them.
+ *
+ * Both skip columns missing a category or either end, so the highlight path
+ * has to skip the same ones — otherwise a single incomplete record shifts
+ * every later highlight onto its neighbour.
+ */
+export function extractSpanItems(series: AmXYSeries): AmDataItem[] {
+  return readSpans(series, 'categoryX', OPEN_Y_KEYS, VALUE_Y_KEYS).map(span => span.item);
+}
+
+// ---------------------------------------------------------------------------
+// Gantt extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * How long one unit of a `DateAxis` base interval lasts, in milliseconds.
+ *
+ * A month and a year have no fixed length; the approximations here are the
+ * ones amCharts uses for its own duration arithmetic. They only ever scale a
+ * length that is then announced with the unit's name, so a schedule measured
+ * in months reads as months rather than as nine-figure millisecond counts.
+ */
+const TIME_UNIT_MS: Record<string, number> = {
+  millisecond: 1,
+  second: 1000,
+  minute: 60_000,
+  hour: 3_600_000,
+  day: 86_400_000,
+  week: 604_800_000,
+  month: 2_592_000_000,
+  year: 31_536_000_000,
+};
+
+/** How a date axis' positions are turned into readable lengths. */
+interface TimeScale {
+  /** Milliseconds per unit. */
+  divisor: number;
+  /** What one unit is called, as {@link GanttData.unit} carries it. */
+  unit: string;
+}
+
+/**
+ * The scale a gantt's axis positions are reported in.
+ *
+ * A `DateAxis` stores positions as epoch milliseconds, and the length of an
+ * interval is the fact a schedule exists to carry — announced in milliseconds
+ * it carries nothing. So the axis' own base interval names the unit, and the
+ * positions are rescaled to it. Its `count` is ignored on purpose: the unit
+ * that travels with the numbers is the time unit's name, and dividing by a
+ * multiple of it would make the two disagree.
+ *
+ * Returns `null` for a value axis, whose numbers are already in whatever unit
+ * the chart's author chose and must be passed through untouched.
+ */
+function readTimeScale(axis: AmAxis | undefined): TimeScale | null {
+  const interval = axis?.get('baseInterval');
+  if (interval == null || typeof interval !== 'object')
+    return null;
+
+  const timeUnit = (interval as { timeUnit?: unknown }).timeUnit;
+  if (typeof timeUnit !== 'string')
+    return null;
+
+  const divisor = TIME_UNIT_MS[timeUnit];
+  return divisor ? { divisor, unit: `${timeUnit}s` } : null;
+}
+
+/**
+ * The lanes a gantt's category axis declares, in axis order.
+ *
+ * Read from the axis rather than from the series so a lane with nothing booked
+ * still exists: an empty lane is a real statement about a schedule, and a lane
+ * list derived from the intervals alone cannot make one.
+ */
+function readLaneNames(axis: AmAxis | undefined): (string | number)[] {
+  const lanes: (string | number)[] = [];
+  for (const item of axis?.dataItems ?? []) {
+    const category = item.get('category');
+    if (category != null)
+      lanes.push(toStringOrNumber(category));
+  }
+  return lanes;
+}
+
+/**
+ * Extract {@link GanttData} from a column series drawn as a schedule.
+ *
+ * amCharts draws a gantt as floating columns on a category axis of lanes and a
+ * date axis of time, which is the pair this reads: one lane per category axis
+ * item, one interval per column, and the unit from the date axis' own base
+ * interval.
+ *
+ * Positions are reported relative to the earliest interval on a date axis, so
+ * a schedule reads as "day 0 to day 30" rather than as two epoch timestamps
+ * thirteen digits long. The absolute dates are dropped by that: what a reader
+ * wants from a schedule is relational — what overlaps what, what hands over to
+ * what — and every one of those questions survives the shift, while none of
+ * them survives a length announced in milliseconds.
+ *
+ * @returns The chart's lanes and intervals, or `null` when no column carries a
+ *   readable interval.
+ */
+export function extractGanttData(series: AmXYSeries): GanttData | null {
+  const grouped = groupGanttSpans(series);
+  if (!grouped)
+    return null;
+
+  const { lanes, spans, scale } = grouped;
+  const origin = scale
+    ? Math.min(...spans.flat().map(span => span.start))
+    : 0;
+  const rescale = (value: number): number =>
+    scale ? withoutFloatNoise((value - origin) / scale.divisor) : value;
+
+  return {
+    points: spans.map(lane => lane.map(span => ({
+      x: span.category,
+      start: rescale(span.start),
+      end: rescale(span.end),
+    }))),
+    lanes,
+    ...(scale ? { unit: scale.unit } : {}),
+  };
+}
+
+/**
+ * The live data items behind a gantt's intervals, lane by lane.
+ *
+ * Grouped by the same pass {@link extractGanttData} emits from, so a MAIDR
+ * `[lane, interval]` position addresses the same column in both — which is
+ * what lets the highlight land on the bar the reader is being told about.
+ */
+export function extractGanttItems(series: AmXYSeries): AmDataItem[][] {
+  const grouped = groupGanttSpans(series);
+  return grouped ? grouped.spans.map(lane => lane.map(span => span.item)) : [];
+}
+
+/** A gantt's intervals, gathered into the lanes the chart draws them in. */
+interface GanttLanes {
+  lanes: (string | number)[];
+  spans: Span[][];
+  scale: TimeScale | null;
+}
+
+/**
+ * Group a gantt series' columns into lanes.
+ *
+ * The category axis supplies the lanes and their order, so a lane with nothing
+ * booked survives; a category the axis does not declare is appended rather
+ * than dropped, which would lose its intervals entirely.
+ */
+function groupGanttSpans(series: AmXYSeries): GanttLanes | null {
+  const columns = readSpans(series, 'categoryY', OPEN_X_KEYS, VALUE_X_KEYS);
+  if (columns.length === 0)
+    return null;
+
+  const lanes = readLaneNames(series.get('yAxis') as AmAxis | undefined);
+  const rowOf = new Map<string, number>(lanes.map((lane, row) => [String(lane), row]));
+  const spans: Span[][] = lanes.map(() => []);
+
+  for (const column of columns) {
+    const key = String(column.category);
+    let row = rowOf.get(key);
+    if (row === undefined) {
+      row = spans.length;
+      rowOf.set(key, row);
+      lanes.push(column.category);
+      spans.push([]);
+    }
+    spans[row].push(column);
+  }
+
+  return { lanes, spans, scale: readTimeScale(series.get('xAxis') as AmAxis | undefined) };
 }
 
 // ---------------------------------------------------------------------------
@@ -332,6 +659,112 @@ export function extractPiePoints(series: AmXYSeries): PiePoint[] {
 }
 
 // ---------------------------------------------------------------------------
+// Hierarchy extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * One node of an am5hierarchy series, as the walk reaches it.
+ *
+ * Carries the live data item alongside the values, because the highlight path
+ * needs the node the reader is on and the walk is the only place the two are
+ * known together — an am5hierarchy series keeps only its root in `dataItems`,
+ * and every other node is reachable only by descending from it.
+ */
+export interface AmHierarchyNode {
+  dataItem: AmDataItem;
+  /** What the node is called. */
+  name: string | number;
+  /** Its ancestors' names, outermost first, excluding the node and the root. */
+  path: (string | number)[];
+  /** Levels below the tree root — the row a MAIDR treemap addresses it by. */
+  depth: number;
+  /** Its own declared magnitude, or `null` for a node that has none. */
+  value: number | null;
+}
+
+/**
+ * Walk an am5hierarchy series and return every node below its root, in
+ * depth-first order.
+ *
+ * The root itself is skipped. amCharts hierarchy data is one root object whose
+ * `children` are the branches — commonly a synthetic "Root" the chart is even
+ * configured to hide (`topDepth: 1`) — so keeping it would add a level that
+ * always holds one node worth 100% of the chart, and put every reader one
+ * extra step away from the data.
+ *
+ * Depth-first is what makes the order usable: MAIDR's treemap addresses a node
+ * by `[depth][index within depth]` and takes the index from the order the
+ * nodes were declared in, so a walk that visits each subtree completely gives
+ * every level its left-to-right order.
+ */
+export function extractHierarchyNodes(series: AmXYSeries): AmHierarchyNode[] {
+  const nodes: AmHierarchyNode[] = [];
+
+  const visit = (item: AmDataItem, path: (string | number)[]): void => {
+    const category = item.get('category');
+    const name = category != null ? toStringOrNumber(category) : '';
+    nodes.push({
+      dataItem: item,
+      name,
+      path,
+      depth: path.length,
+      // The node's own value, never the aggregate amCharts keeps in `sum`: a
+      // branch's total is derived from its children by the trace, and reading
+      // the aggregate back would declare a total that cannot then disagree
+      // with the children even when the chart says it does.
+      value: toNumber(item.get('value')),
+    });
+
+    const childPath = [...path, name];
+    for (const child of childItems(item)) {
+      visit(child, childPath);
+    }
+  };
+
+  const roots = series.dataItems;
+  if (roots.length === 1) {
+    // The ordinary case: amCharts takes one root object and treats every other
+    // data item as unreachable, so the root is the container and its children
+    // are the top level.
+    for (const child of childItems(roots[0])) {
+      visit(child, []);
+    }
+  } else {
+    // Several top-level records, which amCharts does not itself lay out. There
+    // is no container root here, so the records ARE the top level; dropping
+    // all but the first would silently lose most of the tree.
+    for (const item of roots) {
+      visit(item, []);
+    }
+  }
+
+  return nodes;
+}
+
+/** A hierarchy data item's child items, or `[]` for a leaf. */
+function childItems(item: AmDataItem): AmDataItem[] {
+  const children = item.get('children');
+  return Array.isArray(children) ? (children as AmDataItem[]) : [];
+}
+
+/**
+ * Convert an am5hierarchy series into {@link TreemapPoint} data.
+ *
+ * Every node is emitted, not only the leaves: the trace derives a branch's
+ * total from its children, but a branch that declares a value of its own may
+ * carry mass no child accounts for, and only a declared value can say so. A
+ * node with no value of its own is emitted without one and totalled from
+ * below, which is the ordinary case for a branch.
+ */
+export function extractHierarchyPoints(series: AmXYSeries): TreemapPoint[] {
+  return extractHierarchyNodes(series).map(node => ({
+    x: node.name,
+    ...(node.value != null ? { y: node.value } : {}),
+    path: node.path,
+  }));
+}
+
+// ---------------------------------------------------------------------------
 // Series type detection
 // ---------------------------------------------------------------------------
 
@@ -399,6 +832,68 @@ const RADAR_COLUMN_CLASSES = new Set([
   'RadarColumnSeries',
 ]);
 
+/**
+ * Series of the am5hierarchy module, and the tree layout each one draws.
+ *
+ * These are not chart series: an am5hierarchy series is pushed straight into a
+ * plain container, with no chart object around it, which is why the adapter's
+ * discovery has to recognise the series itself. `Sunburst` is deliberately
+ * absent — it extends `Partition` but carries its own class name, so leaving
+ * it out keeps it out rather than reading it as an icicle.
+ */
+const HIERARCHY_KINDS: Record<string, SeriesKind> = {
+  Treemap: 'treemap',
+  Partition: 'icicle',
+};
+
+/** The class names {@link HIERARCHY_KINDS} covers, for discovery to probe. */
+export const HIERARCHY_CLASSES = new Set(Object.keys(HIERARCHY_KINDS));
+
+/** Whether a series binds any of the named open-value settings to a field. */
+function hasOpenField(series: AmXYSeries, ...settings: string[]): boolean {
+  return settings.some(setting => typeof series.get(setting) === 'string');
+}
+
+/**
+ * Whether a series of floating columns is a bridge rather than a barbell.
+ *
+ * A waterfall chains: each step opens where the one before it closed, because
+ * the bars trace a single running total. A dumbbell's pairs are independent —
+ * two values compared at one category — so the chain breaks at the second row
+ * of any real one, which makes it decisive rather than merely suggestive.
+ *
+ * A step that opens on the baseline is not a link in the chain: those are the
+ * opening, closing and subtotal bars, which restate the running total instead
+ * of continuing it, and every real waterfall ends with one.
+ */
+function isWaterfallChain(series: AmXYSeries): boolean {
+  let previousEnd: number | null = null;
+
+  for (const span of readSpans(series, 'categoryX', OPEN_Y_KEYS, VALUE_Y_KEYS)) {
+    if (span.start === 0) {
+      previousEnd = span.end;
+      continue;
+    }
+    if (previousEnd !== null && !nearlyEqual(span.start, previousEnd))
+      return false;
+    previousEnd = span.end;
+  }
+
+  return true;
+}
+
+/**
+ * Whether two axis positions are the same value.
+ *
+ * Compared with a relative tolerance because a running total is commonly
+ * carried through a producer's own arithmetic before it is authored, and a
+ * chain broken by the last bit of a float would read the chart as the wrong
+ * type entirely.
+ */
+function nearlyEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) <= 1e-9 * Math.max(1, Math.abs(a), Math.abs(b));
+}
+
 export type SeriesKind
   = | 'bar'
     | 'line'
@@ -410,6 +905,11 @@ export type SeriesKind
     | 'funnel'
     | 'radar'
     | 'polar'
+    | 'waterfall'
+    | 'dumbbell'
+    | 'gantt'
+    | 'treemap'
+    | 'icicle'
     | 'unknown';
 
 /**
@@ -428,10 +928,25 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
     return 'polar';
   }
 
+  const hierarchy = HIERARCHY_KINDS[className];
+  if (hierarchy) {
+    return hierarchy;
+  }
+
   if (COLUMN_CLASSES.has(className)) {
     // Heatmap: both category X and category Y fields.
     if (hasCategoryX(series) && hasCategoryY(series))
       return 'heatmap';
+
+    // A schedule: lanes on the category axis, and columns that float between
+    // two positions on the time axis rather than rising from a baseline.
+    if (hasCategoryY(series) && hasOpenField(series, 'openValueXField', 'openDateXField'))
+      return 'gantt';
+
+    // A bridge and a barbell share this signature exactly — floating columns
+    // at one category each — so the chain is what separates them.
+    if (hasCategoryX(series) && hasOpenField(series, 'openValueYField'))
+      return isWaterfallChain(series) ? 'waterfall' : 'dumbbell';
 
     // Histogram: value-based X axis with openValueX bin edges.
     if (!hasCategoryX(series) && !hasCategoryY(series)

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -664,6 +664,92 @@ export function extractLinePoints(series: AmXYSeries): LinePoint[] {
 }
 
 // ---------------------------------------------------------------------------
+// Rank detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a setting off anything that answers `get`, without asserting a type.
+ *
+ * The axis a series is bound to, and the renderer that axis draws itself with,
+ * are both reached this way: they are am5 entities the adapter never models,
+ * and every read of one is a single setting deep.
+ */
+function settingOf(entity: unknown, key: string): unknown {
+  if (entity == null || typeof entity !== 'object')
+    return undefined;
+  const get = (entity as { get?: unknown }).get;
+  if (typeof get !== 'function')
+    return undefined;
+  return (get as (k: string) => unknown).call(entity, key);
+}
+
+/**
+ * Whether every line of a layer is plotted against an upside-down value axis.
+ *
+ * A rank axis runs the other way: first place is the smallest number and sits
+ * at the top, which amCharts draws by inverting the axis' renderer. That is the
+ * one thing a bump chart declares about itself, and it is asked of every series
+ * rather than of any — a chart mixing an inversed line with an ordinary one is
+ * not a table of ranks, and reading it as one would invert the pitch of both.
+ *
+ * It is not sufficient on its own. An inversed axis is also how a plain chart
+ * of descending magnitudes is drawn, so {@link holdsRanks} has to agree before
+ * the layer is announced as a bump chart.
+ */
+export function hasRankAxis(seriesList: AmXYSeries[]): boolean {
+  return seriesList.length > 0 && seriesList.every((series) => {
+    const renderer = settingOf(series.get('yAxis'), 'renderer');
+    return settingOf(renderer, 'inversed') === true;
+  });
+}
+
+/**
+ * Whether a group of line series carries ranks rather than magnitudes.
+ *
+ * A rank is a permutation, and that is what makes this decidable from the data
+ * alone: every value is a whole place between first and last, no two
+ * competitors hold the same place in the same period, and somebody comes first.
+ * Counts and magnitudes fail all three the moment there is more than one of
+ * them — two series that ever share a value are not a ranking, and a value
+ * above the number of competitors is not a place any of them can hold.
+ *
+ * Deliberately strict about what it will not read: a chart showing places 3
+ * through 9 of a twenty-strong field is a genuine bump chart this answers `false`
+ * for, and it stays a line chart rather than being sonified against a rank
+ * range that does not include the leader it never draws.
+ */
+export function holdsRanks(seriesList: AmXYSeries[]): boolean {
+  const competitors = seriesList.length;
+  if (competitors === 0)
+    return false;
+
+  const takenAt = new Map<string, Set<number>>();
+  let best = Number.POSITIVE_INFINITY;
+  let ranks = 0;
+
+  for (const series of seriesList) {
+    for (const point of extractLinePoints(series)) {
+      if (!Number.isInteger(point.y) || point.y < 1 || point.y > competitors)
+        return false;
+
+      const period = String(point.x);
+      const taken = takenAt.get(period);
+      if (taken == null)
+        takenAt.set(period, new Set([point.y]));
+      else if (taken.has(point.y))
+        return false;
+      else
+        taken.add(point.y);
+
+      best = Math.min(best, point.y);
+      ranks++;
+    }
+  }
+
+  return ranks > 0 && best === 1;
+}
+
+// ---------------------------------------------------------------------------
 // Pie extraction
 // ---------------------------------------------------------------------------
 

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -48,6 +48,33 @@ function hasCategoryY(series: AmXYSeries): boolean {
   return typeof series.get('categoryYField') === 'string';
 }
 
+/**
+ * Determine whether a line series is drawn with the region between it and the
+ * baseline filled in — which is what makes it an area chart.
+ *
+ * amCharts has no area series: an area is a `LineSeries` whose `fills`
+ * template has been made visible (`fills.template.setAll({ visible: true,
+ * fillOpacity: 0.5 })` is the documented recipe), so those settings are the
+ * only runtime signal there is. An explicit `visible: false` settles the
+ * question on its own — a template can carry a fill opacity it never paints
+ * with — and otherwise a declared opacity decides, since a fill at opacity
+ * zero draws nothing whatever it claims to be.
+ */
+function hasVisibleFill(series: AmXYSeries): boolean {
+  const template = series.fills?.template;
+  if (!template || typeof template.get !== 'function')
+    return false;
+
+  const visible = template.get('visible');
+  if (visible === false)
+    return false;
+
+  const opacity = template.get('fillOpacity');
+  if (typeof opacity === 'number')
+    return opacity > 0;
+  return visible === true;
+}
+
 // ---------------------------------------------------------------------------
 // Column / Bar extraction
 // ---------------------------------------------------------------------------
@@ -270,6 +297,10 @@ export function extractLinePoints(series: AmXYSeries): LinePoint[] {
 /**
  * Extract {@link PiePoint} data from an am5percent pie series.
  *
+ * Also serves an am5percent funnel series, whose stages carry the same
+ * `category`/`value` pair in the same data order — a funnel's `BarPoint[]` and
+ * a pie's `PiePoint[]` are the same `{ x, y }` shape.
+ *
  * A pie series is bound to no axis: each data item carries the slice's
  * `category` and its `value`, and the wedges are drawn in data-item order.
  * Items with no category or no finite value are skipped — a slice with
@@ -336,13 +367,66 @@ const PIE_CLASSES = new Set([
   'PieSeries',
 ]);
 
-export type SeriesKind = 'bar' | 'line' | 'step' | 'histogram' | 'heatmap' | 'pie' | 'unknown';
+/**
+ * Series an am5percent `SlicedChart` draws as ordered stages — a funnel, its
+ * triangular pyramid variant, and the pictorial stack. All three carry one
+ * `category`/`value` pair per stage in data order, which is exactly the
+ * retention reading MAIDR's funnel trace is built on, so all three map to it.
+ */
+const FUNNEL_CLASSES = new Set([
+  'FunnelSeries',
+  'PyramidSeries',
+  'PictorialStackedSeries',
+]);
+
+/**
+ * Series an am5radar `RadarChart` draws around a circle, joined into a closed
+ * outline. Recognising them explicitly is what keeps a radar from being read
+ * as something else: a `RadarChart` extends `XYChart`, so the adapter has
+ * always found it, and {@link classifySeriesKind} answers `'bar'` for anything
+ * it does not know — a radar was therefore announced as a row of bars.
+ */
+const RADAR_LINE_CLASSES = new Set([
+  'RadarLineSeries',
+  'SmoothedRadarLineSeries',
+]);
+
+/**
+ * The same spokes drawn as wedges rather than as an outline — a coxcomb or
+ * rose chart. Read exactly as a radar is; only the mark differs.
+ */
+const RADAR_COLUMN_CLASSES = new Set([
+  'RadarColumnSeries',
+]);
+
+export type SeriesKind
+  = | 'bar'
+    | 'line'
+    | 'area'
+    | 'step'
+    | 'histogram'
+    | 'heatmap'
+    | 'pie'
+    | 'funnel'
+    | 'radar'
+    | 'polar'
+    | 'unknown';
 
 /**
  * Determine the MAIDR trace kind for a given amCharts series.
  */
 export function classifySeriesKind(series: AmXYSeries): SeriesKind {
   const className = series.className ?? '';
+
+  // Radar first: its series carry their own class names, and a radar chart is
+  // otherwise indistinguishable from any other XY chart at this level.
+  if (RADAR_LINE_CLASSES.has(className)) {
+    return 'radar';
+  }
+
+  if (RADAR_COLUMN_CLASSES.has(className)) {
+    return 'polar';
+  }
 
   if (COLUMN_CLASSES.has(className)) {
     // Heatmap: both category X and category Y fields.
@@ -359,6 +443,11 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
   }
 
   if (LINE_CLASSES.has(className)) {
+    // amCharts draws an area with the line series, so the fill is the only
+    // thing that separates the two.
+    if (hasVisibleFill(series))
+      return 'area';
+
     // A "line" series with value-only axes (no category) is still a line in MAIDR.
     return 'line';
   }
@@ -369,6 +458,10 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
 
   if (PIE_CLASSES.has(className)) {
     return 'pie';
+  }
+
+  if (FUNNEL_CLASSES.has(className)) {
+    return 'funnel';
   }
 
   // Default to bar for category-based series.

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -16,7 +16,7 @@ import type {
   WaterfallKind,
   WaterfallPoint,
 } from '@type/grammar';
-import type { AmAxis, AmDataItem, AmXYSeries } from './types';
+import type { AmAxis, AmDataItem, AmSprite, AmXYSeries } from './types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -164,16 +164,28 @@ function withoutFloatNoise(value: number): number {
 // Column / Bar extraction
 // ---------------------------------------------------------------------------
 
-/**
- * Extract {@link BarPoint} data from a column or bar series.
- */
-export function extractBarPoints(series: AmXYSeries): BarPoint[] {
-  const points: BarPoint[] = [];
+/** One mark of a category-bound series: what it names, and what it measures. */
+interface CategoryValue {
+  category: string | number;
+  value: number;
+}
 
+/**
+ * Read every mark of a category-bound series as a category and a value.
+ *
+ * The pair of fields depends on which way the bars run — amCharts puts the
+ * categories on `categoryY` and the values on `valueX` for a horizontal chart
+ * — and nothing else about the reading does, which is why the bar, the
+ * segmented bar and the diverging-pair test all take it from here. Marks
+ * missing either half are skipped, so an index into the result keeps naming
+ * the mark it addresses.
+ */
+function readCategoryValues(series: AmXYSeries): CategoryValue[] {
   const isHorizontal = hasCategoryY(series);
   const categoryField = isHorizontal ? 'categoryY' : 'categoryX';
   const valueField = isHorizontal ? 'valueX' : 'valueY';
 
+  const marks: CategoryValue[] = [];
   for (const item of series.dataItems) {
     const category = item.get(categoryField);
     const value = item.get(valueField);
@@ -185,13 +197,25 @@ export function extractBarPoints(series: AmXYSeries): BarPoint[] {
     if (numValue == null)
       continue;
 
-    points.push({
-      x: isHorizontal ? numValue : toStringOrNumber(category),
-      y: isHorizontal ? toStringOrNumber(category) : numValue,
-    });
+    marks.push({ category: toStringOrNumber(category), value: numValue });
   }
+  return marks;
+}
 
-  return points;
+/**
+ * Extract {@link BarPoint} data from a column or bar series.
+ *
+ * Also serves the two marks MAIDR reads as a bar chart with a different
+ * glyph — a dot plot's point and a lollipop's stem — which carry the same
+ * category and value and differ only in what the chart is called.
+ */
+export function extractBarPoints(series: AmXYSeries): BarPoint[] {
+  const isHorizontal = hasCategoryY(series);
+
+  return readCategoryValues(series).map(mark => ({
+    x: isHorizontal ? mark.value : mark.category,
+    y: isHorizontal ? mark.category : mark.value,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -206,32 +230,54 @@ export function extractBarPoints(series: AmXYSeries): BarPoint[] {
  * ggplot2 convention where `fill` maps a variable to grouped visual encoding.
  */
 export function extractSegmentedPoints(series: AmXYSeries): SegmentedPoint[] {
-  const points: SegmentedPoint[] = [];
   const fill = (series.get('name') as string | undefined) ?? '';
-
   const isHorizontal = hasCategoryY(series);
-  const categoryField = isHorizontal ? 'categoryY' : 'categoryX';
-  const valueField = isHorizontal ? 'valueX' : 'valueY';
 
-  for (const item of series.dataItems) {
-    const category = item.get(categoryField);
-    const value = item.get(valueField);
+  return readCategoryValues(series).map(mark => ({
+    x: isHorizontal ? mark.value : mark.category,
+    y: isHorizontal ? mark.category : mark.value,
+    z: fill,
+  }));
+}
 
-    if (category == null || value == null)
-      continue;
+/**
+ * Whether two column series are drawn back to back across a shared axis — a
+ * population pyramid, or a Likert scale split around a neutral midpoint.
+ *
+ * amCharts has no diverging series: the chart is two ordinary column series
+ * on one category axis with one side's values negated, which is otherwise the
+ * signature of a dodged bar chart. What separates them is the sign — one
+ * series entirely on each side of the baseline, over the same categories in
+ * the same order — and that is a statement about the data rather than about
+ * how it was drawn, so it is decisive where a styling probe would not be.
+ *
+ * Both sides must actually reach their side of the baseline: a pair of series
+ * that are merely non-negative is every dodged bar chart ever drawn.
+ */
+export function isDivergingPair(seriesList: AmXYSeries[]): boolean {
+  if (seriesList.length !== 2)
+    return false;
 
-    const numValue = toNumber(value);
-    if (numValue == null)
-      continue;
+  const [left, right] = seriesList.map(readCategoryValues);
+  if (left.length === 0 || left.length !== right.length)
+    return false;
+  if (left.some((mark, index) => String(mark.category) !== String(right[index].category)))
+    return false;
 
-    points.push({
-      x: isHorizontal ? numValue : toStringOrNumber(category),
-      y: isHorizontal ? toStringOrNumber(category) : numValue,
-      z: fill,
-    });
-  }
+  const leftValues = left.map(mark => mark.value);
+  const rightValues = right.map(mark => mark.value);
+  return (growsNegative(leftValues) && growsPositive(rightValues))
+    || (growsPositive(leftValues) && growsNegative(rightValues));
+}
 
-  return points;
+/** Whether every value sits at or below the baseline, and one below it. */
+function growsNegative(values: number[]): boolean {
+  return values.every(value => value <= 0) && values.some(value => value < 0);
+}
+
+/** Whether every value sits at or above the baseline, and one above it. */
+function growsPositive(values: number[]): boolean {
+  return values.every(value => value >= 0) && values.some(value => value > 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -624,9 +670,10 @@ export function extractLinePoints(series: AmXYSeries): LinePoint[] {
 /**
  * Extract {@link PiePoint} data from an am5percent pie series.
  *
- * Also serves an am5percent funnel series, whose stages carry the same
- * `category`/`value` pair in the same data order — a funnel's `BarPoint[]` and
- * a pie's `PiePoint[]` are the same `{ x, y }` shape.
+ * Also serves an am5percent funnel series and an am5wc word cloud, whose
+ * stages and terms carry the same `category`/`value` pair in the same data
+ * order — a funnel's `BarPoint[]`, a word cloud's `WordCloudPoint[]` and a
+ * pie's `PiePoint[]` are the same `{ x, y }` shape.
  *
  * A pie series is bound to no axis: each data item carries the slice's
  * `category` and its `value`, and the wedges are drawn in data-item order.
@@ -833,21 +880,102 @@ const RADAR_COLUMN_CLASSES = new Set([
 ]);
 
 /**
- * Series of the am5hierarchy module, and the tree layout each one draws.
+ * Series that are not inside a chart at all, and what each one draws.
  *
- * These are not chart series: an am5hierarchy series is pushed straight into a
- * plain container, with no chart object around it, which is why the adapter's
- * discovery has to recognise the series itself. `Sunburst` is deliberately
- * absent — it extends `Partition` but carries its own class name, so leaving
- * it out keeps it out rather than reading it as an icicle.
+ * An am5hierarchy layout and an am5wc word cloud are `am5.Series` pushed
+ * straight into a plain container, with no chart object around them, which is
+ * why the adapter's discovery has to recognise the series itself. `Sunburst`
+ * is deliberately absent — it extends `Partition` but carries its own class
+ * name, so leaving it out keeps it out rather than reading it as an icicle.
+ *
+ * One record rather than one set per module: discovery asks a single question
+ * ("is this series a panel of its own?"), and a per-module set would have to
+ * be unioned back together at every call site to answer it.
  */
-const HIERARCHY_KINDS: Record<string, SeriesKind> = {
+const STANDALONE_KINDS: Record<string, SeriesKind> = {
   Treemap: 'treemap',
   Partition: 'icicle',
+  WordCloud: 'wordcloud',
 };
 
-/** The class names {@link HIERARCHY_KINDS} covers, for discovery to probe. */
-export const HIERARCHY_CLASSES = new Set(Object.keys(HIERARCHY_KINDS));
+/** The class names {@link STANDALONE_KINDS} covers, for discovery to probe. */
+export const STANDALONE_SERIES_CLASSES = new Set(Object.keys(STANDALONE_KINDS));
+
+/**
+ * How thin a column has to be before it is read as a lollipop's stem.
+ *
+ * A lollipop is an ordinary column series with its columns narrowed to a
+ * hairline and a bullet put on the end — amCharts has no lollipop series — so
+ * the width is the only signal there is. A few pixels is far below any width a
+ * bar chart is drawn at, and the bullet requirement is what keeps a merely
+ * narrow bar chart out.
+ */
+const LOLLIPOP_MAX_STEM_PX = 6;
+
+/** Whether a series has any bullets configured. */
+function hasBullets(series: AmXYSeries): boolean {
+  return (series.bullets?.values.length ?? 0) > 0;
+}
+
+/**
+ * Read a graphics template's setting as a plain number.
+ *
+ * A `Percent` answers `null` rather than its own value: amCharts accepts one
+ * for every dimension, and a percentage is not a pixel count — a column 50% of
+ * its cell is not a hairline however small the number reads.
+ */
+function numberSetting(template: AmSprite | undefined, key: string): number | null {
+  const value = template?.get?.(key);
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Whether a line series is drawn as points alone — a Cleveland dot plot.
+ *
+ * amCharts has no dot or scatter series: the recipe is a `LineSeries` with its
+ * stroke switched off and bullets pushed onto it, so the plot is entirely the
+ * bullets. Both halves are required, because either alone is something else: a
+ * strokeless series with no bullets draws nothing, and a series with bullets
+ * and a stroke is a line chart with markers on it.
+ *
+ * A category axis is required as well. The same drawing on two value axes is a
+ * scatter plot, which MAIDR reads with a trace of its own and this adapter
+ * does not emit — so that case is left reading as a line rather than
+ * announced as a dot plot it is not.
+ */
+function isDotPlot(series: AmXYSeries): boolean {
+  if (!hasCategoryX(series) && !hasCategoryY(series))
+    return false;
+  if (!hasBullets(series))
+    return false;
+
+  const template = series.strokes?.template;
+  const opacity = numberSetting(template, 'strokeOpacity');
+  if (opacity !== null)
+    return opacity <= 0;
+  const width = numberSetting(template, 'strokeWidth');
+  return width !== null && width <= 0;
+}
+
+/**
+ * Whether a column series is drawn as a stem with a dot on the end.
+ *
+ * Measured across the bars rather than along them: a vertical lollipop's stem
+ * is thin in `width` and a horizontal one's in `height`, and reading the wrong
+ * one of the two would answer with the bar's length.
+ */
+function isLollipop(series: AmXYSeries): boolean {
+  if (!hasCategoryX(series) && !hasCategoryY(series))
+    return false;
+  if (!hasBullets(series))
+    return false;
+
+  const thickness = numberSetting(
+    series.columns?.template,
+    hasCategoryY(series) ? 'height' : 'width',
+  );
+  return thickness !== null && thickness <= LOLLIPOP_MAX_STEM_PX;
+}
 
 /** Whether a series binds any of the named open-value settings to a field. */
 function hasOpenField(series: AmXYSeries, ...settings: string[]): boolean {
@@ -896,6 +1024,8 @@ function nearlyEqual(a: number, b: number): boolean {
 
 export type SeriesKind
   = | 'bar'
+    | 'dot'
+    | 'lollipop'
     | 'line'
     | 'area'
     | 'step'
@@ -910,6 +1040,7 @@ export type SeriesKind
     | 'gantt'
     | 'treemap'
     | 'icicle'
+    | 'wordcloud'
     | 'unknown';
 
 /**
@@ -928,9 +1059,9 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
     return 'polar';
   }
 
-  const hierarchy = HIERARCHY_KINDS[className];
-  if (hierarchy) {
-    return hierarchy;
+  const standalone = STANDALONE_KINDS[className];
+  if (standalone) {
+    return standalone;
   }
 
   if (COLUMN_CLASSES.has(className)) {
@@ -954,14 +1085,26 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
       return 'histogram';
     }
 
+    // A bar narrowed to a hairline and finished with a bullet. Read after the
+    // field-based kinds above, which describe what the columns MEAN; this one
+    // only describes what they look like.
+    if (isLollipop(series))
+      return 'lollipop';
+
     return 'bar';
   }
 
   if (LINE_CLASSES.has(className)) {
     // amCharts draws an area with the line series, so the fill is the only
-    // thing that separates the two.
+    // thing that separates the two. Asked before the stroke, since an area
+    // whose outline is switched off is still an area.
     if (hasVisibleFill(series))
       return 'area';
+
+    // The same series with no stroke and bullets on it is a dot plot: what is
+    // drawn is the points alone.
+    if (isDotPlot(series))
+      return 'dot';
 
     // A "line" series with value-only axes (no category) is still a line in MAIDR.
     return 'line';

--- a/src/adapters/amcharts/geometry.ts
+++ b/src/adapters/amcharts/geometry.ts
@@ -163,7 +163,7 @@ export function wedgeBounds(slice: AmSprite): AmBounds | null {
 /**
  * Read a pie panel's bounds as the union of its wedges' boxes.
  *
- * An am5percent `PieChart` has no `plotContainer` — it has no plot area, which
+ * An am5percent chart has no `plotContainer` — it has no plot area, which
  * is why {@link AmChart.plotContainer} is optional — so {@link readPlotBounds}
  * reports nothing for it and the binder, which suppresses a highlight it cannot
  * clip to a panel, would leave every pie in a multi-panel root unhighlighted.

--- a/src/adapters/amcharts/index.ts
+++ b/src/adapters/amcharts/index.ts
@@ -23,7 +23,7 @@
  *
  * Multi-panel roots are supported by both paths: every `XYChart` in the
  * root's container tree (including am5stock `StockPanel`s) and every
- * `PieChart` becomes one MAIDR subplot, arranged in a grid matching the
+ * am5percent chart becomes one MAIDR subplot, arranged in a grid matching the
  * rendered layout. Arrow keys move between panels; Enter drills into a panel
  * and Escape returns.
  *

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -21,13 +21,13 @@ import {
 /**
  * The am5 entities to highlight for a navigation position.
  * `kind` tells the overlay which geometry to read: a column's box, a line
- * point, or the wedge-shaped sprite of a pie slice, funnel stage or polar
- * column.
+ * point, the wedge-shaped sprite of a pie slice, funnel stage or polar column,
+ * or the glyph of a word cloud's term.
  */
 export interface NavTarget {
   series: AmXYSeries;
   dataItem: AmDataItem;
-  kind: 'column' | 'point' | 'slice';
+  kind: 'column' | 'point' | 'slice' | 'label';
 }
 
 /**
@@ -63,6 +63,10 @@ export interface NavMapEntry {
 export interface SeriesGroups {
   /** Single → BAR layer; multiple → one segmented layer. */
   barSeriesList: AmXYSeries[];
+  /** One DOT layer each, in series order. */
+  dotSeriesList: AmXYSeries[];
+  /** One LOLLIPOP layer each, in series order. */
+  lollipopSeriesList: AmXYSeries[];
   /** Merged into a single multi-line LINE layer (one entry per line). */
   lineSeriesList: AmXYSeries[];
   /** Merged into a single STEP layer, the staircase counterpart of the above. */
@@ -89,6 +93,8 @@ export interface SeriesGroups {
   ganttSeriesList: AmXYSeries[];
   /** One TREEMAP or ICICLE layer each, in series order. */
   hierarchySeriesList: AmXYSeries[];
+  /** One WORD_CLOUD layer each, in series order. */
+  wordCloudSeriesList: AmXYSeries[];
 }
 
 type Resolver = (row: number, col: number) => NavTarget[];
@@ -168,6 +174,23 @@ function filterPieItems(series: AmXYSeries): AmDataItem[] {
     kept.push(item);
   }
   return kept;
+}
+
+/**
+ * Mirror `WordCloudTrace`: the terms a cloud declares, heaviest first.
+ *
+ * A word cloud is the one layer whose navigation order is not the order it was
+ * declared in. Its arrangement on the page is chosen to pack glyphs and
+ * carries nothing, so MAIDR walks the terms by weight — and the position it
+ * reports is an index into THAT order. Filtering alone would leave every
+ * highlight on whichever term happens to sit at the same rank.
+ *
+ * Sorted with the same comparison the trace uses, on a stable sort, so terms
+ * of equal weight keep their declared order in both.
+ */
+function filterWordCloudItems(series: AmXYSeries): AmDataItem[] {
+  return filterPieItems(series)
+    .sort((a, b) => Number(b.get('value')) - Number(a.get('value')));
 }
 
 /** Mirror `extractHistogramPoints`: keep items with finite valueX and valueY. */
@@ -301,6 +324,8 @@ function addEntryResolvers(
     items: filterColumnItems(series),
   }));
   const segmentedBars = barItems.filter(entry => entry.items.length > 0);
+  const dotSeries = filterSeries(groups.dotSeriesList, filterColumnItems);
+  const lollipopSeries = filterSeries(groups.lollipopSeriesList, filterColumnItems);
   const lineSeries = filterSeries(groups.lineSeriesList, filterLineItems);
   const stepSeries = filterSeries(groups.stepSeriesList, filterLineItems);
   const areaSeries = filterSeries(groups.areaSeriesList, filterLineItems);
@@ -311,6 +336,7 @@ function addEntryResolvers(
   const funnelSeries = filterSeries(groups.funnelSeriesList, filterPieItems);
   const waterfallSeries = filterSeries(groups.waterfallSeriesList, extractSpanItems);
   const dumbbellSeries = filterSeries(groups.dumbbellSeriesList, extractSpanItems);
+  const wordCloudSeries = filterSeries(groups.wordCloudSeriesList, filterWordCloudItems);
 
   // Every merged layer indexes its OWN series list — sharing one would
   // misplace every highlight on a chart carrying two of these at once.
@@ -324,6 +350,8 @@ function addEntryResolvers(
     [TraceType.POLAR_AREA]: polarSeries,
   };
 
+  let dotIdx = 0;
+  let lollipopIdx = 0;
   let histIdx = 0;
   let heatIdx = 0;
   let pieIdx = 0;
@@ -332,6 +360,7 @@ function addEntryResolvers(
   let dumbbellIdx = 0;
   let ganttIdx = 0;
   let hierarchyIdx = 0;
+  let wordCloudIdx = 0;
 
   const register = (layerId: string, resolver: Resolver): void => {
     resolvers.set(layerId, resolver);
@@ -345,10 +374,32 @@ function addEntryResolvers(
         register(layer.id, (_row, col) => columnTargetFrom(entry, col));
         break;
       }
+      // A diverging pair is two column series read as one layer, exactly as a
+      // dodged one is; only the sign of the values differs.
       case TraceType.STACKED:
       case TraceType.DODGED:
+      case TraceType.DIVERGING:
       case TraceType.NORMALIZED: {
         register(layer.id, (row, col) => columnTargetFrom(segmentedBars[row], col));
+        break;
+      }
+      case TraceType.DOT: {
+        // The mark is the bullet, not a column, so the overlay measures the
+        // point the bullet sits on.
+        const entry = dotSeries[dotIdx++];
+        register(layer.id, (_row, col) => {
+          const dataItem = entry?.items[col];
+          return entry && dataItem
+            ? [{ series: entry.series, dataItem, kind: 'point' }]
+            : [];
+        });
+        break;
+      }
+      case TraceType.LOLLIPOP: {
+        // A stem is still a column, thin as it is, and the box around it is
+        // what puts the highlight on the whole mark rather than on the dot.
+        const entry = lollipopSeries[lollipopIdx++];
+        register(layer.id, (_row, col) => columnTargetFrom(entry, col));
         break;
       }
       case TraceType.LINE:
@@ -425,6 +476,19 @@ function addEntryResolvers(
           layer.id,
           buildHierarchyResolver(groups.hierarchySeriesList[hierarchyIdx++]),
         );
+        break;
+      }
+      case TraceType.WORD_CLOUD: {
+        // A cloud is a single row of terms, so only the column moves — and it
+        // indexes them by weight, which `filterWordCloudItems` has already put
+        // the data items in.
+        const entry = wordCloudSeries[wordCloudIdx++];
+        register(layer.id, (_row, col) => {
+          const dataItem = entry?.items[col];
+          return entry && dataItem
+            ? [{ series: entry.series, dataItem, kind: 'label' }]
+            : [];
+        });
         break;
       }
       case TraceType.HEATMAP: {

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -67,7 +67,12 @@ export interface SeriesGroups {
   dotSeriesList: AmXYSeries[];
   /** One LOLLIPOP layer each, in series order. */
   lollipopSeriesList: AmXYSeries[];
-  /** Merged into a single multi-line LINE layer (one entry per line). */
+  /**
+   * Merged into a single multi-line layer (one entry per line) — a LINE, or
+   * the BUMP the same lines become when they carry ranks. The two are one
+   * bucket because they are one layer: what differs is how the numbers are
+   * announced, not which mark each position addresses.
+   */
   lineSeriesList: AmXYSeries[];
   /** Merged into a single STEP layer, the staircase counterpart of the above. */
   stepSeriesList: AmXYSeries[];
@@ -342,6 +347,7 @@ function addEntryResolvers(
   // misplace every highlight on a chart carrying two of these at once.
   const mergedByType: Partial<Record<TraceType, FilteredSeries[]>> = {
     [TraceType.LINE]: lineSeries,
+    [TraceType.BUMP]: lineSeries,
     [TraceType.STEP]: stepSeries,
     [TraceType.AREA]: areaSeries,
     [TraceType.STACKED_AREA]: areaSeries,
@@ -402,7 +408,11 @@ function addEntryResolvers(
         register(layer.id, (_row, col) => columnTargetFrom(entry, col));
         break;
       }
+      // A bump chart is navigated as the multi-line layer it is drawn as, and
+      // its lines were collected with the rest — the rank is what the trace
+      // announces, not a different mark to point at.
       case TraceType.LINE:
+      case TraceType.BUMP:
       case TraceType.STEP:
       case TraceType.AREA:
       case TraceType.STACKED_AREA:

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -16,7 +16,8 @@ import { TraceType } from '@type/grammar';
 /**
  * The am5 entities to highlight for a navigation position.
  * `kind` tells the overlay which geometry to read: a column's box, a line
- * point, or a pie slice's wedge.
+ * point, or the wedge-shaped sprite of a pie slice, funnel stage or polar
+ * column.
  */
 export interface NavTarget {
   series: AmXYSeries;
@@ -61,12 +62,20 @@ export interface SeriesGroups {
   lineSeriesList: AmXYSeries[];
   /** Merged into a single STEP layer, the staircase counterpart of the above. */
   stepSeriesList: AmXYSeries[];
+  /** Merged into one AREA / STACKED_AREA / NORMALIZED_AREA layer. */
+  areaSeriesList: AmXYSeries[];
+  /** Merged into a single RADAR layer (one entry per closed outline). */
+  radarSeriesList: AmXYSeries[];
+  /** Merged into a single POLAR_AREA layer, the wedge counterpart of the above. */
+  polarSeriesList: AmXYSeries[];
   /** One HISTOGRAM layer each, in series order. */
   histogramSeries: AmXYSeries[];
   /** One HEATMAP layer each, in series order. */
   heatmapSeries: AmXYSeries[];
   /** One PIE layer each, in series order. */
   pieSeriesList: AmXYSeries[];
+  /** One FUNNEL layer each, in series order. */
+  funnelSeriesList: AmXYSeries[];
 }
 
 type Resolver = (row: number, col: number) => NavTarget[];
@@ -130,7 +139,10 @@ function filterLineItems(series: AmXYSeries): AmDataItem[] {
   return kept;
 }
 
-/** Mirror `extractPiePoints`: keep items with a category and a finite value. */
+/**
+ * Mirror `extractPiePoints`: keep items with a category and a finite value.
+ * Serves funnel stages too, which the extractor reads through the same fields.
+ */
 function filterPieItems(series: AmXYSeries): AmDataItem[] {
   const kept: AmDataItem[] = [];
   for (const item of series.dataItems) {
@@ -158,6 +170,20 @@ function filterHistogramItems(series: AmXYSeries): AmDataItem[] {
     kept.push(item);
   }
   return kept;
+}
+
+/**
+ * Pair each series with its gap-filtered items and drop the series left with
+ * none — exactly what the adapter does when it builds the layers, so MAIDR's
+ * row indices keep naming the same series the extractor emitted.
+ */
+function filterSeries(
+  seriesList: AmXYSeries[],
+  keep: (series: AmXYSeries) => AmDataItem[],
+): FilteredSeries[] {
+  return seriesList
+    .map(series => ({ series, items: keep(series) }))
+    .filter(entry => entry.items.length > 0);
 }
 
 function columnTargetFrom(entry: FilteredSeries | undefined, col: number): NavTarget[] {
@@ -229,22 +255,31 @@ function addEntryResolvers(
     items: filterColumnItems(series),
   }));
   const segmentedBars = barItems.filter(entry => entry.items.length > 0);
-  const lineSeries = groups.lineSeriesList
-    .map(series => ({ series, items: filterLineItems(series) }))
-    .filter(entry => entry.items.length > 0);
-  const stepSeries = groups.stepSeriesList
-    .map(series => ({ series, items: filterLineItems(series) }))
-    .filter(entry => entry.items.length > 0);
-  const histogramSeries = groups.histogramSeries
-    .map(series => ({ series, items: filterHistogramItems(series) }))
-    .filter(entry => entry.items.length > 0);
-  const pieSeries = groups.pieSeriesList
-    .map(series => ({ series, items: filterPieItems(series) }))
-    .filter(entry => entry.items.length > 0);
+  const lineSeries = filterSeries(groups.lineSeriesList, filterLineItems);
+  const stepSeries = filterSeries(groups.stepSeriesList, filterLineItems);
+  const areaSeries = filterSeries(groups.areaSeriesList, filterLineItems);
+  const radarSeries = filterSeries(groups.radarSeriesList, filterLineItems);
+  const polarSeries = filterSeries(groups.polarSeriesList, filterLineItems);
+  const histogramSeries = filterSeries(groups.histogramSeries, filterHistogramItems);
+  const pieSeries = filterSeries(groups.pieSeriesList, filterPieItems);
+  const funnelSeries = filterSeries(groups.funnelSeriesList, filterPieItems);
+
+  // Every merged layer indexes its OWN series list — sharing one would
+  // misplace every highlight on a chart carrying two of these at once.
+  const mergedByType: Partial<Record<TraceType, FilteredSeries[]>> = {
+    [TraceType.LINE]: lineSeries,
+    [TraceType.STEP]: stepSeries,
+    [TraceType.AREA]: areaSeries,
+    [TraceType.STACKED_AREA]: areaSeries,
+    [TraceType.NORMALIZED_AREA]: areaSeries,
+    [TraceType.RADAR]: radarSeries,
+    [TraceType.POLAR_AREA]: polarSeries,
+  };
 
   let histIdx = 0;
   let heatIdx = 0;
   let pieIdx = 0;
+  let funnelIdx = 0;
 
   const register = (layerId: string, resolver: Resolver): void => {
     resolvers.set(layerId, resolver);
@@ -265,15 +300,23 @@ function addEntryResolvers(
         break;
       }
       case TraceType.LINE:
-      case TraceType.STEP: {
-        // A step layer holds its own series, so it indexes its own list —
-        // sharing one would misplace every highlight on a chart with both.
-        const seriesList = layer.type === TraceType.STEP ? stepSeries : lineSeries;
+      case TraceType.STEP:
+      case TraceType.AREA:
+      case TraceType.STACKED_AREA:
+      case TraceType.NORMALIZED_AREA:
+      case TraceType.RADAR:
+      case TraceType.POLAR_AREA: {
+        const seriesList = mergedByType[layer.type] ?? [];
+        // A polar area draws its values as wedges rather than as points on a
+        // line, so the sprite the overlay measures differs even though the
+        // navigable grid is the same.
+        const kind: NavTarget['kind']
+          = layer.type === TraceType.POLAR_AREA ? 'slice' : 'point';
         register(layer.id, (row, col) => {
           const entry = seriesList[row];
           const dataItem = entry?.items[col];
           return entry && dataItem
-            ? [{ series: entry.series, dataItem, kind: 'point' }]
+            ? [{ series: entry.series, dataItem, kind }]
             : [];
         });
         break;
@@ -286,6 +329,17 @@ function addEntryResolvers(
       case TraceType.PIE: {
         // A pie is a single row of slices, so only the column moves.
         const entry = pieSeries[pieIdx++];
+        register(layer.id, (_row, col) => {
+          const dataItem = entry?.items[col];
+          return entry && dataItem
+            ? [{ series: entry.series, dataItem, kind: 'slice' }]
+            : [];
+        });
+        break;
+      }
+      case TraceType.FUNNEL: {
+        // A funnel is a single row of stages, so only the column moves.
+        const entry = funnelSeries[funnelIdx++];
         register(layer.id, (_row, col) => {
           const dataItem = entry?.items[col];
           return entry && dataItem

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -12,6 +12,11 @@
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
 import type { AmChart, AmDataItem, AmXYSeries } from './types';
 import { TraceType } from '@type/grammar';
+import {
+  extractGanttItems,
+  extractHierarchyNodes,
+  extractSpanItems,
+} from './extractor';
 
 /**
  * The am5 entities to highlight for a navigation position.
@@ -76,6 +81,14 @@ export interface SeriesGroups {
   pieSeriesList: AmXYSeries[];
   /** One FUNNEL layer each, in series order. */
   funnelSeriesList: AmXYSeries[];
+  /** One WATERFALL layer each, in series order. */
+  waterfallSeriesList: AmXYSeries[];
+  /** One DUMBBELL layer each, in series order. */
+  dumbbellSeriesList: AmXYSeries[];
+  /** One GANTT layer each, in series order. */
+  ganttSeriesList: AmXYSeries[];
+  /** One TREEMAP or ICICLE layer each, in series order. */
+  hierarchySeriesList: AmXYSeries[];
 }
 
 type Resolver = (row: number, col: number) => NavTarget[];
@@ -192,6 +205,39 @@ function columnTargetFrom(entry: FilteredSeries | undefined, col: number): NavTa
 }
 
 /**
+ * Build a resolver for a gantt layer: MAIDR walks lanes by intervals, and so
+ * does the grouping the extractor emitted, so the position indexes it directly.
+ */
+function buildGanttResolver(series: AmXYSeries | undefined): Resolver {
+  const lanes = series ? extractGanttItems(series) : [];
+  return (row, col) => {
+    const dataItem = lanes[row]?.[col];
+    return series && dataItem ? [{ series, dataItem, kind: 'column' }] : [];
+  };
+}
+
+/**
+ * Build a resolver for a treemap or icicle layer.
+ *
+ * MAIDR addresses a tree node by depth and by its position within that depth,
+ * taking the position from the order the nodes were declared in — which is the
+ * order the walk emitted them, so gathering the walk by depth rebuilds exactly
+ * the grid the reader is navigating.
+ */
+function buildHierarchyResolver(series: AmXYSeries | undefined): Resolver {
+  const levels: AmDataItem[][] = [];
+  for (const node of series ? extractHierarchyNodes(series) : []) {
+    (levels[node.depth] ??= []).push(node.dataItem);
+  }
+  return (row, col) => {
+    const dataItem = levels[row]?.[col];
+    // A node is drawn as a rectangle, which the overlay measures the same way
+    // it measures a column.
+    return series && dataItem ? [{ series, dataItem, kind: 'column' }] : [];
+  };
+}
+
+/**
  * Build a resolver for a heatmap layer. amCharts heatmap dataItems are a flat,
  * insertion-ordered list, so we index them by `categoryX`/`categoryY` value.
  * MAIDR's Heatmap model reverses the Y axis (`src/model/heatmap.ts`), so we
@@ -263,6 +309,8 @@ function addEntryResolvers(
   const histogramSeries = filterSeries(groups.histogramSeries, filterHistogramItems);
   const pieSeries = filterSeries(groups.pieSeriesList, filterPieItems);
   const funnelSeries = filterSeries(groups.funnelSeriesList, filterPieItems);
+  const waterfallSeries = filterSeries(groups.waterfallSeriesList, extractSpanItems);
+  const dumbbellSeries = filterSeries(groups.dumbbellSeriesList, extractSpanItems);
 
   // Every merged layer indexes its OWN series list — sharing one would
   // misplace every highlight on a chart carrying two of these at once.
@@ -280,6 +328,10 @@ function addEntryResolvers(
   let heatIdx = 0;
   let pieIdx = 0;
   let funnelIdx = 0;
+  let waterfallIdx = 0;
+  let dumbbellIdx = 0;
+  let ganttIdx = 0;
+  let hierarchyIdx = 0;
 
   const register = (layerId: string, resolver: Resolver): void => {
     resolvers.set(layerId, resolver);
@@ -346,6 +398,33 @@ function addEntryResolvers(
             ? [{ series: entry.series, dataItem, kind: 'slice' }]
             : [];
         });
+        break;
+      }
+      case TraceType.WATERFALL: {
+        // A bridge is a single row of steps, so only the column moves.
+        const entry = waterfallSeries[waterfallIdx++];
+        register(layer.id, (_row, col) => columnTargetFrom(entry, col));
+        break;
+      }
+      case TraceType.DUMBBELL: {
+        // Rows are the two ends and columns the categories, but a chart draws
+        // one column per category and not one per dot — so both ends resolve
+        // to the same mark, which is the honest rendering of a highlight that
+        // stays put while the announcement moves between the ends.
+        const entry = dumbbellSeries[dumbbellIdx++];
+        register(layer.id, (_row, col) => columnTargetFrom(entry, col));
+        break;
+      }
+      case TraceType.GANTT: {
+        register(layer.id, buildGanttResolver(groups.ganttSeriesList[ganttIdx++]));
+        break;
+      }
+      case TraceType.TREEMAP:
+      case TraceType.ICICLE: {
+        register(
+          layer.id,
+          buildHierarchyResolver(groups.hierarchySeriesList[hierarchyIdx++]),
+        );
         break;
       }
       case TraceType.HEATMAP: {

--- a/src/adapters/amcharts/overlay.ts
+++ b/src/adapters/amcharts/overlay.ts
@@ -162,29 +162,40 @@ function columnRect(target: NavTarget): OverlayRect | null {
     return null;
   }
 
-  // Proven path: toGlobal maps the sprite's LOCAL corners ({0,0} = top-left,
-  // {width,height} = bottom-right) to root-container CSS px. (Passing the
-  // sprite's own x()/y() double-counts its offset — the earlier bug.)
-  if (sprite.toGlobal && sprite.width && sprite.height) {
-    const w = sprite.width();
-    const h = sprite.height();
-    const tl = sprite.toGlobal({ x: 0, y: 0 });
-    const br = sprite.toGlobal({ x: w, y: h });
-    return {
-      left: Math.min(tl.x, br.x),
-      top: Math.min(tl.y, br.y),
-      width: Math.abs(br.x - tl.x),
-      height: Math.abs(br.y - tl.y),
-    };
+  // Proven path: the sprite's own laid-out box. `globalBounds()` is the
+  // fallback for builds where `toGlobal` isn't exposed.
+  const box = spriteBoxRect(sprite);
+  if (box) {
+    return box;
   }
-
-  // Fallback for builds where toGlobal isn't exposed.
   const bounds = sprite.globalBounds?.();
   return bounds ? boundsToRect(bounds) : null;
 }
 
 /**
- * Rectangle for a pie slice: the bounding box of the wedge graphic.
+ * The box a sprite reports through its own laid-out geometry.
+ *
+ * `toGlobal` maps the sprite's LOCAL corners ({0,0} = top-left,
+ * {width,height} = bottom-right) to root-container CSS px. (Passing the
+ * sprite's own x()/y() double-counts its offset — the earlier bug.)
+ */
+function spriteBoxRect(sprite: AmSprite): OverlayRect | null {
+  if (!sprite.toGlobal || !sprite.width || !sprite.height) {
+    return null;
+  }
+  const tl = sprite.toGlobal({ x: 0, y: 0 });
+  const br = sprite.toGlobal({ x: sprite.width(), y: sprite.height() });
+  return {
+    left: Math.min(tl.x, br.x),
+    top: Math.min(tl.y, br.y),
+    width: Math.abs(br.x - tl.x),
+    height: Math.abs(br.y - tl.y),
+  };
+}
+
+/**
+ * Rectangle for a wedge-shaped mark: a pie slice, a funnel stage, or a polar
+ * area's column.
  *
  * A box around a wedge is coarse — a large slice's box covers most of the pie
  * — but the overlay can only draw rectangles, and amCharts paints the wedge
@@ -195,11 +206,28 @@ function columnRect(target: NavTarget): OverlayRect | null {
  * Measured from the wedge's settings rather than its `globalBounds()`, which a
  * `Slice` reports as a degenerate point at its own centre (#774) — a rect from
  * that collapses to nothing, and the caller then drew no highlight at all.
+ *
+ * A pie keeps its wedge on the data item's `slice`; a polar column series keeps
+ * the same `Slice` on `graphics`, where a plain column series keeps its
+ * rectangle. A funnel stage is not a wedge at all — it carries no radius for
+ * {@link sliceExtent} to measure — but it is laid out with a width and a
+ * height of its own, which is what the sprite box answers with.
  */
 function sliceRect(target: NavTarget): OverlayRect | null {
-  const slice = target.dataItem.get('slice') as AmSprite | undefined;
-  const bounds = slice ? sliceExtent(slice) : null;
-  return bounds ? boundsToRect(bounds) : null;
+  const slice = (target.dataItem.get('slice') ?? target.dataItem.get('graphics')) as
+    | AmSprite
+    | undefined;
+  if (!slice) {
+    return null;
+  }
+
+  const bounds = sliceExtent(slice);
+  if (bounds) {
+    return boundsToRect(bounds);
+  }
+
+  const box = spriteBoxRect(slice);
+  return box && box.width > 0 && box.height > 0 ? box : null;
 }
 
 /**

--- a/src/adapters/amcharts/overlay.ts
+++ b/src/adapters/amcharts/overlay.ts
@@ -147,6 +147,8 @@ function readRect(target: NavTarget): OverlayRect | null {
       return pointRect(target);
     case 'slice':
       return sliceRect(target);
+    case 'label':
+      return labelRect(target);
     case 'column':
       return columnRect(target);
   }
@@ -227,6 +229,36 @@ function sliceRect(target: NavTarget): OverlayRect | null {
   }
 
   const box = spriteBoxRect(slice);
+  return box && box.width > 0 && box.height > 0 ? box : null;
+}
+
+/**
+ * Rectangle for a mark that is a piece of text — a word cloud's term, which
+ * amCharts keeps on the data item's `label`.
+ *
+ * Measured from the reported box rather than from the sprite's own corners,
+ * which is the opposite of what a column needs: a cloud rotates roughly half
+ * its words, and a rotated sprite's local top-left and bottom-right map to two
+ * corners of a tilted box rather than to the box a highlight has to draw.
+ * `globalBounds()` maps all four, which is the axis-aligned box around the
+ * glyph however it is turned. The sprite's own corners stay as the fallback
+ * for a build that reports no bounds.
+ */
+function labelRect(target: NavTarget): OverlayRect | null {
+  const label = target.dataItem.get('label') as AmSprite | undefined;
+  if (!label) {
+    return null;
+  }
+
+  const bounds = label.globalBounds?.();
+  if (bounds) {
+    const box = boundsToRect(bounds);
+    if (box.width > 0 && box.height > 0) {
+      return box;
+    }
+  }
+
+  const box = spriteBoxRect(label);
   return box && box.width > 0 && box.height > 0 ? box : null;
 }
 

--- a/src/adapters/amcharts/overlay.ts
+++ b/src/adapters/amcharts/overlay.ts
@@ -278,10 +278,15 @@ function intersectRect(rect: OverlayRect, bounds: AmBounds): OverlayRect | null 
 
 /**
  * Resolve the column graphics sprite for a dataItem. amCharts exposes it as
- * the `graphics` (or legacy `column`) data-item property.
+ * the `graphics` (or legacy `column`) data-item property, and an am5hierarchy
+ * node — a treemap block, an icicle bar — as `rectangle`. All three are plain
+ * rectangles laid out with a width and a height, which is what the box read
+ * above needs; only the property they hang on differs.
  */
 function readColumnSprite(target: NavTarget): AmSprite | undefined {
-  const graphics = target.dataItem.get('graphics') ?? target.dataItem.get('column');
+  const graphics = target.dataItem.get('graphics')
+    ?? target.dataItem.get('column')
+    ?? target.dataItem.get('rectangle');
   return graphics as AmSprite | undefined;
 }
 

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -233,4 +233,23 @@ export interface AmChartsBinderOptions {
    * says which dot the cursor is on but not what it stands for.
    */
   dumbbellLabels?: { start?: string; end?: string };
+
+  /**
+   * Whether the chart's line series carry ranks — a bump chart — rather than
+   * magnitudes.
+   *
+   * amCharts has no bump series: a rank table is line series on a value axis
+   * whose renderer is inversed, so first place sits at the top. That inversion
+   * is also how a plain chart of descending magnitudes is drawn, which is why
+   * the adapter corroborates it against the values themselves and why this
+   * option exists at all.
+   *
+   * - `true` says the lines are ranks when amCharts was not told to invert the
+   *   axis. The values still have to read as ranks, since the option applies to
+   *   every panel of the figure and must not invert a plain line chart's pitch.
+   * - `false` suppresses the reading entirely, for a chart of small integers
+   *   that happens to look like a ranking.
+   * - Left out, the adapter decides from the axis and the values together.
+   */
+  bump?: boolean;
 }

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -74,7 +74,8 @@ export interface AmEntity {
 
 /**
  * Minimal interface for a chart the adapter can convert: an `XYChart` (or an
- * am5stock `StockPanel`, which extends it) or an am5percent `PieChart`.
+ * am5stock `StockPanel`, which extends it) or an am5percent chart -- a
+ * `PieChart` or the `SlicedChart` a funnel lives in.
  *
  * Both expose their data through a series list. Only an XY chart is bound to
  * axes and owns a plot area, so `xAxes` / `yAxes` / `plotContainer` are
@@ -114,6 +115,14 @@ export interface AmXYSeries extends AmEntity {
   columns?: AmListLike<AmSprite>;
   bullets?: AmListLike<AmBullet>;
   strokes?: AmListLike<AmSprite>;
+  /**
+   * The fill graphics of a line series, as an am5 `ListTemplate`.
+   *
+   * amCharts has no area series class — an area chart is a `LineSeries` whose
+   * fills have been made visible — so the template's settings are the only
+   * thing that tells an area from a line.
+   */
+  fills?: { template?: AmSprite };
   /** Converts a series-local point to root-container coordinates. */
   toGlobal?: (point: AmPoint) => AmPoint;
 }

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -112,9 +112,18 @@ export type AmXYChart = AmChart;
  */
 export interface AmXYSeries extends AmEntity {
   dataItems: AmDataItem[];
-  columns?: AmListLike<AmSprite>;
+  /**
+   * The per-kind graphics lists, each an am5 `ListTemplate`: the drawn sprites
+   * under `values`, and the template they were all made from under `template`.
+   *
+   * The template is where a chart's styling is declared, and styling is the
+   * only signal amCharts leaves for the marks it has no series class for — a
+   * hairline `columns.template` is a lollipop's stem, and a `strokes.template`
+   * at zero opacity is what makes a line series a dot plot.
+   */
+  columns?: AmListLike<AmSprite> & { template?: AmSprite };
   bullets?: AmListLike<AmBullet>;
-  strokes?: AmListLike<AmSprite>;
+  strokes?: AmListLike<AmSprite> & { template?: AmSprite };
   /**
    * The fill graphics of a line series, as an am5 `ListTemplate`.
    *

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -125,6 +125,15 @@ export interface AmXYSeries extends AmEntity {
   fills?: { template?: AmSprite };
   /** Converts a series-local point to root-container coordinates. */
   toGlobal?: (point: AmPoint) => AmPoint;
+  /**
+   * The series' own laid-out box, which every am5 series has because a series
+   * is a `Container`. Read only for a standalone series — an am5hierarchy
+   * layout pushed straight into the root container — where the series IS the
+   * panel and there is no `plotContainer` to measure instead.
+   */
+  width?: () => number;
+  height?: () => number;
+  globalBounds?: () => AmBounds;
 }
 
 /**
@@ -204,4 +213,15 @@ export interface AmChartsBinderOptions {
    * Keys are `"x"` or `"y"`.
    */
   axisLabels?: { x?: string; y?: string };
+
+  /**
+   * What a dumbbell chart's two ends are called — "1990" and "2020", "before"
+   * and "after".
+   *
+   * Supplied here because there is nowhere to read them from: amCharts names
+   * the series, not the two ends of its columns, so anything taken off the
+   * chart would be a guess. Left out, MAIDR announces "start" and "end", which
+   * says which dot the cursor is on but not what it stands for.
+   */
+  dumbbellLabels?: { start?: string; end?: string };
 }

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -1,13 +1,26 @@
-import type { BarPoint, LinePoint, MaidrLayer, PiePoint } from '@type/grammar';
+import type { AmXYSeries } from '@adapters/amcharts/types';
+import type {
+  BarPoint,
+  DumbbellData,
+  GanttData,
+  LinePoint,
+  MaidrLayer,
+  PiePoint,
+  TreemapPoint,
+  WaterfallPoint,
+} from '@type/grammar';
 import { findCharts, findXYCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 import {
   fakeAreaSeries,
   fakeBarSeries,
   fakeChart,
   fakeContainer,
   fakeContainerEl,
+  fakeFloatingColumnSeries,
   fakeFunnelSeries,
+  fakeGanttSeries,
+  fakeHierarchySeries,
   fakeLineSeries,
   fakePieChart,
   fakePieSeries,
@@ -498,6 +511,233 @@ describe('fromAmCharts (sliced chart)', () => {
 
     expect(result.subplots[0][0].layers[0].axes)
       .toEqual({ x: { label: 'Step' }, y: { label: 'People' } });
+  });
+});
+
+describe('fromAmCharts (waterfall and dumbbell)', () => {
+  // amCharts draws both with the same floating columns; a bridge chains and a
+  // barbell does not, which is the only thing that tells them apart.
+  const BRIDGE = [
+    { categoryX: 'Opening', openValueY: 0, valueY: 1200 },
+    { categoryX: 'Marketing', openValueY: 1200, valueY: 950 },
+    { categoryX: 'Sales', openValueY: 950, valueY: 1430 },
+    { categoryX: 'Closing', openValueY: 0, valueY: 1430 },
+  ];
+  const PAIRS = [
+    { categoryX: 'Denmark', openValueY: 71.2, valueY: 78.4 },
+    { categoryX: 'Latvia', openValueY: 74.6, valueY: 69.5 },
+  ];
+
+  function layerOf(series: AmXYSeries, options?: Parameters<typeof fromAmCharts>[1]): MaidrLayer {
+    return fromAmCharts(fakeRoot([fakeChart({ series: [series] })]), options)
+      .subplots[0][0]
+      .layers[0];
+  }
+
+  it('reads chained floating columns as a waterfall, with both ends per step', () => {
+    const layer = layerOf(fakeFloatingColumnSeries('Budget', BRIDGE));
+
+    expect(layer.type).toBe(TraceType.WATERFALL);
+    expect(layer.title).toBe('Budget');
+    expect(layer.data as WaterfallPoint[]).toEqual([
+      { x: 'Opening', start: 0, end: 1200, delta: 1200, kind: 'total' },
+      { x: 'Marketing', start: 1200, end: 950, delta: -250, kind: 'decrease' },
+      { x: 'Sales', start: 950, end: 1430, delta: 480, kind: 'increase' },
+      { x: 'Closing', start: 0, end: 1430, delta: 1430, kind: 'total' },
+    ]);
+  });
+
+  it('strips float noise from a contribution the chart never rounded', () => {
+    const layer = layerOf(fakeFloatingColumnSeries('Budget', [
+      { categoryX: 'Opening', openValueY: 0, valueY: 1.1 },
+      { categoryX: 'Sales', openValueY: 1.1, valueY: 2.3 },
+    ]));
+
+    expect((layer.data as WaterfallPoint[])[1].delta).toBe(1.2);
+  });
+
+  it('reads independent pairs as a dumbbell, not as a bridge', () => {
+    const layer = layerOf(fakeFloatingColumnSeries('Life expectancy', PAIRS));
+
+    expect(layer.type).toBe(TraceType.DUMBBELL);
+    expect(layer.data as DumbbellData).toEqual({
+      points: [
+        { x: 'Denmark', start: 71.2, end: 78.4 },
+        { x: 'Latvia', start: 74.6, end: 69.5 },
+      ],
+    });
+  });
+
+  it('names a dumbbell\'s two ends from the binder options', () => {
+    const layer = layerOf(
+      fakeFloatingColumnSeries('Life expectancy', PAIRS),
+      { dumbbellLabels: { start: '1990', end: '2020' } },
+    );
+
+    const data = layer.data as DumbbellData;
+    expect(data.startLabel).toBe('1990');
+    expect(data.endLabel).toBe('2020');
+  });
+
+  it('skips columns missing an end, so step k stays the step it names', () => {
+    const layer = layerOf(fakeFloatingColumnSeries('Budget', [
+      { categoryX: 'Opening', openValueY: 0, valueY: 1200 },
+      { categoryX: 'Unknown', openValueY: null, valueY: 950 },
+      { categoryX: 'Sales', openValueY: 1200, valueY: 1430 },
+    ]));
+
+    expect((layer.data as WaterfallPoint[]).map(step => step.x))
+      .toEqual(['Opening', 'Sales']);
+  });
+
+  it('leaves a plain column series a bar chart', () => {
+    const layer = layerOf(fakeBarSeries('Tips', BAR_DATA));
+
+    expect(layer.type).toBe(TraceType.BAR);
+  });
+});
+
+describe('fromAmCharts (gantt chart)', () => {
+  const BARS = [
+    { categoryY: 'Design', openValueX: 0, valueX: 2_592_000_000 },
+    { categoryY: 'Design', openValueX: 5_184_000_000, valueX: 6_480_000_000 },
+    { categoryY: 'Build', openValueX: 2_592_000_000, valueX: 8_640_000_000 },
+  ];
+
+  function ganttLayer(config: { lanes?: string[]; timeUnit?: string }): MaidrLayer {
+    const series = fakeGanttSeries('Schedule', BARS, config);
+    return fromAmCharts(fakeRoot([fakeChart({
+      series: [series],
+      xLabel: 'Day',
+      yLabel: 'Phase',
+    })])).subplots[0][0].layers[0];
+  }
+
+  it('reads floating columns on a lane axis as a schedule, one row per lane', () => {
+    const layer = ganttLayer({ lanes: ['Design', 'Build', 'Launch'], timeUnit: 'day' });
+
+    expect(layer.type).toBe(TraceType.GANTT);
+    // A schedule runs left to right, so the lanes are on the y axis.
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(layer.axes).toEqual({ x: { label: 'Day' }, y: { label: 'Phase' } });
+
+    const data = layer.data as GanttData;
+    // Epoch milliseconds are rescaled to the axis' own unit, measured from the
+    // earliest interval -- a length in milliseconds carries nothing.
+    expect(data.unit).toBe('days');
+    expect(data.points).toEqual([
+      [
+        { x: 'Design', start: 0, end: 30 },
+        { x: 'Design', start: 60, end: 75 },
+      ],
+      [{ x: 'Build', start: 30, end: 100 }],
+      [],
+    ]);
+  });
+
+  it('keeps an empty lane, which a schedule needs to be able to say', () => {
+    const data = ganttLayer({ lanes: ['Design', 'Build', 'Launch'], timeUnit: 'day' })
+      .data as GanttData;
+
+    expect(data.lanes).toEqual(['Design', 'Build', 'Launch']);
+    expect(data.points[2]).toEqual([]);
+  });
+
+  it('appends a lane the category axis never declared rather than dropping it', () => {
+    const data = ganttLayer({ lanes: ['Design'], timeUnit: 'day' }).data as GanttData;
+
+    expect(data.lanes).toEqual(['Design', 'Build']);
+    expect(data.points[1]).toHaveLength(1);
+  });
+
+  it('passes a value axis\' positions through untouched and names no unit', () => {
+    const series = fakeGanttSeries('Schedule', [
+      { categoryY: 'Design', openValueX: 0, valueX: 30 },
+    ], { lanes: ['Design'] });
+
+    const layer = fromAmCharts(fakeRoot([fakeChart({ series: [series] })]))
+      .subplots[0][0]
+      .layers[0];
+
+    const data = layer.data as GanttData;
+    expect(data.unit).toBeUndefined();
+    expect(data.points[0]).toEqual([{ x: 'Design', start: 0, end: 30 }]);
+  });
+});
+
+describe('fromAmCharts (hierarchy)', () => {
+  const TREE = {
+    category: 'Root',
+    children: [
+      {
+        category: 'Asia',
+        children: [
+          { category: 'China', value: 1425 },
+          { category: 'India', value: 1428 },
+        ],
+      },
+      {
+        category: 'Africa',
+        children: [{ category: 'Nigeria', value: 224 }],
+      },
+    ],
+  };
+
+  it('finds a standalone hierarchy series, which is no chart at all', () => {
+    // An am5hierarchy layout is a bare series in a plain container: no series
+    // list, no axes, nothing the chart-shaped checks recognise.
+    const series = fakeHierarchySeries('Population', TREE);
+    const root = fakeRoot([fakeContainer([series])]);
+
+    const found = findCharts(root);
+    expect(found).toHaveLength(1);
+    expect(found[0].series.values).toEqual([series]);
+    expect(findXYCharts(root)).toEqual([]);
+  });
+
+  it('converts a treemap into nodes addressed by path, dropping the root', () => {
+    const series = fakeHierarchySeries('Population', TREE);
+
+    const layer = fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.TREEMAP);
+    expect(layer.title).toBe('Population');
+    // A tree is bound to no axis, so the dimensions name what they hold.
+    expect(layer.axes).toEqual({ x: { label: 'Node' }, y: { label: 'Value' } });
+    // Depth-first, so each level comes out in its left-to-right order -- and
+    // a branch carries no value of its own, which the trace totals from below.
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'Asia', path: [] },
+      { x: 'China', y: 1425, path: ['Asia'] },
+      { x: 'India', y: 1428, path: ['Asia'] },
+      { x: 'Africa', path: [] },
+      { x: 'Nigeria', y: 224, path: ['Africa'] },
+    ]);
+  });
+
+  it('keeps a branch total the chart declared for itself', () => {
+    const series = fakeHierarchySeries('Population', {
+      category: 'Root',
+      children: [{ category: 'Asia', value: 3000, children: [{ category: 'China', value: 1425 }] }],
+    });
+
+    const data = fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].data;
+
+    expect((data as TreemapPoint[])[0]).toEqual({ x: 'Asia', y: 3000, path: [] });
+  });
+
+  it('reads a Partition as an icicle, the same tree drawn another way', () => {
+    const series = fakeHierarchySeries('Population', TREE, 'Partition');
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].type)
+      .toBe(TraceType.ICICLE);
+  });
+
+  it('emits no selectors: amCharts renders the nodes to canvas, not to SVG', () => {
+    const series = fakeHierarchySeries('Population', TREE);
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].selectors)
+      .toBeUndefined();
   });
 });
 

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -1,15 +1,20 @@
-import type { BarPoint, MaidrLayer, PiePoint } from '@type/grammar';
+import type { BarPoint, LinePoint, MaidrLayer, PiePoint } from '@type/grammar';
 import { findCharts, findXYCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
 import { TraceType } from '@type/grammar';
 import {
+  fakeAreaSeries,
   fakeBarSeries,
   fakeChart,
   fakeContainer,
   fakeContainerEl,
+  fakeFunnelSeries,
   fakeLineSeries,
   fakePieChart,
   fakePieSeries,
+  fakePolarSeries,
+  fakeRadarSeries,
   fakeRoot,
+  fakeSlicedChart,
   fakeStepSeries,
 } from './helpers';
 
@@ -259,6 +264,240 @@ describe('fromAmCharts (pie chart)', () => {
     expect(result.subplots).toHaveLength(1);
     expect(result.subplots[0].map(subplot => subplot.layers[0].type))
       .toEqual([TraceType.BAR, TraceType.PIE]);
+  });
+});
+
+describe('fromAmCharts (area chart)', () => {
+  const BAND_A = [
+    { categoryX: '2020', valueY: 10 },
+    { categoryX: '2021', valueY: 14 },
+  ];
+  const BAND_B = [
+    { categoryX: '2020', valueY: 4 },
+    { categoryX: '2021', valueY: 6 },
+  ];
+
+  function layerOf(...series: ReturnType<typeof fakeAreaSeries>[]): MaidrLayer {
+    return fromAmCharts(fakeRoot([fakeChart({ series })])).subplots[0][0].layers[0];
+  }
+
+  it('reads a filled line series as an area, not as a line', () => {
+    const layer = layerOf(fakeAreaSeries('Sales', BAND_A));
+
+    expect(layer.type).toBe(TraceType.AREA);
+    expect(layer.title).toBe('Sales');
+    expect(layer.data as LinePoint[][]).toEqual([[
+      { x: '2020', y: 10, z: 'Sales' },
+      { x: '2021', y: 14, z: 'Sales' },
+    ]]);
+  });
+
+  it('leaves an unfilled line series a line', () => {
+    const layer = layerOf(fakeAreaSeries('Sales', BAND_A, { fillOpacity: 0 }));
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('leaves a line whose fills are switched off a line, whatever they are filled with', () => {
+    const layer = layerOf(
+      fakeAreaSeries('Sales', BAND_A, { fillOpacity: 0.8, fillVisible: false }),
+    );
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('reads stacked bands as a stacked area, one row per band', () => {
+    const layer = layerOf(
+      fakeAreaSeries('Sales', BAND_A, { stacked: true }),
+      fakeAreaSeries('Expenses', BAND_B, { stacked: true }),
+    );
+
+    expect(layer.type).toBe(TraceType.STACKED_AREA);
+    expect(layer.title).toBe('Sales, Expenses');
+    expect((layer.data as LinePoint[][]).map(band => band.map(point => point.y)))
+      .toEqual([[10, 14], [4, 6]]);
+  });
+
+  it('keeps the bottom band in the stack when only the bands above declare `stacked`', () => {
+    // amCharts commonly sets `stacked` on the bands that sit ON another one
+    // and leaves it off the bottom band; splitting by the flag would announce
+    // that band as an area chart of its own.
+    const layer = layerOf(
+      fakeAreaSeries('Sales', BAND_A),
+      fakeAreaSeries('Expenses', BAND_B, { stacked: true }),
+    );
+
+    expect(layer.type).toBe(TraceType.STACKED_AREA);
+    expect(layer.data as LinePoint[][]).toHaveLength(2);
+  });
+
+  it('reads a 100% stack as a normalized area', () => {
+    const layer = layerOf(
+      fakeAreaSeries('Sales', BAND_A, { stacked: true }),
+      fakeAreaSeries('Expenses', BAND_B, { stacked: true, normalized: true }),
+    );
+
+    expect(layer.type).toBe(TraceType.NORMALIZED_AREA);
+  });
+
+  it('keeps area series out of the line layer when a chart has both', () => {
+    const chart = fakeChart({
+      series: [fakeLineSeries('Trend', BAND_A), fakeAreaSeries('Band', BAND_B)],
+    });
+
+    const layers = fromAmCharts(fakeRoot([chart])).subplots[0][0].layers;
+
+    expect(layers.map(layer => [layer.type, layer.title])).toEqual([
+      [TraceType.LINE, 'Trend'],
+      [TraceType.AREA, 'Band'],
+    ]);
+  });
+});
+
+describe('fromAmCharts (radar chart)', () => {
+  const SPOKES_A = [
+    { categoryX: 'Speed', valueY: 8 },
+    { categoryX: 'Range', valueY: 4 },
+    { categoryX: 'Comfort', valueY: 6 },
+  ];
+  const SPOKES_B = [
+    { categoryX: 'Speed', valueY: 5 },
+    { categoryX: 'Range', valueY: 7 },
+    { categoryX: 'Comfort', valueY: 3 },
+  ];
+
+  it('reads a RadarLineSeries as a radar, not as the bar chart it fell back to', () => {
+    const chart = fakeChart({
+      className: 'RadarChart',
+      series: [fakeRadarSeries('Model A', SPOKES_A), fakeRadarSeries('Model B', SPOKES_B)],
+      xLabel: 'Attribute',
+      yLabel: 'Score',
+    });
+
+    const layer = fromAmCharts(fakeRoot([chart])).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.RADAR);
+    expect(layer.title).toBe('Model A, Model B');
+    expect(layer.axes).toEqual({ x: { label: 'Attribute' }, y: { label: 'Score' } });
+    // One row per series, one column per spoke, in spoke order.
+    expect(layer.data as LinePoint[][]).toEqual([
+      [
+        { x: 'Speed', y: 8, z: 'Model A' },
+        { x: 'Range', y: 4, z: 'Model A' },
+        { x: 'Comfort', y: 6, z: 'Model A' },
+      ],
+      [
+        { x: 'Speed', y: 5, z: 'Model B' },
+        { x: 'Range', y: 7, z: 'Model B' },
+        { x: 'Comfort', y: 3, z: 'Model B' },
+      ],
+    ]);
+  });
+
+  it('reads a RadarColumnSeries as a polar area', () => {
+    const chart = fakeChart({
+      className: 'RadarChart',
+      series: [fakePolarSeries('Rainfall', SPOKES_A)],
+    });
+
+    const layer = fromAmCharts(fakeRoot([chart])).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.POLAR_AREA);
+    expect(layer.title).toBe('Rainfall');
+    expect((layer.data as LinePoint[][])[0].map(point => point.y)).toEqual([8, 4, 6]);
+  });
+
+  it('keeps the two radar marks in layers of their own', () => {
+    const chart = fakeChart({
+      className: 'RadarChart',
+      series: [fakeRadarSeries('Outline', SPOKES_A), fakePolarSeries('Wedges', SPOKES_B)],
+    });
+
+    const layers = fromAmCharts(fakeRoot([chart])).subplots[0][0].layers;
+
+    expect(layers.map(layer => layer.type))
+      .toEqual([TraceType.RADAR, TraceType.POLAR_AREA]);
+  });
+});
+
+describe('fromAmCharts (sliced chart)', () => {
+  const STAGES = [
+    { category: 'Visited', value: 10000 },
+    { category: 'Signed up', value: 2400 },
+    { category: 'Purchased', value: 100 },
+  ];
+
+  it('finds a SlicedChart, which like a PieChart has a series list but no axes', () => {
+    const sliced = fakeSlicedChart({ series: [fakeFunnelSeries('Checkout', STAGES)] });
+    const root = fakeRoot([sliced]);
+
+    expect(findCharts(root)).toEqual([sliced]);
+    expect(findXYCharts(root)).toEqual([]);
+  });
+
+  it('converts a funnel series into a funnel layer, stages in data order', () => {
+    const sliced = fakeSlicedChart({
+      series: [fakeFunnelSeries('Checkout', STAGES)],
+      title: 'Checkout funnel',
+    });
+
+    const result = fromAmCharts(fakeRoot([sliced], 'funnel-chart'));
+
+    expect(result.title).toBe('Checkout funnel');
+    const layer = result.subplots[0][0].layers[0];
+    expect(layer.type).toBe(TraceType.FUNNEL);
+    expect(layer.title).toBe('Checkout');
+    // A sliced chart is bound to no axis, so the dimensions name what they hold.
+    expect(layer.axes).toEqual({ x: { label: 'Stage' }, y: { label: 'Value' } });
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'Visited', y: 10000 },
+      { x: 'Signed up', y: 2400 },
+      { x: 'Purchased', y: 100 },
+    ]);
+  });
+
+  it('reads a pyramid as the same ordered stages a funnel is', () => {
+    const sliced = fakeSlicedChart({
+      series: [fakeFunnelSeries('Checkout', STAGES, 'PyramidSeries')],
+    });
+
+    expect(fromAmCharts(fakeRoot([sliced])).subplots[0][0].layers[0].type)
+      .toBe(TraceType.FUNNEL);
+  });
+
+  it('skips stages with no value so stage k stays the stage it names', () => {
+    const sliced = fakeSlicedChart({
+      series: [fakeFunnelSeries('Checkout', [
+        { category: 'Visited', value: 10000 },
+        { category: 'Signed up', value: null },
+        { category: 'Purchased', value: 100 },
+      ])],
+    });
+
+    const layer = fromAmCharts(fakeRoot([sliced])).subplots[0][0].layers[0];
+
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: 'Visited', y: 10000 },
+      { x: 'Purchased', y: 100 },
+    ]);
+  });
+
+  it('emits no selectors: amCharts renders the stages to canvas, not to SVG', () => {
+    const sliced = fakeSlicedChart({ series: [fakeFunnelSeries('Checkout', STAGES)] });
+
+    expect(fromAmCharts(fakeRoot([sliced])).subplots[0][0].layers[0].selectors)
+      .toBeUndefined();
+  });
+
+  it('honors axis-label overrides on a funnel layer', () => {
+    const sliced = fakeSlicedChart({ series: [fakeFunnelSeries('Checkout', STAGES)] });
+
+    const result = fromAmCharts(fakeRoot([sliced]), {
+      axisLabels: { x: 'Step', y: 'People' },
+    });
+
+    expect(result.subplots[0][0].layers[0].axes)
+      .toEqual({ x: { label: 'Step' }, y: { label: 'People' } });
   });
 });
 

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -1,4 +1,4 @@
-import type { AmXYSeries } from '@adapters/amcharts/types';
+import type { AmChartsBinderOptions, AmXYSeries } from '@adapters/amcharts/types';
 import type {
   BarPoint,
   DumbbellData,
@@ -31,6 +31,7 @@ import {
   fakePieSeries,
   fakePolarSeries,
   fakeRadarSeries,
+  fakeRankSeries,
   fakeRoot,
   fakeSeries,
   fakeSlicedChart,
@@ -371,6 +372,158 @@ describe('fromAmCharts (area chart)', () => {
       [TraceType.LINE, 'Trend'],
       [TraceType.AREA, 'Band'],
     ]);
+  });
+});
+
+describe('fromAmCharts (bump chart)', () => {
+  const ASH = [
+    { categoryX: 'R1', valueY: 1 },
+    { categoryX: 'R2', valueY: 2 },
+    { categoryX: 'R3', valueY: 3 },
+  ];
+  const BIRCH = [
+    { categoryX: 'R1', valueY: 2 },
+    { categoryX: 'R2', valueY: 3 },
+    { categoryX: 'R3', valueY: 1 },
+  ];
+  const CEDAR = [
+    { categoryX: 'R1', valueY: 3 },
+    { categoryX: 'R2', valueY: 1 },
+    { categoryX: 'R3', valueY: 2 },
+  ];
+
+  function layerOf(series: AmXYSeries[], options?: AmChartsBinderOptions): MaidrLayer {
+    const chart = fakeChart({ series, xLabel: 'Round', yLabel: 'Rank' });
+    return fromAmCharts(fakeRoot([chart]), options).subplots[0][0].layers[0];
+  }
+
+  it('reads places on an inversed value axis as a bump chart', () => {
+    const layer = layerOf([
+      fakeRankSeries('Ash', ASH),
+      fakeRankSeries('Birch', BIRCH),
+      fakeRankSeries('Cedar', CEDAR),
+    ]);
+
+    expect(layer.type).toBe(TraceType.BUMP);
+    expect(layer.title).toBe('Ash, Birch, Cedar');
+    expect(layer.axes).toEqual({ x: { label: 'Round' }, y: { label: 'Rank' } });
+    expect((layer.data as LinePoint[][])[0]).toEqual([
+      { x: 'R1', y: 1, z: 'Ash' },
+      { x: 'R2', y: 2, z: 'Ash' },
+      { x: 'R3', y: 3, z: 'Ash' },
+    ]);
+  });
+
+  it('leaves the same places on an upright axis a line chart', () => {
+    // Nothing about the numbers says which way up the chart was drawn, and a
+    // rank axis is the one thing a bump chart declares about itself.
+    const layer = layerOf([
+      fakeRankSeries('Ash', ASH, { inversed: false }),
+      fakeRankSeries('Birch', BIRCH, { inversed: false }),
+      fakeRankSeries('Cedar', CEDAR, { inversed: false }),
+    ]);
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('leaves descending magnitudes on an inversed axis a line chart', () => {
+    // An inversed axis is also how a plain chart counting DOWN is drawn, so
+    // the axis alone would invert the pitch of every one of them.
+    const layer = layerOf([
+      fakeRankSeries('Ash', [
+        { categoryX: 'R1', valueY: 40 },
+        { categoryX: 'R2', valueY: 25 },
+      ]),
+      fakeRankSeries('Birch', [
+        { categoryX: 'R1', valueY: 30 },
+        { categoryX: 'R2', valueY: 12 },
+      ]),
+    ]);
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('leaves two lines that share a place in one period a line chart', () => {
+    // A ranking is a permutation: two competitors cannot both come second in
+    // the same round, so a chart that says they did is measuring something
+    // else with small integers.
+    const layer = layerOf([
+      fakeRankSeries('Ash', [
+        { categoryX: 'R1', valueY: 1 },
+        { categoryX: 'R2', valueY: 2 },
+      ]),
+      fakeRankSeries('Birch', [
+        { categoryX: 'R1', valueY: 1 },
+        { categoryX: 'R2', valueY: 2 },
+      ]),
+    ]);
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('leaves a chart drawn from the middle of a larger field a line chart', () => {
+    // Places 2 and 3 of a field whose leader is never drawn. It IS a bump
+    // chart, and it is left as a line rather than sonified against a rank
+    // range the chart does not carry.
+    const layer = layerOf([
+      fakeRankSeries('Ash', [{ categoryX: 'R1', valueY: 2 }, { categoryX: 'R2', valueY: 3 }]),
+      fakeRankSeries('Birch', [{ categoryX: 'R1', valueY: 3 }, { categoryX: 'R2', valueY: 2 }]),
+      fakeRankSeries('Cedar', [{ categoryX: 'R3', valueY: 2 }]),
+    ]);
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('reads places as a bump chart when the option declares one and the axis does not', () => {
+    const layer = layerOf(
+      [
+        fakeRankSeries('Ash', ASH, { inversed: false }),
+        fakeRankSeries('Birch', BIRCH, { inversed: false }),
+        fakeRankSeries('Cedar', CEDAR, { inversed: false }),
+      ],
+      { bump: true },
+    );
+
+    expect(layer.type).toBe(TraceType.BUMP);
+  });
+
+  it('leaves a declared bump chart a line when its values are not places', () => {
+    // The option is figure-wide, so a `true` meant for one panel must not
+    // invert the pitch of a plain line chart in the next one.
+    const layer = layerOf(
+      [
+        fakeRankSeries('Ash', [
+          { categoryX: 'R1', valueY: 40 },
+          { categoryX: 'R2', valueY: 25 },
+        ]),
+        fakeRankSeries('Birch', [
+          { categoryX: 'R1', valueY: 30 },
+          { categoryX: 'R2', valueY: 12 },
+        ]),
+      ],
+      { bump: true },
+    );
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('leaves a rank chart a line when the option says it is not one', () => {
+    const layer = layerOf(
+      [
+        fakeRankSeries('Ash', ASH),
+        fakeRankSeries('Birch', BIRCH),
+        fakeRankSeries('Cedar', CEDAR),
+      ],
+      { bump: false },
+    );
+
+    expect(layer.type).toBe(TraceType.LINE);
+  });
+
+  it('leaves an ordinary line chart alone', () => {
+    const layer = layerOf([fakeLineSeries('Trend', BAR_DATA)]);
+
+    expect(layer.type).toBe(TraceType.LINE);
   });
 });
 

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -6,8 +6,10 @@ import type {
   LinePoint,
   MaidrLayer,
   PiePoint,
+  SegmentedPoint,
   TreemapPoint,
   WaterfallPoint,
+  WordCloudPoint,
 } from '@type/grammar';
 import { findCharts, findXYCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
 import { Orientation, TraceType } from '@type/grammar';
@@ -17,18 +19,23 @@ import {
   fakeChart,
   fakeContainer,
   fakeContainerEl,
+  fakeDotSeries,
   fakeFloatingColumnSeries,
   fakeFunnelSeries,
   fakeGanttSeries,
   fakeHierarchySeries,
+  fakeHorizontalBarSeries,
   fakeLineSeries,
+  fakeLollipopSeries,
   fakePieChart,
   fakePieSeries,
   fakePolarSeries,
   fakeRadarSeries,
   fakeRoot,
+  fakeSeries,
   fakeSlicedChart,
   fakeStepSeries,
+  fakeWordCloudSeries,
 } from './helpers';
 
 const BAR_DATA = [
@@ -738,6 +745,253 @@ describe('fromAmCharts (hierarchy)', () => {
 
     expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].selectors)
       .toBeUndefined();
+  });
+});
+
+describe('fromAmCharts (diverging bars)', () => {
+  const MEN = [
+    { categoryY: '0-14', valueX: -1200 },
+    { categoryY: '15-29', valueX: -1150 },
+  ];
+  const WOMEN = [
+    { categoryY: '0-14', valueX: 1140 },
+    { categoryY: '15-29', valueX: 1100 },
+  ];
+
+  function layerOf(...series: AmXYSeries[]): MaidrLayer {
+    return fromAmCharts(fakeRoot([fakeChart({ series })])).subplots[0][0].layers[0];
+  }
+
+  it('reads two column series on opposite sides of the baseline as a pyramid', () => {
+    const layer = layerOf(
+      fakeHorizontalBarSeries('Men', MEN),
+      fakeHorizontalBarSeries('Women', WOMEN),
+    );
+
+    expect(layer.type).toBe(TraceType.DIVERGING);
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    // The sign is a direction, not a magnitude, so it survives the extraction
+    // exactly as the chart drew it -- the trace pitches the size and announces
+    // the side.
+    expect(layer.data as SegmentedPoint[][]).toEqual([
+      [
+        { x: -1200, y: '0-14', z: 'Men' },
+        { x: -1150, y: '15-29', z: 'Men' },
+      ],
+      [
+        { x: 1140, y: '0-14', z: 'Women' },
+        { x: 1100, y: '15-29', z: 'Women' },
+      ],
+    ]);
+  });
+
+  it('reads a vertical pair the same way: the sides are the sign, not the axis', () => {
+    const layer = layerOf(
+      fakeBarSeries('Losses', [{ categoryX: 'Q1', valueY: -30 }]),
+      fakeBarSeries('Gains', [{ categoryX: 'Q1', valueY: 45 }]),
+    );
+
+    expect(layer.type).toBe(TraceType.DIVERGING);
+    expect(layer.orientation).toBeUndefined();
+  });
+
+  it('leaves an ordinary grouped pair a dodged bar chart', () => {
+    const layer = layerOf(
+      fakeBarSeries('2023', [{ categoryX: 'Q1', valueY: 30 }]),
+      fakeBarSeries('2024', [{ categoryX: 'Q1', valueY: 45 }]),
+    );
+
+    expect(layer.type).toBe(TraceType.DODGED);
+  });
+
+  it('leaves a pair over different categories a dodged bar chart', () => {
+    // Back-to-back only means anything across a SHARED axis; two series that
+    // do not line up are two charts drawn in one frame.
+    const layer = layerOf(
+      fakeHorizontalBarSeries('Men', MEN),
+      fakeHorizontalBarSeries('Women', [
+        { categoryY: '30-44', valueX: 1140 },
+        { categoryY: '45-59', valueX: 1100 },
+      ]),
+    );
+
+    expect(layer.type).toBe(TraceType.DODGED);
+  });
+
+  it('leaves a declared stack alone: a pyramid is not stacked', () => {
+    const layer = layerOf(
+      fakeSeries({
+        name: 'Men',
+        settings: { categoryYField: 'category', stacked: true },
+        data: MEN,
+      }),
+      fakeSeries({
+        name: 'Women',
+        settings: { categoryYField: 'category', stacked: true },
+        data: WOMEN,
+      }),
+    );
+
+    expect(layer.type).toBe(TraceType.STACKED);
+  });
+
+  it('leaves three series a dodged bar chart, whatever their signs', () => {
+    const layer = layerOf(
+      fakeBarSeries('A', [{ categoryX: 'Q1', valueY: -30 }]),
+      fakeBarSeries('B', [{ categoryX: 'Q1', valueY: 45 }]),
+      fakeBarSeries('C', [{ categoryX: 'Q1', valueY: 12 }]),
+    );
+
+    expect(layer.type).toBe(TraceType.DODGED);
+  });
+});
+
+describe('fromAmCharts (dot plot and lollipop)', () => {
+  const POINTS = [
+    { categoryX: '/search', valueY: 412 },
+    { categoryX: '/checkout', valueY: 318 },
+  ];
+
+  function layerOf(...series: AmXYSeries[]): MaidrLayer {
+    return fromAmCharts(fakeRoot([fakeChart({ series })])).subplots[0][0].layers[0];
+  }
+
+  it('reads a strokeless line series with bullets as a dot plot', () => {
+    const layer = layerOf(fakeDotSeries('Response time', POINTS));
+
+    expect(layer.type).toBe(TraceType.DOT);
+    expect(layer.title).toBe('Response time');
+    // A category and a value, exactly as a bar chart carries them -- the mark
+    // is what differs, not what a reader navigates.
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: '/search', y: 412 },
+      { x: '/checkout', y: 318 },
+    ]);
+  });
+
+  it('accepts a stroke hidden by width rather than by opacity', () => {
+    const series = fakeDotSeries('Response time', POINTS);
+    (series as unknown as Record<string, unknown>).strokes = {
+      values: [],
+      template: { get: (key: string) => (key === 'strokeWidth' ? 0 : undefined) },
+    };
+
+    expect(layerOf(series).type).toBe(TraceType.DOT);
+  });
+
+  it('leaves a line with visible strokes and bullets a line chart', () => {
+    // Markers on a line are a line chart with markers, not a dot plot.
+    expect(layerOf(fakeDotSeries('Trend', POINTS, { strokeOpacity: 1 })).type)
+      .toBe(TraceType.LINE);
+  });
+
+  it('leaves a strokeless line with no bullets a line chart', () => {
+    expect(layerOf(fakeDotSeries('Trend', POINTS, { bullets: false })).type)
+      .toBe(TraceType.LINE);
+  });
+
+  it('leaves a filled band an area, however its outline is drawn', () => {
+    const band = fakeAreaSeries('Sales', POINTS);
+    const raw = band as unknown as Record<string, unknown>;
+    raw.strokes = { values: [], template: { get: () => 0 } };
+    raw.bullets = { values: [{ get: () => undefined }] };
+
+    expect(layerOf(band).type).toBe(TraceType.AREA);
+  });
+
+  it('reads hairline columns with bullets as a lollipop', () => {
+    const layer = layerOf(fakeLollipopSeries('Life expectancy', POINTS));
+
+    expect(layer.type).toBe(TraceType.LOLLIPOP);
+    expect(layer.data as BarPoint[]).toEqual([
+      { x: '/search', y: 412 },
+      { x: '/checkout', y: 318 },
+    ]);
+  });
+
+  it('leaves columns of an ordinary width a bar chart', () => {
+    expect(layerOf(fakeLollipopSeries('Sales', POINTS, { thickness: 40 })).type)
+      .toBe(TraceType.BAR);
+  });
+
+  it('leaves hairline columns with no bullets a bar chart', () => {
+    expect(layerOf(fakeLollipopSeries('Sales', POINTS, { bullets: false })).type)
+      .toBe(TraceType.BAR);
+  });
+
+  it('reads a stem width declared as a percentage as an ordinary bar', () => {
+    // amCharts accepts a `Percent` for any dimension, and a column half its
+    // cell wide is not a hairline however small the number reads.
+    const series = fakeLollipopSeries('Sales', POINTS);
+    (series as unknown as Record<string, unknown>).columns = {
+      values: [],
+      template: { get: () => ({ value: 0.5 }) },
+    };
+
+    expect(layerOf(series).type).toBe(TraceType.BAR);
+  });
+
+  it('keeps a dot plot and a lollipop in layers of their own', () => {
+    const chart = fakeChart({
+      series: [fakeDotSeries('Dots', POINTS), fakeLollipopSeries('Stems', POINTS)],
+    });
+
+    const layers = fromAmCharts(fakeRoot([chart])).subplots[0][0].layers;
+
+    expect(layers.map(layer => layer.type)).toEqual([TraceType.DOT, TraceType.LOLLIPOP]);
+  });
+});
+
+describe('fromAmCharts (word cloud)', () => {
+  const TERMS = [
+    { category: 'neural', value: 128 },
+    { category: 'machine', value: 412 },
+    { category: 'gradient', value: 57 },
+  ];
+
+  it('finds a standalone word cloud series, which like a treemap is no chart', () => {
+    const series = fakeWordCloudSeries('Terms', TERMS);
+    const root = fakeRoot([fakeContainer([series])]);
+
+    const found = findCharts(root);
+    expect(found).toHaveLength(1);
+    expect(found[0].series.values).toEqual([series]);
+    expect(findXYCharts(root)).toEqual([]);
+  });
+
+  it('converts a word cloud into terms and weights, in data order', () => {
+    const layer = fromAmCharts(fakeRoot([fakeWordCloudSeries('Terms', TERMS)]))
+      .subplots[0][0]
+      .layers[0];
+
+    expect(layer.type).toBe(TraceType.WORD_CLOUD);
+    expect(layer.title).toBe('Terms');
+    // Bound to no axis: the dimensions name what they hold, since a cloud's
+    // layout is chosen to pack glyphs and encodes nothing.
+    expect(layer.axes).toEqual({ x: { label: 'Term' }, y: { label: 'Weight' } });
+    // Declared order, not weight order -- MAIDR derives the reading order from
+    // the weights themselves.
+    expect(layer.data as WordCloudPoint[]).toEqual([
+      { x: 'neural', y: 128 },
+      { x: 'machine', y: 412 },
+      { x: 'gradient', y: 57 },
+    ]);
+  });
+
+  it('skips terms with no weight so term k stays the term it names', () => {
+    const layer = fromAmCharts(fakeRoot([fakeWordCloudSeries('Terms', [
+      { category: 'neural', value: 128 },
+      { category: 'unmeasured', value: null },
+      { category: 'machine', value: 412 },
+    ])])).subplots[0][0].layers[0];
+
+    expect((layer.data as WordCloudPoint[]).map(term => term.x))
+      .toEqual(['neural', 'machine']);
+  });
+
+  it('emits no selectors: amCharts renders the glyphs to canvas, not to SVG', () => {
+    expect(fromAmCharts(fakeRoot([fakeWordCloudSeries('Terms', TERMS)]))
+      .subplots[0][0].layers[0].selectors).toBeUndefined();
   });
 });
 

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -164,6 +164,42 @@ export function fakeLineSeries(
 }
 
 /**
+ * A value axis, optionally drawn upside down — the rank axis a bump chart
+ * plots on. amCharts keeps the inversion on the axis' renderer rather than on
+ * the axis itself, which is where the adapter reads it from.
+ */
+export function fakeValueAxis(inversed: boolean): AmAxis {
+  const renderer = {
+    get: (key: string) => (key === 'inversed' ? inversed : undefined),
+  };
+  return {
+    className: 'ValueAxis',
+    get: (key: string) => (key === 'renderer' ? renderer : undefined),
+    dataItems: [],
+  } as unknown as AmAxis;
+}
+
+/**
+ * One competitor of a bump chart: an ordinary `LineSeries` carrying places
+ * rather than magnitudes, bound by default to an inversed value axis.
+ */
+export function fakeRankSeries(
+  name: string,
+  places: Array<{ categoryX: string; valueY: number }>,
+  config: { inversed?: boolean } = {},
+): AmXYSeries {
+  return fakeSeries({
+    className: 'LineSeries',
+    name,
+    settings: {
+      categoryXField: 'category',
+      yAxis: fakeValueAxis(config.inversed !== false),
+    },
+    data: places,
+  });
+}
+
+/**
  * How an area series declares its band, mirroring the settings amCharts reads:
  * a visible fill is what makes a `LineSeries` an area at all, and `stacked` /
  * `valueYShow` are what make the bands a stack.

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -56,6 +56,100 @@ export function fakeBarSeries(
   });
 }
 
+/**
+ * A horizontal column series: categories on the Y axis and values on the X
+ * one, which is how amCharts draws a bar chart lying on its side — and the
+ * only way it draws a population pyramid.
+ */
+export function fakeHorizontalBarSeries(
+  name: string,
+  points: Array<{ categoryY: string; valueX: number | null }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'ColumnSeries',
+    name,
+    settings: { categoryYField: 'category' },
+    data: points,
+  });
+}
+
+/**
+ * What amCharts leaves behind when it draws a mark it has no series class for:
+ * the styling on the graphics template, and whether bullets were pushed on.
+ */
+export interface FakeMarkConfig {
+  /** `strokes.template.get('strokeOpacity')`, for a dot plot's hidden line. */
+  strokeOpacity?: number;
+  /** `columns.template.get(width|height)`, for a lollipop's hairline stem. */
+  thickness?: number;
+  /** Whether any bullet was configured. Defaults to true. */
+  bullets?: boolean;
+}
+
+/**
+ * A `LineSeries` drawn as a Cleveland dot plot: the stroke switched off and
+ * bullets pushed on, so what is drawn is the points alone.
+ */
+export function fakeDotSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number }>,
+  config: FakeMarkConfig = {},
+): AmXYSeries {
+  const strokeSettings: Record<string, unknown> = {
+    strokeOpacity: config.strokeOpacity ?? 0,
+  };
+  const series = fakeSeries({
+    className: 'LineSeries',
+    name,
+    settings: { categoryXField: 'category' },
+    data: points,
+  });
+  const raw = series as unknown as Record<string, unknown>;
+  raw.strokes = { values: [], template: { get: (key: string) => strokeSettings[key] } };
+  raw.bullets = { values: config.bullets === false ? [] : [{ get: () => undefined }] };
+  return series;
+}
+
+/**
+ * A `ColumnSeries` drawn as a lollipop: columns narrowed to a stem, with a
+ * bullet on the end. `graphics` stands in for the column sprite the overlay
+ * measures.
+ */
+export function fakeLollipopSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number; graphics?: unknown }>,
+  config: FakeMarkConfig = {},
+): AmXYSeries {
+  const columnSettings: Record<string, unknown> = { width: config.thickness ?? 2 };
+  const series = fakeSeries({
+    className: 'ColumnSeries',
+    name,
+    settings: { categoryXField: 'category' },
+    data: points,
+  });
+  const raw = series as unknown as Record<string, unknown>;
+  raw.columns = { values: [], template: { get: (key: string) => columnSettings[key] } };
+  raw.bullets = { values: config.bullets === false ? [] : [{ get: () => undefined }] };
+  return series;
+}
+
+/**
+ * An am5wc `WordCloud`: like a hierarchy layout it is a bare series in a plain
+ * container, and like a pie its terms carry a `category`/`value` pair. `label`
+ * stands in for the glyph the overlay measures.
+ */
+export function fakeWordCloudSeries(
+  name: string,
+  terms: Array<{ category: string; value: number | null; label?: unknown }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'WordCloud',
+    name,
+    settings: { categoryField: 'category', valueField: 'value' },
+    data: terms,
+  });
+}
+
 /** A line series with `categoryX`/`valueY` data items. */
 export function fakeLineSeries(
   name: string,

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -10,6 +10,7 @@ import type {
   AmAxis,
   AmBounds,
   AmChart,
+  AmDataItem,
   AmRoot,
   AmXYSeries,
 } from '@adapters/amcharts/types';
@@ -173,6 +174,120 @@ export function fakePieSeries(
     settings: { categoryField: 'category', valueField: 'value' },
     data: slices,
   });
+}
+
+/**
+ * A column series whose bars float between two values on the value axis —
+ * the shape amCharts draws both a waterfall and a dumbbell with. `graphics`
+ * stands in for the column sprite the overlay measures.
+ */
+export function fakeFloatingColumnSeries(
+  name: string,
+  columns: Array<{
+    categoryX: string;
+    openValueY: number | null;
+    valueY: number | null;
+    graphics?: unknown;
+  }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'ColumnSeries',
+    name,
+    settings: { categoryXField: 'category', openValueYField: 'open' },
+    data: columns,
+  });
+}
+
+/** A category axis, whose data items name the lanes of a schedule. */
+export function fakeCategoryAxis(categories: string[]): AmAxis {
+  return {
+    className: 'CategoryAxis',
+    get: () => undefined,
+    dataItems: categories.map(category => ({
+      get: (key: string) => (key === 'category' ? category : undefined),
+    })),
+  } as unknown as AmAxis;
+}
+
+/**
+ * A date axis, which reports the unit its positions are measured in through
+ * its base interval. Passing no unit makes it a plain value axis instead.
+ */
+export function fakeTimeAxis(timeUnit?: string): AmAxis {
+  const baseInterval = timeUnit != null ? { timeUnit, count: 1 } : undefined;
+  return {
+    className: timeUnit != null ? 'DateAxis' : 'ValueAxis',
+    get: (key: string) => (key === 'baseInterval' ? baseInterval : undefined),
+    dataItems: [],
+  } as unknown as AmAxis;
+}
+
+/**
+ * An amCharts gantt: floating columns on a category axis of lanes and a date
+ * axis of time. The axes are settings of the series, which is where the
+ * adapter reads the lane names and the unit from.
+ */
+export function fakeGanttSeries(
+  name: string,
+  bars: Array<{
+    categoryY: string;
+    openValueX: number | null;
+    valueX: number | null;
+    graphics?: unknown;
+  }>,
+  config: { lanes?: string[]; timeUnit?: string } = {},
+): AmXYSeries {
+  return fakeSeries({
+    className: 'ColumnSeries',
+    name,
+    settings: {
+      categoryYField: 'category',
+      openValueXField: 'fromDate',
+      xAxis: fakeTimeAxis(config.timeUnit),
+      yAxis: fakeCategoryAxis(config.lanes ?? []),
+    },
+    data: bars,
+  });
+}
+
+/** One node of a fake am5hierarchy tree. */
+export interface FakeNode {
+  category: string;
+  value?: number;
+  children?: FakeNode[];
+  /** Stands in for the rectangle sprite the overlay measures. */
+  rectangle?: unknown;
+}
+
+function fakeHierarchyItem(node: FakeNode): AmDataItem {
+  const children = node.children?.map(fakeHierarchyItem);
+  const settings: Record<string, unknown> = {
+    category: node.category,
+    ...(node.value != null ? { value: node.value } : {}),
+    ...(children != null ? { children } : {}),
+    ...(node.rectangle != null ? { rectangle: node.rectangle } : {}),
+  };
+  return { get: (key: string) => settings[key] } as unknown as AmDataItem;
+}
+
+/**
+ * An am5hierarchy series — a `Treemap`, or the `Partition` amCharts draws an
+ * icicle with. Unlike every other series here it is not inside a chart: it is
+ * pushed straight into a container, and its nodes hang off the single root
+ * data item rather than off the series.
+ */
+export function fakeHierarchySeries(
+  name: string,
+  root: FakeNode,
+  className = 'Treemap',
+): AmXYSeries {
+  const settings: Record<string, unknown> = { name };
+  return {
+    className,
+    uid: nextUid++,
+    get: (key: string) => settings[key],
+    dataItems: [fakeHierarchyItem(root)],
+  } as unknown as AmXYSeries;
 }
 
 /** A step-line series, drawn as a staircase rather than an interpolated line. */

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -69,6 +69,97 @@ export function fakeLineSeries(
 }
 
 /**
+ * How an area series declares its band, mirroring the settings amCharts reads:
+ * a visible fill is what makes a `LineSeries` an area at all, and `stacked` /
+ * `valueYShow` are what make the bands a stack.
+ */
+export interface FakeAreaConfig {
+  /** `fills.template.get('fillOpacity')`. Defaults to a visible 0.5. */
+  fillOpacity?: number;
+  /** `fills.template.get('visible')`. */
+  fillVisible?: boolean;
+  stacked?: boolean;
+  /** Set for a 100% stack (`valueYShow: 'valueYTotalPercent'`). */
+  normalized?: boolean;
+}
+
+/**
+ * A `LineSeries` drawn as an area: the same series a line uses, with the fill
+ * template amCharts requires before it paints the band.
+ */
+export function fakeAreaSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number }>,
+  config: FakeAreaConfig = {},
+): AmXYSeries {
+  const fillSettings: Record<string, unknown> = {
+    fillOpacity: config.fillOpacity ?? 0.5,
+    ...(config.fillVisible != null ? { visible: config.fillVisible } : {}),
+  };
+  const series = fakeSeries({
+    className: 'LineSeries',
+    name,
+    settings: {
+      categoryXField: 'category',
+      ...(config.stacked ? { stacked: true } : {}),
+      ...(config.normalized ? { valueYShow: 'valueYTotalPercent' } : {}),
+    },
+    data: points,
+  });
+  (series as unknown as Record<string, unknown>).fills = {
+    template: { get: (key: string) => fillSettings[key] },
+  };
+  return series;
+}
+
+/** An am5radar `RadarLineSeries`: one closed outline over the spokes. */
+export function fakeRadarSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'RadarLineSeries',
+    name,
+    settings: { categoryXField: 'category' },
+    data: points,
+  });
+}
+
+/**
+ * An am5radar `RadarColumnSeries`: the same spokes drawn as wedges. Its
+ * wedges live on each data item's `graphics`, where a plain column series
+ * keeps its rectangle.
+ */
+export function fakePolarSeries(
+  name: string,
+  points: Array<{ categoryX: string; valueY: number; graphics?: unknown }>,
+): AmXYSeries {
+  return fakeSeries({
+    className: 'RadarColumnSeries',
+    name,
+    settings: { categoryXField: 'category' },
+    data: points,
+  });
+}
+
+/**
+ * An am5percent funnel series: `category`/`value` stages in data order, with
+ * `slice` standing in for the stage graphic the overlay measures.
+ */
+export function fakeFunnelSeries(
+  name: string,
+  stages: Array<{ category: string; value: number | null; slice?: unknown }>,
+  className = 'FunnelSeries',
+): AmXYSeries {
+  return fakeSeries({
+    className,
+    name,
+    settings: { categoryField: 'category', valueField: 'value' },
+    data: stages,
+  });
+}
+
+/**
  * An am5percent pie series: `category`/`value` data items, no axis fields.
  * `slice` stands in for the wedge graphic the overlay reads geometry from.
  */
@@ -165,6 +256,18 @@ export function fakePieChart(config: { series?: AmXYSeries[]; title?: string } =
       }],
     };
   }
+  return chart as unknown as AmChart;
+}
+
+/**
+ * An am5percent `SlicedChart` — the funnel/pyramid counterpart of a
+ * `PieChart`: a series list and a class name, no axes and no plot container.
+ */
+export function fakeSlicedChart(
+  config: { series?: AmXYSeries[]; title?: string } = {},
+): AmChart {
+  const chart = fakePieChart(config) as unknown as Record<string, unknown>;
+  chart.className = 'SlicedChart';
   return chart as unknown as AmChart;
 }
 

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -18,6 +18,7 @@ import {
   fakePieSeries,
   fakePolarSeries,
   fakeRadarSeries,
+  fakeRankSeries,
   fakeSlicedChart,
   fakeWordCloudSeries,
 } from './helpers';
@@ -405,5 +406,32 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     expect(targets[0].dataItem.get('valueY')).toBe(60);
     expect(targets[0].kind).toBe('point');
     expect(navMap.chartFor('lines')).toBe(chart);
+  });
+
+  it('resolves a bump layer to the competitor whose place is being announced', () => {
+    // A bump chart is drawn as lines and collected with them, so the position
+    // addresses the same mark a line layer's does — the rank is what the trace
+    // announces, not a different thing to point at.
+    const ash = fakeRankSeries('Ash', [
+      { categoryX: 'R1', valueY: 1 },
+      { categoryX: 'R2', valueY: 2 },
+    ]);
+    const birch = fakeRankSeries('Birch', [
+      { categoryX: 'R1', valueY: 2 },
+      { categoryX: 'R2', valueY: 1 },
+    ]);
+    const chart = fakeChart({ series: [ash, birch] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'places', type: TraceType.BUMP, data: [] }],
+      groups: { ...emptyGroups(), lineSeriesList: [ash, birch] },
+    }]);
+
+    const targets = navMap.resolve('places', 1, 1);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].series).toBe(birch);
+    expect(targets[0].dataItem.get('valueY')).toBe(1);
+    expect(targets[0].kind).toBe('point');
+    expect(navMap.resolve('places', 2, 0)).toEqual([]);
   });
 });

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -7,7 +7,10 @@ import {
   fakeAreaSeries,
   fakeBarSeries,
   fakeChart,
+  fakeFloatingColumnSeries,
   fakeFunnelSeries,
+  fakeGanttSeries,
+  fakeHierarchySeries,
   fakeLineSeries,
   fakePieChart,
   fakePieSeries,
@@ -28,6 +31,10 @@ function emptyGroups(): SeriesGroups {
     heatmapSeries: [],
     pieSeriesList: [],
     funnelSeriesList: [],
+    waterfallSeriesList: [],
+    dumbbellSeriesList: [],
+    ganttSeriesList: [],
+    hierarchySeriesList: [],
   };
 }
 
@@ -203,6 +210,92 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     // col 1 is the SECOND kept stage, i.e. Purchased (the gap is skipped).
     expect(targets[0].dataItem.get('category')).toBe('Purchased');
     expect(targets[0].kind).toBe('slice');
+  });
+
+  it('resolves a waterfall layer to one column per step, skipping partial ones', () => {
+    const series = fakeFloatingColumnSeries('Budget', [
+      { categoryX: 'Opening', openValueY: 0, valueY: 1200 },
+      { categoryX: 'Unknown', openValueY: null, valueY: 950 },
+      { categoryX: 'Sales', openValueY: 1200, valueY: 1430 },
+    ]);
+    const chart = fakeChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'bridge', type: TraceType.WATERFALL, data: [] }],
+      groups: { ...emptyGroups(), waterfallSeriesList: [series] },
+    }]);
+
+    const targets = navMap.resolve('bridge', 0, 1);
+    expect(targets).toHaveLength(1);
+    // col 1 is the SECOND kept step, i.e. Sales (the partial column is skipped).
+    expect(targets[0].dataItem.get('categoryX')).toBe('Sales');
+    expect(targets[0].kind).toBe('column');
+  });
+
+  it('resolves both ends of a dumbbell to the one column the chart drew', () => {
+    const series = fakeFloatingColumnSeries('Life expectancy', [
+      { categoryX: 'Denmark', openValueY: 71.2, valueY: 78.4 },
+      { categoryX: 'Latvia', openValueY: 74.6, valueY: 69.5 },
+    ]);
+    const chart = fakeChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'pairs', type: TraceType.DUMBBELL, data: [] }],
+      groups: { ...emptyGroups(), dumbbellSeriesList: [series] },
+    }]);
+
+    // Row 0 is the starting end and row 1 the finishing one; a chart draws one
+    // connector per category, so both resolve to the same mark.
+    const start = navMap.resolve('pairs', 0, 1);
+    const end = navMap.resolve('pairs', 1, 1);
+    expect(start[0].dataItem.get('categoryX')).toBe('Latvia');
+    expect(end[0].dataItem).toBe(start[0].dataItem);
+  });
+
+  it('resolves a gantt layer by [lane, interval], the grouping the layer holds', () => {
+    const series = fakeGanttSeries('Schedule', [
+      { categoryY: 'Design', openValueX: 0, valueX: 30 },
+      { categoryY: 'Design', openValueX: 60, valueX: 75 },
+      { categoryY: 'Build', openValueX: 30, valueX: 100 },
+    ], { lanes: ['Design', 'Build', 'Launch'] });
+    const chart = fakeChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'schedule', type: TraceType.GANTT, data: [] }],
+      groups: { ...emptyGroups(), ganttSeriesList: [series] },
+    }]);
+
+    const second = navMap.resolve('schedule', 0, 1);
+    expect(second[0].dataItem.get('openValueX')).toBe(60);
+    expect(second[0].kind).toBe('column');
+
+    expect(navMap.resolve('schedule', 1, 0)[0].dataItem.get('valueX')).toBe(100);
+    // A lane with nothing booked is navigable and highlights nothing.
+    expect(navMap.resolve('schedule', 2, 0)).toEqual([]);
+  });
+
+  it('resolves a treemap layer by [depth, index within depth]', () => {
+    const series = fakeHierarchySeries('Population', {
+      category: 'Root',
+      children: [
+        { category: 'Asia', children: [{ category: 'China', value: 1425 }] },
+        { category: 'Africa', children: [{ category: 'Nigeria', value: 224 }] },
+      ],
+    });
+    const chart = fakeChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'tree', type: TraceType.TREEMAP, data: [] }],
+      groups: { ...emptyGroups(), hierarchySeriesList: [series] },
+    }]);
+
+    // Row 0 is the top level below the (dropped) root.
+    expect(navMap.resolve('tree', 0, 1)[0].dataItem.get('category')).toBe('Africa');
+    // Row 1 holds the leaves, in the order the walk reached them.
+    expect(navMap.resolve('tree', 1, 1)[0].dataItem.get('category')).toBe('Nigeria');
+    // A node is a rectangle, which the overlay measures as it measures a column.
+    expect(navMap.resolve('tree', 1, 1)[0].kind).toBe('column');
+    expect(navMap.resolve('tree', 2, 0)).toEqual([]);
   });
 
   it('resolves line layers to point targets by [row, col]', () => {

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -7,21 +7,26 @@ import {
   fakeAreaSeries,
   fakeBarSeries,
   fakeChart,
+  fakeDotSeries,
   fakeFloatingColumnSeries,
   fakeFunnelSeries,
   fakeGanttSeries,
   fakeHierarchySeries,
   fakeLineSeries,
+  fakeLollipopSeries,
   fakePieChart,
   fakePieSeries,
   fakePolarSeries,
   fakeRadarSeries,
   fakeSlicedChart,
+  fakeWordCloudSeries,
 } from './helpers';
 
 function emptyGroups(): SeriesGroups {
   return {
     barSeriesList: [],
+    dotSeriesList: [],
+    lollipopSeriesList: [],
     lineSeriesList: [],
     stepSeriesList: [],
     areaSeriesList: [],
@@ -35,6 +40,7 @@ function emptyGroups(): SeriesGroups {
     dumbbellSeriesList: [],
     ganttSeriesList: [],
     hierarchySeriesList: [],
+    wordCloudSeriesList: [],
   };
 }
 
@@ -296,6 +302,85 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     // A node is a rectangle, which the overlay measures as it measures a column.
     expect(navMap.resolve('tree', 1, 1)[0].kind).toBe('column');
     expect(navMap.resolve('tree', 2, 0)).toEqual([]);
+  });
+
+  it('resolves a diverging layer as it resolves a dodged one, one row per side', () => {
+    const men = fakeBarSeries('Men', [
+      { categoryX: '0-14', valueY: -1200 },
+      { categoryX: '15-29', valueY: -1150 },
+    ]);
+    const women = fakeBarSeries('Women', [
+      { categoryX: '0-14', valueY: 1140 },
+      { categoryX: '15-29', valueY: 1100 },
+    ]);
+    const chart = fakeChart({ series: [men, women] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'pyramid', type: TraceType.DIVERGING, data: [] }],
+      groups: { ...emptyGroups(), barSeriesList: [men, women] },
+    }]);
+
+    const target = navMap.resolve('pyramid', 1, 1);
+    expect(target[0].series).toBe(women);
+    expect(target[0].dataItem.get('valueY')).toBe(1100);
+    expect(target[0].kind).toBe('column');
+  });
+
+  it('resolves a dot layer to its bullets and a lollipop layer to its stems', () => {
+    const dots = fakeDotSeries('Response time', [
+      { categoryX: '/search', valueY: 412 },
+      { categoryX: '/checkout', valueY: 318 },
+    ]);
+    const stems = fakeLollipopSeries('Life expectancy', [
+      { categoryX: 'Norway', valueY: 84 },
+      { categoryX: 'Japan', valueY: 81 },
+    ]);
+    const chart = fakeChart({ series: [dots, stems] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [
+        { id: 'dots', type: TraceType.DOT, data: [] },
+        { id: 'stems', type: TraceType.LOLLIPOP, data: [] },
+      ],
+      groups: { ...emptyGroups(), dotSeriesList: [dots], lollipopSeriesList: [stems] },
+    }]);
+
+    // A dot's mark is the bullet, so the overlay measures a point.
+    const dot = navMap.resolve('dots', 0, 1);
+    expect(dot[0].series).toBe(dots);
+    expect(dot[0].dataItem.get('valueY')).toBe(318);
+    expect(dot[0].kind).toBe('point');
+
+    // A stem is still a column, thin as it is.
+    const stem = navMap.resolve('stems', 0, 0);
+    expect(stem[0].series).toBe(stems);
+    expect(stem[0].kind).toBe('column');
+  });
+
+  it('resolves a word cloud layer in weight order, not in declared order', () => {
+    // The one layer whose navigation order is not the order it was declared
+    // in: MAIDR walks the terms heaviest first, and the position it reports is
+    // an index into THAT order.
+    const series = fakeWordCloudSeries('Terms', [
+      { category: 'neural', value: 128 },
+      { category: 'unmeasured', value: null },
+      { category: 'machine', value: 412 },
+      { category: 'gradient', value: 57 },
+    ]);
+    const chart = fakeChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'cloud', type: TraceType.WORD_CLOUD, data: [] }],
+      groups: { ...emptyGroups(), wordCloudSeriesList: [series] },
+    }]);
+
+    expect(navMap.resolve('cloud', 0, 0)[0].dataItem.get('category')).toBe('machine');
+    expect(navMap.resolve('cloud', 0, 1)[0].dataItem.get('category')).toBe('neural');
+    // The weightless term is skipped, exactly as the extraction skips it.
+    expect(navMap.resolve('cloud', 0, 2)[0].dataItem.get('category')).toBe('gradient');
+    expect(navMap.resolve('cloud', 0, 3)).toEqual([]);
+    // A term is a glyph, which the overlay measures as neither a box nor a wedge.
+    expect(navMap.resolve('cloud', 0, 0)[0].kind).toBe('label');
   });
 
   it('resolves line layers to point targets by [row, col]', () => {

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -3,16 +3,31 @@ import type { AmXYChart, AmXYSeries } from '@adapters/amcharts/types';
 import type { MaidrLayer } from '@type/grammar';
 import { buildNavigationMap } from '@adapters/amcharts/navmap';
 import { TraceType } from '@type/grammar';
-import { fakeBarSeries, fakeChart, fakeLineSeries, fakePieChart, fakePieSeries } from './helpers';
+import {
+  fakeAreaSeries,
+  fakeBarSeries,
+  fakeChart,
+  fakeFunnelSeries,
+  fakeLineSeries,
+  fakePieChart,
+  fakePieSeries,
+  fakePolarSeries,
+  fakeRadarSeries,
+  fakeSlicedChart,
+} from './helpers';
 
 function emptyGroups(): SeriesGroups {
   return {
     barSeriesList: [],
     lineSeriesList: [],
     stepSeriesList: [],
+    areaSeriesList: [],
+    radarSeriesList: [],
+    polarSeriesList: [],
     histogramSeries: [],
     heatmapSeries: [],
     pieSeriesList: [],
+    funnelSeriesList: [],
   };
 }
 
@@ -113,6 +128,80 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     expect(targets).toHaveLength(1);
     // col 1 is the SECOND kept slice, i.e. Cherries (the gap is skipped).
     expect(targets[0].dataItem.get('category')).toBe('Cherries');
+    expect(targets[0].kind).toBe('slice');
+  });
+
+  it('resolves an area layer to point targets, indexing its own series list', () => {
+    const line = fakeLineSeries('Trend', [
+      { categoryX: '2020', valueY: 100 },
+      { categoryX: '2021', valueY: 120 },
+    ]);
+    const band = fakeAreaSeries('Band', [
+      { categoryX: '2020', valueY: 10 },
+      { categoryX: '2021', valueY: 14 },
+    ]);
+    const chart = fakeChart({ series: [line, band] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [lineLayer('lines'), { id: 'bands', type: TraceType.AREA, data: [] }],
+      groups: { ...emptyGroups(), lineSeriesList: [line], areaSeriesList: [band] },
+    }]);
+
+    // Row 0 of the area layer is the area layer's OWN first series, not the
+    // line's -- sharing one list would highlight the wrong mark.
+    const targets = navMap.resolve('bands', 0, 1);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].series).toBe(band);
+    expect(targets[0].dataItem.get('valueY')).toBe(14);
+    expect(targets[0].kind).toBe('point');
+  });
+
+  it('resolves a radar layer to point targets and a polar one to wedges', () => {
+    const outline = fakeRadarSeries('Model A', [
+      { categoryX: 'Speed', valueY: 8 },
+      { categoryX: 'Range', valueY: 4 },
+    ]);
+    const wedges = fakePolarSeries('Rainfall', [
+      { categoryX: 'Jan', valueY: 30 },
+      { categoryX: 'Feb', valueY: 20 },
+    ]);
+    const chart = fakeChart({ className: 'RadarChart', series: [outline, wedges] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [
+        { id: 'radar', type: TraceType.RADAR, data: [] },
+        { id: 'polar', type: TraceType.POLAR_AREA, data: [] },
+      ],
+      groups: { ...emptyGroups(), radarSeriesList: [outline], polarSeriesList: [wedges] },
+    }]);
+
+    const spoke = navMap.resolve('radar', 0, 1);
+    expect(spoke[0].dataItem.get('valueY')).toBe(4);
+    expect(spoke[0].kind).toBe('point');
+
+    // A polar column is a wedge sprite, so the overlay measures it as one.
+    const wedge = navMap.resolve('polar', 0, 0);
+    expect(wedge[0].series).toBe(wedges);
+    expect(wedge[0].kind).toBe('slice');
+  });
+
+  it('resolves a funnel layer to stage targets, skipping valueless stages', () => {
+    const series = fakeFunnelSeries('Checkout', [
+      { category: 'Visited', value: 10000 },
+      { category: 'Signed up', value: null },
+      { category: 'Purchased', value: 100 },
+    ]);
+    const chart = fakeSlicedChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'funnel', type: TraceType.FUNNEL, data: [] }],
+      groups: { ...emptyGroups(), funnelSeriesList: [series] },
+    }]);
+
+    const targets = navMap.resolve('funnel', 0, 1);
+    expect(targets).toHaveLength(1);
+    // col 1 is the SECOND kept stage, i.e. Purchased (the gap is skipped).
+    expect(targets[0].dataItem.get('category')).toBe('Purchased');
     expect(targets[0].kind).toBe('slice');
   });
 

--- a/test/adapters/amcharts/overlay.test.ts
+++ b/test/adapters/amcharts/overlay.test.ts
@@ -1,0 +1,78 @@
+import type { NavTarget } from '@adapters/amcharts/navmap';
+import type { AmDataItem, AmSprite, AmXYSeries } from '@adapters/amcharts/types';
+import { dataItemToOverlayRect } from '@adapters/amcharts/overlay';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * A `Slice` as amCharts reports one: a degenerate box at its own centre and
+ * zero width/height, with the wedge's real extent only in its settings (#774).
+ */
+function wedgeSprite(cx: number, cy: number, settings: Record<string, unknown>): AmSprite {
+  return {
+    globalBounds: () => ({ left: cx, top: cy, right: cx, bottom: cy }),
+    width: () => 0,
+    height: () => 0,
+    get: (key: string) => settings[key],
+  };
+}
+
+/**
+ * A funnel stage's graphic: no radius to measure, but a laid-out box of its
+ * own, which is what a `FunnelSlice` actually carries.
+ */
+function stageSprite(left: number, top: number, width: number, height: number): AmSprite {
+  return {
+    width: () => width,
+    height: () => height,
+    toGlobal: point => ({ x: left + point.x, y: top + point.y }),
+    get: () => undefined,
+  };
+}
+
+function target(properties: Record<string, unknown>): NavTarget {
+  const dataItem = { get: (key: string) => properties[key] } as unknown as AmDataItem;
+  return { series: {} as AmXYSeries, dataItem, kind: 'slice' };
+}
+
+describe('dataItemToOverlayRect (wedge-shaped marks)', () => {
+  it('measures a pie wedge from its settings, which is where its extent lives', () => {
+    // -90 is 12 o'clock and angles run clockwise: the top-right quarter.
+    const slice = wedgeSprite(100, 100, { radius: 50, startAngle: -90, arc: 90 });
+
+    expect(dataItemToOverlayRect(target({ slice }), null))
+      .toEqual({ left: 100, top: 50, width: 50, height: 50 });
+  });
+
+  it('measures a polar column, which the series keeps on `graphics`', () => {
+    const slice = wedgeSprite(0, 0, { radius: 10, startAngle: 0, arc: 90 });
+
+    // 0..90 is the bottom-right quarter (y grows down), so the box runs from
+    // the centre out to (r, r).
+    expect(dataItemToOverlayRect(target({ graphics: slice }), null))
+      .toEqual({ left: 0, top: 0, width: 10, height: 10 });
+  });
+
+  it('falls back to the sprite box for a funnel stage, which is no wedge', () => {
+    const slice = stageSprite(20, 40, 120, 30);
+
+    expect(dataItemToOverlayRect(target({ slice }), null))
+      .toEqual({ left: 20, top: 40, width: 120, height: 30 });
+  });
+
+  it('reports nothing for a mark that reports neither a wedge nor a box', () => {
+    // A pie asked before its first layout: a degenerate centre, no radius.
+    const slice = wedgeSprite(100, 100, {});
+
+    expect(dataItemToOverlayRect(target({ slice }), null)).toBeNull();
+    expect(dataItemToOverlayRect(target({}), null)).toBeNull();
+  });
+
+  it('clips a wedge to the panel it belongs to', () => {
+    const slice = wedgeSprite(100, 100, { radius: 50, startAngle: -90, arc: 90 });
+
+    expect(dataItemToOverlayRect(
+      target({ slice }),
+      { left: 0, top: 80, right: 130, bottom: 200 },
+    )).toEqual({ left: 100, top: 80, width: 30, height: 20 });
+  });
+});

--- a/test/adapters/amcharts/overlay.test.ts
+++ b/test/adapters/amcharts/overlay.test.ts
@@ -29,9 +29,9 @@ function stageSprite(left: number, top: number, width: number, height: number): 
   };
 }
 
-function target(properties: Record<string, unknown>): NavTarget {
+function target(properties: Record<string, unknown>, kind: NavTarget['kind'] = 'slice'): NavTarget {
   const dataItem = { get: (key: string) => properties[key] } as unknown as AmDataItem;
-  return { series: {} as AmXYSeries, dataItem, kind: 'slice' };
+  return { series: {} as AmXYSeries, dataItem, kind };
 }
 
 describe('dataItemToOverlayRect (wedge-shaped marks)', () => {
@@ -65,6 +65,33 @@ describe('dataItemToOverlayRect (wedge-shaped marks)', () => {
 
     expect(dataItemToOverlayRect(target({ slice }), null)).toBeNull();
     expect(dataItemToOverlayRect(target({}), null)).toBeNull();
+  });
+
+  it('measures a word cloud term from the box it reports, rotation included', () => {
+    // A cloud turns roughly half its words. The sprite's own corners map to
+    // two corners of a tilted box; `globalBounds()` maps all four, which is
+    // the box a highlight has to draw.
+    const label: AmSprite = {
+      globalBounds: () => ({ left: 30, top: 10, right: 46, bottom: 70 }),
+      width: () => 60,
+      height: () => 16,
+      toGlobal: point => ({ x: 30 + point.y, y: 70 - point.x }),
+    };
+
+    expect(dataItemToOverlayRect(target({ label }, 'label'), null))
+      .toEqual({ left: 30, top: 10, width: 16, height: 60 });
+  });
+
+  it('falls back to a term\'s own corners when it reports no box', () => {
+    const label: AmSprite = {
+      width: () => 60,
+      height: () => 16,
+      toGlobal: point => ({ x: 30 + point.x, y: 10 + point.y }),
+    };
+
+    expect(dataItemToOverlayRect(target({ label }, 'label'), null))
+      .toEqual({ left: 30, top: 10, width: 60, height: 16 });
+    expect(dataItemToOverlayRect(target({}, 'label'), null)).toBeNull();
   });
 
   it('clips a wedge to the panel it belongs to', () => {


### PR DESCRIPTION
# Pull Request

## Description

The amCharts 5 adapter stopped at the pie chart: its whole vocabulary was BAR, STACKED / NORMALIZED / DODGED, HISTOGRAM, HEATMAP, PIE and LINE / STEP. Everything else amCharts can draw was either dropped from the figure or, worse, silently announced as something it is not — `classifySeriesKind` ended in `return 'bar'`, so a radar chart was read out as a row of bars and a floating-column waterfall kept only the end of each interval and threw the start away.

This adds **16 of the 22 in-scope trace types** from #869. The work is adapter-local: nothing under `src/model/`, `src/service/`, `src/state/`, `src/ui/`, `src/command/` or `src/type/grammar.ts` is touched — the core already supports every type read here.

The recurring theme is that amCharts has no series class for most of these charts. An area is a `LineSeries` with its fill switched on; a waterfall, a dumbbell and a gantt are all one `ColumnSeries` floating between two values; a diverging bar is two column series with one side negated; a dot plot is a line with no stroke; a bump chart is lines on an inversed axis. So each type is detected from what the chart *declares* — fills, open-value fields, signs, axis renderers — and, where the drawing alone is ambiguous, corroborated against the data itself.

Highlighting is wired in the same commit as every detection, per the "sonifies but does not highlight is not done" rule. amCharts renders to `<canvas>`, so there are no SVG nodes to select and the overlay measures each mark from the sprite amCharts keeps it on.

## Related Issues

Closes #869

## Changes Made

### Trace types added (16)

| TraceType | Detected from |
|---|---|
| `AREA` | `LineSeries` whose `fills` template is visible |
| `STACKED_AREA` | visible fills + `stacked`, read across the whole group (amCharts leaves the flag off the bottom band) |
| `NORMALIZED_AREA` | the above + `valueYShow: "valueYTotalPercent"` |
| `RADAR` | `RadarLineSeries` — previously fell through to `bar` |
| `POLAR_AREA` | `RadarColumnSeries` — previously fell through to `bar` |
| `FUNNEL` | `am5percent.FunnelSeries` / `PyramidSeries` / `PictorialStackedSeries`, with `SlicedChart` added to chart discovery |
| `WATERFALL` | floating `ColumnSeries` on a category X axis whose bars **chain** (each opens where the last closed); baseline bars read as opening / closing / subtotal steps |
| `DUMBBELL` | the same floating-column signature where the bars do **not** chain; `dumbbellLabels` option names the two ends, which amCharts does not |
| `GANTT` | floating `ColumnSeries` on a category Y axis; lanes taken from the axis so an empty lane survives, `DateAxis` epoch positions rescaled to the axis' own `baseInterval` |
| `TREEMAP` | `am5hierarchy.Treemap` |
| `ICICLE` | `am5hierarchy.Partition` |
| `DIVERGING` | two `ColumnSeries` on shared categories, one entirely negative and one entirely positive; values reach MAIDR signed |
| `DOT` | `LineSeries` with the stroke switched off and bullets pushed on, on a category axis |
| `LOLLIPOP` | `ColumnSeries` narrowed to a hairline pixel width, with bullets |
| `WORD_CLOUD` | `am5wc.WordCloud`; MAIDR walks terms heaviest first, so the highlight sorts the data items the same way |
| `BUMP` | `LineSeries` on a `ValueAxis` whose renderer is `inversed`, corroborated by the values being a genuine ranking; `bump` option settles the ambiguity |

### In-scope trace types **not** added (6)

| TraceType | Why not |
|---|---|
| `SUNBURST` | Not implemented. `Sunburst` is deliberately excluded from the standalone-series table rather than left to fall through: it extends `Partition`, so omitting it keeps it out instead of reading it as an icicle. The discovery branch it needs now exists, so this is a class-name mapping plus a wedge highlight path. |
| `SANKEY` | Not implemented — no flow/link extraction path exists in the adapter (`am5flow` dataItems carry source/target node items, which nothing here reads yet). |
| `CHORD` | Not implemented — same missing flow extraction as `SANKEY`. |
| `NETWORK` | Not implemented — `am5hierarchy.ForceDirected` / `am5flow.ArcDiagram` link-pair extraction not written. |
| `CHOROPLETH` | Not implemented — `am5map.MapChart` discovery not added, and the payload needs `geoCentroid()` reads the adapter makes nowhere. |
| `GAUGE` | Not implemented. It is the one in-scope type that is not series-shaped — a gauge has zero series and its value lives on a `ClockHand`'s axis data item — so it does not fit the series-driven layer building this PR extends, and it still hits the "no supported data" path. |

`SCATTER` is also not added, and that is a decision rather than an omission: amCharts draws a scatter as a hidden-stroke `LineSeries` with bullets, which is exactly how it draws a Cleveland dot plot. The only thing separating them is the axis, so a hidden-stroke series on a **category** axis is read as a dot plot and the same series on two **value** axes stays a line chart, rather than being announced as a scatter MAIDR would then read as a dot plot. Box plots, candlestick, violin and smooth/regression layers remain unsupported by this adapter.

### Options added

`dumbbellLabels: { start, end }` and `bump` (`true` stands in for an inversed axis but still requires rank-shaped values; `false` suppresses the reading outright). Both are documented.

### Discovery, highlighting and tests

- Chart discovery gained `SlicedChart` alongside `PieChart`, and a new branch for **standalone series** — an `am5hierarchy` layout or an `am5wc` cloud is a series pushed straight into a plain container, with no chart and no axes, so `findCharts` used to recurse past it. Each is now wrapped as its own one-series panel.
- The navigation map mirrors each new trace's addressing (a bridge's steps, a dumbbell's shared connector, a gantt's lanes by interval, a tree's depth by index within it, a cloud's weight order), and the overlay learned to measure a hierarchy node from its `rectangle` and a funnel stage from its laid-out box when it carries no radius to measure as a wedge.
- `test/adapters/amcharts/` covers every newly detected type: 5 suites, 137 tests (+1,637 lines, including a new `overlay.test.ts`), all on duck-typed fakes with no amCharts import.
- 8 runnable example pages: `amcharts-area.html`, `amcharts-radar.html`, `amcharts-funnel.html`, `amcharts-floating-columns.html`, `amcharts-treemap.html`, `amcharts-marks.html`, `amcharts-wordcloud.html`, `amcharts-bump.html`.
- `docs/amcharts.md` documents every new type, its detection signal and its reading, with a runnable snippet per family.

## Screenshots (if applicable)

n/a — no visual change to MAIDR's own UI.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is left unticked deliberately: the automated gate below was run in full and passes, but the browser pass over `ManualTestingProcess.md` with a screen reader was not performed. The example pages are there to make that pass straightforward.

## Additional Notes

**Gate:** `npm run lint:fix` (clean, no changes), `npm run type-check` (clean), `npm run build` (all targets built), `npm test` (188 suites / 2696 tests and 7 suites / 73 tests, all passing). No pre-existing failures encountered.

**Two detection decisions worth reviewing:**

1. **Bump is decided at the layer level, not per series.** Rank uniqueness is a cross-series property — you cannot answer "are these ranks?" from one series — so it is settled in `buildChartLayers` via `lineTraceType`, following the existing diverging-pair precedent, rather than in `classifySeriesKind`. Consequence: no new `SeriesKind`, and bump competitors stay in the line bucket the highlight path already collects them from.

2. **The rank test is a permutation test, not "positive integers".** "Consecutive positive integers unique per x" is too weak — a single-series count chart (5, 12, 30) satisfies it, and on an inversed axis would have been announced as a bump chart with inverted pitch. The check is instead: whole places bounded by the number of competitors, distinct within each period, with somebody in first. The documented cost is that a chart of places 3–9 of a twenty-strong field is a real bump chart that stays a line chart — the safe direction to fail in.

Verified against the shipped library (`https://cdn.amcharts.com/lib/5/xy.js`) that `inversed` is a setting on the axis **renderer**, not on the axis.

`scripts/build-site.js` carries a hardcoded example list that does not include the new pages; it is outside this PR's scope and was left alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_