### PR TITLE
feat(d3): read the chart types deferred out of the coverage PR

### DIFF
--- a/docs/d3.md
+++ b/docs/d3.md
@@ -233,6 +233,7 @@ When you omit an accessor, the binder tries a sensible default (`x`, `y`, `fill`
 | `bindD3Ridgeline` | Ridgeline / joy plot | `<path>` density curve per group | [Ridgeline](examples.html) |
 | `bindD3Hexbin` | Hexbin density | `<path>` hexagon per bin | [Hexbin](examples.html) |
 | `bindD3Contour` | Contour / density field | `<path>` per level | [Contour](examples.html) |
+| `bindD3Choropleth` | Choropleth map | `<path>` per region | [Choropleth](examples.html) |
 
 ## Multi-Panel Charts
 
@@ -999,6 +1000,34 @@ maidrD3.bindD3Contour(svgElement, {
 
 The level is carried on every point of its curve, which is where the grammar has room for it, and the trace announces it on the `z` axis — the field's own — rather than as a series name. A level drawn as several disjoint rings is flattened into one curve in ring order, since a payload row is a single polyline: every point announced is real, but the jump from one ring to the next is inaudible. Rows keep the order the paths were drawn in, which for `d3.contours()` is ascending threshold — the order the trace measures the gap to the adjacent level in.
 
+### Choropleth Map
+
+`d3.geoPath()` draws one `<path>` per GeoJSON feature, and the feature is what is bound to it — so a string accessor names a key on the feature **or** in its `properties`, which is where a place name and a joined value live on every real map:
+
+```js
+svg.selectAll('path.region')
+  .data(topojson.feature(us, us.objects.states).features)
+  .join('path')
+  .attr('d', d3.geoPath(projection));
+
+maidrD3.bindD3Choropleth(svgElement, {
+  selector: 'path.region',
+  title: 'Unemployment by State',
+  axes: { x: 'State', y: 'Rate' },
+  value: d => rateByFips.get(d.id),   // the join, keyed by the feature's id
+  lon: d => d3.geoCentroid(d)[0],     // DEGREES
+  lat: d => d3.geoCentroid(d)[1],
+});
+```
+
+> **`lon`/`lat` are `d3.geoCentroid`, never `d3.geoPath().centroid`.** The latter returns the centre of the *drawn* shape in projected pixels. Fed those, the arrows follow the projection's paper layout instead of the compass — north and south come out swapped on a south-up projection and meaningless on an interrupted one. A coordinate outside ±180°/±90° is dropped rather than converted by guesswork, with a warning naming the count.
+
+The centroids are what make this more than a bar chart whose categories happen to be places: with them the regions are banded by latitude and ordered west to east inside each band, so Up is north and Right is east. Without them the map is read as a region list in drawn order — a poorer reading, but the one the data supports. It is all or nothing, so a map that resolves centroids for some of its regions and not the rest warns and falls back to the list.
+
+A region the value join missed is left out of the payload — it is drawn in the "no data" colour and carries no number, and a `y` of 0 would sonify it as the lowest region on the map. Its path is left out of the highlight selectors with it, so the announced region and the lit shape stay in step; the selectors are stamped per region for exactly that reason.
+
+`neighbors` is not read. Adjacency is not recoverable from rendered paths, and deriving it needs shared-border topology (`topojson.neighbors`) that this package does not depend on. A layer that declares none keeps the spatial walk and is simply told nothing about borders — to get the border readings (the neighbour rotor, the sharpest borders, the cluster of high regions), author the layer's JSON directly with a `neighbors` array per region.
+
 ### Gauge / Bullet Chart
 
 A drawn gauge binds one number, so the rest of the reading is config — and it *is* the reading: "73" means nothing without the range it sits in, the target it was aiming at, and the band it lands in:
@@ -1080,6 +1109,7 @@ import type {
   D3HistogramConfig,
   D3HeatmapConfig,
   D3CandlestickConfig,
+  D3ChoroplethConfig,
   D3ContourConfig,
   D3HexbinConfig,
   D3ParallelConfig,

--- a/examples/d3-bindchoropleth.html
+++ b/examples/d3-bindchoropleth.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + D3.js Choropleth Map Example</title>
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/d3.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + D3.js Choropleth Map</h1>
+    <p>
+      Click on the chart and use arrow keys to move across the map. Up goes
+      north, Down goes south, Left goes west and Right goes east: the regions
+      are banded by latitude and ordered west to east inside each band, out of
+      the centroids alone. Each region announces its name and the rate it is
+      shaded by.
+    </p>
+    <div id="chart"></div>
+
+    <script>
+      // Simplified state outlines — real degrees, rectangular shapes. A real
+      // map would come from `topojson.feature(us, us.objects.states)`; what
+      // matters to the binder is identical either way: one <path> per feature,
+      // with the feature bound to it.
+      const STATES = [
+        { name: 'Washington', box: [-124.8, 45.5, -116.9, 49.0] },
+        { name: 'Oregon', box: [-124.6, 42.0, -116.5, 46.3] },
+        { name: 'Idaho', box: [-117.2, 42.0, -111.0, 49.0] },
+        { name: 'California', box: [-124.4, 32.5, -114.1, 42.0] },
+        { name: 'Nevada', box: [-120.0, 35.0, -114.0, 42.0] },
+        { name: 'Utah', box: [-114.1, 37.0, -109.0, 42.0] },
+        { name: 'Arizona', box: [-114.8, 31.3, -109.0, 37.0] },
+      ];
+
+      // The values arrive in their own table, keyed by name — the ordinary
+      // shape of a choropleth join.
+      const rateByState = new Map([
+        ['Washington', 12.1],
+        ['Oregon', 16.4],
+        ['Idaho', 18.9],
+        ['California', 41.7],
+        ['Nevada', 38.9],
+        ['Utah', 36.2],
+        ['Arizona', 34.8],
+      ]);
+
+      const features = STATES.map(({ name, box }) => {
+        const [west, south, east, north] = box;
+        return {
+          type: 'Feature',
+          id: name,
+          properties: { name },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [[
+              [west, south], [east, south], [east, north], [west, north], [west, south],
+            ]],
+          },
+        };
+      });
+
+      const width = 560;
+      const height = 460;
+
+      const svg = d3.select('#chart')
+        .append('svg')
+        .attr('id', 'd3-choropleth-map')
+        .attr('width', width)
+        .attr('height', height);
+
+      const projection = d3.geoMercator()
+        .fitSize([width - 40, height - 60], { type: 'FeatureCollection', features });
+      const path = d3.geoPath(projection);
+
+      const color = d3.scaleSequential()
+        .domain(d3.extent(rateByState.values()))
+        .interpolator(d3.interpolateBlues);
+
+      svg.append('g')
+        .attr('transform', 'translate(20, 40)')
+        .selectAll('path.region')
+        .data(features)
+        .join('path')
+        .attr('class', 'region')
+        .attr('d', path)
+        .attr('fill', d => color(rateByState.get(d.properties.name)))
+        .attr('stroke', '#fff');
+
+      svg.append('text')
+        .attr('x', width / 2)
+        .attr('y', 24)
+        .attr('text-anchor', 'middle')
+        .text('Something per Thousand, by State');
+
+      // === MAIDR Integration ===
+      const svgElement = document.getElementById('d3-choropleth-map');
+      const result = maidrD3.bindD3Choropleth(svgElement, {
+        selector: 'path.region',
+        title: 'Something per Thousand, by State',
+        axes: { x: 'State', y: 'Rate' },
+        // `region` needs no accessor: the default reads `properties.name`.
+        value: d => rateByState.get(d.properties.name),
+        // DEGREES, and this is the call that returns them. `path.centroid(d)`
+        // would return the centre of the DRAWN shape in pixels, and the arrows
+        // would then follow the projection's paper layout rather than the
+        // compass.
+        lon: d => d3.geoCentroid(d)[0],
+        lat: d => d3.geoCentroid(d)[1],
+      });
+      // The binder auto-applies `maidr-data` to the SVG.
+      void result;
+    </script>
+  </body>
+</html>

--- a/src/adapters/d3/MaidrD3.tsx
+++ b/src/adapters/d3/MaidrD3.tsx
@@ -162,6 +162,8 @@ function buildSpec(props: MaidrD3Props): D3AdapterSpec {
       return { chartType: 'candlestick', config: props.config };
     case 'chord':
       return { chartType: 'chord', config: props.config };
+    case 'choropleth':
+      return { chartType: 'choropleth', config: props.config };
     case 'contour':
       return { chartType: 'contour', config: props.config };
     case 'diverging':

--- a/src/adapters/d3/binders/choropleth.ts
+++ b/src/adapters/d3/binders/choropleth.ts
@@ -1,0 +1,380 @@
+/**
+ * D3 binder for choropleth maps.
+ *
+ * A choropleth is `d3.geoPath()` over a projection: one `<path>` per region,
+ * each bound to the GeoJSON feature it was drawn from. So `selector` matches
+ * the region paths, and the two fields a map is read for — the region's name
+ * and the value it is shaded by — are read off the feature, whose `properties`
+ * is where a joined value and a place name almost always live.
+ *
+ * **The centroid is the part that has to be given, and the part that is easy
+ * to give wrongly.** `ChoroplethPoint.lon`/`lat` are degrees, and degrees are
+ * what let the reader arrow north rather than merely to the next row of a
+ * list. `d3.geoPath().centroid(feature)` returns the centre in **projected
+ * pixels**, so passing it makes the arrows follow the projection's paper
+ * layout — inverted north on a south-up projection, and nonsense on an
+ * interrupted one. `d3.geoCentroid(feature)` is the call that returns the
+ * unprojected pair, and it is what the accessors should read. Coordinates
+ * outside the degree ranges are dropped rather than converted by guesswork:
+ * the map then reads as a region list in declared order, which is the poorer
+ * reading the grammar explicitly sanctions.
+ *
+ * `neighbors` is not read here. Adjacency is not recoverable from rendered
+ * paths, and computing it needs shared-border topology (`topojson.neighbors`)
+ * that this repository does not depend on.
+ */
+
+import type { ChoroplethPoint, MaidrLayer } from '../../../type/grammar';
+import type { D3PanelScope } from '../selectors';
+import type { D3BinderResult, D3BuiltLayer, D3ChoroplethConfig, DataAccessor } from '../types';
+import { TraceType } from '../../../type/grammar';
+import { scopeSelector, stampOrderedSelectors } from '../selectors';
+import { buildAxes, buildNoDatumError, buildNoElementsError, finalizeSingleChart, generateId, inferAccessor, queryD3Elements, resolveAccessorOptional } from '../util';
+
+/** Attribute the binder stamps on each region to key its highlight. */
+const REGION_ATTRIBUTE = 'data-maidr-choropleth-index';
+
+/** Names accepted for the region, after the canonical `region`. */
+const REGION_KEYS = ['name', 'NAME', 'name_long', 'admin', 'state', 'id', 'label', 'x'];
+
+/** Names accepted for the shaded value, after the canonical `value`. */
+const VALUE_KEYS = ['y', 'rate', 'density', 'count'];
+
+/** How far a longitude may run, in degrees east. */
+const LON_LIMIT = 180;
+
+/** How far a latitude may run, in degrees north. */
+const LAT_LIMIT = 90;
+
+/**
+ * Whether a value can be read as a keyed record.
+ *
+ * @param value - Anything
+ * @returns True when a string accessor can be looked up on it
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * A GeoJSON feature's own `properties` bag, when it has one.
+ *
+ * `d3.geoPath()` binds whole features, and everything a map joins onto one —
+ * the place name, the value, a precomputed centroid — is written into
+ * `properties` rather than onto the feature itself. So it is the second place
+ * every accessor looks.
+ *
+ * @param datum - The element's D3-bound datum
+ * @returns The properties bag, or undefined when the datum has none
+ */
+function featureProperties(datum: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(datum)) {
+    return undefined;
+  }
+  const properties = datum.properties;
+  return isRecord(properties) ? properties : undefined;
+}
+
+/**
+ * The record the field names are inferred against: one feature's own keys and
+ * its `properties`, flattened.
+ *
+ * Used only to ask which names are *present* — which one wins is decided by
+ * the order the candidates are tried in, and where it is read from by
+ * {@link resolveField}. So the shadowing this flattening implies never
+ * decides anything.
+ *
+ * The feature it samples is the first one carrying a value rather than simply
+ * the first one drawn. A map's "no data" regions are drawn like any other and
+ * one of them can perfectly well be first, and a feature the join missed
+ * names none of the keys the join would have written — so sampling it would
+ * leave the whole map unreadable on the strength of one region.
+ *
+ * @param elements - Every matched region, with its D3-bound datum
+ * @returns The names available on the sampled feature
+ */
+function inferenceSample(elements: { datum: unknown }[]): unknown {
+  const candidates = ['value', ...VALUE_KEYS];
+  const sampled = elements.find(({ datum }) => {
+    const properties = featureProperties(datum);
+    return candidates.some(key =>
+      (isRecord(datum) && key in datum) || (properties !== undefined && key in properties));
+  }) ?? elements[0];
+
+  const { datum } = sampled;
+  const properties = featureProperties(datum);
+  if (properties === undefined) {
+    return datum;
+  }
+  return { ...(isRecord(datum) ? datum : {}), ...properties };
+}
+
+/**
+ * Reads one field off a feature.
+ *
+ * A function accessor is invoked with the feature, which is what a d3 caller
+ * expects — `lon: d => d3.geoCentroid(d)[0]` needs the whole feature, not one
+ * of its properties. A string names a key on the feature **or** on its
+ * `properties`, in that order: a GeoJSON feature keeps only `type`, `id`,
+ * `geometry` and `properties` at the top level, so an author writing `'NAME'`
+ * can only mean the property, and making them write the path would be
+ * ceremony over a shape the format fixes.
+ *
+ * @param datum - The element's D3-bound datum
+ * @param accessor - The accessor for this field
+ * @param index - The region's index within the selection
+ * @returns The value, or undefined when neither place carries the key
+ */
+function resolveField<T>(
+  datum: unknown,
+  accessor: DataAccessor<T>,
+  index: number,
+): T | undefined {
+  if (typeof accessor === 'function') {
+    return accessor(datum, index);
+  }
+  const own = isRecord(datum)
+    ? resolveAccessorOptional<T>(datum, accessor, index)
+    : undefined;
+  if (own !== undefined) {
+    return own;
+  }
+  const properties = featureProperties(datum);
+  return properties === undefined
+    ? undefined
+    : resolveAccessorOptional<T>(properties, accessor, index);
+}
+
+/**
+ * Coerces a read value to a finite number, or nothing.
+ *
+ * @param raw - Whatever the accessor resolved
+ * @returns The number, or undefined when it is not one
+ */
+function readFinite(raw: unknown): number | undefined {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Binds a D3.js choropleth map to MAIDR, generating the accessible data
+ * representation.
+ *
+ * Point `selector` at the region paths — one per feature — and the defaults
+ * read the name and the value off the feature's `properties`. Pass `lon` and
+ * `lat` as `d3.geoCentroid(d)[0]` / `[1]`: with them the arrow keys move
+ * north, south, east and west across the map, and without them the map is
+ * read as a region list in the order it was drawn.
+ *
+ * A region whose value does not resolve is left out of the payload rather
+ * than shaded with a zero — a map's "no data" regions are drawn, and
+ * announcing one as zero is a number the chart does not contain. Its path is
+ * left out of the highlight selectors with it, so the two stay in step.
+ *
+ * @remarks
+ * **Timing — call after D3 has rendered.** Like every D3 binder, this reads
+ * each matched element's D3-bound `__data__`; calling it before
+ * `.data().join()` has run (or before the SVG is mounted) throws "No elements
+ * found for selector …".
+ *
+ * @see {@link MaidrD3}
+ * @see {@link useD3Adapter}
+ *
+ * @param svg - The SVG element containing the D3 map.
+ * @param config - Configuration specifying the selector and data accessors.
+ * @returns A {@link D3BinderResult} with the MAIDR data and generated layer.
+ * @throws Error when the selector matches nothing, when a matched element
+ *         carries no D3-bound datum, or when no region resolves a value.
+ *
+ * @example
+ * ```ts
+ * svg.selectAll('path.region')
+ *   .data(topojson.feature(us, us.objects.states).features)
+ *   .join('path')
+ *   .attr('d', d3.geoPath(projection));
+ *
+ * const result = bindD3Choropleth(svgElement, {
+ *   selector: 'path.region',
+ *   title: 'Unemployment by State',
+ *   axes: { x: 'State', y: 'Rate' },
+ *   value: d => rateByFips.get(d.id),
+ *   lon: d => d3.geoCentroid(d)[0],   // DEGREES — never geoPath().centroid
+ *   lat: d => d3.geoCentroid(d)[1],
+ * });
+ * ```
+ */
+export function bindD3Choropleth(svg: Element, config: D3ChoroplethConfig): D3BinderResult {
+  return finalizeSingleChart(svg, config, buildChoroplethLayer(svg, config));
+}
+
+/**
+ * Pure extraction core for choropleth maps. See {@link buildBarLayer} for the
+ * single-chart vs multi-panel contract.
+ *
+ * @internal
+ */
+export function buildChoroplethLayer(
+  root: Element,
+  config: D3ChoroplethConfig,
+  panel?: D3PanelScope,
+): D3BuiltLayer {
+  const { title, axes, format, selector } = config;
+
+  const elements = queryD3Elements(root, selector);
+  if (elements.length === 0) {
+    throw buildNoElementsError(root, selector, 'region');
+  }
+
+  const sample = inferenceSample(elements);
+  const regionAccessor = inferAccessor<string | number>(config, 'region', 'region', REGION_KEYS, sample);
+  const valueAccessor = inferAccessor<number>(config, 'value', 'value', VALUE_KEYS, sample);
+  const lonAccessor = inferAccessor<number>(config, 'lon', 'lon', ['longitude', 'long'], sample);
+  const latAccessor = inferAccessor<number>(config, 'lat', 'lat', ['latitude'], sample);
+
+  const data: ChoroplethPoint[] = [];
+  const shaded: Element[] = [];
+  let unshaded = 0;
+  let projected = 0;
+
+  for (const { element, datum, index } of elements) {
+    if (datum === undefined || datum === null) {
+      throw buildNoDatumError(selector, index);
+    }
+
+    const value = readFinite(resolveField<number>(datum, valueAccessor, index));
+    if (value === undefined) {
+      // A region the join found no row for. It is drawn — in the "no data"
+      // colour — but it carries no number, and the grammar has no way to say
+      // so: a `y` of 0 would be sonified as the lowest region on the map.
+      unshaded += 1;
+      continue;
+    }
+
+    const name = resolveField<string | number>(datum, regionAccessor, index);
+    if (name === undefined || name === null || name === '') {
+      throw buildNoRegionError(datum, index, selector);
+    }
+    const point: ChoroplethPoint = {
+      x: typeof name === 'number' ? name : String(name),
+      y: value,
+    };
+
+    const lon = readFinite(resolveField<number>(datum, lonAccessor, index));
+    const lat = readFinite(resolveField<number>(datum, latAccessor, index));
+    if (lon !== undefined && lat !== undefined) {
+      if (Math.abs(lon) <= LON_LIMIT && Math.abs(lat) <= LAT_LIMIT) {
+        // Both or neither: a longitude alone places nothing, and the trace
+        // needs the pair on every region before it bands the map at all.
+        point.lon = lon;
+        point.lat = lat;
+      } else {
+        projected += 1;
+      }
+    }
+
+    data.push(point);
+    shaded.push(element);
+  }
+
+  if (data.length === 0) {
+    throw new Error(
+      `No region matched by "${selector}" carries a value: the \`value\` `
+      + `accessor resolved to nothing on every feature. A choropleth's value `
+      + `is usually joined onto the feature's \`properties\` — pass a `
+      + `\`value\` accessor naming where it lives, e.g. `
+      + `\`value: d => rateById.get(d.id)\`.`,
+    );
+  }
+
+  warnPartialCentroids(data, selector);
+  if (projected > 0) {
+    console.warn(
+      `[maidr/d3] Dropped the centroid of ${projected} of the `
+      + `${elements.length} regions matched by "${selector}": it fell outside `
+      + `±${LON_LIMIT}° longitude or ±${LAT_LIMIT}° latitude, so it is a `
+      + `projected coordinate rather than a geographic one. `
+      + `\`d3.geoPath().centroid(d)\` returns pixels; \`d3.geoCentroid(d)\` `
+      + `returns the degrees this needs.`,
+    );
+  }
+  if (unshaded > 0) {
+    console.warn(
+      `[maidr/d3] Left ${unshaded} of the ${elements.length} regions matched `
+      + `by "${selector}" out of the choropleth: the \`value\` accessor `
+      + `resolved to nothing on them. Regions with no joined value are not `
+      + `announced, rather than being announced as zero.`,
+    );
+  }
+
+  const layer: MaidrLayer = {
+    id: generateId(),
+    type: TraceType.CHOROPLETH,
+    title,
+    // One selector per region, in the payload's order. A single selector
+    // matching every path would resolve the unshaded regions too, and
+    // `ChoroplethTrace` withdraws highlighting entirely when the counts
+    // disagree — so on any map with a "no data" region nothing would light up.
+    selectors: elements.length === 1
+      ? scopeSelector(root, selector, panel)
+      : stampOrderedSelectors(root, selector, REGION_ATTRIBUTE, shaded, panel),
+    axes: buildAxes(axes, format),
+    data,
+  };
+
+  return { layer };
+}
+
+/**
+ * Builds the "this region has no name" error.
+ *
+ * Every reading of a map is by name — the announcement, the border list, the
+ * cluster the description names — so a region the accessor cannot name is a
+ * misconfiguration rather than a gap to degrade around. The properties are
+ * listed because a GeoJSON feature keeps the name in `properties`, which is
+ * where the author needs to look.
+ *
+ * @param datum - The feature bound to the region's path
+ * @param index - Position of the path in the selection
+ * @param selector - The user's selector, to locate the map
+ * @returns The error to throw
+ */
+function buildNoRegionError(datum: unknown, index: number, selector: string): Error {
+  const properties = featureProperties(datum);
+  const available = properties === undefined
+    ? isRecord(datum) ? Object.keys(datum).join(', ') : String(datum)
+    : Object.keys(properties).join(', ');
+  return new Error(
+    `The region at index ${index} (matched by "${selector}") has no name: the `
+    + `\`region\` accessor resolved to nothing on it. Available properties: `
+    + `${available}. Pass a \`region\` accessor naming the property that `
+    + `carries the place name.`,
+  );
+}
+
+/**
+ * Says so when only some of the regions came out placed.
+ *
+ * `ChoroplethTrace` bands the map only when every region carries a centroid,
+ * so a map that resolves them for most of its regions and not the rest is
+ * read as a plain list — the spatial reading is lost, and nothing else on the
+ * page says why.
+ *
+ * @param data - The regions that made it into the payload
+ * @param selector - The user's selector, to locate the map
+ */
+function warnPartialCentroids(data: ChoroplethPoint[], selector: string): void {
+  const placed = data.filter(point => point.lon !== undefined).length;
+  if (placed === 0 || placed === data.length) {
+    return;
+  }
+  console.warn(
+    `[maidr/d3] Only ${placed} of the ${data.length} regions matched by `
+    + `"${selector}" resolved a centroid, so the map is read as a region list `
+    + `in drawn order rather than banded by latitude. The arrows move north, `
+    + `south, east and west only when EVERY region carries \`lon\` and `
+    + `\`lat\` in degrees.`,
+  );
+}

--- a/src/adapters/d3/binders/choropleth.ts
+++ b/src/adapters/d3/binders/choropleth.ts
@@ -90,6 +90,16 @@ function featureProperties(datum: unknown): Record<string, unknown> | undefined 
  * names none of the keys the join would have written — so sampling it would
  * leave the whole map unreadable on the strength of one region.
  *
+ * The bias is toward a value-bearing feature only, and deliberately not also
+ * toward one carrying a region name. `id` is itself a region candidate and
+ * every feature `topojson.feature()` emits has one, so a feature that names a
+ * value practically always names a region key too — the extra test would
+ * qualify the same feature and decide nothing. Ranking the region key across
+ * features instead (preferring a `name` some *other* feature carries) would
+ * trade this fallback for a hard throw on any map whose odd feature names a
+ * key the rest do not, which is the worse failure. Real exports carry uniform
+ * `properties` and the question does not arise.
+ *
  * @param elements - Every matched region, with its D3-bound datum
  * @returns The names available on the sampled feature
  */
@@ -292,8 +302,10 @@ export function buildChoroplethLayer(
   warnPartialCentroids(data, selector);
   if (projected > 0) {
     console.warn(
+      // Counted against the regions that carried a value, not against every
+      // matched path: a region with no value never reached the centroid check.
       `[maidr/d3] Dropped the centroid of ${projected} of the `
-      + `${elements.length} regions matched by "${selector}": it fell outside `
+      + `${data.length} regions read from "${selector}": it fell outside `
       + `±${LON_LIMIT}° longitude or ±${LAT_LIMIT}° latitude, so it is a `
       + `projected coordinate rather than a geographic one. `
       + `\`d3.geoPath().centroid(d)\` returns pixels; \`d3.geoCentroid(d)\` `

--- a/src/adapters/d3/binders/subplots.ts
+++ b/src/adapters/d3/binders/subplots.ts
@@ -42,6 +42,7 @@ import { buildBarLayer } from './bar';
 import { buildBoxLayer } from './box';
 import { buildBoxenLayer } from './boxen';
 import { buildCandlestickLayer } from './candlestick';
+import { buildChoroplethLayer } from './choropleth';
 import { buildContourLayer } from './contour';
 import { buildDumbbellLayer } from './dumbbell';
 import { buildErrorBarLayer, buildForestLayer } from './errorBar';
@@ -262,6 +263,8 @@ function buildPanelLayer(root: Element, spec: D3PanelChartSpec, panel: D3PanelSc
       return buildCandlestickLayer(root, spec.config, panel);
     case 'chord':
       return buildFlowLayer(root, spec.config, panel, TraceType.CHORD);
+    case 'choropleth':
+      return buildChoroplethLayer(root, spec.config, panel);
     case 'contour':
       return buildContourLayer(root, spec.config, panel);
     case 'diverging':

--- a/src/adapters/d3/index.ts
+++ b/src/adapters/d3/index.ts
@@ -50,6 +50,7 @@
  * - **Parallel coordinates plots** via {@link bindD3Parallel}
  * - **Ridgeline / joy plots** via {@link bindD3Ridgeline}
  * - **Hexbin density plots** via {@link bindD3Hexbin}
+ * - **Choropleth maps** via {@link bindD3Choropleth}
  * - **Contour plots** via {@link bindD3Contour}
  * - **Smooth/regression curves** via {@link bindD3Smooth}
  *
@@ -129,6 +130,7 @@ export { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/ba
 export { bindD3Box } from './binders/box';
 export { bindD3Boxen } from './binders/boxen';
 export { bindD3Candlestick } from './binders/candlestick';
+export { bindD3Choropleth } from './binders/choropleth';
 export { bindD3Contour } from './binders/contour';
 export { bindD3Dumbbell } from './binders/dumbbell';
 export { bindD3ErrorBar, bindD3Forest } from './binders/errorBar';
@@ -163,6 +165,7 @@ export type {
   D3BoxConfig,
   D3BoxenConfig,
   D3CandlestickConfig,
+  D3ChoroplethConfig,
   D3ContourConfig,
   D3DumbbellConfig,
   D3ErrorBarConfig,

--- a/src/adapters/d3/types.ts
+++ b/src/adapters/d3/types.ts
@@ -1435,6 +1435,69 @@ export interface D3ContourConfig extends D3BinderConfig {
 }
 
 /**
+ * Configuration for binding a D3 choropleth map.
+ *
+ * A choropleth is `d3.geoPath()` over a projection: one `<path>` per region,
+ * each bound to the GeoJSON feature it was drawn from. So `selector` matches
+ * the region paths, and a **string accessor names a key on the feature or on
+ * its `properties`**, in that order — a feature keeps only `type`, `id`,
+ * `geometry` and `properties` at the top level, so the joined value and the
+ * place name are in `properties` on almost every map. A function accessor is
+ * invoked with the whole feature.
+ *
+ * **`lon` and `lat` are degrees, and the wrong call gives pixels.**
+ * `d3.geoPath().centroid(feature)` returns the centre of the drawn shape in
+ * projected screen coordinates; `d3.geoCentroid(feature)` returns the
+ * unprojected longitude/latitude pair, and that is the one to read:
+ *
+ * ```ts
+ * lon: d => d3.geoCentroid(d)[0],
+ * lat: d => d3.geoCentroid(d)[1],
+ * ```
+ *
+ * Where only a projection is to hand, `projection.invert([px, py])` inverts
+ * the pixels — but `invert` is optional in d3's projection API and several
+ * projections do not implement it. When neither yields degrees, leave both
+ * out: a coordinate outside ±180°/±90° is dropped rather than converted by
+ * guesswork, and the map is then read as a region list in drawn order, which
+ * is the poorer reading the grammar sanctions. A wrong pair is worse, because
+ * it puts regions in directions from one another that the map does not.
+ *
+ * `neighbors` is not read: adjacency is not recoverable from rendered paths,
+ * and deriving it needs shared-border topology this repository has no
+ * dependency for. A layer that declares none keeps the spatial walk.
+ */
+export interface D3ChoroplethConfig extends D3BinderConfig {
+  /** CSS selector for the region paths (e.g. `'path.region'`). One per region. */
+  selector: string;
+  /**
+   * Accessor for the region's name.
+   * @default 'region', falling back to `name`, `NAME`, `name_long`, `admin`,
+   * `state`, `id`, `label` or `x` — on the feature or in its `properties`.
+   */
+  region?: DataAccessor<string | number>;
+  /**
+   * Accessor for the value the region is shaded by. A region this resolves
+   * nothing for is left out of the payload — and out of the highlight
+   * selectors with it — rather than announced as a zero.
+   * @default 'value', falling back to `y`, `rate`, `density` or `count`.
+   */
+  value?: DataAccessor<number>;
+  /**
+   * Accessor for the region's centroid longitude, in **degrees east**.
+   * `d3.geoCentroid(d)[0]`, never `d3.geoPath().centroid(d)[0]`.
+   * @default 'lon', falling back to `longitude` or `long`.
+   */
+  lon?: DataAccessor<number>;
+  /**
+   * Accessor for the region's centroid latitude, in **degrees north**.
+   * `d3.geoCentroid(d)[1]`, never `d3.geoPath().centroid(d)[1]`.
+   * @default 'lat', falling back to `latitude`.
+   */
+  lat?: DataAccessor<number>;
+}
+
+/**
  * Result of a D3 binder function.
  * Contains the complete MAIDR data structure and the generated layer
  * for further customization if needed.
@@ -1471,6 +1534,7 @@ export type D3PanelChartSpec
     | { chartType: 'bump'; config: D3LineConfig }
     | { chartType: 'candlestick'; config: D3CandlestickConfig }
     | { chartType: 'chord'; config: D3FlowConfig }
+    | { chartType: 'choropleth'; config: D3ChoroplethConfig }
     | { chartType: 'contour'; config: D3ContourConfig }
     | { chartType: 'diverging'; config: D3SegmentedConfig }
     | { chartType: 'dot'; config: D3BarConfig }

--- a/src/adapters/d3/useD3Adapter.ts
+++ b/src/adapters/d3/useD3Adapter.ts
@@ -68,6 +68,7 @@ import { bindD3Bar, bindD3Dot, bindD3Funnel, bindD3Lollipop } from './binders/ba
 import { bindD3Box } from './binders/box';
 import { bindD3Boxen } from './binders/boxen';
 import { bindD3Candlestick } from './binders/candlestick';
+import { bindD3Choropleth } from './binders/choropleth';
 import { bindD3Contour } from './binders/contour';
 import { bindD3Dumbbell } from './binders/dumbbell';
 import { bindD3ErrorBar, bindD3Forest } from './binders/errorBar';
@@ -146,6 +147,8 @@ function runBinder(svg: Element, spec: D3AdapterSpec): D3BinderResult | D3MultiP
       return bindD3Candlestick(svg, { ...spec.config, autoApply: false });
     case 'chord':
       return bindD3Chord(svg, { ...spec.config, autoApply: false });
+    case 'choropleth':
+      return bindD3Choropleth(svg, { ...spec.config, autoApply: false });
     case 'contour':
       return bindD3Contour(svg, { ...spec.config, autoApply: false });
     case 'diverging':
@@ -241,6 +244,8 @@ function withFacetsAutoApplyOff(cfg: D3FacetsConfig): D3FacetsConfig {
     case 'candlestick':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'chord':
+      return { ...cfg, config: { ...cfg.config, autoApply: false } };
+    case 'choropleth':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };
     case 'contour':
       return { ...cfg, config: { ...cfg.config, autoApply: false } };

--- a/test/adapters/d3/choropleth.test.ts
+++ b/test/adapters/d3/choropleth.test.ts
@@ -174,6 +174,24 @@ describe('bindD3Choropleth', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/geoCentroid/));
   });
 
+  test('counts the dropped centroids against the regions that carried a value', () => {
+    // California is drawn but never reaches the centroid check — it has no
+    // value, so it is out of the payload before the coordinates are read.
+    // Counting it in the denominator would offer a total that no region in
+    // the warning could have come from.
+    const svg = buildMapSvg([
+      WASHINGTON,
+      CALIFORNIA,
+      feature('41', { name: 'Oregon', rate: 16.4, lon: 480.2, lat: 320.9 }),
+    ]);
+
+    bindD3Choropleth(svg, { selector: 'path.region' });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(/Dropped the centroid of 1 of the 2 regions/),
+    );
+  });
+
   test('drops the pair when only one half of the centroid resolves', () => {
     // A longitude alone places nothing, and `ChoroplethTrace` bands the map
     // only when every region carries both — so half a centroid is a field

--- a/test/adapters/d3/choropleth.test.ts
+++ b/test/adapters/d3/choropleth.test.ts
@@ -1,0 +1,301 @@
+import type { ChoroplethTrace } from '@model/choropleth';
+import type { ChoroplethPoint } from '@type/grammar';
+import { bindD3Choropleth } from '@adapters/d3/binders/choropleth';
+import { afterAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+import { JSDOM } from 'jsdom';
+import { withPageDocument } from './pageDocument';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * A GeoJSON feature of the shape `topojson.feature(...)` hands to
+ * `d3.geoPath()`: an id at the top level, and everything the map joined onto
+ * it — the place name, the rate, the centroid — inside `properties`.
+ */
+function feature(
+  id: string,
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    type: 'Feature',
+    id,
+    properties,
+    geometry: { type: 'Polygon', coordinates: [] },
+  };
+}
+
+/**
+ * Three western states whose rate arrived, and one whose join missed — which
+ * is the ordinary case on a real map, drawn in the "no data" colour.
+ *
+ * The rate is under `rate` rather than `value`, and the centroid inside
+ * `properties`, so the defaults are exercised where a real feature carries
+ * them rather than where a hand-built object would.
+ */
+const WASHINGTON = feature('53', { name: 'Washington', rate: 12.1, lon: -120.5, lat: 47.4 });
+const OREGON = feature('41', { name: 'Oregon', rate: 16.4, lon: -120.6, lat: 43.9 });
+const NEVADA = feature('32', { name: 'Nevada', rate: 38.9, lon: -116.6, lat: 39.3 });
+const CALIFORNIA = feature('06', { name: 'California', lon: -119.4, lat: 37.2 });
+
+/** The shaded states alone, in the order they are drawn. */
+const SHADED = [WASHINGTON, OREGON, NEVADA];
+
+/**
+ * The whole map: the state with no value sits in the MIDDLE of the drawn
+ * order, so a selector list that kept its path is off by one for everything
+ * after it rather than merely one entry too long.
+ */
+const WEST = [WASHINGTON, CALIFORNIA, OREGON, NEVADA];
+
+/**
+ * Builds an SVG holding one `path.region` per feature, in the order given.
+ */
+function buildMapSvg(features: unknown[], id = 'map-svg'): SVGElement {
+  const dom = new JSDOM(`<!doctype html><svg xmlns="${SVG_NS}" id="${id}"></svg>`);
+  const doc = dom.window.document;
+  const svg = doc.querySelector('svg') as unknown as SVGElement;
+  for (const datum of features) {
+    const path = doc.createElementNS(SVG_NS, 'path');
+    path.setAttribute('class', 'region');
+    (path as unknown as { __data__: unknown }).__data__ = datum;
+    svg.appendChild(path);
+  }
+  return svg;
+}
+
+/** The name on the feature bound to whatever a selector resolves to. */
+function nameBehind(svg: SVGElement, selector: string): string | undefined {
+  const matched = svg.ownerDocument.querySelectorAll(selector);
+  expect(matched).toHaveLength(1);
+  const datum = (matched[0] as unknown as { __data__: { properties: { name: string } } }).__data__;
+  return datum.properties.name;
+}
+
+const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  warn.mockClear();
+});
+
+afterAll(() => {
+  warn.mockRestore();
+});
+
+describe('bindD3Choropleth', () => {
+  test('reads the region and its value out of the feature properties', () => {
+    const svg = buildMapSvg(SHADED);
+
+    const result = bindD3Choropleth(svg, {
+      selector: 'path.region',
+      title: 'Something per thousand',
+      axes: { x: 'State', y: 'Rate' },
+    });
+
+    expect(result.layer.type).toBe(TraceType.CHOROPLETH);
+    // A GeoJSON feature keeps only `type`, `id`, `geometry` and `properties`
+    // at the top level, so a binder that looked at the feature alone would
+    // find neither the name nor the rate.
+    expect(result.layer.data).toEqual([
+      { x: 'Washington', y: 12.1, lon: -120.5, lat: 47.4 },
+      { x: 'Oregon', y: 16.4, lon: -120.6, lat: 43.9 },
+      { x: 'Nevada', y: 38.9, lon: -116.6, lat: 39.3 },
+    ]);
+  });
+
+  test('hands the whole feature to a function accessor', () => {
+    // The usual join: the values arrive in their own table, keyed by the id
+    // the feature carries at its top level.
+    const rateByFips = new Map([['53', 1], ['41', 2], ['32', 3]]);
+    const svg = buildMapSvg(SHADED);
+
+    const result = bindD3Choropleth(svg, {
+      selector: 'path.region',
+      value: d => rateByFips.get(String((d as { id: string }).id)) ?? Number.NaN,
+    });
+
+    expect((result.layer.data as ChoroplethPoint[]).map(point => point.y))
+      .toEqual([1, 2, 3]);
+  });
+
+  test('leaves a region with no value out, and its path out of the selectors', () => {
+    const svg = buildMapSvg(WEST);
+
+    const result = bindD3Choropleth(svg, { selector: 'path.region' });
+
+    // California's rate never arrived. Announcing it as 0 would sonify it as
+    // the lowest state on the map; announcing it at all would need a number
+    // the chart does not contain.
+    const data = result.layer.data as ChoroplethPoint[];
+    expect(data.map(point => point.x)).toEqual(['Washington', 'Oregon', 'Nevada']);
+
+    // `ChoroplethTrace` withdraws highlighting entirely when the resolved
+    // element count differs from the declared region count, so a single
+    // selector matching all four paths would leave the map unhighlightable.
+    const selectors = result.layer.selectors as string[];
+    expect(selectors).toHaveLength(3);
+    expect(selectors.map(one => nameBehind(svg, one)))
+      .toEqual(['Washington', 'Oregon', 'Nevada']);
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Left 1 of the 4 regions/));
+  });
+
+  test('infers the value field from a region that has one', () => {
+    // The "no data" region is drawn like any other and can perfectly well be
+    // drawn first. A binder that sampled the first feature for its field
+    // names would find no value key on it, fall back to the canonical
+    // `value`, resolve nothing anywhere, and refuse the whole map on the
+    // strength of one region.
+    const svg = buildMapSvg([CALIFORNIA, WASHINGTON, OREGON]);
+
+    const result = bindD3Choropleth(svg, { selector: 'path.region' });
+
+    expect((result.layer.data as ChoroplethPoint[]).map(point => point.x))
+      .toEqual(['Washington', 'Oregon']);
+  });
+
+  test('drops a centroid that is a projected coordinate', () => {
+    // `d3.geoPath().centroid(d)` returns the centre of the DRAWN shape, in
+    // pixels. Passed through, the arrows would follow the projection's paper
+    // layout — and on a south-up or interrupted projection, announce north
+    // as south.
+    const svg = buildMapSvg([
+      feature('53', { name: 'Washington', rate: 12.1, lon: 137.4, lat: 61.8 }),
+      feature('41', { name: 'Oregon', rate: 16.4, lon: 480.2, lat: 320.9 }),
+    ]);
+
+    const result = bindD3Choropleth(svg, { selector: 'path.region' });
+
+    const data = result.layer.data as ChoroplethPoint[];
+    expect(data[1].lon).toBeUndefined();
+    expect(data[1].lat).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/geoCentroid/));
+  });
+
+  test('drops the pair when only one half of the centroid resolves', () => {
+    // A longitude alone places nothing, and `ChoroplethTrace` bands the map
+    // only when every region carries both — so half a centroid is a field
+    // that reads as data and decides nothing.
+    const svg = buildMapSvg([
+      feature('53', { name: 'Washington', rate: 12.1, lon: -120.5 }),
+    ]);
+
+    const result = bindD3Choropleth(svg, { selector: 'path.region' });
+
+    expect(result.layer.data).toEqual([{ x: 'Washington', y: 12.1 }]);
+  });
+
+  test('says so when only some of the regions came out placed', () => {
+    const svg = buildMapSvg([
+      feature('53', { name: 'Washington', rate: 12.1, lon: -120.5, lat: 47.4 }),
+      feature('41', { name: 'Oregon', rate: 16.4 }),
+    ]);
+
+    bindD3Choropleth(svg, { selector: 'path.region' });
+
+    // The spatial reading is silently lost on a map that places most of its
+    // regions and not the rest, and nothing else on the page says why.
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Only 1 of the 2 regions/));
+  });
+
+  test('reads the names an accessor points at rather than the ones it found', () => {
+    const svg = buildMapSvg([
+      feature('53', { name: 'Washington', NAME_1: 'WA', rate: 12.1 }),
+    ]);
+
+    const result = bindD3Choropleth(svg, { selector: 'path.region', region: 'NAME_1' });
+
+    expect((result.layer.data as ChoroplethPoint[])[0].x).toBe('WA');
+  });
+
+  test('refuses to stand in for a region it cannot name', () => {
+    // Every reading of a map is by name — the announcement, the borders, the
+    // cluster the description names — so an ordinal would not degrade the
+    // reading, it would replace it.
+    // No name and no id: a feature keyed only by its FIPS id still announces
+    // that, which is a poor name but a real one.
+    const svg = buildMapSvg([
+      { type: 'Feature', properties: { rate: 12.1 }, geometry: { type: 'Polygon' } },
+    ]);
+
+    expect(() => bindD3Choropleth(svg, { selector: 'path.region' }))
+      .toThrow(/has no name/);
+  });
+
+  test('says where the value lives when no region carries one', () => {
+    const svg = buildMapSvg([
+      feature('53', { name: 'Washington' }),
+      feature('41', { name: 'Oregon' }),
+    ]);
+
+    expect(() => bindD3Choropleth(svg, { selector: 'path.region' }))
+      .toThrow(/carries a value/);
+  });
+
+  test('scopes a single region with one selector', () => {
+    const svg = buildMapSvg([feature('53', { name: 'Washington', rate: 12.1 })]);
+
+    const result = bindD3Choropleth(svg, { selector: 'path.region' });
+
+    expect(result.layer.selectors).toBe('#map-svg path.region');
+  });
+
+  test('throws an actionable error when the selector matches no regions', () => {
+    const svg = buildMapSvg(WEST);
+
+    expect(() => bindD3Choropleth(svg, { selector: 'path.state' })).toThrow(/region/);
+  });
+});
+
+describe('core-model integration', () => {
+  test('the emitted layer constructs a Figure that reads as a map', () => {
+    const svg = buildMapSvg(WEST);
+    const result = bindD3Choropleth(svg, {
+      selector: 'path.region',
+      title: 'Something per thousand',
+      axes: { x: 'State', y: 'Rate' },
+    });
+
+    withPageDocument(svg, () => {
+      const figure = new Figure(result.maidr);
+      figure.applyLayout(resolveSubplotLayout(figure.subplots));
+
+      expect(figure.state.empty).toBe(false);
+      expect(figure.subplots[0][0].traceTypes).toEqual([TraceType.CHOROPLETH]);
+    });
+  });
+
+  test('the highlighted path is the one the announcement named', () => {
+    const svg = buildMapSvg(WEST);
+    const result = bindD3Choropleth(svg, { selector: 'path.region' });
+
+    withPageDocument(svg, () => {
+      const trace = TraceFactory.create(result.layer) as ChoroplethTrace;
+      // The first move is the initial entry, which lands rather than moves;
+      // it lands at the west end of the southern band, which is Oregon — not
+      // Washington, which the layer declared first.
+      trace.moveOnce('FORWARD');
+
+      const state = trace.state;
+      if (state.empty || state.highlight.empty) {
+        throw new Error('Expected a populated highlight state');
+      }
+      expect(state.text.main.value).toBe('Oregon');
+
+      // The regions are banded by latitude while the selectors are in drawn
+      // order, so the trace indexes the list by the region's declared
+      // position — 1 for Oregon, the second state that carried a value.
+      // California is drawn between them and carries none: a list that had
+      // kept its path would light California while the reader was told
+      // Oregon, and one that had emitted a bare selector would resolve four
+      // paths for three regions and withdraw highlighting altogether.
+      const highlighted = state.highlight.elements;
+      const first = Array.isArray(highlighted) ? highlighted.flat()[0] : highlighted;
+      expect(first?.getAttribute('data-maidr-choropleth-index')).toBe('1');
+      expect(nameBehind(svg, `#map-svg path.region[data-maidr-choropleth-index="1"]:not([data-maidr-owned])`))
+        .toBe('Oregon');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds the choropleth map to the D3 adapter — the one trace type the D3 coverage
PR deferred that is implementable without a new dependency.

A choropleth in D3 is `d3.geoPath()` over a projection: one `<path>` per region,
each bound to the GeoJSON feature it was drawn from. `bindD3Choropleth` reads
those bound features and emits a `ChoroplethPoint[]` layer, and — because a
trace that sonifies but does not highlight is not done — stamps the highlight
selectors in the same pass.

Per the adapter convention's Rejected list, D3 declares by binder: calling
`bindD3Choropleth` **is** the declaration. No co-located `maidr` block was added
to D3, the public `DataAccessor<T>` type is unchanged, and this adapter makes no
`validateDeclaration` call.

## Related Issues

Part of #885

## Changes Made

**Trace type added**

- **`choropleth`** — `bindD3Choropleth` in `src/adapters/d3/binders/choropleth.ts`,
  configured by a new `D3ChoroplethConfig` (`selector`, `region`, `value`, `lon`,
  `lat`) in `src/adapters/d3/types.ts`, exported from `src/adapters/d3/index.ts`,
  and wired into the multi-panel binder (`binders/subplots.ts`), the React hook
  (`useD3Adapter.ts`) and `<MaidrD3>` through the existing `D3PanelChartSpec`
  union.
  - *Payload* — `ChoroplethPoint[]` exactly as `src/type/grammar.ts` defines it:
    `x` (region name), `y` (value), optional `lon`/`lat` in degrees. A string
    accessor resolves on the feature and then on its `properties`, which is
    where a place name and a joined value actually live on a real map; a
    function accessor receives the whole feature.
  - *Centroids* — `lon`/`lat` are emitted only when both resolve **and** both
    fall inside ±180°/±90°. Anything else is dropped with a warning naming
    `d3.geoCentroid(d)` (unprojected degrees) against
    `d3.geoPath().centroid(d)` (projected pixels). A map that places only some
    of its regions warns too, since `ChoroplethTrace` needs the pair on every
    region before it bands the map.
  - *Highlighting* — one stamped `data-maidr-choropleth-index` selector per
    announced region (a single scoped selector for a one-region map), so the
    announced region and the lit shape stay in step even when a "no data"
    region's path sits between two announced ones. Pinned by a test that builds
    the real `ChoroplethTrace` and asserts the highlighted element after a move.
  - *No-data regions* — a region whose value join missed is omitted from the
    payload and from the selectors rather than zero-filled; `ChoroplethPoint.y`
    is required and a `y` of 0 would sonify "no data" as the lowest value on
    the map. A region the `region` accessor cannot name throws rather than
    degrading to an ordinal, since every reading of a map is by name.

**Not added**

- **`neighbors` on the choropleth layer** — deferred. Adjacency is not
  recoverable from rendered SVG paths, and deriving it needs shared-border
  topology (`topojson.neighbors`); `topojson-client` is not a dependency of this
  repository and this change does not add one. The grammar explicitly sanctions
  a layer that declares no neighbours, so the map still reads — as a spatial
  walk rather than with borders. `docs/d3.md` tells authors to hand-author the
  layer JSON in the meantime.

**Docs and examples**

- `docs/d3.md`: new "Choropleth Map" section, a binder-table row, and
  `D3ChoroplethConfig` in the type list.
- `examples/d3-bindchoropleth.html`: `d3.geoMercator` + `d3.geoPath` over inline
  GeoJSON, joined by name, with `lon`/`lat` supplied via `d3.geoCentroid`.

**Tests**

- `test/adapters/d3/choropleth.test.ts`: 14 cases covering properties-level
  defaults, function accessors, the omitted no-data region and its selectors,
  projected-coordinate rejection, half-resolved centroids, the partial-centroid
  warning, an explicit `region` accessor, both refusals (no name; no value
  anywhere), single-region scoping, the no-match error, field inference from a
  region that carries a value, and the `Figure`/highlight integration.

Nothing outside `src/adapters/d3/`, `test/adapters/d3/`, `examples/` and `docs/`
is touched. `src/type/declaration.ts` and
`src/adapters/shared/traceDeclaration.ts` are unchanged.

## Screenshots (if applicable)

N/A — no visual change. `examples/d3-bindchoropleth.html` renders the map this
binder reads.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is unticked deliberately: the automated gate was run in
full and is green, but `ManualTestingProcess.md` was not walked with a screen
reader. Verification actually run on this branch:

- `npm run lint:fix` — clean, no files changed
- `npm run type-check` (`tsc --noEmit` + `tsconfig.ci.json`) — clean
- `npm run build` — all 12 bundles built
- `npm test` — 269 suites / 3784 tests passed (unit), 7 suites / 73 tests
  passed (component). No test skipped, no snapshot written.

## Additional Notes

Notes below matter to the sibling adapter PRs on #885.

**Foundation gaps (reported, not changed).** Neither
`src/adapters/shared/traceDeclaration.ts` nor `src/type/declaration.ts` was
modified.

1. `resolveFieldRef` reads `row[name]` flat, with no notion of nesting. The D3
   row source the convention names is `element.__data__`, which for a
   choropleth is a GeoJSON `Feature` whose region name and joined value live one
   level down in `feature.properties` — so a `ChoroplethDeclaration.region` or
   `.value` could not name them through the shared resolver. D3 is exempt (it
   declares by binder), so this cost nothing here and a feature-then-properties
   lookup was implemented locally. It will bite whoever wires Vega-Lite
   `geoshape`, or any other adapter whose row is a GeoJSON feature.
2. `FIELD_REF_FALLBACKS.value = ['x', 't', 'position']` is the ridgeline chain
   and is actively wrong on a map: a region table that puts the place name in an
   `x` column resolves the **name** as the shaded value.
   `ChoroplethDeclaration.value`'s doc comment says as much and tells the author
   to name the field, but the table offers no map-appropriate chain (`rate`,
   `density`, `count`) and has no entry for `region` at all — so an undeclared
   choropleth resolves nothing in a declaration-driven adapter. This binder uses
   map-appropriate chains documented on `D3ChoroplethConfig` instead: region →
   `name`, `NAME`, `name_long`, `admin`, `state`, `id`, `label`, `x`; value →
   `y`, `rate`, `density`, `count`.
3. Nothing in the grammar or the declaration can express a region that is
   **drawn but carries no value** — `ChoroplethPoint.y` is required and there is
   no null. That is the ordinary case on a real map (the "no data" colour).
   Those regions are omitted here, per semanticsSpec §3's "never substitute a
   zero", but a declaration-driven adapter meets the same question with no
   guidance and could plausibly answer it differently. Worth a sentence in the
   spec so the eight adapters do not diverge.

**Spec corrections.**

- The D3 mandate is right that `d3.geoPath().centroid(d)` returns projected
  pixels and `d3.geoCentroid(d)` is the correct call, and right that
  `topojson-client` is not a dependency (verified absent from `package.json`).
  It understates one thing: `d3` itself is only a `devDependency`, and no D3
  binder imports d3 at runtime (`grep "from 'd3" src/` is empty) — so computing
  centroids inside the binder was never an option under any dependency
  arrangement. Accessors are the only route, which is why the geoCentroid
  instruction lives in the config's doc comment rather than in a call.
- The mandate says `x` = region name via `d.properties.name` and `y` = the
  joined value. Correct, but incomplete where it matters: `properties` is also
  where the **value** usually is, so a string accessor must resolve on the
  feature *and* on its `properties`. Every other D3 binder's
  `resolveAccessor`/`inferAccessor` is a flat key lookup on the datum, and on a
  GeoJSON feature that only ever sees `type`, `id`, `geometry`, `properties` — a
  straight reuse would have made the defaults resolve nothing on every real map.
- All line references in the mandate check out against current `main` (the
  binder export block, `DataAccessor<T>`, and the survival/forest/manhattan/
  volcano/ridgeline/hexbin/boxen config types), with one drift:
  `D3ParallelConfig.dimensions` is at `types.ts:1302`, not `:1298`.

**Implementation note for reviewers.** Field inference samples the first feature
that carries a value key rather than the first feature drawn. A no-data region
can be drawn first, and a feature the join missed names none of the keys the
join would have written — a first-datum sample would refuse an entire working
map on the strength of one region. That has its own test case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_