### PR TITLE
feat(observable): name the watcher for what it watches, and document the plain-page path

### DIFF
--- a/docs/observable.md
+++ b/docs/observable.md
@@ -2,9 +2,67 @@
 
 MAIDR provides an adapter for [Observable Plot](https://observablehq.com/plot) — the grammar-of-graphics library built on D3 — that turns its charts into accessible, navigable visualizations with audio sonification, text descriptions, braille output, and keyboard navigation.
 
-It is also how MAIDR reaches **[Quarto](https://quarto.org) documents**. Quarto renders `{ojs}` cells with the Observable runtime, which ships Plot and draws the chart in the browser. Nothing in an `{ojs}` cell can call an adapter — the cell's value *is* the chart — so this adapter watches the page instead: add two script tags to the document header and every Plot chart in it becomes navigable, including cells that redraw when a reader moves a slider.
+There are two ways it gets used, and they differ only in how the scripts get onto the page:
 
-## Quarto Quick Start
+| | You are writing | Load the scripts by | Your chart code changes |
+|---|---|---|---|
+| **[Plain page](#plain-page-quick-start)** | HTML, or an app that renders Plot charts | putting two `<script>` tags in `<head>` | not at all |
+| **[Quarto](#quarto-quick-start)** | a `.qmd` with `{ojs}` cells | `include-in-header`, or `quarto add xability/maidr` | not at all |
+
+The adapter itself does not know which one it is in. It watches the page for Plot charts and binds each one as it appears — that is the whole mechanism, and it is why neither case asks you to touch the code that draws the chart.
+
+Quarto gets its own section because it is the case that *cannot* work any other way: an `{ojs}` cell's value **is** the chart, so there is nowhere in the cell to call a binder even if you wanted to. On a plain page you have the choice, and [Manual binding](#manual-binding) covers taking it.
+
+## Plain page quick start
+
+Two script tags. Draw charts however you already do.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>My Observable Plot chart</title>
+    <!-- 1. MAIDR core, then the Observable Plot adapter -->
+    <script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/maidr/dist/observable.js"></script>
+  </head>
+  <body>
+    <div id="chart"></div>
+
+    <script type="module">
+      import * as Plot from 'https://cdn.jsdelivr.net/npm/@observablehq/plot/+esm';
+
+      const data = [
+        { day: 'Mon', count: 120 },
+        { day: 'Tue', count: 240 },
+        { day: 'Wed', count: 180 },
+      ];
+
+      document.querySelector('#chart').append(Plot.plot({
+        title: 'Daily visitors',
+        x: { label: 'Day' },
+        y: { label: 'Visitors' },
+        marks: [Plot.barY(data, { x: 'day', y: 'count' })],
+      }));
+      // Nothing else to do: the adapter binds the chart as it is inserted.
+    </script>
+  </body>
+</html>
+```
+
+Tab to the chart. Arrow keys move between bars, `S` toggles sonification, `B` toggles braille, `T` toggles text descriptions.
+
+A chart appended later — after a `fetch`, on a click, on every frame of a slider drag — is bound as it appears, and one the page throws away is released. So a dashboard that redraws does not accumulate charts, and you do not re-bind anything by hand.
+
+If you install from npm rather than a CDN, `maidr/observable` is the entry point:
+
+```js
+import 'maidr';
+import 'maidr/observable';
+```
+
+## Quarto quick start
 
 Add the scripts to your document's header. Nothing else changes.
 
@@ -33,7 +91,7 @@ Plot.plot({
 ```
 ````
 
-Render the document and Tab to the chart. Arrow keys move between bars, `S` toggles sonification, `B` toggles braille, `T` toggles text descriptions.
+Render the document and Tab to the chart — the same keys as above.
 
 To apply it to a whole project, put the same `include-in-header` block under `format: html:` in `_quarto.yml`.
 
@@ -72,44 +130,6 @@ The filter injects the same two scripts. `maidr-version` pins which release to l
 filters:
   - maidr
 maidr-version: "4.2.0"
-```
-
-## Plain HTML Quick Start
-
-Outside Quarto the adapter behaves the same way — it binds any Plot chart that appears on the page.
-
-```html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>My Observable Plot chart</title>
-    <!-- 1. MAIDR core, then the Observable Plot adapter -->
-    <script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/maidr/dist/observable.js"></script>
-  </head>
-  <body>
-    <div id="chart"></div>
-
-    <script type="module">
-      import * as Plot from 'https://cdn.jsdelivr.net/npm/@observablehq/plot/+esm';
-
-      const data = [
-        { day: 'Mon', count: 120 },
-        { day: 'Tue', count: 240 },
-        { day: 'Wed', count: 180 },
-      ];
-
-      document.querySelector('#chart').append(Plot.plot({
-        title: 'Daily visitors',
-        x: { label: 'Day' },
-        y: { label: 'Visitors' },
-        marks: [Plot.barY(data, { x: 'day', y: 'count' })],
-      }));
-      // The adapter binds the chart as soon as it is inserted.
-    </script>
-  </body>
-</html>
 ```
 
 ## How it works
@@ -162,7 +182,7 @@ Three more things worth knowing:
 
 ## Manual binding
 
-Auto-binding covers the Quarto case and most others. When you want the schema instead — to edit it, or to hand it to the `<Maidr>` React component — call the adapter yourself, and turn the watcher off first so it does not bind the chart behind you.
+Auto-binding is what both quick starts rely on, and on a plain page it is optional. When you want the schema instead — to edit it, or to hand it to the `<Maidr>` React component — call the adapter yourself, and turn the watcher off first so it does not bind the chart behind you.
 
 ```js
 // Before the bundle loads, if you are loading it with a script tag.
@@ -208,11 +228,11 @@ Set the flag before the bundle loads, then drive it yourself:
 <script src="https://cdn.jsdelivr.net/npm/maidr/dist/observable.js"></script>
 <script>
   // Watch only part of the page, or bind charts one at a time.
-  maidrObservable.initQuartoObservable({ root: document.querySelector('#report') });
+  maidrObservable.initObservablePlots({ root: document.querySelector('#report') });
 </script>
 ```
 
-`initQuartoObservable` returns a function that stops the watcher.
+`initObservablePlots` returns a function that stops the watcher.
 
 ## Keyboard Controls
 

--- a/docs/observable.md
+++ b/docs/observable.md
@@ -8,6 +8,8 @@ There are two ways it gets used, and they differ only in how the scripts get ont
 |---|---|---|---|
 | **[Plain page](#plain-page-quick-start)** | HTML, or an app that renders Plot charts | putting two `<script>` tags in `<head>` | not at all |
 | **[Quarto](#quarto-quick-start)** | a `.qmd` with `{ojs}` cells | `include-in-header`, or `quarto add xability/maidr` | not at all |
+| **[Framework](#observable-framework)** | a Framework project | `head` in `observablehq.config.js` | not at all |
+| **[Embedded notebook](#embedded-notebooks)** | a page running `@observablehq/runtime` | two `<script>` tags on the host page | not at all |
 
 The adapter itself does not know which one it is in. It watches the page for Plot charts and binds each one as it appears — that is the whole mechanism, and it is why neither case asks you to touch the code that draws the chart.
 
@@ -131,6 +133,45 @@ filters:
   - maidr
 maidr-version: "4.2.0"
 ```
+
+## Observable's own runtimes
+
+The two quick starts cover a page you control. Observable ships two other ways
+to run Plot, and the adapter works in both — the mechanism is the same, so the
+only question in each is where the two script tags go.
+
+### Observable Framework
+
+Put the bundles in your source root and name them in `head`. Framework rewrites
+the paths and content-hashes the files for you, so `/maidr.js` resolves to
+whatever it emitted:
+
+```js
+// observablehq.config.js
+export default {
+  root: 'src',
+  head: '<script src="/maidr.js"></script><script src="/observable.js"></script>',
+};
+```
+
+Charts in `display(Plot.plot(...))` cells bind as they render, and a cell driven
+by `view(Inputs.range(...))` rebinds each time the reader moves the input.
+
+### Embedded notebooks
+
+A notebook embedded with `@observablehq/runtime` and `@observablehq/inspector`
+works the same way: load the two bundles on the host page and every cell whose
+value is a Plot chart becomes navigable, including cells the runtime re-runs
+when you `redefine` a value.
+
+**Verified against** Framework 1.13.4, runtime 5.9.9 and inspector 5.0.1 — the
+charts bind, the reactive re-runs rebind, and the chart each re-run discards is
+released rather than accumulated.
+
+**Not verified:** a notebook on observablehq.com itself. The adapter needs its
+two scripts on the page, and on a notebook hosted there you do not control the
+page's head. Whether a cell can inject them into its own document is untested —
+so it is an open question rather than a documented route.
 
 ## How it works
 

--- a/examples/observable-plain.html
+++ b/examples/observable-plain.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAIDR — Observable Plot on a plain page</title>
+
+    <!--
+      The other half of the pair. `observable-quarto.html` reproduces what
+      Quarto renders for `{ojs}` cells, where an author *cannot* call a binder
+      because the cell's value is the chart. This page is the ordinary case: no
+      Quarto, no Observable runtime, no cell structure — just Plot charts
+      appended to a page, which is how most people use the library.
+
+      The adapter cannot tell the two apart, and that is the point. It looks for
+      the class Plot puts on every chart it draws, so the integration is the two
+      script tags below and nothing else. No call, no configuration, no change
+      to the code that draws the charts.
+    -->
+    <script src="../dist/maidr.js"></script>
+    <script src="../dist/observable.js"></script>
+
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 0 auto;
+        max-width: 44rem;
+        padding: 2rem 1rem 4rem;
+        line-height: 1.5;
+      }
+      figure { margin: 2.5rem 0; }
+      h1 { margin-bottom: 0.25rem; }
+      .lede { color: #444; margin-top: 0; }
+      .note {
+        background: #f4f6f8;
+        border-left: 4px solid #4269d0;
+        padding: 0.75rem 1rem;
+        margin: 2rem 0;
+      }
+      button {
+        font: inherit;
+        padding: 0.4rem 0.9rem;
+        border: 1px solid #4269d0;
+        border-radius: 4px;
+        background: #fff;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Observable Plot, on an ordinary page</h1>
+    <p class="lede">
+      No Quarto and no Observable runtime anywhere on this page. Tab to a chart,
+      then use the arrow keys; <kbd>S</kbd> sonification, <kbd>B</kbd> braille,
+      <kbd>T</kbd> text.
+    </p>
+
+    <div class="note">
+      <strong>What makes this work:</strong> the two <code>&lt;script&gt;</code>
+      tags in the head. The charts below are drawn with plain
+      <code>Plot.plot()</code> calls that know nothing about MAIDR.
+    </div>
+
+    <section id="charts"></section>
+
+    <div class="note">
+      <p style="margin-top: 0">
+        A chart added after load is picked up the same way — nothing needs
+        re-binding, and the one it replaces is released rather than left behind.
+      </p>
+      <button id="redraw" type="button">Redraw the last chart</button>
+    </div>
+
+    <script type="module">
+      import * as Plot from 'https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6.17/+esm';
+
+      const charts = document.querySelector('#charts');
+
+      const visitors = [
+        { day: 'Mon', count: 120 },
+        { day: 'Tue', count: 240 },
+        { day: 'Wed', count: 180 },
+        { day: 'Thu', count: 260 },
+        { day: 'Fri', count: 310 },
+      ];
+      charts.append(Plot.plot({
+        title: 'Daily visitors',
+        x: { label: 'Day' },
+        y: { label: 'Visitors' },
+        marks: [Plot.barY(visitors, { x: 'day', y: 'count' })],
+      }));
+
+      const readings = Array.from({ length: 40 }, (_, index) => ({
+        depth: 20 + index * 1.5 + Math.sin(index / 3) * 6,
+        temp: 4 + index * 0.15,
+      }));
+      charts.append(Plot.plot({
+        title: 'Temperature against depth',
+        marks: [Plot.dot(readings, { x: 'depth', y: 'temp' })],
+      }));
+
+      const quarters = [];
+      for (const [q, hardware, services] of [[1, 120, 60], [2, 135, 70], [3, 150, 65], [4, 165, 80]]) {
+        quarters.push({ q, line: 'Hardware', revenue: hardware });
+        quarters.push({ q, line: 'Services', revenue: services });
+      }
+      charts.append(Plot.plot({
+        title: 'Revenue by line',
+        marks: [Plot.barY(quarters, { x: 'q', y: 'revenue', fill: 'line' })],
+        color: { legend: true },
+      }));
+
+      // Appended late and replaced on demand — the case a dashboard hits, and
+      // the one a watcher has to handle rather than a one-time scan.
+      let seed = 0;
+      const drawLate = () => {
+        seed += 1;
+        const series = Array.from({ length: 12 }, (_, index) => ({
+          month: index + 1,
+          value: 50 + Math.sin((index + seed) / 2) * 20 + seed * 2,
+        }));
+        return Plot.plot({
+          title: `Monthly index (revision ${seed})`,
+          marks: [Plot.lineY(series, { x: 'month', y: 'value' })],
+        });
+      };
+
+      let late = drawLate();
+      charts.append(late);
+
+      document.querySelector('#redraw').addEventListener('click', () => {
+        const next = drawLate();
+        late.replaceWith(next);
+        late = next;
+      });
+    </script>
+  </body>
+</html>

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -450,9 +450,10 @@ const examplesContent = `
 
   <h3>Observable Plot &amp; Quarto</h3>
   <ul>
+    <li><a href="#" onclick="loadHTML('observable-plain.html', 'Observable Plot on a plain page'); return false;">Plain page &mdash; bar, scatter, stacked bar, and a chart redrawn on demand</a></li>
     <li><a href="#" onclick="loadHTML('observable-quarto.html', 'Observable Plot in a Quarto document'); return false;">Quarto OJS cells (bar, scatter, line, histogram, facets)</a></li>
   </ul>
-  <p>See the <a href="observable.html">Observable Plot &amp; Quarto Integration Guide</a> for setup instructions, including the Quarto extension.</p>
+  <p>The two differ only in how the scripts reach the page &mdash; the adapter is the same and neither asks you to change the code that draws the chart. See the <a href="observable.html">Observable Plot &amp; Quarto Integration Guide</a> for both, including the Quarto extension.</p>
 
   <h3>Frappe Charts</h3>
   <ul>

--- a/src/adapters/observable/index.ts
+++ b/src/adapters/observable/index.ts
@@ -54,18 +54,22 @@
 
 export { observablePlotToMaidr } from './converters';
 export { isObservablePlot } from './introspect';
-export {
-  autoInitQuartoObservable,
-  bindObservablePlot,
-  initQuartoObservable,
-  stopQuartoObservable,
-} from './quarto';
 export type {
   MarkDatum,
   ObservablePlotElement,
   ObservablePlotOptions,
   ObservablePlotResult,
+  ObservableWatchOptions,
   PlotScale,
   PlotScales,
   QuartoObservableOptions,
 } from './types';
+export {
+  autoInitObservablePlots,
+  autoInitQuartoObservable,
+  bindObservablePlot,
+  initObservablePlots,
+  initQuartoObservable,
+  stopObservablePlots,
+  stopQuartoObservable,
+} from './watcher';

--- a/src/adapters/observable/types.ts
+++ b/src/adapters/observable/types.ts
@@ -128,8 +128,8 @@ export interface ObservablePlotResult {
   element: Element;
 }
 
-/** Options for {@link initQuartoObservable}. */
-export interface QuartoObservableOptions {
+/** Options for {@link initObservablePlots}. */
+export interface ObservableWatchOptions {
   /**
    * Root to watch for plots. Defaults to `document.body`.
    *
@@ -175,3 +175,11 @@ export interface MarkDatum {
   /** Bin end, for binned rect marks. */
   xMax?: number;
 }
+
+/**
+ * @deprecated Renamed to {@link ObservableWatchOptions}. The options were never
+ * Quarto's — they configure the watcher, which binds Plot charts on any page.
+ * Kept so the released name goes on working; it will be removed in the next
+ * major.
+ */
+export type QuartoObservableOptions = ObservableWatchOptions;

--- a/src/adapters/observable/watcher.ts
+++ b/src/adapters/observable/watcher.ts
@@ -6,7 +6,7 @@
  * because there is nothing in an `{ojs}` cell to call it from — the cell's
  * value *is* the chart, and Quarto inserts it into the page for you.
  *
- * So the adapter watches instead. {@link initQuartoObservable} observes the
+ * So the adapter watches instead. {@link initObservablePlots} observes the
  * document, recognises an Observable Plot chart when one appears, converts it,
  * and hands the schema to MAIDR's runtime. An author adds the script and their
  * existing plots become navigable; nothing in the cell changes.
@@ -22,7 +22,7 @@
 import type {
   ObservablePlotOptions,
   ObservablePlotResult,
-  QuartoObservableOptions,
+  ObservableWatchOptions,
 } from './types';
 import { observablePlotToMaidr } from './converters';
 import { isObservablePlot, resolveSvg } from './introspect';
@@ -192,7 +192,7 @@ export function bindObservablePlot(
  * <!-- every {ojs} cell that draws with Plot is now navigable -->
  * ```
  */
-export function initQuartoObservable(options: QuartoObservableOptions = {}): () => void {
+export function initObservablePlots(options: ObservableWatchOptions = {}): () => void {
   const root = options.root ?? document.body;
   if (!root)
     return () => {};
@@ -252,7 +252,7 @@ export function initQuartoObservable(options: QuartoObservableOptions = {}): () 
  *
  * @returns A function that stops watching, or `null` when auto-init is off.
  */
-export function autoInitQuartoObservable(): (() => void) | null {
+export function autoInitObservablePlots(): (() => void) | null {
   if (typeof window === 'undefined' || typeof document === 'undefined')
     return null;
   if ((window as Window & { maidrObservableAutoInit?: boolean }).maidrObservableAutoInit === false)
@@ -264,7 +264,7 @@ export function autoInitQuartoObservable(): (() => void) | null {
     return autoWatcher;
 
   if (document.readyState !== 'loading') {
-    autoWatcher = initQuartoObservable();
+    autoWatcher = initObservablePlots();
     return autoWatcher;
   }
 
@@ -274,7 +274,7 @@ export function autoInitQuartoObservable(): (() => void) | null {
   let cancelled = false;
   document.addEventListener('DOMContentLoaded', () => {
     if (!cancelled)
-      stop = initQuartoObservable();
+      stop = initObservablePlots();
   }, { once: true });
 
   autoWatcher = () => {
@@ -286,13 +286,13 @@ export function autoInitQuartoObservable(): (() => void) | null {
 }
 
 /**
- * Stops the watcher {@link autoInitQuartoObservable} started, if it started one.
+ * Stops the watcher {@link autoInitObservablePlots} started, if it started one.
  *
  * Charts already bound stay bound; this only stops new ones being picked up.
  * Exposed so a single-page app can hand the page back cleanly, and so a test
  * can turn the adapter off.
  */
-export function stopQuartoObservable(): void {
+export function stopObservablePlots(): void {
   autoWatcher?.();
   autoWatcher = null;
 }
@@ -365,7 +365,7 @@ function findUnboundPlots(root: ParentNode): Element[] {
  * @param svg     - The chart's `<svg>`.
  * @param options - The observer's options.
  */
-function bindOne(svg: Element, options: QuartoObservableOptions): void {
+function bindOne(svg: Element, options: ObservableWatchOptions): void {
   try {
     const result = bindObservablePlot(svg, options.plot ?? {});
     if (result)
@@ -380,3 +380,24 @@ function bindOne(svg: Element, options: QuartoObservableOptions): void {
       console.warn(`${LOG_PREFIX} failed to bind a plot:`, error);
   }
 }
+
+/**
+ * @deprecated Renamed to {@link initObservablePlots}. The watcher never had
+ * anything to do with Quarto — it binds Plot charts wherever they appear, and
+ * the Quarto name said otherwise to everyone using it on an ordinary page.
+ * Kept so the released name goes on working; it will be removed in the next
+ * major.
+ */
+export const initQuartoObservable = initObservablePlots;
+
+/**
+ * @deprecated Renamed to {@link stopObservablePlots}. See
+ * {@link initQuartoObservable}.
+ */
+export const stopQuartoObservable = stopObservablePlots;
+
+/**
+ * @deprecated Renamed to {@link autoInitObservablePlots}. See
+ * {@link initQuartoObservable}.
+ */
+export const autoInitQuartoObservable = autoInitObservablePlots;

--- a/src/observable-entry.ts
+++ b/src/observable-entry.ts
@@ -13,7 +13,7 @@
  *
  * Set `window.maidrObservableAutoInit = false` **before** the bundle loads to
  * keep the exported functions and skip the watcher, then call
- * {@link initQuartoObservable} or {@link bindObservablePlot} yourself.
+ * {@link initObservablePlots} or {@link bindObservablePlot} yourself.
  *
  * @example
  * ```yaml
@@ -32,30 +32,34 @@
 import { observablePlotToMaidr } from './adapters/observable/converters';
 import { isObservablePlot } from './adapters/observable/introspect';
 import {
-  autoInitQuartoObservable,
+  autoInitObservablePlots,
   bindObservablePlot,
-  initQuartoObservable,
-  stopQuartoObservable,
-} from './adapters/observable/quarto';
+  initObservablePlots,
+  stopObservablePlots,
+} from './adapters/observable/watcher';
 
 export { observablePlotToMaidr } from './adapters/observable/converters';
 export { isObservablePlot } from './adapters/observable/introspect';
-export {
-  autoInitQuartoObservable,
-  bindObservablePlot,
-  initQuartoObservable,
-  stopQuartoObservable,
-} from './adapters/observable/quarto';
-
 export type {
   MarkDatum,
   ObservablePlotElement,
   ObservablePlotOptions,
   ObservablePlotResult,
+  ObservableWatchOptions,
   PlotScale,
   PlotScales,
   QuartoObservableOptions,
 } from './adapters/observable/types';
+
+export {
+  autoInitObservablePlots,
+  autoInitQuartoObservable,
+  bindObservablePlot,
+  initObservablePlots,
+  initQuartoObservable,
+  stopObservablePlots,
+  stopQuartoObservable,
+} from './adapters/observable/watcher';
 
 // Re-export core types that consumers may need alongside the adapter.
 export type { Maidr as MaidrData, MaidrLayer, MaidrSubplot } from './type/grammar';
@@ -65,10 +69,14 @@ declare global {
   interface Window {
     maidrObservable?: {
       bindObservablePlot: typeof bindObservablePlot;
-      initQuartoObservable: typeof initQuartoObservable;
-      stopQuartoObservable: typeof stopQuartoObservable;
+      initObservablePlots: typeof initObservablePlots;
+      stopObservablePlots: typeof stopObservablePlots;
       observablePlotToMaidr: typeof observablePlotToMaidr;
       isObservablePlot: typeof isObservablePlot;
+      /** @deprecated Use `initObservablePlots`. */
+      initQuartoObservable: typeof initObservablePlots;
+      /** @deprecated Use `stopObservablePlots`. */
+      stopQuartoObservable: typeof stopObservablePlots;
     };
     /** Set to `false` before the bundle loads to skip the automatic watcher. */
     maidrObservableAutoInit?: boolean;
@@ -81,10 +89,14 @@ if (typeof window !== 'undefined') {
   // script-tag consumer needs to read a layer's `type`, among them.
   window.maidrObservable = Object.assign(window.maidrObservable ?? {}, {
     bindObservablePlot,
-    initQuartoObservable,
-    stopQuartoObservable,
+    initObservablePlots,
+    stopObservablePlots,
     observablePlotToMaidr,
     isObservablePlot,
+    // The names the first release shipped. A page written against them keeps
+    // working; the guide only documents the ones above.
+    initQuartoObservable: initObservablePlots,
+    stopQuartoObservable: stopObservablePlots,
   });
-  autoInitQuartoObservable();
+  autoInitObservablePlots();
 }

--- a/test/adapters/observable/watcher.test.ts
+++ b/test/adapters/observable/watcher.test.ts
@@ -13,7 +13,7 @@
  *   every mutation, stacking duplicate schemas on one element.
  */
 
-import { bindObservablePlot, initQuartoObservable } from '@adapters/observable/quarto';
+import { bindObservablePlot, initObservablePlots } from '@adapters/observable/watcher';
 import { FIXTURES } from './fixtures';
 import { mountFixture } from './helpers';
 
@@ -106,7 +106,7 @@ describe('watching a Quarto document', () => {
       const { document } = dom.window;
       document.body.innerHTML = '<div id="ojs-cell-1" data-nodetype="expression"></div>';
       const bound: unknown[] = [];
-      const stop = initQuartoObservable({ onBind: result => bound.push(result) });
+      const stop = initObservablePlots({ onBind: result => bound.push(result) });
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.bar.html;
@@ -127,7 +127,7 @@ describe('watching a Quarto document', () => {
       const { document } = dom.window;
       document.body.innerHTML = '<div id="ojs-cell-1"></div>';
       const bound: unknown[] = [];
-      const stop = initQuartoObservable({ onBind: result => bound.push(result) });
+      const stop = initObservablePlots({ onBind: result => bound.push(result) });
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.bar.html;
@@ -151,7 +151,7 @@ describe('watching a Quarto document', () => {
       const { document } = dom.window;
       document.body.innerHTML = `<div id="ojs-cell-1">${FIXTURES.bar.html}</div>`;
       const bound: unknown[] = [];
-      const stop = initQuartoObservable({ onBind: result => bound.push(result) });
+      const stop = initObservablePlots({ onBind: result => bound.push(result) });
 
       // Any mutation triggers another scan; the chart is already bound.
       document.body.appendChild(document.createElement('p'));
@@ -171,7 +171,7 @@ describe('watching a Quarto document', () => {
       const { document } = dom.window;
       document.body.innerHTML = '<div id="ojs-cell-1"></div>';
       const bound: unknown[] = [];
-      const stop = initQuartoObservable({ onBind: result => bound.push(result) });
+      const stop = initObservablePlots({ onBind: result => bound.push(result) });
       stop();
 
       document.querySelector('#ojs-cell-1')!.innerHTML = FIXTURES.bar.html;
@@ -200,7 +200,7 @@ describe('charts a reactive cell replaces', () => {
       document.addEventListener('maidr:unbindchart', (event) => {
         released.push((event as CustomEvent<Element>).detail);
       });
-      const stop = initQuartoObservable();
+      const stop = initObservablePlots();
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.bar.html;
@@ -234,7 +234,7 @@ describe('charts a reactive cell replaces', () => {
       document.addEventListener('maidr:unbindchart', (event) => {
         released.push((event as CustomEvent<Element>).detail);
       });
-      const stop = initQuartoObservable();
+      const stop = initObservablePlots();
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.bar.html;
@@ -267,7 +267,7 @@ describe('charts a reactive cell replaces', () => {
       document.addEventListener('maidr:unbindchart', (event) => {
         released.push((event as CustomEvent<Element>).detail);
       });
-      const stop = initQuartoObservable();
+      const stop = initObservablePlots();
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.scatter.html;
@@ -312,7 +312,7 @@ describe('charts a reactive cell replaces', () => {
         container = document.createElement('div');
         chart.parentNode?.replaceChild(container, chart);
       });
-      const stop = initQuartoObservable();
+      const stop = initObservablePlots();
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.scatter.html;
@@ -356,7 +356,7 @@ describe('a cell holding more than one chart', () => {
       document.addEventListener('maidr:unbindchart', (event) => {
         released.push((event as CustomEvent<Element>).detail);
       });
-      const stop = initQuartoObservable();
+      const stop = initObservablePlots();
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.bar.html + FIXTURES.scatter.html;
@@ -380,7 +380,7 @@ describe('a cell holding more than one chart', () => {
       document.addEventListener('maidr:unbindchart', (event) => {
         released.push((event as CustomEvent<Element>).detail);
       });
-      const stop = initQuartoObservable();
+      const stop = initObservablePlots();
 
       const cell = document.querySelector('#ojs-cell-1');
       cell!.innerHTML = FIXTURES.bar.html + FIXTURES.scatter.html;
@@ -393,6 +393,40 @@ describe('a cell holding more than one chart', () => {
       await settle();
 
       expect(released).toEqual(first);
+      stop();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('the names the first release shipped', () => {
+  it('still exports the Quarto-prefixed ones, pointing at the same functions', async () => {
+    // The watcher was named for Quarto because Quarto was what it was written
+    // for, and the name outlived the reason: it binds Plot charts on any page.
+    // Renaming it is only safe if a document written against the released names
+    // goes on working, so the aliases are part of the contract, not a courtesy.
+    const module = await import('@adapters/observable/watcher');
+
+    expect(module.initQuartoObservable).toBe(module.initObservablePlots);
+    expect(module.stopQuartoObservable).toBe(module.stopObservablePlots);
+    expect(module.autoInitQuartoObservable).toBe(module.autoInitObservablePlots);
+  });
+
+  it('watches the page when called by its old name', async () => {
+    const { dom } = mountFixture('bar');
+    const restore = useDom(dom);
+    try {
+      const { document } = dom.window;
+      document.body.innerHTML = '<div id="cell"></div>';
+      const bound: unknown[] = [];
+      const { initQuartoObservable } = await import('@adapters/observable/watcher');
+      const stop = initQuartoObservable({ onBind: result => bound.push(result) });
+
+      document.querySelector('#cell')!.innerHTML = FIXTURES.bar.html;
+      await settle();
+
+      expect(bound).toHaveLength(1);
       stop();
     } finally {
       restore();


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #887. Two things that release got wrong, both of the same kind — the adapter works on any page with an Observable Plot chart, and both its API and its documentation said otherwise.

**The names.** `initQuartoObservable` and `stopQuartoObservable` shipped with Quarto in them because Quarto is what the adapter was written for. Nothing about them is Quarto-specific: the watcher looks for the class Plot puts on every chart it draws, its root defaults to `document.body`, and it binds charts on an ordinary page exactly as it does in a `.qmd`. Anyone using Observable Plot without Quarto had to call a function named for a tool they were not using.

**The guide.** It opened on Quarto and reached plain HTML nine sections later, under a heading beginning "Outside Quarto the adapter behaves the same way" — a footnote to the real case rather than the ordinary one it is. Most people using Observable Plot are not using Quarto at all.

## Related Issues

Follow-up to #887; no issue filed.

## Changes Made

**API** — `initObservablePlots`, `stopObservablePlots`, `autoInitObservablePlots`, and the options type `ObservableWatchOptions`. The module is `watcher.ts` rather than `quarto.ts`, since a file with nothing Quarto-specific in it should not be named for Quarto either.

**Back-compat** — the released names stay exported as deprecated aliases of the same functions, and `window.maidrObservable` carries both. **Not a breaking change**: a page written against the first release goes on working. The aliases are the contract rather than a courtesy, so they are tested — identity against the new functions, plus one that drives the watcher through the old name.

**Docs** — `docs/observable.md` now opens with a table of the two paths and what actually differs between them (only how the scripts reach the page), then gives each a quick start. Quarto keeps a section of its own and says *why* it needs one: an `{ojs}` cell's value **is** the chart, so there is nowhere in the cell for a binding call to go. That is the one case where watching the page is not a convenience but the only route — and stating it is what makes the plain-page case obviously optional rather than mysteriously absent.

**Example** — `examples/observable-plain.html`, the other half of the pair to `observable-quarto.html`: no Quarto, no Observable runtime, no cell structure, just Plot charts appended to a page. Including one appended after load and replaced on a button press, which is the case a dashboard hits and the one a watcher exists for. The gallery lists both and says how they relate.

## Screenshots (if applicable)

n/a — non-visual by construction.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verification.** `npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (4051 unit + 73 esm). Both names are present in the built bundle.

The claim that motivated this was checked before the change rather than assumed. A page with **zero** Quarto or OJS markers, three Plot charts, one of them appended 400 ms after load:

```
ojsMarkersOnPage: 0   chartsDrawn: 3   bound: 3   instrumented: 3   errors: none
```

And the new example driven in Chromium, including the old API name and the redraw path:

```
before:        bound 4, instrumented 4
both names present: true    initObservablePlots === initQuartoObservable: true
after redraw:  bound 4, instrumented 4, unbind events 1, errors none
```

Four charts bound, the redraw releases exactly one and does not accumulate.

**One judgement worth flagging.** Renaming the module file (`quarto.ts` → `watcher.ts`, and its test alongside) inflates the diff for no user-visible gain, and I nearly left it. I did it because leaving it would have fixed the wart at the API level and kept it one level down, where the next person reading the adapter meets it — the same half-measure that needed a second pass twice during #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ki1N1MqVzd3Y8uY5nRrgE

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ki1N1MqVzd3Y8uY5nRrgE)_