### PR TITLE
feat(d3): support the chart types added since the pie chart

### DIFF
--- a/docs/d3.md
+++ b/docs/d3.md
@@ -228,6 +228,11 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Sankey` | Sankey | `<path>` ribbon per link | [Sankey](examples.html) |
 | `bindD3Alluvial` | Alluvial | `<path>` ribbon per link | [Alluvial](examples.html) |
 | `bindD3Chord` | Chord | `<path>` ribbon per chord | [Chord](examples.html) |
+| `bindD3Survival` | Kaplan-Meier survival curve | `<path>` per arm, plus `censoredSelector` for the ticks | [Survival](examples.html) |
+| `bindD3Parallel` | Parallel coordinates | `<path>` or `<polyline>` per observation | [Parallel](examples.html) |
+| `bindD3Ridgeline` | Ridgeline / joy plot | `<path>` density curve per group | [Ridgeline](examples.html) |
+| `bindD3Hexbin` | Hexbin density | `<path>` hexagon per bin | [Hexbin](examples.html) |
+| `bindD3Contour` | Contour / density field | `<path>` per level | [Contour](examples.html) |
 
 ## Multi-Panel Charts
 
@@ -892,6 +897,108 @@ maidrD3.bindD3Chord(svgElement, {
 
 The ribbons are emitted in the order they were declared, and the trace keys its selectors to that order: from a node, arrow keys follow the largest flow out of it and the rotor steps through the rest.
 
+### Kaplan-Meier Survival Curve
+
+A survival curve is a step line, so `selector`, `x`, `y` and `fill` are the line binder's. What a survival figure adds is the two things it is read for — which times were **censored**, and how wide the confidence band is:
+
+```js
+maidrD3.bindD3Survival(svgElement, {
+  selector: 'path.km',
+  censoredSelector: 'line.censor',     // the ticks, drawn by their own join
+  title: 'Overall Survival',
+  axes: { x: 'Months', y: 'Survival probability', fill: 'Arm' },
+  x: 'time',
+  y: 'surv',
+  fill: 'arm',
+  yMin: 'lower',
+  yMax: 'upper',
+});
+```
+
+Censoring marks are drawn as ticks precisely because censoring does not change the estimate — so they come from a separate join whose times are not, in general, vertices of the curve. The binder merges each tick into the arm its `fill` names: flagging the vertex already at that time, or inserting one carrying the probability the curve holds across the interval it falls in. On a chart whose own samples already carry a `censored` column, leave `censoredSelector` out and the `censored` accessor reads it (`true`, `1`, `'1'` and `'true'` count; nothing else does, because `'0'` is truthy and censors nobody).
+
+The trace derives median survival itself and offers a rotor over the censored times, so nothing here computes either.
+
+### Parallel Coordinates
+
+One `<path>` per **observation** crossing several per-variable scales, with the whole observation bound to it. The binder transposes that into one point per axis, and `dimensions` is the axis order — the same list you built one scale per:
+
+```js
+maidrD3.bindD3Parallel(svgElement, {
+  selector: 'path.observation',
+  title: 'Car Characteristics',
+  axes: { x: 'Variable', y: 'Value', fill: 'Car' },
+  dimensions: ['mpg', 'hp', 'weight'],
+  label: 'name',                       // what this observation is called
+  // value: (d, dimension) => d.values[dimension],   // when the numbers nest
+});
+```
+
+> **`dimensions` is required.** An object's key order is not an axis order, and the order the axes are drawn in is the order a reader arrows through them. An observation short of a declared dimension is an error rather than a gap: dropping it would shift every axis after it, announcing each value under the next variable's name.
+
+The trace derives each axis' range from the data and sonifies every value against its own axis, so no per-axis minimum is needed in the payload — a car with the best economy and the worst power sounds like exactly that, rather than like the units the two variables happen to be measured in.
+
+### Ridgeline / Joy Plot
+
+One `d3.area()` density curve per group, offset down the page. The three per-sample fields are named for what they mean rather than for the payload keys they land on, because a ridgeline's value axis is usually the drawn `x`:
+
+```js
+maidrD3.bindD3Ridgeline(svgElement, {
+  selector: 'path.ridge',
+  title: 'Delivery Time by Cohort',
+  axes: { x: 'Days', y: 'Cohort', fill: 'Cohort' },
+  group: 'cohort',                     // names the ridge
+  value: 'days',                       // position along the value axis
+  density: 'density',                  // the curve's OWN half-width
+});
+```
+
+> **`density` is never the drawn y.** A ridgeline is drawn by adding each group's baseline to its density, and that baseline is layout: fed to MAIDR it would make every group's loudness a function of where it happened to be stacked, and the lowest ridge the loudest chart-wide. Pass the kernel-density array you computed before offsetting it — the number inside the offset arithmetic in your `d3.area().y1(...)`, not its result. The binder cannot detect the mistake; it can only refuse when there is no density at all.
+
+Each path's datum supplies its group's samples: the array itself, a `d3.groups()` tuple, or a `values` / `samples` / `points` / `curve` property holding one. One element per group is exactly what the trace wants — it lights that ridge's whole curve from any of its samples — so a single scoped selector is emitted.
+
+### Hexbin Density
+
+The `d3-hexbin` plugin returns one bin per occupied hexagon, each an array of the points that fell in it carrying `.x`/`.y` (the centre) and `.length` (the count) — which is what the defaults read:
+
+```js
+const bins = hexbin(points);
+svg.selectAll('path.hexagon').data(bins).join('path').attr('d', hexbin.hexagon());
+
+maidrD3.bindD3Hexbin(svgElement, {
+  selector: 'path.hexagon',
+  title: 'Point Density',
+  axes: { x: 'Carat', y: 'Price', fill: 'Count' },
+  x: d => xScale.invert(d.x),          // the centres come out in PIXELS
+  y: d => yScale.invert(d.y),
+});
+```
+
+> **Pass the inverse scales.** `d3-hexbin` bins the projected points, so `bin.x` is a screen coordinate. Left as it is, every bin announces its position in pixels — which sounds entirely plausible and is entirely wrong.
+
+The lattice rows are assembled by the binder: bins grouped by their `y`, ordered from the lowest upward, each row ordered left to right. An empty bin is not drawn at all, so the rows do not hold the same number of bins and no rectangular grid could be laid over them. Supply `row` only if your `y` centres do not come out identical within a row. The highlight selectors are stamped per bin in that lattice order, because a bare selector would resolve in the order the plugin generated the bins in — with the counts still matching, so the trace could not tell.
+
+### Contour / Density Field
+
+`d3.contours()` and `d3.contourDensity()` emit one GeoJSON `MultiPolygon` per threshold, carrying the threshold as `.value`. Bind those objects to the paths — not the `d` strings you drew them with:
+
+```js
+const levels = d3.contours().size([n, m])(values);
+svg.selectAll('path.contour').data(levels).join('path').attr('d', d3.geoPath());
+
+maidrD3.bindD3Contour(svgElement, {
+  selector: 'path.contour',
+  title: 'Density Field',
+  axes: { x: 'X', y: 'Y', fill: 'Density' },
+  x: column => x0 + column * cellWidth,   // contours() emits GRID INDICES
+  y: row => y0 + row * cellHeight,
+});
+```
+
+> **The coordinates are not in data space.** `d3.contours()` walks a grid and emits indices; `d3.contourDensity()` bins projected points and emits pixels (use `x: px => xScale.invert(px)` for that one). Neither is a position on an axis.
+
+The level is carried on every point of its curve, which is where the grammar has room for it, and the trace announces it on the `z` axis — the field's own — rather than as a series name. A level drawn as several disjoint rings is flattened into one curve in ring order, since a payload row is a single polyline: every point announced is real, but the jump from one ring to the next is inaudible. Rows keep the order the paths were drawn in, which for `d3.contours()` is ascending threshold — the order the trace measures the gap to the adjacent level in.
+
 ### Gauge / Bullet Chart
 
 A drawn gauge binds one number, so the rest of the reading is config — and it *is* the reading: "73" means nothing without the range it sits in, the target it was aiming at, and the band it lands in:
@@ -973,6 +1080,11 @@ import type {
   D3HistogramConfig,
   D3HeatmapConfig,
   D3CandlestickConfig,
+  D3ContourConfig,
+  D3HexbinConfig,
+  D3ParallelConfig,
+  D3RidgelineConfig,
+  D3SurvivalConfig,   // extends D3LineConfig
   D3SegmentedConfig,
   D3MosaicConfig,
   D3NetworkConfig,
@@ -995,6 +1107,7 @@ import type {
   BarMarkTraceType,
   LineMarkTraceType,
   FlowTraceType,
+  D3GridTransform,    // (gridCoordinate: number) => number, for bindD3Contour
   ScatterMarkTraceType,
   SegmentedTraceType,
   TreemapTraceType,

--- a/docs/d3.md
+++ b/docs/d3.md
@@ -193,7 +193,12 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | Binder | Chart type | Selector targets | Example |
 |--------|-----------|------------------|---------|
 | `bindD3Bar` | Bar | `<rect>` per bar | [Bar chart](examples.html) |
+| `bindD3Dot` | Cleveland dot plot | `<circle>` per category | [Dot plot](examples.html) |
+| `bindD3Lollipop` | Lollipop | `<circle>` head per category | [Lollipop](examples.html) |
+| `bindD3Funnel` | Funnel / stage chart | `<path>` or `<rect>` per stage | [Funnel](examples.html) |
 | `bindD3Line` | Line / multi-line | `<path>` per series, optional `<circle>` points | [Line chart](examples.html) |
+| `bindD3Area` | Area / stacked area / 100% stacked area | `<path>` per series | [Area chart](examples.html) |
+| `bindD3Bump` | Bump / rank chart | `<path>` per competitor | [Bump chart](examples.html) |
 | `bindD3Scatter` | Scatter | `<circle>` per point | [Scatter plot](examples.html) |
 | `bindD3Box` | Box plot | `<g>` per box (containing `<rect>` + `<line>` + `<circle>`) | [Box plot](examples.html) |
 | `bindD3Histogram` | Histogram | `<rect>` per bin | [Histogram](examples.html) |
@@ -222,7 +227,7 @@ svg.selectAll('g.panel')
 
 maidrD3.bindD3Facets(svgElement, {
   panelSelector: 'g.panel',
-  chartType: 'bar',                       // any of the ten chart types
+  chartType: 'bar',                       // any of the single-chart types
   config: {                               // the usual per-type config;
     selector: 'rect.bar',                 // resolved inside each panel
     title: 'Sales by Day, faceted by Region',  // figure title
@@ -306,6 +311,42 @@ maidrD3.bindD3Bar(svgElement, {
   title: 'Tips by Day',
   axes: { x: 'Day', y: 'Count' },
   x: 'day',
+  y: 'count',
+});
+```
+
+### Dot Plot, Lollipop, and Funnel
+
+Three marks that carry the same `{ category, value }` datum a bar does, so they take the same config — only the binder differs, and with it the chart MAIDR announces:
+
+```js
+// Cleveland dot plot: categories down the page, so x is the value.
+svg.selectAll('circle.dot')
+  .data(endpoints).join('circle')
+  .attr('class', 'dot')
+  .attr('cx', d => x(d.ms))
+  .attr('cy', d => y(d.endpoint));
+
+maidrD3.bindD3Dot(svgElement, {
+  selector: 'circle.dot',
+  title: 'Median Response Time',
+  orientation: 'horz',
+  axes: { x: 'Milliseconds', y: 'Endpoint' },
+  x: 'ms',
+  y: 'endpoint',
+});
+```
+
+For a **lollipop**, point `selector` at the heads (one `<circle>` per category) or at a `<g>` wrapping each head-and-stem pair — never at a selector that also matches the `<line>` stems, which would double every category.
+
+A **funnel** is read for its drop-offs: the trace pitches the retention between adjacent stages rather than the raw counts, so stage order is load-bearing. The binder keeps the elements in the order D3 joined them, so draw them in funnel order:
+
+```js
+maidrD3.bindD3Funnel(svgElement, {
+  selector: 'path.stage',
+  title: 'Checkout Funnel',
+  axes: { x: 'Stage', y: 'People' },
+  x: 'stage',
   y: 'count',
 });
 ```
@@ -462,6 +503,57 @@ maidrD3.bindD3Candlestick(svgElement, {
 
 `trend` is auto-computed from `open` vs `close` when not supplied.
 
+### Area / Stacked Area / 100% Stacked Area
+
+`bindD3Area` handles all three variants through `type: 'area' | 'stacked_area' | 'stacked_normalized_area'` (`'area'` is the default). It reads the two shapes D3 produces, telling them apart from the datum bound to the first `<path>`:
+
+- **Plain point arrays** — one `{x, y}` array per `<path>`, exactly as `bindD3Line` reads them (`pointSelector` works here too).
+- **`d3.stack()` output** — the datum bound to each `<path>` is the *series* array itself, carrying `.key`, whose items are `[y0, y1]` tuples with a `.data` back-reference to the row. The binder unwraps that shape for you: `x` is read from the row, `y` is the band's own height (`y1 - y0`), and `.key` names the series.
+
+```js
+const series = d3.stack().keys(['Subscriptions', 'Services'])(rows);
+
+svg.selectAll('path.area')
+  .data(series).join('path')
+  .attr('class', 'area')
+  .attr('fill', d => color(d.key))
+  .attr('d', d3.area()
+    .x(d => x(d.data.year))
+    .y0(d => y(d[0]))
+    .y1(d => y(d[1])));
+
+maidrD3.bindD3Area(svgElement, {
+  selector: 'path.area',
+  type: 'stacked_area',
+  title: 'Revenue by Product',
+  axes: { x: 'Year', y: 'Revenue ($K)', fill: 'Product' },
+  x: 'year',   // a key on the stacked ROW, not on the [y0, y1] tuple
+});
+```
+
+In that shape the two accessors address different objects, because that is where the two values live: `x` is resolved against the **row** — function accessors included, so write `d => d.year`, not `d => d.data.year` — while an explicit `y` is resolved against the **tuple**, keeping `d => d[1] - d[0]` expressible.
+
+> **Give the band's own value, not the top edge.** The trace re-derives the running total by summing the series it is given, so it announces the stack height at each x and the point's share of it. The binder already emits `y1 - y0` for `d3.stack()` output; only supply your own `y` accessor if you stacked the data by hand.
+
+A streamgraph (`d3.stackOffsetWiggle`) is `'stacked_area'`; a 100% stacked area (`d3.stackOffsetExpand`) is `'stacked_normalized_area'`.
+
+### Bump / Rank Chart
+
+A bump chart is a multi-line layer whose y values are **ranks** — 1 is the best position and the smallest number. Bind the ranks you already plotted; `BumpTrace` inverts the pitch so first place is the highest note, and announces the places gained or lost at each period:
+
+```js
+maidrD3.bindD3Bump(svgElement, {
+  selector: 'path.rank-line',
+  title: 'League Table by Round',
+  axes: { x: 'Round', y: 'Rank', fill: 'Team' },
+  x: 'round',
+  y: 'rank',
+  fill: 'team',
+});
+```
+
+A slope graph of *values* is a line chart with two samples, not this.
+
 ### Stacked / Dodged / Normalized Bars
 
 `bindD3Segmented` handles the three common multi-series bar variants. Pass `type: 'stacked_bar' | 'dodged_bar' | 'normalized_bar'`:
@@ -543,8 +635,9 @@ All public types are exported from the `maidr/d3` entry (and re-exported from `m
 ```ts
 import type {
   // Per-binder configs
-  D3BarConfig,
-  D3LineConfig,
+  D3BarConfig,        // also bindD3Dot / bindD3Lollipop / bindD3Funnel
+  D3LineConfig,       // also bindD3Bump
+  D3AreaConfig,
   D3ScatterConfig,
   D3BoxConfig,
   D3HistogramConfig,
@@ -564,6 +657,9 @@ import type {
   D3BinderConfig,
   D3BinderResult,
   DataAccessor,
+  AreaTraceType,
+  BarMarkTraceType,
+  LineMarkTraceType,
   SegmentedTraceType,
   // MAIDR schema re-exports
   MaidrData,

--- a/docs/d3.md
+++ b/docs/d3.md
@@ -204,6 +204,8 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Volcano` | Volcano plot | `<circle>` per gene | [Volcano](examples.html) |
 | `bindD3Box` | Box plot | `<g>` per box (containing `<rect>` + `<line>` + `<circle>`) | [Box plot](examples.html) |
 | `bindD3ErrorBar` | Error bar / point range | `<g>` per estimate (containing `<line>` + marker) | [Error bar](examples.html) |
+| `bindD3Forest` | Forest / meta-analysis | `<g>` per study, plus `pooledSelector` for the diamond | [Forest](examples.html) |
+| `bindD3Boxen` | Boxen / letter-value | `<g>` per distribution (the stack of rungs) | [Boxen](examples.html) |
 | `bindD3Dumbbell` | Dumbbell / connected dot | `<line>` connector per row | [Dumbbell](examples.html) |
 | `bindD3Waterfall` | Waterfall / bridge | `<rect>` per step | [Waterfall](examples.html) |
 | `bindD3Histogram` | Histogram | `<rect>` per bin | [Histogram](examples.html) |
@@ -213,6 +215,7 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Diverging` | Diverging bars / population pyramid | `<rect>` per bar | [Pyramid](examples.html) |
 | `bindD3Mosaic` | Mosaic / marimekko | `<rect>` per cell | [Mosaic](examples.html) |
 | `bindD3WordCloud` | Word cloud | `<text>` per term | [Word cloud](examples.html) |
+| `bindD3Gantt` | Gantt / timeline / swimlane | `<rect>` per interval | [Gantt](examples.html) |
 | `bindD3Gauge` | Gauge / bullet chart | the needle or value arc | [Gauge](examples.html) |
 | `bindD3Smooth` | Smooth / regression curve | `<circle>` per sample | [Smooth curve](examples.html) |
 | `bindD3Pie` | Pie / doughnut | `<path>` per wedge | [Pie chart](examples.html) |
@@ -221,6 +224,10 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Network` | Force-directed network | `<line>` per link | [Network](examples.html) |
 | `bindD3Treemap` | Treemap | `<rect>` per node | [Treemap](examples.html) |
 | `bindD3Sunburst` | Sunburst | `<path>` arc per node | [Sunburst](examples.html) |
+| `bindD3Icicle` | Icicle | `<rect>` band per node | [Icicle](examples.html) |
+| `bindD3Sankey` | Sankey | `<path>` ribbon per link | [Sankey](examples.html) |
+| `bindD3Alluvial` | Alluvial | `<path>` ribbon per link | [Alluvial](examples.html) |
+| `bindD3Chord` | Chord | `<path>` ribbon per chord | [Chord](examples.html) |
 
 ## Multi-Panel Charts
 
@@ -501,6 +508,26 @@ The binder classifies siblings by geometry:
 
 Each sub-part is stamped with `data-maidr-box-part="iq|q2|lower-whisker|upper-whisker|lower-outlier|upper-outlier"` so visual highlighting works for every box region.
 
+### Boxen / Letter-Value Plot
+
+A boxen is a box plot whose ladder keeps going: a larger sample gets *more* rungs, so its tails stay legible instead of collapsing into a whisker and a scatter of dots. Point `selector` at one element per distribution — the `<g>` holding that category's stack of rungs — and let the datum carry the ladder:
+
+```js
+maidrD3.bindD3Boxen(svgElement, {
+  selector: 'g.boxen',
+  title: 'Response Time by Group',
+  axes: { x: 'Group', y: 'Milliseconds' },
+  x: 'group',
+  median: 'median',
+  levels: 'letterValues',              // [{ p, lo, hi }, …], deepest last
+  upperOutliers: 'beyond',
+});
+```
+
+Each rung is a tail probability `p` with the pair of quantiles it cuts, and the trace sorts them outward from the median itself — so a producer emitting them inward-first is read correctly either way. A rung whose three numbers are not all finite is dropped rather than announced as a percentile the data never computed.
+
+The ladder is read from your datum and never measured off the rendered rungs: a boxen computes its quantiles before it draws them, and a height in pixels is a layout fact. Every rung highlights the whole distribution's group, because a chart does not draw an element per quantile that MAIDR could pair up positionally.
+
 ### Histogram
 
 ```js
@@ -731,6 +758,30 @@ maidrD3.bindD3ErrorBar(svgElement, {
 
 The bounds are absolute positions on the value axis, and they are independently optional — a one-sided interval is a real chart, and a datum carrying neither still emits its estimate.
 
+### Forest Plot
+
+A forest plot is the point-range chart above with the three things a meta-analysis is read by: the null line, each study's weight, and the pooled diamond at the bottom.
+
+```js
+maidrD3.bindD3Forest(svgElement, {
+  selector: 'g.study',
+  pooledSelector: 'path.pooled',       // the diamond is a DIFFERENT mark
+  title: 'Effect of the Intervention',
+  orientation: 'horz',
+  axes: { x: 'Odds ratio', y: 'Study' },
+  x: 'study',
+  y: 'or',
+  yMin: 'ciLow',
+  yMax: 'ciHigh',
+  weight: 'weight',                    // a fraction of one
+  nullValue: 1,                        // 1 for a ratio, 0 for a difference
+});
+```
+
+> **Declare `nullValue`.** Whether a study's interval crosses it *is the result for that study*, and there is deliberately no default: a ratio chart guessed at 0 would report every study as not crossing, which is a confident wrong answer given to every row. Omit it and the reader gets the estimates, the intervals and the weights, and no claim about significance.
+
+The pooled row is selected separately because it is drawn separately, and its rows are appended after the studies so the selector list stays parallel to the payload. A chart that draws the summary like any other row can mark it with the `pooled` accessor instead.
+
 ### Dumbbell / Connected Dot
 
 Point `selector` at the **connectors**, one `<line>` per row — not at the dots, which a chart draws two of per row:
@@ -767,6 +818,30 @@ maidrD3.bindD3Waterfall(svgElement, {
 
 > **Mark the totals.** An opening, closing or subtotal bar is drawn exactly like a step but contributes nothing, and nothing in the numbers reveals which bars those are. An accessor returning `undefined` leaves every other bar classified from the sign of its contribution.
 
+### Gantt / Timeline / Swimlane
+
+One `<rect>` per booked interval on a band scale of lanes. The binder groups the rects into lanes itself, so a flat `.data(rows)` join sorted by start date is fine:
+
+```js
+maidrD3.bindD3Gantt(svgElement, {
+  selector: 'rect.task',
+  title: 'Project Schedule',
+  axes: { x: 'Day', y: 'Phase' },
+  x: 'phase',                          // the LANE
+  start: 'from',
+  end: 'to',
+  label: 'task',                       // what this interval is called
+  lanes: ['Design', 'Build', 'Review', 'Launch'],
+  unit: 'days',
+});
+```
+
+> **Declare `lanes` when a lane can be empty.** A lane with nothing booked has no element in the DOM at all, so the binder cannot discover it — and an empty row is a real statement about a schedule, and the one row a reader can navigate onto and be told nothing about. Populated lanes name themselves and need no entry; anything the binder finds and `lanes` does not declare is appended after it.
+
+Dates are coerced to epoch milliseconds so lengths can be measured at all — pass `format: { type: 'date' }` so the ends are announced as dates rather than as timestamps. `unit` names what a length is counted in, which a bare number cannot say.
+
+The highlight selectors are stamped per interval, in the payload's lane-grouped order, rather than emitted as one selector: the trace slices a flat element list lane by lane, and a chart that drew its rects in any other order would highlight one task while announcing another — with the counts still matching, so nothing would look wrong.
+
 ### Word Cloud
 
 The defaults are `d3-cloud`'s own datum keys, so a cloud laid out with the plugin needs no accessors — and call the binder inside `on('end', …)`, since the words are placed asynchronously:
@@ -787,6 +862,35 @@ cloud()
 ```
 
 Where a term landed is a packing artefact rather than data, so the layout coordinates are deliberately dropped. The trace reads the terms heaviest first and permutes the glyphs to match, so their DOM order does not have to mean anything.
+
+### Sankey / Alluvial / Chord
+
+All three are the same weighted graph drawn three ways, so one config reads them. Point `selector` at the **ribbons**, one `<path>` per link — not at the node rectangles, which are derived from the links:
+
+```js
+// d3-sankey: the layout replaces each link's source/target with node objects,
+// and the binder reads their names for you.
+maidrD3.bindD3Sankey(svgElement, {
+  selector: 'path.ribbon',
+  title: 'Energy flow',
+  axes: { x: 'Node', y: 'Petajoules' },
+});
+
+// An alluvial is a sankey whose node columns repeat.
+maidrD3.bindD3Alluvial(svgElement, { selector: 'path.ribbon' });
+
+// A chord is computed from a MATRIX, so its ends are row indices.
+maidrD3.bindD3Chord(svgElement, {
+  selector: 'path.chord',
+  title: 'Migration between regions',
+  axes: { x: 'Region', y: 'People' },
+  names: ['Africa', 'Americas', 'Asia', 'Europe'],
+});
+```
+
+> **Declare `names` for a chord.** `d3.chord()` binds `{ index, value, … }` to each end because a matrix has no names in it, and the labels a sighted reader takes from the ring are nowhere in the data. Without them the chart announces "0 to 3" — true, and useless. The magnitude is read off the ends too, since a chord carries none of its own.
+
+The ribbons are emitted in the order they were declared, and the trace keys its selectors to that order: from a node, arrow keys follow the largest flow out of it and the rotor steps through the rest.
 
 ### Gauge / Bullet Chart
 
@@ -861,13 +965,18 @@ import type {
   D3ScatterConfig,
   D3VolcanoConfig,
   D3BoxConfig,
+  D3BoxenConfig,
+  D3ErrorBarConfig,
+  D3ForestConfig,
+  D3FlowConfig,      // bindD3Sankey / bindD3Alluvial / bindD3Chord
+  D3GanttConfig,
   D3HistogramConfig,
   D3HeatmapConfig,
   D3CandlestickConfig,
   D3SegmentedConfig,
   D3MosaicConfig,
   D3NetworkConfig,
-  D3TreemapConfig,    // also bindD3Sunburst
+  D3TreemapConfig,    // also bindD3Sunburst / bindD3Icicle
   D3SmoothConfig,
   D3PieConfig,
   D3PolarAreaConfig,
@@ -885,6 +994,7 @@ import type {
   AreaTraceType,
   BarMarkTraceType,
   LineMarkTraceType,
+  FlowTraceType,
   ScatterMarkTraceType,
   SegmentedTraceType,
   TreemapTraceType,

--- a/docs/d3.md
+++ b/docs/d3.md
@@ -200,11 +200,18 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Area` | Area / stacked area / 100% stacked area | `<path>` per series | [Area chart](examples.html) |
 | `bindD3Bump` | Bump / rank chart | `<path>` per competitor | [Bump chart](examples.html) |
 | `bindD3Scatter` | Scatter | `<circle>` per point | [Scatter plot](examples.html) |
+| `bindD3Manhattan` | Manhattan plot | `<circle>` per marker | [Manhattan](examples.html) |
 | `bindD3Box` | Box plot | `<g>` per box (containing `<rect>` + `<line>` + `<circle>`) | [Box plot](examples.html) |
+| `bindD3ErrorBar` | Error bar / point range | `<g>` per estimate (containing `<line>` + marker) | [Error bar](examples.html) |
+| `bindD3Dumbbell` | Dumbbell / connected dot | `<line>` connector per row | [Dumbbell](examples.html) |
+| `bindD3Waterfall` | Waterfall / bridge | `<rect>` per step | [Waterfall](examples.html) |
 | `bindD3Histogram` | Histogram | `<rect>` per bin | [Histogram](examples.html) |
 | `bindD3Heatmap` | Heatmap | `<rect>` per cell | [Heatmap](examples.html) |
 | `bindD3Candlestick` | OHLC candlestick | `<rect>` per candle | [Candlestick](examples.html) |
 | `bindD3Segmented` | Stacked / dodged / normalized bars | `<rect>` per segment | [Stacked](examples.html), [Dodged](examples.html) |
+| `bindD3Diverging` | Diverging bars / population pyramid | `<rect>` per bar | [Pyramid](examples.html) |
+| `bindD3WordCloud` | Word cloud | `<text>` per term | [Word cloud](examples.html) |
+| `bindD3Gauge` | Gauge / bullet chart | the needle or value arc | [Gauge](examples.html) |
 | `bindD3Smooth` | Smooth / regression curve | `<circle>` per sample | [Smooth curve](examples.html) |
 | `bindD3Pie` | Pie / doughnut | `<path>` per wedge | [Pie chart](examples.html) |
 
@@ -374,6 +381,32 @@ maidrD3.bindD3Scatter(svgElement, {
   y: 'weight',
 });
 ```
+
+### Manhattan Plot
+
+A Manhattan plot is a scatter read almost entirely through a threshold, so the parts a reader cannot see without them — what each point *is*, which chromosome it sits on, and where the significance line was drawn — are what this binder adds:
+
+```js
+svg.selectAll('circle.snp')
+  .data(markers).join('circle')
+  .attr('class', 'snp')
+  .attr('cx', d => x(d.pos))
+  .attr('cy', d => y(d.logP))
+  .attr('r', 2);
+
+maidrD3.bindD3Manhattan(svgElement, {
+  selector: 'circle.snp',
+  title: 'Genome-wide Association',
+  axes: { x: 'Position', y: '-log10(p)', fill: 'Chromosome' },
+  x: 'pos',
+  y: 'logP',
+  label: 'snp',          // what the point IS — the answer the chart is read for
+  group: 'chromosome',
+  significance: 7.3,     // no default: the conventions differ by field
+});
+```
+
+> **A raw p axis runs the other way.** There `p <= 0.05` is the finding, so pass `significanceDirection: 'below'` — fixed to the default, the reading would select exactly the markers that failed to reach significance and announce them as the result.
 
 ### Line Chart (single and multi-line)
 
@@ -584,6 +617,116 @@ maidrD3.bindD3Segmented(svgElement, {
 ```
 
 > **DOM order.** The binder auto-detects whether your `<rect>`s are interleaved by category (`subject-major`, typical for dodged bars) or grouped by series (`series-major`, typical for stacked bars). Override with `domOrder` if your drawing pattern is unusual.
+
+### Diverging Bars / Population Pyramid
+
+A diverging chart is two series drawn back to back rather than one on top of the other. It is the segmented extraction with a different reading, so `bindD3Diverging` takes the same config:
+
+```js
+maidrD3.bindD3Diverging(svgElement, {
+  selector: 'rect.band',
+  title: 'Population by Age Band',
+  orientation: 'horz',                 // a pyramid is drawn on its side
+  axes: { x: 'People, thousands', y: 'Age band', fill: 'Sex' },
+  x: 'people',                         // negative for the side drawn left
+  y: 'band',
+  fill: 'sex',
+});
+```
+
+> **Emit the values as the chart draws them.** The sign is a *side*, not a magnitude: the trace pitches the magnitude and announces which side the bar is on, and the balance it reports between the two sides is that subtraction. Handed unsigned data it has no way to tell the sides apart.
+
+### Error Bars / Point Range
+
+One `<g>` per estimate, holding the interval's `<line>` and the estimate's marker:
+
+```js
+maidrD3.bindD3ErrorBar(svgElement, {
+  selector: 'g.estimate',
+  title: 'Mean Response by Dose',
+  axes: { x: 'Group', y: 'Response' },
+  x: 'group',
+  y: 'mean',
+  yMin: d => d.mean - 1.96 * d.se,     // ABSOLUTE bounds, not half-widths
+  yMax: d => d.mean + 1.96 * d.se,
+});
+```
+
+The bounds are absolute positions on the value axis, and they are independently optional — a one-sided interval is a real chart, and a datum carrying neither still emits its estimate.
+
+### Dumbbell / Connected Dot
+
+Point `selector` at the **connectors**, one `<line>` per row — not at the dots, which a chart draws two of per row:
+
+```js
+maidrD3.bindD3Dumbbell(svgElement, {
+  selector: 'line.connector',
+  title: 'Life Expectancy, 1990 against 2020',
+  orientation: 'horz',
+  axes: { x: 'Years', y: 'Country' },
+  x: 'country',
+  start: 'y1990',
+  end: 'y2020',
+  startLabel: '1990',                  // what the two ends are CALLED
+  endLabel: '2020',
+});
+```
+
+The end labels belong to the chart rather than to any row, which is why they are config. Without them a reader is told they are on the "start" dot, which is the one thing they already knew.
+
+### Waterfall / Bridge
+
+Each step is a bar floating between the running total before it and the running total after it, so those two numbers are what the binder reads; the contribution is derived:
+
+```js
+maidrD3.bindD3Waterfall(svgElement, {
+  selector: 'rect.step',
+  title: 'Quarterly Budget Bridge',
+  axes: { x: 'Step', y: 'Amount (thousands)' },
+  x: 'label',
+  kind: d => (d.isTotal ? 'total' : undefined),
+});
+```
+
+> **Mark the totals.** An opening, closing or subtotal bar is drawn exactly like a step but contributes nothing, and nothing in the numbers reveals which bars those are. An accessor returning `undefined` leaves every other bar classified from the sign of its contribution.
+
+### Word Cloud
+
+The defaults are `d3-cloud`'s own datum keys, so a cloud laid out with the plugin needs no accessors — and call the binder inside `on('end', …)`, since the words are placed asynchronously:
+
+```js
+cloud()
+  .words(terms.map(t => ({ text: t.term, size: t.count })))
+  .on('end', (words) => {
+    svg.selectAll('text.term').data(words).join('text')/* … */;
+
+    maidrD3.bindD3WordCloud(svgElement, {
+      selector: 'text.term',
+      title: 'Terms in the Abstracts',
+      axes: { x: 'Term', y: 'Occurrences' },
+    });
+  })
+  .start();
+```
+
+Where a term landed is a packing artefact rather than data, so the layout coordinates are deliberately dropped. The trace reads the terms heaviest first and permutes the glyphs to match, so their DOM order does not have to mean anything.
+
+### Gauge / Bullet Chart
+
+A drawn gauge binds one number, so the rest of the reading is config — and it *is* the reading: "73" means nothing without the range it sits in, the target it was aiming at, and the band it lands in:
+
+```js
+maidrD3.bindD3Gauge(svgElement, {
+  selector: 'rect.measure',            // the mark that moves with the value
+  title: 'Conversion Rate against Target',
+  axes: { x: 'Measure', y: 'Percent' },
+  label: 'Conversion',
+  min: 0,
+  max: 100,
+  target: 80,
+  bands: [{ to: 50, label: 'poor' }, { to: 75, label: 'ok' }, { to: 100, label: 'good' }],
+});
+```
 
 ### Smooth / Regression Curve
 

--- a/docs/d3.md
+++ b/docs/d3.md
@@ -201,6 +201,7 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Bump` | Bump / rank chart | `<path>` per competitor | [Bump chart](examples.html) |
 | `bindD3Scatter` | Scatter | `<circle>` per point | [Scatter plot](examples.html) |
 | `bindD3Manhattan` | Manhattan plot | `<circle>` per marker | [Manhattan](examples.html) |
+| `bindD3Volcano` | Volcano plot | `<circle>` per gene | [Volcano](examples.html) |
 | `bindD3Box` | Box plot | `<g>` per box (containing `<rect>` + `<line>` + `<circle>`) | [Box plot](examples.html) |
 | `bindD3ErrorBar` | Error bar / point range | `<g>` per estimate (containing `<line>` + marker) | [Error bar](examples.html) |
 | `bindD3Dumbbell` | Dumbbell / connected dot | `<line>` connector per row | [Dumbbell](examples.html) |
@@ -210,10 +211,16 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Candlestick` | OHLC candlestick | `<rect>` per candle | [Candlestick](examples.html) |
 | `bindD3Segmented` | Stacked / dodged / normalized bars | `<rect>` per segment | [Stacked](examples.html), [Dodged](examples.html) |
 | `bindD3Diverging` | Diverging bars / population pyramid | `<rect>` per bar | [Pyramid](examples.html) |
+| `bindD3Mosaic` | Mosaic / marimekko | `<rect>` per cell | [Mosaic](examples.html) |
 | `bindD3WordCloud` | Word cloud | `<text>` per term | [Word cloud](examples.html) |
 | `bindD3Gauge` | Gauge / bullet chart | the needle or value arc | [Gauge](examples.html) |
 | `bindD3Smooth` | Smooth / regression curve | `<circle>` per sample | [Smooth curve](examples.html) |
 | `bindD3Pie` | Pie / doughnut | `<path>` per wedge | [Pie chart](examples.html) |
+| `bindD3PolarArea` | Polar area / coxcomb / rose | `<path>` per wedge | [Polar area](examples.html) |
+| `bindD3Radar` | Radar / spider | `<path>` per series | [Radar](examples.html) |
+| `bindD3Network` | Force-directed network | `<line>` per link | [Network](examples.html) |
+| `bindD3Treemap` | Treemap | `<rect>` per node | [Treemap](examples.html) |
+| `bindD3Sunburst` | Sunburst | `<path>` arc per node | [Sunburst](examples.html) |
 
 ## Multi-Panel Charts
 
@@ -408,6 +415,25 @@ maidrD3.bindD3Manhattan(svgElement, {
 
 > **A raw p axis runs the other way.** There `p <= 0.05` is the finding, so pass `significanceDirection: 'below'` — fixed to the default, the reading would select exactly the markers that failed to reach significance and announce them as the result.
 
+### Volcano Plot
+
+A volcano is a Manhattan plot with a second cutoff: a gene matters when its change is both large *and* significant, so `effect` joins `significance`.
+
+```js
+maidrD3.bindD3Volcano(svgElement, {
+  selector: 'circle.gene',
+  title: 'Differential Expression',
+  axes: { x: 'log2 fold change', y: '-log10(p)' },
+  x: 'lfc',
+  y: 'logP',
+  label: 'gene',       // the gene name IS the payload here
+  significance: 1.3,
+  effect: 1,           // applied to the magnitude — a volcano is symmetric
+});
+```
+
+The binder warns (rather than throwing) when no point resolves a label: the chart still reads as a scatter with a cutoff, but a reader told "x is 2.3, y is 14.1" has been given the two numbers whose shape they can already hear and withheld the one thing they came for.
+
 ### Line Chart (single and multi-line)
 
 The adapter supports two layouts:
@@ -587,6 +613,38 @@ maidrD3.bindD3Bump(svgElement, {
 
 A slope graph of *values* is a line chart with two samples, not this.
 
+### Radar / Spider Chart
+
+A radar is a multi-line layer wrapped around a circle: one closed `d3.lineRadial()` `<path>` per series, `x` naming the **spoke** and `fill` naming the series. `RadarTrace` pans each spoke by its angle — 12 o'clock centre, 3 o'clock hard right — so the chart sounds like a circle rather than a row of bars.
+
+```js
+maidrD3.bindD3Radar(svgElement, {
+  selector: 'path.radar-area',
+  title: 'Model Comparison',
+  axes: { x: 'Attribute', y: 'Score', fill: 'Model' },
+  x: 'attribute',
+  y: 'score',
+  fill: 'model',
+});
+```
+
+> **The closing vertex is dropped for you.** A closed outline is drawn by repeating the first vertex at the end; that repeat is how the polygon shuts, not a spoke, so a trailing sample whose `x` matches the first one is removed. Left in, the chart would announce one spoke more than it has and every angle would rotate off the mark.
+
+### Polar Area / Coxcomb
+
+A polar area draws one wedge per category and encodes the value as the **radius** rather than the angle. The wedges are `d3.arc()` paths exactly as a pie's are — including over `d3.pie()` output, which the binder unwraps — so the config is the pie's:
+
+```js
+maidrD3.bindD3PolarArea(svgElement, {
+  selector: 'path.wedge',
+  title: 'Causes of Mortality',
+  axes: { x: 'Month', y: 'Deaths' },
+  x: 'month',
+});
+```
+
+The values are read as one series around the spokes rather than as shares of a whole, so nothing announces a percentage. Like a pie, it has no fill axis.
+
 ### Stacked / Dodged / Normalized Bars
 
 `bindD3Segmented` handles the three common multi-series bar variants. Pass `type: 'stacked_bar' | 'dodged_bar' | 'normalized_bar'`:
@@ -635,6 +693,25 @@ maidrD3.bindD3Diverging(svgElement, {
 ```
 
 > **Emit the values as the chart draws them.** The sign is a *side*, not a magnitude: the trace pitches the magnitude and announces which side the bar is on, and the balance it reports between the two sides is that subtraction. Handed unsigned data it has no way to tell the sides apart.
+
+### Mosaic / Marimekko
+
+A mosaic is a stacked bar whose **column widths also encode data** — each category's share of all observations. That share is the one thing the segmented extraction does not already read:
+
+```js
+maidrD3.bindD3Mosaic(svgElement, {
+  selector: 'rect.cell',
+  title: 'Survival by Passenger Class',
+  axes: { x: 'Class', y: 'Proportion', fill: 'Outcome' },
+  x: 'klass',
+  y: 'share',
+  fill: 'outcome',
+  width: 'columnShare',   // the column's share of all observations, 0–1
+  count: 'n',             // the cell's own count, when you have the table
+});
+```
+
+Every cell then announces its column's share alongside its own proportion. Both extra fields are optional and neither is invented: the width is read from your datum and **never measured off the rendered `<rect>`**, because a drawn width is padding and scale as much as data.
 
 ### Error Bars / Point Range
 
@@ -779,16 +856,21 @@ All public types are exported from the `maidr/d3` entry (and re-exported from `m
 import type {
   // Per-binder configs
   D3BarConfig,        // also bindD3Dot / bindD3Lollipop / bindD3Funnel
-  D3LineConfig,       // also bindD3Bump
+  D3LineConfig,       // also bindD3Bump / bindD3Radar
   D3AreaConfig,
   D3ScatterConfig,
+  D3VolcanoConfig,
   D3BoxConfig,
   D3HistogramConfig,
   D3HeatmapConfig,
   D3CandlestickConfig,
   D3SegmentedConfig,
+  D3MosaicConfig,
+  D3NetworkConfig,
+  D3TreemapConfig,    // also bindD3Sunburst
   D3SmoothConfig,
   D3PieConfig,
+  D3PolarAreaConfig,
   // Multi-panel
   D3FacetsConfig,
   D3SubplotsConfig,
@@ -803,7 +885,9 @@ import type {
   AreaTraceType,
   BarMarkTraceType,
   LineMarkTraceType,
+  ScatterMarkTraceType,
   SegmentedTraceType,
+  TreemapTraceType,
   // MAIDR schema re-exports
   MaidrData,
   MaidrLayer,

--- a/examples/d3-bindarea.html
+++ b/examples/d3-bindarea.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Stacked Area Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Stacked Area Chart</h1>
+    <p>
+      Click on the chart and use arrow keys to navigate. Left and Right move
+      along the years; Up and Down move between the bands. Each point announces
+      the band's own value, the stack total at that year, and its share of it.
+    </p>
+    <div id="chart"></div>
+
+    <script>
+      const rows = [
+        { year: '2019', Subscriptions: 120, Services: 40, Hardware: 25 },
+        { year: '2020', Subscriptions: 165, Services: 55, Hardware: 20 },
+        { year: '2021', Subscriptions: 210, Services: 72, Hardware: 18 },
+        { year: '2022', Subscriptions: 260, Services: 96, Hardware: 15 },
+        { year: '2023', Subscriptions: 335, Services: 120, Hardware: 12 },
+      ];
+
+      const products = ['Subscriptions', 'Services', 'Hardware'];
+      const colors = { Subscriptions: '#2196F3', Services: '#FF9800', Hardware: '#4CAF50' };
+
+      const margin = { top: 40, right: 120, bottom: 50, left: 60 };
+      const width = 640 - margin.left - margin.right;
+      const height = 400 - margin.top - margin.bottom;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-area-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      // d3.stack() binds one SERIES to each <path>: an array of [y0, y1]
+      // tuples carrying `.key` (the product) and `.data` (the original row).
+      // The binder reads that shape directly — no pre-flattening needed.
+      const series = d3.stack().keys(products)(rows);
+
+      const x = d3.scalePoint().domain(rows.map(d => d.year)).range([0, width]);
+      const y = d3.scaleLinear().domain([0, 500]).range([height, 0]);
+
+      const area = d3.area()
+        .x(d => x(d.data.year))
+        .y0(d => y(d[0]))
+        .y1(d => y(d[1]));
+
+      svg.selectAll('path.area')
+        .data(series)
+        .join('path')
+        .attr('class', 'area')
+        .attr('fill', d => colors[d.key])
+        .attr('d', area);
+
+      svg.append('g').attr('transform', `translate(0,${height})`).call(d3.axisBottom(x));
+      svg.append('g').call(d3.axisLeft(y));
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .text('Revenue by Product');
+
+      // X-axis title
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 40)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '13px')
+        .text('Year');
+
+      // Y-axis title
+      svg.append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('x', -height / 2)
+        .attr('y', -45)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '13px')
+        .text('Revenue ($K)');
+
+      // Legend (product swatches)
+      const legend = svg.append('g').attr('transform', `translate(${width + 10}, 0)`);
+      products.forEach((product, i) => {
+        const row = legend.append('g').attr('transform', `translate(0, ${i * 20})`);
+        row.append('rect').attr('width', 14).attr('height', 14).attr('fill', colors[product]);
+        row.append('text').attr('x', 20).attr('y', 11).style('font-size', '12px').text(product);
+      });
+      legend.append('text')
+        .attr('x', 0)
+        .attr('y', -6)
+        .style('font-size', '12px')
+        .style('font-weight', 'bold')
+        .text('Product');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-area-chart');
+      const result = maidrD3.bindD3Area(svgElement, {
+        selector: 'path.area',
+        type: 'stacked_area',
+        title: 'Revenue by Product',
+        axes: { x: 'Year', y: 'Revenue ($K)', fill: 'Product' },
+        // `year` is a key on the stacked ROW, not on the [y0, y1] tuple; the
+        // binder resolves it against `d.data` for you. The value needs no
+        // accessor: each band's height is `y1 - y0`, which is what the trace
+        // sums to recover the stack total.
+        x: 'year',
+      });
+      // The binder auto-applies `maidr-data` to the SVG.
+      void result;
+    </script>
+  </body>
+</html>

--- a/examples/d3-bindfunnel.html
+++ b/examples/d3-bindfunnel.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Funnel Chart Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Funnel Chart</h1>
+    <p>
+      Click on the chart and use arrow keys to move between stages. The pitch
+      carries the <strong>retention</strong> — what fraction of the previous
+      stage survived — because that is the number a funnel is read for; the
+      counts are announced alongside it.
+    </p>
+    <div id="chart"></div>
+
+    <script>
+      // Draw order is stage order, and the trace reads each stage against the
+      // one before it — so keep the array in funnel order.
+      const stages = [
+        { stage: 'Visited', count: 10000 },
+        { stage: 'Signed up', count: 2400 },
+        { stage: 'Viewed cart', count: 2300 },
+        { stage: 'Purchased', count: 100 },
+      ];
+
+      const margin = { top: 40, right: 40, bottom: 50, left: 120 };
+      const width = 600 - margin.left - margin.right;
+      const height = 360 - margin.top - margin.bottom;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-funnel-chart')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      const yScale = d3.scaleBand()
+        .domain(stages.map(d => d.stage))
+        .range([0, height])
+        .padding(0.25);
+      const widthScale = d3.scaleLinear()
+        .domain([0, d3.max(stages, d => d.count)])
+        .range([0, width]);
+
+      // One centred <rect> per stage: the classic funnel silhouette, and one
+      // element per stage is exactly what the binder wants.
+      svg.selectAll('rect.stage')
+        .data(stages)
+        .join('rect')
+        .attr('class', 'stage')
+        .attr('x', d => (width - widthScale(d.count)) / 2)
+        .attr('y', d => yScale(d.stage))
+        .attr('width', d => widthScale(d.count))
+        .attr('height', yScale.bandwidth())
+        .attr('fill', '#2196F3');
+
+      svg.append('g').call(d3.axisLeft(yScale));
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', -10)
+        .attr('text-anchor', 'middle')
+        .text('Checkout Funnel');
+
+      // X-axis title
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 40)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '13px')
+        .text('People');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-funnel-chart');
+      const result = maidrD3.bindD3Funnel(svgElement, {
+        selector: 'rect.stage',
+        title: 'Checkout Funnel',
+        axes: { x: 'Stage', y: 'People' },
+        // `stage` / `count` would also be inferred from the datum's keys.
+        x: 'stage',
+        y: 'count',
+      });
+      // The binder auto-applies `maidr-data` to the SVG.
+      void result;
+    </script>
+  </body>
+</html>

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -176,14 +176,28 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'lollipop', config: props.config };
     case 'manhattan':
       return { chartType: 'manhattan', config: props.config };
+    case 'mosaic':
+      return { chartType: 'mosaic', config: props.config };
+    case 'network':
+      return { chartType: 'network', config: props.config };
     case 'pie':
       return { chartType: 'pie', config: props.config };
+    case 'polarArea':
+      return { chartType: 'polarArea', config: props.config };
+    case 'radar':
+      return { chartType: 'radar', config: props.config };
     case 'scatter':
       return { chartType: 'scatter', config: props.config };
     case 'segmented':
       return { chartType: 'segmented', config: props.config };
     case 'smooth':
       return { chartType: 'smooth', config: props.config };
+    case 'sunburst':
+      return { chartType: 'sunburst', config: props.config };
+    case 'treemap':
+      return { chartType: 'treemap', config: props.config };
+    case 'volcano':
+      return { chartType: 'volcano', config: props.config };
     case 'waterfall':
       return { chartType: 'waterfall', config: props.config };
     case 'wordCloud':

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -146,18 +146,28 @@ export function MaidrD3(props: MaidrD3Props): JSX.Element {
  */
 function buildSpec(props: MaidrD3Props): D3AdapterSpec {
   switch (props.chartType) {
+    case 'area':
+      return { chartType: 'area', config: props.config };
     case 'bar':
       return { chartType: 'bar', config: props.config };
     case 'box':
       return { chartType: 'box', config: props.config };
+    case 'bump':
+      return { chartType: 'bump', config: props.config };
     case 'candlestick':
       return { chartType: 'candlestick', config: props.config };
+    case 'dot':
+      return { chartType: 'dot', config: props.config };
+    case 'funnel':
+      return { chartType: 'funnel', config: props.config };
     case 'heatmap':
       return { chartType: 'heatmap', config: props.config };
     case 'histogram':
       return { chartType: 'histogram', config: props.config };
     case 'line':
       return { chartType: 'line', config: props.config };
+    case 'lollipop':
+      return { chartType: 'lollipop', config: props.config };
     case 'pie':
       return { chartType: 'pie', config: props.config };
     case 'scatter':

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -158,8 +158,14 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'candlestick', config: props.config };
     case 'dot':
       return { chartType: 'dot', config: props.config };
+    case 'dumbbell':
+      return { chartType: 'dumbbell', config: props.config };
+    case 'errorBar':
+      return { chartType: 'errorBar', config: props.config };
     case 'funnel':
       return { chartType: 'funnel', config: props.config };
+    case 'gauge':
+      return { chartType: 'gauge', config: props.config };
     case 'heatmap':
       return { chartType: 'heatmap', config: props.config };
     case 'histogram':
@@ -168,6 +174,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'line', config: props.config };
     case 'lollipop':
       return { chartType: 'lollipop', config: props.config };
+    case 'manhattan':
+      return { chartType: 'manhattan', config: props.config };
     case 'pie':
       return { chartType: 'pie', config: props.config };
     case 'scatter':
@@ -176,6 +184,10 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'segmented', config: props.config };
     case 'smooth':
       return { chartType: 'smooth', config: props.config };
+    case 'waterfall':
+      return { chartType: 'waterfall', config: props.config };
+    case 'wordCloud':
+      return { chartType: 'wordCloud', config: props.config };
     case 'facets':
       return { chartType: 'facets', config: props.config };
     case 'subplots':

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -162,6 +162,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'candlestick', config: props.config };
     case 'chord':
       return { chartType: 'chord', config: props.config };
+    case 'contour':
+      return { chartType: 'contour', config: props.config };
     case 'dot':
       return { chartType: 'dot', config: props.config };
     case 'dumbbell':
@@ -178,6 +180,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'gauge', config: props.config };
     case 'heatmap':
       return { chartType: 'heatmap', config: props.config };
+    case 'hexbin':
+      return { chartType: 'hexbin', config: props.config };
     case 'histogram':
       return { chartType: 'histogram', config: props.config };
     case 'icicle':
@@ -192,12 +196,16 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'mosaic', config: props.config };
     case 'network':
       return { chartType: 'network', config: props.config };
+    case 'parallel':
+      return { chartType: 'parallel', config: props.config };
     case 'pie':
       return { chartType: 'pie', config: props.config };
     case 'polarArea':
       return { chartType: 'polarArea', config: props.config };
     case 'radar':
       return { chartType: 'radar', config: props.config };
+    case 'ridgeline':
+      return { chartType: 'ridgeline', config: props.config };
     case 'sankey':
       return { chartType: 'sankey', config: props.config };
     case 'scatter':
@@ -208,6 +216,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'smooth', config: props.config };
     case 'sunburst':
       return { chartType: 'sunburst', config: props.config };
+    case 'survival':
+      return { chartType: 'survival', config: props.config };
     case 'treemap':
       return { chartType: 'treemap', config: props.config };
     case 'volcano':

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -146,30 +146,42 @@ export function MaidrD3(props: MaidrD3Props): JSX.Element {
  */
 function buildSpec(props: MaidrD3Props): D3AdapterSpec {
   switch (props.chartType) {
+    case 'alluvial':
+      return { chartType: 'alluvial', config: props.config };
     case 'area':
       return { chartType: 'area', config: props.config };
     case 'bar':
       return { chartType: 'bar', config: props.config };
     case 'box':
       return { chartType: 'box', config: props.config };
+    case 'boxen':
+      return { chartType: 'boxen', config: props.config };
     case 'bump':
       return { chartType: 'bump', config: props.config };
     case 'candlestick':
       return { chartType: 'candlestick', config: props.config };
+    case 'chord':
+      return { chartType: 'chord', config: props.config };
     case 'dot':
       return { chartType: 'dot', config: props.config };
     case 'dumbbell':
       return { chartType: 'dumbbell', config: props.config };
     case 'errorBar':
       return { chartType: 'errorBar', config: props.config };
+    case 'forest':
+      return { chartType: 'forest', config: props.config };
     case 'funnel':
       return { chartType: 'funnel', config: props.config };
+    case 'gantt':
+      return { chartType: 'gantt', config: props.config };
     case 'gauge':
       return { chartType: 'gauge', config: props.config };
     case 'heatmap':
       return { chartType: 'heatmap', config: props.config };
     case 'histogram':
       return { chartType: 'histogram', config: props.config };
+    case 'icicle':
+      return { chartType: 'icicle', config: props.config };
     case 'line':
       return { chartType: 'line', config: props.config };
     case 'lollipop':
@@ -186,6 +198,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'polarArea', config: props.config };
     case 'radar':
       return { chartType: 'radar', config: props.config };
+    case 'sankey':
+      return { chartType: 'sankey', config: props.config };
     case 'scatter':
       return { chartType: 'scatter', config: props.config };
     case 'segmented':

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -164,6 +164,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'chord', config: props.config };
     case 'contour':
       return { chartType: 'contour', config: props.config };
+    case 'diverging':
+      return { chartType: 'diverging', config: props.config };
     case 'dot':
       return { chartType: 'dot', config: props.config };
     case 'dumbbell':

--- a/src/adapters/d3/binders/area.ts
+++ b/src/adapters/d3/binders/area.ts
@@ -1,0 +1,248 @@
+/**
+ * D3 binder for area charts: plain bands, stacked areas / streamgraphs, and
+ * 100% stacked areas.
+ *
+ * An area is a line with the region under it filled, so the extraction is the
+ * line binder's — except for the one shape a line never sees. `d3.stack()`
+ * binds a whole *series* to each `<path>`: the datum is an array carrying the
+ * series' `.key`, whose items are `[y0, y1]` tuples with a `.data`
+ * back-reference to the row they came from. This module recognises that shape
+ * and unwraps it; everything else falls through to `buildLineLayer`.
+ */
+
+import type { LinePoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3AreaConfig, D3BinderResult, D3BuiltLayer } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+import { buildLineLayer, stampSeriesSelectors } from './line';
+
+/**
+ * One `d3.stack()` datum: the `[y0, y1]` pair the band is drawn between, plus
+ * a back-reference to the row it was computed from.
+ */
+interface StackTuple extends Array<number> {
+  /** The original row — where the x value (and any other field) still lives. */
+  data?: unknown;
+}
+
+/**
+ * One `d3.stack()` series: the array bound to a stacked area's `<path>`,
+ * carrying the key it was stacked under.
+ */
+interface StackSeries extends Array<StackTuple> {
+  /** The series name, set by `d3.stack().keys(...)`. */
+  key?: unknown;
+}
+
+/**
+ * Whether a `<path>`'s datum is a `d3.stack()` series rather than the plain
+ * point array a line path carries.
+ *
+ * Both are arrays, so the discriminator is the item: a stack item is itself a
+ * two-number array with a `data` back-reference, which no point array has.
+ * Mirrors the shape check `binders/segmented.ts` uses to detect the same
+ * output bound to `<rect>` elements.
+ *
+ * @param datum - The datum bound to a series path.
+ * @returns True when the datum is `d3.stack()` output.
+ */
+function isStackSeries(datum: unknown): datum is StackSeries {
+  if (!Array.isArray(datum) || datum.length === 0) {
+    return false;
+  }
+  const first: unknown = datum[0];
+  return Array.isArray(first)
+    && first.length === 2
+    && typeof first[0] === 'number'
+    && typeof first[1] === 'number'
+    && 'data' in (first as object);
+}
+
+/**
+ * Reads a `d3.stack()` series' name off its `.key`.
+ *
+ * @param series - The series array bound to one `<path>`.
+ * @returns The key as text, or `undefined` when the series carries none.
+ */
+function seriesKey(series: StackSeries): string | undefined {
+  const { key } = series;
+  if (key === undefined || key === null || key === '') {
+    return undefined;
+  }
+  return String(key);
+}
+
+/**
+ * Binds a D3.js area chart to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Handles all three variants through `config.type`: independent bands
+ * (`TraceType.AREA`, the default), stacked areas and streamgraphs
+ * (`TraceType.STACKED_AREA`), and 100% stacked areas
+ * (`TraceType.NORMALIZED_AREA`). The variant decides how the layer is read: a
+ * stacked trace announces the running total at each x, and the point's share
+ * of it, alongside the band's own value.
+ *
+ * Two D3 patterns are supported, and the binder tells them apart by the datum
+ * bound to the first matched `<path>`:
+ *
+ * 1. **`d3.stack()` output** — the series array itself, with `.key`, whose
+ *    items are `[y0, y1]` tuples. `x` is read from each tuple's `.data` row
+ *    (function accessors included, so write `d => d.year`, not
+ *    `d => d.data.year`), `y` is the band's own height (`y1 - y0`, which is
+ *    what the trace needs — it re-derives the running total itself), and
+ *    `.key` names the series.
+ * 2. **Plain point arrays** — one `{ x, y }` array per `<path>`, or per-point
+ *    elements via `pointSelector`. Read exactly as {@link bindD3Line} reads
+ *    them.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 area chart.
+ * @param config - Configuration specifying selectors, accessors, and variant.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * // d3.stack() + d3.area().y0(d => y(d[0])).y1(d => y(d[1]))
+ * const series = d3.stack().keys(['Subscriptions', 'Services'])(rows);
+ * svg.selectAll('path.area').data(series).join('path').attr('d', area);
+ *
+ * bindD3Area(svgElement, {
+ *   selector: 'path.area',
+ *   type: TraceType.STACKED_AREA,
+ *   title: 'Revenue by Product',
+ *   axes: { x: 'Year', y: 'Revenue', fill: 'Product' },
+ *   x: 'year',   // a key on the stacked row, not on the [y0, y1] tuple
+ * });
+ * ```
+ */
+export function bindD3Area(svg: Element, config: D3AreaConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildAreaLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for area charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildAreaLayer(root: Element, config: D3AreaConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    type = TraceType.AREA,
+  } = config;
+
+  const pathElements = queryD3Elements(root, selector);
+  if (pathElements.length === 0) {
+    throw buildNoElementsError(root, selector, 'area path');
+  }
+
+  // Anything that is not d3.stack() output is the point array a line path
+  // carries, which the line binder already reads in both its variants
+  // (per-path arrays, or `pointSelector` + fill grouping).
+  if (!isStackSeries(pathElements[0].datum)) {
+    return buildLineLayer(root, config, panel, type);
+  }
+
+  // Infer the x accessor from a stacked ROW, not from the tuple: the tuple is
+  // a pair of stack edges and carries no category.
+  const sampleRow = pathElements[0].datum[0]?.data;
+  const xAccessor = inferAccessor<number | string>(
+    config,
+    'x',
+    'x',
+    ['category', 'label', 'name', 'date', 'time'],
+    sampleRow,
+  );
+  const fillAccessor = inferAccessor<string>(
+    config,
+    'fill',
+    'fill',
+    ['group', 'series', 'category', 'z', 'color'],
+    sampleRow,
+  );
+
+  const data: LinePoint[][] = [];
+  const legend: string[] = [];
+  // The `<path>` that renders each emitted row, parallel to `data`. In this
+  // shape one path IS one series, so the pairing is never ambiguous.
+  const rowPaths: Element[] = [];
+
+  for (const { element, datum, index } of pathElements) {
+    if (!isStackSeries(datum)) {
+      throw new Error(
+        `The datum bound to "${selector}" at index ${index} is not d3.stack() `
+        + `output, but the first matched path's was. Every series must come `
+        + `from the same join for the bands to be read as one chart — check `
+        + `that "${selector}" does not also match a non-stacked path (an axis `
+        + `line, a reference band, a hand-appended shape).`,
+      );
+    }
+
+    // The series' own name: its `.key`, falling back to the fill accessor read
+    // off the first row for a stack assembled without `d3.stack().keys(...)`.
+    const firstRow = datum[0]?.data;
+    const key = seriesKey(datum)
+      ?? (firstRow === undefined || firstRow === null
+        ? undefined
+        : resolveAccessorOptional<string>(firstRow, fillAccessor, 0));
+
+    const seriesData: LinePoint[] = datum.map((tuple, pointIndex) => {
+      const point: LinePoint = {
+        x: resolveAccessor<number | string>(tuple.data, xAccessor, pointIndex),
+        // The band's own height, which is what the trace wants: it sums the
+        // series it is given to recover the running total, so handing it the
+        // already-accumulated top edge would double-count every band above
+        // the first. An explicit `y` accessor is resolved against the tuple,
+        // so `d => d[1] - d[0]` and any custom offset stay expressible.
+        y: config.y === undefined
+          ? tuple[1] - tuple[0]
+          : resolveAccessor<number>(tuple, config.y, pointIndex),
+      };
+      if (key !== undefined) {
+        point.z = key;
+      }
+      return point;
+    });
+
+    if (seriesData.length === 0) {
+      continue;
+    }
+    data.push(seriesData);
+    rowPaths.push(element);
+    if (key !== undefined) {
+      legend.push(key);
+    }
+  }
+
+  // One selector per band, so the model can highlight the series the cursor is
+  // in. See {@link stampSeriesSelectors}.
+  const selectorValue: string | string[] | undefined = pathElements.length > 1
+    ? stampSeriesSelectors(root, selector, rowPaths, data.length, panel)
+    // Exactly one path matched → a single scoped selector highlights it.
+    : scopeSelector(root, selector, panel);
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type,
+    title,
+    selectors: selectorValue,
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer, legend };
+}

--- a/src/adapters/d3/binders/bar.ts
+++ b/src/adapters/d3/binders/bar.ts
@@ -1,13 +1,16 @@
 /**
- * D3 binder for bar charts.
+ * D3 binder for the bar family: bar charts, Cleveland dot plots, lollipop
+ * charts, and funnels.
  *
- * Extracts data from D3.js-rendered bar chart SVG elements and generates
- * the MAIDR JSON schema for accessible bar chart interaction.
+ * Extracts data from D3.js-rendered SVG elements and generates the MAIDR JSON
+ * schema for accessible interaction. All four marks carry one category and one
+ * value per element, which is why they share a single extraction core and
+ * differ only in the trace type the layer announces.
  */
 
 import type { BarPoint, MaidrLayer } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
-import type { D3BarConfig, D3BinderResult, D3BuiltLayer } from '../types';
+import type { BarMarkTraceType, D3BarConfig, D3BinderResult, D3BuiltLayer } from '../types';
 import { Orientation, TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
 import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
@@ -63,15 +66,119 @@ export function bindD3Bar(svg: Element, config: D3BarConfig): D3BinderResult {
 }
 
 /**
- * Pure extraction core for bar charts: reads D3-bound data under `root` and
- * builds the MAIDR layer, without wrapping it in a figure or touching
+ * Binds a D3.js Cleveland dot plot to MAIDR.
+ *
+ * A dot plot is a bar chart drawn with a different mark: one category, one
+ * value, navigated the same way. The extraction is therefore identical to
+ * {@link bindD3Bar} — point `selector` at the `<circle>` marks so MAIDR
+ * highlights the dots themselves — and only the announced chart type differs.
+ *
+ * Dot plots are usually drawn with the categories down the page. Pass
+ * `orientation: Orientation.HORIZONTAL` (with `x` reading the value and `y`
+ * the category) so the axes are announced the way the chart was drawn.
+ *
+ * @param svg - The SVG element (or container) containing the D3 dot plot.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Dot(svgElement, {
+ *   selector: 'circle.dot',
+ *   title: 'Median Response Time',
+ *   orientation: Orientation.HORIZONTAL,
+ *   axes: { x: 'Milliseconds', y: 'Endpoint' },
+ *   x: 'ms',
+ *   y: 'endpoint',
+ * });
+ * ```
+ */
+export function bindD3Dot(svg: Element, config: D3BarConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildBarLayer(svg, config, undefined, TraceType.DOT));
+}
+
+/**
+ * Binds a D3.js lollipop chart to MAIDR.
+ *
+ * A lollipop is a dot plot with a stem to the baseline: the stem is what the
+ * mark looks like, not a second magnitude, so the extraction is again that of
+ * {@link bindD3Bar}.
+ *
+ * Point `selector` at the **heads** (one `<circle>` per category) or at a
+ * `<g>` wrapping each head-and-stem pair — one matched element per category.
+ * A selector that also matched the `<line>` stems would produce two elements
+ * per category, so the data would be doubled and highlighting would land on
+ * the wrong mark.
+ *
+ * @param svg - The SVG element (or container) containing the D3 lollipop chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Lollipop(svgElement, {
+ *   selector: 'circle.head',
+ *   title: 'Life Expectancy',
+ *   orientation: Orientation.HORIZONTAL,
+ *   axes: { x: 'Years', y: 'Country' },
+ *   x: 'years',
+ *   y: 'country',
+ * });
+ * ```
+ */
+export function bindD3Lollipop(svg: Element, config: D3BarConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildBarLayer(svg, config, undefined, TraceType.LOLLIPOP));
+}
+
+/**
+ * Binds a D3.js funnel chart to MAIDR.
+ *
+ * A funnel is a bar chart whose **order is meaningful**: the trace pitches the
+ * retention between adjacent stages rather than the raw counts, because the
+ * drop-off is what the chart is drawn for. Stage order therefore comes
+ * straight from the DOM — the binder keeps the elements in the order D3 joined
+ * them, so draw the stages top-to-bottom (or left-to-right) in funnel order.
+ *
+ * `selector` matches one element per stage, whichever mark you drew it with:
+ * a trapezoid `<path>`, a centred `<rect>`, or a `<g>` per stage.
+ *
+ * @param svg - The SVG element (or container) containing the D3 funnel chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Funnel(svgElement, {
+ *   selector: 'path.stage',
+ *   title: 'Checkout Funnel',
+ *   axes: { x: 'Stage', y: 'People' },
+ *   x: 'stage',
+ *   y: 'count',
+ * });
+ * ```
+ */
+export function bindD3Funnel(svg: Element, config: D3BarConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildBarLayer(svg, config, undefined, TraceType.FUNNEL));
+}
+
+/**
+ * Pure extraction core for the bar family: reads D3-bound data under `root`
+ * and builds the MAIDR layer, without wrapping it in a figure or touching
  * `maidr-data`. Used by {@link bindD3Bar} (root = the SVG) and by the
  * multi-panel binders in `binders/subplots.ts` (root = one panel element,
  * with `panel` scoping the emitted selectors to that panel).
  *
+ * The trailing `type` selects which mark the layer announces itself as; the
+ * extraction is the same for all four (see {@link BarMarkTraceType}).
+ *
  * @internal
  */
-export function buildBarLayer(root: Element, config: D3BarConfig, panel?: D3PanelScope): D3BuiltLayer {
+export function buildBarLayer(
+  root: Element,
+  config: D3BarConfig,
+  panel?: D3PanelScope,
+  type: BarMarkTraceType = TraceType.BAR,
+): D3BuiltLayer {
   const {
     title,
     axes,
@@ -86,12 +193,14 @@ export function buildBarLayer(root: Element, config: D3BarConfig, panel?: D3Pane
   }
 
   // Infer accessors from the first datum's keys when the user did not specify.
+  // `stage` is in the list for the funnel's `{ stage, count }` datum, which is
+  // the shape that mark is almost always drawn from.
   const firstDatum = elements[0].datum;
   const xAccessor = inferAccessor<string | number>(
     config,
     'x',
     'x',
-    ['category', 'label', 'name', 'key', 'date'],
+    ['category', 'label', 'name', 'key', 'date', 'stage'],
     firstDatum,
   );
   const yAccessor = inferAccessor<number | string>(
@@ -114,7 +223,7 @@ export function buildBarLayer(root: Element, config: D3BarConfig, panel?: D3Pane
 
   const layer: MaidrLayer = {
     id: generateId(),
-    type: TraceType.BAR,
+    type,
     title,
     selectors: scopeSelector(root, selector, panel),
     orientation,

--- a/src/adapters/d3/binders/boxen.ts
+++ b/src/adapters/d3/binders/boxen.ts
@@ -1,0 +1,248 @@
+/**
+ * D3 binder for boxen (letter-value) plots.
+ *
+ * Extracts the ladder of quantiles each distribution was drawn from and
+ * generates the MAIDR JSON schema for accessible interaction. Structurally this
+ * is `binders/box.ts` with a variable number of rungs instead of a fixed
+ * five-number summary — which is the whole point of a letter-value plot: a
+ * large sample gets *more* rungs, so its tails stay legible.
+ *
+ * The ladder is read from the datum, never measured off the rendered rungs. A
+ * boxen computes its quantiles before it draws them, and a height in pixels is
+ * a layout fact rather than a quantile.
+ */
+
+import type { BoxenPoint, LetterValueLevel, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BoxenConfig, D3BuiltLayer, DataAccessor } from '../types';
+import { Orientation, TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+
+/** Keys a rung's tail probability is carried under, canonical first. */
+const P_KEYS = ['p', 'prob', 'probability', 'depth'] as const;
+
+/** Keys a rung's lower quantile is carried under, canonical first. */
+const LO_KEYS = ['lo', 'lower', 'low', 'min', 'y0'] as const;
+
+/** Keys a rung's upper quantile is carried under, canonical first. */
+const HI_KEYS = ['hi', 'upper', 'high', 'max', 'y1'] as const;
+
+/**
+ * Reads one number off a rung, trying each key in turn.
+ *
+ * @param rung - One entry of the ladder
+ * @param keys - The keys to try, canonical first
+ * @returns The number, or `undefined` when the rung carries none of them
+ */
+function readRungValue(rung: Record<string, unknown>, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    if (key in rung) {
+      const value = Number(rung[key]);
+      if (Number.isFinite(value)) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Normalizes the ladder a distribution declares into {@link LetterValueLevel}s.
+ *
+ * A rung whose three numbers are not all present and finite is dropped rather
+ * than emitted: a rung is a labelled position on the distribution, and one
+ * carrying `NaN` would be announced as a percentile the data never computed.
+ * The order is left alone — the trace sorts the ladder outward from the median
+ * itself, so a producer emitting it inward-first is read correctly either way.
+ *
+ * @param raw - Whatever the `levels` accessor produced
+ * @param index - Position of the distribution in the selection
+ * @returns The rungs the payload carries
+ * @throws Error when the accessor produced no array at all
+ */
+function resolveLevels(raw: unknown, index: number): LetterValueLevel[] {
+  if (!Array.isArray(raw)) {
+    throw new TypeError(
+      `The distribution at index ${index} has no ladder: the \`levels\` `
+      + `accessor resolved to ${String(raw)} rather than an array of `
+      + `{ p, lo, hi } rungs. A boxen is that ladder — without it the chart is `
+      + `a box plot, and \`bindD3Box\` reads it.`,
+    );
+  }
+
+  const levels: LetterValueLevel[] = [];
+  for (const entry of raw) {
+    if (entry === null || typeof entry !== 'object') {
+      continue;
+    }
+    const rung = entry as Record<string, unknown>;
+    const p = readRungValue(rung, P_KEYS);
+    const lo = readRungValue(rung, LO_KEYS);
+    const hi = readRungValue(rung, HI_KEYS);
+    if (p === undefined || lo === undefined || hi === undefined) {
+      continue;
+    }
+    levels.push({ p, lo, hi });
+  }
+  return levels;
+}
+
+/**
+ * Reads an outlier list, keeping only the numbers in it.
+ *
+ * @param datum - The datum bound to the distribution's element
+ * @param accessor - The outlier accessor
+ * @param index - Position of the distribution in the selection
+ * @returns The outliers, or `undefined` when the chart declares none
+ */
+function readOutliers(
+  datum: unknown,
+  accessor: DataAccessor<number[]>,
+  index: number,
+): number[] | undefined {
+  const raw = resolveAccessorOptional<number[]>(datum, accessor, index);
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const values = raw.map(Number).filter(value => Number.isFinite(value));
+  return values.length > 0 ? values : undefined;
+}
+
+/**
+ * Binds a D3.js boxen (letter-value) plot to MAIDR, generating the accessible
+ * data representation.
+ *
+ * Point `selector` at one element per distribution — the `<g>` holding that
+ * category's stack of nested rungs — the way {@link bindD3Box} points at a box
+ * group. Every rung of a distribution highlights that group: a chart does not
+ * draw an element per quantile that MAIDR could pair up positionally, and
+ * inventing one would highlight geometry the chart never drew.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 boxen plot.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * // One <g> per distribution, its datum carrying the ladder the rungs
+ * // were drawn from.
+ * const result = bindD3Boxen(svgElement, {
+ *   selector: 'g.boxen',
+ *   title: 'Response Time by Group',
+ *   axes: { x: 'Group', y: 'Milliseconds' },
+ *   x: 'group',
+ *   levels: 'letterValues',
+ * });
+ * ```
+ */
+export function bindD3Boxen(svg: Element, config: D3BoxenConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildBoxenLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for boxen plots. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildBoxenLayer(root: Element, config: D3BoxenConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    orientation = Orientation.VERTICAL,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'boxen group');
+  }
+
+  // Infer accessors from the first datum's keys when the user did not specify.
+  const firstDatum = elements[0].datum;
+  const xAccessor = inferAccessor<string | number>(
+    config,
+    'x',
+    'x',
+    ['z', 'category', 'label', 'name', 'key', 'group'],
+    firstDatum,
+  );
+  const medianAccessor = inferAccessor<number>(
+    config,
+    'median',
+    'median',
+    ['q2', 'mid', 'y'],
+    firstDatum,
+  );
+  const levelsAccessor = inferAccessor<unknown[]>(
+    config,
+    'levels',
+    'levels',
+    ['letterValues', 'letter_values', 'quantiles', 'ladder'],
+    firstDatum,
+  );
+  const lowerAccessor = inferAccessor<number[]>(
+    config,
+    'lowerOutliers',
+    'lowerOutliers',
+    ['lower_outliers', 'outliersLow'],
+    firstDatum,
+  );
+  const upperAccessor = inferAccessor<number[]>(
+    config,
+    'upperOutliers',
+    'upperOutliers',
+    ['upper_outliers', 'outliersHigh'],
+    firstDatum,
+  );
+
+  const data: BoxenPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const point: BoxenPoint = {
+      z: String(resolveAccessor<string | number>(datum, xAccessor, index)),
+      median: Number(resolveAccessor<number>(datum, medianAccessor, index)),
+      levels: resolveLevels(resolveAccessor<unknown[]>(datum, levelsAccessor, index), index),
+    };
+
+    const lowerOutliers = readOutliers(datum, lowerAccessor, index);
+    if (lowerOutliers !== undefined) {
+      point.lowerOutliers = lowerOutliers;
+    }
+    const upperOutliers = readOutliers(datum, upperAccessor, index);
+    if (upperOutliers !== undefined) {
+      point.upperOutliers = upperOutliers;
+    }
+
+    return point;
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.BOXEN,
+    title,
+    // One scoped selector matching every distribution: the trace pairs them
+    // one-to-one with the ladders and repeats each element across its own
+    // rungs, withdrawing highlighting on a count mismatch rather than
+    // highlighting a neighbouring distribution.
+    selectors: scopeSelector(root, selector, panel),
+    orientation,
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/contour.ts
+++ b/src/adapters/d3/binders/contour.ts
@@ -1,0 +1,225 @@
+/**
+ * D3 binder for contour plots.
+ *
+ * `d3.contours()` and `d3.contourDensity()` emit one GeoJSON `MultiPolygon`
+ * per threshold, carrying the threshold as `.value` and the curves as
+ * `.coordinates`, and a chart draws one `<path>` per one of those. So the
+ * layer's rows are the levels, which is structurally the multi-line layer
+ * `binders/line.ts` builds — with the level carried on every point of its
+ * curve, because that is where the grammar has room for it and because
+ * `ContourTrace` announces it as the field's own value rather than as a series
+ * name.
+ *
+ * **The coordinates are not in data space.** `d3.contours()` walks a grid and
+ * emits grid indices; `d3.contourDensity()` bins projected points and emits
+ * pixels. Neither is a position on an axis, so `x` and `y` are the transforms
+ * back — and left out, the chart announces its curves in grid cells or screen
+ * pixels, which is wrong in a way that sounds entirely plausible.
+ */
+
+import type { ContourPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3ContourConfig, D3GridTransform } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessorOptional } from '../util';
+import { stampSeriesSelectors } from './line';
+
+/** Passes a coordinate through unchanged, for a chart already in data space. */
+const identity: D3GridTransform = coordinate => coordinate;
+
+/**
+ * Whether a value is a `[x, y]` coordinate pair.
+ *
+ * @param value - A candidate entry of a ring
+ * @returns True when it is a position
+ */
+function isPosition(value: unknown): value is number[] {
+  return Array.isArray(value) && typeof value[0] === 'number';
+}
+
+/**
+ * Collects a level's rings, whatever nesting its geometry arrived in.
+ *
+ * A `MultiPolygon` nests polygon, then ring, then position; a `Polygon` nests
+ * ring, then position; and a bare ring is just positions. All three are
+ * flattened to a list of rings, so the caller does not have to know which of
+ * them `d3.contours` handed it.
+ *
+ * @param coordinates - Whatever the `coordinates` accessor produced
+ * @returns Every ring in it, in order
+ */
+function collectRings(coordinates: unknown): number[][][] {
+  if (!Array.isArray(coordinates)) {
+    return [];
+  }
+  if (isPosition(coordinates[0])) {
+    return [coordinates as number[][]];
+  }
+  return coordinates.flatMap(entry => collectRings(entry));
+}
+
+/**
+ * Binds a D3.js contour plot to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the level paths — one per threshold — and give `x` and
+ * `y` the transforms from the grid `d3.contours()` walked back onto the
+ * chart's axes (`x: i => x0 + i * dx`), or the inverse scales when the
+ * geometry is `d3.contourDensity()`'s pixels (`x: px => xScale.invert(px)`).
+ *
+ * A level drawn as several disjoint rings is flattened into one curve, in the
+ * order the rings appear: a row of the payload is a single polyline. Every
+ * point announced is a real point of that level; what a reader cannot hear is
+ * the jump from the end of one ring to the start of the next.
+ *
+ * The rows keep the order the paths were drawn in, which for `d3.contours()`
+ * is ascending threshold — the order `ContourTrace` measures the gap to the
+ * adjacent* level in, which is how it reports the gradient.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 contour plot.
+ * @param config - Configuration specifying the selector and grid transforms.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const contours = d3.contours().size([n, m])(values);
+ * svg.selectAll('path.contour').data(contours).join('path').attr('d', d3.geoPath());
+ *
+ * const result = bindD3Contour(svgElement, {
+ *   selector: 'path.contour',
+ *   title: 'Density Field',
+ *   axes: { x: 'X', y: 'Y', fill: 'Density' },
+ *   x: column => x0 + column * cellWidth,
+ *   y: row => y0 + row * cellHeight,
+ * });
+ * ```
+ */
+export function bindD3Contour(svg: Element, config: D3ContourConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildContourLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for contour plots. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildContourLayer(
+  root: Element,
+  config: D3ContourConfig,
+  panel?: D3PanelScope,
+): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    coordinates: coordinatesAccessor = 'coordinates',
+    x: toX = identity,
+    y: toY = identity,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'contour level path');
+  }
+
+  const levelAccessor = inferAccessor<number>(
+    config,
+    'level',
+    'value',
+    ['level', 'threshold', 'z'],
+    elements[0].datum,
+  );
+
+  const data: ContourPoint[][] = [];
+  const levelPaths: Element[] = [];
+
+  for (const { element, datum, index } of elements) {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const raw = resolveAccessorOptional<number>(datum, levelAccessor, index);
+    const level = Number(raw);
+    const rings = collectRings(resolveAccessorOptional(datum, coordinatesAccessor, index));
+    if (rings.length === 0) {
+      throw new Error(
+        `The level at index ${index} carries no rings: the \`coordinates\` `
+        + `accessor resolved to nothing shaped like a GeoJSON geometry. `
+        + `\`d3.contours()\` binds a MultiPolygon per threshold — bind those `
+        + `objects to the paths, not the \`d\` strings you drew them with.`,
+      );
+    }
+
+    const curve: ContourPoint[] = [];
+    for (const ring of rings) {
+      // A GeoJSON ring repeats its first position to close itself. That repeat
+      // is geometry, not a sample of the level, and left in it would announce
+      // the same place twice at the seam of every ring.
+      const positions = closesOnItself(ring) ? ring.slice(0, -1) : ring;
+      for (const [gridX, gridY] of positions) {
+        const point: ContourPoint = { x: toX(gridX), y: toY(gridY) };
+        // Carried on every point of the curve, which is where the grammar has
+        // room for it: the trace reads the first one it finds.
+        if (Number.isFinite(level)) {
+          point.level = level;
+        }
+        curve.push(point);
+      }
+    }
+
+    if (curve.length > 0) {
+      data.push(curve);
+      levelPaths.push(element);
+    }
+  }
+
+  if (data.length === 0) {
+    throw new Error(
+      `No contour levels could be read from "${selector}": every matched path `
+      + `resolved to an empty set of rings.`,
+    );
+  }
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.CONTOUR,
+    title,
+    // One selector per level. `ContourTrace` inherits `LineTrace`'s
+    // resolution, which pairs the selector list with the rows one for one, so
+    // a bare selector matching every level path withdraws highlighting.
+    selectors: levelPaths.length > 1
+      ? stampSeriesSelectors(root, selector, levelPaths, data.length, panel)
+      : scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}
+
+/**
+ * Whether a ring ends where it started, as a GeoJSON ring does.
+ *
+ * @param ring - One ring of a level's geometry
+ * @returns True when the last position repeats the first
+ */
+function closesOnItself(ring: number[][]): boolean {
+  if (ring.length < 2) {
+    return false;
+  }
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+  return first[0] === last[0] && first[1] === last[1];
+}

--- a/src/adapters/d3/binders/dumbbell.ts
+++ b/src/adapters/d3/binders/dumbbell.ts
@@ -1,0 +1,145 @@
+/**
+ * D3 binder for dumbbell (connected-dot) charts.
+ *
+ * Extracts data from the connector each row is drawn with and generates the
+ * MAIDR JSON schema for accessible interaction. Unlike every other D3 binder,
+ * the emitted `data` is a single object rather than an array: the names of the
+ * two ends belong to the chart and not to any one row.
+ */
+
+import type { DumbbellData, DumbbellPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3DumbbellConfig } from '../types';
+import { Orientation, TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+
+/**
+ * Binds a D3.js dumbbell chart to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the **connectors** — one `<line>` per row — rather than
+ * at the dots. A dumbbell draws one segment and two dots per row, so the
+ * connectors are the elements that map one-to-one onto the data; a selector
+ * matching the dots would produce twice as many elements as rows and the trace
+ * would withdraw highlighting rather than pair them wrongly.
+ *
+ * Name the two ends with `startLabel` / `endLabel`. They are what the chart's
+ * legend gives a sighted reader for free: without them a chart of life
+ * expectancy in 1990 against 2020 tells the reader they are on the "start"
+ * dot, which is the one thing they already knew.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 dumbbell chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Dumbbell(svgElement, {
+ *   selector: 'line.connector',
+ *   title: 'Life Expectancy, 1990 against 2020',
+ *   orientation: Orientation.HORIZONTAL,
+ *   axes: { x: 'Years', y: 'Country' },
+ *   x: 'country',
+ *   start: 'y1990',
+ *   end: 'y2020',
+ *   startLabel: '1990',
+ *   endLabel: '2020',
+ * });
+ * ```
+ */
+export function bindD3Dumbbell(svg: Element, config: D3DumbbellConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildDumbbellLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for dumbbell charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildDumbbellLayer(root: Element, config: D3DumbbellConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    startLabel,
+    endLabel,
+    orientation = Orientation.VERTICAL,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'dumbbell connector');
+  }
+
+  // Infer accessors from the first datum's keys when the user did not specify.
+  const firstDatum = elements[0].datum;
+  const xAccessor = inferAccessor<string | number>(
+    config,
+    'x',
+    'x',
+    ['category', 'label', 'name', 'key', 'group'],
+    firstDatum,
+  );
+  const startAccessor = inferAccessor<number>(
+    config,
+    'start',
+    'start',
+    ['from', 'before', 'y0'],
+    firstDatum,
+  );
+  const endAccessor = inferAccessor<number>(
+    config,
+    'end',
+    'end',
+    ['to', 'after', 'y1'],
+    firstDatum,
+  );
+
+  const points: DumbbellPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+    return {
+      x: resolveAccessor<string | number>(datum, xAccessor, index),
+      start: resolveAccessor<number>(datum, startAccessor, index),
+      end: resolveAccessor<number>(datum, endAccessor, index),
+    };
+  });
+
+  // The object payload, not an array: the end labels describe the chart, and
+  // repeating them on every row would let the rows disagree about what is
+  // being compared. Each is omitted when unnamed, so the trace falls back to
+  // "start" and "end" rather than being handed an empty label.
+  const data: DumbbellData = {
+    points,
+    ...(startLabel !== undefined ? { startLabel } : {}),
+    ...(endLabel !== undefined ? { endLabel } : {}),
+  };
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.DUMBBELL,
+    title,
+    // One scoped selector matching every connector: the trace maps them
+    // one-to-one onto the rows and highlights the same segment at both ends,
+    // which is what the chart drew.
+    selectors: scopeSelector(root, selector, panel),
+    orientation,
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/errorBar.ts
+++ b/src/adapters/d3/binders/errorBar.ts
@@ -1,14 +1,18 @@
 /**
- * D3 binder for error-bar (point-range) charts.
+ * D3 binder for error-bar (point-range) and forest charts.
  *
  * Extracts data from D3.js-rendered estimate groups — the `<line>` plus marker
  * a confidence interval is drawn from — and generates the MAIDR JSON schema
  * for accessible interaction.
+ *
+ * A forest plot is that chart with three things added: how much each study
+ * weighs, which row is the pooled summary, and where the null line sits. All
+ * three are read off the same groups, so one core builds both.
  */
 
-import type { ErrorBarPoint, MaidrLayer } from '../../../type/grammar';
+import type { ForestPoint, MaidrLayer } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
-import type { D3BinderResult, D3BuiltLayer, D3ErrorBarConfig, DataAccessor } from '../types';
+import type { D3BinderResult, D3BuiltLayer, D3ErrorBarConfig, D3ForestConfig, DataAccessor } from '../types';
 import { Orientation, TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
 import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
@@ -84,24 +88,148 @@ export function bindD3ErrorBar(svg: Element, config: D3ErrorBarConfig): D3Binder
 }
 
 /**
+ * Binds a D3.js forest plot to MAIDR, generating the accessible data
+ * representation.
+ *
+ * A forest plot is a point-range chart of studies against a shared null line,
+ * so `selector` matches one element per study exactly as
+ * {@link bindD3ErrorBar}'s does, and the bounds are the same absolute positions
+ * on the value axis.
+ *
+ * Three things make it a forest plot rather than an error bar, and each is what
+ * a sighted reader takes from the drawing:
+ *
+ * - **`nullValue`** — the line at 1 (a ratio) or 0 (a difference). Whether a
+ *   study's interval crosses it *is the result for that study*, and the trace
+ *   announces the crossing. Without it, no claim about significance is made:
+ *   there is no default, because a ratio chart guessed at 0 would report every
+ *   study as not crossing.
+ * - **`weight`** — the marker area, which is a magnitude a reader is otherwise
+ *   never told; two studies whose intervals look alike can contribute wholly
+ *   differently to the result.
+ * - **`pooledSelector`** — the diamond at the bottom. It is drawn as a
+ *   different mark from the studies, so it is selected separately and appended
+ *   after them; it is not evidence, it is what the evidence came to, and
+ *   announcing it as one more study invites a reader to count it among them.
+ *
+ * @param svg - The SVG element containing the D3 forest plot.
+ * @param config - Configuration specifying the selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Forest(svgElement, {
+ *   selector: 'g.study',
+ *   pooledSelector: 'path.pooled',
+ *   title: 'Effect of the Intervention',
+ *   orientation: Orientation.HORIZONTAL,
+ *   axes: { x: 'Odds ratio', y: 'Study' },
+ *   x: 'study',
+ *   y: 'or',
+ *   yMin: 'ciLow',
+ *   yMax: 'ciHigh',
+ *   weight: 'weight',
+ *   nullValue: 1,
+ * });
+ * ```
+ */
+export function bindD3Forest(svg: Element, config: D3ForestConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildForestLayer(svg, config));
+}
+
+/**
  * Pure extraction core for error-bar charts. See {@link buildBarLayer} for the
  * single-chart vs multi-panel contract.
  *
  * @internal
  */
 export function buildErrorBarLayer(root: Element, config: D3ErrorBarConfig, panel?: D3PanelScope): D3BuiltLayer {
+  return buildIntervalLayer(root, config, panel, TraceType.ERROR_BAR);
+}
+
+/**
+ * Pure extraction core for forest plots. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildForestLayer(root: Element, config: D3ForestConfig, panel?: D3PanelScope): D3BuiltLayer {
+  return buildIntervalLayer(root, config, panel, TraceType.FOREST);
+}
+
+/**
+ * Builds an error-bar or forest layer from the estimate groups a chart drew.
+ *
+ * The forest-only fields are read only when the layer is a forest, so an error
+ * bar chart whose datum happens to carry a `weight` key is not silently given
+ * one.
+ *
+ * @param root - The extraction root (the SVG, or a panel element)
+ * @param config - The user's config; the forest fields are ignored for an
+ *                 error-bar layer
+ * @param panel - Optional panel scope for multi-panel binds
+ * @param type - Which of the two the layer announces itself as
+ * @returns The extracted layer
+ */
+function buildIntervalLayer(
+  root: Element,
+  config: D3ForestConfig,
+  panel: D3PanelScope | undefined,
+  type: typeof TraceType.ERROR_BAR | typeof TraceType.FOREST,
+): D3BuiltLayer {
   const {
     title,
     axes,
     format,
     selector,
+    pooledSelector,
+    nullValue,
     orientation = Orientation.VERTICAL,
   } = config;
 
-  const elements = queryD3Elements(root, selector);
-  if (elements.length === 0) {
-    throw buildNoElementsError(root, selector, 'error-bar estimate');
+  const isForest = type === TraceType.FOREST;
+
+  const estimates = queryD3Elements(root, selector);
+  if (estimates.length === 0) {
+    throw buildNoElementsError(root, selector, isForest ? 'forest study' : 'error-bar estimate');
   }
+
+  // The pooled summary, when it is drawn as its own mark. Its rows follow the
+  // studies, which is both the order the chart draws them in and the order the
+  // selector list has to be in for the highlight to land on the right row.
+  const pooledElements = isForest && pooledSelector !== undefined
+    ? queryD3Elements(root, pooledSelector)
+    : [];
+  if (isForest && pooledSelector !== undefined && pooledElements.length === 0) {
+    throw buildNoElementsError(root, pooledSelector, 'pooled summary');
+  }
+
+  // Two selectors matching one element would emit that row twice — announced
+  // once as a study and once as the summary — and the doubled selector list
+  // would still have the same length as the doubled payload, so nothing
+  // downstream could notice. Said here instead, where it is fixable.
+  const overlap = pooledElements.filter(
+    pooledEntry => estimates.some(estimate => estimate.element === pooledEntry.element),
+  ).length;
+  if (overlap > 0) {
+    throw new Error(
+      `The pooled selector "${pooledSelector}" also matches ${overlap} of the `
+      + `${estimates.length} elements matched by "${selector}", so those rows `
+      + `would be emitted twice — once as a study and once as the summary. `
+      + `Narrow one of the two, e.g. \`selector: '${selector}:not(.pooled)'\`.`,
+    );
+  }
+
+  const elements = [
+    ...estimates.map(entry => ({ ...entry, isPooledMark: false })),
+    // Indexes continue past the studies so a function accessor sees one
+    // position per emitted row rather than two rows numbered zero.
+    ...pooledElements.map(entry => ({
+      ...entry,
+      index: entry.index + estimates.length,
+      isPooledMark: true,
+    })),
+  ];
 
   // Infer accessors from the first datum's keys when the user did not specify.
   const firstDatum = elements[0].datum;
@@ -134,11 +262,29 @@ export function buildErrorBarLayer(root: Element, config: D3ErrorBarConfig, pane
     firstDatum,
   );
 
-  const data: ErrorBarPoint[] = elements.map(({ datum, index }) => {
+  const weightAccessor = inferAccessor<number>(
+    config,
+    'weight',
+    'weight',
+    ['w', 'share'],
+    firstDatum,
+  );
+  const pooledAccessor = inferAccessor<boolean>(
+    config,
+    'pooled',
+    'pooled',
+    ['isPooled', 'summary'],
+    firstDatum,
+  );
+
+  // Typed as the wider row throughout: a `ForestPoint` with neither `weight`
+  // nor `pooled` set IS an `ErrorBarPoint`, so an error-bar layer emits
+  // exactly what it did before.
+  const data: ForestPoint[] = elements.map(({ datum, index, isPooledMark }) => {
     if (datum === undefined || datum === null) {
-      throw buildNoDatumError(selector, index);
+      throw buildNoDatumError(isPooledMark && pooledSelector !== undefined ? pooledSelector : selector, index);
     }
-    const point: ErrorBarPoint = {
+    const point: ForestPoint = {
       x: resolveAccessor<string | number>(datum, xAccessor, index),
       y: resolveAccessor<number>(datum, yAccessor, index),
     };
@@ -150,21 +296,49 @@ export function buildErrorBarLayer(root: Element, config: D3ErrorBarConfig, pane
     if (yMax !== undefined) {
       point.yMax = yMax;
     }
+
+    if (!isForest) {
+      return point;
+    }
+
+    // The weight is a fraction of one, and absent is a real answer: a forest
+    // plot drawn without weights is a real chart, so nothing is derived here.
+    const weight = Number(resolveAccessorOptional<number>(datum, weightAccessor, index));
+    if (Number.isFinite(weight)) {
+      point.weight = weight;
+    }
+    // Its own mark makes a row pooled; so does the datum saying so, for a
+    // chart that draws every row alike.
+    if (isPooledMark || resolveAccessorOptional<boolean>(datum, pooledAccessor, index) === true) {
+      point.pooled = true;
+    }
     return point;
   });
 
+  // One selector per selection, in the order the rows were built. The trace
+  // flattens the list and pairs it one-to-one with the rows, highlighting the
+  // same element at each of the three sections a column is read through — so
+  // the studies' groups must come before the pooled mark, as they do above.
+  const selectors = pooledElements.length > 0 && pooledSelector !== undefined
+    ? [scopeSelector(root, selector, panel), scopeSelector(root, pooledSelector, panel)]
+    : scopeSelector(root, selector, panel);
+
   const layer: MaidrLayer = {
     id: generateId(),
-    type: TraceType.ERROR_BAR,
+    type,
     title,
-    // One scoped selector matching every estimate group: the trace maps them
-    // one-to-one onto the samples and highlights the same group at each of the
-    // three sections a column is read through.
-    selectors: scopeSelector(root, selector, panel),
+    selectors,
     orientation,
     axes: buildAxes(axes, format),
     data,
   };
+
+  // Declared only when the caller gave one: the trace deliberately has no
+  // default, and a guessed null line would sort every study onto the wrong
+  // side of it silently.
+  if (isForest && typeof nullValue === 'number' && Number.isFinite(nullValue)) {
+    layer.forestOptions = { nullValue };
+  }
 
   return { layer };
 }

--- a/src/adapters/d3/binders/errorBar.ts
+++ b/src/adapters/d3/binders/errorBar.ts
@@ -1,0 +1,170 @@
+/**
+ * D3 binder for error-bar (point-range) charts.
+ *
+ * Extracts data from D3.js-rendered estimate groups — the `<line>` plus marker
+ * a confidence interval is drawn from — and generates the MAIDR JSON schema
+ * for accessible interaction.
+ */
+
+import type { ErrorBarPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3ErrorBarConfig, DataAccessor } from '../types';
+import { Orientation, TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+
+/**
+ * Reads an interval bound, keeping only a usable number.
+ *
+ * The bounds are optional and independently so — a one-sided interval is a
+ * real chart, and a datum that carries no bound at all is an estimate drawn
+ * without one. Anything that is not a finite number is therefore dropped
+ * rather than emitted: a `NaN` bound would be announced as a bound, and the
+ * reader has no way to tell it from a measured one.
+ *
+ * @param datum - The datum bound to the estimate's element.
+ * @param accessor - The bound's accessor.
+ * @param index - The estimate's index, for accessor functions.
+ * @returns The bound, or undefined when the chart does not draw one.
+ */
+function readBound(
+  datum: unknown,
+  accessor: DataAccessor<number>,
+  index: number,
+): number | undefined {
+  const value = resolveAccessorOptional<number>(datum, accessor, index);
+  const numeric = Number(value);
+  return value === undefined || value === null || Number.isNaN(numeric)
+    ? undefined
+    : numeric;
+}
+
+/**
+ * Binds a D3.js error-bar chart to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at one element per estimate — the canonical D3 idiom is a
+ * `<g>` holding the interval's `<line>` and the estimate's marker, and that
+ * group is what the reader's cursor should highlight.
+ *
+ * **The bounds are absolute positions on the value axis, not half-widths.**
+ * Producers disagree about which they hand out, so the grammar fixes one and
+ * each adapter converts. The binder cannot tell an offset from a bound by
+ * looking at it, so a datum carrying `±se` needs a function accessor:
+ * `yMin: d => d.mean - 1.96 * d.se`.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 error-bar chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3ErrorBar(svgElement, {
+ *   selector: 'g.estimate',
+ *   title: 'Mean Response by Dose',
+ *   axes: { x: 'Group', y: 'Response' },
+ *   x: 'group',
+ *   y: 'mean',
+ *   yMin: 'ciLow',
+ *   yMax: 'ciHigh',
+ * });
+ * ```
+ */
+export function bindD3ErrorBar(svg: Element, config: D3ErrorBarConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildErrorBarLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for error-bar charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildErrorBarLayer(root: Element, config: D3ErrorBarConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    orientation = Orientation.VERTICAL,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'error-bar estimate');
+  }
+
+  // Infer accessors from the first datum's keys when the user did not specify.
+  const firstDatum = elements[0].datum;
+  const xAccessor = inferAccessor<string | number>(
+    config,
+    'x',
+    'x',
+    ['category', 'label', 'name', 'key', 'group'],
+    firstDatum,
+  );
+  const yAccessor = inferAccessor<number>(
+    config,
+    'y',
+    'y',
+    ['value', 'mean', 'estimate', 'median'],
+    firstDatum,
+  );
+  const yMinAccessor = inferAccessor<number>(
+    config,
+    'yMin',
+    'yMin',
+    ['lower', 'ciLow', 'ci_low', 'low', 'min'],
+    firstDatum,
+  );
+  const yMaxAccessor = inferAccessor<number>(
+    config,
+    'yMax',
+    'yMax',
+    ['upper', 'ciHigh', 'ci_high', 'high', 'max'],
+    firstDatum,
+  );
+
+  const data: ErrorBarPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+    const point: ErrorBarPoint = {
+      x: resolveAccessor<string | number>(datum, xAccessor, index),
+      y: resolveAccessor<number>(datum, yAccessor, index),
+    };
+    const yMin = readBound(datum, yMinAccessor, index);
+    if (yMin !== undefined) {
+      point.yMin = yMin;
+    }
+    const yMax = readBound(datum, yMaxAccessor, index);
+    if (yMax !== undefined) {
+      point.yMax = yMax;
+    }
+    return point;
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.ERROR_BAR,
+    title,
+    // One scoped selector matching every estimate group: the trace maps them
+    // one-to-one onto the samples and highlights the same group at each of the
+    // three sections a column is read through.
+    selectors: scopeSelector(root, selector, panel),
+    orientation,
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/flow.ts
+++ b/src/adapters/d3/binders/flow.ts
@@ -1,0 +1,313 @@
+/**
+ * D3 binder for sankey, alluvial and chord diagrams.
+ *
+ * Extracts the two ends and the magnitude of every ribbon the layout drew and
+ * generates the MAIDR JSON schema for accessible interaction. The nodes are
+ * derived from the links rather than read separately — a flow list names both
+ * of its ends, so a separate node selection would be a second source of truth
+ * for something the ribbons already say.
+ *
+ * The three layouts differ in where they put the ribbons, not in what they
+ * carry, so one core builds all three and the type the layer announces is what
+ * changes.
+ */
+
+import type { FlowPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3FlowConfig, DataAccessor, FlowTraceType } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+
+/** Keys a node object is named by, in the order `d3-sankey` itself tries `id`. */
+const NODE_NAME_KEYS = ['id', 'name', 'key', 'label'] as const;
+
+/**
+ * Normalizes one end of a ribbon to the node it names.
+ *
+ * There are three shapes to read, and a chart draws whichever its layout
+ * produced:
+ *
+ * 1. **A name**, for a graph drawn by hand — used as it stands.
+ * 2. **A node object**, which is what `d3-sankey` leaves behind: like
+ *    `d3.forceLink`, it replaces each link's `source` and `target` with the
+ *    nodes it resolved them to, so a binder called after the layout sees
+ *    objects. Read through {@link NODE_NAME_KEYS}.
+ * 3. **A matrix index**, which is what `d3.chord()` produces: its ends are
+ *    `{ index, value, startAngle, … }` and a matrix has no names in it. The
+ *    caller's `names` supplies them; without it the index is announced as
+ *    itself, since a bare number is at least the position the chart drew.
+ *
+ * @param raw - The value the accessor produced for this end
+ * @param names - The matrix's row labels, when the caller declared them
+ * @param endpoint - Which end, for the error message
+ * @param index - Position of the ribbon in the selection
+ * @returns The node's name
+ * @throws Error when an object end carries neither a name nor an index
+ */
+function resolveEndpoint(
+  raw: unknown,
+  names: (string | number)[] | undefined,
+  endpoint: 'source' | 'target',
+  index: number,
+): string | number {
+  if (typeof raw === 'number') {
+    return names?.[raw] ?? raw;
+  }
+  if (typeof raw === 'string') {
+    return raw;
+  }
+  if (raw !== null && typeof raw === 'object') {
+    const node = raw as Record<string, unknown>;
+    for (const key of NODE_NAME_KEYS) {
+      const value = node[key];
+      if (typeof value === 'string' || typeof value === 'number') {
+        return value;
+      }
+    }
+    // A chord's end, which names its group by position in the matrix.
+    if (typeof node.index === 'number') {
+      return names?.[node.index] ?? node.index;
+    }
+    throw new Error(
+      `The "${endpoint}" of the flow at index ${index} is a node object with `
+      + `no name: none of ${NODE_NAME_KEYS.join(', ')} is set on it. `
+      + `Available properties: ${Object.keys(node).join(', ')}. Pass a `
+      + `\`${endpoint}\` accessor that names the node, e.g. `
+      + `\`${endpoint}: d => d.${endpoint}.title\`.`,
+    );
+  }
+  throw new Error(
+    `The "${endpoint}" of the flow at index ${index} resolved to `
+    + `${String(raw)}, which names no node. A flow needs both of its ends.`,
+  );
+}
+
+/**
+ * Reads how much flows along one ribbon.
+ *
+ * `d3.chord()` puts the magnitude on each **end** of the ribbon rather than on
+ * the ribbon itself — the same number the drawn width came from — so a datum
+ * with no value of its own falls back to it. Nothing is derived beyond that: a
+ * ribbon whose weight cannot be read is the whole content of the chart missing,
+ * and a guessed one would be announced as measured.
+ *
+ * @param datum - The datum bound to the ribbon's element
+ * @param accessor - The resolved value accessor
+ * @param index - Position of the ribbon in the selection
+ * @returns The magnitude
+ * @throws Error when neither the datum nor its source end carries one
+ */
+function resolveValue(
+  datum: unknown,
+  accessor: DataAccessor<number>,
+  index: number,
+): number {
+  const direct = Number(resolveAccessorOptional<number>(datum, accessor, index));
+  if (Number.isFinite(direct)) {
+    return direct;
+  }
+
+  const source = (datum as Record<string, unknown>).source;
+  if (source !== null && typeof source === 'object') {
+    const nested = Number((source as Record<string, unknown>).value);
+    if (Number.isFinite(nested)) {
+      return nested;
+    }
+  }
+
+  const available = datum !== null && typeof datum === 'object'
+    ? ` Available properties: ${Object.keys(datum as Record<string, unknown>).join(', ')}.`
+    : '';
+  throw new Error(
+    `The flow at index ${index} carries no magnitude: neither the datum nor `
+    + `its source end has a usable number.${available} Pass a \`value\` `
+    + `accessor naming the property that carries it.`,
+  );
+}
+
+/**
+ * Binds a D3.js sankey diagram to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the **ribbons** — one `<path>` per link, the
+ * `d3-sankey` idiom being `.data(graph.links).join('path')` — rather than at
+ * the node rectangles. The nodes are derived from the links, so the links are
+ * what map one-to-one onto the payload; a selector matching the node rects
+ * would give the trace a node count where it expects a link count, and
+ * highlighting would be withdrawn.
+ *
+ * @remarks
+ * **Timing — call after the layout has run.** `sankey(graph)` replaces each
+ * link's `source` and `target` with the resolved node objects, and the binder
+ * reads names either way; what it cannot do is run before the ribbons are
+ * joined.
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 sankey.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const graph = sankey({ nodes, links });
+ * svg.selectAll('path.ribbon').data(graph.links).join('path')…;
+ *
+ * bindD3Sankey(svgElement, {
+ *   selector: 'path.ribbon',
+ *   title: 'Energy flow',
+ *   axes: { x: 'Node', y: 'Petajoules' },
+ * });
+ * ```
+ */
+export function bindD3Sankey(svg: Element, config: D3FlowConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildFlowLayer(svg, config));
+}
+
+/**
+ * Binds a D3.js alluvial diagram to MAIDR.
+ *
+ * An alluvial is a sankey whose node columns repeat — the same category
+ * observed at several points, with the ribbons carrying how much moved between
+ * them — so the extraction is that of {@link bindD3Sankey} and only the chart's
+ * announced name changes.
+ *
+ * @param svg - The SVG element containing the D3 alluvial diagram.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Alluvial(svgElement, {
+ *   selector: 'path.ribbon',
+ *   title: 'Party support between elections',
+ *   axes: { x: 'Group', y: 'Voters' },
+ * });
+ * ```
+ */
+export function bindD3Alluvial(svg: Element, config: D3FlowConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildFlowLayer(svg, config, undefined, TraceType.ALLUVIAL),
+  );
+}
+
+/**
+ * Binds a D3.js chord diagram to MAIDR.
+ *
+ * `selector` matches the ribbon `<path>` elements `d3.ribbon()` drew from
+ * `d3.chord()(matrix)` — the chords themselves, not the group arcs around the
+ * dial.
+ *
+ * **Declare `names`.** A chord layout is computed from a matrix, so each end of
+ * a ribbon is a row *index* (`{ index, value, … }`) and the labels a sighted
+ * reader takes from the ring are not in the data at all. Without `names` the
+ * chart announces "0 to 3" — true, and useless.
+ *
+ * @param svg - The SVG element containing the D3 chord diagram.
+ * @param config - Configuration specifying the selector, the group names and
+ *                 any data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const chords = d3.chord()(matrix);
+ * svg.selectAll('path.chord').data(chords).join('path').attr('d', d3.ribbon()…);
+ *
+ * bindD3Chord(svgElement, {
+ *   selector: 'path.chord',
+ *   title: 'Migration between regions',
+ *   axes: { x: 'Region', y: 'People' },
+ *   names: ['Africa', 'Americas', 'Asia', 'Europe'],
+ * });
+ * ```
+ */
+export function bindD3Chord(svg: Element, config: D3FlowConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildFlowLayer(svg, config, undefined, TraceType.CHORD),
+  );
+}
+
+/**
+ * Pure extraction core for sankey, alluvial and chord diagrams. See
+ * {@link buildBarLayer} for the single-chart vs multi-panel contract.
+ *
+ * The trailing `type` selects which diagram the layer announces itself as; the
+ * graph is the same for all three (see {@link FlowTraceType}).
+ *
+ * @internal
+ */
+export function buildFlowLayer(
+  root: Element,
+  config: D3FlowConfig,
+  panel?: D3PanelScope,
+  type: FlowTraceType = TraceType.SANKEY,
+): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    names,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'flow ribbon');
+  }
+
+  // Infer accessors from the first datum's keys when the user did not specify.
+  const firstDatum = elements[0].datum;
+  const sourceAccessor = inferAccessor<unknown>(
+    config,
+    'source',
+    'source',
+    ['from', 'src'],
+    firstDatum,
+  );
+  const targetAccessor = inferAccessor<unknown>(
+    config,
+    'target',
+    'target',
+    ['to', 'dst'],
+    firstDatum,
+  );
+  const valueAccessor = inferAccessor<number>(
+    config,
+    'value',
+    'value',
+    ['weight', 'amount', 'count', 'y'],
+    firstDatum,
+  );
+
+  const data: FlowPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+    return {
+      source: resolveEndpoint(resolveAccessor(datum, sourceAccessor, index), names, 'source', index),
+      target: resolveEndpoint(resolveAccessor(datum, targetAccessor, index), names, 'target', index),
+      value: resolveValue(datum, valueAccessor, index),
+    };
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type,
+    title,
+    // One scoped selector matching every ribbon: the trace keys them to the
+    // flows in DECLARED order — which is the order they were queried in — and
+    // highlights, from a node, the ribbons that touch it. A selector list that
+    // reordered them would highlight one ribbon while announcing another.
+    selectors: scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/gantt.ts
+++ b/src/adapters/d3/binders/gantt.ts
@@ -1,0 +1,275 @@
+/**
+ * D3 binder for gantt (timeline, swimlane) charts.
+ *
+ * Extracts the intervals a band scale of lanes was drawn from and generates the
+ * MAIDR JSON schema for accessible interaction. Unlike most binders the emitted
+ * `data` is an object rather than an array, and its points are nested **by
+ * lane**: an empty lane is a real statement about a schedule — nothing is
+ * booked — and a flat list has no way to say it.
+ *
+ * The grouping is the binder's own work. A chart draws its rects in whatever
+ * order the data arrived in, so DOM order is not the payload's order, which is
+ * why the highlight selectors are stamped per interval rather than left as one
+ * selector matching everything.
+ */
+
+import type { GanttData, GanttPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3GanttConfig, DataAccessor } from '../types';
+import { Orientation, TraceType } from '../../../type/grammar';
+import { scopeSelector, selectorPrefix } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+
+/** Attribute the binder stamps on each interval to key its highlight. */
+const INTERVAL_ATTRIBUTE = 'data-maidr-gantt-index';
+
+/**
+ * Coerces an interval end to a number on the axis.
+ *
+ * A schedule is usually drawn against dates, and a `Date` — or the string one
+ * was parsed from — cannot be subtracted from another to give a length. So the
+ * ends are coerced to epoch milliseconds and the chart is expected to declare
+ * `format: { type: 'date' }`, which is what turns them back into dates when
+ * they are announced. A numeric string stays the number it reads as: a gantt
+ * drawn over day offsets is as real as one drawn over dates.
+ *
+ * @param value - Whatever the accessor produced
+ * @param end - Which end, for the error message
+ * @param index - Position of the interval in the selection
+ * @returns The position on the axis
+ * @throws Error when the value is neither a number nor a parsable date
+ */
+function coerceTime(value: unknown, end: 'start' | 'end', index: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (value instanceof Date) {
+    const time = value.getTime();
+    if (Number.isFinite(time)) {
+      return time;
+    }
+  }
+  if (typeof value === 'string') {
+    const numeric = Number(value);
+    if (value.trim() !== '' && Number.isFinite(numeric)) {
+      return numeric;
+    }
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  throw new Error(
+    `The "${end}" of the interval at index ${index} resolved to `
+    + `${String(value)}, which is neither a number nor a parsable date. `
+    + `Pass a \`${end}\` accessor that returns one, e.g. `
+    + `\`${end}: d => +d.${end}Date\`.`,
+  );
+}
+
+/**
+ * Emits one highlight selector per interval, in the payload's lane-grouped
+ * order, by stamping each element with a MAIDR-owned attribute.
+ *
+ * `GanttTrace` resolves the selectors to a flat list and slices it lane by
+ * lane, so the list has to be in the order the payload nests them — which is
+ * not the order the chart drew them in unless the data happened to arrive
+ * grouped. A bare selector would resolve in DOM order and hand each lane
+ * whichever intervals sat at those positions, highlighting one task while
+ * announcing another; the trace cannot detect that, because the count matches.
+ *
+ * @param root - The extraction root (the SVG, or a panel element)
+ * @param selector - The user-provided selector matching the intervals
+ * @param ordered - The interval elements, in payload order
+ * @param panel - Optional panel scope for multi-panel binds
+ * @returns One selector per interval, in payload order
+ */
+function stampIntervalSelectors(
+  root: Element,
+  selector: string,
+  ordered: Element[],
+  panel?: D3PanelScope,
+): string[] {
+  const prefix = selectorPrefix(root, panel);
+  return ordered.map((element, index) => {
+    // Clear any prior stamp so rebinding after a D3 data update produces a
+    // clean, deterministic state.
+    element.removeAttribute(INTERVAL_ATTRIBUTE);
+    element.setAttribute(INTERVAL_ATTRIBUTE, String(index));
+    return `${prefix} ${selector}[${INTERVAL_ATTRIBUTE}="${index}"]`;
+  });
+}
+
+/**
+ * Binds a D3.js gantt chart to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the interval marks — one `<rect>` per booked interval.
+ * The binder groups them into lanes itself, so a lane holding several intervals
+ * needs nothing extra; what it cannot discover is an **empty** lane, which has
+ * no element in the DOM at all. Declare those with `lanes`.
+ *
+ * **Dates become epoch milliseconds.** A `Date`, or a string one parses from,
+ * is coerced so the trace can measure lengths; pair it with
+ * `format: { type: 'date' }` so the ends are announced as dates. `unit` names
+ * what a length is counted in, which a bare number cannot say.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 gantt chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Gantt(svgElement, {
+ *   selector: 'rect.task',
+ *   title: 'Project Schedule',
+ *   axes: { x: 'Day', y: 'Phase' },
+ *   x: 'phase',
+ *   start: 'from',
+ *   end: 'to',
+ *   label: 'task',
+ *   lanes: ['Design', 'Build', 'Review', 'Launch'],
+ *   unit: 'days',
+ * });
+ * ```
+ */
+export function bindD3Gantt(svg: Element, config: D3GanttConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildGanttLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for gantt charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildGanttLayer(root: Element, config: D3GanttConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    lanes: declaredLanes,
+    unit,
+    orientation = Orientation.HORIZONTAL,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'gantt interval');
+  }
+
+  // Infer accessors from the first datum's keys when the user did not specify.
+  const firstDatum = elements[0].datum;
+  const xAccessor = inferAccessor<string | number | Date>(
+    config,
+    'x',
+    'x',
+    ['lane', 'category', 'label', 'name', 'key', 'group', 'task'],
+    firstDatum,
+  );
+  const startAccessor = inferAccessor<number | string | Date>(
+    config,
+    'start',
+    'start',
+    ['from', 'begin', 'x0', 'startDate'],
+    firstDatum,
+  );
+  const endAccessor = inferAccessor<number | string | Date>(
+    config,
+    'end',
+    'end',
+    ['to', 'finish', 'x1', 'endDate'],
+    firstDatum,
+  );
+  const labelAccessor: DataAccessor<string> = inferAccessor<string>(
+    config,
+    'label',
+    'label',
+    ['name', 'task', 'title', 'activity'],
+    firstDatum,
+  );
+
+  // The lane order the chart declares comes first, so an empty lane keeps the
+  // position it was drawn in; anything the chart draws and the config does not
+  // name is appended in the order it was drawn.
+  const laneOrder: (string | number)[] = [...(declaredLanes ?? [])];
+  const laneAt = new Map<string, number>(
+    laneOrder.map((lane, index) => [String(lane), index]),
+  );
+  const grouped: GanttPoint[][] = laneOrder.map(() => []);
+  const groupedElements: Element[][] = laneOrder.map(() => []);
+
+  for (const { element, datum, index } of elements) {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const lane = resolveAccessor<string | number | Date>(datum, xAccessor, index);
+    // The lane names the row, so it is announced as it stands rather than
+    // coerced; only the key it is grouped by is stringified.
+    const laneName = lane instanceof Date ? lane.toISOString() : lane;
+    const key = String(laneName);
+    let row = laneAt.get(key);
+    if (row === undefined) {
+      row = laneOrder.length;
+      laneAt.set(key, row);
+      laneOrder.push(laneName);
+      grouped.push([]);
+      groupedElements.push([]);
+    }
+
+    const point: GanttPoint = {
+      x: laneName,
+      start: coerceTime(resolveAccessor(datum, startAccessor, index), 'start', index),
+      end: coerceTime(resolveAccessor(datum, endAccessor, index), 'end', index),
+    };
+    // The interval's own name, when the lane is not already it. A lane
+    // commonly holds several intervals, and the label is what distinguishes
+    // them; omitted when the datum carries none, since an interval labelled
+    // with its own lane says nothing twice.
+    const label = resolveAccessorOptional<string>(datum, labelAccessor, index);
+    if (label !== undefined && label !== null && String(label) !== key) {
+      point.label = String(label);
+    }
+
+    grouped[row].push(point);
+    groupedElements[row].push(element);
+  }
+
+  const data: GanttData = {
+    points: grouped,
+    // Declared lane names travel with the payload only when the chart declared
+    // them: they exist for the lanes that carry no interval to name themselves,
+    // and the trace prefers a lane's own intervals wherever both are present.
+    ...(declaredLanes !== undefined ? { lanes: laneOrder } : {}),
+    ...(unit !== undefined ? { unit } : {}),
+  };
+
+  const ordered = groupedElements.flat();
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.GANTT,
+    title,
+    // One selector per interval, in the payload's lane-grouped order. See
+    // {@link stampIntervalSelectors} for why a bare selector will not do —
+    // except when there is exactly one interval, where the two agree.
+    selectors: ordered.length > 1
+      ? stampIntervalSelectors(root, selector, ordered, panel)
+      : scopeSelector(root, selector, panel),
+    orientation,
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/gantt.ts
+++ b/src/adapters/d3/binders/gantt.ts
@@ -17,7 +17,7 @@ import type { GanttData, GanttPoint, MaidrLayer } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
 import type { D3BinderResult, D3BuiltLayer, D3GanttConfig, DataAccessor } from '../types';
 import { Orientation, TraceType } from '../../../type/grammar';
-import { scopeSelector, selectorPrefix } from '../selectors';
+import { scopeSelector, stampOrderedSelectors } from '../selectors';
 import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
 
 /** Attribute the binder stamps on each interval to key its highlight. */
@@ -65,39 +65,6 @@ function coerceTime(value: unknown, end: 'start' | 'end', index: number): number
     + `Pass a \`${end}\` accessor that returns one, e.g. `
     + `\`${end}: d => +d.${end}Date\`.`,
   );
-}
-
-/**
- * Emits one highlight selector per interval, in the payload's lane-grouped
- * order, by stamping each element with a MAIDR-owned attribute.
- *
- * `GanttTrace` resolves the selectors to a flat list and slices it lane by
- * lane, so the list has to be in the order the payload nests them — which is
- * not the order the chart drew them in unless the data happened to arrive
- * grouped. A bare selector would resolve in DOM order and hand each lane
- * whichever intervals sat at those positions, highlighting one task while
- * announcing another; the trace cannot detect that, because the count matches.
- *
- * @param root - The extraction root (the SVG, or a panel element)
- * @param selector - The user-provided selector matching the intervals
- * @param ordered - The interval elements, in payload order
- * @param panel - Optional panel scope for multi-panel binds
- * @returns One selector per interval, in payload order
- */
-function stampIntervalSelectors(
-  root: Element,
-  selector: string,
-  ordered: Element[],
-  panel?: D3PanelScope,
-): string[] {
-  const prefix = selectorPrefix(root, panel);
-  return ordered.map((element, index) => {
-    // Clear any prior stamp so rebinding after a D3 data update produces a
-    // clean, deterministic state.
-    element.removeAttribute(INTERVAL_ATTRIBUTE);
-    element.setAttribute(INTERVAL_ATTRIBUTE, String(index));
-    return `${prefix} ${selector}[${INTERVAL_ATTRIBUTE}="${index}"]`;
-  });
 }
 
 /**
@@ -260,11 +227,14 @@ export function buildGanttLayer(root: Element, config: D3GanttConfig, panel?: D3
     id: generateId(),
     type: TraceType.GANTT,
     title,
-    // One selector per interval, in the payload's lane-grouped order. See
-    // {@link stampIntervalSelectors} for why a bare selector will not do —
-    // except when there is exactly one interval, where the two agree.
+    // One selector per interval, in the payload's lane-grouped order.
+    // `GanttTrace` resolves the selectors to a flat list and slices it lane by
+    // lane, so the list has to be in the order the payload nests them, which
+    // is not DOM order unless the data happened to arrive grouped. See
+    // {@link stampOrderedSelectors} — except when there is exactly one
+    // interval, where the two agree.
     selectors: ordered.length > 1
-      ? stampIntervalSelectors(root, selector, ordered, panel)
+      ? stampOrderedSelectors(root, selector, INTERVAL_ATTRIBUTE, ordered, panel)
       : scopeSelector(root, selector, panel),
     orientation,
     axes: buildAxes(axes, format),

--- a/src/adapters/d3/binders/gauge.ts
+++ b/src/adapters/d3/binders/gauge.ts
@@ -1,0 +1,134 @@
+/**
+ * D3 binder for gauges and bullet charts.
+ *
+ * A drawn gauge binds one number — the measure the needle or the value arc
+ * moves with — so this binder reads that from the DOM and takes the rest of
+ * the reading from config. The dial's range, the target marker and the
+ * qualitative bands are drawn from numbers the author holds; the SVG records
+ * only where they ended up on screen.
+ */
+
+import type { GaugePoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3GaugeConfig } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+
+/**
+ * Binds a D3.js gauge or bullet chart to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the mark that moves with the value — the needle, the
+ * value arc, the bullet's measure bar. Only the first match is read: a gauge
+ * draws exactly one measure, which is why its payload is a single object
+ * rather than an array of one.
+ *
+ * `min` and `max` are required because the value alone is not the reading.
+ * "73" means nothing without the range it sits in, the target it was aiming
+ * at, and the band it lands in — and a sighted reader takes all three from the
+ * dial's geometry, which is exactly what a screen reader cannot reach.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * the matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 gauge.
+ * @param config - Configuration specifying the selector, the range and the
+ *                 chart's own annotations.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Gauge(svgElement, {
+ *   selector: 'rect.measure',
+ *   title: 'Conversion Rate against Target',
+ *   axes: { x: 'Measure', y: 'Percent' },
+ *   label: 'Conversion',
+ *   min: 0,
+ *   max: 100,
+ *   target: 80,
+ *   bands: [
+ *     { to: 50, label: 'poor' },
+ *     { to: 75, label: 'ok' },
+ *     { to: 100, label: 'good' },
+ *   ],
+ * });
+ * ```
+ */
+export function bindD3Gauge(svg: Element, config: D3GaugeConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildGaugeLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for gauges. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildGaugeLayer(root: Element, config: D3GaugeConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    min,
+    max,
+    label,
+    target,
+    bands,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'gauge value');
+  }
+
+  // The first match, because a gauge draws one measure. A selector that
+  // matched the dial's other arcs as well still reads the right number, since
+  // the value mark is the one it is pointed at.
+  const { datum } = elements[0];
+  if (datum === undefined || datum === null) {
+    throw buildNoDatumError(selector, 0);
+  }
+
+  // A gauge is routinely joined against the bare number it displays, in which
+  // case the datum *is* the measure and there is no key to name.
+  const valueAccessor = inferAccessor<number>(
+    config,
+    'value',
+    'value',
+    ['y', 'amount', 'measure', 'current', 'actual'],
+    datum,
+  );
+  const value = config.value === undefined && typeof datum === 'number'
+    ? datum
+    : Number(resolveAccessor<number>(datum, valueAccessor, 0));
+
+  const data: GaugePoint = {
+    value,
+    min,
+    max,
+    ...(label !== undefined ? { label } : {}),
+    ...(target !== undefined ? { target } : {}),
+    ...(bands !== undefined ? { bands } : {}),
+  };
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.GAUGE,
+    title,
+    // Scoped as usual; the trace highlights the first element the selector
+    // resolves to, which is the mark the value is drawn as.
+    selectors: scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/hexbin.ts
+++ b/src/adapters/d3/binders/hexbin.ts
@@ -1,0 +1,231 @@
+/**
+ * D3 binder for hexbin density plots.
+ *
+ * The `d3-hexbin` plugin answers an overplotted scatter by binning the points
+ * into hexagons: `hexbin(points)` returns one bin per **occupied** hexagon, and
+ * each bin is an array of the points that fell in it carrying `.x` and `.y`
+ * (the hexagon's centre) and `.length` (the count). So the default accessors
+ * read exactly that, and a chart drawn any other way only has to say where its
+ * three numbers live.
+ *
+ * Two things make this more than a scatter binder.
+ *
+ * **The centres come out in screen space.** `d3-hexbin` bins the projected
+ * points, so `bin.x` is a pixel. `x`/`y` are where the inverse scales go
+ * (`x: d => xScale.invert(d.x)`); passed through unchanged, every bin would
+ * announce its position in pixels.
+ *
+ * **The lattice is the binder's own work.** `HexbinTrace` navigates rows of
+ * bins, and the DOM is a flat list in generation order with the empty bins
+ * simply absent from it. So the rows are assembled here — grouped by the bins'
+ * `y`, ordered from the lowest upward, each row ordered left to right — and
+ * the highlight selectors are stamped in that order rather than left to
+ * resolve in the order the hexagons happen to be drawn.
+ */
+
+import type { HexbinPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3HexbinConfig, DataAccessor } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector, stampOrderedSelectors } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+
+/** Attribute the binder stamps on each hexagon to key its highlight. */
+const BIN_ATTRIBUTE = 'data-maidr-hexbin-index';
+
+/**
+ * How many significant digits a `y` centre is compared on when grouping bins
+ * into lattice rows.
+ *
+ * Every bin in a hex row is placed by the same arithmetic on the same row
+ * number, so their `y` centres come out bit-identical and an exact comparison
+ * would do — until an inverse scale is applied, where the last digit or two of
+ * a `double` can differ. Twelve digits is far beyond any real lattice's
+ * spacing and well inside that noise.
+ */
+const ROW_PRECISION = 12;
+
+/**
+ * Reads one of a bin's three numbers, refusing anything non-finite.
+ *
+ * @param datum - The bin
+ * @param accessor - The accessor for this number
+ * @param field - Which number, for the error message
+ * @param index - The bin's index within the selection
+ * @returns The number
+ * @throws Error when the bin carries no finite value for it
+ */
+function readNumber(
+  datum: unknown,
+  accessor: DataAccessor<number>,
+  field: 'x' | 'y' | 'count',
+  index: number,
+): number {
+  const raw = resolveAccessorOptional<number>(datum, accessor, index);
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new TypeError(
+      `The bin at index ${index} has no ${field}: the \`${field}\` accessor `
+      + `resolved to ${String(raw)}. A \`d3-hexbin\` bin carries its centre as `
+      + `\`.x\`/\`.y\` and its count as \`.length\`, in SCREEN space — pass the `
+      + `inverse scales, e.g. \`x: d => xScale.invert(d.x)\`.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Binds a D3.js hexbin density plot to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the hexagons — one per bin — and give `x` and `y` the
+ * inverse scales, so the bins announce their centres on the chart's own axes
+ * rather than in pixels. `count` defaults to a bin's `length`, which is what
+ * `d3-hexbin` gives it.
+ *
+ * The lattice rows are assembled from the emitted data rather than assumed:
+ * an empty bin is not drawn, so the rows do not all hold the same number of
+ * bins and no rectangular grid could be laid over them.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 hexbin plot.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Hexbin(svgElement, {
+ *   selector: 'path.hexagon',
+ *   title: 'Point Density',
+ *   axes: { x: 'Carat', y: 'Price', fill: 'Count' },
+ *   x: d => xScale.invert(d.x),
+ *   y: d => yScale.invert(d.y),
+ * });
+ * ```
+ */
+export function bindD3Hexbin(svg: Element, config: D3HexbinConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildHexbinLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for hexbin plots. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildHexbinLayer(
+  root: Element,
+  config: D3HexbinConfig,
+  panel?: D3PanelScope,
+): D3BuiltLayer {
+  const { title, axes, format, selector, row: rowAccessor } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'hexagon');
+  }
+
+  const firstDatum = elements[0].datum;
+  const xAccessor = inferAccessor<number>(config, 'x', 'x', ['x0', 'cx'], firstDatum);
+  const yAccessor = inferAccessor<number>(config, 'y', 'y', ['y0', 'cy'], firstDatum);
+  const countAccessor = inferAccessor<number>(
+    config,
+    'count',
+    'count',
+    ['length', 'value', 'n', 'total'],
+    firstDatum,
+  );
+
+  // One entry per bin, keyed by the lattice row it belongs to. The row is kept
+  // as a number wherever possible so the rows can be ordered from the bottom
+  // up, which is the direction `HexbinTrace` steps its row index in.
+  const bins: { key: string; order: number; point: HexbinPoint; element: Element }[] = [];
+
+  for (const { element, datum, index } of elements) {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const x = readNumber(datum, xAccessor, 'x', index);
+    const y = readNumber(datum, yAccessor, 'y', index);
+    const count = readNumber(datum, countAccessor, 'count', index);
+
+    const declared = rowAccessor === undefined
+      ? undefined
+      : resolveAccessor<number | string>(datum, rowAccessor, index);
+    const order = declared === undefined ? y : Number(declared);
+
+    bins.push({
+      key: declared === undefined ? y.toPrecision(ROW_PRECISION) : String(declared),
+      // A row named by something that is not a number keeps its first-seen
+      // position rather than sorting to the front as `NaN` would.
+      order: Number.isFinite(order) ? order : Number.POSITIVE_INFINITY,
+      point: { x, y, count },
+      element,
+    });
+  }
+
+  const rows = groupIntoRows(bins);
+
+  const data: HexbinPoint[][] = rows.map(row => row.map(bin => bin.point));
+  const ordered = rows.flat().map(bin => bin.element);
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.HEXBIN,
+    title,
+    // One selector per bin, in the payload's lattice order. `HexbinTrace`
+    // resolves the selectors to a flat list and slices it row by row, and a
+    // bare selector would resolve in the order the hexagons were drawn —
+    // which is the order `d3-hexbin` generated the bins in, not the lattice's.
+    // The count would still match, so nothing would detect it.
+    selectors: ordered.length > 1
+      ? stampOrderedSelectors(root, selector, BIN_ATTRIBUTE, ordered, panel)
+      : scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}
+
+/**
+ * Assembles the lattice: bins grouped into rows, rows ordered from the lowest
+ * upward, each row ordered left to right.
+ *
+ * `HexbinTrace` steps its row index up for `UPWARD`, so row 0 has to be the
+ * bottom of the chart; within a row the column index *is* the position, so the
+ * bins have to be in x order for a sideways move to walk the lattice rather
+ * than the order the plugin happened to emit.
+ *
+ * @param bins - Every bin, with the row key and ordinal it was read with
+ * @returns The lattice, rows outermost
+ */
+function groupIntoRows<T extends { key: string; order: number; point: HexbinPoint }>(
+  bins: T[],
+): T[][] {
+  const rows = new Map<string, T[]>();
+  const order = new Map<string, number>();
+
+  for (const bin of bins) {
+    const row = rows.get(bin.key);
+    if (row === undefined) {
+      rows.set(bin.key, [bin]);
+      order.set(bin.key, bin.order);
+    } else {
+      row.push(bin);
+    }
+  }
+
+  return Array.from(rows.entries())
+    .sort(([a], [b]) => (order.get(a) ?? 0) - (order.get(b) ?? 0))
+    .map(([, row]) => row.sort((a, b) => Number(a.point.x) - Number(b.point.x)));
+}

--- a/src/adapters/d3/binders/line.ts
+++ b/src/adapters/d3/binders/line.ts
@@ -1,13 +1,16 @@
 /**
- * D3 binder for line charts.
+ * D3 binder for line and bump charts.
  *
  * Extracts data from D3.js-rendered line chart SVG elements and generates
- * the MAIDR JSON schema for accessible line chart interaction.
+ * the MAIDR JSON schema for accessible line chart interaction. A bump chart
+ * plots ranks instead of magnitudes but is drawn and navigated as a multi-line
+ * layer, so it shares this extraction core; the area family builds on it too
+ * (see `binders/area.ts`).
  */
 
 import type { LinePoint, MaidrLayer } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
-import type { D3BinderResult, D3BuiltLayer, D3LineConfig, DataAccessor } from '../types';
+import type { D3BinderResult, D3BuiltLayer, D3LineConfig, DataAccessor, LineMarkTraceType } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector, selectorPrefix } from '../selectors';
 import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, getD3Datum, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
@@ -61,12 +64,52 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
 }
 
 /**
+ * Binds a D3.js bump chart (rank over time) to MAIDR.
+ *
+ * A bump chart is a multi-line layer whose y values are **ranks**: 1 is the
+ * best position and the smallest number. The extraction is that of
+ * {@link bindD3Line} — one `<path>` per competitor, `fill` naming it — and the
+ * ranks you already bind are what `y` should read. The trace inverts the pitch
+ * so first place is the highest note, and announces the places gained or lost
+ * at each period, so nothing extra has to be computed here.
+ *
+ * A slope graph of *values* is a line chart with two samples, not this.
+ *
+ * @param svg - The SVG element containing the D3 bump chart.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Bump(svgElement, {
+ *   selector: 'path.rank-line',
+ *   title: 'League Table by Round',
+ *   axes: { x: 'Round', y: 'Rank', fill: 'Team' },
+ *   x: 'round',
+ *   y: 'rank',
+ *   fill: 'team',
+ * });
+ * ```
+ */
+export function bindD3Bump(svg: Element, config: D3LineConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildLineLayer(svg, config, undefined, TraceType.BUMP));
+}
+
+/**
  * Pure extraction core for line charts. See {@link buildBarLayer} for the
  * single-chart vs multi-panel contract.
  *
+ * The trailing `type` selects which chart the layer announces itself as; the
+ * extraction is the same for all of them (see {@link LineMarkTraceType}).
+ *
  * @internal
  */
-export function buildLineLayer(root: Element, config: D3LineConfig, panel?: D3PanelScope): D3BuiltLayer {
+export function buildLineLayer(
+  root: Element,
+  config: D3LineConfig,
+  panel?: D3PanelScope,
+  type: LineMarkTraceType = TraceType.LINE,
+): D3BuiltLayer {
   const {
     title,
     axes,
@@ -234,60 +277,17 @@ export function buildLineLayer(root: Element, config: D3LineConfig, panel?: D3Pa
     }
   }
 
-  // Ensure the SVG has a stable id so we can emit absolutely-scoped selectors
-  // (the model resolves selectors via global `document.querySelector`, so they
-  // MUST be unique page-wide). `selectorPrefix` auto-assigns an id when the
-  // container lacks one, mirroring `scopeSelector`'s behaviour, and appends
-  // the `data-maidr-panel` segment on multi-panel binds.
-  const prefix = selectorPrefix(root, panel);
-
-  // LineTrace's `mapToSvgElements` requires one selector per line (it uses
-  // `Svg.selectElement(selectors[r])` to grab a single <path> per series for
-  // path-parsing, or `selectAllElements(selectors[r])` for per-point markers).
-  // A bare `selector` like `"path.line"` matches ALL line paths at once, so
-  // `selectors.length (1) !== lineValues.length (N)` → the model bails out
-  // and no highlight renders.
-  //
-  // Structural selectors (e.g. `:nth-child(N)`) are fragile to DOM reordering
-  // (legend/axis insertions, React re-renders, non-path siblings shifting
-  // nth-child indices). Instead, stamp a MAIDR-owned `data-maidr-line-index`
-  // attribute on each line path at bind time and emit selectors that pin
-  // that attribute, absolutely scoped by the SVG's id. This matches the
-  // Google Charts adapter's `data-maidr-line-series` / `data-maidr-point`
-  // convention and survives any DOM reordering that leaves the path itself
-  // intact.
-  // Emit selectors from the same rows that produced `data`. `rowPaths` is
-  // parallel to `data`, so stamping each path with its row index guarantees
-  // `selectors.length === data.length` — even when some paths were dropped
-  // (empty series) or the path↔series mapping was ambiguous. When any surviving
-  // row lacks an identified path, we cannot emit a safe per-series selector, so
-  // degrade to no-highlight (`undefined`) instead of mis-highlighting.
-  //
-  // Stamp a MAIDR-owned `data-maidr-line-index` attribute (absolutely scoped by
-  // the SVG's id) rather than a structural `:nth-child` selector, which is
-  // fragile to DOM reordering. This matches the Google Charts adapter's
-  // `data-maidr-line-series` convention and survives any reordering that leaves
-  // the path itself intact.
-  let selectorValue: string | string[] | undefined;
-  if (lineElements.length > 1) {
-    if (rowPaths.length === data.length && rowPaths.every(el => el !== null)) {
-      selectorValue = rowPaths.map((element, rowIndex) => {
-        // Clear any prior stamp so rebinding after a D3 data update produces
-        // a clean, deterministic state.
-        element!.removeAttribute('data-maidr-line-index');
-        element!.setAttribute('data-maidr-line-index', String(rowIndex));
-        return `${prefix} ${selector}[data-maidr-line-index="${rowIndex}"]`;
-      });
-    } else {
-      selectorValue = undefined;
-    }
-  } else {
+  // Emit selectors from the same rows that produced `data`: `rowPaths` is
+  // parallel to it. See {@link stampSeriesSelectors} for why a bare selector
+  // will not do.
+  const selectorValue: string | string[] | undefined = lineElements.length > 1
+    ? stampSeriesSelectors(root, selector, rowPaths, data.length, panel)
     // Exactly one path matched → a single scoped selector highlights it.
-    selectorValue = scopeSelector(root, selector, panel);
-  }
+    : scopeSelector(root, selector, panel);
+
   const layer: MaidrLayer = {
     id: generateId(),
-    type: TraceType.LINE,
+    type,
     title,
     selectors: selectorValue,
     axes: buildAxes(axes, format),
@@ -295,6 +295,68 @@ export function buildLineLayer(root: Element, config: D3LineConfig, panel?: D3Pa
   };
 
   return { layer, legend };
+}
+
+/**
+ * Emits one highlight selector per series, by stamping each series' `<path>`
+ * with a MAIDR-owned `data-maidr-line-index` attribute and pinning it.
+ *
+ * `LineTrace.mapToSvgElements` requires one selector per line (it uses
+ * `Svg.selectElement(selectors[r])` to grab a single `<path>` per series for
+ * path-parsing, or `selectAllElements(selectors[r])` for per-point markers).
+ * A bare `selector` like `"path.line"` matches ALL line paths at once, so
+ * `selectors.length (1) !== lineValues.length (N)` → the model bails out and
+ * no highlight renders.
+ *
+ * Structural selectors (e.g. `:nth-child(N)`) are fragile to DOM reordering
+ * (legend/axis insertions, React re-renders, non-path siblings shifting
+ * nth-child indices), so the stamp is an attribute the binder owns, absolutely
+ * scoped by the SVG's id. This matches the Google Charts adapter's
+ * `data-maidr-line-series` / `data-maidr-point` convention and survives any
+ * DOM reordering that leaves the path itself intact.
+ *
+ * @param root      - The extraction root (the SVG, or a panel element).
+ * @param selector  - The user-provided selector matching the series paths.
+ * @param rowPaths  - The `<path>` that produced each data row, parallel to the
+ *                    emitted rows. A `null` entry marks a row whose rendering
+ *                    path could not be reliably identified.
+ * @param rowCount  - How many rows the layer emits.
+ * @param panel     - Optional panel scope for multi-panel binds.
+ * @returns One selector per row, or `undefined` when a safe per-series
+ *          selector cannot be emitted — the model then withdraws highlighting
+ *          instead of highlighting the wrong series.
+ *
+ * @internal
+ */
+export function stampSeriesSelectors(
+  root: Element,
+  selector: string,
+  rowPaths: (Element | null)[],
+  rowCount: number,
+  panel?: D3PanelScope,
+): string[] | undefined {
+  if (rowPaths.length !== rowCount) {
+    return undefined;
+  }
+  const paths: Element[] = [];
+  for (const element of rowPaths) {
+    if (element === null) {
+      return undefined;
+    }
+    paths.push(element);
+  }
+
+  // `selectorPrefix` auto-assigns an id when the container lacks one,
+  // mirroring `scopeSelector`'s behaviour, and appends the `data-maidr-panel`
+  // segment on multi-panel binds.
+  const prefix = selectorPrefix(root, panel);
+  return paths.map((element, rowIndex) => {
+    // Clear any prior stamp so rebinding after a D3 data update produces a
+    // clean, deterministic state.
+    element.removeAttribute('data-maidr-line-index');
+    element.setAttribute('data-maidr-line-index', String(rowIndex));
+    return `${prefix} ${selector}[data-maidr-line-index="${rowIndex}"]`;
+  });
 }
 
 /**

--- a/src/adapters/d3/binders/line.ts
+++ b/src/adapters/d3/binders/line.ts
@@ -1,11 +1,12 @@
 /**
- * D3 binder for line and bump charts.
+ * D3 binder for line, bump and radar charts.
  *
  * Extracts data from D3.js-rendered line chart SVG elements and generates
  * the MAIDR JSON schema for accessible line chart interaction. A bump chart
- * plots ranks instead of magnitudes but is drawn and navigated as a multi-line
- * layer, so it shares this extraction core; the area family builds on it too
- * (see `binders/area.ts`).
+ * plots ranks instead of magnitudes and a radar wraps its samples around a
+ * circle, but both are drawn and navigated as a multi-line layer, so they
+ * share this extraction core; the area family builds on it too (see
+ * `binders/area.ts`).
  */
 
 import type { LinePoint, MaidrLayer } from '../../../type/grammar';
@@ -93,6 +94,41 @@ export function bindD3Line(svg: Element, config: D3LineConfig): D3BinderResult {
  */
 export function bindD3Bump(svg: Element, config: D3LineConfig): D3BinderResult {
   return finalizeSingleChart(svg, config, buildLineLayer(svg, config, undefined, TraceType.BUMP));
+}
+
+/**
+ * Binds a D3.js radar (spider) chart to MAIDR.
+ *
+ * A radar is a multi-line layer wrapped around a circle: `selector` matches one
+ * closed `d3.lineRadial()` `<path>` per series, `x` names the **spoke** (the
+ * variable) and `fill` names the series. The trace pans each spoke by its angle
+ * — 12 o'clock centre, 3 o'clock hard right — so a radar sounds like a circle
+ * rather than a row of bars, and nothing extra has to be computed here.
+ *
+ * A closed outline is usually drawn by repeating the first vertex at the end.
+ * That repeat is how the polygon closes, not a spoke of its own, so the binder
+ * drops a trailing sample whose `x` matches the first one — otherwise the chart
+ * announces one spoke more than it has, and the reader walks off the end into
+ * a duplicate.
+ *
+ * @param svg - The SVG element containing the D3 radar chart.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Radar(svgElement, {
+ *   selector: 'path.radar-area',
+ *   title: 'Model Comparison',
+ *   axes: { x: 'Attribute', y: 'Score', fill: 'Model' },
+ *   x: 'attribute',
+ *   y: 'score',
+ *   fill: 'model',
+ * });
+ * ```
+ */
+export function bindD3Radar(svg: Element, config: D3LineConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildLineLayer(svg, config, undefined, TraceType.RADAR));
 }
 
 /**
@@ -264,6 +300,18 @@ export function buildLineLayer(
         data.push(lineData);
         // This path's datum produced this row; pair them for a precise stamp.
         rowPaths.push(element);
+      }
+    }
+  }
+
+  // A closed radar outline repeats its first vertex to shut the polygon. That
+  // repeat is geometry, not a spoke, so it goes before anything counts the
+  // spokes: RadarTrace spaces its angles by the widest series' length, and one
+  // phantom spoke rotates every announced position away from where it is drawn.
+  if (type === TraceType.RADAR) {
+    for (const row of data) {
+      if (row.length > 1 && row[row.length - 1].x === row[0].x) {
+        row.pop();
       }
     }
   }

--- a/src/adapters/d3/binders/line.ts
+++ b/src/adapters/d3/binders/line.ts
@@ -132,11 +132,50 @@ export function bindD3Radar(svg: Element, config: D3LineConfig): D3BinderResult 
 }
 
 /**
+ * Adds a chart-specific field to a point after the line core has read its
+ * `x`, `y` and `z` from the same datum.
+ *
+ * A survival curve is a line whose samples also say whether the time was
+ * censored and how wide the confidence band is there. Those live on the very
+ * datum the core has just resolved, and the core is the only place that knows
+ * which datum produced which point across all three of its extraction
+ * patterns — so the extension point is here rather than a second pass that
+ * would have to guess the pairing.
+ *
+ * @param point - The point the core built, to add fields to in place
+ * @param datum - The datum it was read from
+ * @param index - That datum's index within its selection
+ *
+ * @internal
+ */
+export type LinePointDecorator = (point: LinePoint, datum: unknown, index: number) => void;
+
+/**
+ * Samples a point-level datum the way {@link buildLineLayer} does, so a binder
+ * layered on top of it can infer its own accessors from the same shape.
+ *
+ * @param root - The extraction root (the SVG, or a panel element)
+ * @param config - The binder config, read for `selector` and `pointSelector`
+ * @returns One point's datum, or `undefined` when none can be reached
+ *
+ * @internal
+ */
+export function sampleLineDatum(root: Element, config: D3LineConfig): unknown {
+  if (config.pointSelector) {
+    return queryD3Elements(root, config.pointSelector)[0]?.datum;
+  }
+  const pathDatum = queryD3Elements(root, config.selector)[0]?.datum;
+  return Array.isArray(pathDatum) ? pathDatum[0] : pathDatum;
+}
+
+/**
  * Pure extraction core for line charts. See {@link buildBarLayer} for the
  * single-chart vs multi-panel contract.
  *
  * The trailing `type` selects which chart the layer announces itself as; the
  * extraction is the same for all of them (see {@link LineMarkTraceType}).
+ * `decorate`, when given, adds the fields a chart carries beyond a line's —
+ * see {@link LinePointDecorator}.
  *
  * @internal
  */
@@ -145,6 +184,7 @@ export function buildLineLayer(
   config: D3LineConfig,
   panel?: D3PanelScope,
   type: LineMarkTraceType = TraceType.LINE,
+  decorate?: LinePointDecorator,
 ): D3BuiltLayer {
   const {
     title,
@@ -218,6 +258,7 @@ export function buildLineLayer(
           yAccessor,
           fillAccessor,
           pointSelector,
+          decorate,
         );
         if (lineData.length > 0) {
           data.push(lineData);
@@ -250,6 +291,7 @@ export function buildLineLayer(
         if (fill !== undefined) {
           point.z = fill;
         }
+        decorate?.(point, datum, index);
 
         const key = fill ?? '__default__';
         if (!lineMap.has(key)) {
@@ -293,6 +335,7 @@ export function buildLineLayer(
         if (fill !== undefined) {
           point.z = fill;
         }
+        decorate?.(point, d, index);
         return point;
       });
 
@@ -416,6 +459,7 @@ function extractPointsFromElements(
   yAccessor: DataAccessor<number>,
   fillAccessor: DataAccessor<string>,
   pointSelector: string,
+  decorate?: LinePointDecorator,
 ): LinePoint[] {
   const lineData: LinePoint[] = [];
   for (const { datum, index } of points) {
@@ -430,6 +474,7 @@ function extractPointsFromElements(
     if (fill !== undefined) {
       point.z = fill;
     }
+    decorate?.(point, datum, index);
     lineData.push(point);
   }
   return lineData;

--- a/src/adapters/d3/binders/network.ts
+++ b/src/adapters/d3/binders/network.ts
@@ -1,0 +1,169 @@
+/**
+ * D3 binder for force-directed networks (node-link diagrams).
+ *
+ * Extracts the two ends of every link a `d3-force` simulation drew and
+ * generates the MAIDR JSON schema for accessible interaction. The nodes are
+ * derived from the links rather than read separately, so a link is the unit
+ * here — which is also the element the chart draws one of per datum.
+ *
+ * Positions are deliberately not read. Where a force-directed node lands is a
+ * fact about the solver's seed rather than about the data, so announcing it
+ * would be inventing a finding.
+ */
+
+import type { MaidrLayer, NetworkPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3NetworkConfig } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+
+/** Keys a node object is named by, in the order `d3-force` itself tries `id`. */
+const NODE_NAME_KEYS = ['id', 'name', 'key', 'label'] as const;
+
+/**
+ * Normalizes one end of a link to the node's name.
+ *
+ * `d3.forceLink` **mutates** the links it is given: before the simulation runs
+ * `link.source` is whatever the author wrote (usually an id), and afterwards it
+ * is the node *object* that id resolved to. A binder called after the layout —
+ * which is the only time the lines exist to select — therefore sees objects,
+ * and reading them as names is the difference between "Ada — Grace" and
+ * "[object Object] — [object Object]".
+ *
+ * @param raw - The value the accessor produced for this end
+ * @param endpoint - Which end, for the error message
+ * @param index - Position of the link in the selection
+ * @returns The node's name
+ * @throws Error when an object end carries none of {@link NODE_NAME_KEYS}
+ */
+function resolveEndpoint(
+  raw: unknown,
+  endpoint: 'source' | 'target',
+  index: number,
+): string | number {
+  if (typeof raw === 'string' || typeof raw === 'number') {
+    return raw;
+  }
+  if (raw !== null && typeof raw === 'object') {
+    const node = raw as Record<string, unknown>;
+    for (const key of NODE_NAME_KEYS) {
+      const value = node[key];
+      if (typeof value === 'string' || typeof value === 'number') {
+        return value;
+      }
+    }
+    throw new Error(
+      `The "${endpoint}" of the link at index ${index} is a node object with `
+      + `no name: none of ${NODE_NAME_KEYS.join(', ')} is set on it. `
+      + `Available properties: ${Object.keys(node).join(', ')}. Pass a `
+      + `\`${endpoint}\` accessor that names the node, e.g. `
+      + `\`${endpoint}: d => d.${endpoint}.title\`.`,
+    );
+  }
+  throw new Error(
+    `The "${endpoint}" of the link at index ${index} resolved to `
+    + `${String(raw)}, which names no node. A link needs both of its ends.`,
+  );
+}
+
+/**
+ * Binds a D3.js force-directed network to MAIDR, generating the accessible
+ * data representation.
+ *
+ * Point `selector` at the **links** — one `<line>` per edge — rather than at
+ * the node circles. The nodes are derived from the links, so the links are what
+ * map one-to-one onto the payload; a selector matching the circles would give
+ * the trace a node count where it expects a link count, and highlighting would
+ * be withdrawn.
+ *
+ * @remarks
+ * **Timing — call after the simulation has been wired up.** `d3.forceLink`
+ * replaces each link's `source` and `target` with the resolved node objects, so
+ * the binder reads names either way; what it cannot do is run before the lines
+ * are joined. Bind right after the `.data(links).join('line')` chain — there is
+ * no need to wait for the simulation to settle, since no position is read.
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 network.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const link = svg.selectAll('line.link').data(links).join('line');
+ * d3.forceSimulation(nodes).force('link', d3.forceLink(links).id(d => d.id));
+ *
+ * bindD3Network(svgElement, {
+ *   selector: 'line.link',
+ *   title: 'Collaborations',
+ *   axes: { x: 'Person', y: 'Links' },
+ * });
+ * ```
+ */
+export function bindD3Network(svg: Element, config: D3NetworkConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildNetworkLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for networks. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildNetworkLayer(root: Element, config: D3NetworkConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'network link');
+  }
+
+  // Infer accessors from the first datum's keys when the user did not specify.
+  const firstDatum = elements[0].datum;
+  const sourceAccessor = inferAccessor<unknown>(
+    config,
+    'source',
+    'source',
+    ['from', 'src'],
+    firstDatum,
+  );
+  const targetAccessor = inferAccessor<unknown>(
+    config,
+    'target',
+    'target',
+    ['to', 'dst'],
+    firstDatum,
+  );
+
+  const data: NetworkPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+    return {
+      source: resolveEndpoint(resolveAccessor(datum, sourceAccessor, index), 'source', index),
+      target: resolveEndpoint(resolveAccessor(datum, targetAccessor, index), 'target', index),
+    };
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.NETWORK,
+    title,
+    // One scoped selector matching every link: the trace pairs them with the
+    // links in declared order and highlights, from a node, the line it is
+    // most connected by — which is also where the next keystroke goes.
+    selectors: scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/parallel.ts
+++ b/src/adapters/d3/binders/parallel.ts
@@ -1,0 +1,180 @@
+/**
+ * D3 binder for parallel coordinates plots.
+ *
+ * A parallel coordinates plot draws one `<path>` (or `<polyline>`) per
+ * observation across several per-variable scales, and the datum bound to that
+ * element is the observation as a whole — `{ mpg: 21, hp: 110, weight: 2600 }`.
+ * The layer's rows are the observations and its columns are the axes, so the
+ * binder's work is a transpose: each observation becomes a row of points whose
+ * `x` is an axis' name and whose `y` is that observation's value on it.
+ *
+ * The axis order comes from the config, not from the datum. An object's key
+ * order is not an axis order, and the chart already has the list — it built one
+ * scale per entry of it.
+ */
+
+import type { LinePoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3ParallelConfig } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessorOptional } from '../util';
+import { stampSeriesSelectors } from './line';
+
+/**
+ * Reads one dimension off an observation.
+ *
+ * A missing dimension is an error rather than a gap: the columns are the axes,
+ * and an observation short of one would shift every axis after it, announcing
+ * each value under the name of the next variable along.
+ *
+ * @param datum - The observation bound to the path
+ * @param dimension - The axis to read
+ * @param index - The observation's index within the selection
+ * @param read - The user's reader, when they gave one
+ * @returns The value on that axis
+ * @throws Error when the observation carries no such dimension
+ */
+function readDimension(
+  datum: unknown,
+  dimension: string,
+  index: number,
+  read?: D3ParallelConfig['value'],
+): number {
+  if (read) {
+    return read(datum, dimension, index);
+  }
+  const record = datum as Record<string, unknown>;
+  if (!(dimension in record)) {
+    throw new Error(
+      `Dimension "${dimension}" not found on the observation at index ${index}. `
+      + `Available properties: ${Object.keys(record).join(', ')}. Every `
+      + `observation has to carry every dimension — a row short of one would `
+      + `announce its remaining values under the wrong axes. Pass a \`value\` `
+      + `reader when the numbers are nested, e.g. `
+      + `\`value: (d, dimension) => d.values[dimension]\`.`,
+    );
+  }
+  return Number(record[dimension]);
+}
+
+/**
+ * Binds a D3.js parallel coordinates plot to MAIDR, generating the accessible
+ * data representation.
+ *
+ * Point `selector` at the observation paths — one per row of your data — and
+ * list the axes in `dimensions`, in the order they are drawn. `label` names
+ * the observation, which is what the trace announces the row as.
+ *
+ * The trace derives each axis' range from the data itself and sonifies every
+ * value against its own axis, so nothing here needs per-axis minima: a car with
+ * the best economy and the worst power sounds like exactly that, rather than
+ * like the units the two variables happen to be measured in.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 parallel coordinates plot.
+ * @param config - Configuration specifying the selector, dimensions and label.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Parallel(svgElement, {
+ *   selector: 'path.observation',
+ *   title: 'Car Characteristics',
+ *   axes: { x: 'Variable', y: 'Value', fill: 'Car' },
+ *   dimensions: ['mpg', 'hp', 'weight'],
+ *   label: 'name',
+ * });
+ * ```
+ */
+export function bindD3Parallel(svg: Element, config: D3ParallelConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildParallelLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for parallel coordinates plots. See
+ * {@link buildBarLayer} for the single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildParallelLayer(
+  root: Element,
+  config: D3ParallelConfig,
+  panel?: D3PanelScope,
+): D3BuiltLayer {
+  const { title, axes, format, selector, dimensions, value } = config;
+
+  if (!Array.isArray(dimensions) || dimensions.length === 0) {
+    throw new Error(
+      `A parallel coordinates plot needs its \`dimensions\`: the axes, in the `
+      + `order they are drawn. That order is the order a reader arrows through `
+      + `them, and nothing on the datum states it — pass the same list you `
+      + `built one scale per.`,
+    );
+  }
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'observation path');
+  }
+
+  const labelAccessor = inferAccessor<string>(
+    config,
+    'label',
+    'name',
+    ['label', 'id', 'key', 'group', 'fill'],
+    elements[0].datum,
+  );
+
+  const data: LinePoint[][] = [];
+  const observations: Element[] = [];
+  const legend: string[] = [];
+
+  for (const { element, datum, index } of elements) {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const label = resolveAccessorOptional<string>(datum, labelAccessor, index);
+    const row: LinePoint[] = dimensions.map((dimension) => {
+      const point: LinePoint = {
+        x: dimension,
+        y: readDimension(datum, dimension, index, value),
+      };
+      if (label !== undefined && label !== null) {
+        point.z = String(label);
+      }
+      return point;
+    });
+
+    data.push(row);
+    observations.push(element);
+    if (label !== undefined && label !== null) {
+      legend.push(String(label));
+    }
+  }
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.PARALLEL,
+    title,
+    // One selector per observation. `ParallelTrace` inherits `LineTrace`'s
+    // resolution, which pairs the selector list with the rows one for one, so
+    // a bare selector matching every path withdraws highlighting entirely.
+    selectors: elements.length > 1
+      ? stampSeriesSelectors(root, selector, observations, data.length, panel)
+      : scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer, legend };
+}

--- a/src/adapters/d3/binders/pie.ts
+++ b/src/adapters/d3/binders/pie.ts
@@ -1,13 +1,16 @@
 /**
- * D3 binder for pie and doughnut charts.
+ * D3 binder for pie, doughnut and polar area charts.
  *
  * Extracts data from D3.js-rendered wedges and generates the MAIDR JSON
- * schema for accessible slice-by-slice interaction.
+ * schema for accessible slice-by-slice interaction. A polar area (coxcomb,
+ * rose) is drawn from the same `d3.arc()` wedges and unwrapped the same way —
+ * it gives every category an equal angle and varies the radius instead — so it
+ * shares this file's arc handling and differs in what it emits.
  */
 
-import type { MaidrLayer, PiePoint } from '../../../type/grammar';
+import type { LinePoint, MaidrLayer, PiePoint } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
-import type { D3BinderResult, D3BuiltLayer, D3PieConfig, DataAccessor } from '../types';
+import type { D3BinderResult, D3BuiltLayer, D3PieConfig, D3PolarAreaConfig, DataAccessor } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
 import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
@@ -147,23 +150,29 @@ export function bindD3Pie(svg: Element, config: D3PieConfig): D3BinderResult {
 }
 
 /**
- * Pure extraction core for pie charts. See {@link buildBarLayer} for the
- * single-chart vs multi-panel contract.
+ * Reads one label and one magnitude off every wedge matched by the config's
+ * selector, unwrapping `d3.pie()` arcs on the way.
  *
- * @internal
+ * Shared by the pie and polar area binders: the wedges are drawn by the same
+ * `d3.arc()` and carry the same datum, and the two charts differ only in what
+ * the wedge encodes (an angle against a radius) and therefore in what the
+ * layer says about them.
+ *
+ * @param root - The extraction root (the SVG, or a panel element)
+ * @param config - The user's binder config
+ * @param elementKind - What to call the wedges in the "no elements" error
+ * @returns One `{ x, y }` per wedge, in DOM order
  */
-export function buildPieLayer(root: Element, config: D3PieConfig, panel?: D3PanelScope): D3BuiltLayer {
-  const {
-    title,
-    axes,
-    format,
-    selector,
-    y: yOverride,
-  } = config;
+function extractWedges(
+  root: Element,
+  config: D3PieConfig,
+  elementKind: string,
+): PiePoint[] {
+  const { selector, y: yOverride } = config;
 
   const elements = queryD3Elements(root, selector);
   if (elements.length === 0) {
-    throw buildNoElementsError(root, selector, 'pie slice');
+    throw buildNoElementsError(root, selector, elementKind);
   }
 
   // Infer accessors from the USER's first datum, not from the arc wrapping
@@ -186,7 +195,7 @@ export function buildPieLayer(root: Element, config: D3PieConfig, panel?: D3Pane
     firstSlice,
   );
 
-  const data: PiePoint[] = elements.map(({ datum, index }) => {
+  return elements.map(({ datum, index }) => {
     if (datum === undefined || datum === null) {
       throw buildNoDatumError(selector, index);
     }
@@ -205,6 +214,18 @@ export function buildPieLayer(root: Element, config: D3PieConfig, panel?: D3Pane
         : toSliceValue(resolveAccessor<number>(slice, yAccessor, index)),
     };
   });
+}
+
+/**
+ * Pure extraction core for pie charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildPieLayer(root: Element, config: D3PieConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const { title, axes, format, selector } = config;
+
+  const data = extractWedges(root, config, 'pie slice');
 
   const layer: MaidrLayer = {
     id: generateId(),
@@ -214,6 +235,81 @@ export function buildPieLayer(root: Element, config: D3PieConfig, panel?: D3Pane
     // No `orientation`: a pie's slices are arranged around a circle, not
     // along an axis. No `z` either — the percentage the model announces is
     // derived from the values, so there is nothing for a fill axis to label.
+    axes: buildAxes({ x: axes?.x, y: axes?.y }, format),
+    data,
+  };
+
+  return { layer };
+}
+
+/**
+ * Binds a D3.js polar area (coxcomb, rose) chart to MAIDR, generating the
+ * accessible data representation.
+ *
+ * Point `selector` at the wedge `<path>` elements, exactly as for
+ * {@link bindD3Pie} — including when they were joined to `d3.pie()` output,
+ * which the binder unwraps for you. The difference is in the reading: a polar
+ * area gives every category the same angle and encodes its value as the
+ * wedge's **radius**, so the values are a series around the spokes rather than
+ * shares of a whole, and the trace announces them as such (with no
+ * percentages) while panning each spoke to where it is drawn on the dial.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 polar area chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * // svg.selectAll('path.wedge').data(d3.pie().value(d => d.deaths)(rows))
+ * const result = bindD3PolarArea(svgElement, {
+ *   selector: 'path.wedge',
+ *   title: 'Causes of Mortality',
+ *   axes: { x: 'Month', y: 'Deaths' },
+ *   x: 'month',   // property name on YOUR datum, not on the arc
+ * });
+ * ```
+ */
+export function bindD3PolarArea(svg: Element, config: D3PolarAreaConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildPolarAreaLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for polar area charts. See {@link buildBarLayer} for
+ * the single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildPolarAreaLayer(
+  root: Element,
+  config: D3PolarAreaConfig,
+  panel?: D3PanelScope,
+): D3BuiltLayer {
+  const { title, axes, format, selector } = config;
+
+  // One row: a polar area draws a single series of wedges around the dial, and
+  // the payload is the multi-line grid {@link RadarTrace} navigates — the same
+  // trace a radar uses, which is what makes the two read alike.
+  const data: LinePoint[][] = [extractWedges(root, config, 'polar area wedge')];
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.POLAR_AREA,
+    title,
+    // One scoped selector matching every wedge: with a single row, the trace
+    // resolves the matches straight onto the spokes, and withdraws
+    // highlighting if the count does not line up rather than guessing.
+    selectors: scopeSelector(root, selector, panel),
+    // No `z` axis: one series of wedges has no fill dimension to name, the
+    // same reason a pie has none.
     axes: buildAxes({ x: axes?.x, y: axes?.y }, format),
     data,
   };

--- a/src/adapters/d3/binders/ridgeline.ts
+++ b/src/adapters/d3/binders/ridgeline.ts
@@ -1,0 +1,284 @@
+/**
+ * D3 binder for ridgeline (joy) plots.
+ *
+ * One `d3.area()` density curve per group, the curves offset down the page so
+ * their shapes can be compared. `selector` matches one `<path>` per group and
+ * the samples come from that path's own bound array.
+ *
+ * **The offset is not data.** A ridgeline's vertical stagger exists so the
+ * curves do not sit on top of one another; it says nothing about any group. So
+ * the binder reads the kernel-density value the chart computed *before* adding
+ * the group's baseline to it — never the drawn y — and refuses to guess when
+ * the samples carry no such value. Fed the drawn y instead, every group's
+ * loudness would be a function of where it happened to be stacked, and the
+ * lowest ridge would be the loudest chart-wide.
+ */
+
+import type { MaidrLayer, ViolinKdePoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3RidgelineConfig, DataAccessor } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+
+/** Properties a group's sample array is commonly carried under. */
+const SAMPLE_KEYS = ['values', 'samples', 'points', 'curve', 'density'] as const;
+
+/**
+ * Whether a datum is the `[key, values]` tuple `d3.group()` and `d3.groups()`
+ * produce, which is how a ridgeline's per-group data most often arrives.
+ *
+ * @param datum - The datum bound to a group's path
+ * @returns True when it is a grouping tuple
+ */
+function isGroupTuple(datum: unknown): datum is [unknown, unknown[]] {
+  return Array.isArray(datum) && datum.length === 2 && Array.isArray(datum[1]);
+}
+
+/**
+ * Finds the samples a group's curve was drawn from.
+ *
+ * @param datum - The datum bound to the group's path
+ * @param accessor - The user's `samples` accessor, when they gave one
+ * @param index - The group's index within the selection
+ * @returns The samples
+ * @throws Error when no sample array can be reached
+ */
+function resolveSamples(
+  datum: unknown,
+  accessor: DataAccessor<unknown[]> | undefined,
+  index: number,
+): unknown[] {
+  const found = accessor !== undefined
+    ? resolveAccessor<unknown[]>(datum, accessor, index)
+    : findSamples(datum);
+
+  if (!Array.isArray(found)) {
+    throw new TypeError(
+      `The ridge at index ${index} has no samples: its datum is `
+      + `${String(datum)} rather than an array of density samples, and carries `
+      + `no ${SAMPLE_KEYS.join('/')} property holding one. Point \`samples\` at `
+      + `the kernel-density array the curve was drawn from.`,
+    );
+  }
+  return found;
+}
+
+/**
+ * Reaches the sample array on a group datum without a user accessor.
+ *
+ * @param datum - The datum bound to the group's path
+ * @returns The samples, or `undefined` when none is reachable
+ */
+function findSamples(datum: unknown): unknown[] | undefined {
+  if (isGroupTuple(datum)) {
+    return datum[1];
+  }
+  if (Array.isArray(datum)) {
+    return datum;
+  }
+  if (datum !== null && typeof datum === 'object') {
+    const record = datum as Record<string, unknown>;
+    for (const key of SAMPLE_KEYS) {
+      const candidate = record[key];
+      if (Array.isArray(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Keys a group's name is commonly carried under, canonical first. */
+const GROUP_KEYS = ['key', 'name', 'x', 'label', 'category'] as const;
+
+/**
+ * Names a group, from whatever its datum says.
+ *
+ * Looked for on the group's own datum first, then on one of its samples —
+ * `selectAll('path').data(d3.groups(rows, d => d.cohort))` puts the name in
+ * the first place, `.data(byCohort)` over ready-made sample arrays puts it in
+ * the second. Falls back to the group's ordinal, which at least distinguishes
+ * the ridges from one another when the chart's data names nothing.
+ *
+ * @param datum - The datum bound to the group's path
+ * @param sample - One of the group's samples
+ * @param config - The binder config, read for an explicit `group` accessor
+ * @param index - The group's index within the selection
+ * @returns The group's name
+ */
+function resolveGroupName(
+  datum: unknown,
+  sample: unknown,
+  config: D3RidgelineConfig,
+  index: number,
+): string | number {
+  const source = isGroupTuple(datum) ? datum[0] : datum;
+  if (typeof source === 'string' || typeof source === 'number') {
+    return source;
+  }
+
+  for (const candidate of [source, sample]) {
+    const accessor = inferAccessor<string | number>(
+      config,
+      'group',
+      'group',
+      [...GROUP_KEYS],
+      candidate,
+    );
+    const name = resolveAccessorOptional<string | number>(candidate, accessor, index);
+    if (typeof name === 'string' || typeof name === 'number') {
+      return name;
+    }
+  }
+  return index;
+}
+
+/**
+ * Binds a D3.js ridgeline (joy) plot to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the group curves — one `<path>` per ridge. Each path's
+ * datum supplies the group's samples: the array itself, a `d3.groups()` tuple,
+ * or a `values`/`samples`/`points`/`curve` property holding one.
+ *
+ * The three per-sample fields are named for what they mean rather than for the
+ * payload keys they land on, because a ridgeline's value axis is usually the
+ * drawn `x`: `group` names the ridge, `value` is the position along the value
+ * axis, and `density` is the curve's own half-width there — the density
+ * **before** the ridge's baseline was added to it. Passing the drawn y for
+ * `density` is the one mistake this chart type invites; the binder cannot
+ * detect it, so it is worth checking against the array you fed
+ * `d3.area().y1(...)`.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 ridgeline plot.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Ridgeline(svgElement, {
+ *   selector: 'path.ridge',
+ *   title: 'Delivery Time by Cohort',
+ *   axes: { x: 'Days', y: 'Cohort', fill: 'Cohort' },
+ *   group: 'cohort',
+ *   value: 'days',
+ *   density: 'density',
+ * });
+ * ```
+ */
+export function bindD3Ridgeline(svg: Element, config: D3RidgelineConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildRidgelineLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for ridgeline plots. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildRidgelineLayer(
+  root: Element,
+  config: D3RidgelineConfig,
+  panel?: D3PanelScope,
+): D3BuiltLayer {
+  const { title, axes, format, selector, samples: samplesAccessor } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'ridge curve');
+  }
+
+  const sampleDatum = resolveSamples(elements[0].datum, samplesAccessor, 0)[0];
+  const valueAccessor = inferAccessor<number>(
+    config,
+    'value',
+    'value',
+    ['x', 't', 'position'],
+    sampleDatum,
+  );
+  const densityAccessor = inferAccessor<number>(
+    config,
+    'density',
+    'density',
+    ['kde', 'width', 'p', 'estimate'],
+    sampleDatum,
+  );
+
+  const data: ViolinKdePoint[][] = [];
+  const legend: string[] = [];
+
+  for (const { datum, index } of elements) {
+    const samples = resolveSamples(datum, samplesAccessor, index);
+    const group = resolveGroupName(datum, samples[0], config, index);
+
+    const curve: ViolinKdePoint[] = samples.map((sample, position) => ({
+      x: group,
+      y: Number(resolveAccessor<number>(sample, valueAccessor, position)),
+      density: readDensity(sample, densityAccessor, group, position),
+    }));
+
+    data.push(curve);
+    legend.push(String(group));
+  }
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.RIDGELINE,
+    title,
+    // One element per group, which is what the chart draws: `RidgelineTrace`
+    // resolves the selectors to a flat list and requires exactly one entry per
+    // ridge, then lights that ridge's whole curve from any of its samples. The
+    // groups are emitted in DOM order, so one scoped selector is already in
+    // the payload's order.
+    selectors: scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer, legend };
+}
+
+/**
+ * Reads a sample's density, refusing anything that is not a finite number.
+ *
+ * The density is the whole chart — it is what the ridge's height *is* — so a
+ * missing one is an error with instructions rather than a `NaN` that sonifies
+ * as silence partway along an otherwise ordinary-sounding curve.
+ *
+ * @param sample - One sample of the group's curve
+ * @param accessor - The density accessor
+ * @param group - The group's name, for the error message
+ * @param position - The sample's position along the curve
+ * @returns The density
+ * @throws Error when the sample carries no finite density
+ */
+function readDensity(
+  sample: unknown,
+  accessor: DataAccessor<number>,
+  group: string | number,
+  position: number,
+): number {
+  const raw = resolveAccessorOptional<number>(sample, accessor, position);
+  const density = Number(raw);
+  if (!Number.isFinite(density)) {
+    throw new TypeError(
+      `Sample ${position} of the ridge "${String(group)}" carries no density: `
+      + `the \`density\` accessor resolved to ${String(raw)}. Point it at the `
+      + `kernel-density value the curve was drawn from — the half-width `
+      + `**before** the ridge's baseline offset was added, which is the number `
+      + `you passed to \`d3.area().y1(...)\` inside the offset arithmetic, not `
+      + `the drawn y itself.`,
+    );
+  }
+  return density;
+}

--- a/src/adapters/d3/binders/scatter.ts
+++ b/src/adapters/d3/binders/scatter.ts
@@ -1,16 +1,20 @@
 /**
- * D3 binder for scatter plots.
+ * D3 binder for scatter plots and Manhattan plots.
  *
- * Extracts data from D3.js-rendered scatter plot SVG elements and generates
- * the MAIDR JSON schema for accessible scatter plot interaction.
+ * Extracts data from D3.js-rendered point elements and generates the MAIDR
+ * JSON schema for accessible interaction. A Manhattan plot is a scatter with
+ * two extra things a reader cannot see without them — what each point *is* and
+ * which chromosome it sits on — so both are built by the same extraction core
+ * and differ only in the type the layer announces and in the accessors the
+ * caller supplies.
  */
 
-import type { MaidrLayer, ScatterPoint } from '../../../type/grammar';
+import type { MaidrLayer, VolcanoPoint } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
-import type { D3BinderResult, D3BuiltLayer, D3ScatterConfig } from '../types';
+import type { D3BinderResult, D3BuiltLayer, D3ManhattanConfig, D3ScatterConfig, ScatterMarkTraceType } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
 
 /**
  * Binds a D3.js scatter plot to MAIDR, generating the accessible data representation.
@@ -55,17 +59,69 @@ export function bindD3Scatter(svg: Element, config: D3ScatterConfig): D3BinderRe
 }
 
 /**
- * Pure extraction core for scatter plots. See {@link buildBarLayer} for the
- * single-chart vs multi-panel contract.
+ * Binds a D3.js Manhattan plot to MAIDR.
+ *
+ * A Manhattan plot is a scatter of `-log10(p)` against genomic position, drawn
+ * with tens of thousands of points of which a few dozen matter. The question a
+ * reader asks it is never "what is at this coordinate" — it is "which points
+ * cross the line, and what are they called", so the two accessors that answer
+ * that (`label`, `group`) and the `significance` cutoff are what this binder
+ * adds to {@link bindD3Scatter}.
+ *
+ * All three are optional, and the chart still reads without them: the trace
+ * simply reports no findings when no cutoff was declared, rather than guessing
+ * one. It is worth supplying them — the cutoff is the whole reason the chart
+ * was drawn, and it is written nowhere a screen reader can reach.
+ *
+ * @param svg - The SVG element containing the D3 Manhattan plot.
+ * @param config - Configuration specifying the selector, accessors and cutoff.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Manhattan(svgElement, {
+ *   selector: 'circle.snp',
+ *   title: 'Genome-wide Association',
+ *   axes: { x: 'Position', y: '-log10(p)', fill: 'Chromosome' },
+ *   x: 'pos',
+ *   y: 'logP',
+ *   label: 'snp',
+ *   group: 'chromosome',
+ *   significance: 7.3,
+ * });
+ * ```
+ */
+export function bindD3Manhattan(svg: Element, config: D3ManhattanConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildScatterLayer(svg, config, undefined, TraceType.MANHATTAN),
+  );
+}
+
+/**
+ * Pure extraction core for scatter and Manhattan plots. See
+ * {@link buildBarLayer} for the single-chart vs multi-panel contract.
+ *
+ * The config is typed as the superset {@link D3ManhattanConfig}: a plain
+ * scatter leaves the Manhattan-only accessors unset, and nothing extra is then
+ * read or emitted.
  *
  * @internal
  */
-export function buildScatterLayer(root: Element, config: D3ScatterConfig, panel?: D3PanelScope): D3BuiltLayer {
+export function buildScatterLayer(
+  root: Element,
+  config: D3ManhattanConfig,
+  panel?: D3PanelScope,
+  type: ScatterMarkTraceType = TraceType.SCATTER,
+): D3BuiltLayer {
   const {
     title,
     axes,
     format,
     selector,
+    significance,
+    significanceDirection,
   } = config;
 
   const elements = queryD3Elements(root, selector);
@@ -90,24 +146,69 @@ export function buildScatterLayer(root: Element, config: D3ScatterConfig, panel?
     firstDatum,
   );
 
-  const data: ScatterPoint[] = elements.map(({ datum, index }) => {
+  // Manhattan-only: a plain scatter carries neither, so nothing extra is read
+  // or emitted for it. Both are read optionally even here — a point whose
+  // datum names no SNP is still a point, and dropping it for want of a label
+  // would lose the reading the chart was drawn for.
+  const identity = type === TraceType.MANHATTAN
+    ? {
+        label: inferAccessor<string>(
+          config,
+          'label',
+          'label',
+          ['snp', 'id', 'name', 'gene', 'probe'],
+          firstDatum,
+        ),
+        group: inferAccessor<string>(
+          config,
+          'group',
+          'group',
+          ['chromosome', 'chrom', 'chr', 'region'],
+          firstDatum,
+        ),
+      }
+    : null;
+
+  const data: VolcanoPoint[] = elements.map(({ datum, index }) => {
     if (datum === undefined || datum === null) {
       throw buildNoDatumError(selector, index);
     }
-    return {
+    const point: VolcanoPoint = {
       x: resolveAccessor<number>(datum, xAccessor, index),
       y: resolveAccessor<number>(datum, yAccessor, index),
     };
+    if (identity === null) {
+      return point;
+    }
+    const label = resolveAccessorOptional<string>(datum, identity.label, index);
+    if (label !== undefined && label !== null) {
+      point.label = String(label);
+    }
+    const group = resolveAccessorOptional<string>(datum, identity.group, index);
+    if (group !== undefined && group !== null) {
+      point.group = String(group);
+    }
+    return point;
   });
 
   const layer: MaidrLayer = {
     id: generateId(),
-    type: TraceType.SCATTER,
+    type,
     title,
     selectors: scopeSelector(root, selector, panel),
     axes: buildAxes(axes, format),
     data,
   };
+
+  // Only when the caller declared a cutoff. There is no default: these charts
+  // are drawn on transformed axes whose conventions differ by field, and a
+  // guessed line would sort every point onto the wrong side silently.
+  if (significance !== undefined || significanceDirection !== undefined) {
+    layer.thresholdOptions = {
+      ...(significance !== undefined ? { significance } : {}),
+      ...(significanceDirection !== undefined ? { significanceDirection } : {}),
+    };
+  }
 
   return { layer };
 }

--- a/src/adapters/d3/binders/scatter.ts
+++ b/src/adapters/d3/binders/scatter.ts
@@ -1,17 +1,18 @@
 /**
- * D3 binder for scatter plots and Manhattan plots.
+ * D3 binder for scatter, Manhattan and volcano plots.
  *
  * Extracts data from D3.js-rendered point elements and generates the MAIDR
  * JSON schema for accessible interaction. A Manhattan plot is a scatter with
  * two extra things a reader cannot see without them — what each point *is* and
- * which chromosome it sits on — so both are built by the same extraction core
+ * which chromosome it sits on — and a volcano is that same reading with an
+ * effect size on the x axis, so all three are built by the same extraction core
  * and differ only in the type the layer announces and in the accessors the
  * caller supplies.
  */
 
 import type { MaidrLayer, VolcanoPoint } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
-import type { D3BinderResult, D3BuiltLayer, D3ManhattanConfig, D3ScatterConfig, ScatterMarkTraceType } from '../types';
+import type { D3BinderResult, D3BuiltLayer, D3ManhattanConfig, D3ScatterConfig, D3VolcanoConfig, ScatterMarkTraceType } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
 import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
@@ -100,18 +101,58 @@ export function bindD3Manhattan(svg: Element, config: D3ManhattanConfig): D3Bind
 }
 
 /**
- * Pure extraction core for scatter and Manhattan plots. See
+ * Binds a D3.js volcano plot to MAIDR.
+ *
+ * A volcano plots effect size against significance, and is read exactly as a
+ * Manhattan plot is: which points clear the line, and what they are called.
+ * The difference is that it has **two** lines — a gene matters when its change
+ * is both large and significant — so `effect` joins `significance`.
+ *
+ * Supply `label`. On a volcano the gene name is the payload: a reader told
+ * "x is 2.3, y is 14.1" has been given the two numbers whose shape they can
+ * already hear, and withheld the one thing they came for. The binder warns
+ * when no label resolves rather than failing, since the chart still reads
+ * without it.
+ *
+ * @param svg - The SVG element containing the D3 volcano plot.
+ * @param config - Configuration specifying the selector, accessors and cutoffs.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Volcano(svgElement, {
+ *   selector: 'circle.gene',
+ *   title: 'Differential Expression',
+ *   axes: { x: 'log2 fold change', y: '-log10(p)' },
+ *   x: 'lfc',
+ *   y: 'logP',
+ *   label: 'gene',
+ *   significance: 1.3,
+ *   effect: 1,
+ * });
+ * ```
+ */
+export function bindD3Volcano(svg: Element, config: D3VolcanoConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildScatterLayer(svg, config, undefined, TraceType.VOLCANO),
+  );
+}
+
+/**
+ * Pure extraction core for scatter, Manhattan and volcano plots. See
  * {@link buildBarLayer} for the single-chart vs multi-panel contract.
  *
- * The config is typed as the superset {@link D3ManhattanConfig}: a plain
- * scatter leaves the Manhattan-only accessors unset, and nothing extra is then
- * read or emitted.
+ * The config is typed as the superset {@link D3VolcanoConfig}: a plain scatter
+ * leaves the threshold accessors unset, and nothing extra is then read or
+ * emitted.
  *
  * @internal
  */
 export function buildScatterLayer(
   root: Element,
-  config: D3ManhattanConfig,
+  config: D3VolcanoConfig,
   panel?: D3PanelScope,
   type: ScatterMarkTraceType = TraceType.SCATTER,
 ): D3BuiltLayer {
@@ -122,6 +163,7 @@ export function buildScatterLayer(
     selector,
     significance,
     significanceDirection,
+    effect,
   } = config;
 
   const elements = queryD3Elements(root, selector);
@@ -146,28 +188,28 @@ export function buildScatterLayer(
     firstDatum,
   );
 
-  // Manhattan-only: a plain scatter carries neither, so nothing extra is read
-  // or emitted for it. Both are read optionally even here — a point whose
+  // Threshold plots only: a plain scatter carries neither, so nothing extra is
+  // read or emitted for it. Both are read optionally even here — a point whose
   // datum names no SNP is still a point, and dropping it for want of a label
   // would lose the reading the chart was drawn for.
-  const identity = type === TraceType.MANHATTAN
-    ? {
+  const identity = type === TraceType.SCATTER
+    ? null
+    : {
         label: inferAccessor<string>(
           config,
           'label',
           'label',
-          ['snp', 'id', 'name', 'gene', 'probe'],
+          ['snp', 'gene', 'symbol', 'id', 'name', 'probe'],
           firstDatum,
         ),
         group: inferAccessor<string>(
           config,
           'group',
           'group',
-          ['chromosome', 'chrom', 'chr', 'region'],
+          ['chromosome', 'chrom', 'chr', 'regulation', 'direction', 'region'],
           firstDatum,
         ),
-      }
-    : null;
+      };
 
   const data: VolcanoPoint[] = elements.map(({ datum, index }) => {
     if (datum === undefined || datum === null) {
@@ -191,6 +233,17 @@ export function buildScatterLayer(
     return point;
   });
 
+  // A volcano is read by gene name, so say so when none resolved. It is a
+  // warning rather than an error: the chart still reads as a scatter with a
+  // cutoff, and refusing to bind would leave the reader with nothing at all.
+  if (type === TraceType.VOLCANO && !data.some(point => point.label !== undefined)) {
+    console.warn(
+      `[maidr/d3] No label resolved for any point of the volcano plot matched `
+      + `by "${selector}". The gene name is what a volcano is read for — pass `
+      + `a \`label\` accessor naming the property that carries it.`,
+    );
+  }
+
   const layer: MaidrLayer = {
     id: generateId(),
     type,
@@ -203,10 +256,11 @@ export function buildScatterLayer(
   // Only when the caller declared a cutoff. There is no default: these charts
   // are drawn on transformed axes whose conventions differ by field, and a
   // guessed line would sort every point onto the wrong side silently.
-  if (significance !== undefined || significanceDirection !== undefined) {
+  if (significance !== undefined || significanceDirection !== undefined || effect !== undefined) {
     layer.thresholdOptions = {
       ...(significance !== undefined ? { significance } : {}),
       ...(significanceDirection !== undefined ? { significanceDirection } : {}),
+      ...(effect !== undefined ? { effect } : {}),
     };
   }
 

--- a/src/adapters/d3/binders/segmented.ts
+++ b/src/adapters/d3/binders/segmented.ts
@@ -1,21 +1,22 @@
 /**
- * D3 binder for segmented bar charts (stacked, dodged, normalized, and
- * diverging).
+ * D3 binder for segmented bar charts (stacked, dodged, normalized, diverging
+ * and mosaic).
  *
  * Extracts data from D3.js-rendered grouped/stacked bar chart SVG elements
- * and generates the MAIDR JSON schema for accessible interaction. All four
+ * and generates the MAIDR JSON schema for accessible interaction. All five
  * carry one category, one value and one series key per mark, which is why
  * they share a single extraction core and differ only in the type the layer
  * announces — the type is what makes a diverging chart read its values as
- * sides rather than as a stack.
+ * sides rather than as a stack. A mosaic adds one thing to the payload, the
+ * column width, because on that chart alone the width is data.
  */
 
-import type { MaidrLayer, SegmentedPoint } from '../../../type/grammar';
+import type { MaidrLayer, MosaicPoint, SegmentedPoint } from '../../../type/grammar';
 import type { D3PanelScope } from '../selectors';
-import type { D3BinderResult, D3BuiltLayer, D3SegmentedConfig } from '../types';
+import type { D3BinderResult, D3BuiltLayer, D3MosaicConfig, D3SegmentedConfig, DataAccessor, SegmentedTraceType } from '../types';
 import { TraceType } from '../../../type/grammar';
 import { scopeSelector } from '../selectors';
-import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
 
 /**
  * Binds a D3.js segmented bar chart (stacked, dodged, or normalized) to MAIDR.
@@ -118,12 +119,143 @@ export function bindD3Diverging(svg: Element, config: D3SegmentedConfig): D3Bind
 }
 
 /**
+ * Binds a D3.js mosaic (marimekko) plot to MAIDR.
+ *
+ * A mosaic is a stacked bar chart in which the **column widths also encode
+ * data** — usually each category's share of all observations. That share is
+ * the one thing this binder reads that the stacked one does not, and it is
+ * worth supplying: a reader given only the segment heights has half the table,
+ * so a category of six people and one of six hundred read identically.
+ *
+ * The width is read from the datum, never measured off the rendered `<rect>`.
+ * A drawn width is a layout fact — padding, margins, the scale the columns
+ * were laid out on — and turning it back into a proportion would announce a
+ * number the data does not contain.
+ *
+ * `count` travels too when you have the contingency table the mosaic was drawn
+ * from, since those counts are the numbers a reader would quote back.
+ *
+ * @param svg - The SVG element containing the D3 mosaic plot.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Mosaic(svgElement, {
+ *   selector: 'rect.cell',
+ *   title: 'Survival by Passenger Class',
+ *   axes: { x: 'Class', y: 'Proportion', fill: 'Outcome' },
+ *   x: 'klass',
+ *   y: 'share',
+ *   fill: 'outcome',
+ *   width: 'columnShare',
+ *   count: 'n',
+ * });
+ * ```
+ */
+export function bindD3Mosaic(svg: Element, config: D3MosaicConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildSegmentedLayer(svg, { ...config, type: TraceType.MOSAIC }),
+  );
+}
+
+/**
+ * The two accessors a mosaic reads on top of the segmented ones, or `null` for
+ * the four chart types that carry neither.
+ */
+interface MosaicAccessors {
+  width: DataAccessor<number>;
+  count: DataAccessor<number>;
+}
+
+/**
+ * Resolves the mosaic-only accessors, once, from a sample datum.
+ *
+ * Returns `null` for every other segmented type, so a stacked bar whose datum
+ * happens to carry a `width` key does not pick up a column share it never
+ * meant to declare.
+ *
+ * @param config - The user's config
+ * @param type - The type the layer will announce
+ * @param sampleDatum - First segment datum, for key inference
+ * @returns The accessors, or `null` when the chart is not a mosaic
+ */
+function inferMosaicAccessors(
+  config: D3MosaicConfig,
+  type: SegmentedTraceType,
+  sampleDatum: unknown,
+): MosaicAccessors | null {
+  if (type !== TraceType.MOSAIC) {
+    return null;
+  }
+  return {
+    width: inferAccessor<number>(
+      config,
+      'width',
+      'width',
+      ['share', 'proportion', 'marginal'],
+      sampleDatum,
+    ),
+    count: inferAccessor<number>(
+      config,
+      'count',
+      'count',
+      ['n', 'freq', 'frequency'],
+      sampleDatum,
+    ),
+  };
+}
+
+/**
+ * Adds the column share and the cell count to a segment, where the datum
+ * declares them.
+ *
+ * Both are optional and both are read optionally: a producer working from
+ * proportions alone genuinely has no counts, and a cell missing its width is a
+ * cell whose column declared one elsewhere — {@link MosaicTrace} reads the
+ * width from whichever series of the column carries it. Non-finite values are
+ * dropped rather than emitted, since `NaN` would be announced as a share.
+ *
+ * @param point - The segment built by the segmented extraction
+ * @param datum - The segment's D3-bound datum
+ * @param index - Position of the segment in its selection
+ * @param mosaic - The mosaic accessors, or `null` for the other types
+ * @returns The same point, with the mosaic fields set where they resolved
+ */
+function withMosaicFields(
+  point: SegmentedPoint,
+  datum: unknown,
+  index: number,
+  mosaic: MosaicAccessors | null,
+): SegmentedPoint {
+  if (mosaic === null) {
+    return point;
+  }
+  const cell = point as MosaicPoint;
+  const width = resolveAccessorOptional<number>(datum, mosaic.width, index);
+  if (typeof width === 'number' && Number.isFinite(width)) {
+    cell.width = width;
+  }
+  const count = resolveAccessorOptional<number>(datum, mosaic.count, index);
+  if (typeof count === 'number' && Number.isFinite(count)) {
+    cell.count = count;
+  }
+  return cell;
+}
+
+/**
  * Pure extraction core for segmented bar charts. See {@link buildBarLayer}
  * for the single-chart vs multi-panel contract.
  *
+ * The config is typed as the superset {@link D3MosaicConfig}: the other four
+ * types leave the mosaic-only accessors unset, and nothing extra is then read
+ * or emitted.
+ *
  * @internal
  */
-export function buildSegmentedLayer(root: Element, config: D3SegmentedConfig, panel?: D3PanelScope): D3BuiltLayer {
+export function buildSegmentedLayer(root: Element, config: D3MosaicConfig, panel?: D3PanelScope): D3BuiltLayer {
   const {
     title,
     axes,
@@ -181,6 +313,7 @@ export function buildSegmentedLayer(root: Element, config: D3SegmentedConfig, pa
       ['group', 'series', 'category', 'z', 'color'],
       sampleDatum,
     );
+    const mosaic = inferMosaicAccessors(config, type, sampleDatum);
 
     for (const { element: groupEl, datum: groupDatum } of groupElements) {
       const segments = queryD3Elements(groupEl, selector);
@@ -195,11 +328,11 @@ export function buildSegmentedLayer(root: Element, config: D3SegmentedConfig, pa
           throw buildNoDatumError(selector, index);
         }
         const fillValue = groupKey ?? resolveAccessor<string>(datum, fillAccessor, index);
-        return {
+        return withMosaicFields({
           x: resolveAccessor<string | number>(datum, xAccessor, index),
           y: resolveAccessor<number | string>(datum, yAccessor, index),
           z: fillValue,
-        };
+        }, datum, index, mosaic);
       });
 
       if (groupPoints.length > 0) {
@@ -280,17 +413,18 @@ export function buildSegmentedLayer(root: Element, config: D3SegmentedConfig, pa
       ['group', 'series', 'category', 'z', 'color'],
       sampleDatum,
     );
+    const mosaic = inferMosaicAccessors(config, type, sampleDatum);
 
     const groups = new Map<string, SegmentedPoint[]>();
     for (const { datum, index } of elements) {
       if (datum === undefined || datum === null) {
         throw buildNoDatumError(selector, index);
       }
-      const point: SegmentedPoint = {
+      const point: SegmentedPoint = withMosaicFields({
         x: resolveAccessor<string | number>(datum, xAccessor, index),
         y: resolveAccessor<number | string>(datum, yAccessor, index),
         z: resolveAccessor<string>(datum, fillAccessor, index),
-      };
+      }, datum, index, mosaic);
       if (!groups.has(point.z)) {
         groupOrder.push(point.z);
         groups.set(point.z, []);

--- a/src/adapters/d3/binders/segmented.ts
+++ b/src/adapters/d3/binders/segmented.ts
@@ -1,8 +1,13 @@
 /**
- * D3 binder for segmented bar charts (stacked, dodged, and normalized).
+ * D3 binder for segmented bar charts (stacked, dodged, normalized, and
+ * diverging).
  *
  * Extracts data from D3.js-rendered grouped/stacked bar chart SVG elements
- * and generates the MAIDR JSON schema for accessible interaction.
+ * and generates the MAIDR JSON schema for accessible interaction. All four
+ * carry one category, one value and one series key per mark, which is why
+ * they share a single extraction core and differ only in the type the layer
+ * announces — the type is what makes a diverging chart read its values as
+ * sides rather than as a stack.
  */
 
 import type { MaidrLayer, SegmentedPoint } from '../../../type/grammar';
@@ -70,6 +75,49 @@ export function bindD3Segmented(svg: Element, config: D3SegmentedConfig): D3Bind
 }
 
 /**
+ * Binds a D3.js diverging bar chart — a population pyramid, a Likert scale —
+ * to MAIDR.
+ *
+ * A diverging chart is two series drawn back to back across a shared category
+ * axis, which is the segmented extraction with a different reading: the sign
+ * of a value is a **side**, not a magnitude, and the trace pitches the
+ * magnitude while announcing the side.
+ *
+ * So emit the values **as the chart draws them** — the left-hand series
+ * negative — and do not take their absolute value. Handed unsigned data the
+ * trace has no way to tell the two sides apart, and the balance it reports
+ * between them becomes a total instead of a comparison.
+ *
+ * A pyramid is usually drawn on its side. Pass
+ * `orientation: Orientation.HORIZONTAL` (with `x` reading the signed value and
+ * `y` the category) so the axes are announced the way it was drawn.
+ *
+ * @param svg - The SVG element containing the D3 diverging bar chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * bindD3Diverging(svgElement, {
+ *   selector: 'rect.band',
+ *   title: 'Population by Age Band',
+ *   orientation: Orientation.HORIZONTAL,
+ *   axes: { x: 'People, thousands', y: 'Age band', fill: 'Sex' },
+ *   x: 'people',   // negative for the side drawn to the left
+ *   y: 'band',
+ *   fill: 'sex',
+ * });
+ * ```
+ */
+export function bindD3Diverging(svg: Element, config: D3SegmentedConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildSegmentedLayer(svg, { ...config, type: TraceType.DIVERGING }),
+  );
+}
+
+/**
  * Pure extraction core for segmented bar charts. See {@link buildBarLayer}
  * for the single-chart vs multi-panel contract.
  *
@@ -83,6 +131,7 @@ export function buildSegmentedLayer(root: Element, config: D3SegmentedConfig, pa
     selector,
     groupSelector,
     type = TraceType.STACKED,
+    orientation,
     domOrder: domOrderOverride,
   } = config;
 
@@ -290,6 +339,9 @@ export function buildSegmentedLayer(root: Element, config: D3SegmentedConfig, pa
     type,
     title,
     selectors: selectorValue,
+    // Omitted when the caller did not declare one, so the core keeps applying
+    // its own default rather than being told a value the chart never claimed.
+    ...(orientation ? { orientation } : {}),
     axes: buildAxes(axes, format),
     data,
     domMapping,

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -42,19 +42,24 @@ import { buildBarLayer } from './bar';
 import { buildBoxLayer } from './box';
 import { buildBoxenLayer } from './boxen';
 import { buildCandlestickLayer } from './candlestick';
+import { buildContourLayer } from './contour';
 import { buildDumbbellLayer } from './dumbbell';
 import { buildErrorBarLayer, buildForestLayer } from './errorBar';
 import { buildFlowLayer } from './flow';
 import { buildGanttLayer } from './gantt';
 import { buildGaugeLayer } from './gauge';
 import { buildHeatmapLayer } from './heatmap';
+import { buildHexbinLayer } from './hexbin';
 import { buildHistogramLayer } from './histogram';
 import { buildLineLayer } from './line';
 import { buildNetworkLayer } from './network';
+import { buildParallelLayer } from './parallel';
 import { buildPieLayer, buildPolarAreaLayer } from './pie';
+import { buildRidgelineLayer } from './ridgeline';
 import { buildScatterLayer } from './scatter';
 import { buildSegmentedLayer } from './segmented';
 import { buildSmoothLayer } from './smooth';
+import { buildSurvivalLayer } from './survival';
 import { buildTreemapLayer } from './treemap';
 import { buildWaterfallLayer } from './waterfall';
 import { buildWordCloudLayer } from './wordCloud';
@@ -257,6 +262,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildCandlestickLayer(root, spec.config, panel);
     case 'chord':
       return buildFlowLayer(root, spec.config, panel, TraceType.CHORD);
+    case 'contour':
+      return buildContourLayer(root, spec.config, panel);
     case 'dot':
       return buildBarLayer(root, spec.config, panel, TraceType.DOT);
     case 'dumbbell':
@@ -273,6 +280,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildGaugeLayer(root, spec.config, panel);
     case 'heatmap':
       return buildHeatmapLayer(root, spec.config, panel);
+    case 'hexbin':
+      return buildHexbinLayer(root, spec.config, panel);
     case 'histogram':
       return buildHistogramLayer(root, spec.config, panel);
     case 'icicle':
@@ -287,12 +296,16 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildSegmentedLayer(root, { ...spec.config, type: TraceType.MOSAIC }, panel);
     case 'network':
       return buildNetworkLayer(root, spec.config, panel);
+    case 'parallel':
+      return buildParallelLayer(root, spec.config, panel);
     case 'pie':
       return buildPieLayer(root, spec.config, panel);
     case 'polarArea':
       return buildPolarAreaLayer(root, spec.config, panel);
     case 'radar':
       return buildLineLayer(root, spec.config, panel, TraceType.RADAR);
+    case 'ridgeline':
+      return buildRidgelineLayer(root, spec.config, panel);
     case 'sankey':
       return buildFlowLayer(root, spec.config, panel, TraceType.SANKEY);
     case 'scatter':
@@ -303,6 +316,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildSmoothLayer(root, spec.config, panel);
     case 'sunburst':
       return buildTreemapLayer(root, spec.config, panel, TraceType.SUNBURST);
+    case 'survival':
+      return buildSurvivalLayer(root, spec.config, panel);
     case 'treemap':
       return buildTreemapLayer(root, spec.config, panel);
     case 'volcano':

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -47,10 +47,12 @@ import { buildGaugeLayer } from './gauge';
 import { buildHeatmapLayer } from './heatmap';
 import { buildHistogramLayer } from './histogram';
 import { buildLineLayer } from './line';
-import { buildPieLayer } from './pie';
+import { buildNetworkLayer } from './network';
+import { buildPieLayer, buildPolarAreaLayer } from './pie';
 import { buildScatterLayer } from './scatter';
 import { buildSegmentedLayer } from './segmented';
 import { buildSmoothLayer } from './smooth';
+import { buildTreemapLayer } from './treemap';
 import { buildWaterfallLayer } from './waterfall';
 import { buildWordCloudLayer } from './wordCloud';
 
@@ -266,14 +268,28 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildBarLayer(root, spec.config, panel, TraceType.LOLLIPOP);
     case 'manhattan':
       return buildScatterLayer(root, spec.config, panel, TraceType.MANHATTAN);
+    case 'mosaic':
+      return buildSegmentedLayer(root, { ...spec.config, type: TraceType.MOSAIC }, panel);
+    case 'network':
+      return buildNetworkLayer(root, spec.config, panel);
     case 'pie':
       return buildPieLayer(root, spec.config, panel);
+    case 'polarArea':
+      return buildPolarAreaLayer(root, spec.config, panel);
+    case 'radar':
+      return buildLineLayer(root, spec.config, panel, TraceType.RADAR);
     case 'scatter':
       return buildScatterLayer(root, spec.config, panel);
     case 'segmented':
       return buildSegmentedLayer(root, spec.config, panel);
     case 'smooth':
       return buildSmoothLayer(root, spec.config, panel);
+    case 'sunburst':
+      return buildTreemapLayer(root, spec.config, panel, TraceType.SUNBURST);
+    case 'treemap':
+      return buildTreemapLayer(root, spec.config, panel);
+    case 'volcano':
+      return buildScatterLayer(root, spec.config, panel, TraceType.VOLCANO);
     case 'waterfall':
       return buildWaterfallLayer(root, spec.config, panel);
     case 'wordCloud':

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -40,9 +40,12 @@ import { applyMaidrData, generateId, getD3Datum, isMaidrOwned, resolveAccessorOp
 import { buildAreaLayer } from './area';
 import { buildBarLayer } from './bar';
 import { buildBoxLayer } from './box';
+import { buildBoxenLayer } from './boxen';
 import { buildCandlestickLayer } from './candlestick';
 import { buildDumbbellLayer } from './dumbbell';
-import { buildErrorBarLayer } from './errorBar';
+import { buildErrorBarLayer, buildForestLayer } from './errorBar';
+import { buildFlowLayer } from './flow';
+import { buildGanttLayer } from './gantt';
 import { buildGaugeLayer } from './gauge';
 import { buildHeatmapLayer } from './heatmap';
 import { buildHistogramLayer } from './histogram';
@@ -238,30 +241,42 @@ function buildPanelGrid(
 /** Dispatches a panel cell to the matching per-type extraction core. */
 function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelScope): D3BuiltLayer {
   switch (spec.chartType) {
+    case 'alluvial':
+      return buildFlowLayer(root, spec.config, panel, TraceType.ALLUVIAL);
     case 'area':
       return buildAreaLayer(root, spec.config, panel);
     case 'bar':
       return buildBarLayer(root, spec.config, panel);
     case 'box':
       return buildBoxLayer(root, spec.config, panel);
+    case 'boxen':
+      return buildBoxenLayer(root, spec.config, panel);
     case 'bump':
       return buildLineLayer(root, spec.config, panel, TraceType.BUMP);
     case 'candlestick':
       return buildCandlestickLayer(root, spec.config, panel);
+    case 'chord':
+      return buildFlowLayer(root, spec.config, panel, TraceType.CHORD);
     case 'dot':
       return buildBarLayer(root, spec.config, panel, TraceType.DOT);
     case 'dumbbell':
       return buildDumbbellLayer(root, spec.config, panel);
     case 'errorBar':
       return buildErrorBarLayer(root, spec.config, panel);
+    case 'forest':
+      return buildForestLayer(root, spec.config, panel);
     case 'funnel':
       return buildBarLayer(root, spec.config, panel, TraceType.FUNNEL);
+    case 'gantt':
+      return buildGanttLayer(root, spec.config, panel);
     case 'gauge':
       return buildGaugeLayer(root, spec.config, panel);
     case 'heatmap':
       return buildHeatmapLayer(root, spec.config, panel);
     case 'histogram':
       return buildHistogramLayer(root, spec.config, panel);
+    case 'icicle':
+      return buildTreemapLayer(root, spec.config, panel, TraceType.ICICLE);
     case 'line':
       return buildLineLayer(root, spec.config, panel);
     case 'lollipop':
@@ -278,6 +293,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildPolarAreaLayer(root, spec.config, panel);
     case 'radar':
       return buildLineLayer(root, spec.config, panel, TraceType.RADAR);
+    case 'sankey':
+      return buildFlowLayer(root, spec.config, panel, TraceType.SANKEY);
     case 'scatter':
       return buildScatterLayer(root, spec.config, panel);
     case 'segmented':

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -34,8 +34,10 @@ import type {
   D3SubplotsConfig,
   DataAccessor,
 } from '../types';
+import { TraceType } from '../../../type/grammar';
 import { ensureContainerId, PANEL_ATTRIBUTE } from '../selectors';
 import { applyMaidrData, generateId, getD3Datum, isMaidrOwned, resolveAccessorOptional } from '../util';
+import { buildAreaLayer } from './area';
 import { buildBarLayer } from './bar';
 import { buildBoxLayer } from './box';
 import { buildCandlestickLayer } from './candlestick';
@@ -229,18 +231,28 @@ function buildPanelGrid(
 /** Dispatches a panel cell to the matching per-type extraction core. */
 function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelScope): D3BuiltLayer {
   switch (spec.chartType) {
+    case 'area':
+      return buildAreaLayer(root, spec.config, panel);
     case 'bar':
       return buildBarLayer(root, spec.config, panel);
     case 'box':
       return buildBoxLayer(root, spec.config, panel);
+    case 'bump':
+      return buildLineLayer(root, spec.config, panel, TraceType.BUMP);
     case 'candlestick':
       return buildCandlestickLayer(root, spec.config, panel);
+    case 'dot':
+      return buildBarLayer(root, spec.config, panel, TraceType.DOT);
+    case 'funnel':
+      return buildBarLayer(root, spec.config, panel, TraceType.FUNNEL);
     case 'heatmap':
       return buildHeatmapLayer(root, spec.config, panel);
     case 'histogram':
       return buildHistogramLayer(root, spec.config, panel);
     case 'line':
       return buildLineLayer(root, spec.config, panel);
+    case 'lollipop':
+      return buildBarLayer(root, spec.config, panel, TraceType.LOLLIPOP);
     case 'pie':
       return buildPieLayer(root, spec.config, panel);
     case 'scatter':

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -41,6 +41,9 @@ import { buildAreaLayer } from './area';
 import { buildBarLayer } from './bar';
 import { buildBoxLayer } from './box';
 import { buildCandlestickLayer } from './candlestick';
+import { buildDumbbellLayer } from './dumbbell';
+import { buildErrorBarLayer } from './errorBar';
+import { buildGaugeLayer } from './gauge';
 import { buildHeatmapLayer } from './heatmap';
 import { buildHistogramLayer } from './histogram';
 import { buildLineLayer } from './line';
@@ -48,6 +51,8 @@ import { buildPieLayer } from './pie';
 import { buildScatterLayer } from './scatter';
 import { buildSegmentedLayer } from './segmented';
 import { buildSmoothLayer } from './smooth';
+import { buildWaterfallLayer } from './waterfall';
+import { buildWordCloudLayer } from './wordCloud';
 
 /**
  * Binds a faceted D3 chart (homogeneous small multiples) to MAIDR.
@@ -243,8 +248,14 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildCandlestickLayer(root, spec.config, panel);
     case 'dot':
       return buildBarLayer(root, spec.config, panel, TraceType.DOT);
+    case 'dumbbell':
+      return buildDumbbellLayer(root, spec.config, panel);
+    case 'errorBar':
+      return buildErrorBarLayer(root, spec.config, panel);
     case 'funnel':
       return buildBarLayer(root, spec.config, panel, TraceType.FUNNEL);
+    case 'gauge':
+      return buildGaugeLayer(root, spec.config, panel);
     case 'heatmap':
       return buildHeatmapLayer(root, spec.config, panel);
     case 'histogram':
@@ -253,6 +264,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildLineLayer(root, spec.config, panel);
     case 'lollipop':
       return buildBarLayer(root, spec.config, panel, TraceType.LOLLIPOP);
+    case 'manhattan':
+      return buildScatterLayer(root, spec.config, panel, TraceType.MANHATTAN);
     case 'pie':
       return buildPieLayer(root, spec.config, panel);
     case 'scatter':
@@ -261,6 +274,10 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildSegmentedLayer(root, spec.config, panel);
     case 'smooth':
       return buildSmoothLayer(root, spec.config, panel);
+    case 'waterfall':
+      return buildWaterfallLayer(root, spec.config, panel);
+    case 'wordCloud':
+      return buildWordCloudLayer(root, spec.config, panel);
   }
 }
 

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -264,6 +264,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildFlowLayer(root, spec.config, panel, TraceType.CHORD);
     case 'contour':
       return buildContourLayer(root, spec.config, panel);
+    case 'diverging':
+      return buildSegmentedLayer(root, { ...spec.config, type: TraceType.DIVERGING }, panel);
     case 'dot':
       return buildBarLayer(root, spec.config, panel, TraceType.DOT);
     case 'dumbbell':

--- a/src/adapters/d3/binders/survival.ts
+++ b/src/adapters/d3/binders/survival.ts
@@ -1,0 +1,307 @@
+/**
+ * D3 binder for Kaplan-Meier survival curves.
+ *
+ * A survival curve is a step line — `d3.line().curve(d3.curveStepAfter)` over
+ * one `<path>` per arm — so the extraction is `binders/line.ts`'s, reading the
+ * same `x`, `y` and `fill` off the same data. What a survival figure carries
+ * beyond a step chart is the two things it is read for, and both are added on
+ * top of that core: which times were **censored**, and how wide the
+ * **confidence band** is at each time.
+ *
+ * Censoring marks are the awkward part. They are drawn as ticks from their own
+ * data join rather than as vertices of the curve, precisely because censoring
+ * does not change the estimate — so they arrive as a second selection whose
+ * times are not, in general, times the curve has a vertex at. The binder
+ * merges them into the arm they belong to by time: flagging the vertex already
+ * there, or inserting one carrying the probability the curve holds across that
+ * interval.
+ */
+
+import type { SurvivalPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3SurvivalConfig, DataAccessor } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { buildNoElementsError, finalizeSingleChart, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+import { buildLineLayer, sampleLineDatum } from './line';
+
+/**
+ * Whether a value means "this subject was censored".
+ *
+ * Read strictly rather than by truthiness: survival data carries the flag as a
+ * boolean, as a 0/1 indicator, or as the string one of those was parsed from,
+ * and `'0'` is truthy in every one of those readings but censors nobody.
+ *
+ * @param value - Whatever the `censored` accessor produced
+ * @returns True when the value marks a censored time
+ */
+function isCensored(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value === 1;
+  }
+  if (typeof value === 'string') {
+    return value === '1' || value === 'true';
+  }
+  return false;
+}
+
+/**
+ * Reads a confidence bound off a datum, keeping only a finite number.
+ *
+ * @param datum - The datum bound to the sample
+ * @param accessor - The bound's accessor
+ * @param index - The sample's index within its selection
+ * @returns The bound, or `undefined` when the chart declares none here
+ */
+function readBound(
+  datum: unknown,
+  accessor: DataAccessor<number>,
+  index: number,
+): number | undefined {
+  const raw = resolveAccessorOptional<number>(datum, accessor, index);
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Merges one censoring tick into the arm it belongs to.
+ *
+ * A tick whose time is already a vertex of the curve just flags that vertex.
+ * Otherwise a vertex is inserted at that time, carrying the probability — and
+ * the band — the curve holds across the interval it falls in, which is what
+ * the estimate says there: a censored time is a subject leaving, not a step.
+ *
+ * @param arm - The curve to merge into, in ascending time order
+ * @param time - The censored time
+ * @param index - The tick's index within its selection, for the error message
+ * @throws Error when the arm's times cannot be compared with the tick's
+ */
+function mergeCensoredTime(arm: SurvivalPoint[], time: number | string, index: number): void {
+  const existing = arm.findIndex(point => point.x === time);
+  if (existing !== -1) {
+    arm[existing].censored = true;
+    return;
+  }
+
+  const at = Number(time);
+  if (!Number.isFinite(at)) {
+    throw new TypeError(
+      `The censoring tick at index ${index} is at "${String(time)}", which is `
+      + `not a time on its curve and is not a number that could be placed `
+      + `between two. Point \`x\` at the tick's own time — the same value the `
+      + `curve's samples carry.`,
+    );
+  }
+
+  // The last vertex at or before the tick: the estimate holds from there.
+  let previous = -1;
+  for (let position = 0; position < arm.length; position++) {
+    const vertex = Number(arm[position].x);
+    if (Number.isFinite(vertex) && vertex <= at) {
+      previous = position;
+    }
+  }
+
+  // A tick before the curve's first vertex takes that vertex's probability,
+  // which on a Kaplan-Meier curve is the 1.0 it starts at.
+  const held = arm[previous === -1 ? 0 : previous];
+  if (held === undefined) {
+    throw new Error(
+      `The censoring tick at index ${index} has no curve to merge into: the `
+      + `arm it names carries no samples.`,
+    );
+  }
+
+  const inserted: SurvivalPoint = { x: at, y: held.y, censored: true };
+  if (held.z !== undefined) {
+    inserted.z = held.z;
+  }
+  if (held.yMin !== undefined) {
+    inserted.yMin = held.yMin;
+  }
+  if (held.yMax !== undefined) {
+    inserted.yMax = held.yMax;
+  }
+  arm.splice(previous + 1, 0, inserted);
+}
+
+/**
+ * Merges every censoring tick drawn by a separate join into the curves.
+ *
+ * Each tick names its arm the way the curve's own samples do — through `fill`
+ * — and a single-curve chart needs no naming at all. A tick naming an arm the
+ * chart does not draw is an error rather than a silent drop: it is a subject
+ * the reader would never be told about.
+ *
+ * @param root - The extraction root (the SVG, or a panel element)
+ * @param config - The binder config
+ * @param arms - The curves the line core produced, in row order
+ * @throws Error when the selector matches nothing, or a tick names no arm
+ */
+function mergeCensoredTicks(
+  root: Element,
+  config: D3SurvivalConfig,
+  arms: SurvivalPoint[][],
+): void {
+  const { censoredSelector } = config;
+  if (censoredSelector === undefined) {
+    return;
+  }
+
+  const ticks = queryD3Elements(root, censoredSelector);
+  if (ticks.length === 0) {
+    throw buildNoElementsError(root, censoredSelector, 'censoring tick');
+  }
+
+  const sample = ticks[0].datum;
+  const xAccessor = inferAccessor<number | string>(
+    config,
+    'x',
+    'x',
+    ['time', 't', 'date'],
+    sample,
+  );
+  const fillAccessor = inferAccessor<string>(
+    config,
+    'fill',
+    'fill',
+    ['group', 'arm', 'series', 'strata', 'z'],
+    sample,
+  );
+
+  for (const { datum, index } of ticks) {
+    const time = resolveAccessor<number | string>(datum, xAccessor, index);
+    const fill = resolveAccessorOptional<string>(datum, fillAccessor, index);
+
+    let row = 0;
+    if (fill !== undefined && fill !== null) {
+      row = arms.findIndex(arm => arm[0]?.z === fill);
+      if (row === -1) {
+        throw new Error(
+          `The censoring tick at index ${index} names the arm "${String(fill)}", `
+          + `which no curve matched by "${config.selector}" is drawn for. The `
+          + `ticks and the curves have to name their arms the same way — `
+          + `check the \`fill\` accessor.`,
+        );
+      }
+    } else if (arms.length > 1) {
+      throw new Error(
+        `The censoring tick at index ${index} names no arm, and the chart draws `
+        + `${arms.length} of them. Give the ticks the same \`fill\` their `
+        + `curves carry, so each tick can be merged into the curve it belongs to.`,
+      );
+    }
+
+    mergeCensoredTime(arms[row], time, index);
+  }
+}
+
+/**
+ * Binds a D3.js Kaplan-Meier survival curve to MAIDR, generating the
+ * accessible data representation.
+ *
+ * Point `selector` at the step paths — one per arm — exactly as with
+ * {@link bindD3Line}, and `fill` at whatever names the arm. Everything a
+ * survival figure adds is optional and read from the same data:
+ *
+ * - **Censoring.** Either the curve's samples carry a `censored` column, or
+ *   the ticks are their own selection — set `censoredSelector` and the binder
+ *   merges each tick into its arm by time.
+ * - **The confidence band.** `yMin` and `yMax` are announced alongside the
+ *   estimate, which is the comparison a reader makes when two arms look
+ *   separated.
+ *
+ * The trace derives median survival itself, so nothing here computes it.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 survival curve.
+ * @param config - Configuration specifying selectors and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Survival(svgElement, {
+ *   selector: 'path.km-curve',
+ *   censoredSelector: 'line.censor-tick',
+ *   title: 'Overall Survival',
+ *   axes: { x: 'Months', y: 'Survival probability', fill: 'Arm' },
+ *   x: 'time',
+ *   y: 'surv',
+ *   fill: 'arm',
+ *   yMin: 'lower',
+ *   yMax: 'upper',
+ * });
+ * ```
+ */
+export function bindD3Survival(svg: Element, config: D3SurvivalConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildSurvivalLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for survival curves. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildSurvivalLayer(
+  root: Element,
+  config: D3SurvivalConfig,
+  panel?: D3PanelScope,
+): D3BuiltLayer {
+  const sample = sampleLineDatum(root, config);
+  const censoredAccessor = inferAccessor<unknown>(
+    config,
+    'censored',
+    'censored',
+    ['censor', 'isCensored'],
+    sample,
+  );
+  const yMinAccessor = inferAccessor<number>(
+    config,
+    'yMin',
+    'yMin',
+    ['lower', 'lo', 'ciLower', 'low'],
+    sample,
+  );
+  const yMaxAccessor = inferAccessor<number>(
+    config,
+    'yMax',
+    'yMax',
+    ['upper', 'hi', 'ciUpper', 'high'],
+    sample,
+  );
+
+  const built = buildLineLayer(root, config, panel, TraceType.SURVIVAL, (point, datum, index) => {
+    const survival = point as SurvivalPoint;
+    if (isCensored(resolveAccessorOptional<unknown>(datum, censoredAccessor, index))) {
+      survival.censored = true;
+    }
+    const low = readBound(datum, yMinAccessor, index);
+    if (low !== undefined) {
+      survival.yMin = low;
+    }
+    const high = readBound(datum, yMaxAccessor, index);
+    if (high !== undefined) {
+      survival.yMax = high;
+    }
+  });
+
+  // The ticks are merged after the curves are built, because a tick's time is
+  // placed relative to the vertices the core has just read.
+  mergeCensoredTicks(root, config, built.layer.data as SurvivalPoint[][]);
+
+  return built;
+}

--- a/src/adapters/d3/binders/treemap.ts
+++ b/src/adapters/d3/binders/treemap.ts
@@ -1,5 +1,5 @@
 /**
- * D3 binder for treemaps and sunbursts.
+ * D3 binder for treemaps, sunbursts and icicles.
  *
  * Extracts the tree a `d3.treemap()` or `d3.partition()` laid out and generates
  * the MAIDR JSON schema for accessible interaction. Both layouts run over a
@@ -219,8 +219,45 @@ export function bindD3Sunburst(svg: Element, config: D3TreemapConfig): D3BinderR
 }
 
 /**
- * Pure extraction core for treemaps and sunbursts. See {@link buildBarLayer}
- * for the single-chart vs multi-panel contract.
+ * Binds a D3.js icicle to MAIDR.
+ *
+ * An icicle is the sunburst's partition drawn in cartesian coordinates: the
+ * same `d3.partition()` over the same `d3.hierarchy()`, laid out as
+ * depth-ordered bands rather than concentric arcs. Nothing about the tree
+ * changes, so the extraction is that of {@link bindD3Sunburst} — `selector`
+ * matches the `<rect>` bands the partition produced, and whatever you joined
+ * (leaves alone, or `descendants()` with its interior nodes) is what the reader
+ * navigates.
+ *
+ * @param svg - The SVG element containing the D3 icicle.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const root = d3.partition().size([height, width])(
+ *   d3.hierarchy(data).sum(d => d.population),
+ * );
+ * svg.selectAll('rect.band').data(root.descendants().slice(1)).join('rect')…;
+ *
+ * bindD3Icicle(svgElement, {
+ *   selector: 'rect.band',
+ *   title: 'World population by region',
+ *   axes: { x: 'Region', y: 'Population, millions' },
+ * });
+ * ```
+ */
+export function bindD3Icicle(svg: Element, config: D3TreemapConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildTreemapLayer(svg, config, undefined, TraceType.ICICLE),
+  );
+}
+
+/**
+ * Pure extraction core for treemaps, sunbursts and icicles. See
+ * {@link buildBarLayer} for the single-chart vs multi-panel contract.
  *
  * The trailing `type` selects which layout the layer announces itself as; the
  * tree is the same for both (see {@link TreemapTraceType}).

--- a/src/adapters/d3/binders/treemap.ts
+++ b/src/adapters/d3/binders/treemap.ts
@@ -1,0 +1,321 @@
+/**
+ * D3 binder for treemaps and sunbursts.
+ *
+ * Extracts the tree a `d3.treemap()` or `d3.partition()` laid out and generates
+ * the MAIDR JSON schema for accessible interaction. Both layouts run over a
+ * `d3.hierarchy()`, so the datum bound to each mark is a hierarchy node — the
+ * binder recognises it and reads the node's value and its ancestor chain
+ * directly, the way the pie binder unwraps a `d3.pie()` arc.
+ */
+
+import type { MaidrLayer, TreemapPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3TreemapConfig, DataAccessor, TreemapTraceType } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessorOptional } from '../util';
+
+/**
+ * The node `d3.hierarchy()` wraps each of the caller's rows in: their own row
+ * under `data`, the total `.sum(...)` computed under `value`, and the tree
+ * itself reachable through `ancestors()`.
+ *
+ * `d3.treemap()` and `d3.partition()` add the node's rectangle (`x0`/`y0`/…)
+ * but change nothing here, which is why one interface serves both layouts.
+ */
+interface D3HierarchyNode {
+  data: unknown;
+  depth: number;
+  value?: number;
+  ancestors: () => D3HierarchyNode[];
+}
+
+/**
+ * Whether a bound datum is a `d3.hierarchy()` node rather than the caller's own
+ * row.
+ *
+ * Recognised by the shape the layout documents — `ancestors()` is the method
+ * the path is derived from, and testing for it means a hand-rolled object that
+ * merely happens to have a `data` key is not mistaken for a node.
+ *
+ * @param datum - The element's D3-bound datum
+ * @returns True when the datum is a hierarchy node
+ */
+function isHierarchyNode(datum: unknown): datum is D3HierarchyNode {
+  if (typeof datum !== 'object' || datum === null) {
+    return false;
+  }
+  return 'data' in datum
+    && 'depth' in datum
+    && typeof (datum as { ancestors?: unknown }).ancestors === 'function';
+}
+
+/**
+ * Reads what one node is called.
+ *
+ * Used for the node itself and for every ancestor of it, so the breadcrumb a
+ * reader is given several levels down names things exactly as the nodes do. A
+ * row that is a bare string or number names its own node, since a string
+ * accessor cannot address a primitive.
+ *
+ * @param row - The caller's own datum for this node
+ * @param accessor - The resolved name accessor
+ * @param index - Position of the mark in the selection, for the error message
+ * @returns The node's name
+ * @throws Error when the accessor resolves to nothing on an object row
+ */
+function resolveNodeName(
+  row: unknown,
+  accessor: DataAccessor<string | number>,
+  index: number,
+): string | number {
+  if (typeof accessor === 'string' && (row === null || typeof row !== 'object')) {
+    return typeof row === 'number' ? row : String(row);
+  }
+
+  const name = resolveAccessorOptional<string | number>(row, accessor, index);
+  if (name !== undefined && name !== null) {
+    return name;
+  }
+  const available = row !== null && typeof row === 'object'
+    ? ` Available properties: ${Object.keys(row as Record<string, unknown>).join(', ')}.`
+    : '';
+  throw new Error(
+    `The node at index ${index} (or one of its ancestors) has no name: the `
+    + `accessor resolved to nothing on it.${available} Pass an \`x\` accessor `
+    + `naming the property that carries it.`,
+  );
+}
+
+/**
+ * Reads a node's magnitude off the caller's own row.
+ *
+ * Reached only when the layout has no total to offer — a tree built by hand,
+ * or one whose `y` the caller named themselves. A row that is a bare number is
+ * its own magnitude, since a string accessor cannot address a primitive; a
+ * function accessor is always invoked, as it may be index-based.
+ *
+ * @param row - The caller's own datum for this node
+ * @param accessor - The resolved value accessor
+ * @param index - Position of the mark in the selection
+ * @returns The magnitude, or `undefined` when the row declares none
+ */
+function resolveNodeValue(
+  row: unknown,
+  accessor: DataAccessor<number>,
+  index: number,
+): number | undefined {
+  if (typeof accessor === 'string' && (row === null || typeof row !== 'object')) {
+    return typeof row === 'number' ? row : undefined;
+  }
+  return resolveAccessorOptional<number>(row, accessor, index);
+}
+
+/**
+ * Reads a node's declared ancestors off the caller's own row.
+ *
+ * Used for a tree that was NOT built with `d3.hierarchy()` — there is no
+ * ancestor chain to walk, so the path has to be declared. `path` is the
+ * canonical key and needs no config; anything else is named through the
+ * accessor. A row that is a bare string or number declares no ancestors, and
+ * is a top-level node.
+ *
+ * @param row - The caller's own datum for this node
+ * @param accessor - The user's `path` accessor, when they gave one
+ * @param index - Position of the mark in the selection
+ * @returns The ancestors, or `undefined` when the row declares none
+ */
+function resolvePath(
+  row: unknown,
+  accessor: DataAccessor<(string | number)[]> | undefined,
+  index: number,
+): (string | number)[] | undefined {
+  const resolved = accessor ?? 'path';
+  if (typeof resolved === 'string' && (row === null || typeof row !== 'object')) {
+    return undefined;
+  }
+  return resolveAccessorOptional<(string | number)[]>(row, resolved, index);
+}
+
+/**
+ * Binds a D3.js treemap to MAIDR, generating the accessible data representation.
+ *
+ * Point `selector` at the node marks — one `<rect>` per leaf for the canonical
+ * `d3.treemap()(root).leaves()` join. Every matched element becomes one point,
+ * in DOM order, and **nothing is filtered**: the interior nodes and their
+ * totals are derived from the paths, so selecting the leaves alone is a
+ * complete tree, and selecting more than you drew would leave the reader
+ * navigating nodes that highlight nothing.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 treemap.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const root = d3.treemap().size([w, h])(
+ *   d3.hierarchy(data).sum(d => d.population),
+ * );
+ * svg.selectAll('rect.leaf').data(root.leaves()).join('rect')…;
+ *
+ * bindD3Treemap(svgElement, {
+ *   selector: 'rect.leaf',
+ *   title: 'World population by region',
+ *   axes: { x: 'Region', y: 'Population, millions' },
+ * });
+ * ```
+ */
+export function bindD3Treemap(svg: Element, config: D3TreemapConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildTreemapLayer(svg, config));
+}
+
+/**
+ * Binds a D3.js sunburst to MAIDR.
+ *
+ * A sunburst is the same tree as a treemap drawn in polar coordinates, so the
+ * extraction is that of {@link bindD3Treemap}: `selector` matches the arc
+ * `<path>` elements a `d3.partition()` produced. The trace pans each node by
+ * its angle around the dial, which is what distinguishes a ring from a row of
+ * rectangles by ear.
+ *
+ * What differs in practice is *which* nodes are drawn: a partition lays out
+ * interior nodes as well as leaves, and `root.descendants()` includes the root
+ * itself. Whatever you joined is what the binder emits, so select exactly the
+ * arcs you drew.
+ *
+ * @param svg - The SVG element containing the D3 sunburst.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const root = d3.partition().size([2 * Math.PI, radius])(
+ *   d3.hierarchy(data).sum(d => d.population),
+ * );
+ * svg.selectAll('path.arc').data(root.descendants().slice(1)).join('path')…;
+ *
+ * bindD3Sunburst(svgElement, {
+ *   selector: 'path.arc',
+ *   title: 'World population by region',
+ *   axes: { x: 'Region', y: 'Population, millions' },
+ * });
+ * ```
+ */
+export function bindD3Sunburst(svg: Element, config: D3TreemapConfig): D3BinderResult {
+  return finalizeSingleChart(
+    svg,
+    config,
+    buildTreemapLayer(svg, config, undefined, TraceType.SUNBURST),
+  );
+}
+
+/**
+ * Pure extraction core for treemaps and sunbursts. See {@link buildBarLayer}
+ * for the single-chart vs multi-panel contract.
+ *
+ * The trailing `type` selects which layout the layer announces itself as; the
+ * tree is the same for both (see {@link TreemapTraceType}).
+ *
+ * @internal
+ */
+export function buildTreemapLayer(
+  root: Element,
+  config: D3TreemapConfig,
+  panel?: D3PanelScope,
+  type: TreemapTraceType = TraceType.TREEMAP,
+): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    y: yOverride,
+    path: pathOverride,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'treemap node');
+  }
+
+  // Infer accessors from the USER's first row, not from the hierarchy node
+  // wrapping it: the keys worth guessing (`name`, `value`, …) are the ones the
+  // caller wrote, and every node carries the same layout keys regardless.
+  const firstDatum = elements[0].datum;
+  const firstRow = isHierarchyNode(firstDatum) ? firstDatum.data : firstDatum;
+  const xAccessor = inferAccessor<string | number>(
+    config,
+    'x',
+    'name',
+    ['id', 'label', 'key', 'x'],
+    firstRow,
+  );
+  const yAccessor = inferAccessor<number>(
+    config,
+    'y',
+    'value',
+    ['size', 'count', 'amount', 'total', 'y'],
+    firstRow,
+  );
+
+  const data: TreemapPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const node = isHierarchyNode(datum) ? datum : null;
+    const row = node ? node.data : datum;
+
+    const point: TreemapPoint = {
+      x: resolveNodeName(row, xAccessor, index),
+    };
+
+    // `d3.hierarchy().sum(...)` has already totalled each node, and that total
+    // is what the rectangle's area was drawn from — so reading it back keeps
+    // the sonified magnitude identical to the mark on screen. An explicit `y`
+    // still wins: it is what binds a tree laid out by hand.
+    const value = node !== null && yOverride === undefined && typeof node.value === 'number'
+      ? node.value
+      : resolveNodeValue(row, yAccessor, index);
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      point.y = value;
+    }
+
+    // Root first and excluding the node itself, which is the order and the
+    // extent the grammar asks for. `ancestors()` runs the other way (self
+    // first, root last), hence the reverse before the trailing slice — it
+    // returns a fresh array each call, so reversing it in place is safe.
+    const path = node !== null && pathOverride === undefined
+      ? node.ancestors().reverse().slice(0, -1).map(ancestor => resolveNodeName(ancestor.data, xAccessor, index))
+      : resolvePath(row, pathOverride, index);
+    if (path !== undefined && path !== null && path.length > 0) {
+      point.path = path;
+    }
+
+    return point;
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type,
+    title,
+    // One scoped selector matching every mark: the trace indexes the matches by
+    // declaration order, gives the interior nodes it derived a hidden
+    // placeholder, and withdraws highlighting on a count mismatch rather than
+    // highlighting a neighbouring rectangle for the rest of the chart.
+    selectors: scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/binders/waterfall.ts
+++ b/src/adapters/d3/binders/waterfall.ts
@@ -1,0 +1,169 @@
+/**
+ * D3 binder for waterfall (bridge) charts.
+ *
+ * Extracts data from the floating bar each step is drawn as and generates the
+ * MAIDR JSON schema for accessible interaction. A waterfall bar is drawn
+ * between two running totals, so those two numbers are what the binder reads;
+ * the contribution the bar's height represents is derived from them.
+ */
+
+import type { MaidrLayer, WaterfallKind, WaterfallPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3WaterfallConfig } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor, resolveAccessorOptional } from '../util';
+
+/**
+ * Binds a D3.js waterfall chart to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at one element per step — the floating `<rect>` the bar is
+ * drawn as, or a `<g>` wrapping it and its label. The step's two running
+ * totals are read from the datum: `start` is where the bar's base sits and
+ * `end` where its top does, which is what a waterfall's `y` scale is already
+ * called with.
+ *
+ * **Mark the totals.** An opening, closing or subtotal bar is drawn exactly
+ * like a step but contributes nothing, and no amount of looking at the numbers
+ * reveals which bars those are — so pass a `kind` accessor for them. Without
+ * one they are announced as ordinary increases, and the chart's count of
+ * increases and decreases includes bars that changed nothing.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …" or "Property '…' not found on datum".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 waterfall chart.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * const result = bindD3Waterfall(svgElement, {
+ *   selector: 'rect.step',
+ *   title: 'Quarterly Budget Bridge',
+ *   axes: { x: 'Step', y: 'Amount (thousands)' },
+ *   x: 'label',
+ *   kind: d => (d.isTotal ? 'total' : undefined),
+ * });
+ * ```
+ */
+export function bindD3Waterfall(svg: Element, config: D3WaterfallConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildWaterfallLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for waterfall charts. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildWaterfallLayer(root: Element, config: D3WaterfallConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+    kind: kindAccessor,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'waterfall step');
+  }
+
+  // Infer accessors from the first datum's keys when the user did not specify.
+  const firstDatum = elements[0].datum;
+  const xAccessor = inferAccessor<string | number>(
+    config,
+    'x',
+    'x',
+    ['category', 'label', 'name', 'key', 'step'],
+    firstDatum,
+  );
+  const startAccessor = inferAccessor<number>(
+    config,
+    'start',
+    'start',
+    ['from', 'y0', 'base'],
+    firstDatum,
+  );
+  const endAccessor = inferAccessor<number>(
+    config,
+    'end',
+    'end',
+    ['to', 'y1', 'cumulative'],
+    firstDatum,
+  );
+
+  const data: WaterfallPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+    const start = Number(resolveAccessor<number>(datum, startAccessor, index));
+    const end = Number(resolveAccessor<number>(datum, endAccessor, index));
+    // Carried rather than left to the trace, because the two totals are what
+    // the bar was drawn from and their difference is what its height means.
+    const delta = end - start;
+
+    return {
+      x: resolveAccessor<string | number>(datum, xAccessor, index),
+      start,
+      end,
+      delta,
+      kind: resolveKind(datum, index, delta, kindAccessor),
+    };
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.WATERFALL,
+    title,
+    // One scoped selector matching every step: the trace maps them one-to-one
+    // onto the columns it navigates.
+    selectors: scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}
+
+/**
+ * Classifies a step: what the caller said it was, else what its contribution
+ * says.
+ *
+ * The sign answers it for every ordinary step, and for nothing else: a total
+ * is drawn like a step and contributes like one, so only the author can say
+ * which bars restate the running total rather than moving it. An accessor that
+ * returns `undefined` therefore falls back to the sign, which is what lets
+ * `d => (d.isTotal ? 'total' : undefined)` mark the totals alone.
+ *
+ * A step that moved nothing is called an increase of zero rather than a total,
+ * because "total" is a claim about the bar's role in the chart and a zero
+ * contribution is not evidence for it.
+ *
+ * @param datum - The datum bound to the step's element.
+ * @param index - The step's index, for accessor functions.
+ * @param delta - The step's signed contribution.
+ * @param accessor - The caller's `kind` accessor, when they gave one.
+ * @returns The step's kind.
+ */
+function resolveKind(
+  datum: unknown,
+  index: number,
+  delta: number,
+  accessor: D3WaterfallConfig['kind'],
+): WaterfallKind {
+  const declared = accessor === undefined
+    ? undefined
+    : resolveAccessorOptional<WaterfallKind | undefined>(datum, accessor, index);
+
+  return declared ?? (delta < 0 ? 'decrease' : 'increase');
+}

--- a/src/adapters/d3/binders/wordCloud.ts
+++ b/src/adapters/d3/binders/wordCloud.ts
@@ -1,0 +1,128 @@
+/**
+ * D3 binder for word clouds.
+ *
+ * Extracts each term and its weight from the `<text>` glyphs a cloud is drawn
+ * as — laid out by `d3-cloud` or by hand — and generates the MAIDR JSON schema
+ * for accessible interaction.
+ *
+ * The layout is deliberately not read. Where a term landed is a packing
+ * artefact rather than data, so the payload is the term and its weight alone:
+ * the weight is the one quantity a word cloud carries, and it is written down
+ * nowhere on the page.
+ */
+
+import type { MaidrLayer, WordCloudPoint } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3WordCloudConfig } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessor } from '../util';
+
+/**
+ * Binds a D3.js word cloud to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the `<text>` elements — one per term. The default
+ * accessors are `d3-cloud`'s own datum keys (`text` and `size`), since the
+ * plugin writes them onto every word it lays out; a cloud drawn from another
+ * shape names its keys through `x` / `y` as usual.
+ *
+ * The trace reads the terms heaviest first regardless of the order they are
+ * emitted in, and matches the glyphs to them by the same permutation — so the
+ * DOM order of the `<text>` elements (which for a cloud is packing order) does
+ * not have to mean anything.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** With `d3-cloud` that means inside
+ * the layout's `on('end', …)` callback: the words are placed asynchronously,
+ * so a binder called straight after `.start()` sees an empty SVG and throws
+ * "No elements found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 word cloud.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ *
+ * @example
+ * ```ts
+ * cloud()
+ *   .words(terms.map(t => ({ text: t.term, size: t.count })))
+ *   .on('end', words => {
+ *     svg.selectAll('text.term').data(words).join('text')…;
+ *     bindD3WordCloud(svgElement, {
+ *       selector: 'text.term',
+ *       title: 'Terms in the Abstracts',
+ *       axes: { x: 'Term', y: 'Occurrences' },
+ *     });
+ *   })
+ *   .start();
+ * ```
+ */
+export function bindD3WordCloud(svg: Element, config: D3WordCloudConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildWordCloudLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for word clouds. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildWordCloudLayer(root: Element, config: D3WordCloudConfig, panel?: D3PanelScope): D3BuiltLayer {
+  const {
+    title,
+    axes,
+    format,
+    selector,
+  } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'word cloud term');
+  }
+
+  // `text` and `size` are the canonical keys rather than `x` and `y` here:
+  // they are what `d3-cloud` binds, and a cloud laid out by anything else is
+  // the exception. Both fall back to the usual aliases, `x` / `y` included.
+  const firstDatum = elements[0].datum;
+  const xAccessor = inferAccessor<string>(
+    config,
+    'x',
+    'text',
+    ['word', 'term', 'label', 'name', 'x'],
+    firstDatum,
+  );
+  const yAccessor = inferAccessor<number | string>(
+    config,
+    'y',
+    'size',
+    ['value', 'weight', 'count', 'frequency', 'y'],
+    firstDatum,
+  );
+
+  const data: WordCloudPoint[] = elements.map(({ datum, index }) => {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+    return {
+      x: String(resolveAccessor<string>(datum, xAccessor, index)),
+      y: resolveAccessor<number | string>(datum, yAccessor, index),
+    };
+  });
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.WORD_CLOUD,
+    title,
+    // One scoped selector matching every glyph: the trace reorders them into
+    // weight order itself, and withdraws highlighting if the count does not
+    // match the terms rather than pairing them by guesswork.
+    selectors: scopeSelector(root, selector, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -25,6 +25,13 @@
  * - **Histograms** via {@link bindD3Histogram}
  * - **Candlestick charts** via {@link bindD3Candlestick}
  * - **Segmented bar charts** (stacked, dodged, normalized) via {@link bindD3Segmented}
+ * - **Diverging bars / population pyramids** via {@link bindD3Diverging}
+ * - **Error-bar / point-range charts** via {@link bindD3ErrorBar}
+ * - **Dumbbell charts** via {@link bindD3Dumbbell}
+ * - **Waterfall / bridge charts** via {@link bindD3Waterfall}
+ * - **Word clouds** via {@link bindD3WordCloud}
+ * - **Gauges and bullet charts** via {@link bindD3Gauge}
+ * - **Manhattan plots** via {@link bindD3Manhattan}
  * - **Smooth/regression curves** via {@link bindD3Smooth}
  *
  * ## Multi-Panel Charts
@@ -102,14 +109,19 @@ export { bindD3Area } from './binders/area';
 export { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/bar';
 export { bindD3Box } from './binders/box';
 export { bindD3Candlestick } from './binders/candlestick';
+export { bindD3Dumbbell } from './binders/dumbbell';
+export { bindD3ErrorBar } from './binders/errorBar';
+export { bindD3Gauge } from './binders/gauge';
 export { bindD3Heatmap } from './binders/heatmap';
 export { bindD3Histogram } from './binders/histogram';
 export { bindD3Bump, bindD3Line } from './binders/line';
 export { bindD3Pie } from './binders/pie';
-export { bindD3Scatter } from './binders/scatter';
-export { bindD3Segmented } from './binders/segmented';
+export { bindD3Manhattan, bindD3Scatter } from './binders/scatter';
+export { bindD3Diverging, bindD3Segmented } from './binders/segmented';
 export { bindD3Smooth } from './binders/smooth';
 export { bindD3Facets, bindD3Subplots } from './binders/subplots';
+export { bindD3Waterfall } from './binders/waterfall';
+export { bindD3WordCloud } from './binders/wordCloud';
 
 // Types
 export type {
@@ -121,10 +133,14 @@ export type {
   D3BinderResult,
   D3BoxConfig,
   D3CandlestickConfig,
+  D3DumbbellConfig,
+  D3ErrorBarConfig,
   D3FacetsConfig,
+  D3GaugeConfig,
   D3HeatmapConfig,
   D3HistogramConfig,
   D3LineConfig,
+  D3ManhattanConfig,
   D3MultiPanelResult,
   D3PanelChartSpec,
   D3PanelLayout,
@@ -134,7 +150,10 @@ export type {
   D3SmoothConfig,
   D3SubplotEntry,
   D3SubplotsConfig,
+  D3WaterfallConfig,
+  D3WordCloudConfig,
   DataAccessor,
   LineMarkTraceType,
+  ScatterMarkTraceType,
   SegmentedTraceType,
 } from './types';

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -46,6 +46,11 @@
  * - **Sankey diagrams** via {@link bindD3Sankey}
  * - **Alluvial diagrams** via {@link bindD3Alluvial}
  * - **Chord diagrams** via {@link bindD3Chord}
+ * - **Kaplan-Meier survival curves** via {@link bindD3Survival}
+ * - **Parallel coordinates plots** via {@link bindD3Parallel}
+ * - **Ridgeline / joy plots** via {@link bindD3Ridgeline}
+ * - **Hexbin density plots** via {@link bindD3Hexbin}
+ * - **Contour plots** via {@link bindD3Contour}
  * - **Smooth/regression curves** via {@link bindD3Smooth}
  *
  * ## Multi-Panel Charts
@@ -124,20 +129,25 @@ export { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/ba
 export { bindD3Box } from './binders/box';
 export { bindD3Boxen } from './binders/boxen';
 export { bindD3Candlestick } from './binders/candlestick';
+export { bindD3Contour } from './binders/contour';
 export { bindD3Dumbbell } from './binders/dumbbell';
 export { bindD3ErrorBar, bindD3Forest } from './binders/errorBar';
 export { bindD3Alluvial, bindD3Chord, bindD3Sankey } from './binders/flow';
 export { bindD3Gantt } from './binders/gantt';
 export { bindD3Gauge } from './binders/gauge';
 export { bindD3Heatmap } from './binders/heatmap';
+export { bindD3Hexbin } from './binders/hexbin';
 export { bindD3Histogram } from './binders/histogram';
 export { bindD3Bump, bindD3Line, bindD3Radar } from './binders/line';
 export { bindD3Network } from './binders/network';
+export { bindD3Parallel } from './binders/parallel';
 export { bindD3Pie, bindD3PolarArea } from './binders/pie';
+export { bindD3Ridgeline } from './binders/ridgeline';
 export { bindD3Manhattan, bindD3Scatter, bindD3Volcano } from './binders/scatter';
 export { bindD3Diverging, bindD3Mosaic, bindD3Segmented } from './binders/segmented';
 export { bindD3Smooth } from './binders/smooth';
 export { bindD3Facets, bindD3Subplots } from './binders/subplots';
+export { bindD3Survival } from './binders/survival';
 export { bindD3Icicle, bindD3Sunburst, bindD3Treemap } from './binders/treemap';
 export { bindD3Waterfall } from './binders/waterfall';
 export { bindD3WordCloud } from './binders/wordCloud';
@@ -153,6 +163,7 @@ export type {
   D3BoxConfig,
   D3BoxenConfig,
   D3CandlestickConfig,
+  D3ContourConfig,
   D3DumbbellConfig,
   D3ErrorBarConfig,
   D3FacetsConfig,
@@ -160,7 +171,9 @@ export type {
   D3ForestConfig,
   D3GanttConfig,
   D3GaugeConfig,
+  D3GridTransform,
   D3HeatmapConfig,
+  D3HexbinConfig,
   D3HistogramConfig,
   D3LineConfig,
   D3ManhattanConfig,
@@ -169,13 +182,16 @@ export type {
   D3NetworkConfig,
   D3PanelChartSpec,
   D3PanelLayout,
+  D3ParallelConfig,
   D3PieConfig,
   D3PolarAreaConfig,
+  D3RidgelineConfig,
   D3ScatterConfig,
   D3SegmentedConfig,
   D3SmoothConfig,
   D3SubplotEntry,
   D3SubplotsConfig,
+  D3SurvivalConfig,
   D3TreemapConfig,
   D3VolcanoConfig,
   D3WaterfallConfig,

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -22,14 +22,17 @@
  * - **Scatter plots** via {@link bindD3Scatter}
  * - **Heatmaps** via {@link bindD3Heatmap}
  * - **Box plots** via {@link bindD3Box}
+ * - **Boxen / letter-value plots** via {@link bindD3Boxen}
  * - **Histograms** via {@link bindD3Histogram}
  * - **Candlestick charts** via {@link bindD3Candlestick}
  * - **Segmented bar charts** (stacked, dodged, normalized) via {@link bindD3Segmented}
  * - **Diverging bars / population pyramids** via {@link bindD3Diverging}
  * - **Error-bar / point-range charts** via {@link bindD3ErrorBar}
+ * - **Forest plots** via {@link bindD3Forest}
  * - **Dumbbell charts** via {@link bindD3Dumbbell}
  * - **Waterfall / bridge charts** via {@link bindD3Waterfall}
  * - **Word clouds** via {@link bindD3WordCloud}
+ * - **Gantt / timeline / swimlane charts** via {@link bindD3Gantt}
  * - **Gauges and bullet charts** via {@link bindD3Gauge}
  * - **Manhattan plots** via {@link bindD3Manhattan}
  * - **Volcano plots** via {@link bindD3Volcano}
@@ -39,6 +42,10 @@
  * - **Force-directed networks** via {@link bindD3Network}
  * - **Treemaps** via {@link bindD3Treemap}
  * - **Sunbursts** via {@link bindD3Sunburst}
+ * - **Icicles** via {@link bindD3Icicle}
+ * - **Sankey diagrams** via {@link bindD3Sankey}
+ * - **Alluvial diagrams** via {@link bindD3Alluvial}
+ * - **Chord diagrams** via {@link bindD3Chord}
  * - **Smooth/regression curves** via {@link bindD3Smooth}
  *
  * ## Multi-Panel Charts
@@ -115,9 +122,12 @@ export { Orientation, TraceType } from '../../type/grammar';
 export { bindD3Area } from './binders/area';
 export { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/bar';
 export { bindD3Box } from './binders/box';
+export { bindD3Boxen } from './binders/boxen';
 export { bindD3Candlestick } from './binders/candlestick';
 export { bindD3Dumbbell } from './binders/dumbbell';
-export { bindD3ErrorBar } from './binders/errorBar';
+export { bindD3ErrorBar, bindD3Forest } from './binders/errorBar';
+export { bindD3Alluvial, bindD3Chord, bindD3Sankey } from './binders/flow';
+export { bindD3Gantt } from './binders/gantt';
 export { bindD3Gauge } from './binders/gauge';
 export { bindD3Heatmap } from './binders/heatmap';
 export { bindD3Histogram } from './binders/histogram';
@@ -128,7 +138,7 @@ export { bindD3Manhattan, bindD3Scatter, bindD3Volcano } from './binders/scatter
 export { bindD3Diverging, bindD3Mosaic, bindD3Segmented } from './binders/segmented';
 export { bindD3Smooth } from './binders/smooth';
 export { bindD3Facets, bindD3Subplots } from './binders/subplots';
-export { bindD3Sunburst, bindD3Treemap } from './binders/treemap';
+export { bindD3Icicle, bindD3Sunburst, bindD3Treemap } from './binders/treemap';
 export { bindD3Waterfall } from './binders/waterfall';
 export { bindD3WordCloud } from './binders/wordCloud';
 
@@ -141,10 +151,14 @@ export type {
   D3BinderConfig,
   D3BinderResult,
   D3BoxConfig,
+  D3BoxenConfig,
   D3CandlestickConfig,
   D3DumbbellConfig,
   D3ErrorBarConfig,
   D3FacetsConfig,
+  D3FlowConfig,
+  D3ForestConfig,
+  D3GanttConfig,
   D3GaugeConfig,
   D3HeatmapConfig,
   D3HistogramConfig,
@@ -167,6 +181,7 @@ export type {
   D3WaterfallConfig,
   D3WordCloudConfig,
   DataAccessor,
+  FlowTraceType,
   LineMarkTraceType,
   ScatterMarkTraceType,
   SegmentedTraceType,

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -32,6 +32,13 @@
  * - **Word clouds** via {@link bindD3WordCloud}
  * - **Gauges and bullet charts** via {@link bindD3Gauge}
  * - **Manhattan plots** via {@link bindD3Manhattan}
+ * - **Volcano plots** via {@link bindD3Volcano}
+ * - **Radar / spider charts** via {@link bindD3Radar}
+ * - **Polar area / coxcomb charts** via {@link bindD3PolarArea}
+ * - **Mosaic / marimekko plots** via {@link bindD3Mosaic}
+ * - **Force-directed networks** via {@link bindD3Network}
+ * - **Treemaps** via {@link bindD3Treemap}
+ * - **Sunbursts** via {@link bindD3Sunburst}
  * - **Smooth/regression curves** via {@link bindD3Smooth}
  *
  * ## Multi-Panel Charts
@@ -114,12 +121,14 @@ export { bindD3ErrorBar } from './binders/errorBar';
 export { bindD3Gauge } from './binders/gauge';
 export { bindD3Heatmap } from './binders/heatmap';
 export { bindD3Histogram } from './binders/histogram';
-export { bindD3Bump, bindD3Line } from './binders/line';
-export { bindD3Pie } from './binders/pie';
-export { bindD3Manhattan, bindD3Scatter } from './binders/scatter';
-export { bindD3Diverging, bindD3Segmented } from './binders/segmented';
+export { bindD3Bump, bindD3Line, bindD3Radar } from './binders/line';
+export { bindD3Network } from './binders/network';
+export { bindD3Pie, bindD3PolarArea } from './binders/pie';
+export { bindD3Manhattan, bindD3Scatter, bindD3Volcano } from './binders/scatter';
+export { bindD3Diverging, bindD3Mosaic, bindD3Segmented } from './binders/segmented';
 export { bindD3Smooth } from './binders/smooth';
 export { bindD3Facets, bindD3Subplots } from './binders/subplots';
+export { bindD3Sunburst, bindD3Treemap } from './binders/treemap';
 export { bindD3Waterfall } from './binders/waterfall';
 export { bindD3WordCloud } from './binders/wordCloud';
 
@@ -141,19 +150,25 @@ export type {
   D3HistogramConfig,
   D3LineConfig,
   D3ManhattanConfig,
+  D3MosaicConfig,
   D3MultiPanelResult,
+  D3NetworkConfig,
   D3PanelChartSpec,
   D3PanelLayout,
   D3PieConfig,
+  D3PolarAreaConfig,
   D3ScatterConfig,
   D3SegmentedConfig,
   D3SmoothConfig,
   D3SubplotEntry,
   D3SubplotsConfig,
+  D3TreemapConfig,
+  D3VolcanoConfig,
   D3WaterfallConfig,
   D3WordCloudConfig,
   DataAccessor,
   LineMarkTraceType,
   ScatterMarkTraceType,
   SegmentedTraceType,
+  TreemapTraceType,
 } from './types';

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -12,7 +12,12 @@
  * ## Supported Chart Types
  *
  * - **Bar charts** via {@link bindD3Bar}
+ * - **Dot plots** via {@link bindD3Dot}
+ * - **Lollipop charts** via {@link bindD3Lollipop}
+ * - **Funnel charts** via {@link bindD3Funnel}
  * - **Line charts** (single and multi-line) via {@link bindD3Line}
+ * - **Area charts** (plain, stacked, 100% stacked) via {@link bindD3Area}
+ * - **Bump / rank charts** via {@link bindD3Bump}
  * - **Pie and doughnut charts** via {@link bindD3Pie}
  * - **Scatter plots** via {@link bindD3Scatter}
  * - **Heatmaps** via {@link bindD3Heatmap}
@@ -93,12 +98,13 @@ export type { Maidr as MaidrData, MaidrLayer, MaidrSubplot } from '../../type/gr
 export { Orientation, TraceType } from '../../type/grammar';
 
 // Binder functions
-export { bindD3Bar } from './binders/bar';
+export { bindD3Area } from './binders/area';
+export { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/bar';
 export { bindD3Box } from './binders/box';
 export { bindD3Candlestick } from './binders/candlestick';
 export { bindD3Heatmap } from './binders/heatmap';
 export { bindD3Histogram } from './binders/histogram';
-export { bindD3Line } from './binders/line';
+export { bindD3Bump, bindD3Line } from './binders/line';
 export { bindD3Pie } from './binders/pie';
 export { bindD3Scatter } from './binders/scatter';
 export { bindD3Segmented } from './binders/segmented';
@@ -107,6 +113,9 @@ export { bindD3Facets, bindD3Subplots } from './binders/subplots';
 
 // Types
 export type {
+  AreaTraceType,
+  BarMarkTraceType,
+  D3AreaConfig,
   D3BarConfig,
   D3BinderConfig,
   D3BinderResult,
@@ -126,5 +135,6 @@ export type {
   D3SubplotEntry,
   D3SubplotsConfig,
   DataAccessor,
+  LineMarkTraceType,
   SegmentedTraceType,
 } from './types';

--- a/src/adapters/d3/selectors.ts
+++ b/src/adapters/d3/selectors.ts
@@ -94,3 +94,40 @@ export function selectorPrefix(container: Element, panel?: D3PanelScope): string
 export function scopeSelector(container: Element, selector: string, panel?: D3PanelScope): string {
   return `${selectorPrefix(container, panel)} ${selector}`;
 }
+
+/**
+ * Emits one selector per element, in the order given, by stamping each with a
+ * MAIDR-owned index attribute.
+ *
+ * For the traces whose payload order is the binder's own rather than the DOM's
+ * — a gantt nests its intervals by lane, a hexbin its bins by lattice row —
+ * a single selector matching every mark is worse than no selector at all: it
+ * resolves in DOM order, so the model pairs each announced datum with whatever
+ * mark sat at that position, and the counts still match so nothing detects it.
+ *
+ * The stamp is an attribute the binder owns rather than a structural
+ * `:nth-child(N)`, which any later DOM insertion would shift, and it is
+ * cleared before it is set so rebinding after a D3 data update leaves a clean
+ * state.
+ *
+ * @param container - The extraction root (the SVG, or a panel element).
+ * @param selector - The user-provided selector matching the marks.
+ * @param attribute - The `data-maidr-*` attribute to key the marks by.
+ * @param ordered - The elements, in the payload's order.
+ * @param panel - Optional panel scope for multi-panel binds.
+ * @returns One selector per element, in the same order.
+ */
+export function stampOrderedSelectors(
+  container: Element,
+  selector: string,
+  attribute: string,
+  ordered: Element[],
+  panel?: D3PanelScope,
+): string[] {
+  const prefix = selectorPrefix(container, panel);
+  return ordered.map((element, index) => {
+    element.removeAttribute(attribute);
+    element.setAttribute(attribute, String(index));
+    return `${prefix} ${selector}[${attribute}="${index}"]`;
+  });
+}

--- a/src/adapters/d3/selectors.ts
+++ b/src/adapters/d3/selectors.ts
@@ -106,9 +106,9 @@ export function scopeSelector(container: Element, selector: string, panel?: D3Pa
  * mark sat at that position, and the counts still match so nothing detects it.
  *
  * The stamp is an attribute the binder owns rather than a structural
- * `:nth-child(N)`, which any later DOM insertion would shift, and it is
- * cleared before it is set so rebinding after a D3 data update leaves a clean
- * state.
+ * `:nth-child(N)`, which any later DOM insertion would shift, and every stamp
+ * already under the root is cleared before the new ones are laid down so
+ * rebinding after a D3 data update leaves a clean state.
  *
  * @param container - The extraction root (the SVG, or a panel element).
  * @param selector - The user-provided selector matching the marks.
@@ -125,8 +125,19 @@ export function stampOrderedSelectors(
   panel?: D3PanelScope,
 ): string[] {
   const prefix = selectorPrefix(container, panel);
+
+  // Clear every stamp under this root before laying down the new ones.
+  // Clearing only the elements about to be re-stamped would leave a mark that
+  // has dropped out of the payload — a rebind after a D3 update that draws
+  // fewer bins, an `exit()` selection still in the DOM — carrying its old
+  // index, and the emitted `[attribute="N"]` selector would then resolve to
+  // two elements for one datum. Scoped to the root, so a panel never clears
+  // its siblings' stamps.
+  for (const stale of Array.from(container.querySelectorAll(`[${attribute}]`))) {
+    stale.removeAttribute(attribute);
+  }
+
   return ordered.map((element, index) => {
-    element.removeAttribute(attribute);
     element.setAttribute(attribute, String(index));
     return `${prefix} ${selector}[${attribute}="${index}"]`;
   });

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -9,10 +9,14 @@ import type {
   AxisConfig,
   AxisFormat,
   BarPoint,
+  BoxenPoint,
   BoxPoint,
   CandlestickPoint,
   DumbbellData,
   ErrorBarPoint,
+  FlowPoint,
+  ForestPoint,
+  GanttData,
   GaugeBand,
   GaugePoint,
   HeatmapData,
@@ -599,16 +603,272 @@ export interface D3NetworkConfig extends D3BinderConfig {
 }
 
 /**
+ * Trace types that share the flow extraction: one ribbon per weighted link,
+ * named by the pair of nodes it joins.
+ *
+ * A sankey runs its ribbons left to right, an alluvial repeats the node columns
+ * and a chord wraps them around a circle; all three are the same weighted graph,
+ * so all three are built by {@link buildFlowLayer} and differ only in the type
+ * the layer announces.
+ */
+export type FlowTraceType
+  = | typeof TraceType.ALLUVIAL
+    | typeof TraceType.CHORD
+    | typeof TraceType.SANKEY;
+
+/**
+ * Configuration for binding a D3 sankey, alluvial or chord diagram.
+ *
+ * Point `selector` at the **ribbons** — one `<path>` per link — rather than at
+ * the node rectangles: the nodes are derived from the links exactly as a
+ * network's are, so a link is what maps one-to-one onto the payload.
+ *
+ * `d3-sankey` **replaces** each link's `source` and `target` with the node
+ * objects it resolved them to, the way `d3.forceLink` does, so an object end is
+ * read through its `id`, `name`, `key` or `label`. `d3.chord()` is the one that
+ * needs help: its ends are the matrix's row and column **indices**, which is
+ * what {@link D3FlowConfig.names} is for.
+ *
+ * @example
+ * ```ts
+ * bindD3Sankey(svgElement, {
+ *   selector: 'path.ribbon',
+ *   axes: { x: 'Node', y: 'Petajoules' },
+ * });
+ * ```
+ */
+export interface D3FlowConfig extends D3BinderConfig {
+  /** CSS selector for the ribbon elements (e.g. `'path.ribbon'`). */
+  selector: string;
+  /**
+   * Accessor for the node a flow leaves. @default 'source', falling back to
+   * `from` or `src`. An object end is named through its `id`, `name`, `key` or
+   * `label`, or — for a chord — through {@link D3FlowConfig.names}.
+   */
+  source?: DataAccessor<unknown>;
+  /**
+   * Accessor for the node a flow arrives at. @default 'target', falling back
+   * to `to` or `dst`. Named the same way as {@link D3FlowConfig.source}.
+   */
+  target?: DataAccessor<unknown>;
+  /**
+   * Accessor for how much flows. @default 'value', falling back to `weight`,
+   * `amount`, `count`, or `y`. When the datum carries none of them, the
+   * magnitude `d3.chord()` put on each end (`d.source.value`) is used, which
+   * is what the ribbon's width was drawn from.
+   */
+  value?: DataAccessor<number>;
+  /**
+   * What the matrix's rows are called, in matrix order — the labels a chord
+   * diagram draws around the dial.
+   *
+   * `d3.chord()` binds `{ index, value, … }` to each end rather than a name,
+   * because a matrix has no names in it. Without this a chord announces its
+   * ends as the bare indices they are; with it, the reader is told which
+   * groups the ribbon joins.
+   */
+  names?: (string | number)[];
+}
+
+/**
+ * Configuration for binding a D3 gantt (timeline, swimlane) chart.
+ *
+ * Point `selector` at the interval marks — one `<rect>` per booked interval on
+ * a band scale of lanes. The binder groups them into lanes itself: the payload
+ * is nested by lane, and the DOM order a chart happens to draw in is not that
+ * grouping.
+ *
+ * **Dates are coerced to epoch milliseconds.** A `Date` or a date string is
+ * turned into a number so the trace can measure lengths at all; pair it with
+ * `format: { type: 'date' }` so the ends are announced as dates rather than as
+ * timestamps.
+ *
+ * @example
+ * ```ts
+ * bindD3Gantt(svgElement, {
+ *   selector: 'rect.task',
+ *   axes: { x: 'Day', y: 'Phase' },
+ *   x: 'phase',
+ *   start: 'from',
+ *   end: 'to',
+ *   label: 'task',
+ *   lanes: ['Design', 'Build', 'Review', 'Launch'],
+ *   unit: 'days',
+ * });
+ * ```
+ */
+export interface D3GanttConfig extends D3BinderConfig {
+  /** CSS selector for the interval elements (e.g. `'rect.task'`). */
+  selector: string;
+  /**
+   * Accessor for the lane an interval belongs to. @default 'x', falling back
+   * to `lane`, `category`, `label`, `name`, `key`, `group`, or `task`.
+   */
+  x?: DataAccessor<string | number | Date>;
+  /**
+   * Accessor for where the interval begins. @default 'start', falling back to
+   * `from`, `begin`, `x0`, or `startDate`.
+   */
+  start?: DataAccessor<number | string | Date>;
+  /**
+   * Accessor for where the interval ends. @default 'end', falling back to
+   * `to`, `finish`, `x1`, or `endDate`.
+   */
+  end?: DataAccessor<number | string | Date>;
+  /**
+   * Accessor for what the interval is called, when the lane is not already its
+   * name. @default 'label', falling back to `name`, `task`, `title`, or
+   * `activity`. Omitted from the payload when the datum carries none of them.
+   */
+  label?: DataAccessor<string>;
+  /**
+   * The lanes, in the order the chart draws them.
+   *
+   * Needed only for **empty** lanes: a lane with nothing booked has no element
+   * in the DOM at all, so the binder cannot discover it, and an empty row is a
+   * real statement about a schedule. Lanes carrying intervals name themselves
+   * and need no entry here; any the binder finds and this does not declare are
+   * appended in the order they were drawn.
+   */
+  lanes?: (string | number)[];
+  /** What a unit of the axis is called — `'days'`, `'hours'`, `'weeks'`. */
+  unit?: string;
+  /**
+   * Chart orientation. @default Orientation.HORIZONTAL — a gantt drawn the
+   * ordinary way runs its bars left to right, which puts the axis on x and the
+   * lanes on y. Pass `Orientation.VERTICAL` for a schedule drawn as columns.
+   */
+  orientation?: Orientation;
+}
+
+/**
+ * Configuration for binding a D3 boxen (letter-value) plot.
+ *
+ * Point `selector` at one element per distribution — the `<g>` holding the
+ * stack of nested rungs — the way {@link D3BoxConfig} points at a box group.
+ * Every rung of a distribution highlights that whole group, because a chart
+ * does not draw an element per quantile that MAIDR could pair up positionally.
+ *
+ * The ladder is read from the datum rather than measured off the rungs: a
+ * letter-value plot computes its quantiles before it draws them, and a height
+ * in pixels is a layout fact rather than a quantile.
+ *
+ * @example
+ * ```ts
+ * bindD3Boxen(svgElement, {
+ *   selector: 'g.boxen',
+ *   axes: { x: 'Group', y: 'Milliseconds' },
+ *   x: 'group',
+ *   median: 'median',
+ *   levels: 'letterValues',
+ * });
+ * ```
+ */
+export interface D3BoxenConfig extends D3BinderConfig {
+  /** CSS selector for the per-distribution elements (e.g. `'g.boxen'`). */
+  selector: string;
+  /**
+   * Accessor for the category the distribution summarises. @default 'x',
+   * falling back to `z`, `category`, `label`, `name`, `key`, or `group`.
+   */
+  x?: DataAccessor<string | number>;
+  /**
+   * Accessor for the middle of the distribution. @default 'median', falling
+   * back to `q2`, `mid`, or `y`.
+   */
+  median?: DataAccessor<number>;
+  /**
+   * Accessor for the ladder of quantile pairs — one entry per rung, each
+   * carrying the tail probability `p` and the pair of quantiles `lo` / `hi`
+   * (`lower` / `upper` are accepted too).
+   *
+   * @default 'levels', falling back to `letterValues`, `letter_values`,
+   * `quantiles`, or `ladder`. A rung whose three numbers are not all finite is
+   * dropped rather than announced as a quantile the data does not contain.
+   */
+  levels?: DataAccessor<unknown[]>;
+  /** Accessor for values below the deepest rung. @default 'lowerOutliers' */
+  lowerOutliers?: DataAccessor<number[]>;
+  /** Accessor for values above the deepest rung. @default 'upperOutliers' */
+  upperOutliers?: DataAccessor<number[]>;
+  /** Chart orientation. @default Orientation.VERTICAL */
+  orientation?: Orientation;
+}
+
+/**
+ * Configuration for binding a D3 forest plot.
+ *
+ * Extends {@link D3ErrorBarConfig} because a forest plot *is* a point-range
+ * chart: one row per study, an estimate and an interval read the same way. What
+ * it adds is the part a sighted reader takes from the drawing — how much each
+ * study weighs, which row is the pooled summary, and where the null line sits.
+ *
+ * The pooled row is usually a differently-shaped mark (a diamond `<path>`, not
+ * a whip), so it is selected separately with `pooledSelector` and appended
+ * after the studies. A chart that draws every row alike can instead mark it
+ * with the `pooled` accessor.
+ *
+ * @example
+ * ```ts
+ * bindD3Forest(svgElement, {
+ *   selector: 'g.study',
+ *   pooledSelector: 'path.pooled',
+ *   orientation: Orientation.HORIZONTAL,
+ *   axes: { x: 'Odds ratio', y: 'Study' },
+ *   x: 'study',
+ *   y: 'or',
+ *   yMin: 'ciLow',
+ *   yMax: 'ciHigh',
+ *   weight: 'weight',
+ *   nullValue: 1,
+ * });
+ * ```
+ */
+export interface D3ForestConfig extends D3ErrorBarConfig {
+  /**
+   * Accessor for the study's weight in the pooled estimate, as a fraction of
+   * one. @default 'weight', falling back to `w` or `share`. Omitted from the
+   * payload when the datum carries none of them — a forest plot without
+   * weights is a real chart.
+   */
+  weight?: DataAccessor<number>;
+  /**
+   * Accessor marking a row as the pooled summary rather than a study.
+   * @default 'pooled', falling back to `isPooled` or `summary`. Every row
+   * matched by `pooledSelector` is pooled regardless.
+   */
+  pooled?: DataAccessor<boolean>;
+  /**
+   * CSS selector for the pooled summary's own mark, when it is drawn
+   * differently from the studies — the diamond a meta-analysis ends with.
+   * Its rows are appended after the studies, in the order they are drawn.
+   */
+  pooledSelector?: string;
+  /**
+   * The value that means "no effect" — 1 for a ratio measure, 0 for a
+   * difference.
+   *
+   * Whether a study's interval crosses it is the result for that study, so the
+   * trace announces the crossing. There is deliberately **no default**: a ratio
+   * chart guessed at 0 would report every study as not crossing, which is a
+   * confident wrong answer given to every row.
+   */
+  nullValue?: number;
+}
+
+/**
  * Trace types that share the hierarchy extraction: one node per mark, named by
  * the path from the root down to it.
  *
- * A treemap lays the tree out as nested rectangles and a sunburst as concentric
- * arcs; the tree is the same, so both are built by {@link buildTreemapLayer}
- * and differ only in the type the layer announces — which is what makes the
- * sunburst pan by the node's angle around the dial.
+ * A treemap lays the tree out as nested rectangles, a sunburst as concentric
+ * arcs and an icicle as depth-ordered bands; the tree is the same, so all three
+ * are built by {@link buildTreemapLayer} and differ only in the type the layer
+ * announces — which is what makes the sunburst pan by the node's angle around
+ * the dial.
  */
 export type TreemapTraceType
-  = | typeof TraceType.SUNBURST
+  = | typeof TraceType.ICICLE
+    | typeof TraceType.SUNBURST
     | typeof TraceType.TREEMAP;
 
 /**
@@ -1002,18 +1262,24 @@ export interface D3BuiltLayer {
  * base of the React adapter's {@link D3AdapterSpec}.
  */
 export type D3PanelChartSpec
-  = | { chartType: 'area'; config: D3AreaConfig }
+  = | { chartType: 'alluvial'; config: D3FlowConfig }
+    | { chartType: 'area'; config: D3AreaConfig }
     | { chartType: 'bar'; config: D3BarConfig }
     | { chartType: 'box'; config: D3BoxConfig }
+    | { chartType: 'boxen'; config: D3BoxenConfig }
     | { chartType: 'bump'; config: D3LineConfig }
     | { chartType: 'candlestick'; config: D3CandlestickConfig }
+    | { chartType: 'chord'; config: D3FlowConfig }
     | { chartType: 'dot'; config: D3BarConfig }
     | { chartType: 'dumbbell'; config: D3DumbbellConfig }
     | { chartType: 'errorBar'; config: D3ErrorBarConfig }
+    | { chartType: 'forest'; config: D3ForestConfig }
     | { chartType: 'funnel'; config: D3BarConfig }
+    | { chartType: 'gantt'; config: D3GanttConfig }
     | { chartType: 'gauge'; config: D3GaugeConfig }
     | { chartType: 'heatmap'; config: D3HeatmapConfig }
     | { chartType: 'histogram'; config: D3HistogramConfig }
+    | { chartType: 'icicle'; config: D3TreemapConfig }
     | { chartType: 'line'; config: D3LineConfig }
     | { chartType: 'lollipop'; config: D3BarConfig }
     | { chartType: 'manhattan'; config: D3ManhattanConfig }
@@ -1022,6 +1288,7 @@ export type D3PanelChartSpec
     | { chartType: 'pie'; config: D3PieConfig }
     | { chartType: 'polarArea'; config: D3PolarAreaConfig }
     | { chartType: 'radar'; config: D3LineConfig }
+    | { chartType: 'sankey'; config: D3FlowConfig }
     | { chartType: 'scatter'; config: D3ScatterConfig }
     | { chartType: 'segmented'; config: D3SegmentedConfig }
     | { chartType: 'smooth'; config: D3SmoothConfig }
@@ -1140,10 +1407,14 @@ export interface D3MultiPanelResult {
  */
 export type D3ExtractedData
   = | BarPoint[]
+    | BoxenPoint[]
     | BoxPoint[]
     | CandlestickPoint[]
     | DumbbellData
     | ErrorBarPoint[]
+    | FlowPoint[]
+    | ForestPoint[]
+    | GanttData
     | GaugePoint
     | HeatmapData
     | HistogramPoint[]

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -86,7 +86,26 @@ export interface D3BinderConfig {
 export type DataAccessor<T> = string | ((datum: unknown, index: number) => T);
 
 /**
+ * Trace types that share the bar extraction: one category and one value per
+ * mark, read the same way whichever mark is drawn.
+ *
+ * A dot plot draws a point where a bar chart draws a bar, a lollipop adds a
+ * stem to the baseline, and a funnel draws its stages as trapezoids — none of
+ * which changes what a reader navigates, so all four are built by
+ * {@link buildBarLayer} and differ only in the type the layer announces.
+ */
+export type BarMarkTraceType
+  = | typeof TraceType.BAR
+    | typeof TraceType.DOT
+    | typeof TraceType.FUNNEL
+    | typeof TraceType.LOLLIPOP;
+
+/**
  * Configuration for binding a D3 bar chart.
+ *
+ * Also the config for the other three bar-family marks — {@link bindD3Dot},
+ * {@link bindD3Lollipop} and {@link bindD3Funnel} — which read the same
+ * `{ category, value }` datum off a different element.
  */
 export interface D3BarConfig extends D3BinderConfig {
   /** CSS selector for the bar elements (e.g., `'rect.bar'`, `'rect'`, `'path'`). */
@@ -119,6 +138,71 @@ export interface D3LineConfig extends D3BinderConfig {
   y?: DataAccessor<number>;
   /** Accessor for the series/fill label. @default 'fill' */
   fill?: DataAccessor<string>;
+}
+
+/**
+ * Trace types that share the line extraction: one series per path, one value
+ * per sample.
+ *
+ * An area fills the band under the line and a bump chart plots ranks instead
+ * of magnitudes; both are navigated as a multi-line grid, so all of them are
+ * built by {@link buildLineLayer} and differ only in the type the layer
+ * announces — which is what makes the trace read the values correctly (an
+ * area reports its stack total, a bump inverts its pitch).
+ */
+export type LineMarkTraceType
+  = | typeof TraceType.AREA
+    | typeof TraceType.BUMP
+    | typeof TraceType.LINE
+    | typeof TraceType.NORMALIZED_AREA
+    | typeof TraceType.STACKED_AREA;
+
+/**
+ * Area chart type: independent bands, stacked bands, or stacked bands scaled
+ * to a common whole.
+ */
+export type AreaTraceType
+  = | typeof TraceType.AREA
+    | typeof TraceType.NORMALIZED_AREA
+    | typeof TraceType.STACKED_AREA;
+
+/**
+ * Configuration for binding a D3 area chart (plain, stacked, or 100% stacked).
+ *
+ * Extends {@link D3LineConfig} because an area is a line with the band under
+ * it filled: `selector` matches one `<path>` per series, and the same
+ * accessors read each sample.
+ *
+ * Supports both common D3 patterns:
+ *
+ * 1. **Plain point arrays** — `d3.area()` over an array of `{ x, y }` rows,
+ *    one array bound per `<path>` (or per-point elements via `pointSelector`).
+ * 2. **`d3.stack()` output** — the datum bound to each `<path>` is the series
+ *    array itself, carrying `.key`, whose items are `[y0, y1]` tuples with a
+ *    `.data` back-reference to the row. The binder recognises that shape and
+ *    unwraps it: `x` is read from the row, `y` is the band's own height
+ *    (`y1 - y0`), and the series' `.key` becomes its name.
+ *
+ * In that second shape the two accessors address different objects, because
+ * that is where the two values live: `x` is resolved against the **row** —
+ * function accessors included, so write `d => d.year`, not `d => d.data.year`
+ * — while an explicit `y` is resolved against the **tuple**, keeping
+ * `d => d[1] - d[0]` and any custom offset expressible.
+ *
+ * @example
+ * ```ts
+ * // d3.stack() + d3.area().y0(d => y(d[0])).y1(d => y(d[1]))
+ * bindD3Area(svg, {
+ *   selector: 'path.area',
+ *   type: TraceType.STACKED_AREA,
+ *   axes: { x: 'Year', y: 'Revenue', fill: 'Product' },
+ *   x: 'year',   // a key on the stacked row, not on the [y0, y1] tuple
+ * });
+ * ```
+ */
+export interface D3AreaConfig extends D3LineConfig {
+  /** The type of area chart. @default TraceType.AREA */
+  type?: AreaTraceType;
 }
 
 /**
@@ -385,12 +469,17 @@ export interface D3BuiltLayer {
  * base of the React adapter's {@link D3AdapterSpec}.
  */
 export type D3PanelChartSpec
-  = | { chartType: 'bar'; config: D3BarConfig }
+  = | { chartType: 'area'; config: D3AreaConfig }
+    | { chartType: 'bar'; config: D3BarConfig }
     | { chartType: 'box'; config: D3BoxConfig }
+    | { chartType: 'bump'; config: D3LineConfig }
     | { chartType: 'candlestick'; config: D3CandlestickConfig }
+    | { chartType: 'dot'; config: D3BarConfig }
+    | { chartType: 'funnel'; config: D3BarConfig }
     | { chartType: 'heatmap'; config: D3HeatmapConfig }
     | { chartType: 'histogram'; config: D3HistogramConfig }
     | { chartType: 'line'; config: D3LineConfig }
+    | { chartType: 'lollipop'; config: D3BarConfig }
     | { chartType: 'pie'; config: D3PieConfig }
     | { chartType: 'scatter'; config: D3ScatterConfig }
     | { chartType: 'segmented'; config: D3SegmentedConfig }

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -11,6 +11,10 @@ import type {
   BarPoint,
   BoxPoint,
   CandlestickPoint,
+  DumbbellData,
+  ErrorBarPoint,
+  GaugeBand,
+  GaugePoint,
   HeatmapData,
   HistogramPoint,
   LinePoint,
@@ -22,6 +26,10 @@ import type {
   SegmentedPoint,
   SmoothPoint,
   TraceType,
+  VolcanoPoint,
+  WaterfallKind,
+  WaterfallPoint,
+  WordCloudPoint,
 } from '../../type/grammar';
 
 /**
@@ -218,6 +226,70 @@ export interface D3ScatterConfig extends D3BinderConfig {
 }
 
 /**
+ * Trace types that share the scatter extraction: one x and one y per point.
+ *
+ * A Manhattan plot is a scatter read almost entirely through a threshold —
+ * `-log10(p)` against genomic position — so it carries two things a scatter
+ * does not (what each point *is*, and which region it belongs to) but is
+ * extracted the same way, by {@link buildScatterLayer}.
+ */
+export type ScatterMarkTraceType
+  = | typeof TraceType.MANHATTAN
+    | typeof TraceType.SCATTER;
+
+/**
+ * Configuration for binding a D3 Manhattan plot.
+ *
+ * Extends {@link D3ScatterConfig} because the marks are the same: one element
+ * per point, with `x` the genomic position and `y` the transformed p-value.
+ * What it adds is the part of the chart a sighted reader takes from the labels
+ * and the colours — which SNP a point is, which chromosome it sits on, and
+ * where the significance line was drawn.
+ *
+ * @example
+ * ```ts
+ * bindD3Manhattan(svgElement, {
+ *   selector: 'circle.snp',
+ *   axes: { x: 'Position', y: '-log10(p)', fill: 'Chromosome' },
+ *   x: 'pos',
+ *   y: 'logP',
+ *   label: 'snp',
+ *   group: 'chromosome',
+ *   significance: 7.3,
+ * });
+ * ```
+ */
+export interface D3ManhattanConfig extends D3ScatterConfig {
+  /**
+   * Accessor for what each point *is* — a SNP id, a probe, a marker.
+   * @default 'label', falling back to `snp`, `id`, `name`, `gene`, or `probe`.
+   * Left out of the payload when the datum carries none of them.
+   */
+  label?: DataAccessor<string>;
+  /**
+   * Accessor for the region a point belongs to — its chromosome.
+   * @default 'group', falling back to `chromosome`, `chrom`, `chr`, or
+   * `region`. Left out of the payload when the datum carries none of them.
+   */
+  group?: DataAccessor<string>;
+  /**
+   * The significance cutoff on the y axis, on the axis the chart is drawn
+   * against — 7.3 for genome-wide significance on a `-log10(p)` axis.
+   *
+   * There is deliberately no default: the conventions differ by field and by
+   * software, and a guessed line would sort every point onto the wrong side
+   * silently. Omit it and the trace simply reports no findings.
+   */
+  significance?: number;
+  /**
+   * Which side of `significance` is the significant one. `'above'` (the
+   * default) suits the transformed axes these charts usually carry; a **raw p
+   * axis runs the other way** and needs `'below'`.
+   */
+  significanceDirection?: 'above' | 'below';
+}
+
+/**
  * Configuration for binding a D3 heatmap.
  */
 export interface D3HeatmapConfig extends D3BinderConfig {
@@ -311,12 +383,20 @@ export interface D3CandlestickConfig extends D3BinderConfig {
 }
 
 /**
- * Segmented bar chart type for stacked, dodged, or normalized.
+ * Trace types that share the segmented extraction: one category, one value and
+ * one series key per mark.
+ *
+ * A diverging bar chart (a population pyramid, a Likert scale) is two series
+ * drawn back to back rather than one on top of the other, which changes how the
+ * values are read but not how they are extracted — so it is built by
+ * {@link buildSegmentedLayer} like the other three, selected through
+ * `config.type`.
  */
 export type SegmentedTraceType
   = | typeof TraceType.STACKED
     | typeof TraceType.DODGED
-    | typeof TraceType.NORMALIZED;
+    | typeof TraceType.NORMALIZED
+    | typeof TraceType.DIVERGING;
 
 /**
  * Configuration for binding a D3 segmented bar chart (stacked, dodged, or normalized).
@@ -354,6 +434,15 @@ export interface D3SegmentedConfig extends D3BinderConfig {
   groupSelector?: string;
   /** The type of segmented chart. @default TraceType.STACKED */
   type?: SegmentedTraceType;
+  /**
+   * Chart orientation. Emitted only when given, so a chart that does not
+   * declare one is read the core's way (vertical).
+   *
+   * Set it for the charts that are drawn on their side — a population pyramid
+   * is the usual one: with `Orientation.HORIZONTAL`, `x` reads the (signed)
+   * value and `y` the category, which is the order the bars are drawn in.
+   */
+  orientation?: Orientation;
   /** Accessor for the x-axis (category) value. @default 'x' */
   x?: DataAccessor<string | number>;
   /** Accessor for the y-axis (numeric) value. @default 'y' */
@@ -441,6 +530,235 @@ export interface D3PieConfig extends D3BinderConfig {
 }
 
 /**
+ * Configuration for binding a D3 error-bar (point-range) chart.
+ *
+ * The canonical D3 idiom is one `<g>` per estimate holding a `<line>` for the
+ * interval and a marker for the estimate itself, so point `selector` at those
+ * groups — one matched element per estimate, whichever mark carries it.
+ *
+ * The bounds are **absolute positions** on the value axis, not half-widths.
+ * That is the one conversion this binder cannot do for you: a datum carrying
+ * `±se` needs a function accessor (`yMin: d => d.mean - d.se`), because the
+ * binder has no way to tell an offset from a bound by looking at it.
+ *
+ * @example
+ * ```ts
+ * bindD3ErrorBar(svgElement, {
+ *   selector: 'g.estimate',
+ *   axes: { x: 'Group', y: 'Response' },
+ *   x: 'group',
+ *   y: 'mean',
+ *   yMin: d => d.mean - 1.96 * d.se,
+ *   yMax: d => d.mean + 1.96 * d.se,
+ * });
+ * ```
+ */
+export interface D3ErrorBarConfig extends D3BinderConfig {
+  /** CSS selector for the per-estimate elements (e.g. `'g.estimate'`). */
+  selector: string;
+  /** Accessor for the x-axis (category) value. @default 'x' */
+  x?: DataAccessor<string | number>;
+  /**
+   * Accessor for the estimate itself. @default 'y', falling back to `value`,
+   * `mean`, `estimate`, or `median`.
+   */
+  y?: DataAccessor<number>;
+  /**
+   * Accessor for the interval's absolute lower bound. @default 'yMin',
+   * falling back to `lower`, `ciLow`, `ci_low`, `low`, or `min`. Omitted from
+   * the payload when the datum carries none of them — a one-sided interval is
+   * a real chart.
+   */
+  yMin?: DataAccessor<number>;
+  /**
+   * Accessor for the interval's absolute upper bound. @default 'yMax',
+   * falling back to `upper`, `ciHigh`, `ci_high`, `high`, or `max`.
+   */
+  yMax?: DataAccessor<number>;
+  /** Chart orientation. @default Orientation.VERTICAL */
+  orientation?: Orientation;
+}
+
+/**
+ * Configuration for binding a D3 dumbbell (connected-dot) chart.
+ *
+ * Point `selector` at the **connectors** — one `<line>` per row — rather than
+ * at the dots: a chart draws one segment per row and two dots, so the
+ * connectors are the elements that map one-to-one onto the data, and the
+ * trace highlights the same segment at both ends of a row.
+ *
+ * `startLabel` / `endLabel` are config rather than accessors because they
+ * belong to the chart and not to any one row — they are what the two dots are
+ * called ("1990" and "2020"), which is exactly what a legend gives a sighted
+ * reader and what the announcement would otherwise have to call "start" and
+ * "end".
+ *
+ * @example
+ * ```ts
+ * bindD3Dumbbell(svgElement, {
+ *   selector: 'line.connector',
+ *   orientation: Orientation.HORIZONTAL,
+ *   axes: { x: 'Years', y: 'Country' },
+ *   x: 'country',
+ *   start: 'y1990',
+ *   end: 'y2020',
+ *   startLabel: '1990',
+ *   endLabel: '2020',
+ * });
+ * ```
+ */
+export interface D3DumbbellConfig extends D3BinderConfig {
+  /** CSS selector for the connector elements (e.g. `'line.connector'`). */
+  selector: string;
+  /** Accessor for the category value. @default 'x' */
+  x?: DataAccessor<string | number>;
+  /**
+   * Accessor for the value the segment starts at. @default 'start',
+   * falling back to `from`, `before`, or `y0`.
+   */
+  start?: DataAccessor<number>;
+  /**
+   * Accessor for the value the segment ends at. @default 'end',
+   * falling back to `to`, `after`, or `y1`.
+   */
+  end?: DataAccessor<number>;
+  /** What the starting end is called — `'1990'`, `'before'`, `'control'`. */
+  startLabel?: string;
+  /** What the finishing end is called — `'2020'`, `'after'`, `'treatment'`. */
+  endLabel?: string;
+  /** Chart orientation. @default Orientation.VERTICAL */
+  orientation?: Orientation;
+}
+
+/**
+ * Configuration for binding a D3 waterfall (bridge) chart.
+ *
+ * A waterfall draws each step as a bar floating between the running total
+ * before it and the running total after it, so `start` and `end` are the two
+ * numbers the rect is already drawn from. The contribution (`delta`) is
+ * derived from them.
+ *
+ * `kind` is the one thing the binder cannot infer: an opening, closing or
+ * subtotal bar is drawn exactly like a step but contributes nothing, and only
+ * the author knows which bars those are. Supply the accessor for them; every
+ * other bar is classified from the sign of its contribution.
+ *
+ * @example
+ * ```ts
+ * bindD3Waterfall(svgElement, {
+ *   selector: 'rect.step',
+ *   axes: { x: 'Step', y: 'Amount' },
+ *   x: 'label',
+ *   kind: d => (d.isTotal ? 'total' : undefined),
+ * });
+ * ```
+ */
+export interface D3WaterfallConfig extends D3BinderConfig {
+  /** CSS selector for the per-step elements (e.g. `'rect.step'`). */
+  selector: string;
+  /** Accessor for the step's label. @default 'x' */
+  x?: DataAccessor<string | number>;
+  /**
+   * Accessor for the running total before the step. @default 'start',
+   * falling back to `from`, `y0`, or `base`.
+   */
+  start?: DataAccessor<number>;
+  /**
+   * Accessor for the running total after the step. @default 'end',
+   * falling back to `to`, `y1`, or `cumulative`.
+   */
+  end?: DataAccessor<number>;
+  /**
+   * Accessor marking a bar as an opening, closing or subtotal (`'total'`).
+   * Returning `undefined` falls back to the derived kind, so
+   * `d => (d.isTotal ? 'total' : undefined)` marks only the totals.
+   *
+   * When omitted, a step is an `'increase'` unless its contribution is
+   * negative, in which case it is a `'decrease'`.
+   */
+  kind?: DataAccessor<WaterfallKind | undefined>;
+}
+
+/**
+ * Configuration for binding a D3 word cloud.
+ *
+ * The layout — `d3-cloud`'s `cloud().words(...)`, or any other — is
+ * deliberately not read: where a term landed carries no data, so the payload
+ * is the term and its weight alone. Point `selector` at the `<text>` glyphs.
+ *
+ * The default accessors are `d3-cloud`'s own datum keys (`text` and `size`),
+ * since that is what all but hand-rolled clouds are laid out with.
+ *
+ * @example
+ * ```ts
+ * bindD3WordCloud(svgElement, {
+ *   selector: 'text.term',
+ *   axes: { x: 'Term', y: 'Occurrences' },
+ * });
+ * ```
+ */
+export interface D3WordCloudConfig extends D3BinderConfig {
+  /** CSS selector for the term elements (e.g. `'text.term'`). */
+  selector: string;
+  /**
+   * Accessor for the term. @default 'text', falling back to `word`,
+   * `term`, `label`, `name`, or `x`.
+   */
+  x?: DataAccessor<string>;
+  /**
+   * Accessor for the term's weight. @default 'size', falling back to
+   * `value`, `weight`, `count`, `frequency`, or `y`.
+   */
+  y?: DataAccessor<number | string>;
+}
+
+/**
+ * Configuration for binding a D3 gauge or bullet chart.
+ *
+ * A drawn gauge binds only the measure — the dial's range, the target marker
+ * and the qualitative bands are drawn from numbers the author holds and the
+ * DOM does not carry, which is why they are config rather than accessors.
+ * They are also the whole reading: "73" means nothing without the range it
+ * sits in, the target it was aiming at, and the band it lands in.
+ *
+ * Point `selector` at the needle, the value arc, or the bullet's measure bar
+ * — the mark that moves with the value.
+ *
+ * @example
+ * ```ts
+ * bindD3Gauge(svgElement, {
+ *   selector: 'rect.measure',
+ *   axes: { x: 'Measure', y: 'Percent' },
+ *   label: 'Conversion',
+ *   min: 0,
+ *   max: 100,
+ *   target: 80,
+ *   bands: [{ to: 50, label: 'poor' }, { to: 75, label: 'ok' }, { to: 100, label: 'good' }],
+ * });
+ * ```
+ */
+export interface D3GaugeConfig extends D3BinderConfig {
+  /** CSS selector for the needle or value arc (e.g. `'path.needle'`). */
+  selector: string;
+  /**
+   * Accessor for the measure. @default 'value', falling back to `y`,
+   * `amount`, `measure`, `current`, or `actual`. A datum that is a bare
+   * number is the measure itself.
+   */
+  value?: DataAccessor<number>;
+  /** Lower end of the dial. */
+  min: number;
+  /** Upper end of the dial. */
+  max: number;
+  /** What the measure is called — `'Conversion'`. */
+  label?: string;
+  /** The target marker a bullet chart draws, when it has one. */
+  target?: number;
+  /** Qualitative bands, in ascending order. */
+  bands?: GaugeBand[];
+}
+
+/**
  * Result of a D3 binder function.
  * Contains the complete MAIDR data structure and the generated layer
  * for further customization if needed.
@@ -475,15 +793,21 @@ export type D3PanelChartSpec
     | { chartType: 'bump'; config: D3LineConfig }
     | { chartType: 'candlestick'; config: D3CandlestickConfig }
     | { chartType: 'dot'; config: D3BarConfig }
+    | { chartType: 'dumbbell'; config: D3DumbbellConfig }
+    | { chartType: 'errorBar'; config: D3ErrorBarConfig }
     | { chartType: 'funnel'; config: D3BarConfig }
+    | { chartType: 'gauge'; config: D3GaugeConfig }
     | { chartType: 'heatmap'; config: D3HeatmapConfig }
     | { chartType: 'histogram'; config: D3HistogramConfig }
     | { chartType: 'line'; config: D3LineConfig }
     | { chartType: 'lollipop'; config: D3BarConfig }
+    | { chartType: 'manhattan'; config: D3ManhattanConfig }
     | { chartType: 'pie'; config: D3PieConfig }
     | { chartType: 'scatter'; config: D3ScatterConfig }
     | { chartType: 'segmented'; config: D3SegmentedConfig }
-    | { chartType: 'smooth'; config: D3SmoothConfig };
+    | { chartType: 'smooth'; config: D3SmoothConfig }
+    | { chartType: 'waterfall'; config: D3WaterfallConfig }
+    | { chartType: 'wordCloud'; config: D3WordCloudConfig };
 
 /**
  * Grid layout hint for multi-panel binds.
@@ -596,10 +920,16 @@ export type D3ExtractedData
   = | BarPoint[]
     | BoxPoint[]
     | CandlestickPoint[]
+    | DumbbellData
+    | ErrorBarPoint[]
+    | GaugePoint
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]
     | PiePoint[]
     | ScatterPoint[]
     | SegmentedPoint[][]
-    | SmoothPoint[][];
+    | SmoothPoint[][]
+    | VolcanoPoint[]
+    | WaterfallPoint[]
+    | WordCloudPoint[];

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -1472,6 +1472,7 @@ export type D3PanelChartSpec
     | { chartType: 'candlestick'; config: D3CandlestickConfig }
     | { chartType: 'chord'; config: D3FlowConfig }
     | { chartType: 'contour'; config: D3ContourConfig }
+    | { chartType: 'diverging'; config: D3SegmentedConfig }
     | { chartType: 'dot'; config: D3BarConfig }
     | { chartType: 'dumbbell'; config: D3DumbbellConfig }
     | { chartType: 'errorBar'; config: D3ErrorBarConfig }

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -20,12 +20,15 @@ import type {
   LinePoint,
   Maidr,
   MaidrLayer,
+  MosaicPoint,
+  NetworkPoint,
   Orientation,
   PiePoint,
   ScatterPoint,
   SegmentedPoint,
   SmoothPoint,
   TraceType,
+  TreemapPoint,
   VolcanoPoint,
   WaterfallKind,
   WaterfallPoint,
@@ -152,17 +155,19 @@ export interface D3LineConfig extends D3BinderConfig {
  * Trace types that share the line extraction: one series per path, one value
  * per sample.
  *
- * An area fills the band under the line and a bump chart plots ranks instead
- * of magnitudes; both are navigated as a multi-line grid, so all of them are
- * built by {@link buildLineLayer} and differ only in the type the layer
- * announces — which is what makes the trace read the values correctly (an
- * area reports its stack total, a bump inverts its pitch).
+ * An area fills the band under the line, a bump chart plots ranks instead of
+ * magnitudes, and a radar wraps the samples around a circle; all of them are
+ * navigated as a multi-line grid, so all of them are built by
+ * {@link buildLineLayer} and differ only in the type the layer announces —
+ * which is what makes the trace read the values correctly (an area reports its
+ * stack total, a bump inverts its pitch, a radar pans by the spoke's angle).
  */
 export type LineMarkTraceType
   = | typeof TraceType.AREA
     | typeof TraceType.BUMP
     | typeof TraceType.LINE
     | typeof TraceType.NORMALIZED_AREA
+    | typeof TraceType.RADAR
     | typeof TraceType.STACKED_AREA;
 
 /**
@@ -229,13 +234,15 @@ export interface D3ScatterConfig extends D3BinderConfig {
  * Trace types that share the scatter extraction: one x and one y per point.
  *
  * A Manhattan plot is a scatter read almost entirely through a threshold —
- * `-log10(p)` against genomic position — so it carries two things a scatter
- * does not (what each point *is*, and which region it belongs to) but is
- * extracted the same way, by {@link buildScatterLayer}.
+ * `-log10(p)` against genomic position — and a volcano is the same reading
+ * with effect size on the x axis. Both carry two things a scatter does not
+ * (what each point *is*, and which region it belongs to) but are extracted the
+ * same way, by {@link buildScatterLayer}.
  */
 export type ScatterMarkTraceType
   = | typeof TraceType.MANHATTAN
-    | typeof TraceType.SCATTER;
+    | typeof TraceType.SCATTER
+    | typeof TraceType.VOLCANO;
 
 /**
  * Configuration for binding a D3 Manhattan plot.
@@ -287,6 +294,40 @@ export interface D3ManhattanConfig extends D3ScatterConfig {
    * axis runs the other way** and needs `'below'`.
    */
   significanceDirection?: 'above' | 'below';
+}
+
+/**
+ * Configuration for binding a D3 volcano plot.
+ *
+ * Extends {@link D3ManhattanConfig} because the two are the same chart read
+ * the same way: `label` names the gene the way it names the SNP, and
+ * `significance` is the same cutoff on the same axis. What a volcano adds is
+ * the **second** cutoff — the x axis is an effect size rather than a position,
+ * so a point is a finding only when it clears both.
+ *
+ * @example
+ * ```ts
+ * bindD3Volcano(svgElement, {
+ *   selector: 'circle.gene',
+ *   axes: { x: 'log2 fold change', y: '-log10(p)' },
+ *   x: 'lfc',
+ *   y: 'logP',
+ *   label: 'gene',
+ *   significance: 1.3,
+ *   effect: 1,
+ * });
+ * ```
+ */
+export interface D3VolcanoConfig extends D3ManhattanConfig {
+  /**
+   * The effect-size cutoff on the x axis, applied to its **magnitude** — a
+   * volcano is symmetric, and a fold change of -2 is as large an effect as
+   * one of +2.
+   *
+   * Like `significance`, there is no default: the conventions differ by field,
+   * and a guessed line would sort every gene onto the wrong side silently.
+   */
+  effect?: number;
 }
 
 /**
@@ -391,12 +432,17 @@ export interface D3CandlestickConfig extends D3BinderConfig {
  * values are read but not how they are extracted — so it is built by
  * {@link buildSegmentedLayer} like the other three, selected through
  * `config.type`.
+ *
+ * A mosaic is a stacked bar whose column widths carry a second magnitude. That
+ * width is the one thing the segmented extraction does not already read, so a
+ * mosaic is the same core with two extra accessors ({@link D3MosaicConfig}).
  */
 export type SegmentedTraceType
   = | typeof TraceType.STACKED
     | typeof TraceType.DODGED
     | typeof TraceType.NORMALIZED
-    | typeof TraceType.DIVERGING;
+    | typeof TraceType.DIVERGING
+    | typeof TraceType.MOSAIC;
 
 /**
  * Configuration for binding a D3 segmented bar chart (stacked, dodged, or normalized).
@@ -470,6 +516,154 @@ export interface D3SegmentedConfig extends D3BinderConfig {
 }
 
 /**
+ * Configuration for binding a D3 mosaic (marimekko) plot.
+ *
+ * Extends {@link D3SegmentedConfig} because a mosaic *is* a stacked bar: same
+ * `<rect>` per cell, same `{ x, y, fill }` extraction, same DOM-order
+ * detection. What it adds is the column **width**, which on every other chart
+ * is how the bars were drawn and here is the second magnitude the plot exists
+ * to show — a category of six people and one of six hundred read identically
+ * without it.
+ *
+ * The width is read from the datum, never measured off the rendered `<rect>`:
+ * a drawn width is a layout fact (padding, margins, a log scale) and turning
+ * it back into a proportion would announce a number the data does not contain.
+ *
+ * @example
+ * ```ts
+ * bindD3Mosaic(svgElement, {
+ *   selector: 'rect.cell',
+ *   axes: { x: 'Class', y: 'Proportion', fill: 'Outcome' },
+ *   x: 'klass',
+ *   y: 'share',
+ *   fill: 'outcome',
+ *   width: 'columnShare',
+ *   count: 'n',
+ * });
+ * ```
+ */
+export interface D3MosaicConfig extends D3SegmentedConfig {
+  /**
+   * Accessor for the column's share of all observations, as a fraction of one.
+   * @default 'width', falling back to `share`, `proportion`, or `marginal`.
+   * Omitted from the payload when the datum carries none of them, and when the
+   * value read is not a finite number.
+   */
+  width?: DataAccessor<number>;
+  /**
+   * Accessor for the cell's own count, when the producer has the contingency
+   * table the mosaic was drawn from.
+   * @default 'count', falling back to `n`, `freq`, or `frequency`. Omitted
+   * from the payload when absent — a count multiplied out of a rounded share
+   * is a number the data does not contain.
+   */
+  count?: DataAccessor<number>;
+}
+
+/**
+ * Configuration for binding a D3 force-directed network.
+ *
+ * Point `selector` at the **links** — one `<line>` per edge — rather than at
+ * the node circles: the nodes are derived from the links, so a link is what
+ * maps one-to-one onto the payload, and it is what the chart draws between a
+ * pair of nodes.
+ *
+ * Positions are deliberately not read. Where a force-directed node lands is a
+ * fact about the solver's seed rather than about the data.
+ *
+ * @example
+ * ```ts
+ * bindD3Network(svgElement, {
+ *   selector: 'line.link',
+ *   axes: { x: 'Person', y: 'Links' },
+ * });
+ * ```
+ */
+export interface D3NetworkConfig extends D3BinderConfig {
+  /** CSS selector for the link elements (e.g. `'line.link'`). */
+  selector: string;
+  /**
+   * Accessor for the node a link leaves. @default 'source', falling back to
+   * `from` or `src`.
+   *
+   * `d3.forceLink` **replaces** each link's `source` with the node object it
+   * resolved the id to, so the resolved value is normalised either way: an
+   * object end is read through its `id`, `name`, `key` or `label`.
+   */
+  source?: DataAccessor<unknown>;
+  /**
+   * Accessor for the node a link arrives at. @default 'target', falling back
+   * to `to` or `dst`. Normalised the same way as {@link D3NetworkConfig.source}.
+   */
+  target?: DataAccessor<unknown>;
+}
+
+/**
+ * Trace types that share the hierarchy extraction: one node per mark, named by
+ * the path from the root down to it.
+ *
+ * A treemap lays the tree out as nested rectangles and a sunburst as concentric
+ * arcs; the tree is the same, so both are built by {@link buildTreemapLayer}
+ * and differ only in the type the layer announces — which is what makes the
+ * sunburst pan by the node's angle around the dial.
+ */
+export type TreemapTraceType
+  = | typeof TraceType.SUNBURST
+    | typeof TraceType.TREEMAP;
+
+/**
+ * Configuration for binding a D3 treemap or sunburst.
+ *
+ * The canonical layout is `d3.treemap()` / `d3.partition()` over a
+ * `d3.hierarchy()`, so the datum bound to each mark is a **hierarchy node**:
+ * the binder recognises it and reads the node's own `value` plus its ancestor
+ * chain, exactly as the pie binder unwraps a `d3.pie()` arc. Both accessors
+ * are then read against YOUR datum (`node.data`), not against the node.
+ *
+ * Every matched element becomes one point, in DOM order — nothing is filtered.
+ * A treemap draws only its leaves and a sunburst draws its interior nodes too;
+ * whichever you select is what the reader navigates, and the counts have to
+ * match for highlighting to survive.
+ *
+ * @example
+ * ```ts
+ * // svg.selectAll('rect.leaf').data(d3.treemap()(root).leaves())
+ * bindD3Treemap(svgElement, {
+ *   selector: 'rect.leaf',
+ *   axes: { x: 'Region', y: 'Population, millions' },
+ * });
+ * ```
+ */
+export interface D3TreemapConfig extends D3BinderConfig {
+  /** CSS selector for the node elements (e.g. `'rect.leaf'`, `'path.arc'`). */
+  selector: string;
+  /**
+   * Accessor for the node's own name, read against your datum.
+   * @default 'name', falling back to `id`, `label`, `key`, or `x`. A datum
+   * that is a bare string or number names its own node.
+   *
+   * The same accessor names every ancestor when `path` is derived, so the
+   * breadcrumb and the node agree about what things are called.
+   */
+  x?: DataAccessor<string | number>;
+  /**
+   * Accessor for the node's magnitude. Defaults to the `value` that
+   * `d3.hierarchy().sum(...)` computed — which is what the rectangle's area
+   * was drawn from — falling back to `value` or `size` on your datum.
+   */
+  y?: DataAccessor<number>;
+  /**
+   * Accessor for the node's ancestors, root first and **excluding the node
+   * itself**. Defaults to the hierarchy node's own ancestor chain, so a layout
+   * built with `d3.hierarchy()` needs nothing here.
+   *
+   * Supply it for a tree drawn without `d3.hierarchy()`: `[]` (or an omitted
+   * value) marks a top-level node.
+   */
+  path?: DataAccessor<(string | number)[]>;
+}
+
+/**
  * Configuration for binding a D3 smooth/regression curve.
  */
 export interface D3SmoothConfig extends D3BinderConfig {
@@ -528,6 +722,27 @@ export interface D3PieConfig extends D3BinderConfig {
     y?: D3AxisInput;
   };
 }
+
+/**
+ * Configuration for binding a D3 polar area (coxcomb, rose) chart.
+ *
+ * The wedges are drawn the way a pie's are — `d3.arc()` per category, usually
+ * over `d3.pie()` output — so this is {@link D3PieConfig} verbatim, and the
+ * binder unwraps the layout's arc for you the same way. What differs is what
+ * the wedge encodes: a polar area gives every category the same angle and
+ * varies the **radius**, so the values are read as a series around the spokes
+ * rather than as shares of a whole.
+ *
+ * @example
+ * ```ts
+ * bindD3PolarArea(svgElement, {
+ *   selector: 'path.wedge',
+ *   axes: { x: 'Month', y: 'Deaths' },
+ *   x: 'month',
+ * });
+ * ```
+ */
+export type D3PolarAreaConfig = D3PieConfig;
 
 /**
  * Configuration for binding a D3 error-bar (point-range) chart.
@@ -802,10 +1017,17 @@ export type D3PanelChartSpec
     | { chartType: 'line'; config: D3LineConfig }
     | { chartType: 'lollipop'; config: D3BarConfig }
     | { chartType: 'manhattan'; config: D3ManhattanConfig }
+    | { chartType: 'mosaic'; config: D3MosaicConfig }
+    | { chartType: 'network'; config: D3NetworkConfig }
     | { chartType: 'pie'; config: D3PieConfig }
+    | { chartType: 'polarArea'; config: D3PolarAreaConfig }
+    | { chartType: 'radar'; config: D3LineConfig }
     | { chartType: 'scatter'; config: D3ScatterConfig }
     | { chartType: 'segmented'; config: D3SegmentedConfig }
     | { chartType: 'smooth'; config: D3SmoothConfig }
+    | { chartType: 'sunburst'; config: D3TreemapConfig }
+    | { chartType: 'treemap'; config: D3TreemapConfig }
+    | { chartType: 'volcano'; config: D3VolcanoConfig }
     | { chartType: 'waterfall'; config: D3WaterfallConfig }
     | { chartType: 'wordCloud'; config: D3WordCloudConfig };
 
@@ -926,10 +1148,13 @@ export type D3ExtractedData
     | HeatmapData
     | HistogramPoint[]
     | LinePoint[][]
+    | MosaicPoint[][]
+    | NetworkPoint[]
     | PiePoint[]
     | ScatterPoint[]
     | SegmentedPoint[][]
     | SmoothPoint[][]
+    | TreemapPoint[]
     | VolcanoPoint[]
     | WaterfallPoint[]
     | WordCloudPoint[];

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -160,11 +160,12 @@ export interface D3LineConfig extends D3BinderConfig {
  * per sample.
  *
  * An area fills the band under the line, a bump chart plots ranks instead of
- * magnitudes, and a radar wraps the samples around a circle; all of them are
- * navigated as a multi-line grid, so all of them are built by
- * {@link buildLineLayer} and differ only in the type the layer announces —
- * which is what makes the trace read the values correctly (an area reports its
- * stack total, a bump inverts its pitch, a radar pans by the spoke's angle).
+ * magnitudes, a radar wraps the samples around a circle, and a survival curve
+ * steps down them; all of them are navigated as a multi-line grid, so all of
+ * them are built by {@link buildLineLayer} and differ only in the type the
+ * layer announces — which is what makes the trace read the values correctly
+ * (an area reports its stack total, a bump inverts its pitch, a radar pans by
+ * the spoke's angle, a survival curve finds its median).
  */
 export type LineMarkTraceType
   = | typeof TraceType.AREA
@@ -172,7 +173,8 @@ export type LineMarkTraceType
     | typeof TraceType.LINE
     | typeof TraceType.NORMALIZED_AREA
     | typeof TraceType.RADAR
-    | typeof TraceType.STACKED_AREA;
+    | typeof TraceType.STACKED_AREA
+    | typeof TraceType.SURVIVAL;
 
 /**
  * Area chart type: independent bands, stacked bands, or stacked bands scaled
@@ -1234,6 +1236,205 @@ export interface D3GaugeConfig extends D3BinderConfig {
 }
 
 /**
+ * Configuration for binding a D3 Kaplan-Meier survival curve.
+ *
+ * A survival curve is a step line — `d3.line().curve(d3.curveStepAfter)` over
+ * one `<path>` per arm — so `selector`, `pointSelector` and the `x`/`y`/`fill`
+ * accessors are {@link D3LineConfig}'s, unchanged. What a survival figure
+ * carries beyond a step chart is the two things it is read for: which times
+ * were **censored**, and how wide the **confidence band** is.
+ *
+ * Censoring marks are drawn as ticks from their own data join, not as vertices
+ * of the curve, so they are usually a separate selection: point
+ * `censoredSelector` at them and the binder merges each tick into its arm by
+ * time — flagging the vertex already at that time, or inserting one carrying
+ * the probability the curve holds there. When the curve's own samples already
+ * say (a `censored` column), leave `censoredSelector` unset and let the
+ * `censored` accessor read it.
+ */
+export interface D3SurvivalConfig extends D3LineConfig {
+  /**
+   * Accessor for whether a sample is a censored time. @default 'censored',
+   * falling back to `censor` or `isCensored`. `true`, `1`, `'1'` and `'true'`
+   * count as censored; anything else does not.
+   *
+   * Deliberately NOT aliased to `event`, which most survival datasets carry
+   * with the opposite meaning — a 1 there is the event happening, which is
+   * exactly the times that are not censored.
+   */
+  censored?: DataAccessor<unknown>;
+  /**
+   * CSS selector for the censoring tick marks, when the chart draws them from
+   * a separate data join (e.g. `'line.censor'`). Each tick is merged into the
+   * arm its `fill` names — or the only arm, on a single-curve chart — at the
+   * time its `x` gives.
+   */
+  censoredSelector?: string;
+  /** Accessor for the confidence band's lower bound. @default 'yMin', falling back to `lower`, `lo`, `ciLower` or `low`. */
+  yMin?: DataAccessor<number>;
+  /** Accessor for the confidence band's upper bound. @default 'yMax', falling back to `upper`, `hi`, `ciUpper` or `high`. */
+  yMax?: DataAccessor<number>;
+}
+
+/**
+ * Configuration for binding a D3 parallel coordinates plot.
+ *
+ * The chart draws one `<path>` (or `<polyline>`) per **observation** across
+ * several per-variable scales, and the datum bound to it is that observation
+ * as a whole — `{ mpg: 21, hp: 110, weight: 2600 }`. The layer's rows are the
+ * observations and its columns are the axes, so the binder transposes: for
+ * each observation it emits one point per entry of `dimensions`, whose `x` is
+ * the axis' name and whose `y` is that observation's value on it.
+ *
+ * `dimensions` is required, and is the same list the chart already built one
+ * scale per: the order is the order the axes are drawn in, which is the order
+ * a reader arrows through them. Nothing on the datum says it — an object's key
+ * order is not an axis order — and a guessed one would announce the chart's
+ * columns in the wrong places.
+ */
+export interface D3ParallelConfig extends D3BinderConfig {
+  /**
+   * CSS selector for the observation paths (e.g. `'path.observation'`,
+   * `'polyline.line'`). Each matched element is one observation.
+   */
+  selector: string;
+  /** The axes, in the order they are drawn. Each is a key on the observation. */
+  dimensions: string[];
+  /**
+   * Reads one dimension off an observation. Defaults to a plain property
+   * lookup — supply this when the values are nested (`d.values[dimension]`)
+   * or need converting.
+   */
+  value?: (datum: unknown, dimension: string, index: number) => number;
+  /**
+   * Accessor for the observation's name, announced as its series name.
+   * @default 'name', falling back to `label`, `id`, `key`, `group` or `fill`.
+   */
+  label?: DataAccessor<string>;
+}
+
+/**
+ * Configuration for binding a D3 ridgeline (joy) plot.
+ *
+ * One `d3.area()` density curve per group, the curves offset down the page so
+ * their shapes can be compared. `selector` matches one `<path>` per group, and
+ * the samples come from that path's own bound array.
+ *
+ * **`density` is the curve's own half-width, never the drawn y.** A ridgeline
+ * is drawn by adding the group's baseline to every density, and that baseline
+ * is layout rather than data: fed to MAIDR it would make every group's
+ * loudness a function of where it happened to be stacked, and the lowest ridge
+ * the loudest. So the binder reads the kernel-density value the chart computed
+ * before* offsetting it, and refuses to guess when the samples do not carry
+ * one.
+ *
+ * The fields are named for what they mean rather than for the payload keys
+ * they land on, because a ridgeline's value axis is usually the drawn `x`
+ * while the payload's `y` is that same value: `group` names the ridge,
+ * `value` is the position along the value axis, `density` is the height there.
+ */
+export interface D3RidgelineConfig extends D3BinderConfig {
+  /** CSS selector for the group curves (e.g. `'path.ridge'`). One per group. */
+  selector: string;
+  /**
+   * Accessor for the sample array, when the path's datum wraps it rather than
+   * being it. Defaults to the datum itself when it is an array, the second
+   * item of a `d3.groups()` tuple, or a `values` / `samples` / `points` /
+   * `curve` property.
+   */
+  samples?: DataAccessor<unknown[]>;
+  /**
+   * Accessor for the group's name, resolved against the path's datum.
+   * @default 'group', falling back to `key`, `name`, `x`, `label` or
+   * `category`; then to the group's ordinal when the datum names nothing.
+   */
+  group?: DataAccessor<string | number>;
+  /**
+   * Accessor for a sample's position along the value axis.
+   * @default 'value', falling back to `x`, `t` or `position`.
+   */
+  value?: DataAccessor<number>;
+  /**
+   * Accessor for the curve's own half-width at a sample — the density before
+   * the group's baseline was added.
+   * @default 'density', falling back to `kde`, `width`, `p` or `estimate`.
+   */
+  density?: DataAccessor<number>;
+}
+
+/**
+ * Configuration for binding a D3 hexbin density plot.
+ *
+ * The `d3-hexbin` plugin returns one bin per occupied hexagon, and each bin is
+ * an **array** of the points that fell in it, carrying `.x` and `.y` (the
+ * hexagon's centre, in SCREEN space) and `.length` (the count). So the default
+ * accessors read `x`, `y` and `length` off the bin, and `x`/`y` are where the
+ * inverse scales go: `x: d => xScale.invert(d.x)`. Passing the screen
+ * coordinates through unchanged would announce every bin's position in pixels.
+ *
+ * The payload is a lattice of rows, which the binder assembles itself: a
+ * hexbin's DOM is a flat list in whatever order the bins were generated, and
+ * an empty bin is simply absent from it. Rows are grouped by the bins' `y`
+ * (override with `row` when the y values do not come out identical per row),
+ * ordered from the lowest upward, and each row is ordered left to right.
+ */
+export interface D3HexbinConfig extends D3BinderConfig {
+  /** CSS selector for the hexagons (e.g. `'path.hexagon'`). One per bin. */
+  selector: string;
+  /** Accessor for the bin's centre along the x axis. @default 'x', falling back to `x0` or `cx`. */
+  x?: DataAccessor<number>;
+  /** Accessor for the bin's centre along the y axis. @default 'y', falling back to `y0` or `cy`. */
+  y?: DataAccessor<number>;
+  /** Accessor for how many points fell in the bin. @default 'count', falling back to `length`, `value`, `n` or `total`. */
+  count?: DataAccessor<number>;
+  /**
+   * Accessor for the lattice row a bin belongs to. Supply this only when the
+   * bins' `y` centres do not come out identical within a row — `d3-hexbin`'s
+   * do, so the default grouping by `y` is normally right.
+   */
+  row?: DataAccessor<number | string>;
+}
+
+/**
+ * Maps one coordinate of a contour's grid onto the data axis it stands for.
+ *
+ * Not a {@link DataAccessor}: the input is a single number from a coordinate
+ * pair, not a bound datum, and there is no element index to pass.
+ */
+export type D3GridTransform = (gridCoordinate: number) => number;
+
+/**
+ * Configuration for binding a D3 contour plot.
+ *
+ * `d3.contours()` and `d3.contourDensity()` emit one GeoJSON `MultiPolygon`
+ * per threshold, carrying the threshold as `.value`, so `selector` matches one
+ * `<path>` per level and the layer's rows are the levels.
+ *
+ * **The coordinates are not in data space.** `d3.contours()` emits grid
+ * indices and `d3.contourDensity()` emits pixels, so `x` and `y` are the
+ * transforms back onto the axes — `x: i => x0 + i * dx` for the former,
+ * `x: px => xScale.invert(px)` for the latter. Left out, the chart announces
+ * its positions in grid cells or screen pixels.
+ *
+ * A level drawn as several disjoint rings is flattened into one curve, in the
+ * order the rings appear, since a row of the payload is a single polyline.
+ * Every point announced is a real point of the level; what a reader cannot
+ * hear is the jump from the end of one ring to the start of the next.
+ */
+export interface D3ContourConfig extends D3BinderConfig {
+  /** CSS selector for the level paths (e.g. `'path.contour'`). One per level. */
+  selector: string;
+  /** Accessor for the level's value. @default 'value', falling back to `level`, `threshold` or `z`. */
+  level?: DataAccessor<number>;
+  /** Accessor for the GeoJSON rings. @default 'coordinates'. */
+  coordinates?: DataAccessor<unknown>;
+  /** Maps a grid x onto the x axis. @default identity. */
+  x?: D3GridTransform;
+  /** Maps a grid y onto the y axis. @default identity. */
+  y?: D3GridTransform;
+}
+
+/**
  * Result of a D3 binder function.
  * Contains the complete MAIDR data structure and the generated layer
  * for further customization if needed.
@@ -1270,6 +1471,7 @@ export type D3PanelChartSpec
     | { chartType: 'bump'; config: D3LineConfig }
     | { chartType: 'candlestick'; config: D3CandlestickConfig }
     | { chartType: 'chord'; config: D3FlowConfig }
+    | { chartType: 'contour'; config: D3ContourConfig }
     | { chartType: 'dot'; config: D3BarConfig }
     | { chartType: 'dumbbell'; config: D3DumbbellConfig }
     | { chartType: 'errorBar'; config: D3ErrorBarConfig }
@@ -1278,6 +1480,7 @@ export type D3PanelChartSpec
     | { chartType: 'gantt'; config: D3GanttConfig }
     | { chartType: 'gauge'; config: D3GaugeConfig }
     | { chartType: 'heatmap'; config: D3HeatmapConfig }
+    | { chartType: 'hexbin'; config: D3HexbinConfig }
     | { chartType: 'histogram'; config: D3HistogramConfig }
     | { chartType: 'icicle'; config: D3TreemapConfig }
     | { chartType: 'line'; config: D3LineConfig }
@@ -1285,14 +1488,17 @@ export type D3PanelChartSpec
     | { chartType: 'manhattan'; config: D3ManhattanConfig }
     | { chartType: 'mosaic'; config: D3MosaicConfig }
     | { chartType: 'network'; config: D3NetworkConfig }
+    | { chartType: 'parallel'; config: D3ParallelConfig }
     | { chartType: 'pie'; config: D3PieConfig }
     | { chartType: 'polarArea'; config: D3PolarAreaConfig }
     | { chartType: 'radar'; config: D3LineConfig }
+    | { chartType: 'ridgeline'; config: D3RidgelineConfig }
     | { chartType: 'sankey'; config: D3FlowConfig }
     | { chartType: 'scatter'; config: D3ScatterConfig }
     | { chartType: 'segmented'; config: D3SegmentedConfig }
     | { chartType: 'smooth'; config: D3SmoothConfig }
     | { chartType: 'sunburst'; config: D3TreemapConfig }
+    | { chartType: 'survival'; config: D3SurvivalConfig }
     | { chartType: 'treemap'; config: D3TreemapConfig }
     | { chartType: 'volcano'; config: D3VolcanoConfig }
     | { chartType: 'waterfall'; config: D3WaterfallConfig }

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -66,9 +66,12 @@ import { useEffect, useRef, useState } from 'react';
 import { bindD3Area } from './binders/area';
 import { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/bar';
 import { bindD3Box } from './binders/box';
+import { bindD3Boxen } from './binders/boxen';
 import { bindD3Candlestick } from './binders/candlestick';
 import { bindD3Dumbbell } from './binders/dumbbell';
-import { bindD3ErrorBar } from './binders/errorBar';
+import { bindD3ErrorBar, bindD3Forest } from './binders/errorBar';
+import { bindD3Alluvial, bindD3Chord, bindD3Sankey } from './binders/flow';
+import { bindD3Gantt } from './binders/gantt';
 import { bindD3Gauge } from './binders/gauge';
 import { bindD3Heatmap } from './binders/heatmap';
 import { bindD3Histogram } from './binders/histogram';
@@ -79,7 +82,7 @@ import { bindD3Manhattan, bindD3Scatter, bindD3Volcano } from './binders/scatter
 import { bindD3Mosaic, bindD3Segmented } from './binders/segmented';
 import { bindD3Smooth } from './binders/smooth';
 import { bindD3Facets, bindD3Subplots } from './binders/subplots';
-import { bindD3Sunburst, bindD3Treemap } from './binders/treemap';
+import { bindD3Icicle, bindD3Sunburst, bindD3Treemap } from './binders/treemap';
 import { bindD3Waterfall } from './binders/waterfall';
 import { bindD3WordCloud } from './binders/wordCloud';
 
@@ -122,30 +125,42 @@ export interface UseD3AdapterResult {
  */
 function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiPanelResult {
   switch (spec.chartType) {
+    case 'alluvial':
+      return bindD3Alluvial(svg, { ...spec.config, autoApply: false });
     case 'area':
       return bindD3Area(svg, { ...spec.config, autoApply: false });
     case 'bar':
       return bindD3Bar(svg, { ...spec.config, autoApply: false });
     case 'box':
       return bindD3Box(svg, { ...spec.config, autoApply: false });
+    case 'boxen':
+      return bindD3Boxen(svg, { ...spec.config, autoApply: false });
     case 'bump':
       return bindD3Bump(svg, { ...spec.config, autoApply: false });
     case 'candlestick':
       return bindD3Candlestick(svg, { ...spec.config, autoApply: false });
+    case 'chord':
+      return bindD3Chord(svg, { ...spec.config, autoApply: false });
     case 'dot':
       return bindD3Dot(svg, { ...spec.config, autoApply: false });
     case 'dumbbell':
       return bindD3Dumbbell(svg, { ...spec.config, autoApply: false });
     case 'errorBar':
       return bindD3ErrorBar(svg, { ...spec.config, autoApply: false });
+    case 'forest':
+      return bindD3Forest(svg, { ...spec.config, autoApply: false });
     case 'funnel':
       return bindD3Funnel(svg, { ...spec.config, autoApply: false });
+    case 'gantt':
+      return bindD3Gantt(svg, { ...spec.config, autoApply: false });
     case 'gauge':
       return bindD3Gauge(svg, { ...spec.config, autoApply: false });
     case 'heatmap':
       return bindD3Heatmap(svg, { ...spec.config, autoApply: false });
     case 'histogram':
       return bindD3Histogram(svg, { ...spec.config, autoApply: false });
+    case 'icicle':
+      return bindD3Icicle(svg, { ...spec.config, autoApply: false });
     case 'line':
       return bindD3Line(svg, { ...spec.config, autoApply: false });
     case 'lollipop':
@@ -162,6 +177,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3PolarArea(svg, { ...spec.config, autoApply: false });
     case 'radar':
       return bindD3Radar(svg, { ...spec.config, autoApply: false });
+    case 'sankey':
+      return bindD3Sankey(svg, { ...spec.config, autoApply: false });
     case 'scatter':
       return bindD3Scatter(svg, { ...spec.config, autoApply: false });
     case 'segmented':
@@ -192,15 +209,21 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
  */
 function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
   switch (cfg.chartType) {
+    case 'alluvial':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'area':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'bar':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'box':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'boxen':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'bump':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'candlestick':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'chord':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'dot':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
@@ -208,13 +231,19 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'errorBar':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'forest':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'funnel':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'gantt':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'gauge':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'heatmap':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'histogram':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'icicle':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'line':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
@@ -231,6 +260,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
     case 'polarArea':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'radar':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'sankey':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'scatter':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -72,12 +72,14 @@ import { bindD3ErrorBar } from './binders/errorBar';
 import { bindD3Gauge } from './binders/gauge';
 import { bindD3Heatmap } from './binders/heatmap';
 import { bindD3Histogram } from './binders/histogram';
-import { bindD3Bump, bindD3Line } from './binders/line';
-import { bindD3Pie } from './binders/pie';
-import { bindD3Manhattan, bindD3Scatter } from './binders/scatter';
-import { bindD3Segmented } from './binders/segmented';
+import { bindD3Bump, bindD3Line, bindD3Radar } from './binders/line';
+import { bindD3Network } from './binders/network';
+import { bindD3Pie, bindD3PolarArea } from './binders/pie';
+import { bindD3Manhattan, bindD3Scatter, bindD3Volcano } from './binders/scatter';
+import { bindD3Mosaic, bindD3Segmented } from './binders/segmented';
 import { bindD3Smooth } from './binders/smooth';
 import { bindD3Facets, bindD3Subplots } from './binders/subplots';
+import { bindD3Sunburst, bindD3Treemap } from './binders/treemap';
 import { bindD3Waterfall } from './binders/waterfall';
 import { bindD3WordCloud } from './binders/wordCloud';
 
@@ -150,14 +152,28 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Lollipop(svg, { ...spec.config, autoApply: false });
     case 'manhattan':
       return bindD3Manhattan(svg, { ...spec.config, autoApply: false });
+    case 'mosaic':
+      return bindD3Mosaic(svg, { ...spec.config, autoApply: false });
+    case 'network':
+      return bindD3Network(svg, { ...spec.config, autoApply: false });
     case 'pie':
       return bindD3Pie(svg, { ...spec.config, autoApply: false });
+    case 'polarArea':
+      return bindD3PolarArea(svg, { ...spec.config, autoApply: false });
+    case 'radar':
+      return bindD3Radar(svg, { ...spec.config, autoApply: false });
     case 'scatter':
       return bindD3Scatter(svg, { ...spec.config, autoApply: false });
     case 'segmented':
       return bindD3Segmented(svg, { ...spec.config, autoApply: false });
     case 'smooth':
       return bindD3Smooth(svg, { ...spec.config, autoApply: false });
+    case 'sunburst':
+      return bindD3Sunburst(svg, { ...spec.config, autoApply: false });
+    case 'treemap':
+      return bindD3Treemap(svg, { ...spec.config, autoApply: false });
+    case 'volcano':
+      return bindD3Volcano(svg, { ...spec.config, autoApply: false });
     case 'waterfall':
       return bindD3Waterfall(svg, { ...spec.config, autoApply: false });
     case 'wordCloud':
@@ -206,13 +222,27 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'manhattan':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'mosaic':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'network':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'pie':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'polarArea':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'radar':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'scatter':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'segmented':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'smooth':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'sunburst':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'treemap':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'volcano':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'waterfall':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -67,14 +67,19 @@ import { bindD3Area } from './binders/area';
 import { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/bar';
 import { bindD3Box } from './binders/box';
 import { bindD3Candlestick } from './binders/candlestick';
+import { bindD3Dumbbell } from './binders/dumbbell';
+import { bindD3ErrorBar } from './binders/errorBar';
+import { bindD3Gauge } from './binders/gauge';
 import { bindD3Heatmap } from './binders/heatmap';
 import { bindD3Histogram } from './binders/histogram';
 import { bindD3Bump, bindD3Line } from './binders/line';
 import { bindD3Pie } from './binders/pie';
-import { bindD3Scatter } from './binders/scatter';
+import { bindD3Manhattan, bindD3Scatter } from './binders/scatter';
 import { bindD3Segmented } from './binders/segmented';
 import { bindD3Smooth } from './binders/smooth';
 import { bindD3Facets, bindD3Subplots } from './binders/subplots';
+import { bindD3Waterfall } from './binders/waterfall';
+import { bindD3WordCloud } from './binders/wordCloud';
 
 /**
  * Discriminated union describing which binder to run and the config to pass it.
@@ -127,8 +132,14 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Candlestick(svg, { ...spec.config, autoApply: false });
     case 'dot':
       return bindD3Dot(svg, { ...spec.config, autoApply: false });
+    case 'dumbbell':
+      return bindD3Dumbbell(svg, { ...spec.config, autoApply: false });
+    case 'errorBar':
+      return bindD3ErrorBar(svg, { ...spec.config, autoApply: false });
     case 'funnel':
       return bindD3Funnel(svg, { ...spec.config, autoApply: false });
+    case 'gauge':
+      return bindD3Gauge(svg, { ...spec.config, autoApply: false });
     case 'heatmap':
       return bindD3Heatmap(svg, { ...spec.config, autoApply: false });
     case 'histogram':
@@ -137,6 +148,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Line(svg, { ...spec.config, autoApply: false });
     case 'lollipop':
       return bindD3Lollipop(svg, { ...spec.config, autoApply: false });
+    case 'manhattan':
+      return bindD3Manhattan(svg, { ...spec.config, autoApply: false });
     case 'pie':
       return bindD3Pie(svg, { ...spec.config, autoApply: false });
     case 'scatter':
@@ -145,6 +158,10 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Segmented(svg, { ...spec.config, autoApply: false });
     case 'smooth':
       return bindD3Smooth(svg, { ...spec.config, autoApply: false });
+    case 'waterfall':
+      return bindD3Waterfall(svg, { ...spec.config, autoApply: false });
+    case 'wordCloud':
+      return bindD3WordCloud(svg, { ...spec.config, autoApply: false });
     case 'facets':
       return bindD3Facets(svg, withFacetsAutoApplyOff(spec.config));
     case 'subplots':
@@ -171,7 +188,13 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'dot':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'dumbbell':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'errorBar':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'funnel':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'gauge':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'heatmap':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
@@ -181,6 +204,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'lollipop':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'manhattan':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'pie':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'scatter':
@@ -188,6 +213,10 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
     case 'segmented':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'smooth':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'waterfall':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'wordCloud':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
   }
 }

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -83,7 +83,7 @@ import { bindD3Parallel } from './binders/parallel';
 import { bindD3Pie, bindD3PolarArea } from './binders/pie';
 import { bindD3Ridgeline } from './binders/ridgeline';
 import { bindD3Manhattan, bindD3Scatter, bindD3Volcano } from './binders/scatter';
-import { bindD3Mosaic, bindD3Segmented } from './binders/segmented';
+import { bindD3Diverging, bindD3Mosaic, bindD3Segmented } from './binders/segmented';
 import { bindD3Smooth } from './binders/smooth';
 import { bindD3Facets, bindD3Subplots } from './binders/subplots';
 import { bindD3Survival } from './binders/survival';
@@ -148,6 +148,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Chord(svg, { ...spec.config, autoApply: false });
     case 'contour':
       return bindD3Contour(svg, { ...spec.config, autoApply: false });
+    case 'diverging':
+      return bindD3Diverging(svg, { ...spec.config, autoApply: false });
     case 'dot':
       return bindD3Dot(svg, { ...spec.config, autoApply: false });
     case 'dumbbell':
@@ -241,6 +243,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
     case 'chord':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'contour':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'diverging':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'dot':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -63,12 +63,13 @@ import type {
   D3SubplotsConfig,
 } from './types';
 import { useEffect, useRef, useState } from 'react';
-import { bindD3Bar } from './binders/bar';
+import { bindD3Area } from './binders/area';
+import { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/bar';
 import { bindD3Box } from './binders/box';
 import { bindD3Candlestick } from './binders/candlestick';
 import { bindD3Heatmap } from './binders/heatmap';
 import { bindD3Histogram } from './binders/histogram';
-import { bindD3Line } from './binders/line';
+import { bindD3Bump, bindD3Line } from './binders/line';
 import { bindD3Pie } from './binders/pie';
 import { bindD3Scatter } from './binders/scatter';
 import { bindD3Segmented } from './binders/segmented';
@@ -81,7 +82,7 @@ import { bindD3Facets, bindD3Subplots } from './binders/subplots';
  * The `chartType` field narrows the associated `config` to the correct
  * binder-specific type. This is what `useD3Adapter` and `<MaidrD3>` consume.
  *
- * Besides the ten single-chart types, `'facets'` (homogeneous small
+ * Besides the single-chart types, `'facets'` (homogeneous small
  * multiples) and `'subplots'` (heterogeneous panel grids) select the
  * multi-panel binders.
  */
@@ -114,18 +115,28 @@ export interface UseD3AdapterResult {
  */
 function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiPanelResult {
   switch (spec.chartType) {
+    case 'area':
+      return bindD3Area(svg, { ...spec.config, autoApply: false });
     case 'bar':
       return bindD3Bar(svg, { ...spec.config, autoApply: false });
     case 'box':
       return bindD3Box(svg, { ...spec.config, autoApply: false });
+    case 'bump':
+      return bindD3Bump(svg, { ...spec.config, autoApply: false });
     case 'candlestick':
       return bindD3Candlestick(svg, { ...spec.config, autoApply: false });
+    case 'dot':
+      return bindD3Dot(svg, { ...spec.config, autoApply: false });
+    case 'funnel':
+      return bindD3Funnel(svg, { ...spec.config, autoApply: false });
     case 'heatmap':
       return bindD3Heatmap(svg, { ...spec.config, autoApply: false });
     case 'histogram':
       return bindD3Histogram(svg, { ...spec.config, autoApply: false });
     case 'line':
       return bindD3Line(svg, { ...spec.config, autoApply: false });
+    case 'lollipop':
+      return bindD3Lollipop(svg, { ...spec.config, autoApply: false });
     case 'pie':
       return bindD3Pie(svg, { ...spec.config, autoApply: false });
     case 'scatter':
@@ -148,17 +159,27 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
  */
 function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
   switch (cfg.chartType) {
+    case 'area':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'bar':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'box':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'bump':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'candlestick':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'dot':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'funnel':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'heatmap':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'histogram':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'line':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'lollipop':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'pie':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -68,20 +68,25 @@ import { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/ba
 import { bindD3Box } from './binders/box';
 import { bindD3Boxen } from './binders/boxen';
 import { bindD3Candlestick } from './binders/candlestick';
+import { bindD3Contour } from './binders/contour';
 import { bindD3Dumbbell } from './binders/dumbbell';
 import { bindD3ErrorBar, bindD3Forest } from './binders/errorBar';
 import { bindD3Alluvial, bindD3Chord, bindD3Sankey } from './binders/flow';
 import { bindD3Gantt } from './binders/gantt';
 import { bindD3Gauge } from './binders/gauge';
 import { bindD3Heatmap } from './binders/heatmap';
+import { bindD3Hexbin } from './binders/hexbin';
 import { bindD3Histogram } from './binders/histogram';
 import { bindD3Bump, bindD3Line, bindD3Radar } from './binders/line';
 import { bindD3Network } from './binders/network';
+import { bindD3Parallel } from './binders/parallel';
 import { bindD3Pie, bindD3PolarArea } from './binders/pie';
+import { bindD3Ridgeline } from './binders/ridgeline';
 import { bindD3Manhattan, bindD3Scatter, bindD3Volcano } from './binders/scatter';
 import { bindD3Mosaic, bindD3Segmented } from './binders/segmented';
 import { bindD3Smooth } from './binders/smooth';
 import { bindD3Facets, bindD3Subplots } from './binders/subplots';
+import { bindD3Survival } from './binders/survival';
 import { bindD3Icicle, bindD3Sunburst, bindD3Treemap } from './binders/treemap';
 import { bindD3Waterfall } from './binders/waterfall';
 import { bindD3WordCloud } from './binders/wordCloud';
@@ -141,6 +146,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Candlestick(svg, { ...spec.config, autoApply: false });
     case 'chord':
       return bindD3Chord(svg, { ...spec.config, autoApply: false });
+    case 'contour':
+      return bindD3Contour(svg, { ...spec.config, autoApply: false });
     case 'dot':
       return bindD3Dot(svg, { ...spec.config, autoApply: false });
     case 'dumbbell':
@@ -157,6 +164,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Gauge(svg, { ...spec.config, autoApply: false });
     case 'heatmap':
       return bindD3Heatmap(svg, { ...spec.config, autoApply: false });
+    case 'hexbin':
+      return bindD3Hexbin(svg, { ...spec.config, autoApply: false });
     case 'histogram':
       return bindD3Histogram(svg, { ...spec.config, autoApply: false });
     case 'icicle':
@@ -171,12 +180,16 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Mosaic(svg, { ...spec.config, autoApply: false });
     case 'network':
       return bindD3Network(svg, { ...spec.config, autoApply: false });
+    case 'parallel':
+      return bindD3Parallel(svg, { ...spec.config, autoApply: false });
     case 'pie':
       return bindD3Pie(svg, { ...spec.config, autoApply: false });
     case 'polarArea':
       return bindD3PolarArea(svg, { ...spec.config, autoApply: false });
     case 'radar':
       return bindD3Radar(svg, { ...spec.config, autoApply: false });
+    case 'ridgeline':
+      return bindD3Ridgeline(svg, { ...spec.config, autoApply: false });
     case 'sankey':
       return bindD3Sankey(svg, { ...spec.config, autoApply: false });
     case 'scatter':
@@ -187,6 +200,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Smooth(svg, { ...spec.config, autoApply: false });
     case 'sunburst':
       return bindD3Sunburst(svg, { ...spec.config, autoApply: false });
+    case 'survival':
+      return bindD3Survival(svg, { ...spec.config, autoApply: false });
     case 'treemap':
       return bindD3Treemap(svg, { ...spec.config, autoApply: false });
     case 'volcano':
@@ -225,6 +240,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'chord':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'contour':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'dot':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'dumbbell':
@@ -241,6 +258,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'heatmap':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'hexbin':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'histogram':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'icicle':
@@ -255,11 +274,15 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'network':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'parallel':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'pie':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'polarArea':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'radar':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'ridgeline':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'sankey':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
@@ -270,6 +293,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
     case 'smooth':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'sunburst':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'survival':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'treemap':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };

--- a/test/adapters/d3/area.test.ts
+++ b/test/adapters/d3/area.test.ts
@@ -1,0 +1,250 @@
+import type { LinePoint } from '@type/grammar';
+import { bindD3Area } from '@adapters/d3/binders/area';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+
+/** One row of the wide table `d3.stack()` is applied to. */
+type Row = Record<string, string | number>;
+
+/**
+ * Builds what `d3.stack().keys(keys)(rows)` leaves bound to each `<path>`: one
+ * array per series, carrying its `.key`, whose items are `[y0, y1]` tuples
+ * with a `.data` back-reference to the row they were computed from.
+ */
+function stack(keys: string[], rows: Row[]): unknown[] {
+  return keys.map((key, seriesIndex) => {
+    const series = rows.map((row) => {
+      // Everything stacked below this series at that row is its lower edge.
+      const y0 = keys
+        .slice(0, seriesIndex)
+        .reduce((sum, lower) => sum + Number(row[lower]), 0);
+      const tuple: number[] & { data?: unknown } = [y0, y0 + Number(row[key])];
+      tuple.data = row;
+      return tuple;
+    });
+    return Object.assign(series, { key, index: seriesIndex });
+  });
+}
+
+/**
+ * Builds an SVG holding one `path.area` per datum, in the order given, with
+ * each datum bound the way `selectAll('path.area').data(...).join('path')`
+ * would leave it.
+ */
+function buildAreaSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="area-svg"></svg>`);
+  const svg = dom.window.document.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const path = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('class', 'area');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+const ROWS: Row[] = [
+  { year: '2019', Subscriptions: 10, Services: 4 },
+  { year: '2020', Subscriptions: 20, Services: 6 },
+  { year: '2021', Subscriptions: 35, Services: 9 },
+];
+
+/** The same table keyed by one of the aliases the binder infers `x` from. */
+const DATED_ROWS: Row[] = ROWS.map(({ year, ...rest }) => ({ date: year, ...rest }));
+
+describe('bindD3Area with d3.stack() output', () => {
+  test('emits each band\'s own height, not the accumulated top edge', () => {
+    const svg = buildAreaSvg(stack(['Subscriptions', 'Services'], ROWS));
+
+    const result = bindD3Area(svg, {
+      selector: 'path.area',
+      type: TraceType.STACKED_AREA,
+      title: 'Revenue by Product',
+      axes: { x: 'Year', y: 'Revenue', fill: 'Product' },
+      x: 'year',
+    });
+
+    expect(result.layer.type).toBe(TraceType.STACKED_AREA);
+    // AreaTrace sums the series it is given to recover the running total, so
+    // `Services` must carry 4/6/9 — its own value — and not 14/26/44.
+    expect(result.layer.data).toEqual([
+      [
+        { x: '2019', y: 10, z: 'Subscriptions' },
+        { x: '2020', y: 20, z: 'Subscriptions' },
+        { x: '2021', y: 35, z: 'Subscriptions' },
+      ],
+      [
+        { x: '2019', y: 4, z: 'Services' },
+        { x: '2020', y: 6, z: 'Services' },
+        { x: '2021', y: 9, z: 'Services' },
+      ],
+    ]);
+  });
+
+  test('infers the x accessor from the stacked row, not from the [y0, y1] tuple', () => {
+    const svg = buildAreaSvg(stack(['Subscriptions'], DATED_ROWS));
+
+    // No `x` given: `date` is found on the row the tuple points back to, which
+    // is the only place a category exists — the tuple is a pair of edges.
+    const result = bindD3Area(svg, { selector: 'path.area', type: TraceType.STACKED_AREA });
+
+    expect((result.layer.data as LinePoint[][])[0].map(point => point.x))
+      .toEqual(['2019', '2020', '2021']);
+  });
+
+  test('names each series from its d3.stack() key and reports them as the legend', () => {
+    const svg = buildAreaSvg(stack(['Subscriptions', 'Services'], ROWS));
+
+    const result = bindD3Area(svg, {
+      selector: 'path.area',
+      type: TraceType.STACKED_AREA,
+      x: 'year',
+    });
+
+    expect(result.maidr.subplots[0][0].legend).toEqual(['Subscriptions', 'Services']);
+  });
+
+  test('stamps one selector per band so the model can highlight a single series', () => {
+    const svg = buildAreaSvg(stack(['Subscriptions', 'Services'], ROWS));
+
+    const result = bindD3Area(svg, {
+      selector: 'path.area',
+      type: TraceType.STACKED_AREA,
+      x: 'year',
+    });
+
+    // A bare selector matches both paths at once, and LineTrace withdraws
+    // highlighting unless the selector count equals the series count.
+    expect(result.layer.selectors).toEqual([
+      '#area-svg path.area[data-maidr-line-index="0"]',
+      '#area-svg path.area[data-maidr-line-index="1"]',
+    ]);
+    const paths = Array.from(svg.querySelectorAll('path.area'));
+    expect(paths.map(path => path.getAttribute('data-maidr-line-index'))).toEqual(['0', '1']);
+  });
+
+  test('reads a d3.stackOffsetExpand chart as shares of the whole', () => {
+    // 100% stacked: the offset scales each column to 1, and the band height is
+    // still `y1 - y0` — the share this series holds at that x.
+    const expanded = [0, 1].map((seriesIndex) => {
+      const series = ROWS.map((row) => {
+        const total = Number(row.Subscriptions) + Number(row.Services);
+        const own = seriesIndex === 0 ? Number(row.Subscriptions) : Number(row.Services);
+        const y0 = seriesIndex === 0 ? 0 : Number(row.Subscriptions) / total;
+        const tuple: number[] & { data?: unknown } = [y0, y0 + own / total];
+        tuple.data = row;
+        return tuple;
+      });
+      return Object.assign(series, { key: seriesIndex === 0 ? 'Subscriptions' : 'Services' });
+    });
+    const svg = buildAreaSvg(expanded);
+
+    const result = bindD3Area(svg, {
+      selector: 'path.area',
+      type: TraceType.NORMALIZED_AREA,
+      x: 'year',
+    });
+
+    expect(result.layer.type).toBe(TraceType.NORMALIZED_AREA);
+    const data = result.layer.data as LinePoint[][];
+    expect(data[0][0].y).toBeCloseTo(10 / 14);
+    expect(data[1][0].y).toBeCloseTo(4 / 14);
+  });
+
+  test('honors an explicit y accessor, resolved against the tuple', () => {
+    const svg = buildAreaSvg(stack(['Subscriptions'], ROWS));
+
+    const result = bindD3Area(svg, {
+      selector: 'path.area',
+      type: TraceType.STACKED_AREA,
+      x: 'year',
+      y: (d: unknown) => (d as number[])[1] - (d as number[])[0],
+    });
+
+    expect((result.layer.data as LinePoint[][])[0].map(point => point.y)).toEqual([10, 20, 35]);
+  });
+});
+
+describe('bindD3Area with plain point arrays', () => {
+  test('reads the point array a line path carries', () => {
+    const svg = buildAreaSvg([
+      [{ month: 'Jan', temp: 30 }, { month: 'Feb', temp: 34 }],
+    ]);
+
+    const result = bindD3Area(svg, {
+      selector: 'path.area',
+      axes: { x: 'Month', y: 'Temperature' },
+      x: 'month',
+      y: 'temp',
+    });
+
+    // Plain area: independent bands, the default variant.
+    expect(result.layer.type).toBe(TraceType.AREA);
+    expect(result.layer.data).toEqual([[{ x: 'Jan', y: 30 }, { x: 'Feb', y: 34 }]]);
+    // One path → one scoped selector is enough to highlight it.
+    expect(result.layer.selectors).toBe('#area-svg path.area');
+  });
+
+  test('throws an actionable error when the selector matches no bands', () => {
+    const svg = buildAreaSvg([[{ x: 'Jan', y: 1 }]]);
+
+    expect(() => bindD3Area(svg, { selector: 'path.band' })).toThrow(/area path/);
+  });
+
+  test('rejects a selector that mixes a stacked band with a non-stacked path', () => {
+    // An axis line or reference band caught by the same selector would
+    // otherwise be read as a series with no data behind it.
+    const svg = buildAreaSvg([
+      ...stack(['Subscriptions'], ROWS),
+      [{ year: '2019', value: 1 }],
+    ]);
+
+    expect(() => bindD3Area(svg, {
+      selector: 'path.area',
+      type: TraceType.STACKED_AREA,
+      x: 'year',
+    })).toThrow(/not d3\.stack\(\) output/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted stacked-area layer constructs a navigable Figure', () => {
+    const svg = buildAreaSvg(stack(['Subscriptions', 'Services'], ROWS));
+    const result = bindD3Area(svg, {
+      selector: 'path.area',
+      type: TraceType.STACKED_AREA,
+      title: 'Revenue by Product',
+      x: 'year',
+    });
+
+    // Drop the selectors for this assertion only: LineTrace resolves them by
+    // parsing the `<path>` geometry, narrowing with `instanceof
+    // SVGPathElement`, and jsdom implements no such class — so highlighting is
+    // asserted on the emitted selector strings above, and this checks the part
+    // jsdom can run. The model resolves what is left via the page-global
+    // `document`; point it at this test's JSDOM document meanwhile.
+    const { selectors: _selectors, ...layer } = result.layer;
+    const globals = globalThis as { document?: Document };
+    const previousDocument = globals.document;
+    globals.document = svg.ownerDocument;
+    try {
+      const figure = new Figure({ ...result.maidr, subplots: [[{ layers: [layer] }]] });
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      // Reading the state exercises Subplot/Trace construction end-to-end: the
+      // payload is one AreaTrace accepts, and the layer announces the chart
+      // the user drew rather than a plain line.
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.STACKED_AREA]);
+    } finally {
+      if (previousDocument === undefined) {
+        delete globals.document;
+      } else {
+        globals.document = previousDocument;
+      }
+    }
+  });
+});

--- a/test/adapters/d3/bar.test.ts
+++ b/test/adapters/d3/bar.test.ts
@@ -1,0 +1,131 @@
+import type { BarPoint } from '@type/grammar';
+import { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from '@adapters/d3/binders/bar';
+import { describe, expect, test } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * Builds an SVG holding one mark per datum, in the order given, with each
+ * datum bound the way `selectAll(tag).data(...).join(tag)` would leave it.
+ */
+function buildMarkSvg(tag: string, className: string, data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="mark-svg"></svg>`);
+  const svg = dom.window.document.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const mark = dom.window.document.createElementNS('http://www.w3.org/2000/svg', tag);
+    mark.setAttribute('class', className);
+    (mark as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(mark);
+  }
+  return svg;
+}
+
+describe('bindD3Dot', () => {
+  test('announces a dot plot while reading the bar payload', () => {
+    const svg = buildMarkSvg('circle', 'dot', [
+      { endpoint: '/search', ms: 412 },
+      { endpoint: '/checkout', ms: 318 },
+      { endpoint: '/health', ms: 96 },
+    ]);
+
+    const result = bindD3Dot(svg, {
+      selector: 'circle.dot',
+      title: 'Median Response Time',
+      orientation: Orientation.HORIZONTAL,
+      axes: { x: 'Milliseconds', y: 'Endpoint' },
+      x: 'ms',
+      y: 'endpoint',
+    });
+
+    expect(result.layer.type).toBe(TraceType.DOT);
+    // Flat BarPoint[], identical to what a bar chart would emit.
+    expect(result.layer.data).toEqual([
+      { x: 412, y: '/search' },
+      { x: 318, y: '/checkout' },
+      { x: 96, y: '/health' },
+    ]);
+    // Categories down the page: the orientation the mark is usually drawn in.
+    expect(result.layer.orientation).toBe(Orientation.HORIZONTAL);
+  });
+
+  test('highlights the dots themselves, scoped to the SVG', () => {
+    const svg = buildMarkSvg('circle', 'dot', [{ x: 'A', y: 1 }, { x: 'B', y: 2 }]);
+
+    const result = bindD3Dot(svg, { selector: 'circle.dot' });
+
+    // One scoped selector matching all marks: BarTrace maps them 1:1 to rows.
+    expect(result.layer.selectors).toBe('#mark-svg circle.dot');
+  });
+});
+
+describe('bindD3Lollipop', () => {
+  test('announces a lollipop and highlights the heads, not the stems', () => {
+    const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="pop-svg"></svg>`);
+    const doc = dom.window.document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+    // Draw both marks a lollipop is made of, so the selector has something to
+    // pick wrongly: the stems carry the same data and must stay unmatched.
+    for (const datum of [{ country: 'Norway', years: 84 }, { country: 'India', years: 61 }]) {
+      for (const tag of ['line', 'circle']) {
+        const mark = doc.createElementNS('http://www.w3.org/2000/svg', tag);
+        mark.setAttribute('class', tag === 'line' ? 'stem' : 'head');
+        (mark as unknown as { __data__: unknown }).__data__ = datum;
+        svg.appendChild(mark);
+      }
+    }
+
+    const result = bindD3Lollipop(svg, {
+      selector: 'circle.head',
+      orientation: Orientation.HORIZONTAL,
+      x: 'years',
+      y: 'country',
+    });
+
+    expect(result.layer.type).toBe(TraceType.LOLLIPOP);
+    expect(result.layer.data).toEqual([
+      { x: 84, y: 'Norway' },
+      { x: 61, y: 'India' },
+    ]);
+    expect(result.layer.selectors).toBe('#pop-svg circle.head');
+  });
+});
+
+describe('bindD3Funnel', () => {
+  test('keeps the stages in draw order, which is what the retention is read from', () => {
+    // The order is load-bearing: FunnelTrace pitches each stage against the
+    // one before it, so a reordered payload would announce the wrong drop-off.
+    const svg = buildMarkSvg('path', 'stage', [
+      { stage: 'Visited', count: 10000 },
+      { stage: 'Signed up', count: 2400 },
+      { stage: 'Viewed cart', count: 2300 },
+      { stage: 'Purchased', count: 100 },
+    ]);
+
+    const result = bindD3Funnel(svg, {
+      selector: 'path.stage',
+      title: 'Checkout Funnel',
+      axes: { x: 'Stage', y: 'People' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.FUNNEL);
+    // `stage` / `count` are inferred: neither is the canonical `x` / `y` key.
+    expect((result.layer.data as BarPoint[]).map(point => point.x))
+      .toEqual(['Visited', 'Signed up', 'Viewed cart', 'Purchased']);
+    expect((result.layer.data as BarPoint[]).map(point => point.y))
+      .toEqual([10000, 2400, 2300, 100]);
+    expect(result.layer.selectors).toBe('#mark-svg path.stage');
+  });
+});
+
+describe('bindD3Bar', () => {
+  test('still announces itself as a bar chart', () => {
+    // The mark binders share this extraction core; the base case must not
+    // pick up one of their type constants.
+    const svg = buildMarkSvg('rect', 'bar', [{ x: 'Q1', y: 10 }, { x: 'Q2', y: 20 }]);
+
+    const result = bindD3Bar(svg, { selector: 'rect.bar' });
+
+    expect(result.layer.type).toBe(TraceType.BAR);
+    expect(result.layer.orientation).toBe(Orientation.VERTICAL);
+  });
+});

--- a/test/adapters/d3/boxen.test.ts
+++ b/test/adapters/d3/boxen.test.ts
@@ -1,0 +1,170 @@
+import type { BoxenPoint } from '@type/grammar';
+import { bindD3Boxen } from '@adapters/d3/binders/boxen';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `g.boxen` per distribution, each with the stack of
+ * rungs a letter-value plot draws inside it — the way
+ * `selectAll('g.boxen').data(summaries).join('g')` would leave it.
+ */
+function buildBoxenSvg(distributions: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="bx-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of distributions) {
+    const group = doc.createElementNS('http://www.w3.org/2000/svg', 'g');
+    group.setAttribute('class', 'boxen');
+    (group as unknown as { __data__: unknown }).__data__ = datum;
+    // The rungs themselves: several per distribution, which is why the
+    // selector points at the group and not at them.
+    for (let rung = 0; rung < 3; rung++) {
+      group.appendChild(doc.createElementNS('http://www.w3.org/2000/svg', 'rect'));
+    }
+    svg.appendChild(group);
+  }
+  return svg;
+}
+
+const SUMMARIES = [
+  {
+    group: 'control',
+    median: 50,
+    levels: [
+      { p: 0.25, lo: 46, hi: 54 },
+      { p: 0.125, lo: 42, hi: 58 },
+      { p: 0.0625, lo: 38, hi: 62 },
+    ],
+  },
+  {
+    group: 'treatment',
+    median: 62,
+    levels: [
+      { p: 0.25, lo: 57, hi: 68 },
+      { p: 0.125, lo: 51, hi: 74 },
+    ],
+    upperOutliers: [130],
+  },
+];
+
+describe('bindD3Boxen', () => {
+  test('reads the ladder each distribution was drawn from', () => {
+    const svg = buildBoxenSvg(SUMMARIES);
+
+    const result = bindD3Boxen(svg, {
+      selector: 'g.boxen',
+      title: 'Response Time by Group',
+      axes: { x: 'Group', y: 'Milliseconds' },
+      x: 'group',
+    });
+
+    expect(result.layer.type).toBe(TraceType.BOXEN);
+    expect(result.layer.data).toEqual([
+      {
+        z: 'control',
+        median: 50,
+        levels: [
+          { p: 0.25, lo: 46, hi: 54 },
+          { p: 0.125, lo: 42, hi: 58 },
+          { p: 0.0625, lo: 38, hi: 62 },
+        ],
+      },
+      {
+        z: 'treatment',
+        median: 62,
+        levels: [
+          { p: 0.25, lo: 57, hi: 68 },
+          { p: 0.125, lo: 51, hi: 74 },
+        ],
+        upperOutliers: [130],
+      },
+    ]);
+  });
+
+  test('gives each distribution as many rungs as it has', () => {
+    // The point of a letter-value plot: a larger sample gets a deeper ladder,
+    // which is the one thing a five-number summary cannot express.
+    const svg = buildBoxenSvg(SUMMARIES);
+
+    const result = bindD3Boxen(svg, { selector: 'g.boxen', x: 'group' });
+
+    const depths = (result.layer.data as BoxenPoint[]).map(point => point.levels.length);
+    expect(depths).toEqual([3, 2]);
+  });
+
+  test('reads a ladder that names its rungs with other keys', () => {
+    const svg = buildBoxenSvg([{
+      group: 'control',
+      median: 50,
+      letterValues: [{ p: 0.25, lower: 46, upper: 54 }],
+    }]);
+
+    const result = bindD3Boxen(svg, { selector: 'g.boxen', x: 'group' });
+
+    expect((result.layer.data as BoxenPoint[])[0].levels).toEqual([{ p: 0.25, lo: 46, hi: 54 }]);
+  });
+
+  test('drops a rung whose numbers are not all there', () => {
+    // A rung is a labelled position on the distribution; one carrying NaN
+    // would be announced as a percentile the data never computed.
+    const svg = buildBoxenSvg([{
+      group: 'control',
+      median: 50,
+      levels: [{ p: 0.25, lo: 46, hi: 54 }, { p: 0.125, lo: Number.NaN, hi: 58 }, { lo: 1, hi: 2 }],
+    }]);
+
+    const result = bindD3Boxen(svg, { selector: 'g.boxen', x: 'group' });
+
+    expect((result.layer.data as BoxenPoint[])[0].levels).toEqual([{ p: 0.25, lo: 46, hi: 54 }]);
+  });
+
+  test('says what to do when the datum carries no ladder', () => {
+    const svg = buildBoxenSvg([{ group: 'control', median: 50, levels: 3 }]);
+
+    expect(() => bindD3Boxen(svg, { selector: 'g.boxen', x: 'group' }))
+      .toThrow(/has no ladder/);
+  });
+
+  test('highlights one element per distribution, scoped to the SVG', () => {
+    const svg = buildBoxenSvg(SUMMARIES);
+
+    const result = bindD3Boxen(svg, { selector: 'g.boxen', x: 'group' });
+
+    // The trace repeats a distribution's element across its rungs and
+    // withdraws highlighting when the counts disagree — which is what a
+    // selector matching the rungs themselves would produce.
+    expect(result.layer.selectors).toBe('#bx-svg g.boxen');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(SUMMARIES.length);
+  });
+
+  test('throws an actionable error when the selector matches no groups', () => {
+    const svg = buildBoxenSvg(SUMMARIES);
+
+    expect(() => bindD3Boxen(svg, { selector: 'g.box' })).toThrow(/boxen group/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildBoxenSvg(SUMMARIES);
+    const result = bindD3Boxen(svg, {
+      selector: 'g.boxen',
+      title: 'Response Time by Group',
+      axes: { x: 'Group', y: 'Milliseconds' },
+      x: 'group',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.BOXEN]);
+    });
+  });
+});

--- a/test/adapters/d3/contour.test.ts
+++ b/test/adapters/d3/contour.test.ts
@@ -1,0 +1,165 @@
+import type { ContourPoint } from '@type/grammar';
+import { bindD3Contour } from '@adapters/d3/binders/contour';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** A closed GeoJSON ring, first position repeated at the end as the spec has it. */
+function ring(positions: number[][]): number[][] {
+  return [...positions, positions[0]];
+}
+
+/** The `MultiPolygon` `d3.contours()` emits for one threshold. */
+function level(value: number, rings: number[][][]): unknown {
+  return { type: 'MultiPolygon', value, coordinates: rings.map(one => [one]) };
+}
+
+const LEVELS = [
+  level(0.1, [ring([[1, 1], [5, 1], [5, 5], [1, 5]])]),
+  level(0.2, [ring([[2, 2], [4, 2], [4, 4], [2, 4]])]),
+];
+
+/**
+ * Builds an SVG holding one `path.contour` per level, the datum bound to it
+ * being that threshold's `MultiPolygon`.
+ */
+function buildContourSvg(levels: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="ct-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of levels) {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'contour');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+describe('bindD3Contour', () => {
+  test('reads one curve per level, carrying the level on every point', () => {
+    const svg = buildContourSvg(LEVELS);
+
+    const result = bindD3Contour(svg, {
+      selector: 'path.contour',
+      title: 'Density Field',
+      axes: { x: 'X', y: 'Y', fill: 'Density' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.CONTOUR);
+    const data = result.layer.data as ContourPoint[][];
+    expect(data).toHaveLength(2);
+    // The closing repeat is geometry, not a sample: four corners, not five.
+    expect(data[0]).toEqual([
+      { x: 1, y: 1, level: 0.1 },
+      { x: 5, y: 1, level: 0.1 },
+      { x: 5, y: 5, level: 0.1 },
+      { x: 1, y: 5, level: 0.1 },
+    ]);
+    expect(data[1].every(point => point.level === 0.2)).toBe(true);
+  });
+
+  test('maps the grid onto the data axes through the given transforms', () => {
+    // `d3.contours()` walks a grid and emits INDICES; without the transforms
+    // the chart announces its curves in grid cells.
+    const svg = buildContourSvg([level(0.1, [ring([[0, 0], [2, 0], [2, 2]])])]);
+
+    const result = bindD3Contour(svg, {
+      selector: 'path.contour',
+      x: column => -5 + column * 0.5,
+      y: row => 100 + row * 10,
+    });
+
+    const data = result.layer.data as ContourPoint[][];
+    expect(data[0]).toEqual([
+      { x: -5, y: 100, level: 0.1 },
+      { x: -4, y: 100, level: 0.1 },
+      { x: -4, y: 120, level: 0.1 },
+    ]);
+  });
+
+  test('flattens a level drawn as several disjoint rings into one curve', () => {
+    const svg = buildContourSvg([
+      level(0.3, [
+        ring([[0, 0], [1, 0], [1, 1]]),
+        ring([[8, 8], [9, 8], [9, 9]]),
+      ]),
+    ]);
+
+    const result = bindD3Contour(svg, { selector: 'path.contour' });
+
+    const data = result.layer.data as ContourPoint[][];
+    expect(data[0]).toHaveLength(6);
+    expect(data[0].map(point => point.x)).toEqual([0, 1, 1, 8, 9, 9]);
+  });
+
+  test('reads a bare Polygon as readily as a MultiPolygon', () => {
+    const svg = buildContourSvg([
+      { type: 'Polygon', value: 0.4, coordinates: [ring([[0, 0], [1, 0], [1, 1]])] },
+    ]);
+
+    const result = bindD3Contour(svg, { selector: 'path.contour' });
+
+    const data = result.layer.data as ContourPoint[][];
+    expect(data[0]).toHaveLength(3);
+    expect(data[0][0]).toEqual({ x: 0, y: 0, level: 0.4 });
+  });
+
+  test('emits one selector per level', () => {
+    const svg = buildContourSvg(LEVELS);
+
+    const result = bindD3Contour(svg, { selector: 'path.contour' });
+
+    // `ContourTrace` inherits `LineTrace`'s pairing of one selector per row,
+    // so a bare selector matching both level paths withdraws highlighting.
+    expect(result.layer.selectors).toEqual([
+      '#ct-svg path.contour[data-maidr-line-index="0"]',
+      '#ct-svg path.contour[data-maidr-line-index="1"]',
+    ]);
+  });
+
+  test('says so when the paths carry drawing instructions instead of geometry', () => {
+    const svg = buildContourSvg([{ value: 0.1, d: 'M1,1L5,1L5,5Z' }]);
+
+    expect(() => bindD3Contour(svg, { selector: 'path.contour' }))
+      .toThrow(/carries no rings/);
+  });
+
+  test('throws an actionable error when the selector matches no levels', () => {
+    const svg = buildContourSvg(LEVELS);
+
+    expect(() => bindD3Contour(svg, { selector: 'path.iso' }))
+      .toThrow(/contour level path/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildContourSvg(LEVELS);
+    const result = bindD3Contour(svg, {
+      selector: 'path.contour',
+      title: 'Density Field',
+      axes: { x: 'X', y: 'Y', fill: 'Density' },
+    });
+
+    // jsdom 26 does not define `SVGPathElement`, and `LineTrace`'s path-parsing
+    // fallback narrows with `instanceof` — so the Figure is built without the
+    // selectors here. They are asserted on their own above.
+    const { selectors, ...layer } = result.maidr.subplots[0][0].layers[0];
+    expect(selectors).toBeDefined();
+    const data = { ...result.maidr, subplots: [[{ layers: [layer] }]] };
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(data);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.CONTOUR]);
+    });
+  });
+});

--- a/test/adapters/d3/dumbbell.test.ts
+++ b/test/adapters/d3/dumbbell.test.ts
@@ -1,0 +1,142 @@
+import type { DumbbellData } from '@type/grammar';
+import { bindD3Dumbbell } from '@adapters/d3/binders/dumbbell';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { Orientation, TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding what a dumbbell chart draws per row: a connector and
+ * the two dots it joins, each carrying the same datum. Only the connector maps
+ * one-to-one onto the data, which is the thing the binder has to get right.
+ */
+function buildDumbbellSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="db-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const connector = doc.createElementNS('http://www.w3.org/2000/svg', 'line');
+    connector.setAttribute('class', 'connector');
+    (connector as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(connector);
+    for (const end of ['start', 'end']) {
+      const dot = doc.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      dot.setAttribute('class', `dot ${end}`);
+      (dot as unknown as { __data__: unknown }).__data__ = datum;
+      svg.appendChild(dot);
+    }
+  }
+  return svg;
+}
+
+const ROWS = [
+  { country: 'Denmark', y1990: 71.2, y2020: 78.4 },
+  { country: 'Latvia', y1990: 74.6, y2020: 69.5 },
+  { country: 'Malta', y1990: 76.0, y2020: 76.0 },
+];
+
+describe('bindD3Dumbbell', () => {
+  test('emits the object payload, with the end names on the chart', () => {
+    const svg = buildDumbbellSvg(ROWS);
+
+    const result = bindD3Dumbbell(svg, {
+      selector: 'line.connector',
+      title: 'Life Expectancy, 1990 against 2020',
+      orientation: Orientation.HORIZONTAL,
+      axes: { x: 'Years', y: 'Country' },
+      x: 'country',
+      start: 'y1990',
+      end: 'y2020',
+      startLabel: '1990',
+      endLabel: '2020',
+    });
+
+    expect(result.layer.type).toBe(TraceType.DUMBBELL);
+    // Not an array: the two end names belong to the chart, not to a row.
+    expect(result.layer.data).toEqual({
+      points: [
+        { x: 'Denmark', start: 71.2, end: 78.4 },
+        { x: 'Latvia', start: 74.6, end: 69.5 },
+        { x: 'Malta', start: 76.0, end: 76.0 },
+      ],
+      startLabel: '1990',
+      endLabel: '2020',
+    });
+    expect(result.layer.orientation).toBe(Orientation.HORIZONTAL);
+  });
+
+  test('leaves the end names out when the chart does not name them', () => {
+    // Absent rather than empty, so the trace falls back to "start" and "end"
+    // instead of announcing a blank label.
+    const svg = buildDumbbellSvg([{ x: 'A', start: 1, end: 2 }]);
+
+    const result = bindD3Dumbbell(svg, { selector: 'line.connector' });
+
+    expect(result.layer.data).toEqual({ points: [{ x: 'A', start: 1, end: 2 }] });
+  });
+
+  test('keeps a row whose value fell, rather than ordering the two ends', () => {
+    // Latvia's 2020 figure is below its 1990 one; `end` is the finishing value
+    // and not the larger one, and reordering would invert the chart's finding.
+    const svg = buildDumbbellSvg(ROWS);
+
+    const result = bindD3Dumbbell(svg, {
+      selector: 'line.connector',
+      x: 'country',
+      start: 'y1990',
+      end: 'y2020',
+    });
+
+    const { points } = result.layer.data as DumbbellData;
+    expect(points[1]).toEqual({ x: 'Latvia', start: 74.6, end: 69.5 });
+  });
+
+  test('highlights the connectors, one per row, and not the dots', () => {
+    const svg = buildDumbbellSvg(ROWS);
+
+    const result = bindD3Dumbbell(svg, {
+      selector: 'line.connector',
+      x: 'country',
+      start: 'y1990',
+      end: 'y2020',
+    });
+
+    expect(result.layer.selectors).toBe('#db-svg line.connector');
+    // DumbbellTrace withdraws highlighting unless the element count equals the
+    // row count — a selector that caught the dots would match three times over.
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(ROWS.length);
+  });
+
+  test('throws an actionable error when the selector matches no connectors', () => {
+    const svg = buildDumbbellSvg(ROWS);
+
+    expect(() => bindD3Dumbbell(svg, { selector: 'line.link' })).toThrow(/dumbbell connector/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildDumbbellSvg(ROWS);
+    const result = bindD3Dumbbell(svg, {
+      selector: 'line.connector',
+      title: 'Life Expectancy',
+      orientation: Orientation.HORIZONTAL,
+      x: 'country',
+      start: 'y1990',
+      end: 'y2020',
+      startLabel: '1990',
+      endLabel: '2020',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.DUMBBELL]);
+    });
+  });
+});

--- a/test/adapters/d3/errorBar.test.ts
+++ b/test/adapters/d3/errorBar.test.ts
@@ -1,0 +1,141 @@
+import type { ErrorBarPoint } from '@type/grammar';
+import { bindD3ErrorBar } from '@adapters/d3/binders/errorBar';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { Orientation, TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `g.estimate` per datum — the D3 idiom for a
+ * point-range chart, where the group wraps the interval's line and the
+ * estimate's marker — with each datum bound the way a data join would leave it.
+ */
+function buildEstimateSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="eb-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const group = doc.createElementNS('http://www.w3.org/2000/svg', 'g');
+    group.setAttribute('class', 'estimate');
+    (group as unknown as { __data__: unknown }).__data__ = datum;
+    // Both marks a point range is drawn from, so a selector aimed at the wrong
+    // one would show up as a mismatched element count.
+    group.appendChild(doc.createElementNS('http://www.w3.org/2000/svg', 'line'));
+    group.appendChild(doc.createElementNS('http://www.w3.org/2000/svg', 'circle'));
+    svg.appendChild(group);
+  }
+  return svg;
+}
+
+const ESTIMATES = [
+  { group: 'control', mean: 4.2, ciLow: 3.8, ciHigh: 4.6 },
+  { group: 'low dose', mean: 5.1, ciLow: 4.0, ciHigh: 6.6 },
+  { group: 'high dose', mean: 7.3, ciLow: 7.1, ciHigh: 7.4 },
+];
+
+describe('bindD3ErrorBar', () => {
+  test('reads the estimate and its two bounds off each group', () => {
+    const svg = buildEstimateSvg(ESTIMATES);
+
+    const result = bindD3ErrorBar(svg, {
+      selector: 'g.estimate',
+      title: 'Mean Response by Dose',
+      axes: { x: 'Group', y: 'Response' },
+      x: 'group',
+      y: 'mean',
+      yMin: 'ciLow',
+      yMax: 'ciHigh',
+    });
+
+    expect(result.layer.type).toBe(TraceType.ERROR_BAR);
+    expect(result.layer.data).toEqual([
+      { x: 'control', y: 4.2, yMin: 3.8, yMax: 4.6 },
+      { x: 'low dose', y: 5.1, yMin: 4.0, yMax: 6.6 },
+      { x: 'high dose', y: 7.3, yMin: 7.1, yMax: 7.4 },
+    ]);
+    expect(result.layer.orientation).toBe(Orientation.VERTICAL);
+  });
+
+  test('infers all four accessors from the datum\'s own key names', () => {
+    const svg = buildEstimateSvg(ESTIMATES);
+
+    // Nothing named: `group`, `mean`, `ciLow` and `ciHigh` are all aliases.
+    const result = bindD3ErrorBar(svg, { selector: 'g.estimate' });
+
+    expect(result.layer.data).toEqual([
+      { x: 'control', y: 4.2, yMin: 3.8, yMax: 4.6 },
+      { x: 'low dose', y: 5.1, yMin: 4.0, yMax: 6.6 },
+      { x: 'high dose', y: 7.3, yMin: 7.1, yMax: 7.4 },
+    ]);
+  });
+
+  test('keeps a one-sided interval rather than dropping the estimate', () => {
+    // A bound the chart never drew is absent, not zero: an upper bound with no
+    // lower is a real chart, and discarding the row would lose the estimate too.
+    const svg = buildEstimateSvg([{ x: 'ceiling', y: 12, yMax: 15 }]);
+
+    const result = bindD3ErrorBar(svg, { selector: 'g.estimate' });
+
+    expect(result.layer.data).toEqual([{ x: 'ceiling', y: 12, yMax: 15 }]);
+    expect((result.layer.data as ErrorBarPoint[])[0]).not.toHaveProperty('yMin');
+  });
+
+  test('converts half-widths to absolute bounds through function accessors', () => {
+    // The grammar fixes absolute positions, and the binder cannot tell an
+    // offset from a bound by looking at it — so this is the caller's to do.
+    const svg = buildEstimateSvg([{ dose: 10, mean: 4, se: 0.5 }]);
+
+    const result = bindD3ErrorBar(svg, {
+      selector: 'g.estimate',
+      x: 'dose',
+      y: 'mean',
+      yMin: (d: unknown) => (d as { mean: number; se: number }).mean - 1.96 * (d as { se: number }).se,
+      yMax: (d: unknown) => (d as { mean: number; se: number }).mean + 1.96 * (d as { se: number }).se,
+    });
+
+    const [point] = result.layer.data as ErrorBarPoint[];
+    expect(point.yMin).toBeCloseTo(3.02);
+    expect(point.yMax).toBeCloseTo(4.98);
+  });
+
+  test('highlights one group per estimate, scoped to the SVG', () => {
+    const svg = buildEstimateSvg(ESTIMATES);
+
+    const result = bindD3ErrorBar(svg, { selector: 'g.estimate', orientation: Orientation.HORIZONTAL });
+
+    expect(result.layer.selectors).toBe('#eb-svg g.estimate');
+    expect(result.layer.orientation).toBe(Orientation.HORIZONTAL);
+    // ErrorBarTrace withdraws highlighting unless the resolved element count
+    // equals the sample count, so the selector must match the groups alone.
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(ESTIMATES.length);
+  });
+
+  test('throws an actionable error when the selector matches no estimates', () => {
+    const svg = buildEstimateSvg(ESTIMATES);
+
+    expect(() => bindD3ErrorBar(svg, { selector: 'g.range' })).toThrow(/error-bar estimate/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildEstimateSvg(ESTIMATES);
+    const result = bindD3ErrorBar(svg, {
+      selector: 'g.estimate',
+      title: 'Mean Response by Dose',
+      x: 'group',
+      y: 'mean',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.ERROR_BAR]);
+    });
+  });
+});

--- a/test/adapters/d3/flow.test.ts
+++ b/test/adapters/d3/flow.test.ts
@@ -1,0 +1,208 @@
+import type { FlowPoint } from '@type/grammar';
+import { bindD3Alluvial, bindD3Chord, bindD3Sankey } from '@adapters/d3/binders/flow';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `path.ribbon` per datum, the way
+ * `selectAll('path.ribbon').data(graph.links).join('path')` would leave it.
+ */
+function buildFlowSvg(links: unknown[], id = 'fl-svg'): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="${id}"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of links) {
+    const path = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('class', 'ribbon');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+/** The links as the author writes them, before the layout touches them. */
+const AUTHORED = [
+  { source: 'Coal', target: 'Electricity', value: 34 },
+  { source: 'Coal', target: 'Heat', value: 14 },
+  { source: 'Gas', target: 'Electricity', value: 12 },
+];
+
+/**
+ * The same links after `sankey({ nodes, links })` has run: each end is now the
+ * node OBJECT it resolved to, and the layout's own geometry sits alongside.
+ */
+function asLaidOut(links: { source: string; target: string; value: number }[]): unknown[] {
+  const nodes = new Map<string, { name: string; x0: number; x1: number }>();
+  const node = (name: string): unknown => {
+    if (!nodes.has(name)) {
+      nodes.set(name, { name, x0: 0, x1: 20 });
+    }
+    return nodes.get(name);
+  };
+  return links.map(link => ({
+    source: node(link.source),
+    target: node(link.target),
+    value: link.value,
+    width: link.value / 2,
+  }));
+}
+
+/**
+ * One `d3.chord()` chord: both ends are matrix INDICES, and the magnitude sits
+ * on each end rather than on the chord itself.
+ */
+function chord(sourceIndex: number, targetIndex: number, value: number): unknown {
+  return {
+    source: { index: sourceIndex, subindex: targetIndex, startAngle: 0, endAngle: 1, value },
+    target: { index: targetIndex, subindex: sourceIndex, startAngle: 2, endAngle: 3, value },
+  };
+}
+
+describe('bindD3Sankey', () => {
+  test('reads both ends and the magnitude of every ribbon', () => {
+    const svg = buildFlowSvg(AUTHORED);
+
+    const result = bindD3Sankey(svg, {
+      selector: 'path.ribbon',
+      title: 'Energy flow',
+      axes: { x: 'Node', y: 'Petajoules' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.SANKEY);
+    expect(result.layer.data).toEqual(AUTHORED);
+  });
+
+  test('names the ends d3-sankey replaced with node objects', () => {
+    // The layout MUTATES each link: `source` is a name before it runs and the
+    // node object afterwards. Read naively, every ribbon would run between
+    // "[object Object]" and itself.
+    const svg = buildFlowSvg(asLaidOut(AUTHORED));
+
+    const result = bindD3Sankey(svg, { selector: 'path.ribbon' });
+
+    expect(result.layer.data).toEqual(AUTHORED);
+  });
+
+  test('keeps the ribbons in declared order', () => {
+    // The trace keys its selector list to declared order, so a payload that
+    // reordered the flows would highlight one ribbon while announcing another.
+    const svg = buildFlowSvg(AUTHORED);
+
+    const result = bindD3Sankey(svg, { selector: 'path.ribbon' });
+
+    const values = (result.layer.data as FlowPoint[]).map(point => point.value);
+    expect(values).toEqual([34, 14, 12]);
+  });
+
+  test('says what to do when a ribbon carries no magnitude', () => {
+    const svg = buildFlowSvg([{ source: 'Coal', target: 'Heat' }]);
+
+    expect(() => bindD3Sankey(svg, { selector: 'path.ribbon' }))
+      .toThrow(/carries no magnitude/);
+  });
+
+  test('highlights the ribbons, scoped to the SVG', () => {
+    const svg = buildFlowSvg(AUTHORED);
+
+    const result = bindD3Sankey(svg, { selector: 'path.ribbon' });
+
+    // One element per declared flow: the trace withdraws highlighting when
+    // the counts disagree, which is what a selector matching the node rects
+    // instead would produce.
+    expect(result.layer.selectors).toBe('#fl-svg path.ribbon');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(AUTHORED.length);
+  });
+
+  test('throws an actionable error when the selector matches no ribbons', () => {
+    const svg = buildFlowSvg(AUTHORED);
+
+    expect(() => bindD3Sankey(svg, { selector: 'path.link' })).toThrow(/flow ribbon/);
+  });
+});
+
+describe('bindD3Alluvial', () => {
+  test('extracts the same graph and announces itself as alluvial', () => {
+    const svg = buildFlowSvg(AUTHORED);
+
+    const result = bindD3Alluvial(svg, { selector: 'path.ribbon' });
+
+    expect(result.layer.type).toBe(TraceType.ALLUVIAL);
+    expect(result.layer.data).toEqual(AUTHORED);
+  });
+});
+
+describe('bindD3Chord', () => {
+  test('names the matrix indices d3.chord binds from the declared names', () => {
+    const svg = buildFlowSvg([chord(0, 2, 90), chord(1, 3, 40)], 'ch-svg');
+
+    const result = bindD3Chord(svg, {
+      selector: 'path.ribbon',
+      names: ['Africa', 'Americas', 'Asia', 'Europe'],
+    });
+
+    expect(result.layer.type).toBe(TraceType.CHORD);
+    expect(result.layer.data).toEqual([
+      { source: 'Africa', target: 'Asia', value: 90 },
+      { source: 'Americas', target: 'Europe', value: 40 },
+    ]);
+  });
+
+  test('reads the magnitude d3.chord puts on the ribbon\'s ends', () => {
+    // A chord carries no value of its own: the width was drawn from the value
+    // on each end, so that is the honest number to announce.
+    const svg = buildFlowSvg([chord(0, 1, 12)], 'ch-svg');
+
+    const result = bindD3Chord(svg, { selector: 'path.ribbon', names: ['A', 'B'] });
+
+    expect((result.layer.data as FlowPoint[])[0].value).toBe(12);
+  });
+
+  test('falls back to the bare index when no names are declared', () => {
+    const svg = buildFlowSvg([chord(0, 1, 12)], 'ch-svg');
+
+    const result = bindD3Chord(svg, { selector: 'path.ribbon' });
+
+    expect(result.layer.data).toEqual([{ source: 0, target: 1, value: 12 }]);
+  });
+});
+
+describe('core-model integration', () => {
+  test('a sankey layer constructs a navigable Figure', () => {
+    const svg = buildFlowSvg(asLaidOut(AUTHORED));
+    const result = bindD3Sankey(svg, {
+      selector: 'path.ribbon',
+      title: 'Energy flow',
+      axes: { x: 'Node', y: 'Petajoules' },
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.SANKEY]);
+    });
+  });
+
+  test('a chord layer constructs a navigable Figure', () => {
+    const svg = buildFlowSvg([chord(0, 1, 12), chord(1, 2, 7)], 'ch-svg');
+    const result = bindD3Chord(svg, {
+      selector: 'path.ribbon',
+      names: ['Africa', 'Americas', 'Asia'],
+      title: 'Migration',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.CHORD]);
+    });
+  });
+});

--- a/test/adapters/d3/forest.test.ts
+++ b/test/adapters/d3/forest.test.ts
@@ -1,0 +1,161 @@
+import type { ForestPoint } from '@type/grammar';
+import { bindD3Forest } from '@adapters/d3/binders/errorBar';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { Orientation, TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `g.study` per study, and — when a pooled row is
+ * given — the `path.pooled` diamond a meta-analysis ends with.
+ */
+function buildForestSvg(studies: unknown[], pooled?: unknown): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="fo-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of studies) {
+    const group = doc.createElementNS('http://www.w3.org/2000/svg', 'g');
+    group.setAttribute('class', 'study');
+    (group as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(group);
+  }
+  if (pooled !== undefined) {
+    const diamond = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
+    diamond.setAttribute('class', 'pooled');
+    (diamond as unknown as { __data__: unknown }).__data__ = pooled;
+    svg.appendChild(diamond);
+  }
+  return svg;
+}
+
+const STUDIES = [
+  { study: 'Silva 2018', or: 0.62, ciLow: 0.41, ciHigh: 0.94, weight: 0.12 },
+  { study: 'Nguyen 2020', or: 1.34, ciLow: 0.98, ciHigh: 1.83, weight: 0.08 },
+  { study: 'Okafor 2022', or: 1.71, ciLow: 1.22, ciHigh: 2.4, weight: 0.55 },
+];
+
+const POOLED = { study: 'Pooled', or: 1.28, ciLow: 1.02, ciHigh: 1.61 };
+
+/** The config the studies above are read with. */
+const ACCESSORS = {
+  selector: 'g.study',
+  x: 'study',
+  y: 'or',
+  yMin: 'ciLow',
+  yMax: 'ciHigh',
+} as const;
+
+describe('bindD3Forest', () => {
+  test('reads each study\'s estimate, interval and weight', () => {
+    const svg = buildForestSvg(STUDIES);
+
+    const result = bindD3Forest(svg, {
+      ...ACCESSORS,
+      title: 'Effect of the Intervention',
+      orientation: Orientation.HORIZONTAL,
+      axes: { x: 'Odds ratio', y: 'Study' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.FOREST);
+    expect(result.layer.data).toEqual([
+      { x: 'Silva 2018', y: 0.62, yMin: 0.41, yMax: 0.94, weight: 0.12 },
+      { x: 'Nguyen 2020', y: 1.34, yMin: 0.98, yMax: 1.83, weight: 0.08 },
+      { x: 'Okafor 2022', y: 1.71, yMin: 1.22, yMax: 2.4, weight: 0.55 },
+    ]);
+  });
+
+  test('appends the pooled diamond after the studies and marks it', () => {
+    // The diamond is a different mark from the whips, so it is selected
+    // separately — and it is not one more study, which is what `pooled` says.
+    const svg = buildForestSvg(STUDIES, POOLED);
+
+    const result = bindD3Forest(svg, { ...ACCESSORS, pooledSelector: 'path.pooled' });
+
+    const data = result.layer.data as ForestPoint[];
+    expect(data).toHaveLength(4);
+    expect(data[3]).toEqual({ x: 'Pooled', y: 1.28, yMin: 1.02, yMax: 1.61, pooled: true });
+    expect(data.slice(0, 3).every(point => point.pooled === undefined)).toBe(true);
+  });
+
+  test('marks a pooled row a chart drew like any other', () => {
+    const svg = buildForestSvg([...STUDIES, { ...POOLED, pooled: true }]);
+
+    const result = bindD3Forest(svg, ACCESSORS);
+
+    expect((result.layer.data as ForestPoint[])[3].pooled).toBe(true);
+  });
+
+  test('carries the null line only when the caller declared one', () => {
+    const svg = buildForestSvg(STUDIES);
+
+    const declared = bindD3Forest(svg, { ...ACCESSORS, nullValue: 1 });
+    const silent = bindD3Forest(svg, ACCESSORS);
+
+    // A ratio chart guessed at 0 would report every study as not crossing,
+    // so a silent layer makes no claim about significance at all.
+    expect(declared.layer.forestOptions).toEqual({ nullValue: 1 });
+    expect(silent.layer.forestOptions).toBeUndefined();
+  });
+
+  test('omits the weight when the studies declare none', () => {
+    const svg = buildForestSvg([{ study: 'Silva 2018', or: 0.62, ciLow: 0.41, ciHigh: 0.94 }]);
+
+    const result = bindD3Forest(svg, ACCESSORS);
+
+    expect((result.layer.data as ForestPoint[])[0].weight).toBeUndefined();
+  });
+
+  test('highlights the studies and the diamond, in payload order', () => {
+    const svg = buildForestSvg(STUDIES, POOLED);
+
+    const result = bindD3Forest(svg, { ...ACCESSORS, pooledSelector: 'path.pooled' });
+
+    // The trace flattens the list and pairs it one-to-one with the rows, so
+    // the studies' selector has to come first — as the rows do.
+    expect(result.layer.selectors).toEqual(['#fo-svg g.study', '#fo-svg path.pooled']);
+    const matched = [...(result.layer.selectors as string[])]
+      .flatMap(one => [...svg.ownerDocument.querySelectorAll(one)]);
+    expect(matched).toHaveLength((result.layer.data as ForestPoint[]).length);
+  });
+
+  test('refuses a pooled selector that also matches the studies', () => {
+    // Both selectors matching one element would emit that row twice, and the
+    // doubled selector list would still match the doubled payload — so the
+    // only place it can be caught is here.
+    const svg = buildForestSvg([...STUDIES, { ...POOLED, pooled: true }]);
+
+    expect(() => bindD3Forest(svg, { ...ACCESSORS, pooledSelector: 'g.study' }))
+      .toThrow(/would be emitted twice/);
+  });
+
+  test('says what to do when the pooled selector matches nothing', () => {
+    const svg = buildForestSvg(STUDIES);
+
+    expect(() => bindD3Forest(svg, { ...ACCESSORS, pooledSelector: 'path.diamond' }))
+      .toThrow(/pooled summary/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildForestSvg(STUDIES, POOLED);
+    const result = bindD3Forest(svg, {
+      ...ACCESSORS,
+      pooledSelector: 'path.pooled',
+      title: 'Effect of the Intervention',
+      orientation: Orientation.HORIZONTAL,
+      axes: { x: 'Odds ratio', y: 'Study' },
+      nullValue: 1,
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.FOREST]);
+    });
+  });
+});

--- a/test/adapters/d3/gantt.test.ts
+++ b/test/adapters/d3/gantt.test.ts
@@ -1,0 +1,180 @@
+import type { GanttData } from '@type/grammar';
+import { bindD3Gantt } from '@adapters/d3/binders/gantt';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { Orientation, TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `rect.task` per datum, the way
+ * `selectAll('rect.task').data(intervals).join('rect')` would leave it.
+ */
+function buildGanttSvg(intervals: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="gt-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of intervals) {
+    const rect = doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('class', 'task');
+    (rect as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(rect);
+  }
+  return svg;
+}
+
+/**
+ * A schedule whose rects are NOT drawn lane by lane — the ordinary result of
+ * one flat `.data(rows)` join over rows sorted by start date.
+ */
+const INTERLEAVED = [
+  { x: 'Design', start: 0, end: 30, label: 'Wireframes' },
+  { x: 'Build', start: 30, end: 100, label: 'Implementation' },
+  { x: 'Design', start: 60, end: 75, label: 'Revisions' },
+  { x: 'Review', start: 75, end: 90 },
+];
+
+describe('bindD3Gantt', () => {
+  test('nests the intervals by lane rather than by DOM order', () => {
+    const svg = buildGanttSvg(INTERLEAVED);
+
+    const result = bindD3Gantt(svg, {
+      selector: 'rect.task',
+      title: 'Project Schedule',
+      axes: { x: 'Day', y: 'Phase' },
+      unit: 'days',
+    });
+
+    expect(result.layer.type).toBe(TraceType.GANTT);
+    const data = result.layer.data as GanttData;
+    expect(data.points).toEqual([
+      [
+        { x: 'Design', start: 0, end: 30, label: 'Wireframes' },
+        { x: 'Design', start: 60, end: 75, label: 'Revisions' },
+      ],
+      [{ x: 'Build', start: 30, end: 100, label: 'Implementation' }],
+      [{ x: 'Review', start: 75, end: 90 }],
+    ]);
+    expect(data.unit).toBe('days');
+  });
+
+  test('keeps a declared empty lane, which the DOM cannot carry', () => {
+    // A lane with nothing booked has no element at all, and an empty row is a
+    // real statement about a schedule — so it can only come from config.
+    const svg = buildGanttSvg(INTERLEAVED);
+
+    const result = bindD3Gantt(svg, {
+      selector: 'rect.task',
+      lanes: ['Design', 'Build', 'Review', 'Launch'],
+    });
+
+    const data = result.layer.data as GanttData;
+    expect(data.points).toHaveLength(4);
+    expect(data.points[3]).toEqual([]);
+    expect(data.lanes).toEqual(['Design', 'Build', 'Review', 'Launch']);
+  });
+
+  test('appends a lane the chart drew and the config did not declare', () => {
+    const svg = buildGanttSvg(INTERLEAVED);
+
+    const result = bindD3Gantt(svg, {
+      selector: 'rect.task',
+      lanes: ['Design', 'Launch'],
+    });
+
+    const data = result.layer.data as GanttData;
+    // Declared order first, then whatever was drawn — and the names stay
+    // positional with `points`, which is what the trace reads them by.
+    expect(data.lanes).toEqual(['Design', 'Launch', 'Build', 'Review']);
+    expect(data.points[1]).toEqual([]);
+    expect(data.points[2]).toEqual([{ x: 'Build', start: 30, end: 100, label: 'Implementation' }]);
+  });
+
+  test('coerces dates to epoch milliseconds so lengths can be measured', () => {
+    const svg = buildGanttSvg([
+      { x: 'Design', start: new Date('2024-01-01T00:00:00Z'), end: new Date('2024-01-08T00:00:00Z') },
+      { x: 'Build', start: '2024-01-08T00:00:00Z', end: '2024-02-01T00:00:00Z' },
+    ]);
+
+    const result = bindD3Gantt(svg, { selector: 'rect.task' });
+
+    const data = result.layer.data as GanttData;
+    expect(data.points[0][0]).toEqual({
+      x: 'Design',
+      start: Date.parse('2024-01-01T00:00:00Z'),
+      end: Date.parse('2024-01-08T00:00:00Z'),
+    });
+    expect(data.points[1][0].start).toBe(Date.parse('2024-01-08T00:00:00Z'));
+  });
+
+  test('says what to do when an end is neither a number nor a date', () => {
+    const svg = buildGanttSvg([{ x: 'Design', start: 'soon', end: 30 }]);
+
+    expect(() => bindD3Gantt(svg, { selector: 'rect.task' }))
+      .toThrow(/neither a number nor a parsable date/);
+  });
+
+  test('leaves an interval unlabelled when the lane already names it', () => {
+    const svg = buildGanttSvg([{ label: 'Design', start: 0, end: 30 }]);
+
+    const result = bindD3Gantt(svg, { selector: 'rect.task' });
+
+    const data = result.layer.data as GanttData;
+    expect(data.points[0][0]).toEqual({ x: 'Design', start: 0, end: 30 });
+  });
+
+  test('emits one selector per interval, in the payload\'s lane order', () => {
+    const svg = buildGanttSvg(INTERLEAVED);
+
+    const result = bindD3Gantt(svg, { selector: 'rect.task' });
+
+    // The trace slices a FLAT element list lane by lane, so a bare selector
+    // resolving in DOM order would hand Design the Build rect — and the count
+    // would still match, so nothing would look wrong.
+    const selectors = result.layer.selectors as string[];
+    expect(selectors).toHaveLength(4);
+    const labels = selectors.map((one) => {
+      const element = svg.ownerDocument.querySelector(one);
+      const datum = (element as unknown as { __data__: { label?: string; x: string } }).__data__;
+      return datum.label ?? datum.x;
+    });
+    expect(labels).toEqual(['Wireframes', 'Revisions', 'Implementation', 'Review']);
+  });
+
+  test('defaults to the orientation a schedule is drawn in', () => {
+    const svg = buildGanttSvg(INTERLEAVED);
+
+    const result = bindD3Gantt(svg, { selector: 'rect.task' });
+
+    // Bars run left to right, which puts the axis on x and the lanes on y.
+    expect(result.layer.orientation).toBe(Orientation.HORIZONTAL);
+  });
+
+  test('throws an actionable error when the selector matches no intervals', () => {
+    const svg = buildGanttSvg(INTERLEAVED);
+
+    expect(() => bindD3Gantt(svg, { selector: 'rect.bar' })).toThrow(/gantt interval/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildGanttSvg(INTERLEAVED);
+    const result = bindD3Gantt(svg, {
+      selector: 'rect.task',
+      title: 'Project Schedule',
+      axes: { x: 'Day', y: 'Phase' },
+      lanes: ['Design', 'Build', 'Review', 'Launch'],
+      unit: 'days',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.GANTT]);
+    });
+  });
+});

--- a/test/adapters/d3/gauge.test.ts
+++ b/test/adapters/d3/gauge.test.ts
@@ -1,0 +1,143 @@
+import { bindD3Gauge } from '@adapters/d3/binders/gauge';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding a bullet chart's measure bar with the given datum
+ * bound to it, alongside the range band a bullet is drawn over — which carries
+ * no data and must not be what the binder reads.
+ */
+function buildGaugeSvg(datum: unknown): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="gg-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+  const band = doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  band.setAttribute('class', 'band');
+  svg.appendChild(band);
+
+  const measure = doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  measure.setAttribute('class', 'measure');
+  (measure as unknown as { __data__: unknown }).__data__ = datum;
+  svg.appendChild(measure);
+
+  return svg;
+}
+
+const BANDS = [
+  { to: 50, label: 'poor' },
+  { to: 75, label: 'ok' },
+  { to: 100, label: 'good' },
+];
+
+describe('bindD3Gauge', () => {
+  test('emits the single object a gauge draws, not an array of one', () => {
+    const svg = buildGaugeSvg({ value: 73 });
+
+    const result = bindD3Gauge(svg, {
+      selector: 'rect.measure',
+      title: 'Conversion Rate against Target',
+      axes: { x: 'Measure', y: 'Percent' },
+      label: 'Conversion',
+      min: 0,
+      max: 100,
+      target: 80,
+      bands: BANDS,
+    });
+
+    expect(result.layer.type).toBe(TraceType.GAUGE);
+    expect(result.layer.data).toEqual({
+      value: 73,
+      min: 0,
+      max: 100,
+      label: 'Conversion',
+      target: 80,
+      bands: BANDS,
+    });
+  });
+
+  test('takes the measure from a bare numeric datum', () => {
+    // A gauge is routinely joined against the number it displays, in which
+    // case there is no key to name.
+    const svg = buildGaugeSvg(42);
+
+    const result = bindD3Gauge(svg, { selector: 'rect.measure', min: 0, max: 60 });
+
+    expect(result.layer.data).toEqual({ value: 42, min: 0, max: 60 });
+  });
+
+  test('infers the measure from an aliased key', () => {
+    const svg = buildGaugeSvg({ actual: 3.4, label: 'ignored' });
+
+    const result = bindD3Gauge(svg, { selector: 'rect.measure', min: 0, max: 5 });
+
+    expect(result.layer.data).toEqual({ value: 3.4, min: 0, max: 5 });
+  });
+
+  test('honours an explicit accessor even over a bare numeric datum', () => {
+    const svg = buildGaugeSvg(42);
+
+    const result = bindD3Gauge(svg, {
+      selector: 'rect.measure',
+      value: (d: unknown) => (d as number) / 2,
+      min: 0,
+      max: 60,
+    });
+
+    expect(result.layer.data).toEqual({ value: 21, min: 0, max: 60 });
+  });
+
+  test('leaves the annotations out when the chart has none', () => {
+    // Absent rather than empty: the trace announces the band a value lands in
+    // only when bands were declared, and nothing is invented for it.
+    const svg = buildGaugeSvg({ value: 7 });
+
+    const result = bindD3Gauge(svg, { selector: 'rect.measure', min: 0, max: 10 });
+
+    expect(result.layer.data).toEqual({ value: 7, min: 0, max: 10 });
+  });
+
+  test('highlights the mark the value is drawn as, scoped to the SVG', () => {
+    const svg = buildGaugeSvg({ value: 73 });
+
+    const result = bindD3Gauge(svg, { selector: 'rect.measure', min: 0, max: 100 });
+
+    expect(result.layer.selectors).toBe('#gg-svg rect.measure');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(1);
+  });
+
+  test('throws an actionable error when the selector matches no value mark', () => {
+    const svg = buildGaugeSvg({ value: 73 });
+
+    expect(() => bindD3Gauge(svg, { selector: 'path.needle', min: 0, max: 100 }))
+      .toThrow(/gauge value/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildGaugeSvg({ value: 73 });
+    const result = bindD3Gauge(svg, {
+      selector: 'rect.measure',
+      title: 'Conversion Rate against Target',
+      label: 'Conversion',
+      min: 0,
+      max: 100,
+      target: 80,
+      bands: BANDS,
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.GAUGE]);
+    });
+  });
+});

--- a/test/adapters/d3/hexbin.test.ts
+++ b/test/adapters/d3/hexbin.test.ts
@@ -1,0 +1,165 @@
+import type { HexbinPoint } from '@type/grammar';
+import { bindD3Hexbin } from '@adapters/d3/binders/hexbin';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Builds a `d3-hexbin` bin: an array of the points that fell in the hexagon,
+ * carrying its centre as `.x`/`.y` — which is where the count comes from too,
+ * since the bin's `length` is it.
+ */
+function bin(x: number, y: number, count: number): number[] {
+  const points = Array.from({ length: count }, (_, index) => index);
+  return Object.assign(points, { x, y });
+}
+
+/**
+ * Builds an SVG holding one `path.hexagon` per bin, in the order given — which
+ * for `d3-hexbin` is the order the bins were generated in, not the lattice's.
+ */
+function buildHexbinSvg(bins: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="hex-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of bins) {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'hexagon');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+/**
+ * A lattice whose bins are NOT drawn row by row, and whose top row is short —
+ * an empty bin has no hexagon at all, which is the ordinary case.
+ */
+const SCATTERED = [
+  bin(2, 10, 4),
+  bin(1.5, 20, 7),
+  bin(0, 10, 1),
+  bin(1, 10, 3),
+  bin(0.5, 20, 2),
+];
+
+describe('bindD3Hexbin', () => {
+  test('groups the bins into lattice rows, bottom row first', () => {
+    const svg = buildHexbinSvg(SCATTERED);
+
+    const result = bindD3Hexbin(svg, {
+      selector: 'path.hexagon',
+      title: 'Point Density',
+      axes: { x: 'X', y: 'Y', fill: 'Count' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.HEXBIN);
+    const data = result.layer.data as HexbinPoint[][];
+    // `HexbinTrace` steps its row index UP for an upward move, so row 0 has to
+    // be the bottom of the chart; within a row the index is the position.
+    expect(data).toEqual([
+      [
+        { x: 0, y: 10, count: 1 },
+        { x: 1, y: 10, count: 3 },
+        { x: 2, y: 10, count: 4 },
+      ],
+      [
+        { x: 0.5, y: 20, count: 2 },
+        { x: 1.5, y: 20, count: 7 },
+      ],
+    ]);
+  });
+
+  test('reads the centre through the inverse scales it is given', () => {
+    // `d3-hexbin` bins the PROJECTED points, so a bin's centre is a pixel.
+    const svg = buildHexbinSvg([bin(100, 300, 5), bin(200, 300, 2)]);
+
+    const result = bindD3Hexbin(svg, {
+      selector: 'path.hexagon',
+      x: d => (d as { x: number }).x / 10,
+      y: d => 40 - (d as { y: number }).y / 10,
+    });
+
+    const data = result.layer.data as HexbinPoint[][];
+    expect(data).toEqual([[
+      { x: 10, y: 10, count: 5 },
+      { x: 20, y: 10, count: 2 },
+    ]]);
+  });
+
+  test('emits one selector per bin, in the payload\'s lattice order', () => {
+    const svg = buildHexbinSvg(SCATTERED);
+
+    const result = bindD3Hexbin(svg, { selector: 'path.hexagon' });
+
+    // A bare selector would resolve in DOM order — the order the plugin
+    // generated the bins in — and the count would still match, so the trace
+    // could not tell it was lighting the wrong hexagons.
+    const selectors = result.layer.selectors as string[];
+    expect(selectors).toHaveLength(5);
+    const counts = selectors.map((one) => {
+      const element = svg.ownerDocument.querySelector(one);
+      return (element as unknown as { __data__: { length: number } }).__data__.length;
+    });
+    expect(counts).toEqual([1, 3, 4, 2, 7]);
+  });
+
+  test('groups by an explicit `row` accessor when the y values do not line up', () => {
+    const svg = buildHexbinSvg([
+      Object.assign([0], { x: 3, y: 10.0001, row: 0 }),
+      Object.assign([0, 1], { x: 1, y: 9.9998, row: 0 }),
+      Object.assign([0], { x: 2, y: 20.5, row: 1 }),
+    ]);
+
+    const result = bindD3Hexbin(svg, { selector: 'path.hexagon', row: 'row' });
+
+    const data = result.layer.data as HexbinPoint[][];
+    expect(data).toHaveLength(2);
+    expect(data[0].map(hexagon => hexagon.x)).toEqual([1, 3]);
+  });
+
+  test('scopes a single bin with one selector', () => {
+    const svg = buildHexbinSvg([bin(1, 1, 2)]);
+
+    const result = bindD3Hexbin(svg, { selector: 'path.hexagon' });
+
+    expect(result.layer.selectors).toBe('#hex-svg path.hexagon');
+  });
+
+  test('says where the three numbers live when one cannot be read', () => {
+    const svg = buildHexbinSvg([{ cx: 1, cy: 2 }]);
+
+    expect(() => bindD3Hexbin(svg, { selector: 'path.hexagon' }))
+      .toThrow(/has no count/);
+  });
+
+  test('throws an actionable error when the selector matches no hexagons', () => {
+    const svg = buildHexbinSvg(SCATTERED);
+
+    expect(() => bindD3Hexbin(svg, { selector: 'polygon.hex' })).toThrow(/hexagon/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a Figure that highlights its bins', () => {
+    const svg = buildHexbinSvg(SCATTERED);
+    const result = bindD3Hexbin(svg, {
+      selector: 'path.hexagon',
+      title: 'Point Density',
+      axes: { x: 'X', y: 'Y', fill: 'Count' },
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.HEXBIN]);
+    });
+  });
+});

--- a/test/adapters/d3/hexbin.test.ts
+++ b/test/adapters/d3/hexbin.test.ts
@@ -109,6 +109,33 @@ describe('bindD3Hexbin', () => {
     expect(counts).toEqual([1, 3, 4, 2, 7]);
   });
 
+  test('a rebind clears stamps left on MAIDR-owned clones', () => {
+    const svg = buildHexbinSvg(SCATTERED);
+    bindD3Hexbin(svg, { selector: 'path.hexagon' });
+
+    // MAIDR clones a mark to highlight it, and the clone copies the stamp the
+    // bind just laid down. `queryD3Elements` skips owned elements, so the
+    // clone never joins the payload — but the emitted
+    // `path.hexagon[data-maidr-hexbin-index="N"]` does not exclude it, so on a
+    // rebind that index would resolve to two hexagons: the real one and the
+    // clone. The count of selectors still matches the count of bins, so
+    // nothing downstream can tell.
+    const original = svg.querySelector('path.hexagon')!;
+    const clone = original.cloneNode(true) as Element;
+    clone.setAttribute('data-maidr-owned', 'true');
+    svg.appendChild(clone);
+    expect(clone.getAttribute('data-maidr-hexbin-index')).not.toBeNull();
+
+    const result = bindD3Hexbin(svg, { selector: 'path.hexagon' });
+
+    const selectors = result.layer.selectors as string[];
+    expect(selectors).toHaveLength(5);
+    for (const one of selectors) {
+      expect(svg.ownerDocument.querySelectorAll(one)).toHaveLength(1);
+    }
+    expect(clone.hasAttribute('data-maidr-hexbin-index')).toBe(false);
+  });
+
   test('groups by an explicit `row` accessor when the y values do not line up', () => {
     const svg = buildHexbinSvg([
       Object.assign([0], { x: 3, y: 10.0001, row: 0 }),

--- a/test/adapters/d3/line.test.ts
+++ b/test/adapters/d3/line.test.ts
@@ -1,0 +1,123 @@
+import type { LinePoint } from '@type/grammar';
+import { bindD3Bump, bindD3Line } from '@adapters/d3/binders/line';
+import { describe, expect, test } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+/**
+ * Builds an SVG holding one `path.series` per series, with the series' point
+ * array bound to it the way `selectAll('path.series').data(series).join(...)`
+ * would leave it.
+ */
+function buildSeriesSvg(series: unknown[][]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="line-svg"></svg>`);
+  const svg = dom.window.document.querySelector('svg') as unknown as SVGElement;
+  for (const points of series) {
+    const path = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('class', 'series');
+    (path as unknown as { __data__: unknown }).__data__ = points;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+/** Two competitors' ranks over four rounds — one of them overtaking. */
+const RANKS: unknown[][] = [
+  [
+    { round: 'R1', rank: 1, team: 'Ash' },
+    { round: 'R2', rank: 2, team: 'Ash' },
+    { round: 'R3', rank: 3, team: 'Ash' },
+  ],
+  [
+    { round: 'R1', rank: 3, team: 'Cedar' },
+    { round: 'R2', rank: 1, team: 'Cedar' },
+    { round: 'R3', rank: 1, team: 'Cedar' },
+  ],
+];
+
+describe('bindD3Bump', () => {
+  test('emits the ranks as bound, one row per competitor', () => {
+    const svg = buildSeriesSvg(RANKS);
+
+    const result = bindD3Bump(svg, {
+      selector: 'path.series',
+      title: 'League Table by Round',
+      axes: { x: 'Round', y: 'Rank', fill: 'Team' },
+      x: 'round',
+      y: 'rank',
+      fill: 'team',
+    });
+
+    expect(result.layer.type).toBe(TraceType.BUMP);
+    // BumpTrace inverts the pitch and derives the moves itself, so the ranks
+    // travel exactly as the user bound them — 1 is still the best position.
+    expect(result.layer.data).toEqual([
+      [
+        { x: 'R1', y: 1, z: 'Ash' },
+        { x: 'R2', y: 2, z: 'Ash' },
+        { x: 'R3', y: 3, z: 'Ash' },
+      ],
+      [
+        { x: 'R1', y: 3, z: 'Cedar' },
+        { x: 'R2', y: 1, z: 'Cedar' },
+        { x: 'R3', y: 1, z: 'Cedar' },
+      ],
+    ]);
+    expect(result.maidr.subplots[0][0].legend).toEqual(['Ash', 'Cedar']);
+  });
+
+  test('stamps one selector per competitor so a single line can be highlighted', () => {
+    const svg = buildSeriesSvg(RANKS);
+
+    const result = bindD3Bump(svg, {
+      selector: 'path.series',
+      x: 'round',
+      y: 'rank',
+      fill: 'team',
+    });
+
+    expect(result.layer.selectors).toEqual([
+      '#line-svg path.series[data-maidr-line-index="0"]',
+      '#line-svg path.series[data-maidr-line-index="1"]',
+    ]);
+  });
+});
+
+describe('bindD3Line', () => {
+  test('still announces itself as a line chart', () => {
+    // The bump binder shares this extraction core; the base case must not pick
+    // up its type constant.
+    const svg = buildSeriesSvg([[{ x: 'Jan', y: 30 }, { x: 'Feb', y: 34 }]]);
+
+    const result = bindD3Line(svg, { selector: 'path.series' });
+
+    expect(result.layer.type).toBe(TraceType.LINE);
+    expect((result.layer.data as LinePoint[][])[0]).toHaveLength(2);
+    // One path → one scoped selector is enough to highlight it.
+    expect(result.layer.selectors).toBe('#line-svg path.series');
+  });
+
+  test('withdraws highlighting rather than mis-highlighting an ambiguous series', () => {
+    // Shared parent, more paths than fill groups: the path↔series mapping
+    // cannot be established, so no selector is emitted at all.
+    const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="amb-svg"></svg>`);
+    const doc = dom.window.document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+    for (let i = 0; i < 3; i++) {
+      const path = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('class', 'series');
+      (path as unknown as { __data__: unknown }).__data__ = [{ x: 'Jan', y: i, fill: 'One' }];
+      svg.appendChild(path);
+    }
+    for (const datum of [{ x: 'Jan', y: 1, fill: 'One' }, { x: 'Feb', y: 2, fill: 'One' }]) {
+      const circle = doc.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      circle.setAttribute('class', 'point');
+      (circle as unknown as { __data__: unknown }).__data__ = datum;
+      svg.appendChild(circle);
+    }
+
+    const result = bindD3Line(svg, { selector: 'path.series', pointSelector: 'circle.point' });
+
+    expect(result.layer.selectors).toBeUndefined();
+  });
+});

--- a/test/adapters/d3/manhattan.test.ts
+++ b/test/adapters/d3/manhattan.test.ts
@@ -1,0 +1,158 @@
+import type { VolcanoPoint } from '@type/grammar';
+import { bindD3Manhattan, bindD3Scatter } from '@adapters/d3/binders/scatter';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `circle.snp` per datum, the way
+ * `selectAll('circle.snp').data(points).join('circle')` would leave it.
+ */
+function buildManhattanSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="mh-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const circle = doc.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('class', 'snp');
+    (circle as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(circle);
+  }
+  return svg;
+}
+
+const SNPS = [
+  { pos: 1_020_000, logP: 2.1, snp: 'rs1001', chromosome: '1' },
+  { pos: 4_300_000, logP: 9.4, snp: 'rs4300', chromosome: '2' },
+  { pos: 8_800_000, logP: 7.8, snp: 'rs8800', chromosome: '3' },
+];
+
+describe('bindD3Manhattan', () => {
+  test('carries what each point is and which chromosome it sits on', () => {
+    const svg = buildManhattanSvg(SNPS);
+
+    const result = bindD3Manhattan(svg, {
+      selector: 'circle.snp',
+      title: 'Genome-wide Association',
+      axes: { x: 'Position', y: '-log10(p)', fill: 'Chromosome' },
+      x: 'pos',
+      y: 'logP',
+      label: 'snp',
+      group: 'chromosome',
+    });
+
+    expect(result.layer.type).toBe(TraceType.MANHATTAN);
+    // Identity is the payload on this chart: the coordinates alone answer the
+    // question a reader can already see the shape of.
+    expect(result.layer.data).toEqual([
+      { x: 1_020_000, y: 2.1, label: 'rs1001', group: '1' },
+      { x: 4_300_000, y: 9.4, label: 'rs4300', group: '2' },
+      { x: 8_800_000, y: 7.8, label: 'rs8800', group: '3' },
+    ]);
+  });
+
+  test('infers the label and the region from the datum\'s own key names', () => {
+    const svg = buildManhattanSvg([{ x: 1, y: 8, id: 'rs99', chr: 'X' }]);
+
+    const result = bindD3Manhattan(svg, { selector: 'circle.snp' });
+
+    expect(result.layer.data).toEqual([{ x: 1, y: 8, label: 'rs99', group: 'X' }]);
+  });
+
+  test('keeps a point the datum names neither for', () => {
+    // Dropping a point for want of a label would lose the reading the chart
+    // was drawn for; both fields are simply absent.
+    const svg = buildManhattanSvg([{ x: 1, y: 8 }]);
+
+    const result = bindD3Manhattan(svg, { selector: 'circle.snp' });
+
+    const [point] = result.layer.data as VolcanoPoint[];
+    expect(point).toEqual({ x: 1, y: 8 });
+  });
+
+  test('declares the significance cutoff the chart was drawn against', () => {
+    const svg = buildManhattanSvg(SNPS);
+
+    const result = bindD3Manhattan(svg, {
+      selector: 'circle.snp',
+      x: 'pos',
+      y: 'logP',
+      significance: 7.3,
+    });
+
+    expect(result.layer.thresholdOptions).toEqual({ significance: 7.3 });
+  });
+
+  test('emits no threshold at all when none was declared', () => {
+    // There is deliberately no default: these charts are drawn on transformed
+    // axes whose conventions differ, and a guessed line would sort every point
+    // onto the wrong side silently.
+    const svg = buildManhattanSvg(SNPS);
+
+    const result = bindD3Manhattan(svg, { selector: 'circle.snp', x: 'pos', y: 'logP' });
+
+    expect(result.layer.thresholdOptions).toBeUndefined();
+  });
+
+  test('carries a raw p axis\'s inverted cutoff', () => {
+    const svg = buildManhattanSvg([{ x: 1, y: 0.01 }]);
+
+    const result = bindD3Manhattan(svg, {
+      selector: 'circle.snp',
+      significance: 0.05,
+      significanceDirection: 'below',
+    });
+
+    expect(result.layer.thresholdOptions)
+      .toEqual({ significance: 0.05, significanceDirection: 'below' });
+  });
+
+  test('highlights the points, scoped to the SVG', () => {
+    const svg = buildManhattanSvg(SNPS);
+
+    const result = bindD3Manhattan(svg, { selector: 'circle.snp', x: 'pos', y: 'logP' });
+
+    expect(result.layer.selectors).toBe('#mh-svg circle.snp');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(SNPS.length);
+  });
+});
+
+describe('bindD3Scatter alongside it', () => {
+  test('stays a scatter, and reads nothing a scatter does not carry', () => {
+    // The two share an extraction core; a datum with a `name` key must not
+    // pick up the Manhattan's label inference.
+    const svg = buildManhattanSvg([{ x: 1, y: 2, name: 'not a label' }]);
+
+    const result = bindD3Scatter(svg, { selector: 'circle.snp' });
+
+    expect(result.layer.type).toBe(TraceType.SCATTER);
+    expect(result.layer.data).toEqual([{ x: 1, y: 2 }]);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildManhattanSvg(SNPS);
+    const result = bindD3Manhattan(svg, {
+      selector: 'circle.snp',
+      title: 'Genome-wide Association',
+      x: 'pos',
+      y: 'logP',
+      label: 'snp',
+      group: 'chromosome',
+      significance: 7.3,
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.MANHATTAN]);
+    });
+  });
+});

--- a/test/adapters/d3/mosaic.test.ts
+++ b/test/adapters/d3/mosaic.test.ts
@@ -1,0 +1,169 @@
+import type { MosaicPoint } from '@type/grammar';
+import { bindD3Mosaic, bindD3Segmented } from '@adapters/d3/binders/segmented';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `rect.cell` per datum, the way a mosaic is joined
+ * from a flattened contingency table.
+ */
+function buildMosaicSvg(cells: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="mo-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of cells) {
+    const rect = doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('class', 'cell');
+    (rect as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(rect);
+  }
+  return svg;
+}
+
+/** A two-way table: survival by passenger class, one row per cell. */
+const CELLS = [
+  { klass: 'First', share: 0.62, outcome: 'Survived', width: 0.15, n: 203 },
+  { klass: 'Second', share: 0.41, outcome: 'Survived', width: 0.21, n: 118 },
+  { klass: 'First', share: 0.38, outcome: 'Died', width: 0.15, n: 122 },
+  { klass: 'Second', share: 0.59, outcome: 'Died', width: 0.21, n: 167 },
+];
+
+describe('bindD3Mosaic', () => {
+  test('carries the column width alongside the segment heights', () => {
+    const svg = buildMosaicSvg(CELLS);
+
+    const result = bindD3Mosaic(svg, {
+      selector: 'rect.cell',
+      title: 'Survival by Passenger Class',
+      axes: { x: 'Class', y: 'Proportion', fill: 'Outcome' },
+      x: 'klass',
+      y: 'share',
+      fill: 'outcome',
+      count: 'n',
+    });
+
+    expect(result.layer.type).toBe(TraceType.MOSAIC);
+    // Without the width a category of six people and one of six hundred read
+    // identically, which is the whole thing a mosaic is drawn to show.
+    expect(result.layer.data).toEqual([
+      [
+        { x: 'First', y: 0.62, z: 'Survived', width: 0.15, count: 203 },
+        { x: 'Second', y: 0.41, z: 'Survived', width: 0.21, count: 118 },
+      ],
+      [
+        { x: 'First', y: 0.38, z: 'Died', width: 0.15, count: 122 },
+        { x: 'Second', y: 0.59, z: 'Died', width: 0.21, count: 167 },
+      ],
+    ]);
+  });
+
+  test('infers the width from the datum\'s own key names', () => {
+    const svg = buildMosaicSvg([
+      { x: 'First', y: 0.62, fill: 'Survived', share: 0.15 },
+      { x: 'First', y: 0.38, fill: 'Died', share: 0.15 },
+    ]);
+
+    const result = bindD3Mosaic(svg, { selector: 'rect.cell' });
+
+    const [survived] = result.layer.data as MosaicPoint[][];
+    expect(survived[0]).toEqual({ x: 'First', y: 0.62, z: 'Survived', width: 0.15 });
+  });
+
+  test('omits a width the producer does not have, rather than inventing one', () => {
+    // A drawn `<rect>` always has a width, but that width is padding and scale
+    // as much as data — turning it back into a proportion would announce a
+    // number the table does not contain.
+    const svg = buildMosaicSvg([
+      { x: 'First', y: 0.62, fill: 'Survived' },
+      { x: 'First', y: 0.38, fill: 'Died' },
+    ]);
+
+    const result = bindD3Mosaic(svg, { selector: 'rect.cell' });
+
+    const [survived] = result.layer.data as MosaicPoint[][];
+    expect(survived[0]).toEqual({ x: 'First', y: 0.62, z: 'Survived' });
+  });
+
+  test('drops a width that is not a finite number', () => {
+    const svg = buildMosaicSvg([
+      { x: 'First', y: 0.62, fill: 'Survived', width: Number.NaN },
+      { x: 'First', y: 0.38, fill: 'Died', width: 0.15 },
+    ]);
+
+    const result = bindD3Mosaic(svg, { selector: 'rect.cell' });
+
+    const [survived, died] = result.layer.data as MosaicPoint[][];
+    // NaN would be announced as a share; the column's width is read from
+    // whichever series does declare one.
+    expect(survived[0].width).toBeUndefined();
+    expect(died[0].width).toBe(0.15);
+  });
+
+  test('highlights every cell through one scoped selector', () => {
+    const svg = buildMosaicSvg(CELLS);
+
+    const result = bindD3Mosaic(svg, {
+      selector: 'rect.cell',
+      x: 'klass',
+      y: 'share',
+      fill: 'outcome',
+    });
+
+    expect(result.layer.selectors).toBe('#mo-svg rect.cell');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(CELLS.length);
+  });
+});
+
+describe('bindD3Segmented alongside it', () => {
+  test('stays stacked, and reads no width off a datum that has one', () => {
+    // The two share an extraction core; a stacked bar whose datum happens to
+    // carry a `width` must not pick up a column share it never declared.
+    const svg = buildMosaicSvg([
+      { x: 'First', y: 0.62, fill: 'Survived', width: 0.15 },
+      { x: 'First', y: 0.38, fill: 'Died', width: 0.15 },
+    ]);
+
+    const result = bindD3Segmented(svg, { selector: 'rect.cell' });
+
+    expect(result.layer.type).toBe(TraceType.STACKED);
+    expect(result.layer.data).toEqual([
+      [{ x: 'First', y: 0.62, z: 'Survived' }],
+      [{ x: 'First', y: 0.38, z: 'Died' }],
+    ]);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildMosaicSvg(CELLS);
+    const result = bindD3Mosaic(svg, {
+      selector: 'rect.cell',
+      title: 'Survival by Passenger Class',
+      axes: { x: 'Class', y: 'Proportion', fill: 'Outcome' },
+      x: 'klass',
+      y: 'share',
+      fill: 'outcome',
+      count: 'n',
+    });
+
+    // jsdom 26 does not define `SVGPathElement`, and `SegmentedTrace`'s SVG
+    // mapping narrows with `instanceof` — so the Figure is built without the
+    // selectors here. They are asserted on their own above.
+    const { selectors, ...layer } = result.maidr.subplots[0][0].layers[0];
+    expect(selectors).toBeDefined();
+    const data = { ...result.maidr, subplots: [[{ layers: [layer] }]] };
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(data);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.MOSAIC]);
+    });
+  });
+});

--- a/test/adapters/d3/network.test.ts
+++ b/test/adapters/d3/network.test.ts
@@ -1,0 +1,146 @@
+import type { NetworkPoint } from '@type/grammar';
+import { bindD3Network } from '@adapters/d3/binders/network';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `line.link` per datum, the way
+ * `selectAll('line.link').data(links).join('line')` would leave it.
+ */
+function buildNetworkSvg(links: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="nw-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of links) {
+    const line = doc.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('class', 'link');
+    (line as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(line);
+  }
+  return svg;
+}
+
+/** The links as the author writes them, before any simulation touches them. */
+const AUTHORED = [
+  { source: 'Ada', target: 'Grace' },
+  { source: 'Grace', target: 'Alan' },
+  { source: 'Ada', target: 'Alan' },
+];
+
+/**
+ * The same links after `d3.forceLink().id(d => d.id)` has run: each end is now
+ * the node OBJECT the id resolved to, not the id.
+ */
+function asSimulated(links: { source: string; target: string }[]): unknown[] {
+  const nodes = new Map<string, { id: string; x: number; y: number }>();
+  const node = (id: string): unknown => {
+    if (!nodes.has(id)) {
+      nodes.set(id, { id, x: Math.random(), y: Math.random() });
+    }
+    return nodes.get(id);
+  };
+  return links.map(link => ({ source: node(link.source), target: node(link.target) }));
+}
+
+describe('bindD3Network', () => {
+  test('reads the two ends of every link', () => {
+    const svg = buildNetworkSvg(AUTHORED);
+
+    const result = bindD3Network(svg, {
+      selector: 'line.link',
+      title: 'Collaborations',
+      axes: { x: 'Person', y: 'Links' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.NETWORK);
+    expect(result.layer.data).toEqual([
+      { source: 'Ada', target: 'Grace' },
+      { source: 'Grace', target: 'Alan' },
+      { source: 'Ada', target: 'Alan' },
+    ]);
+  });
+
+  test('names the ends d3.forceLink replaced with node objects', () => {
+    // The simulation MUTATES each link: `source` is an id before it runs and
+    // the node object afterwards. Read naively, every link would be drawn
+    // between "[object Object]" and itself.
+    const svg = buildNetworkSvg(asSimulated(AUTHORED));
+
+    const result = bindD3Network(svg, { selector: 'line.link' });
+
+    expect(result.layer.data).toEqual([
+      { source: 'Ada', target: 'Grace' },
+      { source: 'Grace', target: 'Alan' },
+      { source: 'Ada', target: 'Alan' },
+    ]);
+  });
+
+  test('carries no position, however the nodes were laid out', () => {
+    const svg = buildNetworkSvg(asSimulated(AUTHORED));
+
+    const result = bindD3Network(svg, { selector: 'line.link' });
+
+    // Where a force-directed node lands is a fact about the solver's seed
+    // rather than about the data, so there is nowhere for it to go.
+    for (const point of result.layer.data as NetworkPoint[]) {
+      expect(Object.keys(point).sort()).toEqual(['source', 'target']);
+    }
+  });
+
+  test('reads a link that names its ends with other keys', () => {
+    const svg = buildNetworkSvg([{ from: 'Ada', to: 'Grace' }]);
+
+    const result = bindD3Network(svg, { selector: 'line.link' });
+
+    expect(result.layer.data).toEqual([{ source: 'Ada', target: 'Grace' }]);
+  });
+
+  test('says what to do when a node object carries no name', () => {
+    const svg = buildNetworkSvg([{ source: { index: 0 }, target: { index: 1 } }]);
+
+    expect(() => bindD3Network(svg, { selector: 'line.link' }))
+      .toThrow(/node object with no name/);
+  });
+
+  test('highlights the links, scoped to the SVG', () => {
+    const svg = buildNetworkSvg(AUTHORED);
+
+    const result = bindD3Network(svg, { selector: 'line.link' });
+
+    // One element per declared link: the trace withdraws highlighting when the
+    // counts disagree, which is what a selector matching the node circles
+    // instead would produce.
+    expect(result.layer.selectors).toBe('#nw-svg line.link');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(AUTHORED.length);
+  });
+
+  test('throws an actionable error when the selector matches no links', () => {
+    const svg = buildNetworkSvg(AUTHORED);
+
+    expect(() => bindD3Network(svg, { selector: 'line.edge' })).toThrow(/network link/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildNetworkSvg(asSimulated(AUTHORED));
+    const result = bindD3Network(svg, {
+      selector: 'line.link',
+      title: 'Collaborations',
+      axes: { x: 'Person', y: 'Links' },
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.NETWORK]);
+    });
+  });
+});

--- a/test/adapters/d3/pageDocument.ts
+++ b/test/adapters/d3/pageDocument.ts
@@ -1,0 +1,33 @@
+/**
+ * Test helper for the D3 adapter's core-model integration cases.
+ *
+ * The model resolves every layer selector through the page-global `document`
+ * (`Svg.selectAllElements`), which in a Jest `node` environment does not exist
+ * — so a Figure built from a binder's output would silently resolve nothing
+ * and withdraw its highlighting, and the case would pass without exercising
+ * the part it was written for.
+ */
+
+/**
+ * Runs `assert` with the page-global `document` pointed at the one the given
+ * element belongs to, restoring whatever was there before — including its
+ * absence — however the assertion ends.
+ *
+ * @param element - Any element from the JSDOM document the case built.
+ * @param assert - The assertion to run against that document.
+ * @returns Whatever `assert` returns.
+ */
+export function withPageDocument<T>(element: Element, assert: () => T): T {
+  const globals = globalThis as { document?: Document };
+  const previousDocument = globals.document;
+  globals.document = element.ownerDocument;
+  try {
+    return assert();
+  } finally {
+    if (previousDocument === undefined) {
+      delete globals.document;
+    } else {
+      globals.document = previousDocument;
+    }
+  }
+}

--- a/test/adapters/d3/parallel.test.ts
+++ b/test/adapters/d3/parallel.test.ts
@@ -1,0 +1,174 @@
+import type { LinePoint } from '@type/grammar';
+import { bindD3Parallel } from '@adapters/d3/binders/parallel';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const CARS = [
+  { name: 'Honda Civic', mpg: 33, hp: 65, weight: 1800 },
+  { name: 'Ford Sedan', mpg: 21, hp: 110, weight: 2600 },
+  { name: 'Muscle Coupe', mpg: 15, hp: 230, weight: 3400 },
+];
+
+/**
+ * Builds an SVG holding one `path.observation` per row, the datum bound to it
+ * being that whole observation — which is what a parallel coordinates chart
+ * binds, since one path crosses every axis.
+ */
+function buildParallelSvg(rows: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="pc-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const row of rows) {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'observation');
+    (path as unknown as { __data__: unknown }).__data__ = row;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+describe('bindD3Parallel', () => {
+  test('transposes each observation into one point per axis', () => {
+    const svg = buildParallelSvg(CARS);
+
+    const result = bindD3Parallel(svg, {
+      selector: 'path.observation',
+      title: 'Car Characteristics',
+      axes: { x: 'Variable', y: 'Value', fill: 'Car' },
+      dimensions: ['mpg', 'hp', 'weight'],
+    });
+
+    expect(result.layer.type).toBe(TraceType.PARALLEL);
+    const data = result.layer.data as LinePoint[][];
+    expect(data).toHaveLength(3);
+    expect(data[0]).toEqual([
+      { x: 'mpg', y: 33, z: 'Honda Civic' },
+      { x: 'hp', y: 65, z: 'Honda Civic' },
+      { x: 'weight', y: 1800, z: 'Honda Civic' },
+    ]);
+  });
+
+  test('keeps the declared axis order, not the datum\'s key order', () => {
+    // The order the axes are drawn in is the order a reader arrows through
+    // them, and an object's keys are not it.
+    const svg = buildParallelSvg(CARS);
+
+    const result = bindD3Parallel(svg, {
+      selector: 'path.observation',
+      dimensions: ['weight', 'mpg'],
+    });
+
+    const data = result.layer.data as LinePoint[][];
+    expect(data[1].map(point => point.x)).toEqual(['weight', 'mpg']);
+    expect(data[1].map(point => point.y)).toEqual([2600, 21]);
+  });
+
+  test('reads nested values through a `value` reader', () => {
+    const svg = buildParallelSvg([
+      { name: 'A', values: { mpg: 30, hp: 70 } },
+      { name: 'B', values: { mpg: 18, hp: 190 } },
+    ]);
+
+    const result = bindD3Parallel(svg, {
+      selector: 'path.observation',
+      dimensions: ['mpg', 'hp'],
+      value: (d, dimension) => (d as { values: Record<string, number> }).values[dimension],
+    });
+
+    const data = result.layer.data as LinePoint[][];
+    expect(data[1]).toEqual([
+      { x: 'mpg', y: 18, z: 'B' },
+      { x: 'hp', y: 190, z: 'B' },
+    ]);
+  });
+
+  test('says so when an observation is short of a dimension', () => {
+    // Dropped instead, the remaining values would shift up one column and
+    // every one of them would be announced under the next axis' name.
+    const svg = buildParallelSvg([{ name: 'A', mpg: 30 }]);
+
+    expect(() => bindD3Parallel(svg, {
+      selector: 'path.observation',
+      dimensions: ['mpg', 'hp'],
+    })).toThrow(/Dimension "hp" not found/);
+  });
+
+  test('says so when no dimensions were declared', () => {
+    const svg = buildParallelSvg(CARS);
+
+    expect(() => bindD3Parallel(svg, {
+      selector: 'path.observation',
+      dimensions: [],
+    })).toThrow(/needs its `dimensions`/);
+  });
+
+  test('emits one selector per observation', () => {
+    const svg = buildParallelSvg(CARS);
+
+    const result = bindD3Parallel(svg, {
+      selector: 'path.observation',
+      dimensions: ['mpg', 'hp', 'weight'],
+    });
+
+    // `ParallelTrace` inherits `LineTrace`'s pairing of one selector per row,
+    // so a bare selector matching all three paths withdraws highlighting.
+    expect(result.layer.selectors).toEqual([
+      '#pc-svg path.observation[data-maidr-line-index="0"]',
+      '#pc-svg path.observation[data-maidr-line-index="1"]',
+      '#pc-svg path.observation[data-maidr-line-index="2"]',
+    ]);
+  });
+
+  test('scopes a single observation with one selector', () => {
+    const svg = buildParallelSvg([CARS[0]]);
+
+    const result = bindD3Parallel(svg, {
+      selector: 'path.observation',
+      dimensions: ['mpg', 'hp'],
+    });
+
+    expect(result.layer.selectors).toBe('#pc-svg path.observation');
+  });
+
+  test('throws an actionable error when the selector matches no observations', () => {
+    const svg = buildParallelSvg(CARS);
+
+    expect(() => bindD3Parallel(svg, {
+      selector: 'path.line',
+      dimensions: ['mpg'],
+    })).toThrow(/observation path/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildParallelSvg(CARS);
+    const result = bindD3Parallel(svg, {
+      selector: 'path.observation',
+      title: 'Car Characteristics',
+      axes: { x: 'Variable', y: 'Value', fill: 'Car' },
+      dimensions: ['mpg', 'hp', 'weight'],
+    });
+
+    // jsdom 26 does not define `SVGPathElement`, and `LineTrace`'s path-parsing
+    // fallback narrows with `instanceof` — so the Figure is built without the
+    // selectors here. They are asserted on their own above.
+    const { selectors, ...layer } = result.maidr.subplots[0][0].layers[0];
+    expect(selectors).toBeDefined();
+    const data = { ...result.maidr, subplots: [[{ layers: [layer] }]] };
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(data);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.PARALLEL]);
+    });
+  });
+});

--- a/test/adapters/d3/radar.test.ts
+++ b/test/adapters/d3/radar.test.ts
@@ -1,0 +1,276 @@
+import type { LinePoint } from '@type/grammar';
+import { bindD3Radar } from '@adapters/d3/binders/line';
+import { bindD3PolarArea } from '@adapters/d3/binders/pie';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one closed `path.radar-area` per series, the way
+ * `selectAll('path.radar-area').data(series).join('path')` leaves it after a
+ * `d3.lineRadial()` draw.
+ */
+function buildRadarSvg(series: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="rd-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of series) {
+    const path = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('class', 'radar-area');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+/** Builds an SVG holding one `path.wedge` per category, as a coxcomb is drawn. */
+function buildPolarSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="pa-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const path = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('class', 'wedge');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+/** One spoke of a series, as the caller binds it. */
+function spoke(attribute: string, score: number, model: string): unknown {
+  return { attribute, score, model };
+}
+
+const MODEL_A = [
+  spoke('Speed', 8, 'Model A'),
+  spoke('Range', 6, 'Model A'),
+  spoke('Comfort', 9, 'Model A'),
+];
+const MODEL_B = [
+  spoke('Speed', 5, 'Model B'),
+  spoke('Range', 9, 'Model B'),
+  spoke('Comfort', 4, 'Model B'),
+];
+
+describe('bindD3Radar', () => {
+  test('reads one row per series, with the spoke on x', () => {
+    const svg = buildRadarSvg([MODEL_A, MODEL_B]);
+
+    const result = bindD3Radar(svg, {
+      selector: 'path.radar-area',
+      title: 'Model Comparison',
+      axes: { x: 'Attribute', y: 'Score', fill: 'Model' },
+      x: 'attribute',
+      y: 'score',
+      fill: 'model',
+    });
+
+    expect(result.layer.type).toBe(TraceType.RADAR);
+    expect(result.layer.data).toEqual([
+      [
+        { x: 'Speed', y: 8, z: 'Model A' },
+        { x: 'Range', y: 6, z: 'Model A' },
+        { x: 'Comfort', y: 9, z: 'Model A' },
+      ],
+      [
+        { x: 'Speed', y: 5, z: 'Model B' },
+        { x: 'Range', y: 9, z: 'Model B' },
+        { x: 'Comfort', y: 4, z: 'Model B' },
+      ],
+    ]);
+  });
+
+  test('drops the repeated first vertex a closed outline is drawn with', () => {
+    // The repeat is how the polygon shuts, not a spoke: left in, the chart
+    // announces four spokes where it has three, and RadarTrace spaces its
+    // angles by that count — every announced position rotates off the mark.
+    const closed = [...MODEL_A, spoke('Speed', 8, 'Model A')];
+    const svg = buildRadarSvg([closed]);
+
+    const result = bindD3Radar(svg, {
+      selector: 'path.radar-area',
+      x: 'attribute',
+      y: 'score',
+      fill: 'model',
+    });
+
+    const [row] = result.layer.data as LinePoint[][];
+    expect(row.map(point => point.x)).toEqual(['Speed', 'Range', 'Comfort']);
+  });
+
+  test('keeps a spoke that merely repeats a value', () => {
+    // Only a repeated *spoke name* closes the polygon; two spokes scoring the
+    // same is ordinary data.
+    const svg = buildRadarSvg([[
+      spoke('Speed', 7, 'Model A'),
+      spoke('Range', 7, 'Model A'),
+    ]]);
+
+    const result = bindD3Radar(svg, {
+      selector: 'path.radar-area',
+      x: 'attribute',
+      y: 'score',
+      fill: 'model',
+    });
+
+    const [row] = result.layer.data as LinePoint[][];
+    expect(row).toHaveLength(2);
+  });
+
+  test('emits one selector per series, and a legend naming them', () => {
+    const svg = buildRadarSvg([MODEL_A, MODEL_B]);
+
+    const result = bindD3Radar(svg, {
+      selector: 'path.radar-area',
+      x: 'attribute',
+      y: 'score',
+      fill: 'model',
+    });
+
+    // One selector per series: a bare selector matching both outlines at once
+    // makes `selectors.length` disagree with the row count, and the model
+    // withdraws highlighting rather than highlight the wrong series.
+    expect(result.layer.selectors).toEqual([
+      '#rd-svg path.radar-area[data-maidr-line-index="0"]',
+      '#rd-svg path.radar-area[data-maidr-line-index="1"]',
+    ]);
+    for (const selector of result.layer.selectors as string[]) {
+      expect(svg.ownerDocument.querySelectorAll(selector)).toHaveLength(1);
+    }
+  });
+});
+
+describe('bindD3PolarArea', () => {
+  const MONTHS = [
+    { month: 'Jan', deaths: 120 },
+    { month: 'Feb', deaths: 88 },
+    { month: 'Mar', deaths: 210 },
+  ];
+
+  test('reads the wedges as one row of spokes', () => {
+    const svg = buildPolarSvg(MONTHS);
+
+    const result = bindD3PolarArea(svg, {
+      selector: 'path.wedge',
+      title: 'Causes of Mortality',
+      axes: { x: 'Month', y: 'Deaths' },
+      x: 'month',
+      y: 'deaths',
+    });
+
+    expect(result.layer.type).toBe(TraceType.POLAR_AREA);
+    // A single row: a polar area draws one series of wedges around the dial.
+    expect(result.layer.data).toEqual([[
+      { x: 'Jan', y: 120 },
+      { x: 'Feb', y: 88 },
+      { x: 'Mar', y: 210 },
+    ]]);
+  });
+
+  test('unwraps a d3.pie() arc the way the pie binder does', () => {
+    const arcs = MONTHS.map((row, index) => ({
+      data: row,
+      value: row.deaths,
+      startAngle: index,
+      endAngle: index + 1,
+    }));
+    const svg = buildPolarSvg(arcs);
+
+    const result = bindD3PolarArea(svg, { selector: 'path.wedge', x: 'month' });
+
+    // The layout has already applied the caller's own `.value(...)`, so the
+    // magnitude is read back off the arc rather than guessed off the datum.
+    expect(result.layer.data).toEqual([[
+      { x: 'Jan', y: 120 },
+      { x: 'Feb', y: 88 },
+      { x: 'Mar', y: 210 },
+    ]]);
+  });
+
+  test('highlights every wedge through one scoped selector', () => {
+    const svg = buildPolarSvg(MONTHS);
+
+    const result = bindD3PolarArea(svg, { selector: 'path.wedge', x: 'month', y: 'deaths' });
+
+    // With a single row the trace resolves the matches straight onto the
+    // spokes, so the count has to be the wedge count exactly.
+    expect(result.layer.selectors).toBe('#pa-svg path.wedge');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(MONTHS.length);
+  });
+
+  test('names no fill axis: one series of wedges has no fill dimension', () => {
+    const svg = buildPolarSvg(MONTHS);
+
+    const result = bindD3PolarArea(svg, {
+      selector: 'path.wedge',
+      axes: { x: 'Month', y: 'Deaths' },
+      x: 'month',
+      y: 'deaths',
+    });
+
+    expect(result.layer.axes).toEqual({ x: { label: 'Month' }, y: { label: 'Deaths' } });
+  });
+
+  test('throws an actionable error when the selector matches no wedges', () => {
+    const svg = buildPolarSvg(MONTHS);
+
+    expect(() => bindD3PolarArea(svg, { selector: 'path.slice' }))
+      .toThrow(/polar area wedge/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('a polar area layer constructs a navigable Figure', () => {
+    const svg = buildPolarSvg([
+      { month: 'Jan', deaths: 120 },
+      { month: 'Feb', deaths: 88 },
+    ]);
+    const result = bindD3PolarArea(svg, {
+      selector: 'path.wedge',
+      title: 'Causes of Mortality',
+      axes: { x: 'Month', y: 'Deaths' },
+      x: 'month',
+      y: 'deaths',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.POLAR_AREA]);
+    });
+  });
+
+  test('a radar layer constructs a navigable Figure', () => {
+    const svg = buildRadarSvg([MODEL_A, MODEL_B]);
+    const result = bindD3Radar(svg, {
+      selector: 'path.radar-area',
+      title: 'Model Comparison',
+      axes: { x: 'Attribute', y: 'Score', fill: 'Model' },
+      x: 'attribute',
+      y: 'score',
+      fill: 'model',
+    });
+
+    // jsdom 26 does not define `SVGPathElement`, and `LineTrace`'s path-parsing
+    // fallback narrows with `instanceof` — so the Figure is built without the
+    // selectors here. They are asserted on their own above.
+    const { selectors, ...layer } = result.maidr.subplots[0][0].layers[0];
+    expect(selectors).toBeDefined();
+    const data = { ...result.maidr, subplots: [[{ layers: [layer] }]] };
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(data);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.RADAR]);
+    });
+  });
+});

--- a/test/adapters/d3/ridgeline.test.ts
+++ b/test/adapters/d3/ridgeline.test.ts
@@ -1,0 +1,188 @@
+import type { ViolinKdePoint } from '@type/grammar';
+import { bindD3Ridgeline } from '@adapters/d3/binders/ridgeline';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** One group's kernel density, sampled along the value axis. */
+function curve(days: number[], densities: number[]): { days: number; density: number }[] {
+  return days.map((day, index) => ({ days: day, density: densities[index] }));
+}
+
+const COHORTS = [
+  { cohort: '2019', samples: curve([18, 24, 30], [0.005, 0.019, 0.053]) },
+  { cohort: '2020', samples: curve([18, 24, 30], [0.012, 0.041, 0.030]) },
+];
+
+/**
+ * Builds an SVG holding one `path.ridge` per group, the datum bound to it
+ * being that group's density curve — the shape `.data(byCohort).join('path')`
+ * over `d3.area()` leaves.
+ */
+function buildRidgelineSvg(groups: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="rl-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const group of groups) {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'ridge');
+    (path as unknown as { __data__: unknown }).__data__ = group;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+describe('bindD3Ridgeline', () => {
+  test('reads one curve per group, keyed by the group\'s name', () => {
+    const svg = buildRidgelineSvg(COHORTS);
+
+    const result = bindD3Ridgeline(svg, {
+      selector: 'path.ridge',
+      title: 'Delivery Time by Cohort',
+      axes: { x: 'Days', y: 'Cohort', fill: 'Cohort' },
+      group: 'cohort',
+      value: 'days',
+    });
+
+    expect(result.layer.type).toBe(TraceType.RIDGELINE);
+    const data = result.layer.data as ViolinKdePoint[][];
+    expect(data).toHaveLength(2);
+    expect(data[0]).toEqual([
+      { x: '2019', y: 18, density: 0.005 },
+      { x: '2019', y: 24, density: 0.019 },
+      { x: '2019', y: 30, density: 0.053 },
+    ]);
+    expect(data[1][1]).toEqual({ x: '2020', y: 24, density: 0.041 });
+  });
+
+  test('carries the density the curve was drawn from, not the drawn y', () => {
+    // A ridgeline adds each group's baseline to its density before drawing it.
+    // The offset is layout, and fed to MAIDR it would make the lowest ridge
+    // the loudest — so the binder reads the pre-offset value.
+    const svg = buildRidgelineSvg([
+      {
+        cohort: 'A',
+        samples: [
+          { days: 10, density: 0.02, drawn: 100.02 },
+          { days: 20, density: 0.06, drawn: 100.06 },
+        ],
+      },
+    ]);
+
+    const result = bindD3Ridgeline(svg, {
+      selector: 'path.ridge',
+      group: 'cohort',
+      value: 'days',
+      density: 'density',
+    });
+
+    const data = result.layer.data as ViolinKdePoint[][];
+    expect(data[0].map(point => point.density)).toEqual([0.02, 0.06]);
+  });
+
+  test('reads a `d3.groups()` tuple', () => {
+    const svg = buildRidgelineSvg([
+      ['2019', curve([18, 24], [0.005, 0.019])],
+      ['2020', curve([18, 24], [0.012, 0.041])],
+    ]);
+
+    const result = bindD3Ridgeline(svg, {
+      selector: 'path.ridge',
+      value: 'days',
+    });
+
+    const data = result.layer.data as ViolinKdePoint[][];
+    expect(data[0][0]).toEqual({ x: '2019', y: 18, density: 0.005 });
+    expect(data[1][0]).toEqual({ x: '2020', y: 18, density: 0.012 });
+  });
+
+  test('names a group from its samples when the group datum is the array', () => {
+    const svg = buildRidgelineSvg([
+      [{ group: 'Ash', days: 4, density: 0.3 }, { group: 'Ash', days: 8, density: 0.1 }],
+    ]);
+
+    const result = bindD3Ridgeline(svg, { selector: 'path.ridge', value: 'days' });
+
+    const data = result.layer.data as ViolinKdePoint[][];
+    expect(data[0].map(point => point.x)).toEqual(['Ash', 'Ash']);
+  });
+
+  test('says what a missing density means and where to find one', () => {
+    const svg = buildRidgelineSvg([
+      { cohort: 'A', samples: [{ days: 10, y: 100.02 }] },
+    ]);
+
+    expect(() => bindD3Ridgeline(svg, {
+      selector: 'path.ridge',
+      group: 'cohort',
+      value: 'days',
+    })).toThrow(/carries no density/);
+  });
+
+  test('says so when a path carries no samples at all', () => {
+    const svg = buildRidgelineSvg([{ cohort: 'A' }]);
+
+    expect(() => bindD3Ridgeline(svg, { selector: 'path.ridge' }))
+      .toThrow(/has no samples/);
+  });
+
+  test('emits one scoped selector, which resolves to one element per group', () => {
+    const svg = buildRidgelineSvg(COHORTS);
+
+    const result = bindD3Ridgeline(svg, {
+      selector: 'path.ridge',
+      group: 'cohort',
+      value: 'days',
+    });
+
+    // `RidgelineTrace` requires exactly one element per group and lights that
+    // ridge from any of its samples; the groups are emitted in DOM order, so
+    // a single scoped selector is already in the payload's order.
+    expect(result.layer.selectors).toBe('#rl-svg path.ridge');
+    expect(svg.ownerDocument.querySelectorAll('#rl-svg path.ridge')).toHaveLength(2);
+  });
+
+  test('names the groups in the subplot legend', () => {
+    const svg = buildRidgelineSvg(COHORTS);
+
+    const result = bindD3Ridgeline(svg, {
+      selector: 'path.ridge',
+      group: 'cohort',
+      value: 'days',
+    });
+
+    expect(result.maidr.subplots[0][0].legend).toEqual(['2019', '2020']);
+  });
+
+  test('throws an actionable error when the selector matches no curves', () => {
+    const svg = buildRidgelineSvg(COHORTS);
+
+    expect(() => bindD3Ridgeline(svg, { selector: 'path.joy' })).toThrow(/ridge curve/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a Figure that highlights its ridges', () => {
+    const svg = buildRidgelineSvg(COHORTS);
+    const result = bindD3Ridgeline(svg, {
+      selector: 'path.ridge',
+      title: 'Delivery Time by Cohort',
+      axes: { x: 'Days', y: 'Cohort', fill: 'Cohort' },
+      group: 'cohort',
+      value: 'days',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.RIDGELINE]);
+    });
+  });
+});

--- a/test/adapters/d3/segmented.test.ts
+++ b/test/adapters/d3/segmented.test.ts
@@ -1,7 +1,10 @@
-import { bindD3Segmented } from '@adapters/d3/binders/segmented';
+import { bindD3Diverging, bindD3Segmented } from '@adapters/d3/binders/segmented';
 import { describe, expect, test } from '@jest/globals';
-import { TraceType } from '@type/grammar';
+import { Figure } from '@model/plot';
+import { Orientation, TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
 import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
 
 /**
  * Build an SVG with N rect.bar children, attaching `__data__` to each in the
@@ -78,5 +81,120 @@ describe('bindD3Segmented DOM-order auto-detection', () => {
     });
 
     expect(result.layer.domMapping).toEqual({ order: 'row' });
+  });
+});
+
+describe('bindD3Diverging', () => {
+  /** A population pyramid: the left-hand side is drawn negative. */
+  const PYRAMID = [
+    { people: -1200, band: '0-14', sex: 'Men' },
+    { people: -1150, band: '15-29', sex: 'Men' },
+    { people: 1140, band: '0-14', sex: 'Women' },
+    { people: 1100, band: '15-29', sex: 'Women' },
+  ];
+
+  /** Builds the pyramid's bars, one `rect.band` per row, in draw order. */
+  function buildPyramidSvg(): SVGElement {
+    const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="pyramid-svg"></svg>`);
+    const svg = dom.window.document.querySelector('svg') as unknown as SVGElement;
+    for (const datum of PYRAMID) {
+      const rect = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('class', 'band');
+      (rect as unknown as { __data__: unknown }).__data__ = datum;
+      svg.appendChild(rect);
+    }
+    return svg;
+  }
+
+  test('keeps the values signed, because the sign is which side the bar is on', () => {
+    const svg = buildPyramidSvg();
+
+    const result = bindD3Diverging(svg, {
+      selector: 'rect.band',
+      title: 'Population by Age Band',
+      orientation: Orientation.HORIZONTAL,
+      axes: { x: 'People, thousands', y: 'Age band', fill: 'Sex' },
+      x: 'people',
+      y: 'band',
+      fill: 'sex',
+    });
+
+    expect(result.layer.type).toBe(TraceType.DIVERGING);
+    // DivergingTrace reads the sign as a side and the magnitude as the pitch:
+    // absolute values would make the two sides indistinguishable, and the
+    // balance it reports between them a total instead of a comparison.
+    expect(result.layer.data).toEqual([
+      [
+        { x: -1200, y: '0-14', z: 'Men' },
+        { x: -1150, y: '15-29', z: 'Men' },
+      ],
+      [
+        { x: 1140, y: '0-14', z: 'Women' },
+        { x: 1100, y: '15-29', z: 'Women' },
+      ],
+    ]);
+    // The pyramid is drawn on its side, so `x` carries the value and `y` the
+    // category — which only reads correctly with the orientation declared.
+    expect(result.layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(result.maidr.subplots[0][0].legend).toEqual(['Men', 'Women']);
+  });
+
+  test('reports the sides in the order they were drawn', () => {
+    const svg = buildPyramidSvg();
+
+    const result = bindD3Diverging(svg, {
+      selector: 'rect.band',
+      x: 'people',
+      y: 'band',
+      fill: 'sex',
+    });
+
+    // Both series are rendered together, so the DOM is series-major and the
+    // model walks the sides in declaration order — the order a diverging chart
+    // is authored in, unlike a stacked bar's bottom-up segments.
+    expect(result.layer.domMapping).toEqual({ order: 'row' });
+    // Vertical by default: nothing is claimed the chart did not declare.
+    expect(result.layer.orientation).toBeUndefined();
+  });
+
+  test('highlights the bars, scoped to the SVG', () => {
+    const svg = buildPyramidSvg();
+
+    const result = bindD3Diverging(svg, {
+      selector: 'rect.band',
+      x: 'people',
+      y: 'band',
+      fill: 'sex',
+    });
+
+    expect(result.layer.selectors).toBe('#pyramid-svg rect.band');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(PYRAMID.length);
+  });
+
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildPyramidSvg();
+    const result = bindD3Diverging(svg, {
+      selector: 'rect.band',
+      title: 'Population by Age Band',
+      orientation: Orientation.HORIZONTAL,
+      x: 'people',
+      y: 'band',
+      fill: 'sex',
+    });
+
+    // Drop the selectors for this assertion only: SegmentedTrace narrows the
+    // resolved elements with `instanceof SVGPathElement`, and jsdom implements
+    // no such class — so highlighting is asserted on the emitted selector
+    // string above, and this checks the part jsdom can run.
+    const { selectors: _selectors, ...layer } = result.layer;
+
+    withPageDocument(svg, () => {
+      const figure = new Figure({ ...result.maidr, subplots: [[{ layers: [layer] }]] });
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.DIVERGING]);
+    });
   });
 });

--- a/test/adapters/d3/subplots.test.ts
+++ b/test/adapters/d3/subplots.test.ts
@@ -553,6 +553,68 @@ describe('bindD3Subplots', () => {
     ]);
   });
 
+  test('composes a diverging panel beside a bar panel', () => {
+    // `diverging` is the segmented core read as two sides rather than a stack.
+    // It is a chart type of its own in the panel dispatch, so a facet or a
+    // subplot grid can hold a population pyramid without the caller dropping
+    // to the standalone binder.
+    const dom = new JSDOM(`<!doctype html><body><svg xmlns="${SVG_NS}" id="pyramid-grid"></svg></body>`);
+    const doc = dom.window.document as Document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+    const pyramidPanel = doc.createElementNS(SVG_NS, 'g');
+    pyramidPanel.setAttribute('class', 'pyramid');
+    // Negative for the side drawn to the left: the sign is the side, so the
+    // binder must carry it through rather than take a magnitude.
+    for (const datum of [
+      { people: -1230, band: '0-14', sex: 'Men' },
+      { people: -1180, band: '15-29', sex: 'Men' },
+      { people: 1140, band: '0-14', sex: 'Women' },
+      { people: 1100, band: '15-29', sex: 'Women' },
+    ]) {
+      const rect = doc.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('class', 'band');
+      setDatum(rect, datum);
+      pyramidPanel.appendChild(rect);
+    }
+    svg.appendChild(pyramidPanel);
+
+    const barPanel = doc.createElementNS(SVG_NS, 'g');
+    barPanel.setAttribute('class', 'totals');
+    for (const datum of [{ x: 'Men', y: 2410 }, { x: 'Women', y: 2240 }]) {
+      const rect = doc.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('class', 'bar');
+      setDatum(rect, datum);
+      barPanel.appendChild(rect);
+    }
+    svg.appendChild(barPanel);
+
+    const result = bindD3Subplots(svg, {
+      subplots: [[
+        {
+          chartType: 'diverging',
+          root: 'g.pyramid',
+          config: { selector: 'rect.band', title: 'By age band', x: 'people', y: 'band', fill: 'sex' },
+        },
+        { chartType: 'bar', root: 'g.totals', config: { selector: 'rect.bar', title: 'Totals', x: 'x', y: 'y' } },
+      ]],
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    // The panel announces the diverging type, not the stacked one it shares a
+    // core with — the type is what makes the trace read the values as sides.
+    expect(subplots[0][0].layers[0].type).toBe(TraceType.DIVERGING);
+    expect(subplots[0][1].layers[0].type).toBe(TraceType.BAR);
+    expect(subplots[0][0].legend).toEqual(['Men', 'Women']);
+    // Signed values survive the panel path.
+    expect(subplots[0][0].layers[0].data).toEqual([
+      [{ x: -1230, y: '0-14', z: 'Men' }, { x: -1180, y: '15-29', z: 'Men' }],
+      [{ x: 1140, y: '0-14', z: 'Women' }, { x: 1100, y: '15-29', z: 'Women' }],
+    ]);
+    // Highlighting stays inside the panel that owns the marks.
+    expect(subplots[0][0].layers[0].selectors).toBe('#pyramid-grid [data-maidr-panel="0"] rect.band');
+  });
+
   test('rejects empty rows and unresolvable roots', () => {
     const { svg } = buildHeterogeneousSvg();
 

--- a/test/adapters/d3/subplots.test.ts
+++ b/test/adapters/d3/subplots.test.ts
@@ -498,6 +498,61 @@ describe('bindD3Subplots', () => {
     expect(subplots[1][0].layers[0].title).toBe('Panel 2');
   });
 
+  test('composes a stacked-area panel beside a funnel panel', () => {
+    // The bar and line cores serve several marks each; a panel must announce
+    // the mark its entry asked for, and stay scoped to its own subtree.
+    const dom = new JSDOM(`<!doctype html><body><svg xmlns="${SVG_NS}" id="mixed"></svg></body>`);
+    const doc = dom.window.document as Document;
+    const svg = doc.querySelector('svg') as unknown as SVGElement;
+
+    const areaPanel = doc.createElementNS(SVG_NS, 'g');
+    areaPanel.setAttribute('class', 'revenue');
+    for (const [key, offset] of [['Subscriptions', 0], ['Services', 10]] as [string, number][]) {
+      const path = doc.createElementNS(SVG_NS, 'path');
+      path.setAttribute('class', 'area');
+      const series = [0, 1].map((i) => {
+        const tuple: number[] & { data?: unknown } = [offset, offset + 10 + i];
+        tuple.data = { year: `201${9 + i}` };
+        return tuple;
+      });
+      setDatum(path, Object.assign(series, { key }));
+      areaPanel.appendChild(path);
+    }
+    svg.appendChild(areaPanel);
+
+    const funnelPanel = doc.createElementNS(SVG_NS, 'g');
+    funnelPanel.setAttribute('class', 'checkout');
+    for (const datum of [{ stage: 'Visited', count: 900 }, { stage: 'Purchased', count: 40 }]) {
+      const path = doc.createElementNS(SVG_NS, 'path');
+      path.setAttribute('class', 'stage');
+      setDatum(path, datum);
+      funnelPanel.appendChild(path);
+    }
+    svg.appendChild(funnelPanel);
+
+    const result = bindD3Subplots(svg, {
+      subplots: [[
+        { chartType: 'area', root: 'g.revenue', config: { selector: 'path.area', type: TraceType.STACKED_AREA, x: 'year' } },
+        { chartType: 'funnel', root: 'g.checkout', config: { selector: 'path.stage' } },
+      ]],
+    });
+
+    const subplots = subplotGrid(result.maidr.subplots);
+    expect(subplots[0][0].layers[0].type).toBe(TraceType.STACKED_AREA);
+    expect(subplots[0][1].layers[0].type).toBe(TraceType.FUNNEL);
+    // Per-band selectors stay inside their own panel.
+    expect(subplots[0][0].layers[0].selectors).toEqual([
+      '#mixed [data-maidr-panel="0"] path.area[data-maidr-line-index="0"]',
+      '#mixed [data-maidr-panel="0"] path.area[data-maidr-line-index="1"]',
+    ]);
+    expect(subplots[0][0].legend).toEqual(['Subscriptions', 'Services']);
+    expect(subplots[0][1].layers[0].selectors).toBe('#mixed [data-maidr-panel="1"] path.stage');
+    expect(subplots[0][1].layers[0].data).toEqual([
+      { x: 'Visited', y: 900 },
+      { x: 'Purchased', y: 40 },
+    ]);
+  });
+
   test('rejects empty rows and unresolvable roots', () => {
     const { svg } = buildHeterogeneousSvg();
 

--- a/test/adapters/d3/survival.test.ts
+++ b/test/adapters/d3/survival.test.ts
@@ -1,0 +1,221 @@
+import type { SurvivalPoint } from '@type/grammar';
+import { bindD3Survival } from '@adapters/d3/binders/survival';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const CONTROL = [
+  { time: 0, surv: 1, arm: 'Control', lower: 0.88, upper: 1 },
+  { time: 6, surv: 0.71, arm: 'Control', lower: 0.59, upper: 0.83 },
+  { time: 12, surv: 0.41, arm: 'Control', lower: 0.29, upper: 0.53 },
+];
+
+const TREATMENT = [
+  { time: 0, surv: 1, arm: 'Treatment', lower: 0.9, upper: 1 },
+  { time: 6, surv: 0.86, arm: 'Treatment', lower: 0.74, upper: 0.95 },
+  { time: 12, surv: 0.68, arm: 'Treatment', lower: 0.54, upper: 0.8 },
+];
+
+/**
+ * Builds an SVG holding one `path.km` per arm — the datum bound to it being
+ * that arm's samples, as `.data(arms).join('path')` over a step generator
+ * leaves it — plus an optional separate join of `line.censor` ticks.
+ */
+function buildSurvivalSvg(arms: unknown[][], ticks: unknown[] = []): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="km-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const arm of arms) {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'km');
+    (path as unknown as { __data__: unknown }).__data__ = arm;
+    svg.appendChild(path);
+  }
+  for (const tick of ticks) {
+    const mark = doc.createElementNS(SVG_NS, 'line');
+    mark.setAttribute('class', 'censor');
+    (mark as unknown as { __data__: unknown }).__data__ = tick;
+    svg.appendChild(mark);
+  }
+  return svg;
+}
+
+/** The config every case shares, so each one only states its own variable. */
+const BASE = {
+  selector: 'path.km',
+  x: 'time',
+  y: 'surv',
+  fill: 'arm',
+  yMin: 'lower',
+  yMax: 'upper',
+} as const;
+
+describe('bindD3Survival', () => {
+  test('reads one curve per arm, with the confidence band alongside', () => {
+    const svg = buildSurvivalSvg([CONTROL, TREATMENT]);
+
+    const result = bindD3Survival(svg, {
+      ...BASE,
+      title: 'Overall Survival',
+      axes: { x: 'Months', y: 'Survival probability', fill: 'Arm' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.SURVIVAL);
+    const data = result.layer.data as SurvivalPoint[][];
+    expect(data).toHaveLength(2);
+    expect(data[0][0]).toEqual({
+      x: 0,
+      y: 1,
+      z: 'Control',
+      yMin: 0.88,
+      yMax: 1,
+    });
+    expect(data[1][2]).toEqual({
+      x: 12,
+      y: 0.68,
+      z: 'Treatment',
+      yMin: 0.54,
+      yMax: 0.8,
+    });
+  });
+
+  test('flags a censored time the curve already has a vertex at', () => {
+    const svg = buildSurvivalSvg([CONTROL], [{ time: 6, arm: 'Control' }]);
+
+    const result = bindD3Survival(svg, { ...BASE, censoredSelector: 'line.censor' });
+
+    const arm = (result.layer.data as SurvivalPoint[][])[0];
+    expect(arm).toHaveLength(3);
+    expect(arm[1].censored).toBe(true);
+    expect(arm[0].censored).toBeUndefined();
+  });
+
+  test('inserts a censored time between two vertices, holding the estimate', () => {
+    // A censoring tick is not a step: the curve does not move there, so the
+    // inserted point carries the probability held across the interval it
+    // falls in — and the band that goes with it.
+    const svg = buildSurvivalSvg([CONTROL], [{ time: 9, arm: 'Control' }]);
+
+    const result = bindD3Survival(svg, { ...BASE, censoredSelector: 'line.censor' });
+
+    const arm = (result.layer.data as SurvivalPoint[][])[0];
+    expect(arm).toHaveLength(4);
+    expect(arm[2]).toEqual({
+      x: 9,
+      y: 0.71,
+      z: 'Control',
+      yMin: 0.59,
+      yMax: 0.83,
+      censored: true,
+    });
+    expect(arm.map(point => point.x)).toEqual([0, 6, 9, 12]);
+  });
+
+  test('merges each tick into the arm it names', () => {
+    const svg = buildSurvivalSvg(
+      [CONTROL, TREATMENT],
+      [{ time: 9, arm: 'Treatment' }, { time: 3, arm: 'Control' }],
+    );
+
+    const result = bindD3Survival(svg, { ...BASE, censoredSelector: 'line.censor' });
+
+    const [control, treatment] = result.layer.data as SurvivalPoint[][];
+    expect(control.map(point => point.x)).toEqual([0, 3, 6, 12]);
+    expect(control[1].censored).toBe(true);
+    expect(treatment.map(point => point.x)).toEqual([0, 6, 9, 12]);
+    expect(treatment[2].censored).toBe(true);
+  });
+
+  test('says so when a tick names an arm the chart does not draw', () => {
+    const svg = buildSurvivalSvg([CONTROL], [{ time: 9, arm: 'Placebo' }]);
+
+    expect(() => bindD3Survival(svg, { ...BASE, censoredSelector: 'line.censor' }))
+      .toThrow(/names the arm "Placebo"/);
+  });
+
+  test('says so when a tick names no arm on a multi-arm chart', () => {
+    // Merged into the first arm, it would announce a subject leaving a study
+    // they were never in — and nothing downstream could tell.
+    const svg = buildSurvivalSvg([CONTROL, TREATMENT], [{ time: 9 }]);
+
+    expect(() => bindD3Survival(svg, {
+      ...BASE,
+      fill: 'arm',
+      censoredSelector: 'line.censor',
+      x: 'time',
+    })).toThrow(/names no arm/);
+  });
+
+  test('reads censoring off the curve\'s own samples when it is a column', () => {
+    const svg = buildSurvivalSvg([[
+      { time: 0, surv: 1, censored: 0 },
+      { time: 4, surv: 0.9, censored: 1 },
+      { time: 8, surv: 0.9, censored: '0' },
+    ]]);
+
+    const result = bindD3Survival(svg, { selector: 'path.km', x: 'time', y: 'surv' });
+
+    const arm = (result.layer.data as SurvivalPoint[][])[0];
+    // `'0'` is truthy, and reading the flag by truthiness would censor the
+    // last time — a subject who is recorded as having had the event.
+    expect(arm.map(point => point.censored)).toEqual([undefined, true, undefined]);
+  });
+
+  test('emits one selector per arm, which is what the trace pairs rows with', () => {
+    const svg = buildSurvivalSvg([CONTROL, TREATMENT]);
+
+    const result = bindD3Survival(svg, BASE);
+
+    expect(result.layer.selectors).toEqual([
+      '#km-svg path.km[data-maidr-line-index="0"]',
+      '#km-svg path.km[data-maidr-line-index="1"]',
+    ]);
+  });
+
+  test('names the arms in the subplot legend', () => {
+    const svg = buildSurvivalSvg([CONTROL, TREATMENT]);
+
+    const result = bindD3Survival(svg, BASE);
+
+    expect(result.maidr.subplots[0][0].legend).toEqual(['Control', 'Treatment']);
+  });
+
+  test('throws an actionable error when the censoring selector matches nothing', () => {
+    const svg = buildSurvivalSvg([CONTROL]);
+
+    expect(() => bindD3Survival(svg, { ...BASE, censoredSelector: 'line.tick' }))
+      .toThrow(/censoring tick/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildSurvivalSvg([CONTROL, TREATMENT], [{ time: 9, arm: 'Control' }]);
+    const result = bindD3Survival(svg, {
+      ...BASE,
+      title: 'Overall Survival',
+      axes: { x: 'Months', y: 'Survival probability', fill: 'Arm' },
+      censoredSelector: 'line.censor',
+    });
+
+    // jsdom 26 does not define `SVGPathElement`, and `LineTrace`'s path-parsing
+    // fallback narrows with `instanceof` — so the Figure is built without the
+    // selectors here. They are asserted on their own above.
+    const { selectors, ...layer } = result.maidr.subplots[0][0].layers[0];
+    expect(selectors).toBeDefined();
+    const data = { ...result.maidr, subplots: [[{ layers: [layer] }]] };
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(data);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.SURVIVAL]);
+    });
+  });
+});

--- a/test/adapters/d3/treemap.test.ts
+++ b/test/adapters/d3/treemap.test.ts
@@ -1,0 +1,223 @@
+import type { TreemapPoint } from '@type/grammar';
+import { bindD3Sunburst, bindD3Treemap } from '@adapters/d3/binders/treemap';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/** A node of the tree the caller hands to `d3.hierarchy()`. */
+interface Row {
+  name: string;
+  population?: number;
+  children?: Row[];
+}
+
+/**
+ * A `d3.hierarchy()` node, built here rather than pulled in: the adapter
+ * imports no d3 code, so the datum shape is what has to be reproduced —
+ * `data`, `depth`, the summed `value`, and `ancestors()`.
+ */
+interface Node {
+  data: Row;
+  depth: number;
+  value: number;
+  parent: Node | null;
+  ancestors: () => Node[];
+}
+
+/**
+ * Wraps a row tree the way `d3.hierarchy(root).sum(d => d.population)` does,
+ * returning every node in the order `descendants()` yields them (root first,
+ * then each subtree).
+ */
+function hierarchy(row: Row, depth = 0, parent: Node | null = null): Node[] {
+  const node: Node = {
+    data: row,
+    depth,
+    value: 0,
+    parent,
+    ancestors() {
+      const chain: Node[] = [];
+      for (let at: Node | null = node; at !== null; at = at.parent) {
+        chain.push(at);
+      }
+      return chain;
+    },
+  };
+  const descendants = (row.children ?? [])
+    .flatMap(child => hierarchy(child, depth + 1, node));
+  node.value = row.population
+    ?? descendants
+      .filter(child => child.parent === node)
+      .reduce((total, child) => total + child.value, 0);
+  return [node, ...descendants];
+}
+
+const WORLD: Row = {
+  name: 'World',
+  children: [
+    { name: 'Asia', children: [
+      { name: 'China', population: 1425 },
+      { name: 'India', population: 1428 },
+    ] },
+    { name: 'Africa', children: [
+      { name: 'Nigeria', population: 224 },
+    ] },
+  ],
+};
+
+/** Builds an SVG holding one element of `tag` per node, in the given order. */
+function buildTreeSvg(id: string, tag: string, className: string, data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="${id}"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const element = doc.createElementNS('http://www.w3.org/2000/svg', tag);
+    element.setAttribute('class', className);
+    (element as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(element);
+  }
+  return svg;
+}
+
+/** The leaves, which is what `d3.treemap()(root).leaves()` yields. */
+function leaves(): Node[] {
+  return hierarchy(WORLD).filter(node => node.data.children === undefined);
+}
+
+describe('bindD3Treemap', () => {
+  test('names each leaf and walks its ancestors into a path', () => {
+    const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', leaves());
+
+    const result = bindD3Treemap(svg, {
+      selector: 'rect.leaf',
+      title: 'World population by region',
+      axes: { x: 'Region', y: 'Population, millions' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.TREEMAP);
+    // Root first and excluding the node itself, which is what the grammar
+    // asks for and what the reader is told as a breadcrumb.
+    expect(result.layer.data).toEqual([
+      { x: 'China', y: 1425, path: ['World', 'Asia'] },
+      { x: 'India', y: 1428, path: ['World', 'Asia'] },
+      { x: 'Nigeria', y: 224, path: ['World', 'Africa'] },
+    ]);
+  });
+
+  test('reads the total the layout itself summed', () => {
+    // `.sum(...)` is what the rectangle's area was drawn from, so reading it
+    // back keeps the sonified magnitude identical to the mark on screen.
+    const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', hierarchy(WORLD));
+
+    const result = bindD3Treemap(svg, { selector: 'rect.leaf' });
+
+    const [root] = result.layer.data as TreemapPoint[];
+    expect(root).toEqual({ x: 'World', y: 3077 });
+  });
+
+  test('honours an explicit y over the layout\'s total', () => {
+    const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', leaves());
+
+    const result = bindD3Treemap(svg, { selector: 'rect.leaf', y: 'population' });
+
+    const [china] = result.layer.data as TreemapPoint[];
+    expect(china.y).toBe(1425);
+  });
+
+  test('reads a tree drawn without d3.hierarchy from declared paths', () => {
+    const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', [
+      { name: 'China', value: 1425, path: ['World', 'Asia'] },
+      { name: 'Nigeria', value: 224, path: ['World', 'Africa'] },
+    ]);
+
+    const result = bindD3Treemap(svg, { selector: 'rect.leaf' });
+
+    expect(result.layer.data).toEqual([
+      { x: 'China', y: 1425, path: ['World', 'Asia'] },
+      { x: 'Nigeria', y: 224, path: ['World', 'Africa'] },
+    ]);
+  });
+
+  test('highlights every node through one scoped selector', () => {
+    const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', leaves());
+
+    const result = bindD3Treemap(svg, { selector: 'rect.leaf' });
+
+    // The trace indexes the matches by declaration order and withdraws
+    // highlighting on a count mismatch, so the element count must be exactly
+    // the number of points emitted.
+    expect(result.layer.selectors).toBe('#tm-svg rect.leaf');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength((result.layer.data as TreemapPoint[]).length);
+  });
+
+  test('throws an actionable error when the selector matches no nodes', () => {
+    const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', leaves());
+
+    expect(() => bindD3Treemap(svg, { selector: 'rect.tile' })).toThrow(/treemap node/);
+  });
+});
+
+describe('bindD3Sunburst', () => {
+  test('emits the interior arcs a partition draws, alongside the leaves', () => {
+    // A partition lays out interior nodes too, and every arc the reader can
+    // see has to be a point they can reach — and highlight.
+    const arcs = hierarchy(WORLD).slice(1);
+    const svg = buildTreeSvg('sb-svg', 'path', 'arc', arcs);
+
+    const result = bindD3Sunburst(svg, {
+      selector: 'path.arc',
+      title: 'World population by region',
+      axes: { x: 'Region', y: 'Population, millions' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.SUNBURST);
+    expect(result.layer.data).toEqual([
+      { x: 'Asia', y: 2853, path: ['World'] },
+      { x: 'China', y: 1425, path: ['World', 'Asia'] },
+      { x: 'India', y: 1428, path: ['World', 'Asia'] },
+      { x: 'Africa', y: 224, path: ['World'] },
+      { x: 'Nigeria', y: 224, path: ['World', 'Africa'] },
+    ]);
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(arcs.length);
+  });
+});
+
+describe('core-model integration', () => {
+  test('a treemap layer constructs a navigable Figure', () => {
+    const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', leaves());
+    const result = bindD3Treemap(svg, {
+      selector: 'rect.leaf',
+      title: 'World population by region',
+      axes: { x: 'Region', y: 'Population, millions' },
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.TREEMAP]);
+    });
+  });
+
+  test('a sunburst layer constructs a navigable Figure', () => {
+    const svg = buildTreeSvg('sb-svg', 'path', 'arc', hierarchy(WORLD).slice(1));
+    const result = bindD3Sunburst(svg, {
+      selector: 'path.arc',
+      title: 'World population by region',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.SUNBURST]);
+    });
+  });
+});

--- a/test/adapters/d3/treemap.test.ts
+++ b/test/adapters/d3/treemap.test.ts
@@ -1,5 +1,5 @@
 import type { TreemapPoint } from '@type/grammar';
-import { bindD3Sunburst, bindD3Treemap } from '@adapters/d3/binders/treemap';
+import { bindD3Icicle, bindD3Sunburst, bindD3Treemap } from '@adapters/d3/binders/treemap';
 import { describe, expect, test } from '@jest/globals';
 import { Figure } from '@model/plot';
 import { TraceType } from '@type/grammar';
@@ -187,6 +187,32 @@ describe('bindD3Sunburst', () => {
   });
 });
 
+describe('bindD3Icicle', () => {
+  test('reads the same partition a sunburst does, as bands', () => {
+    // An icicle is the sunburst's partition in cartesian coordinates: the
+    // tree is identical, and only the type the layer announces differs.
+    const bands = hierarchy(WORLD).slice(1);
+    const svg = buildTreeSvg('ic-svg', 'rect', 'band', bands);
+
+    const result = bindD3Icicle(svg, {
+      selector: 'rect.band',
+      title: 'World population by region',
+      axes: { x: 'Region', y: 'Population, millions' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.ICICLE);
+    expect(result.layer.data).toEqual([
+      { x: 'Asia', y: 2853, path: ['World'] },
+      { x: 'China', y: 1425, path: ['World', 'Asia'] },
+      { x: 'India', y: 1428, path: ['World', 'Asia'] },
+      { x: 'Africa', y: 224, path: ['World'] },
+      { x: 'Nigeria', y: 224, path: ['World', 'Africa'] },
+    ]);
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(bands.length);
+  });
+});
+
 describe('core-model integration', () => {
   test('a treemap layer constructs a navigable Figure', () => {
     const svg = buildTreeSvg('tm-svg', 'rect', 'leaf', leaves());
@@ -202,6 +228,22 @@ describe('core-model integration', () => {
 
       expect(figure.state.empty).toBe(false);
       expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.TREEMAP]);
+    });
+  });
+
+  test('an icicle layer constructs a navigable Figure', () => {
+    const svg = buildTreeSvg('ic-svg', 'rect', 'band', hierarchy(WORLD).slice(1));
+    const result = bindD3Icicle(svg, {
+      selector: 'rect.band',
+      title: 'World population by region',
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.ICICLE]);
     });
   });
 

--- a/test/adapters/d3/volcano.test.ts
+++ b/test/adapters/d3/volcano.test.ts
@@ -1,0 +1,167 @@
+import type { VolcanoPoint } from '@type/grammar';
+import { bindD3Scatter, bindD3Volcano } from '@adapters/d3/binders/scatter';
+import { afterAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `circle.gene` per datum, the way
+ * `selectAll('circle.gene').data(genes).join('circle')` would leave it.
+ */
+function buildVolcanoSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="vc-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const circle = doc.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('class', 'gene');
+    (circle as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(circle);
+  }
+  return svg;
+}
+
+const GENES = [
+  { lfc: 2.4, logP: 14.1, gene: 'TP53', regulation: 'up' },
+  { lfc: -3.1, logP: 9.8, gene: 'MYC', regulation: 'down' },
+  { lfc: 0.2, logP: 0.6, gene: 'ACTB', regulation: 'ns' },
+];
+
+// The binder warns when no gene name resolves; silence it at file scope so the
+// expected-warning case does not print on every run.
+const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warn.mockClear();
+});
+
+afterAll(() => {
+  warn.mockRestore();
+});
+
+describe('bindD3Volcano', () => {
+  test('carries the gene name and the side it falls on', () => {
+    const svg = buildVolcanoSvg(GENES);
+
+    const result = bindD3Volcano(svg, {
+      selector: 'circle.gene',
+      title: 'Differential Expression',
+      axes: { x: 'log2 fold change', y: '-log10(p)' },
+      x: 'lfc',
+      y: 'logP',
+      label: 'gene',
+      group: 'regulation',
+    });
+
+    expect(result.layer.type).toBe(TraceType.VOLCANO);
+    // Identity is the payload on this chart: the coordinates alone answer the
+    // question a reader can already see the shape of.
+    expect(result.layer.data).toEqual([
+      { x: 2.4, y: 14.1, label: 'TP53', group: 'up' },
+      { x: -3.1, y: 9.8, label: 'MYC', group: 'down' },
+      { x: 0.2, y: 0.6, label: 'ACTB', group: 'ns' },
+    ]);
+  });
+
+  test('infers the gene name from the datum\'s own key names', () => {
+    const svg = buildVolcanoSvg([{ x: 1.2, y: 4, gene: 'BRCA1' }]);
+
+    const result = bindD3Volcano(svg, { selector: 'circle.gene' });
+
+    expect(result.layer.data).toEqual([{ x: 1.2, y: 4, label: 'BRCA1' }]);
+  });
+
+  test('declares both cutoffs a volcano is read through', () => {
+    const svg = buildVolcanoSvg(GENES);
+
+    const result = bindD3Volcano(svg, {
+      selector: 'circle.gene',
+      x: 'lfc',
+      y: 'logP',
+      significance: 1.3,
+      effect: 1,
+    });
+
+    // The effect cutoff is what makes it a volcano rather than a Manhattan:
+    // a gene matters when its change is both large and significant.
+    expect(result.layer.thresholdOptions).toEqual({ significance: 1.3, effect: 1 });
+  });
+
+  test('emits no threshold at all when none was declared', () => {
+    const svg = buildVolcanoSvg(GENES);
+
+    const result = bindD3Volcano(svg, { selector: 'circle.gene', x: 'lfc', y: 'logP' });
+
+    expect(result.layer.thresholdOptions).toBeUndefined();
+  });
+
+  test('warns, but still binds, when no point names a gene', () => {
+    const svg = buildVolcanoSvg([{ x: 1, y: 2 }, { x: 3, y: 4 }]);
+
+    const result = bindD3Volcano(svg, { selector: 'circle.gene' });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toMatch(/label/);
+    // The chart still reads as a scatter with a cutoff; refusing to bind would
+    // leave the reader with nothing at all.
+    expect(result.layer.data).toEqual([{ x: 1, y: 2 }, { x: 3, y: 4 }]);
+  });
+
+  test('stays quiet when even one point names a gene', () => {
+    const svg = buildVolcanoSvg([{ x: 1, y: 2, gene: 'TP53' }, { x: 3, y: 4 }]);
+
+    const result = bindD3Volcano(svg, { selector: 'circle.gene' });
+
+    expect(warn).not.toHaveBeenCalled();
+    const [, unnamed] = result.layer.data as VolcanoPoint[];
+    expect(unnamed).toEqual({ x: 3, y: 4 });
+  });
+
+  test('highlights the points, scoped to the SVG', () => {
+    const svg = buildVolcanoSvg(GENES);
+
+    const result = bindD3Volcano(svg, { selector: 'circle.gene', x: 'lfc', y: 'logP' });
+
+    expect(result.layer.selectors).toBe('#vc-svg circle.gene');
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(GENES.length);
+  });
+});
+
+describe('bindD3Scatter alongside it', () => {
+  test('stays a scatter, and reads no gene name off a datum that has one', () => {
+    const svg = buildVolcanoSvg([{ x: 1, y: 2, gene: 'TP53' }]);
+
+    const result = bindD3Scatter(svg, { selector: 'circle.gene' });
+
+    expect(result.layer.type).toBe(TraceType.SCATTER);
+    expect(result.layer.data).toEqual([{ x: 1, y: 2 }]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildVolcanoSvg(GENES);
+    const result = bindD3Volcano(svg, {
+      selector: 'circle.gene',
+      title: 'Differential Expression',
+      x: 'lfc',
+      y: 'logP',
+      label: 'gene',
+      significance: 1.3,
+      effect: 1,
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.VOLCANO]);
+    });
+  });
+});

--- a/test/adapters/d3/waterfall.test.ts
+++ b/test/adapters/d3/waterfall.test.ts
@@ -1,0 +1,132 @@
+import type { WaterfallPoint } from '@type/grammar';
+import { bindD3Waterfall } from '@adapters/d3/binders/waterfall';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one floating `rect.step` per datum, the way
+ * `selectAll('rect.step').data(steps).join('rect')` would leave it.
+ */
+function buildWaterfallSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="wf-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const rect = doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('class', 'step');
+    (rect as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(rect);
+  }
+  return svg;
+}
+
+/** A budget bridge: an opening total, three steps, a closing total. */
+const STEPS = [
+  { label: 'Opening', start: 0, end: 1200, isTotal: true },
+  { label: 'Marketing', start: 1200, end: 950, isTotal: false },
+  { label: 'Sales', start: 950, end: 1430, isTotal: false },
+  { label: 'Support', start: 1430, end: 1360, isTotal: false },
+  { label: 'Closing', start: 0, end: 1360, isTotal: true },
+];
+
+describe('bindD3Waterfall', () => {
+  test('derives the contribution and the direction from the two running totals', () => {
+    const svg = buildWaterfallSvg(STEPS);
+
+    const result = bindD3Waterfall(svg, {
+      selector: 'rect.step',
+      title: 'Quarterly Budget Bridge',
+      axes: { x: 'Step', y: 'Amount (thousands)' },
+      x: 'label',
+    });
+
+    expect(result.layer.type).toBe(TraceType.WATERFALL);
+    expect((result.layer.data as WaterfallPoint[]).map(step => [step.delta, step.kind])).toEqual([
+      [1200, 'increase'],
+      [-250, 'decrease'],
+      [480, 'increase'],
+      [-70, 'decrease'],
+      [1360, 'increase'],
+    ]);
+  });
+
+  test('marks the totals when the caller says which bars they are', () => {
+    // The one thing the binder cannot infer: a total is drawn like a step and
+    // contributes like one, so only the author knows which bars restate the
+    // running total. An accessor returning undefined leaves the rest derived.
+    const svg = buildWaterfallSvg(STEPS);
+
+    const result = bindD3Waterfall(svg, {
+      selector: 'rect.step',
+      x: 'label',
+      kind: (d: unknown) => ((d as { isTotal: boolean }).isTotal ? 'total' : undefined),
+    });
+
+    expect((result.layer.data as WaterfallPoint[]).map(step => step.kind))
+      .toEqual(['total', 'decrease', 'increase', 'decrease', 'total']);
+  });
+
+  test('carries both totals alongside the contribution', () => {
+    // The height is the contribution and the position is the running total;
+    // neither alone describes the bar, so the payload keeps all three.
+    const svg = buildWaterfallSvg([STEPS[1]]);
+
+    const result = bindD3Waterfall(svg, { selector: 'rect.step', x: 'label' });
+
+    expect(result.layer.data).toEqual([
+      { x: 'Marketing', start: 1200, end: 950, delta: -250, kind: 'decrease' },
+    ]);
+  });
+
+  test('infers the accessors from a datum keyed the way a bridge usually is', () => {
+    const svg = buildWaterfallSvg([{ step: 'Churn', from: 500, to: 420 }]);
+
+    const result = bindD3Waterfall(svg, { selector: 'rect.step' });
+
+    expect(result.layer.data).toEqual([
+      { x: 'Churn', start: 500, end: 420, delta: -80, kind: 'decrease' },
+    ]);
+  });
+
+  test('highlights one element per step, scoped to the SVG', () => {
+    const svg = buildWaterfallSvg(STEPS);
+
+    const result = bindD3Waterfall(svg, { selector: 'rect.step', x: 'label' });
+
+    expect(result.layer.selectors).toBe('#wf-svg rect.step');
+    // WaterfallTrace withdraws highlighting unless the element count equals
+    // the step count.
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(STEPS.length);
+  });
+
+  test('throws an actionable error when the selector matches no steps', () => {
+    const svg = buildWaterfallSvg(STEPS);
+
+    expect(() => bindD3Waterfall(svg, { selector: 'rect.bridge' })).toThrow(/waterfall step/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildWaterfallSvg(STEPS);
+    const result = bindD3Waterfall(svg, {
+      selector: 'rect.step',
+      title: 'Quarterly Budget Bridge',
+      x: 'label',
+      kind: (d: unknown) => ((d as { isTotal: boolean }).isTotal ? 'total' : undefined),
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.WATERFALL]);
+    });
+  });
+});

--- a/test/adapters/d3/wordCloud.test.ts
+++ b/test/adapters/d3/wordCloud.test.ts
@@ -1,0 +1,113 @@
+import { bindD3WordCloud } from '@adapters/d3/binders/wordCloud';
+import { describe, expect, test } from '@jest/globals';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+/**
+ * Builds an SVG holding one `text.term` per datum, the way a cloud is joined
+ * after `d3-cloud` has placed its words.
+ */
+function buildCloudSvg(data: unknown[]): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="http://www.w3.org/2000/svg" id="wc-svg"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of data) {
+    const text = doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.setAttribute('class', 'term');
+    (text as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(text);
+  }
+  return svg;
+}
+
+/** What `cloud().words(...)` writes back onto every word it lays out. */
+const PLACED = [
+  { text: 'neural', size: 128, x: -104, y: 31, rotate: 0, font: 'sans-serif' },
+  { text: 'machine', size: 412, x: 12, y: -8, rotate: 90, font: 'sans-serif' },
+  { text: 'gradient', size: 57, x: 88, y: 66, rotate: 0, font: 'sans-serif' },
+];
+
+describe('bindD3WordCloud', () => {
+  test('reads d3-cloud\'s own keys and drops the layout', () => {
+    const svg = buildCloudSvg(PLACED);
+
+    const result = bindD3WordCloud(svg, {
+      selector: 'text.term',
+      title: 'Terms in the Abstracts',
+      axes: { x: 'Term', y: 'Occurrences' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.WORD_CLOUD);
+    // Where a term landed is a packing artefact, not data — so `x`, `y` and
+    // `rotate` from the layout are deliberately absent from the payload.
+    expect(result.layer.data).toEqual([
+      { x: 'neural', y: 128 },
+      { x: 'machine', y: 412 },
+      { x: 'gradient', y: 57 },
+    ]);
+  });
+
+  test('reads a cloud laid out from another shape through the aliases', () => {
+    const svg = buildCloudSvg([
+      { word: 'tensor', count: 233 },
+      { word: 'embedding', count: 96 },
+    ]);
+
+    const result = bindD3WordCloud(svg, { selector: 'text.term' });
+
+    expect(result.layer.data).toEqual([
+      { x: 'tensor', y: 233 },
+      { x: 'embedding', y: 96 },
+    ]);
+  });
+
+  test('honours explicit accessors over the d3-cloud defaults', () => {
+    const svg = buildCloudSvg([{ text: 'glyph', size: 40, occurrences: 7 }]);
+
+    const result = bindD3WordCloud(svg, { selector: 'text.term', y: 'occurrences' });
+
+    // `size` is the drawn glyph height, which need not be the weight itself.
+    expect(result.layer.data).toEqual([{ x: 'glyph', y: 7 }]);
+  });
+
+  test('emits the terms in DOM order, which the trace reorders by weight', () => {
+    const svg = buildCloudSvg(PLACED);
+
+    const result = bindD3WordCloud(svg, { selector: 'text.term' });
+
+    expect(result.layer.selectors).toBe('#wc-svg text.term');
+    // WordCloudTrace sorts the terms heaviest first and permutes the resolved
+    // glyphs by the same order, so the two only line up when every glyph
+    // resolves — it withdraws highlighting on any mismatch rather than guess.
+    const matched = svg.ownerDocument.querySelectorAll(result.layer.selectors as string);
+    expect(matched).toHaveLength(PLACED.length);
+  });
+
+  test('throws an actionable error when the selector matches no terms', () => {
+    const svg = buildCloudSvg(PLACED);
+
+    expect(() => bindD3WordCloud(svg, { selector: 'text.word' })).toThrow(/word cloud term/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a navigable Figure', () => {
+    const svg = buildCloudSvg(PLACED);
+    const result = bindD3WordCloud(svg, {
+      selector: 'text.term',
+      title: 'Terms in the Abstracts',
+      axes: { x: 'Term', y: 'Occurrences' },
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.WORD_CLOUD]);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The D3 adapter shipped ten binders (bar, box, candlestick, heatmap, histogram, line, pie, scatter, segmented, smooth) and had not kept up with the ~34 trace types MAIDR core has gained since the pie chart. A chart D3 drew perfectly well was therefore dropped from the figure or announced as the wrong chart.

This PR adds binders for **all 33 in-scope trace types** listed in #865. The work is adapter-local: no file under `src/model/`, `src/service/`, `src/state/`, `src/ui/`, `src/command/` or `src/type/grammar.ts` is touched. The core already dispatches every one of these types; what was missing was the extraction, the payload shape, and — the part that is easy to get silently wrong — the selector/highlight contract.

Each new type follows the five-place pattern already established in the adapter: a `binders/*.ts` exporting `bindD3X` plus `buildXLayer`, a config interface and a `D3PanelChartSpec` arm in `types.ts` (which makes the type available to `bindD3Facets` and `bindD3Subplots` for free), arms in the four TS-exhaustive switches (`buildPanelLayer`, `runBinder`, `withFacetsAutoApplyOff`, `MaidrD3.buildSpec`), exports in `index.ts`, and a section in `docs/d3.md`.

## Related Issues

Closes #865

## Changes Made

### Trace types added (33)

Grouped by the extraction core they reuse.

**Bar core** (`binders/bar.ts`) — same `BarPoint[]` payload, different `TraceType`:

- `DOT` — `bindD3Dot`
- `LOLLIPOP` — `bindD3Lollipop`
- `FUNNEL` — `bindD3Funnel` (stage order is load-bearing; emitted in draw order)

**Line core** (`binders/line.ts`):

- `AREA`, `STACKED_AREA`, `NORMALIZED_AREA` — `bindD3Area` (`binders/area.ts`), selected via `config.type`. Unwraps the `d3.stack()` series datum (`[y0, y1]` tuples with a `.data` back-reference, `.key` on the parent group) and emits the series' own value, since `AreaTrace` re-derives the running total itself.
- `BUMP` — `bindD3Bump`
- `RADAR` — `bindD3Radar`, dropping the closing duplicate vertex a closed radial polygon repeats so the spoke count is right
- `POLAR_AREA` — `bindD3PolarArea`, an arc-per-category walk emitting a single-row `LinePoint[][]`
- `SURVIVAL` — `bindD3Survival` (`binders/survival.ts`), via a new internal point-decorator hook reading `censored`, `yMin` and `yMax` off the same datum. Censoring ticks drawn by their own join are merged into the curve by time: an exact vertex is flagged, otherwise a vertex is inserted carrying the probability held across that interval. Censoring is read strictly (`true`/`1`/`'1'`/`'true'`), never by truthiness.
- `PARALLEL` — `bindD3Parallel` (`binders/parallel.ts`), transposing each observation datum across a required `dimensions: string[]`

**Segmented core** (`binders/segmented.ts`):

- `DIVERGING` — `bindD3Diverging`; values arrive signed and are not `abs`'d, because `DivergingTrace` reads the sign as a side
- `MOSAIC` — `bindD3Mosaic`, adding `width` (the marginal proportion) and optional `count`

**Scatter core** (`binders/scatter.ts`):

- `VOLCANO` — `bindD3Volcano`, plus `thresholdOptions.{significance, effect, significanceDirection}`
- `MANHATTAN` — `bindD3Manhattan`, adding the SNP `label` and chromosome `group` accessors and the significance cutoff

**New shapes** (each with its own file):

- `ERROR_BAR` — `bindD3ErrorBar` (`binders/errorBar.ts`), absolute `yMin`/`yMax` bounds with alias fallbacks
- `FOREST` — `bindD3Forest`, sharing the error-bar core; adds `weight`, `pooled`, a separate `pooledSelector` for the diamond, and `forestOptions.nullValue`
- `DUMBBELL` — `bindD3Dumbbell` (`binders/dumbbell.ts`); emits the `DumbbellData` **object** `{points, startLabel, endLabel}`, not an array
- `WATERFALL` — `bindD3Waterfall` (`binders/waterfall.ts`), reading `start`/`end` and deriving the contribution, with a `kind` override so total bars can be marked
- `WORD_CLOUD` — `bindD3WordCloud` (`binders/wordCloud.ts`); d3-cloud's `{text, size}` are the default accessors, layout coordinates deliberately dropped
- `GAUGE` — `bindD3Gauge` (`binders/gauge.ts`); emits the `GaugePoint` **object**, not an array
- `NETWORK` — `bindD3Network` (`binders/network.ts`); the default endpoint accessor handles `d3.forceLink` mutating `source`/`target` from an id into the node object
- `TREEMAP`, `SUNBURST`, `ICICLE` — `bindD3Treemap` / `bindD3Sunburst` / `bindD3Icicle` (`binders/treemap.ts`), one core with a layout discriminator, deriving `path` by walking the `d3.hierarchy` ancestor chain
- `SANKEY`, `ALLUVIAL`, `CHORD` — `bindD3Sankey` / `bindD3Alluvial` / `bindD3Chord` (`binders/flow.ts`), one core. Endpoint normalisation handles the node objects d3-sankey substitutes for `source`/`target`; chord adds a `names` config mapping `d3.chord()`'s matrix indices to labels.
- `GANTT` — `bindD3Gantt` (`binders/gantt.ts`); emits the `GanttData` **object** with points nested **by lane** (grouped by the binder — flat DOM order is not the payload), plus optional `lanes` (so empty lanes, which have no DOM element at all, survive) and `unit`. Dates coerced to epoch ms.
- `BOXEN` — `bindD3Boxen` (`binders/boxen.ts`), reading `median` plus the `{p, lo, hi}` rung ladder off the per-distribution group datum, with key-alias normalisation
- `RIDGELINE` — `bindD3Ridgeline` (`binders/ridgeline.ts`); `density` comes from a dedicated accessor (aliases `kde`/`width`/`p`/`estimate` — deliberately never `y`), because the drawn y includes the group's offset baseline
- `HEXBIN` — `bindD3Hexbin` (`binders/hexbin.ts`); defaults read a d3-hexbin bin's `.x`/`.y`/`.length` and the caller supplies inverse scales. The binder assembles the lattice itself, rows keyed on the y centre and ordered **bottom-first**, because `HexbinTrace.moveOnce` steps the row index **up** for `UPWARD`.
- `CONTOUR` — `bindD3Contour` (`binders/contour.ts`); reads the GeoJSON `.value` as the level and flattens MultiPolygon/Polygon/bare-ring nesting into one curve per level, dropping each ring's closing duplicate vertex. A new `D3GridTransform` maps grid indices back to data space.

### Not added, and why

- **`CHOROPLETH`** — explicitly deferred by #865 itself ("Deferred to a follow-up"): it needs a new author-facing opt-in API for geographic centroids, since `d3.geoPath().centroid(d)` returns projected pixels rather than lon/lat. No binder, no `D3PanelChartSpec` arm, no docs row.
- **`STEP`, `VIOLIN_KDE`, `VIOLIN_BOX`, `CANDLESTICK_DELTA`** — not in the issue's in-scope table, so out of scope here. Nothing in the adapter blocks them; each would be another instance of the same five-place pattern.
- **Nothing was skipped for a missing core capability.** No trace type in scope required a change under `src/model/`, `src/service/`, `src/state/`, `src/ui/`, `src/command/` or `src/type/grammar.ts`.

### Highlighting

Selector shape was treated as part of each type, not as a follow-up, because `AbstractTrace.mapToSvgElements` **silently withdraws** highlighting when the element count does not match the row/point count — and in two cases here it does something worse than withdraw. Each binder emits page-unique, panel-scoped selectors through the existing `scopeSelector`/`selectorPrefix` helpers; none emits a bare selector.

Three distinct shapes were needed, chosen per trace against what its `mapToSvgElements`/`pairWith` actually requires:

- **One scoped selector, one element per row** — the flat types (dot, lollipop, funnel, waterfall, word cloud, gauge, network, error bar, dumbbell connectors, treemap/sunburst/icicle nodes, flow ribbons).
- **One selector per series/group**, stamped with `data-maidr-line-index` — the area family, radar, parallel, survival, contour, reusing the line binder's helper.
- **One stamped selector per element in payload order** (`data-maidr-gantt-index`, `data-maidr-hexbin-index`) — gantt and hexbin, where the payload order is *not* DOM order. Both traces slice a **flat** element list and check only the total count, so a bare selector would mis-highlight with the counts still matching, which is silent and worse than no highlighting. Generalised into a shared `stampOrderedSelectors` in `selectors.ts`.

Two traces required the opposite of stamping, and per-element selectors would have broken them: `BoxenTrace.pairWith` and `RidgelineTrace.pairWith` both require exactly **one element per group** and repeat it across the group's rungs/samples, so both emit a single scoped selector per group. Forest emits a two-entry array (studies, then pooled) in payload order and **throws** when `pooledSelector` overlaps the studies selector, since a duplicated row would keep the counts consistent and go unnoticed.

### Tests

26 new/extended files under `test/adapters/d3/`, jsdom-based, stamping `__data__` by hand in the style of the existing `pie.test.ts`. `npx jest test/adapters/d3` is now 28 suites / 246 tests (was 5 files on `main`). Coverage per type: payload shape against `src/type/grammar.ts`, accessor inference and alias fallbacks, error messages, a core-model `Figure` construction, and the selector/highlight contract specifically — element count vs payload count, lane-order and lattice-order stamping verified by resolving each selector back to its datum, and one-element-per-group for boxen/ridgeline.

### Docs and examples

- `docs/d3.md` — +552 lines: a table row and a worked section per new type, plus the exported TypeScript config types.
- `examples/d3-bindarea.html`, `examples/d3-bindfunnel.html` — two new live binder demos. See Additional Notes.

## Screenshots (if applicable)

n/a — no visual change to MAIDR's own UI.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass. — the automated suite passes in full (see below), but the manual screen-reader pass in `ManualTestingProcess.md` has **not** been run.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verification.** Run in order on this branch, all green, no fixes required:

| Command | Result |
|---|---|
| `npm run lint:fix` | clean, no changes |
| `npm run type-check` | clean (`tsc --noEmit` + `tsconfig.ci.json`) |
| `npm run build` | all 12 targets built |
| `npm test` | 210 suites / 2816 tests + 7 ESM suites / 73 tests, all passing |

**Scope discipline.** The diff is 56 files across `src/adapters/d3/` (27), `test/adapters/d3/` (26), `docs/d3.md` and `examples/`. Nothing else is touched.

**No new dependencies.** The adapter imports no d3 code at all — it reads whatever the page drew off `__data__` — so the binders for the plugin-drawn types (d3-sankey, d3-hexbin, d3-cloud, d3-contour) need no package added, and none was.

**Known gap — demo pages.** Only `area` and `funnel` got new `examples/d3-bind*.html` demos; the other 31 types have no live binder demo, and the hand-authored `examples/*.html` files (which carry `maidr=` JSON directly) remain their reference payloads. These are worth adding as a follow-up, but every type is covered by unit tests and documented in `docs/d3.md`.

**Known gap — diverging in panels.** `bindD3Diverging` works standalone, but `D3PanelChartSpec` exposes `chartType: 'segmented'` and `'mosaic'` without a `'diverging'` alias, so inside a facet or subplot a diverging bar chart must be declared as `{ chartType: 'segmented', config: { type: 'diverging_bar', … } }`. Functional, but less discoverable than the other types; a one-line alias arm would fix it.

**Interpretation notes** where the issue left a decision open:

- *Chord without `names`* — the binder degrades to the bare matrix index rather than throwing. Honest but useless as an announcement, so the docs say to declare `names`.
- *Survival censoring merge* — a Kaplan-Meier curve steps only at events, so a censoring tick's time is usually not a vertex. Matching by x alone would silently drop most ticks, hence the insert-a-vertex behaviour described above. Row lengths therefore change relative to the drawn vertex count; harmless, because `LineTrace` falls back to path parsing via `reconcilePathCoordinates`.
- *Contour multi-ring levels* — all rings of a level are concatenated (each ring's closing duplicate dropped) rather than taking the largest, so no real geometry is dropped. The jump between rings is inaudible; documented.
- *Contour row order* — rows keep DOM order rather than being re-sorted by level, since `d3.contours` emits ascending thresholds and `ContourTrace` measures the gap to the **adjacent** row.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_