### PR TITLE
feat(plotly): read the chart types deferred out of the coverage PR

### DIFF
--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -201,7 +201,10 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   skipped instead of being announced as one. Plotly draws a level as whole
   curves with no element per vertex, so the visual highlight is synthesised
   along the drawn curve; each level's selector is scoped to that level's own
-  group, so a highlight always lands on the level being read.
+  group, so a highlight always lands on the level being read. A fill-only
+  contour — one that turned `contours.showlines` off — is drawn as one filled
+  path per level with no curve elements at all, so it is read and sonified but
+  not highlighted.
 
 - A mosaic (marimekko) is **declared**, not detected. Plotly draws one as
   stacked `bar` traces with a per-column `width`, but `width` is ordinary bar
@@ -256,6 +259,11 @@ bar traces — it declares the layer, not the series. Then:
   from proportions alone genuinely has no counts, and multiplying a rounded
   share back out would put a number in the announcement that the data does not
   contain.
+- **`customdata` rows must be objects**, `{ share: 0.3, count: 203 }` rather
+  than `['First', 0.3, 203]`. A declared field is a column *name*, and Plotly's
+  other canonical shape — one array per point — has no names to resolve
+  against, so a declared column is reported as unresolved rather than guessed
+  at by position.
 - **The column names** come from the trace's `text`, then its `hovertext`, and
   then the axis `ticktext` at the matching `tickvals`. A marimekko's `x` is a
   precomputed position rather than a category, so without one of those a column

--- a/docs/plotly.md
+++ b/docs/plotly.md
@@ -92,6 +92,8 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
 | Dot Plot | `type: 'scatter'`, `mode: 'markers'`, one marker per category | [Dot plot](examples.html) |
 | Word Cloud | `type: 'scatter'`, `mode: 'text'`, array `textfont.size` | [Word cloud](examples.html) |
 | Choropleth | `type: 'choropleth'` | [Choropleth map](examples.html) |
+| Contour | `type: 'contour'` or `type: 'histogram2dcontour'` | [Contour plot](examples.html) |
+| Mosaic / Marimekko | stacked `bar` traces declaring `meta: { maidr: { type: 'mosaic' } }` | [Mosaic plot](examples.html) |
 | Subplots / Facets | multiple `xaxis`/`yaxis` pairs, `layout.grid`, or Plotly Express facets | [Subplots](examples.html) |
 
 **Notes on chart-type detection:**
@@ -183,6 +185,32 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   layer carries no selectors — audio, text, braille, and navigation all work,
   visual highlighting alone does not.
 
