### PR TITLE
feat(amcharts): read the chart types deferred out of the coverage PR

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -202,7 +202,9 @@ var estimate = chart.series.push(am5xy.LineSeries.new(root, {
 
 An absorbed companion is merged into the parent layer **by position**, not by index — a companion carrying fewer rows than the series it decorates still lines up — and it does not become a layer of its own. `openValueY` maps to `yMin` and `valueY` to `yMax` (`openValueX`/`valueX` on a horizontal chart); the bounds are **absolute positions** on the value axis, never offsets. An interval your data holds as an offset instead is declared with `error`, which takes a number for a symmetric interval or a `[lower, upper]` pair for an asymmetric one, both as positive magnitudes.
 
-The four roles are `intervalSeries` (error bar, forest), `censoredSeries` and `bandSeries` (survival), and `pooledSeries` (forest). A role naming no series is reported and the layer is emitted without that half.
+The four roles are `intervalSeries` (error bar, forest), `censoredSeries` and `bandSeries` (survival), and `pooledSeries` (forest). A role naming no series is reported and the layer is emitted without that half — as is a role naming a series that declares a layer of its own, or one another declaration has already absorbed, since reading a series into two layers would announce the same rows twice over.
+
+On a forest plot declaring both `intervalSeries` and `pooledSeries`, the interval companion covers the summary too: the join is by position, so a chart drawing every interval in one column series, the summary's included, has already said where the summary's interval is. The pooled series' own row fields and `error` offset still outrank it.
 
 ### Merging siblings
 

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -124,6 +124,12 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Lollipop | `ColumnSeries` | category axis + hairline `columns.template` width + bullets |
 | Word Cloud | `am5wc.WordCloud` | series class (requires `wc.js`) |
 | Bump (rank over time) | `LineSeries` | value axis renderer `inversed: true` **and** values that are a ranking; or the `bump` option |
+| Survival (Kaplan-Meier) | `StepLineSeries` | **declared** — `userData: { maidr: { type: "survival" } }` |
+| Error bar | any XY series, with a floating column behind it | **declared** — `{ type: "error_bar" }` |
+| Forest (meta-analysis) | horizontal `openValueXField` columns plus estimate marks | **declared** — `{ type: "forest" }` |
+| Volcano | hidden-stroke `LineSeries` with bullets, two value axes | **declared** — `{ type: "volcano" }` |
+| Manhattan | the same, one series per chromosome | **declared** — `{ type: "manhattan" }` |
+| Scatter | the same | **declared** — `{ type: "point" }` |
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
@@ -133,7 +139,78 @@ A `FunnelSeries` lives in the same `percent.js` module, inside a `SlicedChart` r
 
 `RadarLineSeries` and `RadarColumnSeries` need `radar.js` on top of `xy.js`; a `RadarChart` extends `XYChart`, so the binder finds it with the rest.
 
-> Box plots, candlestick, violin, and smooth/regression layers are **not** supported by the amCharts binder. Neither is **scatter**: amCharts draws one as a hidden-stroke `LineSeries` with bullets, which is also how it draws a dot plot, and the only thing separating them is the axis — so a hidden-stroke series on a **category** axis is read as a dot plot and the same series on two **value** axes stays a line chart rather than being announced as a scatter MAIDR would then read as a dot plot.
+The last seven rows are **declared** rather than detected — see [Declaring What a Chart Means](#declaring-what-a-chart-means) below.
+
+> Box plots, candlestick, violin, and smooth/regression layers are **not** supported by the amCharts binder, and neither are sankey, alluvial or chord diagrams (`am5flow`).
+
+## Declaring What a Chart Means
+
+Some readings amCharts leaves no signature for. A Kaplan-Meier curve and a step line are one series class. An error bar is a second series of floating columns, which is also how a waterfall and a dumbbell are drawn. A volcano, a Manhattan and a plain scatter are all a `LineSeries` with its stroke switched off and bullets pushed on, and so is a dot plot. Every one of those configurations is worn by an ordinary chart, so the adapter's heuristics cannot separate them and do not try: a step line read as a survival curve announces censoring the chart never carried, which is worse than reading it as the step line it is.
+
+What separates them is the author saying so, in the `userData` slot amCharts documents as *"a storage for any custom user data"*:
+
+```js
+var series = chart.series.push(am5xy.StepLineSeries.new(root, {
+  name: "Treated",
+  xAxis: xAxis, yAxis: yAxis, valueXField: "time", valueYField: "surv",
+  userData: { maidr: { type: "survival", censored: "censored" } },
+}));
+```
+
+`series.set("userData", { maidr: { … } })` works just as well, and the block survives JSON — so it can be written into a serialised chart config. A runnable page covering all five figures is at [`examples/amcharts-declared.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-declared.html).
+
+Two rules decide how every field is written:
+
+1. **A fact that differs per point names a column of your own data; a fact that is the same for the whole layer carries the value itself.** So `weight` is a field name and `nullValue` is a number.
+2. **Every field is spelled exactly like the grammar field it fills, and every field naming a column defaults to that same name.** A row that already carries a `censored` or a `weight` column needs nothing said about it.
+
+A field you leave out falls back to its canonical name and then to a short list of common spellings of it (`ciLower` for `yMin`, `isCensored` for `censored`, `chr` for `group`). A field you *do* name is used verbatim, because a name that misses is a mistake worth reporting rather than papering over — the adapter warns and leaves the field out. The column is looked up on the row you handed amCharts (`dataItem.dataContext`), not on the chart's own reading of it, so a column the series was never bound to is still reachable.
+
+**Nothing is guessed.** The four values that would invert a reading if guessed wrong — `significance`, `significanceDirection`, `effect` and `nullValue` — have no defaults at all. A chart that does not declare one gets the points, the intervals and the weights, and makes no claim about significance. A declaration the adapter cannot honour degrades the same way: it warns once, prefixed `[MAIDR amCharts]`, and reads the chart as whatever it was without the block.
+
+### What each type accepts
+
+| type | fields |
+|---|---|
+| `"survival"` | `censored`, `yMin`, `yMax`, `stepDirection`, `censoredSeries`, `bandSeries`, `merge` (default `true`) |
+| `"error_bar"` | `yMin`, `yMax`, `error`, `intervalSeries`, `orientation` |
+| `"forest"` | everything `error_bar` takes, plus `weight`, `pooled`, `pooledIndex`, `pooledSeries`, `nullValue` |
+| `"manhattan"` | `label`, `group`, `significance`, `significanceDirection`, `effect`, `merge` (default `true`) |
+| `"volcano"` | the same, with `merge` defaulting to `false` |
+| `"point"` | `label`, `merge` (default `false`) — note the value is `"point"`, not `"scatter"` |
+
+Every variant also accepts `title` (what the chart is called) and `name` (what this layer is called among its siblings). Any other key is reported and ignored, which is what catches a `significanse: 7.3` in plain JavaScript, where nothing else would.
+
+### Companion series
+
+A figure routinely spreads one layer over several series. The declaration names the extra one by its am5 `id` — `IEntitySettings.id`, which every am5 entity accepts. Setting an `id` on the companion is the one edit a working chart needs:
+
+```js
+// The interval: a column floating between `openValueY` and `valueY`.
+var interval = chart.series.push(am5xy.ColumnSeries.new(root, {
+  id: "ci",                      // ← the only edit this chart needs
+  xAxis: xAxis, yAxis: yAxis,
+  valueYField: "hi", openValueYField: "lo", categoryXField: "category",
+}));
+
+// The estimate, which declares the layer and absorbs the interval.
+var estimate = chart.series.push(am5xy.LineSeries.new(root, {
+  xAxis: xAxis, yAxis: yAxis, valueYField: "mean", categoryXField: "category",
+  userData: { maidr: { type: "error_bar", intervalSeries: "ci" } },
+}));
+```
+
+An absorbed companion is merged into the parent layer **by position**, not by index — a companion carrying fewer rows than the series it decorates still lines up — and it does not become a layer of its own. `openValueY` maps to `yMin` and `valueY` to `yMax` (`openValueX`/`valueX` on a horizontal chart); the bounds are **absolute positions** on the value axis, never offsets. An interval your data holds as an offset instead is declared with `error`, which takes a number for a symmetric interval or a `[lower, upper]` pair for an asymmetric one, both as positive magnitudes.
+
+The four roles are `intervalSeries` (error bar, forest), `censoredSeries` and `bandSeries` (survival), and `pooledSeries` (forest). A role naming no series is reported and the layer is emitted without that half.
+
+### Merging siblings
+
+A Manhattan is usually drawn as one series per chromosome, and a survival figure as one per arm. Both are **one** layer: `merge` folds every *following* sibling of the same drawn kind that carries no declaration of its own into the declared layer, so a reader gets one navigable trace rather than twenty-two layers to switch between. It is on by default for `survival` and `manhattan`, and off for `volcano` and `point`, whose sibling series are usually the comparison a reader wants kept apart. Set `merge: false` (or `true`) to say otherwise.
+
+### Highlighting a declared layer
+
+A survival curve, an error bar and a forest plot highlight like every other amCharts layer: the overlay outlines the mark the reader is on. A **volcano, Manhattan or scatter layer does not**. MAIDR's canvas overlay is driven by the position the navigation callback carries, and a scatter publishes a *binned grid* rather than its individual points — so a position there names a cell of that grid, and outlining the point that happens to sit at the same ordinal would put the box on the wrong gene. The overlay is cleared instead. Sonification, the text description, the findings a threshold produces and the point-level navigation are all unaffected; this is the visual highlight alone, and only on the three cloud types.
 
 ## Multi-Panel Charts
 
@@ -433,6 +510,8 @@ stems.bullets.push(function () {
 ```
 
 Both probes require the bullets, because either half alone is something else: a strokeless line with no bullets draws nothing, a line with bullets **and** a stroke is a line chart with markers, and a narrow bar chart with no bullets is a narrow bar chart. A stem width declared as a `Percent` is read as an ordinary bar — a column half its cell wide is not a hairline however small the number reads.
+
+The dot-plot probe also requires a **category** axis, and that is what keeps it apart from a scatter: the same drawing on two value axes is a scatter, a volcano or a Manhattan, and nothing about the configuration says which. So it stays a line chart unless the author declares one — see [Declaring What a Chart Means](#declaring-what-a-chart-means).
 
 ### Word Cloud
 

--- a/examples/amcharts-declared.html
+++ b/examples/amcharts-declared.html
@@ -1,0 +1,441 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Declared Traces</title>
+
+    <!-- 1. Load amCharts 5 (core + XY). Every chart here is an ordinary XY
+         chart: amCharts has no series class for any of these five. -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 700px;
+        height: 420px;
+      }
+      code { background: #f4f4f4; padding: 1px 4px; }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Declared Traces</h1>
+    <p>
+      Five readings amCharts leaves no signature for. A survival curve and a
+      step line are the same series class; an error bar is a floating column
+      behind another series; a volcano, a Manhattan and a plain scatter are all
+      a <code>LineSeries</code> with the stroke switched off. Every one of those
+      configurations is worn by an ordinary chart too, so the adapter does not
+      guess — the author says which it is, in the
+      <code>userData</code> slot amCharts documents as "a storage for any custom
+      user data":
+    </p>
+    <pre><code>am5xy.StepLineSeries.new(root, {
+  /* … the settings you already wrote … */
+  userData: { maidr: { type: "survival", censored: "censored" } },
+});</code></pre>
+    <p>
+      Every field is spelled exactly like the grammar field it fills, and every
+      field naming a column of your data defaults to that same name — so a row
+      that already carries a <code>censored</code> or a <code>weight</code>
+      column needs nothing said about it. Nothing is ever guessed: the values
+      that would invert a reading if guessed wrong (a significance cutoff, a
+      forest plot's null line) have no defaults at all, and a chart that does
+      not declare one simply makes no claim.
+    </p>
+
+    <h2>Survival: a Kaplan-Meier curve, censoring and all</h2>
+    <div id="survival-chart" class="chart"></div>
+
+    <h2>Error bar: an estimate and the column drawing its interval</h2>
+    <div id="errorbar-chart" class="chart"></div>
+
+    <h2>Forest: a meta-analysis, with weights and a pooled summary</h2>
+    <div id="forest-chart" class="chart"></div>
+
+    <h2>Volcano: effect size against significance</h2>
+    <div id="volcano-chart" class="chart"></div>
+
+    <h2>Manhattan: three chromosomes read as one cloud</h2>
+    <div id="manhattan-chart" class="chart"></div>
+
+    <script>
+      // Collects { root, options } for each chart so the block below can mount
+      // MAIDR once amCharts finishes rendering.
+      window.__amBindings = [];
+
+      function register(root, options) {
+        window.__amBindings.push({ root: root, options: options });
+      }
+
+      /** An XY chart on two value axes. */
+      function valueChart(elId) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        var xAxis = chart.xAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererX.new(root, {}) })
+        );
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) })
+        );
+        return { root: root, chart: chart, xAxis: xAxis, yAxis: yAxis };
+      }
+
+      /** An XY chart with the categories on the X axis. */
+      function categoryChart(elId, categories) {
+        var root = am5.Root.new(elId);
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        var xAxis = chart.xAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "category",
+            renderer: am5xy.AxisRendererX.new(root, {}),
+          })
+        );
+        xAxis.data.setAll(categories);
+        var yAxis = chart.yAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererY.new(root, {}) })
+        );
+        return { root: root, chart: chart, xAxis: xAxis, yAxis: yAxis };
+      }
+
+      /** Circle bullets, which is how amCharts draws a point. */
+      function addBullets(root, series, radius) {
+        series.bullets.push(function () {
+          return am5.Bullet.new(root, {
+            sprite: am5.Circle.new(root, {
+              radius: radius,
+              fill: series.get("fill"),
+            }),
+          });
+        });
+      }
+
+      // --- Survival ------------------------------------------------------
+      // Two step lines, and one declaration. `censored` names the column on
+      // the author's own rows: the chart was never bound to it, so nothing but
+      // the declaration can reach it. The second arm needs no block of its
+      // own — `merge` is on by default for a survival figure, because treated
+      // and control are read against each other.
+      var TREATED = [
+        { time: 0, surv: 1.0, censored: false },
+        { time: 4, surv: 0.94, censored: false },
+        { time: 9, surv: 0.94, censored: true },
+        { time: 14, surv: 0.81, censored: false },
+        { time: 22, surv: 0.74, censored: true },
+        { time: 30, surv: 0.68, censored: false },
+      ];
+      var CONTROL = [
+        { time: 0, surv: 1.0, censored: false },
+        { time: 3, surv: 0.88, censored: false },
+        { time: 8, surv: 0.72, censored: false },
+        { time: 15, surv: 0.55, censored: true },
+        { time: 24, surv: 0.41, censored: false },
+        { time: 30, surv: 0.33, censored: false },
+      ];
+
+      (function () {
+        var built = valueChart("survival-chart");
+        var treated = built.chart.series.push(
+          am5xy.StepLineSeries.new(built.root, {
+            name: "Treated",
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueXField: "time",
+            valueYField: "surv",
+            // A Kaplan-Meier curve holds until an event drops it, which is
+            // what `stepDirection: "hv"` says. MAIDR substitutes no default,
+            // so declaring it is what keeps the description from staying
+            // silent about the convention.
+            userData: {
+              maidr: { type: "survival", censored: "censored", stepDirection: "hv" },
+            },
+          })
+        );
+        treated.data.setAll(TREATED);
+
+        var control = built.chart.series.push(
+          am5xy.StepLineSeries.new(built.root, {
+            name: "Control",
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueXField: "time",
+            valueYField: "surv",
+          })
+        );
+        control.data.setAll(CONTROL);
+
+        register(built.root, {
+          title: "Overall Survival by Arm",
+          axisLabels: { x: "Months since randomisation", y: "Surviving fraction" },
+        });
+      })();
+
+      // --- Error bar -----------------------------------------------------
+      // The interval is a second series: a column floating between
+      // `openValueY` and `valueY`. `intervalSeries` names it by its am5 `id`,
+      // which is the one edit this chart needs — set an `id` on the series
+      // drawing the interval. It is then absorbed into the estimate's layer
+      // rather than announced as a chart of its own.
+      var TREATMENTS = [
+        { category: "Placebo", mean: 4.1, lo: 3.4, hi: 4.8 },
+        { category: "Low dose", mean: 5.6, lo: 5.0, hi: 6.2 },
+        { category: "High dose", mean: 7.2, lo: 6.1, hi: 8.3 },
+      ];
+
+      (function () {
+        var built = categoryChart("errorbar-chart", TREATMENTS);
+        var interval = built.chart.series.push(
+          am5xy.ColumnSeries.new(built.root, {
+            id: "ci",
+            name: "95% CI",
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueYField: "hi",
+            openValueYField: "lo",
+            categoryXField: "category",
+          })
+        );
+        interval.columns.template.setAll({ width: 2 });
+        interval.data.setAll(TREATMENTS);
+
+        var estimate = built.chart.series.push(
+          am5xy.LineSeries.new(built.root, {
+            name: "Mean response",
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueYField: "mean",
+            categoryXField: "category",
+            userData: { maidr: { type: "error_bar", intervalSeries: "ci" } },
+          })
+        );
+        estimate.strokes.template.setAll({ strokeOpacity: 0 });
+        addBullets(built.root, estimate, 7);
+        estimate.data.setAll(TREATMENTS);
+
+        register(built.root, {
+          title: "Mean Response by Treatment",
+          axisLabels: { x: "Treatment", y: "Response" },
+        });
+      })();
+
+      // --- Forest --------------------------------------------------------
+      // Everything the error bar needs, plus the three things a meta-analysis
+      // carries that a row of intervals does not: the weight each study
+      // contributes, which row is the pooled result rather than evidence, and
+      // where the null line sits. `nullValue` has no default on purpose — 0
+      // guessed for an odds ratio would report every study as not crossing.
+      var STUDIES = [
+        { category: "Ross 1998", or: 0.82, lo: 0.61, hi: 1.1, weight: 0.18, pooled: false },
+        { category: "Patel 2004", or: 1.14, lo: 0.92, hi: 1.41, weight: 0.31, pooled: false },
+        { category: "Okafor 2011", or: 0.67, lo: 0.44, hi: 1.02, weight: 0.14, pooled: false },
+        { category: "Lindqvist 2019", or: 0.79, lo: 0.65, hi: 0.96, weight: 0.24, pooled: false },
+        { category: "Pooled", or: 0.86, lo: 0.76, hi: 0.97, weight: 0.13, pooled: true },
+      ];
+
+      (function () {
+        var root = am5.Root.new("forest-chart");
+        var chart = root.container.children.push(
+          am5xy.XYChart.new(root, { layout: root.verticalLayout })
+        );
+        var yAxis = chart.yAxes.push(
+          am5xy.CategoryAxis.new(root, {
+            categoryField: "category",
+            renderer: am5xy.AxisRendererY.new(root, { inversed: true }),
+          })
+        );
+        yAxis.data.setAll(STUDIES);
+        var xAxis = chart.xAxes.push(
+          am5xy.ValueAxis.new(root, { renderer: am5xy.AxisRendererX.new(root, {}) })
+        );
+
+        var interval = chart.series.push(
+          am5xy.ColumnSeries.new(root, {
+            id: "ci",
+            name: "95% CI",
+            xAxis: xAxis,
+            yAxis: yAxis,
+            valueXField: "hi",
+            openValueXField: "lo",
+            categoryYField: "category",
+          })
+        );
+        interval.columns.template.setAll({ height: 2 });
+        interval.data.setAll(STUDIES);
+
+        var effect = chart.series.push(
+          am5xy.LineSeries.new(root, {
+            name: "Odds ratio",
+            xAxis: xAxis,
+            yAxis: yAxis,
+            valueXField: "or",
+            categoryYField: "category",
+            // `weight` and `pooled` are spelled exactly like the grammar
+            // fields they fill, and the rows already carry both — so neither
+            // has to be named here. They are, to show where they would go.
+            userData: {
+              maidr: {
+                type: "forest",
+                intervalSeries: "ci",
+                weight: "weight",
+                pooled: "pooled",
+                nullValue: 1,
+              },
+            },
+          })
+        );
+        effect.strokes.template.setAll({ strokeOpacity: 0 });
+        addBullets(root, effect, 7);
+        effect.data.setAll(STUDIES);
+
+        register(root, {
+          title: "Odds of Relapse: Meta-analysis",
+          axisLabels: { x: "Odds ratio", y: "Study" },
+        });
+      })();
+
+      // --- Volcano -------------------------------------------------------
+      // A scatter recipe: a LineSeries with its stroke switched off and
+      // bullets pushed on. Undeclared it reads as a line chart, which is the
+      // misannouncement this block exists to correct. The gene name is the
+      // payload — a reader told "x is -2.4, y is 9.1" has been handed the two
+      // numbers whose shape they can already hear.
+      var GENES = [
+        { gene: "BRCA1", lfc: -2.4, sig: 9.1 },
+        { gene: "TP53", lfc: 2.9, sig: 11.4 },
+        { gene: "EGFR", lfc: 1.7, sig: 4.2 },
+        { gene: "MYC", lfc: 0.4, sig: 0.9 },
+        { gene: "ACTB", lfc: 0.1, sig: 0.2 },
+        { gene: "PTEN", lfc: -1.8, sig: 6.6 },
+        { gene: "KRAS", lfc: 0.9, sig: 1.1 },
+        { gene: "VEGFA", lfc: -0.6, sig: 0.7 },
+      ];
+
+      (function () {
+        var built = valueChart("volcano-chart");
+        var series = built.chart.series.push(
+          am5xy.LineSeries.new(built.root, {
+            name: "Differential expression",
+            xAxis: built.xAxis,
+            yAxis: built.yAxis,
+            valueXField: "lfc",
+            valueYField: "sig",
+            userData: {
+              maidr: {
+                type: "volcano",
+                label: "gene",
+                // On a -log10(p) axis, 1.3 is p < 0.05. There is no default:
+                // a guessed line would sort every gene onto the wrong side.
+                significance: 1.3,
+                effect: 1,
+              },
+            },
+          })
+        );
+        series.strokes.template.setAll({ strokeOpacity: 0 });
+        addBullets(built.root, series, 5);
+        series.data.setAll(GENES);
+
+        register(built.root, {
+          title: "Differential Expression",
+          axisLabels: { x: "log2 fold change", y: "-log10(p)" },
+        });
+      })();
+
+      // --- Manhattan -----------------------------------------------------
+      // One series per chromosome is how these are drawn, and all of them are
+      // one cloud: `merge` is on by default for a Manhattan, so the following
+      // series need no block of their own and a reader gets one navigable
+      // trace rather than three layers to switch between.
+      var CHROMOSOMES = [
+        {
+          name: "chr1",
+          points: [
+            { snp: "rs1041", pos: 12, logp: 2.1, chr: "1" },
+            { snp: "rs2276", pos: 31, logp: 8.4, chr: "1" },
+            { snp: "rs3891", pos: 58, logp: 1.4, chr: "1" },
+          ],
+        },
+        {
+          name: "chr2",
+          points: [
+            { snp: "rs4102", pos: 84, logp: 3.3, chr: "2" },
+            { snp: "rs5521", pos: 96, logp: 9.7, chr: "2" },
+            { snp: "rs6018", pos: 118, logp: 2.8, chr: "2" },
+          ],
+        },
+        {
+          name: "chr3",
+          points: [
+            { snp: "rs7734", pos: 140, logp: 1.2, chr: "3" },
+            { snp: "rs8290", pos: 163, logp: 5.1, chr: "3" },
+            { snp: "rs9455", pos: 181, logp: 7.6, chr: "3" },
+          ],
+        },
+      ];
+
+      (function () {
+        var built = valueChart("manhattan-chart");
+        CHROMOSOMES.forEach(function (chromosome, index) {
+          var series = built.chart.series.push(
+            am5xy.LineSeries.new(built.root, {
+              name: chromosome.name,
+              xAxis: built.xAxis,
+              yAxis: built.yAxis,
+              valueXField: "pos",
+              valueYField: "logp",
+              // Only the first series declares. `label` and `group` are left
+              // to their defaults: the rows carry `snp` and `chr`, both of
+              // which the default chains already answer to.
+              userData:
+                index === 0
+                  ? { maidr: { type: "manhattan", significance: 7.3 } }
+                  : undefined,
+            })
+          );
+          series.strokes.template.setAll({ strokeOpacity: 0 });
+          addBullets(built.root, series, 4);
+          series.data.setAll(chromosome.points);
+        });
+
+        register(built.root, {
+          title: "Genome-wide Association",
+          axisLabels: { x: "Genomic position (Mb)", y: "-log10(p)" },
+        });
+      })();
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to a series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -598,7 +598,9 @@ function buildDeclaredLayer(
         data,
       };
     }
