### PR TITLE
feat(recharts): read the chart types deferred out of the coverage PR

### DIFF
--- a/docs/recharts.md
+++ b/docs/recharts.md
@@ -66,7 +66,7 @@ function AccessibleBarChart() {
 | `data` | `Record<string, unknown>[]` | Simple/composed mode | Recharts data array. Each item is one data point with named fields. In subplot mode it is the default data for panels without their own `data`. |
 | `xKey` | `string` | Yes | Key in data objects for x-axis values. |
 | `chartType` | `RechartsChartType` | Simple mode | Chart type (see supported types below). |
-| `yKeys` | `string[]` | Simple mode | Keys in data objects for y-axis values. Each key is a data series. |
+| `yKeys` | `string[]` | Simple mode | Keys in data objects for y-axis values. Each key is a data series. Not used by `parallel`, `ridgeline` and `boxen`, whose fields are all named by their own config; on a `hexbin` the first entry is the bin centre's y. |
 | `layers` | `RechartsLayerConfig[]` | Composed mode | Layer configs for mixed chart types (see Composed Charts). |
 | `subplots` | `RechartsSubplotConfig[][]` or `RechartsSubplotConfig[]` | Subplot mode | Panel grid for multi-panel (faceted) figures (see Multi-Panel Charts). Mutually exclusive with `chartType`/`layers`. |
 | `columns` | `number` | No | Panels per row when `subplots` is a flat array. Ignored for 2D grids. |
@@ -83,6 +83,10 @@ function AccessibleBarChart() {
 | `errorConfig` | `ErrorIntervalConfig` | Error bar/forest | Which field holds the interval, as an offset or as absolute bounds. |
 | `forestConfig` | `ForestPlotConfig` | Forest only | Study weights, the pooled row, and the null line. |
 | `survivalConfig` | `SurvivalCurveConfig` | Survival only | Per-arm censoring and confidence band keys, and the step direction. |
+| `parallelConfig` | `ParallelAxesConfig` | Parallel only | The axes in draw order, naming the raw fields, and the observation's label key. |
+| `ridgelineConfig` | `RidgelineCurveConfig` | Ridgeline only | Group key, value key, and the density key — the density BEFORE the ridge offset. |
+| `hexbinConfig` | `HexbinLatticeConfig` | Hexbin | Bin centre, count and lattice row keys. |
+| `boxenConfig` | `BoxenLadderConfig` | Boxen | Median, ladder and outlier keys. |
 | `selectorOverride` | `string` | No | Custom CSS selector for SVG highlighting (see Advanced section). |
 
 ## Configuration Modes
@@ -165,6 +169,10 @@ Use `subplots` when your figure is a grid of small multiples (faceted charts). S
 | `'treemap'` | `<Treemap>` | A hierarchy laid out as nested area (nested `data`) |
 | `'sunburst'` | `<SunburstChart>` | The same hierarchy drawn as rings (nested `data`) |
 | `'icicle'` | `<BarChart layout="vertical">` + floating `<Bar>` | The same hierarchy drawn as depth-ordered bands (nested `data`) |
+| `'parallel'` | `<LineChart>` + one `<Line>` per observation | Parallel coordinates: an axis per variable (`parallelConfig`) |
+| `'ridgeline'` | Overlapping `<Area>`s, one per group | Ridgeline/joy plot: a density curve per group (`ridgelineConfig`) |
+| `'hexbin'` | `<Scatter shape={hexagon}>` | Hexagonal binning of an overplotted scatter (`hexbinConfig`) |
+| `'boxen'` | Stacked `<Bar>`s over a transparent base | Letter-value plot: a variable-depth quantile ladder (`boxenConfig`) |
 
 ## Data Examples by Chart Type
 
@@ -1080,6 +1088,184 @@ const bands = [
 
 Built the other obvious way — one stacked `<Bar>` per depth level — the rectangles come out series-major rather than depth-first, which is not the order the nodes are in. Such a chart needs `selectorOverride`.
 
+### Parallel Coordinates
+
+An observation per row, an axis per variable. Recharts has no parallel coordinates chart and cannot quite have one: a `<Line>` binds to a single `yAxisId`, so a polyline crossing axes measured in different units has to be drawn from values **min-max normalised** onto one shared scale, over rows keyed by axis with one `<Line>` per observation.
+
+MAIDR must not see those normalised numbers. It derives each column's own extent and pitches a value against its **own** axis — that is the whole chart — so handed 0-to-1 values every axis would run the same range and the crossings the plot is drawn to show would be gone. So `data` here is the **observations, with their raw values**, and `parallelConfig.dimensions` names the raw fields in the order the axes are drawn:
+
+```tsx
+const cars = [
+  { car: 'Mazda RX4', mpg: 21, hp: 110, wt: 2.62 },
+  { car: 'Datsun 710', mpg: 22.8, hp: 93, wt: 2.32 },
+  { car: 'Hornet 4 Drive', mpg: 21.4, hp: 110, wt: 3.215 },
+  { car: 'Valiant', mpg: 18.1, hp: 105, wt: 3.46 },
+];
+
+// What the chart is drawn from: the transpose, normalised per axis.
+const axisRows = [
+  { axis: 'Miles per gallon', obs0: 0.62, obs1: 1, obs2: 0.7, obs3: 0 },
+  { axis: 'Horsepower', obs0: 0.2, obs1: 0, obs2: 0.2, obs3: 0.14 },
+  { axis: 'Weight (1000 lb)', obs0: 0.26, obs1: 0, obs2: 0.79, obs3: 1 },
+];
+
+<MaidrRecharts
+  id="parallel-example"
+  title="Cars by Specification"
+  data={cars}
+  chartType="parallel"
+  xKey="car"
+  parallelConfig={{
+    dimensions: ['mpg', 'hp', { label: 'Weight (1000 lb)', key: 'wt' }],
+    labelKey: 'car',
+  }}
+  xLabel="Variable"
+  yLabel="Value"
+>
+  <LineChart width={600} height={350} data={axisRows}>
+    <XAxis dataKey="axis" />
+    <YAxis domain={[0, 1]} />
+    {cars.map((car, i) => (
+      <Line key={car.car} dataKey={`obs${i}`} name={car.car} dot={false} />
+    ))}
+  </LineChart>
+</MaidrRecharts>
+```
+
+A bare `dimensions` string names both the axis and the field; the object form separates them, for a column whose key is not what a reader should hear. The order is the order a reader arrows through the axes, and nothing on an observation states it — an object's key order is not an axis order.
+
+`labelKey` names the observation, which becomes the polyline's series name. Without it an observation is announced by its position among the rest.
+
+Highlighting resolves one `<Line>` path per observation and marks each vertex on it. It is withheld in one case: a chart with exactly as many observations as axes, where MAIDR's element-based resolution cannot tell the two counts apart and would light the wrong polyline.
+
+### Ridgeline (Joy) Plot
+
+One density curve per group along a shared value axis, the curves offset down the page so their shapes can be compared. There is no primitive for it: the chart is overlapping `<Area>`s with a per-group offset **baked into the plotted values**.
+
+The offset is presentation — it exists so the curves do not overlap illegibly, and says nothing about any group — so `densityKey` must name the density **before** it was added. Fed the drawn y instead, every group's loudness becomes a function of where it was stacked, and the lowest ridge is the loudest thing on the chart. Where nothing resolves as a density the adapter refuses the reading rather than subtracting a guessed baseline.
+
+The kernel density itself is computed outside both Recharts and the adapter; `data` is the sampled curves, one row per sample:
+
+```tsx
+const samples = [
+  { month: 'Jan', temp: -4, density: 0.06, plotted: 2.06 },
+  { month: 'Jan', temp: 0, density: 0.11, plotted: 2.11 },
+  { month: 'Feb', temp: -2, density: 0.08, plotted: 1.08 },
+  { month: 'Feb', temp: 2, density: 0.13, plotted: 1.13 },
+];
+
+<MaidrRecharts
+  id="ridgeline-example"
+  title="Daily Temperature by Month"
+  data={samples}
+  chartType="ridgeline"
+  xKey="temp"
+  ridgelineConfig={{ groupKey: 'month', valueKey: 'temp', densityKey: 'density' }}
+  xLabel="Temperature (C)"
+  yLabel="Month"
+>
+  <AreaChart width={600} height={350}>
+    <XAxis dataKey="temp" type="number" />
+    <YAxis type="number" />
+    {['Jan', 'Feb'].map(month => (
+      <Area
+        key={month}
+        data={samples.filter(s => s.month === month)}
+        dataKey="plotted"
+        name={month}
+      />
+    ))}
+  </AreaChart>
+</MaidrRecharts>
+```
+
+Groups are announced in the order they first appear in `data`. Highlighting lights one whole ridge — a chart draws a filled band per group, not an element per sample — so the `<Area>`s have to be declared in that same order; otherwise pass `selectorOverride`.
+
+Arrowing up and down moves between groups **holding the value**, which is the comparison a ridgeline exists for and the one a listener cannot make by holding a dozen numbers in their head.
+
+### Hexbin
+
+The standard answer to an overplotted scatter: bin the points into hexagons and encode the count. Recharts places the marks and nothing else — `<Scatter>` accepts a custom `shape`, which is documented API — so the binning happens before the chart is drawn and `data` is one row per **occupied** bin, its centre in **data units**:
+
+```tsx
+const bins = [
+  { carat: 0.35, price: 800, count: 41 },
+  { carat: 0.55, price: 800, count: 96 },
+  { carat: 0.45, price: 1600, count: 27 },
+  { carat: 0.65, price: 1600, count: 88 },
+];
+
+<MaidrRecharts
+  id="hexbin-example"
+  title="Carat against Price"
+  data={bins}
+  chartType="hexbin"
+  xKey="carat"
+  yKeys={['price']}
+  hexbinConfig={{ countKey: 'count' }}
+  xLabel="Carat"
+  yLabel="Price ($)"
+>
+  <ScatterChart width={600} height={350}>
+    <XAxis dataKey="carat" type="number" />
+    <YAxis dataKey="price" type="number" />
+    <Scatter data={bins} shape={Hexagon} />
+  </ScatterChart>
+</MaidrRecharts>
+```
+
+The adapter assembles the **lattice** those bins form: rows grouped by their y centre (or by `rowKey`), ordered from the lowest upward, each row ordered left to right. MAIDR needs that shape because a hex lattice staggers alternate rows — a column index is not a position, so a vertical move keeps the bin whose centre is nearest the x the reader started from, and every bin is announced by its centre rather than by an index.
+
+Screen coordinates must not be passed through: a bin computed with `d3-hexbin` carries its centre in pixels, so invert the scales before handing the rows over. A `count` left undeclared is read from a `count`, `length`, `value`, `n` or `total` column — the `length` fallback being what makes a `d3-hexbin` bin, which *is* the array of points that fell in it, work untouched.
+
+Highlighting is emitted only when the rows already arrive in lattice order, since a `<Scatter>` draws its symbols in row order and any other order would light a bin half a field away.
+
+### Boxen (Letter-Value) Plot
+
+A box plot's five-number summary generalised to a variable-depth ladder: a large sample gets *more* rungs, so its tails stay legible instead of collapsing into a whisker and a scatter of dots. Recharts has no box primitive at all, so the rungs are drawn as stacked `<Bar>`s over a transparent base — and neither the ladder nor the median is anything that construction holds. Both are computed from the raw sample and arrive through `data`, one row per distribution:
+
+```tsx
+const distributions = [
+  {
+    region: 'East',
+    median: 180,
+    levels: [
+      { p: 0.25, lo: 150, hi: 240 },
+      { p: 0.125, lo: 130, hi: 310 },
+      { p: 0.0625, lo: 110, hi: 420 },
+    ],
+    slow: [820, 910],
+  },
+  { region: 'West', median: 210, levels: [{ p: 0.25, lo: 175, hi: 260 }] },
+];
+
+<MaidrRecharts
+  id="boxen-example"
+  title="Response Time by Region"
+  data={distributions}
+  chartType="boxen"
+  xKey="region"
+  boxenConfig={{ upperOutliersKey: 'slow' }}
+  selectorOverride="#maidr-article-boxen-example .boxen-centre .recharts-rectangle"
+  xLabel="Region"
+  yLabel="Response time (ms)"
+>
+  <BarChart width={600} height={350} data={drawn}>
+    <XAxis dataKey="region" />
+    <YAxis />
+    <Bar dataKey="base" stackId="ladder" fill="transparent" />
+    <Bar dataKey="seg0" stackId="ladder" fill="#dcdcf0" />
+    {/* ... one <Bar> per gap between consecutive ladder positions ... */}
+  </BarChart>
+</MaidrRecharts>
+```
+
+`p` is the **tail** probability, which is how letter-value plots are defined and how the libraries that draw them report it: `p = 0.25` is the rung spanning the middle half, `p = 0.125` the middle three quarters, and so on inwards. MAIDR announces each position as the percentile it actually is, and walks the ladder in value order — deepest lower quantile, inward to the median, outward again — so arrowing across rises monotonically through the distribution and the *rate* it rises at is where the sample is thin. The order the rungs arrive in does not matter.
+
+A rung whose three numbers are not all finite is dropped rather than announced as a quantile the data never contained, and a row with no median is dropped entirely: the median is the ladder's centre and a navigable position in its own right.
+
+No highlight selector is generated. A rung is a rectangle and a distribution is not, and no class name says which rung is which — so a chart that wants highlighting puts a `className` on the single `<Bar>` that can stand for the whole distribution and passes it as `selectorOverride`, as above.
+
 ### Composed Chart (Bar + Line)
 
 Use `layers` mode to mix different chart types in a single chart:
@@ -1235,7 +1421,11 @@ type RechartsChartType =
   | 'sankey'
   | 'treemap'
   | 'sunburst'
-  | 'icicle';
+  | 'icicle'
+  | 'parallel'
+  | 'ridgeline'
+  | 'hexbin'
+  | 'boxen';
 ```
 
 ### `RechartsLayerConfig`
@@ -1362,6 +1552,50 @@ interface GaugeDialConfig {
   target?: number;     // The target marker a bullet chart draws
   bands?: GaugeBand[]; // Qualitative bands, ascending, upper edges only
   label?: string;      // What the measure is called (defaults to the xKey value)
+}
+```
+
+### `ParallelAxesConfig`
+
+```typescript
+interface ParallelAxesConfig {
+  // The axes in draw order, naming the RAW fields — not the normalised ones
+  // the chart plots. A bare string is both the axis name and the field.
+  dimensions: (string | { label?: string; key: string })[];
+  labelKey?: string; // Key naming the observation (defaults to label/snp/id/name/gene/probe)
+}
+```
+
+### `RidgelineCurveConfig`
+
+```typescript
+interface RidgelineCurveConfig {
+  groupKey: string;    // Key holding the group a sample's curve belongs to
+  valueKey?: string;   // Position on the value axis (defaults to value/x/t/position)
+  densityKey?: string; // Density BEFORE the ridge offset (defaults to density/kde/width/p/estimate)
+}
+```
+
+### `HexbinLatticeConfig`
+
+```typescript
+interface HexbinLatticeConfig {
+  xKey?: string;     // Bin centre x, in DATA units (defaults to the chart's xKey)
+  yKey?: string;     // Bin centre y, in DATA units (defaults to the first yKeys entry)
+  countKey?: string; // Points in the bin (defaults to count/length/value/n/total)
+  rowKey?: string;   // Lattice row (defaults to grouping by identical y)
+}
+```
+
+### `BoxenLadderConfig`
+
+```typescript
+interface BoxenLadderConfig {
+  xKey?: string;             // The category (defaults to the chart's xKey)
+  medianKey?: string;        // Defaults to median/q2/mid/y
+  levelsKey?: string;        // The { p, lo, hi } ladder (defaults to levels/letterValues/letter_values/quantiles/ladder)
+  lowerOutliersKey?: string; // Values below the deepest rung
+  upperOutliersKey?: string; // Values above the deepest rung
 }
 ```
 

--- a/examples/recharts/App.tsx
+++ b/examples/recharts/App.tsx
@@ -31,6 +31,10 @@ import { SankeyExample } from './examples/SankeyExample';
 import { TreemapExample } from './examples/TreemapExample';
 import { SunburstExample } from './examples/SunburstExample';
 import { IcicleExample } from './examples/IcicleExample';
+import { ParallelCoordinatesExample } from './examples/ParallelCoordinatesExample';
+import { RidgelineExample } from './examples/RidgelineExample';
+import { HexbinExample } from './examples/HexbinExample';
+import { BoxenExample } from './examples/BoxenExample';
 import { ComposedChartExample } from './examples/ComposedChartExample';
 import { FacetExample } from './examples/FacetExample';
 
@@ -66,6 +70,10 @@ const examples: { name: string; component: () => JSX.Element }[] = [
   { name: 'Treemap', component: TreemapExample },
   { name: 'Sunburst', component: SunburstExample },
   { name: 'Icicle', component: IcicleExample },
+  { name: 'Parallel Coordinates', component: ParallelCoordinatesExample },
+  { name: 'Ridgeline', component: RidgelineExample },
+  { name: 'Hexbin', component: HexbinExample },
+  { name: 'Boxen', component: BoxenExample },
   { name: 'Composed Chart', component: ComposedChartExample },
   { name: 'Faceted (Multi-Panel)', component: FacetExample },
 ];

--- a/examples/recharts/examples/BoxenExample.tsx
+++ b/examples/recharts/examples/BoxenExample.tsx
@@ -1,0 +1,123 @@
+import type { JSX } from 'react';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// One row per distribution, carrying the letter-value ladder computed from the
+// raw sample. `p` is the TAIL probability: 0.25 is the rung spanning the middle
+// half, 0.125 the middle three quarters, and so on outwards. A box plot is this
+// shape with exactly one rung, and that fixed depth is why it cannot express a
+// large sample's tails.
+const distributions = [
+  {
+    region: 'East',
+    median: 180,
+    levels: [
+      { p: 0.25, lo: 150, hi: 240 },
+      { p: 0.125, lo: 130, hi: 310 },
+      { p: 0.0625, lo: 110, hi: 420 },
+    ],
+    slow: [820, 910],
+  },
+  {
+    region: 'West',
+    median: 210,
+    levels: [
+      { p: 0.25, lo: 175, hi: 260 },
+      { p: 0.125, lo: 150, hi: 330 },
+      { p: 0.0625, lo: 120, hi: 450 },
+    ],
+    fast: [40],
+  },
+  {
+    region: 'North',
+    median: 150,
+    levels: [
+      { p: 0.25, lo: 130, hi: 185 },
+      { p: 0.125, lo: 115, hi: 240 },
+      { p: 0.0625, lo: 95, hi: 330 },
+    ],
+  },
+];
+
+/** The ladder walked outward from the median, which is the order it is drawn in. */
+function positionsOf(row: (typeof distributions)[number]): number[] {
+  const outward = [...row.levels].sort((a, b) => a.p - b.p);
+  return [
+    ...outward.map(level => level.lo),
+    row.median,
+    ...[...outward].reverse().map(level => level.hi),
+  ];
+}
+
+const segmentCount = positionsOf(distributions[0]).length - 1;
+
+// Recharts has no box primitive at all, so the rungs are stacked <Bar>s over a
+// transparent base: one segment per gap between consecutive ladder positions.
+const drawn = distributions.map((row) => {
+  const positions = positionsOf(row);
+  const bar: Record<string, number | string> = { region: row.region, base: positions[0] };
+  for (let i = 0; i < positions.length - 1; i++) {
+    bar[`seg${i}`] = positions[i + 1] - positions[i];
+  }
+  return bar;
+});
+
+/** How far a segment sits from the median, as a shade. */
+const shades = ['#dcdcf0', '#b3b3e0', '#8a8ad0', '#8a8ad0', '#b3b3e0', '#dcdcf0'];
+
+export function BoxenExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Boxen (Letter-Value) Plot</h2>
+      <p>
+        The box plot&apos;s five-number summary generalised: a large sample gets
+        more rungs, so its tails stay legible. MAIDR walks each ladder in value
+        order — deepest lower quantile, inward to the median, outward again —
+        and announces every position as the percentile it actually is. Where the
+        pitch jumps is where the sample is thin.
+      </p>
+      <p>
+        The rungs are stacked bars here, so no class name identifies a
+        distribution: the chart names its central segment and passes that as
+        <code>selectorOverride</code>
+        {' '}
+        to get one highlight per region.
+      </p>
+      <MaidrRecharts
+        id="boxen-example"
+        title="Response Time by Region"
+        subtitle="Letter-value summary of 40,000 requests"
+        data={distributions}
+        chartType="boxen"
+        xKey="region"
+        boxenConfig={{ lowerOutliersKey: 'fast', upperOutliersKey: 'slow' }}
+        selectorOverride="#maidr-article-boxen-example .boxen-centre .recharts-rectangle"
+        xLabel="Region"
+        yLabel="Response time (ms)"
+      >
+        <BarChart width={600} height={350} data={drawn}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="region" />
+          <YAxis domain={[0, 500]} />
+          <Tooltip />
+          {/* The transparent base lifts the stack off the axis to the deepest
+              lower quantile; every visible segment above it is one rung gap. */}
+          <Bar dataKey="base" stackId="ladder" fill="transparent" isAnimationActive={false} />
+          {Array.from({ length: segmentCount }, (_, index) => (
+            <Bar
+              key={index}
+              dataKey={`seg${index}`}
+              stackId="ladder"
+              fill={shades[index]}
+              stroke="#4a4a80"
+              // One rectangle per region, right at the centre of the
+              // distribution — the one mark that can stand for the whole of it.
+              className={index === segmentCount / 2 ? 'boxen-centre' : undefined}
+              isAnimationActive={false}
+            />
+          ))}
+        </BarChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/HexbinExample.tsx
+++ b/examples/recharts/examples/HexbinExample.tsx
@@ -1,0 +1,81 @@
+import type { JSX } from 'react';
+import { CartesianGrid, Scatter, ScatterChart, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// One row per OCCUPIED bin, its centre in DATA units. The binning happens
+// before the chart is drawn — Recharts only places the marks — and the rows
+// arrive in lattice order: bottom row first, each row left to right. Note the
+// half-cell stagger between rows, which is what lets hexagons tessellate and
+// why a column index is not a position.
+const bins = [
+  { carat: 0.35, price: 800, count: 41 },
+  { carat: 0.55, price: 800, count: 96 },
+  { carat: 0.75, price: 800, count: 18 },
+  { carat: 0.45, price: 1600, count: 27 },
+  { carat: 0.65, price: 1600, count: 88 },
+  { carat: 0.85, price: 1600, count: 52 },
+  { carat: 1.05, price: 1600, count: 11 },
+  { carat: 0.75, price: 2400, count: 14 },
+  { carat: 0.95, price: 2400, count: 63 },
+  { carat: 1.15, price: 2400, count: 39 },
+  { carat: 1.05, price: 3200, count: 22 },
+  { carat: 1.25, price: 3200, count: 31 },
+];
+
+const HEX_RADIUS = 13;
+
+/**
+ * The mark a hexbin draws. Recharts has no hexagon among its own symbol types,
+ * so the bins are a `<Scatter>` given a custom `shape` — documented API, and
+ * still wrapped in Recharts' own `g.recharts-shape`, which is what the
+ * adapter's highlight selector targets.
+ *
+ * @param props - The point Recharts places, carrying its centre and its datum
+ * @returns One hexagon, shaded by the bin's count
+ */
+function Hexagon(props: unknown): JSX.Element {
+  const { cx, cy, count } = props as { cx: number; cy: number; count: number };
+  const points = [0, 1, 2, 3, 4, 5]
+    .map((corner) => {
+      const angle = (Math.PI / 180) * (60 * corner - 30);
+      return `${cx + HEX_RADIUS * Math.cos(angle)},${cy + HEX_RADIUS * Math.sin(angle)}`;
+    })
+    .join(' ');
+  const shade = Math.min(1, count / 100);
+  return <polygon points={points} fill={`rgba(64, 64, 160, ${0.2 + shade * 0.8})`} stroke="#fff" />;
+}
+
+export function HexbinExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Hexbin</h2>
+      <p>
+        The standard answer to an overplotted scatter: bin the points into
+        hexagons and read the count. MAIDR navigates the lattice — left and
+        right along a row, up and down between rows, holding the x you started
+        from, because a staggered row has no bin directly above any other. Each
+        bin is announced by its CENTRE rather than by a column index.
+      </p>
+      <MaidrRecharts
+        id="hexbin-example"
+        title="Carat against Price"
+        subtitle="Point density"
+        data={bins}
+        chartType="hexbin"
+        xKey="carat"
+        yKeys={['price']}
+        hexbinConfig={{ countKey: 'count' }}
+        xLabel="Carat"
+        yLabel="Price ($)"
+      >
+        <ScatterChart width={600} height={350} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="carat" type="number" domain={[0.2, 1.4]} name="Carat" />
+          <YAxis dataKey="price" type="number" domain={[400, 3600]} name="Price" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <Scatter data={bins} shape={Hexagon} isAnimationActive={false} />
+        </ScatterChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/ParallelCoordinatesExample.tsx
+++ b/examples/recharts/examples/ParallelCoordinatesExample.tsx
@@ -1,0 +1,81 @@
+import type { JSX } from 'react';
+import { CartesianGrid, Legend, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+// The observations, with their RAW values. This is what MAIDR is given: it
+// derives each column's own extent and pitches a value against its own axis,
+// so handing it the normalised numbers below would make every axis run 0 to 1
+// and flatten the one thing the chart is drawn to show.
+const cars = [
+  { car: 'Mazda RX4', mpg: 21, hp: 110, wt: 2.62 },
+  { car: 'Datsun 710', mpg: 22.8, hp: 93, wt: 2.32 },
+  { car: 'Hornet 4 Drive', mpg: 21.4, hp: 110, wt: 3.215 },
+  { car: 'Valiant', mpg: 18.1, hp: 105, wt: 3.46 },
+  { car: 'Merc 450SL', mpg: 17.3, hp: 180, wt: 3.73 },
+];
+
+const dimensions = [
+  { label: 'Miles per gallon', key: 'mpg' },
+  { label: 'Horsepower', key: 'hp' },
+  { label: 'Weight (1000 lb)', key: 'wt' },
+] as const;
+
+// What the CHART is drawn from: the transpose, min-max normalised onto one
+// shared scale, because a Recharts <Line> binds to a single yAxisId and a
+// polyline crossing axes of different units cannot be drawn any other way.
+const axisRows = dimensions.map(({ label, key }) => {
+  const values = cars.map(car => car[key] as number);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const row: Record<string, number | string> = { axis: label };
+  cars.forEach((car, index) => {
+    row[`obs${index}`] = max === min ? 0.5 : ((car[key] as number) - min) / (max - min);
+  });
+  return row;
+});
+
+export function ParallelCoordinatesExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Parallel Coordinates</h2>
+      <p>
+        One polyline per car, crossing an axis per specification. Arrow left and
+        right along a car to hear where it sits on each variable; arrow up and
+        down to rank the cars on the variable you are on. Two cars whose pitches
+        swap between adjacent axes are the crossing lines that mean negative
+        correlation.
+      </p>
+      <MaidrRecharts
+        id="parallel-example"
+        title="Cars by Specification"
+        subtitle="Economy, power and weight"
+        data={cars}
+        chartType="parallel"
+        xKey="car"
+        parallelConfig={{ dimensions: [...dimensions], labelKey: 'car' }}
+        xLabel="Variable"
+        yLabel="Value"
+      >
+        <LineChart width={600} height={350} data={axisRows}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="axis" />
+          {/* The drawn scale is the normalised one; MAIDR announces the raw values. */}
+          <YAxis domain={[0, 1]} tickFormatter={() => ''} />
+          <Tooltip />
+          <Legend />
+          {cars.map((car, index) => (
+            <Line
+              key={car.car}
+              type="linear"
+              dataKey={`obs${index}`}
+              name={car.car}
+              stroke={['#8884d8', '#82ca9d', '#ffc658', '#ff7f7f', '#8dd1e1'][index]}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/examples/recharts/examples/RidgelineExample.tsx
+++ b/examples/recharts/examples/RidgelineExample.tsx
@@ -1,0 +1,91 @@
+import type { JSX } from 'react';
+import { Area, AreaChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
+import { MaidrRecharts } from '../../../src/adapters/recharts/MaidrRecharts';
+
+const months = ['Jan', 'Apr', 'Jul', 'Oct'];
+
+/**
+ * A stand-in for a kernel density estimate: a normal bump per month, sampled
+ * over a shared temperature grid. A real chart computes this with a KDE — the
+ * point is that it happens OUTSIDE both Recharts and the adapter.
+ *
+ * @param centre - Where the month's distribution peaks
+ * @param spread - Its standard deviation
+ * @returns The sampled density
+ */
+function densityCurve(centre: number, spread: number): { temp: number; density: number }[] {
+  const samples: { temp: number; density: number }[] = [];
+  for (let temp = -15; temp <= 35; temp += 2.5) {
+    const z = (temp - centre) / spread;
+    samples.push({ temp, density: Math.exp(-0.5 * z * z) / (spread * Math.sqrt(2 * Math.PI)) });
+  }
+  return samples;
+}
+
+const shapes = [
+  { month: 'Jan', centre: -2, spread: 5 },
+  { month: 'Apr', centre: 9, spread: 4.5 },
+  { month: 'Jul', centre: 22, spread: 4 },
+  { month: 'Oct', centre: 11, spread: 5.5 },
+];
+
+// One row per sample. `density` is the curve's own height; `plotted` is that
+// height with the ridge's offset added, and is what the <Area> draws. Only the
+// first of the two is data — the offset exists so the curves do not overlap
+// illegibly, and says nothing about any month.
+const samples = shapes.flatMap(({ month, centre, spread }, index) =>
+  densityCurve(centre, spread).map(sample => ({
+    month,
+    temp: sample.temp,
+    density: sample.density,
+    plotted: sample.density + (shapes.length - 1 - index) * 0.09,
+  })));
+
+export function RidgelineExample(): JSX.Element {
+  return (
+    <div>
+      <h2>Ridgeline (Joy) Plot</h2>
+      <p>
+        One temperature distribution per month, the curves offset down the page
+        so their shapes can be compared. Arrow up and down to move between
+        months at the same temperature — the comparison the chart exists for.
+        MAIDR is given each curve WITHOUT its offset, so a low ridge is not
+        heard as a loud one.
+      </p>
+      <MaidrRecharts
+        id="ridgeline-example"
+        title="Daily Temperature by Month"
+        subtitle="Kernel density, Chicago"
+        data={samples}
+        chartType="ridgeline"
+        xKey="temp"
+        ridgelineConfig={{ groupKey: 'month', valueKey: 'temp', densityKey: 'density' }}
+        xLabel="Temperature (C)"
+        yLabel="Month"
+      >
+        <AreaChart width={600} height={350}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="temp" type="number" domain={[-15, 35]} />
+          <YAxis type="number" tickFormatter={() => ''} />
+          <Tooltip />
+          {/* One <Area> per group, declared in the order the months first
+              appear in the data — which is the order MAIDR announces them in,
+              and therefore the order the highlight resolves in. */}
+          {months.map((month, index) => (
+            <Area
+              key={month}
+              data={samples.filter(sample => sample.month === month)}
+              dataKey="plotted"
+              name={month}
+              type="monotone"
+              stroke="#333"
+              fill={['#8884d8', '#82ca9d', '#ffc658', '#8dd1e1'][index]}
+              fillOpacity={0.85}
+              isAnimationActive={false}
+            />
+          ))}
+        </AreaChart>
+      </MaidrRecharts>
+    </div>
+  );
+}

--- a/src/adapters/recharts/MaidrRecharts.tsx
+++ b/src/adapters/recharts/MaidrRecharts.tsx
@@ -132,6 +132,10 @@ export function MaidrRecharts({
   waterfallConfig,
   ganttConfig,
   gaugeConfig,
+  parallelConfig,
+  ridgelineConfig,
+  hexbinConfig,
+  boxenConfig,
   selectorOverride,
   children,
 }: MaidrRechartsProps): JSX.Element {
@@ -161,9 +165,13 @@ export function MaidrRecharts({
       waterfallConfig,
       ganttConfig,
       gaugeConfig,
+      parallelConfig,
+      ridgelineConfig,
+      hexbinConfig,
+      boxenConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, parallelConfig, ridgelineConfig, hexbinConfig, boxenConfig, selectorOverride],
   );
 
   return (

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -22,10 +22,14 @@
  *   GaugePoint          = { value, min, max, ... }       (a single OBJECT)
  *   GanttData           = { points: [[{ x, start, end }]], lanes?, unit? }
  *   DumbbellData        = { points: [{ x, start, end }], startLabel?, endLabel? }
+ *   HexbinPoint[][]     = [[{ x, y, count }, ...], ...]  (a staggered LATTICE)
+ *   ViolinKdePoint[][]  = [[{ x, y, density }, ...], ...] (one curve per group)
+ *   BoxenPoint[]        = [{ z, median, levels, ... }, ...]
  */
 
 import type {
   BarPoint,
+  BoxenPoint,
   DumbbellData,
   DumbbellPoint,
   ErrorBarPoint,
@@ -34,7 +38,9 @@ import type {
   GanttData,
   GanttPoint,
   GaugePoint,
+  HexbinPoint,
   HistogramPoint,
+  LetterValueLevel,
   LinePoint,
   Maidr,
   MaidrLayer,
@@ -44,12 +50,14 @@ import type {
   SegmentedPoint,
   SurvivalPoint,
   TreemapPoint,
+  ViolinKdePoint,
   VolcanoPoint,
   WaterfallKind,
   WaterfallPoint,
 } from '@type/grammar';
 import type { RechartsAdapterConfig, RechartsChartType, RechartsLayerConfig, RechartsSubplotConfig } from './types';
 import { cssEscape } from '@adapters/shared/selectorUtil';
+import { resolveFieldRef } from '@adapters/shared/traceDeclaration';
 import { Orientation, TraceType } from '@type/grammar';
 import { getPanelClassSelector, getRechartsSelector } from './selectors';
 
@@ -187,6 +195,10 @@ function buildPanelSubplot(
     waterfallConfig: config.waterfallConfig,
     ganttConfig: config.ganttConfig,
     gaugeConfig: config.gaugeConfig,
+    parallelConfig: config.parallelConfig,
+    ridgelineConfig: config.ridgelineConfig,
+    hexbinConfig: config.hexbinConfig,
+    boxenConfig: config.boxenConfig,
     selectorOverride: panel.selectorOverride,
   };
 
@@ -226,13 +238,37 @@ function buildLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrL
 function buildSimpleLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
   const { data, chartType, xKey, yKeys, xLabel, yLabel, orientation, fillKeys, selectorOverride } = config;
 
-  if (!chartType || !yKeys || yKeys.length === 0) {
+  if (!chartType) {
     throw new Error(
       'RechartsAdapter: either provide chartType + yKeys (simple mode) or layers (composed mode)',
     );
   }
   if (!data) {
     throw new Error('RechartsAdapter: data is required (top-level or per subplot panel)');
+  }
+
+  // Four types whose payload is a grid grouped by something that is not a
+  // series: the observations of a parallel plot, the groups of a ridgeline,
+  // the rows of a hex lattice, the ladders of a boxen. None of them declares
+  // `yKeys` — every field they read is named by their own config — so they are
+  // dispatched before the check for it.
+  switch (chartType) {
+    case 'parallel':
+      return [buildParallelLayer(data, chartType, xLabel, yLabel, config.parallelConfig, selectorOverride, config.id, panelScope)];
+    case 'ridgeline':
+      return [buildRidgelineLayer(data, chartType, xLabel, yLabel, config.ridgelineConfig, selectorOverride, config.id, panelScope)];
+    case 'hexbin':
+      return [buildHexbinLayer(data, chartType, xKey, yKeys?.[0], xLabel, yLabel, config.hexbinConfig, selectorOverride, config.id, panelScope)];
+    case 'boxen':
+      return [buildBoxenLayer(data, chartType, xKey, xLabel, yLabel, orientation, config.boxenConfig, selectorOverride, config.id, panelScope)];
+    default:
+      break;
+  }
+
+  if (!yKeys || yKeys.length === 0) {
+    throw new Error(
+      'RechartsAdapter: either provide chartType + yKeys (simple mode) or layers (composed mode)',
+    );
   }
 
   const hasMultipleSeries = yKeys.length > 1;
@@ -678,6 +714,414 @@ function buildDumbbellLayer(
 }
 
 /**
+ * Builds a single parallel coordinates layer, one row per observation.
+ *
+ * The payload is the transpose of what the chart is drawn from. A Recharts
+ * `<Line>` binds to one `yAxisId`, so a polyline crossing axes of different
+ * units has to be drawn from values min-max normalised onto a shared scale,
+ * over rows keyed by axis — while a MAIDR layer is one row per observation and
+ * one column per axis. `ParallelTrace` derives each column's own extent and pitches a
+ * value against its OWN axis, so it must never see those normalised numbers —
+ * every axis would run 0 to 1 and the crossings the chart exists to show would
+ * be gone. Hence `dimensions`, which names the RAW fields on the observation.
+ */
+function buildParallelLayer(
+  data: Record<string, unknown>[],
+  chartType: RechartsChartType,
+  xLabel?: string,
+  yLabel?: string,
+  parallelConfig?: RechartsAdapterConfig['parallelConfig'],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  const dimensions = parallelConfig?.dimensions;
+  if (!dimensions || dimensions.length === 0) {
+    throw new Error(
+      'RechartsAdapter: parallelConfig with dimensions is required when chartType is "parallel" — the axes, in the order they are drawn, naming the RAW fields rather than the normalised ones the chart plots',
+    );
+  }
+
+  const axes = dimensions.map(dimension => (
+    typeof dimension === 'string'
+      ? { label: dimension, key: dimension }
+      : { label: dimension.label ?? dimension.key, key: dimension.key }
+  ));
+
+  const observations: LinePoint[][] = data.map((item) => {
+    const name = toText(resolveFieldRef(item, parallelConfig?.labelKey, 'label'));
+    return axes.map(({ label, key }) => {
+      const point: LinePoint = { x: label, y: toNumber(item[key]) };
+      if (name !== undefined) {
+        point.z = name;
+      }
+      return point;
+    });
+  });
+
+  const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope);
+
+  // One selector per observation, all of them the same: Recharts draws one
+  // `<Line>` path per observation, and `ParallelTrace` inherits `LineTrace`'s
+  // resolution — which pairs the list with the rows one for one, then parses
+  // each path's vertices into a mark per value.
+  //
+  // Withheld when the chart holds exactly as many observations as it has axes.
+  // `LineTrace` tries whole ELEMENTS before parsing, accepting a match whose
+  // count equals the row's own length, and with one path per observation those
+  // two counts coincide only then — every value of every observation would
+  // light some other observation's whole polyline.
+  const alignable = data.length > 0 && data.length !== axes.length;
+
+  return {
+    id: '0',
+    type: TraceType.PARALLEL,
+    selectors: selector !== undefined && alignable ? data.map(() => selector) : undefined,
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+    },
+    data: observations,
+  };
+}
+
+/** What a ridgeline's densities are called, since no axis of the chart draws them. */
+const RIDGELINE_DENSITY_AXIS = 'Density';
+
+/**
+ * Builds a single ridgeline layer, one curve per group.
+ *
+ * Recharts has no ridgeline primitive: the chart is overlapping `<Area>`s with
+ * a per-group vertical offset baked into the plotted values. That offset is
+ * presentation — it exists so the curves do not overlap illegibly — so the
+ * payload carries each curve on its own terms and `densityKey` names the
+ * density BEFORE it was added. Read off the drawn y instead, every group's
+ * loudness would be a function of where it was stacked and the lowest ridge
+ * would be the loudest thing on the chart.
+ *
+ * The groups come out in first-appearance order, which is the order the
+ * `<Area>`s have to be declared in for the highlight to land on the right one.
+ */
+function buildRidgelineLayer(
+  data: Record<string, unknown>[],
+  chartType: RechartsChartType,
+  xLabel?: string,
+  yLabel?: string,
+  ridgelineConfig?: RechartsAdapterConfig['ridgelineConfig'],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  const groupKey = ridgelineConfig?.groupKey;
+  if (groupKey === undefined) {
+    throw new Error('RechartsAdapter: ridgelineConfig with a groupKey is required when chartType is "ridgeline"');
+  }
+
+  const { valueKey, densityKey } = ridgelineConfig ?? {};
+  const curves = new Map<string, ViolinKdePoint[]>();
+
+  for (const item of data) {
+    const group = toText(item[groupKey]);
+    const value = toOptionalNumber(resolveFieldRef(item, valueKey, 'value'));
+    const density = toOptionalNumber(resolveFieldRef(item, densityKey, 'density'));
+    // A sample needs both a place on the value axis and a height there. One
+    // without either is not a sample of anything, and filling in a zero would
+    // put a trough in the curve where the data said nothing.
+    if (group === undefined || value === undefined || density === undefined) {
+      continue;
+    }
+
+    const point: ViolinKdePoint = { x: group, y: value, density };
+    const curve = curves.get(group);
+    if (curve === undefined) {
+      curves.set(group, [point]);
+    } else {
+      curve.push(point);
+    }
+  }
+
+  if (curves.size === 0) {
+    throw new Error(
+      `RechartsAdapter: no ridgeline row carried both a value and a density (looked for "${valueKey ?? 'value'}" and "${densityKey ?? 'density'}"). `
+      + 'The density is the kernel-density value BEFORE the group\'s ridge offset was added, and the drawn y is not a substitute for it',
+    );
+  }
+
+  return {
+    id: '0',
+    type: TraceType.RIDGELINE,
+    // One element per group, which is what the chart draws: `RidgelineTrace`
+    // resolves the selector to a flat list, requires exactly one entry per
+    // ridge, and then lights that ridge's whole curve from any of its samples.
+    selectors: selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope),
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+      z: { label: RIDGELINE_DENSITY_AXIS },
+    },
+    data: [...curves.values()],
+  };
+}
+
+/** What a hexbin's counts are called, since the fill is what carries them. */
+const HEXBIN_COUNT_AXIS = 'Count';
+
+/**
+ * How many significant digits a bin's y centre is compared on when grouping
+ * the bins into lattice rows.
+ *
+ * Every bin of a hex row is placed by the same arithmetic on the same row
+ * number, so their centres normally come out identical — but a lattice
+ * computed through a scale can differ in the last digit or two of a `double`.
+ * Twelve digits is far beyond any real lattice's spacing and well inside that
+ * noise. Lifted from the d3 binder so the two adapters group alike.
+ */
+const HEXBIN_ROW_PRECISION = 12;
+
+/** One bin, with the row key and the input position it was read at. */
+interface HexbinBin {
+  key: string;
+  order: number;
+  index: number;
+  point: HexbinPoint;
+}
+
+/**
+ * Builds a single hexbin layer whose data is a staggered LATTICE.
+ *
+ * Recharts places the marks and nothing else — the binning happens before the
+ * chart is drawn — so `data` is one row per OCCUPIED bin and the lattice those
+ * bins form is assembled here: rows grouped by their y centre, ordered from
+ * the lowest upward, each row ordered left to right. `HexbinTrace` steps its
+ * row index up for an upward move and treats a column index as a position
+ * within its row, so neither order is optional.
+ *
+ * The centres stay in DATA units. Passing screen coordinates through would
+ * announce every bin's position in pixels.
+ */
+function buildHexbinLayer(
+  data: Record<string, unknown>[],
+  chartType: RechartsChartType,
+  xKey: string,
+  yKey?: string,
+  xLabel?: string,
+  yLabel?: string,
+  hexbinConfig?: RechartsAdapterConfig['hexbinConfig'],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  const { xKey: binXKey, yKey: binYKey, countKey, rowKey } = hexbinConfig ?? {};
+
+  const bins: HexbinBin[] = [];
+  data.forEach((item, index) => {
+    const x = toOptionalNumber(resolveFieldRef(item, binXKey ?? xKey, 'x'));
+    const y = toOptionalNumber(resolveFieldRef(item, binYKey ?? yKey, 'y'));
+    const count = toOptionalNumber(resolveFieldRef(item, countKey, 'count'));
+    // A bin is its centre and its count. Missing any of the three, there is
+    // nothing to announce and nowhere to announce it from.
+    if (x === undefined || y === undefined || count === undefined) {
+      return;
+    }
+
+    const declared = rowKey === undefined ? undefined : item[rowKey];
+    const order = declared === undefined ? y : toOptionalNumber(declared);
+
+    bins.push({
+      key: declared === undefined ? y.toPrecision(HEXBIN_ROW_PRECISION) : String(declared),
+      // A row named by something that is not a number keeps its first-seen
+      // position rather than sorting to the front as a NaN would.
+      order: order ?? Number.POSITIVE_INFINITY,
+      index,
+      point: { x, y, count },
+    });
+  });
+
+  if (bins.length === 0) {
+    throw new Error(
+      `RechartsAdapter: no hexbin row carried a centre and a count (looked for "${binXKey ?? xKey}", "${binYKey ?? yKey ?? 'y'}" and "${countKey ?? 'count'}"). `
+      + 'The centres are the bins\' positions in DATA units, which is what the reader is given instead of a column index',
+    );
+  }
+
+  const rows = groupIntoHexbinRows(bins);
+  const drawnOrder = rows.flat().map(bin => bin.index);
+
+  // `HexbinTrace` slices its selector's matches row by row down the lattice,
+  // while a `<Scatter>` draws one symbol per row of `data` in the order the
+  // rows arrive. The two agree only when the rows already arrive in lattice
+  // order, so a chart whose bins are listed some other way gets no
+  // highlighting rather than a highlight on a bin half a field away — which on
+  // a stagger is not even a neighbour in the direction a reader would guess.
+  const inLatticeOrder = drawnOrder.every((index, i) => i === 0 || index > drawnOrder[i - 1]);
+  const selector = selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope);
+
+  return {
+    id: '0',
+    type: TraceType.HEXBIN,
+    selectors: inLatticeOrder ? selector : undefined,
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+      z: { label: HEXBIN_COUNT_AXIS },
+    },
+    data: rows.map(row => row.map(bin => bin.point)),
+  };
+}
+
+/**
+ * Assembles the lattice: bins grouped into rows, rows ordered from the lowest
+ * upward, each row ordered left to right.
+ *
+ * @param bins - Every bin, with the row key and ordinal it was read with
+ * @returns The lattice, rows outermost
+ */
+function groupIntoHexbinRows(bins: HexbinBin[]): HexbinBin[][] {
+  const rows = new Map<string, HexbinBin[]>();
+  const order = new Map<string, number>();
+
+  for (const bin of bins) {
+    const row = rows.get(bin.key);
+    if (row === undefined) {
+      rows.set(bin.key, [bin]);
+      order.set(bin.key, bin.order);
+    } else {
+      row.push(bin);
+    }
+  }
+
+  return Array.from(rows.entries())
+    .sort(([a], [b]) => (order.get(a) ?? 0) - (order.get(b) ?? 0))
+    .map(([, row]) => [...row].sort((a, b) => Number(a.point.x) - Number(b.point.x)));
+}
+
+/**
+ * Builds a single boxen layer, one letter-value ladder per distribution.
+ *
+ * Recharts has no box primitive at all, so the rungs are faked as stacked
+ * `<Bar>`s over a transparent base — and neither the ladder nor the median is
+ * anything that construction holds: both are computed from the raw sample
+ * before it is drawn. So both are read from the rows, and a rung whose three
+ * numbers are not all finite is dropped rather than announced as a quantile
+ * the data never computed.
+ *
+ * No selector is generated. A rung is a rectangle rather than a distribution,
+ * `BoxenTrace` wants exactly one element per distribution, and no class name
+ * identifies the outermost rung — so a chart that wants highlighting puts a
+ * `className` on that one `<Bar>` and passes it as `selectorOverride`.
+ */
+function buildBoxenLayer(
+  data: Record<string, unknown>[],
+  chartType: RechartsChartType,
+  xKey: string,
+  xLabel?: string,
+  yLabel?: string,
+  orientation?: Orientation,
+  boxenConfig?: RechartsAdapterConfig['boxenConfig'],
+  selectorOverride?: string,
+  chartId?: string,
+  panelScope?: string,
+): MaidrLayer {
+  const { xKey: categoryKey, medianKey, levelsKey, lowerOutliersKey, upperOutliersKey } = boxenConfig ?? {};
+
+  const points: BoxenPoint[] = [];
+  for (const item of data) {
+    const median = toOptionalNumber(resolveFieldRef(item, medianKey, 'median'));
+    // The median is the middle of the ladder and a navigable position in its
+    // own right. A distribution without one has no centre to walk out from.
+    if (median === undefined) {
+      continue;
+    }
+
+    const point: BoxenPoint = {
+      z: toText(item[categoryKey ?? xKey]) ?? '',
+      median,
+      levels: toLetterValueLevels(resolveFieldRef(item, levelsKey, 'levels')),
+    };
+    const lower = toNumberList(lowerOutliersKey === undefined ? undefined : item[lowerOutliersKey]);
+    if (lower !== undefined) {
+      point.lowerOutliers = lower;
+    }
+    const upper = toNumberList(upperOutliersKey === undefined ? undefined : item[upperOutliersKey]);
+    if (upper !== undefined) {
+      point.upperOutliers = upper;
+    }
+    points.push(point);
+  }
+
+  if (points.length === 0) {
+    throw new Error(
+      `RechartsAdapter: no boxen row carried a median (looked for "${medianKey ?? 'median'}"). `
+      + 'A letter-value plot is computed from the raw sample before it is drawn, and the ladder and the median both arrive through the data rather than from the chart',
+    );
+  }
+
+  return {
+    id: '0',
+    type: TraceType.BOXEN,
+    selectors: selectorOverride ?? getRechartsSelector(chartType, undefined, chartId, panelScope),
+    orientation: orientation ?? Orientation.VERTICAL,
+    axes: {
+      x: { label: xLabel },
+      y: { label: yLabel },
+    },
+    data: points,
+  };
+}
+
+/**
+ * Reads a distribution's ladder, keeping the rungs that are fully numeric.
+ *
+ * `p` is the TAIL probability, exactly as {@link LetterValueLevel} defines it:
+ * 0.25 is the rung spanning the middle half. The order is left alone, since
+ * `BoxenTrace` walks the ladder outward from the median whichever way round it
+ * arrives.
+ *
+ * @param value - Whatever the levels key resolved to
+ * @returns The rungs the payload carries
+ */
+function toLetterValueLevels(value: unknown): LetterValueLevel[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const levels: LetterValueLevel[] = [];
+  for (const entry of value) {
+    if (entry === null || typeof entry !== 'object') {
+      continue;
+    }
+    const rung = entry as Record<string, unknown>;
+    const p = toOptionalNumber(rung.p);
+    const lo = toOptionalNumber(rung.lo);
+    const hi = toOptionalNumber(rung.hi);
+    // A rung is a labelled pair of positions on the distribution. One missing
+    // any of its three numbers would be announced as a percentile the sample
+    // was never asked for.
+    if (p === undefined || lo === undefined || hi === undefined) {
+      continue;
+    }
+    levels.push({ p, lo, hi });
+  }
+  return levels;
+}
+
+/**
+ * Reads a list of numbers — a boxen's outliers — or nothing.
+ *
+ * @param value - Whatever the outlier key resolved to
+ * @returns The finite numbers in it, or undefined when there are none
+ */
+function toNumberList(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const numbers = value
+    .map(toOptionalNumber)
+    .filter((entry): entry is number => entry !== undefined);
+  return numbers.length > 0 ? numbers : undefined;
+}
+
+/**
  * Builds layers for composed mode (mixed chart types via layers config).
  */
 function buildComposedLayers(config: RechartsAdapterConfig, panelScope?: string): MaidrLayer[] {
@@ -798,9 +1242,18 @@ function convertData(
     // Whole-chart types: their payload describes the figure rather than a
     // series, so there is nothing for them to be a layer OF. Only composed
     // mode reaches this — simple mode routes each to its own builder.
+    //
+    // The four grid types are here for the same reason: a parallel plot's rows
+    // are its observations, a ridgeline's its groups, a hexbin's its lattice
+    // rows and a boxen's its ladders — none of them a series of the chart
+    // around it.
     case 'gauge':
     case 'gantt':
     case 'dumbbell':
+    case 'parallel':
+    case 'ridgeline':
+    case 'hexbin':
+    case 'boxen':
       throw new Error(`RechartsAdapter: chartType "${chartType}" describes a whole chart and cannot be a layer of a composed one`);
     // Stacked/dodged/normalized/diverging/histogram handled by dedicated builders
     case 'stacked_bar':
@@ -1438,6 +1891,17 @@ function toTraceType(chartType: RechartsChartType): TraceType {
       return TraceType.ALLUVIAL;
     case 'sankey':
       return TraceType.SANKEY;
+    // `TraceType.PARALLEL` is the string `'parallel_coordinates'`, the way
+    // `'scatter'` here is `TraceType.SCATTER === 'point'`: the adapter keeps
+    // its own house spelling and maps.
+    case 'parallel':
+      return TraceType.PARALLEL;
+    case 'ridgeline':
+      return TraceType.RIDGELINE;
+    case 'hexbin':
+      return TraceType.HEXBIN;
+    case 'boxen':
+      return TraceType.BOXEN;
   }
 }
 

--- a/src/adapters/recharts/index.ts
+++ b/src/adapters/recharts/index.ts
@@ -12,17 +12,21 @@ export { convertRechartsToMaidr, normalizeRechartsSubplotGrid } from './converte
 export { MaidrRecharts } from './MaidrRecharts';
 export { getPanelClassName, getRechartsSelector } from './selectors';
 export type {
+  BoxenLadderConfig,
   ErrorIntervalConfig,
   FlowLinkConfig,
   ForestPlotConfig,
   GanttChartConfig,
   GaugeDialConfig,
+  HexbinLatticeConfig,
   HistogramBinConfig,
   MaidrRechartsProps,
+  ParallelAxesConfig,
   RechartsAdapterConfig,
   RechartsChartType,
   RechartsLayerConfig,
   RechartsSubplotConfig,
+  RidgelineCurveConfig,
   SurvivalCurveConfig,
   VolcanoPointConfig,
   WaterfallStepConfig,

--- a/src/adapters/recharts/selectors.ts
+++ b/src/adapters/recharts/selectors.ts
@@ -155,6 +155,52 @@
  *   highlighting off for the layer rather than mis-aligning it, so audio,
  *   text, and braille still describe every slice including the zero.
  *
+ * Parallel coordinates:
+ *   g.recharts-line > path.recharts-line-curve
+ *   [target: .recharts-line .recharts-line-curve]
+ *
+ *   One `<Line>` per OBSERVATION, so one curve path each — the same selector
+ *   repeated once per observation, which is the shape `ParallelTrace` inherits
+ *   from `LineTrace`. There are no per-vertex marks aligned to the grid, so
+ *   the trace parses each path's own vertices into marks; a chart drawn some
+ *   other way (a `<Line>` per axis, an extra reference line) gets no
+ *   highlighting rather than a highlight on the wrong polyline.
+ *
+ * Ridgeline:
+ *   g.recharts-area > path.recharts-area-area
+ *   [target: .recharts-area .recharts-area-area]
+ *
+ *   One `<Area>` per group, so one filled band each, and `RidgelineTrace`
+ *   wants exactly that — one element per ridge, lit from any sample of it.
+ *   The bands come out in the order the `<Area>`s are declared, so they must
+ *   be declared in the order the groups first appear in `data`.
+ *
+ * Hexbin:
+ *   g.recharts-scatter-symbol > g.recharts-shape > (the drawn hexagon)
+ *   [target: .recharts-scatter-symbol .recharts-shape > *]
+ *
+ *   The bins are a `<Scatter>`, one symbol group per row in row order — but
+ *   Recharts has no hexagon among its own symbol types, so a hexbin always
+ *   passes a custom `shape` and there is no `path.recharts-symbols` to target
+ *   the way the other scatter families do. What both cases share is the
+ *   `g.recharts-shape` wrapper Recharts puts around whatever was drawn, so the
+ *   selector takes its child: one element per bin, custom shape or not.
+ *
+ *   The payload is a LATTICE — rows from the bottom up, each ordered left to
+ *   right — while the symbols come out in the order the rows arrive. The two
+ *   agree only when the rows already arrive in that order, which is what the
+ *   converter checks before emitting this selector at all.
+ *
+ * Boxen:
+ *   no generated selector.
+ *
+ *   A letter-value plot has no box primitive in Recharts: the rungs are
+ *   stacked `<Bar>`s over a transparent base, so the rectangles are one per
+ *   rung per distribution and no class name says which rung is which.
+ *   `BoxenTrace` wants exactly one element per DISTRIBUTION, so a chart that
+ *   wants highlighting puts a `className` on the single `<Bar>` drawing the
+ *   outermost rung and passes it as `selectorOverride`.
+ *
  * Selectors are scoped to their parent container classes to avoid matching
  * Recharts utility elements (e.g. Tooltip cursor rectangles) that share the
  * same leaf class name.
@@ -312,5 +358,14 @@ function baseRechartsSelector(chartType: RechartsChartType): string | undefined 
     case 'pie':
     case 'polar_area':
       return '.recharts-pie-sector .recharts-sector';
+    case 'parallel':
+      return '.recharts-line .recharts-line-curve';
+    case 'ridgeline':
+      return '.recharts-area .recharts-area-area';
+    case 'hexbin':
+      return '.recharts-scatter-symbol .recharts-shape > *';
+    // A boxen has no per-distribution mark of its own; see the module docs.
+    case 'boxen':
+      return undefined;
   }
 }

--- a/src/adapters/recharts/types.ts
+++ b/src/adapters/recharts/types.ts
@@ -84,6 +84,22 @@ import type { GaugeBand, Orientation, StepDirection } from '@type/grammar';
  *   depth-ordered bands. Recharts has no icicle component, so it is built as a
  *   `<BarChart layout="vertical">` of floating bars — one row per node, the
  *   lane its depth — exactly the recipe `'gantt'` uses
+ * - `'parallel'` → `TraceType.PARALLEL` (the string
+ *   `'parallel_coordinates'`) — One polyline per observation crossing an axis
+ *   per variable. A `<Line>` binds to one `yAxisId`, so the drawn values have
+ *   to be min-max normalised onto a shared scale; the announced ones must not
+ *   be, and {@link ParallelAxesConfig} names the RAW fields
+ * - `'ridgeline'` → `TraceType.RIDGELINE` — One density curve per group along
+ *   a shared value axis, drawn as overlapping `<Area>`s with a per-group
+ *   offset baked into the plotted values. The offset is presentation, so
+ *   {@link RidgelineCurveConfig} names the densities BEFORE it was added
+ * - `'hexbin'` → `TraceType.HEXBIN` — A hexagonal lattice of counts, drawn as
+ *   `<Scatter shape={hexagon}>` on numeric axes. Recharts places the marks and
+ *   nothing else: the binning happens outside it, so the rows are precomputed
+ *   bin centres and counts named by {@link HexbinLatticeConfig}
+ * - `'boxen'` → `TraceType.BOXEN` — A letter-value plot: a median and a
+ *   variable-depth ladder of quantile pairs per category, computed outside
+ *   Recharts and named by {@link BoxenLadderConfig}
  */
 export type RechartsChartType
   = | 'bar'
@@ -117,7 +133,11 @@ export type RechartsChartType
     | 'sankey'
     | 'treemap'
     | 'sunburst'
-    | 'icicle';
+    | 'icicle'
+    | 'parallel'
+    | 'ridgeline'
+    | 'hexbin'
+    | 'boxen';
 
 /**
  * A single data series/layer configuration for composed charts.
@@ -384,6 +404,161 @@ export interface GaugeDialConfig {
    * way every other chart type takes its category label from `xKey`.
    */
   label?: string;
+}
+
+/**
+ * Configuration for parallel coordinates plots.
+ * Required when `chartType` is `'parallel'`.
+ *
+ * One data row is one OBSERVATION and one dimension is one axis, which is the
+ * transpose of what the chart is drawn from: a Recharts `<Line>` binds to a
+ * single `yAxisId`, so a polyline crossing axes with different units has to be
+ * drawn from values min-max normalised onto one shared scale, with one
+ * `<Line>` per observation over rows keyed by axis.
+ *
+ * MAIDR is unaffected by that — a parallel trace derives each column's own
+ * extent and pitches a value against its OWN axis — but it must never see the
+ * normalised numbers, since every axis would then run 0 to 1 and the chart's
+ * whole point would be flattened. So {@link dimensions} names the RAW fields,
+ * and `data` here is the observations rather than the array the chart draws.
+ */
+export interface ParallelAxesConfig {
+  /**
+   * The axes, in the order they are drawn — which is the order a reader arrows
+   * through them.
+   *
+   * Required, and required to be a list: nothing on an observation states the
+   * order, and an object's key order is not an axis order. A bare string names
+   * both the axis and the raw field; the object form separates them, for a
+   * column whose key is not what a reader should hear.
+   *
+   * @example
+   * dimensions: ['mpg', 'hp', { label: 'Weight (lb)', key: 'wt' }]
+   */
+  dimensions: (string | { label?: string; key: string })[];
+  /**
+   * Key holding what the observation IS — the car, the country, the patient.
+   * It becomes the polyline's series name, and without it an observation is
+   * announced by its position among the rest.
+   *
+   * Defaults to a `label` column, then `snp`, `id`, `name`, `gene`, `probe`.
+   */
+  labelKey?: string;
+}
+
+/**
+ * Configuration for ridgeline (joy) plots.
+ * Required when `chartType` is `'ridgeline'`.
+ *
+ * Recharts has no ridgeline primitive: the chart is overlapping `<Area>`s with
+ * a per-group vertical offset baked into the plotted values. The offset is
+ * presentation — it exists so the curves do not overlap illegibly — so the
+ * payload carries each curve on its own terms and the config must name the
+ * density BEFORE the offset was added.
+ *
+ * The kernel density itself is computed outside Recharts and outside the
+ * adapter; `data` is the sampled curves, one row per sample, tagged with the
+ * group they belong to.
+ */
+export interface RidgelineCurveConfig {
+  /**
+   * Key holding the group a sample's curve belongs to. Rows are grouped by it
+   * in first-appearance order, which is the order the ridges are announced in
+   * and the order the `<Area>`s have to be declared in for highlighting.
+   */
+  groupKey: string;
+  /**
+   * Key holding the position along the shared value axis.
+   *
+   * Defaults to a `value` column, then `x`, `t`, `position`.
+   */
+  valueKey?: string;
+  /**
+   * Key holding the kernel-density value BEFORE the group's ridge offset was
+   * added.
+   *
+   * Fed the drawn y instead, every group's loudness would become a function of
+   * where it was stacked and the lowest ridge would be the loudest. Where
+   * nothing resolves, the reading is refused rather than a baseline guessed.
+   *
+   * Defaults to a `density` column, then `kde`, `width`, `p`, `estimate`.
+   */
+  densityKey?: string;
+}
+
+/**
+ * Configuration for hexbin density plots.
+ * Optional when `chartType` is `'hexbin'`.
+ *
+ * Recharts has no hexbin either: the marks are a `<Scatter>` given a hexagonal
+ * `shape`, and the binning happens before the chart is drawn. So `data` is one
+ * row per OCCUPIED bin — an empty bin is not drawn and not announced — and the
+ * adapter assembles the lattice those bins form: rows grouped by their y
+ * centre, ordered from the lowest upward, each row ordered left to right.
+ *
+ * The centres are in DATA units. Screen coordinates would announce every bin's
+ * position in pixels.
+ */
+export interface HexbinLatticeConfig {
+  /** Key holding the bin's centre along the x axis. Defaults to the chart's `xKey`. */
+  xKey?: string;
+  /** Key holding the bin's centre along the y axis. Defaults to the first `yKeys` entry, then a `y` column. */
+  yKey?: string;
+  /**
+   * Key holding how many points fell in the bin.
+   *
+   * Defaults to a `count` column, then `length`, `value`, `n`, `total` — the
+   * `length` fallback being what makes a `d3-hexbin` bin work untouched, since
+   * its bins are arrays of the points that fell in them.
+   */
+  countKey?: string;
+  /**
+   * Key holding the lattice row a bin sits on, for data that names it.
+   *
+   * Omitted, rows are grouped by identical y centre, which is what a lattice
+   * computed by the usual libraries produces.
+   */
+  rowKey?: string;
+}
+
+/**
+ * Configuration for boxen (letter-value) plots.
+ * Optional when `chartType` is `'boxen'`, but a boxen with no ladder is a box
+ * plot — see {@link levelsKey}.
+ *
+ * Recharts has no box primitive at all, so the rungs are faked as stacked
+ * `<Bar>`s with a transparent base segment. Neither the ladder nor the median
+ * is anything the chart holds: both are computed from the raw sample before it
+ * is drawn, and this names the columns they were computed into. One data row
+ * is one distribution.
+ */
+export interface BoxenLadderConfig {
+  /** Key holding the category the distribution summarises. Defaults to the chart's `xKey`. */
+  xKey?: string;
+  /**
+   * Key holding the middle of the distribution.
+   *
+   * Defaults to a `median` column, then `q2`, `mid`, `y`.
+   */
+  medianKey?: string;
+  /**
+   * Key holding the ladder: an array of `{ p, lo, hi }` rungs, where `p` is
+   * the TAIL probability — 0.25 for the rung spanning the middle half, 0.125
+   * for the middle three quarters, and so on inwards.
+   *
+   * A rung whose three numbers are not all finite is dropped rather than
+   * announced as a quantile the data does not contain. The order does not
+   * matter: MAIDR walks the ladder outward from the median whichever way round
+   * it arrives.
+   *
+   * Defaults to a `levels` column, then `letterValues`, `letter_values`,
+   * `quantiles`, `ladder`.
+   */
+  levelsKey?: string;
+  /** Key holding the values below the deepest rung. */
+  lowerOutliersKey?: string;
+  /** Key holding the values above the deepest rung. */
+  upperOutliersKey?: string;
 }
 
 /**
@@ -779,6 +954,83 @@ export interface RechartsSubplotConfig {
  * };
  * ```
  *
+ * @example Parallel coordinates
+ * ```typescript
+ * // `data` is the OBSERVATIONS with their raw values; the chart is drawn from
+ * // a normalised transpose of them, because a <Line> binds to one yAxisId.
+ * // MAIDR pitches each value against its own axis, so it must see the raw
+ * // numbers — handed the normalised ones, every axis would run 0 to 1.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'cars-chart',
+ *   title: 'Cars by Specification',
+ *   data: [{ car: 'Mazda RX4', mpg: 21, hp: 110, wt: 2.62 }],
+ *   chartType: 'parallel',
+ *   xKey: 'car',
+ *   parallelConfig: {
+ *     dimensions: ['mpg', 'hp', { label: 'Weight (1000 lb)', key: 'wt' }],
+ *     labelKey: 'car',
+ *   },
+ *   xLabel: 'Variable',
+ *   yLabel: 'Value',
+ * };
+ * ```
+ *
+ * @example Ridgeline plot
+ * ```typescript
+ * // One row per KDE sample, tagged with its group. `densityKey` names the
+ * // density BEFORE the ridge offset: the offset is what keeps the curves from
+ * // overlapping on screen and says nothing about any group.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'temps-chart',
+ *   title: 'Daily Temperature by Month',
+ *   data: [{ month: 'Jan', temp: -4, density: 0.06, plotted: 11.06 }],
+ *   chartType: 'ridgeline',
+ *   xKey: 'temp',
+ *   ridgelineConfig: { groupKey: 'month', valueKey: 'temp', densityKey: 'density' },
+ *   xLabel: 'Temperature (C)',
+ *   yLabel: 'Month',
+ * };
+ * ```
+ *
+ * @example Hexbin plot
+ * ```typescript
+ * // One row per occupied bin, its centre in DATA units. The lattice — rows
+ * // from the bottom up, each ordered left to right — is assembled here, since
+ * // a hex row staggers and a bin's index therefore is not its position.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'diamonds-chart',
+ *   title: 'Carat against Price',
+ *   data: [{ cx: 0.5, cy: 1200, count: 43 }],
+ *   chartType: 'hexbin',
+ *   xKey: 'cx',
+ *   yKeys: ['cy'],
+ *   hexbinConfig: { countKey: 'count' },
+ *   xLabel: 'Carat',
+ *   yLabel: 'Price ($)',
+ * };
+ * ```
+ *
+ * @example Boxen (letter-value) plot
+ * ```typescript
+ * // One row per distribution, carrying the ladder computed from the sample.
+ * // `p` is the TAIL probability, so 0.25 is the rung spanning the middle half.
+ * const config: RechartsAdapterConfig = {
+ *   id: 'latency-chart',
+ *   title: 'Response Time by Region',
+ *   data: [{
+ *     region: 'East',
+ *     median: 180,
+ *     levels: [{ p: 0.25, lo: 150, hi: 240 }, { p: 0.125, lo: 130, hi: 310 }],
+ *     high: [820, 910],
+ *   }],
+ *   chartType: 'boxen',
+ *   xKey: 'region',
+ *   boxenConfig: { upperOutliersKey: 'high' },
+ *   xLabel: 'Region',
+ *   yLabel: 'Milliseconds',
+ * };
+ * ```
+ *
  * @example Composed chart (bar + line)
  * ```typescript
  * const config: RechartsAdapterConfig = {
@@ -952,6 +1204,30 @@ export interface RechartsAdapterConfig {
    * Required when `chartType` is `'gauge'`.
    */
   gaugeConfig?: GaugeDialConfig;
+
+  /**
+   * Axis order and raw value keys for a parallel coordinates plot.
+   * Required when `chartType` is `'parallel'`.
+   */
+  parallelConfig?: ParallelAxesConfig;
+
+  /**
+   * Group, value and density keys for a ridgeline plot.
+   * Required when `chartType` is `'ridgeline'`.
+   */
+  ridgelineConfig?: RidgelineCurveConfig;
+
+  /**
+   * Bin centre, count and lattice row keys for a hexbin plot.
+   * Used when `chartType` is `'hexbin'`.
+   */
+  hexbinConfig?: HexbinLatticeConfig;
+
+  /**
+   * Median, ladder and outlier keys for a boxen plot.
+   * Used when `chartType` is `'boxen'`.
+   */
+  boxenConfig?: BoxenLadderConfig;
 
   /**
    * Custom CSS selector override for SVG highlighting.

--- a/src/adapters/recharts/useRechartsAdapter.ts
+++ b/src/adapters/recharts/useRechartsAdapter.ts
@@ -87,6 +87,10 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
     waterfallConfig,
     ganttConfig,
     gaugeConfig,
+    parallelConfig,
+    ridgelineConfig,
+    hexbinConfig,
+    boxenConfig,
     selectorOverride,
   } = config;
 
@@ -116,8 +120,12 @@ export function useRechartsAdapter(config: RechartsAdapterConfig): Maidr {
       waterfallConfig,
       ganttConfig,
       gaugeConfig,
+      parallelConfig,
+      ridgelineConfig,
+      hexbinConfig,
+      boxenConfig,
       selectorOverride,
     }),
-    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, selectorOverride],
+    [id, title, subtitle, caption, data, chartType, xKey, yKeys, layers, subplots, columns, xLabel, yLabel, orientation, fillKeys, binConfig, flowConfig, volcanoConfig, errorConfig, forestConfig, survivalConfig, waterfallConfig, ganttConfig, gaugeConfig, parallelConfig, ridgelineConfig, hexbinConfig, boxenConfig, selectorOverride],
   );
 }

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -1,5 +1,5 @@
 import type { RechartsAdapterConfig } from '@adapters/recharts/types';
-import type { BarPoint, DumbbellData, ErrorBarPoint, FlowPoint, ForestPoint, GanttData, GaugePoint, HistogramPoint, LinePoint, PiePoint, ScatterPoint, SegmentedPoint, SurvivalPoint, TreemapPoint, VolcanoPoint, WaterfallPoint } from '@type/grammar';
+import type { BarPoint, BoxenPoint, DumbbellData, ErrorBarPoint, FlowPoint, ForestPoint, GanttData, GaugePoint, HexbinPoint, HistogramPoint, LinePoint, PiePoint, ScatterPoint, SegmentedPoint, SurvivalPoint, TreemapPoint, ViolinKdePoint, VolcanoPoint, WaterfallPoint } from '@type/grammar';
 import { convertRechartsToMaidr } from '@adapters/recharts/converters';
 import { Orientation, TraceType } from '@type/grammar';
 
@@ -1706,6 +1706,429 @@ describe('convertRechartsToMaidr', () => {
       for (const point of layer.data as PiePoint[]) {
         expect(point).not.toHaveProperty('percentage');
       }
+    });
+  });
+
+  describe('parallel coordinates', () => {
+    // The RAW values, which is what the payload carries. The chart itself is
+    // drawn from a normalised transpose of these, because a <Line> binds to a
+    // single yAxisId.
+    const cars = [
+      { car: 'Mazda RX4', mpg: 21, hp: 110, wt: 2.62 },
+      { car: 'Datsun 710', mpg: 22.8, hp: 93, wt: 2.32 },
+      { car: 'Hornet', mpg: 21.4, hp: 110, wt: 3.215 },
+      { car: 'Valiant', mpg: 18.1, hp: 105, wt: 3.46 },
+    ];
+
+    const parallelConfig: RechartsAdapterConfig = {
+      id: 'cars',
+      title: 'Cars by Specification',
+      data: cars,
+      chartType: 'parallel',
+      xKey: 'car',
+      parallelConfig: {
+        dimensions: ['mpg', 'hp', { label: 'Weight (1000 lb)', key: 'wt' }],
+        labelKey: 'car',
+      },
+      xLabel: 'Variable',
+      yLabel: 'Value',
+    };
+
+    it('builds one row per observation, in the declared axis order', () => {
+      const layer = convertRechartsToMaidr(parallelConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.PARALLEL);
+
+      const data = layer.data as LinePoint[][];
+      expect(data).toHaveLength(4);
+      // The axis order is the config's, the values are the raw ones, and the
+      // object form's label is what a reader hears while its key stays the
+      // field that was read.
+      expect(data[0]).toEqual([
+        { x: 'mpg', y: 21, z: 'Mazda RX4' },
+        { x: 'hp', y: 110, z: 'Mazda RX4' },
+        { x: 'Weight (1000 lb)', y: 2.62, z: 'Mazda RX4' },
+      ]);
+      expect(data[1][1]).toEqual({ x: 'hp', y: 93, z: 'Datsun 710' });
+    });
+
+    it('names an observation from a name column when no labelKey is declared', () => {
+      const layer = convertRechartsToMaidr({
+        ...parallelConfig,
+        data: [{ name: 'Mazda RX4', mpg: 21, hp: 110, wt: 2.62 }],
+        parallelConfig: { dimensions: ['mpg', 'hp', 'wt'] },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as LinePoint[][];
+      expect(data[0][0]).toEqual({ x: 'mpg', y: 21, z: 'Mazda RX4' });
+    });
+
+    it('leaves an unnamed observation unnamed', () => {
+      const layer = convertRechartsToMaidr({
+        ...parallelConfig,
+        data: [{ mpg: 21, hp: 110, wt: 2.62 }],
+        parallelConfig: { dimensions: ['mpg', 'hp', 'wt'] },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as LinePoint[][];
+      expect(data[0][0]).toEqual({ x: 'mpg', y: 21 });
+    });
+
+    it('targets one curve path per observation', () => {
+      const layer = convertRechartsToMaidr(parallelConfig).subplots[0][0].layers[0];
+
+      // A ParallelTrace is a LineTrace: one selector per ROW, and Recharts
+      // draws one <Line> per observation.
+      expect(layer.selectors).toEqual(Array.from({ length: 4 }, () =>
+        '#maidr-article-cars .recharts-line .recharts-line-curve'));
+    });
+
+    it('withholds the selectors when there are as many observations as axes', () => {
+      // LineTrace accepts whole ELEMENTS whose count equals the row's own
+      // length before it parses any path, so with one path per observation
+      // this is the one shape where every value would light some other
+      // observation's polyline.
+      const layer = convertRechartsToMaidr({
+        ...parallelConfig,
+        data: cars.slice(0, 3),
+        parallelConfig: { dimensions: ['mpg', 'hp', 'wt'], labelKey: 'car' },
+      }).subplots[0][0].layers[0];
+
+      expect((layer.data as LinePoint[][])).toHaveLength(3);
+      expect(layer.selectors).toBeUndefined();
+    });
+
+    it('throws when no dimensions are declared', () => {
+      expect(() => convertRechartsToMaidr({
+        ...parallelConfig,
+        parallelConfig: undefined,
+      })).toThrow('RechartsAdapter');
+    });
+
+    it('cannot be a layer of a composed chart', () => {
+      expect(() => convertRechartsToMaidr({
+        id: 'composed-parallel',
+        data: cars,
+        xKey: 'car',
+        layers: [{ yKey: 'mpg', chartType: 'parallel' }],
+        parallelConfig: { dimensions: ['mpg', 'hp'] },
+      })).toThrow('RechartsAdapter');
+    });
+  });
+
+  describe('ridgeline plot', () => {
+    // One row per KDE sample. `plotted` is what the <Area> draws — the density
+    // with the group's ridge offset added — and is exactly what the payload
+    // must NOT carry.
+    const samples = [
+      { month: 'Jan', temp: -4, density: 0.06, plotted: 2.06 },
+      { month: 'Jan', temp: 0, density: 0.11, plotted: 2.11 },
+      { month: 'Feb', temp: -2, density: 0.08, plotted: 1.08 },
+      { month: 'Feb', temp: 2, density: 0.13, plotted: 1.13 },
+    ];
+
+    const ridgelineConfig: RechartsAdapterConfig = {
+      id: 'temps',
+      title: 'Daily Temperature by Month',
+      data: samples,
+      chartType: 'ridgeline',
+      xKey: 'temp',
+      ridgelineConfig: { groupKey: 'month', valueKey: 'temp', densityKey: 'density' },
+      xLabel: 'Temperature (C)',
+      yLabel: 'Month',
+    };
+
+    it('builds one curve per group, carrying the density without the offset', () => {
+      const layer = convertRechartsToMaidr(ridgelineConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.RIDGELINE);
+
+      const data = layer.data as ViolinKdePoint[][];
+      expect(data).toEqual([
+        [
+          { x: 'Jan', y: -4, density: 0.06 },
+          { x: 'Jan', y: 0, density: 0.11 },
+        ],
+        [
+          { x: 'Feb', y: -2, density: 0.08 },
+          { x: 'Feb', y: 2, density: 0.13 },
+        ],
+      ]);
+      // The offset is presentation: fed the drawn y, the lowest ridge would be
+      // the loudest thing on the chart.
+      expect(data[0][0].density).not.toBe(2.06);
+    });
+
+    it('groups in first-appearance order however the rows are interleaved', () => {
+      const layer = convertRechartsToMaidr({
+        ...ridgelineConfig,
+        data: [samples[2], samples[0], samples[3], samples[1]],
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as ViolinKdePoint[][];
+      expect(data.map(curve => curve[0].x)).toEqual(['Feb', 'Jan']);
+      expect(data[0]).toHaveLength(2);
+    });
+
+    it('drops a sample carrying no density rather than filling in a zero', () => {
+      const layer = convertRechartsToMaidr({
+        ...ridgelineConfig,
+        data: [samples[0], { month: 'Jan', temp: 4, plotted: 2.2 }, samples[1]],
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as ViolinKdePoint[][];
+      expect(data[0]).toEqual([
+        { x: 'Jan', y: -4, density: 0.06 },
+        { x: 'Jan', y: 0, density: 0.11 },
+      ]);
+    });
+
+    it('names the density axis and targets one band per group', () => {
+      const layer = convertRechartsToMaidr(ridgelineConfig).subplots[0][0].layers[0];
+
+      expect(layer.axes?.z).toEqual({ label: 'Density' });
+      // RidgelineTrace wants one element per ridge, not one per sample.
+      expect(layer.selectors).toBe('#maidr-article-temps .recharts-area .recharts-area-area');
+    });
+
+    it('refuses the reading when nothing resolves as a density', () => {
+      // Only the plotted column is present, and reading that as the density
+      // would report each group's loudness as a function of where it was
+      // stacked.
+      expect(() => convertRechartsToMaidr({
+        ...ridgelineConfig,
+        data: samples.map(({ month, temp, plotted }) => ({ month, temp, plotted })),
+        ridgelineConfig: { groupKey: 'month', valueKey: 'temp' },
+      })).toThrow('RechartsAdapter');
+    });
+
+    it('throws when no groupKey is declared', () => {
+      expect(() => convertRechartsToMaidr({
+        ...ridgelineConfig,
+        ridgelineConfig: undefined,
+      })).toThrow('RechartsAdapter');
+    });
+  });
+
+  describe('hexbin plot', () => {
+    // Two lattice rows, the lower one staggered half a cell against the upper.
+    const bins = [
+      { cx: 0.5, cy: 1000, count: 12 },
+      { cx: 1.5, cy: 1000, count: 30 },
+      { cx: 1, cy: 1500, count: 7 },
+      { cx: 2, cy: 1500, count: 4 },
+    ];
+
+    const hexbinConfig: RechartsAdapterConfig = {
+      id: 'diamonds',
+      title: 'Carat against Price',
+      data: bins,
+      chartType: 'hexbin',
+      xKey: 'cx',
+      yKeys: ['cy'],
+      hexbinConfig: { countKey: 'count' },
+      xLabel: 'Carat',
+      yLabel: 'Price ($)',
+    };
+
+    it('assembles a lattice: rows from the bottom up, each left to right', () => {
+      const layer = convertRechartsToMaidr(hexbinConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.HEXBIN);
+
+      const data = layer.data as HexbinPoint[][];
+      expect(data).toEqual([
+        [{ x: 0.5, y: 1000, count: 12 }, { x: 1.5, y: 1000, count: 30 }],
+        [{ x: 1, y: 1500, count: 7 }, { x: 2, y: 1500, count: 4 }],
+      ]);
+    });
+
+    it('orders a shuffled bin list into the lattice, and drops the selectors', () => {
+      const layer = convertRechartsToMaidr({
+        ...hexbinConfig,
+        data: [bins[3], bins[1], bins[2], bins[0]],
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as HexbinPoint[][];
+      expect(data[0].map(bin => bin.x)).toEqual([0.5, 1.5]);
+      expect(data[1].map(bin => bin.x)).toEqual([1, 2]);
+      // A <Scatter> draws its symbols in row order, so a list that is not
+      // already in lattice order would highlight the wrong bin.
+      expect(layer.selectors).toBeUndefined();
+    });
+
+    it('targets one symbol per bin when the rows arrive in lattice order', () => {
+      const layer = convertRechartsToMaidr(hexbinConfig).subplots[0][0].layers[0];
+
+      expect(layer.selectors).toBe('#maidr-article-diamonds .recharts-scatter-symbol .recharts-shape > *');
+      expect(layer.axes?.z).toEqual({ label: 'Count' });
+    });
+
+    it('groups rows by a declared rowKey rather than by the y centre', () => {
+      const layer = convertRechartsToMaidr({
+        ...hexbinConfig,
+        // Two bins on lattice row 0 whose centres differ, which grouping by y
+        // alone would split into two rows of one.
+        data: [
+          { cx: 0.5, cy: 1000, count: 12, r: 0 },
+          { cx: 1.5, cy: 1001, count: 30, r: 0 },
+          { cx: 1, cy: 1500, count: 7, r: 1 },
+        ],
+        hexbinConfig: { countKey: 'count', rowKey: 'r' },
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as HexbinPoint[][];
+      expect(data).toHaveLength(2);
+      expect(data[0]).toHaveLength(2);
+    });
+
+    it('reads a count from a length field, as a d3-hexbin bin carries it', () => {
+      const layer = convertRechartsToMaidr({
+        ...hexbinConfig,
+        data: [{ cx: 0.5, cy: 1000, length: 12 }],
+        hexbinConfig: undefined,
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as HexbinPoint[][];
+      expect(data[0][0]).toEqual({ x: 0.5, y: 1000, count: 12 });
+    });
+
+    it('drops a bin missing any of its three numbers', () => {
+      const layer = convertRechartsToMaidr({
+        ...hexbinConfig,
+        data: [bins[0], { cx: 3, cy: 1000 }, bins[1]],
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as HexbinPoint[][];
+      expect(data).toEqual([[
+        { x: 0.5, y: 1000, count: 12 },
+        { x: 1.5, y: 1000, count: 30 },
+      ]]);
+    });
+
+    it('throws when no row carries a centre and a count', () => {
+      expect(() => convertRechartsToMaidr({
+        ...hexbinConfig,
+        data: [{ cx: 0.5, cy: 1000 }],
+      })).toThrow('RechartsAdapter');
+    });
+  });
+
+  describe('boxen plot', () => {
+    const distributions = [
+      {
+        region: 'East',
+        median: 180,
+        levels: [{ p: 0.25, lo: 150, hi: 240 }, { p: 0.125, lo: 130, hi: 310 }],
+        high: [820, 910],
+      },
+      {
+        region: 'West',
+        median: 210,
+        levels: [{ p: 0.25, lo: 175, hi: 260 }],
+        low: [40],
+      },
+    ];
+
+    const boxenConfig: RechartsAdapterConfig = {
+      id: 'latency',
+      title: 'Response Time by Region',
+      data: distributions,
+      chartType: 'boxen',
+      xKey: 'region',
+      boxenConfig: { lowerOutliersKey: 'low', upperOutliersKey: 'high' },
+      xLabel: 'Region',
+      yLabel: 'Milliseconds',
+    };
+
+    it('builds one ladder per distribution', () => {
+      const layer = convertRechartsToMaidr(boxenConfig).subplots[0][0].layers[0];
+
+      expect(layer.type).toBe(TraceType.BOXEN);
+
+      const data = layer.data as BoxenPoint[];
+      expect(data).toEqual([
+        {
+          z: 'East',
+          median: 180,
+          levels: [{ p: 0.25, lo: 150, hi: 240 }, { p: 0.125, lo: 130, hi: 310 }],
+          upperOutliers: [820, 910],
+        },
+        {
+          z: 'West',
+          median: 210,
+          levels: [{ p: 0.25, lo: 175, hi: 260 }],
+          lowerOutliers: [40],
+        },
+      ]);
+    });
+
+    it('drops a rung whose three numbers are not all finite', () => {
+      const layer = convertRechartsToMaidr({
+        ...boxenConfig,
+        data: [{
+          region: 'East',
+          median: 180,
+          levels: [
+            { p: 0.25, lo: 150, hi: 240 },
+            { p: 0.125, lo: null, hi: 310 },
+            { p: 0.0625, lo: 90 },
+          ],
+        }],
+      }).subplots[0][0].layers[0];
+
+      // A rung missing a bound would be announced as a percentile the sample
+      // was never asked for.
+      const data = layer.data as BoxenPoint[];
+      expect(data[0].levels).toEqual([{ p: 0.25, lo: 150, hi: 240 }]);
+    });
+
+    it('reads the ladder from a letterValues column when no key is declared', () => {
+      const layer = convertRechartsToMaidr({
+        ...boxenConfig,
+        data: [{ region: 'East', q2: 180, letterValues: [{ p: 0.25, lo: 150, hi: 240 }] }],
+        boxenConfig: undefined,
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as BoxenPoint[];
+      expect(data[0]).toEqual({
+        z: 'East',
+        median: 180,
+        levels: [{ p: 0.25, lo: 150, hi: 240 }],
+      });
+    });
+
+    it('drops a distribution with no median', () => {
+      const layer = convertRechartsToMaidr({
+        ...boxenConfig,
+        data: [distributions[0], { region: 'North', levels: [{ p: 0.25, lo: 1, hi: 2 }] }],
+      }).subplots[0][0].layers[0];
+
+      expect((layer.data as BoxenPoint[]).map(point => point.z)).toEqual(['East']);
+    });
+
+    it('throws when no distribution carries a median', () => {
+      expect(() => convertRechartsToMaidr({
+        ...boxenConfig,
+        data: [{ region: 'East', levels: [] }],
+      })).toThrow('RechartsAdapter');
+    });
+
+    it('generates no selector, since a rung is not a distribution', () => {
+      const layer = convertRechartsToMaidr(boxenConfig).subplots[0][0].layers[0];
+
+      // The rungs are stacked <Bar>s: one rectangle per rung per category,
+      // and no class name says which rung is which.
+      expect(layer.selectors).toBeUndefined();
+      expect(layer.orientation).toBe(Orientation.VERTICAL);
+
+      const overridden = convertRechartsToMaidr({
+        ...boxenConfig,
+        orientation: Orientation.HORIZONTAL,
+        selectorOverride: '.boxen-outer .recharts-rectangle',
+      }).subplots[0][0].layers[0];
+      expect(overridden.selectors).toBe('.boxen-outer .recharts-rectangle');
+      expect(overridden.orientation).toBe(Orientation.HORIZONTAL);
     });
   });
 

--- a/test/adapters/recharts/markDom.test.ts
+++ b/test/adapters/recharts/markDom.test.ts
@@ -113,6 +113,43 @@ const icicleBands = [
   { name: 'Fiji', depth: '1', from: 100, to: 101 },
 ];
 
+// A parallel coordinates plot is drawn from the TRANSPOSE of its
+// observations, min-max normalised onto one scale, because a `<Line>` binds to
+// a single yAxisId. The adapter is given the observations with their raw
+// values; the chart is given these rows, one per axis and one `<Line>` per
+// observation.
+const carRows = [
+  { car: 'Mazda RX4', mpg: 21, hp: 110, wt: 2.62 },
+  { car: 'Datsun 710', mpg: 22.8, hp: 93, wt: 2.32 },
+  { car: 'Hornet', mpg: 21.4, hp: 110, wt: 3.215 },
+  { car: 'Valiant', mpg: 18.1, hp: 105, wt: 3.46 },
+];
+const carAxisRows = [
+  { axis: 'mpg', obs0: 0.62, obs1: 1, obs2: 0.7, obs3: 0 },
+  { axis: 'hp', obs0: 1, obs1: 0, obs2: 1, obs3: 0.71 },
+  { axis: 'wt', obs0: 0.26, obs1: 0, obs2: 0.79, obs3: 1 },
+];
+
+// One row per KDE sample. `plotted` is the density with the group's ridge
+// offset added — what the `<Area>` draws, and what the payload must not carry.
+const ridgeSamples = [
+  { month: 'Jan', temp: -4, density: 0.06, plotted: 2.06 },
+  { month: 'Jan', temp: 0, density: 0.11, plotted: 2.11 },
+  { month: 'Jan', temp: 4, density: 0.02, plotted: 2.02 },
+  { month: 'Feb', temp: -2, density: 0.08, plotted: 1.08 },
+  { month: 'Feb', temp: 2, density: 0.13, plotted: 1.13 },
+  { month: 'Feb', temp: 6, density: 0.04, plotted: 1.04 },
+];
+
+// Two lattice rows, the upper staggered half a cell against the lower, already
+// in lattice order — which is what lets the adapter emit selectors at all.
+const hexBins = [
+  { cx: 0.5, cy: 1000, count: 12 },
+  { cx: 1.5, cy: 1000, count: 30 },
+  { cx: 1, cy: 1500, count: 7 },
+  { cx: 2, cy: 1500, count: 4 },
+];
+
 const configs = {
   funnel: {
     id: 'funnel-dom',
@@ -222,6 +259,31 @@ const configs = {
     yKeys: ['value'],
     flowConfig: { targetKey: 'target', nodes: flowNodes },
   },
+  parallel: {
+    id: 'parallel-dom',
+    data: carRows,
+    chartType: 'parallel' as const,
+    xKey: 'car',
+    parallelConfig: {
+      dimensions: ['mpg', 'hp', { label: 'Weight (1000 lb)', key: 'wt' }],
+      labelKey: 'car',
+    },
+  },
+  ridgeline: {
+    id: 'ridgeline-dom',
+    data: ridgeSamples,
+    chartType: 'ridgeline' as const,
+    xKey: 'temp',
+    ridgelineConfig: { groupKey: 'month', valueKey: 'temp', densityKey: 'density' },
+  },
+  hexbin: {
+    id: 'hexbin-dom',
+    data: hexBins,
+    chartType: 'hexbin' as const,
+    xKey: 'cx',
+    yKeys: ['cy'],
+    hexbinConfig: { countKey: 'count' },
+  },
   polarArea: {
     id: 'polar-dom',
     data: coxcombData,
@@ -297,6 +359,8 @@ beforeAll(async () => {
   const { createElement, act } = await import('react');
   const { createRoot } = await import('react-dom/client');
   const {
+    Area,
+    AreaChart,
     Bar,
     BarChart,
     ErrorBar,
@@ -317,6 +381,23 @@ beforeAll(async () => {
     YAxis,
   } = await import('recharts');
   const { MaidrRecharts } = await import('@adapters/recharts/MaidrRecharts');
+
+  /**
+   * The custom mark a hexbin draws: Recharts has no hexagon among its own
+   * symbol types, so a `<Scatter shape>` renders whatever this returns —
+   * inside Recharts' own `g.recharts-shape` wrapper, which is what the
+   * adapter's selector targets.
+   *
+   * @param props - The point Recharts places, carrying its centre
+   * @returns One hexagon
+   */
+  function Hexagon(props: unknown): ReactElement {
+    const { cx, cy } = props as { cx: number; cy: number };
+    const points = [[-6, 0], [-3, -5], [3, -5], [6, 0], [3, 5], [-3, 5]]
+      .map(([dx, dy]) => `${cx + dx},${cy + dy}`)
+      .join(' ');
+    return createElement('polygon', { points, fill: '#8884d8' });
+  }
 
   function wrap(config: (typeof configs)[keyof typeof configs], chart: ReactElement): ReactElement {
     return createElement(MaidrRecharts, { ...config, children: null }, chart);
@@ -433,6 +514,45 @@ beforeAll(async () => {
         height: 300,
         data: { nodes: flowNodes, links: flowLinks },
       })),
+      wrap(configs.parallel, createElement(
+        LineChart,
+        { width: 320, height: 220, data: carAxisRows },
+        createElement(XAxis, { dataKey: 'axis' }),
+        createElement(YAxis, { type: 'number' }),
+        // One `<Line>` per OBSERVATION, over the normalised transpose.
+        ...carRows.map((row, index) => createElement(Line, {
+          key: row.car,
+          dataKey: `obs${index}`,
+          isAnimationActive: false,
+        })),
+      )),
+      wrap(configs.ridgeline, createElement(
+        AreaChart,
+        { width: 320, height: 220 },
+        createElement(XAxis, { dataKey: 'temp', type: 'number' }),
+        createElement(YAxis, { type: 'number' }),
+        // One `<Area>` per group, declared in the order the groups first
+        // appear in the data — which is the order the payload carries them in.
+        createElement(Area, {
+          data: ridgeSamples.filter(sample => sample.month === 'Jan'),
+          dataKey: 'plotted',
+          isAnimationActive: false,
+        }),
+        createElement(Area, {
+          data: ridgeSamples.filter(sample => sample.month === 'Feb'),
+          dataKey: 'plotted',
+          isAnimationActive: false,
+        }),
+      )),
+      wrap(configs.hexbin, createElement(
+        ScatterChart,
+        { width: 320, height: 220 },
+        createElement(XAxis, { dataKey: 'cx', type: 'number' }),
+        createElement(YAxis, { dataKey: 'cy', type: 'number' }),
+        // Recharts has no hexagon symbol, so a hexbin always draws a custom
+        // shape — which is exactly what the selector has to survive.
+        createElement(Scatter, { data: hexBins, shape: Hexagon, isAnimationActive: false }),
+      )),
       wrap(configs.polarArea, createElement(
         PieChart,
         { width: 320, height: 320 },
@@ -553,6 +673,33 @@ describe('recharts rendered mark contract', () => {
   it('matches one pie sector per polar area spoke', () => {
     expect(document.querySelectorAll(firstSelector(maidr.polarArea)))
       .toHaveLength(coxcombData.length);
+  });
+
+  it('matches one curve path per parallel coordinates observation', () => {
+    // `ParallelTrace` inherits `LineTrace`'s resolution: one selector per row,
+    // each resolving to that observation's own polyline.
+    const { selectors } = maidr.parallel.subplots[0][0].layers[0];
+    expect(selectors).toHaveLength(carRows.length);
+    expect(document.querySelectorAll(firstSelector(maidr.parallel)))
+      .toHaveLength(carRows.length);
+  });
+
+  it('matches one filled band per ridgeline group', () => {
+    // One element per RIDGE, not per sample: `RidgelineTrace` lights a group's
+    // whole curve from any sample of it, and withdraws on any other count.
+    const groups = new Set(ridgeSamples.map(sample => sample.month)).size;
+    expect(document.querySelectorAll(firstSelector(maidr.ridgeline)))
+      .toHaveLength(groups);
+  });
+
+  it('matches one custom hexagon per hexbin, lattice order and all', () => {
+    const marks = document.querySelectorAll(firstSelector(maidr.hexbin));
+    expect(marks).toHaveLength(hexBins.length);
+    // Every mark is the drawn shape rather than the group around it, which is
+    // what a highlight can be cloned from.
+    for (const mark of marks) {
+      expect(mark.tagName).toBe('polygon');
+    }
   });
 
   it('scopes every selector to its own chart', () => {


### PR DESCRIPTION
# Pull Request

## Description

The Recharts adapter coverage PR deferred four trace types. This reads all four
of them: parallel coordinates, ridgeline, hexbin and boxen. Each one gets a
typed config prop, a converter that emits the exact payload shape
`src/type/grammar.ts` declares, a highlight selector wired in the same change as
the detection, unit tests, a rendered-DOM test for the selector, a runnable
example and a documented section.

Nothing outside the adapter moved. `src/type/declaration.ts` and
`src/adapters/shared/traceDeclaration.ts` — the foundation merged in #886 that
the sibling adapters depend on — are untouched; this adapter consumes
`resolveFieldRef` from the latter and changes nothing about it.

## Related Issues

Part of #885

## Changes Made

### Trace types added

- **`parallel` → `TraceType.PARALLEL`.** New `ParallelAxesConfig`
  (`dimensions: (string | { label?, key })[]`, `labelKey?`).
  `buildParallelLayer` emits `LinePoint[][]`, one row per observation, `x` = the
  axis label, `y` = the **raw** field value (not the normalised value the chart
  has to draw), `z` = the observation's name. Highlighting: one
  `.recharts-line .recharts-line-curve` selector per observation —
  `LineTrace`'s path-parsing branch turns each polyline's own vertices into
  per-value marks. Selectors are withheld in the single degenerate shape where
  observations === axes, because `LineTrace`'s element-first branch would then
  match on count and light whole polylines instead.

- **`ridgeline` → `TraceType.RIDGELINE`.** New `RidgelineCurveConfig`
  (`groupKey`, `valueKey?`, `densityKey?`). `buildRidgelineLayer` emits
  `ViolinKdePoint[][]`, one curve per group in first-appearance order, carrying
  the density **before** the ridge offset the chart adds for drawing. Samples
  missing a value or a density are dropped rather than zero-filled; if no row
  anywhere resolves a density the layer is refused with a named error rather
  than falling back to the drawn y. `axes.z` is labelled `Density`.
  Highlighting: `.recharts-area .recharts-area-area` — exactly one filled band
  per `<Area>`, which is the one-element-per-group shape
  `RidgelineTrace.pairWith` requires.

- **`hexbin` → `TraceType.HEXBIN`.** New `HexbinLatticeConfig` (`xKey?`,
  `yKey?`, `countKey?`, `rowKey?`). `buildHexbinLayer` emits `HexbinPoint[][]`
  assembled as a lattice — rows grouped by y centre (12 significant digits, the
  same rounding the d3 binder uses) or by an explicit `rowKey`, ordered
  lowest-first, each row left to right. Centres stay in data units; the count
  defaults through the shared `count` chain so a `d3-hexbin` bin's `length`
  resolves untouched. Bins missing any of their three numbers are dropped; an
  empty result throws. `axes.z` is labelled `Count`. Highlighting:
  `.recharts-scatter-symbol .recharts-shape > *`, emitted only when the rows
  already arrive in lattice order, since a `<Scatter>` draws in data order while
  the payload is re-sorted.

- **`boxen` → `TraceType.BOXEN`.** New `BoxenLadderConfig` (`xKey?`,
  `medianKey?`, `levelsKey?`, `lowerOutliersKey?`, `upperOutliersKey?`).
  `buildBoxenLayer` emits `BoxenPoint[]`, one ladder per row, dropping a rung
  whose `p`/`lo`/`hi` are not all finite and a distribution with no finite
  median; an empty result throws. Orientation defaults to vertical.

### Trace type with no generated selector

- **`boxen`** gets **no** generated highlight selector. Recharts has no box
  primitive: a letter-value plot is drawn as stacked `<Bar>`s over a transparent
  base, so the rectangles are one per *rung per distribution* and no class names
  which rung is which, while `BoxenTrace` wants exactly one element per
  *distribution*. Highlighting therefore rides `selectorOverride` — the author
  puts a `className` on the single `<Bar>` drawing the outermost rung — which
  both the example and the docs demonstrate. Sonification, text and braille are
  unaffected.

### Threading and surface

The four `*Config` props are added to `RechartsAdapterConfig`, to the subplot
panel merge in `buildPanelSubplot`, to the `<MaidrRecharts>` and
`useRechartsAdapter` destructures and dependency arrays, and re-exported from
`src/adapters/recharts/index.ts`. Composed mode rejects all four with the
existing "describes a whole chart" error. The four are dispatched in
`buildSimpleLayers` before the `yKeys` requirement, because none of them has a
series — their fields are all named by their own config; both existing
"missing chartType/yKeys" error tests still pass unchanged.

### Tests

Four new describe blocks (25 cases) in
`test/adapters/recharts/converters.test.ts`, plus three rendered-DOM cases in
`markDom.test.ts` that mount real Recharts charts in jsdom (including a custom
hexagon shape) and count what each emitted selector actually resolves to. The
selector counts were established by rendering, not read off documentation, and
each DOM case was checked to fail against a wrong selector.

### Examples and docs

`ParallelCoordinatesExample`, `RidgelineExample`, `HexbinExample` and
`BoxenExample` under `examples/recharts/examples/`, registered in
`examples/recharts/App.tsx`. Each draws the chart the way Recharts really forces
it (normalised transpose, offset areas, custom hexagon shape, stacked rungs)
while handing MAIDR the untransformed values. `docs/recharts.md` gains four rows
in the supported-types table, four prose sections with code, four config type
blocks, the updated union and an amended props table.

## Screenshots (if applicable)

Not applicable — no visual change to MAIDR's own UI.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is unticked deliberately: the automated gate below was run
in full, but `ManualTestingProcess.md` was not walked with a screen reader.

## Additional Notes

### Verification

`npm run lint:fix` clean (no changes produced), `npm run type-check` clean,
`npm run build` succeeded, `npm test` green — 268 suites / 3799 tests in the
unit+component projects and 7 suites / 73 tests in the ESM project, exit 0.
`npx jest test/adapters/recharts` is 220 passing across 5 suites.

### Foundation gaps — relevant to the sibling adapter PRs

Nothing in the foundation was changed. Three gaps were found and worked around:

1. **`FIELD_REF_FALLBACKS` has no chain for a hexbin's `x`/`y`.** The shipped d3
   hexbin binder additionally accepts `x0`/`cx` and `y0`/`cy`
   (`src/adapters/d3/binders/hexbin.ts:136-137`). The shared module's own doc
   says an entry-less canonical name resolves under its own name only, so this
   looks deliberate — but it means a `d3-hexbin` bin object that works in the d3
   binder does not resolve through the shared chain, which is the class of
   divergence the shared module exists to prevent. Not changed; Recharts falls
   back to the chart's own `xKey`/`yKeys` instead.

2. **Nothing in the foundation covers the inside of a payload array.** A boxen's
   ladder is a list of `{ p, lo, hi }` rung objects, and the d3 binder accepts
   `p`/`prob`/`probability`/`depth`, `lo`/`lower`/`low`/`min`/`y0`,
   `hi`/`upper`/`high`/`max`/`y1` from its own private constants
   (`src/adapters/d3/binders/boxen.ts:23-30`). `resolveFieldRef` only reaches
   top-level row fields, so this adapter reads the grammar's exact
   `{ p, lo, hi }` spelling and documents it rather than duplicating d3's alias
   lists. If rung-key parity across adapters matters, that table belongs in the
   shared module.

3. **Only `resolveFieldRef` applies to Recharts.** `validateDeclaration`,
   `readDeclarationSlot`, `isFlagValue` and `warnUnresolvedRef` all assume a
   co-located declaration block or a per-row flag, whereas Recharts declares
   through typed props. That matches the convention's own statement that
   Recharts keeps its own readers; noted only so the export list is not read as
   unused-by-mistake.

### Spec corrections — relevant to the sibling adapter PRs

- **PARALLEL, "highlighting is not workable (one polyline per observation, no
  per-vertex marks aligned to the grid)."** Not so.
  `LineTrace.mapViaPathParsing` (`src/model/line.ts:735-800`) exists for exactly
  this shape: N identical selectors resolve via `Svg.selectNthElement` to the
  r-th path, whose vertices become synthetic per-value marks. Implemented. The
  real hazard is upstream — `mapViaDomElements` (`line.ts:700-726`) accepts an
  element match whose count equals the row's length, so when
  observations === axes it would pair whole polylines with values; the adapter
  withholds selectors in that one case.

- **RIDGELINE, "no per-point marks, so omit selectors."** Not so.
  `RidgelineTrace.pairWith` (`src/model/ridgeline.ts:121-126`) wants exactly one
  element per group and lights that ridge from any sample, and Recharts renders
  one `path.recharts-area-area` per `<Area>` (verified by rendering in jsdom).
  A single scoped selector is emitted, matching the d3 ridgeline binder's own
  comment.

- **HEXBIN, "omit selectors — there is no per-bin mark alignment for empty
  lattice cells."** The premise does not hold: the lattice is built only from
  the occupied bins the author passes, so the flat payload count always equals
  the number of drawn symbols and `HexbinTrace`'s count check never trips on
  emptiness. The real risk is row *order*, since `<Scatter>` draws in data order
  while the payload is re-sorted into the lattice. Selectors are emitted when
  the rows already arrive in lattice order and withheld otherwise — the same
  conditional the shipped gantt builder uses.

- **HEXBIN, suggested selector `.recharts-scatter-symbol .recharts-symbols`.**
  Does not match a hexbin. Recharts has no hexagon among its symbol types, so a
  hexbin must pass a custom `shape`, and `ScatterSymbol` then renders the
  author's own element with no `.recharts-symbols` class. Both variants nest the
  drawn mark in `g.recharts-shape` inside `g.recharts-scatter-symbol`, so the
  adapter targets `.recharts-scatter-symbol .recharts-shape > *`.

- **The four configs were not added to `RechartsSubplotConfig`,** contrary to
  step 3 of the per-adapter spec. The shipped adapter deliberately gives no
  per-panel override to any per-type config — `buildPanelSubplot` passes
  `flowConfig`/`volcanoConfig`/`errorConfig`/`forestConfig`/`survivalConfig`/
  `waterfallConfig`/`ganttConfig`/`gaugeConfig` straight from the top level, with
  a comment explaining that per-type configs name fields and cutoffs which a
  facet grid shares by construction. Adding per-panel overrides for four of
  twelve would contradict that; the four are threaded through the panel merge
  exactly like the other eight.

- **Default field names differ from convention §2,** which gives
  `HexbinDeclaration.x`/`y` and `BoxenDeclaration.x` the defaults `'x'`/`'y'`.
  In Recharts the required top-level `xKey` (and, for a hexbin drawn as a
  `<Scatter>`, the first `yKeys` entry) is the established channel for exactly
  those facts, so the adapter resolves `hexbinConfig.xKey ?? xKey`,
  `hexbinConfig.yKey ?? yKeys[0] ?? 'y'` and `boxenConfig.xKey ?? xKey`. The
  declared key still wins; only the default differs, and it is documented on
  each field.

- **BOXEN, "the adapter does not support plain BOX today either."** Still true
  on current `main` (there is no `box` member of `RechartsChartType`), and BOXEN
  is indeed the first distribution type in this adapter — which is why it is the
  one of the four with no generated selector.

### One more decision worth a reviewer's eye

Where a required config is absent or nothing resolves at all, the builders throw
with a named message rather than warning. That follows the shipped Recharts
pattern (`gaugeConfig`, `flowConfig`, gantt's two `yKeys`) rather than the
convention's never-throw rule, which governs untyped co-located blocks in other
libraries; here the config is typed and the author is the caller.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_