+- A `contour` (and a `histogram2dcontour`) is read as one curve per level.
+  Plotly computes its curves while it draws and keeps none of them — the
+  calculated data holds the grid and nothing else — so MAIDR walks the grid
+  itself by marching squares, at the levels the trace states in
+  `contours.start`, `.end` and `.size`. Those are resolved by Plotly even when
+  `autocontour` chose them, so nothing is guessed: a chart whose levels are not
+  resolved is skipped rather than read at invented ones. The level is announced
+  on the field's own axis — named from the colorbar title when there is one —
+  and each point announces the distance to the nearest point on the adjacent
+  level, which is what the crowding of the lines conveys visually. Where a
+  level is drawn as several disjoint curves, they are walked as one row, in the
+  order they were found. A `contours.type: 'constraint'` trace shades the
+  region satisfying an inequality rather than drawing a level ladder, so it is
+  skipped instead of being announced as one. Plotly draws a level as whole
+  curves with no element per vertex, so the visual highlight is synthesised
+  along the drawn curve; each level's selector is scoped to that level's own
+  group, so a highlight always lands on the level being read.
+
+- A mosaic (marimekko) is **declared**, not detected. Plotly draws one as
+  stacked `bar` traces with a per-column `width`, but `width` is ordinary bar
+  styling that any bar trace may carry, so reading a non-uniform array as data
+  would announce every column's width as a share of all observations — a number
+  the chart does not contain. Writing `meta: { maidr: { type: 'mosaic' } }` on
+  one of the panel's bar traces is what says otherwise; see
+  [Declaring a mosaic](#declaring-a-mosaic).
+
 - Plotly sorts pie slices by descending value unless the trace sets
   `sort: false`, so the authored order is not necessarily the drawn order. The
   adapter reads the slices Plotly actually drew where the rendered chart exposes
@@ -190,6 +218,56 @@ For dynamically-created charts (SPAs, notebooks), a `MutationObserver` watches f
   it emits the layer without selectors, since slice *k* is then not wedge *k*.
   That costs visual highlighting only — audio, text, and braille are unaffected.
   Set `sort: false` to keep both.
+
+## Declaring a mosaic
+
+Most Plotly charts name themselves in `trace.type`, and MAIDR reads them with
+no configuration at all. A marimekko is the exception: it is stacked bars plus
+a convention, and the convention is invisible to the schema. It is declared on
+`meta`, Plotly's own metadata attribute — ordinary trace config, so it survives
+`Plotly.react` and a JSON-authored figure.
+
+```javascript
+{
+  type: 'bar',
+  name: 'Survived',
+  x: centres,          // cumulative column centres, computed by the author
+  y: proportions,
+  width: passengers,   // each column's width, in x-axis units
+  customdata: rows,    // the author's own rows, one per column
+  meta: {
+    maidr: {
+      type: 'mosaic',
+      width: 'share',  // optional: the column of `customdata` holding the share
+      count: 'count'   // optional: the column holding the cell's own count
+    }
+  }
+}
+```
+
+Only the bare `{ type: 'mosaic' }` is required, and only on one of the panel's
+bar traces — it declares the layer, not the series. Then:
+
+- **The share of all observations** comes from `width` when the declaration
+  names a column of `customdata` that carries it, and otherwise from the drawn
+  widths, normalised by their own total. A chart authored in counts, in
+  percentages or already in fractions therefore all read the same.
+- **The cell count** is emitted only when a column holds it. A mosaic drawn
+  from proportions alone genuinely has no counts, and multiplying a rounded
+  share back out would put a number in the announcement that the data does not
+  contain.
+- **The column names** come from the trace's `text`, then its `hovertext`, and
+  then the axis `ticktext` at the matching `tickvals`. A marimekko's `x` is a
+  precomputed position rather than a category, so without one of those a column
+  is announced by the number it sits at.
+
+The declaration is checked when it is read. An unknown key, a value of the
+wrong kind, or a `type` that is not a MAIDR trace type is reported on the
+console and the chart is read as the undeclared one — never dropped, and never
+read as something it is not. A declaration this adapter cannot honour is
+reported too: a `mosaic` on a trace that draws no bars, or on a panel whose
+bars Plotly drew side by side, leaves the panel read as the grouped bar chart
+it is.
 
 ## Code Examples
 
@@ -321,6 +399,64 @@ the ones drawn with a mean line highlight it.
     colorscale: 'Viridis'
   }], {
     title: { text: 'Activity Heatmap' }
+  });
+</script>
+```
+
+### Contour Plot
+
+```html
+<div id="contour-chart" style="width: 700px; height: 500px"></div>
+<script>
+  Plotly.newPlot('contour-chart', [{
+    type: 'contour',
+    z: field,                 // a 2D array of magnitudes
+    x: eastings,              // one coordinate per column
+    y: northings,             // one coordinate per row
+    contours: { start: 0.2, end: 1.4, size: 0.2 },
+    colorbar: { title: { text: 'Concentration' } }
+  }], {
+    title: { text: 'Concentration over the sampling area' },
+    xaxis: { title: { text: 'Easting (km)' } },
+    yaxis: { title: { text: 'Northing (km)' } }
+  });
+</script>
+```
+
+`contours` may be left out entirely — Plotly picks the ladder itself and MAIDR
+reads whichever one it resolved.
+
+### Mosaic (Marimekko)
+
+```html
+<div id="mosaic-chart" style="width: 700px; height: 500px"></div>
+<script>
+  // Column centres are cumulative: everything before the column, plus half
+  // of it. The widths are what makes it a mosaic rather than a stacked bar.
+  Plotly.newPlot('mosaic-chart', [{
+    type: 'bar',
+    name: 'Survived',
+    x: centres,
+    y: [0.62, 0.41, 0.25, 0.24],
+    width: [325, 285, 706, 885],
+    meta: { maidr: { type: 'mosaic' } }
+  }, {
+    type: 'bar',
+    name: 'Died',
+    x: centres,
+    y: [0.38, 0.59, 0.75, 0.76],
+    width: [325, 285, 706, 885]
+  }], {
+    title: { text: 'Titanic survival by class' },
+    barmode: 'stack',
+    bargap: 0,
+    xaxis: {
+      title: { text: 'Class' },
+      tickmode: 'array',
+      tickvals: centres,
+      ticktext: ['First', 'Second', 'Third', 'Crew']
+    },
+    yaxis: { title: { text: 'Proportion' } }
   });
 </script>
 ```

--- a/examples/plotly-contour.html
+++ b/examples/plotly-contour.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Contour Plot - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Contour Plot</h1>
+    <p>
+      A <code>contour</code> trace draws a scalar field as curves of constant
+      value. Plotly computes those curves while it draws and keeps none of
+      them — its calculated data holds the grid and nothing else — so MAIDR
+      walks the grid itself, by marching squares, at the levels the trace
+      states in <code>contours</code>. Each curve becomes one navigable row:
+      the level is announced on the field's own axis rather than as a series
+      name, and every point announces the distance to the nearest point on the
+      adjacent level, which is what the crowding of the lines says visually.
+    </p>
+    <p>
+      Nothing has to be declared. <code>contour</code> and
+      <code>histogram2dcontour</code> name themselves, and plotly resolves the
+      level ladder even when <code>autocontour</code> chose it.
+    </p>
+
+    <div id="contour" style="width: 760px; height: 520px"></div>
+
+    <script>
+      // Two peaks of different heights and widths, so the curves crowd on one
+      // slope and spread on the other.
+      const size = 41;
+      const coordinates = Array.from(
+        { length: size },
+        (_, i) => -3 + (6 * i) / (size - 1)
+      );
+      const field = coordinates.map((y) =>
+        coordinates.map((x) => {
+          const tall = 1.6 * Math.exp(-((x + 1) ** 2 + (y + 0.6) ** 2) / 0.6);
+          const wide = 1.0 * Math.exp(-((x - 1.2) ** 2 + (y - 1) ** 2) / 2.4);
+          return Number((tall + wide).toFixed(4));
+        })
+      );
+
+      Plotly.newPlot(
+        'contour',
+        [
+          {
+            type: 'contour',
+            z: field,
+            x: coordinates,
+            y: coordinates,
+            contours: { start: 0.2, end: 1.4, size: 0.2 },
+            colorbar: { title: { text: 'Concentration' } }
+          }
+        ],
+        {
+          title: { text: 'Concentration over the sampling area' },
+          xaxis: { title: { text: 'Easting (km)' } },
+          yaxis: { title: { text: 'Northing (km)' } }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/examples/plotly-mosaic.html
+++ b/examples/plotly-mosaic.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plotly.js Mosaic Plot - Auto MAIDR</title>
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+  </head>
+  <body>
+    <h1>Plotly.js Mosaic (Marimekko) Plot</h1>
+    <p>
+      A marimekko reaches plotly as stacked <code>bar</code> traces whose
+      columns are drawn at precomputed cumulative positions and given a
+      per-column <code>width</code>. MAIDR does <strong>not</strong> guess at
+      that: <code>width</code> is ordinary bar styling that any bar trace may
+      carry, and reading a non-uniform array as data would announce every
+      column's width as a share of all observations — a number the chart does
+      not contain.
+    </p>
+    <p>
+      So a mosaic is declared, on plotly's own metadata attribute:
+      <code>meta: { maidr: { type: 'mosaic' } }</code>. With it, each cell
+      announces its column's share of all observations alongside its own
+      proportion, and the description names the largest and smallest group —
+      the marginal distribution a reader cannot accumulate by walking the
+      segments. <code>width</code> and <code>count</code> may name columns of
+      <code>customdata</code> when the figure carries the contingency table it
+      was drawn from; without them the drawn widths are normalised into shares.
+    </p>
+
+    <div id="mosaic" style="width: 760px; height: 520px"></div>
+
+    <script>
+      const classes = ['First', 'Second', 'Third', 'Crew'];
+      const passengers = [325, 285, 706, 885];
+      const survived = [203, 118, 178, 212];
+
+      // The bars are positioned by hand: a column's centre is everything
+      // before it plus half of itself, which is what makes the widths mean
+      // something.
+      const total = passengers.reduce((sum, count) => sum + count, 0);
+      let travelled = 0;
+      const centres = passengers.map((count) => {
+        const centre = travelled + count / 2;
+        travelled += count;
+        return centre;
+      });
+
+      const cells = (counts) =>
+        counts.map((count, i) => ({ count, share: passengers[i] / total }));
+
+      Plotly.newPlot(
+        'mosaic',
+        [
+          {
+            type: 'bar',
+            name: 'Survived',
+            x: centres,
+            y: survived.map((count, i) => count / passengers[i]),
+            width: passengers,
+            customdata: cells(survived),
+            // The declaration. `width` and `count` name columns of
+            // `customdata`; leaving them out reads the drawn widths instead.
+            meta: {
+              maidr: { type: 'mosaic', width: 'share', count: 'count' }
+            }
+          },
+          {
+            type: 'bar',
+            name: 'Died',
+            x: centres,
+            y: survived.map((count, i) => 1 - count / passengers[i]),
+            width: passengers,
+            customdata: cells(
+              survived.map((count, i) => passengers[i] - count)
+            )
+          }
+        ],
+        {
+          title: { text: 'Titanic survival by class' },
+          barmode: 'stack',
+          bargap: 0,
+          xaxis: {
+            title: { text: 'Class' },
+            tickmode: 'array',
+            tickvals: centres,
+            ticktext: classes
+          },
+          yaxis: { title: { text: 'Proportion' } }
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -3145,9 +3145,36 @@ function numberGrid(value: unknown): number[][] | null {
   for (const row of value) {
     if (!Array.isArray(row) || row.length < width)
       return null;
-    grid.push(row.slice(0, width).map(cell => Number(cell)));
+    grid.push(row.slice(0, width).map(gridCell));
   }
   return grid;
+}
+
+/**
+ * One cell of a grid, as a magnitude or as `NaN` for a hole.
+ *
+ * `Number()` on its own would read plotly's own way of writing a hole — a
+ * `null` in an authored `z`, and `[[1, null, 3]]` is how the plotly docs write
+ * one — as a 0, and the curves would then be walked through a field that
+ * claims to be zero exactly where it has no data. `''`, `[]` and `false` all
+ * convert the same way.
+ *
+ * The rule here is plotly's: it cleans a grid with `isNumeric(v) ? +v :
+ * undefined`, so anything that is not a number is a hole, and
+ * {@link crossingSegments} already leaves a cell with one out of the walk.
+ * Only the authored fallback needs this — a grid read from calcdata has been
+ * through that cleaning already — but the two must agree, or the same chart
+ * would read differently before and after plotly calculated it.
+ *
+ * @param cell - Whatever the grid held at one position
+ * @returns The magnitude, or `NaN` when the cell holds no number
+ */
+function gridCell(cell: unknown): number {
+  if (typeof cell === 'number')
+    return cell;
+  if (typeof cell === 'string' && cell.trim() !== '')
+    return Number(cell);
+  return Number.NaN;
 }
 
 /**

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -3075,11 +3075,19 @@ function extractContourLayer(
     ? { ...axes, z: { label: fieldLabel } }
     : axes;
 
+  // The selectors address the level groups, and a trace that strokes no lines
+  // has none: plotly builds them only for a trace drawing lines or labels, and
+  // removes them again when only the labels were wanted. A fill-only contour
+  // is one filled path per level with nothing per curve inside it, so the
+  // layer goes out without selectors rather than with ones that match nothing
+  // — the same choice a resorted pie makes, and for the same reason.
+  const linesDrawn = trace.contours?.showlines !== false;
+
   return {
     id,
     type: TraceType.CONTOUR,
     title,
-    selectors: contourLevelSelectors(gd, traceIndex, levelIndices),
+    selectors: linesDrawn ? contourLevelSelectors(gd, traceIndex, levelIndices) : undefined,
     axes: contourAxes,
     data,
   };
@@ -4940,12 +4948,24 @@ function mosaicColumnNames(
  * `customdata` is plotly's only per-point channel for values it does not draw
  * with, which makes it the row a declared field is read off.
  *
+ * An ARRAY row is refused. Plotly's canonical `customdata` shape is one array
+ * per point — `[[a, b], [c, d]]` — and a `FieldRef` is a property NAME, so an
+ * array carries nothing a declared field could resolve against. It would not
+ * be inert, though: `resolveFieldRef` accepts an array as a row on purpose (a
+ * hexbin bin **is** the array of its points), and `count`'s fallback chain
+ * starts at `length`. A marimekko declared with no `count` would then announce
+ * every cell's number of COLUMNS as its number of observations — a fabricated
+ * count, stated with no warning, which is the one thing the declaration
+ * design refuses to do.
+ *
  * @param trace - The resolved plotly trace
  * @param index - Which point
  * @returns The row, or undefined when the point has none
  */
 function customRow(trace: PlotlyTrace, index: number): unknown {
   const row = trace.customdata?.[index];
+  if (Array.isArray(row))
+    return undefined;
   return typeof row === 'object' && row !== null ? row : undefined;
 }
 

--- a/src/adapters/plotly/extractor.ts
+++ b/src/adapters/plotly/extractor.ts
@@ -9,12 +9,14 @@
  * plotly.js charts and they become accessible automatically.
  */
 
+import type { MosaicDeclaration } from '../../type/declaration';
 import type {
   BarPoint,
   BoxPoint,
   BoxSelector,
   CandlestickPoint,
   ChoroplethPoint,
+  ContourPoint,
   ErrorBarPoint,
   FlowPoint,
   GanttData,
@@ -27,6 +29,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  MosaicPoint,
   PiePoint,
   ScatterPoint,
   SegmentedPoint,
@@ -37,6 +40,7 @@ import type {
   WaterfallPoint,
   WordCloudPoint,
 } from '../../type/grammar';
+import type { DeclarationContext } from '../shared/traceDeclaration';
 import type {
   PlotlyAnnotation,
   PlotlyAxis,
@@ -52,10 +56,12 @@ import type {
   PolarSeries,
 } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
+import { readDeclarationSlot, resolveFieldRef, warnUnresolvedRef } from '../shared/traceDeclaration';
 import {
   barPointSelector,
   boxLayerNthChild,
   choroplethRegionSelectors,
+  contourLevelSelectors,
   errorBarAxis,
   generatePlotlySelectors,
   polarSeriesSelectors,
@@ -323,6 +329,14 @@ function mapTraceType(trace: PlotlyTrace): TraceType | null {
     case 'heatmap':
     case 'heatmapgl':
       return TraceType.HEATMAP;
+
+    // Both draw a scalar field as curves of constant value, and differ only
+    // in where the field came from: `contour` is given the grid, and
+    // `histogram2dcontour` bins samples into one first. Plotly draws them
+    // with the same plotter, into the same layer.
+    case 'contour':
+    case 'histogram2dcontour':
+      return TraceType.CONTOUR;
 
     case 'histogram':
       return TraceType.HISTOGRAM;
@@ -697,6 +711,124 @@ function buildSubplotGrid(
 }
 
 /**
+ * How a trace is named in a warning about its declaration.
+ *
+ * The index is what an author can find a trace by — plotly traces have no ids
+ * — and the name is added when there is one, since that is what the legend
+ * shows.
+ *
+ * @param trace      - The resolved plotly trace
+ * @param traceIndex - Its index in `_fullData`
+ * @returns The context every declaration warning is located from
+ */
+function declarationContext(trace: PlotlyTrace, traceIndex: number): DeclarationContext {
+  return {
+    adapter: 'Plotly',
+    seriesRef: trace.name ? `trace ${traceIndex} ("${trace.name}")` : `trace ${traceIndex}`,
+  };
+}
+
+/**
+ * The co-located `maidr` declaration a trace carries, when it is one this
+ * adapter reads.
+ *
+ * Plotly's own arbitrary-metadata attribute is the channel:
+ * `trace.meta.maidr`. It is ordinary trace config, so it survives
+ * `Plotly.react` and a JSON-authored figure, and — unlike an options bag —
+ * it reaches an extractor that is called from a DOM sweep the author never
+ * touches.
+ *
+ * Only the mosaic is declarable here. Every other chart plotly can draw
+ * either names itself in `trace.type` or is read from the figure's own
+ * configuration, so a declaration of another type is reported rather than
+ * quietly dropped: the author wrote it expecting it to do something.
+ *
+ * @param trace      - The resolved plotly trace
+ * @param traceIndex - Its index in `_fullData`
+ * @returns The declaration, or null when there is none to read
+ */
+function readTraceDeclaration(
+  trace: PlotlyTrace,
+  traceIndex: number,
+): MosaicDeclaration | null {
+  const context = declarationContext(trace, traceIndex);
+  const declaration = readDeclarationSlot(trace.meta, context);
+  if (declaration === null) {
+    return null;
+  }
+  if (declaration.type === TraceType.MOSAIC) {
+    return declaration;
+  }
+
+  console.warn(
+    `[MAIDR Plotly] maidr declaration on ${context.seriesRef} declares `
+    + `"${declaration.type}", which the plotly adapter does not read; `
+    + `reading it as the undeclared chart.`,
+  );
+  return null;
+}
+
+/**
+ * The marimekko a panel declares, if the bars it is declared on can draw one.
+ *
+ * A mosaic is opt-in for a reason that is about the schema rather than about
+ * this adapter: plotly's `width` is ordinary bar styling and an array of
+ * widths is a legitimate thing to write on any bar trace, so reading one as a
+ * marimekko would announce every column's width as a share of all
+ * observations — a number the chart does not contain.
+ *
+ * @param group      - The panel's traces
+ * @param barTraces  - The bar traces among them
+ * @param layout     - The resolved layout, for `barmode`
+ * @returns The declaration to read the panel by, or null
+ */
+function declaredMosaic(
+  group: SubplotGroup,
+  barTraces: TraceEntry[],
+  layout: PlotlyFullLayout,
+): MosaicDeclaration | null {
+  let declared: MosaicDeclaration | null = null;
+  let declaredOnBars = false;
+
+  // Read once per trace per binding, which is what keeps each warning to one
+  // line however many layers the panel ends up with.
+  for (let i = 0; i < group.traces.length; i++) {
+    const declaration = readTraceDeclaration(group.traces[i], group.traceIndices[i]);
+    if (declaration === null || declared !== null) {
+      continue;
+    }
+    declared = declaration;
+    declaredOnBars = barTraces.some(entry => entry.trace === group.traces[i]);
+  }
+
+  if (declared === null) {
+    return null;
+  }
+  if (!declaredOnBars) {
+    console.warn(
+      '[MAIDR Plotly] maidr declaration for "mosaic" is not on a bar trace; '
+      + 'a mosaic is drawn as bars. Reading the panel as the undeclared chart.',
+    );
+    return null;
+  }
+
+  // Several bar traces are the cells of one column only when plotly stacked
+  // them. Grouped side by side they are not a mosaic's segments at all, and
+  // the widths would describe columns that were never drawn.
+  const barmode = layout.barmode ?? 'group';
+  if (barTraces.length > 1 && barmode !== 'stack' && barmode !== 'relative') {
+    console.warn(
+      `[MAIDR Plotly] maidr declaration for "mosaic" is on a panel whose bars `
+      + `are drawn with barmode "${barmode}"; a mosaic stacks its segments. `
+      + `Reading the panel as the undeclared chart.`,
+    );
+    return null;
+  }
+
+  return declared;
+}
+
+/**
  * Builds all MAIDR layers for one subplot (one x/y axis-pair group).
  */
 function buildSubplotLayers(
@@ -856,15 +988,32 @@ function buildSubplotLayers(
       layers.push(layer);
   }
 
+  // A declared marimekko is read as one whatever else the panel's bars would
+  // have been taken for: a declaration beats every heuristic.
+  const mosaic = declaredMosaic(group, barTraces, layout);
+  const mosaicLayer = mosaic && barTraces.length > 0
+    ? extractSegmentedBarLayer(
+        barTraces,
+        group,
+        TraceType.MOSAIC,
+        xLabel,
+        yLabel,
+        gd,
+        mosaic,
+      )
+    : null;
+
   // A schedule reaches plotly as bars floated onto a time axis, so it has to
   // be recognised before the bar shapes are: read as bars, the intervals would
   // announce their durations as magnitudes measured from nothing.
-  const ganttLayer = isGanttPanel(barTraces, group, layout)
+  const ganttLayer = !mosaicLayer && isGanttPanel(barTraces, group, layout)
     ? extractGanttLayer(barTraces, group, layout, xLabel, yLabel)
     : null;
 
   // Build bar layers: grouped/stacked/normalized for multiple bar traces.
-  if (ganttLayer) {
+  if (mosaicLayer) {
+    layers.push(mosaicLayer);
+  } else if (ganttLayer) {
     layers.push(ganttLayer);
   } else if (barTraces.length > 1) {
     const barmode = layout.barmode ?? 'group';
@@ -1402,6 +1551,11 @@ function extractLayer(
 
     case TraceType.HEATMAP:
       return extractHeatmapLayer(trace, id, title, selectors, axes, gd);
+
+    // `selectors` is not passed on: a contour needs one per level, and which
+    // levels the field actually crosses is only known once they are walked.
+    case TraceType.CONTOUR:
+      return extractContourLayer(trace, calcdata, id, title, axes, traceIndex, gd);
 
     case TraceType.HISTOGRAM:
       return extractHistogramLayer(trace, calcdata, id, title, selectors, axes, traceIndex, gd);
@@ -2802,6 +2956,508 @@ function extractColorbarTitle(trace: PlotlyTrace, layout: PlotlyLayout | undefin
 }
 
 // ---------------------------------------------------------------------------
+// Contour
+// ---------------------------------------------------------------------------
+
+/**
+ * The scalar field a contour trace was drawn from.
+ *
+ * The grid and the coordinates it is indexed by, in DATA units — never pixels.
+ * Plotly draws the curves by converting these through the axes, and reading
+ * the drawn geometry back would announce every vertex's position on the page.
+ */
+interface ContourField {
+  /** Magnitudes, row-major: `z[row][col]`. */
+  z: number[][];
+  /** Each column's coordinate. */
+  x: number[];
+  /** Each row's coordinate. */
+  y: number[];
+}
+
+/** One vertex of an iso-value curve, in data units. */
+interface ContourVertex {
+  x: number;
+  y: number;
+}
+
+/**
+ * How many levels a ladder may hold before it is refused.
+ *
+ * Every level costs a walk over the whole grid, and a chart that asks for
+ * thousands is an authoring mistake — plotly's own `ncontours` defaults to
+ * 15 — so the ceiling is high enough never to be met by a real chart and low
+ * enough that a bad `size` cannot hang the page.
+ */
+const MAX_CONTOUR_LEVELS = 1000;
+
+/** Trims binary floating-point noise from an interpolated coordinate. */
+function withoutFloatNoise(value: number): number {
+  return Number(value.toPrecision(12));
+}
+
+/**
+ * Builds a contour layer: one iso-value curve per level, walked out of the
+ * field itself.
+ *
+ * Plotly computes its curves at draw time and keeps none of them — `calcdata`
+ * holds the grid and nothing else — so the curves are recomputed here by
+ * marching squares over that grid, at the levels the trace states. The
+ * alternative, reading the rendered `d` attributes back through the axes,
+ * would hand every vertex to smoothing and to whichever points plotly merged
+ * for being too close together.
+ *
+ * @param trace      - The resolved plotly trace
+ * @param calcdata   - Its calculated data, which is where a binned grid lives
+ * @param id         - The layer id
+ * @param title      - The trace name, when it has one
+ * @param axes       - The panel's axis labels
+ * @param traceIndex - The trace's index in `_fullData`, for the selectors
+ * @param gd         - The plotly graph div
+ * @returns The layer, or null when the chart states no levels to walk
+ */
+function extractContourLayer(
+  trace: PlotlyTrace,
+  calcdata: PlotlyCalcData[],
+  id: string,
+  title: string | undefined,
+  axes: MaidrLayer['axes'],
+  traceIndex: number,
+  gd: PlotlyGraphDiv,
+): MaidrLayer | null {
+  // A constraint contour draws the boundary of a region that satisfies an
+  // inequality, not a ladder of iso-values. Its `start` and `end` are the
+  // ends of that interval, so walking them as levels would announce two
+  // curves the chart does not draw.
+  if (trace.contours?.type === 'constraint') {
+    console.warn(
+      '[maidr] Plotly contour draws a constraint region rather than iso-value '
+      + 'curves. Skipping.',
+    );
+    return null;
+  }
+
+  const field = contourField(trace, calcdata);
+  if (!field) {
+    console.warn('[maidr] Plotly contour has no grid to read. Skipping.');
+    return null;
+  }
+
+  const levels = contourLevels(trace);
+  if (!levels) {
+    console.warn('[maidr] Plotly contour states no levels to read. Skipping.');
+    return null;
+  }
+
+  // A level the field never reaches is drawn as an empty group rather than
+  // skipped, so the group's position is the level's place in the ladder and
+  // not the number of curves before it — which is what the selectors count by.
+  const data: ContourPoint[][] = [];
+  const levelIndices: number[] = [];
+  for (const [index, level] of levels.entries()) {
+    const vertices = isoCurves(field, level).flat();
+    if (vertices.length === 0)
+      continue;
+    data.push(vertices.map(vertex => ({ x: vertex.x, y: vertex.y, level })));
+    levelIndices.push(index);
+  }
+
+  if (data.length === 0) {
+    console.warn('[maidr] Plotly contour crosses none of its levels. Skipping.');
+    return null;
+  }
+
+  // The level is announced on the field's own axis, so it takes the colorbar
+  // title when the author gave one. Without one the axis is left unnamed and
+  // the trace says "Level", which is what the number is.
+  const fieldLabel = extractColorbarTitle(trace, gd._fullLayout ?? gd.layout);
+  const contourAxes: MaidrLayer['axes'] = fieldLabel
+    ? { ...axes, z: { label: fieldLabel } }
+    : axes;
+
+  return {
+    id,
+    type: TraceType.CONTOUR,
+    title,
+    selectors: contourLevelSelectors(gd, traceIndex, levelIndices),
+    axes: contourAxes,
+    data,
+  };
+}
+
+/**
+ * The grid a contour was drawn from, with the coordinates it is indexed by.
+ *
+ * Calcdata first: it is where a `histogram2dcontour`'s binned grid lives at
+ * all, and where a `contour`'s grid has already been trimmed to the columns
+ * and rows plotly kept. The trace's own arrays stand in for a chart captured
+ * before plotly computed it.
+ *
+ * @param trace    - The resolved plotly trace
+ * @param calcdata - Its calculated data
+ * @returns The field, or null when there is no usable grid
+ */
+function contourField(trace: PlotlyTrace, calcdata: PlotlyCalcData[]): ContourField | null {
+  const z = numberGrid(calcdata[0]?.z) ?? numberGrid(trace.z);
+  if (!z)
+    return null;
+
+  const rows = z.length;
+  const cols = z[0].length;
+  // One cell is the smallest thing a curve can cross.
+  if (rows < 2 || cols < 2)
+    return null;
+
+  return {
+    z,
+    x: gridCoordinates(calcdata[0]?.x, trace.x, cols),
+    y: gridCoordinates(calcdata[0]?.y, trace.y, rows),
+  };
+}
+
+/**
+ * Narrows a value to a rectangular grid of magnitudes.
+ *
+ * A choropleth carries a flat column on the same attribute, so being a grid
+ * is what a row of rows is. Cells that are not finite are kept as `NaN` and
+ * skipped later, since a hole in the field is not a reason to drop the chart.
+ *
+ * @param value - Whatever `z` held
+ * @returns The grid, or null when the value is not one
+ */
+function numberGrid(value: unknown): number[][] | null {
+  if (!Array.isArray(value) || value.length === 0 || !Array.isArray(value[0]))
+    return null;
+
+  const width = (value[0] as unknown[]).length;
+  if (width === 0)
+    return null;
+
+  const grid: number[][] = [];
+  for (const row of value) {
+    if (!Array.isArray(row) || row.length < width)
+      return null;
+    grid.push(row.slice(0, width).map(cell => Number(cell)));
+  }
+  return grid;
+}
+
+/**
+ * The coordinate of each column or row of a grid.
+ *
+ * Plotly's own calculated array is taken first, then the authored one, and
+ * failing both the indices — which is what plotly itself draws a grid at when
+ * the author names no coordinates, so it is the chart's own reading rather
+ * than a stand-in for one.
+ *
+ * @param calculated - What plotly's calc entry held for the axis
+ * @param authored   - What the trace declared for it
+ * @param length     - How many coordinates the grid needs
+ * @returns One coordinate per column or row
+ */
+function gridCoordinates(
+  calculated: number | number[] | undefined,
+  authored: (number | string)[] | undefined,
+  length: number,
+): number[] {
+  for (const candidate of [calculated, authored]) {
+    if (!Array.isArray(candidate) || candidate.length < length)
+      continue;
+    const values = candidate.slice(0, length).map(Number);
+    if (values.every(value => Number.isFinite(value)))
+      return values;
+  }
+  return Array.from({ length }, (_, index) => index);
+}
+
+/**
+ * The ladder of levels a contour draws its curves at.
+ *
+ * Plotly resolves `start`, `end` and `size` during calc — including for a
+ * trace that left `autocontour` on — so the ladder is read off the chart
+ * rather than derived from the grid. Guessing it would announce curves at
+ * values the chart never drew one at.
+ *
+ * @param trace - The resolved plotly trace
+ * @returns The levels in ascending order, or null when the trace states none
+ */
+function contourLevels(trace: PlotlyTrace): number[] | null {
+  const { start, end, size } = trace.contours ?? {};
+  if (
+    typeof start !== 'number' || !Number.isFinite(start)
+    || typeof end !== 'number' || !Number.isFinite(end)
+    || typeof size !== 'number' || !Number.isFinite(size) || size <= 0
+  ) {
+    return null;
+  }
+
+  // The tolerance is plotly's own: it walks to `end` plus a millionth of a
+  // step, so a ladder whose last level lands exactly on `end` keeps it
+  // instead of losing it to accumulated floating-point error.
+  const count = Math.floor((end - start) / size + 1e-6) + 1;
+  if (count < 1 || count > MAX_CONTOUR_LEVELS)
+    return null;
+
+  return Array.from({ length: count }, (_, index) =>
+    withoutFloatNoise(start + index * size));
+}
+
+/**
+ * Walks one level of the field, by marching squares.
+ *
+ * Every cell the level crosses contributes one or two segments between the
+ * points where it crosses the cell's edges; the segments are then chained
+ * into curves. A closed curve repeats its first vertex at the end, which is
+ * how the shape says it closed.
+ *
+ * The two ambiguous cells — opposite corners on one side of the level — are
+ * resolved by the average of the four corners, the reading that keeps the
+ * side the middle belongs to connected.
+ *
+ * @param field - The grid and its coordinates
+ * @param level - The value to walk
+ * @returns One vertex list per curve, disjoint curves in the order found
+ */
+function isoCurves(field: ContourField, level: number): ContourVertex[][] {
+  const segments = crossingSegments(field, level);
+  return chainSegments(segments)
+    .map(chain => chain.map(edge => edgeVertex(field, edge, level)));
+}
+
+/**
+ * Identifies a grid edge, so that the two cells sharing one name the same
+ * crossing.
+ *
+ * Chaining on identity rather than on coordinates is what makes it exact: a
+ * crossing computed twice from the same two corners can differ in its last
+ * bit depending on which way the interpolation ran, and two curves that
+ * should meet would then not.
+ *
+ * The low bit says which way the edge runs — 0 towards the next column, 1
+ * towards the next row — and the rest is the grid position it starts at.
+ */
+function horizontalEdge(cols: number, row: number, col: number): number {
+  return (row * cols + col) * 2;
+}
+
+function verticalEdge(cols: number, row: number, col: number): number {
+  return (row * cols + col) * 2 + 1;
+}
+
+/**
+ * Every segment the level draws through the grid, as pairs of the edges it
+ * crosses.
+ *
+ * @param field - The grid and its coordinates
+ * @param level - The value being walked
+ * @returns The segments, in row-major cell order
+ */
+function crossingSegments(field: ContourField, level: number): [number, number][] {
+  const { z } = field;
+  const rows = z.length;
+  const cols = z[0].length;
+  const segments: [number, number][] = [];
+
+  for (let row = 0; row < rows - 1; row++) {
+    for (let col = 0; col < cols - 1; col++) {
+      const bottomLeft = z[row][col];
+      const bottomRight = z[row][col + 1];
+      const topRight = z[row + 1][col + 1];
+      const topLeft = z[row + 1][col];
+      // A hole in the field is a cell with no crossing rather than a reason
+      // to stop: the rest of the curve is still the chart's own.
+      if (
+        !Number.isFinite(bottomLeft) || !Number.isFinite(bottomRight)
+        || !Number.isFinite(topRight) || !Number.isFinite(topLeft)
+      ) {
+        continue;
+      }
+
+      const corners = (bottomLeft >= level ? 1 : 0)
+        | (bottomRight >= level ? 2 : 0)
+        | (topRight >= level ? 4 : 0)
+        | (topLeft >= level ? 8 : 0);
+      if (corners === 0 || corners === 15)
+        continue;
+
+      const bottom = horizontalEdge(cols, row, col);
+      const top = horizontalEdge(cols, row + 1, col);
+      const left = verticalEdge(cols, row, col);
+      const right = verticalEdge(cols, row, col + 1);
+
+      // The two saddles: the middle decides which pair of corners the curve
+      // wraps, and getting it backwards joins two curves that never meet.
+      if (corners === 5 || corners === 10) {
+        const middleIsHigh
+          = (bottomLeft + bottomRight + topRight + topLeft) / 4 >= level;
+        // The curve wraps whichever pair of corners the middle does NOT join:
+        // with the bottom-left and top-right corners high (case 5), a high
+        // middle joins them and leaves the other two wrapped, and a low
+        // middle joins the other two and leaves these wrapped.
+        if ((corners === 5) === middleIsHigh) {
+          // Wrapped separately: the bottom-right corner and the top-left one.
+          segments.push([bottom, right], [left, top]);
+        } else {
+          // Wrapped separately: the bottom-left corner and the top-right one.
+          segments.push([left, bottom], [right, top]);
+        }
+        continue;
+      }
+
+      switch (corners) {
+        case 1:
+        case 14:
+          segments.push([left, bottom]);
+          break;
+        case 2:
+        case 13:
+          segments.push([bottom, right]);
+          break;
+        case 3:
+        case 12:
+          segments.push([left, right]);
+          break;
+        case 4:
+        case 11:
+          segments.push([right, top]);
+          break;
+        case 6:
+        case 9:
+          segments.push([bottom, top]);
+          break;
+        case 7:
+        case 8:
+          segments.push([left, top]);
+          break;
+      }
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Chains segments into curves, following each one end to end.
+ *
+ * An edge is shared by at most two cells and each contributes at most one
+ * segment to it, so a curve never has a choice about where to go next. A
+ * curve that returns to where it started repeats that edge and stops; one
+ * that runs off the grid is followed the other way too, so an open curve
+ * comes back whole rather than as the two halves either side of wherever the
+ * walk happened to begin.
+ *
+ * @param segments - The level's segments, as pairs of edges
+ * @returns One edge list per curve
+ */
+function chainSegments(segments: readonly [number, number][]): number[][] {
+  const byEdge = new Map<number, number[]>();
+  segments.forEach(([from, to], index) => {
+    for (const edge of [from, to]) {
+      const holders = byEdge.get(edge);
+      if (holders) {
+        holders.push(index);
+      } else {
+        byEdge.set(edge, [index]);
+      }
+    }
+  });
+
+  const used = Array.from({ length: segments.length }, () => false);
+  const curves: number[][] = [];
+
+  for (let start = 0; start < segments.length; start++) {
+    if (used[start])
+      continue;
+    used[start] = true;
+
+    const curve = [segments[start][0], segments[start][1]];
+    if (!extendCurve(curve, segments, byEdge, used)) {
+      curve.reverse();
+      extendCurve(curve, segments, byEdge, used);
+      curve.reverse();
+    }
+    curves.push(curve);
+  }
+
+  return curves;
+}
+
+/**
+ * Follows a curve forward from its last edge for as long as it goes.
+ *
+ * @param curve    - The edges so far, appended to in place
+ * @param segments - The level's segments
+ * @param byEdge   - Which segments touch each edge
+ * @param used     - Which segments have been walked, marked in place
+ * @returns True when the curve closed on itself
+ */
+function extendCurve(
+  curve: number[],
+  segments: readonly [number, number][],
+  byEdge: ReadonlyMap<number, number[]>,
+  used: boolean[],
+): boolean {
+  for (;;) {
+    const end = curve[curve.length - 1];
+    const next = byEdge.get(end)?.find(index => !used[index]);
+    if (next === undefined)
+      return false;
+
+    used[next] = true;
+    const [from, to] = segments[next];
+    const onward = from === end ? to : from;
+    curve.push(onward);
+    if (onward === curve[0])
+      return true;
+  }
+}
+
+/**
+ * Where the level crosses one grid edge, in data units.
+ *
+ * Linear between the two corners, which is the same reading the marching
+ * squares made when it decided the edge was crossed at all.
+ *
+ * @param field - The grid and its coordinates
+ * @param edge  - The edge identifier
+ * @param level - The value being walked
+ * @returns The crossing point
+ */
+function edgeVertex(field: ContourField, edge: number, level: number): ContourVertex {
+  const { z, x, y } = field;
+  const cols = z[0].length;
+  const cell = Math.floor(edge / 2);
+  const col = cell % cols;
+  const row = (cell - col) / cols;
+
+  if (edge % 2 === 1) {
+    const fraction = crossFraction(z[row][col], z[row + 1][col], level);
+    return {
+      x: withoutFloatNoise(x[col]),
+      y: withoutFloatNoise(y[row] + fraction * (y[row + 1] - y[row])),
+    };
+  }
+  const fraction = crossFraction(z[row][col], z[row][col + 1], level);
+  return {
+    x: withoutFloatNoise(x[col] + fraction * (x[col + 1] - x[col])),
+    y: withoutFloatNoise(y[row]),
+  };
+}
+
+/**
+ * How far along an edge the level falls, as a fraction of it.
+ *
+ * @param from  - The magnitude at the edge's start
+ * @param to    - The magnitude at its end
+ * @param level - The value being walked
+ * @returns The fraction, and the midpoint for an edge with no gradient
+ */
+function crossFraction(from: number, to: number, level: number): number {
+  const span = to - from;
+  return span === 0 ? 0.5 : (level - from) / span;
+}
+
+// ---------------------------------------------------------------------------
 // Choropleth
 // ---------------------------------------------------------------------------
 
@@ -4073,13 +4729,20 @@ function extractSegmentedBarLayer(
   xLabel: string | undefined,
   yLabel: string | undefined,
   gd: PlotlyGraphDiv,
+  mosaic?: MosaicDeclaration,
 ): MaidrLayer | null {
   const data: SegmentedPoint[][] = [];
 
   // Check orientation from first trace (all traces in a group share orientation).
   const isHorizontal = barTraces[0]?.trace.orientation === 'h';
+  const categoryAxis = mosaic
+    ? getAxis(
+        gd._fullLayout ?? {},
+        isHorizontal ? group.yAxisId : group.xAxisId,
+      )
+    : undefined;
 
-  for (const { trace, calcIdx } of barTraces) {
+  for (const { trace, calcIdx, globalIdx } of barTraces) {
     const x = trace.x;
     const y = trace.y;
     if (!x || !y)
@@ -4090,8 +4753,32 @@ function extractSegmentedBarLayer(
     const len = Math.min(x.length, y.length);
     const series: SegmentedPoint[] = [];
 
+    // A marimekko's columns are the two things a stacked bar does not carry:
+    // a name, because plotly draws them at precomputed cumulative positions
+    // rather than at categories, and a share of all observations.
+    const columns = mosaic
+      ? mosaicCells(
+          trace,
+          mosaic,
+          declarationContext(trace, globalIdx),
+          isHorizontal ? y.slice(0, len) : x.slice(0, len),
+          categoryAxis,
+        )
+      : undefined;
+
     for (let i = 0; i < len; i++) {
-      series.push({ ...barPoint(cd[i], x[i], y[i], isHorizontal), z });
+      const point: SegmentedPoint = { ...barPoint(cd[i], x[i], y[i], isHorizontal), z };
+      const column = columns?.[i];
+      if (column) {
+        series.push({
+          ...point,
+          ...(isHorizontal ? { y: column.name } : { x: column.name }),
+          ...(column.width === undefined ? {} : { width: column.width }),
+          ...(column.count === undefined ? {} : { count: column.count }),
+        } satisfies MosaicPoint);
+      } else {
+        series.push(point);
+      }
     }
 
     data.push(series);
@@ -4118,4 +4805,165 @@ function extractSegmentedBarLayer(
     ...(isHorizontal ? { orientation: Orientation.HORIZONTAL } : {}),
     data,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Mosaic
+// ---------------------------------------------------------------------------
+
+/** One cell of a declared marimekko, beyond what a stacked bar carries. */
+interface MosaicCell {
+  /** What the cell's column is called. */
+  name: string | number;
+  /** The column's share of all observations, as a fraction of one. */
+  width?: number;
+  /** The cell's own count, when the chart carries the table it was drawn from. */
+  count?: number;
+}
+
+/**
+ * Reads the facts a marimekko adds to a stacked bar, one per cell of one
+ * trace.
+ *
+ * @param trace       - The resolved plotly trace
+ * @param declaration - What the author declared on it
+ * @param context     - How the trace is named in a warning
+ * @param positions   - The trace's coordinate on the category axis
+ * @param axis        - That axis, which is where the column names may live
+ * @returns One entry per cell, in the trace's own order
+ */
+function mosaicCells(
+  trace: PlotlyTrace,
+  declaration: MosaicDeclaration,
+  context: DeclarationContext,
+  positions: (number | string)[],
+  axis: PlotlyAxis | undefined,
+): MosaicCell[] {
+  const shares = mosaicShares(trace, positions.length);
+  const names = mosaicColumnNames(trace, positions, axis);
+
+  let widthResolved = false;
+  let countResolved = false;
+  const cells = positions.map((_, index) => {
+    const row = customRow(trace, index);
+    const width = finiteNumber(resolveFieldRef(row, declaration.width, 'width'));
+    const count = finiteNumber(resolveFieldRef(row, declaration.count, 'count'));
+    widthResolved = widthResolved || width !== undefined;
+    countResolved = countResolved || count !== undefined;
+    // The drawn widths stand in for a share the author did not declare: they
+    // are what the chart put on the page, and this trace said they mean
+    // something. A declared field that resolves wins over them.
+    return { name: names[index], width: width ?? shares?.[index], count };
+  });
+
+  if (declaration.width !== undefined && !widthResolved)
+    warnUnresolvedRef(context, declaration.width, 'width');
+  if (declaration.count !== undefined && !countResolved)
+    warnUnresolvedRef(context, declaration.count, 'count');
+
+  return cells;
+}
+
+/**
+ * Each column's share of all observations, from the widths plotly drew.
+ *
+ * Normalised by their own total, so a marimekko authored in counts, in
+ * percentages or already in fractions all read the same — and a chart already
+ * authored in fractions is unchanged by it.
+ *
+ * All or nothing: a partial width array would give some columns a share and
+ * leave others without one, and a reader comparing them would be comparing a
+ * fraction against silence.
+ *
+ * @param trace - The resolved plotly trace
+ * @param count - How many columns the trace draws
+ * @returns One share per column, or undefined when the trace draws no widths
+ */
+function mosaicShares(trace: PlotlyTrace, count: number): number[] | undefined {
+  const widths = trace.width;
+  if (!Array.isArray(widths) || widths.length < count)
+    return undefined;
+
+  const drawn = widths.slice(0, count).map(Number);
+  if (!drawn.every(width => Number.isFinite(width) && width >= 0))
+    return undefined;
+
+  const total = drawn.reduce((sum, width) => sum + width, 0);
+  if (total <= 0)
+    return undefined;
+
+  return drawn.map(width => withoutFloatNoise(width / total));
+}
+
+/**
+ * What a marimekko's columns are called.
+ *
+ * A plotly marimekko puts its bars at precomputed cumulative positions, so
+ * the coordinate is a number and the name has to come from somewhere else:
+ * the per-point text the author drew on the columns, the hover text behind
+ * them, or the tick the axis labels that position with. Failing all three the
+ * position stands, which is what the chart itself shows.
+ *
+ * @param trace     - The resolved plotly trace
+ * @param positions - The trace's coordinate on the category axis
+ * @param axis      - That axis
+ * @returns One name per column
+ */
+function mosaicColumnNames(
+  trace: PlotlyTrace,
+  positions: (number | string)[],
+  axis: PlotlyAxis | undefined,
+): (string | number)[] {
+  const drawn = Array.isArray(trace.text) ? trace.text : undefined;
+  const hovered = Array.isArray(trace.hovertext) ? trace.hovertext : undefined;
+  const authored = drawn ?? hovered;
+  const ticks = axis?.ticktext;
+  const tickValues = axis?.tickvals;
+
+  return positions.map((position, index) => {
+    const named = authored?.[index];
+    if (named !== undefined && named !== null && named !== '')
+      return named;
+
+    if (ticks && tickValues) {
+      const tick = tickValues.findIndex(value => Number(value) === Number(position));
+      if (tick >= 0 && tick < ticks.length)
+        return ticks[tick];
+    }
+    return position;
+  });
+}
+
+/**
+ * The author's own row behind one point.
+ *
+ * `customdata` is plotly's only per-point channel for values it does not draw
+ * with, which makes it the row a declared field is read off.
+ *
+ * @param trace - The resolved plotly trace
+ * @param index - Which point
+ * @returns The row, or undefined when the point has none
+ */
+function customRow(trace: PlotlyTrace, index: number): unknown {
+  const row = trace.customdata?.[index];
+  return typeof row === 'object' && row !== null ? row : undefined;
+}
+
+/**
+ * Narrows a resolved field to a number the payload can carry.
+ *
+ * @param value - Whatever the field resolved to
+ * @returns The number, or undefined when it is not one
+ */
+function finiteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : undefined;
+
+  // A row that came from a CSV carries its numbers as strings, and a share
+  // that arrives as "0.25" is still the share.
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
 }

--- a/src/adapters/plotly/selectors.ts
+++ b/src/adapters/plotly/selectors.ts
@@ -57,12 +57,16 @@ export function generatePlotlySelectors(
     // A pyramid is among these: it is a stacked bar chart whose two sides grow
     // opposite ways, drawn through the same renderer, so its bars are the same
     // elements in the same trace-by-trace order.
+    // A marimekko is among these too: plotly draws it as a stacked bar chart
+    // whose columns happen to differ in width, through the same renderer and
+    // into the same elements. Only the reading changes.
     case TraceType.BAR:
     case TraceType.HISTOGRAM:
     case TraceType.DODGED:
     case TraceType.STACKED:
     case TraceType.NORMALIZED:
     case TraceType.DIVERGING:
+    case TraceType.MOSAIC:
       return `${prefix}.trace.bars .point > path`;
 
     // A step trace is a scatter trace plotly drew as a staircase, and an area
@@ -250,6 +254,48 @@ export function choroplethRegionSelectors(
     + ` > g.trace.choropleth:nth-of-type(${position})`;
   return indices.map(index =>
     `${group} > path.choroplethlocation:nth-of-type(${index + 1})`);
+}
+
+/**
+ * The trace types plotly draws into a panel's `g.contourlayer`, and so the
+ * ones whose groups a contour has to count past.
+ *
+ * `histogram2dcontour` names `contourlayer` as its own layer and is drawn by
+ * the contour plotter, so the two share both the layer and the `g.contour`
+ * class plotly gives each trace's group.
+ */
+const CONTOURLAYER_TRACE_TYPES = ['contour', 'histogram2dcontour'];
+
+/**
+ * Contour selectors: the curves plotly drew for one level at a time.
+ *
+ * Plotly gives every level a `g.contourlevel` of its own — one per level in
+ * the ladder, whether or not the field crosses it — and puts the level's
+ * curves inside as `path.openline` and `path.closedline`. A level the field
+ * never reaches therefore still takes a group, which is why a curve is
+ * addressed by the index of the LEVEL it runs at rather than by counting the
+ * curves before it.
+ *
+ * The trace's group is counted within its own panel, since plotly hangs no
+ * uid class on these groups either.
+ *
+ * @param gd           - The plotly graph div
+ * @param traceIndex   - The global index of the contour trace
+ * @param levelIndices - The ladder position of each level the layer emitted
+ * @returns One selector per level
+ */
+export function contourLevelSelectors(
+  gd: PlotlyGraphDiv,
+  traceIndex: number,
+  levelIndices: number[],
+): string[] {
+  const trace = gd._fullData?.[traceIndex];
+  const prefix = subplotCssPrefix(trace?.xaxis, trace?.yaxis);
+  const position = layerNthChild(gd, traceIndex, CONTOURLAYER_TRACE_TYPES);
+  const lines = `${prefix}.contourlayer > g.contour:nth-of-type(${position})`
+    + ` > g.contourlines`;
+  return levelIndices.map(index =>
+    `${lines} > g.contourlevel:nth-of-type(${index + 1}) > path`);
 }
 
 /**

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -223,6 +223,16 @@ export interface PlotlyContours {
    * `start`/`end` are the ends of an interval and not a level ladder.
    */
   type?: 'levels' | 'constraint';
+  /**
+   * Whether the curves themselves are stroked, default `true`.
+   *
+   * It decides whether the elements a contour is highlighted through exist at
+   * all: `createLines` binds the level groups to no data when this is off, and
+   * a labels-only trace has the group removed again once the labels are
+   * placed. A fill-only contour is drawn entirely out of `g.contourfill`
+   * paths, one per level with no per-curve element.
+   */
+  showlines?: boolean;
 }
 
 /**

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -72,6 +72,19 @@ export interface PlotlyTrace {
   textfont?: { size?: number | number[] };
   /** Author-supplied values carried through to hover templates and events. */
   customdata?: unknown[];
+  /**
+   * Plotly's own arbitrary-metadata attribute, and the slot a co-located
+   * `maidr` declaration rides in — `trace.meta.maidr`. Typed `unknown`
+   * because it is very often a plain string that has nothing to do with
+   * MAIDR; {@link readDeclarationSlot} narrows it.
+   */
+  meta?: unknown;
+  /**
+   * How wide each bar is drawn, in position-axis units. Ordinary bar styling
+   * — which is exactly why a non-uniform array is NOT read as a marimekko on
+   * its own. It becomes data only once a trace declares `type: 'mosaic'`.
+   */
+  width?: number | number[];
   // Waterfall-specific
   /**
    * What each step does to the running total: `relative` contributes,
@@ -185,6 +198,31 @@ export interface PlotlyTrace {
   domain?: { x?: [number, number]; y?: [number, number] };
   // Heatmap colorbar
   colorbar?: { title?: { text?: string } | string };
+  // Contour-specific
+  /** The iso-value curves the trace draws. */
+  contours?: PlotlyContours;
+}
+
+/**
+ * The levels a contour trace draws its curves at.
+ *
+ * Plotly resolves all three during calc — `setContours` fills them in even
+ * when the author left `autocontour` on — so a drawn chart states its own
+ * levels and nothing has to be guessed from the grid.
+ */
+export interface PlotlyContours {
+  /** The lowest level drawn. */
+  start?: number;
+  /** The highest level drawn; the walk stops at or before it. */
+  end?: number;
+  /** The value between one level and the next. */
+  size?: number;
+  /**
+   * `levels` for the ordinary reading, `constraint` for the region-shading
+   * one — which draws a boundary rather than a family of iso-curves, so its
+   * `start`/`end` are the ends of an interval and not a level ladder.
+   */
+  type?: 'levels' | 'constraint';
 }
 
 /**
@@ -370,6 +408,12 @@ export interface PlotlyAxis {
   tick0?: number | string;
   tickmode?: 'auto' | 'linear' | 'array';
   tickvals?: number[];
+  /**
+   * The label drawn at each of {@link PlotlyAxis.tickvals}. A marimekko names
+   * its columns here: its bars sit at precomputed cumulative positions, so
+   * the tick text is the only place the category names survive.
+   */
+  ticktext?: (number | string)[];
   type?: string;
   categories?: string[];
   /** Fraction of the plot area this axis spans: `[start, end]` in [0, 1]. */
@@ -392,8 +436,14 @@ export interface PlotlyAxis {
 }
 
 export interface PlotlyCalcData {
-  x?: number;
-  y?: number;
+  /**
+   * One sample's position — and, on the 2d-map traces whose calc entry holds
+   * the whole grid rather than one point, the ARRAY of coordinates that grid
+   * is indexed by. A contour's `x` is its columns' coordinates in data units,
+   * already trimmed to the grid plotly drew.
+   */
+  x?: number | number[];
+  y?: number | number[];
   p?: number | string; // position (bar, box)
   s?: number; // size/value (bar); running total after the step (waterfall)
   s0?: number;

--- a/src/adapters/plotly/types.ts
+++ b/src/adapters/plotly/types.ts
@@ -46,8 +46,11 @@ export interface PlotlyTrace {
    * A heatmap's grid of magnitudes — and a choropleth's flat column of them,
    * which is the same attribute carrying one value per region rather than one
    * per cell.
+   *
+   * A grid cell may be `null`: that is how plotly's own documentation writes a
+   * hole in a field, and the readers here treat any non-number as one.
    */
-  z?: number[][] | (number | string)[];
+  z?: (number | null)[][] | (number | string)[];
   xaxis?: string;
   yaxis?: string;
   orientation?: 'v' | 'h';

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -4713,6 +4713,24 @@ describe('plotly extractor', () => {
       warn.mockRestore();
     });
 
+    it('reports a column named against array rows rather than counting them', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const layer = mosaicLayer(mosaicTraces(
+        { type: 'mosaic', count: 'n' },
+        { customdata: [['First', 203], ['Third', 178]] },
+      ));
+
+      // Naming a column that array rows cannot carry is the author's mistake,
+      // and saying so beats reading the second element because it happens to
+      // be a number.
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('names "n" for count'),
+      );
+      expect((layer.data as MosaicPoint[][])[0][0].count).toBeUndefined();
+      warn.mockRestore();
+    });
+
     it('reads a marimekko drawn on its side off the axis it stacks along', () => {
       const layer = mosaicLayer(
         [

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -4337,6 +4337,23 @@ describe('plotly extractor', () => {
       ]);
     });
 
+    it('withholds the selectors from a contour that strokes no lines', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        z: PEAK,
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        contours: { start: 2, end: 2, size: 1, showlines: false },
+      });
+
+      // A fill-only contour is drawn as one filled path per level and has no
+      // level groups at all, so a selector could only match nothing. The
+      // curves are still read, sonified and navigated.
+      expect(layer.type).toBe(TraceType.CONTOUR);
+      expect(layer.selectors).toBeUndefined();
+      expect((layer.data as ContourPoint[][])[0][0]).toEqual({ x: 1, y: 0.5, level: 2 });
+    });
+
     it('counts a contour past the ones drawn into the same panel before it', () => {
       const maidr = extractPlotlyData(contourGd(
         {
@@ -4608,6 +4625,37 @@ describe('plotly extractor', () => {
           { x: 'Third', y: 0.7, z: 'Died', width: 0.7, count: 528 },
         ],
       ]);
+    });
+
+    it('reads no count off array-shaped customdata rather than inventing one', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const layer = mosaicLayer(mosaicTraces(
+        { type: 'mosaic' },
+        // Plotly's canonical customdata shape: one array per point. A declared
+        // field is a property NAME, so an array row answers to nothing --
+        // least of all `length`, which is the number of columns here and not
+        // the number of observations behind the cell.
+        { customdata: [['First', 203], ['Third', 178]] },
+      ));
+
+      const cells = (layer.data as MosaicPoint[][])[0];
+      expect(cells.map(cell => cell.count)).toEqual([undefined, undefined]);
+      // The share is still the one plotly drew.
+      expect(cells.map(cell => cell.width)).toEqual([0.25, 0.75]);
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('reads a lone bar trace declared a mosaic as a spineplot', () => {
+      const [survived] = mosaicTraces({ type: 'mosaic' });
+      // One trace is a spineplot -- a real chart, and one whose columns plotly
+      // has nothing to stack against, so the barmode check does not apply.
+      const layer = mosaicLayer([survived], { barmode: 'group' });
+
+      expect(layer.type).toBe(TraceType.MOSAIC);
+      expect((layer.data as MosaicPoint[][])[0].map(cell => cell.width))
+        .toEqual([0.25, 0.75]);
     });
 
     it('reports a named column no row carries, and leaves the field out', () => {

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -4337,6 +4337,72 @@ describe('plotly extractor', () => {
       ]);
     });
 
+    it('leaves a hole in the field a hole rather than reading it as a zero', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        // `null` is how plotly's own docs write a missing cell. Read as the 0
+        // it converts to, it would be a corner below the level and the curve
+        // would be walked around a field the chart never drew.
+        z: [
+          [0, 0, null],
+          [0, 4, 0],
+          [0, 0, 0],
+        ],
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        contours: { start: 2, end: 2, size: 1 },
+      });
+
+      // The cell holding it contributes nothing, so the diamond of the whole
+      // grid is walked as an open curve that stops where the data does --
+      // four vertices and no repeat of the first, which is how a curve that
+      // did close says so.
+      expect(layer.data as ContourPoint[][]).toEqual([[
+        { x: 1, y: 0.5, level: 2 },
+        { x: 0.5, y: 1, level: 2 },
+        { x: 1, y: 1.5, level: 2 },
+        { x: 1.5, y: 1, level: 2 },
+      ]]);
+    });
+
+    it('falls back to grid positions when the chart states no coordinates', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        z: PEAK,
+        contours: { start: 2, end: 2, size: 1 },
+      });
+
+      // Without an x or a y the column and row indices are the only honest
+      // coordinates, and they are what plotly draws the grid at too.
+      expect((layer.data as ContourPoint[][])[0]).toEqual([
+        { x: 1, y: 0.5, level: 2 },
+        { x: 0.5, y: 1, level: 2 },
+        { x: 1, y: 1.5, level: 2 },
+        { x: 1.5, y: 1, level: 2 },
+        { x: 1, y: 0.5, level: 2 },
+      ]);
+    });
+
+    it('refuses a ladder of more levels than a reader could walk', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const maidr = extractPlotlyData(contourGd({
+        type: 'contour',
+        z: PEAK,
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        // Every level costs a walk over the whole grid, and no reader walks
+        // 4001 curves: this is an authoring mistake, not a chart.
+        contours: { start: 0, end: 4, size: 0.001 },
+      }));
+
+      expect(maidr).toBeNull();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('states no levels to read'),
+      );
+      warn.mockRestore();
+    });
+
     it('withholds the selectors from a contour that strokes no lines', () => {
       const layer = contourLayer({
         type: 'contour',
@@ -4645,6 +4711,48 @@ describe('plotly extractor', () => {
       expect(cells.map(cell => cell.width)).toEqual([0.25, 0.75]);
       expect(warn).not.toHaveBeenCalled();
       warn.mockRestore();
+    });
+
+    it('reads a marimekko drawn on its side off the axis it stacks along', () => {
+      const layer = mosaicLayer(
+        [
+          {
+            type: 'bar',
+            name: 'Survived',
+            orientation: 'h',
+            x: [0.6, 0.3],
+            y: [15, 75],
+            width: [30, 90],
+            meta: { maidr: { type: 'mosaic' } },
+          },
+          {
+            type: 'bar',
+            name: 'Died',
+            orientation: 'h',
+            x: [0.4, 0.7],
+            y: [15, 75],
+            width: [30, 90],
+          },
+        ],
+        // Turned on its side the columns run along y, so that is the axis
+        // whose ticks name them.
+        {
+          xaxis: { title: { text: 'Proportion' }, domain: [0, 1] },
+          yaxis: {
+            title: { text: 'Class' },
+            domain: [0, 1],
+            tickvals: [15, 75],
+            ticktext: ['First', 'Third'],
+          },
+        },
+      );
+
+      expect(layer.type).toBe(TraceType.MOSAIC);
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      expect((layer.data as MosaicPoint[][])[0]).toEqual([
+        { x: 0.6, y: 'First', z: 'Survived', width: 0.25 },
+        { x: 0.3, y: 'Third', z: 'Survived', width: 0.75 },
+      ]);
     });
 
     it('reads a lone bar trace declared a mosaic as a spineplot', () => {

--- a/test/adapters/plotly/extractor.test.ts
+++ b/test/adapters/plotly/extractor.test.ts
@@ -1,5 +1,5 @@
 import type { PlotlyCalcData, PlotlyFullLayout, PlotlyGraphDiv, PlotlyHierarchyNode, PlotlyTrace } from '@adapters/plotly/types';
-import type { BarPoint, BoxPoint, BoxSelector, ChoroplethPoint, ErrorBarPoint, GanttData, GaugePoint, LinePoint, MaidrLayer, PiePoint, SegmentedPoint, TreemapPoint, ViolinKdePoint } from '@type/grammar';
+import type { BarPoint, BoxPoint, BoxSelector, ChoroplethPoint, ContourPoint, ErrorBarPoint, GanttData, GaugePoint, LinePoint, MaidrLayer, MosaicPoint, PiePoint, SegmentedPoint, TreemapPoint, ViolinKdePoint } from '@type/grammar';
 import { extractPlotlyData } from '@adapters/plotly/extractor';
 import { normalizePlotlySvg } from '@adapters/plotly/normalizer';
 import { describe, expect, it, jest } from '@jest/globals';
@@ -4237,6 +4237,481 @@ describe('plotly extractor', () => {
         .toEqual([TraceType.BAR, TraceType.CHOROPLETH]);
       expect(maidr!.subplots[0][1].layers[0].selectors)
         .toEqual(expect.arrayContaining([expect.stringContaining('g.geo.geo2')]));
+    });
+  });
+  describe('contour', () => {
+    /**
+     * A single peak at the centre of a 3x3 grid. Every level between 0 and 4
+     * crosses it as one closed diamond, which is small enough to write down.
+     */
+    const PEAK = [
+      [0, 0, 0],
+      [0, 4, 0],
+      [0, 0, 0],
+    ];
+
+    function contourGd(
+      trace: PlotlyTrace,
+      calcdata?: PlotlyCalcData[][],
+      extra: PlotlyTrace[] = [],
+    ): PlotlyGraphDiv {
+      return createGraphDiv({
+        traces: [trace, ...extra],
+        layout: {
+          xaxis: { title: { text: 'X' }, domain: [0, 1] },
+          yaxis: { title: { text: 'Y' }, domain: [0, 1] },
+        },
+        calcdata,
+        bgRects: [{ x: 0, y: 0 }],
+      });
+    }
+
+    function contourLayer(
+      trace: PlotlyTrace,
+      calcdata?: PlotlyCalcData[][],
+    ): MaidrLayer {
+      const maidr = extractPlotlyData(contourGd(trace, calcdata));
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('walks the grid itself at the level the trace states', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        z: PEAK,
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        contours: { start: 2, end: 2, size: 1 },
+      });
+
+      expect(layer.type).toBe(TraceType.CONTOUR);
+      // The level runs half way up every edge out of the peak, and the curve
+      // closes by repeating the vertex it started at.
+      expect(layer.data as ContourPoint[][]).toEqual([[
+        { x: 1, y: 0.5, level: 2 },
+        { x: 0.5, y: 1, level: 2 },
+        { x: 1, y: 1.5, level: 2 },
+        { x: 1.5, y: 1, level: 2 },
+        { x: 1, y: 0.5, level: 2 },
+      ]]);
+      expect(layer.axes?.x?.label).toBe('X');
+      expect(layer.axes?.y?.label).toBe('Y');
+    });
+
+    it('reads the coordinates in data units rather than in grid positions', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        z: PEAK,
+        x: [0, 10, 20],
+        y: [0, 5, 10],
+        contours: { start: 2, end: 2, size: 1 },
+      });
+
+      expect((layer.data as ContourPoint[][])[0]).toEqual([
+        { x: 10, y: 2.5, level: 2 },
+        { x: 5, y: 5, level: 2 },
+        { x: 10, y: 7.5, level: 2 },
+        { x: 15, y: 5, level: 2 },
+        { x: 10, y: 2.5, level: 2 },
+      ]);
+    });
+
+    it('keeps a level the field never crosses out of the layer, and out of nothing else', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        z: PEAK,
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        // Nothing is below 0, so the first level of the ladder draws no curve
+        // at all -- but plotly still gives it a group of its own.
+        contours: { start: 0, end: 4, size: 2 },
+      });
+
+      expect((layer.data as ContourPoint[][]).map(curve => curve[0].level))
+        .toEqual([2, 4]);
+      expect(layer.selectors).toEqual([
+        '.subplot.xy .contourlayer > g.contour:nth-of-type(1) > g.contourlines'
+        + ' > g.contourlevel:nth-of-type(2) > path',
+        '.subplot.xy .contourlayer > g.contour:nth-of-type(1) > g.contourlines'
+        + ' > g.contourlevel:nth-of-type(3) > path',
+      ]);
+    });
+
+    it('counts a contour past the ones drawn into the same panel before it', () => {
+      const maidr = extractPlotlyData(contourGd(
+        {
+          type: 'histogram2dcontour',
+          x: [1, 2],
+          y: [1, 2],
+          contours: { start: 2, end: 2, size: 1 },
+        },
+        [[{ z: PEAK, x: [0, 1, 2], y: [0, 1, 2] }], []],
+        [{
+          type: 'contour',
+          z: PEAK,
+          x: [0, 1, 2],
+          y: [0, 1, 2],
+          contours: { start: 2, end: 2, size: 1 },
+        }],
+      ));
+
+      const layers = maidr!.subplots[0][0].layers;
+      expect(layers.map(layer => layer.type))
+        .toEqual([TraceType.CONTOUR, TraceType.CONTOUR]);
+      // Both trace types are drawn into `contourlayer` and given the same
+      // group class, so the second one is the second group.
+      expect(layers[1].selectors).toEqual([
+        '.subplot.xy .contourlayer > g.contour:nth-of-type(2) > g.contourlines'
+        + ' > g.contourlevel:nth-of-type(1) > path',
+      ]);
+    });
+
+    it('reads the grid plotly binned for a histogram2dcontour', () => {
+      const layer = contourLayer(
+        {
+          type: 'histogram2dcontour',
+          x: [1, 2, 3],
+          y: [1, 2, 3],
+          contours: { start: 2, end: 2, size: 1 },
+        },
+        [[{ z: PEAK, x: [0, 10, 20], y: [0, 5, 10] }]],
+      );
+
+      // The trace carries samples rather than a grid; only calcdata has the
+      // binned field, and the bin centres with it.
+      expect(layer.type).toBe(TraceType.CONTOUR);
+      expect((layer.data as ContourPoint[][])[0][0]).toEqual({ x: 10, y: 2.5, level: 2 });
+    });
+
+    it('names the level axis from the colorbar, and leaves it unnamed without one', () => {
+      const trace: PlotlyTrace = {
+        type: 'contour',
+        z: PEAK,
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        contours: { start: 2, end: 2, size: 1 },
+      };
+
+      expect(contourLayer(trace).axes?.z).toBeUndefined();
+      expect(contourLayer({
+        ...trace,
+        colorbar: { title: { text: 'Density' } },
+      }).axes?.z).toEqual({ label: 'Density' });
+    });
+
+    it('skips a contour whose levels plotly has not resolved', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(extractPlotlyData(contourGd({
+        type: 'contour',
+        z: PEAK,
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+      }))).toBeNull();
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('states no levels'));
+      warn.mockRestore();
+    });
+
+    it('skips a constraint contour, which draws a region and not a ladder', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(extractPlotlyData(contourGd({
+        type: 'contour',
+        z: PEAK,
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        contours: { type: 'constraint', start: 1, end: 3, size: 1 },
+      }))).toBeNull();
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('constraint region'));
+      warn.mockRestore();
+    });
+
+    it('flattens a level drawn as several disjoint curves into one row', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        // A ridge along the middle row: the level runs across the grid twice,
+        // once below the ridge and once above it, and neither curve closes.
+        z: [
+          [0, 0, 0],
+          [4, 4, 4],
+          [0, 0, 0],
+        ],
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        contours: { start: 2, end: 2, size: 1 },
+      });
+
+      // One row per LEVEL, not per curve: the level is what the reader
+      // navigates, and the two halves of it are one thing to walk.
+      expect(layer.data as ContourPoint[][]).toEqual([[
+        { x: 0, y: 0.5, level: 2 },
+        { x: 1, y: 0.5, level: 2 },
+        { x: 2, y: 0.5, level: 2 },
+        { x: 0, y: 1.5, level: 2 },
+        { x: 1, y: 1.5, level: 2 },
+        { x: 2, y: 1.5, level: 2 },
+      ]]);
+    });
+
+    it('joins an ambiguous cell the way the field runs through it', () => {
+      const layer = contourLayer({
+        type: 'contour',
+        // An anti-diagonal ridge. Both middle cells have their high corners
+        // opposite each other, so which pair of edges the curve joins is
+        // decided by the middle of the cell -- and joining the other pair
+        // would splice the two curves into one that runs through the ridge.
+        z: [
+          [0, 0, 4],
+          [0, 4, 0],
+          [4, 0, 0],
+        ],
+        x: [0, 1, 2],
+        y: [0, 1, 2],
+        contours: { start: 2, end: 2, size: 1 },
+      });
+
+      expect(layer.data as ContourPoint[][]).toEqual([[
+        // The curve below the ridge, walked back to the end the scan did not
+        // start from.
+        { x: 1.5, y: 0, level: 2 },
+        { x: 1, y: 0.5, level: 2 },
+        { x: 0.5, y: 1, level: 2 },
+        { x: 0, y: 1.5, level: 2 },
+        // And the one above it.
+        { x: 2, y: 0.5, level: 2 },
+        { x: 1.5, y: 1, level: 2 },
+        { x: 1, y: 1.5, level: 2 },
+        { x: 0.5, y: 2, level: 2 },
+      ]]);
+    });
+  });
+
+  describe('mosaic', () => {
+    /**
+     * A two-column marimekko: the columns sit at cumulative centres and are
+     * drawn 30 and 90 wide, so they are a quarter and three quarters of all
+     * observations.
+     */
+    function mosaicTraces(
+      declaration: unknown,
+      overrides: Partial<PlotlyTrace> = {},
+    ): PlotlyTrace[] {
+      return [
+        {
+          type: 'bar',
+          name: 'Survived',
+          x: [15, 75],
+          y: [0.6, 0.3],
+          width: [30, 90],
+          meta: declaration === undefined ? undefined : { maidr: declaration },
+          ...overrides,
+        },
+        {
+          type: 'bar',
+          name: 'Died',
+          x: [15, 75],
+          y: [0.4, 0.7],
+          width: [30, 90],
+        },
+      ];
+    }
+
+    function mosaicGd(
+      traces: PlotlyTrace[],
+      layout: Partial<PlotlyFullLayout> = {},
+    ): PlotlyGraphDiv {
+      return createGraphDiv({
+        traces,
+        layout: {
+          barmode: 'stack',
+          xaxis: {
+            title: { text: 'Class' },
+            domain: [0, 1],
+            tickvals: [15, 75],
+            ticktext: ['First', 'Third'],
+          },
+          yaxis: { title: { text: 'Proportion' }, domain: [0, 1] },
+          ...layout,
+        },
+        bgRects: [{ x: 0, y: 0 }],
+      });
+    }
+
+    function mosaicLayer(
+      traces: PlotlyTrace[],
+      layout: Partial<PlotlyFullLayout> = {},
+    ): MaidrLayer {
+      const maidr = extractPlotlyData(mosaicGd(traces, layout));
+      expect(maidr).not.toBeNull();
+      return maidr!.subplots[0][0].layers[0];
+    }
+
+    it('reads a declared marimekko as one, with each column carrying its share', () => {
+      const layer = mosaicLayer(mosaicTraces({ type: 'mosaic' }));
+
+      expect(layer.type).toBe(TraceType.MOSAIC);
+      expect(layer.data as MosaicPoint[][]).toEqual([
+        [
+          { x: 'First', y: 0.6, z: 'Survived', width: 0.25 },
+          { x: 'Third', y: 0.3, z: 'Survived', width: 0.75 },
+        ],
+        [
+          { x: 'First', y: 0.4, z: 'Died', width: 0.25 },
+          { x: 'Third', y: 0.7, z: 'Died', width: 0.75 },
+        ],
+      ]);
+      // Drawn as a stacked bar chart, and highlighted as one.
+      expect(layer.selectors).toBe('.subplot.xy .trace.bars .point > path');
+    });
+
+    it('leaves an undeclared stacked bar chart a stacked bar chart', () => {
+      const layer = mosaicLayer(mosaicTraces(undefined));
+
+      // The widths are still there and still non-uniform: plotly's `width` is
+      // ordinary bar styling, so nothing but the declaration says otherwise.
+      expect(layer.type).toBe(TraceType.STACKED);
+      expect(layer.data as SegmentedPoint[][]).toEqual([
+        [
+          { x: 15, y: 0.6, z: 'Survived' },
+          { x: 75, y: 0.3, z: 'Survived' },
+        ],
+        [
+          { x: 15, y: 0.4, z: 'Died' },
+          { x: 75, y: 0.7, z: 'Died' },
+        ],
+      ]);
+    });
+
+    it('reads the share and the count off the columns the author named', () => {
+      const [survived, died] = mosaicTraces(
+        { type: 'mosaic', width: 'share', count: 'n' },
+        {
+          customdata: [{ share: 0.3, n: 203 }, { share: 0.7, n: 178 }],
+        },
+      );
+      const layer = mosaicLayer([
+        survived,
+        { ...died, customdata: [{ share: 0.3, n: 122 }, { share: 0.7, n: 528 }] },
+      ]);
+
+      // The declared column wins over the widths plotly drew, which would
+      // have given 0.25 and 0.75.
+      expect(layer.data as MosaicPoint[][]).toEqual([
+        [
+          { x: 'First', y: 0.6, z: 'Survived', width: 0.3, count: 203 },
+          { x: 'Third', y: 0.3, z: 'Survived', width: 0.7, count: 178 },
+        ],
+        [
+          { x: 'First', y: 0.4, z: 'Died', width: 0.3, count: 122 },
+          { x: 'Third', y: 0.7, z: 'Died', width: 0.7, count: 528 },
+        ],
+      ]);
+    });
+
+    it('reports a named column no row carries, and leaves the field out', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const layer = mosaicLayer(mosaicTraces(
+        { type: 'mosaic', count: 'tally' },
+        { customdata: [{ n: 203 }, { n: 178 }] },
+      ));
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('names "tally" for count'),
+      );
+      expect((layer.data as MosaicPoint[][])[0][0].count).toBeUndefined();
+      warn.mockRestore();
+    });
+
+    it('names the columns from the ticks when the bars sit at cumulative positions', () => {
+      const layer = mosaicLayer(mosaicTraces({ type: 'mosaic' }), {
+        xaxis: { domain: [0, 1], tickvals: [15, 75], ticktext: ['Crew', 'Third'] },
+      });
+
+      expect((layer.data as MosaicPoint[][])[0].map(point => point.x))
+        .toEqual(['Crew', 'Third']);
+    });
+
+    it('prefers the text the author drew on the columns to the axis ticks', () => {
+      const [survived, died] = mosaicTraces({ type: 'mosaic' });
+      const layer = mosaicLayer([
+        { ...survived, text: ['First class', 'Third class'] },
+        died,
+      ]);
+
+      const data = layer.data as MosaicPoint[][];
+      expect(data[0].map(point => point.x)).toEqual(['First class', 'Third class']);
+      // Named per trace: the series that drew no text still takes the ticks.
+      expect(data[1].map(point => point.x)).toEqual(['First', 'Third']);
+    });
+
+    it('keeps the position when nothing names the column', () => {
+      const layer = mosaicLayer(mosaicTraces({ type: 'mosaic' }), {
+        xaxis: { domain: [0, 1] },
+      });
+
+      expect((layer.data as MosaicPoint[][])[0].map(point => point.x))
+        .toEqual([15, 75]);
+    });
+
+    it('refuses a mosaic declared on bars plotly drew side by side', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const layer = mosaicLayer(mosaicTraces({ type: 'mosaic' }), {
+        barmode: 'group',
+      });
+
+      expect(layer.type).toBe(TraceType.DODGED);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('barmode "group"'));
+      warn.mockRestore();
+    });
+
+    it('refuses a mosaic declared on a trace that draws no bars', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const maidr = extractPlotlyData(mosaicGd([
+        ...mosaicTraces(undefined),
+        {
+          type: 'scatter',
+          mode: 'markers',
+          x: [1, 2],
+          y: [1, 2],
+          meta: { maidr: { type: 'mosaic' } },
+        },
+      ]));
+
+      expect(maidr!.subplots[0][0].layers.map(layer => layer.type))
+        .toEqual([TraceType.STACKED, TraceType.SCATTER]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('is not on a bar trace'),
+      );
+      warn.mockRestore();
+    });
+
+    it('reports a declared type the adapter does not read, and reads the chart undeclared', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const layer = mosaicLayer(mosaicTraces({ type: 'boxen' }));
+
+      expect(layer.type).toBe(TraceType.STACKED);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('declares "boxen", which the plotly adapter does not read'),
+      );
+      warn.mockRestore();
+    });
+
+    it('passes over a meta that is not a declaration at all', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // `meta` is plotly's own metadata attribute and is very often a plain
+      // string that has nothing to do with MAIDR.
+      const layer = mosaicLayer(mosaicTraces(undefined, { meta: 'run 3' }));
+
+      expect(layer.type).toBe(TraceType.STACKED);
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Adds the two chart types that were deferred out of the plotly.js coverage PR: **contour** (including `histogram2dcontour`) and **mosaic / marimekko**. Both are wired end to end — detection, payload, axes, and the selector/highlight path — in this one change, so neither ships as a type that sonifies without highlighting.

Contour is detected from `trace.type` with no author involvement. Mosaic is opt-in only, declared through `trace.meta.maidr` and narrowed by the shared declaration helpers merged in #886 (`readDeclarationSlot` / `validateDeclaration` / `resolveFieldRef` / `warnUnresolvedRef`), since a marimekko is drawn through plotly's ordinary stacked-bar renderer and cannot be told apart from a stacked bar by inspection alone.

Nothing outside `src/adapters/plotly/`, `test/adapters/plotly/`, `examples/` and `docs/` is touched. The shared foundation (`src/type/declaration.ts`, `src/adapters/shared/traceDeclaration.ts`) is unmodified; two gaps found in it are reported under Additional Notes rather than patched, so the sibling adapter PRs can weigh in.

## Related Issues

Part of #885

## Changes Made

### Trace types added

**Contour** (`TraceType.CONTOUR`) — detected with no declaration from `trace.type` of `contour` and `histogram2dcontour` in `mapTraceType`.

- Curves are recomputed by marching squares over the grid, reading `calcdata[i][0].z` first so a `histogram2dcontour`'s binned grid and a transposed `contour` both work, with `trace.z` as the fallback.
- Levels come from the ladder plotly already resolved on `trace.contours.{start,end,size}`. `setContours` mutates those on the full trace during calc even when `autocontour` chose them, so authored and auto charts read the same way.
- Coordinates are always data units, never pixels: calcdata `x`/`y` first, then the authored `x`/`y`, then grid indices.
- Saddle cells are resolved by the four-corner average. A level's disjoint rings are flattened into one row in ring order; a closed ring repeats its first vertex, matching the convention in the shipped `examples/contour.html`.
- A constraint contour, an unresolved ladder, and a level the field never crosses are each refused or skipped with a warning rather than announced at invented values.
- **Highlight:** new `contourLevelSelectors()` in `selectors.ts` emits one selector per emitted curve, scoped by panel, by the trace's position among the panel's `contourlayer` groups, and by the level's place in the ladder — plotly gives every level a `g.contourlevel` whether or not the field crosses it, so a curve index would drift.
- **Axes:** the level is announced on the field's own `z` axis, named from the colorbar title when the author gave one and left unnamed otherwise, so the model says "Level" rather than a fabricated "Value".

**Mosaic / Marimekko** (`TraceType.MOSAIC`) — opt-in only, via `trace.meta.maidr`.

- A validated mosaic declaration on one of a panel's bar traces routes the panel through `extractSegmentedBarLayer` as `TraceType.MOSAIC`, beating the gantt and stacked/dodged heuristics per the precedence rules.
- Each cell carries `width` (the declared `customdata` column via `resolveFieldRef`, else the drawn `trace.width` array normalised by its own total, so counts, percentages and fractions all read the same) and `count` (declared column only — never derived from a rounded share).
- Columns are named from `trace.text`, then `trace.hovertext`, then the axis `ticktext` at the matching `tickval`, since a marimekko's `x` is a precomputed cumulative number. Failing all three, the position stands.
- **Highlight:** `TraceType.MOSAIC` joins the bar-family case in `generatePlotlySelectors`, since plotly draws a marimekko through the bar renderer into the same `.trace.bars .point > path` elements as a stacked bar.
- **Degradation:** a mosaic declared on a non-bar trace, or on a panel whose bars plotly drew with `barmode: 'group'`, warns naming both what was found and what the type needs, then falls back to the undeclared reading. A declared type this adapter does not read warns and falls back. An explicit `FieldRef` no row carries is reported through `warnUnresolvedRef` and the field is omitted.

### Trace types not added, and why

- Nothing from the deferred set was skipped. Contour and mosaic were the two types deferred out of the coverage PR for this adapter, and both are implemented here.

### Supporting changes

- `src/adapters/plotly/types.ts` — `PlotlyTrace` gained `meta`, `width` and `contours` (plus a new `PlotlyContours` interface); `PlotlyAxis` gained `ticktext`; `PlotlyCalcData.x`/`y` widened to `number | number[]`, since a 2d-map calc entry holds the whole grid's coordinate arrays, mirroring the duality already documented on its `z`.
- `test/adapters/plotly/extractor.test.ts` — 21 new cases (0 removed), in new `contour` and `mosaic` describes.
- `examples/plotly-contour.html` and `examples/plotly-mosaic.html`.
- `docs/plotly.md` — two rows in the supported-types table, two notes, a "Declaring a mosaic" section, and the two example entries.

## Screenshots (if applicable)

N/A — no visual change to MAIDR's own UI.

## Checklist

- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The automated gate was run in full and is green: `npm run lint:fix` (no changes), `npm run type-check`, `npm run build`, and `npm test` (268 suites / 3791 tests, plus the ESM project's 7 suites / 73 tests, all passing). `npx jest test/adapters/plotly` is 212 passing. The `ManualTestingProcess.md` box is left unticked because that manual pass was not performed; the Contributor Guidelines box is left unticked because that document was not read as part of this change.

## Additional Notes

### Foundation gaps (relevant to the sibling adapter PRs)

The shared foundation was deliberately left unmodified. Two gaps are worth recording:

1. **`MosaicDeclaration` has no way to name the column holding a cell's category label.** For plotly this is the bulk of the work: a marimekko's `x` is a precomputed cumulative *number*, so the category name is not on the axis coordinate. It is recovered here from `trace.text` / `hovertext` / axis `ticktext`, which works — but an author whose names live in a `customdata` column has no way to say so. A `label?: FieldRef` on `MosaicDeclaration`, spelled like the grammar's ordinal label as `ManhattanDeclaration` and `ScatterDeclaration` already have, would cover it.
2. **`validateDeclaration` answers "is this a valid declaration of some type", with no way for an adapter to say which types it reads.** Every adapter implementing a subset therefore hand-writes the same "this adapter does not read `<type>`" warning; one is written here in `readTraceDeclaration`. Not blocking, and probably not worth a shared export until a second adapter needs the identical sentence.

### Spec corrections

- The deferred spec's contour route names `.contourlayer path.contourlevel` as the `d`-carrying elements. Checked against plotly.js 2.35.2 (`src/traces/contour/plot.js`, `createLines`): `contourlevel` is a `g`, one per level, and the paths inside are `path.openline` and `path.closedline`. The trace group is `g.contour` — `Lib.makeTraceGroups` is called with the class string `contour`, so it is **not** `g.trace.contour` the way a bar or scatter group is. The selectors in this PR follow the verified shape.
- The spec puts `extractSegmentedBarLayer` at `extractor.ts:2020`; it was at `:4069` before this change. `extractPlotlyData` at `:78` and `mapTraceType` at `:300` were both accurate.
- The per-adapter instruction lists only `meta` and `width` as the missing `PlotlyTrace` fields. Three more were needed and none existed: `contours` on `PlotlyTrace` (without it the level ladder is unreachable and the whole detection is dead), `ticktext` on `PlotlyAxis`, and `PlotlyCalcData.x`/`y` widened to accept the coordinate *arrays* a 2d-map calc entry carries.
- `convention.md`'s shared-module surface (§"Shared module") is stale against what merged in #886: the flag helper is exported as `isFlagValue`, not `isCensoredValue`; there are six exports rather than four, the extra two being `warnUnresolvedRef` and `readDeclarationSlot`; and `resolveFieldRef`'s row parameter is `unknown`, not `Record<string, unknown> | undefined`. The merged version is the better one — `readDeclarationSlot` is exactly what plotly's `meta: unknown` needs — this is a note that the prose is stale, not a complaint.

### Two judgement calls for the reviewer

1. **Contour highlighting is approximate along a curve, and deliberately so.** Plotly draws a level as whole-curve paths with no element per vertex, so per-point highlighting can only be synthetic — `LineTrace` parses the path `d` and makes circles. Plotly's own drawn vertices are also not reproducible from the grid: `find_all_paths.js` merges vertices closer together than a fraction of the average spacing, and `smoothopen`/`smoothclosed` then add control points, so no marching-squares implementation can guarantee vertex-for-vertex correspondence. That does not affect what is *announced* (the curves are recomputed), but the data-point-to-circle mapping can be rotated or offset along the curve. The selectors are emitted anyway rather than withheld (as parcoords and an unsorted pie do), on the grounds that each selector is scoped to its own level group, so the highlight always lands on the correct curve and the error is bounded to a position along it — and withholding would leave contour with no visual modality at all. `docs/plotly.md` states the limitation. If silence is preferred over an approximate pointer, deleting the `selectors:` line in `extractContourLayer` is the whole change.
2. **A single bar trace carrying a mosaic declaration is accepted**, because a spineplot is a real chart. The `barmode` check therefore only applies when a panel has more than one bar trace.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_