-    default: {
+    // Named rather than defaulted, so that a seventh member of `AmDeclaration`
+    // fails to compile here instead of being read out as a plain scatter.
+    case TraceType.SCATTER: {
       const data = extractScatterPoints(declared);
       if (data.length === 0) {
         return null;

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -38,6 +38,7 @@ import type {
   TreemapPoint,
   WaterfallPoint,
 } from '@type/grammar';
+import type { AmDeclaredLayer } from './declaration';
 import type {
   AmChart,
   AmChartsBinderOptions,
@@ -45,6 +46,17 @@ import type {
   AmXYSeries,
 } from './types';
 import { Orientation, TraceType } from '@type/grammar';
+import {
+  extractErrorBarSamples,
+  extractForestSamples,
+  extractScatterPoints,
+  extractSurvivalArms,
+  extractVolcanoPoints,
+  isDeclaredHorizontal,
+  planDeclarations,
+  readForestOptions,
+  readThresholdOptions,
+} from './declaration';
 import {
   classifySeriesKind,
   extractBarPoints,
@@ -59,6 +71,7 @@ import {
   extractWaterfallPoints,
   hasRankAxis,
   holdsRanks,
+  isColumnSeries,
   isDivergingPair,
   readAxisLabel,
   STANDALONE_SERIES_CLASSES,
@@ -266,7 +279,24 @@ function buildChartLayers(
   const areaSeriesList: AmXYSeries[] = [];
   const lineSeriesList: AmXYSeries[] = [];
 
+  // What the author declared outranks every heuristic below, and a series
+  // absorbed into a declared layer — the column drawing an interval, a further
+  // arm of one survival figure — never becomes a layer of its own.
+  const plan = planDeclarations(chart);
+
   for (const series of chart.series.values) {
+    if (plan.absorbed.has(series)) {
+      continue;
+    }
+    const declared = plan.declared.get(series);
+    if (declared) {
+      const layer = buildDeclaredLayer(declared, xLabel, yLabel, containerEl);
+      if (layer) {
+        layers.push(layer);
+      }
+      continue;
+    }
+
     const kind = classifySeriesKind(series);
 
     switch (kind) {
@@ -470,6 +500,161 @@ function areaTraceType(areaSeriesList: AmXYSeries[]): MergedTraceType {
 // ---------------------------------------------------------------------------
 // Layer builders
 // ---------------------------------------------------------------------------
+
+/**
+ * Builds the layer one co-located `maidr` declaration describes.
+ *
+ * These are the six readings amCharts leaves no signature for: a survival curve
+ * and a step line are one series class, an error bar is a floating column
+ * behind another series, and a volcano, a Manhattan and a plain scatter are all
+ * a `LineSeries` with the stroke switched off. Nothing here is guessed — every
+ * fact the drawing does not carry comes off the author's own rows or off the
+ * declaration, and a fact that resolves to nothing is left out rather than
+ * filled in. See `declaration.ts` for what each field resolves to.
+ *
+ * @returns The layer, or `null` when no mark of the series could be read as the
+ *   declared type after all — the declaration then costs the chart nothing.
+ */
+function buildDeclaredLayer(
+  declared: AmDeclaredLayer,
+  xLabel: string,
+  yLabel: string,
+  containerEl: HTMLElement,
+): MaidrLayer | null {
+  const declaration = declared.declaration;
+  const axes = { x: { label: xLabel }, y: { label: yLabel } };
+  const named = {
+    id: layerId(declared.series),
+    ...(declaration.name ? { name: declaration.name } : {}),
+  };
+
+  switch (declaration.type) {
+    case TraceType.SURVIVAL: {
+      const { data } = extractSurvivalArms(declared);
+      if (data.length === 0) {
+        return null;
+      }
+      const arms = [declared.series, ...declared.arms];
+      const selectors = arms
+        .map(series => buildLineSelector(series, containerEl))
+        .filter((selector): selector is string => selector !== undefined);
+
+      return {
+        ...named,
+        type: TraceType.SURVIVAL,
+        title: declaration.title ?? armTitle(arms),
+        ...(selectors.length > 0 ? { selectors } : {}),
+        ...(declaration.stepDirection ? { stepDirection: declaration.stepDirection } : {}),
+        axes,
+        data,
+      };
+    }
+    case TraceType.ERROR_BAR: {
+      const { data } = extractErrorBarSamples(declared);
+      if (data.length === 0) {
+        return null;
+      }
+      return {
+        ...named,
+        type: TraceType.ERROR_BAR,
+        title: declaration.title ?? seriesName(declared.series),
+        ...declaredMarkSelector(declared.series, containerEl),
+        ...declaredOrientation(declared),
+        axes,
+        data,
+      };
+    }
+    case TraceType.FOREST: {
+      const { data } = extractForestSamples(declared);
+      if (data.length === 0) {
+        return null;
+      }
+      const forestOptions = readForestOptions(declaration);
+      return {
+        ...named,
+        type: TraceType.FOREST,
+        title: declaration.title ?? seriesName(declared.series),
+        ...declaredMarkSelector(declared.series, containerEl),
+        ...declaredOrientation(declared),
+        ...(forestOptions ? { forestOptions } : {}),
+        axes,
+        data,
+      };
+    }
+    case TraceType.MANHATTAN:
+    case TraceType.VOLCANO: {
+      const data = extractVolcanoPoints(declared);
+      if (data.length === 0) {
+        return null;
+      }
+      const thresholdOptions = readThresholdOptions(declaration);
+      return {
+        ...named,
+        type: declaration.type,
+        title: declaration.title ?? seriesName(declared.series),
+        ...cloudSelector(declared, containerEl),
+        ...(thresholdOptions ? { thresholdOptions } : {}),
+        axes,
+        data,
+      };
+    }
+    default: {
+      const data = extractScatterPoints(declared);
+      if (data.length === 0) {
+        return null;
+      }
+      return {
+        ...named,
+        type: TraceType.SCATTER,
+        title: declaration.title ?? seriesName(declared.series),
+        ...cloudSelector(declared, containerEl),
+        axes,
+        data,
+      };
+    }
+  }
+}
+
+/** What a survival layer is called: every arm that has a name, in draw order. */
+function armTitle(arms: AmXYSeries[]): string | undefined {
+  const names = arms
+    .map(series => seriesName(series))
+    .filter((name): name is string => name !== undefined);
+  return names.length > 0 ? names.join(', ') : undefined;
+}
+
+/**
+ * The selector for a declared layer's own marks.
+ *
+ * An estimate is drawn either as a column or as a bullet on a line, and the two
+ * live in different places — so the series' own class decides which to ask for,
+ * exactly as {@link classifySeriesKind} would have.
+ */
+function declaredMarkSelector(
+  series: AmXYSeries,
+  containerEl: HTMLElement,
+): { selectors?: string } {
+  const selector = isColumnSeries(series)
+    ? buildColumnSelector(series, containerEl)
+    : buildLineSelector(series, containerEl);
+  return selector ? { selectors: selector } : {};
+}
+
+/** The selector for a cloud, whose marks are the bullets of every merged arm. */
+function cloudSelector(
+  declared: AmDeclaredLayer,
+  containerEl: HTMLElement,
+): { selectors?: string } {
+  const parts = [declared.series, ...declared.arms]
+    .map(series => buildLineSelector(series, containerEl))
+    .filter((selector): selector is string => selector !== undefined);
+  return parts.length > 0 ? { selectors: parts.join(', ') } : {};
+}
+
+/** Which way a declared interval layer runs, when it is not the default. */
+function declaredOrientation(declared: AmDeclaredLayer): { orientation?: Orientation } {
+  return isDeclaredHorizontal(declared) ? { orientation: Orientation.HORIZONTAL } : {};
+}
 
 /**
  * The trace types a bar chart's reading serves: the bar itself, and the two

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -34,6 +34,7 @@ import { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
 import { convertCharts, findCharts } from './adapter';
+import { planDeclarations } from './declaration';
 import { classifySeriesKind } from './extractor';
 import { readPlotBounds, readSliceBounds } from './geometry';
 import { getHighlightColor } from './highlightColor';
@@ -203,9 +204,25 @@ function groupSeries(chart: AmChart): SeriesGroups {
     ganttSeriesList: [],
     hierarchySeriesList: [],
     wordCloudSeriesList: [],
+    declaredList: [],
   };
 
+  // The same plan `buildChartLayers` builds, asked of the same chart: a
+  // declared series is never also classified, and an absorbed one is never a
+  // layer of its own — so the layer a reader hears and the mark the overlay
+  // outlines are always the same series.
+  const plan = planDeclarations(chart);
+
   for (const series of chart.series.values) {
+    if (plan.absorbed.has(series)) {
+      continue;
+    }
+    const declared = plan.declared.get(series);
+    if (declared) {
+      groups.declaredList.push(declared);
+      continue;
+    }
+
     switch (classifySeriesKind(series)) {
       case 'bar':
         groups.barSeriesList.push(series);

--- a/src/adapters/amcharts/declaration.ts
+++ b/src/adapters/amcharts/declaration.ts
@@ -482,10 +482,12 @@ function mergesSiblings(declaration: AmDeclaration): boolean {
 /**
  * Resolve one companion reference to a series, and absorb it.
  *
- * A ref that names nothing, or that names a series declaring a layer of its
- * own, leaves the parent standing without that half — the alternative is
- * silently swallowing somebody else's layer, or matching whatever sits at that
- * position today, which is the failure `SeriesRef` exists to remove.
+ * A ref that names nothing, that names a series declaring a layer of its own,
+ * or that names a series another declaration has already absorbed, leaves the
+ * parent standing without that half — the alternative is silently swallowing
+ * somebody else's layer, reading one series' rows into two announced layers,
+ * or matching whatever sits at that position today, which is the failure
+ * `SeriesRef` exists to remove.
  */
 function absorb(
   declared: AmDeclaredLayer,
@@ -515,6 +517,20 @@ function absorb(
       `companion:${role}`,
       `maidr declaration on ${parent} names ${role} "${ref}", which declares a `
       + `layer of its own; it is left as that layer and not absorbed.`,
+    );
+    return undefined;
+  }
+  if (plan.absorbed.has(companion)) {
+    // Two refs naming one series is an authoring mistake either way round —
+    // one layer's interval column doubling as another's, or a single
+    // declaration naming the same id twice. Reading those rows into both
+    // layers would announce a number twice over with nothing said; the second
+    // claim is refused out loud instead, as a ref naming a declared layer is.
+    warnOnce(
+      declared.declaration,
+      `companion:${role}`,
+      `maidr declaration on ${parent} names ${role} "${ref}", which another `
+      + `declaration already absorbed; the layer is emitted without it.`,
     );
     return undefined;
   }
@@ -895,6 +911,13 @@ export function extractForestSamples(
   const items = [...studies.items];
   const owners = [...studies.owners];
   if (declared.pooled) {
+    // The summary is read exactly as a study is, off its own series' rows —
+    // and `interval` is deliberately left in scope for it. A companion is
+    // joined by position, not by series, so a chart drawing every interval in
+    // one column series, the summary's included, has said where the summary's
+    // interval is; scoping the companion out would drop a bound the author
+    // did draw. The summary's own row fields and `error` offset still win, so
+    // a pooled series that spells its interval out is unaffected either way.
     const summary = extractErrorBarSamples({ ...declared, series: declared.pooled });
     for (const point of summary.data) {
       data.push({ ...point, pooled: true });

--- a/src/adapters/amcharts/declaration.ts
+++ b/src/adapters/amcharts/declaration.ts
@@ -1,0 +1,1026 @@
+/**
+ * The co-located `maidr` declaration, read off an amCharts 5 series.
+ *
+ * amCharts draws marks and says nothing about what they mean. A Kaplan-Meier
+ * curve is a `StepLineSeries`, an error bar is a second `ColumnSeries` bound to
+ * `openValueY`, and a volcano plot is a `LineSeries` with its stroke switched
+ * off and bullets pushed on. Every one of those configurations is also worn by
+ * an ordinary chart, so the heuristics in `extractor.ts` cannot separate them
+ * and must not try: a step line read as a survival curve announces censoring
+ * the chart never carried. What separates them is the author saying so, in the
+ * slot amCharts documents as "a storage for any custom user data":
+ *
+ * ```js
+ * series.set('userData', { maidr: { type: 'survival', censored: 'cens' } });
+ * ```
+ *
+ * This module turns those blocks into a **plan for a whole chart**: which
+ * series declared a layer, which were absorbed into somebody else's layer as a
+ * companion or as a further arm, and what each declared layer's fields resolve
+ * to. Both the JSON path (`adapter.ts`) and the highlight path (`binder.tsx`)
+ * plan the same chart the same way, so the layer a reader hears and the mark
+ * the overlay outlines are always the same series.
+ *
+ * A declaration never throws and never guesses. Anything it cannot honour —
+ * a type this adapter has no amCharts construct for, a companion naming no
+ * series, a field no row carries — degrades to a truthful smaller reading and
+ * says so once, exactly as `src/adapters/shared/traceDeclaration.ts` prescribes.
+ */
+
+import type {
+  ErrorBarDeclaration,
+  ForestDeclaration,
+  MaidrTraceDeclaration,
+  ManhattanDeclaration,
+  ScatterDeclaration,
+  SurvivalDeclaration,
+  VolcanoDeclaration,
+} from '@type/declaration';
+import type {
+  ErrorBarPoint,
+  ForestPoint,
+  ScatterPoint,
+  SurvivalPoint,
+  ThresholdOptions,
+  VolcanoPoint,
+} from '@type/grammar';
+import type { AmChart, AmDataItem, AmXYSeries } from './types';
+import {
+  isFlagValue,
+  readDeclarationSlot,
+  resolveFieldRef,
+  warnUnresolvedRef,
+} from '@adapters/shared/traceDeclaration';
+import { Orientation, TraceType } from '@type/grammar';
+import { classifySeriesKind, readXValue, toNumber, toStringOrNumber } from './extractor';
+
+/** How this adapter names itself in every warning it raises. */
+const ADAPTER = 'amCharts';
+
+/**
+ * The declaration variants an amCharts series can back.
+ *
+ * The union is smaller than `MaidrTraceDeclaration` because a declaration is
+ * still a claim about a drawing: there is no amCharts construct behind a
+ * `hexbin` or a `choropleth`, and a block declaring one is reported rather than
+ * read into a layer with nothing in it.
+ */
+export type AmDeclaration
+  = | ErrorBarDeclaration
+    | ForestDeclaration
+    | ManhattanDeclaration
+    | ScatterDeclaration
+    | SurvivalDeclaration
+    | VolcanoDeclaration;
+
+/**
+ * One layer an author declared, with everything the chart drew for it.
+ *
+ * A figure routinely spreads one layer over several series — an estimate and
+ * the column drawing its interval, a curve and the ticks marking its censored
+ * times, twenty-two chromosomes that are one cloud — and every one of those
+ * extra series is here rather than becoming a layer of its own.
+ */
+export interface AmDeclaredLayer {
+  /** The series carrying the block: the estimate, the curve, the cloud. */
+  series: AmXYSeries;
+  /** The validated block, narrowed to what this adapter can read. */
+  declaration: AmDeclaration;
+  /** `intervalSeries` — the floating column drawing the interval. */
+  interval?: AmXYSeries;
+  /** `censoredSeries` — the ticks marking censored times. */
+  censored?: AmXYSeries;
+  /** `bandSeries` — the confidence band drawn around a curve. */
+  band?: AmXYSeries;
+  /** `pooledSeries` — the summary mark at the foot of a forest plot. */
+  pooled?: AmXYSeries;
+  /**
+   * Following siblings folded into this layer by `merge`: further arms of one
+   * survival figure, or further chromosomes of one Manhattan cloud.
+   */
+  arms: AmXYSeries[];
+}
+
+/** What a chart's declarations come to, resolved together. */
+export interface AmDeclarationPlan {
+  /** The declared layers, keyed by the series carrying the block. */
+  declared: Map<AmXYSeries, AmDeclaredLayer>;
+  /**
+   * Series that must not become a layer of their own — every companion and
+   * every merged sibling. They are drawn, and they are announced, as part of
+   * the layer that named them.
+   */
+  absorbed: Set<AmXYSeries>;
+}
+
+/** The interval around one estimate, as absolute positions on the value axis. */
+interface Bounds {
+  yMin?: number;
+  yMax?: number;
+}
+
+/** The samples of one declared layer, and the live marks behind them. */
+export interface DeclaredSamples<T> {
+  data: T[];
+  /** The live data items, in the order `data` holds their points. */
+  items: AmDataItem[];
+  /**
+   * Which series drew each mark, index-aligned with `items`.
+   *
+   * Not always the declaring one: a forest plot's pooled summary is commonly a
+   * companion series of its own, and its rows are appended after the studies.
+   */
+  owners: AmXYSeries[];
+}
+
+/** A survival figure's arms: one row of points, and one row of marks, each. */
+export interface DeclaredArms {
+  data: SurvivalPoint[][];
+  items: AmDataItem[][];
+}
+
+// ---------------------------------------------------------------------------
+// Reading and validating one block
+// ---------------------------------------------------------------------------
+
+/**
+ * Declarations already validated, keyed by the `userData` object they were
+ * read from.
+ *
+ * A chart is planned twice per binding — once for the layers and once for the
+ * highlight — and `validateDeclaration` warns as it goes, so validating twice
+ * would say everything twice. Keying the memo on the author's own object is
+ * what keeps that from also silencing a *corrected* block: rewriting
+ * `userData` produces a new object, which is validated and reported afresh.
+ */
+const validated = new WeakMap<object, MaidrTraceDeclaration | null>();
+
+/** Problems already reported, per declaration, so each is said once. */
+const reported = new WeakMap<object, Set<string>>();
+
+/**
+ * Whether a problem has already been reported for a declaration, marking it as
+ * reported if not.
+ *
+ * @param declaration - The block the problem belongs to.
+ * @param key         - What the problem is.
+ * @returns True when it has been said already.
+ */
+function alreadyReported(declaration: object, key: string): boolean {
+  let seen = reported.get(declaration);
+  if (seen === undefined) {
+    seen = new Set<string>();
+    reported.set(declaration, seen);
+  }
+  if (seen.has(key)) {
+    return true;
+  }
+  seen.add(key);
+  return false;
+}
+
+/**
+ * Emit one adapter-prefixed warning per declaration per problem.
+ *
+ * @param declaration - The block the problem belongs to.
+ * @param key         - What the problem is, for the once-only check.
+ * @param message     - The sentence following the `[MAIDR amCharts]` prefix.
+ */
+function warnOnce(declaration: object, key: string, message: string): void {
+  if (!alreadyReported(declaration, key)) {
+    console.warn(`[MAIDR ${ADAPTER}] ${message}`);
+  }
+}
+
+/**
+ * How an author finds a series again, for a warning to point at.
+ *
+ * The `id` comes first because it is the name a companion is addressed by, so
+ * a message about an unresolvable `intervalSeries` prints the same string the
+ * author would have to write to fix it.
+ *
+ * @param series - The series being read.
+ * @returns A locating phrase, e.g. `series "estimate"`.
+ */
+export function describeSeries(series: AmXYSeries): string {
+  const id = series.get('id');
+  if (typeof id === 'string' && id.length > 0) {
+    return `series "${id}"`;
+  }
+  const name = series.get('name');
+  if (typeof name === 'string' && name.length > 0) {
+    return `series "${name}"`;
+  }
+  return `series ${series.className ?? 'of unknown class'}`;
+}
+
+/**
+ * Read and validate the `maidr` block on one series' `userData`.
+ *
+ * @param series - The series to read.
+ * @returns The validated declaration, or `null` when there is none to read.
+ */
+function readDeclaration(series: AmXYSeries): MaidrTraceDeclaration | null {
+  const slot = series.get('userData');
+  if (typeof slot !== 'object' || slot === null) {
+    return null;
+  }
+
+  const cached = validated.get(slot);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const declaration = readDeclarationSlot(slot, {
+    adapter: ADAPTER,
+    seriesRef: describeSeries(series),
+  });
+  validated.set(slot, declaration);
+  return declaration;
+}
+
+/** Whether a validated declaration is one an amCharts series can back. */
+function isDeclarable(declaration: MaidrTraceDeclaration): declaration is AmDeclaration {
+  switch (declaration.type) {
+    case TraceType.ERROR_BAR:
+    case TraceType.FOREST:
+    case TraceType.MANHATTAN:
+    case TraceType.SCATTER:
+    case TraceType.SURVIVAL:
+    case TraceType.VOLCANO:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reading one row
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a value read off an author's row to a finite number.
+ *
+ * Stricter than the extractor's own conversion, which coerces `null` and `''`
+ * to zero because its callers have already established the value is there. A
+ * declared field is routinely absent on some rows — a one-sided interval, a
+ * study with no weight — and a zero substituted for one is a claim the data
+ * does not make. Numeric strings are accepted, since a row that came from a
+ * CSV carries every column as one.
+ *
+ * @param value - Whatever the field resolved to.
+ * @returns The number, or `null` when the value is not one.
+ */
+function declaredNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * Strip binary floating-point noise from a bound obtained by arithmetic.
+ *
+ * An interval given as an offset is announced as its absolute bounds, and
+ * `1.4 - 0.2` reads as `1.1999999999999997` otherwise.
+ */
+function withoutFloatNoise(value: number): number {
+  return Number(value.toPrecision(12));
+}
+
+/**
+ * Every field a declaration named explicitly, so one that no row carried can
+ * be reported once the series has been read.
+ *
+ * `resolveFieldRef` answers per row and cannot tell a typo from a row that
+ * legitimately lacks the field. The series is the unit that can: entries are
+ * deleted as they resolve, and whatever is left named nothing.
+ */
+type Misses = Map<string, string>;
+
+/**
+ * Collect the explicit refs of a declaration, keyed by the field they fill.
+ *
+ * `fields` is the set the caller is about to read, and only those: a forest
+ * plot reads its bounds in one pass and its weights in another, and a ref
+ * watched by a pass that never reads it would be reported as missing on every
+ * chart that carries it.
+ *
+ * @param declaration - The block being read.
+ * @param fields      - The canonical field names this pass resolves.
+ * @returns The refs to watch, to be deleted as each one resolves.
+ */
+function explicitRefs(declaration: AmDeclaration, fields: readonly string[]): Misses {
+  const misses: Misses = new Map();
+  const block: Record<string, unknown> = { ...declaration };
+  for (const canonical of fields) {
+    const ref = block[canonical];
+    if (typeof ref === 'string' && ref.trim() !== '') {
+      misses.set(canonical, ref);
+    }
+  }
+  return misses;
+}
+
+/**
+ * Read one declared fact off a row, recording that its explicit name resolved.
+ *
+ * @param row       - The author's own record behind the mark.
+ * @param ref       - The field the declaration named, if any.
+ * @param canonical - The grammar field being filled.
+ * @param misses    - The explicit refs still waiting to resolve.
+ * @returns The value read, or `undefined`.
+ */
+function readField(
+  row: unknown,
+  ref: string | undefined,
+  canonical: string,
+  misses: Misses,
+): unknown {
+  const value = resolveFieldRef<unknown>(row, ref, canonical);
+  if (value !== undefined) {
+    misses.delete(canonical);
+  }
+  return value;
+}
+
+/** Report every explicit ref that no row of the series carried. */
+function reportMisses(declared: AmDeclaredLayer, misses: Misses): void {
+  for (const [canonical, ref] of misses) {
+    if (alreadyReported(declared.declaration, `unresolved:${canonical}`)) {
+      continue;
+    }
+    warnUnresolvedRef(
+      { adapter: ADAPTER, seriesRef: describeSeries(declared.series) },
+      ref,
+      canonical,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orientation and the fields it decides
+// ---------------------------------------------------------------------------
+
+/** Whether a series puts its categories on the Y axis and its values on X. */
+function drawsHorizontally(series: AmXYSeries): boolean {
+  return typeof series.get('categoryYField') === 'string';
+}
+
+/**
+ * Which way a declared interval layer runs.
+ *
+ * A forest plot is horizontal by construction — studies down a category axis,
+ * effect running left to right — and amCharts says so by binding `categoryY`.
+ * The declaration overrides it for the chart that binds neither.
+ */
+export function isDeclaredHorizontal(declared: AmDeclaredLayer): boolean {
+  return declaredHorizontal(declared.series, declared.declaration);
+}
+
+/**
+ * The same question, asked while the plan is still being built and there is no
+ * {@link AmDeclaredLayer} yet.
+ *
+ * Kept as one function because the two answers have to agree: the check that a
+ * series backs its declared type reads the value axis this decides, and a
+ * disagreement would pass a series as readable and then read nothing off it.
+ */
+function declaredHorizontal(series: AmXYSeries, declaration: AmDeclaration): boolean {
+  if (declaration.type === TraceType.ERROR_BAR || declaration.type === TraceType.FOREST) {
+    if (declaration.orientation !== undefined) {
+      return declaration.orientation === Orientation.HORIZONTAL;
+    }
+  }
+  return drawsHorizontally(series);
+}
+
+/** Where a series of the given orientation keeps its estimate and its bounds. */
+function valueFields(horizontal: boolean): { value: string; open: string } {
+  return horizontal
+    ? { value: 'valueX', open: 'openValueX' }
+    : { value: 'valueY', open: 'openValueY' };
+}
+
+/**
+ * The position a mark sits at, on the axis the samples run along.
+ *
+ * A vertical chart puts it on X, where {@link readXValue} already knows the
+ * four places amCharts may keep it; a horizontal one puts it on Y, where a
+ * category axis is what a forest plot's study names arrive on.
+ */
+function readMain(item: AmDataItem, series: AmXYSeries, horizontal: boolean): unknown {
+  if (!horizontal) {
+    return readXValue(item, series);
+  }
+  return item.get('categoryY') ?? item.get('valueY');
+}
+
+// ---------------------------------------------------------------------------
+// Planning a chart
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a series carries the values its declared type is read from.
+ *
+ * This is the "wrong construct" check: `type: 'survival'` on a pie series is a
+ * mistake worth reporting, not a layer to emit with nothing in it. Asked of the
+ * data rather than of the class name, because amCharts draws most of these with
+ * whatever series class the author reached for.
+ *
+ * @param series      - The declaring series.
+ * @param declaration - The block it carries.
+ * @returns True when at least one mark can be read as the declared type.
+ */
+function backsDeclaration(series: AmXYSeries, declaration: AmDeclaration): boolean {
+  switch (declaration.type) {
+    case TraceType.SURVIVAL:
+      return series.dataItems.some(item =>
+        readXValue(item, series) != null && item.get('valueY') != null
+        && toNumber(item.get('valueY')) != null);
+    case TraceType.ERROR_BAR:
+    case TraceType.FOREST: {
+      const horizontal = declaredHorizontal(series, declaration);
+      const { value } = valueFields(horizontal);
+      return series.dataItems.some(item =>
+        readMain(item, series, horizontal) != null && item.get(value) != null
+        && toNumber(item.get(value)) != null);
+    }
+    default:
+      // A cloud is plotted on two value axes, and both coordinates are the
+      // payload: a point missing either is not a point on it.
+      return series.dataItems.some(item =>
+        item.get('valueX') != null && item.get('valueY') != null
+        && toNumber(item.get('valueX')) != null && toNumber(item.get('valueY')) != null);
+  }
+}
+
+/**
+ * Whether a declaration absorbs the undeclared siblings that follow it.
+ *
+ * On by default for the two figures whose series are one thing — a survival
+ * plot's arms are read against each other, and a Manhattan's chromosomes are
+ * one cloud — and off for the two whose siblings are usually the comparison a
+ * reader wants kept apart.
+ */
+function mergesSiblings(declaration: AmDeclaration): boolean {
+  switch (declaration.type) {
+    case TraceType.SURVIVAL:
+    case TraceType.MANHATTAN:
+      return declaration.merge !== false;
+    case TraceType.VOLCANO:
+    case TraceType.SCATTER:
+      return declaration.merge === true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Resolve one companion reference to a series, and absorb it.
+ *
+ * A ref that names nothing, or that names a series declaring a layer of its
+ * own, leaves the parent standing without that half — the alternative is
+ * silently swallowing somebody else's layer, or matching whatever sits at that
+ * position today, which is the failure `SeriesRef` exists to remove.
+ */
+function absorb(
+  declared: AmDeclaredLayer,
+  ref: string | undefined,
+  role: string,
+  byId: Map<string, AmXYSeries>,
+  plan: AmDeclarationPlan,
+): AmXYSeries | undefined {
+  if (ref === undefined) {
+    return undefined;
+  }
+
+  const companion = byId.get(ref);
+  const parent = describeSeries(declared.series);
+  if (companion === undefined || companion === declared.series) {
+    warnOnce(
+      declared.declaration,
+      `companion:${role}`,
+      `maidr declaration on ${parent} names ${role} "${ref}", which is not `
+      + `another series' id; the layer is emitted without it.`,
+    );
+    return undefined;
+  }
+  if (plan.declared.has(companion)) {
+    warnOnce(
+      declared.declaration,
+      `companion:${role}`,
+      `maidr declaration on ${parent} names ${role} "${ref}", which declares a `
+      + `layer of its own; it is left as that layer and not absorbed.`,
+    );
+    return undefined;
+  }
+
+  plan.absorbed.add(companion);
+  return companion;
+}
+
+/**
+ * Resolve every declaration on a chart into the layers they describe.
+ *
+ * Runs in three passes, and the order matters: every declaration is read before
+ * any companion is resolved, so a companion of a later layer is not swallowed
+ * as an earlier layer's merged sibling, and every companion is absorbed before
+ * the merge pass, so an absorbed series is never also an arm.
+ *
+ * @param chart - The chart to plan.
+ * @returns The declared layers, and the series they absorbed.
+ */
+export function planDeclarations(chart: AmChart): AmDeclarationPlan {
+  const plan: AmDeclarationPlan = { declared: new Map(), absorbed: new Set() };
+  const seriesList = chart.series.values;
+
+  for (const series of seriesList) {
+    const declaration = readDeclaration(series);
+    if (declaration === null) {
+      continue;
+    }
+    if (!isDeclarable(declaration)) {
+      warnOnce(
+        declaration,
+        'undeclarable',
+        `maidr declaration on ${describeSeries(series)} declares "${declaration.type}", `
+        + `which no amCharts series draws; reading it as the undeclared chart.`,
+      );
+      continue;
+    }
+    if (!backsDeclaration(series, declaration)) {
+      warnOnce(
+        declaration,
+        'unbacked',
+        `maidr declaration on ${describeSeries(series)} declares "${declaration.type}", `
+        + `but no mark of it carries the values that type is read from; reading it `
+        + `as the undeclared chart.`,
+      );
+      continue;
+    }
+    plan.declared.set(series, { series, declaration, arms: [] });
+  }
+
+  const byId = new Map<string, AmXYSeries>();
+  for (const series of seriesList) {
+    const id = series.get('id');
+    if (typeof id === 'string' && id.length > 0) {
+      byId.set(id, series);
+    }
+  }
+
+  for (const declared of plan.declared.values()) {
+    const declaration = declared.declaration;
+    switch (declaration.type) {
+      case TraceType.SURVIVAL:
+        declared.censored = absorb(declared, declaration.censoredSeries, 'censoredSeries', byId, plan);
+        declared.band = absorb(declared, declaration.bandSeries, 'bandSeries', byId, plan);
+        break;
+      case TraceType.FOREST:
+        declared.interval = absorb(declared, declaration.intervalSeries, 'intervalSeries', byId, plan);
+        declared.pooled = absorb(declared, declaration.pooledSeries, 'pooledSeries', byId, plan);
+        break;
+      case TraceType.ERROR_BAR:
+        declared.interval = absorb(declared, declaration.intervalSeries, 'intervalSeries', byId, plan);
+        break;
+      default:
+        break;
+    }
+  }
+
+  for (const [series, declared] of plan.declared) {
+    if (!mergesSiblings(declared.declaration)) {
+      continue;
+    }
+    // What "the same drawn kind" means here is what the heuristic would have
+    // called the series had nobody declared it — which is why the declaration
+    // is not hooked into `classifySeriesKind`: the undeclared reading is still
+    // the question being asked of the siblings.
+    const drawn = classifySeriesKind(series);
+    for (const sibling of seriesList.slice(seriesList.indexOf(series) + 1)) {
+      if (plan.absorbed.has(sibling) || readDeclaration(sibling) !== null) {
+        continue;
+      }
+      if (classifySeriesKind(sibling) !== drawn) {
+        continue;
+      }
+      declared.arms.push(sibling);
+      plan.absorbed.add(sibling);
+    }
+  }
+
+  return plan;
+}
+
+// ---------------------------------------------------------------------------
+// Survival
+// ---------------------------------------------------------------------------
+
+/**
+ * The censored times a companion series draws, as the positions it draws them
+ * at.
+ *
+ * A figure that joins its censoring ticks separately has one mark per censored
+ * time and no flag column at all, so the ticks' own x values *are* the flag.
+ */
+function readCensoredAt(series: AmXYSeries): Set<string> {
+  const times = new Set<string>();
+  for (const item of series.dataItems) {
+    const x = readXValue(item, series);
+    if (x != null) {
+      times.add(String(toStringOrNumber(x)));
+    }
+  }
+  return times;
+}
+
+/**
+ * The interval a companion series draws, keyed by the position it is drawn at.
+ *
+ * amCharts has no error-bar and no band series: both are a second series of
+ * floating marks behind the first, whose two ends are the `openValue*` /
+ * `value*` pair every floating column in this adapter is read through. The two
+ * series are joined on the position rather than by index, because a companion
+ * routinely carries fewer rows than the series it decorates.
+ */
+function readCompanionBounds(series: AmXYSeries, horizontal: boolean): Map<string, Bounds> {
+  const { value, open } = valueFields(horizontal);
+  const bounds = new Map<string, Bounds>();
+
+  for (const item of series.dataItems) {
+    const main = readMain(item, series, horizontal);
+    if (main == null) {
+      continue;
+    }
+    const low = item.get(open) != null ? toNumber(item.get(open)) : null;
+    const high = item.get(value) != null ? toNumber(item.get(value)) : null;
+    if (low == null && high == null) {
+      continue;
+    }
+    bounds.set(String(toStringOrNumber(main)), {
+      ...(low != null ? { yMin: low } : {}),
+      ...(high != null ? { yMax: high } : {}),
+    });
+  }
+
+  return bounds;
+}
+
+/**
+ * Read a declared survival figure: one row of points per arm.
+ *
+ * The curve itself is read exactly as a step line is — amCharts varies only how
+ * it draws between the samples — and everything a survival figure carries
+ * beyond one comes off the author's own row, or off the companion series that
+ * drew it. The companions decorate the **declaring** arm: a censoring tick or a
+ * confidence band is part of the curve that named it, not of every arm folded
+ * in after it.
+ *
+ * @param declared - The declared layer and everything it absorbed.
+ * @returns The arms' points, and the live marks behind them.
+ */
+export function extractSurvivalArms(declared: AmDeclaredLayer): DeclaredArms {
+  const declaration = declared.declaration as SurvivalDeclaration;
+  const misses = explicitRefs(declaration, ['censored', 'yMin', 'yMax']);
+  const censoredAt = declared.censored ? readCensoredAt(declared.censored) : null;
+  const band = declared.band ? readCompanionBounds(declared.band, false) : null;
+
+  const data: SurvivalPoint[][] = [];
+  const items: AmDataItem[][] = [];
+
+  for (const [arm, series] of [declared.series, ...declared.arms].entries()) {
+    const armPoints: SurvivalPoint[] = [];
+    const armItems: AmDataItem[] = [];
+    const name = series.get('name');
+
+    for (const item of series.dataItems) {
+      const x = readXValue(item, series);
+      const y = item.get('valueY') != null ? toNumber(item.get('valueY')) : null;
+      if (x == null || y == null) {
+        continue;
+      }
+
+      const at = String(toStringOrNumber(x));
+      const row = item.dataContext;
+      const point: SurvivalPoint = { x: toStringOrNumber(x), y };
+      if (typeof name === 'string' && name.length > 0) {
+        point.z = name;
+      }
+
+      const censored = readField(row, declaration.censored, 'censored', misses);
+      if (censored !== undefined) {
+        point.censored = isFlagValue(censored);
+      } else if (arm === 0 && censoredAt?.has(at)) {
+        point.censored = true;
+      }
+
+      const companion = arm === 0 ? band?.get(at) : undefined;
+      const yMin = declaredNumber(readField(row, declaration.yMin, 'yMin', misses))
+        ?? companion?.yMin ?? null;
+      const yMax = declaredNumber(readField(row, declaration.yMax, 'yMax', misses))
+        ?? companion?.yMax ?? null;
+      if (yMin != null) {
+        point.yMin = yMin;
+      }
+      if (yMax != null) {
+        point.yMax = yMax;
+      }
+
+      armPoints.push(point);
+      armItems.push(item);
+    }
+
+    if (armPoints.length > 0) {
+      data.push(armPoints);
+      items.push(armItems);
+    }
+  }
+
+  reportMisses(declared, misses);
+  return { data, items };
+}
+
+// ---------------------------------------------------------------------------
+// Error bar and forest
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn an interval given as an offset from the estimate into absolute bounds.
+ *
+ * Both forms are positive magnitudes, as `yerr` is: a pair `[0.2, 0.3]` around
+ * 1.4 is 1.2 to 1.7. A negative entry is left out rather than flipped, since
+ * neither reading is detectable downstream once the bounds are emitted.
+ */
+function boundsFromOffset(estimate: number, value: unknown): Bounds {
+  const [low, high] = Array.isArray(value)
+    ? [declaredNumber(value[0]), declaredNumber(value[1])]
+    : [declaredNumber(value), declaredNumber(value)];
+
+  return {
+    ...(low != null && low >= 0 ? { yMin: withoutFloatNoise(estimate - low) } : {}),
+    ...(high != null && high >= 0 ? { yMax: withoutFloatNoise(estimate + high) } : {}),
+  };
+}
+
+/**
+ * The interval around one estimate.
+ *
+ * Resolved from the row first, then from the offset the row may carry instead,
+ * and finally from the companion series drawing the interval — per bound, so a
+ * one-sided interval keeps the half it has and a companion fills only what the
+ * row left unsaid. The row comes first because a column the author named is the
+ * most specific thing said about that point; the companion is what an amCharts
+ * chart usually has instead of one.
+ */
+function readBounds(
+  row: unknown,
+  declaration: ErrorBarDeclaration | ForestDeclaration,
+  estimate: number,
+  companion: Bounds | undefined,
+  misses: Misses,
+): Bounds {
+  const offset = boundsFromOffset(
+    estimate,
+    readField(row, declaration.error, 'error', misses),
+  );
+
+  const yMin = declaredNumber(readField(row, declaration.yMin, 'yMin', misses))
+    ?? offset.yMin ?? companion?.yMin ?? null;
+  const yMax = declaredNumber(readField(row, declaration.yMax, 'yMax', misses))
+    ?? offset.yMax ?? companion?.yMax ?? null;
+
+  return {
+    ...(yMin != null ? { yMin } : {}),
+    ...(yMax != null ? { yMax } : {}),
+  };
+}
+
+/**
+ * Read a declared error-bar layer: one estimate per mark, with its interval.
+ *
+ * @param declared - The declared layer and the companion drawing its interval.
+ * @returns The samples, and the live marks behind them.
+ */
+export function extractErrorBarSamples(
+  declared: AmDeclaredLayer,
+): DeclaredSamples<ErrorBarPoint> {
+  const declaration = declared.declaration as ErrorBarDeclaration;
+  const horizontal = isDeclaredHorizontal(declared);
+  const misses = explicitRefs(declaration, ['yMin', 'yMax', 'error']);
+  const companion = declared.interval
+    ? readCompanionBounds(declared.interval, horizontal)
+    : null;
+
+  const { value } = valueFields(horizontal);
+  const data: ErrorBarPoint[] = [];
+  const items: AmDataItem[] = [];
+
+  for (const item of declared.series.dataItems) {
+    const main = readMain(item, declared.series, horizontal);
+    const estimate = item.get(value) != null ? toNumber(item.get(value)) : null;
+    if (main == null || estimate == null) {
+      continue;
+    }
+
+    const at = String(toStringOrNumber(main));
+    const bounds = readBounds(
+      item.dataContext,
+      declaration,
+      estimate,
+      companion?.get(at),
+      misses,
+    );
+    data.push({ x: toStringOrNumber(main), y: estimate, ...bounds });
+    items.push(item);
+  }
+
+  reportMisses(declared, misses);
+  return { data, items, owners: items.map(() => declared.series) };
+}
+
+/**
+ * Read a declared forest plot: an error bar per study, plus the three things a
+ * meta-analysis carries that a row of intervals does not.
+ *
+ * The pooled summary is whichever the chart says it is: a flag column, the row
+ * index for data that carries no such column, or a companion series drawing the
+ * summary's own diamond — whose rows are appended after the studies, which is
+ * where the figure draws them.
+ *
+ * @param declared - The declared layer and everything it absorbed.
+ * @returns The studies, and the live marks behind them.
+ */
+export function extractForestSamples(
+  declared: AmDeclaredLayer,
+): DeclaredSamples<ForestPoint> {
+  const declaration = declared.declaration as ForestDeclaration;
+  const misses = explicitRefs(declaration, ['weight', 'pooled']);
+  const studies = extractErrorBarSamples(declared);
+
+  // `pooledIndex` counts the declaring series' own rows as authored, which is
+  // the only sequence an author can see — so it addresses a data item rather
+  // than a point, which a dropped row would already have shifted.
+  const pooledItem = declaration.pooledIndex === undefined
+    ? undefined
+    : declared.series.dataItems[declaration.pooledIndex];
+
+  const data: ForestPoint[] = [];
+  for (const [at, point] of studies.data.entries()) {
+    const item = studies.items[at];
+    const row = item.dataContext;
+    const study: ForestPoint = { ...point };
+
+    const weight = declaredNumber(readField(row, declaration.weight, 'weight', misses));
+    // A fraction of one, never a percentage. Meta-analysis software reports
+    // this column as `12.5` for one study in eight, and dividing by 100 would
+    // guess that the column sums to 100 while passing it through announces
+    // "weight 1250%".
+    if (weight != null && weight >= 0 && weight <= 1) {
+      study.weight = weight;
+    }
+
+    const flag = readField(row, declaration.pooled, 'pooled', misses);
+    const byIndex = pooledItem !== undefined && item === pooledItem;
+    if (flag !== undefined || byIndex) {
+      study.pooled = byIndex || isFlagValue(flag);
+    }
+
+    data.push(study);
+  }
+
+  const items = [...studies.items];
+  const owners = [...studies.owners];
+  if (declared.pooled) {
+    const summary = extractErrorBarSamples({ ...declared, series: declared.pooled });
+    for (const point of summary.data) {
+      data.push({ ...point, pooled: true });
+    }
+    items.push(...summary.items);
+    owners.push(...summary.owners);
+  }
+
+  reportMisses(declared, misses);
+  return { data, items, owners };
+}
+
+/**
+ * The forest options a declaration carries, or nothing at all.
+ *
+ * `nullValue` has no default on purpose: 0 guessed for a ratio measure reports
+ * every study as not crossing, since odds ratios are all positive, which is a
+ * confident wrong answer handed to every row. Undeclared, the layer gets the
+ * estimate, the interval and the weight, and makes no claim about significance.
+ */
+export function readForestOptions(declaration: ForestDeclaration): { nullValue: number } | null {
+  return declaration.nullValue === undefined ? null : { nullValue: declaration.nullValue };
+}
+
+// ---------------------------------------------------------------------------
+// Volcano, Manhattan and the plain scatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a declared cloud: one point per mark, on two value axes.
+ *
+ * amCharts has no scatter series — the recipe is a `LineSeries` with its stroke
+ * switched off and bullets pushed on — so the points are read straight off the
+ * data items under the declared type rather than through a classification that
+ * would call the same drawing a line chart.
+ *
+ * The identity is the payload on these charts: a reader told "x is 2.3, y is
+ * 14.1" has been handed the two numbers whose shape they can already hear and
+ * withheld the gene name they came for. It is left out only when nothing
+ * resolves.
+ *
+ * @param declared - The declared layer and the siblings merged into it.
+ * @returns One point per readable mark, in chart order.
+ */
+export function extractVolcanoPoints(declared: AmDeclaredLayer): VolcanoPoint[] {
+  const declaration = declared.declaration as ManhattanDeclaration | VolcanoDeclaration;
+  const misses = explicitRefs(declaration, ['label', 'group']);
+  const points: VolcanoPoint[] = [];
+
+  for (const series of [declared.series, ...declared.arms]) {
+    for (const item of series.dataItems) {
+      const point = readCloudPoint(item);
+      if (point === null) {
+        continue;
+      }
+
+      const row = item.dataContext;
+      const label = readField(row, declaration.label, 'label', misses);
+      if (label != null && label !== '') {
+        point.label = String(label);
+      }
+      const group = readField(row, declaration.group, 'group', misses);
+      if (group != null && group !== '') {
+        point.group = String(group);
+      }
+      points.push(point);
+    }
+  }
+
+  reportMisses(declared, misses);
+  return points;
+}
+
+/**
+ * Read a declared plain scatter.
+ *
+ * `ScatterPoint` has nowhere to put a point's name, so a declared `label` is
+ * accepted and not read here — a chart whose points carry an identity declares
+ * `volcano` or `manhattan`, which is where the grammar carries one.
+ *
+ * @param declared - The declared layer and the siblings merged into it.
+ * @returns One point per readable mark, in chart order.
+ */
+export function extractScatterPoints(declared: AmDeclaredLayer): ScatterPoint[] {
+  const points: ScatterPoint[] = [];
+  for (const series of [declared.series, ...declared.arms]) {
+    for (const item of series.dataItems) {
+      const point = readCloudPoint(item);
+      if (point !== null) {
+        points.push(point);
+      }
+    }
+  }
+  return points;
+}
+
+/** One point of a cloud, or `null` for a mark missing either coordinate. */
+function readCloudPoint(item: AmDataItem): VolcanoPoint | null {
+  const x = item.get('valueX') != null ? toNumber(item.get('valueX')) : null;
+  const y = item.get('valueY') != null ? toNumber(item.get('valueY')) : null;
+  return x == null || y == null ? null : { x, y };
+}
+
+/**
+ * The threshold options a declaration carries, or nothing at all.
+ *
+ * None of the three has a default, and the omission is the whole point:
+ * a guessed significance line sorts every point on the figure onto the wrong
+ * side silently, a `significanceDirection` fixed to `'above'` selects precisely
+ * the points that failed to reach significance on a raw p axis, and a
+ * Manhattan's x-axis lines are chromosome dividers rather than an effect
+ * cutoff. Absent, the trace reports no findings, which is the truthful smaller
+ * reading.
+ *
+ * @param declaration - The cloud's declaration.
+ * @returns The options block, or `null` when the author declared none.
+ */
+export function readThresholdOptions(
+  declaration: ManhattanDeclaration | VolcanoDeclaration,
+): ThresholdOptions | null {
+  const options: ThresholdOptions = {
+    ...(declaration.significance !== undefined ? { significance: declaration.significance } : {}),
+    ...(declaration.significanceDirection !== undefined
+      ? { significanceDirection: declaration.significanceDirection }
+      : {}),
+    ...(declaration.effect !== undefined ? { effect: declaration.effect } : {}),
+  };
+  return Object.keys(options).length === 0 ? null : options;
+}

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -1130,6 +1130,19 @@ export type SeriesKind
     | 'unknown';
 
 /**
+ * Whether a series draws its marks as columns.
+ *
+ * The one question a declared layer still has to ask about how it was drawn:
+ * an estimate laid out as a column and one laid out as a bullet on a line keep
+ * their geometry in different places, so the highlight has to know which. It is
+ * asked of the class name rather than of the declaration, because the mark is
+ * amCharts' business and the meaning is the author's.
+ */
+export function isColumnSeries(series: AmXYSeries): boolean {
+  return COLUMN_CLASSES.has(series.className ?? '');
+}
+
+/**
  * Determine the MAIDR trace kind for a given amCharts series.
  */
 export function classifySeriesKind(series: AmXYSeries): SeriesKind {
@@ -1216,7 +1229,18 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
 // Utilities
 // ---------------------------------------------------------------------------
 
-function readXValue(item: AmDataItem, series: AmXYSeries): unknown {
+/**
+ * Read the position a mark sits at along the main axis.
+ *
+ * The four places amCharts may keep it, in the order a chart is most likely to
+ * mean: the category it was bound to, the value on a value axis, the `Date` a
+ * date axis stores, and finally the raw column the series named as its category
+ * field for a chart whose data items have not been processed yet.
+ *
+ * Exported for the declared-trace reader, which reads the same position off
+ * series the heuristics deliberately do not classify.
+ */
+export function readXValue(item: AmDataItem, series: AmXYSeries): unknown {
   // Try category first, then numeric value.
   const cat = item.get('categoryX');
   if (cat != null)
@@ -1242,13 +1266,21 @@ function readXValue(item: AmDataItem, series: AmXYSeries): unknown {
  * Convert an unknown value to a finite number, or `null` if the
  * conversion is not possible. Callers should skip data items that
  * return `null` to avoid silent data corruption.
+ *
+ * Coerces the way `Number()` does, so `null` reads as 0 and `''` as 0: every
+ * caller here has already established that the value is present. A value that
+ * may legitimately be absent — anything read off an author's own row — goes
+ * through the declared reader's stricter conversion instead.
  */
-function toNumber(value: unknown): number | null {
+export function toNumber(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }
 
-function toStringOrNumber(value: unknown): string | number {
+/**
+ * Render an axis position as the `string | number` the grammar's points carry.
+ */
+export function toStringOrNumber(value: unknown): string | number {
   if (typeof value === 'number' && Number.isFinite(value))
     return value;
   return String(value ?? '');

--- a/src/adapters/amcharts/index.ts
+++ b/src/adapters/amcharts/index.ts
@@ -21,6 +21,12 @@
  *    attribute or `<Maidr data={...}>`. Enables audio/text/braille but NOT
  *    visual highlighting (the highlight callback cannot survive JSON).
  *
+ * A handful of readings amCharts leaves no signature for — a survival curve, an
+ * error bar, a forest plot, a volcano, a Manhattan, a scatter — are declared
+ * rather than detected, in a `maidr` block on the series' own `userData`. See
+ * {@link MaidrTraceDeclaration}, re-exported here so a TypeScript author gets
+ * the field names checked.
+ *
  * Multi-panel roots are supported by both paths: every `XYChart` in the
  * root's container tree (including am5stock `StockPanel`s) and every
  * am5percent chart becomes one MAIDR subplot, arranged in a grid matching the
@@ -44,3 +50,14 @@ export { findCharts, findXYCharts, fromAmCharts, fromXYChart, fromXYCharts } fro
 export { bindAmCharts, bindXYChart } from './binder';
 export type { AmChartsBinding, AmChartsBindOptions } from './binder';
 export type { AmChart, AmChartsBinderOptions, AmRoot, AmXYChart, AmXYSeries } from './types';
+export type {
+  ErrorBarDeclaration,
+  FieldRef,
+  ForestDeclaration,
+  MaidrTraceDeclaration,
+  ManhattanDeclaration,
+  ScatterDeclaration,
+  SeriesRef,
+  SurvivalDeclaration,
+  VolcanoDeclaration,
+} from '@type/declaration';

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -10,12 +10,19 @@
  */
 
 import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import type { AmDeclaredLayer } from './declaration';
 import type { AmChart, AmDataItem, AmXYSeries } from './types';
 import { TraceType } from '@type/grammar';
+import {
+  extractErrorBarSamples,
+  extractForestSamples,
+  extractSurvivalArms,
+} from './declaration';
 import {
   extractGanttItems,
   extractHierarchyNodes,
   extractSpanItems,
+  isColumnSeries,
 } from './extractor';
 
 /**
@@ -100,6 +107,16 @@ export interface SeriesGroups {
   hierarchySeriesList: AmXYSeries[];
   /** One WORD_CLOUD layer each, in series order. */
   wordCloudSeriesList: AmXYSeries[];
+  /**
+   * One layer each for the series that declared what they mean, in series
+   * order — a survival curve, an error bar, a forest plot, a cloud.
+   *
+   * Kept as the plan rather than as a series list: a declared layer routinely
+   * spans several series (the column drawing an interval, the arms merged into
+   * one curve), and the highlight has to walk exactly the ones the layer was
+   * built from.
+   */
+  declaredList: AmDeclaredLayer[];
 }
 
 type Resolver = (row: number, col: number) => NavTarget[];
@@ -266,6 +283,49 @@ function buildHierarchyResolver(series: AmXYSeries | undefined): Resolver {
 }
 
 /**
+ * Build a resolver for a declared survival figure.
+ *
+ * Rows are the arms and columns the samples, exactly as a merged line layer is
+ * navigated — a survival curve is a step line with two more things said about
+ * it, and neither of them changes which mark a position addresses.
+ */
+function buildSurvivalResolver(declared: AmDeclaredLayer | undefined): Resolver {
+  const arms = declared ? extractSurvivalArms(declared).items : [];
+  const series = declared ? [declared.series, ...declared.arms] : [];
+  return (row, col) => {
+    const dataItem = arms[row]?.[col];
+    const owner = series[row];
+    return owner && dataItem ? [{ series: owner, dataItem, kind: 'point' }] : [];
+  };
+}
+
+/**
+ * Build a resolver for a declared error bar or forest plot.
+ *
+ * The row walks the interval's three sections — lower bound, estimate, upper
+ * bound — and a chart draws one mark per sample rather than one per bound, so
+ * every section resolves to the same mark. A highlight that stays put while the
+ * announcement moves between the bounds is the honest rendering of that; the
+ * alternative is pointing at marks the chart never drew, which is the call the
+ * dumbbell's two ends already make.
+ */
+function buildIntervalResolver(declared: AmDeclaredLayer | undefined): Resolver {
+  if (!declared) {
+    return () => [];
+  }
+  const { items, owners } = declared.declaration.type === TraceType.FOREST
+    ? extractForestSamples(declared)
+    : extractErrorBarSamples(declared);
+  const kind: NavTarget['kind'] = isColumnSeries(declared.series) ? 'column' : 'point';
+
+  return (_row, col) => {
+    const dataItem = items[col];
+    const owner = owners[col];
+    return dataItem && owner ? [{ series: owner, dataItem, kind }] : [];
+  };
+}
+
+/**
  * Build a resolver for a heatmap layer. amCharts heatmap dataItems are a flat,
  * insertion-ordered list, so we index them by `categoryX`/`categoryY` value.
  * MAIDR's Heatmap model reverses the Y axis (`src/model/heatmap.ts`), so we
@@ -355,6 +415,21 @@ function addEntryResolvers(
     [TraceType.RADAR]: radarSeries,
     [TraceType.POLAR_AREA]: polarSeries,
   };
+
+  // Declared layers keep one queue per declared type rather than one counter:
+  // several types can be declared on one chart, and each type's layers appear
+  // in the same order as the series that declared them.
+  const declaredQueues = new Map<string, AmDeclaredLayer[]>();
+  for (const declared of groups.declaredList) {
+    const queue = declaredQueues.get(declared.declaration.type);
+    if (queue) {
+      queue.push(declared);
+    } else {
+      declaredQueues.set(declared.declaration.type, [declared]);
+    }
+  }
+  const nextDeclared = (type: TraceType): AmDeclaredLayer | undefined =>
+    declaredQueues.get(type)?.shift();
 
   let dotIdx = 0;
   let lollipopIdx = 0;
@@ -499,6 +574,29 @@ function addEntryResolvers(
             ? [{ series: entry.series, dataItem, kind: 'label' }]
             : [];
         });
+        break;
+      }
+      case TraceType.SURVIVAL: {
+        register(layer.id, buildSurvivalResolver(nextDeclared(TraceType.SURVIVAL)));
+        break;
+      }
+      case TraceType.ERROR_BAR:
+      case TraceType.FOREST: {
+        register(layer.id, buildIntervalResolver(nextDeclared(layer.type)));
+        break;
+      }
+      case TraceType.MANHATTAN:
+      case TraceType.VOLCANO:
+      case TraceType.SCATTER: {
+        // Deliberately unresolved, and the queue is drained so a second cloud
+        // still matches its own layer. A canvas highlight is driven by the
+        // braille position the navigation callback carries, and a scatter's
+        // braille surface is a *binned grid* rather than the points — so a
+        // position here names a cell of that grid, and reading it as a point
+        // index would outline whichever mark happens to sit at that ordinal.
+        // Resolving to nothing clears the overlay instead, which is the
+        // truthful answer until the position says which point it means.
+        nextDeclared(layer.type);
         break;
       }
       case TraceType.HEATMAP: {

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -159,6 +159,18 @@ export interface AmDataItem {
   get: (key: string) => unknown;
   uid?: number;
   bullets?: AmBullet[];
+  /**
+   * The author's own record behind the mark — the object they put in
+   * `series.data`, which amCharts keeps untouched on every data item it makes.
+   *
+   * `get()` answers with the *chart's* reading of a row (`valueY`, `categoryX`,
+   * the fields a series was told to bind), so a column the chart was never
+   * bound to — a censoring flag, a gene name, a study's weight — is reachable
+   * nowhere else. It is the row a co-located declaration's field names are
+   * resolved against, which is why it is typed `unknown` and narrowed once, in
+   * `resolveFieldRef`.
+   */
+  dataContext?: unknown;
 }
 
 /**

--- a/test/adapters/amcharts/declaration.test.ts
+++ b/test/adapters/amcharts/declaration.test.ts
@@ -349,6 +349,35 @@ describe('declared error bars', () => {
     expect(points[1]).toMatchObject({ x: 'B', yMin: 1.9, yMax: 2.3 });
   });
 
+  it('refuses a companion another declaration has already absorbed', () => {
+    const interval = columnSeries('CI', [
+      { categoryX: 'A', openValueY: 1.1, valueY: 1.7 },
+      { categoryX: 'B', openValueY: 1.9, valueY: 2.3 },
+    ], { id: 'ci' });
+    const layers = layersOf([
+      columnSeries('Mean', ESTIMATES, {
+        maidr: { type: 'error_bar', intervalSeries: 'ci' },
+      }),
+      columnSeries('Median', ESTIMATES, {
+        maidr: { type: 'error_bar', intervalSeries: 'ci' },
+      }),
+      interval,
+    ]);
+
+    // One column of intervals cannot be two layers' intervals: the first claim
+    // stands, the second is refused out loud, and the rows are announced once.
+    expect(layers).toHaveLength(2);
+    expect(layers[0].data as ErrorBarPoint[]).toEqual([
+      { x: 'A', y: 1.4, yMin: 1.1, yMax: 1.7 },
+      { x: 'B', y: 2.1, yMin: 1.9, yMax: 2.3 },
+    ]);
+    expect(layers[1].data as ErrorBarPoint[]).toEqual([
+      { x: 'A', y: 1.4 },
+      { x: 'B', y: 2.1 },
+    ]);
+    expect(warnings()).toContain('which another declaration already absorbed');
+  });
+
   it('lets the declaration settle an orientation the drawing does not state', () => {
     const onValueAxes = [{ valueX: 1.4, valueY: 3 }];
     const upright = layerOf([fakeSeries({
@@ -463,6 +492,62 @@ describe('declared forest plots', () => {
     expect(layers).toHaveLength(1);
     expect(points).toHaveLength(3);
     expect(points[2]).toMatchObject({ x: 'Overall', y: 0.95, pooled: true });
+  });
+
+  it('fills the pooled summary from the interval companion at its own position', () => {
+    const interval = columnSeries('CI', [
+      { categoryY: 'Ross 1998', openValueX: 0.6, valueX: 1 },
+      { categoryY: 'Overall', openValueX: 0.85, valueX: 1.05 },
+    ], { id: 'ci', horizontal: true });
+    const summary = columnSeries('Pooled', [
+      { categoryY: 'Overall', valueX: 0.95 },
+    ], { id: 'summary', horizontal: true });
+    const layers = layersOf([
+      columnSeries('Effect', STUDIES.slice(0, 2), {
+        horizontal: true,
+        maidr: { type: 'forest', intervalSeries: 'ci', pooledSeries: 'summary' },
+      }),
+      interval,
+      summary,
+    ]);
+    const points = layers[0].data as ForestPoint[];
+
+    // A forest plot routinely draws every interval in one column series, the
+    // summary's included, so the interval companion stays in scope for the
+    // pooled rows too. The join is by position either way: the summary takes
+    // the interval drawn at its own category, and the study the companion
+    // draws nothing for keeps no bounds at all.
+    expect(layers).toHaveLength(1);
+    expect(points).toEqual([
+      { x: 'Ross 1998', y: 0.8, yMin: 0.6, yMax: 1 },
+      { x: 'Patel 2004', y: 1.2 },
+      { x: 'Overall', y: 0.95, yMin: 0.85, yMax: 1.05, pooled: true },
+    ]);
+  });
+
+  it('lets the pooled summary\'s own row outrank the interval companion', () => {
+    const interval = columnSeries('CI', [
+      { categoryY: 'Ross 1998', openValueX: 0.6, valueX: 1 },
+      { categoryY: 'Overall', openValueX: 0.85, valueX: 1.05 },
+    ], { id: 'ci', horizontal: true });
+    const summary = columnSeries('Pooled', [
+      { categoryY: 'Overall', valueX: 0.95 },
+    ], { id: 'summary', horizontal: true, rows: [{ study: 'Overall', lower: 0.9 }] });
+    const layers = layersOf([
+      columnSeries('Effect', STUDIES.slice(0, 2), {
+        horizontal: true,
+        maidr: { type: 'forest', intervalSeries: 'ci', pooledSeries: 'summary' },
+        rows: [{ study: 'Ross 1998' }, { study: 'Patel 2004' }],
+      }),
+      interval,
+      summary,
+    ]);
+    const points = layers[0].data as ForestPoint[];
+
+    // Row fields → `error` offset → companion, for the summary exactly as for
+    // a study: a bound the summary's own row states is the more specific
+    // statement, and the companion fills only the half it left unsaid.
+    expect(points[2]).toEqual({ x: 'Overall', y: 0.95, yMin: 0.9, yMax: 1.05, pooled: true });
   });
 });
 

--- a/test/adapters/amcharts/declaration.test.ts
+++ b/test/adapters/amcharts/declaration.test.ts
@@ -1,0 +1,627 @@
+import type { AmXYSeries } from '@adapters/amcharts/types';
+import type {
+  ErrorBarPoint,
+  ForestPoint,
+  MaidrLayer,
+  ScatterPoint,
+  SurvivalPoint,
+  VolcanoPoint,
+} from '@type/grammar';
+import { fromXYChart } from '@adapters/amcharts/adapter';
+import { planDeclarations } from '@adapters/amcharts/declaration';
+import { buildNavigationMap } from '@adapters/amcharts/navmap';
+import { Orientation, TraceType } from '@type/grammar';
+import { fakeChart, fakeContainerEl, fakePieSeries, fakeSeries } from './helpers';
+
+/**
+ * The declared reading is opt-in, so every case here is really two charts: the
+ * one amCharts drew, and the one an author said it was. The tests assert the
+ * difference between them — a step line that becomes a survival curve, a line
+ * series that stops being announced as a line — rather than the declared
+ * payload alone, which would pass just as well if the declaration were ignored
+ * and the heuristic happened to agree.
+ */
+
+const CONTAINER = fakeContainerEl('chartdiv');
+
+/** Build the layers of a one-chart figure. */
+function layersOf(series: AmXYSeries[]): MaidrLayer[] {
+  const maidr = fromXYChart(fakeChart({ series }), CONTAINER);
+  return maidr.subplots[0][0].layers;
+}
+
+/** The single layer a chart of these series produces. */
+function layerOf(series: AmXYSeries[]): MaidrLayer {
+  const layers = layersOf(series);
+  expect(layers).toHaveLength(1);
+  return layers[0];
+}
+
+/** A `StepLineSeries` drawing a curve, with an optional declaration on it. */
+function stepSeries(
+  name: string,
+  data: Array<Record<string, unknown>>,
+  config: { maidr?: unknown; id?: string; rows?: Array<Record<string, unknown>> } = {},
+): AmXYSeries {
+  return fakeSeries({
+    className: 'StepLineSeries',
+    name,
+    id: config.id,
+    userData: config.maidr === undefined ? undefined : { maidr: config.maidr },
+    settings: { categoryXField: 'time' },
+    data,
+    rows: config.rows,
+  });
+}
+
+/**
+ * The amCharts scatter recipe: a `LineSeries` on two value axes. Undeclared it
+ * falls into the line reading, which is exactly the misannouncement a volcano
+ * or Manhattan declaration exists to correct.
+ */
+function cloudSeries(
+  name: string,
+  data: Array<Record<string, unknown>>,
+  config: { maidr?: unknown; rows?: Array<Record<string, unknown>> } = {},
+): AmXYSeries {
+  return fakeSeries({
+    className: 'LineSeries',
+    name,
+    userData: config.maidr === undefined ? undefined : { maidr: config.maidr },
+    data,
+    rows: config.rows,
+  });
+}
+
+/** A column series of estimates, or of the intervals drawn behind them. */
+function columnSeries(
+  name: string,
+  data: Array<Record<string, unknown>>,
+  config: { maidr?: unknown; id?: string; rows?: Array<Record<string, unknown>>; horizontal?: boolean } = {},
+): AmXYSeries {
+  return fakeSeries({
+    className: 'ColumnSeries',
+    name,
+    id: config.id,
+    userData: config.maidr === undefined ? undefined : { maidr: config.maidr },
+    settings: config.horizontal
+      ? { categoryYField: 'study' }
+      : { categoryXField: 'group' },
+    data,
+    rows: config.rows,
+  });
+}
+
+let warn: jest.SpyInstance;
+
+beforeEach(() => {
+  warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+});
+
+/** Every warning raised so far, joined for a substring assertion. */
+function warnings(): string {
+  return warn.mock.calls.map(call => String(call[0])).join('\n');
+}
+
+describe('declaration precedence', () => {
+  const CURVE = [
+    { categoryX: 0, valueY: 1 },
+    { categoryX: 4, valueY: 0.8 },
+  ];
+
+  it('reads an undeclared step line as a step layer', () => {
+    expect(layerOf([stepSeries('Arm A', CURVE)]).type).toBe(TraceType.STEP);
+  });
+
+  it('reads the same series as a survival curve once it declares one', () => {
+    const layer = layerOf([stepSeries('Arm A', CURVE, { maidr: { type: 'survival' } })]);
+
+    expect(layer.type).toBe(TraceType.SURVIVAL);
+  });
+
+  it('falls back to the undeclared reading when the type names no trace', () => {
+    const layer = layerOf([stepSeries('Arm A', CURVE, { maidr: { type: 'survivial' } })]);
+
+    expect(layer.type).toBe(TraceType.STEP);
+    expect(warnings()).toContain('unknown type "survivial"');
+  });
+
+  it('falls back when the declared type is one no amCharts series draws', () => {
+    const layer = layerOf([stepSeries('Arm A', CURVE, { maidr: { type: 'hexbin' } })]);
+
+    expect(layer.type).toBe(TraceType.STEP);
+    expect(warnings()).toContain('which no amCharts series draws');
+  });
+
+  it('falls back when the series carries none of the values the type needs', () => {
+    const pie = fakePieSeries('Share', [{ category: 'A', value: 3 }]);
+    const declared = fakeSeries({
+      className: 'PieSeries',
+      name: 'Share',
+      userData: { maidr: { type: 'survival' } },
+      settings: { categoryField: 'category', valueField: 'value' },
+      data: [{ category: 'A', value: 3 }],
+    });
+
+    expect(layerOf([declared]).type).toBe(layerOf([pie]).type);
+    expect(warnings()).toContain('no mark of it carries the values');
+  });
+
+  it('drops a key the declared type does not accept and keeps the rest', () => {
+    const layer = layerOf([stepSeries('Arm A', CURVE, {
+      maidr: { type: 'survival', stepDirection: 'hv', significanse: 7.3 },
+    })]);
+
+    expect(layer.type).toBe(TraceType.SURVIVAL);
+    expect(layer.stepDirection).toBe('hv');
+    expect(warnings()).toContain('unknown key "significanse"');
+  });
+});
+
+describe('declared survival curves', () => {
+  const TIMES = [
+    { categoryX: 0, valueY: 1 },
+    { categoryX: 4, valueY: 0.8 },
+    { categoryX: 9, valueY: 0.6 },
+  ];
+
+  it('reads the censoring flag off the author\'s own row', () => {
+    const layer = layerOf([stepSeries('Arm A', TIMES, {
+      maidr: { type: 'survival' },
+      // Only on the row: the chart was never bound to this column, so nothing
+      // but `dataContext` can answer for it.
+      rows: [
+        { time: 0, isCensored: false },
+        { time: 4, isCensored: true },
+        { time: 9, isCensored: '0' },
+      ],
+    })]);
+    const arms = layer.data as SurvivalPoint[][];
+
+    // '0' is the string a 0/1 indicator arrives as out of a CSV, and it
+    // censors nobody however truthy JavaScript finds it.
+    expect(arms[0].map(point => point.censored)).toEqual([false, true, false]);
+  });
+
+  it('uses an explicit field name verbatim and reports one that misses', () => {
+    const layer = layerOf([stepSeries('Arm A', TIMES, {
+      maidr: { type: 'survival', censored: 'cens' },
+      rows: [
+        { time: 0, isCensored: true },
+        { time: 4, isCensored: true },
+        { time: 9, isCensored: true },
+      ],
+    })]);
+    const arms = layer.data as SurvivalPoint[][];
+
+    expect(arms[0].every(point => point.censored === undefined)).toBe(true);
+    expect(warnings()).toContain('names "cens" for censored');
+  });
+
+  it('folds a following arm into the same layer', () => {
+    const layer = layerOf([
+      stepSeries('Treated', TIMES, { maidr: { type: 'survival' } }),
+      stepSeries('Control', TIMES),
+    ]);
+    const arms = layer.data as SurvivalPoint[][];
+
+    expect(layer.type).toBe(TraceType.SURVIVAL);
+    expect(arms).toHaveLength(2);
+    expect(arms[1][0].z).toBe('Control');
+  });
+
+  it('leaves the second arm its own layer when merge is off', () => {
+    const layers = layersOf([
+      stepSeries('Treated', TIMES, { maidr: { type: 'survival', merge: false } }),
+      stepSeries('Control', TIMES),
+    ]);
+
+    expect(layers.map(layer => layer.type)).toEqual([TraceType.SURVIVAL, TraceType.STEP]);
+  });
+
+  it('absorbs the companion drawing the censoring ticks', () => {
+    const ticks = fakeSeries({
+      className: 'LineSeries',
+      name: 'Censored',
+      id: 'ticks',
+      settings: { categoryXField: 'time' },
+      data: [{ categoryX: 4, valueY: 0.8 }],
+    });
+    const layers = layersOf([
+      stepSeries('Arm A', TIMES, { maidr: { type: 'survival', censoredSeries: 'ticks' } }),
+      ticks,
+    ]);
+    const arms = layers[0].data as SurvivalPoint[][];
+
+    // One layer, not two: the ticks are part of the curve that named them.
+    expect(layers).toHaveLength(1);
+    expect(arms[0].map(point => point.censored)).toEqual([undefined, true, undefined]);
+  });
+
+  it('reports a companion that names no series and emits the curve without it', () => {
+    const layer = layerOf([
+      stepSeries('Arm A', TIMES, { maidr: { type: 'survival', bandSeries: 'band' } }),
+    ]);
+    const arms = layer.data as SurvivalPoint[][];
+
+    expect(layer.type).toBe(TraceType.SURVIVAL);
+    expect(arms[0].every(point => point.yMin === undefined)).toBe(true);
+    expect(warnings()).toContain('names bandSeries "band"');
+  });
+
+  it('takes the confidence band from the companion drawing it', () => {
+    const band = fakeSeries({
+      className: 'LineSeries',
+      name: 'CI',
+      id: 'band',
+      settings: { categoryXField: 'time' },
+      data: [
+        { categoryX: 4, openValueY: 0.7, valueY: 0.9 },
+        { categoryX: 9, openValueY: 0.4, valueY: 0.75 },
+      ],
+    });
+    const layer = layerOf([
+      stepSeries('Arm A', TIMES, { maidr: { type: 'survival', bandSeries: 'band' } }),
+      band,
+    ]);
+    const arms = layer.data as SurvivalPoint[][];
+
+    expect(arms[0][0].yMin).toBeUndefined();
+    expect(arms[0][1]).toMatchObject({ x: 4, y: 0.8, yMin: 0.7, yMax: 0.9 });
+  });
+});
+
+describe('declared error bars', () => {
+  const ESTIMATES = [
+    { categoryX: 'A', valueY: 1.4 },
+    { categoryX: 'B', valueY: 2.1 },
+  ];
+
+  it('reads absolute bounds off the row under their common spellings', () => {
+    const layer = layerOf([columnSeries('Mean', ESTIMATES, {
+      maidr: { type: 'error_bar' },
+      rows: [
+        { group: 'A', lower: 1.1, upper: 1.7 },
+        { group: 'B', lower: 1.9 },
+      ],
+    })]);
+
+    expect(layer.type).toBe(TraceType.ERROR_BAR);
+    // A one-sided interval keeps the half it has rather than losing the
+    // estimate with it.
+    expect(layer.data as ErrorBarPoint[]).toEqual([
+      { x: 'A', y: 1.4, yMin: 1.1, yMax: 1.7 },
+      { x: 'B', y: 2.1, yMin: 1.9 },
+    ]);
+  });
+
+  it('converts an offset into the absolute bounds the grammar fixes', () => {
+    const layer = layerOf([columnSeries('Mean', ESTIMATES, {
+      maidr: { type: 'error_bar', error: 'err' },
+      rows: [
+        { group: 'A', err: 0.2 },
+        { group: 'B', err: [0.2, 0.3] },
+      ],
+    })]);
+
+    expect(layer.data as ErrorBarPoint[]).toEqual([
+      { x: 'A', y: 1.4, yMin: 1.2, yMax: 1.6 },
+      { x: 'B', y: 2.1, yMin: 1.9, yMax: 2.4 },
+    ]);
+  });
+
+  it('takes the interval from the companion column and suppresses it', () => {
+    const interval = columnSeries('CI', [
+      { categoryX: 'A', openValueY: 1.1, valueY: 1.7 },
+      { categoryX: 'B', openValueY: 1.9, valueY: 2.3 },
+    ], { id: 'ci' });
+    const layers = layersOf([
+      columnSeries('Mean', ESTIMATES, {
+        maidr: { type: 'error_bar', intervalSeries: 'ci' },
+      }),
+      interval,
+    ]);
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].data as ErrorBarPoint[]).toEqual([
+      { x: 'A', y: 1.4, yMin: 1.1, yMax: 1.7 },
+      { x: 'B', y: 2.1, yMin: 1.9, yMax: 2.3 },
+    ]);
+  });
+
+  it('joins the companion on the position rather than by index', () => {
+    const interval = columnSeries('CI', [
+      { categoryX: 'B', openValueY: 1.9, valueY: 2.3 },
+    ], { id: 'ci' });
+    const layer = layerOf([
+      columnSeries('Mean', ESTIMATES, {
+        maidr: { type: 'error_bar', intervalSeries: 'ci' },
+      }),
+      interval,
+    ]);
+    const points = layer.data as ErrorBarPoint[];
+
+    expect(points[0].yMin).toBeUndefined();
+    expect(points[1]).toMatchObject({ x: 'B', yMin: 1.9, yMax: 2.3 });
+  });
+
+  it('lets the declaration settle an orientation the drawing does not state', () => {
+    const onValueAxes = [{ valueX: 1.4, valueY: 3 }];
+    const upright = layerOf([fakeSeries({
+      className: 'LineSeries',
+      name: 'Mean',
+      userData: { maidr: { type: 'error_bar' } },
+      data: onValueAxes,
+    })]);
+    const sideways = layerOf([fakeSeries({
+      className: 'LineSeries',
+      name: 'Mean',
+      userData: { maidr: { type: 'error_bar', orientation: 'horz' } },
+      data: onValueAxes,
+    })]);
+
+    // Neither axis is categorical, so the drawing says nothing: the samples
+    // run along x by default and along y when the author says so, and the
+    // estimate is read off the other one either way.
+    expect(upright.data as ErrorBarPoint[]).toEqual([{ x: 1.4, y: 3 }]);
+    expect(sideways.data as ErrorBarPoint[]).toEqual([{ x: 3, y: 1.4 }]);
+  });
+
+  it('reads a chart drawn on its side as horizontal', () => {
+    const layer = layerOf([columnSeries('Mean', [
+      { categoryY: 'A', valueX: 1.4 },
+    ], { horizontal: true, maidr: { type: 'error_bar' } })]);
+
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(layer.data as ErrorBarPoint[]).toEqual([{ x: 'A', y: 1.4 }]);
+  });
+});
+
+describe('declared forest plots', () => {
+  const STUDIES = [
+    { categoryY: 'Ross 1998', valueX: 0.8 },
+    { categoryY: 'Patel 2004', valueX: 1.2 },
+    { categoryY: 'Pooled', valueX: 0.95 },
+  ];
+
+  function forestLayer(maidr: unknown, rows?: Array<Record<string, unknown>>): MaidrLayer {
+    return layerOf([columnSeries('Effect', STUDIES, { horizontal: true, maidr, rows })]);
+  }
+
+  it('carries the weight and the pooled flag off the rows', () => {
+    const layer = forestLayer({ type: 'forest', nullValue: 1 }, [
+      { study: 'Ross 1998', w: 0.25 },
+      { study: 'Patel 2004', w: 0.35 },
+      { study: 'Pooled', w: 0.4, pooled: true },
+    ]);
+
+    expect(layer.type).toBe(TraceType.FOREST);
+    expect(layer.forestOptions).toEqual({ nullValue: 1 });
+    expect((layer.data as ForestPoint[]).map(point => point.weight)).toEqual([0.25, 0.35, 0.4]);
+    expect((layer.data as ForestPoint[])[2].pooled).toBe(true);
+  });
+
+  it('leaves out a weight reported as a percentage rather than rescaling it', () => {
+    const layer = forestLayer({ type: 'forest' }, [
+      { study: 'Ross 1998', weight: 25 },
+      { study: 'Patel 2004', weight: 35 },
+      { study: 'Pooled', weight: 40 },
+    ]);
+
+    // Dividing by 100 guesses that the column sums to 100; passing it through
+    // announces "weight 2500%". Neither is what the chart said.
+    expect((layer.data as ForestPoint[]).every(point => point.weight === undefined)).toBe(true);
+  });
+
+  it('makes no claim about significance when no null value is declared', () => {
+    expect(forestLayer({ type: 'forest' }).forestOptions).toBeUndefined();
+  });
+
+  it('counts pooledIndex over the rows as authored, including dropped ones', () => {
+    const layer = layerOf([columnSeries('Effect', [
+      { categoryY: 'Ross 1998', valueX: 0.8 },
+      // A row the chart drew nothing for: it still counts, because the
+      // sequence an author can see is the one they wrote.
+      { categoryY: 'Kim 2001', valueX: null },
+      { categoryY: 'Pooled', valueX: 0.95 },
+    ], { horizontal: true, maidr: { type: 'forest', pooledIndex: 2 } })]);
+    const points = layer.data as ForestPoint[];
+
+    expect(points.map(point => point.x)).toEqual(['Ross 1998', 'Pooled']);
+    expect(points.map(point => point.pooled)).toEqual([undefined, true]);
+  });
+
+  it('reports only the field that missed, not the one another pass resolved', () => {
+    const layer = forestLayer({ type: 'forest', yMin: 'lo', weight: 'w' }, [
+      { study: 'Ross 1998', lo: 0.6 },
+      { study: 'Patel 2004', lo: 0.9 },
+      { study: 'Pooled', lo: 0.8 },
+    ]);
+
+    expect((layer.data as ForestPoint[])[0].yMin).toBe(0.6);
+    expect(warnings()).toContain('names "w" for weight');
+    expect(warnings()).not.toContain('for yMin');
+  });
+
+  it('appends the companion drawing the pooled summary', () => {
+    const summary = columnSeries('Pooled', [
+      { categoryY: 'Overall', valueX: 0.95, openValueX: 0.85 },
+    ], { id: 'summary', horizontal: true });
+    const layers = layersOf([
+      columnSeries('Effect', STUDIES.slice(0, 2), {
+        horizontal: true,
+        maidr: { type: 'forest', pooledSeries: 'summary' },
+      }),
+      summary,
+    ]);
+    const points = layers[0].data as ForestPoint[];
+
+    expect(layers).toHaveLength(1);
+    expect(points).toHaveLength(3);
+    expect(points[2]).toMatchObject({ x: 'Overall', y: 0.95, pooled: true });
+  });
+});
+
+describe('declared clouds', () => {
+  const GENES = [
+    { valueX: -2.4, valueY: 9.1 },
+    { valueX: 0.1, valueY: 0.4 },
+  ];
+  const NAMES = [{ gene: 'BRCA1' }, { gene: 'ACTB' }];
+
+  it('reads an undeclared scatter recipe as a line, and a declared one as a volcano', () => {
+    const undeclared = layerOf([cloudSeries('DE', GENES, { rows: NAMES })]);
+    const layer = layerOf([cloudSeries('DE', GENES, {
+      rows: NAMES,
+      maidr: { type: 'volcano', significance: 1.3, effect: 1 },
+    })]);
+
+    expect(undeclared.type).toBe(TraceType.LINE);
+    expect(layer.type).toBe(TraceType.VOLCANO);
+    expect(layer.data as VolcanoPoint[]).toEqual([
+      { x: -2.4, y: 9.1, label: 'BRCA1' },
+      { x: 0.1, y: 0.4, label: 'ACTB' },
+    ]);
+    expect(layer.thresholdOptions).toEqual({ significance: 1.3, effect: 1 });
+  });
+
+  it('reports no findings when the cutoffs were not declared', () => {
+    const layer = layerOf([cloudSeries('DE', GENES, {
+      maidr: { type: 'volcano' },
+    })]);
+
+    // A guessed line sorts every point onto the wrong side silently, so the
+    // layer says nothing about significance at all.
+    expect(layer.thresholdOptions).toBeUndefined();
+  });
+
+  it('folds every chromosome of a Manhattan into one cloud', () => {
+    const layers = layersOf([
+      cloudSeries('chr1', [{ valueX: 1, valueY: 3 }], {
+        rows: [{ snp: 'rs1', chr: '1' }],
+        maidr: { type: 'manhattan', significance: 7.3 },
+      }),
+      cloudSeries('chr2', [{ valueX: 2, valueY: 8 }], { rows: [{ snp: 'rs2', chr: '2' }] }),
+    ]);
+    const points = layers[0].data as VolcanoPoint[];
+
+    expect(layers).toHaveLength(1);
+    expect(points).toEqual([
+      { x: 1, y: 3, label: 'rs1', group: '1' },
+      { x: 2, y: 8, label: 'rs2', group: '2' },
+    ]);
+  });
+
+  it('keeps a volcano\'s sibling series apart, which a Manhattan\'s are not', () => {
+    const layers = layersOf([
+      cloudSeries('Up', GENES, { maidr: { type: 'volcano' } }),
+      cloudSeries('Down', GENES),
+    ]);
+
+    expect(layers.map(layer => layer.type)).toEqual([TraceType.VOLCANO, TraceType.LINE]);
+  });
+
+  it('reads a plain declared scatter as coordinates alone', () => {
+    const layer = layerOf([cloudSeries('Cloud', GENES, {
+      rows: NAMES,
+      maidr: { type: 'point' },
+    })]);
+
+    // `ScatterPoint` has nowhere to put a name, so the declared `label` chain
+    // is not read into one: the layer carries what the grammar can carry.
+    expect(layer.type).toBe(TraceType.SCATTER);
+    expect(layer.data as ScatterPoint[]).toEqual([
+      { x: -2.4, y: 9.1 },
+      { x: 0.1, y: 0.4 },
+    ]);
+  });
+});
+
+describe('declared layers and the highlight', () => {
+  /** The navigation map for a one-chart figure, as the binder builds it. */
+  function navMapOf(series: AmXYSeries[]): ReturnType<typeof buildNavigationMap> {
+    const chart = fakeChart({ series });
+    const layers = fromXYChart(chart, CONTAINER).subplots[0][0].layers;
+    // Mirrors `groupSeries` in binder.tsx for a chart whose layers are all
+    // declared: the plan is what the highlight path walks.
+    const plan = planDeclarations(chart);
+    return buildNavigationMap([{
+      layers,
+      chart,
+      groups: {
+        barSeriesList: [],
+        dotSeriesList: [],
+        lollipopSeriesList: [],
+        lineSeriesList: [],
+        stepSeriesList: [],
+        areaSeriesList: [],
+        radarSeriesList: [],
+        polarSeriesList: [],
+        histogramSeries: [],
+        heatmapSeries: [],
+        pieSeriesList: [],
+        funnelSeriesList: [],
+        waterfallSeriesList: [],
+        dumbbellSeriesList: [],
+        ganttSeriesList: [],
+        hierarchySeriesList: [],
+        wordCloudSeriesList: [],
+        declaredList: [...plan.declared.values()],
+      },
+    }]);
+  }
+
+  it('points a survival position at the mark of that arm and that sample', () => {
+    const treated = stepSeries('Treated', [
+      { categoryX: 0, valueY: 1 },
+      { categoryX: 4, valueY: 0.8 },
+    ], { maidr: { type: 'survival' } });
+    const control = stepSeries('Control', [
+      { categoryX: 0, valueY: 1 },
+      { categoryX: 4, valueY: 0.6 },
+    ]);
+    const navMap = navMapOf([treated, control]);
+    const layerId = layersOf([treated, control])[0].id;
+
+    const targets = navMap.resolve(layerId, 1, 1);
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0].series).toBe(control);
+    expect(targets[0].dataItem).toBe(control.dataItems[1]);
+  });
+
+  it('points every section of an error bar at the sample it belongs to', () => {
+    const estimate = columnSeries('Mean', [
+      { categoryX: 'A', valueY: 1.4 },
+      { categoryX: 'B', valueY: 2.1 },
+    ], { maidr: { type: 'error_bar' } });
+    const navMap = navMapOf([estimate]);
+    const layerId = layersOf([estimate])[0].id;
+
+    // Rows are the lower bound, the estimate and the upper bound; a chart
+    // draws one mark per sample, so all three land on it.
+    const lower = navMap.resolve(layerId, 0, 1);
+    const upper = navMap.resolve(layerId, 2, 1);
+
+    expect(lower[0].dataItem).toBe(estimate.dataItems[1]);
+    expect(upper[0].dataItem).toBe(estimate.dataItems[1]);
+    expect(lower[0].kind).toBe('column');
+  });
+
+  it('resolves nothing for a cloud, whose position names a grid cell', () => {
+    const cloud = cloudSeries('DE', [{ valueX: 1, valueY: 2 }], {
+      maidr: { type: 'volcano' },
+    });
+    const navMap = navMapOf([cloud]);
+    const layerId = layersOf([cloud])[0].id;
+
+    // A scatter publishes a binned grid rather than its points, so a position
+    // here does not name a mark: the overlay is cleared instead of outlining
+    // whichever point happens to sit at that ordinal.
+    expect(navMap.resolve(layerId, 0, 0)).toEqual([]);
+  });
+});

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -22,23 +22,41 @@ export interface FakeSeriesConfig {
   className?: string;
   /** Series name (used for layer titles / segmented fill). */
   name?: string;
+  /** `IEntitySettings.id` — the name a companion series is addressed by. */
+  id?: string;
+  /**
+   * The `userData` slot, which a co-located `maidr` declaration rides in:
+   * pass `{ maidr: { type: 'survival', … } }`.
+   */
+  userData?: unknown;
   /** Extra series settings readable via `series.get(key)`. */
   settings?: Record<string, unknown>;
   /** Data-item records readable via `dataItem.get(key)`. */
   data?: Array<Record<string, unknown>>;
+  /**
+   * The authors' own rows, as `dataItem.dataContext`, index-aligned with
+   * `data`. Defaults to the `data` record itself, which is the ordinary case —
+   * amCharts derives a data item's readable values from the row it was given.
+   * Pass this to put a column *only* on the row, which is where a declared
+   * field the chart was never bound to actually lives.
+   */
+  rows?: Array<Record<string, unknown>>;
 }
 
 export function fakeSeries(config: FakeSeriesConfig = {}): AmXYSeries {
   const settings: Record<string, unknown> = {
     ...(config.name != null ? { name: config.name } : {}),
+    ...(config.id != null ? { id: config.id } : {}),
+    ...(config.userData != null ? { userData: config.userData } : {}),
     ...config.settings,
   };
   return {
     className: config.className ?? 'ColumnSeries',
     uid: nextUid++,
     get: (key: string) => settings[key],
-    dataItems: (config.data ?? []).map(record => ({
+    dataItems: (config.data ?? []).map((record, at) => ({
       get: (key: string) => record[key],
+      dataContext: config.rows?.[at] ?? record,
     })),
   } as unknown as AmXYSeries;
 }

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -42,6 +42,7 @@ function emptyGroups(): SeriesGroups {
     ganttSeriesList: [],
     hierarchySeriesList: [],
     wordCloudSeriesList: [],
+    declaredList: [],
   };
 }
 


### PR DESCRIPTION
## Description

amCharts leaves no signature for a handful of readings: a survival curve and a
step chart are the same `StepLineSeries`, a volcano and a scatter are the same
strokeless `LineSeries` with bullets, and an error bar's interval lives in
columns the chart was never bound to. This PR teaches the amCharts adapter to
read those meanings from the opt-in `maidr` declaration block on a series'
`userData`, using the shared foundation in `src/type/declaration.ts` and
`src/adapters/shared/traceDeclaration.ts` (both untouched here).

The declaration is resolved once per chart as a three-pass plan — read the
slots, absorb companion series, merge sibling arms — and the same plan backs
both entry points, so the layer a reader hears and the mark the overlay
outlines are always the same series. Detection and the selector/highlight path
land together: every type added here registers a navmap resolver, except where
the highlight contract itself cannot address the mark (see Additional Notes).

Diff: 12 files, +2558 / −5. New: `src/adapters/amcharts/declaration.ts`,
`test/adapters/amcharts/declaration.test.ts`, `examples/amcharts-declared.html`.
Changed: the adapter's `adapter.ts`, `binder.tsx`, `extractor.ts`, `navmap.ts`,
`types.ts`, `index.ts`, plus `docs/amcharts.md` and two test helpers. Nothing
outside `src/adapters/amcharts/`, `test/adapters/amcharts/`, `examples/` and
`docs/`.

## Related Issues

Part of #885

## Changes Made

### Trace types added

- **SURVIVAL** — `{ type: 'survival' }` on a `StepLineSeries` (or any XY series
  carrying `valueY`). Reads `censored`, `yMin` and `yMax` off
  `dataItem.dataContext` through the shared fallback chains and `isFlagValue`,
  passes `stepDirection` through to the layer, absorbs a `censoredSeries`
  (ticks joined by x) and a `bandSeries` (`openValueY`→`yMin`,
  `valueY`→`yMax`, joined by x), and folds following `StepLineSeries` siblings
  in as further arms (merge defaults true). Payload `SurvivalPoint[][]`, one row
  per arm, arm name on `z`. Highlight: navmap resolver, rows = arms,
  cols = samples, kind `point`.
- **ERROR_BAR** — `{ type: 'error_bar' }` on the estimate series. Bounds resolve
  *per bound*, in the order row fields → an `error` offset (a number or
  `[lower, upper]`, read as positive magnitudes, negatives dropped, float noise
  stripped) → an absorbed `intervalSeries` companion. The companion is joined
  **by position, not by index**, and is suppressed from becoming a layer of its
  own. Orientation comes from the declaration, else from `categoryYField`.
  Payload `ErrorBarPoint[]`. Highlight: col addresses the sample, every braille
  section resolving to the same mark (the dumbbell's call), kind `column` or
  `point` depending on the estimate series' class.
- **FOREST** — `{ type: 'forest' }`: everything ERROR_BAR takes, plus `weight`
  (a resolved value above 1 or below 0 is left out rather than rescaled),
  `pooled` (strict flag reading), `pooledIndex` (counted over the declaring
  series' data items as authored, so a dropped row still counts), a
  `pooledSeries` companion (rows appended after the studies, marked pooled), and
  `nullValue` → `forestOptions`, with no default. Payload `ForestPoint[]`.
- **VOLCANO** — `{ type: 'volcano' }` on the scatter recipe (a strokeless
  `LineSeries` with bullets on two value axes), which is announced as a LINE
  layer without it. Points read straight off `valueX`/`valueY`; `label` and
  `group` off `dataContext`. `significance`, `significanceDirection` and
  `effect` become `thresholdOptions` only when declared — no block at all when
  none is. Merge defaults false.
- **MANHATTAN** — the same reading with merge defaulting true, so one series per
  chromosome becomes one navigable cloud. Siblings are absorbed only when they
  carry no declaration of their own and their *undeclared* heuristic kind
  matches the declaring series'.
- **SCATTER** (`type: 'point'`) — the plain declarable case that falls out of the
  cloud path. `label` is accepted and not read, because `ScatterPoint` has
  nowhere to put it.

### Trace types not added

- **ALLUVIAL** — skipped deliberately, on two findings the spec did not
  anticipate. (1) The per-adapter instruction ("reuse the existing extractor and
  change only the emitted type") rests on a SANKEY extractor that does not
  exist: `grep -rn 'Sankey|FlowPoint' src/adapters/amcharts/` returns nothing,
  and an `am5flow.Sankey` is a bare series in the root container that discovery
  does not find today. The item is not opt-in plumbing; it is flow discovery,
  extraction and highlight from zero. (2) The highlight cannot be wired
  truthfully without duplicating model code: amCharts renders to canvas, so
  highlighting goes through the overlay, which is handed `{layerId, row, col}`
  from `state.braille`; `FlowTrace` addresses nodes by a longest-path stage
  layering (`src/model/flow.ts` `assignStages`/`buildNodes`, with a cyclic-graph
  fallback) and its braille getter additionally transposes the pair
  (flow.ts:449-465). Turning a position back into an am5 node would mean
  re-implementing that inside the adapter, where it would drift silently and put
  the highlight box on the wrong node. Compounding both: amCharts is commercial
  and is not installed here, so `am5flow`'s data-item surface could not be
  verified against anything.

### Supporting changes

- `src/adapters/amcharts/declaration.ts` (new) — validation through
  `readDeclarationSlot`, the chart-level three-pass plan, warn-once
  bookkeeping, and the payload extractors.
- `adapter.ts` (`buildChartLayers`) and `binder.tsx` (`groupSeries`) — the
  declared short-circuit lives at these two call sites rather than at the top of
  `classifySeriesKind`, so `classifySeriesKind` stays a pure statement about the
  drawing and the sibling-merge pass can still ask it what a candidate sibling
  actually draws.
- `navmap.ts` — resolvers for the declared layers.
- `extractor.ts` — exports `isColumnSeries`, `readXValue`, `toNumber` and
  `toStringOrNumber` for the declared reader; no behaviour change.
- `types.ts` — one optional `dataContext?: unknown` on `AmDataItem`; without it
  the author's own row is unreachable in TypeScript.
- `index.ts` — re-exports the declaration types so a TypeScript author gets the
  field names checked.
- `docs/amcharts.md` — a new "Declaring What a Chart Means" section (the slot,
  the two naming laws, a per-type field table, companion series, merging, and an
  explicit statement of the cloud highlight limitation), seven new rows in the
  supported-types table, and a corrected note on scatter vs dot plot.
- `examples/amcharts-declared.html` (new) — five runnable charts.
- `test/adapters/amcharts/declaration.test.ts` (new) — 33 cases. Each declared
  reading is asserted against the *undeclared* reading of the same series (step
  vs survival, line vs volcano), so a test cannot pass by the heuristic
  happening to agree.

## Screenshots (if applicable)

N/A — no visual change to existing charts. `examples/amcharts-declared.html`
exercises the new readings.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is left unticked: amCharts is a commercial library and is
not installed in this environment, so the charts could not be driven in a
browser. Automated verification actually run, all green:
`npm run lint:fix` (clean, no files changed), `npm run type-check` (clean),
`npm run build` (exit 0), `npm test` (exit 0 — unit: 3803 passed / 269 suites;
esm: 73 passed / 7 suites). `npm run e2e` was **not** run (no browser available)
and **no e2e spec was added**; `.claude/rules/testing.md` asks for one per new
trace type, so that is a known gap in this change.

## Additional Notes

These matter to the sibling adapter PRs under #885.

### Foundation gaps (nothing in the shared foundation was changed)

1. **`validateDeclaration` warns on every call and holds no state.** An adapter
   that resolves declarations at two entry points per binding — the JSON path
   and the highlight path both re-walk the chart — then says everything twice,
   breaking the spec's own "each distinct warning at most once per chart per
   binding" clause. Solved locally with a `WeakMap` keyed on the author's
   `userData` object, which also lets a *corrected* block be re-reported since
   rewriting it produces a new object. Every adapter with two entry points will
   need the same seven lines; a memo inside the shared module, or a `once` flag
   on `DeclarationContext`, would belong there. The same applies to
   `warnUnresolvedRef`, documented as "call this once per series per field" but
   leaving the caller to arrange it.
2. **The canvas-overlay highlight contract cannot address a scatter-family
   point.** `Controller.registerNavigateCallback` (controller.ts:572-583) only
   fires when `!state.braille.empty`, and `ScatterTrace.braille`
   (scatter.ts:452-490) returns the empty state outside grid mode — so a
   volcano, Manhattan or scatter layer emits no navigation event at all in
   ordinary navigation, and in grid mode the row/col are *binned grid cells*,
   not point indices. Every SVG adapter is unaffected (it highlights through
   `selectors`); every canvas adapter — amCharts, Chart.js — is affected. The
   resolver is deliberately left unregistered here, so the overlay clears rather
   than outlining whichever point happens to sit at that ordinal, and this is
   documented in `docs/amcharts.md`. Not fixable inside an adapter: it needs
   either a point-level position in `TraceState` for scatter traces, or a
   highlight channel that is not the braille position.
3. Two smaller notes, neither blocking: `FIELD_REF_FALLBACKS` has no entry for
   `error`, so an offset column must be spelled exactly `error` or named
   explicitly (possibly intentional — `yerr`/`sd`/`sem` are ambiguous); and the
   union in `MaidrTraceDeclaration` has no way for an adapter to say "I read
   this subset", so each adapter hand-writes its own narrowing predicate
   (`isDeclarable` here) and its own "this type names no construct I draw"
   warning.

### Spec corrections

- `deferred-amcharts.md` ALLUVIAL: "The work is almost entirely the opt-in
  plumbing on top of the SANKEY extractor." There is no SANKEY extractor in
  `src/adapters/amcharts/` — no flow reading, no `am5flow` discovery, nothing.
  `per-adapter.json` repeats this. See the skip entry above.
- `per-adapter.json` item 2: "add a short-circuit at the top of
  `classifySeriesKind` … This one hook unblocks all six items." The hook alone
  is neither sufficient nor safe. Companion absorption and sibling merge are
  chart-level facts a per-series classifier cannot express, and — decisively —
  the merge rule needs the *undeclared* kind of the declaring series to decide
  what "the same drawn kind" means for its siblings, which a short-circuit at
  the top of `classifySeriesKind` destroys. The line number is also stale:
  `classifySeriesKind` is at extractor.ts:1146 on current main, not 1135.
- `per-adapter.json` item 1: "**No type changes.**" Almost right —
  `AmChartsBinderOptions` and `AmEntity` needed nothing, as claimed. But the
  normative row source for amCharts is `dataItem.dataContext`, and `AmDataItem`
  declared only `get`/`uid`/`bullets`, so one optional field had to be added to
  the adapter's own `types.ts`.
- `per-adapter.json` item 4: "the `StepLineSeries` the adapter currently emits as
  STEP (`adapter.ts:309-311`)". There is no dedicated step branch there: step
  shares one `case 'line': case 'step': case 'area': case 'radar': case 'polar':`
  arm. The behaviour described is right; the location is not.
- Verified and correct, for the record: `AmEntity.get` reads `userData` with no
  change; `AmChartsBinderOptions` needed nothing; a scatter-configured
  `LineSeries` does fall into `LINE_CLASSES` and become a LINE layer, so there
  was no pre-existing scatter path; `ErrorBarPoint`'s bounds are absolute
  (grammar.ts:380-389); MANHATTAN and VOLCANO do share `VolcanoTrace`;
  ALLUVIAL/CHORD/SANKEY do share `FlowTrace`.

### Design decisions worth a reviewer's eye

- **Bound precedence for error bar / forest**: row fields → `error` offset →
  companion series, resolved per bound, so a one-sided interval keeps its half
  and a companion fills only what the row left unsaid. The declaration's own doc
  fixes `error` as losing to `yMin`/`yMax`; it says nothing about where a
  companion sits, and it is placed last here on the grounds that a column the
  author named is the more specific statement. The opposite order is defensible.
- **Companion joins are by position, never by index**, and a companion carrying
  fewer rows than the series it decorates still lines up. There is a test for
  this specifically, because index-joining is the failure that looks correct on
  the happy path.
- **A companion ref naming a series that declares its own layer is refused with a
  warning** rather than absorbed. The spec only covers refs naming nothing;
  absorbing a declared series would silently delete a layer, so the loud smaller
  reading was chosen.
- **The pooled summary's owner is tracked** (`DeclaredSamples.owners`) so the
  highlight follows a row appended from `pooledSeries` onto the companion series
  that drew it.
- One fragile invariant to know about: `planDeclarations` gates on
  `backsDeclaration`, and `buildDeclaredLayer`'s `null` return is only reachable
  if that gate and the extractors ever disagree about what counts as a readable
  mark. If they did, the navmap's per-type queue would slip by one for a chart
  carrying two declared layers of the same type. The two are deliberately written
  from the same predicates, and `backsDeclaration` shares `declaredHorizontal`
  with the extractors for exactly this reason, but it is a coupling a future edit
  could break quietly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_