### PR TITLE
feat(adapters): add the co-located maidr trace declaration

### DIFF
--- a/src/adapters/shared/traceDeclaration.ts
+++ b/src/adapters/shared/traceDeclaration.ts
@@ -5,35 +5,67 @@
  * the grammar they feed. What lives here is the part that must not be
  * re-implemented eight times: how a {@link FieldRef} is read off an author's
  * row, which spellings of a canonical field name are accepted when no ref is
- * given, what counts as a censored observation, and how an untyped block from
- * a chart config is narrowed.
+ * given, what counts as a raised flag, and how an untyped block from a chart
+ * config is narrowed and checked.
  *
  * Eight independent implementations of the fallback chains would mean an
- * author's `isCensored` column works in d3 and silently does not in Chart.js,
- * which is an accessibility regression class rather than a style question —
- * the same argument `selectorUtil.ts` records for itself.
+ * author's `isCensored` column works in one adapter and silently does not in
+ * the next, which is an accessibility regression class rather than a style
+ * question — the same argument `selectorUtil.ts` records for itself. The
+ * guarantee is over the adapters that read this block: Recharts declares
+ * through its own `*Config` props and d3 through which `bindD3*` binder is
+ * called, so both keep the readers they shipped and neither is bound by the
+ * table below.
  *
  * Nothing else belongs in this file. Anything that mirrors `MaidrLayer`'s
  * option blocks would become a second grammar that can drift from the first.
  */
 
 import type { AlluvialDeclaration, BoxenDeclaration, ChoroplethDeclaration, ErrorBarDeclaration, FieldRef, ForestDeclaration, HexbinDeclaration, MaidrTraceDeclaration, ManhattanDeclaration, MosaicDeclaration, ParallelDeclaration, RidgelineDeclaration, ScatterDeclaration, SurvivalDeclaration, VolcanoDeclaration } from '../../type/declaration';
