### PR TITLE
fix(plotly): scope a candlestick's selector to its own panel and trace

### DIFF
--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -326,7 +326,12 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
     case 'histogram':
       return TraceType.HISTOGRAM;
 
+    // `ohlc` carries the same four numbers and differs only in how plotly
+    // draws a bar — a tick either side of a vertical range rather than a
+    // filled body — so a reader is told open, high, low and close either way.
+    // It draws into a layer of its own, which the selector handles.
     case 'candlestick':
+    case 'ohlc':
       return TraceType.CANDLESTICK;
 
     case 'pie':

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -107,8 +107,7 @@ export function generatePlotlySelectors(
       return `${prefix}.heatmaplayer image`;
 
     case TraceType.CANDLESTICK:
-      // Candlestick reuses box plot rendering: boxlayer > trace.boxes > path.box
-      return `${prefix}.trace.boxes .box`;
+      return candlestickSelector(plotlyGd, traceIndex, prefix);
 
     case TraceType.PIE:
       return pieSelector(plotlyGd, traceIndex);
@@ -382,6 +381,76 @@ function pieSelector(gd: PlotlyGraphDiv, traceIndex: number): string {
  * Whether a trace is a pie plotly put on the paper. A hidden or legend-only
  * trace gets no group in `.pielayer`, so it must not shift the count.
  */
+/**
+ * The trace types plotly draws into `g.boxlayer`, and so the ones that
+ * occupy a slot a candlestick has to count past.
+ *
+ * A `go.Violin` draws into `g.violinlayer` and a scatter into
+ * `g.scatterlayer`, so neither shifts the count — measured, not assumed.
+ */
+const BOXLAYER_TRACE_TYPES = new Set(['box', 'candlestick']);
+
+/**
+ * The marks of one candlestick or OHLC trace.
+ *
+ * Scoped three ways, each for a measured reason.
+ *
+ * **The subplot prefix excludes the rangeslider.** Plotly gives a candlestick
+ * chart one *by default*, and it holds a complete second copy of the plot at
+ * `g.infolayer > g.rangeslider-container > g.rangeslider-rangeplot`. For a
+ * four-candle chart the old `.trace.boxes .box` matched **eight** elements,
+ * so the index-to-element mapping was wrong for every candle and half the
+ * highlights landed in the thumbnail. The duplicate's ancestor carries the
+ * `xy` class but not `subplot`, so the prefix is what leaves it out.
+ *
+ * **`nth-child` picks this trace out of its layer.** A `go.Box` shares
+ * `g.boxlayer` and draws its own `path.box`, so one box beside one
+ * four-candle trace made `.trace.boxes path.box` match five. Counting
+ * siblings is safe here in a way it is not for `.scatterlayer`, whose groups
+ * are in fill z-order: measured with three interleaved traces, `boxlayer`
+ * children follow `_fullData` order.
+ *
+ * **`ohlc` is a different layer.** It draws into
+ * `g.ohlclayer > g.trace.ohlc > path` rather than sharing the box machinery,
+ * so a `boxlayer` selector matches nothing at all for it.
+ *
+ * @param gd         - The plotly graph div
+ * @param traceIndex - The trace's index in `_fullData`
+ * @param prefix     - The subplot prefix the trace is drawn in
+ * @returns The selector for that trace's marks
+ */
+function candlestickSelector(
+  gd: PlotlyGraphDiv,
+  traceIndex: number,
+  prefix: string,
+): string {
+  const traces = gd._fullData ?? [];
+  const self = traces[traceIndex];
+  const isOhlc = self?.type === 'ohlc';
+
+  let drawnBefore = 0;
+  for (let i = 0; i < traceIndex; i++) {
+    const other = traces[i];
+    const type = other?.type;
+    if (!(isOhlc ? type === 'ohlc' : BOXLAYER_TRACE_TYPES.has(type ?? ''))) {
+      continue;
+    }
+    // Each panel has a `boxlayer`/`ohlclayer` of its own, so only traces
+    // sharing this one's axis pair take a slot in it. Counting the figure's
+    // traces instead — which is right for a pie, whose `pielayer` is
+    // figure-level — puts every panel after the first out by however many
+    // candlesticks preceded it, onto a group that does not exist.
+    if (other?.xaxis === self?.xaxis && other?.yaxis === self?.yaxis) {
+      drawnBefore++;
+    }
+  }
+
+  const nth = drawnBefore + 1;
+  return isOhlc
+    ? `${prefix}.ohlclayer > .trace.ohlc:nth-child(${nth}) > path`
+    : `${prefix}.boxlayer > .trace.boxes:nth-child(${nth}) path.box`;
+}
+
 function isDrawnPie(trace: PlotlyTrace | undefined): boolean {
   return trace?.type === 'pie'
     && trace.visible !== false

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -403,12 +403,18 @@ const BOXLAYER_TRACE_TYPES = new Set(['box', 'candlestick']);
  * highlights landed in the thumbnail. The duplicate's ancestor carries the
  * `xy` class but not `subplot`, so the prefix is what leaves it out.
  *
- * **`nth-child` picks this trace out of its layer.** A `go.Box` shares
+ * **The position picks this trace out of its layer.** A `go.Box` shares
  * `g.boxlayer` and draws its own `path.box`, so one box beside one
  * four-candle trace made `.trace.boxes path.box` match five. Counting
  * siblings is safe here in a way it is not for `.scatterlayer`, whose groups
  * are in fill z-order: measured with three interleaved traces, `boxlayer`
  * children follow `_fullData` order.
+ *
+ * The count comes from {@link drawnBefore}, once per type sharing the layer,
+ * so a hidden trace does not take a slot — it draws no group, and counting it
+ * would push its neighbours onto one that does not exist. Only traces on this
+ * panel are counted, because each panel has a `boxlayer` of its own; a pie is
+ * counted across the figure instead, since `pielayer` is figure-level.
  *
  * **`ohlc` is a different layer.** It draws into
  * `g.ohlclayer > g.trace.ohlc > path` rather than sharing the box machinery,
@@ -424,31 +430,24 @@ function candlestickSelector(
   traceIndex: number,
   prefix: string,
 ): string {
-  const traces = gd._fullData ?? [];
-  const self = traces[traceIndex];
+  const self = gd._fullData?.[traceIndex];
   const isOhlc = self?.type === 'ohlc';
+  const onThisPanel = (trace: PlotlyTrace): boolean =>
+    trace.xaxis === self?.xaxis && trace.yaxis === self?.yaxis;
 
-  let drawnBefore = 0;
-  for (let i = 0; i < traceIndex; i++) {
-    const other = traces[i];
-    const type = other?.type;
-    if (!(isOhlc ? type === 'ohlc' : BOXLAYER_TRACE_TYPES.has(type ?? ''))) {
-      continue;
-    }
-    // Each panel has a `boxlayer`/`ohlclayer` of its own, so only traces
-    // sharing this one's axis pair take a slot in it. Counting the figure's
-    // traces instead — which is right for a pie, whose `pielayer` is
-    // figure-level — puts every panel after the first out by however many
-    // candlesticks preceded it, onto a group that does not exist.
-    if (other?.xaxis === self?.xaxis && other?.yaxis === self?.yaxis) {
-      drawnBefore++;
-    }
-  }
+  // `drawnBefore` counts one plotly type at a time, so the box-family layer
+  // takes one call per type it holds. Summing them is the whole count,
+  // because a trace has exactly one type.
+  const types = isOhlc ? ['ohlc'] : [...BOXLAYER_TRACE_TYPES];
+  const position = types.reduce(
+    (total, type) => total + drawnBefore(gd, traceIndex, type, onThisPanel),
+    0,
+  );
 
-  const nth = drawnBefore + 1;
+  const nth = position + 1;
   return isOhlc
-    ? `${prefix}.ohlclayer > .trace.ohlc:nth-child(${nth}) > path`
-    : `${prefix}.boxlayer > .trace.boxes:nth-child(${nth}) path.box`;
+    ? `${prefix}.ohlclayer > .trace.ohlc:nth-of-type(${nth}) > path`
+    : `${prefix}.boxlayer > .trace.boxes:nth-of-type(${nth}) path.box`;
 }
 
 function isDrawnPie(trace: PlotlyTrace | undefined): boolean {

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -2570,7 +2570,7 @@ describe('plotly extractor', () => {
       // this four-candle chart:
       //
       //   .trace.boxes .box                                     8   ** the copy
-      //   .subplot.xy .boxlayer > .trace.boxes:nth-child(1) …   4
+      //   .subplot.xy .boxlayer > .trace.boxes:nth-of-type(1) …   4
       //
       // The duplicate sits under `g.rangeslider-rangeplot.xy`, which carries
       // the `xy` class but not `subplot` — so the prefix is what excludes it.
@@ -2583,7 +2583,7 @@ describe('plotly extractor', () => {
 
       expect(layer.type).toBe(TraceType.CANDLESTICK);
       expect(layer.selectors).toBe(
-        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
+        '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(1) path.box',
       );
     });
 
@@ -2602,7 +2602,7 @@ describe('plotly extractor', () => {
 
       const candlestick = layers.find(l => l.type === TraceType.CANDLESTICK);
       expect(candlestick?.selectors).toBe(
-        '.subplot.xy .boxlayer > .trace.boxes:nth-child(2) path.box',
+        '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(2) path.box',
       );
     });
 
@@ -2620,7 +2620,7 @@ describe('plotly extractor', () => {
 
       const candlestick = layers.find(l => l.type === TraceType.CANDLESTICK);
       expect(candlestick?.selectors).toBe(
-        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
+        '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(1) path.box',
       );
     });
 
@@ -2641,7 +2641,7 @@ describe('plotly extractor', () => {
 
       const candlestick = layers.find(l => l.type === TraceType.CANDLESTICK);
       expect(candlestick?.selectors).toBe(
-        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
+        '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(1) path.box',
       );
     });
 
@@ -2673,7 +2673,7 @@ describe('plotly extractor', () => {
       }));
 
       expect(layer.selectors).toBe(
-        '.subplot.xy .ohlclayer > .trace.ohlc:nth-child(1) > path',
+        '.subplot.xy .ohlclayer > .trace.ohlc:nth-of-type(1) > path',
       );
     });
 
@@ -2695,9 +2695,32 @@ describe('plotly extractor', () => {
         .map(l => l.selectors);
 
       expect(selectors).toEqual([
-        '.subplot.xy .boxlayer > .trace.boxes:nth-child(2) path.box',
-        '.subplot.xy .ohlclayer > .trace.ohlc:nth-child(1) > path',
+        '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(2) path.box',
+        '.subplot.xy .ohlclayer > .trace.ohlc:nth-of-type(1) > path',
       ]);
+    });
+
+    it('does not count a hidden trace, which draws no group', () => {
+      // A `visible: false` or `'legendonly'` trace gets no `<g>` in
+      // `boxlayer` at all — measured in Chromium, the layer has a single
+      // child for the candlestick. Counting it would put this trace at the
+      // second slot of a one-child layer, so the selector would match
+      // nothing: the audio, braille and text stay correct and the highlight
+      // just stops appearing, with nothing to say why.
+      for (const hidden of [false, 'legendonly'] as const) {
+        const layers = layersOf(createGraphDiv({
+          traces: [
+            { type: 'box', y: [1, 2, 3, 4], name: 'spread', visible: hidden },
+            candlestickTrace(),
+          ],
+          layout: SINGLE_PANEL,
+        }));
+
+        const candlestick = layers.find(l => l.type === TraceType.CANDLESTICK);
+        expect(candlestick?.selectors).toBe(
+          '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(1) path.box',
+        );
+      }
     });
 
     it('scopes a candlestick on a second panel to that panel', () => {
@@ -2724,8 +2747,8 @@ describe('plotly extractor', () => {
         .flatMap(subplot => subplot.layers.map(layer => layer.selectors));
 
       expect(selectors).toEqual([
-        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
-        '.subplot.x2y2 .boxlayer > .trace.boxes:nth-child(1) path.box',
+        '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(1) path.box',
+        '.subplot.x2y2 .boxlayer > .trace.boxes:nth-of-type(1) path.box',
       ]);
     });
   });

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -2539,6 +2539,197 @@ describe('plotly extractor', () => {
     });
   });
 
+  describe('candlestick and OHLC traces', () => {
+    const SINGLE_PANEL = {
+      xaxis: { title: { text: 'Date' }, domain: [0, 1] as [number, number] },
+      yaxis: { title: { text: 'Price' }, domain: [0, 1] as [number, number] },
+    };
+
+    function candlestickTrace(overrides: Partial<PlotlyTrace> = {}): PlotlyTrace {
+      return {
+        type: 'candlestick',
+        x: ['d1', 'd2', 'd3', 'd4'],
+        open: [1, 2, 3, 2.5],
+        high: [2, 3, 4, 3.2],
+        low: [0, 1, 2, 1.8],
+        close: [1.5, 2.5, 3.5, 2],
+        name: 'ACME',
+        ...overrides,
+      };
+    }
+
+    function layersOf(gd: PlotlyGraphDiv): MaidrLayer[] {
+      const maidr = extractPlotlyData(gd);
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers;
+    }
+
+    it('scopes the selector to the panel, leaving the rangeslider out', () => {
+      // Plotly gives a candlestick chart a rangeslider *by default*, and it
+      // holds a complete second copy of the plot. Measured in Chromium for
+      // this four-candle chart:
+      //
+      //   .trace.boxes .box                                     8   ** the copy
+      //   .subplot.xy .boxlayer > .trace.boxes:nth-child(1) …   4
+      //
+      // The duplicate sits under `g.rangeslider-rangeplot.xy`, which carries
+      // the `xy` class but not `subplot` — so the prefix is what excludes it.
+      // Unscoped, the index-to-element mapping was wrong for every candle and
+      // half the highlights landed in the thumbnail.
+      const [layer] = layersOf(createGraphDiv({
+        traces: [candlestickTrace()],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.CANDLESTICK);
+      expect(layer.selectors).toBe(
+        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
+      );
+    });
+
+    it('counts past a box plot sharing the same layer', () => {
+      // A `go.Box` draws into `g.boxlayer` too, and emits its own `path.box`.
+      // Measured: one box beside this four-candle trace makes
+      // `.subplot.xy .trace.boxes path.box` match five, and the candlestick's
+      // marks are the *second* group's.
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          { type: 'box', y: [1, 2, 3, 4], name: 'spread' },
+          candlestickTrace(),
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      const candlestick = layers.find(l => l.type === TraceType.CANDLESTICK);
+      expect(candlestick?.selectors).toBe(
+        '.subplot.xy .boxlayer > .trace.boxes:nth-child(2) path.box',
+      );
+    });
+
+    it('keeps the first slot when the candlestick is declared first', () => {
+      // The mirror of the case above. `boxlayer` children follow `_fullData`
+      // order — verified in Chromium with three interleaved traces, unlike
+      // `.scatterlayer`, whose groups are in fill z-order.
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          candlestickTrace(),
+          { type: 'box', y: [1, 2, 3, 4], name: 'spread' },
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      const candlestick = layers.find(l => l.type === TraceType.CANDLESTICK);
+      expect(candlestick?.selectors).toBe(
+        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
+      );
+    });
+
+    it('does not count a violin or a scatter, which draw in other layers', () => {
+      // A `go.Violin` draws into `g.violinlayer` and a scatter into
+      // `g.scatterlayer`, so neither takes a `boxlayer` slot. Counting every
+      // preceding trace instead would push this one to a group that does not
+      // exist — and a selector matching nothing loses the highlight silently,
+      // with the audio and text still correct, so nothing else would report it.
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          { type: 'violin', y: [1, 2, 3, 4], name: 'shape' },
+          scatterTrace({ name: 'points' }),
+          candlestickTrace(),
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      const candlestick = layers.find(l => l.type === TraceType.CANDLESTICK);
+      expect(candlestick?.selectors).toBe(
+        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
+      );
+    });
+
+    it('reads an OHLC trace as a candlestick', () => {
+      // `ohlc` carries the same four numbers and differs only in how plotly
+      // draws a bar. Before this it mapped to no MAIDR type at all, so the
+      // trace was dropped and the chart announced nothing.
+      const [layer] = layersOf(createGraphDiv({
+        traces: [candlestickTrace({ type: 'ohlc' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.type).toBe(TraceType.CANDLESTICK);
+      expect(layer.data).toEqual([
+        { value: 'd1', open: 1, high: 2, low: 0, close: 1.5, volume: undefined, trend: 'Bull', volatility: 2 },
+        { value: 'd2', open: 2, high: 3, low: 1, close: 2.5, volume: undefined, trend: 'Bull', volatility: 2 },
+        { value: 'd3', open: 3, high: 4, low: 2, close: 3.5, volume: undefined, trend: 'Bull', volatility: 2 },
+        { value: 'd4', open: 2.5, high: 3.2, low: 1.8, close: 2, volume: undefined, trend: 'Bear', volatility: 3.2 - 1.8 },
+      ]);
+    });
+
+    it('addresses an OHLC trace in its own layer', () => {
+      // Measured: `ohlc` draws into `g.ohlclayer > g.trace.ohlc > path`, not
+      // into `boxlayer`. A shared selector would match nothing for it, which
+      // is a silent loss rather than a visible one.
+      const [layer] = layersOf(createGraphDiv({
+        traces: [candlestickTrace({ type: 'ohlc' })],
+        layout: SINGLE_PANEL,
+      }));
+
+      expect(layer.selectors).toBe(
+        '.subplot.xy .ohlclayer > .trace.ohlc:nth-child(1) > path',
+      );
+    });
+
+    it('counts OHLC traces among themselves, not among box-family ones', () => {
+      // The two layers are independent, so a box before an OHLC trace must
+      // not push it out of the first `ohclayer` slot, and a candlestick must
+      // not either.
+      const layers = layersOf(createGraphDiv({
+        traces: [
+          { type: 'box', y: [1, 2, 3, 4], name: 'spread' },
+          candlestickTrace({ name: 'candles' }),
+          candlestickTrace({ type: 'ohlc', name: 'bars' }),
+        ],
+        layout: SINGLE_PANEL,
+      }));
+
+      const selectors = layers
+        .filter(l => l.type === TraceType.CANDLESTICK)
+        .map(l => l.selectors);
+
+      expect(selectors).toEqual([
+        '.subplot.xy .boxlayer > .trace.boxes:nth-child(2) path.box',
+        '.subplot.xy .ohlclayer > .trace.ohlc:nth-child(1) > path',
+      ]);
+    });
+
+    it('scopes a candlestick on a second panel to that panel', () => {
+      // Two panels each holding one candlestick both sit at the first slot of
+      // their own `boxlayer`, so the axis pair is the only thing telling them
+      // apart.
+      const gd = createGraphDiv({
+        traces: [
+          candlestickTrace(),
+          candlestickTrace({ xaxis: 'x2', yaxis: 'y2', name: 'OTHER' }),
+        ],
+        layout: {
+          xaxis: { title: { text: 'Date' }, domain: [0, 0.45] },
+          yaxis: { title: { text: 'Price' }, domain: [0, 1] },
+          xaxis2: { title: { text: 'Date' }, domain: [0.55, 1] },
+          yaxis2: { title: { text: 'Price' }, domain: [0, 1] },
+        },
+        bgRects: [{ x: 0, y: 0 }, { x: 100, y: 0 }],
+      });
+
+      const maidr = extractPlotlyData(gd);
+      const selectors = maidr!.subplots
+        .flat()
+        .flatMap(subplot => subplot.layers.map(layer => layer.selectors));
+
+      expect(selectors).toEqual([
+        '.subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box',
+        '.subplot.x2y2 .boxlayer > .trace.boxes:nth-child(1) path.box',
+      ]);
+    });
+  });
+
   describe('waterfall traces', () => {
     const SINGLE_PANEL = {
       xaxis: { title: { text: 'Step' }, domain: [0, 1] as [number, number] },


### PR DESCRIPTION
Closes #881.

## The defect

```ts
case TraceType.CANDLESTICK:
  // Candlestick reuses box plot rendering: boxlayer > trace.boxes > path.box
  return `${prefix}.trace.boxes .box`;
```

For a single-subplot figure `prefix` is empty, so this was effectively global. It over-matched in two independent ways, both measured in Chromium against real plotly output.

**1. The rangeslider.** Plotly gives a candlestick chart one **by default**, and it holds a complete second copy of the plot. For a four-candle chart:

```
.trace.boxes .box                                      8    ** two per candle
.subplot.xy .boxlayer > .trace.boxes:nth-child(1) …    4
```

The duplicate lives at `g.infolayer > g.rangeslider-container > g.rangeslider-rangeplot.xy > … > g.boxlayer.mlayer.rangeplot`. That ancestor carries the panel's `xy` class but **not** `subplot`, so the prefix is what excludes it. Setting `xaxis_rangeslider_visible=False` drops the unscoped count to 4, confirming the extra four are the slider's.

With 8 elements matched for 4 points the index-to-element mapping is wrong for every candle, and half the highlights land in the thumbnail.

**2. `go.Box` shares the layer**, and draws its own `path.box`:

```
one box + one four-candle trace:
  .subplot.xy .trace.boxes path.box                       5    (1 + 4)
  .subplot.xy .boxlayer > .trace.boxes:nth-child(1) …     1    the box
  .subplot.xy .boxlayer > .trace.boxes:nth-child(2) …     4    the candlestick
```

Throughout, the audio, braille and text were all correct — only a sighted reader could see the highlight was on the wrong bar.

## The fix

`candlestickSelector` scopes three ways: the subplot prefix, the trace's position among the panel's box-family traces, and a different layer for `ohlc`.

Two things I checked rather than assumed:

**Sibling counting is safe for `boxlayer`.** It is not for `.scatterlayer` — `scatterTraceScope` in this same file notes its groups are in fill z-order rather than `_fullData` order, which is why it uses the uid class instead. Measured with three interleaved traces declared out of position order:

```
_fullData: candlestick:C3, box:B1, candlestick:C2
boxlayer:  #1 boxes=2      #2 boxes=1  #3 boxes=2
```

Declaration order, not position order.

**Only same-panel traces take a slot.** Each panel has a `boxlayer` of its own. My first version counted the figure's traces — the shape `pieSelector` correctly uses, since `pielayer` is figure-level — and the two-panel test I had written caught it: the second panel's candlestick came out at `nth-child(2)` of a layer that only has one child. A selector matching nothing loses the highlight silently, so this was worth having a test for rather than discovering later.

## Second commit: `ohlc`

`go.Ohlc` carries the same four numbers and differs only in how plotly draws a bar. It mapped to no MAIDR type at all, so the trace was dropped and a chart of nothing but OHLC bars announced nothing. It draws into `g.ohlclayer > g.trace.ohlc > path` — measured, `boxlayer` selectors match zero for it — so it takes its own layer's selector and counts among OHLC traces.

Split into its own commit since it is a feature rather than the fix.

## Falsification

Each mechanism reverted in turn, against the 8 new tests.

| reverted to | failures |
|---|---|
| the original `.trace.boxes .box` | 7 |
| `ohlc` not mapped to a trace type | 3 |
| box-family set narrowed to `{candlestick}` | 2 |
| `ohlc` sharing the box layer's selector | 2 |
| no same-panel filter on the count | 1 |

## Checks

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass: **3612 tests in 266 suites**, plus the 73 ESM tests, and all 12 example builds.

## Related

The Python binding builds its plotly schema itself rather than through this adapter, and its candlestick support (xability/py-maidr#396) uses the same scoping, verified against the same DOM. Its `layer_position` was already panel-correct — it is passed only the subplot's traces — which is why the bug this PR's second-panel test caught did not exist there.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_