### PR TITLE
feat(chartjs): read the chart types deferred out of the coverage PR

### DIFF
--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -83,8 +83,10 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Normalized Area | stacked area whose categories all total 100 (or 1) | — | [Line chart](examples.html) |
 | Bump | `'line'` with `scales.y.reverse` and ranked values | — | [Bump chart](examples.html) |
 | Dot Plot | `'line'` with `showLine: false` on a category axis | — | [Dot plot](examples.html) |
-| Survival | `'line'` with `stepped` and `plugins.maidr.traceType` | — | [Survival curve](examples.html) |
+| Survival | `'line'` with `stepped` and a `maidr` declaration | — | [Survival curve](examples.html) |
 | Scatter | `'scatter'` | — | [Scatter plot](examples.html) |
+| Volcano | `'scatter'` with a `maidr` declaration | — | [Volcano plot](examples.html) |
+| Manhattan | `'scatter'` with a `maidr` declaration | — | [Manhattan plot](examples.html) |
 | Radar | `'radar'` | — | [Radar chart](examples.html) |
 | Polar Area | `'polarArea'` | — | [Radar chart](examples.html) |
 | Box Plot | `'boxplot'` | `@sgratzl/chartjs-chart-boxplot` | [Box plot](examples.html) |
@@ -116,6 +118,45 @@ Three readings are shape-identical to another recipe, so no test on the config o
 - **Dumbbell** (`traceType: 'dumbbell'`) — a horizontal floating bar chart, which is the same `[start, end]` datum a one-interval-per-lane gantt uses. `plugins.maidr.startLabel` and `endLabel` name the two ends ("1990", "2020"); without them the reader is told which dot they are on but not which year it is. Rows with no pair are skipped rather than kept as empty rows, unlike a gantt lane. A dumbbell is one pair per row, so only the first dataset is read — several intervals in the same row are a gantt.
 - **Survival** (`traceType: 'survival'`) — a `stepped: 'after'` line, which is how every staircase is drawn. Chart.js ignores properties it does not know, so ride the two things a survival figure carries and a step chart does not on the points themselves: `{x, y, censored: true}` for a censoring mark and `{yMin, yMax}` for the confidence band. Each dataset is one arm, gathered into a single layer.
 - **Gauge** (`traceType: 'gauge'`) — for a dial the geometry above misses, and for the target and bands Chart.js records only as styling: `plugins.maidr.target` is the bullet marker and `plugins.maidr.bands` is a `[{ to, label }]` list in ascending order.
+
+### The `maidr` Block on a Dataset
+
+`plugins.maidr.traceType` says what the *chart* is, which is all a figure drawn as one dataset needs. A figure drawn as several — a Manhattan plot with a dataset per chromosome, a volcano beside its unchanged genes — needs to say it per dataset, and needs to name the columns its points carry. That is the co-located `maidr` block:
+
+```js
+datasets: [{
+  label: 'chr1',
+  data: [{ x: 1_000_000, y: 8.2, snp: 'rs1234', chr: 1 }],
+  maidr: { type: 'manhattan', label: 'snp', group: 'chr', significance: 7.3 },
+}]
+```
+
+Chart.js has no reserved slot for third-party metadata, but it passes dataset properties it does not know through untouched — the same mechanism a survival curve's `censored` datum rides on — so the block sits directly on the dataset. It wins over `plugins.maidr.traceType`, which is retained as the chart-wide shorthand; where the two disagree the block wins and MAIDR names both.
+
+Every block is checked when it is read. A `type` that names no trace, a key the declared type does not accept (`significanse`), or a value that is not what its key takes (`significanceDirection: 'Below'`) is reported to the console and dropped, and the chart is read exactly as it would have been with no block at all. Nothing is ever guessed in its place.
+
+**Volcano** (`type: 'volcano'`) and **Manhattan** (`type: 'manhattan'`) are the two readings this unlocks on a Chart.js scatter. Both are drawn as a plain scatter — a volcano puts effect size against significance, a Manhattan puts genomic position against it — and both are read through a threshold rather than point by point: MAIDR opens with how many points clear the line, and the rotor offers those points as a navigation unit so the few dozen that matter are a few dozen keystrokes away rather than twelve thousand.
+
+| key | what it takes | what it does |
+|---|---|---|
+| `label` | a property name on your datum | What each point *is* — a gene, a SNP, a probe. Identity is the payload on these charts; the coordinates are the two numbers the axes already describe. Defaults to `label`, then `snp`, `id`, `name`, `gene`, `probe`. |
+| `group` | a property name on your datum | The region a point belongs to — its chromosome. Defaults to `group`, then `chromosome`, `chrom`, `chr`, `region`. |
+| `significance` | a number | The cutoff on the y axis, in the units the chart is drawn in — 1.3 for p &lt; 0.05 on a `-log10(p)` axis, 7.3 for genome-wide significance. |
+| `significanceDirection` | `'above'` or `'below'` | Which side is the significant one. `'above'` suits the transformed axes these charts usually carry; a raw p axis needs `'below'`. |
+| `effect` | a number | The effect-size cutoff on the x axis, applied to its magnitude. Meaningful on a volcano; a Manhattan's x is a position, so leave it out. |
+| `merge` | a boolean | Whether the following datasets drawn the same way join this layer. `true` by default for a Manhattan, `false` for a volcano. |
+| `title`, `name` | strings | The layer's announced title, and its name among sibling layers. |
+
+Two rules are worth knowing before you write one:
+
+- **A field name you write is used verbatim.** `label: 'symbol'` reads `symbol` and nothing else; if no row carries it, MAIDR says so and leaves the identity out rather than quietly resolving `gene` instead. Leave the key out to get the default chain.
+- **No cutoff is ever inferred.** Chart.js states no line anywhere in its config, and a guessed one would sort every point in the figure onto the wrong side of it, silently. A layer that declares no `significance` is still emitted — it just reports no findings, and warns naming the field.
+
+`merge` is what makes a 22-dataset Manhattan one navigable trace. The declaration goes on the first dataset; every *following* dataset drawn the same way that carries no block of its own is folded into that layer, up to the next dataset that declares something. Highlighting follows the merge — a column reaches the points sharing that x in whichever dataset drew them.
+
+A block whose type this adapter has no construct for (a `hexbin` on a scatter, a `volcano` on a bar chart) is reported and ignored. `type: 'survival'` on a `'line'` dataset reaches exactly the same reading `plugins.maidr.traceType: 'survival'` does.
+
+`plugins.maidr.traceType: 'volcano'` or `'manhattan'` still reads a chart whose datasets carry no block of their own: it names the trace type and the default chains still find an identity on each point. What it cannot carry is a cutoff, so a figure with one — which is most of them — wants the block.
 
 ## Code Examples
 
@@ -205,6 +246,88 @@ Three readings are shape-identical to another recipe, so no test on the config o
       scales: {
         x: { title: { display: true, text: 'Sepal Length (cm)' } },
         y: { title: { display: true, text: 'Sepal Width (cm)' } },
+      },
+    },
+  });
+</script>
+```
+
+### Volcano Plot
+
+```html
+<div style="width: 700px; height: 400px">
+  <canvas id="volcano-chart"></canvas>
+</div>
+<script>
+  Chart.register(maidrChartjs.maidrPlugin);
+
+  new Chart(document.getElementById('volcano-chart'), {
+    type: 'scatter',
+    data: {
+      datasets: [{
+        label: 'Differential expression',
+        data: [
+          { x: -3.1, y: 6.8, gene: 'TP53' }, { x: -2.4, y: 4.1, gene: 'BRCA1' },
+          { x: -0.9, y: 1.1, gene: 'ACTB' }, { x: 0.4, y: 0.8, gene: 'RPL13A' },
+          { x: 1.9, y: 3.4, gene: 'VEGFA' }, { x: 3.4, y: 7.2, gene: 'CDKN1A' },
+        ],
+        // A volcano is a plain scatter until the dataset says otherwise.
+        maidr: { type: 'volcano', label: 'gene', significance: 1.3, effect: 1 },
+      }],
+    },
+    options: {
+      plugins: { title: { display: true, text: 'Treated vs. control' } },
+      scales: {
+        x: { title: { display: true, text: 'log2 fold change' } },
+        y: { title: { display: true, text: '-log10(p)' } },
+      },
+    },
+  });
+</script>
+```
+
+### Manhattan Plot
+
+One dataset per chromosome is how the alternating colours are drawn. `merge` — on by default for a Manhattan — folds them into a single navigable cloud, so only the first dataset carries a block.
+
+```html
+<div style="width: 700px; height: 400px">
+  <canvas id="manhattan-chart"></canvas>
+</div>
+<script>
+  Chart.register(maidrChartjs.maidrPlugin);
+
+  new Chart(document.getElementById('manhattan-chart'), {
+    type: 'scatter',
+    data: {
+      datasets: [
+        {
+          label: 'chr1',
+          data: [
+            { x: 5, y: 1.2, snp: 'rs1001', chr: 1 },
+            { x: 44, y: 8.6, snp: 'rs1004', chr: 1 },
+          ],
+          pointBackgroundColor: '#1f77b4',
+          maidr: { type: 'manhattan', label: 'snp', group: 'chr', significance: 7.3 },
+        },
+        {
+          label: 'chr2',
+          data: [
+            { x: 106, y: 2.2, snp: 'rs2001', chr: 2 },
+            { x: 133, y: 4.9, snp: 'rs2003', chr: 2 },
+          ],
+          pointBackgroundColor: '#ff7f0e',
+        },
+      ],
+    },
+    options: {
+      plugins: {
+        title: { display: true, text: 'Genome-wide association study' },
+        legend: { display: false },
+      },
+      scales: {
+        x: { title: { display: true, text: 'Genomic position (kb)' } },
+        y: { title: { display: true, text: '-log10(p)' } },
       },
     },
   });

--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -156,6 +156,8 @@ Two rules are worth knowing before you write one:
 
 A block whose type this adapter has no construct for (a `hexbin` on a scatter, a `volcano` on a bar chart) is reported and ignored. `type: 'survival'` on a `'line'` dataset reaches exactly the same reading `plugins.maidr.traceType: 'survival'` does.
 