-import { TraceType } from '../../type/grammar';
+import { Orientation, TraceType } from '../../type/grammar';
+
+/**
+ * Who is reading a declaration, and what they are reading it off.
+ *
+ * Every warning this module raises is prefixed and located from one of these,
+ * so the eight adapters print one sentence rather than eight spellings of it.
+ */
+export interface DeclarationContext {
+  /**
+   * Names the adapter in the `[MAIDR <Adapter>]` warning prefix, e.g.
+   * `'Highcharts'`.
+   */
+  adapter: string;
+  /**
+   * How the author can find the series. Printed verbatim, so pass a locating
+   * phrase — `'series "sales"'`, `'dataset 2'` — rather than a bare number.
+   */
+  seriesRef: string;
+}
 
 /**
  * Alternative property names accepted for each canonical grammar field name,
  * in priority order.
  *
- * Lifted from the shipped d3 binder configs — `censored` at
+ * Informed by the shipped d3 binder configs — `censored` at
  * `d3/binders/survival.ts`, the bounds at `d3/binders/errorBar.ts`, the ladder
- * at `d3/binders/boxen.ts` — so a column that works in one adapter works in
- * all of them. The two bound chains are the union of the survival and
- * error-bar binders' lists, which differ by a name or two each.
+ * at `d3/binders/boxen.ts` — so a column an author already carries is read
+ * without a declaration. The two bound chains are the union of the survival
+ * and error-bar binders' lists, which differ by a name or two each; the rest
+ * are the chains those binders document, not always the longer lists their
+ * implementations accept. Reconciling a d3 binder with its own doc comment is
+ * that binder's business, and this table is the one every adapter reading a
+ * declaration shares.
  *
  * Consulted **only** when the author named no field: an explicit
  * {@link FieldRef} is used verbatim, per {@link resolveFieldRef}. A canonical
  * name with no entry here — `width`, `x`, `y`, `region` — resolves under its
  * own name and nothing else.
+ *
+ * The chains are keyed by canonical name across every declared type, so a name
+ * borrowed by two of them is shared: `value` carries the ridgeline chain and a
+ * choropleth's `value` therefore also answers to `x`, which is called out on
+ * {@link ChoroplethDeclaration.value}.
  *
  * `censored` is deliberately not aliased to `event`, which most survival
  * datasets carry with the opposite meaning.
@@ -59,11 +91,16 @@ export const FIELD_REF_FALLBACKS: Readonly<Record<string, readonly string[]>> = 
  * Reads one declared fact off an author's row.
  *
  * An explicit `ref` is used verbatim with **no fallback**: a name the author
- * wrote that misses is their error, and reporting it — the caller warns per
- * the adapter's `[MAIDR <Adapter>]` contract — beats papering over it with a
- * column they did not name. Only the defaulted path walks
+ * wrote that misses is their error, and reporting it — with
+ * {@link warnUnresolvedRef}, once the series is read — beats papering over it
+ * with a column they did not name. Only the defaulted path walks
  * {@link FIELD_REF_FALLBACKS}, trying `canonical` first and then each
  * alternative in order.
+ *
+ * `undefined` and `null` both mean "no ref given" here, exactly as they do in
+ * {@link validateDeclaration}: the slots this rides in are frequently untyped
+ * chart config, where `null` is how an author writes "not set", and reading
+ * `row['null']` for one would be a puzzle with no explanation attached.
  *
  * Returns `undefined` when nothing resolves, and the field is then **omitted**
  * from the payload. Never substitute a zero, a false or a placeholder: a
@@ -79,29 +116,35 @@ export const FIELD_REF_FALLBACKS: Readonly<Record<string, readonly string[]>> = 
  *
  * @param row       - The row the charting library bound to the mark — a
  *                    Chart.js datum, a Highcharts `point.options`, an amCharts
- *                    `dataItem.dataContext`, a d3 `element.__data__`.
+ *                    `dataItem.dataContext`, a d3 `element.__data__`. Typed
+ *                    `unknown` because most of those arrive that way; anything
+ *                    that is not an object resolves to nothing.
  * @param ref       - The field the author named, or `undefined` to default.
  * @param canonical - The grammar field name being filled, e.g. `'yMin'`.
  * @returns The value read, or `undefined` when nothing resolves.
  */
 export function resolveFieldRef<T>(
-  row: Record<string, unknown> | undefined,
+  row: unknown,
   ref: FieldRef | undefined,
   canonical: string,
 ): T | undefined {
   if (row === null || typeof row !== 'object') {
     return undefined;
   }
+
+  // The one narrowing this module exists to do: a library's row is an untyped
+  // bag of the author's own columns, and the names are resolved from data.
+  const record = row as Record<string, unknown>;
   if (typeof ref === 'string') {
-    return row[ref] as T | undefined;
+    return record[ref] as T | undefined;
   }
 
-  const canonicalValue = row[canonical];
+  const canonicalValue = record[canonical];
   if (canonicalValue !== undefined) {
     return canonicalValue as T;
   }
   for (const alternative of FIELD_REF_FALLBACKS[canonical] ?? []) {
-    const value = row[alternative];
+    const value = record[alternative];
     if (value !== undefined) {
       return value as T;
     }
@@ -110,18 +153,54 @@ export function resolveFieldRef<T>(
 }
 
 /**
- * Whether a resolved value marks a censored observation.
+ * Reports an explicit {@link FieldRef} that no row in the series carried.
  *
- * Read strictly rather than by truthiness, because survival data carries the
- * flag as a boolean, as a 0/1 indicator, or as the string one of those was
- * parsed from — and `'0'` is truthy in every one of those readings but censors
- * nobody. `true`, `1`, `'1'` and `'true'` count; everything else, `'yes'`
+ * {@link resolveFieldRef} answers per row and cannot tell a typo from a row
+ * that legitimately lacks the field — a one-sided interval has no `yMin` on
+ * some rows and that is not an error. The series is the unit that can:
+ * call this once, after reading a series, when an explicit ref resolved on no
+ * row of it. The field is then left out of the payload, and the author is told
+ * why rather than being handed a chart quietly missing what they declared.
+ *
+ * The message lives here so all eight adapters print the same sentence; the
+ * "at most once per chart per binding" contract is satisfied by calling this
+ * once per series per field, since it holds no state of its own.
+ *
+ * @param context   - Who is reading, and what they are reading it off.
+ * @param ref       - The field name the author wrote.
+ * @param canonical - The grammar field it was meant to fill, e.g. `'yMin'`.
+ */
+export function warnUnresolvedRef(
+  context: DeclarationContext,
+  ref: FieldRef,
+  canonical: string,
+): void {
+  warn(
+    context.adapter,
+    `maidr declaration on ${context.seriesRef} names "${ref}" for ${canonical}, `
+    + `which no row carries; ${canonical} is left out.`,
+  );
+}
+
+/**
+ * Whether a resolved value raises a per-row flag — `censored` on a survival
+ * curve, `pooled` on a forest plot.
+ *
+ * Read strictly rather than by truthiness, because the flag arrives as a
+ * boolean, as a 0/1 indicator, or as the string one of those was parsed
+ * from — and `'0'` is truthy in every one of those readings while raising
+ * nothing. `true`, `1`, `'1'` and `'true'` count; everything else, `'yes'`
  * included, does not.
  *
- * @param value - Whatever the `censored` field resolved to.
- * @returns True when the value marks a censored time.
+ * One helper for both flags on purpose. They are the same fact in two charts
+ * and the cost of disagreeing is not symmetric: a `pooled` read by truthiness
+ * marks every study as the summary the moment a CSV hands over the string
+ * `'0'`, which drops the whole body of evidence out of the announcement.
+ *
+ * @param value - Whatever the flag field resolved to.
+ * @returns True when the value raises the flag.
  */
-export function isCensoredValue(value: unknown): boolean {
+export function isFlagValue(value: unknown): boolean {
   if (typeof value === 'boolean') {
     return value;
   }
@@ -138,14 +217,47 @@ export function isCensoredValue(value: unknown): boolean {
 type DeclaredType = MaidrTraceDeclaration['type'];
 
 /**
- * Every key a declaration variant accepts, other than its discriminant.
+ * What a key's value has to look like for the declaration to keep it.
  *
- * `Record` over these is exhaustive in both directions, which is what makes
- * the runtime key sets below provably the compile-time ones: a field added to
- * a variant without being added to its set fails to compile, and so does a set
- * naming a field the variant does not have.
+ * Names rather than predicates, so the key sets below stay a table an author
+ * of an adapter can read straight down. `'field'` and `'series'` are both
+ * non-empty strings and are distinguished because they say what the string
+ * addresses — a column of the author's data, or a sibling series.
  */
-type FieldKeySet<T> = Readonly<Record<Exclude<keyof T, 'type'> & string, true>>;
+type ValueKind
+  = | 'field'
+    | 'series'
+    | 'text'
+    | 'number'
+    | 'index'
+    | 'boolean'
+    | 'dimensions'
+    | 'orientation'
+    | 'stepDirection'
+    | 'significanceDirection';
+
+/**
+ * A key's value kind, marked `'required'` when the variant cannot be read
+ * without it.
+ */
+type KeyRule = ValueKind | readonly [ValueKind, 'required'];
+
+/** The rule shape a field's own optionality demands. */
+type KeyRuleFor<V> = undefined extends V ? ValueKind : readonly [ValueKind, 'required'];
+
+/**
+ * Every key a declaration variant accepts, other than its discriminant, with
+ * the kind of value each takes.
+ *
+ * The mapped type is exhaustive in both directions, which is what makes the
+ * runtime key sets below provably the compile-time ones: a field added to a
+ * variant without being added to its set fails to compile, so does a set
+ * naming a field the variant does not have, and so does a set that calls a
+ * required field optional or the other way round.
+ */
+type FieldKeySet<T> = Readonly<{
+  [K in Exclude<keyof T, 'type'> & string]-?: KeyRuleFor<T[K]>
+}>;
 
 /**
  * The closed key set of each variant, by declared type.
@@ -155,116 +267,234 @@ type FieldKeySet<T> = Readonly<Record<Exclude<keyof T, 'type'> & string, true>>;
  * {@link DeclaredType} means a new variant cannot be added to
  * `src/type/declaration.ts` without landing here too.
  */
-const DECLARATION_KEYS: Readonly<Record<DeclaredType, Readonly<Record<string, true>>>> = {
+const DECLARATION_KEYS: Readonly<Record<DeclaredType, Readonly<Record<string, KeyRule>>>> = {
   [TraceType.SURVIVAL]: {
-    title: true,
-    name: true,
-    censored: true,
-    yMin: true,
-    yMax: true,
-    stepDirection: true,
-    censoredSeries: true,
-    bandSeries: true,
+    title: 'text',
+    name: 'text',
+    censored: 'field',
+    yMin: 'field',
+    yMax: 'field',
+    stepDirection: 'stepDirection',
+    censoredSeries: 'series',
+    bandSeries: 'series',
+    merge: 'boolean',
   } satisfies FieldKeySet<SurvivalDeclaration>,
   [TraceType.ERROR_BAR]: {
-    title: true,
-    name: true,
-    yMin: true,
-    yMax: true,
-    error: true,
-    intervalSeries: true,
-    orientation: true,
+    title: 'text',
+    name: 'text',
+    yMin: 'field',
+    yMax: 'field',
+    error: 'field',
+    intervalSeries: 'series',
+    orientation: 'orientation',
   } satisfies FieldKeySet<ErrorBarDeclaration>,
   [TraceType.FOREST]: {
-    title: true,
-    name: true,
-    yMin: true,
-    yMax: true,
-    error: true,
-    intervalSeries: true,
-    orientation: true,
-    weight: true,
-    pooled: true,
-    pooledIndex: true,
-    pooledSeries: true,
-    nullValue: true,
+    title: 'text',
+    name: 'text',
+    yMin: 'field',
+    yMax: 'field',
+    error: 'field',
+    intervalSeries: 'series',
+    orientation: 'orientation',
+    weight: 'field',
+    pooled: 'field',
+    pooledIndex: 'index',
+    pooledSeries: 'series',
+    nullValue: 'number',
   } satisfies FieldKeySet<ForestDeclaration>,
   [TraceType.MANHATTAN]: {
-    title: true,
-    name: true,
-    label: true,
-    group: true,
-    significance: true,
-    significanceDirection: true,
-    effect: true,
-    merge: true,
+    title: 'text',
+    name: 'text',
+    label: 'field',
+    group: 'field',
+    significance: 'number',
+    significanceDirection: 'significanceDirection',
+    effect: 'number',
+    merge: 'boolean',
   } satisfies FieldKeySet<ManhattanDeclaration>,
   [TraceType.VOLCANO]: {
-    title: true,
-    name: true,
-    label: true,
-    group: true,
-    significance: true,
-    significanceDirection: true,
-    effect: true,
-    merge: true,
+    title: 'text',
+    name: 'text',
+    label: 'field',
+    group: 'field',
+    significance: 'number',
+    significanceDirection: 'significanceDirection',
+    effect: 'number',
+    merge: 'boolean',
   } satisfies FieldKeySet<VolcanoDeclaration>,
   [TraceType.SCATTER]: {
-    title: true,
-    name: true,
-    label: true,
-    merge: true,
+    title: 'text',
+    name: 'text',
+    label: 'field',
+    merge: 'boolean',
   } satisfies FieldKeySet<ScatterDeclaration>,
   [TraceType.ALLUVIAL]: {
-    title: true,
-    name: true,
+    title: 'text',
+    name: 'text',
   } satisfies FieldKeySet<AlluvialDeclaration>,
   [TraceType.MOSAIC]: {
-    title: true,
-    name: true,
-    width: true,
-    count: true,
+    title: 'text',
+    name: 'text',
+    width: 'field',
+    count: 'field',
   } satisfies FieldKeySet<MosaicDeclaration>,
   [TraceType.CHOROPLETH]: {
-    title: true,
-    name: true,
-    region: true,
-    value: true,
-    lon: true,
-    lat: true,
+    title: 'text',
+    name: 'text',
+    region: 'field',
+    value: 'field',
+    lon: 'field',
+    lat: 'field',
   } satisfies FieldKeySet<ChoroplethDeclaration>,
   [TraceType.PARALLEL]: {
-    title: true,
-    name: true,
-    dimensions: true,
-    label: true,
+    title: 'text',
+    name: 'text',
+    dimensions: ['dimensions', 'required'],
+    label: 'field',
   } satisfies FieldKeySet<ParallelDeclaration>,
   [TraceType.RIDGELINE]: {
-    title: true,
-    name: true,
-    group: true,
-    value: true,
-    density: true,
+    title: 'text',
+    name: 'text',
+    group: ['field', 'required'],
+    value: 'field',
+    density: 'field',
   } satisfies FieldKeySet<RidgelineDeclaration>,
   [TraceType.HEXBIN]: {
-    title: true,
-    name: true,
-    x: true,
-    y: true,
-    count: true,
-    row: true,
+    title: 'text',
+    name: 'text',
+    x: 'field',
+    y: 'field',
+    count: 'field',
+    row: 'field',
   } satisfies FieldKeySet<HexbinDeclaration>,
   [TraceType.BOXEN]: {
-    title: true,
-    name: true,
-    x: true,
-    median: true,
-    levels: true,
-    lowerOutliers: true,
-    upperOutliers: true,
-    orientation: true,
+    title: 'text',
+    name: 'text',
+    x: 'field',
+    median: 'field',
+    levels: 'field',
+    lowerOutliers: 'field',
+    upperOutliers: 'field',
+    orientation: 'orientation',
   } satisfies FieldKeySet<BoxenDeclaration>,
 };
+
+/**
+ * What each {@link ValueKind} accepts, phrased to finish the sentence
+ * "expected …" in a warning an author reads.
+ *
+ * The two-value vocabularies are spelled out because their values are the
+ * grammar's, not the words they stand for: `Orientation.HORIZONTAL` is
+ * `'horz'`, and an author writing `'horizontal'` in plain JS has no compiler
+ * to tell them otherwise.
+ */
+const VALUE_EXPECTATIONS: Readonly<Record<ValueKind, string>> = {
+  field: 'a field name',
+  series: 'a series id',
+  text: 'a string',
+  number: 'a number',
+  index: 'a row index',
+  boolean: 'a boolean',
+  dimensions: 'a non-empty list of axes',
+  orientation: '"horz" or "vert"',
+  stepDirection: '"hv", "vh" or "mid"',
+  significanceDirection: '"above" or "below"',
+};
+
+/**
+ * Whether a value is the kind its key takes.
+ *
+ * `'dimensions'` is not decided here: its entries are reported one by one, so
+ * it goes through {@link isValidDimensions} where the warnings can be raised.
+ *
+ * @param kind  - The kind the key's rule names.
+ * @param value - The value the author wrote.
+ * @returns True when the value can be kept.
+ */
+function isValidValue(kind: Exclude<ValueKind, 'dimensions'>, value: unknown): boolean {
+  switch (kind) {
+    case 'field':
+    case 'series':
+      return typeof value === 'string' && value.trim() !== '';
+    case 'text':
+      return typeof value === 'string';
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'index':
+      return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'orientation':
+      return value === Orientation.VERTICAL || value === Orientation.HORIZONTAL;
+    case 'stepDirection':
+      return value === 'hv' || value === 'vh' || value === 'mid';
+    case 'significanceDirection':
+      return value === 'above' || value === 'below';
+  }
+}
+
+/**
+ * Whether a parallel-coordinates axis list is usable, reporting each entry
+ * that is not.
+ *
+ * Checked entry by entry because `dimensions` is the one thing a parallel
+ * trace cannot degrade without — a guessed order announces the chart's columns
+ * in the wrong places — and because the object form's `key` is the field a
+ * Recharts- or Highcharts-shaped author is most likely to spell `dataKey`. An
+ * entry naming no field makes the whole list unusable rather than leaving a
+ * hole in the axis order.
+ *
+ * @param value  - The value at the `dimensions` key.
+ * @param report - Raises one warning, already located on the series. Its
+ *                 argument follows "…on <series> ", so each message starts
+ *                 with a verb.
+ * @returns True when every entry names a field.
+ */
+function isValidDimensions(value: unknown, report: (message: string) => void): boolean {
+  if (!Array.isArray(value) || value.length === 0) {
+    report(
+      `has dimensions ${describeValue(value)}; `
+      + `expected ${VALUE_EXPECTATIONS.dimensions}; ignored.`,
+    );
+    return false;
+  }
+
+  let usable = true;
+  value.forEach((entry, index) => {
+    if (typeof entry === 'string' && entry.trim() !== '') {
+      return;
+    }
+
+    const axis = typeof entry === 'object' && entry !== null && !Array.isArray(entry)
+      ? entry as Record<string, unknown>
+      : undefined;
+    if (axis !== undefined) {
+      for (const key of Object.keys(axis)) {
+        if (key !== 'key' && key !== 'label') {
+          report(`has dimensions[${index}] with unknown key "${key}"; ignored.`);
+        }
+      }
+      if (axis.label !== undefined && axis.label !== null && !isValidValue('text', axis.label)) {
+        report(
+          `has dimensions[${index}] with label ${describeValue(axis.label)}; `
+          + `expected ${VALUE_EXPECTATIONS.text}.`,
+        );
+        usable = false;
+        return;
+      }
+      if (isValidValue('field', axis.key)) {
+        return;
+      }
+    }
+
+    report(
+      `has dimensions[${index}] naming no field; `
+      + `expected a field name or { key: 'column' }.`,
+    );
+    usable = false;
+  });
+  return usable;
+}
 
 /**
  * Whether a string is a type {@link MaidrTraceDeclaration} has a variant for.
@@ -277,41 +507,86 @@ function isDeclaredType(value: string): value is DeclaredType {
 }
 
 /**
+ * Splits a {@link KeyRule} into the two things a check needs.
+ *
+ * @param rule - The rule a key set gives for one key.
+ * @returns Its value kind and whether the key is required.
+ */
+function readRule(rule: KeyRule): { kind: ValueKind; required: boolean } {
+  return typeof rule === 'string'
+    ? { kind: rule, required: false }
+    : { kind: rule[0], required: true };
+}
+
+/**
+ * Renders a value for a warning, without ever throwing on one.
+ *
+ * @param value - Whatever the author wrote.
+ * @returns A short phrase naming it.
+ */
+function describeValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+  if (Array.isArray(value)) {
+    return 'a list';
+  }
+  if (typeof value === 'object' && value !== null) {
+    return 'an object';
+  }
+  if (typeof value === 'function') {
+    return 'a function';
+  }
+  return String(value);
+}
+
+/**
  * Narrows an unknown value read from a library's pass-through slot into a
  * validated declaration, or `null`.
  *
  * A co-located block is untyped in plain JS, so this read-time check is the
  * only defence an author has against a typo. It warns once per distinct
- * problem — an unknown or missing `type`, a block that is not an object, and
- * each key the declared variant does not accept — and **never throws**: a
- * binder that throws takes the host page down, so every failure degrades to
- * the undeclared reading instead.
+ * problem and **never throws**: a binder that throws takes the host page down,
+ * so every failure degrades to the undeclared reading instead.
  *
- * An unknown key is warned about and left alone; the declaration still stands
- * and its known fields are still read. An unknown `type` rejects the block
- * outright, and the caller falls through to its chart-level declaration and
- * then to its heuristic. A `TraceType` value with no variant in
- * {@link MaidrTraceDeclaration} — `'bar'`, say — is unknown in the same sense:
- * there is nothing here to declare about it.
+ * What it checks, and what each failure costs:
+ *
+ * - A block that is not an object, or whose `type` names no variant, is
+ *   rejected outright, and the caller falls through to its chart-level
+ *   declaration and then to its heuristic. A `TraceType` value with no variant
+ *   in {@link MaidrTraceDeclaration} — `'bar'`, say — is unknown in the same
+ *   sense: there is nothing here to declare about it.
+ * - A key the variant does not accept is warned about and left alone; the
+ *   declaration still stands and its known fields are still read.
+ * - A key whose **value** is not the kind it takes is warned about and
+ *   dropped, so the grammar's own default applies — the truthful smaller
+ *   reading. This is what stops `significanceDirection: 'Below'` from being
+ *   read as `'above'` and announcing precisely the points that failed to reach
+ *   significance as the findings.
+ * - A variant missing a key it cannot be read without — `dimensions` on a
+ *   parallel plot, `group` on a ridgeline — is rejected. The alternative is
+ *   returning a block typed as if the field were there, which is an invitation
+ *   to the throw this function exists to prevent.
+ *
+ * `undefined` and `null` are "not given" wherever they appear, both as the
+ * block and as any key's value.
+ *
+ * The returned declaration is the block itself where nothing was dropped, and
+ * a copy without the dropped keys otherwise: the author's chart config is
+ * never mutated.
  *
  * This is the only place an `unknown` from a chart config is narrowed; `any`
  * must not escape it. Calling it once per series per binding is what satisfies
  * the "each distinct warning at most once per chart per binding" contract —
  * this function holds no state of its own.
  *
- * @param raw     - The value at the library's `maidr` slot. `undefined` and
- *                  `null` mean "no declaration" and pass quietly.
+ * @param raw     - The value at the library's `maidr` slot.
  * @param context - Who is reading, and what they are reading it off.
- * @param context.adapter - Names the adapter in the `[MAIDR <Adapter>]`
- *                  warning prefix, e.g. `'Highcharts'`.
- * @param context.seriesRef - How the author can find the series. Printed
- *                  verbatim, so pass a locating phrase — `'series "sales"'`,
- *                  `'dataset 2'` — rather than a bare number.
  * @returns The validated declaration, or `null` when there is none to read.
  */
 export function validateDeclaration(
   raw: unknown,
-  context: { adapter: string; seriesRef: string },
+  context: DeclarationContext,
 ): MaidrTraceDeclaration | null {
   if (raw === undefined || raw === null) {
     return null;
@@ -334,17 +609,83 @@ export function validateDeclaration(
     return null;
   }
 
+  const located = (message: string): void =>
+    warn(adapter, `maidr declaration for "${type}" on ${seriesRef} ${message}`);
+
   const accepted = DECLARATION_KEYS[type];
+  const dropped: string[] = [];
   for (const key of Object.keys(block)) {
-    if (key !== 'type' && !Object.hasOwn(accepted, key)) {
-      warn(
-        adapter,
-        `maidr declaration for "${type}" on ${seriesRef} has unknown key "${key}"; ignored.`,
+    if (key === 'type') {
+      continue;
+    }
+    if (!Object.hasOwn(accepted, key)) {
+      located(`has unknown key "${key}"; ignored.`);
+      continue;
+    }
+
+    const value = block[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    const { kind } = readRule(accepted[key]);
+    if (kind === 'dimensions') {
+      if (!isValidDimensions(value, located)) {
+        dropped.push(key);
+      }
+      continue;
+    }
+    if (!isValidValue(kind, value)) {
+      located(
+        `has ${key} ${describeValue(value)}; expected ${VALUE_EXPECTATIONS[kind]}; ignored.`,
       );
+      dropped.push(key);
     }
   }
 
-  return block as unknown as MaidrTraceDeclaration;
+  for (const [key, rule] of Object.entries(accepted)) {
+    const missing = block[key] === undefined || block[key] === null || dropped.includes(key);
+    if (readRule(rule).required && missing) {
+      located(`is missing required key "${key}"; reading it as the undeclared chart.`);
+      return null;
+    }
+  }
+
+  if (dropped.length === 0) {
+    return block as unknown as MaidrTraceDeclaration;
+  }
+  const kept = { ...block };
+  for (const key of dropped) {
+    delete kept[key];
+  }
+  return kept as unknown as MaidrTraceDeclaration;
+}
+
+/**
+ * Reads the `maidr` key off a library's pass-through slot and validates it.
+ *
+ * Two of the slots arrive as `unknown` — amCharts' `userData`, Plotly's
+ * `meta` — so `validateDeclaration(slot?.maidr, …)` does not compile there,
+ * and the alternative is each adapter hand-rolling the same container guard or
+ * reaching for `any` under deadline. The container is narrowed once, here.
+ *
+ * A container that is not an object, or that carries no `maidr` key, is no
+ * declaration and passes quietly: Plotly's `meta` is very often a plain string
+ * that has nothing to do with MAIDR.
+ *
+ * @param container - The library's slot — `series.options.custom`,
+ *                    `series.get('userData')`, `trace.meta`, `usermeta`.
+ * @param context   - Who is reading, and what they are reading it off.
+ * @returns The validated declaration, or `null` when there is none to read.
+ */
+export function readDeclarationSlot(
+  container: unknown,
+  context: DeclarationContext,
+): MaidrTraceDeclaration | null {
+  if (typeof container !== 'object' || container === null || !('maidr' in container)) {
+    return null;
+  }
+  return validateDeclaration(container.maidr, context);
 }
 
 /**

--- a/src/adapters/shared/traceDeclaration.ts
+++ b/src/adapters/shared/traceDeclaration.ts
@@ -1,0 +1,358 @@
+/**
+ * Shared resolution rules for the co-located `maidr` declaration block.
+ *
+ * The declaration types themselves live in `src/type/declaration.ts`, beside
+ * the grammar they feed. What lives here is the part that must not be
+ * re-implemented eight times: how a {@link FieldRef} is read off an author's
+ * row, which spellings of a canonical field name are accepted when no ref is
+ * given, what counts as a censored observation, and how an untyped block from
+ * a chart config is narrowed.
+ *
+ * Eight independent implementations of the fallback chains would mean an
+ * author's `isCensored` column works in d3 and silently does not in Chart.js,
+ * which is an accessibility regression class rather than a style question —
+ * the same argument `selectorUtil.ts` records for itself.
+ *
+ * Nothing else belongs in this file. Anything that mirrors `MaidrLayer`'s
+ * option blocks would become a second grammar that can drift from the first.
+ */
+
+import type { AlluvialDeclaration, BoxenDeclaration, ChoroplethDeclaration, ErrorBarDeclaration, FieldRef, ForestDeclaration, HexbinDeclaration, MaidrTraceDeclaration, ManhattanDeclaration, MosaicDeclaration, ParallelDeclaration, RidgelineDeclaration, ScatterDeclaration, SurvivalDeclaration, VolcanoDeclaration } from '../../type/declaration';
+import { TraceType } from '../../type/grammar';
+
+/**
+ * Alternative property names accepted for each canonical grammar field name,
+ * in priority order.
+ *
+ * Lifted from the shipped d3 binder configs — `censored` at
+ * `d3/binders/survival.ts`, the bounds at `d3/binders/errorBar.ts`, the ladder
+ * at `d3/binders/boxen.ts` — so a column that works in one adapter works in
+ * all of them. The two bound chains are the union of the survival and
+ * error-bar binders' lists, which differ by a name or two each.
+ *
+ * Consulted **only** when the author named no field: an explicit
+ * {@link FieldRef} is used verbatim, per {@link resolveFieldRef}. A canonical
+ * name with no entry here — `width`, `x`, `y`, `region` — resolves under its
+ * own name and nothing else.
+ *
+ * `censored` is deliberately not aliased to `event`, which most survival
+ * datasets carry with the opposite meaning.
+ */
+export const FIELD_REF_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
+  censored: ['censor', 'isCensored'],
+  yMin: ['lower', 'lo', 'ciLower', 'ciLow', 'ci_low', 'low', 'min'],
+  yMax: ['upper', 'hi', 'ciUpper', 'ciHigh', 'ci_high', 'high', 'max'],
+  weight: ['w', 'share'],
+  pooled: ['isPooled', 'summary'],
+  label: ['snp', 'id', 'name', 'gene', 'probe'],
+  group: ['chromosome', 'chrom', 'chr', 'region'],
+  value: ['x', 't', 'position'],
+  density: ['kde', 'width', 'p', 'estimate'],
+  count: ['length', 'value', 'n', 'total'],
+  median: ['q2', 'mid', 'y'],
+  levels: ['letterValues', 'letter_values', 'quantiles', 'ladder'],
+  lon: ['longitude', 'long'],
+  lat: ['latitude'],
+};
+
+/**
+ * Reads one declared fact off an author's row.
+ *
+ * An explicit `ref` is used verbatim with **no fallback**: a name the author
+ * wrote that misses is their error, and reporting it — the caller warns per
+ * the adapter's `[MAIDR <Adapter>]` contract — beats papering over it with a
+ * column they did not name. Only the defaulted path walks
+ * {@link FIELD_REF_FALLBACKS}, trying `canonical` first and then each
+ * alternative in order.
+ *
+ * Returns `undefined` when nothing resolves, and the field is then **omitted**
+ * from the payload. Never substitute a zero, a false or a placeholder: a
+ * missing weight is a forest plot without weights, while a weight of 0 is a
+ * study that counted for nothing.
+ *
+ * A falsy value that is present — `0`, `''`, `false`, `null` — resolves and
+ * stops the walk. Only an `undefined` reading moves on to the next name.
+ *
+ * An array counts as a row here rather than being rejected: a d3-hexbin bin
+ * **is** the array of points that fell in it, which is why `length` is one of
+ * `count`'s fallbacks.
+ *
+ * @param row       - The row the charting library bound to the mark — a
+ *                    Chart.js datum, a Highcharts `point.options`, an amCharts
+ *                    `dataItem.dataContext`, a d3 `element.__data__`.
+ * @param ref       - The field the author named, or `undefined` to default.
+ * @param canonical - The grammar field name being filled, e.g. `'yMin'`.
+ * @returns The value read, or `undefined` when nothing resolves.
+ */
+export function resolveFieldRef<T>(
+  row: Record<string, unknown> | undefined,
+  ref: FieldRef | undefined,
+  canonical: string,
+): T | undefined {
+  if (row === null || typeof row !== 'object') {
+    return undefined;
+  }
+  if (typeof ref === 'string') {
+    return row[ref] as T | undefined;
+  }
+
+  const canonicalValue = row[canonical];
+  if (canonicalValue !== undefined) {
+    return canonicalValue as T;
+  }
+  for (const alternative of FIELD_REF_FALLBACKS[canonical] ?? []) {
+    const value = row[alternative];
+    if (value !== undefined) {
+      return value as T;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether a resolved value marks a censored observation.
+ *
+ * Read strictly rather than by truthiness, because survival data carries the
+ * flag as a boolean, as a 0/1 indicator, or as the string one of those was
+ * parsed from — and `'0'` is truthy in every one of those readings but censors
+ * nobody. `true`, `1`, `'1'` and `'true'` count; everything else, `'yes'`
+ * included, does not.
+ *
+ * @param value - Whatever the `censored` field resolved to.
+ * @returns True when the value marks a censored time.
+ */
+export function isCensoredValue(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value === 1;
+  }
+  if (typeof value === 'string') {
+    return value === '1' || value === 'true';
+  }
+  return false;
+}
+
+/** The `type` values {@link MaidrTraceDeclaration} covers. */
+type DeclaredType = MaidrTraceDeclaration['type'];
+
+/**
+ * Every key a declaration variant accepts, other than its discriminant.
+ *
+ * `Record` over these is exhaustive in both directions, which is what makes
+ * the runtime key sets below provably the compile-time ones: a field added to
+ * a variant without being added to its set fails to compile, and so does a set
+ * naming a field the variant does not have.
+ */
+type FieldKeySet<T> = Readonly<Record<Exclude<keyof T, 'type'> & string, true>>;
+
+/**
+ * The closed key set of each variant, by declared type.
+ *
+ * Closedness is the point: it is what makes `significanse: 7.3` detectable in
+ * plain JS, where nothing else would catch it. Keying the map by
+ * {@link DeclaredType} means a new variant cannot be added to
+ * `src/type/declaration.ts` without landing here too.
+ */
+const DECLARATION_KEYS: Readonly<Record<DeclaredType, Readonly<Record<string, true>>>> = {
+  [TraceType.SURVIVAL]: {
+    title: true,
+    name: true,
+    censored: true,
+    yMin: true,
+    yMax: true,
+    stepDirection: true,
+    censoredSeries: true,
+    bandSeries: true,
+  } satisfies FieldKeySet<SurvivalDeclaration>,
+  [TraceType.ERROR_BAR]: {
+    title: true,
+    name: true,
+    yMin: true,
+    yMax: true,
+    error: true,
+    intervalSeries: true,
+    orientation: true,
+  } satisfies FieldKeySet<ErrorBarDeclaration>,
+  [TraceType.FOREST]: {
+    title: true,
+    name: true,
+    yMin: true,
+    yMax: true,
+    error: true,
+    intervalSeries: true,
+    orientation: true,
+    weight: true,
+    pooled: true,
+    pooledIndex: true,
+    pooledSeries: true,
+    nullValue: true,
+  } satisfies FieldKeySet<ForestDeclaration>,
+  [TraceType.MANHATTAN]: {
+    title: true,
+    name: true,
+    label: true,
+    group: true,
+    significance: true,
+    significanceDirection: true,
+    effect: true,
+    merge: true,
+  } satisfies FieldKeySet<ManhattanDeclaration>,
+  [TraceType.VOLCANO]: {
+    title: true,
+    name: true,
+    label: true,
+    group: true,
+    significance: true,
+    significanceDirection: true,
+    effect: true,
+    merge: true,
+  } satisfies FieldKeySet<VolcanoDeclaration>,
+  [TraceType.SCATTER]: {
+    title: true,
+    name: true,
+    label: true,
+    merge: true,
+  } satisfies FieldKeySet<ScatterDeclaration>,
+  [TraceType.ALLUVIAL]: {
+    title: true,
+    name: true,
+  } satisfies FieldKeySet<AlluvialDeclaration>,
+  [TraceType.MOSAIC]: {
+    title: true,
+    name: true,
+    width: true,
+    count: true,
+  } satisfies FieldKeySet<MosaicDeclaration>,
+  [TraceType.CHOROPLETH]: {
+    title: true,
+    name: true,
+    region: true,
+    value: true,
+    lon: true,
+    lat: true,
+  } satisfies FieldKeySet<ChoroplethDeclaration>,
+  [TraceType.PARALLEL]: {
+    title: true,
+    name: true,
+    dimensions: true,
+    label: true,
+  } satisfies FieldKeySet<ParallelDeclaration>,
+  [TraceType.RIDGELINE]: {
+    title: true,
+    name: true,
+    group: true,
+    value: true,
+    density: true,
+  } satisfies FieldKeySet<RidgelineDeclaration>,
+  [TraceType.HEXBIN]: {
+    title: true,
+    name: true,
+    x: true,
+    y: true,
+    count: true,
+    row: true,
+  } satisfies FieldKeySet<HexbinDeclaration>,
+  [TraceType.BOXEN]: {
+    title: true,
+    name: true,
+    x: true,
+    median: true,
+    levels: true,
+    lowerOutliers: true,
+    upperOutliers: true,
+    orientation: true,
+  } satisfies FieldKeySet<BoxenDeclaration>,
+};
+
+/**
+ * Whether a string is a type {@link MaidrTraceDeclaration} has a variant for.
+ *
+ * @param value - The `type` read off the block.
+ * @returns True when a variant declares it.
+ */
+function isDeclaredType(value: string): value is DeclaredType {
+  return Object.hasOwn(DECLARATION_KEYS, value);
+}
+
+/**
+ * Narrows an unknown value read from a library's pass-through slot into a
+ * validated declaration, or `null`.
+ *
+ * A co-located block is untyped in plain JS, so this read-time check is the
+ * only defence an author has against a typo. It warns once per distinct
+ * problem — an unknown or missing `type`, a block that is not an object, and
+ * each key the declared variant does not accept — and **never throws**: a
+ * binder that throws takes the host page down, so every failure degrades to
+ * the undeclared reading instead.
+ *
+ * An unknown key is warned about and left alone; the declaration still stands
+ * and its known fields are still read. An unknown `type` rejects the block
+ * outright, and the caller falls through to its chart-level declaration and
+ * then to its heuristic. A `TraceType` value with no variant in
+ * {@link MaidrTraceDeclaration} — `'bar'`, say — is unknown in the same sense:
+ * there is nothing here to declare about it.
+ *
+ * This is the only place an `unknown` from a chart config is narrowed; `any`
+ * must not escape it. Calling it once per series per binding is what satisfies
+ * the "each distinct warning at most once per chart per binding" contract —
+ * this function holds no state of its own.
+ *
+ * @param raw     - The value at the library's `maidr` slot. `undefined` and
+ *                  `null` mean "no declaration" and pass quietly.
+ * @param context - Who is reading, and what they are reading it off.
+ * @param context.adapter - Names the adapter in the `[MAIDR <Adapter>]`
+ *                  warning prefix, e.g. `'Highcharts'`.
+ * @param context.seriesRef - How the author can find the series. Printed
+ *                  verbatim, so pass a locating phrase — `'series "sales"'`,
+ *                  `'dataset 2'` — rather than a bare number.
+ * @returns The validated declaration, or `null` when there is none to read.
+ */
+export function validateDeclaration(
+  raw: unknown,
+  context: { adapter: string; seriesRef: string },
+): MaidrTraceDeclaration | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+
+  const { adapter, seriesRef } = context;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    warn(adapter, `maidr declaration on ${seriesRef} is not an object; ignored.`);
+    return null;
+  }
+
+  const block = raw as Record<string, unknown>;
+  const type = block.type;
+  if (typeof type !== 'string' || !isDeclaredType(type)) {
+    warn(
+      adapter,
+      `maidr declaration on ${seriesRef} has unknown type "${String(type)}"; `
+      + `reading it as the undeclared chart.`,
+    );
+    return null;
+  }
+
+  const accepted = DECLARATION_KEYS[type];
+  for (const key of Object.keys(block)) {
+    if (key !== 'type' && !Object.hasOwn(accepted, key)) {
+      warn(
+        adapter,
+        `maidr declaration for "${type}" on ${seriesRef} has unknown key "${key}"; ignored.`,
+      );
+    }
+  }
+
+  return block as unknown as MaidrTraceDeclaration;
+}
+
+/**
+ * Emits one adapter-prefixed warning.
+ *
+ * @param adapter - The adapter name, e.g. `'Highcharts'`.
+ * @param message - The sentence following the prefix.
+ */
+function warn(adapter: string, message: string): void {
+  console.warn(`[MAIDR ${adapter}] ${message}`);
+}

--- a/src/type/declaration.ts
+++ b/src/type/declaration.ts
@@ -1,0 +1,727 @@
+/**
+ * The co-located `maidr` declaration — what a chart says about itself.
+ *
+ * A charting library draws marks. It does not say what they *mean*: nothing in
+ * a Highcharts `line` series says the step is a survival curve, and nothing in
+ * a Chart.js scatter says a column of the data is a gene name. Where that
+ * meaning cannot be recovered from the drawing, the author declares it, in one
+ * block written beside the series they already wrote.
+ *
+ * ## Where the block goes
+ *
+ * Always in the charting library's **own documented pass-through slot**, under
+ * the key `maidr` — never as an invented top-level key on an object the
+ * library owns:
+ *
+ * | library    | write site                     |
+ * |------------|--------------------------------|
+ * | Highcharts | `series.custom.maidr`          |
+ * | amCharts   | `series.set('userData', { maidr })` |
+ * | Chart.js   | `dataset.maidr`                |
+ * | Plotly     | `trace.meta.maidr`             |
+ * | Vega-Lite  | `usermeta.maidr` on the unit or layer child spec |
+ *
+ * Recharts declares through its own `chartType` plus `*Config` props, and d3
+ * declares by which `bindD3*` binder is called; neither reads this block.
+ *
+ * ## The two laws that decide how a field is written
+ *
+ * 1. **If a fact differs per point, the declaration names a data field — a
+ *    {@link FieldRef}, the name of a property on your own row objects. If a
+ *    fact is the same for the whole layer, the declaration carries the value
+ *    itself.** So `weight` is a field name and `nullValue` is a number.
+ * 2. **Every field here is spelled exactly like the grammar field it fills,
+ *    and every {@link FieldRef} defaults to that same name.** An author who
+ *    has read `ForestPoint.weight` in `grammar.ts` knows what to write, and a
+ *    row that already carries a `weight` column needs no declaration at all.
+ *
+ * A `FieldRef` that is left out falls back to its canonical name and then to a
+ * short list of common spellings of it (`ciLower` for `yMin`, `isCensored`
+ * for `censored`); a `FieldRef` that is given is used verbatim, because an
+ * explicit name that misses is a mistake worth reporting rather than papering
+ * over. The fallback lists live in `src/adapters/shared/traceDeclaration.ts`
+ * so a column that works in one adapter works in all of them.
+ *
+ * ## What a declaration is worth
+ *
+ * A declaration outranks every heuristic an adapter has, and a declaration
+ * that cannot be honoured degrades to a **truthful smaller** reading — the
+ * layer is emitted without the option block it could not fill — never to a
+ * confident wrong one. Nothing here is ever guessed: the four values that
+ * would invert a reading if guessed wrong ({@link ManhattanDeclaration.significance},
+ * {@link ManhattanDeclaration.significanceDirection},
+ * {@link ManhattanDeclaration.effect} and {@link ForestDeclaration.nullValue})
+ * have no defaults at all.
+ *
+ * These are input types, authored by whoever draws the chart, exactly as
+ * `grammar.ts` is. They are read by chart authors, not only by contributors.
+ */
+
+import type { Orientation, StepDirection, TraceType } from './grammar';
+
+/**
+ * The name of a property on the author's own datum/row object.
+ *
+ * Never a function: a declaration must survive JSON, because four of the slots
+ * it rides in are serialised chart config and a function cannot be written in
+ * one. d3 keeps its `DataAccessor<T>` (`string | function`) and accepts a bare
+ * `FieldRef` wherever this file names one.
+ *
+ * The name is resolved against the row the charting library bound to the mark
+ * — a Chart.js datum, a Highcharts `point.options`, an amCharts
+ * `dataItem.dataContext` — so it is the column name in your data, not a label
+ * on the chart.
+ *
+ * @example
+ * // rows are { time: 4, surv: 0.8, isCensored: true }
+ * { type: TraceType.SURVIVAL, censored: 'isCensored' }
+ */
+export type FieldRef = string;
+
+/**
+ * A library-native identifier for another series in the same chart —
+ * Highcharts `series.options.id`, amCharts `IEntitySettings.id`, Chart.js
+ * `dataset.label`, Recharts `dataKey`.
+ *
+ * **Never an index.** Positional addressing into a series list goes stale the
+ * moment a series is filtered, reordered or toggled — a routine chart edit
+ * nobody associates with accessibility — and that is the failure this design
+ * exists to remove.
+ *
+ * A ref that names no series is reported and the parent layer is emitted
+ * without that half, rather than silently matching whatever sits at that
+ * position today.
+ */
+export type SeriesRef = string;
+
+/** Fields every declaration accepts, whatever its `type`. */
+export interface DeclarationBase {
+  /**
+   * Overrides the layer's announced title. Maps to `MaidrLayer.title`.
+   *
+   * Names the *chart*; use {@link DeclarationBase.name} to say which layer of
+   * it this is.
+   */
+  title?: string;
+  /**
+   * Names this layer among sibling layers. Maps to `MaidrLayer.name`.
+   *
+   * Announced on a layer switch in place of the trace type, so a hue-split
+   * figure says "Male" and "Female" rather than "error_bar plot" twice.
+   */
+  name?: string;
+}
+
+/**
+ * A declaration of what one series means, discriminated on its `type`.
+ *
+ * `type` is the **`TraceType` string value**, not a private alias: the word
+ * the author writes is the word emitted in `MaidrLayer.type` and printed in
+ * every warning. Two of them surprise people and are called out on the fields
+ * that carry them — `TraceType.SCATTER` is `'point'` and `TraceType.PARALLEL`
+ * is `'parallel_coordinates'`.
+ *
+ * The key set of each variant is **closed**, and adapters check it at read
+ * time: a plain-JS author who writes `significanse: 7.3` is told so, which is
+ * the only defence available outside TypeScript.
+ */
+export type MaidrTraceDeclaration
+  = | SurvivalDeclaration
+    | ErrorBarDeclaration
+    | ForestDeclaration
+    | VolcanoDeclaration
+    | ManhattanDeclaration
+    | AlluvialDeclaration
+    | MosaicDeclaration
+    | ScatterDeclaration
+    | ChoroplethDeclaration
+    | ParallelDeclaration
+    | RidgelineDeclaration
+    | HexbinDeclaration
+    | BoxenDeclaration;
+
+/**
+ * A Kaplan-Meier survival curve drawn as a step line.
+ *
+ * What a survival figure carries beyond a step chart is the two things it is
+ * read for: which times were **censored**, and how wide the **confidence
+ * band** is. Censoring marks are drawn as ticks rather than as steps, and a
+ * reader who cannot tell a censored time from an ordinary one cannot tell a
+ * flat tail backed by two hundred subjects from one backed by three.
+ *
+ * @example
+ * // Highcharts, one arm whose own samples carry the flag
+ * { custom: { maidr: { type: 'survival', censored: 'cens' } } }
+ */
+export interface SurvivalDeclaration extends DeclarationBase {
+  /** `TraceType.SURVIVAL` — the string `'survival'`. */
+  type: TraceType.SURVIVAL;
+  /**
+   * Field marking a sample as a censored time. Maps to `SurvivalPoint.censored`.
+   *
+   * `true`, `1`, `'1'` and `'true'` count as censored; anything else does
+   * not — the flag arrives as a boolean, as a 0/1 indicator or as the string
+   * one of those was parsed from, and `'0'` is truthy in every one of those
+   * readings but censors nobody.
+   *
+   * Deliberately **not** aliased to `event`, which most survival datasets
+   * carry with the opposite meaning: a 1 there is the event happening, which
+   * is exactly the times that are not censored.
+   *
+   * @default 'censored', falling back to `censor` or `isCensored`
+   */
+  censored?: FieldRef;
+  /**
+   * Field holding the confidence band's lower bound at this time. Maps to
+   * `SurvivalPoint.yMin`.
+   *
+   * @default 'yMin', falling back to `lower`, `lo`, `ciLower`, `ciLow`,
+   * `ci_low`, `low` or `min`
+   */
+  yMin?: FieldRef;
+  /**
+   * Field holding the confidence band's upper bound at this time. Maps to
+   * `SurvivalPoint.yMax`.
+   *
+   * @default 'yMax', falling back to `upper`, `hi`, `ciUpper`, `ciHigh`,
+   * `ci_high`, `high` or `max`
+   */
+  yMax?: FieldRef;
+  /**
+   * Where the curve jumps between times. Maps to `MaidrLayer.stepDirection`.
+   *
+   * `'hv'` is what a Kaplan-Meier curve means — survival holds until an event
+   * drops it — but MAIDR substitutes no default of its own, so declare it
+   * rather than letting the description stay silent about the convention.
+   */
+  stepDirection?: StepDirection;
+  /**
+   * Companion series drawing the censoring ticks, when they come from their
+   * own data join rather than from a `censored` column on the curve.
+   *
+   * Each tick is merged into this layer at the time its x gives, and the
+   * companion is suppressed from becoming a layer of its own. Highcharts
+   * charts that already pair with `linkedTo` need not repeat themselves here.
+   */
+  censoredSeries?: SeriesRef;
+  /** Companion series drawing the confidence band, merged in by x as above. */
+  bandSeries?: SeriesRef;
+}
+
+/**
+ * An estimate with the interval drawn around it — an error bar, a confidence
+ * interval, a point range.
+ *
+ * The bounds are **absolute positions** on the value axis, never offsets from
+ * the estimate. Producers disagree about which they hand out (matplotlib's
+ * `yerr` is an offset, Vega-Lite's `errorbar` computes bounds), so the grammar
+ * fixes one and {@link ErrorBarDeclaration.error} is how the other is
+ * declared and converted.
+ *
+ * The two bounds are optional and independently so: a one-sided interval is a
+ * real chart, and dropping the point for want of its other half would lose the
+ * estimate too.
+ */
+export interface ErrorBarDeclaration extends DeclarationBase {
+  /** `TraceType.ERROR_BAR` — the string `'error_bar'`. */
+  type: TraceType.ERROR_BAR;
+  /**
+   * Field holding the **absolute** lower bound. Maps to `ErrorBarPoint.yMin`.
+   *
+   * @default 'yMin', falling back to `lower`, `lo`, `ciLower`, `ciLow`,
+   * `ci_low`, `low` or `min`
+   */
+  yMin?: FieldRef;
+  /**
+   * Field holding the **absolute** upper bound. Maps to `ErrorBarPoint.yMax`.
+   *
+   * @default 'yMax', falling back to `upper`, `hi`, `ciUpper`, `ciHigh`,
+   * `ci_high`, `high` or `max`
+   */
+  yMax?: FieldRef;
+  /**
+   * Field holding the interval as an **offset** from the estimate — the field
+   * a Recharts `<ErrorBar dataKey>` or a matplotlib `yerr` points at. A number
+   * is a symmetric offset; a `[lower, upper]` pair is an asymmetric one.
+   *
+   * Normalised to absolute bounds on the way into the payload. Loses to
+   * `yMin`/`yMax` where both are declared, since those need no arithmetic.
+   */
+  error?: FieldRef;
+  /**
+   * Companion series drawing the interval rather than the estimate — an
+   * amCharts `openValueY`/`openValueX` column, a Highcharts `errorbar`.
+   *
+   * Merged into this layer by x and suppressed from becoming a layer of its
+   * own.
+   */
+  intervalSeries?: SeriesRef;
+  /** Which axis the estimate runs along. Maps to `MaidrLayer.orientation`. */
+  orientation?: Orientation;
+}
+
+/**
+ * One effect estimate with its interval per study, against a shared null line,
+ * with a pooled summary at the foot — the standard figure of a meta-analysis.
+ *
+ * It *is* an {@link ErrorBarDeclaration} laid out on a categorical row axis,
+ * so it accepts every field one does. What it adds is the part a sighted
+ * reader takes from the drawing and is otherwise never told: how much each
+ * study weighs, which row is the pooled result rather than evidence, and where
+ * the null line sits.
+ */
+export interface ForestDeclaration extends Omit<ErrorBarDeclaration, 'type'> {
+  /** `TraceType.FOREST` — the string `'forest'`. */
+  type: TraceType.FOREST;
+  /**
+   * Field holding the study's weight in the pooled estimate, as a fraction of
+   * one. Maps to `ForestPoint.weight`.
+   *
+   * A forest plot encodes this as marker *area*: two studies whose intervals
+   * look alike can contribute wholly differently to the result. Omitted from
+   * the payload when nothing resolves — a forest plot without weights is a
+   * real chart.
+   *
+   * @default 'weight', falling back to `w` or `share`
+   */
+  weight?: FieldRef;
+  /**
+   * Field marking a row as the pooled summary rather than a study. Maps to
+   * `ForestPoint.pooled`.
+   *
+   * It is a different kind of row — it is not evidence, it is what the
+   * evidence came to — and announcing it as one more study invites a reader to
+   * count it among them.
+   *
+   * @default 'pooled', falling back to `isPooled` or `summary`
+   */
+  pooled?: FieldRef;
+  /**
+   * Row index of the pooled summary, for data that carries no flag column. A
+   * meta-analysis draws the pooled row last, so this is usually the last
+   * index.
+   */
+  pooledIndex?: number;
+  /**
+   * Companion series drawing the pooled summary's own mark — the diamond a
+   * meta-analysis ends with, when it is drawn differently from the studies.
+   *
+   * Its rows are appended after the studies and the companion is suppressed
+   * from becoming a layer of its own.
+   */
+  pooledSeries?: SeriesRef;
+  /**
+   * The value that means "no effect" — 1 for a ratio measure, 0 for a
+   * difference. Maps to `MaidrLayer.forestOptions.nullValue`.
+   *
+   * Whether a study's interval crosses it *is the result for that study*, so
+   * the trace announces the crossing. There is deliberately **no default**: a
+   * ratio chart guessed at 0 would report every study as not crossing, since
+   * odds ratios are all positive, and that is a confident wrong answer given
+   * to every row. Undeclared, the layer gets the estimate, the interval and
+   * the weight, and makes no claim about significance.
+   */
+  nullValue?: number;
+}
+
+/**
+ * Genomic position against significance — the standard figure of a GWAS.
+ *
+ * Read as a scatter it offers point-by-point navigation over tens of thousands
+ * of points, which is not a viable path to the few dozen that matter. What a
+ * reader wants is which points cross the line and what they are called.
+ *
+ * @example
+ * // Chart.js, 22 chromosome datasets that read as one cloud
+ * { maidr: { type: 'manhattan', label: 'snp', group: 'chr', significance: 7.3 } }
+ */
+export interface ManhattanDeclaration extends DeclarationBase {
+  /** `TraceType.MANHATTAN` — the string `'manhattan'`. */
+  type: TraceType.MANHATTAN;
+  /**
+   * Field holding what each point *is* — a SNP id, a probe, a marker. Maps to
+   * `VolcanoPoint.label`.
+   *
+   * Identity is the payload on these charts, not the coordinates: a reader
+   * told "x is 2.3, y is 14.1" has been given the two numbers whose shape they
+   * can already hear and withheld the one thing they came for. Left out of the
+   * payload when nothing resolves.
+   *
+   * @default 'label', falling back to `snp`, `id`, `name`, `gene` or `probe`
+   */
+  label?: FieldRef;
+  /**
+   * Field holding the region a point belongs to — its chromosome. Maps to
+   * `VolcanoPoint.group`.
+   *
+   * @default 'group', falling back to `chromosome`, `chrom`, `chr` or `region`
+   */
+  group?: FieldRef;
+  /**
+   * The significance cutoff on the y axis, on the axis the chart is drawn
+   * against — 7.3 for genome-wide significance on a `-log10(p)` axis. Maps to
+   * `MaidrLayer.thresholdOptions.significance`.
+   *
+   * There is deliberately **no default**: the conventions differ by field and
+   * by software, and a guessed line would sort every point on the figure onto
+   * the wrong side, silently. Undeclared, the trace simply reports no
+   * findings.
+   */
+  significance?: number;
+  /**
+   * Which side of `significance` is the significant one. Maps to
+   * `MaidrLayer.thresholdOptions.significanceDirection`.
+   *
+   * `'above'` suits the transformed axes these charts usually carry; a **raw p
+   * axis runs the other way** and needs `'below'`, where a reading fixed to
+   * `'above'` would select precisely the points that failed to reach
+   * significance and announce them as the result.
+   *
+   * The grammar's `'above'` default is the grammar's to apply: pass your value
+   * through or pass nothing.
+   */
+  significanceDirection?: 'above' | 'below';
+  /**
+   * The effect-size cutoff on the x axis, applied to its **magnitude**. Maps
+   * to `MaidrLayer.thresholdOptions.effect`.
+   *
+   * Meaningful on a volcano, whose x is an effect size. A Manhattan's x is a
+   * genomic position and its x-axis plot lines are chromosome dividers rather
+   * than cutoffs, so this is never inferred for one — declare it or leave it
+   * out.
+   */
+  effect?: number;
+  /**
+   * Absorb *following* sibling series of the same drawn kind that carry no
+   * declaration of their own into this layer.
+   *
+   * This is how a 22-dataset Manhattan becomes one navigable trace rather than
+   * 22 layers a reader must switch between.
+   *
+   * @default true
+   */
+  merge?: boolean;
+}
+
+/**
+ * Effect size against significance — the standard figure of a differential
+ * expression analysis.
+ *
+ * The same chart as a {@link ManhattanDeclaration}, read the same way and
+ * accepting the same fields: `label` names the gene the way it names the SNP,
+ * and `significance` is the same cutoff on the same axis. What a volcano adds
+ * is the **second** cutoff — its x is an effect size rather than a position,
+ * so a point is a finding only when it clears both.
+ */
+export interface VolcanoDeclaration extends Omit<ManhattanDeclaration, 'type' | 'merge'> {
+  /** `TraceType.VOLCANO` — the string `'volcano'`. */
+  type: TraceType.VOLCANO;
+  /**
+   * Absorb following undeclared siblings of the same drawn kind, as
+   * {@link ManhattanDeclaration.merge} does.
+   *
+   * Off by default, the other way round from a Manhattan: a volcano's sibling
+   * series are usually up-regulated, down-regulated and unchanged — three
+   * things a reader wants told apart, not one cloud.
+   *
+   * @default false
+   */
+  merge?: boolean;
+}
+
+/**
+ * An ordinary scatter, declared rather than detected.
+ *
+ * Worth declaring for the two things a scatter cannot say for itself: that its
+ * points carry an identity beyond their coordinates, and that several series
+ * are one cloud.
+ */
+export interface ScatterDeclaration extends DeclarationBase {
+  /**
+   * `TraceType.SCATTER` — the string **`'point'`**, not `'scatter'`. The
+   * grammar names the mark, and the value is what an adapter emits and what
+   * every warning prints.
+   */
+  type: TraceType.SCATTER;
+  /**
+   * Field holding what each point *is*, announced alongside its coordinates.
+   *
+   * @default 'label', falling back to `snp`, `id`, `name`, `gene` or `probe`
+   */
+  label?: FieldRef;
+  /**
+   * Absorb following undeclared siblings of the same drawn kind into this
+   * layer, as {@link ManhattanDeclaration.merge} does.
+   *
+   * @default false
+   */
+  merge?: boolean;
+}
+
+/**
+ * Categories that stay put while a quantity is re-divided between them at each
+ * step — an alluvial diagram.
+ *
+ * The same weighted flow a sankey carries, drawn without a left-to-right
+ * budget, so it needs nothing declared beyond which of the two it is: the
+ * nodes, the links and their magnitudes are already in the drawing.
+ */
+export interface AlluvialDeclaration extends DeclarationBase {
+  /** `TraceType.ALLUVIAL` — the string `'alluvial'`. */
+  type: TraceType.ALLUVIAL;
+}
+
+/**
+ * A stacked bar chart whose bar **widths** also encode data — a mosaic or
+ * marimekko, a two-way contingency table drawn as tiles.
+ *
+ * Read as a plain stacked bar it loses the width entirely, which is half the
+ * table: the conditional proportions arrive without the group sizes they were
+ * computed from, so a category of six people and one of six hundred read
+ * identically.
+ *
+ * Always declared, never detected. A non-uniform width array on a stacked bar
+ * is a claim about how authors behave, not about what the data means, and a
+ * false positive would announce every column's width as a share of all
+ * observations — a number the chart does not contain.
+ */
+export interface MosaicDeclaration extends DeclarationBase {
+  /** `TraceType.MOSAIC` — the string `'mosaic'`. */
+  type: TraceType.MOSAIC;
+  /**
+   * Field holding the category's share of all observations, as a fraction of
+   * one — the width its column is drawn at. Maps to `MosaicPoint.width`.
+   *
+   * @default 'width'
+   */
+  width?: FieldRef;
+  /**
+   * Field holding the cell's own count, when the producer has the contingency
+   * table. Maps to `MosaicPoint.count`.
+   *
+   * Optional because a producer working from proportions alone genuinely does
+   * not have it, and multiplying out a rounded share would put a number in the
+   * announcement that the data does not contain.
+   *
+   * @default 'count', falling back to `length`, `value`, `n` or `total`
+   */
+  count?: FieldRef;
+}
+
+/**
+ * Geographic regions shaded by a value.
+ *
+ * Read as a bar chart whose categories happen to be places, it loses
+ * everything spatial: where the high values sit, which way the gradient runs,
+ * and which borders the value jumps across. `lon`/`lat` are what buy that
+ * back.
+ */
+export interface ChoroplethDeclaration extends DeclarationBase {
+  /** `TraceType.CHOROPLETH` — the string `'choropleth'`. */
+  type: TraceType.CHOROPLETH;
+  /**
+   * Field holding the region's name. Maps to `ChoroplethPoint.x`.
+   *
+   * @default 'region'
+   */
+  region?: FieldRef;
+  /**
+   * Field holding the value the region is shaded by. Maps to
+   * `ChoroplethPoint.y`.
+   *
+   * @default 'value', falling back to `x`, `t` or `position`
+   */
+  value?: FieldRef;
+  /**
+   * Field holding the region's centroid longitude, in **degrees east**. Maps
+   * to `ChoroplethPoint.lon`.
+   *
+   * Degrees only. Projected or normalised coordinates must be **omitted**
+   * rather than converted by guesswork: without the pair the map is read as a
+   * region list in declared order, which is a poorer reading but the one the
+   * data supports, while a wrong compass direction is a confident wrong
+   * answer.
+   *
+   * @default 'lon', falling back to `longitude` or `long`
+   */
+  lon?: FieldRef;
+  /**
+   * Field holding the region's centroid latitude, in **degrees north**. Maps
+   * to `ChoroplethPoint.lat`. Degrees only, exactly as
+   * {@link ChoroplethDeclaration.lon}.
+   *
+   * @default 'lat', falling back to `latitude`
+   */
+  lat?: FieldRef;
+}
+
+/**
+ * One polyline per observation across several axes, one axis per variable.
+ *
+ * Every column is a different quantity, so a value is pitched against its
+ * **own** axis rather than against one range for the layer — which is why the
+ * axes must be named and why they must be named in draw order.
+ */
+export interface ParallelDeclaration extends DeclarationBase {
+  /**
+   * `TraceType.PARALLEL` — the string **`'parallel_coordinates'`**, not
+   * `'parallel'`.
+   */
+  type: TraceType.PARALLEL;
+  /**
+   * The axes, in the order they are drawn — which is the order a reader arrows
+   * through them.
+   *
+   * Required, and required to be a list: nothing on the observation says it,
+   * an object's key order is not an axis order and must never be used as one,
+   * and a guessed order would announce the chart's columns in the wrong
+   * places.
+   *
+   * A bare string names both the axis and the **raw, un-normalised** field on
+   * the observation. The object form separates them, for a chart whose column
+   * key is not what a reader should hear. Either way the field named is the
+   * value *before* the chart scaled it to the axis: a trace derives each
+   * column's own extent, so it must never see 0–1 values.
+   *
+   * @example
+   * dimensions: ['mpg', 'hp', { label: 'Weight (lb)', key: 'wt' }]
+   */
+  dimensions: (string | { label?: string; key: FieldRef })[];
+  /**
+   * Field holding the observation's name, announced as its series name.
+   *
+   * @default 'label', falling back to `snp`, `id`, `name`, `gene` or `probe`
+   */
+  label?: FieldRef;
+}
+
+/**
+ * One density curve per group along a shared value axis, the curves offset
+ * down the page so their shapes can be compared.
+ *
+ * The offset is presentation — it exists so the curves do not overlap
+ * illegibly — so a layer carries each group's curve on its own terms and never
+ * the baseline it was drawn from.
+ */
+export interface RidgelineDeclaration extends DeclarationBase {
+  /** `TraceType.RIDGELINE` — the string `'ridgeline'`. */
+  type: TraceType.RIDGELINE;
+  /**
+   * Field holding the group a curve belongs to — the row it is drawn on. Maps
+   * to the categorical axis of `ViolinKdePoint`.
+   *
+   * Required, and therefore always used verbatim: without it there is nothing
+   * to separate the curves by, and one ridgeline read as a single density is a
+   * different chart.
+   */
+  group: FieldRef;
+  /**
+   * Field holding the position along the value axis. Maps to
+   * `ViolinKdePoint.y`.
+   *
+   * @default 'value', falling back to `x`, `t` or `position`
+   */
+  value?: FieldRef;
+  /**
+   * Field holding the kernel-density value **before** the group's ridge offset
+   * was added. Maps to `ViolinKdePoint.density`.
+   *
+   * Fed the drawn y instead, every group's loudness becomes a function of
+   * where it was stacked and the lowest ridge is the loudest. Where this
+   * resolves to nothing the reading is refused outright — an adapter warns and
+   * falls back to the undeclared chart type rather than subtracting a guessed
+   * baseline.
+   *
+   * @default 'density', falling back to `kde`, `width`, `p` or `estimate`
+   */
+  density?: FieldRef;
+}
+
+/**
+ * Hexagonal binning: the standard answer to an overplotted scatter.
+ *
+ * A lattice of cells each carrying a count, with the one difference that
+ * decides its navigation: a hex lattice staggers alternate rows, so a column
+ * index does not identify a position and each bin carries its own centre.
+ */
+export interface HexbinDeclaration extends DeclarationBase {
+  /** `TraceType.HEXBIN` — the string `'hexbin'`. */
+  type: TraceType.HEXBIN;
+  /**
+   * Field holding the bin's centre along the x axis, in **data units**. Maps
+   * to `HexbinPoint.x`.
+   *
+   * Screen coordinates would announce every bin's position in pixels.
+   *
+   * @default 'x'
+   */
+  x?: FieldRef;
+  /**
+   * Field holding the bin's centre along the y axis, in **data units**. Maps
+   * to `HexbinPoint.y`.
+   *
+   * @default 'y'
+   */
+  y?: FieldRef;
+  /**
+   * Field holding how many points fell in the bin. Maps to
+   * `HexbinPoint.count`.
+   *
+   * The `length` fallback is what makes a d3-hexbin bin work untouched: its
+   * bins are arrays of the points that fell in them.
+   *
+   * @default 'count', falling back to `length`, `value`, `n` or `total`
+   */
+  count?: FieldRef;
+  /**
+   * Field holding the lattice row a bin sits on, for data that names it.
+   *
+   * Omitted, rows are grouped by identical `y`, which is what a lattice
+   * computed by the usual libraries produces.
+   */
+  row?: FieldRef;
+}
+
+/**
+ * A letter-value plot: the box plot's five-number summary generalised to a
+ * variable-depth ladder of quantiles.
+ *
+ * The ladder is precomputed outside the charting library, so the declaration
+ * names the columns it was computed into. A box plot's summary is this shape
+ * with exactly one rung, and that fixed depth is why a box plot cannot express
+ * a boxen.
+ */
+export interface BoxenDeclaration extends DeclarationBase {
+  /** `TraceType.BOXEN` — the string `'boxen'`. */
+  type: TraceType.BOXEN;
+  /**
+   * Field holding the category this boxen summarises. Maps to `BoxenPoint.z`.
+   *
+   * @default 'x'
+   */
+  x?: FieldRef;
+  /**
+   * Field holding the middle of the distribution. Maps to
+   * `BoxenPoint.median`.
+   *
+   * @default 'median', falling back to `q2`, `mid` or `y`
+   */
+  median?: FieldRef;
+  /**
+   * Field holding the rungs — the ladder of `{ p, lo, hi }` quantile pairs.
+   * Maps to `BoxenPoint.levels`.
+   *
+   * The trace sorts them outward from the median rather than trusting the
+   * order they arrive in.
+   *
+   * @default 'levels', falling back to `letterValues`, `letter_values`,
+   * `quantiles` or `ladder`
+   */
+  levels?: FieldRef;
+  /** Field holding the values below the deepest rung. Maps to `BoxenPoint.lowerOutliers`. */
+  lowerOutliers?: FieldRef;
+  /** Field holding the values above the deepest rung. Maps to `BoxenPoint.upperOutliers`. */
+  upperOutliers?: FieldRef;
+  /** Which axis the distributions run along. Maps to `MaidrLayer.orientation`. */
+  orientation?: Orientation;
+}

--- a/src/type/declaration.ts
+++ b/src/type/declaration.ts
@@ -40,7 +40,8 @@
  * for `censored`); a `FieldRef` that is given is used verbatim, because an
  * explicit name that misses is a mistake worth reporting rather than papering
  * over. The fallback lists live in `src/adapters/shared/traceDeclaration.ts`
- * so a column that works in one adapter works in all of them.
+ * so a column that works in one adapter reading this block works in all of
+ * them.
  *
  * ## What a declaration is worth
  *
@@ -122,8 +123,12 @@ export interface DeclarationBase {
  * is `'parallel_coordinates'`.
  *
  * The key set of each variant is **closed**, and adapters check it at read
- * time: a plain-JS author who writes `significanse: 7.3` is told so, which is
- * the only defence available outside TypeScript.
+ * time — the key names, the shape of each value, and the presence of the few
+ * fields a variant cannot be read without. A plain-JS author who writes
+ * `significanse: 7.3`, or `significanceDirection: 'Below'`, is told so, which
+ * is the only defence available outside TypeScript. A value that is not what
+ * its key takes is dropped rather than passed on, so the grammar's own default
+ * applies instead of a wrong reading.
  */
 export type MaidrTraceDeclaration
   = | SurvivalDeclaration
@@ -162,7 +167,8 @@ export interface SurvivalDeclaration extends DeclarationBase {
    * `true`, `1`, `'1'` and `'true'` count as censored; anything else does
    * not — the flag arrives as a boolean, as a 0/1 indicator or as the string
    * one of those was parsed from, and `'0'` is truthy in every one of those
-   * readings but censors nobody.
+   * readings but censors nobody. The same table decides
+   * {@link ForestDeclaration.pooled}.
    *
    * Deliberately **not** aliased to `event`, which most survival datasets
    * carry with the opposite meaning: a 1 there is the event happening, which
@@ -206,6 +212,23 @@ export interface SurvivalDeclaration extends DeclarationBase {
   censoredSeries?: SeriesRef;
   /** Companion series drawing the confidence band, merged in by x as above. */
   bandSeries?: SeriesRef;
+  /**
+   * Absorb *following* sibling series of the same drawn kind into this layer
+   * as further **arms** of the same curve, as
+   * {@link ManhattanDeclaration.merge} absorbs further points into one cloud.
+   *
+   * On by default, because a survival figure is one figure whose arms belong
+   * together: treated and control are read against each other, and two arms
+   * split into two layers is a reader switching layers to compare the two
+   * numbers the chart exists to compare. `SurvivalTrace` carries an arm per
+   * row, so the arms stay individually navigable either way.
+   *
+   * Set `false` for the rare figure whose curves are genuinely separate
+   * charts. A second arm needs no declaration block of its own.
+   *
+   * @default true
+   */
+  merge?: boolean;
 }
 
 /**
@@ -244,6 +267,13 @@ export interface ErrorBarDeclaration extends DeclarationBase {
    * a Recharts `<ErrorBar dataKey>` or a matplotlib `yerr` points at. A number
    * is a symmetric offset; a `[lower, upper]` pair is an asymmetric one.
    *
+   * Both forms are **positive magnitudes**, as `yerr` is: the bounds are
+   * `estimate - lower` and `estimate + upper`, so an interval given as
+   * `[0.2, 0.3]` around 1.4 is 1.2 to 1.7. Signed offsets are not a second
+   * accepted spelling — read that way the same pair would give 1.6 to 1.7, and
+   * neither reading is detectable downstream once the absolute bounds are
+   * emitted. A negative entry is left out rather than flipped.
+   *
    * Normalised to absolute bounds on the way into the payload. Loses to
    * `yMin`/`yMax` where both are declared, since those need no arithmetic.
    */
@@ -256,7 +286,13 @@ export interface ErrorBarDeclaration extends DeclarationBase {
    * own.
    */
   intervalSeries?: SeriesRef;
-  /** Which axis the estimate runs along. Maps to `MaidrLayer.orientation`. */
+  /**
+   * Which axis the estimate runs along. Maps to `MaidrLayer.orientation`.
+   *
+   * The `Orientation` values, which are **`'horz'` and `'vert'`** — not the
+   * words they abbreviate. `'horizontal'` is not accepted, and a declaration
+   * carrying it is warned about and read without the key.
+   */
   orientation?: Orientation;
 }
 
@@ -282,6 +318,12 @@ export interface ForestDeclaration extends Omit<ErrorBarDeclaration, 'type'> {
    * the payload when nothing resolves — a forest plot without weights is a
    * real chart.
    *
+   * A **fraction of one**, not a percentage. Meta-analysis software reports
+   * this column as a percentage — `12.5` for one study in eight — and that is
+   * the number the default chain will find. A resolved weight above 1 is left
+   * out rather than rescaled: dividing by 100 guesses that the column sums to
+   * 100, and announcing it untouched says "weight 1250%".
+   *
    * @default 'weight', falling back to `w` or `share`
    */
   weight?: FieldRef;
@@ -293,6 +335,12 @@ export interface ForestDeclaration extends Omit<ErrorBarDeclaration, 'type'> {
    * evidence came to — and announcing it as one more study invites a reader to
    * count it among them.
    *
+   * Read on the same strict table as
+   * {@link SurvivalDeclaration.censored}: `true`, `1`, `'1'` and `'true'` mark
+   * the pooled row and nothing else does. Read by truthiness instead, a CSV's
+   * `'0'` marks every study as the summary and empties the evidence the trace
+   * counts and compares.
+   *
    * @default 'pooled', falling back to `isPooled` or `summary`
    */
   pooled?: FieldRef;
@@ -300,6 +348,12 @@ export interface ForestDeclaration extends Omit<ErrorBarDeclaration, 'type'> {
    * Row index of the pooled summary, for data that carries no flag column. A
    * meta-analysis draws the pooled row last, so this is usually the last
    * index.
+   *
+   * Counts **the declaring series' own rows, as authored**, from zero —
+   * including any row an adapter goes on to drop for want of a finite value,
+   * since that is the only sequence an author can see. It is resolved before
+   * any {@link ForestDeclaration.pooledSeries} is absorbed, so it never
+   * addresses a row that arrived from the companion.
    */
   pooledIndex?: number;
   /**
@@ -444,7 +498,19 @@ export interface ScatterDeclaration extends DeclarationBase {
    */
   type: TraceType.SCATTER;
   /**
-   * Field holding what each point *is*, announced alongside its coordinates.
+   * Field holding what each point *is*, announced alongside its coordinates
+   * wherever the emitted point carries a name.
+   *
+   * `ScatterPoint` has no label field today, so a plain `point` layer has
+   * nowhere to put one: declare `volcano` or `manhattan` where identity is the
+   * payload, which is where the grammar carries it. The key is accepted here
+   * rather than reported as unknown because it is the field's obvious home,
+   * and warning about a spelling the declaration documents would send an
+   * author looking for a typo they did not make.
+   *
+   * The default chain is the genomics one, so a row carrying an `id` or a
+   * `name` column resolves to it. Where those are chart plumbing rather than
+   * the point's identity, name the field explicitly.
    *
    * @default 'label', falling back to `snp`, `id`, `name`, `gene` or `probe`
    */
@@ -529,6 +595,11 @@ export interface ChoroplethDeclaration extends DeclarationBase {
    * Field holding the value the region is shaded by. Maps to
    * `ChoroplethPoint.y`.
    *
+   * The fallback chain is shared with {@link RidgelineDeclaration.value},
+   * where `x` genuinely is the position on the value axis. On a map whose rows
+   * put the region name in an `x` column, that chain would resolve the name as
+   * the value — so name the field, on any row shaped that way.
+   *
    * @default 'value', falling back to `x`, `t` or `position`
    */
   value?: FieldRef;
@@ -589,6 +660,10 @@ export interface ParallelDeclaration extends DeclarationBase {
   dimensions: (string | { label?: string; key: FieldRef })[];
   /**
    * Field holding the observation's name, announced as its series name.
+   *
+   * The default chain is the genomics one, so a row carrying an `id` or a
+   * `name` column resolves to it. Where that column is chart plumbing rather
+   * than the observation's name, name the field explicitly.
    *
    * @default 'label', falling back to `snp`, `id`, `name`, `gene` or `probe`
    */
@@ -722,6 +797,11 @@ export interface BoxenDeclaration extends DeclarationBase {
   lowerOutliers?: FieldRef;
   /** Field holding the values above the deepest rung. Maps to `BoxenPoint.upperOutliers`. */
   upperOutliers?: FieldRef;
-  /** Which axis the distributions run along. Maps to `MaidrLayer.orientation`. */
+  /**
+   * Which axis the distributions run along. Maps to `MaidrLayer.orientation`.
+   *
+   * The `Orientation` values, which are **`'horz'` and `'vert'`** — not the
+   * words they abbreviate, exactly as {@link ErrorBarDeclaration.orientation}.
+   */
   orientation?: Orientation;
 }

--- a/test/adapters/shared/traceDeclaration.test.ts
+++ b/test/adapters/shared/traceDeclaration.test.ts
@@ -1,9 +1,11 @@
 import type { MaidrTraceDeclaration } from '@type/declaration';
 import {
   FIELD_REF_FALLBACKS,
-  isCensoredValue,
+  isFlagValue,
+  readDeclarationSlot,
   resolveFieldRef,
   validateDeclaration,
+  warnUnresolvedRef,
 } from '@adapters/shared/traceDeclaration';
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { Orientation, TraceType } from '@type/grammar';
@@ -33,7 +35,7 @@ describe('resolveFieldRef — an explicit ref is used verbatim', () => {
   test('an explicit ref that misses resolves to nothing, with NO fallback', () => {
     // `lower` is a `yMin` fallback and the row carries it, but the author
     // named `ciLow`. Papering over the miss would announce a bound the author
-    // did not point at; the caller warns about it instead.
+    // did not point at; `warnUnresolvedRef` reports it instead.
     expect(resolveFieldRef({ lower: 3 }, 'ciLow', 'yMin')).toBeUndefined();
   });
 
@@ -81,7 +83,7 @@ describe('resolveFieldRef — the defaulted path walks the fallback chain', () =
 
   test('an array is a row, so a d3-hexbin bin reads its own length as the count', () => {
     const bin = Object.assign([{ x: 1 }, { x: 2 }, { x: 3 }], { x: 1, y: 2 });
-    expect(resolveFieldRef(bin as unknown as Record<string, unknown>, undefined, 'count')).toBe(3);
+    expect(resolveFieldRef(bin, undefined, 'count')).toBe(3);
   });
 
   test.each([
@@ -90,20 +92,42 @@ describe('resolveFieldRef — the defaulted path walks the fallback chain', () =
     ['a string', 'not a row'],
     ['a number', 7],
   ])('%s is not a row and resolves to undefined', (_label, row) => {
-    const notARow = row as unknown as Record<string, unknown> | undefined;
-    expect(resolveFieldRef(notARow, undefined, 'yMin')).toBeUndefined();
-    expect(resolveFieldRef(notARow, 'yMin', 'yMin')).toBeUndefined();
+    // The parameter is `unknown` because that is how the amCharts data
+    // context, the Plotly customdatum and the Vega-Lite datum all arrive; an
+    // adapter that had to assert its way in would be asserting past the guard
+    // below rather than being served by it.
+    expect(resolveFieldRef(row, undefined, 'yMin')).toBeUndefined();
+    expect(resolveFieldRef(row, 'yMin', 'yMin')).toBeUndefined();
   });
 });
 
-describe('isCensoredValue — the truth table, read strictly', () => {
+describe('warnUnresolvedRef — an explicit name that misses is reported', () => {
+  test('the message names the field, the canonical it filled and the series', () => {
+    warnUnresolvedRef(CONTEXT, 'cens', 'censored');
+
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration on series "sales" names "cens" for '
+      + 'censored, which no row carries; censored is left out.',
+    ]);
+  });
+
+  test('the sentence is the module\'s, so eight adapters print one of them', () => {
+    warnUnresolvedRef({ adapter: 'Chart.js', seriesRef: 'dataset 2' }, 'wgt', 'weight');
+    expect(warnings[0]).toBe(
+      '[MAIDR Chart.js] maidr declaration on dataset 2 names "wgt" for weight, '
+      + 'which no row carries; weight is left out.',
+    );
+  });
+});
+
+describe('isFlagValue — the truth table, read strictly', () => {
   test.each([
     ['the boolean true', true],
     ['the number 1', 1],
     ['the string "1"', '1'],
     ['the string "true"', 'true'],
-  ])('%s marks a censored observation', (_label, value) => {
-    expect(isCensoredValue(value)).toBe(true);
+  ])('%s raises the flag', (_label, value) => {
+    expect(isFlagValue(value)).toBe(true);
   });
 
   test.each([
@@ -120,7 +144,14 @@ describe('isCensoredValue — the truth table, read strictly', () => {
     ['null', null],
     ['an object', {}],
   ])('%s does not', (_label, value) => {
-    expect(isCensoredValue(value)).toBe(false);
+    expect(isFlagValue(value)).toBe(false);
+  });
+
+  test('one table decides both flags, so `pooled` cannot drift from `censored`', () => {
+    // A `pooled` read by truthiness marks every study as the summary the
+    // moment a CSV hands over `'0'`, which empties the evidence.
+    expect(isFlagValue('0')).toBe(false);
+    expect(isFlagValue(1)).toBe(true);
   });
 });
 
@@ -201,6 +232,7 @@ const FULL_DECLARATIONS: readonly MaidrTraceDeclaration[] = [
     stepDirection: 'hv',
     censoredSeries: 'ticks',
     bandSeries: 'band',
+    merge: true,
   },
   {
     type: TraceType.ERROR_BAR,
@@ -309,6 +341,15 @@ describe('validateDeclaration — a valid block passes through untouched', () =>
   test('all thirteen variants are covered by the fixtures above', () => {
     expect(new Set(FULL_DECLARATIONS.map(d => d.type)).size).toBe(13);
   });
+
+  test('a survival curve may say its siblings are further arms of it', () => {
+    // Chart.js already folds every line dataset of a survival figure into one
+    // layer of arms; `merge` is how the other adapters say the same thing.
+    expect(validateDeclaration({ type: TraceType.SURVIVAL, merge: false }, CONTEXT))
+      .not
+      .toBeNull();
+    expect(warnings).toEqual([]);
+  });
 });
 
 describe('validateDeclaration — the key set of a variant is closed', () => {
@@ -370,12 +411,241 @@ describe('validateDeclaration — the key set of a variant is closed', () => {
   });
 });
 
+describe('validateDeclaration — a value of the wrong kind is dropped, not passed on', () => {
+  test('a direction spelt in title case would invert the finding set', () => {
+    // `volcano.ts` reads anything that is not exactly `'below'` as above, so
+    // `'Below'` on a raw-p axis would announce precisely the points that
+    // failed to reach significance as the result.
+    const block = { type: TraceType.VOLCANO, significance: 0.05, significanceDirection: 'Below' };
+    const declaration = validateDeclaration(block, CONTEXT);
+
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "volcano" on series "sales" has '
+      + 'significanceDirection "Below"; expected "above" or "below"; ignored.',
+    ]);
+    expect(declaration).toEqual({ type: TraceType.VOLCANO, significance: 0.05 });
+  });
+
+  test('the author\'s own object is never mutated', () => {
+    const block = { type: TraceType.VOLCANO, significanceDirection: 'Below' };
+    const declaration = validateDeclaration(block, CONTEXT);
+
+    expect(declaration).not.toBe(block);
+    expect(block.significanceDirection).toBe('Below');
+  });
+
+  test('the words an author writes for an orientation are not the grammar\'s values', () => {
+    // `Orientation.HORIZONTAL` is `'horz'`. Left in place, `'horizontal'` is
+    // non-nullish and never equal to it, so a horizontal forest plot would
+    // navigate and highlight as a vertical one for good.
+    const declaration = validateDeclaration(
+      { type: TraceType.FOREST, orientation: 'horizontal' },
+      CONTEXT,
+    );
+
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "forest" on series "sales" has '
+      + 'orientation "horizontal"; expected "horz" or "vert"; ignored.',
+    ]);
+    expect(declaration).toEqual({ type: TraceType.FOREST });
+  });
+
+  /** One wrong-kinded value per value kind the key sets use. */
+  const WRONG_VALUES: readonly [string, MaidrTraceDeclaration['type'], string, unknown][] = [
+    ['a step direction in caps', TraceType.SURVIVAL, 'stepDirection', 'HV'],
+    ['a merge flag as a string', TraceType.SURVIVAL, 'merge', 'false'],
+    ['a field ref that is a boolean', TraceType.SURVIVAL, 'censored', true],
+    ['an empty field ref', TraceType.SURVIVAL, 'censored', ''],
+    ['a series ref that is a number', TraceType.SURVIVAL, 'bandSeries', 2],
+    ['a title that is not a string', TraceType.ALLUVIAL, 'title', 7],
+    ['an orientation given as a boolean', TraceType.BOXEN, 'orientation', true],
+    ['a null value as a string', TraceType.FOREST, 'nullValue', '1'],
+    ['a row index as a string', TraceType.FOREST, 'pooledIndex', '2'],
+    ['a negative row index', TraceType.FOREST, 'pooledIndex', -1],
+    ['a fractional row index', TraceType.FOREST, 'pooledIndex', 2.5],
+    ['a significance that is not finite', TraceType.MANHATTAN, 'significance', Number.NaN],
+    ['an effect given as a string', TraceType.MANHATTAN, 'effect', '1.5'],
+  ];
+
+  test.each(WRONG_VALUES)('%s is warned about and left out', (_label, type, key, value) => {
+    const declaration = validateDeclaration({ type, [key]: value }, CONTEXT);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(`has ${key} `);
+    expect(declaration).toEqual({ type });
+  });
+
+  test('a field ref that is `true` does not quietly walk the fallback chain', () => {
+    // `censored: true` reads as "this series is censored data" to its author.
+    // Left in place it would mean "go and find a `censor` column", so an
+    // unrelated column would decide which times are announced as censored.
+    const declaration = validateDeclaration({ type: TraceType.SURVIVAL, censored: true }, CONTEXT);
+
+    expect(warnings[0]).toContain('expected a field name; ignored.');
+    expect(declaration).toEqual({ type: TraceType.SURVIVAL });
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+  ])('a key written as %s is "not given" rather than an error', (_label, value) => {
+    const declaration = validateDeclaration({ type: TraceType.SURVIVAL, censored: value }, CONTEXT);
+
+    expect(warnings).toEqual([]);
+    expect(declaration).not.toBeNull();
+  });
+
+  test('a wrong value on one key leaves the rest of the declaration standing', () => {
+    const declaration = validateDeclaration(
+      { type: TraceType.FOREST, nullValue: 1, pooledIndex: '2', weight: 'w' },
+      CONTEXT,
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(declaration).toEqual({ type: TraceType.FOREST, nullValue: 1, weight: 'w' });
+  });
+});
+
+describe('validateDeclaration — a variant without its required key is rejected', () => {
+  test('a parallel plot with no dimensions is refused rather than typed as if it had them', () => {
+    // `dimensions` is non-optional on the type, so a block returned without it
+    // makes `declaration.dimensions.map(…)` compile and throw — out of a
+    // binder, which takes the host page down.
+    expect(validateDeclaration({ type: TraceType.PARALLEL, label: 'model' }, CONTEXT)).toBeNull();
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "parallel_coordinates" on series '
+      + '"sales" is missing required key "dimensions"; reading it as the undeclared chart.',
+    ]);
+  });
+
+  test('a misspelt required key is reported twice: as unknown, and as missing', () => {
+    expect(validateDeclaration({ type: TraceType.PARALLEL, dimensons: ['mpg'] }, CONTEXT))
+      .toBeNull();
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('unknown key "dimensons"');
+    expect(warnings[1]).toContain('missing required key "dimensions"');
+  });
+
+  test('a ridgeline with no group is refused, since one curve is a different chart', () => {
+    expect(validateDeclaration({ type: TraceType.RIDGELINE, value: 'temp' }, CONTEXT)).toBeNull();
+    expect(warnings[0]).toContain('missing required key "group"');
+  });
+
+  test('a required key whose value is wrong is dropped and then missing', () => {
+    expect(validateDeclaration({ type: TraceType.RIDGELINE, group: 3 }, CONTEXT)).toBeNull();
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('has group 3; expected a field name; ignored.');
+    expect(warnings[1]).toContain('missing required key "group"');
+  });
+
+  test('the narrowed declaration carries the field the type promises', () => {
+    const declaration = validateDeclaration(
+      { type: TraceType.PARALLEL, dimensions: ['mpg', { key: 'wt' }] },
+      CONTEXT,
+    );
+
+    expect(declaration).not.toBeNull();
+    if (declaration?.type === TraceType.PARALLEL) {
+      // The line eight adapters will write. It type-checks, so it must not
+      // throw.
+      expect(declaration.dimensions).toHaveLength(2);
+    }
+  });
+});
+
+describe('validateDeclaration — the axes of a parallel plot are checked one by one', () => {
+  test.each<[string, unknown]>([
+    ['a comma-separated string', 'mpg,hp'],
+    ['an empty list', []],
+    ['an object', { 0: 'mpg' }],
+  ])('%s is not a list of axes', (_label, dimensions) => {
+    expect(validateDeclaration({ type: TraceType.PARALLEL, dimensions }, CONTEXT)).toBeNull();
+    expect(warnings[0]).toContain('expected a non-empty list of axes; ignored.');
+  });
+
+  test('an axis object spelt the Recharts way is named by its index', () => {
+    expect(
+      validateDeclaration(
+        { type: TraceType.PARALLEL, dimensions: ['mpg', { label: 'Weight', dataKey: 'wt' }] },
+        CONTEXT,
+      ),
+    ).toBeNull();
+
+    expect(warnings[0]).toContain('has dimensions[1] with unknown key "dataKey"; ignored.');
+    expect(warnings[1]).toContain('has dimensions[1] naming no field');
+    expect(warnings[2]).toContain('missing required key "dimensions"');
+  });
+
+  test.each<[string, unknown]>([
+    ['a number', 3],
+    ['null', null],
+    ['an empty string', ''],
+    ['an object with no key', { label: 'Weight' }],
+  ])('an axis given as %s names no field', (_label, entry) => {
+    expect(validateDeclaration({ type: TraceType.PARALLEL, dimensions: [entry] }, CONTEXT))
+      .toBeNull();
+    expect(warnings[0]).toContain('has dimensions[0] naming no field');
+  });
+
+  test('an axis label that is not a string refuses the list rather than the type', () => {
+    // The label is what a reader hears for that axis, and a declaration typed
+    // as if it were a string is the lie this check exists to stop.
+    expect(
+      validateDeclaration(
+        { type: TraceType.PARALLEL, dimensions: [{ label: 7, key: 'wt' }] },
+        CONTEXT,
+      ),
+    ).toBeNull();
+    expect(warnings[0]).toContain('has dimensions[0] with label 7; expected a string.');
+  });
+
+  test('the object form is accepted with both of its keys', () => {
+    expect(
+      validateDeclaration(
+        { type: TraceType.PARALLEL, dimensions: [{ label: 'Weight (lb)', key: 'wt' }] },
+        CONTEXT,
+      ),
+    ).not.toBeNull();
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('readDeclarationSlot — the container is narrowed once, here', () => {
+  test('a slot carrying a declaration reads it', () => {
+    const declaration = { type: TraceType.SURVIVAL, censored: 'cens' };
+    expect(readDeclarationSlot({ maidr: declaration }, CONTEXT)).toBe(declaration);
+    expect(warnings).toEqual([]);
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    // Plotly's `meta` is very often a plain string that has nothing to do
+    // with MAIDR.
+    ['a string', 'quarterly'],
+    ['a number', 3],
+    ['an object with no maidr key', { legend: 'right' }],
+  ])('%s is no declaration and passes quietly', (_label, container) => {
+    expect(readDeclarationSlot(container, CONTEXT)).toBeNull();
+    expect(warnings).toEqual([]);
+  });
+
+  test('a maidr key that is not a declaration is still reported', () => {
+    expect(readDeclarationSlot({ maidr: 'survival' }, CONTEXT)).toBeNull();
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration on series "sales" is not an object; ignored.',
+    ]);
+  });
+});
+
 describe('validateDeclaration — a binder that throws takes the page down', () => {
   test.each([
     ['a prototype-less block', Object.assign(Object.create(null), { type: TraceType.ALLUVIAL })],
     ['a block whose type is an object', { type: {} }],
     ['a block whose type is null', { type: null }],
     ['an empty block', {}],
+    ['a block whose keys hold functions', { type: TraceType.FOREST, weight: (): number => 1 }],
+    ['a block whose dimensions hold themselves', { type: TraceType.PARALLEL, dimensions: [[]] }],
   ])('%s is handled rather than thrown on', (_label, raw) => {
     expect(() => validateDeclaration(raw, CONTEXT)).not.toThrow();
   });

--- a/test/adapters/shared/traceDeclaration.test.ts
+++ b/test/adapters/shared/traceDeclaration.test.ts
@@ -1,0 +1,382 @@
+import type { MaidrTraceDeclaration } from '@type/declaration';
+import {
+  FIELD_REF_FALLBACKS,
+  isCensoredValue,
+  resolveFieldRef,
+  validateDeclaration,
+} from '@adapters/shared/traceDeclaration';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+
+/** Context every warning in this suite is raised against. */
+const CONTEXT = { adapter: 'Highcharts', seriesRef: 'series "sales"' };
+
+/** Captures `console.warn` so the warning contract can be asserted on. */
+let warnings: string[];
+
+beforeEach(() => {
+  warnings = [];
+  jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('resolveFieldRef — an explicit ref is used verbatim', () => {
+  test('an explicit ref reads the field it names', () => {
+    expect(resolveFieldRef({ ciLow: 3, yMin: 9 }, 'ciLow', 'yMin')).toBe(3);
+  });
+
+  test('an explicit ref that misses resolves to nothing, with NO fallback', () => {
+    // `lower` is a `yMin` fallback and the row carries it, but the author
+    // named `ciLow`. Papering over the miss would announce a bound the author
+    // did not point at; the caller warns about it instead.
+    expect(resolveFieldRef({ lower: 3 }, 'ciLow', 'yMin')).toBeUndefined();
+  });
+
+  test('an explicit ref does not fall back to the canonical name either', () => {
+    expect(resolveFieldRef({ yMin: 3 }, 'ciLow', 'yMin')).toBeUndefined();
+  });
+});
+
+describe('resolveFieldRef — the defaulted path walks the fallback chain', () => {
+  test('the canonical name wins over every fallback', () => {
+    expect(resolveFieldRef({ yMin: 1, lower: 2, lo: 3 }, undefined, 'yMin')).toBe(1);
+  });
+
+  test('an earlier fallback wins over a later one', () => {
+    // `lower` precedes `min` in the chain.
+    expect(resolveFieldRef({ min: 2, lower: 1 }, undefined, 'yMin')).toBe(1);
+  });
+
+  test.each(
+    Object.entries(FIELD_REF_FALLBACKS).flatMap(([canonical, alternatives]) =>
+      alternatives.map(alternative => [canonical, alternative] as const),
+    ),
+  )('%s resolves from a row carrying only `%s`', (canonical, alternative) => {
+    expect(resolveFieldRef({ [alternative]: 'read' }, undefined, canonical)).toBe('read');
+  });
+
+  test('a canonical name with no chain resolves under its own name only', () => {
+    expect(FIELD_REF_FALLBACKS.width).toBeUndefined();
+    expect(resolveFieldRef({ width: 0.25 }, undefined, 'width')).toBe(0.25);
+    expect(resolveFieldRef({ share: 0.25 }, undefined, 'width')).toBeUndefined();
+  });
+
+  test('nothing resolving yields undefined rather than a placeholder', () => {
+    expect(resolveFieldRef({ estimate: 4 }, undefined, 'weight')).toBeUndefined();
+  });
+
+  test.each([
+    ['zero', 0],
+    ['an empty string', ''],
+    ['false', false],
+    ['null', null],
+  ])('%s is a present value and stops the walk', (_label, present) => {
+    expect(resolveFieldRef({ weight: present, w: 0.5 }, undefined, 'weight')).toBe(present);
+  });
+
+  test('an array is a row, so a d3-hexbin bin reads its own length as the count', () => {
+    const bin = Object.assign([{ x: 1 }, { x: 2 }, { x: 3 }], { x: 1, y: 2 });
+    expect(resolveFieldRef(bin as unknown as Record<string, unknown>, undefined, 'count')).toBe(3);
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a string', 'not a row'],
+    ['a number', 7],
+  ])('%s is not a row and resolves to undefined', (_label, row) => {
+    const notARow = row as unknown as Record<string, unknown> | undefined;
+    expect(resolveFieldRef(notARow, undefined, 'yMin')).toBeUndefined();
+    expect(resolveFieldRef(notARow, 'yMin', 'yMin')).toBeUndefined();
+  });
+});
+
+describe('isCensoredValue — the truth table, read strictly', () => {
+  test.each([
+    ['the boolean true', true],
+    ['the number 1', 1],
+    ['the string "1"', '1'],
+    ['the string "true"', 'true'],
+  ])('%s marks a censored observation', (_label, value) => {
+    expect(isCensoredValue(value)).toBe(true);
+  });
+
+  test.each([
+    ['the boolean false', false],
+    ['the number 0', 0],
+    // Truthy in JavaScript and censors nobody — the reason for reading
+    // strictly rather than by truthiness.
+    ['the string "0"', '0'],
+    ['the string "yes"', 'yes'],
+    ['the string "TRUE"', 'TRUE'],
+    ['the string "True"', 'True'],
+    ['the number 2', 2],
+    ['undefined', undefined],
+    ['null', null],
+    ['an object', {}],
+  ])('%s does not', (_label, value) => {
+    expect(isCensoredValue(value)).toBe(false);
+  });
+});
+
+describe('validateDeclaration — a block that is not one', () => {
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+  ])('%s is no declaration and passes quietly', (_label, raw) => {
+    expect(validateDeclaration(raw, CONTEXT)).toBeNull();
+    expect(warnings).toEqual([]);
+  });
+
+  test.each([
+    ['a string', 'survival'],
+    ['a number', 3],
+    ['an array', [{ type: TraceType.SURVIVAL }]],
+  ])('%s is rejected loudly', (_label, raw) => {
+    expect(validateDeclaration(raw, CONTEXT)).toBeNull();
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration on series "sales" is not an object; ignored.',
+    ]);
+  });
+});
+
+describe('validateDeclaration — the type must name a declarable trace', () => {
+  test('a block with no type is rejected, naming the series', () => {
+    expect(validateDeclaration({ censored: 'cens' }, CONTEXT)).toBeNull();
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration on series "sales" has unknown type '
+      + '"undefined"; reading it as the undeclared chart.',
+    ]);
+  });
+
+  test('a misspelt type is rejected, quoting what was written', () => {
+    expect(validateDeclaration({ type: 'survivl' }, CONTEXT)).toBeNull();
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration on series "sales" has unknown type '
+      + '"survivl"; reading it as the undeclared chart.',
+    ]);
+  });
+
+  test('a non-string type is rejected rather than coerced', () => {
+    expect(validateDeclaration({ type: 3 }, CONTEXT)).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('has unknown type "3"');
+  });
+
+  test('a real TraceType with no declaration variant is rejected too', () => {
+    // `bar` is a trace type, but there is nothing to declare about one, so it
+    // is unknown in the only sense this file has.
+    expect(validateDeclaration({ type: TraceType.BAR }, CONTEXT)).toBeNull();
+    expect(warnings[0]).toContain('has unknown type "bar"');
+  });
+
+  test('the two surprising spellings are the ones that are accepted', () => {
+    expect(validateDeclaration({ type: 'point' }, CONTEXT)).not.toBeNull();
+    expect(validateDeclaration({ type: 'parallel_coordinates', dimensions: ['mpg'] }, CONTEXT))
+      .not
+      .toBeNull();
+    expect(validateDeclaration({ type: 'scatter' }, CONTEXT)).toBeNull();
+    expect(validateDeclaration({ type: 'parallel' }, CONTEXT)).toBeNull();
+  });
+});
+
+/**
+ * One fully-populated block per variant: every key the variant accepts, so a
+ * key set that lost a field shows up as a spurious warning rather than as
+ * silence.
+ */
+const FULL_DECLARATIONS: readonly MaidrTraceDeclaration[] = [
+  {
+    type: TraceType.SURVIVAL,
+    title: 'Overall survival',
+    name: 'Treated',
+    censored: 'cens',
+    yMin: 'lo',
+    yMax: 'hi',
+    stepDirection: 'hv',
+    censoredSeries: 'ticks',
+    bandSeries: 'band',
+  },
+  {
+    type: TraceType.ERROR_BAR,
+    title: 't',
+    name: 'n',
+    yMin: 'lo',
+    yMax: 'hi',
+    error: 'se',
+    intervalSeries: 'whiskers',
+    orientation: Orientation.HORIZONTAL,
+  },
+  {
+    type: TraceType.FOREST,
+    title: 't',
+    name: 'n',
+    yMin: 'lo',
+    yMax: 'hi',
+    error: 'se',
+    intervalSeries: 'whiskers',
+    orientation: Orientation.HORIZONTAL,
+    weight: 'w',
+    pooled: 'isPooled',
+    pooledIndex: 12,
+    pooledSeries: 'diamond',
+    nullValue: 1,
+  },
+  {
+    type: TraceType.MANHATTAN,
+    title: 't',
+    name: 'n',
+    label: 'snp',
+    group: 'chr',
+    significance: 7.3,
+    significanceDirection: 'above',
+    effect: 1,
+    merge: true,
+  },
+  {
+    type: TraceType.VOLCANO,
+    title: 't',
+    name: 'n',
+    label: 'gene',
+    group: 'direction',
+    significance: 1.3,
+    significanceDirection: 'below',
+    effect: 1,
+    merge: false,
+  },
+  { type: TraceType.SCATTER, title: 't', name: 'n', label: 'id', merge: false },
+  { type: TraceType.ALLUVIAL, title: 't', name: 'n' },
+  { type: TraceType.MOSAIC, title: 't', name: 'n', width: 'share', count: 'n' },
+  {
+    type: TraceType.CHOROPLETH,
+    title: 't',
+    name: 'n',
+    region: 'state',
+    value: 'rate',
+    lon: 'longitude',
+    lat: 'latitude',
+  },
+  {
+    type: TraceType.PARALLEL,
+    title: 't',
+    name: 'n',
+    dimensions: ['mpg', { label: 'Weight (lb)', key: 'wt' }],
+    label: 'car',
+  },
+  {
+    type: TraceType.RIDGELINE,
+    title: 't',
+    name: 'n',
+    group: 'month',
+    value: 'temp',
+    density: 'kde',
+  },
+  {
+    type: TraceType.HEXBIN,
+    title: 't',
+    name: 'n',
+    x: 'cx',
+    y: 'cy',
+    count: 'n',
+    row: 'lattice',
+  },
+  {
+    type: TraceType.BOXEN,
+    title: 't',
+    name: 'n',
+    x: 'species',
+    median: 'q2',
+    levels: 'letterValues',
+    lowerOutliers: 'lowOut',
+    upperOutliers: 'highOut',
+    orientation: Orientation.VERTICAL,
+  },
+];
+
+describe('validateDeclaration — a valid block passes through untouched', () => {
+  test('every variant is accepted with every key it documents', () => {
+    for (const declaration of FULL_DECLARATIONS) {
+      expect(validateDeclaration(declaration, CONTEXT)).toBe(declaration);
+    }
+    expect(warnings).toEqual([]);
+  });
+
+  test('all thirteen variants are covered by the fixtures above', () => {
+    expect(new Set(FULL_DECLARATIONS.map(d => d.type)).size).toBe(13);
+  });
+});
+
+describe('validateDeclaration — the key set of a variant is closed', () => {
+  test('a misspelt key is named in a warning, which is all a plain-JS author gets', () => {
+    const declaration = validateDeclaration(
+      { type: TraceType.VOLCANO, significanse: 7.3 },
+      CONTEXT,
+    );
+
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "volcano" on series "sales" has '
+      + 'unknown key "significanse"; ignored.',
+    ]);
+    // Warned about, not fatal: the rest of the declaration still stands.
+    expect(declaration).not.toBeNull();
+  });
+
+  test('each unknown key is named separately', () => {
+    validateDeclaration({ type: TraceType.ALLUVIAL, of: 'x', unit: 'days' }, CONTEXT);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('unknown key "of"');
+    expect(warnings[1]).toContain('unknown key "unit"');
+  });
+
+  test('a key another variant accepts is still unknown on this one', () => {
+    // `weight` belongs to a forest plot; a survival curve has no use for it,
+    // which is the whole reason the union beats one flat options bag.
+    validateDeclaration({ type: TraceType.SURVIVAL, weight: 'w' }, CONTEXT);
+
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "survival" on series "sales" has '
+      + 'unknown key "weight"; ignored.',
+    ]);
+  });
+
+  test('the discriminant itself is never reported as unknown', () => {
+    validateDeclaration({ type: TraceType.ALLUVIAL }, CONTEXT);
+    expect(warnings).toEqual([]);
+  });
+
+  test('the warning carries the adapter and series it came from', () => {
+    validateDeclaration(
+      { type: TraceType.MOSAIC, widht: 'share' },
+      { adapter: 'Chart.js', seriesRef: 'dataset 2' },
+    );
+
+    expect(warnings).toEqual([
+      '[MAIDR Chart.js] maidr declaration for "mosaic" on dataset 2 has unknown '
+      + 'key "widht"; ignored.',
+    ]);
+  });
+
+  test('an inherited key is not reported as unknown on the variant that inherits it', () => {
+    // `ForestDeclaration` extends the error-bar fields; a key set that only
+    // listed the forest-specific ones would warn about the author's `yMin`.
+    validateDeclaration({ type: TraceType.FOREST, yMin: 'lo', error: 'se' }, CONTEXT);
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('validateDeclaration — a binder that throws takes the page down', () => {
+  test.each([
+    ['a prototype-less block', Object.assign(Object.create(null), { type: TraceType.ALLUVIAL })],
+    ['a block whose type is an object', { type: {} }],
+    ['a block whose type is null', { type: null }],
+    ['an empty block', {}],
+  ])('%s is handled rather than thrown on', (_label, raw) => {
+    expect(() => validateDeclaration(raw, CONTEXT)).not.toThrow();
+  });
+});

--- a/test/type/declaration.test.ts
+++ b/test/type/declaration.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, test } from '@jest/globals';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 
 /** The declaration union, whose `type` values are what authors type. */
 const DECLARATION = join(__dirname, '..', '..', 'src', 'type', 'declaration.ts');
@@ -40,5 +40,15 @@ describe('the declaration union is keyed on TraceType string values', () => {
     expect(TraceType.SCATTER).toBe('point');
     expect(members).toContain('PARALLEL');
     expect(TraceType.PARALLEL).toBe('parallel_coordinates');
+  });
+
+  test('an orientation is written the grammar\'s way, not the word\'s', () => {
+    // A plain-JS author has no enum, no autocomplete and no type error, and
+    // will write `orientation: 'horizontal'`. It is warned about and dropped,
+    // and both values are named on the two fields that carry them, so the
+    // abbreviations are documented where they are written.
+    expect(Orientation.HORIZONTAL).toBe('horz');
+    expect(Orientation.VERTICAL).toBe('vert');
+    expect(source).toContain('`\'horz\'` and `\'vert\'`');
   });
 });

--- a/test/type/declaration.test.ts
+++ b/test/type/declaration.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+
+/** The declaration union, whose `type` values are what authors type. */
+const DECLARATION = join(__dirname, '..', '..', 'src', 'type', 'declaration.ts');
+
+/** `  type: TraceType.SURVIVAL;` — one per variant of the union. */
+const DISCRIMINANT = /^\s*type:\s*TraceType\.(\w+);$/gm;
+
+/**
+ * The word an author writes is the word MAIDR emits.
+ *
+ * A declaration's `type` is the `TraceType` **string value**, not a private
+ * alias, so renaming one of those values is a breaking change to every chart
+ * config in the wild that declares it — and the compiler cannot see it,
+ * because the config is JSON or plain JS. Two of the values do not read like
+ * their member names and are the ones an author is most likely to get wrong,
+ * so they are pinned here by hand.
+ */
+describe('the declaration union is keyed on TraceType string values', () => {
+  const source = readFileSync(DECLARATION, 'utf8');
+  const members = [...source.matchAll(DISCRIMINANT)].map(match => match[1]);
+
+  test('every variant discriminates on a TraceType member', () => {
+    expect(members.length).toBeGreaterThan(0);
+    const unknown = members.filter(member => !(member in TraceType));
+    expect(unknown).toEqual([]);
+  });
+
+  test('the union covers the thirteen declarable types, each exactly once', () => {
+    expect(members).toHaveLength(13);
+    expect(new Set(members).size).toBe(13);
+  });
+
+  test('the two spellings that surprise authors are the ones that ship', () => {
+    // `type: 'scatter'` and `type: 'parallel'` are rejected as unknown types.
+    expect(members).toContain('SCATTER');
+    expect(TraceType.SCATTER).toBe('point');
+    expect(members).toContain('PARALLEL');
+    expect(TraceType.PARALLEL).toBe('parallel_coordinates');
+  });
+});

--- a/test/type/grammarDocs.test.ts
+++ b/test/type/grammarDocs.test.ts
@@ -2,8 +2,17 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, test } from '@jest/globals';
 
-/** The input schema, where every addition lands between existing members. */
-const GRAMMAR = join(__dirname, '..', '..', 'src', 'type', 'grammar.ts');
+/**
+ * The input types, where every addition lands between existing members: the
+ * schema itself, and the co-located declaration block that feeds it.
+ *
+ * Each entry carries a landmark string that must still be found, so a path
+ * that stopped resolving cannot make the case below vacuous.
+ */
+const INPUT_TYPES = [
+  { file: 'grammar.ts', landmark: 'export enum TraceType' },
+  { file: 'declaration.ts', landmark: 'export type MaidrTraceDeclaration' },
+] as const;
 
 /**
  * Two JSDoc blocks in a row, with only whitespace between them.
@@ -27,19 +36,18 @@ const STACKED_BLOCKS = /\*\/[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\
  * the file compiles, the tests pass, and the damage is to documentation that
  * only shows up where nobody is looking.
  */
-describe('no doc comment is orphaned in the grammar', () => {
-  const source = readFileSync(GRAMMAR, 'utf8');
+describe.each(INPUT_TYPES)('no doc comment is orphaned in $file', ({ file, landmark }) => {
+  const source = readFileSync(join(__dirname, '..', '..', 'src', 'type', file), 'utf8');
 
-  test('the grammar is where it is expected to be', () => {
-    // A path that stopped resolving would make the case below vacuous.
-    expect(source).toContain('export enum TraceType');
+  test('the file is where it is expected to be', () => {
+    expect(source).toContain(landmark);
   });
 
   test('no JSDoc block is immediately followed by another', () => {
     const lineOf = (index: number): number =>
       source.slice(0, index).split('\n').length;
     const stranded = [...source.matchAll(STACKED_BLOCKS)]
-      .map(match => `grammar.ts:${lineOf(match.index ?? 0)}`);
+      .map(match => `${file}:${lineOf(match.index ?? 0)}`);
 
     expect(stranded).toEqual([]);
   });


### PR DESCRIPTION
# Pull Request

## Description

A chart library draws marks; it does not say what they mean. Nothing in a Highcharts `line` series says the step is a survival curve, and nothing in a Chart.js scatter says one column of the data is a gene name. This PR adds the two pieces every adapter will need to read that meaning off a block the author writes beside the series they already wrote:

- `src/type/declaration.ts` — the `maidr` declaration types, co-located with the grammar they feed, and documented for chart authors rather than only for contributors.
- `src/adapters/shared/traceDeclaration.ts` — the resolution rules that must not be re-implemented eight times: how a `FieldRef` is read off an author's row, which spellings of a field name are accepted when none is given, what raises a per-row flag, and how an untyped block from a chart config is narrowed and checked.

**This PR adds no adapter behaviour, on purpose.** No file under `src/adapters/*/` changes, no extractor or binder reads the new module, and no chart's announcement is different after it. It is the foundation eight adapter PRs build on, so the new exports have no callers yet — that is expected here rather than an oversight. Each adapter PR adds its own call sites and its own entry re-exports alongside the code that consumes them.

## Related Issues

Part of #885.

## Changes Made

### `src/type/declaration.ts` (new)

Thirteen declaration variants discriminated on the `TraceType` **string value** the author writes — survival, error bar, forest, volcano, Manhattan, scatter, alluvial, mosaic, choropleth, parallel coordinates, ridgeline, hexbin, boxen — under two laws stated at the top of the file:

1. A fact that differs per point is declared as a **field name**; a fact that is the same for the whole layer carries the **value**. So `weight` is a field name and `nullValue` is a number.
2. Every field is spelled exactly like the grammar field it fills, and every field ref defaults to that same name — a row that already carries a `weight` column needs no declaration at all.

Nothing is guessed. The four values that would invert a reading if guessed wrong — `significance`, `significanceDirection`, `effect`, `nullValue` — have no defaults, and a declaration that cannot be honoured degrades to a truthful smaller layer rather than a confident wrong one.

The doc comments carry the traps an author cannot see: that `TraceType.SCATTER` is `'point'` and `TraceType.PARALLEL` is `'parallel_coordinates'`; that `Orientation` is `'horz'`/`'vert'` and not the words they abbreviate; that `error` entries are positive magnitudes, so `[0.2, 0.3]` around 1.4 is 1.2 to 1.7; that `weight` is a fraction of one, while meta-analysis software reports the column as a percentage; that `pooledIndex` counts the declaring series' own rows as authored; and that the shared `value` chain will resolve an `x` column, which a choropleth should declare away.

### `src/adapters/shared/traceDeclaration.ts` (new)

Seven exports:

- `FIELD_REF_FALLBACKS` — the alternative spellings accepted per canonical field, in priority order, so an author's `isCensored` or `ciLower` column reads the same way in every adapter that reads this block.
- `resolveFieldRef` — reads one declared fact off a row. An explicit ref is used verbatim with **no** fallback; only the defaulted path walks the chain. Nothing resolving means the field is omitted, never zeroed. The row is typed `unknown`, which is how amCharts, Plotly and Vega-Lite all hand one over.
- `warnUnresolvedRef` — reports an explicit ref that no row in the series carried, so the eight adapters print one sentence rather than eight spellings of it.
- `isFlagValue` — the strict truth table for `censored` and `pooled`: `true`, `1`, `'1'`, `'true'`, and nothing else. One helper for both, because `'0'` from a CSV is truthy and would mark every study in a forest plot as the pooled summary.
- `validateDeclaration` — narrows an untyped block and checks it: the key names of a closed per-variant set, the **kind of each value**, and the presence of the fields a variant cannot be read without. A wrong-kinded value is warned about and dropped so the grammar's own default applies; a missing required field rejects the block. It never throws, never mutates the author's config, and returns the block itself when nothing was dropped.
- `readDeclarationSlot` — plucks `maidr` off a slot that arrives as `unknown` (amCharts' `userData`, Plotly's `meta`) and delegates, so each adapter does not hand-roll the same container guard or reach for `any`.
- `DeclarationContext` — the adapter name and the locating phrase every warning is built from.

The per-variant key sets are proved against the types in both directions: a field added to a variant without being added to its set fails to compile, so does a set naming a field the variant does not have, and so does a set that calls a required field optional or the other way round.

### Tests

- `test/adapters/shared/traceDeclaration.test.ts` — the fallback chains parametrised over the table itself, the explicit-ref-wins-verbatim rule, the flag truth table, one fully-populated block per variant, the closed key set, one wrong-kinded value per value kind, the required-field rejections, the axis-list checks, and the slot reader.
- `test/type/declaration.test.ts` — pins that every variant discriminates on a real `TraceType` member and that the spellings authors get wrong (`'point'`, `'parallel_coordinates'`, `'horz'`, `'vert'`) are the ones that ship.
- `test/type/grammarDocs.test.ts` — parametrised over `grammar.ts` and `declaration.ts` rather than duplicating its regex, since the new file is the second long stack of doc blocks where an insertion can strand the block above it.

## Screenshots (if applicable)

Not applicable — no runtime behaviour and no UI changes.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

On the two unticked boxes: there is no manual test to run, because nothing an adapter emits changes — the automated gate below is the whole of what can be verified here, and the manual process applies to the adapter PRs that follow. The docs site is likewise untouched; the declaration types are their own documentation for now, and the guide belongs with the first adapter that reads them.

Ran on this branch, all green: `npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (268 unit/component suites, 3770 tests; 7 ESM suites, 73 tests).

Known and deliberate, for the adapter PRs that follow:

- The fallback table is the shared one, not any single binder's list. The shipped d3 binders accept a few names their own doc comments do not (`symbol` for a label, `share` for a mosaic's width); reconciling a d3 binder with its own comment is that binder's business, and d3 and Recharts declare through their own APIs rather than through this block.
- `ScatterDeclaration.label` is accepted but has nowhere to land until `ScatterPoint` carries a label; the field says so, and points at `volcano`/`manhattan`, which is where the grammar carries identity today.
- The declaration types are not re-exported from the package entries yet. Doing it here would put eight PRs into the same export lists; each adds its own beside the code that consumes the type.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_