### PR TITLE
fix(plotly): count a box's group across the whole box layer

### DIFF
--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -54,6 +54,7 @@ import type {
 import { Orientation, TraceType } from '../../type/grammar';
 import {
   barPointSelector,
+  boxLayerNthChild,
   choroplethRegionSelectors,
   errorBarAxis,
   generatePlotlySelectors,
@@ -2257,9 +2258,13 @@ function extractMultiBoxLayer(
   const prefix = subplotCssPrefix(firstTrace?.xaxis, firstTrace?.yaxis);
 
   for (let boxIdx = 0; boxIdx < boxTraces.length; boxIdx++) {
-    const { trace, calcIdx } = boxTraces[boxIdx];
+    const { trace, calcIdx, globalIdx } = boxTraces[boxIdx];
     const cd = group.calcdata[calcIdx] ?? [];
-    const nthChild = boxIdx + 1;
+    // Counted across the panel's boxlayer groups rather than across these
+    // boxes. A candlestick is drawn through the same renderer and takes a
+    // group of its own, so one declared first shifts every box after it — and
+    // a box plotly did not draw takes no group at all.
+    const nthChild = boxLayerNthChild(gd, globalIdx);
 
     // Extract data for this box.
     const boxPoint = extractSingleBoxData(trace, cd.length > 0 ? cd[0] : undefined);

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -430,24 +430,57 @@ function candlestickSelector(
   traceIndex: number,
   prefix: string,
 ): string {
-  const self = gd._fullData?.[traceIndex];
-  const isOhlc = self?.type === 'ohlc';
-  const onThisPanel = (trace: PlotlyTrace): boolean =>
-    trace.xaxis === self?.xaxis && trace.yaxis === self?.yaxis;
+  const isOhlc = gd._fullData?.[traceIndex]?.type === 'ohlc';
+  const nth = isOhlc
+    ? layerNthChild(gd, traceIndex, ['ohlc'])
+    : boxLayerNthChild(gd, traceIndex);
 
-  // `drawnBefore` counts one plotly type at a time, so the box-family layer
-  // takes one call per type it holds. Summing them is the whole count,
-  // because a trace has exactly one type.
-  const types = isOhlc ? ['ohlc'] : [...BOXLAYER_TRACE_TYPES];
-  const position = types.reduce(
-    (total, type) => total + drawnBefore(gd, traceIndex, type, onThisPanel),
-    0,
-  );
-
-  const nth = position + 1;
   return isOhlc
     ? `${prefix}.ohlclayer > .trace.ohlc:nth-of-type(${nth}) > path`
     : `${prefix}.boxlayer > .trace.boxes:nth-of-type(${nth}) path.box`;
+}
+
+/**
+ * A trace's 1-based position among the groups plotly drew into its panel's
+ * `g.boxlayer`.
+ *
+ * Box and candlestick share that layer, so the count has to span both: a
+ * candlestick declared first takes the first group, and a walk over boxes
+ * alone would hand the box that follows the candlestick's group.
+ *
+ * @param gd         - The plotly graph div
+ * @param traceIndex - The trace's index in `_fullData`
+ * @returns Its 1-based position among the panel's boxlayer groups
+ */
+export function boxLayerNthChild(gd: PlotlyGraphDiv, traceIndex: number): number {
+  return layerNthChild(gd, traceIndex, [...BOXLAYER_TRACE_TYPES]);
+}
+
+/**
+ * A trace's 1-based position among the same-panel traces of the given types.
+ *
+ * `drawnBefore` counts one plotly type at a time, so a layer holding more than
+ * one takes a call per type. Summing them is the whole count, because a trace
+ * has exactly one type.
+ *
+ * @param gd         - The plotly graph div
+ * @param traceIndex - The trace's index in `_fullData`
+ * @param types      - The plotly trace types sharing the layer
+ * @returns Its 1-based position among them
+ */
+function layerNthChild(
+  gd: PlotlyGraphDiv,
+  traceIndex: number,
+  types: string[],
+): number {
+  const self = gd._fullData?.[traceIndex];
+  const onThisPanel = (trace: PlotlyTrace): boolean =>
+    trace.xaxis === self?.xaxis && trace.yaxis === self?.yaxis;
+
+  return types.reduce(
+    (total, type) => total + drawnBefore(gd, traceIndex, type, onThisPanel),
+    0,
+  ) + 1;
 }
 
 function isDrawnPie(trace: PlotlyTrace | undefined): boolean {

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -2751,6 +2751,36 @@ describe('plotly extractor', () => {
         '.subplot.x2y2 .boxlayer > .trace.boxes:nth-of-type(1) path.box',
       ]);
     });
+
+    it('shifts a box that a candlestick was declared before', () => {
+      // The mirror of the case above, and the one `extractMultiBoxLayer` got
+      // wrong: it numbered its groups across box traces alone, so the box here
+      // came out `nth-child(1)` — the candlestick's group. Measured in
+      // Chromium with the candlestick declared first, `boxlayer > g:nth-child(1)`
+      // matches its 4 candles and `g:nth-child(2)` the box's 1.
+      const gd = createGraphDiv({
+        traces: [candlestickTrace(), { type: 'box', y: [1, 2, 3, 4], name: 'spread' }],
+        layout: SINGLE_PANEL,
+        calcdata: [
+          [],
+          [{ min: 1, q1: 2, med: 3, q3: 4, max: 9, pts2: [] }] as PlotlyCalcData[],
+        ],
+      });
+
+      const layers = layersOf(gd);
+      const candlestick = layers.find(layer => layer.type === TraceType.CANDLESTICK);
+      const box = layers.find(layer => layer.type === TraceType.BOX);
+      expect(candlestick).toBeDefined();
+      expect(box).toBeDefined();
+
+      expect(candlestick!.selectors).toBe(
+        '.subplot.xy .boxlayer > .trace.boxes:nth-of-type(1) path.box',
+      );
+      const boxSelectors = box!.selectors as unknown as BoxSelector[];
+      expect(boxSelectors[0].q2).toBe(
+        '.subplot.xy .boxlayer > g:nth-child(2) > path.box',
+      );
+    });
   });
 
   describe('waterfall traces', () => {


### PR DESCRIPTION
# Pull Request

## Description

**This PR was originally a duplicate of #882 and has been rebased down to the one thing #882 did not cover.** #882 landed the candlestick selector fix — better than my version, since it also handles `ohlc` and skips undrawn traces via `drawnBefore`. All of that is dropped from here.

What remains is the mirror case on the box side. `extractMultiBoxLayer` numbers its groups with `boxIdx + 1` — counting across box traces alone:

```ts
const nthChild = boxIdx + 1;
```

Box and candlestick share `g.boxlayer`. A candlestick declared first takes the first group, so the box that follows is addressed as `nth-child(1)` — the candlestick's marks. Measured in Chromium against plotly 2.35.2, candlestick declared before box:

| selector | matches |
|---|---|
| `.subplot.xy .boxlayer > g:nth-child(1) > path.box` | 4 — the candles |
| `.subplot.xy .boxlayer > g:nth-child(2) > path.box` | 1 — the box |

As with #881, audio, braille and text stay correct — only the outline lands on the wrong mark.

## Related Issues

Follows #882 / #881.

## Changes Made

- **`selectors.ts`** — extracted `boxLayerNthChild` out of `candlestickSelector` and exported it, so both sides of the shared layer count the same way. The type-summing part stays as `layerNthChild` for the `ohlc` layer to share. No behaviour change for the candlestick path.
- **`extractor.ts`** — `extractMultiBoxLayer` uses `boxLayerNthChild(gd, globalIdx)`. Reusing `drawnBefore` also stops a box plotly never drew from taking a slot from its neighbour.
- **`extractor.test.ts`** — one case: a candlestick declared before a box, asserting the candlestick keeps group 1 and the box gets group 2. It fails on `main` (`Received: nth-child(1)`) and passes here.

I wrote a second test for the undrawn-box case and **deleted it before pushing**: it passed with and without the fix, so it pinned nothing. #882's `does not count a hidden trace, which draws no group` already covers that contract.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Local gate on the rebased branch: `lint:fix`, `type-check`, `build` (12/12 bundles) and `npm test` (266 suites / 3614 tests, plus 7 ESM suites / 73 tests) all pass. `npm run e2e` was not run locally; CI covers it.

The documentation box is unticked: no user-facing behaviour changed, only which element gets outlined.