### PR TITLE
feat(anychart): read the chart types deferred out of the coverage PR

### DIFF
--- a/docs/anychart.md
+++ b/docs/anychart.md
@@ -87,6 +87,8 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 | Radar | `anychart.radar()`, and a polar `line` / `marker` series | [Radar chart](examples.html) |
 | Polar Area | `anychart.polar()` with a `column` / `area` series | [Radar chart](examples.html) |
 | Mosaic | `anychart.mekko()`, `anychart.mosaic()`, `anychart.barmekko()` | [Marimekko chart](examples.html) |
+| Choropleth | a `choropleth` series on `anychart.map()` | [Choropleth map](examples.html) |
+| Gantt | `anychart.ganttProject()`, `anychart.ganttResource()` | [Gantt chart](examples.html) |
 
 `step-area` is the one series that still loses its fill: MAIDR has no stepped area trace, so it keeps its staircase and maps to a step trace. A console warning is emitted when that downgrade occurs.
 
@@ -118,6 +120,16 @@ AnyChart must be loaded separately — the adapter does not bundle the AnyChart 
 - **Diverging bars** — a tornado chart, or a population pyramid — are **opt-in** via `bindAnyChart(chart, { diverging: true })`. AnyChart has no diverging chart type: the idiom is a stacked `anychart.bar()` whose two series straddle zero, and nothing distinguishes that from a stacked bar chart that happens to contain negative values. Guessing would not merely rename an ordinary chart — a diverging trace replaces the sign in every announcement with the name of a side, which is the one clue a reader would have that the reading was wrong. When declared, every bar series is merged into **one** layer, because the balance MAIDR announces is a difference read down a column of one grid; the values are emitted signed, exactly as the chart draws them, and each side is named by its series. A chart with fewer than two bar series keeps its ordinary bar layers and says why.
 
 - **Tag clouds** come from `anychart-tag-cloud.min.js` and report `getType()` as `'tag-cloud'`. Axis labels fall back to `Term` and `Weight`. Highlighting pairs each term with its own `<text>` element by matching the rendered text rather than by counting DOM order: a cloud writes its words in packing order, which has no relation to the order they were declared in, so counting them off would announce one term while highlighting another. A term that does not match exactly one rendered word disables highlighting for the whole chart rather than placing a guess.
+
+- **Choropleth** maps come from `anychart-map.min.js` plus a geodata file, and the `choropleth` series is what carries the data — `marker`, `bubble` and `connector` draw *over* a map rather than colouring it. The **series' own type is the whole detection**: `chart.getType()` is deliberately not required, because it answers `''` on a build without it and on a chart that has not been drawn, and gating on it would drop working maps. A row names a region by the id the geodata declared (`US.NV`) and never by name, so the name is read from the bound geo feature — `point.getFeatureProp()` where the build offers it, and the geodata's own `properties` matched by id otherwise. A region nothing names keeps its id, which is a poor name but a true one. Axis labels fall back to `Region` and `Value`.
+
+  `lon` and `lat` are **deliberately omitted**. MAIDR's centroids are degrees east and north; what AnyChart has are its features' `middle-x` / `middle-y`, normalised coordinates in the map's own projection, which cannot be turned into degrees without inverting a projection the chart does not name. Passing them through would tell a reader that one region lies north of another when the map says nothing of the kind, so the map is read as a region list in declared order — the poorer reading the schema explicitly sanctions. `neighbors` is not derivable from AnyChart either and stays absent.
+
+- **Gantt** charts come from `anychart-gantt.min.js`. `anychart.ganttProject()` and `anychart.ganttResource()` report `'gantt-project'` and `'gantt-resource'`, and the type name is corroborated structurally before anything is read: a gantt has no series API at all and its `chart.data()` hands back an `anychart.data.Tree` of tasks rather than a data view, so a chart naming itself a gantt with no tree behind it is bound as nothing rather than as an empty schedule. The tree is flattened depth-first — parents before their children, the order the chart stacks its rows in — into one lane per row. A parent task states no dates of its own, so the pair AnyChart derived for it (`autoStart` / `autoEnd`) is read instead; a task with a start and no end is a milestone and is emitted as the zero-length interval it is; a resource chart's `periods` array becomes several intervals in one lane. A task with no dates at all becomes an **empty lane** that still carries its name, which is what MAIDR's nested gantt shape exists to express. Axis labels fall back to `Date` and `Task` (`Resource` on a resource chart).
+
+  The ends are restated in whole days — or hours, on a schedule spanning less than two days — and the unit is named alongside them, because a gantt is read for how long its intervals run and epoch milliseconds announce as an unreadable nine-digit figure. This is read rather than guessed: a gantt's timeline is a date-time scale, so what the tree holds is instants. The x axis carries a formatter that turns a position back into a date, so each end is still announced as one.
+
+  `anychart.timeline()` is **not** read. It is a third constructor with a series API of its own whose `moment` series are instants rather than intervals, and announcing one as a schedule would describe work the chart never drew; it binds as nothing instead.
 
 ## Code Examples
 
@@ -436,6 +448,8 @@ AnyChart's SVG output uses opaque, internally-generated ids (`ac_path_*`, `ac_re
 | Waterfall | `data-maidr-anychart-waterfall-step` | `"<seriesIndex>-<stepIndex>"` |
 | Radar / polar | `data-maidr-anychart-spoke` | `"<seriesIndex>-<spokeIndex>"` |
 | Marimekko | `data-maidr-anychart-tile` | `"<seriesIndex>-<categoryIndex>"` |
+| Choropleth | `data-maidr-anychart-region` | `"<seriesIndex>-<regionIndex>"` |
+| Gantt | `data-maidr-anychart-task-bar` | `"<laneIndex>-<intervalIndex>"` |
 
 The adapter's generated `selectors` then target those attributes (e.g. `[data-maidr-anychart-bar="0-3"]`), which keeps highlighting stable across re-renders.
 
@@ -447,6 +461,11 @@ The adapter uses this `clip-path` presence as the primary discriminator when pic
 
 - Paths with `fill-opacity < 1` (hover / selection overlays).
 - Degenerate paths whose `d` attribute contains a single SVG command (clip-path boundary sentinels).
+
+Two families cannot be found by counting at all:
+
+- A **choropleth** is *located* rather than counted. AnyChart paints every feature of the bound geodata — all fifty states for a table naming six — in the geodata's order rather than the data's, and the paths carry no id, so counting them off would put California's highlight on Alabama's shape. Each region is instead matched to the shape whose own box is the one `point.getFeatureBounds()` says the chart drew it at. A region matching no shape, or more than one, disables highlighting for the whole map.
+- A **gantt** is picked out by count, but from more filled shapes than any other chart here: the row stripes behind both halves of the split widget, the header, and the progress fill inside a bar that has one. When the whole SVG holds exactly as many filled paths as the schedule has intervals they are the bars; otherwise the search narrows to the `<g>` layer holding exactly that many. Two layers answering to the same count — the stripes behind a one-interval-per-row project chart are exactly that — are separated by the one property a schedule has and a backdrop does not: its bars begin and end in different places. Anything still ambiguous is left unstamped and said out loud.
 
 If you want to bypass auto-stamping entirely, pass explicit `selectors` — they always take precedence over the generated `data-maidr-anychart-*` selectors.
 