+The readings that take the whole chart at once — a survival curve, a dumbbell, a waterfall, a gantt, a gauge — are one figure, so they take one answer. Several datasets may carry a block (a survival curve's arms each say what they are), but where two name *different* types the first in chart order wins and MAIDR names every type it found, the same way it does when a block and `plugins.maidr.traceType` disagree. Volcano, Manhattan and scatter are read per dataset instead, so each block there is honoured on its own dataset.
+
 `plugins.maidr.traceType: 'volcano'` or `'manhattan'` still reads a chart whose datasets carry no block of their own: it names the trace type and the default chains still find an identity on each point. What it cannot carry is a cutoff, so a figure with one — which is most of them — wants the block.
 
 ## Code Examples
@@ -647,7 +649,7 @@ For the full list, see the [Keyboard Controls](docs/CONTROLS.html) reference.
 | Data source | Manual JSON schema | Manual JSON schema | Auto-extracted from Chart.js |
 | Element addressing | Manual CSS selectors | Manual CSS selectors | Auto-generated from canvas elements |
 | Configuration | Required | Required | Zero configuration |
-| Chart types | All MAIDR types | All MAIDR types | [23 Chart.js types](#supported-chart-types) (incl. plugins) |
+| Chart types | All MAIDR types | All MAIDR types | [25 Chart.js types](#supported-chart-types) (incl. plugins) |
 | Dynamic charts | Manual init | React lifecycle | Auto-handled per chart |
 
 ## npm Installation (Optional)

--- a/examples/chartjs/manhattan.html
+++ b/examples/chartjs/manhattan.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Manhattan Plot Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Manhattan Plot</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions. The four chromosome datasets are read as one cloud rather than four layers, and the rotor offers the SNPs above the genome-wide line as a navigation unit of their own.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="manhattan-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // A Manhattan plot is drawn as one Chart.js scatter dataset per
+      // chromosome, so that the colours alternate. Read literally that is
+      // four layers a reader has to switch between; the declaration on the
+      // first dataset absorbs the following ones into a single navigable
+      // cloud, which is what `merge` does (and what a Manhattan does by
+      // default — the key is written out here only to show it).
+      const snps = (chromosome, start, points) =>
+        points.map(([offset, y], i) => ({
+          x: start + offset,
+          y,
+          snp: `rs${chromosome}${String(i + 1).padStart(3, '0')}`,
+          chr: chromosome,
+        }));
+
+      new Chart(document.getElementById('manhattan-chart'), {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'chr1',
+              data: snps(1, 0, [
+                [5, 1.2], [18, 2.4], [31, 0.8], [44, 8.6], [57, 1.9], [70, 3.1],
+              ]),
+              pointBackgroundColor: '#1f77b4',
+              // Only the first dataset carries a block. The rest are folded
+              // into this layer, and their `chr` column keeps each point's
+              // chromosome in the announcement.
+              maidr: {
+                type: 'manhattan',
+                label: 'snp',
+                group: 'chr',
+                significance: 7.3,
+                merge: true,
+              },
+            },
+            {
+              label: 'chr2',
+              data: snps(2, 100, [
+                [6, 2.2], [20, 1.1], [33, 4.9], [46, 2.0], [61, 0.7],
+              ]),
+              pointBackgroundColor: '#ff7f0e',
+            },
+            {
+              label: 'chr3',
+              data: snps(3, 200, [
+                [4, 0.9], [17, 9.4], [29, 1.6], [42, 2.8], [55, 1.3],
+              ]),
+              pointBackgroundColor: '#1f77b4',
+            },
+            {
+              label: 'chr4',
+              data: snps(4, 300, [
+                [8, 1.5], [21, 3.3], [35, 0.6], [48, 7.9], [62, 2.1],
+              ]),
+              pointBackgroundColor: '#ff7f0e',
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Genome-wide association study' },
+            legend: { display: false },
+          },
+          scales: {
+            x: { title: { display: true, text: 'Genomic position (kb)' } },
+            y: { title: { display: true, text: '-log10(p)' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/examples/chartjs/volcano.html
+++ b/examples/chartjs/volcano.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Chart.js Volcano Plot Example</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="../../dist/chartjs.js"></script>
+  </head>
+  <body>
+    <h1>MAIDR + Chart.js Volcano Plot</h1>
+    <p>Click on the chart and use arrow keys to navigate. Press 'b' for braille, 't' for text descriptions. The description opens with how many genes clear both cutoffs, and the rotor offers those genes as a navigation unit of their own — the few that matter, without walking the cloud.</p>
+
+    <div style="width: 700px; height: 400px">
+      <canvas id="volcano-chart"></canvas>
+    </div>
+
+    <script>
+      Chart.register(maidrChartjs.maidrPlugin);
+
+      // A volcano is a plain Chart.js scatter, so nothing in the config says
+      // which of the axes is an effect size or where the lines sit. The
+      // co-located `maidr` block on the dataset does: Chart.js passes dataset
+      // properties it does not know through untouched, so the block rides
+      // there, and the gene name rides on each datum the same way.
+      new Chart(document.getElementById('volcano-chart'), {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'Differential expression',
+              data: [
+                { x: -3.1, y: 6.8, gene: 'TP53' },
+                { x: -2.4, y: 4.1, gene: 'BRCA1' },
+                { x: -1.8, y: 2.6, gene: 'MYC' },
+                { x: -0.9, y: 1.1, gene: 'ACTB' },
+                { x: -0.2, y: 0.3, gene: 'GAPDH' },
+                { x: 0.4, y: 0.8, gene: 'RPL13A' },
+                { x: 1.2, y: 1.2, gene: 'EGFR' },
+                { x: 1.9, y: 3.4, gene: 'VEGFA' },
+                { x: 2.7, y: 5.9, gene: 'IL6' },
+                { x: 3.4, y: 7.2, gene: 'CDKN1A' },
+              ],
+              pointBackgroundColor: '#1f77b4',
+              // `label` names the property each datum carries the gene on;
+              // `gene` is one of the spellings the default chain already
+              // accepts, so this line could be left out entirely.
+              maidr: {
+                type: 'volcano',
+                label: 'gene',
+                significance: 1.3,
+                effect: 1,
+              },
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: 'Treated vs. control' },
+          },
+          scales: {
+            x: { title: { display: true, text: 'log2 fold change' } },
+            y: { title: { display: true, text: '-log10(p)' } },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -14,9 +14,12 @@
  * semantically equivalent trace for them.
  */
 
-import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, WaterfallKind, WaterfallPoint } from '../../type/grammar';
+import type { FieldRef, MaidrTraceDeclaration, ManhattanDeclaration, ScatterDeclaration, VolcanoDeclaration } from '../../type/declaration';
+import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, ThresholdOptions, VolcanoPoint, WaterfallKind, WaterfallPoint } from '../../type/grammar';
+import type { DeclarationContext } from '../shared/traceDeclaration';
 import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsPointValue, ChartJsRangeBound, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
+import { resolveFieldRef, validateDeclaration, warnUnresolvedRef } from '../shared/traceDeclaration';
 
 // ---------------------------------------------------------------------------
 // Monotonic ID counter for guaranteed unique IDs
@@ -580,6 +583,130 @@ export function isMatrixValue(v: ChartJsDataValue): v is { x: string | number; y
   return v != null && typeof v === 'object' && 'v' in v;
 }
 
+// ---------------------------------------------------------------------------
+// The co-located `maidr` declaration
+// ---------------------------------------------------------------------------
+
+/** How this adapter names itself in a declaration warning. */
+const ADAPTER = 'Chart.js';
+
+/**
+ * Every dataset's validated `maidr` block, in chart order, `null` where the
+ * dataset carries none this adapter can read.
+ *
+ * Read once per extraction, before any layer is built, so a block with a typo
+ * in it is reported once rather than once per reader that consults it.
+ */
+type DatasetDeclarations = readonly (MaidrTraceDeclaration | null)[];
+
+/**
+ * Which Chart.js constructs can back each declared trace type.
+ *
+ * A declaration says what a drawing means; it cannot make a pie chart into a
+ * survival curve. A type absent from this table is one the Chart.js adapter
+ * has no reading for at all — the union covers every library, and a hexbin or
+ * a choropleth has no Chart.js construct behind it here.
+ */
+const DECLARED_TYPE_CONSTRUCTS: Partial<Record<TraceType, readonly string[]>> = {
+  [TraceType.SURVIVAL]: ['line'],
+  [TraceType.SCATTER]: ['scatter', 'bubble'],
+  [TraceType.VOLCANO]: ['scatter', 'bubble'],
+  [TraceType.MANHATTAN]: ['scatter', 'bubble'],
+};
+
+/**
+ * Emits one adapter-prefixed warning.
+ *
+ * @param message - The sentence following the prefix
+ */
+function warn(message: string): void {
+  console.warn(`[MAIDR ${ADAPTER}] ${message}`);
+}
+
+/**
+ * How a warning names a dataset, so its author can find it.
+ *
+ * @param dataset - The dataset being read
+ * @param index - Its position in `chart.data.datasets`
+ * @returns A locating phrase — a label where the dataset has one
+ */
+function datasetRef(dataset: ChartJsDataset, index: number): string {
+  return dataset.label ? `dataset "${dataset.label}"` : `dataset ${index}`;
+}
+
+/** Who is reading a dataset's declaration, and what they are reading it off. */
+function declarationContext(dataset: ChartJsDataset, index: number): DeclarationContext {
+  return { adapter: ADAPTER, seriesRef: datasetRef(dataset, index) };
+}
+
+/**
+ * Whether the dataset carries a `maidr` block at all, readable or not.
+ *
+ * Distinct from having a usable declaration: a block this adapter rejected is
+ * still the author saying something about this dataset, which is what keeps it
+ * out of a neighbour's merged layer.
+ *
+ * @param dataset - The dataset being read
+ * @returns True when a block was written on it
+ */
+function carriesDeclaration(dataset: ChartJsDataset): boolean {
+  return dataset.maidr !== undefined && dataset.maidr !== null;
+}
+
+/**
+ * Reads every dataset's co-located `maidr` block.
+ *
+ * Two failures are settled here so no layer builder has to: a block the shared
+ * validator rejects, and a block declaring a type this adapter cannot back
+ * with the construct it was written on. Both degrade to `null` — the chart is
+ * read exactly as it would have been with no block at all — and both say so.
+ *
+ * @param chart - The chart being read
+ * @param chartType - What Chart.js is drawing the chart as
+ * @returns One entry per dataset, in chart order
+ */
+function readDeclarations(chart: ChartJsChart, chartType: string): DatasetDeclarations {
+  return chart.data.datasets.map((dataset, index) => {
+    const declaration = validateDeclaration(
+      dataset.maidr,
+      declarationContext(dataset, index),
+    );
+    if (declaration === null)
+      return null;
+
+    const constructs = DECLARED_TYPE_CONSTRUCTS[declaration.type];
+    const drawn = drawnKind(dataset, chartType);
+    if (constructs === undefined) {
+      warn(
+        `maidr declaration for "${declaration.type}" on ${datasetRef(dataset, index)} `
+        + `names a trace the Chart.js adapter has no reading for; `
+        + `reading it as the undeclared chart.`,
+      );
+      return null;
+    }
+    if (!constructs.includes(drawn)) {
+      warn(
+        `maidr declaration for "${declaration.type}" on ${datasetRef(dataset, index)} `
+        + `needs a ${constructs.join(' or ')} dataset and this one is drawn as "${drawn}"; `
+        + `reading it as the undeclared chart.`,
+      );
+      return null;
+    }
+    return declaration;
+  });
+}
+
+/**
+ * What Chart.js draws a dataset with: its own `type`, or the chart's.
+ *
+ * @param dataset - The dataset being read
+ * @param chartType - What Chart.js is drawing the chart as
+ * @returns The resolved Chart.js type string
+ */
+function drawnKind(dataset: ChartJsDataset, chartType: string): string {
+  return dataset.type ?? chartType;
+}
+
 /**
  * What the page's author declared the chart to be, if anything.
  *
@@ -587,11 +714,30 @@ export function isMatrixValue(v: ChartJsDataValue): v is { x: string | number; y
  * every heuristic below, and for the three readings no heuristic can reach —
  * a survival curve, a dumbbell, a gauge — it is the only way in.
  *
+ * A co-located block on a dataset outranks the chart-wide
+ * {@link MaidrPluginOptions.traceType}, which stays the shorthand for a figure
+ * drawn as a single dataset. Where the two disagree the block wins and both
+ * are named, because a chart carrying two answers is an edit half-finished.
+ *
+ * @param declarations - Every dataset's validated block, in chart order
  * @param pluginOptions - Optional per-chart plugin options
  * @returns The declared trace type, or `undefined` when the page does not say
  */
-function declaredType(pluginOptions?: MaidrPluginOptions): TraceType | undefined {
-  return pluginOptions?.traceType;
+function declaredType(
+  declarations: DatasetDeclarations,
+  pluginOptions?: MaidrPluginOptions,
+): TraceType | undefined {
+  const declared = declarations.find(one => one !== null)?.type;
+  const chartWide = pluginOptions?.traceType;
+  if (declared === undefined)
+    return chartWide;
+  if (chartWide !== undefined && chartWide !== declared) {
+    warn(
+      `a maidr declaration reads this chart as "${declared}" and `
+      + `plugins.maidr.traceType reads it as "${chartWide}"; the declaration wins.`,
+    );
+  }
+  return declared;
 }
 
 function isStacked(chart: ChartJsChart): boolean {
@@ -619,17 +765,19 @@ function extractLayers(
   pluginOptions?: MaidrPluginOptions,
   datasetIndices?: LocalDatasetIndices,
 ): MaidrLayer[] {
+  const declarations = readDeclarations(chart, chartType);
+
   switch (chartType) {
     case 'bar':
-      return extractBarLayers(chart, pluginOptions);
+      return extractBarLayers(chart, declarations, pluginOptions);
     case 'line':
-      return extractLineLayers(chart, pluginOptions, datasetIndices);
+      return extractLineLayers(chart, declarations, pluginOptions, datasetIndices);
     case 'scatter':
     case 'bubble':
-      return extractScatterLayers(chart, pluginOptions);
+      return extractScatterLayers(chart, declarations, pluginOptions, datasetIndices);
     case 'pie':
     case 'doughnut':
-      return extractPieLayers(chart, pluginOptions, datasetIndices);
+      return extractPieLayers(chart, declarations, pluginOptions, datasetIndices);
     // A radar joins its values into a closed outline and a polar area draws
     // them as wedges; a reader navigates the same spokes either way, which is
     // why `RadarTrace` serves both and the payload is identical.
@@ -659,6 +807,7 @@ function extractLayers(
 
 function extractBarLayers(
   chart: ChartJsChart,
+  declarations: DatasetDeclarations,
   pluginOptions?: MaidrPluginOptions,
 ): MaidrLayer[] {
   const data = chart.data;
@@ -669,7 +818,7 @@ function extractBarLayers(
   // Floating bars carry two positions rather than a magnitude, so they are
   // neither a bar nor a segmented bar — checked before either.
   if (data.datasets.some(dataset => dataset.data.some(isRangeValue)))
-    return [extractFloatingBarLayer(chart, pluginOptions)];
+    return [extractFloatingBarLayer(chart, declarations, pluginOptions)];
 
   if (data.datasets.length > 1) {
     const traceType = isStacked(chart)
@@ -860,13 +1009,14 @@ function isWaterfallSequence(chart: ChartJsChart): boolean {
 
 function extractFloatingBarLayer(
   chart: ChartJsChart,
+  declarations: DatasetDeclarations,
   pluginOptions?: MaidrPluginOptions,
 ): MaidrLayer {
   // A dumbbell has no heuristic of its own on purpose. One interval per
   // category on a horizontal axis is the same figure a one-lane-per-task gantt
   // draws, down to the datum, so any test that read one as a dumbbell would
   // read every schedule as one too. The author says which, or it stays a gantt.
-  switch (declaredType(pluginOptions)) {
+  switch (declaredType(declarations, pluginOptions)) {
     case TraceType.DUMBBELL:
       return extractDumbbellLayer(chart, pluginOptions);
     case TraceType.WATERFALL:
@@ -1309,11 +1459,11 @@ function isCategoryScale(chart: ChartJsChart, axisId: string): boolean {
  * has two measured coordinates rather than a value per named category.
  *
  * @param chart - The chart to classify
- * @param pluginOptions - Optional per-chart plugin options
+ * @param declared - What the page declared the chart to be, if anything
  * @returns True when the chart draws one value per category as a point
  */
-function isDotPlot(chart: ChartJsChart, pluginOptions?: MaidrPluginOptions): boolean {
-  if (declaredType(pluginOptions) === TraceType.DOT)
+function isDotPlot(chart: ChartJsChart, declared: TraceType | undefined): boolean {
+  if (declared === TraceType.DOT)
     return true;
   if (!isCategoryScale(chart, categoryAxis(chart)))
     return false;
@@ -1449,6 +1599,7 @@ function extractSurvivalLayer(
 
 function extractLineLayers(
   chart: ChartJsChart,
+  declarations: DatasetDeclarations,
   pluginOptions?: MaidrPluginOptions,
   datasetIndices?: LocalDatasetIndices,
 ): MaidrLayer[] {
@@ -1473,10 +1624,11 @@ function extractLineLayers(
   // settled before the datasets are bucketed by mark: a dot plot has no line
   // to be stepped or filled, and a survival curve is one figure whose arms
   // belong together whatever each dataset declares.
-  if (declaredType(pluginOptions) === TraceType.SURVIVAL)
+  const declared = declaredType(declarations, pluginOptions);
+  if (declared === TraceType.SURVIVAL)
     return [extractSurvivalLayer(chart, pluginOptions)];
 
-  if (isDotPlot(chart, pluginOptions))
+  if (isDotPlot(chart, declared))
     return extractDotLayers(chart, pluginOptions, datasetIndices);
 
   // Skip gap markers (`null` / `NaN`) so they are never sonified as a 0 tone;
@@ -1640,36 +1792,296 @@ function extractRadarLayers(
  */
 const DEFAULT_BUBBLE_SIZE_LABEL = 'Size';
 
+/**
+ * A declaration this adapter reads a cloud of points from.
+ *
+ * All three are drawn as a Chart.js scatter and navigated identically; what a
+ * volcano and a Manhattan add is an identity per point and the threshold the
+ * figure is read through.
+ */
+type PointDeclaration = ScatterDeclaration | VolcanoDeclaration | ManhattanDeclaration;
+
+/** A declaration whose points carry an identity the grammar has room for. */
+type NamedPointDeclaration = VolcanoDeclaration | ManhattanDeclaration;
+
+/**
+ * Whether a validated block declares one of the point-cloud readings.
+ *
+ * @param declaration - A dataset's validated block, or `null`
+ * @returns True when the block is a point-cloud declaration
+ */
+function isPointDeclaration(
+  declaration: MaidrTraceDeclaration | null,
+): declaration is PointDeclaration {
+  return declaration !== null
+    && (declaration.type === TraceType.SCATTER
+      || declaration.type === TraceType.VOLCANO
+      || declaration.type === TraceType.MANHATTAN);
+}
+
+/**
+ * The declaration whose points carry a label and a group, when this one does.
+ *
+ * `ScatterPoint` has no identity field, so a declared `point` layer reads
+ * exactly as an undeclared one and nothing is read off its data rows.
+ *
+ * @param declaration - The layer's declaration, when it has one
+ * @returns The declaration, or `undefined` when it names no identity
+ */
+function namedPoints(
+  declaration: PointDeclaration | null,
+): NamedPointDeclaration | undefined {
+  return declaration !== null && declaration.type !== TraceType.SCATTER
+    ? declaration
+    : undefined;
+}
+
+/**
+ * Whether a declaration absorbs the sibling datasets drawn after it.
+ *
+ * A Manhattan is one cloud split across a dataset per chromosome — 22 layers
+ * a reader must switch between is not a reading of that figure — so it
+ * absorbs by default. A volcano's siblings are usually up-regulated,
+ * down-regulated and unchanged, which are three things a reader wants told
+ * apart, so it does not.
+ *
+ * @param declaration - The declaration starting the layer
+ * @returns True when following undeclared siblings join this layer
+ */
+function mergesSiblings(declaration: PointDeclaration): boolean {
+  return declaration.merge ?? declaration.type === TraceType.MANHATTAN;
+}
+
+/**
+ * The chart-wide reading, in the form a layer is built from.
+ *
+ * `plugins.maidr.traceType` predates the co-located block and stays the
+ * shorthand for a figure drawn as a single dataset; it is the third step of
+ * the precedence order, below a block on the dataset itself. It carries no
+ * field names and no cutoffs, so what it buys is the trace type and whatever
+ * identity the default name chain finds on the data — a real reading, and a
+ * smaller one than a block gives.
+ *
+ * @param pluginOptions - Optional per-chart plugin options
+ * @returns The chart-wide declaration, or `null` when the page names no point cloud
+ */
+function chartWidePointDeclaration(
+  pluginOptions?: MaidrPluginOptions,
+): PointDeclaration | null {
+  switch (pluginOptions?.traceType) {
+    case TraceType.VOLCANO:
+      return { type: TraceType.VOLCANO };
+    case TraceType.MANHATTAN:
+      return { type: TraceType.MANHATTAN };
+    default:
+      return null;
+  }
+}
+
+/** One emitted point layer: which datasets back it, and what they declare. */
+interface PointGroup {
+  /** The dataset the layer is identified and titled by. */
+  index: number;
+  /** Every dataset backing the layer, in chart order. */
+  indices: number[];
+  declaration: PointDeclaration | null;
+}
+
+/**
+ * Which datasets become one layer.
+ *
+ * The shipped convention is one layer per dataset, which is what keeps a
+ * two-series scatter's series apart and its highlights routed. A declaration
+ * that merges overrides it for its own run: every *following* dataset drawn
+ * the same way that carries no declaration of its own joins the declaring
+ * layer, up to the next dataset that declares something.
+ *
+ * @param chart - The chart being read
+ * @param declarations - Every dataset's validated block, in chart order
+ * @param chartWide - The chart-wide reading, for datasets carrying no block
+ * @returns One group per emitted layer, in chart order
+ */
+function groupPointDatasets(
+  chart: ChartJsChart,
+  declarations: DatasetDeclarations,
+  chartWide: PointDeclaration | null,
+): PointGroup[] {
+  const chartType = chart.config.type;
+  const groups: PointGroup[] = [];
+  let absorbing: PointGroup | null = null;
+
+  for (let index = 0; index < chart.data.datasets.length; index++) {
+    const dataset = chart.data.datasets[index];
+    const declaration = declarations[index] ?? null;
+
+    // A dataset carrying a block of its own is never absorbed, even where the
+    // block turned out to be one this adapter cannot read: the author was
+    // saying this dataset is not simply more of the cloud before it, and they
+    // have already been told why the block did not take.
+    if (
+      !carriesDeclaration(dataset)
+      && absorbing !== null
+      && drawnKind(dataset, chartType)
+      === drawnKind(chart.data.datasets[absorbing.index], chartType)
+    ) {
+      absorbing.indices.push(index);
+      continue;
+    }
+
+    const group: PointGroup = {
+      index,
+      indices: [index],
+      declaration: isPointDeclaration(declaration) ? declaration : chartWide,
+    };
+    groups.push(group);
+    absorbing = group.declaration !== null && mergesSiblings(group.declaration)
+      ? group
+      : null;
+  }
+
+  return groups;
+}
+
+/**
+ * The cutoffs a volcano or Manhattan layer is read through.
+ *
+ * Nothing here is inferred. A Chart.js scatter states no line, and a guessed
+ * one would sort every point in the figure onto the wrong side of it,
+ * silently; a Manhattan's x-axis dividers are chromosome boundaries rather
+ * than an effect-size cutoff. A layer that declares neither is emitted with no
+ * option block at all and reports no findings, which is the reading its data
+ * supports.
+ *
+ * @param declaration - The layer's declaration
+ * @returns The declared cutoffs, or `undefined` when none were declared
+ */
+function thresholdOptionsOf(declaration: NamedPointDeclaration): ThresholdOptions | undefined {
+  const options: ThresholdOptions = {
+    ...(declaration.significance !== undefined
+      ? { significance: declaration.significance }
+      : {}),
+    ...(declaration.significanceDirection !== undefined
+      ? { significanceDirection: declaration.significanceDirection }
+      : {}),
+    ...(declaration.effect !== undefined ? { effect: declaration.effect } : {}),
+  };
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
+/**
+ * One point's identity or region, in the form the grammar carries it.
+ *
+ * `VolcanoPoint.label` and `.group` are strings, and a chromosome is very
+ * often authored as the number 7. Anything else — an object, a boolean, an
+ * empty string — is left out rather than stringified into an announcement.
+ *
+ * @param row - The datum the chart bound to the mark
+ * @param ref - The field the author named, or `undefined` to default
+ * @param canonical - The grammar field being filled
+ * @returns The text, or `undefined` when nothing usable resolved
+ */
+function pointText(
+  row: unknown,
+  ref: FieldRef | undefined,
+  canonical: string,
+): string | undefined {
+  const value = resolveFieldRef<unknown>(row, ref, canonical);
+  if (typeof value === 'string' && value !== '')
+    return value;
+  if (typeof value === 'number' && Number.isFinite(value))
+    return String(value);
+  return undefined;
+}
+
 function extractScatterLayers(
   chart: ChartJsChart,
+  declarations: DatasetDeclarations,
   pluginOptions?: MaidrPluginOptions,
+  datasetIndices?: LocalDatasetIndices,
 ): MaidrLayer[] {
-  // Preserve per-dataset layers so multi-series scatter plots keep
-  // their dataset distinction (needed for correct highlighting).
-  return chart.data.datasets.map((dataset, idx) => {
-    const scatterData: ScatterPoint[] = datasetToScatterPoints(dataset);
+  const chartWide = chartWidePointDeclaration(pluginOptions);
+  return groupPointDatasets(chart, declarations, chartWide).map((group) => {
+    const declaration = group.declaration;
+    const named = namedPoints(declaration);
+    const points = group.indices.flatMap(index =>
+      datasetToScatterPoints(chart.data.datasets[index], named));
+    reportPointGaps(chart, group, points);
+
+    const id = String(group.index);
+    // Each layer says which datasets back it. The caller's per-type default
+    // reads a scatter layer's id as its lone dataset index, which a merged
+    // Manhattan — one layer over 22 datasets — is not.
+    datasetIndices?.set(id, group.indices);
+
+    const thresholds = named !== undefined ? thresholdOptionsOf(named) : undefined;
+    // A merged layer's declaring dataset names one chromosome of a cloud, not
+    // the cloud, so only a layer that really is one series takes its label.
+    const title = declaration?.title
+      ?? (group.indices.length === 1 ? chart.data.datasets[group.index].label : undefined);
 
     return {
-      id: String(idx),
-      type: TraceType.SCATTER,
-      title: dataset.label,
+      id,
+      type: declaration?.type ?? TraceType.SCATTER,
+      title,
+      ...(declaration?.name !== undefined ? { name: declaration.name } : {}),
       axes: {
         x: { label: getAxisLabel(chart, 'x', pluginOptions) },
         y: { label: getAxisLabel(chart, 'y', pluginOptions) },
-        // Only when a radius was actually carried. This function serves plain
-        // scatter too, and a `z` axis on a chart with no third variable would
-        // announce a label for something that is not there.
-        ...(scatterData.some(point => point.z !== undefined) && {
+        // Only when a radius was actually carried. This serves plain scatter
+        // too, and a `z` axis on a chart with no third variable would announce
+        // a label for something that is not there.
+        ...(points.some(point => point.z !== undefined) && {
           z: { label: pluginOptions?.axes?.z ?? DEFAULT_BUBBLE_SIZE_LABEL },
         }),
       },
-      data: scatterData,
+      ...(thresholds !== undefined ? { thresholdOptions: thresholds } : {}),
+      data: points,
     };
   });
 }
 
 /**
- * Turn a dataset's points into scatter points, keeping a bubble's radius.
+ * Reports what a declared point layer asked for and did not get.
+ *
+ * Two silences are worth breaking. A field name the author wrote that no row
+ * carries is a typo, and the layer would otherwise arrive quietly missing the
+ * identity the chart is read for. A volcano or Manhattan with no significance
+ * cutoff is a real chart and is emitted, but it reports no findings — which is
+ * the one thing an author declaring the type was after.
+ *
+ * @param chart - The chart being read
+ * @param group - The datasets backing the layer, and what they declare
+ * @param points - The points the layer emitted
+ */
+function reportPointGaps(
+  chart: ChartJsChart,
+  group: PointGroup,
+  points: ScatterPoint[],
+): void {
+  const declaration = namedPoints(group.declaration);
+  if (declaration === undefined)
+    return;
+
+  const context = declarationContext(chart.data.datasets[group.index], group.index);
+  const carried = points as VolcanoPoint[];
+  if (points.length > 0) {
+    if (declaration.label !== undefined && !carried.some(point => point.label !== undefined))
+      warnUnresolvedRef(context, declaration.label, 'label');
+    if (declaration.group !== undefined && !carried.some(point => point.group !== undefined))
+      warnUnresolvedRef(context, declaration.group, 'group');
+  }
+  if (declaration.significance === undefined) {
+    warn(
+      `maidr declaration for "${declaration.type}" on ${context.seriesRef} `
+      + `declares no significance; the layer is emitted without a threshold and `
+      + `reports no findings.`,
+    );
+  }
+}
+
+/**
+ * Turn a dataset's points into scatter points, keeping a bubble's radius and
+ * whatever identity a declaration names.
  *
  * A Chart.js bubble datum is `{x, y, r}`, and `r` is a whole encoded variable
  * -- population, market cap, sample size -- which is usually the reason the
@@ -1679,17 +2091,42 @@ function extractScatterLayers(
  *
  * A plain scatter has no `r` and gets no `z`, which is what keeps `hasZ`
  * false and leaves its announcements unchanged.
+ *
+ * On a volcano or a Manhattan the coordinates are the *least* of the payload:
+ * a reader told "x is 2.3, y is 14.1" has been given the two numbers the axes
+ * already describe and withheld which gene that is. Chart.js passes properties
+ * it does not know through untouched, so the gene name rides on the datum the
+ * same way a survival curve's censoring mark does, and the declaration says
+ * which property it is. Neither field is fabricated when nothing resolves.
+ *
+ * @param dataset - The dataset to read
+ * @param declaration - The layer's declaration, when its points carry an identity
+ * @returns The dataset's points, gaps and non-point entries dropped
  */
-function datasetToScatterPoints(dataset: ChartJsDataset): ScatterPoint[] {
+function datasetToScatterPoints(
+  dataset: ChartJsDataset,
+  declaration?: NamedPointDeclaration,
+): ScatterPoint[] {
   const points: ScatterPoint[] = [];
   for (const point of dataset.data) {
-    if (isPointValue(point)) {
-      points.push(
-        typeof point.r === 'number'
-          ? { x: point.x, y: point.y, z: point.r }
-          : { x: point.x, y: point.y },
-      );
+    if (!isPointValue(point))
+      continue;
+
+    const position: ScatterPoint = typeof point.r === 'number'
+      ? { x: point.x, y: point.y, z: point.r }
+      : { x: point.x, y: point.y };
+    if (declaration === undefined) {
+      points.push(position);
+      continue;
     }
+
+    const label = pointText(point, declaration.label, 'label');
+    const group = pointText(point, declaration.group, 'group');
+    points.push({
+      ...position,
+      ...(label !== undefined ? { label } : {}),
+      ...(group !== undefined ? { group } : {}),
+    } satisfies VolcanoPoint);
   }
   return points;
 }
@@ -1729,11 +2166,10 @@ function getPieAxes(pluginOptions?: MaidrPluginOptions): MaidrLayer['axes'] {
  * misses, declaring `pie` keeps two slices two slices.
  *
  * @param chart - The chart to classify
- * @param pluginOptions - Optional per-chart plugin options
+ * @param declared - What the page declared the chart to be, if anything
  * @returns True when the chart draws one measure against a dial
  */
-function isGaugeDial(chart: ChartJsChart, pluginOptions?: MaidrPluginOptions): boolean {
-  const declared = declaredType(pluginOptions);
+function isGaugeDial(chart: ChartJsChart, declared: TraceType | undefined): boolean {
   if (declared === TraceType.GAUGE)
     return true;
   if (declared !== undefined)
@@ -1821,12 +2257,14 @@ function extractGaugeLayer(
  */
 function extractPieLayers(
   chart: ChartJsChart,
+  declarations: DatasetDeclarations,
   pluginOptions?: MaidrPluginOptions,
   datasetIndices?: LocalDatasetIndices,
 ): MaidrLayer[] {
   // A dial is the same ring drawn part way round, so it is settled here rather
   // than in the dispatcher — the chart type is `doughnut` either way.
-  if (chart.data.datasets.length > 0 && isGaugeDial(chart, pluginOptions))
+  const declared = declaredType(declarations, pluginOptions);
+  if (chart.data.datasets.length > 0 && isGaugeDial(chart, declared))
     return [extractGaugeLayer(chart, pluginOptions)];
 
   const labels = chart.data.labels ?? [];

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -719,6 +719,11 @@ function drawnKind(dataset: ChartJsDataset, chartType: string): string {
  * drawn as a single dataset. Where the two disagree the block wins and both
  * are named, because a chart carrying two answers is an edit half-finished.
  *
+ * Only one whole-chart reading can win, so where several datasets declare
+ * differing types the first in chart order wins and every type found is
+ * named. Several datasets declaring the same type is the ordinary case —
+ * a survival curve's arms each say what they are — and passes silently.
+ *
  * @param declarations - Every dataset's validated block, in chart order
  * @param pluginOptions - Optional per-chart plugin options
  * @returns The declared trace type, or `undefined` when the page does not say
@@ -727,10 +732,26 @@ function declaredType(
   declarations: DatasetDeclarations,
   pluginOptions?: MaidrPluginOptions,
 ): TraceType | undefined {
-  const declared = declarations.find(one => one !== null)?.type;
+  const declaredTypes = [...new Set(
+    declarations
+      .filter((one): one is MaidrTraceDeclaration => one !== null)
+      .map(one => one.type),
+  )];
+  const declared = declaredTypes[0];
   const chartWide = pluginOptions?.traceType;
   if (declared === undefined)
     return chartWide;
+  // Several datasets may carry a block — a survival curve's arms each declare
+  // themselves — but only one whole-chart reading can win, so blocks that
+  // disagree are an edit half-finished in the same way a block disagreeing
+  // with the chart-wide option is, and are named the same way.
+  if (declaredTypes.length > 1) {
+    warn(
+      `maidr declarations on this chart read it as `
+      + `${declaredTypes.map(one => `"${one}"`).join(' and ')}; a chart has one `
+      + `whole-chart reading, so the first ("${declared}") wins.`,
+    );
+  }
   if (chartWide !== undefined && chartWide !== declared) {
     warn(
       `a maidr declaration reads this chart as "${declared}" and `

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -25,14 +25,33 @@ export type LayerDatasetIndices = ReadonlyMap<string, number[]>;
  * maps re-derive the raw indices from the chart to keep highlights aligned.
  */
 export interface TargetMaps {
-  /** Scatter: `scatterBuckets[layerId][col]` lists the Chart.js dataset indices sharing that X. */
-  scatterBuckets: Map<string, number[][]>;
+  /**
+   * Point clouds: `pointBuckets[layerId][col]` is every element sharing that X.
+   *
+   * Each entry names its own dataset rather than the layer naming one for all
+   * of them, because a merged volcano or Manhattan is a single layer drawn
+   * from several datasets — one per chromosome, typically.
+   */
+  pointBuckets: Map<string, ChartJsActiveElement[][]>;
   /** Bar/line: `barLineIndices[layerId][row][col]` is the original Chart.js element index (gaps skipped). */
   barLineIndices: Map<string, number[][]>;
   /** Heatmap: `heatmapIndices[layerId]` maps `"x\0y"` to the flat Chart.js element index. */
   heatmapIndices: Map<string, Map<string, number>>;
   /** Gantt: `ganttTargets[layerId][lane][interval]` is the element drawing it. */
   ganttTargets: Map<string, ChartJsActiveElement[][]>;
+}
+
+/**
+ * Whether a layer is navigated as a cloud of points.
+ *
+ * `VolcanoTrace` extends `ScatterTrace`, so a volcano and a Manhattan are
+ * positioned exactly as a scatter is — the threshold changes what is
+ * announced, not where a point lives.
+ */
+function isPointCloudType(type: string): boolean {
+  return type === TraceType.SCATTER
+    || type === TraceType.VOLCANO
+    || type === TraceType.MANHATTAN;
 }
 
 function isSegmentedType(type: string): boolean {
@@ -104,29 +123,44 @@ function buildGanttTargets(
 }
 
 /**
- * Mirror `ScatterTrace`'s X-bucket construction (`src/model/scatter.ts:86-100`)
- * to map MAIDR's `col` (an X-bucket index) back to one or more original
- * Chart.js dataset indices. Points are sorted by X, then Y; consecutive points
- * sharing an X form a bucket. Reads the raw dataset (not the filtered layer
- * data) so bucket entries are original, highlight-aligned indices.
+ * Mirror `ScatterTrace`'s X-bucket construction (`src/model/scatter.ts:172-186`)
+ * to map MAIDR's `col` (an X-bucket index) back to the original Chart.js
+ * elements. Points are sorted by X, then Y; consecutive points sharing an X
+ * form a bucket. Reads the raw datasets (not the filtered layer data) so bucket
+ * entries are original, highlight-aligned indices.
+ *
+ * The datasets are walked in the order the layer was built from them, which is
+ * the order their points were concatenated into it — so a merged layer's
+ * buckets hold the same elements the trace groups, whichever dataset drew
+ * them.
+ *
+ * @param datasets - The chart's datasets
+ * @param dsIndices - The dataset indices backing the layer, in MAIDR row order
+ * @returns One bucket per distinct X, in ascending X order
  */
-function buildScatterBuckets(data: ChartJsDataValue[]): number[][] {
-  // Track original dataset indices through the (x, y) sort so bucket entries are
-  // Chart.js element indices, not positions in the gap-filtered point list.
-  const indexed: { x: number; y: number; i: number }[] = [];
-  data.forEach((value, i) => {
-    if (isPointValue(value))
-      indexed.push({ x: value.x, y: value.y, i });
-  });
+function buildPointBuckets(
+  datasets: ChartJsDataset[],
+  dsIndices: number[],
+): ChartJsActiveElement[][] {
+  // Track the original dataset and element indices through the (x, y) sort so
+  // bucket entries are Chart.js elements, not positions in the point list.
+  const indexed: { x: number; y: number; target: ChartJsActiveElement }[] = [];
+  for (const datasetIndex of dsIndices) {
+    (datasets[datasetIndex]?.data ?? []).forEach((value, index) => {
+      if (isPointValue(value))
+        indexed.push({ x: value.x, y: value.y, target: { datasetIndex, index } });
+    });
+  }
   indexed.sort((a, b) => a.x - b.x || a.y - b.y);
-  const buckets: number[][] = [];
+
+  const buckets: ChartJsActiveElement[][] = [];
   let currentX: number | null = null;
-  for (const { x, i } of indexed) {
+  for (const { x, target } of indexed) {
     if (currentX === null || currentX !== x) {
       currentX = x;
       buckets.push([]);
     }
-    buckets[buckets.length - 1].push(i);
+    buckets[buckets.length - 1].push(target);
   }
   return buckets;
 }
@@ -173,7 +207,7 @@ export function computeTargetMaps(
   layers: MaidrLayer[],
   layerDatasetIndices: LayerDatasetIndices,
 ): TargetMaps {
-  const scatterBuckets = new Map<string, number[][]>();
+  const pointBuckets = new Map<string, ChartJsActiveElement[][]>();
   const barLineIndices = new Map<string, number[][]>();
   const heatmapIndices = new Map<string, Map<string, number>>();
   const ganttTargets = new Map<string, ChartJsActiveElement[][]>();
@@ -181,9 +215,15 @@ export function computeTargetMaps(
 
   for (const layer of layers) {
     switch (layer.type) {
-      case TraceType.SCATTER: {
-        const dsIdx = firstDatasetIndex(layerDatasetIndices, layer.id);
-        scatterBuckets.set(layer.id, buildScatterBuckets(datasets[dsIdx]?.data ?? []));
+      // A volcano and a Manhattan are scatters read through a threshold, so
+      // they are navigated by the same X buckets — over however many datasets
+      // the declared layer merged.
+      case TraceType.SCATTER:
+      case TraceType.VOLCANO:
+      case TraceType.MANHATTAN: {
+        const dsIndices = layerDatasetIndices.get(layer.id)
+          ?? [firstDatasetIndex(layerDatasetIndices, layer.id)];
+        pointBuckets.set(layer.id, buildPointBuckets(datasets, dsIndices));
         break;
       }
       case TraceType.BAR:
@@ -249,7 +289,7 @@ export function computeTargetMaps(
     }
   }
 
-  return { scatterBuckets, barLineIndices, heatmapIndices, ganttTargets };
+  return { pointBuckets, barLineIndices, heatmapIndices, ganttTargets };
 }
 
 /**
@@ -275,13 +315,14 @@ export function resolveActiveTargets(
   if (isSegmentedType(layer.type))
     return [{ datasetIndex: rowDatasetIndex(layerDatasetIndices, layerId, row), index: col }];
 
-  // Scatter: col is an X-bucket; expand to all points sharing that X.
-  if (layer.type === TraceType.SCATTER) {
-    const buckets = maps.scatterBuckets.get(layer.id);
+  // A point cloud: col is an X-bucket; expand to every point sharing that X.
+  // Each entry carries its own dataset, so a merged volcano or Manhattan
+  // highlights across the datasets it was folded from.
+  if (isPointCloudType(layer.type)) {
+    const buckets = maps.pointBuckets.get(layer.id);
     if (!buckets || col < 0 || col >= buckets.length)
       return [];
-    const datasetIndex = firstDatasetIndex(layerDatasetIndices, layer.id);
-    return buckets[col].map(index => ({ datasetIndex, index }));
+    return [...buckets[col]];
   }
 
   // Gantt: MAIDR row = lane (the Chart.js element index), col = which dataset

--- a/src/adapters/chartjs/index.ts
+++ b/src/adapters/chartjs/index.ts
@@ -37,6 +37,14 @@
  * @packageDocumentation
  */
 
+export type {
+  FieldRef,
+  MaidrTraceDeclaration,
+  ManhattanDeclaration,
+  ScatterDeclaration,
+  SurvivalDeclaration,
+  VolcanoDeclaration,
+} from '../../type/declaration';
 export { extractChartData, extractMaidrData } from './extractor';
 export type { ChartJsExtraction } from './extractor';
 export { maidrPlugin } from './plugin';

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -6,6 +6,7 @@
  * objects will satisfy these interfaces.
  */
 
+import type { MaidrTraceDeclaration } from '../../type/declaration';
 import type { GaugeBand, TraceType } from '../../type/grammar';
 
 /**
@@ -41,6 +42,17 @@ export interface ChartJsPointValue {
   yMin?: number;
   /** Upper bound of the confidence band at this point. */
   yMax?: number;
+  /**
+   * Whatever else the author's own row carries.
+   *
+   * The three members above are the facts this adapter looks for under a fixed
+   * name. A volcano's gene and a Manhattan's chromosome are the same kind of
+   * rider, but their column is the author's to name — the co-located `maidr`
+   * block says which it is — so they cannot be listed, and a datum written in
+   * TypeScript would otherwise be rejected for carrying the very column the
+   * declaration points at.
+   */
+  [column: string]: unknown;
 }
 
 /**
@@ -137,6 +149,28 @@ export interface ChartJsDataset {
     | number
     | string
     | { target?: boolean | number | string; value?: number };
+  /**
+   * What this dataset *means*, when the drawing cannot say.
+   *
+   * Chart.js has no reserved slot for third-party metadata, but it passes
+   * dataset properties it does not know through untouched — the same mechanism
+   * a survival curve's `censored` datum rides on ({@link ChartJsPointValue}) —
+   * so the co-located `maidr` block is written straight onto the dataset:
+   *
+   * ```js
+   * datasets: [{
+   *   label: 'chr1',
+   *   data: [{ x: 1e6, y: 8.2, snp: 'rs1234' }],
+   *   maidr: { type: 'manhattan', label: 'snp', significance: 7.3 },
+   * }]
+   * ```
+   *
+   * It wins over `plugins.maidr.traceType`, which stays the chart-wide
+   * shorthand for a figure drawn as one dataset. A block whose `type` names
+   * nothing, or whose keys the declared type does not accept, is reported and
+   * the chart is read as if it carried none.
+   */
+  maidr?: MaidrTraceDeclaration;
 }
 
 /**

--- a/test/adapters/chartjs/volcano.test.ts
+++ b/test/adapters/chartjs/volcano.test.ts
@@ -1,0 +1,462 @@
+import type { ChartJsChart, ChartJsData, ChartJsDataset, ChartJsOptions, MaidrPluginOptions } from '@adapters/chartjs/types';
+import type { MaidrLayer, ScatterPoint, VolcanoPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Build a minimal chart for the extractor to read.
+ *
+ * @param datasets The datasets the chart carries
+ * @param type What Chart.js is drawing the chart as
+ * @param options Chart options, for the scales
+ * @returns A chart object shaped the way the extractor expects
+ */
+function chartOf(
+  datasets: ChartJsDataset[],
+  type = 'scatter',
+  options: ChartJsOptions = {},
+): ChartJsChart {
+  const data: ChartJsData = { datasets };
+  return {
+    canvas: { id: 'test-chart' } as unknown as HTMLCanvasElement,
+    data,
+    options,
+    config: { type },
+    getDatasetMeta: () => ({ data: [], type }),
+    setActiveElements: () => {},
+    update: () => {},
+  };
+}
+
+/** The layers a chart produces, in emission order. */
+function layersOf(chart: ChartJsChart, pluginOptions?: MaidrPluginOptions): MaidrLayer[] {
+  return extractChartData(chart, pluginOptions).maidr.subplots[0][0].layers;
+}
+
+/** The points of a chart's only layer, as a volcano carries them. */
+function pointsOf(chart: ChartJsChart): VolcanoPoint[] {
+  return layersOf(chart)[0].data as VolcanoPoint[];
+}
+
+/** Everything the plugin's navigation bridge resolves highlights through. */
+function highlightsOf(chart: ChartJsChart): (
+  layerId: string,
+  row: number,
+  col: number,
+) => { datasetIndex: number; index: number }[] {
+  const { maidr, layerDatasetIndices } = extractChartData(chart);
+  const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
+  const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
+  return (layerId, row, col) =>
+    resolveActiveTargets(layers, maps, layerDatasetIndices, layerId, row, col);
+}
+
+/** Two genes of a differential expression analysis, as a page would write them. */
+const genes: ChartJsDataset = {
+  label: 'Genes',
+  data: [
+    { x: -2.4, y: 8.1, gene: 'TP53' },
+    { x: 1.1, y: 0.6, gene: 'ACTB' },
+  ],
+};
+
+describe('chart.js volcano and manhattan extraction', () => {
+  let warnings: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    jest.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+      warnings.push(String(message));
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('reading the declaration', () => {
+    it('reads a declared scatter as a volcano, with the thresholds it declares', () => {
+      const chart = chartOf([{
+        ...genes,
+        maidr: {
+          type: TraceType.VOLCANO,
+          significance: 1.3,
+          effect: 1,
+          significanceDirection: 'above',
+        },
+      }]);
+
+      const layer = layersOf(chart)[0];
+
+      expect(layer.type).toBe(TraceType.VOLCANO);
+      expect(layer.thresholdOptions).toEqual({
+        significance: 1.3,
+        effect: 1,
+        significanceDirection: 'above',
+      });
+    });
+
+    it('carries the identity the declaration names off the datum', () => {
+      // Chart.js passes properties it does not know through untouched, which
+      // is where the gene name rides; the coordinates alone are the two
+      // numbers the axes already describe.
+      const chart = chartOf([{
+        ...genes,
+        maidr: { type: TraceType.VOLCANO, label: 'gene', significance: 1.3 },
+      }]);
+
+      expect(pointsOf(chart)).toEqual([
+        { x: -2.4, y: 8.1, label: 'TP53' },
+        { x: 1.1, y: 0.6, label: 'ACTB' },
+      ]);
+    });
+
+    it('defaults the identity field to the grammar name and its spellings', () => {
+      // `label` falls back to snp, id, name, gene, probe — so a row that
+      // already carries one of them needs no field named at all.
+      const chart = chartOf([{ ...genes, maidr: { type: TraceType.VOLCANO } }]);
+
+      expect(pointsOf(chart).map(point => point.label)).toEqual(['TP53', 'ACTB']);
+    });
+
+    it('uses an explicit field name verbatim, with no fallback', () => {
+      // An explicit name that misses is the author's mistake, and resolving
+      // `gene` behind their back would hide it.
+      const chart = chartOf([{
+        data: [{ x: 1, y: 2, gene: 'TP53', symbol: 'p53' }],
+        maidr: { type: TraceType.VOLCANO, label: 'symbol', significance: 1.3 },
+      }]);
+
+      expect(pointsOf(chart)[0].label).toBe('p53');
+    });
+
+    it('omits an identity no row carries, and says so', () => {
+      const chart = chartOf([{
+        label: 'Genes',
+        data: [{ x: 1, y: 2, gene: 'TP53' }],
+        maidr: { type: TraceType.VOLCANO, label: 'symbol', significance: 1.3 },
+      }]);
+
+      expect(pointsOf(chart)[0]).toEqual({ x: 1, y: 2 });
+      expect(warnings).toContainEqual(
+        expect.stringContaining('names "symbol" for label, which no row carries'),
+      );
+    });
+
+    it('reads a chromosome written as a number', () => {
+      // `group` falls back to chromosome, chrom, chr, region, and a
+      // chromosome is very often authored as the number 7.
+      const chart = chartOf([{
+        data: [{ x: 1e6, y: 8.2, snp: 'rs123', chr: 7 }],
+        maidr: { type: TraceType.MANHATTAN, significance: 7.3 },
+      }]);
+
+      expect(pointsOf(chart)[0]).toEqual({
+        x: 1e6,
+        y: 8.2,
+        label: 'rs123',
+        group: '7',
+      });
+    });
+
+    it('leaves an undeclared scatter exactly as it was', () => {
+      // The identity fields are read only where a declaration asks for them:
+      // a `gene` column on an ordinary scatter is the author's data, not a
+      // MAIDR annotation, and reading it would announce it unasked.
+      const layer = layersOf(chartOf([genes]))[0];
+
+      expect(layer.type).toBe(TraceType.SCATTER);
+      expect(layer.thresholdOptions).toBeUndefined();
+      expect(layer.data as ScatterPoint[]).toEqual([
+        { x: -2.4, y: 8.1 },
+        { x: 1.1, y: 0.6 },
+      ]);
+    });
+
+    it('keeps a bubble volcano radius on z', () => {
+      const chart = chartOf([{
+        data: [{ x: 1, y: 2, r: 9, gene: 'TP53' }],
+        maidr: { type: TraceType.VOLCANO, significance: 1.3 },
+      }], 'bubble');
+
+      expect(pointsOf(chart)[0]).toEqual({ x: 1, y: 2, z: 9, label: 'TP53' });
+      expect(layersOf(chart)[0].axes?.z?.label).toBe('Size');
+    });
+  });
+
+  describe('never defaulting an inversion', () => {
+    it('emits no threshold block at all when none is declared', () => {
+      // A guessed line sorts every point in the figure onto the wrong side of
+      // it, silently, so the layer degrades to a cloud that reports no
+      // findings — and says which field it wanted.
+      const chart = chartOf([{ ...genes, maidr: { type: TraceType.VOLCANO } }]);
+
+      const layer = layersOf(chart)[0];
+
+      expect(layer.type).toBe(TraceType.VOLCANO);
+      expect(layer.thresholdOptions).toBeUndefined();
+      expect(warnings).toContainEqual(expect.stringContaining('declares no significance'));
+    });
+
+    it('emits an effect cutoff on its own', () => {
+      const chart = chartOf([{ ...genes, maidr: { type: TraceType.VOLCANO, effect: 1.5 } }]);
+
+      expect(layersOf(chart)[0].thresholdOptions).toEqual({ effect: 1.5 });
+    });
+
+    it('passes a below-the-line reading through', () => {
+      // A raw p axis runs the other way: fixed to 'above', the reading would
+      // select precisely the points that failed to reach significance.
+      const chart = chartOf([{
+        ...genes,
+        maidr: {
+          type: TraceType.VOLCANO,
+          significance: 0.05,
+          significanceDirection: 'below',
+        },
+      }]);
+
+      expect(layersOf(chart)[0].thresholdOptions?.significanceDirection).toBe('below');
+    });
+
+    it('drops a mis-cased direction rather than reading it as the other one', () => {
+      const chart = chartOf([{
+        ...genes,
+        maidr: {
+          type: TraceType.VOLCANO,
+          significance: 0.05,
+          // Not an Orientation-style typo an author would catch: 'Below' is
+          // the plain-JS spelling of the value that inverts the finding.
+          significanceDirection: 'Below' as 'below',
+        },
+      }]);
+
+      // Dropped, so the grammar's own 'above' default applies rather than a
+      // wrong reading being carried into the layer.
+      expect(layersOf(chart)[0].thresholdOptions).toEqual({ significance: 0.05 });
+      expect(warnings).toContainEqual(
+        expect.stringContaining('has significanceDirection "Below"'),
+      );
+    });
+  });
+
+  describe('several datasets, one cloud', () => {
+    /** A chromosome's worth of points, as a per-chromosome dataset carries them. */
+    const chromosome = (label: string, x: number): ChartJsDataset => ({
+      label,
+      data: [{ x, y: 8, snp: `rs${x}` }],
+    });
+
+    it('merges a manhattan chart\'s following datasets into one layer', () => {
+      const chart = chartOf([
+        { ...chromosome('chr1', 1), maidr: { type: TraceType.MANHATTAN, significance: 7.3 } },
+        chromosome('chr2', 2),
+        chromosome('chr3', 3),
+      ]);
+
+      const layers = layersOf(chart);
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.MANHATTAN);
+      expect((layers[0].data as VolcanoPoint[]).map(point => point.x)).toEqual([1, 2, 3]);
+      // The declaring dataset names one chromosome, not the cloud, so the
+      // merged layer does not wear its label as the figure's title.
+      expect(layers[0].title).toBeUndefined();
+    });
+
+    it('keeps a manhattan chart\'s datasets apart when the page says not to merge', () => {
+      const chart = chartOf([
+        {
+          ...chromosome('chr1', 1),
+          maidr: { type: TraceType.MANHATTAN, significance: 7.3, merge: false },
+        },
+        chromosome('chr2', 2),
+      ]);
+
+      const layers = layersOf(chart);
+
+      expect(layers).toHaveLength(2);
+      expect(layers.map(layer => layer.type)).toEqual([
+        TraceType.MANHATTAN,
+        TraceType.SCATTER,
+      ]);
+      expect(layers[0].title).toBe('chr1');
+    });
+
+    it('leaves a volcano\'s siblings alone unless it asks for them', () => {
+      // Up-regulated, down-regulated and unchanged are three things a reader
+      // wants told apart, not one cloud.
+      const chart = chartOf([
+        { ...genes, maidr: { type: TraceType.VOLCANO, significance: 1.3 } },
+        { label: 'Unchanged', data: [{ x: 0.1, y: 0.2 }] },
+      ]);
+
+      expect(layersOf(chart).map(layer => layer.type)).toEqual([
+        TraceType.VOLCANO,
+        TraceType.SCATTER,
+      ]);
+    });
+
+    it('stops merging at the next dataset that declares something', () => {
+      const chart = chartOf([
+        { ...chromosome('chr1', 1), maidr: { type: TraceType.MANHATTAN, significance: 7.3 } },
+        chromosome('chr2', 2),
+        {
+          ...chromosome('replication', 3),
+          maidr: { type: TraceType.MANHATTAN, significance: 5, merge: false },
+        },
+        chromosome('trailing', 4),
+      ]);
+
+      const layers = layersOf(chart);
+
+      expect(layers.map(layer => layer.id)).toEqual(['0', '2', '3']);
+      expect((layers[0].data as VolcanoPoint[]).map(point => point.x)).toEqual([1, 2]);
+      expect((layers[1].data as VolcanoPoint[]).map(point => point.x)).toEqual([3]);
+      expect(layers[2].type).toBe(TraceType.SCATTER);
+    });
+
+    it('does not absorb a dataset whose own block failed to read', () => {
+      // The block did not take, and the author was told so — but they were
+      // saying this dataset is not simply more of the cloud before it, and
+      // folding it in anyway would answer a mistake with a merge.
+      const chart = chartOf([
+        { ...chromosome('chr1', 1), maidr: { type: TraceType.MANHATTAN, significance: 7.3 } },
+        { ...chromosome('other', 2), maidr: { type: TraceType.HEXBIN } },
+      ]);
+
+      const layers = layersOf(chart);
+
+      expect(layers.map(layer => layer.type)).toEqual([
+        TraceType.MANHATTAN,
+        TraceType.SCATTER,
+      ]);
+      expect((layers[0].data as VolcanoPoint[]).map(point => point.x)).toEqual([1]);
+    });
+
+    it('highlights across every dataset a merged layer was folded from', () => {
+      // The whole point of the merge: one navigable trace whose columns still
+      // reach the elements Chart.js drew, in whichever dataset they live.
+      const chart = chartOf([
+        {
+          label: 'chr1',
+          data: [{ x: 3, y: 8 }, { x: 1, y: 5 }],
+          maidr: { type: TraceType.MANHATTAN, significance: 7.3 },
+        },
+        { label: 'chr2', data: [{ x: 2, y: 6 }, { x: 3, y: 9 }] },
+      ]);
+
+      const resolve = highlightsOf(chart);
+
+      // Buckets run in ascending x, as `ScatterTrace` orders its columns:
+      // x = 1, x = 2, then the two points sharing x = 3.
+      expect(resolve('0', 0, 0)).toEqual([{ datasetIndex: 0, index: 1 }]);
+      expect(resolve('0', 0, 1)).toEqual([{ datasetIndex: 1, index: 0 }]);
+      expect(resolve('0', 0, 2)).toEqual([
+        { datasetIndex: 0, index: 0 },
+        { datasetIndex: 1, index: 1 },
+      ]);
+    });
+  });
+
+  describe('a declaration that cannot be honoured', () => {
+    it('reads a volcano declared on a bar chart as the bar chart it is', () => {
+      const chart = chartOf(
+        [{ label: 'Sales', data: [1, 2, 3], maidr: { type: TraceType.VOLCANO } }],
+        'bar',
+      );
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.BAR);
+      expect(warnings).toContainEqual(
+        expect.stringContaining('needs a scatter or bubble dataset'),
+      );
+    });
+
+    it('reads a type this adapter has no construct for as the undeclared chart', () => {
+      const chart = chartOf([{ ...genes, maidr: { type: TraceType.HEXBIN } }]);
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.SCATTER);
+      expect(warnings).toContainEqual(
+        expect.stringContaining('has no reading for'),
+      );
+    });
+
+    it('keeps the known keys of a block that carries an unknown one', () => {
+      const chart = chartOf([{
+        ...genes,
+        maidr: {
+          type: TraceType.VOLCANO,
+          significance: 1.3,
+          // The typo a plain-JS author has no compiler to catch.
+          significanse: 7.3,
+        } as never,
+      }]);
+
+      expect(layersOf(chart)[0].thresholdOptions).toEqual({ significance: 1.3 });
+      expect(warnings).toContainEqual(
+        expect.stringContaining('has unknown key "significanse"'),
+      );
+    });
+
+    it('reads a block that is not an object as no declaration at all', () => {
+      const chart = chartOf([{ ...genes, maidr: 'volcano' as never }]);
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.SCATTER);
+      expect(warnings).toContainEqual(expect.stringContaining('is not an object'));
+    });
+  });
+
+  describe('precedence against the chart-wide declaration', () => {
+    it('lets a dataset block reach the survival path plugins.maidr.traceType reaches', () => {
+      const chart = chartOf([{
+        label: 'Treatment',
+        data: [{ x: 0, y: 1 }, { x: 6, y: 0.82, censored: true }],
+        stepped: 'after',
+        maidr: { type: TraceType.SURVIVAL },
+      }], 'line', { scales: { x: { type: 'linear' } } });
+
+      const layer = layersOf(chart)[0];
+
+      expect(layer.type).toBe(TraceType.SURVIVAL);
+      expect(layer.stepDirection).toBe('vh');
+    });
+
+    it('reads the chart-wide traceType where no dataset carries a block', () => {
+      // The shorthand names no field and no cutoff, so what it buys is the
+      // trace type and whatever the default name chain finds — smaller than a
+      // block gives, and still a volcano.
+      const layer = layersOf(chartOf([genes]), { traceType: TraceType.VOLCANO })[0];
+
+      expect(layer.type).toBe(TraceType.VOLCANO);
+      expect(layer.thresholdOptions).toBeUndefined();
+      expect((layer.data as VolcanoPoint[])[0].label).toBe('TP53');
+    });
+
+    it('lets a dataset block outrank the chart-wide traceType', () => {
+      const chart = chartOf([{
+        ...genes,
+        maidr: { type: TraceType.MANHATTAN, significance: 7.3 },
+      }]);
+
+      expect(layersOf(chart, { traceType: TraceType.VOLCANO })[0].type)
+        .toBe(TraceType.MANHATTAN);
+    });
+
+    it('lets the dataset block win over plugins.maidr.traceType, naming both', () => {
+      const chart = chartOf([{
+        label: 'Treatment',
+        data: [{ x: 0, y: 1 }],
+        stepped: 'after',
+        maidr: { type: TraceType.SURVIVAL },
+      }], 'line', { scales: { x: { type: 'linear' } } });
+
+      const layer = layersOf(chart, { traceType: TraceType.DOT })[0];
+
+      expect(layer.type).toBe(TraceType.SURVIVAL);
+      expect(warnings).toContainEqual(
+        expect.stringContaining('the declaration wins'),
+      );
+    });
+  });
+});

--- a/test/adapters/chartjs/volcano.test.ts
+++ b/test/adapters/chartjs/volcano.test.ts
@@ -458,5 +458,49 @@ describe('chart.js volcano and manhattan extraction', () => {
         expect.stringContaining('the declaration wins'),
       );
     });
+
+    it('names every type where two datasets declare the chart differently', () => {
+      // A mixed chart: the survival arm is drawn as a line, the second dataset
+      // as a scatter, so both blocks survive their construct check and reach
+      // the one whole-chart reading a line chart gets.
+      const chart = chartOf([
+        {
+          label: 'Treatment',
+          data: [{ x: 0, y: 1 }],
+          stepped: 'after',
+          maidr: { type: TraceType.SURVIVAL },
+        },
+        {
+          label: 'Genes',
+          type: 'scatter',
+          data: [{ x: -2.4, y: 8.1, gene: 'TP53' }],
+          maidr: { type: TraceType.VOLCANO },
+        },
+      ], 'line', { scales: { x: { type: 'linear' } } });
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.SURVIVAL);
+      expect(warnings).toContainEqual(
+        expect.stringContaining('"survival" and "volcano"'),
+      );
+    });
+
+    it('stays silent where several datasets declare the same type', () => {
+      const arm = (label: string): ChartJsDataset => ({
+        label,
+        data: [{ x: 0, y: 1 }],
+        stepped: 'after',
+        maidr: { type: TraceType.SURVIVAL },
+      });
+      const chart = chartOf(
+        [arm('Treatment'), arm('Control')],
+        'line',
+        { scales: { x: { type: 'linear' } } },
+      );
+
+      expect(layersOf(chart)[0].type).toBe(TraceType.SURVIVAL);
+      expect(warnings).not.toContainEqual(
+        expect.stringContaining('whole-chart reading'),
+      );
+    });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

The Chart.js adapter learns to read a co-located `maidr` declaration written straight onto a dataset, and uses it to reach the trace types no heuristic can reach from the drawing alone. A Chart.js `scatter` is the same drawing whether it is a plain scatter, a volcano plot or a Manhattan plot — what separates them is meaning the author holds and the chart config does not state. This adds the slot for the author to say so, and the readings that slot unlocks.

Chart.js has no reserved place for third-party metadata, but it passes dataset properties it does not know through untouched — the same mechanism a survival curve's `censored` datum already rides on — so the block lives on the dataset:

```js
datasets: [{
  label: 'chr1',
  data: [{ x: 1e6, y: 8.2, snp: 'rs1234' }],
  maidr: { type: 'manhattan', label: 'snp', significance: 7.3 },
}]
```

The block is validated once per extraction through the shared `validateDeclaration` from #886; field names resolve through the shared `resolveFieldRef` chains. Sonification and highlighting are wired in the same change — a merged Manhattan's columns still reach the elements Chart.js actually drew, in whichever dataset they live.

## Related Issues

Part of #885

## Changes Made

**Trace types added**

- **VOLCANO** — a `scatter`/`bubble` dataset carrying `maidr: { type: 'volcano', … }` is read as `TraceType.VOLCANO`. `label`/`group` resolve off each datum through the shared field-ref chains; `significance`, `significanceDirection` and `effect` map straight into `MaidrLayer.thresholdOptions`. `merge` defaults to false, since a volcano's sibling datasets are usually up-regulated / down-regulated / unchanged — three things a reader wants told apart.
- **MANHATTAN** — the same reading with `merge` defaulting to true, so a chart drawn as one dataset per chromosome becomes a single navigable cloud rather than 22 layers to switch between. Every following sibling dataset drawn the same way that carries no block of its own is folded into the declaring layer; the merged layer records its full dataset list in `layerDatasetIndices`.
- **SURVIVAL via the dataset block** — a dataset-level `{ type: 'survival' }` on a `line` chart now reaches the existing `extractSurvivalLayer` path unchanged. No duplicate code path; the block is simply a second door onto the reading `plugins.maidr.traceType` already opened.
- **SCATTER (`point`)** — accepted as naming what the chart already is, honouring `title`, `name` and `merge`. `label` is deliberately not carried: `ScatterPoint` has nowhere to put it, as `ScatterDeclaration.label` documents.

**Trace types not added, and why**

- **Chart.js module augmentation** (`declare module 'chart.js' { … }`) — **not shipped.** `chart.js` is an optional peer dependency and is not installed, so the augmentation fails type-check with TS2664 (`module 'chart.js' cannot be found`), verified empirically. Shipping it needs `chart.js` added as a devDependency. Typed authors still get the field through MAIDR's own `ChartJsDataset.maidr`; plain-JS authors get the runtime validator, which is the defence that actually matters here. Worth a follow-up.
- **Any type with no Chart.js construct behind it** (hexbin, choropleth, and the rest of the union that belongs to other libraries) — a block declaring one warns and the chart is read as if it carried none, rather than half-building a trace the library cannot draw.

**Supporting changes**

- `ChartJsDataset.maidr?: MaidrTraceDeclaration` and a documented `[column: string]: unknown` index signature on `ChartJsPointValue`, so a TypeScript author can actually write the identity column the declaration points at (see Additional Notes).
- `declaredType` extended into the full three-level precedence: dataset block → `plugins.maidr.traceType` → heuristic, with a single warning naming both when levels 1 and 3 disagree. `MaidrPluginOptions` is structurally unchanged.
- Highlight path: `TargetMaps.scatterBuckets` (`Map<string, number[][]>`, one dataset per layer) became `pointBuckets` (`Map<string, ChartJsActiveElement[][]>`), built by one `buildPointBuckets` serving scatter, volcano and manhattan. Bucket entries carry `{ datasetIndex, index }` pairs, so a column reaches the points sharing that x in whichever dataset drew them. Plain-scatter behaviour is unchanged and its existing tests pass untouched.
- Degradation and no-inversion: a block whose type has no construct here, or whose construct does not match (a volcano on a bar chart), warns naming both what was found and what the type needs, and the chart is read exactly as if no block were present. Nothing throws. `significance` / `effect` / `significanceDirection` are never synthesised — a declared volcano with no `significance` is emitted with no `thresholdOptions` at all plus a warning naming the field.
- Tests: `test/adapters/chartjs/volcano.test.ts`, 25 cases across declaration reading, field-ref resolution and fallbacks, never-defaulting-an-inversion, merge/absorption grouping, merged-layer highlight routing, unreadable declarations, and precedence against `plugins.maidr.traceType`.
- Examples: `examples/chartjs/volcano.html` and `examples/chartjs/manhattan.html`.
- Docs: `docs/chartjs.md` gains two supported-type rows, a normative "The `maidr` Block on a Dataset" section (key table, the two rules about verbatim field names and never-inferred cutoffs, merge semantics, degradation), and Volcano/Manhattan code examples.

Nothing under `src/model/`, `src/service/`, `src/state/`, `src/ui/`, `src/command/`, `src/type/`, or `src/adapters/shared/` was modified.

## Screenshots (if applicable)

Not applicable — no visual UI change. The two new example pages under `examples/chartjs/` exercise the readings by hand.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The third box is left unticked deliberately: the automated gate is green (`lint:fix`, `type-check`, `build`, and `npm test` at 269 + 7 suites / 3796 + 73 tests, all passing, no pre-existing test modified), but the `ManualTestingProcess.md` screen-reader pass was not performed. The merged-highlight test was mutation-checked rather than trusted — restricting `buildPointBuckets` to the first dataset makes "highlights across every dataset a merged layer was folded from" fail, so it pins the routing rather than restating it.

## Additional Notes

These matter to the seven sibling adapter PRs.

**Foundation gaps** (reported, not changed — `src/adapters/shared/traceDeclaration.ts` and `src/type/declaration.ts` were left alone as the shared foundation)

1. `validateDeclaration` gives no way to distinguish "no block was written" from "a block was written and rejected". §6(b) merge turns on whether a series *carries no declaration of its own*, which is the second question, so this adapter re-reads `dataset.maidr` itself (`carriesDeclaration`) to keep a dataset with a broken block out of a neighbour's merged layer. Every adapter implementing merge will need the same workaround, or `validateDeclaration` could return a discriminated result.
2. No helper for reading a `FieldRef` into the grammar's **string** fields (`VolcanoPoint.label`, `.group`). `resolveFieldRef<T>` returns the raw value, so each adapter decides for itself whether a chromosome authored as the number `7` becomes `'7'`, and whether `''` / `false` / an object are accepted — exactly the by-adapter drift `FIELD_REF_FALLBACKS` exists to prevent. Implemented locally as `pointText` (string kept as-is, finite number stringified, everything else omitted); a second caller would justify lifting it.
3. `warnUnresolvedRef` is documented as "call this once, after reading a series, when an explicit ref resolved on no row of it", but nothing in the module can answer that question — the adapter has to scan the emitted payload afterwards. A per-series resolver that tracked whether anything resolved would remove a fiddly, easy-to-forget step from all eight adapters.
4. No shared spelling for the §7.1 "wrong construct" warning, unlike the §3 unresolved-ref message which is centralised. The Chart.js phrasing here was written by hand, so the eight adapters will very likely word this differently.

**Spec corrections**

- `deferred-chartjs.md`'s line numbers are stale after the coverage PR: `datasetToScatterPoints` is at `extractor.ts:1683-1695` (not 930-942), `extractScatterLayers` at 1643-1668 (not 890-916), `declaredType` at 593-595 (not 585-595). `per-adapter.json`'s numbers were correct.
- `per-adapter.json` notes that `ChartJsDataset` "currently ends at the `fill?` field" — true — but does not mention that `ChartJsPointValue` is a **closed** interface. Instruction 4 (carry `label`/`group` off the datum) is not writable by a TypeScript author without a change there: `{ x: 1, y: 2, gene: 'TP53' }` is rejected by excess-property checking, so the very column the declaration points at cannot be authored. A documented `[column: string]: unknown` index signature was added. The three named riders (`censored`, `yMin`, `yMax`) stay as they are, so the file still reads as a statement about what the adapter looks for under a fixed name.
- `per-adapter.json` instruction 5 says the merged layer's id "must stay resolvable by `firstDatasetIndex` in highlightTargets.ts". `firstDatasetIndex` returns one dataset index for a whole layer, which cannot express a merged layer at all — a Manhattan merged from 22 datasets needs a dataset index *per highlighted element*. The per-dataset id convention is kept (the merged layer is identified by its declaring dataset's index, so `firstDatasetIndex` still answers correctly for anything that asks), but the bucket entries carry `{ datasetIndex, index }` pairs, which is what actually makes the merged highlight work.
- `convention.md`'s slot table says the Chart.js type change is `ChartJsDataset` plus a `declare module 'chart.js'` augmentation "shipped from the maidr/chartjs entry". That augmentation is not shippable while `chart.js` is an uninstalled optional peer dependency. **Any sibling adapter told to ship a library-module augmentation should check the library is actually resolvable at type-check time first.**
- `deferred-chartjs.md` says a Manhattan is "typically plus a threshold line dataset". Nothing was done with such a dataset: a straight line drawn at the cutoff is a scatter/line dataset like any other, and reading a cutoff out of it would be inferring `significance` from the drawing, which §5 forbids. It is absorbed into the cloud as a sibling if it carries no block, so an author drawing one should give it its own block or put the significance in the declaration — noted in the docs' merge paragraph.

**Judgement calls worth a reviewer's eye**

1. `TargetMaps.scatterBuckets` was **replaced** rather than joined by a second map. Two implementations of the same `(x asc, y asc)` sort-and-group, both of which must stay in step with `ScatterTrace`'s column order, is exactly the drift `shared/selectorUtil.ts` records as its reason for existing. `scatterBuckets` was referenced only inside `highlightTargets.ts` and no test asserted on it.
2. Chart-wide `plugins.maidr.traceType: 'volcano' | 'manhattan'` is honoured as precedence level 3 for a chart whose datasets carry no block. It buys the trace type and whatever the default name chains find, and carries no cutoff — a smaller reading than a block gives, and the one the precedence table asks for.

**What was deliberately not done:** infer `significance` from anything. Chart.js has no `plotLines` equivalent, and an annotation-plugin line is not part of the chart config — a cutoff read out of a decoration would sort every point in the figure onto the wrong side of it, silently. A declared volcano with no `significance` is emitted as a truthful smaller reading: the cloud, the identities, no findings, and a warning naming the field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_