### PR TITLE
feat(vegalite): read the chart types deferred out of the coverage PR

### DIFF
--- a/docs/vegalite.md
+++ b/docs/vegalite.md
@@ -109,6 +109,7 @@ Because Vega-Lite renders **asynchronously** through `vegaEmbed()`, the adapter 
 | `errorbar`, `errorband` | — | Error bar | [vegalite-errorbar.html](https://github.com/xability/maidr/blob/main/examples/vegalite-errorbar.html) |
 | `arc` | `theta` encoding | Pie (`mark.innerRadius` makes it a doughnut) | [vegalite-pie.html](https://github.com/xability/maidr/blob/main/examples/vegalite-pie.html) |
 | `arc` | `radius` bound to a field | Polar area (coxcomb, rose) | — |
+| `geoshape` | a `color` or `fill` field, or a declared `value` | Choropleth map | [vegalite-choropleth.html](https://github.com/xability/maidr/blob/main/examples/vegalite-choropleth.html) |
 | `rule` + `point` layers | shared category and value channels | Lollipop | — |
 | `rule` + `point` layers, or `line` + `point` where the `line` has a `detail` naming the category | two values per category, told apart by `color` | Dumbbell | [vegalite-dumbbell.html](https://github.com/xability/maidr/blob/main/examples/vegalite-dumbbell.html) |
 
@@ -117,6 +118,8 @@ An `arc` mark is only a pie when it has a `theta` encoding: `theta` is the chann
 Two of these charts have no mark of their own in Vega-Lite and are authored as a pair of layers: a lollipop is a `rule` from the baseline plus its dots, and a dumbbell is a connector plus two dots per category (Vega-Lite's own "Ranged Dot Plot"). MAIDR collapses each pair into one trace, so the stem's magnitude and the gap between a pair are announced rather than dropped. The two ends of a dumbbell are named from the colour field — "1995" and "2000" rather than "start" and "end" — since those names are the whole content of the comparison. A `line` connector has to say what it joins, by naming the category in `detail` the way the Ranged Dot Plot does: a `line` under a dot layer without one is the ordinary line-with-markers idiom, and a two-series version of it would otherwise be read as a comparison of its two series.
 
 Four more charts have no mark of their own either and are recognised from the transform that built them. A `line` is a bump chart only when the ranked column is the one actually plotted on `y` — the same `window` rank is also how a spec picks a top-n before drawing the underlying magnitude, which is an ordinary line. A folded `line` split by `detail` is parallel coordinates, and the fold's raw `value` column is handed to the trace rather than any pre-normalised one, so each axis keeps its own units. A `row` facet of density curves is a ridgeline, whose panel order is read from the compiled view rather than the facet domain, because Vega sorts that domain before laying the cells out. A diverging bar is decided per series — every series wholly one side of the baseline, and both sides used — which recognises a pyramid and a Likert scale while leaving an ordinary stacked bar that merely dips negative alone.
+
+A `geoshape` mark is the one mark that names itself: it draws geography and nothing else compiles to it, so a map needs no annotation to be recognised. It is only a *choropleth* once a value shades it, which is why a `color` or `fill` field is required — a `geoshape` with neither is the outline layer such a map is usually drawn on top of, carries no data, and is left unread rather than announced as a chart with no values.
 
 A ranged bar — gantt or waterfall — needs the axis opposite its two bounds typed in the spec as `nominal` or `ordinal`. A type Vega-Lite infers from the data is written down nowhere MAIDR can read it, and without one the bar reads as an ordinary bar whose magnitude is its lower bound alone, so MAIDR warns to the console when it sees a two-bound bar with an untyped category axis.
 
@@ -429,6 +432,70 @@ maidrVegaLite.embed('#chart', spec, { id: 'fruit-pie' });
 An `arc` has no `x` or `y` to name its axes after, so the slice labels come from the `color` (or `fill`) channel and the magnitudes from `theta`, and the layer's axis labels are taken from those two channels' titles. Left and Right move between slices; Up and Down are out of bounds, since a pie is a single row. Each slice announces its label, its value, and its share of the whole — "Apples, 30, 26.1%". Adding `mark: { type: 'arc', innerRadius: 60 }` makes it a doughnut, which reads identically.
 
 See [`examples/vegalite-pie.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-pie.html) for a runnable version.
+
+### Choropleth map
+
+```js
+const states = [
+  { id: 53, state: 'Washington', rate: 4.9, lon: -120.4, lat: 47.4 },
+  { id: 41, state: 'Oregon', rate: 4.6, lon: -120.6, lat: 43.9 },
+  { id: 6, state: 'California', rate: 5.3, lon: -119.7, lat: 37.2 },
+  { id: 32, state: 'Nevada', rate: 5.8, lon: -116.6, lat: 39.3 },
+];
+
+const spec = {
+  $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+  width: 640,
+  height: 400,
+  title: 'Unemployment rate, western states',
+  data: {
+    url: 'https://cdn.jsdelivr.net/npm/vega-datasets@2/data/us-10m.json',
+    format: { type: 'topojson', feature: 'states' },
+  },
+  transform: [
+    {
+      lookup: 'id',
+      from: { data: { values: states }, key: 'id', fields: ['state', 'rate', 'lon', 'lat'] },
+    },
+    { filter: 'isValid(datum.rate)' },
+  ],
+  projection: { type: 'albersUsa' },
+  mark: 'geoshape',
+  encoding: {
+    color: { field: 'rate', type: 'quantitative', title: 'Unemployment rate (%)' },
+  },
+  usermeta: {
+    maidr: { type: 'choropleth', region: 'state' },
+  },
+};
+
+maidrVegaLite.embed('#chart', spec, { id: 'states-choropleth' });
+```
+
+A map has no `x` or `y` channel, so MAIDR names its two axes after the two things it does carry: what a region is called, and what shades it. The region name is read from the `lookup` transform's join key — the one field present on every drawn feature and distinct between them, including a nested one such as `properties.name`. Failing that, from the first `tooltip` entry that is not the shaded value itself. A map that names its regions in neither place is left unread, because numbering them 0, 1, 2 would announce a position in the file as if it were a place.
+
+Geometry the join left unmatched carries no value. Those regions are **dropped** rather than shaded zero — a region announced as 0 is a claim the map does not make, and on a rate it is the lowest value on the scale. Once regions are dropped they no longer line up one-to-one with the drawn shapes, so the layer loses its highlighting; a `filter` on the joined column, as above, keeps the two aligned.
+
+#### Declaring what a map means
+
+`usermeta` is Vega-Lite's own slot for third-party metadata, and `usermeta.maidr` is where a spec says what MAIDR cannot read off the drawing. On a choropleth it carries four optional fields, each named exactly like the value it fills:
+
+| field | what it names | default |
+|---|---|---|
+| `region` | the column holding each region's name | the `lookup` join key, then a `tooltip` field |
+| `value` | the column holding the value shading it | the `color` / `fill` field |
+| `lon` | centroid longitude, **degrees east** | a `lon`, `longitude` or `long` column |
+| `lat` | centroid latitude, **degrees north** | a `lat` or `latitude` column |
+
+`region` is worth writing whenever the join key is a code rather than a name: the map above joins on the numeric FIPS `id`, so without it the reader is told "6" rather than "California".
+
+`lon` and `lat` are what buy back everything spatial. With them the arrow keys move **across the map** — up is north, down is south, left is west, right is east — and the description names where the high values sit and which way the gradient runs. Without them the map is read as a region list in declared order, which is a poorer reading but the one the data supports. MAIDR does not invert the projection to synthesise the pair: degrees are the only accepted form, anything else is left out, and a coordinate that is not one is dropped rather than coerced — a wrong compass direction is worse than no compass at all.
+
+A declaration outranks every heuristic, but only where the marks can back it: a `maidr` block on a spec whose mark is not a `geoshape` is reported to the console and the chart is read as what was actually drawn. The block belongs on the spec node that becomes **one** layer — a single-view spec, a `layer[i]` child, a concat or facet leaf. One written on a composite parent — a `layer`, `concat`, `facet` or `repeat` node — names none of the layers below it and is ignored. `title` and `name` are accepted on any layer and override what it is announced as.
+
+Field names given explicitly are used verbatim, with no fallback: a name that no row carries is a typo worth reporting, and MAIDR says so to the console rather than quietly substituting a column you did not ask for.
+
+See [`examples/vegalite-choropleth.html`](https://github.com/xability/maidr/blob/main/examples/vegalite-choropleth.html) for a runnable version.
 
 ## Multi-panel charts (facet, repeat, concat)
 

--- a/examples/vegalite-choropleth.html
+++ b/examples/vegalite-choropleth.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Vega-Lite Choropleth Example</title>
+    <!-- Vega-Lite and its dependencies -->
+    <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+    <!-- MAIDR Vega-Lite adapter (bundles MAIDR core) -->
+    <script src="../dist/vegalite.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Vega-Lite Choropleth</h1>
+    <p>
+      Click on the chart and use the arrow keys to move across the map: up is
+      north, down is south, left is west and right is east. Each region
+      announces its name and the value shading it. Press 'b' for braille, 't'
+      for text descriptions.
+    </p>
+    <p>
+      The rates below are illustrative figures made up for this demo, not real
+      unemployment data.
+    </p>
+    <div
+      id="choropleth-chart"
+      aria-label="Choropleth map loading"
+      style="min-height: 420px"
+    ></div>
+
+    <script>
+      // The values joined onto the geometry, plus each region's centroid in
+      // DEGREES. The centroids are what turn a list of regions read in
+      // declared order into a walk across the map — they are the one thing
+      // that settles whether a rising value means north or south, and no
+      // amount of inspecting the drawn SVG recovers them.
+      const states = [
+        { id: 53, state: 'Washington', rate: 4.9, lon: -120.4, lat: 47.4 },
+        { id: 41, state: 'Oregon', rate: 4.6, lon: -120.6, lat: 43.9 },
+        { id: 6, state: 'California', rate: 5.3, lon: -119.7, lat: 37.2 },
+        { id: 32, state: 'Nevada', rate: 5.8, lon: -116.6, lat: 39.3 },
+        { id: 16, state: 'Idaho', rate: 3.2, lon: -114.6, lat: 44.4 },
+        { id: 30, state: 'Montana', rate: 3.0, lon: -109.6, lat: 47.0 },
+        { id: 56, state: 'Wyoming', rate: 3.4, lon: -107.6, lat: 43.0 },
+        { id: 49, state: 'Utah', rate: 2.7, lon: -111.7, lat: 39.3 },
+        { id: 8, state: 'Colorado', rate: 3.6, lon: -105.5, lat: 39.0 },
+        { id: 4, state: 'Arizona', rate: 4.4, lon: -111.7, lat: 34.3 },
+        { id: 35, state: 'New Mexico', rate: 4.8, lon: -106.1, lat: 34.4 },
+      ];
+
+      // A choropleth is the one Vega-Lite mark that names itself: `geoshape`
+      // draws geography and nothing else compiles to it, so MAIDR recognises
+      // the map with no annotation at all — the `lookup` transform's join key
+      // names the regions and the `color` field shades them.
+      //
+      // The `usermeta.maidr` block below is Vega-Lite's own slot for
+      // third-party metadata, and it is worth writing here for one reason:
+      // this map joins on the numeric FIPS `id`, so the undeclared reading
+      // would announce "6" rather than "California". Naming `region` fixes
+      // that. `lon` and `lat` need no declaring — they default to the columns
+      // of those names, which the join has already brought in.
+      const spec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        width: 640,
+        height: 400,
+        title: 'Unemployment rate, western states (illustrative)',
+        data: {
+          url: 'https://cdn.jsdelivr.net/npm/vega-datasets@2/data/us-10m.json',
+          format: { type: 'topojson', feature: 'states' },
+        },
+        transform: [
+          {
+            lookup: 'id',
+            from: {
+              data: { values: states },
+              key: 'id',
+              fields: ['state', 'rate', 'lon', 'lat'],
+            },
+          },
+          // Keep only the states the table covers. Geometry the join left
+          // unmatched carries no value to announce, so MAIDR drops it — and
+          // once the regions no longer line up one-to-one with the drawn
+          // shapes, the layer loses its highlighting.
+          { filter: 'isValid(datum.rate)' },
+        ],
+        projection: { type: 'albersUsa' },
+        mark: 'geoshape',
+        encoding: {
+          color: {
+            field: 'rate',
+            type: 'quantitative',
+            title: 'Unemployment rate (%)',
+          },
+          tooltip: [
+            { field: 'state', type: 'nominal', title: 'State' },
+            { field: 'rate', type: 'quantitative', title: 'Rate (%)' },
+          ],
+        },
+        usermeta: {
+          maidr: { type: 'choropleth', region: 'state' },
+        },
+      };
+
+      // === MAIDR Integration ===
+      // maidrVegaLite.embed() runs vegaEmbed() internally and mounts the
+      // accessible MAIDR UI on the rendered SVG once it's ready.
+      maidrVegaLite
+        .embed('#choropleth-chart', spec, { id: 'western-states-choropleth' })
+        .catch((err) => console.error('[vegalite-choropleth]', err));
+    </script>
+  </body>
+</html>

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -16,9 +16,11 @@
  * into one.
  */
 
+import type { ChoroplethDeclaration, MaidrTraceDeclaration } from '@type/declaration';
 import type {
   BarPoint,
   BoxPoint,
+  ChoroplethPoint,
   DumbbellData,
   DumbbellPoint,
   ErrorBarPoint,
@@ -48,6 +50,7 @@ import type {
   VegaLiteTransform,
   VegaView,
 } from './types';
+import { readDeclarationSlot, resolveFieldRef, warnUnresolvedRef } from '@adapters/shared/traceDeclaration';
 import { Orientation, TraceType } from '@type/grammar';
 import {
   chunkIntoRows,
@@ -98,6 +101,8 @@ export function vegaLiteToMaidr(
   const caption = spec.description;
 
   const domOrder = options?.domOrder;
+
+  warnCompositeDeclaration(spec);
 
   // Handle composite views (concat).
   if (spec.hconcat) {
@@ -1064,6 +1069,16 @@ function resolveTraceType(
     case 'errorbar':
     case 'errorband':
       return TraceType.ERROR_BAR;
+    // The one mark that names itself. `geoshape` draws geography and
+    // nothing else compiles to it, so no author sentence is needed to
+    // recognise a map — but a map is only a *choropleth* once a value
+    // shades it. A `geoshape` with no colour or fill field is the outline
+    // layer such a spec is usually built on top of: it carries no data, and
+    // it is left unread rather than announced as a chart with no values.
+    case 'geoshape':
+      return hasField(encoding?.color) || hasField(encoding?.fill)
+        ? TraceType.CHOROPLETH
+        : null;
     default:
       return null;
   }
@@ -2416,6 +2431,357 @@ function extractDumbbellData(
   return { points, startLabel: ends[0], endLabel: ends[1] };
 }
 
+// ---------------------------------------------------------------------------
+// Choropleth
+// ---------------------------------------------------------------------------
+
+/** How the shared declaration reader names this adapter in its warnings. */
+const DECLARATION_ADAPTER = 'Vega-Lite';
+
+/**
+ * Where a `geoshape` layer's two facts live: what each region is called,
+ * and the value it is shaded by.
+ *
+ * The region field is the part a map does not carry positionally — a
+ * choropleth has no `x` — so it is recovered from the join that built the
+ * layer, or named outright in a `usermeta.maidr` block.
+ */
+interface ChoroplethFields {
+  /** Field naming each region, resolved against the row. */
+  region: string;
+  /** What to call the regions on the announced axis. */
+  regionLabel: string;
+  /** Field carrying the shaded value. */
+  value: string;
+  /** What to call the values on the announced axis. */
+  valueLabel: string;
+  /**
+   * The channel `value` came from, when it came from the encoding rather
+   * than from a declaration — which is what says whether Vega-Lite renamed
+   * the column while aggregating it.
+   */
+  valueChannel?: VegaLiteChannelDef;
+  /** The declaration, when the spec carried one. */
+  declaration?: ChoroplethDeclaration;
+}
+
+/**
+ * Read a field off a row, reaching into nested objects for a dotted name.
+ *
+ * TopoJSON features nest everything a spec can key on: a world map joins on
+ * `properties.name` and a US one on `id`, and Vega resolves both as field
+ * accessors. A flat property wins, since Vega-Lite escapes a literal dot in
+ * a column name and the unescaped form is then the nested one.
+ *
+ * @param row - The row the layer resolved
+ * @param field - The field name, possibly a dotted path
+ * @returns The value, or `undefined` when the path leads nowhere
+ */
+function readFieldPath(row: Record<string, unknown>, field: string): unknown {
+  if (field in row)
+    return row[field];
+  if (!field.includes('.'))
+    return undefined;
+
+  let value: unknown = row;
+  for (const step of field.split('.')) {
+    if (typeof value !== 'object' || value === null)
+      return undefined;
+    value = (value as Record<string, unknown>)[step];
+  }
+  return value;
+}
+
+/**
+ * A number in degrees, or nothing.
+ *
+ * Degrees are the whole point of a centroid — they are what settles whether
+ * a rising value means north or south — so anything that is not one is left
+ * out rather than passed on. A projected or normalised coordinate would put
+ * regions in compass directions from one another that the map does not.
+ *
+ * @param value - Whatever the centroid field resolved to
+ * @returns The coordinate, or `undefined`
+ */
+function toDegrees(value: unknown): number | undefined {
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== 'string' || value.trim() === '')
+    return undefined;
+  const degrees = Number(value);
+  return Number.isFinite(degrees) ? degrees : undefined;
+}
+
+/**
+ * The field a `geoshape` layer names its regions with, read off the spec.
+ *
+ * A choropleth is built by joining values onto geometry, and the join key
+ * is* the region's identity — it is the one field guaranteed present on
+ * every drawn feature and distinct between them. Failing that, the tooltip:
+ * on a map it is the only place left where a spec says what a region is,
+ * since there is no positional channel to say it. A tooltip entry naming
+ * the shaded value is skipped, because announcing the value as the region's
+ * name would leave the map with no names at all.
+ *
+ * @param encoding - The layer's encoding, merged with any parent's
+ * @param transform - The transforms in scope for the layer
+ * @param valueField - The field the regions are shaded by
+ * @returns The field and the label to announce it under, or `null`
+ */
+function resolveRegionSource(
+  encoding: VegaLiteEncoding,
+  transform: VegaLiteTransform[] | undefined,
+  valueField: string | undefined,
+): { field: string; label: string } | null {
+  const joined = transform?.find(entry => typeof entry.lookup === 'string')?.lookup;
+  if (typeof joined === 'string' && joined.length > 0) {
+    // `properties.name` is a path into the feature, not a name a reader
+    // would recognise; the leaf of it is.
+    const leaf = joined.slice(joined.lastIndexOf('.') + 1);
+    return { field: joined, label: leaf };
+  }
+
+  const tooltip = encoding.tooltip;
+  const channels = Array.isArray(tooltip) ? tooltip : tooltip ? [tooltip] : [];
+  const named = channels.find(
+    channel => hasField(channel) && channel.field !== valueField,
+  );
+  return named?.field ? { field: named.field, label: getAxisLabel(named) } : null;
+}
+
+/**
+ * Work out which columns a choropleth layer reads.
+ *
+ * A declaration outranks the spec for both facts. Note that `region` does
+ * **not** fall back to a column literally called `region` the way the
+ * naming law's other fields fall back to their own names: a `geoshape`
+ * spec's join already names the field, so the spec-derived answer is the
+ * better default and is used wherever the author named nothing.
+ *
+ * @param encoding - The layer's encoding, merged with any parent's
+ * @param transform - The transforms in scope for the layer
+ * @param declaration - The layer's `usermeta.maidr` block, when it declared one
+ * @param seriesRef - How the author can find this layer, for warnings
+ * @returns The fields to read, or `null` when the spec names no regions
+ */
+function resolveChoroplethFields(
+  encoding: VegaLiteEncoding,
+  transform: VegaLiteTransform[] | undefined,
+  declaration: ChoroplethDeclaration | undefined,
+  seriesRef: string,
+): ChoroplethFields | null {
+  const valueChannel = encoding.color ?? encoding.fill;
+  const value = declaration?.value ?? valueChannel?.field;
+  if (value === undefined) {
+    console.warn(
+      `[MAIDR ${DECLARATION_ADAPTER}] maidr declaration for "choropleth" on `
+      + `${seriesRef} has no colour or fill field to shade the regions by and `
+      + `names none with "value"; the map is left unread.`,
+    );
+    return null;
+  }
+
+  const region = declaration?.region
+    ? { field: declaration.region, label: declaration.region }
+    : resolveRegionSource(encoding, transform, valueChannel?.field);
+  if (!region) {
+    console.warn(
+      `[maidr/vegalite] A geoshape map on ${seriesRef} names its regions `
+      + `nowhere MAIDR can read: add the "lookup" transform that joins the `
+      + `values on, a "tooltip" naming the region field, or a `
+      + `usermeta.maidr block declaring "region". The map is left unread.`,
+    );
+    return null;
+  }
+
+  return {
+    region: region.field,
+    regionLabel: region.label,
+    value,
+    valueLabel: declaration?.value !== undefined || !valueChannel
+      ? value
+      : getAxisLabel(valueChannel),
+    valueChannel: declaration?.value === undefined ? valueChannel : undefined,
+    declaration,
+  };
+}
+
+/**
+ * Read one region per row: what it is called and the value shading it.
+ *
+ * A row the join left unmatched carries no value — Vega still draws the
+ * geometry, unshaded — and is dropped rather than shaded with a stand-in:
+ * a region announced as zero is a claim the map does not make. Dropping it
+ * costs the layer its highlighting when it happens, since the regions then
+ * no longer line up one-to-one with the drawn shapes, so say so.
+ *
+ * `lon`/`lat` are read only from a declaration. A projection is not
+ * inverted to synthesise them: with the pair the reader walks the map by
+ * compass direction, and with a *wrong* pair they walk a map that does not
+ * exist, so the centroids come from the author or not at all.
+ *
+ * @param rows - The layer's resolved rows
+ * @param fields - The columns this layer reads
+ * @param seriesRef - How the author can find this layer, for warnings
+ * @returns One region per readable row, in data-flow order
+ */
+function extractChoroplethData(
+  rows: Record<string, unknown>[],
+  fields: ChoroplethFields,
+  seriesRef: string,
+): ChoroplethPoint[] {
+  const { declaration } = fields;
+  const resolved = new Set<string>();
+  const points: ChoroplethPoint[] = [];
+
+  for (const row of rows) {
+    const name = readFieldPath(row, fields.region);
+    if (name !== undefined && name !== null) {
+      resolved.add('region');
+    }
+    const read = fields.valueChannel
+      ? readEncodedValue(row, fields.valueChannel, fields.value)
+      : readFieldPath(row, fields.value);
+    if (read !== undefined && read !== null) {
+      resolved.add('value');
+    }
+
+    const shaded = Number(read);
+    if (name === undefined || name === null || !Number.isFinite(shaded)) {
+      continue;
+    }
+
+    const point: ChoroplethPoint = {
+      x: typeof name === 'number' ? name : String(name),
+      y: shaded,
+    };
+    if (declaration) {
+      const lon = toDegrees(resolveFieldRef(row, declaration.lon, 'lon'));
+      const lat = toDegrees(resolveFieldRef(row, declaration.lat, 'lat'));
+      // Both or neither: half a centroid places a region nowhere, and
+      // `ChoroplethTrace` bands the map only when every region has the pair.
+      if (lon !== undefined && lat !== undefined) {
+        point.lon = lon;
+        point.lat = lat;
+        resolved.add('lon');
+        resolved.add('lat');
+      }
+    }
+    points.push(point);
+  }
+
+  if (points.length < rows.length) {
+    console.warn(
+      `[maidr/vegalite] ${rows.length - points.length} of ${rows.length} `
+      + `geoshape features on ${seriesRef} carry no value to announce and were `
+      + `dropped; the remaining regions no longer line up with the drawn `
+      + `shapes, so this layer is not highlighted.`,
+    );
+  }
+  reportUnresolvedRefs(declaration, resolved, seriesRef);
+  return points;
+}
+
+/**
+ * Report every field the author named that no row of the layer carried.
+ *
+ * An explicit {@link FieldRef} is used verbatim, so a typo resolves to
+ * nothing on every row and the fact is quietly left out of the payload.
+ * Saying which name missed is what turns that into something the author can
+ * fix.
+ *
+ * @param declaration - The layer's declaration, when it carried one
+ * @param resolved - The canonical names that resolved on at least one row
+ * @param seriesRef - How the author can find this layer
+ */
+function reportUnresolvedRefs(
+  declaration: ChoroplethDeclaration | undefined,
+  resolved: Set<string>,
+  seriesRef: string,
+): void {
+  if (!declaration) {
+    return;
+  }
+  const named: [string, string | undefined][] = [
+    ['region', declaration.region],
+    ['value', declaration.value],
+    ['lon', declaration.lon],
+    ['lat', declaration.lat],
+  ];
+  for (const [canonical, ref] of named) {
+    if (ref !== undefined && !resolved.has(canonical)) {
+      warnUnresolvedRef(
+        { adapter: DECLARATION_ADAPTER, seriesRef },
+        ref,
+        canonical,
+      );
+    }
+  }
+}
+
+/**
+ * Apply a `usermeta.maidr` block's `type` over the mark's own reading.
+ *
+ * A declaration outranks every heuristic, but only where the library
+ * construct can back it: Vega-Lite says what most of its marks are, and the
+ * one thing a spec cannot say for itself here is that a `geoshape` is a
+ * choropleth when no colour encoding shades it. Anything else declared is
+ * reported against what was actually drawn and read as the undeclared
+ * chart, per the disagreement rule — never thrown, and never announced as a
+ * chart the marks do not draw.
+ *
+ * @param declaration - The layer's declaration, when it carried one
+ * @param mark - The layer's mark
+ * @param resolved - What the mark and its encoding resolved to
+ * @param seriesRef - How the author can find this layer
+ * @returns The type to read the layer as
+ */
+function applyDeclaredType(
+  declaration: MaidrTraceDeclaration | null,
+  mark: string,
+  resolved: TraceType | null,
+  seriesRef: string,
+): TraceType | null {
+  if (!declaration || declaration.type === resolved) {
+    return resolved;
+  }
+  if (declaration.type === TraceType.CHOROPLETH && mark === 'geoshape') {
+    return TraceType.CHOROPLETH;
+  }
+  console.warn(
+    `[MAIDR ${DECLARATION_ADAPTER}] maidr declaration for "${declaration.type}" `
+    + `on ${seriesRef} names a chart this adapter cannot read from a "${mark}" `
+    + `mark; reading it as the undeclared chart.`,
+  );
+  return resolved;
+}
+
+/**
+ * Report a declaration written on a spec node that becomes no single layer.
+ *
+ * A declaration says what **one** layer means. On a `layer`, `concat`,
+ * `facet` or `repeat` parent it names none of the several layers below it,
+ * and guessing which one it meant would announce the wrong half of a
+ * composite map as the chart. Move it down onto the child it describes.
+ *
+ * @param spec - The spec about to be converted
+ */
+function warnCompositeDeclaration(spec: VegaLiteSpec): void {
+  if (spec.usermeta?.maidr === undefined) {
+    return;
+  }
+  const composite = spec.layer ?? spec.hconcat ?? spec.vconcat ?? spec.concat
+    ?? spec.facet ?? spec.repeat;
+  if (composite === undefined) {
+    return;
+  }
+  console.warn(
+    `[MAIDR ${DECLARATION_ADAPTER}] maidr declaration on a composite spec `
+    + `names no one layer; move it onto the layer, concat or facet child it `
+    + `describes. Ignored.`,
+  );
+}
+
 /**
  * Convert a segment layer and the dot layer that follows it into the one
  * chart they draw together.
@@ -2577,7 +2943,22 @@ function convertLayerSpec(
     : spec.transform;
 
   const stepDirection = getStepDirection(spec);
-  const traceType = resolveTraceType(mark, encoding, stepDirection, transform);
+
+  // `usermeta` is Vega-Lite's own slot for third-party metadata, and the
+  // only home a JSON-authored or Altair-produced spec has for a
+  // declaration. Read before the mark's own reading, since a declaration
+  // outranks every heuristic.
+  const seriesRef = `layer ${index}`;
+  const declaration = readDeclarationSlot(spec.usermeta, {
+    adapter: DECLARATION_ADAPTER,
+    seriesRef,
+  });
+  const traceType = applyDeclaredType(
+    declaration,
+    mark,
+    resolveTraceType(mark, encoding, stepDirection, transform),
+    seriesRef,
+  );
 
   if (!traceType)
     return null;
@@ -2764,6 +3145,30 @@ function convertLayerSpec(
       data = extractHeatmapData(rows, encoding);
       selectors = buildSelector(mark, selectorLayerIndex, layered, markGroupPrefix);
       break;
+    // A map has no positional channels at all, so its axes are named after
+    // the two things it does carry: what a region is called, and what
+    // shades it.
+    case TraceType.CHOROPLETH: {
+      const fields = resolveChoroplethFields(
+        encoding,
+        transform,
+        declaration?.type === TraceType.CHOROPLETH ? declaration : undefined,
+        seriesRef,
+      );
+      if (!fields) {
+        return null;
+      }
+      data = extractChoroplethData(rows, fields, seriesRef);
+      // Emitted unconditionally: Vega draws one `<path>` per feature, and
+      // `ChoroplethTrace` refuses a selector set whose element count does
+      // not match the regions it was given, so a map that dropped an
+      // unmatched feature degrades to no highlight rather than to the wrong
+      // one.
+      selectors = buildSelector(mark, selectorLayerIndex, layered, markGroupPrefix);
+      axes.x = { label: fields.regionLabel };
+      axes.y = { label: fields.valueLabel };
+      break;
+    }
     case TraceType.PIE:
       data = extractPieData(rows, encoding);
       selectors = buildSelector(mark, selectorLayerIndex, layered, markGroupPrefix);
@@ -2884,6 +3289,15 @@ function convertLayerSpec(
     data,
   };
 
+  // Naming is independent of the type: an author whose declared type could
+  // not be honoured still named this layer, and the two fields are the only
+  // way a spec says which of several layers a reader has switched to.
+  if (declaration?.title !== undefined) {
+    layer.title = declaration.title;
+  }
+  if (declaration?.name !== undefined) {
+    layer.name = declaration.name;
+  }
   if (stepDirection && traceType === TraceType.STEP) {
     layer.stepDirection = stepDirection;
   }

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -2658,13 +2658,22 @@ function extractChoroplethData(
     if (declaration) {
       const lon = toDegrees(resolveFieldRef(row, declaration.lon, 'lon'));
       const lat = toDegrees(resolveFieldRef(row, declaration.lat, 'lat'));
+      // Each half is tracked on its own, because the diagnostic answers a
+      // different question than the payload does: whether *this* name found
+      // degrees on the row. Tracking the pair together makes a correctly
+      // named `lon` report as missing whenever `lat` is the typo, pointing
+      // the author at the one field that was right.
+      if (lon !== undefined) {
+        resolved.add('lon');
+      }
+      if (lat !== undefined) {
+        resolved.add('lat');
+      }
       // Both or neither: half a centroid places a region nowhere, and
       // `ChoroplethTrace` bands the map only when every region has the pair.
       if (lon !== undefined && lat !== undefined) {
         point.lon = lon;
         point.lat = lat;
-        resolved.add('lon');
-        resolved.add('lat');
       }
     }
     points.push(point);
@@ -2763,6 +2772,12 @@ function applyDeclaredType(
  * `facet` or `repeat` parent it names none of the several layers below it,
  * and guessing which one it meant would announce the wrong half of a
  * composite map as the chart. Move it down onto the child it describes.
+ *
+ * Called at every point a composite node is descended into, not only on the
+ * entry spec: a concat child or a faceted child can itself be a `layer`, and
+ * a declaration stranded on one of those is as unusable as on the outer
+ * node. Each call site fires once per node, so a misplaced declaration is
+ * reported once however many panels the node expands into.
  *
  * @param spec - The spec about to be converted
  */
@@ -3332,6 +3347,10 @@ function buildConcatMaidr(
   let globalLayerIndex = 0;
 
   const subplotEntries: MaidrSubplot[] = specs.map((childSpec, i) => {
+    // A concat child is a spec node `vegaLiteToMaidr` never sees, so a
+    // declaration written on one that is itself composite is caught here or
+    // not at all. Once per child, not once per layer.
+    warnCompositeDeclaration(childSpec);
     // Each concat child compiles to a per-cell Vega scope group
     // (`concat_<i>_group`) wrapping the panel's background path. Pointing
     // the subplot selector at that background gives MAIDR core a real
@@ -3770,6 +3789,15 @@ function buildFacetMaidr(
   domOrder?: 'series-major' | 'subject-major',
 ): Maidr {
   const childSpec = descriptor.childSpec;
+  // With the `facet` operator the child is a separate spec node that
+  // `vegaLiteToMaidr` never inspects, so a declaration misplaced on a
+  // layered child is caught here. The `encoding.row`/`column` shorthand is
+  // deliberately excluded: there the child is the entry spec with the facet
+  // channels stripped, carrying the same declaration object, and it was
+  // already checked once — warning again would print the same line twice.
+  if (spec.facet != null && spec.spec != null) {
+    warnCompositeDeclaration(spec.spec);
+  }
   const isLayered = childSpec.layer != null && childSpec.layer.length > 0;
   const layerSpecs = isLayered ? childSpec.layer! : [childSpec];
   const facetFields = [
@@ -3964,6 +3992,11 @@ function buildRepeatMaidr(
   domOrder?: 'series-major' | 'subject-major',
 ): Maidr {
   const childSpec = descriptor.childSpec;
+  // `describeRepeat` only answers for `spec.repeat` + `spec.spec`, so the
+  // child is always a separate node the entry check never saw. Warn once
+  // here, before the per-cell loop — a misplaced declaration is one mistake,
+  // not one per repeated panel.
+  warnCompositeDeclaration(childSpec);
 
   // Grid of per-cell field mappings in reading order.
   interface RepeatCellDef { mapping: RepeatCellMapping; title: string }

--- a/src/adapters/vegalite/index.ts
+++ b/src/adapters/vegalite/index.ts
@@ -46,3 +46,8 @@ export type {
   VegaLiteToMaidrOptions,
   VegaView,
 } from './types';
+
+// The co-located declaration a spec writes on `usermeta.maidr`. Re-exported
+// here so an author typing a spec against this barrel can type the block on
+// it too, without reaching into `src/type/`.
+export type { ChoroplethDeclaration, MaidrTraceDeclaration } from '@type/declaration';

--- a/src/adapters/vegalite/selectors.ts
+++ b/src/adapters/vegalite/selectors.ts
@@ -50,6 +50,12 @@ export function markToCssClass(mark: string): string {
       return 'mark-rect';
     case 'boxplot':
       return 'mark-rect';
+    // Vega has no `geoshape` mark either: Vega-Lite compiles one to a Vega
+    // `shape` mark, which renders as `mark-shape`. The default branch's
+    // `mark-geoshape` matches nothing in a rendered map, which would cost a
+    // choropleth its highlighting without costing it anything else.
+    case 'geoshape':
+      return 'mark-shape';
     case 'errorbar':
       return 'mark-rule';
     default:

--- a/src/adapters/vegalite/types.ts
+++ b/src/adapters/vegalite/types.ts
@@ -9,6 +9,8 @@
  * @see https://vega.github.io/vega-lite/
  */
 
+import type { MaidrTraceDeclaration } from '@type/declaration';
+
 /**
  * Minimal subset of a Vega `View` that the adapter needs at runtime.
  *
@@ -89,6 +91,17 @@ export type VegaLiteRepeatDef = string[] | { row?: string[]; column?: string[] }
  * `encoding.column` shorthand), and repeated (`repeat`) specs.
  */
 export interface VegaLiteSpec {
+  /**
+   * Vega-Lite's own sanctioned slot for third-party metadata, and the only
+   * home a JSON-authored or Altair-produced spec has for one.
+   *
+   * `usermeta.maidr` carries a {@link MaidrTraceDeclaration} — what the chart
+   * means, where the drawing does not say. It belongs on the spec node that
+   * becomes **one MAIDR layer**: a single-view spec, a `layer[i]` child, a
+   * concat or facet leaf. A block on a composite parent names no one layer
+   * and is ignored with a warning.
+   */
+  usermeta?: { maidr?: MaidrTraceDeclaration };
   $schema?: string;
   title?: string | { text?: string; subtitle?: string };
   description?: string;
@@ -185,6 +198,16 @@ export interface VegaLiteEncoding {
    * the rows.
    */
   detail?: VegaLiteChannelDef;
+  /**
+   * What a sighted reader is shown on hover, as one channel or a list of
+   * them.
+   *
+   * Read for one chart only: a `geoshape` map has no positional channel, so
+   * the tooltip is often the only place its spec names the regions it draws.
+   * Everywhere else the positional channels already say what a point is, and
+   * the tooltip repeats them.
+   */
+  tooltip?: VegaLiteChannelDef | VegaLiteChannelDef[];
   row?: VegaLiteChannelDef;
   column?: VegaLiteChannelDef;
 }
@@ -269,6 +292,16 @@ export interface VegaLiteTransform {
    * mark says "parallel coordinates"; the fold does.
    */
   fold?: string[];
+  /**
+   * The field on the primary data a `lookup` transform joins on.
+   *
+   * That field is what identifies a region on a choropleth: the geometry
+   * carries a name or a code, the values arrive from a second dataset keyed
+   * by it, and the join is the only place a `geoshape` spec writes the pair
+   * down. Vega resolves it as a field accessor, so a dotted name
+   * (`properties.name`) reaches into the feature's own properties.
+   */
+  lookup?: string;
   /** The field a `density` transform estimates a distribution over. */
   density?: string;
   /** The grouping keys of a `density` or `aggregate` transform. */

--- a/src/vegalite-entry.ts
+++ b/src/vegalite-entry.ts
@@ -1584,6 +1584,9 @@ export type {
   VegaView,
 } from './adapters/vegalite/types';
 
+// The co-located declaration a spec writes on `usermeta.maidr`.
+export type { ChoroplethDeclaration, MaidrTraceDeclaration } from './type/declaration';
+
 /**
  * Initialise MAIDR on an already-rendered Vega-Lite chart.
  *

--- a/test/adapters/vegalite/choropleth.test.ts
+++ b/test/adapters/vegalite/choropleth.test.ts
@@ -1,0 +1,361 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { ChoroplethPoint, MaidrLayer } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { TraceType } from '@type/grammar';
+import { makeView } from './fixtures/testView';
+
+/**
+ * The Vega-Lite gallery's choropleth recipe: geometry from a TopoJSON file,
+ * values joined onto it by a `lookup` transform, and a colour encoding
+ * shading each region.
+ *
+ * `projection` is omitted throughout — it is what draws the map, but nothing
+ * in it says the chart is a choropleth, and the adapter never reads it.
+ */
+const CHOROPLETH_SPEC: VegaLiteSpec = {
+  data: { url: 'states.json', format: { type: 'topojson', feature: 'states' } },
+  transform: [
+    {
+      lookup: 'properties.name',
+      from: { data: { url: 'unemployment.csv' }, key: 'state', fields: ['rate'] },
+    },
+  ],
+  mark: 'geoshape',
+  encoding: {
+    color: { field: 'rate', type: 'quantitative', title: 'Unemployment rate' },
+  },
+};
+
+/**
+ * The features as Vega hands them over after the join: GeoJSON features
+ * whose name is nested under `properties`, with the joined column alongside.
+ */
+const STATE_ROWS = [
+  { type: 'Feature', properties: { name: 'Nevada' }, rate: 4.2 },
+  { type: 'Feature', properties: { name: 'Utah' }, rate: 2.8 },
+  { type: 'Feature', properties: { name: 'Idaho' }, rate: 3.1 },
+];
+
+/**
+ * Convert a spec and return its single layer.
+ *
+ * @param spec The Vega-Lite spec to convert
+ * @param datasets The compiled view's datasets
+ * @returns The single converted layer
+ */
+function onlyLayer(
+  spec: VegaLiteSpec,
+  datasets: Record<string, unknown[]> = { data_0: STATE_ROWS },
+): MaidrLayer {
+  const layers = vegaLiteToMaidr(spec, makeView(datasets)).subplots[0][0].layers;
+  expect(layers).toHaveLength(1);
+  return layers[0];
+}
+
+/**
+ * Convert a spec and return every layer it produced.
+ *
+ * @param spec The Vega-Lite spec to convert
+ * @param datasets The compiled view's datasets
+ * @returns The converted layers
+ */
+function allLayers(
+  spec: VegaLiteSpec,
+  datasets: Record<string, unknown[]> = { data_0: STATE_ROWS },
+): MaidrLayer[] {
+  return vegaLiteToMaidr(spec, makeView(datasets)).subplots[0][0].layers;
+}
+
+/**
+ * The regions of a choropleth layer.
+ *
+ * @param layer The converted layer
+ * @returns Its payload, typed
+ */
+function regionsOf(layer: MaidrLayer): ChoroplethPoint[] {
+  return layer.data as ChoroplethPoint[];
+}
+
+describe('vega-Lite geoshape maps', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('reads a shaded geoshape as a choropleth', () => {
+    // Before this, `geoshape` fell to `resolveTraceType`'s `default: return
+    // null`, the spec produced zero layers and `bindVegaLite` skipped
+    // binding outright — the map was invisible to MAIDR, not merely
+    // unannounced.
+    expect(onlyLayer(CHOROPLETH_SPEC).type).toBe(TraceType.CHOROPLETH);
+  });
+
+  it('names the regions from the join and shades them from the colour field', () => {
+    // The join key IS the region's identity: it is the one field present on
+    // every drawn feature and distinct between them. `properties.name` is a
+    // path into the feature, which is why a flat `row[field]` read is not
+    // enough.
+    expect(regionsOf(onlyLayer(CHOROPLETH_SPEC))).toEqual([
+      { x: 'Nevada', y: 4.2 },
+      { x: 'Utah', y: 2.8 },
+      { x: 'Idaho', y: 3.1 },
+    ]);
+  });
+
+  it('announces the region names and the shaded quantity as the two axes', () => {
+    const layer = onlyLayer(CHOROPLETH_SPEC);
+
+    // A map has no `x` or `y` channel at all, so without this both axes are
+    // announced as the empty string: the reader is told a name and a number
+    // and never what either measures. The region axis is named after the
+    // leaf of the join path rather than the path itself.
+    expect(layer.axes?.x?.label).toBe('name');
+    expect(layer.axes?.y?.label).toBe('Unemployment rate');
+  });
+
+  it('points the highlight at the shape group Vega actually renders', () => {
+    // Vega has no `geoshape` mark: Vega-Lite compiles one to a Vega `shape`
+    // mark. `mark-geoshape` — what the default branch of `markToCssClass`
+    // produces — matches nothing in a rendered map, so the layer would
+    // sonify and announce while highlighting nothing.
+    expect(onlyLayer(CHOROPLETH_SPEC).selectors).toBe(
+      'g.mark-shape.role-mark.marks path, g.mark-shape.role-mark.layer_0_marks path',
+    );
+  });
+
+  it('leaves an unshaded geoshape unread', () => {
+    // The outline layer a choropleth is usually drawn on top of. It carries
+    // no data, and announcing it would give the reader a chart of nothing.
+    const outline: VegaLiteSpec = { mark: 'geoshape', encoding: {} };
+
+    expect(allLayers(outline)).toHaveLength(0);
+  });
+
+  it('reads the shaded layer of an outline-plus-choropleth map', () => {
+    const layered: VegaLiteSpec = {
+      transform: CHOROPLETH_SPEC.transform,
+      layer: [
+        { mark: 'geoshape', encoding: {} },
+        { mark: 'geoshape', encoding: CHOROPLETH_SPEC.encoding },
+      ],
+    };
+
+    const layers = allLayers(layered, { data_1: STATE_ROWS });
+    expect(layers).toHaveLength(1);
+    // The outline drops out, but the choropleth is still Vega layer 1 and
+    // its marks are rendered under `layer_1_marks`. Highlighting the wrong
+    // group would highlight the unshaded outlines.
+    expect(layers[0].selectors).toBe('g.mark-shape.role-mark.layer_1_marks path');
+  });
+
+  it('drops a feature the join left unmatched rather than shading it zero', () => {
+    const rows = [
+      { properties: { name: 'Nevada' }, rate: 4.2 },
+      { properties: { name: 'Wyoming' } },
+      { properties: { name: 'Utah' }, rate: 2.8 },
+    ];
+
+    const layer = onlyLayer(CHOROPLETH_SPEC, { data_0: rows });
+
+    // A region announced as 0 is a claim the map does not make, and on a
+    // rate it is the lowest value on the scale: the loudest possible wrong
+    // answer.
+    expect(regionsOf(layer).map(region => region.x)).toEqual(['Nevada', 'Utah']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('carry no value'));
+  });
+
+  it('names the regions from the tooltip when no lookup transform built the map', () => {
+    const inlined: VegaLiteSpec = {
+      mark: 'geoshape',
+      encoding: {
+        color: { field: 'rate', type: 'quantitative' },
+        tooltip: [
+          { field: 'rate', type: 'quantitative' },
+          { field: 'state', type: 'nominal', title: 'State' },
+        ],
+      },
+    };
+
+    const layer = onlyLayer(inlined, {
+      data_0: [
+        { state: 'Nevada', rate: 4.2 },
+        { state: 'Utah', rate: 2.8 },
+      ],
+    });
+
+    // The first tooltip entry names the shaded value. Taking it would
+    // announce "4.2" as the region's name and leave the map without any.
+    expect(regionsOf(layer).map(region => region.x)).toEqual(['Nevada', 'Utah']);
+    expect(layer.axes?.x?.label).toBe('State');
+  });
+
+  it('leaves a map whose regions are named nowhere unread', () => {
+    const anonymous: VegaLiteSpec = {
+      mark: 'geoshape',
+      encoding: { color: { field: 'rate', type: 'quantitative' } },
+    };
+
+    // Numbering the regions 0, 1, 2 would announce a position in the file as
+    // if it were a place.
+    expect(allLayers(anonymous, { data_0: [{ rate: 4.2 }] })).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('names its regions'));
+  });
+});
+
+describe('vega-Lite geoshape maps with a usermeta declaration', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('reads the declared columns over the ones the spec would give', () => {
+    const declared: VegaLiteSpec = {
+      ...CHOROPLETH_SPEC,
+      usermeta: {
+        maidr: { type: TraceType.CHOROPLETH, region: 'label', value: 'pct' },
+      },
+    };
+
+    const layer = onlyLayer(declared, {
+      data_0: [
+        { properties: { name: 'NV' }, label: 'Nevada', rate: 99, pct: 4.2 },
+        { properties: { name: 'UT' }, label: 'Utah', rate: 99, pct: 2.8 },
+      ],
+    });
+
+    // Both facts come from the block, not from the join key or the colour
+    // channel — a declaration outranks every heuristic.
+    expect(regionsOf(layer)).toEqual([
+      { x: 'Nevada', y: 4.2 },
+      { x: 'Utah', y: 2.8 },
+    ]);
+  });
+
+  it('places the regions on the map when the rows carry centroids', () => {
+    const declared: VegaLiteSpec = {
+      ...CHOROPLETH_SPEC,
+      usermeta: { maidr: { type: TraceType.CHOROPLETH } },
+    };
+
+    const layer = onlyLayer(declared, {
+      data_0: [
+        { properties: { name: 'Nevada' }, rate: 4.2, lon: -116.6, lat: 39.3 },
+        { properties: { name: 'Utah' }, rate: 2.8, longitude: -111.7, latitude: 39.3 },
+      ],
+    });
+
+    // `lon`/`lat` default to their own names and then to the shared fallback
+    // chain, so a row that already carries `longitude` needs nothing said.
+    // The pair is what turns the region list into a walk across the map.
+    expect(regionsOf(layer)).toEqual([
+      { x: 'Nevada', y: 4.2, lon: -116.6, lat: 39.3 },
+      { x: 'Utah', y: 2.8, lon: -111.7, lat: 39.3 },
+    ]);
+  });
+
+  it('omits a centroid whose coordinates are not degrees', () => {
+    const declared: VegaLiteSpec = {
+      ...CHOROPLETH_SPEC,
+      usermeta: { maidr: { type: TraceType.CHOROPLETH, lon: 'px', lat: 'py' } },
+    };
+
+    const layer = onlyLayer(declared, {
+      data_0: [{ properties: { name: 'Nevada' }, rate: 4.2, px: null, py: 'left' }],
+    });
+
+    // A projected or unparseable coordinate is left out rather than coerced:
+    // `Number(null)` is 0, which would place the region off the west coast of
+    // Africa and send every compass direction on the map through it.
+    expect(regionsOf(layer)).toEqual([{ x: 'Nevada', y: 4.2 }]);
+  });
+
+  it('reports a declared field no row carries', () => {
+    const declared: VegaLiteSpec = {
+      ...CHOROPLETH_SPEC,
+      usermeta: { maidr: { type: TraceType.CHOROPLETH, lon: 'centoidLon', lat: 'lat' } },
+    };
+
+    const layer = onlyLayer(declared, {
+      data_0: [{ properties: { name: 'Nevada' }, rate: 4.2, centroidLon: -116.6, lat: 39.3 }],
+    });
+
+    // An explicit name is used verbatim with no fallback, so the typo
+    // resolves on no row and the map quietly loses its spatial walk. Saying
+    // which name missed is the only way the author finds out.
+    expect(regionsOf(layer)).toEqual([{ x: 'Nevada', y: 4.2 }]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"centoidLon"'));
+  });
+
+  it('reads a declared choropleth that no colour encoding shades', () => {
+    // The one thing a `geoshape` spec cannot say for itself: the regions are
+    // drawn plain and the value lives in a column. Without the declaration
+    // this is the outline map above, and reads as nothing.
+    const declared: VegaLiteSpec = {
+      mark: 'geoshape',
+      transform: CHOROPLETH_SPEC.transform,
+      usermeta: { maidr: { type: TraceType.CHOROPLETH, value: 'rate' } },
+    };
+
+    const layer = onlyLayer(declared);
+    expect(layer.type).toBe(TraceType.CHOROPLETH);
+    expect(regionsOf(layer)).toHaveLength(3);
+  });
+
+  it('names the layer without honouring a type the marks cannot back', () => {
+    const declared: VegaLiteSpec = {
+      data: { values: [{ a: 'A', b: 28 }] },
+      mark: 'bar',
+      encoding: {
+        x: { field: 'a', type: 'nominal' },
+        y: { field: 'b', type: 'quantitative' },
+      },
+      usermeta: { maidr: { type: TraceType.CHOROPLETH, name: 'Sales' } },
+    };
+
+    const layer = onlyLayer(declared, { data_0: [{ a: 'A', b: 28 }] });
+
+    // Reading a bar as a map would announce category names as places and
+    // walk them by compass direction. The disagreement is reported and the
+    // chart is read as what was actually drawn.
+    expect(layer.type).toBe(TraceType.BAR);
+    expect(layer.name).toBe('Sales');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"bar" mark'));
+  });
+
+  it('ignores a declaration written on a composite parent', () => {
+    const composite: VegaLiteSpec = {
+      transform: CHOROPLETH_SPEC.transform,
+      usermeta: { maidr: { type: TraceType.CHOROPLETH } },
+      layer: [{ mark: 'geoshape', encoding: CHOROPLETH_SPEC.encoding }],
+    };
+
+    // A block on a parent names none of the several layers below it, so
+    // there is no layer it could be applied to without guessing.
+    expect(allLayers(composite, { data_1: STATE_ROWS })[0].type)
+      .toBe(TraceType.CHOROPLETH);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('composite spec'));
+  });
+
+  it('falls back to the drawn chart when the declaration is malformed', () => {
+    const declared: VegaLiteSpec = {
+      ...CHOROPLETH_SPEC,
+      usermeta: { maidr: { type: 'chloropleth' } as never },
+    };
+
+    // The typo is the case the closed key set and the type check exist for:
+    // in plain JS nothing else would catch it. The map still reads, because
+    // the mark says what it is.
+    expect(onlyLayer(declared).type).toBe(TraceType.CHOROPLETH);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unknown type "chloropleth"'));
+  });
+});