--- a/examples/anychart/choropleth.html
+++ b/examples/anychart/choropleth.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + AnyChart Choropleth Example</title>
+    <style>
+      body { font-family: sans-serif; margin: 2rem; }
+      #container { width: 800px; height: 500px; margin-bottom: 1rem; }
+      p { max-width: 800px; }
+    </style>
+    <!-- 1. Load AnyChart (CDN). A map needs the map module on top of
+         anychart-base, plus a geodata file for the regions it draws. -->
+    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-base.min.js"></script>
+    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-map.min.js"></script>
+    <script src="https://cdn.anychart.com/releases/8.13.0/geodata/countries/united_states_of_america/united_states_of_america.js"></script>
+    <!-- 2. Load the core MAIDR runtime. -->
+    <script src="../../dist/maidr.js"></script>
+    <!-- 3. Load the MAIDR AnyChart adapter (UMD build — exposes window.maidrAnyChart). -->
+    <script src="../../dist/anychart.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const chart = anychart.map();
+        chart.geoData(anychart.maps.united_states_of_america);
+
+        // Every row names a region by the id the geodata declared and gives it
+        // the value the map shades it by. The human-readable name is NOT in
+        // the data — it belongs to the geo feature, and MAIDR reads it from
+        // there so the reading is "Nevada" rather than "US.NV".
+        const series = chart.choropleth([
+          { id: 'US.NV', value: 42.1 },
+          { id: 'US.UT', value: 17.9 },
+          { id: 'US.AZ', value: 31.4 },
+          { id: 'US.CA', value: 68.3 },
+          { id: 'US.OR', value: 24.6 },
+          { id: 'US.ID', value: 12.2 },
+        ]);
+        series.name('Solar capacity');
+
+        chart.title('Installed solar capacity by state');
+        chart.container('container');
+        chart.draw();
+
+        maidrAnyChart.bindAnyChart(chart, {
+          id: 'anychart-choropleth',
+          // A map is bound to no axis, so there is no axis title to extract.
+          // Drop these and the adapter falls back to "Region" and "Value".
+          axes: { x: 'State', y: 'Gigawatts' },
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <h1>MAIDR + AnyChart Choropleth Map</h1>
+    <p>
+      Click on the chart and use the left and right arrow keys to move between
+      the shaded regions, in the order the data declares them. Each move
+      announces the region and the value it is shaded by. Press <kbd>B</kbd> for
+      braille, <kbd>T</kbd> for text descriptions, and <kbd>S</kbd> to toggle
+      sonification.
+    </p>
+    <p>
+      The regions are read as a <strong>list in declared order</strong> rather
+      than as a map walked north and south. MAIDR's spatial walk needs a
+      centroid in degrees of longitude and latitude, and what AnyChart carries
+      is each feature's <code>middle-x</code> / <code>middle-y</code> — a
+      normalised coordinate in the map's own projection, which is not a compass
+      bearing and cannot be turned into one without inverting a projection the
+      chart does not name. Announcing it as one would tell you a region lies
+      north of another when the map says nothing of the kind, so it is left out.
+    </p>
+    <p>
+      Highlighting locates each region rather than counting shapes off: the map
+      paints every feature of the geodata — all fifty states for the six rows
+      above — in the geodata's order, so a region is found by matching the
+      drawn bounds AnyChart reports for it. A region that cannot be placed
+      switches highlighting off for the whole map rather than putting one
+      state's outline around another.
+    </p>
+    <div id="container"></div>
+  </body>
+</html>

--- a/examples/anychart/gantt.html
+++ b/examples/anychart/gantt.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + AnyChart Gantt Example</title>
+    <style>
+      body { font-family: sans-serif; margin: 2rem; }
+      #container { width: 820px; height: 420px; margin-bottom: 1rem; }
+      p { max-width: 820px; }
+    </style>
+    <!-- 1. Load AnyChart (CDN). Both gantt constructors ship in the gantt
+         module on top of anychart-base. -->
+    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-base.min.js"></script>
+    <script src="https://cdn.anychart.com/releases/8.13.0/js/anychart-gantt.min.js"></script>
+    <!-- 2. Load the core MAIDR runtime. -->
+    <script src="../../dist/maidr.js"></script>
+    <!-- 3. Load the MAIDR AnyChart adapter (UMD build — exposes window.maidrAnyChart). -->
+    <script src="../../dist/anychart.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        // A gantt's data is a TREE rather than a series: parents carry their
+        // children, and a parent states no dates of its own — AnyChart derives
+        // them from what is beneath it, and MAIDR reads the derived pair so a
+        // summary row is a lane like any other.
+        const treeData = anychart.data.tree([
+          {
+            id: 'design',
+            name: 'Design',
+            children: [
+              {
+                id: 'research',
+                name: 'User research',
+                actualStart: Date.UTC(2024, 0, 8),
+                actualEnd: Date.UTC(2024, 0, 22),
+              },
+              {
+                id: 'wireframes',
+                name: 'Wireframes',
+                actualStart: Date.UTC(2024, 0, 22),
+                actualEnd: Date.UTC(2024, 1, 5),
+              },
+            ],
+          },
+          {
+            id: 'build',
+            name: 'Build',
+            actualStart: Date.UTC(2024, 1, 5),
+            actualEnd: Date.UTC(2024, 2, 18),
+          },
+          {
+            id: 'launch',
+            name: 'Launch',
+            // A start with no end is a milestone: an instant, drawn as a
+            // diamond, and read as the zero-length interval it is.
+            actualStart: Date.UTC(2024, 2, 25),
+          },
+          {
+            // A row with no dates at all is an EMPTY lane. It survives the
+            // reading — nothing is booked on it, which is a real statement
+            // about a plan — and is named from the row rather than from an
+            // interval it does not have.
+            id: 'support',
+            name: 'Support (unscheduled)',
+          },
+        ], 'as-tree');
+
+        const chart = anychart.ganttProject();
+        chart.data(treeData);
+        chart.container('container');
+        chart.draw();
+        chart.fitAll();
+
+        maidrAnyChart.bindAnyChart(chart, { id: 'anychart-gantt' });
+      });
+    </script>
+  </head>
+  <body>
+    <h1>MAIDR + AnyChart Gantt Chart</h1>
+    <p>
+      Click on the chart and use the up and down arrow keys to move between
+      lanes, and the left and right arrow keys to move between the intervals
+      booked on one. Pitch carries how <em>long</em> an interval runs and the
+      stereo position carries <em>when</em> it starts — mapped along the whole
+      timeline rather than by column — so two tasks that overlap sound like
+      they overlap. Press <kbd>B</kbd> for braille, <kbd>T</kbd> for text
+      descriptions, and <kbd>S</kbd> to toggle sonification.
+    </p>
+    <p>
+      The dates are restated in whole days and announced with the unit named,
+      because the tree holds milliseconds since the epoch and a nine-digit
+      figure carries nothing by ear. A schedule shorter than two days is read
+      in hours instead. Each end is still announced as a date: the x axis
+      carries a formatter that turns a position back into one.
+    </p>
+    <p>
+      <code>anychart.ganttResource()</code> is read the same way. Its rows carry
+      a <code>periods</code> array rather than one pair of dates, so a lane
+      holds several intervals — which is what the nested shape is for.
+      <code>anychart.timeline()</code> is a different chart and is not read
+      here: its <code>moment</code> series are instants rather than intervals,
+      and reading one as a schedule would announce work the chart never drew.
+    </p>
+    <div id="container"></div>
+  </body>
+</html>

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -1040,8 +1040,12 @@ function enableLineMarkersIfNeeded(chart: AnyChartInstance): boolean {
     return false;
   // A sankey is one too: its ribbons are already one element per flow, and
   // asking it for a series count throws. A gantt is the same shape again —
-  // its data is a task tree rather than a series list — and no series a map
-  // carries is drawn as a line.
+  // its data is a task tree rather than a series list.
+  //
+  // A map is deliberately *not* in this list: it does expose the series API,
+  // so it falls through to the loop below, which no-ops because
+  // `'choropleth'` is not in `LINE_LIKE_SERIES_TYPES`. No early return is
+  // needed for it.
   if (
     isFunnelChart(chart)
     || isWordCloudChart(chart)

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -25,9 +25,12 @@ import type {
   BoxSelector,
   CandlestickPoint,
   CandlestickTrend,
+  ChoroplethPoint,
   DumbbellData,
   DumbbellPoint,
   FlowPoint,
+  GanttData,
+  GanttPoint,
   HeatmapData,
   LinePoint,
   Maidr,
@@ -43,15 +46,18 @@ import type {
 } from '@type/grammar';
 import type {
   AnyChartBinderOptions,
+  AnyChartDataView,
   AnyChartGridInput,
   AnyChartInstance,
   AnyChartIterator,
   AnyChartsBinderOptions,
   AnyChartSeries,
   AnyChartTitle,
+  AnyChartTree,
+  AnyChartTreeItem,
 } from './types';
 import { nextId } from '@adapters/shared/selectorUtil';
-import { TraceType } from '@type/grammar';
+import { Orientation, TraceType } from '@type/grammar';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -88,6 +94,7 @@ type AnyChartTraceType
     | TraceType.DUMBBELL
     | TraceType.HEATMAP
     | TraceType.CANDLESTICK
+    | TraceType.CHOROPLETH
     | TraceType.PIE;
 
 /**
@@ -124,6 +131,10 @@ type AnyChartTraceType
  *   ordinal x scale is a Cleveland dot plot rather than a point cloud. That is
  *   a question about the chart's scale rather than about the series, so
  *   {@link resolveMarkerVariant} asks it and promotes the layer.
+ * - `choropleth` is the map module's shaded-region series. It names itself, so
+ *   nothing chart-level is required to recognise one — deliberately, because
+ *   {@link readChartType} answers `''` on a build with no `getType()` and on a
+ *   chart that has not been drawn, and gating on it would drop working maps.
  * - `"pie"` covers doughnuts too: AnyChart draws one with `chart.innerRadius()`
  *   on an ordinary pie, so both report the same type and read identically.
  *   A pie chart has no series API of its own, so this branch only fires for
@@ -159,6 +170,10 @@ export function mapSeriesType(anyChartType: string): AnyChartTraceType | null {
     'heat': TraceType.HEATMAP,
     'candlestick': TraceType.CANDLESTICK,
     'ohlc': TraceType.CANDLESTICK,
+    // A map's regions, shaded by value. The one map series that carries a
+    // magnitude — `marker`, `bubble` and `connector` draw over a map rather
+    // than colouring it — and its own name is the whole detection.
+    'choropleth': TraceType.CHOROPLETH,
     'pie': TraceType.PIE,
   };
 
@@ -217,6 +232,32 @@ function readChartType(chart: AnyChartInstance): string {
   } catch {
     return '';
   }
+}
+
+/**
+ * The chart-level data view, on a chart that has one.
+ *
+ * `chart.data()` answers with a data view on every single-dataset chart type
+ * and with an {@link AnyChartTree} on a gantt, and the two share no method:
+ * asking a tree for an iterator throws. Which one arrived is therefore
+ * decided by the object rather than by the chart type, so a gantt reaching a
+ * reader written for a data view is a no-op instead of an exception.
+ *
+ * @param chart - The chart to ask
+ * @returns Its data view, or `undefined` when it has none
+ */
+function resolveChartDataView(
+  chart: AnyChartInstance,
+): AnyChartDataView | undefined {
+  let data: AnyChartDataView | AnyChartTree | undefined;
+  try {
+    data = chart.data?.();
+  } catch {
+    return undefined;
+  }
+  if (data && 'getIterator' in data && typeof data.getIterator === 'function')
+    return data;
+  return undefined;
 }
 
 /** Resolve the DOM element that holds the AnyChart SVG rendering. */
@@ -430,6 +471,9 @@ function readRows(iterator: AnyChartIterator): Array<Record<string, unknown>> {
       'volume',
       // Heatmap cell value
       'heat',
+      // The geo feature a map row is matched to. Carries the id the geodata
+      // declared (`'US.CA'`), never the region's name.
+      'id',
       // Sankey flow: both ends and how much runs between them
       'from',
       'to',
@@ -515,6 +559,21 @@ const WATERFALL_SERIES_TYPES = new Set(['waterfall']);
 
 /** The one series type a marimekko draws its tiles from. */
 const MOSAIC_SERIES_TYPES = new Set(['mekko']);
+
+/**
+ * The map series that shades its regions by value. Its siblings — `marker`,
+ * `bubble`, `connector` — draw *over* a map rather than colouring it, and are
+ * distinct type strings, so nothing plainer wears this name.
+ */
+const CHOROPLETH_SERIES_TYPES = new Set(['choropleth']);
+
+/**
+ * The chart types AnyChart's two gantt constructors report. A project chart
+ * gives every task its own `actualStart` / `actualEnd`; a resource chart gives
+ * each row a `periods` array and can therefore hold several intervals in one
+ * lane. Both are read as one schedule.
+ */
+const GANTT_CHART_TYPES = new Set(['gantt-project', 'gantt-resource']);
 
 /**
  * The series types a radar or polar chart draws that this adapter can read.
@@ -650,6 +709,22 @@ const RADAR_ATTR = 'data-maidr-anychart-spoke';
 const DUMBBELL_ATTR = 'data-maidr-anychart-pair';
 
 /**
+ * Attribute name stamped onto each shaded region of a map by
+ * {@link stampChoroplethAttributes}. The value encodes
+ * `<seriesIndex>-<regionIndex>`, where the region index is the row's position
+ * in the SERIES' data — a map draws every feature of its geodata, in the
+ * geodata's order, so document order is not data order here.
+ */
+const CHOROPLETH_ATTR = 'data-maidr-anychart-region';
+
+/**
+ * Attribute name stamped onto each task bar of a gantt chart by
+ * {@link stampGanttAttributes}. The value encodes `<laneIndex>-<intervalIndex>`
+ * — a gantt has no series API, so the first half names the lane instead.
+ */
+const GANTT_ATTR = 'data-maidr-anychart-task-bar';
+
+/**
  * Attribute name stamped onto each panel's own `<svg>` root by
  * {@link bindAnyCharts}. Its value is the panel token
  * (`<figureId>-<row>-<col>`), which uniquely identifies one chart's SVG
@@ -779,10 +854,13 @@ function resolveSelector(
     // a defensive default when the heatmap path is bypassed.
     case TraceType.HEATMAP:
       return `${scope}[${HEATMAP_ATTR}]`;
-    // Both own their selector construction in their layer builder — see the
-    // BOX note above; candlestick likewise emits a CandlestickSelector.
+    // All three own their selector construction in their layer builder — see
+    // the BOX note above; candlestick likewise emits a CandlestickSelector,
+    // and a choropleth needs one exact-match entry per region in DATA order,
+    // which a prefix selector (resolved in document order) cannot express.
     case TraceType.BOX:
     case TraceType.CANDLESTICK:
+    case TraceType.CHOROPLETH:
       return undefined;
   }
 }
@@ -961,9 +1039,17 @@ function enableLineMarkersIfNeeded(chart: AnyChartInstance): boolean {
   if (chartType?.includes('pie'))
     return false;
   // A sankey is one too: its ribbons are already one element per flow, and
-  // asking it for a series count throws.
-  if (isFunnelChart(chart) || isWordCloudChart(chart) || isSankeyChart(chart))
+  // asking it for a series count throws. A gantt is the same shape again —
+  // its data is a task tree rather than a series list — and no series a map
+  // carries is drawn as a line.
+  if (
+    isFunnelChart(chart)
+    || isWordCloudChart(chart)
+    || isSankeyChart(chart)
+    || isGanttChart(chart)
+  ) {
     return false;
+  }
 
   const seriesCount = chart.getSeriesCount();
   let mutated = false;
@@ -1974,7 +2060,7 @@ function stampHeatmapAttributes(
     return;
   }
 
-  const dataView = chart.data?.();
+  const dataView = resolveChartDataView(chart);
   if (!dataView)
     return;
   let iterator: AnyChartIterator | null = null;
@@ -2278,6 +2364,45 @@ function isSankeyChart(chart: AnyChartInstance): boolean {
 }
 
 /**
+ * Whether a chart draws a map.
+ *
+ * Asked only by the paths that need a CHART-level answer — which stampers to
+ * run, and whether the line stamper should keep away. The reading itself is
+ * decided by the SERIES, whose `'choropleth'` type names itself: a chart whose
+ * `getType()` is unavailable (an undrawn chart, a build without it) still has
+ * its series, and a map recognised only by its chart type would be dropped
+ * exactly when {@link readChartType} answers `''`.
+ *
+ * `'heat-map'` contains `'map'`, so the chart-type half is an exact match
+ * rather than the tolerant one the pie and heatmap paths use.
+ */
+function isMapChart(chart: AnyChartInstance): boolean {
+  if (readChartType(chart) === 'map')
+    return true;
+  return collectSeriesOfType(chart, CHOROPLETH_SERIES_TYPES).length > 0;
+}
+
+/**
+ * Whether a chart is a gantt.
+ *
+ * `anychart.ganttProject()` and `anychart.ganttResource()` are two distinct
+ * constructors reporting their own names back, and neither shares anything
+ * with the rest of the adapter: a gantt has no series API at all, and its
+ * `data()` hands back a task tree rather than a data view. The type name is
+ * therefore corroborated structurally by {@link readTaskTree} before anything
+ * is read — a chart naming itself a gantt with no tree behind it is bound as
+ * nothing rather than as an empty schedule.
+ *
+ * `anychart.timeline()` is deliberately NOT matched. It is a third
+ * constructor with a series API and its own `range` / `moment` series, whose
+ * moments are instants rather than intervals; reading one here would announce
+ * a schedule whose every zero-length row the chart drew as a point.
+ */
+function isGanttChart(chart: AnyChartInstance): boolean {
+  return GANTT_CHART_TYPES.has(readChartType(chart));
+}
+
+/**
  * Whether a chart is a marimekko.
  *
  * `anychart.mekko()`, `anychart.mosaic()` and `anychart.barmekko()` report
@@ -2340,7 +2465,7 @@ function resolveRadialType(
  * both, so one reader serves all three.
  */
 function readChartRows(chart: AnyChartInstance): Array<Record<string, unknown>> {
-  const dataView = chart.data?.();
+  const dataView = resolveChartDataView(chart);
   if (!dataView)
     return [];
   try {
@@ -2476,6 +2601,17 @@ function resolveStampers(
     return [['word cloud', stampWordCloudAttributes]];
   if (isSankeyChart(chart))
     return [['sankey', stampSankeyAttributes]];
+  // A map does have a series API, but none of the XY stampers may run on one:
+  // they pair a datum with a shape by counting DOM order, and a map's shapes
+  // are its geodata's features — every one of them, in the geodata's order —
+  // so the bar stamper would stamp Alabama for California and the count would
+  // be right often enough to say nothing about it.
+  if (isMapChart(chart))
+    return [['choropleth', stampChoroplethAttributes]];
+  // A gantt has no series API at all, and its bars are the one mark family
+  // here that no cartesian stamper draws.
+  if (isGanttChart(chart))
+    return [['gantt', stampGanttAttributes]];
   // A radial chart does have a series API, but none of the XY stampers may run
   // on one: its series report themselves as lines and markers, and the line
   // stamper pairs those with marks by their left-to-right order — which on a
@@ -3285,6 +3421,669 @@ function stampDumbbellAttributes(
 }
 
 // ---------------------------------------------------------------------------
+// Choropleth region naming and attribute stamping
+// ---------------------------------------------------------------------------
+
+/** Whether a value is a plain object whose properties can be read by name. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The geo features of whatever geodata a map was bound to.
+ *
+ * AnyChart accepts both of the formats its own map files ship in, and they
+ * nest their features differently: GeoJSON puts them in a flat `features`
+ * array, TopoJSON in one `geometries` array per entry of `objects`. Both carry
+ * the same per-feature `properties`, which is the only thing read here.
+ *
+ * @param geoData - Whatever `chart.geoData()` answered with
+ * @returns Its features, or nothing when the shape is neither
+ */
+function collectGeoFeatures(geoData: unknown): Array<Record<string, unknown>> {
+  if (!isRecord(geoData))
+    return [];
+
+  if (Array.isArray(geoData.features))
+    return geoData.features.filter(isRecord);
+
+  const features: Array<Record<string, unknown>> = [];
+  if (isRecord(geoData.objects)) {
+    for (const object of Object.values(geoData.objects)) {
+      if (isRecord(object) && Array.isArray(object.geometries))
+        features.push(...object.geometries.filter(isRecord));
+    }
+  }
+  return features;
+}
+
+/**
+ * What each region of a map's geodata is called, keyed by the id its rows are
+ * matched on.
+ *
+ * A choropleth's rows carry an id and a value and nothing else — `'US.CA'`,
+ * `42` — because the name belongs to the geodata rather than to the data. A
+ * map read without this announces every region by a code, which is a reading
+ * a listener cannot follow.
+ *
+ * @param chart - The map to read
+ * @returns Region names by feature id, empty when the geodata says none
+ */
+function readRegionNames(chart: AnyChartInstance): Map<string, string> {
+  const names = new Map<string, string>();
+
+  let geoData: unknown;
+  try {
+    geoData = chart.geoData?.();
+  } catch {
+    return names;
+  }
+
+  // Which property the rows' `id` is matched against. AnyChart defaults to
+  // `'id'` and a chart that renames it renames it for the lookup here too.
+  let idField = 'id';
+  try {
+    idField = chart.geoIdField?.() || 'id';
+  } catch {
+    idField = 'id';
+  }
+
+  for (const feature of collectGeoFeatures(geoData)) {
+    const properties = isRecord(feature.properties) ? feature.properties : {};
+    const id = properties[idField] ?? feature.id ?? properties.id;
+    const name = properties.name;
+    if (id !== undefined && typeof name === 'string' && name.length > 0)
+      names.set(String(id), name);
+  }
+  return names;
+}
+
+/**
+ * The name the bound geo feature gives one region, when the build exposes it.
+ *
+ * The direct route, and the one that needs no id matching: a map series' point
+ * hands back the properties of the feature it was drawn onto. Older builds do
+ * not offer it, and the caller then falls back to the geodata lookup.
+ *
+ * @param series - The choropleth series
+ * @param index - The row's own index within the series
+ * @returns The feature's name, or `undefined`
+ */
+function readFeatureName(
+  series: AnyChartSeries,
+  index: number,
+): string | undefined {
+  try {
+    const properties = series.getPoint(index)?.getFeatureProp?.();
+    const name = isRecord(properties) ? properties.name : undefined;
+    return typeof name === 'string' && name.length > 0 ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * What one region of a choropleth is announced as.
+ *
+ * In falling order of how much the chart itself says: the bound feature's own
+ * name, the same name looked up in the geodata by id, whatever the row called
+ * itself, and finally the bare id. The last is a poor name but a true one —
+ * every alternative would be a region the map does not contain.
+ *
+ * @param series - The choropleth series the row belongs to
+ * @param row - The row
+ * @param names - Region names by feature id, from {@link readRegionNames}
+ * @returns The region's name
+ */
+function regionNameOf(
+  series: AnyChartSeries,
+  row: Record<string, unknown>,
+  names: Map<string, string>,
+): string {
+  const fromFeature = readFeatureName(series, asNumber(row._index, -1));
+  if (fromFeature)
+    return fromFeature;
+
+  const id = row.id === undefined ? undefined : String(row.id);
+  const fromGeoData = id === undefined ? undefined : names.get(id);
+  if (fromGeoData)
+    return fromGeoData;
+
+  const own = asString(row.name ?? row.x);
+  if (own.length > 0)
+    return own;
+
+  return id ?? asString(row._index);
+}
+
+/** A rectangle in the coordinates the stage draws its shapes in. */
+interface RegionBox {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * How far apart two measurements of one drawn shape may be and still be the
+ * same shape: a region's own box against the bounds AnyChart reports for its
+ * feature, or one gantt bar's left edge against another's.
+ *
+ * A region's two readings are the same rectangle read twice — the chart
+ * computed the bounds and then drew the path from them — so the tolerance
+ * covers rounding rather than disagreement, and staying tight is what keeps
+ * two adjacent regions from both answering to one set of bounds.
+ */
+const DRAWN_BOX_TOLERANCE_PX = 1.5;
+
+/**
+ * The bounds AnyChart reports for the feature one row was matched to.
+ *
+ * @param series - The choropleth series
+ * @param index - The row's own index within the series
+ * @returns The feature's drawn box, or `undefined` when the build has none
+ */
+function readFeatureBox(
+  series: AnyChartSeries,
+  index: number,
+): RegionBox | undefined {
+  let bounds: unknown;
+  try {
+    bounds = series.getPoint(index)?.getFeatureBounds?.();
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(bounds))
+    return undefined;
+
+  const box = {
+    left: Number(bounds.left),
+    top: Number(bounds.top),
+    width: Number(bounds.width),
+    height: Number(bounds.height),
+  };
+  const finite = Object.values(box).every(Number.isFinite);
+  return finite && box.width > 0 && box.height > 0 ? box : undefined;
+}
+
+/** The box a rendered shape occupies, when it can be measured. */
+function readDrawnBox(element: SVGElement): RegionBox | undefined {
+  let bbox: DOMRect | null = null;
+  try {
+    bbox = (element as unknown as SVGGraphicsElement).getBBox?.() ?? null;
+  } catch {
+    bbox = null;
+  }
+  if (!bbox || bbox.width <= 0 || bbox.height <= 0)
+    return undefined;
+  return { left: bbox.x, top: bbox.y, width: bbox.width, height: bbox.height };
+}
+
+/** Whether two boxes are the same rectangle read twice. */
+function boxesMatch(a: RegionBox, b: RegionBox): boolean {
+  return Math.abs(a.left - b.left) <= DRAWN_BOX_TOLERANCE_PX
+    && Math.abs(a.top - b.top) <= DRAWN_BOX_TOLERANCE_PX
+    && Math.abs(a.width - b.width) <= DRAWN_BOX_TOLERANCE_PX
+    && Math.abs(a.height - b.height) <= DRAWN_BOX_TOLERANCE_PX;
+}
+
+/**
+ * Stamp `data-maidr-anychart-region="<seriesIndex>-<regionIndex>"` on the path
+ * a map drew for each region the data names.
+ *
+ * Every other stamper in this file pairs a datum with a shape by counting DOM
+ * order, and a map is the family where that cannot work: AnyChart paints every
+ * feature of the bound geodata — all fifty states for a table naming three —
+ * in the geodata's order rather than the data's, and the paths carry no id. A
+ * count would put California's highlight on Alabama's shape.
+ *
+ * Each region is therefore *located* instead. AnyChart reports the drawn
+ * bounds of the feature a row was matched to, and the path it drew from them
+ * has exactly that box, so a region is the shape whose own box is the one the
+ * chart said it would be. A region matching no shape, or more than one, is a
+ * region this cannot place: nothing is stamped for the whole chart then, for
+ * the reason {@link stampWordCloudAttributes} gives — a half-stamped map costs
+ * the same highlight while looking, in the DOM, like it worked.
+ *
+ * On a chart with no choropleth series this is a no-op.
+ */
+function stampChoroplethAttributes(
+  chart: AnyChartInstance,
+  svg: SVGElement,
+  stampPrefix = '',
+): void {
+  const entries = collectSeriesOfType(chart, CHOROPLETH_SERIES_TYPES);
+  if (entries.length === 0)
+    return;
+
+  const regions: Array<{ series: number; region: number; box: RegionBox }> = [];
+  for (const { series, index } of entries) {
+    const rows = extractRawRows(series).filter(isDrawnDatum);
+    for (const [region, row] of rows.entries()) {
+      const box = readFeatureBox(series, asNumber(row._index, -1));
+      if (!box) {
+        console.warn(
+          '[maidr/anychart] Highlighting is disabled for this map: AnyChart '
+          + `reports no drawn bounds for the region at index ${region} of `
+          + `series ${index}, and the regions of a map cannot be paired with `
+          + 'its paths by position. Pass an explicit `selectors` entry to '
+          + 'override.',
+        );
+        return;
+      }
+      regions.push({ series: index, region, box });
+    }
+  }
+  if (regions.length === 0)
+    return;
+
+  const candidates = collectFilledDataPaths(svg).filter(
+    // Idempotency — skip regions stamped on a prior bind.
+    path => !path.hasAttribute(CHOROPLETH_ATTR),
+  );
+
+  const matched: SVGElement[] = [];
+  const taken = new Set<SVGElement>();
+  for (const { box } of regions) {
+    const hits = candidates.filter((path) => {
+      const drawn = readDrawnBox(path);
+      return drawn !== undefined && boxesMatch(drawn, box);
+    });
+    if (hits.length !== 1 || taken.has(hits[0])) {
+      console.warn(
+        `[maidr/anychart] Expected exactly one drawn shape at the bounds `
+        + `AnyChart reports for a region but found ${hits.length}. `
+        + 'Highlighting is disabled for this map; pass an explicit '
+        + '`selectors` entry to override.',
+      );
+      return;
+    }
+    taken.add(hits[0]);
+    matched.push(hits[0]);
+  }
+
+  matched.forEach((path, i) => {
+    const { series, region } = regions[i];
+    path.setAttribute(CHOROPLETH_ATTR, `${stampPrefix}${series}-${region}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Gantt task tree, axis scale and attribute stamping
+// ---------------------------------------------------------------------------
+
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * The widest span a schedule may cover and still be read in hours. Two days —
+ * past that an hour is too fine to compare tasks by, and below it a day is too
+ * coarse to distinguish them at all.
+ */
+const GANTT_HOURLY_MAX_SPAN = 2 * MS_PER_DAY;
+
+/** One interval of a schedule, before the axis unit has been decided. */
+interface GanttSpan {
+  /** When it begins, in milliseconds since the epoch. */
+  start: number;
+  /** When it ends. Equal to {@link GanttSpan.start} for a milestone. */
+  end: number;
+  /** What the interval is called, when the lane does not already name it. */
+  label?: string;
+}
+
+/** One row of a schedule: a task or a resource, and the work booked on it. */
+interface GanttLane {
+  name: string;
+  spans: GanttSpan[];
+}
+
+/** How a schedule's milliseconds are turned into the axis a reader hears. */
+interface GanttScale {
+  /** Milliseconds per axis unit. */
+  perUnit: number;
+  /** What one unit is called. */
+  unit: string;
+}
+
+/**
+ * The task tree behind a gantt chart.
+ *
+ * The structural half of the detection: `chart.data()` answers with an
+ * `anychart.data.Tree` on a gantt and with a flat data view on every other
+ * chart-level type, and the two share no method. A chart naming itself a gantt
+ * with no tree behind it has not been given its data, and binding it would
+ * announce a schedule with no work in it.
+ *
+ * @param chart - The chart to ask
+ * @returns Its task tree, or `null` when it has none
+ */
+function readTaskTree(chart: AnyChartInstance): AnyChartTree | null {
+  let data: AnyChartDataView | AnyChartTree | undefined;
+  try {
+    data = chart.data?.();
+  } catch {
+    return null;
+  }
+  if (
+    data
+    && 'numChildren' in data
+    && typeof data.numChildren === 'function'
+    && typeof data.getChildAt === 'function'
+  ) {
+    return data;
+  }
+  return null;
+}
+
+/**
+ * One date off a task, as milliseconds since the epoch.
+ *
+ * A gantt's axis is a date-time scale whatever the author wrote against it:
+ * AnyChart accepts a `Date`, an ISO string and a bare timestamp for the same
+ * field and draws all three at the same instant, so all three are read as one
+ * here.
+ *
+ * @param value - Whatever the tree item held
+ * @returns The instant, or `NaN` when the value names none
+ */
+function toTimestamp(value: unknown): number {
+  if (value instanceof Date)
+    return value.getTime();
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : Number.NaN;
+  if (typeof value === 'string') {
+    const asNumeric = Number(value);
+    return Number.isFinite(asNumeric) ? asNumeric : Date.parse(value);
+  }
+  return Number.NaN;
+}
+
+/**
+ * One of a task's own dates, falling back to the one the chart worked out.
+ *
+ * A parent task states no dates: AnyChart derives them from its children and
+ * keeps the answer in the item's meta as `autoStart` / `autoEnd`. Reading only
+ * the authored field would leave every summary row of a project chart empty.
+ *
+ * @param item - The tree item to read
+ * @param field - The authored field name
+ * @param derived - The meta key AnyChart computes it into
+ * @returns The instant, or `NaN` when neither is set
+ */
+function readTaskDate(
+  item: AnyChartTreeItem,
+  field: string,
+  derived: string,
+): number {
+  let own: unknown;
+  try {
+    own = item.get(field);
+  } catch {
+    own = undefined;
+  }
+  const authored = toTimestamp(own);
+  if (Number.isFinite(authored))
+    return authored;
+
+  try {
+    return toTimestamp(item.meta?.(derived));
+  } catch {
+    return Number.NaN;
+  }
+}
+
+/**
+ * The intervals booked on one row of a schedule.
+ *
+ * A resource chart puts several on a row — that is what its `periods` array
+ * is for, and it is the case {@link GanttData}'s nested shape exists to carry.
+ * A project chart puts at most one there. A task with a start and no end is a
+ * milestone: AnyChart draws it as a diamond at an instant, so it is emitted as
+ * the zero-length interval it is rather than dropped.
+ *
+ * @param item - The tree item to read
+ * @returns Its intervals, in the order the row holds them
+ */
+function readTaskSpans(item: AnyChartTreeItem): GanttSpan[] {
+  let periods: unknown;
+  try {
+    periods = item.get('periods');
+  } catch {
+    periods = undefined;
+  }
+
+  if (Array.isArray(periods)) {
+    const spans: GanttSpan[] = [];
+    for (const period of periods) {
+      if (!isRecord(period))
+        continue;
+      const start = toTimestamp(period.start);
+      if (!Number.isFinite(start))
+        continue;
+      const end = toTimestamp(period.end);
+      const label = asString(period.name ?? period.id);
+      spans.push({
+        start,
+        end: Number.isFinite(end) ? end : start,
+        ...(label ? { label } : {}),
+      });
+    }
+    return spans;
+  }
+
+  const start = readTaskDate(item, 'actualStart', 'autoStart');
+  if (!Number.isFinite(start))
+    return [];
+  const end = readTaskDate(item, 'actualEnd', 'autoEnd');
+  return [{ start, end: Number.isFinite(end) ? end : start }];
+}
+
+/**
+ * Flatten a gantt's task tree into one lane per row, in draw order.
+ *
+ * Depth-first, parents before their children, which is the order the chart
+ * stacks its rows in. A parent is a lane of its own rather than a heading: it
+ * carries the span AnyChart derived for it, and a reader arrowing down the
+ * lanes meets it exactly where the chart draws it.
+ *
+ * @param tree - The chart's task tree
+ * @returns Its lanes, in row order
+ */
+function collectGanttLanes(tree: AnyChartTree): GanttLane[] {
+  const lanes: GanttLane[] = [];
+
+  const visit = (item: AnyChartTreeItem): void => {
+    const name = asString(item.get('name') ?? item.get('id'))
+      || `Lane ${lanes.length + 1}`;
+    lanes.push({ name, spans: readTaskSpans(item) });
+
+    let children = 0;
+    try {
+      children = item.numChildren?.() ?? 0;
+    } catch {
+      children = 0;
+    }
+    for (let i = 0; i < children; i++) {
+      const child = item.getChildAt?.(i);
+      if (child)
+        visit(child);
+    }
+  };
+
+  let rows = 0;
+  try {
+    rows = tree.numChildren();
+  } catch {
+    return lanes;
+  }
+  for (let i = 0; i < rows; i++) {
+    const child = tree.getChildAt(i);
+    if (child)
+      visit(child);
+  }
+  return lanes;
+}
+
+/**
+ * What one unit of a schedule's axis is, and how many milliseconds it holds.
+ *
+ * The length of an interval is the fact a gantt exists to carry, and MAIDR
+ * announces it as a bare number with {@link GanttData.unit} after it. Left in
+ * milliseconds every task in a project would be announced as an unreadable
+ * nine-digit figure, so the axis is restated in the unit its own span calls
+ * for. The unit is READ rather than guessed: AnyChart's gantt timeline is a
+ * date-time scale, so what the tree holds is instants, and saying so is not
+ * an inference about the data.
+ *
+ * @param lanes - The schedule's lanes
+ * @returns The unit its axis reads in
+ */
+function resolveGanttScale(lanes: GanttLane[]): GanttScale {
+  const instants = lanes.flatMap(lane =>
+    lane.spans.flatMap(span => [span.start, span.end]));
+  const span = instants.length > 0
+    ? Math.max(...instants) - Math.min(...instants)
+    : 0;
+  return span <= GANTT_HOURLY_MAX_SPAN
+    ? { perUnit: MS_PER_HOUR, unit: 'hours' }
+    : { perUnit: MS_PER_DAY, unit: 'days' };
+}
+
+/**
+ * Stamp `data-maidr-anychart-task-bar="<laneIndex>-<intervalIndex>"` on every
+ * bar of a gantt chart.
+ *
+ * A gantt renders as a split widget — a data grid on the left, a timeline on
+ * the right — sharing one SVG, and its bars have no counterpart among the
+ * cartesian mark families: no series drew them, so no series-scoped lookup
+ * finds them. What is left is the count, and a gantt offers more filled shapes
+ * than any other chart here: the row stripes behind both halves, the header,
+ * the progress fill inside a bar that has one.
+ *
+ * So the schedule's own interval count is what picks them out. When the whole
+ * SVG holds exactly that many filled paths they are the bars; otherwise the
+ * search narrows to the LAYER holding exactly that many, since AnyChart draws
+ * each family into a layer of its own. Two layers answering to the same count
+ * — the stripes behind a one-interval-per-row project chart are exactly that —
+ * are separated by the one property a schedule has and a background does not:
+ * its bars begin and end in different places. Anything still ambiguous is left
+ * unstamped and said out loud, because a bar highlighted for the wrong task is
+ * worse than none at all.
+ *
+ * On any other chart type this is a no-op.
+ */
+function stampGanttAttributes(
+  chart: AnyChartInstance,
+  svg: SVGElement,
+  stampPrefix = '',
+): void {
+  if (!isGanttChart(chart))
+    return;
+
+  const tree = readTaskTree(chart);
+  if (!tree)
+    return;
+
+  const drawn: Array<{ lane: number; interval: number }> = [];
+  collectGanttLanes(tree).forEach((lane, index) => {
+    lane.spans.forEach((_, interval) => drawn.push({ lane: index, interval }));
+  });
+  if (drawn.length === 0)
+    return;
+
+  const candidates = collectFilledDataPaths(svg).filter(
+    // Idempotency — skip bars stamped on a prior bind.
+    path => !path.hasAttribute(GANTT_ATTR),
+  );
+
+  const bars = resolveGanttBars(candidates, drawn.length);
+  if (!bars) {
+    console.warn(
+      `[maidr/anychart] Could not tell this gantt's ${drawn.length} task bars `
+      + `apart from the ${candidates.length} filled shapes its SVG holds. `
+      + 'Highlighting is disabled for this chart; pass an explicit '
+      + '`selectors` entry to override.',
+    );
+    return;
+  }
+
+  bars.forEach((bar, i) => {
+    const { lane, interval } = drawn[i];
+    bar.setAttribute(GANTT_ATTR, `${stampPrefix}${lane}-${interval}`);
+  });
+}
+
+/**
+ * Pick the schedule's task bars out of a gantt's filled shapes.
+ *
+ * @param candidates - Every filled path the SVG holds
+ * @param expected - How many intervals the schedule emitted
+ * @returns The bars, in document order, or `null` when they cannot be told
+ * apart from the rest of the chart
+ */
+function resolveGanttBars(
+  candidates: SVGElement[],
+  expected: number,
+): SVGElement[] | null {
+  if (candidates.length === expected)
+    return candidates;
+
+  const byLayer = new Map<Element, SVGElement[]>();
+  for (const candidate of candidates) {
+    const layer = candidate.closest('g[id^="ac_layer_"]');
+    if (!layer)
+      continue;
+    const group = byLayer.get(layer);
+    if (group)
+      group.push(candidate);
+    else
+      byLayer.set(layer, [candidate]);
+  }
+
+  const matching = Array.from(byLayer.values()).filter(
+    group => group.length === expected,
+  );
+  if (matching.length === 1)
+    return matching[0];
+  if (matching.length === 0)
+    return null;
+
+  // Several layers hold the right number of shapes. A schedule's bars start
+  // and end in different places; a column of row backgrounds is one rectangle
+  // repeated down the chart, and that is the difference.
+  const varied = matching.filter(hasVaryingSpans);
+  return varied.length === 1 ? varied[0] : null;
+}
+
+/**
+ * Whether a group of shapes sits at more than one position and width.
+ *
+ * A shape that cannot be measured answers no rather than yes: this separates
+ * a schedule from a backdrop, and a group it cannot see is a group it cannot
+ * vouch for.
+ *
+ * @param group - The shapes to measure
+ * @returns True when they do not all share one left edge and one width
+ */
+function hasVaryingSpans(group: SVGElement[]): boolean {
+  const boxes: RegionBox[] = [];
+  for (const shape of group) {
+    const box = readDrawnBox(shape);
+    if (!box)
+      return false;
+    boxes.push(box);
+  }
+  const [first] = boxes;
+  if (!first)
+    return false;
+  return boxes.some(
+    box => Math.abs(box.left - first.left) > DRAWN_BOX_TOLERANCE_PX
+      || Math.abs(box.width - first.width) > DRAWN_BOX_TOLERANCE_PX,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Layer builders – one per MAIDR trace type
 // ---------------------------------------------------------------------------
 
@@ -3632,7 +4431,7 @@ function buildHeatmapLayerFromChart(
   selectors: string | string[] | undefined,
   panel?: PanelContext,
 ): MaidrLayer | null {
-  const dataView = chart.data?.();
+  const dataView = resolveChartDataView(chart);
   if (!dataView)
     return null;
   let iterator: AnyChartIterator | null = null;
@@ -3795,6 +4594,66 @@ function buildPieLayer(
 }
 
 /**
+ * Build a CHOROPLETH layer from an AnyChart map's shaded-region series.
+ *
+ * Each row is a region and its value. The name comes from the geodata rather
+ * than from the row — see {@link regionNameOf} — and a row with no numeric
+ * value is dropped, because AnyChart shades no region for one and keeping it
+ * would slide every later region's highlight onto its neighbour.
+ *
+ * **`lon` and `lat` are deliberately omitted.** The grammar's centroids are
+ * degrees east and north (`ChoroplethPoint.lon` / `.lat`), and what AnyChart
+ * has are its features' `middle-x` / `middle-y` — normalised coordinates in
+ * the map's own projection, which are not degrees and cannot be turned into
+ * them without inverting a projection the chart does not name. Passing them
+ * through would tell a reader that one region lies north of another when the
+ * map says nothing of the kind. Without them `ChoroplethTrace` reads the
+ * regions as a list in declared order: a poorer reading, and the one the data
+ * supports. `neighbors` is not derivable from AnyChart at all and stays
+ * absent too.
+ *
+ * The selectors are emitted as an ARRAY, one exact-match entry per region in
+ * DATA order, for the reason {@link stampChoroplethAttributes} explains: a map
+ * paints every feature of its geodata in the geodata's order, so a prefix
+ * selector — which resolves in document order — would hand the trace its
+ * regions shuffled.
+ *
+ * @param chart - The map the series belongs to, for its geodata
+ * @param series - The choropleth series
+ * @param seriesIndex - Index used as the layer id and in the default selectors
+ * @param selectors - Caller-supplied selector override, when there is one
+ * @param panel - The owning panel, in multi-panel mode
+ * @returns The MAIDR choropleth layer
+ */
+function buildChoroplethLayer(
+  chart: AnyChartInstance,
+  series: AnyChartSeries,
+  seriesIndex: number,
+  selectors: string | string[] | undefined,
+  panel?: PanelContext,
+): MaidrLayer {
+  const names = readRegionNames(chart);
+  const data: ChoroplethPoint[] = extractRawRows(series)
+    .filter(isDrawnDatum)
+    .map(row => ({
+      x: regionNameOf(series, row, names),
+      y: asNumber(row.value ?? row.y),
+    }));
+
+  const scope = panelScope(panel);
+  const stamp = panelStampPrefix(panel);
+  const defaultSelectors = data.map(
+    (_, i) => `${scope}[${CHOROPLETH_ATTR}="${stamp}${seriesIndex}-${i}"]`,
+  );
+  return {
+    id: String(seriesIndex),
+    type: TraceType.CHOROPLETH,
+    selectors: selectors ?? defaultSelectors,
+    data,
+  };
+}
+
+/**
  * Build a FUNNEL layer from an AnyChart funnel's (or pyramid's) stage rows.
  *
  * Only the count is emitted. `FunnelTrace` derives each stage's share of the
@@ -3921,6 +4780,88 @@ function buildSankeyLayer(
     id: '0',
     type: TraceType.SANKEY,
     selectors: selectors ?? defaultSelectors,
+    data,
+  };
+}
+
+/**
+ * Build a GANTT layer from a gantt chart's task tree.
+ *
+ * The lanes are NESTED, one array per row of the chart, which is what lets an
+ * empty one survive: a task with no dates — a heading, a row whose work has
+ * not been scheduled — is a real statement about a plan, and a flat list
+ * grouped by lane cannot make it. Every lane is named in `lanes` in the same
+ * order for the same reason, since an empty lane holds no interval to carry
+ * its own name in `x`.
+ *
+ * The ends are restated in whole days (or hours, on a schedule short enough to
+ * need them) rather than left as the milliseconds the tree holds, and the unit
+ * is named alongside them — see {@link resolveGanttScale}. The x axis carries
+ * a formatter that turns a position back into a date, so a reader is told when
+ * a task runs as well as how long it takes.
+ *
+ * The selectors are emitted as an ARRAY, one exact-match entry per interval in
+ * lane order: `GanttTrace` slices the resolved elements lane by lane, so the
+ * order they arrive in is the reading, and it withdraws the highlight entirely
+ * unless the count matches exactly.
+ *
+ * @param lanes - The schedule's rows, in draw order
+ * @param selectors - Caller-supplied selector override, when there is one
+ * @param panel - The owning panel, in multi-panel mode
+ * @returns The MAIDR gantt layer
+ */
+function buildGanttLayer(
+  lanes: GanttLane[],
+  selectors: string | string[] | undefined,
+  panel?: PanelContext,
+): MaidrLayer {
+  const scale = resolveGanttScale(lanes);
+  const points: GanttPoint[][] = lanes.map(lane =>
+    lane.spans.map(span => ({
+      x: lane.name,
+      start: span.start / scale.perUnit,
+      end: span.end / scale.perUnit,
+      ...(span.label && span.label !== lane.name ? { label: span.label } : {}),
+    })));
+
+  const data: GanttData = {
+    points,
+    lanes: lanes.map(lane => lane.name),
+    unit: scale.unit,
+  };
+
+  const scope = panelScope(panel);
+  const stamp = panelStampPrefix(panel);
+  const defaultSelectors: string[] = [];
+  points.forEach((lane, index) => {
+    lane.forEach((_, interval) => {
+      defaultSelectors.push(
+        `${scope}[${GANTT_ATTR}="${stamp}${index}-${interval}"]`,
+      );
+    });
+  });
+
+  return {
+    id: '0',
+    type: TraceType.GANTT,
+    // A schedule runs its bars left to right, which puts the dates on x and
+    // the lanes on y — the opposite of the trace's own default.
+    orientation: Orientation.HORIZONTAL,
+    selectors: selectors ?? defaultSelectors,
+    // The positions stay readable as dates even though the lengths are now
+    // counted in units: without this an end announces as the unit count it
+    // is, which says how far along the axis a task sits and not when it runs.
+    axes: {
+      x: {
+        format: {
+          function: `return new Date(value * ${scale.perUnit}).${
+            scale.perUnit === MS_PER_HOUR
+              ? 'toLocaleString()'
+              : 'toLocaleDateString()'
+          }`,
+        },
+      },
+    },
     data,
   };
 }
@@ -4329,6 +5270,7 @@ function radarSelector(seriesIndex: number, panel?: PanelContext): string {
  * until a matching case is added here.
  */
 function buildLayer(
+  chart: AnyChartInstance,
   series: AnyChartSeries,
   seriesIndex: number,
   traceType: AnyChartTraceType,
@@ -4357,6 +5299,10 @@ function buildLayer(
       return buildHeatmapLayer(series, seriesIndex, selectors);
     case TraceType.CANDLESTICK:
       return buildCandlestickLayer(series, seriesIndex, selectors, panel);
+    // The one builder that needs the chart as well as the series: a region's
+    // name lives in the geodata the CHART was bound to, never in the row.
+    case TraceType.CHOROPLETH:
+      return buildChoroplethLayer(chart, series, seriesIndex, selectors, panel);
     case TraceType.PIE:
       return buildPieLayer(extractRawRows(series), seriesIndex, selectors, panel);
   }
@@ -4395,6 +5341,36 @@ const WORD_CLOUD_AXIS_FALLBACKS = { x: 'Term', y: 'Weight' };
 const SANKEY_AXIS_FALLBACKS = { x: 'Node', y: 'Flow' };
 
 /**
+ * What a choropleth's two dimensions are called when the chart names neither.
+ * A map is bound to no axis: its regions are places rather than positions on a
+ * scale, and AnyChart's map chart has no `xAxis()` / `yAxis()` to borrow a
+ * title from.
+ */
+const CHOROPLETH_AXIS_FALLBACKS = { x: 'Region', y: 'Value' };
+
+/**
+ * What a gantt's two dimensions are called when the chart names neither. A
+ * gantt draws its own timeline header rather than an `xAxis()` / `yAxis()`
+ * pair, so there is no axis title to extract; a resource chart's rows are
+ * named separately, because what they hold is who is booked rather than what
+ * is to be done.
+ */
+const GANTT_PROJECT_AXIS_FALLBACKS = { x: 'Date', y: 'Task' };
+const GANTT_RESOURCE_AXIS_FALLBACKS = { x: 'Date', y: 'Resource' };
+
+/**
+ * The fallbacks for the trace types a SERIES can produce that are bound to no
+ * axis. Looked up by trace type so the series loop states the rule once
+ * instead of asking about each of them in turn.
+ */
+const AXIS_FALLBACKS_BY_TYPE: Partial<
+  Record<AnyChartTraceType, { x: string; y: string }>
+> = {
+  [TraceType.PIE]: PIE_AXIS_FALLBACKS,
+  [TraceType.CHOROPLETH]: CHOROPLETH_AXIS_FALLBACKS,
+};
+
+/**
  * Build one {@link MaidrSubplot} from a single AnyChart chart instance.
  *
  * This is the per-chart body shared by {@link anyChartToMaidr} (single
@@ -4431,12 +5407,17 @@ function buildSubplot(
   ): void => {
     const x = xAxisLabel ?? fallbacks?.x;
     const y = yAxisLabel ?? fallbacks?.y;
-    if (x || y) {
-      layer.axes = {
-        ...(x ? { x: { label: x } } : {}),
-        ...(y ? { y: { label: y } } : {}),
-      };
-    }
+    if (!x && !y)
+      return;
+    // Merged onto whatever the builder already put there, rather than
+    // replacing it: a gantt's x axis arrives carrying the formatter that turns
+    // its positions back into dates, and that is not a label's to discard.
+    const axes = { ...layer.axes };
+    if (x)
+      axes.x = { ...axes.x, label: x };
+    if (y)
+      axes.y = { ...axes.y, label: y };
+    layer.axes = axes;
   };
 
   const finalize = (layers: MaidrLayer[]): MaidrSubplot => {
@@ -4544,6 +5525,31 @@ function buildSubplot(
       return null;
     const layer = buildSankeyLayer(rows, chartLevelSelector, panel);
     attachAxes(layer, SANKEY_AXIS_FALLBACKS);
+    return finalize([layer]);
+  }
+
+  // A gantt is the last of the chart-level types, and the one furthest from
+  // the rest: it has no series API to reach the loop below with, and its data
+  // is a task tree rather than a data view — so the `getSeriesCount()`
+  // fallback would route its schedule to the heatmap builder, which would find
+  // no iterator and bind nothing at all.
+  if (isGanttChart(chart)) {
+    const tree = readTaskTree(chart);
+    if (!tree)
+      return null;
+    const lanes = collectGanttLanes(tree);
+    // A plan whose every row is undated is not a schedule to read: the lanes
+    // exist but nothing is booked in any of them, and a trace of empty lanes
+    // announces a chart the reader cannot navigate anywhere within.
+    if (lanes.every(lane => lane.spans.length === 0))
+      return null;
+    const layer = buildGanttLayer(lanes, chartLevelSelector, panel);
+    attachAxes(
+      layer,
+      readChartType(chart) === 'gantt-resource'
+        ? GANTT_RESOURCE_AXIS_FALLBACKS
+        : GANTT_PROJECT_AXIS_FALLBACKS,
+    );
     return finalize([layer]);
   }
 
@@ -4663,10 +5669,10 @@ function buildSubplot(
     }
 
     const selectors = resolveSelector(i, traceType, options, panel);
-    const layer = buildLayer(series, i, traceType, selectors, panel);
+    const layer = buildLayer(chart, series, i, traceType, selectors, panel);
 
     // Attach axis labels.
-    attachAxes(layer, traceType === TraceType.PIE ? PIE_AXIS_FALLBACKS : undefined);
+    attachAxes(layer, AXIS_FALLBACKS_BY_TYPE[traceType]);
 
     layers.push(layer);
   }

--- a/src/adapters/anychart/converters.ts
+++ b/src/adapters/anychart/converters.ts
@@ -2601,11 +2601,14 @@ function resolveStampers(
     return [['word cloud', stampWordCloudAttributes]];
   if (isSankeyChart(chart))
     return [['sankey', stampSankeyAttributes]];
-  // A map does have a series API, but none of the XY stampers may run on one:
-  // they pair a datum with a shape by counting DOM order, and a map's shapes
-  // are its geodata's features — every one of them, in the geodata's order —
-  // so the bar stamper would stamp Alabama for California and the count would
-  // be right often enough to say nothing about it.
+  // A map does have a series API, and its regions are a mark family no XY
+  // stamper writes — so a map running the XY set would be stamped by nothing
+  // at all. Running the region stamper ALONE is the second half of that: a
+  // map carrying a `marker` or `bubble` overlay would otherwise have the
+  // scatter stamper loose on it, and its geometric filter cannot tell an
+  // overlaid point from the small islands and legend swatches a map is full
+  // of. The overlay loses its highlight, which is what the pie and radar
+  // branches above already choose over a placed guess.
   if (isMapChart(chart))
     return [['choropleth', stampChoroplethAttributes]];
   // A gantt has no series API at all, and its bars are the one mark family

--- a/src/adapters/anychart/types.ts
+++ b/src/adapters/anychart/types.ts
@@ -21,6 +21,27 @@ export interface AnyChartPoint {
   get: (field: string) => unknown;
   getIndex: () => number;
   exists: () => boolean;
+
+  /**
+   * The bound geo feature's own properties, on a point of a map series.
+   *
+   * This is where a region's human-readable name lives: the data row carries
+   * only the id it was matched on (`'US.CA'`), and the name (`'California'`)
+   * belongs to the feature the geodata declared. Absent on every non-map
+   * series, and on builds that predate the map module's point API — the
+   * region then keeps the id as its name, which is poorer but still true.
+   */
+  getFeatureProp?: () => unknown;
+
+  /**
+   * The drawn bounds of the bound geo feature, in the stage's pixels.
+   *
+   * The only handle a map offers on WHICH shape it drew for a region:
+   * AnyChart paints every feature of the geodata, not only the rows it was
+   * given, and the paths carry no id. Matching a path's own box against this
+   * is what lets a region be highlighted rather than counted off.
+   */
+  getFeatureBounds?: () => unknown;
 }
 
 /** A data view (mapping / set) backing a series. */
@@ -65,6 +86,34 @@ export interface AnyChartSeries {
    * candlestick series do not expose this method.
    */
   markers?: () => AnyChartMarkers;
+}
+
+/**
+ * One node of the task tree backing a gantt chart.
+ *
+ * A gantt is the one AnyChart chart type whose data is neither a series nor a
+ * flat data view: `chart.data()` hands back an `anychart.data.Tree` whose
+ * items carry `actualStart` / `actualEnd` (a project chart) or a `periods`
+ * array (a resource chart), and whose children are the rows drawn beneath
+ * their parent.
+ */
+export interface AnyChartTreeItem {
+  /** Reads one field of the task — `'name'`, `'actualStart'`, `'periods'`. */
+  get: (field: string) => unknown;
+  /**
+   * Reads a value the chart computed for the task rather than one the author
+   * wrote. A parent task states no dates of its own: AnyChart derives them
+   * from its children and stores them as `'autoStart'` / `'autoEnd'`.
+   */
+  meta?: (key: string) => unknown;
+  numChildren?: () => number;
+  getChildAt?: (index: number) => AnyChartTreeItem | null;
+}
+
+/** The task tree returned by a gantt chart's `data()`. */
+export interface AnyChartTree {
+  numChildren: () => number;
+  getChildAt: (index: number) => AnyChartTreeItem | null;
 }
 
 /** Title object returned by `chart.title()`. */
@@ -189,8 +238,25 @@ export interface AnyChartInstance {
    * as Heatmap, which do not expose a series-based API and instead store
    * their cells in a top-level data view. Absent on multi-series Cartesian
    * charts (bar, line, scatter, box, candlestick).
+   *
+   * A gantt chart answers with an {@link AnyChartTree} instead of a data
+   * view — the two are told apart by whether the result can hand out an
+   * iterator, never by the chart type alone.
    */
-  data?: () => AnyChartDataView;
+  data?: () => AnyChartDataView | AnyChartTree;
+
+  /**
+   * The geodata a map was bound to (`anychart.maps.*`), as GeoJSON or
+   * TopoJSON. Read for one thing only: the region names, which the data rows
+   * do not carry. Present on a map chart.
+   */
+  geoData?: () => unknown;
+
+  /**
+   * Which property of a geo feature the data rows' `id` is matched against.
+   * Defaults to `'id'`. Present on a map chart.
+   */
+  geoIdField?: () => string | undefined;
 
   /** SVG string export. */
   toSvg?: () => string;

--- a/test/adapters/anychart/choropleth.test.ts
+++ b/test/adapters/anychart/choropleth.test.ts
@@ -1,0 +1,344 @@
+import type {
+  AnyChartInstance,
+  AnyChartIterator,
+  AnyChartSeries,
+} from '@adapters/anychart/types';
+import type { ChoroplethPoint } from '@type/grammar';
+import { anyChartToMaidr, bindAnyChart } from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface Box {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** One row of a choropleth series: the geo id it is matched on, and a value. */
+interface RegionRow {
+  id: string;
+  value: number | null;
+  /** The bounds AnyChart reports for the feature this row was matched to. */
+  bounds?: Box;
+  /** The name the map module's own point API answers with, when it does. */
+  featureName?: string;
+}
+
+function createIterator(rows: Array<Record<string, unknown>>): AnyChartIterator {
+  let index = -1;
+  return {
+    advance: () => ++index < rows.length,
+    get: (field: string) => rows[index]?.[field],
+    getIndex: () => index,
+    getRowsCount: () => rows.length,
+    reset: () => {
+      index = -1;
+    },
+  };
+}
+
+/**
+ * A drawn choropleth series. `getPoint(i)` is the map module's own point API:
+ * it answers with the bound feature's properties and its drawn bounds, which
+ * is where a region's name and its highlight both come from.
+ */
+function createChoroplethSeries(rows: RegionRow[]): AnyChartSeries {
+  return {
+    id: () => 0,
+    name: () => 'Population',
+    seriesType: () => 'choropleth',
+    getIterator: () => createIterator(rows.map(r => ({ id: r.id, value: r.value }))),
+    getPoint: (index: number) => ({
+      get: () => undefined,
+      getIndex: () => index,
+      exists: () => index < rows.length,
+      getFeatureProp: () => {
+        const name = rows[index]?.featureName;
+        return name === undefined ? undefined : { name };
+      },
+      getFeatureBounds: () => rows[index]?.bounds,
+    }),
+    getStat: () => undefined,
+  };
+}
+
+/** GeoJSON, the shape AnyChart's own `anychart.maps.*` files parse into. */
+function geoJson(features: Array<[string, string]>): unknown {
+  return {
+    type: 'FeatureCollection',
+    features: features.map(([id, name]) => ({
+      // `middle-x` / `middle-y` are AnyChart's normalised projected centroids.
+      // They are NOT degrees, and nothing may pass them through as such.
+      properties: { id, name, 'middle-x': 0.42, 'middle-y': 0.61 },
+    })),
+  };
+}
+
+function createMapChart(
+  rows: RegionRow[],
+  extra: {
+    container?: HTMLElement;
+    geoData?: unknown;
+    chartType?: string;
+    series?: AnyChartSeries[];
+  } = {},
+): AnyChartInstance {
+  const series = extra.series ?? [createChoroplethSeries(rows)];
+  return {
+    title: () => 'Population by state',
+    container: () => extra.container ?? '',
+    getType: () => extra.chartType ?? 'map',
+    getSeriesCount: () => series.length,
+    getSeriesAt: (i: number) => series[i] ?? null,
+    geoData: () => extra.geoData,
+  } as unknown as AnyChartInstance;
+}
+
+/** A container holding a rendered map: one filled path per geo feature. */
+function createRenderedMap(id: string, boxes: Box[]): {
+  container: HTMLElement;
+  paths: SVGElement[];
+} {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  const layer = document.createElementNS(SVG_NS, 'g');
+  layer.id = 'ac_layer_1';
+  svg.appendChild(layer);
+  container.appendChild(svg);
+  document.body.appendChild(container);
+
+  const paths = boxes.map((box, i) => {
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.id = `ac_path_${i}`;
+    path.setAttribute('d', 'M 0 0 L 10 0 L 10 10 Z');
+    path.setAttribute('fill', '#cccccc');
+    Object.defineProperty(path, 'getBBox', {
+      value: () => ({
+        x: box.left,
+        y: box.top,
+        width: box.width,
+        height: box.height,
+      }),
+    });
+    layer.appendChild(path);
+    return path as unknown as SVGElement;
+  });
+
+  return { container, paths };
+}
+
+function cleanUp(container: HTMLElement): void {
+  (container.closest('[data-maidr-anychart-host]') ?? container).remove();
+}
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('anyChartToMaidr (choropleth)', () => {
+  it('reads a map series as a choropleth, named from the geodata', () => {
+    const chart = createMapChart(
+      [
+        { id: 'US.NV', value: 42.1 },
+        { id: 'US.UT', value: 17.9 },
+      ],
+      { geoData: geoJson([['US.NV', 'Nevada'], ['US.UT', 'Utah']]) },
+    );
+
+    const layer = anyChartToMaidr(chart)?.subplots[0][0].layers[0];
+
+    expect(layer?.type).toBe(TraceType.CHOROPLETH);
+    // The rows carry an id and a value; the NAME belongs to the geodata, and a
+    // map announced by code is a map a listener cannot follow.
+    expect(layer?.data as ChoroplethPoint[]).toEqual([
+      { x: 'Nevada', y: 42.1 },
+      { x: 'Utah', y: 17.9 },
+    ]);
+  });
+
+  it('omits lon and lat rather than passing the projected centroids through', () => {
+    const chart = createMapChart(
+      [{ id: 'US.NV', value: 42.1 }],
+      { geoData: geoJson([['US.NV', 'Nevada']]) },
+    );
+
+    const [region] = anyChartToMaidr(chart)!.subplots[0][0].layers[0].data as ChoroplethPoint[];
+
+    // AnyChart's `middle-x` / `middle-y` are normalised projected coordinates,
+    // and the grammar's centroids are degrees. Announcing the first as the
+    // second would tell a reader that one region lies north of another when
+    // the map says nothing of the kind.
+    expect(region.lon).toBeUndefined();
+    expect(region.lat).toBeUndefined();
+    expect(region.neighbors).toBeUndefined();
+  });
+
+  it('detects the series even when the chart names no type', () => {
+    // `getType()` answers `''` on a build without it and on an undrawn chart,
+    // so a map gated on the chart type would be dropped exactly then. The
+    // series type is self-describing and is the whole detection.
+    const chart = createMapChart(
+      [{ id: 'US.NV', value: 42.1 }],
+      { chartType: '', geoData: geoJson([['US.NV', 'Nevada']]) },
+    );
+
+    expect(anyChartToMaidr(chart)?.subplots[0][0].layers[0].type)
+      .toBe(TraceType.CHOROPLETH);
+  });
+
+  it('prefers the feature the point is bound to over the geodata lookup', () => {
+    const chart = createMapChart(
+      [{ id: 'US.NV', value: 1, featureName: 'Nevada' }],
+      // The geodata names the same id something else; the bound feature is the
+      // one the chart actually drew.
+      { geoData: geoJson([['US.NV', 'NV']]) },
+    );
+
+    const [region] = anyChartToMaidr(chart)!.subplots[0][0].layers[0].data as ChoroplethPoint[];
+    expect(region.x).toBe('Nevada');
+  });
+
+  it('keeps the id as the name when nothing else names the region', () => {
+    const chart = createMapChart([{ id: 'US.NV', value: 1 }]);
+
+    const [region] = anyChartToMaidr(chart)!.subplots[0][0].layers[0].data as ChoroplethPoint[];
+    // A poor name, but a true one: every alternative is a region the map does
+    // not contain.
+    expect(region.x).toBe('US.NV');
+  });
+
+  it('drops a region the map shades no colour for', () => {
+    const chart = createMapChart(
+      [
+        { id: 'US.NV', value: 42.1 },
+        { id: 'US.UT', value: null },
+        { id: 'US.ID', value: 3 },
+      ],
+      { geoData: geoJson([['US.NV', 'Nevada'], ['US.UT', 'Utah'], ['US.ID', 'Idaho']]) },
+    );
+
+    const data = anyChartToMaidr(chart)!.subplots[0][0].layers[0].data as ChoroplethPoint[];
+    expect(data.map(r => r.x)).toEqual(['Nevada', 'Idaho']);
+  });
+
+  it('names the two dimensions a map has no axis to name', () => {
+    const chart = createMapChart([{ id: 'US.NV', value: 1 }]);
+
+    const layer = anyChartToMaidr(chart)!.subplots[0][0].layers[0];
+    expect(layer.axes?.x).toEqual({ label: 'Region' });
+    expect(layer.axes?.y).toEqual({ label: 'Value' });
+  });
+
+  it('emits one exact-match selector per region, in data order', () => {
+    const chart = createMapChart([
+      { id: 'US.NV', value: 1 },
+      { id: 'US.UT', value: 2 },
+    ]);
+
+    // Not a `^=` prefix selector: that resolves in DOCUMENT order, which on a
+    // map is the geodata's order and not the data's.
+    expect(anyChartToMaidr(chart)!.subplots[0][0].layers[0].selectors).toEqual([
+      '[data-maidr-anychart-region="0-0"]',
+      '[data-maidr-anychart-region="0-1"]',
+    ]);
+  });
+});
+
+describe('bindAnyChart (choropleth stamping)', () => {
+  it('stamps each region by its bounds, not by document order', () => {
+    // The map paints every feature of its geodata — four here — in the
+    // geodata's order, while the data names two of them in another order.
+    // Counting shapes off would highlight Alabama for Nevada.
+    const boxes: Box[] = [
+      { left: 0, top: 0, width: 10, height: 10 },
+      { left: 50, top: 0, width: 12, height: 8 },
+      { left: 90, top: 30, width: 20, height: 20 },
+      { left: 10, top: 60, width: 5, height: 5 },
+    ];
+    const { container, paths } = createRenderedMap('map-bounds', boxes);
+    const chart = createMapChart(
+      [
+        { id: 'US.ID', value: 3, bounds: boxes[2] },
+        { id: 'US.NV', value: 42, bounds: boxes[0] },
+      ],
+      { container },
+    );
+
+    bindAnyChart(chart);
+
+    expect(paths.map(p => p.getAttribute('data-maidr-anychart-region')))
+      .toEqual(['0-1', null, '0-0', null]);
+
+    cleanUp(container);
+  });
+
+  it('disables highlighting when a region matches more than one shape', () => {
+    const box: Box = { left: 0, top: 0, width: 10, height: 10 };
+    const { container, paths } = createRenderedMap('map-ambiguous', [box, box]);
+    const chart = createMapChart([{ id: 'US.NV', value: 1, bounds: box }], {
+      container,
+    });
+    const warn = jest.spyOn(console, 'warn');
+
+    bindAnyChart(chart);
+
+    // A guess would put the announcement on one shape and the highlight on
+    // another, with nothing in the DOM to say so.
+    expect(paths.every(p => !p.hasAttribute('data-maidr-anychart-region')))
+      .toBe(true);
+    expect(warn.mock.calls.flat().join(' ')).toContain('Highlighting is disabled');
+
+    cleanUp(container);
+  });
+
+  it('disables highlighting when the build reports no feature bounds', () => {
+    const { container, paths } = createRenderedMap('map-unplaced', [
+      { left: 0, top: 0, width: 10, height: 10 },
+    ]);
+    // No `bounds`: an older map build with no point API to ask.
+    const chart = createMapChart([{ id: 'US.NV', value: 1 }], { container });
+
+    bindAnyChart(chart);
+
+    expect(paths[0].hasAttribute('data-maidr-anychart-region')).toBe(false);
+
+    cleanUp(container);
+  });
+
+  it('runs the region stamper on a map, and no cartesian stamper', () => {
+    const boxes: Box[] = [{ left: 0, top: 0, width: 10, height: 10 }];
+    const { container, paths } = createRenderedMap('map-stampers', boxes);
+    const chart = createMapChart([{ id: 'US.NV', value: 1, bounds: boxes[0] }], {
+      container,
+    });
+
+    bindAnyChart(chart);
+
+    // The bar stamper pairs shapes with data by counting DOM order, which on a
+    // map pairs a row with whichever feature the geodata happened to declare
+    // in that position.
+    expect(paths[0].hasAttribute('data-maidr-anychart-bar')).toBe(false);
+    expect(paths[0].getAttribute('data-maidr-anychart-region')).toBe('0-0');
+
+    cleanUp(container);
+  });
+});

--- a/test/adapters/anychart/gantt.test.ts
+++ b/test/adapters/anychart/gantt.test.ts
@@ -1,0 +1,410 @@
+import type {
+  AnyChartInstance,
+  AnyChartTreeItem,
+} from '@adapters/anychart/types';
+import type { GanttData } from '@type/grammar';
+import { anyChartToMaidr, bindAnyChart } from '@adapters/anychart/converters';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Orientation, TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+Object.assign(globalThis, {
+  document: dom.window.document,
+  window: dom.window,
+  HTMLElement: dom.window.HTMLElement,
+  SVGElement: dom.window.SVGElement,
+  Node: dom.window.Node,
+  CustomEvent: dom.window.CustomEvent,
+  MutationObserver: dom.window.MutationObserver,
+});
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 86_400_000;
+
+/** A task as an author writes one into `anychart.data.tree`. */
+interface TaskSpec {
+  name?: string;
+  id?: string;
+  actualStart?: number | string | Date;
+  actualEnd?: number | string | Date;
+  /** What AnyChart derived for a parent task that states no dates itself. */
+  meta?: Record<string, unknown>;
+  /** A resource chart's bookings. */
+  periods?: Array<Record<string, unknown>>;
+  children?: TaskSpec[];
+}
+
+function createTreeItem(spec: TaskSpec): AnyChartTreeItem {
+  const children = (spec.children ?? []).map(createTreeItem);
+  return {
+    get: (field: string) => (spec as Record<string, unknown>)[field],
+    meta: (key: string) => spec.meta?.[key],
+    numChildren: () => children.length,
+    getChildAt: (index: number) => children[index] ?? null,
+  };
+}
+
+function createGanttChart(
+  tasks: TaskSpec[],
+  extra: {
+    container?: HTMLElement;
+    chartType?: string;
+    /** Hands back a flat data view instead of a task tree. */
+    dataView?: boolean;
+  } = {},
+): AnyChartInstance {
+  const roots = tasks.map(createTreeItem);
+  const tree = {
+    numChildren: () => roots.length,
+    getChildAt: (index: number) => roots[index] ?? null,
+  };
+  return {
+    title: () => 'Release plan',
+    container: () => extra.container ?? '',
+    getType: () => extra.chartType ?? 'gantt-project',
+    data: () => (extra.dataView ? { getIterator: () => undefined } : tree),
+    // A gantt has NO series API; a mock that offered one would let a broken
+    // route look like a working one.
+  } as unknown as AnyChartInstance;
+}
+
+function ganttData(chart: AnyChartInstance): GanttData {
+  const maidr = anyChartToMaidr(chart);
+  return maidr!.subplots[0][0].layers[0].data as GanttData;
+}
+
+/**
+ * A rendered gantt: `layers` describes one AnyChart layer per entry, each
+ * holding filled paths at the given boxes. A real one holds several — the row
+ * stripes behind both halves of the split widget, then the task bars.
+ */
+function createRenderedGantt(
+  id: string,
+  layers: Array<Array<{ left: number; width: number }>>,
+): { container: HTMLElement; paths: SVGElement[][] } {
+  const container = document.createElement('div');
+  container.id = id;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  container.appendChild(svg);
+  document.body.appendChild(container);
+
+  const paths = layers.map((shapes, layerIndex) => {
+    const layer = document.createElementNS(SVG_NS, 'g');
+    layer.id = `ac_layer_${layerIndex}`;
+    svg.appendChild(layer);
+    return shapes.map((shape, i) => {
+      const path = document.createElementNS(SVG_NS, 'path');
+      path.id = `ac_path_${layerIndex}_${i}`;
+      path.setAttribute('d', 'M 0 0 L 10 0 L 10 10 Z');
+      path.setAttribute('fill', '#4682b4');
+      Object.defineProperty(path, 'getBBox', {
+        value: () => ({
+          x: shape.left,
+          y: i * 20,
+          width: shape.width,
+          height: 12,
+        }),
+      });
+      layer.appendChild(path);
+      return path as unknown as SVGElement;
+    });
+  });
+
+  return { container, paths };
+}
+
+function cleanUp(container: HTMLElement): void {
+  (container.closest('[data-maidr-anychart-host]') ?? container).remove();
+}
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('anyChartToMaidr (gantt)', () => {
+  it('reads a project chart as one lane per task, in row order', () => {
+    const chart = createGanttChart([
+      {
+        name: 'Research',
+        actualStart: Date.UTC(2024, 0, 1),
+        actualEnd: Date.UTC(2024, 0, 15),
+      },
+      {
+        name: 'Write',
+        actualStart: Date.UTC(2024, 0, 15),
+        actualEnd: Date.UTC(2024, 1, 5),
+      },
+    ]);
+
+    const layer = anyChartToMaidr(chart)!.subplots[0][0].layers[0];
+    expect(layer.type).toBe(TraceType.GANTT);
+    // A schedule runs its bars left to right: the dates are the x axis and the
+    // lanes are the rows, the opposite of the trace's own default.
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+
+    const data = layer.data as GanttData;
+    expect(data.lanes).toEqual(['Research', 'Write']);
+    expect(data.points).toEqual([
+      [{
+        x: 'Research',
+        start: Date.UTC(2024, 0, 1) / MS_PER_DAY,
+        end: Date.UTC(2024, 0, 15) / MS_PER_DAY,
+      }],
+      [{
+        x: 'Write',
+        start: Date.UTC(2024, 0, 15) / MS_PER_DAY,
+        end: Date.UTC(2024, 1, 5) / MS_PER_DAY,
+      }],
+    ]);
+    // The length of an interval is what a gantt is read for, and a bare number
+    // does not carry it. Left in milliseconds every task announces a
+    // nine-digit figure.
+    expect(data.unit).toBe('days');
+    expect(layer.axes?.x?.format?.function)
+      .toBe(`return new Date(value * ${MS_PER_DAY}).toLocaleDateString()`);
+    expect(layer.axes?.x?.label).toBe('Date');
+    expect(layer.axes?.y?.label).toBe('Task');
+  });
+
+  it('reads a schedule shorter than two days in hours', () => {
+    const chart = createGanttChart([
+      {
+        name: 'Deploy',
+        actualStart: Date.UTC(2024, 0, 1, 9),
+        actualEnd: Date.UTC(2024, 0, 1, 11),
+      },
+    ]);
+
+    const data = ganttData(chart);
+    expect(data.unit).toBe('hours');
+    expect(data.points[0][0].start).toBe(Date.UTC(2024, 0, 1, 9) / MS_PER_HOUR);
+  });
+
+  it('accepts a date written as a string or a Date, as the chart does', () => {
+    const chart = createGanttChart([
+      {
+        name: 'Research',
+        actualStart: '2024-01-01T00:00:00Z',
+        actualEnd: new Date(Date.UTC(2024, 0, 15)),
+      },
+    ]);
+
+    expect(ganttData(chart).points[0][0]).toEqual({
+      x: 'Research',
+      start: Date.UTC(2024, 0, 1) / MS_PER_DAY,
+      end: Date.UTC(2024, 0, 15) / MS_PER_DAY,
+    });
+  });
+
+  it('gives a parent task the dates the chart worked out for it', () => {
+    const chart = createGanttChart([
+      {
+        name: 'Phase one',
+        // A summary row states no dates of its own: AnyChart derives them
+        // from the children and keeps them in the item's meta. Reading only
+        // the authored fields would leave every summary row empty.
+        meta: {
+          autoStart: Date.UTC(2024, 0, 1),
+          autoEnd: Date.UTC(2024, 1, 5),
+        },
+        children: [
+          {
+            name: 'Research',
+            actualStart: Date.UTC(2024, 0, 1),
+            actualEnd: Date.UTC(2024, 0, 15),
+          },
+          {
+            name: 'Write',
+            actualStart: Date.UTC(2024, 0, 15),
+            actualEnd: Date.UTC(2024, 1, 5),
+          },
+        ],
+      },
+    ]);
+
+    const data = ganttData(chart);
+    // Depth first, parents before their children — the order the chart stacks
+    // its rows in.
+    expect(data.lanes).toEqual(['Phase one', 'Research', 'Write']);
+    expect(data.points[0][0].start).toBe(Date.UTC(2024, 0, 1) / MS_PER_DAY);
+    expect(data.points[0][0].end).toBe(Date.UTC(2024, 1, 5) / MS_PER_DAY);
+  });
+
+  it('keeps an undated task as an empty lane that still has a name', () => {
+    const chart = createGanttChart([
+      {
+        name: 'Research',
+        actualStart: Date.UTC(2024, 0, 1),
+        actualEnd: Date.UTC(2024, 0, 15),
+      },
+      { name: 'Unscheduled' },
+    ]);
+
+    const data = ganttData(chart);
+    // Nothing is booked in it, which is a real statement about a plan — and
+    // the row a reader can navigate onto and otherwise be told nothing about.
+    expect(data.points[1]).toEqual([]);
+    expect(data.lanes?.[1]).toBe('Unscheduled');
+  });
+
+  it('reads a milestone as the instant it is', () => {
+    const chart = createGanttChart([
+      { name: 'Ship', actualStart: Date.UTC(2024, 0, 15) },
+      {
+        name: 'Write',
+        actualStart: Date.UTC(2024, 0, 1),
+        actualEnd: Date.UTC(2024, 0, 20),
+      },
+    ]);
+
+    const [milestone] = ganttData(chart).points[0];
+    expect(milestone.start).toBe(milestone.end);
+  });
+
+  it('reads a resource chart as several intervals in one lane', () => {
+    const chart = createGanttChart(
+      [
+        {
+          name: 'Alice',
+          periods: [
+            { id: 'p1', start: Date.UTC(2024, 0, 1), end: Date.UTC(2024, 0, 5) },
+            { id: 'p2', start: Date.UTC(2024, 0, 9), end: Date.UTC(2024, 0, 12) },
+          ],
+        },
+      ],
+      { chartType: 'gantt-resource' },
+    );
+
+    const layer = anyChartToMaidr(chart)!.subplots[0][0].layers[0];
+    const data = layer.data as GanttData;
+    expect(data.points[0]).toHaveLength(2);
+    expect(data.points[0].map(p => p.label)).toEqual(['p1', 'p2']);
+    // A resource chart's rows are who is booked, not what is to be done.
+    expect(layer.axes?.y?.label).toBe('Resource');
+  });
+
+  it('emits one exact-match selector per interval, lane by lane', () => {
+    const chart = createGanttChart([
+      {
+        name: 'Research',
+        actualStart: Date.UTC(2024, 0, 1),
+        actualEnd: Date.UTC(2024, 0, 15),
+      },
+      { name: 'Unscheduled' },
+      {
+        name: 'Write',
+        actualStart: Date.UTC(2024, 0, 15),
+        actualEnd: Date.UTC(2024, 1, 5),
+      },
+    ]);
+
+    // `GanttTrace` slices the resolved elements lane by lane, so the order
+    // they arrive in IS the reading. The empty lane contributes none.
+    expect(anyChartToMaidr(chart)!.subplots[0][0].layers[0].selectors).toEqual([
+      '[data-maidr-anychart-task-bar="0-0"]',
+      '[data-maidr-anychart-task-bar="2-0"]',
+    ]);
+  });
+
+  it('binds nothing when a chart names itself a gantt but holds no tree', () => {
+    // The structural half of the detection: a gantt with a flat data view has
+    // not been given its schedule, and silence is the acceptable failure.
+    expect(anyChartToMaidr(createGanttChart([], { dataView: true }))).toBeNull();
+  });
+
+  it('binds nothing when no task in the plan is dated', () => {
+    const chart = createGanttChart([{ name: 'One' }, { name: 'Two' }]);
+    expect(anyChartToMaidr(chart)).toBeNull();
+  });
+
+  it('leaves a timeline chart alone', () => {
+    // `anychart.timeline()` is a third constructor with a series API of its
+    // own, whose moments are instants rather than intervals. Reading one here
+    // would announce a schedule the chart did not draw.
+    const chart = createGanttChart(
+      [{ name: 'Talk', actualStart: Date.UTC(2024, 0, 1) }],
+      { chartType: 'timeline' },
+    );
+    expect(anyChartToMaidr(chart)).toBeNull();
+  });
+});
+
+describe('bindAnyChart (gantt stamping)', () => {
+  const TASKS: TaskSpec[] = [
+    {
+      name: 'Research',
+      actualStart: Date.UTC(2024, 0, 1),
+      actualEnd: Date.UTC(2024, 0, 15),
+    },
+    {
+      name: 'Write',
+      actualStart: Date.UTC(2024, 0, 15),
+      actualEnd: Date.UTC(2024, 1, 5),
+    },
+  ];
+
+  it('stamps the task bars lane by lane', () => {
+    const { container, paths } = createRenderedGantt('gantt-plain', [
+      [{ left: 10, width: 40 }, { left: 50, width: 60 }],
+    ]);
+    bindAnyChart(createGanttChart(TASKS, { container }));
+
+    expect(paths[0].map(p => p.getAttribute('data-maidr-anychart-task-bar')))
+      .toEqual(['0-0', '1-0']);
+
+    cleanUp(container);
+  });
+
+  it('picks the bars out of the row stripes drawn behind them', () => {
+    // A project chart draws one stripe per row and one bar per row, so both
+    // layers hold exactly as many shapes as the schedule has intervals. What
+    // separates them is that a schedule's bars begin and end in different
+    // places and a backdrop is one rectangle repeated down the chart.
+    const { container, paths } = createRenderedGantt('gantt-stripes', [
+      [{ left: 0, width: 300 }, { left: 0, width: 300 }],
+      [{ left: 10, width: 40 }, { left: 50, width: 60 }],
+    ]);
+    bindAnyChart(createGanttChart(TASKS, { container }));
+
+    expect(paths[0].every(p => !p.hasAttribute('data-maidr-anychart-task-bar')))
+      .toBe(true);
+    expect(paths[1].map(p => p.getAttribute('data-maidr-anychart-task-bar')))
+      .toEqual(['0-0', '1-0']);
+
+    cleanUp(container);
+  });
+
+  it('stamps nothing when two layers both look like the schedule', () => {
+    const { container, paths } = createRenderedGantt('gantt-ambiguous', [
+      [{ left: 10, width: 40 }, { left: 50, width: 60 }],
+      [{ left: 15, width: 30 }, { left: 70, width: 20 }],
+    ]);
+    const warn = jest.spyOn(console, 'warn');
+
+    bindAnyChart(createGanttChart(TASKS, { container }));
+
+    // A bar highlighted for the wrong task is worse than none at all.
+    expect(paths.flat().every(p => !p.hasAttribute('data-maidr-anychart-task-bar')))
+      .toBe(true);
+    expect(warn.mock.calls.flat().join(' ')).toContain('task bars');
+
+    cleanUp(container);
+  });
+
+  it('stamps nothing when no layer holds the right number of shapes', () => {
+    const { container, paths } = createRenderedGantt('gantt-mismatch', [
+      [{ left: 10, width: 40 }, { left: 50, width: 60 }, { left: 90, width: 20 }],
+    ]);
+    bindAnyChart(createGanttChart(TASKS, { container }));
+
+    expect(paths.flat().every(p => !p.hasAttribute('data-maidr-anychart-task-bar')))
+      .toBe(true);
+
+    cleanUp(container);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The AnyChart adapter's coverage PR deferred the chart types that needed more
than a series-type lookup. This reads two of them: **choropleth maps** and
**gantt schedules**. Both are detected, bound to the grammar's payload shapes,
and highlighted — a trace that sonifies but does not highlight is not done, so
the selector/stamper path lands in the same change as the detection.

`anychart.timeline()` is deliberately left unread; the reason is under Changes
Made.

## Related Issues

Part of #885

## Changes Made

### Trace types added

**`CHOROPLETH`** — a `choropleth` series on `anychart.map()`.

- `'choropleth'` joins the `mapSeriesType` table, so the **series names itself**
  and no chart-level check gates it. `chart.getType()` answers `''` on a build
  without it and on a chart that has not been drawn; gating on it would drop
  working maps, and a test pins that a map reporting `''` is still read.
- Emits `ChoroplethPoint[]` as `{ x: region name, y: value }`. Rows with no
  value are dropped.
- A data row names its region by the id the geodata declared (`US.CA`), never
  by name, so the name is read from the bound feature: `point.getFeatureProp()`
  where the build offers it, else a geodata walk matched on `chart.geoIdField()`
  (defaulting to `'id'`), else the row's own `name`/`x`, else the bare id. The
  walk handles **both** shapes AnyChart accepts — GeoJSON `features[]` and
  TopoJSON `objects.<key>.geometries[]`.
- `lon`/`lat` are **omitted on purpose**: what AnyChart holds are the features'
  `middle-x`/`middle-y`, normalised coordinates in the chart's own projection,
  not degrees. Passing them through would tell a reader one region lies north
  of another when the map says nothing of the kind. `neighbors` is not
  derivable from AnyChart at all and stays absent. The map is read as a region
  list in declared order — the poorer reading the schema explicitly sanctions.
- **Highlighting:** a map is *located*, not counted. AnyChart paints every
  feature of the bound geodata (all fifty states for a table naming six) in the
  geodata's order, and the paths carry no id, so counting them off would put
  California's highlight on Alabama's shape. Each region is matched to the
  shape whose `getBBox()` equals the bounds `point.getFeatureBounds()` reports,
  within 1.5px. Zero matches, several matches, or a shape already claimed
  disables highlighting for the whole map with a warning — the word-cloud
  precedent. New stamper `data-maidr-anychart-region="<seriesIndex>-<regionIndex>"`.

**`GANTT`** — `anychart.ganttProject()` and `anychart.ganttResource()`.

- The type name is corroborated structurally before anything is read: a gantt
  has no series API and its `chart.data()` returns an `anychart.data.Tree`, so
  a chart naming itself a gantt with a flat data view behind it binds as
  nothing rather than as an empty schedule.
- Emits `GanttData` with `points` **nested one array per lane**, `lanes` naming
  every lane in the same order (so an undated task survives as an empty lane),
  `unit`, and `orientation: 'horz'` because a schedule runs left to right.
- The tree flattens depth-first — parents before children, the chart's own row
  order. A parent that states no dates takes `meta('autoStart')`/`meta('autoEnd')`;
  a resource row's `periods[]` becomes several intervals in one lane; a start
  with no end becomes the zero-length milestone AnyChart draws as a diamond.
- The ends are restated in whole days (hours below a two-day span) and the unit
  is named, plus an x-axis `format.function` that turns a position back into a
  date. This mirrors the shipped google-charts gantt; without it every task
  announces as a nine-digit millisecond figure. See Additional Notes — this
  departs from the spec's framing of `unit` as authored.
- **Highlighting:** a gantt is counted, but from more filled shapes than any
  other chart here (row stripes on both halves of the split widget, header,
  progress fills). The whole-SVG count is used when it equals the interval
  count; otherwise the search narrows to the single `ac_layer_*` holding
  exactly that many; when two layers tie — the stripes behind a
  one-bar-per-row project chart are exactly that — they are separated by the
  one property a schedule has and a backdrop does not, that its bars start and
  end in different places. Anything still ambiguous is left unstamped and
  warned about, never mislabelled. New stamper
  `data-maidr-anychart-task-bar="<laneIndex>-<intervalIndex>"`.

### Trace types not added

- **`anychart.timeline()`** — `readChartType` returns `'timeline'` for a third
  constructor unlike the two gantt ones: it has a series API, and its series
  are `range` (an interval) and `moment` (an instant). A timeline drawn mostly
  from moments has no intervals to announce, and emitting zero-length rows for
  them would describe work the chart never drew. It binds as nothing (silence),
  the acceptable failure the per-adapter mandate names. The two tree-backed
  constructors, `gantt-project` and `gantt-resource`, are both implemented.

### Collateral changes inside the adapter

- `AnyChartInstance.data()` now returns `AnyChartDataView | AnyChartTree`; the
  three existing readers go through a new `resolveChartDataView` that narrows
  on `'getIterator' in data`, so a gantt reaching a data-view reader is a no-op
  instead of an exception.
- `readRows` gained `'id'` in its field list — a choropleth row previously
  arrived carrying only `value`, with no region key at all.
- `buildLayer` gained a `chart` parameter (only the choropleth builder needs
  it, for the geodata).
- `attachAxes` now **merges** onto whatever a builder already put on an axis
  instead of replacing it, so the gantt's date formatter survives the label
  pass. No existing builder sets an axis, so behaviour is unchanged for them.
- `enableLineMarkersIfNeeded` exits early for a gantt (no series API to ask).
- `isMapChart` matches `getType() === 'map'` **exactly**, or the presence of a
  choropleth series — the tolerant substring match the pie/heatmap paths use
  would have caught `'heat-map'`.
- `src/adapters/anychart/index.ts` is untouched: neither item reads a
  declaration, so there is nothing new to re-export.

### Files

| File | |
|---|---|
| `src/adapters/anychart/converters.ts` | detection, payloads, stampers |
| `src/adapters/anychart/types.ts` | `AnyChartTree`/`AnyChartTreeItem`, optional map point API, `geoData()`/`geoIdField()` |
| `test/adapters/anychart/choropleth.test.ts` | 12 cases |
| `test/adapters/anychart/gantt.test.ts` | 15 cases |
| `examples/anychart/choropleth.html`, `examples/anychart/gantt.html` | |
| `docs/anychart.md` | supported-types table, per-type notes, stamper table, "cannot be found by counting" section |

## Screenshots (if applicable)

n/a — no visual change to MAIDR's own UI.

## Checklist

- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

`ManualTestingProcess.md` is unticked because the manual pass needs AnyChart's
map and gantt bundles from the CDN in a real browser, which was not available
here. Everything automatable was run and is green (below).

## Additional Notes

### Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` were
all run on this branch and all pass: **3797 unit tests across 270 suites** plus
**73 ESM tests across 7 suites**, no failures. The 27 new cases pass. No e2e
spec was run or added — no AnyChart adapter has one, since they need the
AnyChart CDN in a browser.

### Foundation gaps — these matter to the sibling adapter PRs

`src/type/declaration.ts` and `src/adapters/shared/traceDeclaration.ts` were
**not modified**, per the shared-foundation rule. Two gaps observed there:

1. **`MaidrTraceDeclaration` (declaration.ts:133) has no `GANTT` variant**, so
   `TraceType.GANTT` cannot be declared in any adapter. Not blocking here — an
   AnyChart schedule is drawn by a dedicated constructor and is detectable —
   but a chart that draws a schedule out of ordinary series (a `range-bar`
   whose low/high are dates) has no way to say so, and the hole exists in every
   adapter. It would also be the only home for `GanttData.unit`, which the
   convention treats as authored.
2. **`ChoroplethDeclaration` (declaration.ts:585) offers `region`/`value`/
   `lon`/`lat` but no `neighbors`** — and `neighbors` is the one
   `ChoroplethPoint` field the grammar itself says cannot be recovered from a
   rendering (grammar.ts:765-772). AnyChart could not have used it (no
   per-point author slot), so nothing was blocked, but a declaration surface
   that omits the only underivable field leaves it underivable everywhere.

No gap in the parts that were used: `readDeclarationSlot`, `validateDeclaration`,
`resolveFieldRef` and `isFlagValue` were read and are sound. Neither trace type
here reads a declaration — both are `detectableWithoutOptIn` — and
`AnyChartBinderOptions` is untouched.

### Spec corrections

- **The region name is not reached "via `chart.geoData()`"** as
  `deferred-anychart.md` and `per-adapter.json` both state; that is only the
  fallback. AnyChart's map module exposes the feature's own properties on the
  point — `series.getPoint(i).getFeatureProp()` — which needs no id matching
  and survives a chart whose geodata was set by name rather than by object. The
  adapter prefers it. The geodata walk also has to handle **both** GeoJSON and
  TopoJSON; the spec mentioned only "the bound geodata feature's `properties`".
- **`per-adapter.json` says region rows "carry `id` and `value` through the
  existing `AnyChartIterator`".** True of the iterator, but not of `readRows`,
  whose field list is a fixed array that did not contain `id`. A choropleth row
  arrived carrying only `value`, with no region key. `'id'` had to be added.
- **`per-adapter.json` item 5 says `unit` is "the one authored value"** and
  that, absent, MAIDR should announce a length without naming a unit. That is
  wrong for AnyChart: a gantt's timeline is a `GanttDateTime` scale, so what
  the task tree holds is instants, and the unit is **read** rather than
  authored or guessed. Leaving it out would announce every task as a nine-digit
  millisecond figure — the failure the shipped google-charts gantt avoids at
  `converters.ts:2407-2439`. No `unit` field was added to
  `AnyChartBinderOptions`.
- **`per-adapter.json` item 6 asks for the gantt stamper to be its own commit.**
  It landed in the same commit as the choropleth work: both types edit
  interleaved regions of the single 5.5k-line `converters.ts`, and splitting
  them would have required `git checkout`/`git restore` on that file, which the
  working rules forbid. The branch carries two commits (the feature, then a
  comment correction), not one per trace type.
- Line references checked and **found accurate**: `mapSeriesType` at
  converters.ts:133, `readChartType` at :214 (spec said 208-220),
  `AnyChartBinderOptions` at types.ts:202-261, `GanttData` at grammar.ts:579-628,
  `ChoroplethPoint.lon`/`lat` at grammar.ts:754-762.

### Known limitation

The AnyChart library is not in `node_modules` and the adapter is entirely
duck-typed, so the map point API itself could not be verified against a real
build. `getFeatureProp()` and `getFeatureBounds()` are therefore declared
optional, called through `?.` inside `try`/`catch`, and a build lacking either
degrades to the id-as-name reading and to no highlighting respectively — never
to a wrong one. The gantt bar-layer search is the piece least verifiable
without the real library; every failure path is silence plus a warning naming
both counts, and `options.selectors` overrides it entirely.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_