--- a/test/adapters/vegalite/choropleth.test.ts
+++ b/test/adapters/vegalite/choropleth.test.ts
@@ -294,6 +294,29 @@ describe('vega-Lite geoshape maps with a usermeta declaration', () => {
     // which name missed is the only way the author finds out.
     expect(regionsOf(layer)).toEqual([{ x: 'Nevada', y: 4.2 }]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('"centoidLon"'));
+
+    // Only the name that missed. `lat` is on the row and reads as degrees;
+    // it is left out of the point because its partner is missing, which is a
+    // fact about the *pair*, not about the name `lat`. Reporting it here
+    // would send the author to rename the one field that was correct.
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('"lat"'));
+  });
+
+  it('reports only the missing half when the other centroid field resolves', () => {
+    // The mirror of the case above, so a regression that re-couples the two
+    // is caught whichever half the author typos.
+    const declared: VegaLiteSpec = {
+      ...CHOROPLETH_SPEC,
+      usermeta: { maidr: { type: TraceType.CHOROPLETH, lon: 'lon', lat: 'centoidLat' } },
+    };
+
+    const layer = onlyLayer(declared, {
+      data_0: [{ properties: { name: 'Nevada' }, rate: 4.2, lon: -116.6, centroidLat: 39.3 }],
+    });
+
+    expect(regionsOf(layer)).toEqual([{ x: 'Nevada', y: 4.2 }]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"centoidLat"'));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('"lon"'));
   });
 
   it('reads a declared choropleth that no colour encoding shades', () => {
@@ -344,6 +367,61 @@ describe('vega-Lite geoshape maps with a usermeta declaration', () => {
     expect(allLayers(composite, { data_1: STATE_ROWS })[0].type)
       .toBe(TraceType.CHOROPLETH);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('composite spec'));
+  });
+
+  it('ignores a declaration on a composite nested inside a composite', () => {
+    const composite: VegaLiteSpec = {
+      data: { values: [{ a: 'A', b: 28 }] },
+      hconcat: [
+        {
+          usermeta: { maidr: { type: TraceType.CHOROPLETH, name: 'Rates' } },
+          layer: [
+            {
+              mark: 'bar',
+              encoding: {
+                x: { field: 'a', type: 'nominal' },
+                y: { field: 'b', type: 'quantitative' },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    // The entry spec carries no declaration, so the check that fires on it
+    // sees nothing. A concat child is descended into without passing back
+    // through `vegaLiteToMaidr`, so a block stranded on a layered child is
+    // caught at the descent or never — and it names no one layer either
+    // way. Left silent, the author gets a `name` that never appears on any
+    // layer and no reason why.
+    const layers = vegaLiteToMaidr(composite, makeView({ data_0: [{ a: 'A', b: 28 }] }))
+      .subplots[0][0]
+      .layers;
+    expect(layers[0].type).toBe(TraceType.BAR);
+    expect(layers[0].name).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('composite spec'));
+  });
+
+  it('reports a misplaced declaration once for a whole repeat grid', () => {
+    const composite: VegaLiteSpec = {
+      data: { values: [{ a: 1, b: 2, c: 3 }] },
+      repeat: { column: ['b', 'c'] },
+      spec: {
+        usermeta: { maidr: { type: TraceType.CHOROPLETH } },
+        layer: [
+          { mark: 'point', encoding: { x: { field: 'a', type: 'quantitative' } } },
+        ],
+      },
+    };
+
+    vegaLiteToMaidr(composite, makeView({ data_0: [{ a: 1, b: 2, c: 3 }] }));
+
+    // One mistake, one line. The repeated child is converted once per panel,
+    // so warning from inside that loop would print the same sentence for
+    // every column and bury whatever else the conversion had to say.
+    const composites = warn.mock.calls
+      .filter(([message]) => String(message).includes('composite spec'));
+    expect(composites).toHaveLength(1);
   });
 
   it('falls back to the drawn chart when the declaration is malformed', () => {


### PR DESCRIPTION
# Pull Request

## Description

The Vega-Lite adapter's coverage PR deferred the geographic chart type. This adds it: a `geoshape` mark shaded by a `color` or `fill` field is now read as a `TraceType.CHOROPLETH`, with no author annotation required, and highlighting is wired in the same change.

Highlighting was the load-bearing half. Vega-Lite compiles `geoshape` to a Vega `shape` mark, so the rendered DOM carries `mark-shape`, not `mark-geoshape`. Without the mapping in `markToCssClass` the layer would have sonified and announced correctly while highlighting nothing — a failure invisible from every other channel.

Item 5 of the mandate (co-located declarations) is implemented at parity with the shared foundation: `usermeta.maidr` is read through `readDeclarationSlot` at precedence level 1, with `resolveFieldRef` / `warnUnresolvedRef` for the field chains. No part of the shared module is reimplemented, and `src/type/declaration.ts` and `src/adapters/shared/traceDeclaration.ts` are untouched.

## Related Issues

Part of #885

## Changes Made

**Trace types added**

- **Choropleth** (`TraceType.CHOROPLETH`) — `resolveTraceType` now answers `geoshape`. Payload is `ChoroplethPoint[]`: `x` is the region name, `y` the shaded value, `neighbors` omitted.
  - Region name comes from the `lookup` transform's join key — the one field present on every drawn feature and distinct between them — with dotted paths resolved so `properties.name` on a TopoJSON world map works. Failing that, the first `tooltip` entry that is not the shaded value itself. A map that names its regions in neither place is refused with a warning rather than numbered `0, 1, 2`.
  - Value comes from the `color` / `fill` field through the existing `readEncodedValue`, so an aggregated column resolves under the name Vega-Lite gave it.
  - Axis labels are named after the two things a map carries — the region field and the shaded quantity — since a choropleth has no positional channel.
  - Highlighting: `markToCssClass` returns `mark-shape` for `geoshape`. Covered for the layered case (`layer_1_marks`) too, since outline-plus-choropleth is the normal authoring shape and the wrong group would highlight the unshaded outlines.

**Trace types not added, with reasons**

- **`lon` / `lat` centroids on the detected path** — omitted deliberately, per the mandate. Inverting a projection to synthesise centroids would place regions in compass directions the map does not, and a wrong spatial walk is worse than no spatial walk. They *are* read on the declared path, where the author has named the columns outright: degrees only, both-or-neither, anything non-numeric dropped rather than coerced.
- **Unshaded `geoshape`** — left unread on purpose, not skipped work. A `geoshape` with no colour encoding is the outline layer a real map is drawn on top of; it carries no data, and warning there would fire on every well-built map.
- No other deferred type was in scope for this adapter.

**Declaration support (`usermeta.maidr`)**

- `usermeta?: { maidr?: MaidrTraceDeclaration }` added to `VegaLiteSpec`; `tooltip` and `transform.lookup` added to the encoding / transform types.
- A declared type the marks cannot back is warned about and the chart is read as what was actually drawn. `title` / `name` are applied regardless of what happened to the type — an author whose type could not be honoured still named the layer.
- A declaration on a composite parent (`layer`, `concat`, `facet`, `repeat`) names no one layer and is ignored with a warning.
- `VegaLiteToMaidrOptions` is untouched: no `traces` array, no declaration field.
- `MaidrTraceDeclaration` / `ChoroplethDeclaration` re-exported from `src/adapters/vegalite/index.ts` and `src/vegalite-entry.ts` so a spec author can type the block without reaching into `src/type/`.

**Data honesty**

A `lookup` leaves some features unjoined and Vega still draws them. Those rows are dropped, never zero-filled — on a rate, `0` is the bottom of the scale and the loudest possible wrong answer. Dropping them breaks the one-to-one with the drawn shapes, so the adapter warns with the count. Selectors are still emitted, because `ChoroplethTrace.mapToSvgElements` already refuses a selector set whose element count differs from the region count; the layer therefore degrades to *no* highlight rather than the wrong one, and the rule lives in one place instead of two.

**Docs and example**

- `docs/vegalite.md`: choropleth row in the mark table, the recognition rule, a runnable spec, the axis-naming and dropped-feature behaviour, and a table of the four declaration fields.
- `examples/vegalite-choropleth.html`: live `vega-datasets` US map with an inline value table and a `filter` keeping the join one-to-one so highlighting works in the demo.

**Tests**

`test/adapters/vegalite/choropleth.test.ts`, 17 tests. Each pins a decision against a wrong alternative that can be named: the tooltip test fails if the value entry is not skipped (regions announced as "4.2"), the unmatched-feature test fails if rows are zero-filled, the selector test fails if `markToCssClass` regresses to `mark-geoshape`, the layered test fails if the selector is not scoped to `layer_1_marks`, the centroid test fails if `Number(null)` is allowed through.

## Screenshots (if applicable)

None. The example page could not be exercised in a browser in this environment, so it is unverified at runtime; the data-resolution path it relies on (`data_0` as the post-transform dataset for a single-view spec) is the one every other single-view example uses.

## Checklist

- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is left unticked because no browser was available here; the automated suite below did run in full and passes.

## Additional Notes

### Checks

`npm run lint:fix`, `npm run type-check`, `npm run build` (12 bundles) and `npm test` all pass. Full suite: 269 + 7 suites, 3787 + 73 tests, exit 0.

One correction worth passing to the sibling PRs: running `npx jest` directly appears to fail 7 suites in the `esm` project on module resolution against the shared symlinked `node_modules`. That is an artifact of bypassing `scripts/test.js`, which supplies `--experimental-vm-modules` and runs one Jest process per project for the reasons documented in its header. `npm test` is green; `npx jest` is not the gate.

### Foundation gaps

These are reported, not worked around — nothing in `src/type/declaration.ts` or `src/adapters/shared/traceDeclaration.ts` is modified.

1. **Per-binding warning dedup.** `validateDeclaration` / `readDeclarationSlot` are stateless, and their doc comments say the "each distinct warning at most once per chart per binding" contract (spec §5) is met by calling them once per series. That holds for adapters that walk a series list once, but not for Vega-Lite: `buildFacetMaidr` and `buildRepeatMaidr` call `convertLayerSpec` on the *same leaf spec object* once per panel, so a malformed `usermeta.maidr` on a faceted leaf warns once per cell — 12 identical console lines for a 12-panel facet. Meeting the contract needs either adapter-side dedup state or a `validateDeclaration` variant taking a per-binding seen-set. Adapter-side dedup was not added, since a second warning mechanism living outside the shared module is exactly what that module exists to prevent. Ships as a known limitation.

2. **No `warnUnbackedType`.** The module has `warnUnresolvedRef` for the §7.3 case but nothing for §7.1 — the "declared type this library construct cannot back" warning, which every adapter must emit and for which the spec gives a fixed sentence. It is hand-rolled here in `applyDeclaredType` (`src/adapters/vegalite/converters.ts`); seven siblings are about to hand-roll seven more spellings of the same sentence. A `warnUnbackedType(context, declaredType, construct)` export would close it.

3. **No dotted-path field resolution.** `resolveFieldRef` does a flat `record[ref]` only, but several slot sources routinely carry nested rows — a TopoJSON feature's `properties.name`, a d3 `__data__` bound to a GeoJSON feature. A local `readFieldPath` was written for the choropleth region field, so a declared `region: 'properties.name'` works in this adapter and would not in another one using `resolveFieldRef` alone. That is the cross-adapter inconsistency the shared module exists to prevent; left local pending a second caller.

4. **`FIELD_REF_FALLBACKS.value`** is `['x', 't', 'position']`, shared with the ridgeline. `ChoroplethDeclaration.value` documents the hazard — a map whose rows put the region name in an `x` column resolves the name as the value — and tells the author to name the field. In Vega-Lite it is mostly moot because `value` defaults to the `color` / `fill` field rather than to the canonical chain, but an adapter that *does* default it will silently announce region names as magnitudes. The only mitigation on offer is a doc sentence rather than a mechanism.

### Spec corrections

- `deferred-vegalite.md`'s line numbers are stale, as it warns they might be. `geoshape` reaching `default: return null` is at `converters.ts:1067`, not `:706-707`; `markToCssClass` starts at `selectors.ts:32`, not `:25`. `per-adapter.json`'s numbers (`resolveTraceType` at `:950`, `markToCssClass` at `:32-56`, `VegaLiteSpec` at `types.ts:91`, `VegaLiteToMaidrOptions` at `:289-312`) were all correct against current `main`, as was the `vegalite-entry.ts:1654-1660` bind-skip claim and the core claim that `geoshape` appears nowhere in the adapter.
- Both spec files say the region name falls back to "the `key` or `tooltip` field". Vega-Lite's `key` channel is real but is a data-join hint for data-driven transitions, not a naming channel, and is not where a choropleth writes region names. Implemented as `lookup` join key → `tooltip`, skipping `key` rather than modelling a channel on a guess. `from.key` — the other reading of "the `key` field" — is also unusable: it names a column of the *secondary* dataset, which a `lookup` with an explicit `fields` list never copies onto the rows the marks are drawn from.
- The mandate says the `lookup` join field gives the region name. In practice that field is very often a *path* (`properties.name` on a world map) rather than a flat column, so a literal `row[field]` read returns nothing on the commonest world-map recipe. Handled with the dotted-path reader above. Not mentioned anywhere in the specs, and any sibling adapter reading GeoJSON rows will hit it.
- The mandate says to omit `lon` / `lat` this round. They are omitted on the *detected* path and read on the *declared* path — reading a field the author named is not the projection-inversion work that was deferred, and the centroids are the whole difference between a spatial walk and a region list.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_