### PR TITLE
fix(highlight): let a canvas adapter address a scatter-family point

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -212,7 +212,9 @@ A Manhattan is usually drawn as one series per chromosome, and a survival figure
 
 ### Highlighting a declared layer
 
-A survival curve, an error bar and a forest plot highlight like every other amCharts layer: the overlay outlines the mark the reader is on. A **volcano, Manhattan or scatter layer does not**. MAIDR's canvas overlay is driven by the position the navigation callback carries, and a scatter publishes a *binned grid* rather than its individual points — so a position there names a cell of that grid, and outlining the point that happens to sit at the same ordinal would put the box on the wrong gene. The overlay is cleared instead. Sonification, the text description, the findings a threshold produces and the point-level navigation are all unaffected; this is the visual highlight alone, and only on the three cloud types.
+Every declared layer highlights like the rest of the amCharts adapter: the overlay outlines the mark the reader is on. A volcano, Manhattan or scatter layer is addressed differently from the others, and it is worth knowing why. A cloud is navigated through several different index spaces — columns of shared x, rows of shared y, a flat point order, a binned grid — so no single row/column position can say which mark is selected. MAIDR therefore sends the *identity* of the highlighted points instead: their indices into the `data` array this adapter supplied. The adapter maps them back through the same walk that produced that array, so the binning stays in MAIDR's model and is never reconstructed here.
+
+One position often covers several marks — a column holds every point sharing an x, a grid cell every point binned into it — and the overlay outlines all of them. Where a reader is on a single point, as in point navigation or on a volcano's significant-point rotor, exactly one mark is outlined.
 
 ## Multi-Panel Charts
 

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -65,6 +65,12 @@ interface NavEvent {
   layerId: string;
   row: number;
   col: number;
+  /**
+   * A point cloud's selection, as `layer.data` indices. Recorded alongside the
+   * position so the resize replay re-resolves the same points rather than the
+   * `-1` pair that accompanies them.
+   */
+  pointIndices?: readonly number[];
 }
 
 // ---------------------------------------------------------------------------
@@ -116,7 +122,7 @@ function applyHighlight(
   navMap: NavMap,
   event: NavEvent,
 ): void {
-  const targets = navMap.resolve(event.layerId, event.row, event.col);
+  const targets = navMap.resolve(event.layerId, event.row, event.col, event.pointIndices);
   if (targets.length === 0) {
     overlay.clear();
     return;

--- a/src/adapters/amcharts/declaration.ts
+++ b/src/adapters/amcharts/declaration.ts
@@ -1014,6 +1014,37 @@ export function extractScatterPoints(declared: AmDeclaredLayer): ScatterPoint[] 
   return points;
 }
 
+/**
+ * The live marks behind a declared cloud, in the order its points were read.
+ *
+ * The index-twin of {@link extractScatterPoints} / {@link extractVolcanoPoints}:
+ * the same walk over `[series, ...arms]`, keeping exactly the items
+ * `readCloudPoint` accepts, so the entry at index `i` is the mark that drew the
+ * layer's `data[i]`.
+ *
+ * It lives beside those two, and is written as the same loop, because the
+ * alignment is the entire contract — MAIDR addresses a cloud's highlight by
+ * data index, and the two walks drifting apart would outline a confidently
+ * wrong point. Keeping them in one file is what makes a drift visible in a
+ * side-by-side read.
+ *
+ * @param declared - The declared layer and the siblings merged into it.
+ * @returns One `{ series, item }` per readable mark, in chart order.
+ */
+export function extractCloudMarks(
+  declared: AmDeclaredLayer,
+): { series: AmXYSeries; item: AmDataItem }[] {
+  const marks: { series: AmXYSeries; item: AmDataItem }[] = [];
+  for (const series of [declared.series, ...declared.arms]) {
+    for (const item of series.dataItems) {
+      if (readCloudPoint(item) !== null) {
+        marks.push({ series, item });
+      }
+    }
+  }
+  return marks;
+}
+
 /** One point of a cloud, or `null` for a mark missing either coordinate. */
 function readCloudPoint(item: AmDataItem): VolcanoPoint | null {
   const x = item.get('valueX') != null ? toNumber(item.get('valueX')) : null;

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -14,6 +14,7 @@ import type { AmDeclaredLayer } from './declaration';
 import type { AmChart, AmDataItem, AmXYSeries } from './types';
 import { TraceType } from '@type/grammar';
 import {
+  extractCloudMarks,
   extractErrorBarSamples,
   extractForestSamples,
   extractSurvivalArms,
@@ -41,7 +42,20 @@ export interface NavTarget {
  * Resolves a MAIDR navigation position to the am5 targets to highlight.
  */
 export interface NavMap {
-  resolve: (layerId: string, row: number, col: number) => NavTarget[];
+  /**
+   * @param layerId - The layer the position belongs to
+   * @param row - The MAIDR row, or `-1` when `pointIndices` is given
+   * @param col - The MAIDR column, or `-1` when `pointIndices` is given
+   * @param pointIndices - For a point cloud, the `layer.data` indices to
+   *   outline. A cloud's selection is a set of points that no row/column pair
+   *   can name, so it is addressed by data index instead.
+   */
+  resolve: (
+    layerId: string,
+    row: number,
+    col: number,
+    pointIndices?: readonly number[],
+  ) => NavTarget[];
   /**
    * The chart owning a layer, so highlights can be clipped against the owning
    * panel's plot bounds. Layer ids are unique figure-wide, so the id alone
@@ -119,7 +133,11 @@ export interface SeriesGroups {
   declaredList: AmDeclaredLayer[];
 }
 
-type Resolver = (row: number, col: number) => NavTarget[];
+type Resolver = (
+  row: number,
+  col: number,
+  pointIndices?: readonly number[],
+) => NavTarget[];
 
 /** A live series paired with its extractor-filtered (gap-free) data items. */
 interface FilteredSeries {
@@ -326,6 +344,61 @@ function buildIntervalResolver(declared: AmDeclaredLayer | undefined): Resolver 
 }
 
 /**
+ * Build a resolver for a declared point cloud — a scatter, a volcano or a
+ * Manhattan.
+ *
+ * A cloud is the one family whose selection is a *set of points* rather than a
+ * position: the model navigates it through x-buckets, y-buckets, a flat point
+ * order, a binned grid and a within-cell grouping, and no row/column pair can
+ * say which of those is live. It therefore names the points it has highlighted
+ * by their index in the `data` array this adapter supplied, and this inverts
+ * that index against the same walk `extractScatterPoints` and
+ * `extractVolcanoPoints` used to build it.
+ *
+ * The binning stays in the model. Nothing here reconstructs it — a copy would
+ * drift silently and outline a confidently wrong mark, which is why this
+ * resolver was left unregistered until the position could say which point it
+ * meant.
+ *
+ * The marks are read once, at build time, and the resolver is a lookup — the
+ * same shape as {@link buildSurvivalResolver} and {@link buildIntervalResolver},
+ * which index their own extractor-order lists.
+ *
+ * @param declared - The declared cloud layer, if one matched.
+ * @param layer - The emitted layer, whose `data` the indices address.
+ * @returns A resolver mapping data indices to the marks that drew them.
+ */
+function buildCloudResolver(
+  declared: AmDeclaredLayer | undefined,
+  layer: MaidrLayer,
+): Resolver {
+  const marks = declared ? extractCloudMarks(declared) : [];
+  // An index only means anything if this list and `layer.data` are the same
+  // list. Both come from the one walk over `[series, ...arms]` filtered by
+  // `readCloudPoint`, so a mismatch means the chart moved underneath the
+  // extraction. Resolving to nothing then clears the overlay, which is the
+  // honest answer — the same one this layer type gave before it had a resolver
+  // at all, and strictly better than a box on a mark picked by a stale index.
+  const aligned = Array.isArray(layer.data) && marks.length === layer.data.length;
+  if (!aligned) {
+    return () => [];
+  }
+  return (_row, _col, pointIndices) => {
+    if (!pointIndices) {
+      return [];
+    }
+    const targets: NavTarget[] = [];
+    for (const index of pointIndices) {
+      const mark = marks[index];
+      if (mark) {
+        targets.push({ series: mark.series, dataItem: mark.item, kind: 'point' });
+      }
+    }
+    return targets;
+  };
+}
+
+/**
  * Build a resolver for a heatmap layer. amCharts heatmap dataItems are a flat,
  * insertion-ordered list, so we index them by `categoryX`/`categoryY` value.
  * MAIDR's Heatmap model reverses the Y axis (`src/model/heatmap.ts`), so we
@@ -368,7 +441,8 @@ export function buildNavigationMap(entries: readonly NavMapEntry[]): NavMap {
   }
 
   return {
-    resolve: (layerId, row, col) => resolvers.get(layerId)?.(row, col) ?? [],
+    resolve: (layerId, row, col, pointIndices) =>
+      resolvers.get(layerId)?.(row, col, pointIndices) ?? [],
     chartFor: layerId => owners.get(layerId),
     chartCount: new Set(entries.map(entry => entry.chart)).size,
   };
@@ -588,15 +662,12 @@ function addEntryResolvers(
       case TraceType.MANHATTAN:
       case TraceType.VOLCANO:
       case TraceType.SCATTER: {
-        // Deliberately unresolved, and the queue is drained so a second cloud
-        // still matches its own layer. A canvas highlight is driven by the
-        // braille position the navigation callback carries, and a scatter's
-        // braille surface is a *binned grid* rather than the points — so a
-        // position here names a cell of that grid, and reading it as a point
-        // index would outline whichever mark happens to sit at that ordinal.
-        // Resolving to nothing clears the overlay instead, which is the
-        // truthful answer until the position says which point it means.
-        nextDeclared(layer.type);
+        // The navigation callback now says which points it means, by their
+        // index in the `data` this adapter supplied, so a cloud resolves to the
+        // marks that drew them. It stayed unresolved for as long as the only
+        // position on offer was the braille one, which for a scatter is a cell
+        // of a *binned grid* rather than a point.
+        register(layer.id, buildCloudResolver(nextDeclared(layer.type), layer));
         break;
       }
       case TraceType.HEATMAP: {

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -26,13 +26,20 @@ export type LayerDatasetIndices = ReadonlyMap<string, number[]>;
  */
 export interface TargetMaps {
   /**
-   * Point clouds: `pointBuckets[layerId][col]` is every element sharing that X.
+   * Point clouds: `pointTargets[layerId][i]` is the element drawing the layer's
+   * `data[i]` — the table in the layer's own data order, not a grouping of it.
+   *
+   * MAIDR names a cloud's selection by data index (see
+   * `NavigateCallback.pointIndices`), because a scatter selects a *set* of
+   * points and no row/column pair can name one. Keeping the table in data order
+   * is what lets this adapter answer that without re-deriving the model's
+   * x-bucketing or its grid binning, which would drift from the model silently.
    *
    * Each entry names its own dataset rather than the layer naming one for all
    * of them, because a merged volcano or Manhattan is a single layer drawn
    * from several datasets — one per chromosome, typically.
    */
-  pointBuckets: Map<string, ChartJsActiveElement[][]>;
+  pointTargets: Map<string, ChartJsActiveElement[]>;
   /** Bar/line: `barLineIndices[layerId][row][col]` is the original Chart.js element index (gaps skipped). */
   barLineIndices: Map<string, number[][]>;
   /** Heatmap: `heatmapIndices[layerId]` maps `"x\0y"` to the flat Chart.js element index. */
@@ -123,46 +130,38 @@ function buildGanttTargets(
 }
 
 /**
- * Mirror `ScatterTrace`'s X-bucket construction (`src/model/scatter.ts:172-186`)
- * to map MAIDR's `col` (an X-bucket index) back to the original Chart.js
- * elements. Points are sorted by X, then Y; consecutive points sharing an X
- * form a bucket. Reads the raw datasets (not the filtered layer data) so bucket
- * entries are original, highlight-aligned indices.
+ * The Chart.js element drawing each of a point layer's data entries, in the
+ * layer's own `data` order.
  *
- * The datasets are walked in the order the layer was built from them, which is
- * the order their points were concatenated into it — so a merged layer's
- * buckets hold the same elements the trace groups, whichever dataset drew
- * them.
+ * `extractScatterLayers` builds that data as
+ * `group.indices.flatMap(i => datasetToScatterPoints(datasets[i]))`, keeping
+ * every entry `isPointValue` accepts. This walks the same datasets in the same
+ * order with the same filter, so the element at index `i` here drew `data[i]`
+ * there.
+ *
+ * That correspondence is the whole contract: MAIDR names the points it has
+ * highlighted by their position in the array this adapter supplied, and the
+ * adapter inverts it by replaying its own extraction. Nothing about the model's
+ * x-bucketing, its reading order or its grid binning is reconstructed here — a
+ * copy of that would drift from the model silently and outline a confidently
+ * wrong point.
  *
  * @param datasets - The chart's datasets
  * @param dsIndices - The dataset indices backing the layer, in MAIDR row order
- * @returns One bucket per distinct X, in ascending X order
+ * @returns One element per point of the layer, in `layer.data` order
  */
-function buildPointBuckets(
+function buildPointTargets(
   datasets: ChartJsDataset[],
   dsIndices: number[],
-): ChartJsActiveElement[][] {
-  // Track the original dataset and element indices through the (x, y) sort so
-  // bucket entries are Chart.js elements, not positions in the point list.
-  const indexed: { x: number; y: number; target: ChartJsActiveElement }[] = [];
+): ChartJsActiveElement[] {
+  const targets: ChartJsActiveElement[] = [];
   for (const datasetIndex of dsIndices) {
     (datasets[datasetIndex]?.data ?? []).forEach((value, index) => {
       if (isPointValue(value))
-        indexed.push({ x: value.x, y: value.y, target: { datasetIndex, index } });
+        targets.push({ datasetIndex, index });
     });
   }
-  indexed.sort((a, b) => a.x - b.x || a.y - b.y);
-
-  const buckets: ChartJsActiveElement[][] = [];
-  let currentX: number | null = null;
-  for (const { x, target } of indexed) {
-    if (currentX === null || currentX !== x) {
-      currentX = x;
-      buckets.push([]);
-    }
-    buckets[buckets.length - 1].push(target);
-  }
-  return buckets;
+  return targets;
 }
 
 /**
@@ -207,7 +206,7 @@ export function computeTargetMaps(
   layers: MaidrLayer[],
   layerDatasetIndices: LayerDatasetIndices,
 ): TargetMaps {
-  const pointBuckets = new Map<string, ChartJsActiveElement[][]>();
+  const pointTargets = new Map<string, ChartJsActiveElement[]>();
   const barLineIndices = new Map<string, number[][]>();
   const heatmapIndices = new Map<string, Map<string, number>>();
   const ganttTargets = new Map<string, ChartJsActiveElement[][]>();
@@ -216,14 +215,21 @@ export function computeTargetMaps(
   for (const layer of layers) {
     switch (layer.type) {
       // A volcano and a Manhattan are scatters read through a threshold, so
-      // they are navigated by the same X buckets — over however many datasets
-      // the declared layer merged.
+      // they are addressed by the same data indices — over however many
+      // datasets the declared layer merged.
       case TraceType.SCATTER:
       case TraceType.VOLCANO:
       case TraceType.MANHATTAN: {
         const dsIndices = layerDatasetIndices.get(layer.id)
           ?? [firstDatasetIndex(layerDatasetIndices, layer.id)];
-        pointBuckets.set(layer.id, buildPointBuckets(datasets, dsIndices));
+        const targets = buildPointTargets(datasets, dsIndices);
+        // An index only means anything if this table and `layer.data` are the
+        // same list. They are built by the same walk over the same datasets, so
+        // a mismatch means the chart moved underneath the extraction — and a
+        // stale index would outline a mark chosen at random. Registering
+        // nothing clears the overlay instead, which is the truthful answer.
+        if (Array.isArray(layer.data) && targets.length === layer.data.length)
+          pointTargets.set(layer.id, targets);
         break;
       }
       case TraceType.BAR:
@@ -289,13 +295,22 @@ export function computeTargetMaps(
     }
   }
 
-  return { pointBuckets, barLineIndices, heatmapIndices, ganttTargets };
+  return { pointTargets, barLineIndices, heatmapIndices, ganttTargets };
 }
 
 /**
  * Resolve a MAIDR navigation event into the Chart.js active elements that
- * should be highlighted. Returns an array because scatter X-buckets can
- * contain multiple points that share an X coordinate.
+ * should be highlighted. Returns an array because one position can cover
+ * several marks — a scatter column holds every point sharing an X.
+ *
+ * @param layers - The layers of the figure
+ * @param maps - The prebuilt per-layer lookups
+ * @param layerDatasetIndices - Layer id to the dataset indices backing it
+ * @param layerId - The layer the position belongs to
+ * @param row - The MAIDR row, or `-1` when the event carries `pointIndices`
+ * @param col - The MAIDR column, or `-1` when the event carries `pointIndices`
+ * @param pointIndices - For a point cloud, the `layer.data` indices to outline
+ * @returns The elements to highlight, empty when nothing resolves
  */
 export function resolveActiveTargets(
   layers: MaidrLayer[],
@@ -304,6 +319,7 @@ export function resolveActiveTargets(
   layerId: string,
   row: number,
   col: number,
+  pointIndices?: readonly number[],
 ): ChartJsActiveElement[] {
   const layer = layers.find(l => l.id === layerId);
   if (!layer)
@@ -315,14 +331,22 @@ export function resolveActiveTargets(
   if (isSegmentedType(layer.type))
     return [{ datasetIndex: rowDatasetIndex(layerDatasetIndices, layerId, row), index: col }];
 
-  // A point cloud: col is an X-bucket; expand to every point sharing that X.
-  // Each entry carries its own dataset, so a merged volcano or Manhattan
-  // highlights across the datasets it was folded from.
+  // A point cloud names its selection by `layer.data` index, not by position:
+  // the model navigates it through five different index spaces (x-bucket,
+  // y-bucket, flat point, grid cell, in-cell group) and no row/column pair can
+  // say which one is live. Each entry carries its own dataset, so a merged
+  // volcano or Manhattan highlights across the datasets it was folded from.
   if (isPointCloudType(layer.type)) {
-    const buckets = maps.pointBuckets.get(layer.id);
-    if (!buckets || col < 0 || col >= buckets.length)
+    const targets = maps.pointTargets.get(layer.id);
+    if (!targets || !pointIndices)
       return [];
-    return [...buckets[col]];
+    const active: ChartJsActiveElement[] = [];
+    for (const index of pointIndices) {
+      const target = targets[index];
+      if (target)
+        active.push(target);
+    }
+    return active;
   }
 
   // Gantt: MAIDR row = lane (the Chart.js element index), col = which dataset

--- a/src/adapters/chartjs/plugin.tsx
+++ b/src/adapters/chartjs/plugin.tsx
@@ -43,6 +43,12 @@ interface NavEvent {
   layerId: string;
   row: number;
   col: number;
+  /**
+   * A point cloud's selection, as `layer.data` indices. Carried through the
+   * resize replay as well, so a re-resolve after a resize outlines the same
+   * points rather than falling back to the `-1` position that accompanies it.
+   */
+  pointIndices?: readonly number[];
 }
 
 interface MaidrChartBinding {
@@ -190,6 +196,7 @@ function createHighlightCallback(
             event.layerId,
             event.row,
             event.col,
+            event.pointIndices,
           );
       applyHighlight(chart, getOverlay(), targets);
     } catch {
@@ -389,6 +396,7 @@ function handleResize(chart: ChartJsChart): void {
         active.layerId,
         active.row,
         active.col,
+        active.pointIndices,
       );
       applyHighlight(chart, overlay, targets);
     } catch {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2,8 +2,6 @@ import type { AppendedPointInfo } from '@service/liveData';
 import type { AppStore } from '@state/store';
 import type { Disposable } from '@type/disposable';
 import type { Maidr, NavigateCallback } from '@type/grammar';
-import type { Observer } from '@type/observable';
-import type { TraceState } from '@type/state';
 import { Context } from '@model/context';
 import { Figure } from '@model/plot';
 import { AudioService } from '@service/audio';
@@ -42,6 +40,7 @@ import { ReviewViewModel } from '@state/viewModel/reviewViewModel';
 import { RotorNavigationViewModel } from '@state/viewModel/rotorNavigationViewModel';
 import { SettingsViewModel } from '@state/viewModel/settingsViewModel';
 import { TextViewModel } from '@state/viewModel/textViewModel';
+import { createNavigateObserver } from '@util/navigateObserver';
 import { resolveSubplotLayout } from '@util/subplotLayout';
 
 /**
@@ -570,20 +569,9 @@ export class Controller implements Disposable {
    * Used by canvas-based charting libraries (e.g., Chart.js) for visual highlighting.
    */
   private registerNavigateCallback(callback: NavigateCallback): void {
-    const observer: Observer<TraceState> = {
-      update: (state: TraceState) => {
-        if (!state.empty && !state.braille.empty) {
-          callback({
-            layerId: state.layerId,
-            row: state.braille.row,
-            col: state.braille.col,
-          });
-        }
-      },
-    };
     this.figure.subplots.forEach(subplotRow => subplotRow.forEach((subplot) => {
       subplot.traces.forEach(traceRow => traceRow.forEach((trace) => {
-        trace.addObserver(observer);
+        trace.addObserver(createNavigateObserver(trace, callback));
       }));
     }));
 

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -1,6 +1,6 @@
 import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
-import type { GridNavigable, PointNavigable } from '@type/navigation';
+import type { GridNavigable, PointCloudHighlightable, PointNavigable } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, HighlightState, TextState, TraceEmptyState, TraceState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
 import { Constant } from '@util/constant';
@@ -40,6 +40,13 @@ interface GridCell {
   xValues: number[];
   zValues: number[];
   svgElements: SVGElement[];
+  /**
+   * Indices into the layer's `data` array of the points binned into this cell,
+   * index-aligned with `points`. Unlike `svgElements` this is filled whether or
+   * not the binder supplied elements, so a canvas chart — which has none — can
+   * still say which points a cell holds.
+   */
+  indices: number[];
   xRange: { min: number; max: number };
   yRange: { min: number; max: number };
 }
@@ -64,7 +71,7 @@ interface FlatPoint {
   yIndexInColumn: number;
 }
 
-export class ScatterTrace extends AbstractTrace implements GridNavigable, PointNavigable {
+export class ScatterTrace extends AbstractTrace implements GridNavigable, PointNavigable, PointCloudHighlightable {
   private mode: NavMode;
   protected readonly movable: MovablePlane;
   protected readonly supportsExtrema = false;
@@ -115,6 +122,12 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
   private cellPointIndex: number;
   private cellXPoints: ScatterXPoint[]; // Grouped cell points by X (like xPoints)
   private cellSvgGroups: SVGElement[][]; // SVG elements grouped by X
+  /**
+   * `data` indices grouped by X, parallel to `cellXPoints`. The index twin of
+   * `cellSvgGroups`, built unconditionally so a canvas chart can resolve a
+   * cell-mode highlight it has no elements for.
+   */
+  private cellIndexGroups: number[][];
 
   // Point navigation state (POINT_MODE)
   // - flatPoints: every individual datapoint, in original data order
@@ -157,6 +170,16 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
   //   user on the points they were just hearing.
   private readonly xPointsSvg: (SVGElement | null)[][] | null;
   private readonly yPointsSvg: (SVGElement | null)[][] | null;
+  /**
+   * The index twins of `xPointsSvg` / `yPointsSvg`: `[col][k]` is the `data`
+   * index of the point `xPoints[col].y[k]` came from (and likewise for y).
+   *
+   * Built unconditionally, where the SVG arrays are built only when the binder
+   * supplied one element per datapoint. A canvas chart has no elements at all,
+   * so the identity of a highlighted point has to survive their absence.
+   */
+  private readonly xPointIndices: number[][];
+  private readonly yPointIndices: number[][];
   private readonly hasIntersectableStack: boolean;
   private isInIntersectionMode: boolean;
   private intersectionStackIndex: number;
@@ -242,6 +265,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
     this.cellPointIndex = 0;
     this.cellXPoints = [];
     this.cellSvgGroups = [];
+    this.cellIndexGroups = [];
     const gridConfig = this.resolveGridConfig(layer);
     if (gridConfig) {
       const xSteps = this.computeGridSteps(gridConfig.xMin, gridConfig.xMax, gridConfig.xTickStep);
@@ -307,11 +331,13 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
     // stacks, from ROW it uses y-row stacks, so we offer the mode whenever
     // either is non-trivial.
     const hasSvg = allSvgClones.length === data.length;
+    this.xPointIndices = ScatterTrace.buildStackedIndices(data, 'x');
+    this.yPointIndices = ScatterTrace.buildStackedIndices(data, 'y');
     this.xPointsSvg = hasSvg
-      ? this.buildStackedSvg(data, allSvgClones, 'x')
+      ? this.xPointIndices.map(group => group.map(i => allSvgClones[i] ?? null))
       : null;
     this.yPointsSvg = hasSvg
-      ? this.buildStackedSvg(data, allSvgClones, 'y')
+      ? this.yPointIndices.map(group => group.map(i => allSvgClones[i] ?? null))
       : null;
     this.hasIntersectableStack
       = this.xPoints.some(p => p.y.length >= 2)
@@ -322,19 +348,23 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
 
   /**
    * Build an array parallel to xPoints / yPoints whose [col][k] (or [row][k])
-   * is the SVG element for xPoints[col].y[k] / yPoints[row].x[k].
+   * is the `data` index of the point behind xPoints[col].y[k] /
+   * yPoints[row].x[k].
    *
    * xPoints is constructed by sorting (x asc, y asc); yPoints by (y asc, x
    * asc). We walk the same sort order over data indices and group on the
-   * primary axis so each entry lines up with its rendered element. Required
-   * for INTERSECTION highlight, which focuses a single point in a stack
-   * rather than the whole chord.
+   * primary axis, so each entry lines up with the value the *Points entry
+   * holds. Required for INTERSECTION highlight, which focuses a single point
+   * in a stack rather than the whole chord.
+   *
+   * The index is the durable identity: the caller maps it to an SVG element
+   * when the binder supplied one, and publishes it as-is to a canvas adapter,
+   * which has no element to map it to.
    */
-  private buildStackedSvg(
+  private static buildStackedIndices(
     data: ScatterPoint[],
-    svgs: SVGElement[],
     primary: 'x' | 'y',
-  ): (SVGElement | null)[][] {
+  ): number[][] {
     const secondary = primary === 'x' ? 'y' : 'x';
     const sortedIndices = data
       .map((_, i) => i)
@@ -343,8 +373,8 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
           data[a][primary] - data[b][primary]
           || data[a][secondary] - data[b][secondary],
       );
-    const result: (SVGElement | null)[][] = [];
-    let group: (SVGElement | null)[] | null = null;
+    const result: number[][] = [];
+    let group: number[] | null = null;
     let prevKey: number | null = null;
     for (const i of sortedIndices) {
       const key = data[i][primary];
@@ -353,7 +383,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
         result.push(group);
         prevKey = key;
       }
-      group.push(svgs[i] ?? null);
+      group.push(i);
     }
     return result;
   }
@@ -926,6 +956,61 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
     };
   }
 
+  /**
+   * The points the highlight currently covers, as indices into this layer's
+   * `data` array.
+   *
+   * This is `highlight` answered in a renderer-neutral currency. `highlight`
+   * resolves the same five navigation modes into `SVGElement`s, which a canvas
+   * chart has none of — so a canvas adapter is handed back an index into the
+   * `data` array it supplied, and inverts it against its own extraction walk.
+   * That keeps the binning here, in the model that owns it: the adapter never
+   * learns what a grid cell or an x-bucket is.
+   *
+   * Deliberately not gated on SVG availability, where `highlight` falls back to
+   * out-of-bounds when the binder supplied no elements. A canvas chart has no
+   * elements by definition, and that is exactly the case this exists to serve.
+   *
+   * Returns an empty array when nothing is addressed, which a consumer reads as
+   * "clear the overlay".
+   *
+   * @returns Indices into `layer.data`, in no particular order.
+   */
+  public get highlightedPointIndices(): readonly number[] {
+    if (this.isInIntersectionMode) {
+      // A single point in the current stack, selected the same way the SVG
+      // branch selects its element.
+      const stack = this.mode === NavMode.COL
+        ? this.xPointIndices[this.col]
+        : this.yPointIndices[this.row];
+      if (!stack || stack.length === 0) {
+        return [];
+      }
+      const idx = Math.min(this.intersectionStackIndex, Math.max(0, stack.length - 1));
+      const index = stack[idx];
+      return index === undefined ? [] : [index];
+    }
+
+    if (this.isInPointMode) {
+      // pointModeIndex indexes flatPoints, which is `data.map(...)` — so it is
+      // already a data index, with no bookkeeping in between.
+      return this.pointModeIndex >= 0 && this.pointModeIndex < this.flatPoints.length
+        ? [this.pointModeIndex]
+        : [];
+    }
+
+    if (this.isInGridMode && this.gridCells) {
+      if (this.isInGridCellMode && this.cellIndexGroups.length > 0) {
+        return this.cellIndexGroups[this.cellPointIndex] ?? [];
+      }
+      return this.gridCells[this.gridRow]?.[this.gridCol]?.indices ?? [];
+    }
+
+    return (this.mode === NavMode.COL
+      ? this.xPointIndices[this.col]
+      : this.yPointIndices[this.row]) ?? [];
+  }
+
   protected override get hasMultiPoints(): boolean {
     return true;
   }
@@ -1473,31 +1558,43 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
     }
 
     // Build cellXPoints by grouping cell points by X (sorted by X, then Y)
-    const pointsWithSvg = cell.points.map((p, i) => ({ point: p, svg: cell.svgElements[i] }));
+    const pointsWithSvg = cell.points.map((p, i) => ({
+      point: p,
+      svg: cell.svgElements[i],
+      index: cell.indices[i],
+    }));
     const sorted = [...pointsWithSvg].sort((a, b) => a.point.x - b.point.x || a.point.y - b.point.y);
 
     this.cellXPoints = [];
     this.cellSvgGroups = [];
+    this.cellIndexGroups = [];
     let currentX: ScatterXPoint | null = null;
     let currentSvgGroup: SVGElement[] = [];
+    let currentIndexGroup: number[] = [];
 
-    for (const { point, svg } of sorted) {
+    for (const { point, svg, index } of sorted) {
       if (!currentX || currentX.x !== point.x) {
         if (currentX) {
           this.cellXPoints.push(currentX);
           this.cellSvgGroups.push(currentSvgGroup);
+          this.cellIndexGroups.push(currentIndexGroup);
         }
         currentX = { x: point.x, y: [], z: [] };
         currentSvgGroup = [];
+        currentIndexGroup = [];
       }
       currentX.y.push(point.y);
       currentX.z.push(typeof point.z === 'number' ? point.z : Number.NaN);
       if (svg)
         currentSvgGroup.push(svg);
+      // Unconditional, unlike the SVG push above: a canvas cell still knows
+      // which points it holds.
+      currentIndexGroup.push(index);
     }
     if (currentX) {
       this.cellXPoints.push(currentX);
       this.cellSvgGroups.push(currentSvgGroup);
+      this.cellIndexGroups.push(currentIndexGroup);
     }
 
     this.isInGridCellMode = true;
@@ -1906,6 +2003,7 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
           xValues: [],
           zValues: [],
           svgElements: [],
+          indices: [],
           xRange: xSteps[c],
           yRange: ySteps[r],
         };
@@ -1924,6 +2022,9 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
         grid[rowIdx][colIdx].yValues.push(point.y);
         grid[rowIdx][colIdx].xValues.push(point.x);
         grid[rowIdx][colIdx].zValues.push(typeof point.z === 'number' ? point.z : Number.NaN);
+        // Not guarded by hasElements: the identity of a binned point does not
+        // depend on the binder having drawn something we could select.
+        grid[rowIdx][colIdx].indices.push(i);
         if (hasElements) {
           grid[rowIdx][colIdx].svgElements.push(svgClones[i]);
         }

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -143,8 +143,20 @@ export interface ViolinKdePoint {
  * @param info.layerId - The ID of the active layer/trace
  * @param info.row - The current row index (e.g., dataset index)
  * @param info.col - The current column index (e.g., data point index)
+ * @param info.pointIndices - Present only for a point cloud (scatter, volcano,
+ *   manhattan), whose selection is a *set of points* rather than a cell of a
+ *   grid: the indices into that layer's `data` array — as the producer supplied
+ *   it — of every point the highlight covers. When it is present `row` and
+ *   `col` are both `-1`, because no row/column pair can name the selection, and
+ *   a consumer that bounds-checks them (as it must) then clears the overlay
+ *   rather than outlining an arbitrary mark.
  */
-export type NavigateCallback = (info: { layerId: string; row: number; col: number } | null) => void;
+export type NavigateCallback = (info: {
+  layerId: string;
+  row: number;
+  col: number;
+  pointIndices?: readonly number[];
+} | null) => void;
 
 /**
  * Root MAIDR data structure containing figure metadata and subplot grid.

--- a/src/type/navigation.ts
+++ b/src/type/navigation.ts
@@ -61,6 +61,36 @@ export function isPointNavigable(plot: unknown): plot is PointNavigable {
 }
 
 /**
+ * Interface for traces whose highlight is a set of individual data points
+ * rather than a position on a row/column grid.
+ *
+ * A scatter-family trace navigates five different index spaces (x-bucket,
+ * y-bucket, flat point, grid cell, in-cell x-group), so no single row/column
+ * pair can name what it has selected. It publishes the selection as indices
+ * into its layer's `data` array instead — the one currency the producing
+ * adapter already shares with the model, since the adapter built that array.
+ *
+ * This is what lets a canvas chart draw a highlight: it has no SVG elements to
+ * select, so the element-based highlight path cannot reach it, and an adapter
+ * that reconstructed the model's binning would drift from it silently.
+ */
+export interface PointCloudHighlightable {
+  /** Indices into the layer's `data` array of the currently highlighted points. */
+  readonly highlightedPointIndices: readonly number[];
+}
+
+/**
+ * Type guard to check if a plot publishes point-level highlight identity.
+ */
+export function isPointCloudHighlightable(plot: unknown): plot is PointCloudHighlightable {
+  return (
+    plot !== null
+    && typeof plot === 'object'
+    && 'highlightedPointIndices' in plot
+  );
+}
+
+/**
  * Union type for all point types that have an 'x' property
  */
 export type PointWithX = BarPoint | LinePoint | ScatterPoint | SegmentedPoint | SmoothPoint;

--- a/src/type/navigation.ts
+++ b/src/type/navigation.ts
@@ -81,12 +81,20 @@ export interface PointCloudHighlightable {
 
 /**
  * Type guard to check if a plot publishes point-level highlight identity.
+ *
+ * The shape is checked, not merely the name: the sibling guards above assert
+ * `typeof … === 'function'` on the member they test, and the equivalent here is
+ * that the member reads as an array. Reading it is safe and cheap — the getter
+ * is pure over fields fixed at construction — and a trace that happened to
+ * carry a same-named property of another shape would otherwise be fed to a
+ * consumer expecting indices.
  */
 export function isPointCloudHighlightable(plot: unknown): plot is PointCloudHighlightable {
   return (
     plot !== null
     && typeof plot === 'object'
     && 'highlightedPointIndices' in plot
+    && Array.isArray((plot as PointCloudHighlightable).highlightedPointIndices)
   );
 }
 

--- a/src/util/navigateObserver.ts
+++ b/src/util/navigateObserver.ts
@@ -1,0 +1,64 @@
+import type { NavigateCallback } from '@type/grammar';
+import type { Observer } from '@type/observable';
+import type { TraceState } from '@type/state';
+import { isPointCloudHighlightable } from '@type/navigation';
+
+/**
+ * Build the observer that turns a trace's state updates into navigate events.
+ *
+ * This is the only path a canvas chart has to a highlight. An SVG adapter
+ * highlights through `selectors` and never registers a `NavigateCallback` at
+ * all, so nothing here can reach one; a canvas adapter has no elements to
+ * select and draws an overlay from what this reports instead.
+ *
+ * Two kinds of trace report differently:
+ *
+ * - A **point cloud** — a scatter, volcano or Manhattan — selects a *set of
+ *   points*, and its braille surface is a binned grid that names none of them.
+ *   The position it could carry would address a cell of that grid, so an
+ *   overlay reading it as a point index would outline whichever mark happened
+ *   to sit at that ordinal. The identity of the points is sent instead, as
+ *   indices into the layer's `data` array. The `-1` position is deliberate: a
+ *   consumer that has not learned about `pointIndices` bounds-checks the pair
+ *   and clears, rather than outlining the wrong mark.
+ * - **Everything else** reports the braille position, which for those traces
+ *   does name the mark, and stays silent while braille is empty.
+ *
+ * Extracted from `Controller` so the contract is testable: constructing a
+ * `Controller` needs a live DOM, a Redux store and every service, and a test
+ * that re-implemented this instead would keep passing while the shipped
+ * wiring drifted.
+ *
+ * @param trace - The trace being observed, feature-tested once here rather
+ *   than on every keystroke: whether it can name its points is fixed at
+ *   construction.
+ * @param callback - The adapter's navigate callback.
+ * @returns An observer to register on that trace.
+ */
+export function createNavigateObserver(
+  trace: unknown,
+  callback: NavigateCallback,
+): Observer<TraceState> {
+  const cloud = isPointCloudHighlightable(trace) ? trace : null;
+  return {
+    update: (state: TraceState): void => {
+      if (state.empty) {
+        return;
+      }
+      if (cloud) {
+        callback({
+          layerId: state.layerId,
+          row: -1,
+          col: -1,
+          pointIndices: cloud.highlightedPointIndices,
+        });
+      } else if (!state.braille.empty) {
+        callback({
+          layerId: state.layerId,
+          row: state.braille.row,
+          col: state.braille.col,
+        });
+      }
+    },
+  };
+}

--- a/test/adapters/amcharts/declaration.test.ts
+++ b/test/adapters/amcharts/declaration.test.ts
@@ -697,16 +697,59 @@ describe('declared layers and the highlight', () => {
     expect(lower[0].kind).toBe('column');
   });
 
-  it('resolves nothing for a cloud, whose position names a grid cell', () => {
+  it('resolves a cloud by data index, so a volcano point outlines', () => {
+    // A cloud has no row/column position that names a mark -- its braille
+    // surface is a binned grid -- so it is addressed by `layer.data` index
+    // instead (#897). Before that channel existed this resolver was left
+    // unregistered on purpose, and volcano and Manhattan outlined nothing.
+    const cloud = cloudSeries('DE', [
+      { valueX: 1, valueY: 2 },
+      { valueX: 3, valueY: 4 },
+    ], {
+      maidr: { type: 'volcano' },
+    });
+    const navMap = navMapOf([cloud]);
+    const layerId = layersOf([cloud])[0].id;
+
+    const first = navMap.resolve(layerId, -1, -1, [0]);
+    const second = navMap.resolve(layerId, -1, -1, [1]);
+
+    expect(first[0].dataItem).toBe(cloud.dataItems[0]);
+    expect(first[0].kind).toBe('point');
+    expect(second[0].dataItem).toBe(cloud.dataItems[1]);
+  });
+
+  it('resolves every point of a multi-point cloud selection', () => {
+    // A scatter column selects every point sharing an X, and a grid cell every
+    // point binned into it, so one position routinely covers several marks.
+    const cloud = cloudSeries('DE', [
+      { valueX: 1, valueY: 2 },
+      { valueX: 3, valueY: 4 },
+    ], {
+      maidr: { type: 'volcano' },
+    });
+    const navMap = navMapOf([cloud]);
+    const layerId = layersOf([cloud])[0].id;
+
+    const both = navMap.resolve(layerId, -1, -1, [0, 1]);
+
+    expect(both.map(target => target.dataItem)).toEqual([
+      cloud.dataItems[0],
+      cloud.dataItems[1],
+    ]);
+  });
+
+  it('clears rather than guesses when a cloud carries no point indices', () => {
+    // A consumer that has not learned about `pointIndices` sends the -1 pair
+    // through. Resolving to nothing keeps #895's honest blank instead of
+    // outlining whichever mark sits at that ordinal.
     const cloud = cloudSeries('DE', [{ valueX: 1, valueY: 2 }], {
       maidr: { type: 'volcano' },
     });
     const navMap = navMapOf([cloud]);
     const layerId = layersOf([cloud])[0].id;
 
-    // A scatter publishes a binned grid rather than its points, so a position
-    // here does not name a mark: the overlay is cleared instead of outlining
-    // whichever point happens to sit at that ordinal.
     expect(navMap.resolve(layerId, 0, 0)).toEqual([]);
+    expect(navMap.resolve(layerId, -1, -1)).toEqual([]);
   });
 });

--- a/test/adapters/chartjs/highlightTargets.test.ts
+++ b/test/adapters/chartjs/highlightTargets.test.ts
@@ -18,6 +18,14 @@ function createChart(type: string, data: ChartJsData, options?: ChartJsOptions):
 function setup(chart: ChartJsChart): {
   layers: ReturnType<typeof extractChartData>['maidr']['subplots'][number][number]['layers'];
   resolve: (layerId: string, row: number, col: number) => { datasetIndex: number; index: number }[];
+  /**
+   * Resolve a point cloud, which is addressed by `layer.data` index rather than
+   * by position — the callback sends the -1 sentinel for the pair.
+   */
+  resolvePoints: (
+    layerId: string,
+    pointIndices: readonly number[],
+  ) => { datasetIndex: number; index: number }[];
 } {
   const { maidr, layerDatasetIndices } = extractChartData(chart);
   const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
@@ -26,6 +34,8 @@ function setup(chart: ChartJsChart): {
     layers,
     resolve: (layerId, row, col) =>
       resolveActiveTargets(layers, maps, layerDatasetIndices, layerId, row, col),
+    resolvePoints: (layerId, pointIndices) =>
+      resolveActiveTargets(layers, maps, layerDatasetIndices, layerId, -1, -1, pointIndices),
   };
 }
 
@@ -73,13 +83,22 @@ describe('chart.js highlight target resolution', () => {
         ],
       });
 
-      const { resolve } = setup(chart);
+      const { resolve, resolvePoints } = setup(chart);
 
-      // Layer '1' is dataset 1; its col 0 X-bucket holds both x=2 points.
-      expect(resolve('1', 0, 0)).toEqual([
+      // Layer '1' is dataset 1, and its data is that dataset's two points in
+      // order, so data index 0 and 1 are its element 0 and 1.
+      expect(resolvePoints('1', [0])).toEqual([{ datasetIndex: 1, index: 0 }]);
+      expect(resolvePoints('1', [1])).toEqual([{ datasetIndex: 1, index: 1 }]);
+      // A selection covering several points — what a column of shared X, or a
+      // grid cell, resolves to — outlines all of them.
+      expect(resolvePoints('1', [0, 1])).toEqual([
         { datasetIndex: 1, index: 0 },
         { datasetIndex: 1, index: 1 },
       ]);
+
+      // A consumer that has not learned about `pointIndices` sends the -1 pair
+      // through unchanged, and gets nothing rather than an arbitrary mark.
+      expect(resolve('1', -1, -1)).toEqual([]);
     });
 
     it('maps pie navigation to the slice, skipping gap markers', () => {
@@ -154,13 +173,13 @@ describe('chart.js highlight target resolution', () => {
         ],
       }, stackedScales);
 
-      const { resolve } = setup(chart);
+      const { resolvePoints } = setup(chart);
 
       // Bottom-first rows: panel 0 is the y2 band (S2, S3), panel 1 is y (S1).
-      expect(resolve('0_0', 0, 0)).toEqual([{ datasetIndex: 1, index: 0 }]);
-      expect(resolve('1_0', 0, 0)).toEqual([{ datasetIndex: 0, index: 0 }]);
-      // Second layer of the y2 panel = dataset 2; its bucket has two shared-X points.
-      expect(resolve('0_1', 0, 0)).toEqual([
+      expect(resolvePoints('0_0', [0])).toEqual([{ datasetIndex: 1, index: 0 }]);
+      expect(resolvePoints('1_0', [0])).toEqual([{ datasetIndex: 0, index: 0 }]);
+      // Second layer of the y2 panel = dataset 2; both of its points.
+      expect(resolvePoints('0_1', [0, 1])).toEqual([
         { datasetIndex: 2, index: 0 },
         { datasetIndex: 2, index: 1 },
       ]);

--- a/test/adapters/chartjs/volcano.test.ts
+++ b/test/adapters/chartjs/volcano.test.ts
@@ -42,14 +42,15 @@ function pointsOf(chart: ChartJsChart): VolcanoPoint[] {
 /** Everything the plugin's navigation bridge resolves highlights through. */
 function highlightsOf(chart: ChartJsChart): (
   layerId: string,
-  row: number,
-  col: number,
+  pointIndices: readonly number[],
 ) => { datasetIndex: number; index: number }[] {
   const { maidr, layerDatasetIndices } = extractChartData(chart);
   const layers = maidr.subplots.flat().flatMap(subplot => subplot.layers);
   const maps = computeTargetMaps(chart, layers, layerDatasetIndices);
-  return (layerId, row, col) =>
-    resolveActiveTargets(layers, maps, layerDatasetIndices, layerId, row, col);
+  // A cloud is addressed by `layer.data` index, so the position pair the
+  // callback carries alongside it is the -1 sentinel.
+  return (layerId, pointIndices) =>
+    resolveActiveTargets(layers, maps, layerDatasetIndices, layerId, -1, -1, pointIndices);
 }
 
 /** Two genes of a differential expression analysis, as a page would write them. */
@@ -349,11 +350,15 @@ describe('chart.js volcano and manhattan extraction', () => {
 
       const resolve = highlightsOf(chart);
 
-      // Buckets run in ascending x, as `ScatterTrace` orders its columns:
-      // x = 1, x = 2, then the two points sharing x = 3.
-      expect(resolve('0', 0, 0)).toEqual([{ datasetIndex: 0, index: 1 }]);
-      expect(resolve('0', 0, 1)).toEqual([{ datasetIndex: 1, index: 0 }]);
-      expect(resolve('0', 0, 2)).toEqual([
+      // The merged layer's `data` runs chr1's points then chr2's, in dataset
+      // order — so index 0..3 walk (ds0,0), (ds0,1), (ds1,0), (ds1,1).
+      expect(resolve('0', [0])).toEqual([{ datasetIndex: 0, index: 0 }]);
+      expect(resolve('0', [1])).toEqual([{ datasetIndex: 0, index: 1 }]);
+      expect(resolve('0', [2])).toEqual([{ datasetIndex: 1, index: 0 }]);
+
+      // The whole point of the merge: one selection reaching elements in more
+      // than one dataset. The two points sharing x = 3 are data 0 and 3.
+      expect(resolve('0', [0, 3])).toEqual([
         { datasetIndex: 0, index: 0 },
         { datasetIndex: 1, index: 1 },
       ]);

--- a/test/controller/navigateCallbackClear.test.ts
+++ b/test/controller/navigateCallbackClear.test.ts
@@ -4,12 +4,20 @@
 
 import type { Maidr, NavigateCallback } from '@type/grammar';
 import type { MovableDirection } from '@type/movable';
-import type { TraceState } from '@type/state';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Context } from '@model/context';
 import { Figure } from '@model/plot';
 import { TraceType } from '@type/grammar';
+import { createNavigateObserver } from '@util/navigateObserver';
 import { resolveSubplotLayout } from '@util/subplotLayout';
+
+/** What the callback is handed, mirroring `NavigateCallback`'s parameter. */
+type NavEvent = {
+  layerId: string;
+  row: number;
+  col: number;
+  pointIndices?: readonly number[];
+} | null;
 
 /**
  * Leaving a subplot has to reach a canvas adapter, or its highlight is stranded.
@@ -56,24 +64,13 @@ const FORWARD: MovableDirection = 'FORWARD';
 describe('the navigate callback reports the selection ending', () => {
   let figure: Figure;
   let context: Context;
-  let seen: Array<{ layerId: string; row: number; col: number } | null>;
+  let seen: NavEvent[];
 
-  /** Mirrors `Controller.registerNavigateCallback`. */
+  /** Registers what `Controller.registerNavigateCallback` registers. */
   function register(callback: NavigateCallback): void {
-    const observer = {
-      update: (state: TraceState): void => {
-        if (!state.empty && !state.braille.empty) {
-          callback({
-            layerId: state.layerId,
-            row: state.braille.row,
-            col: state.braille.col,
-          });
-        }
-      },
-    };
     figure.subplots.forEach(row => row.forEach((subplot) => {
       subplot.traces.forEach(traceRow => traceRow.forEach((trace) => {
-        trace.addObserver(observer as never);
+        trace.addObserver(createNavigateObserver(trace, callback));
       }));
     }));
     figure.addObserver({ update: () => callback(null) } as never);

--- a/test/controller/navigateCallbackPointCloud.test.ts
+++ b/test/controller/navigateCallbackPointCloud.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { Maidr, NavigateCallback } from '@type/grammar';
+import type { MovableDirection } from '@type/movable';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { createNavigateObserver } from '@util/navigateObserver';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+
+/**
+ * A canvas adapter could not highlight a scatter-family point at all (#897).
+ *
+ * The navigate callback — the only path a canvas chart has to an overlay, since
+ * it has no SVG elements for `selectors` to reach — fired only when
+ * `state.braille` was non-empty. `ScatterTrace.braille` is empty outside grid
+ * mode, so a scatter, volcano or Manhattan layer on amCharts or Chart.js
+ * emitted **no navigation event whatever** during ordinary point-by-point
+ * navigation, and the overlay never moved.
+ *
+ * Grid mode was not the escape hatch it looked like: it needs
+ * `axes.{x,y}.{min,max,tickStep}`, and neither canvas adapter emits those — so
+ * for those two adapters the callback fired literally never. Where it *did*
+ * fire, the `row`/`col` it carried were binned grid cells, and an overlay
+ * trusting them would outline whichever point sat at that ordinal.
+ *
+ * Constructing a `Controller` needs a live DOM, a Redux store and every
+ * service, so this registers `createNavigateObserver` — the observer the
+ * controller registers, imported rather than re-implemented, so that the
+ * shipped wiring is what runs here — and drives the moves through `Context`
+ * exactly as a keypress does.
+ */
+
+/** What the callback is handed, mirroring `NavigateCallback`'s parameter. */
+type NavEvent = {
+  layerId: string;
+  row: number;
+  col: number;
+  pointIndices?: readonly number[];
+} | null;
+
+const FORWARD: MovableDirection = 'FORWARD';
+
+/**
+ * A scatter beside a bar, in one panel each.
+ *
+ * The scatter carries only axis *labels* — the shape both canvas adapters emit
+ * — so grid mode is unavailable and this is exactly the reported case. Two of
+ * its points share an X, so a column selects a set.
+ */
+function figureData(): Maidr {
+  return {
+    id: 'cloud-and-bar',
+    subplots: [
+      [
+        {
+          layers: [{
+            id: 'cloud',
+            type: TraceType.SCATTER,
+            axes: { x: { label: 'X' }, y: { label: 'Y' } },
+            data: [
+              { x: 1, y: 10 },
+              { x: 2, y: 20 },
+              { x: 2, y: 30 },
+            ],
+          }],
+        },
+        {
+          layers: [{
+            id: 'bars',
+            type: TraceType.BAR,
+            data: [{ x: 'Apples', y: 30 }, { x: 'Bananas', y: 50 }],
+          }],
+        },
+      ],
+    ],
+  } as Maidr;
+}
+
+describe('the navigate callback reaches a point cloud', () => {
+  let figure: Figure;
+  let context: Context;
+  let seen: NavEvent[];
+
+  /** Registers what `Controller.registerNavigateCallback` registers. */
+  function register(callback: NavigateCallback): void {
+    figure.subplots.forEach(row => row.forEach((subplot) => {
+      subplot.traces.forEach(traceRow => traceRow.forEach((trace) => {
+        trace.addObserver(createNavigateObserver(trace, callback));
+      }));
+    }));
+    figure.addObserver({ update: () => callback(null) } as never);
+  }
+
+  beforeEach(() => {
+    figure = new Figure(figureData());
+    figure.applyLayout(resolveSubplotLayout(figure.subplots));
+    context = new Context(figure);
+    seen = [];
+    register(event => void seen.push(event));
+  });
+
+  it('fires at all for a scatter outside grid mode', () => {
+    context.enterSubplot();
+    seen.length = 0;
+
+    // The cursor sits before the first column on entry, so the first move
+    // lands on column 0 rather than stepping past it.
+    context.moveOnce(FORWARD);
+
+    // The bug in one assertion: this array stayed empty, so a canvas overlay
+    // was never told anything had been selected.
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.at(-1)).not.toBeNull();
+  });
+
+  it('addresses the points rather than a position', () => {
+    context.enterSubplot();
+    seen.length = 0;
+
+    context.moveOnce(FORWARD);
+    // Column 0 is x=1, which only data[0] sits in.
+    expect(seen.at(-1)).toEqual({
+      layerId: 'cloud',
+      row: -1,
+      col: -1,
+      pointIndices: [0],
+    });
+
+    context.moveOnce(FORWARD);
+    // Column 1 is x=2, holding both data[1] and data[2]. A row/column pair
+    // could not have said this.
+    expect(seen.at(-1)).toEqual({
+      layerId: 'cloud',
+      row: -1,
+      col: -1,
+      pointIndices: [1, 2],
+    });
+  });
+
+  it('sends -1 for the position, so an un-updated consumer clears', () => {
+    context.enterSubplot();
+    seen.length = 0;
+    context.moveOnce(FORWARD);
+
+    const event = seen.at(-1);
+    // Every existing consumer bounds-checks the pair before indexing with it
+    // (see `resolveActiveTargets`), so -1 degrades to no highlight rather than
+    // to a box on an arbitrary mark. That is the behaviour #895 chose when it
+    // declined to register a resolver at all, preserved here for free.
+    expect(event?.row).toBe(-1);
+    expect(event?.col).toBe(-1);
+  });
+
+  it('leaves a non-cloud trace emitting exactly what it emitted before', () => {
+    // An SVG adapter highlights through `selectors` and never registers this
+    // callback, but a canvas bar chart does — and its events must not shift.
+    context.enterSubplot();
+    context.exitSubplot();
+    // The lobby cursor starts before the first panel, so the first move lands
+    // on panel 1 and the second is what reaches the bar panel.
+    context.moveOnce(FORWARD);
+    context.moveOnce(FORWARD);
+    context.enterSubplot();
+    seen.length = 0;
+
+    context.moveOnce(FORWARD);
+
+    // The braille row/col pair, unchanged and with no `pointIndices` field.
+    expect(seen.at(-1)).toEqual({ layerId: 'bars', row: 0, col: 0 });
+  });
+});

--- a/test/model/scatterPointIndices.test.ts
+++ b/test/model/scatterPointIndices.test.ts
@@ -1,0 +1,289 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { ScatterTrace } from '@model/scatter';
+import { TraceType } from '@type/grammar';
+import { isPointCloudHighlightable } from '@type/navigation';
+
+/**
+ * A scatter-family trace publishes the *identity* of the points it has
+ * highlighted, as indices into its layer's `data` array (#897).
+ *
+ * `highlight` answers the same question in `SVGElement`s, which a canvas chart
+ * has none of — so amCharts and Chart.js could not outline a scatter, volcano
+ * or Manhattan point at all. The only position on offer was the braille one,
+ * and a scatter's braille surface is a *binned grid*: it is empty outside grid
+ * mode, and inside it names a cell rather than a point.
+ *
+ * These pin the index channel against the five navigation modes, and — where
+ * the SVG channel is available — pin the two to each other, since a highlight
+ * that says one thing to an SVG adapter and another to a canvas one is worse
+ * than either alone.
+ */
+
+/**
+ * A scatter layer with no axis ranges — the shape both canvas adapters emit
+ * (`src/adapters/chartjs/extractor.ts` emits labels only, and amCharts emits no
+ * min/max/tickStep at all), so `resolveGridConfig` returns null and grid mode
+ * is unavailable. This is the configuration the bug was reported against.
+ */
+function createLayer(data: ScatterPoint[]): MaidrLayer {
+  return {
+    id: 'cloud',
+    type: TraceType.SCATTER,
+    title: 'Point identity',
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  };
+}
+
+/** The same layer with the six values `resolveGridConfig` requires. */
+function createGriddedLayer(data: ScatterPoint[]): MaidrLayer {
+  return {
+    id: 'cloud',
+    type: TraceType.SCATTER,
+    title: 'Point identity, binned',
+    axes: {
+      x: { label: 'X', min: 0, max: 10, tickStep: 5 },
+      y: { label: 'Y', min: 0, max: 10, tickStep: 5 },
+    },
+    data,
+  };
+}
+
+/**
+ * Three points, two of which share an X — so a column selects a *set*, which is
+ * the case no single row/column pair can name.
+ */
+const shared: ScatterPoint[] = [
+  { x: 1, y: 10 },
+  { x: 2, y: 20 },
+  { x: 2, y: 30 },
+];
+
+describe('a scatter names the points it has highlighted', () => {
+  test('declares the capability, so the controller can feature-test it', () => {
+    const trace = new ScatterTrace(createLayer(shared));
+
+    expect(isPointCloudHighlightable(trace)).toBe(true);
+  });
+
+  test('COL mode selects every point sharing the column X', () => {
+    const trace = new ScatterTrace(createLayer(shared));
+
+    // The cursor sits before the first column on entry, so the first move
+    // lands on column 0 rather than stepping past it.
+    trace.moveOnce('FORWARD');
+    // xPoints is grouped on (x asc, y asc): column 0 is x=1, holding data[0].
+    expect([...trace.highlightedPointIndices]).toEqual([0]);
+
+    trace.moveOnce('FORWARD');
+    // Column 1 is x=2, which both data[1] and data[2] sit in. A single index
+    // could not say this, which is why the channel carries a list.
+    expect([...trace.highlightedPointIndices]).toEqual([1, 2]);
+  });
+
+  test('ROW mode selects every point sharing the row Y', () => {
+    const trace = new ScatterTrace(createLayer([
+      { x: 1, y: 5 },
+      { x: 2, y: 5 },
+      { x: 3, y: 9 },
+    ]));
+
+    // The first UPWARD consumes the initial-entry handshake; the second
+    // toggles into ROW mode, as the arrow keys do in the live UI.
+    trace.moveOnce('UPWARD');
+    trace.moveOnce('UPWARD');
+
+    // yPoints is grouped on (y asc, x asc): row 0 is y=5, holding data[0] and
+    // data[1].
+    expect([...trace.highlightedPointIndices]).toEqual([0, 1]);
+  });
+
+  test('point mode selects exactly the point being announced', () => {
+    // Every coordinate distinct, so the index can only be right by naming the
+    // right point. `pointModeIndex` indexes flatPoints, which is
+    // `data.map(...)`, so it is already a data index — this pins that.
+    const data: ScatterPoint[] = [
+      { x: 1, y: 70 },
+      { x: 2, y: 80 },
+      { x: 3, y: 90 },
+    ];
+    const trace = new ScatterTrace(createLayer(data));
+    trace.setPointMode(true);
+
+    /** The data point the trace says it is standing on, read off its own text. */
+    const announced = (): { x: unknown; y: unknown } => {
+      const state = trace.state;
+      if (state.empty) {
+        throw new Error('expected a non-empty state');
+      }
+      return { x: state.text.main.value, y: state.text.cross.value };
+    };
+
+    /** The data point the published index names. */
+    const named = (): { x: unknown; y: unknown } => {
+      const indices = [...trace.highlightedPointIndices];
+      expect(indices).toHaveLength(1);
+      const point = data[indices[0]];
+      return { x: point.x, y: point.y };
+    };
+
+    expect(named()).toEqual(announced());
+
+    // Walk the reading order; the index has to follow the announcement, not
+    // some other cursor left behind by an earlier mode.
+    const seen = new Set<number>([trace.highlightedPointIndices[0]]);
+    while (trace.movePointLeft()) {
+      expect(named()).toEqual(announced());
+      seen.add(trace.highlightedPointIndices[0]);
+    }
+    while (trace.movePointRight()) {
+      expect(named()).toEqual(announced());
+      seen.add(trace.highlightedPointIndices[0]);
+    }
+
+    // Every point is reachable, and each is named exactly once.
+    expect([...seen].sort()).toEqual([0, 1, 2]);
+  });
+
+  test('intersection mode selects one point of the column stack', () => {
+    const trace = new ScatterTrace(createLayer(shared));
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+    // Column 1 stacks data[1] and data[2].
+    expect([...trace.highlightedPointIndices]).toEqual([1, 2]);
+
+    trace.setIntersectionMode(true);
+    // Intersection focuses a single point of that stack rather than the chord.
+    expect([...trace.highlightedPointIndices]).toEqual([1]);
+
+    trace.moveToNextIntersection();
+    expect([...trace.highlightedPointIndices]).toEqual([2]);
+  });
+
+  test('grid mode selects every point binned into the cell', () => {
+    const trace = new ScatterTrace(createGriddedLayer([
+      { x: 1, y: 1 },
+      { x: 2, y: 2 },
+      { x: 8, y: 8 },
+    ]));
+    trace.setGridMode(true);
+
+    // The low bin holds the two points near the origin; the far one is in
+    // another cell entirely. Which cell the cursor starts in is the model's
+    // business — what matters is that the answer is a set of data indices and
+    // that it never mixes the two bins.
+    const cell = [...trace.highlightedPointIndices];
+    expect(cell.length).toBeGreaterThan(0);
+    const isLowBin = cell.includes(0);
+    expect(cell).toEqual(isLowBin ? [0, 1] : [2]);
+  });
+
+  test('the index channel and the SVG channel never name different points', () => {
+    // The accessibility invariant: an SVG adapter highlights through
+    // `selectors` and a canvas one through these indices, and the two must
+    // agree about what is selected or the same chart says two things.
+    // One element per datapoint, positioned where its data says — the shape a
+    // real SVG binder supplies, and what `groupSvgElements` groups on.
+    document.body.innerHTML = `<svg>${
+      shared.map(p => `<circle class="pt" cx="${p.x}" cy="${p.y}" r="1"/>`).join('')
+    }</svg>`;
+
+    const trace = new ScatterTrace({
+      ...createLayer(shared),
+      selectors: 'circle.pt',
+    } as MaidrLayer);
+
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty || state.highlight.empty) {
+      throw new Error('expected the SVG channel to resolve for this layer');
+    }
+    const elements = Array.isArray(state.highlight.elements)
+      ? state.highlight.elements
+      : [state.highlight.elements];
+
+    // One index per element: the two channels cover the same marks.
+    expect(trace.highlightedPointIndices).toHaveLength(elements.length);
+  });
+
+  test('the SVG channel still picks the right element in intersection mode', () => {
+    // Guards the refactor behind this fix: `buildStackedSvg` became
+    // `buildStackedIndices` plus a lookup, and it is the array intersection
+    // highlighting indexes. An SVG adapter must keep outlining the one point of
+    // the stack the user is on.
+    document.body.innerHTML = `<svg>${
+      shared.map(p => `<circle class="pt" cx="${p.x}" cy="${p.y}" r="1"/>`).join('')
+    }</svg>`;
+
+    const trace = new ScatterTrace({
+      ...createLayer(shared),
+      selectors: 'circle.pt',
+    } as MaidrLayer);
+
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+    trace.setIntersectionMode(true);
+
+    /** The cy of the single element the SVG channel is outlining. */
+    const outlined = (): string | null => {
+      const state = trace.state;
+      if (state.empty || state.highlight.empty) {
+        throw new Error('expected the SVG channel to resolve');
+      }
+      const elements = Array.isArray(state.highlight.elements)
+        ? state.highlight.elements
+        : [state.highlight.elements];
+      expect(elements).toHaveLength(1);
+      return elements[0].getAttribute('cy');
+    };
+
+    // The x=2 stack runs (x2,y20) then (x2,y30) — data[1] then data[2].
+    expect(outlined()).toBe('20');
+    expect([...trace.highlightedPointIndices]).toEqual([1]);
+
+    trace.moveToNextIntersection();
+    expect(outlined()).toBe('30');
+    expect([...trace.highlightedPointIndices]).toEqual([2]);
+  });
+
+  test('names its points even when no SVG element was ever supplied', () => {
+    // The canvas case, and the whole reason the channel exists. `highlight`
+    // falls back to out-of-bounds without elements to point at; the identity
+    // of the points does not depend on anything having been drawn in SVG.
+    const trace = new ScatterTrace(createLayer(shared));
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('expected a non-empty state');
+    }
+    expect(state.highlight.empty).toBe(true);
+    expect([...trace.highlightedPointIndices]).toEqual([0]);
+  });
+
+  test('names its points while the braille surface stays empty', () => {
+    // The decoupling #897 asked for, in one assertion. Braille is empty
+    // outside grid mode because that is the correct braille answer for a
+    // point cloud, not an oversight — so the old highlight path, gated on
+    // braille having something to say, could never fire. The identity channel
+    // carries a selection at the very moment braille carries none, which is
+    // what lets the overlay move without degrading what a blind user reads to
+    // feed a sighted one.
+    const trace = new ScatterTrace(createLayer(shared));
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('expected a non-empty state');
+    }
+    expect(state.braille.empty).toBe(true);
+    expect([...trace.highlightedPointIndices]).toEqual([0]);
+  });
+});

--- a/test/model/scatterPointIndices.test.ts
+++ b/test/model/scatterPointIndices.test.ts
@@ -71,6 +71,17 @@ describe('a scatter names the points it has highlighted', () => {
     expect(isPointCloudHighlightable(trace)).toBe(true);
   });
 
+  test('the capability test reads the shape, not just the name', () => {
+    // A trace carrying the name but not the shape must not be fed to a
+    // consumer that will spread it as indices.
+    expect(isPointCloudHighlightable({ highlightedPointIndices: 3 })).toBe(false);
+    expect(isPointCloudHighlightable({ highlightedPointIndices: undefined })).toBe(false);
+    expect(isPointCloudHighlightable({ somethingElse: [] })).toBe(false);
+    expect(isPointCloudHighlightable(null)).toBe(false);
+
+    expect(isPointCloudHighlightable({ highlightedPointIndices: [] })).toBe(true);
+  });
+
   test('COL mode selects every point sharing the column X', () => {
     const trace = new ScatterTrace(createLayer(shared));
 


### PR DESCRIPTION
# Pull Request

## Description

A scatter, volcano or Manhattan layer drawn on a canvas library (amCharts, Chart.js) produced **no visual highlight at all** during ordinary point-by-point navigation. A canvas chart has no SVG elements for `selectors` to reach, so its only path to a highlight is the navigate callback — and that callback fired only while `state.braille` was non-empty. `ScatterTrace.braille` is empty outside grid mode, so the callback never fired. Grid mode was not an escape hatch either: it requires `axes.{x,y}.{min,max,tickStep}`, which neither canvas adapter emits, and where it *did* fire, the `row`/`col` it carried named a cell of a **binned grid** rather than a point.

The root cause is the coupling of "where the highlight is" to "what braille says". This decouples them rather than distorting braille to carry a position it has no business carrying — option 2 of the issue.

`ScatterTrace` now publishes the *identity* of the points it has highlighted, as indices into its layer's `data` array. That is `highlight` answered in a renderer-neutral currency: it resolves the same five navigation modes (x-bucket, y-bucket, flat point, grid cell, in-cell group) that no single row/column pair can name. The binning stays in the model that owns it — an adapter inverts an index against its own extraction walk and never learns what a grid cell is. This is deliberately *not* the approach #895 tried, where an adapter reconstructed the model's binning and could drift from it silently.

## Related Issues

Closes #897

## Changes Made

**Which layers changed, and why**

- **Model** (`src/model/scatter.ts`) — `ScatterTrace` implements a new `PointCloudHighlightable` and exposes `highlightedPointIndices`. Index twins are added beside the existing SVG arrays (`xPointIndices`/`yPointIndices`, `GridCell.indices`, `cellIndexGroups`), built **unconditionally** where the SVG arrays are built only when the binder supplied one element per datapoint — a canvas chart has none by definition, which is the case this exists to serve. `buildStackedSvg` becomes `static buildStackedIndices` plus an element lookup, which is behaviour-preserving for the SVG channel. No service import; the model still only calls `notifyStateUpdate()`.
- **Types** (`src/type/navigation.ts`, `src/type/grammar.ts`) — `PointCloudHighlightable` + its guard; `NavigateCallback` gains an optional `pointIndices`.
- **Wiring** (`src/controller.ts`, new `src/util/navigateObserver.ts`) — the observer that turns trace state updates into navigate events is extracted to `createNavigateObserver(trace, callback)`, so the shipped contract is testable. `Controller` still constructs and registers; nothing new crosses a boundary (the util imports types plus one type guard).
- **Adapters** (`src/adapters/amcharts/`, `src/adapters/chartjs/`) — outside the MVVC core. amCharts gains `extractCloudMarks` (the index-twin of `extractScatterPoints`/`extractVolcanoPoints`, the same walk over `[series, ...arms]` filtered by `readCloudPoint`) and `buildCloudResolver`, replacing the deliberate no-op the three cloud types shipped with. Chart.js replaces `pointBuckets` — an X-bucket table that mirrored `ScatterTrace`'s grouping, i.e. exactly the duplicated binning #895 refused to ship — with `pointTargets`, one element per data entry in `layer.data` order. Both carry the indices through their resize replay.
- **No service, ViewModel or React change.** `state.highlight` and `HighlightService` are untouched.

**Refusing to guess.** Both adapters register nothing when their mark table and `layer.data` differ in length, and resolve to nothing when a caller sends no `pointIndices`. A stale index clears the overlay rather than outlining a mark chosen at random.

## Screenshots (if applicable)

N/A — the change has no UI surface of its own.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The third box is unticked deliberately: the automated gate is fully green (see below), but `ManualTestingProcess.md` was not walked by hand, and the canvas overlay geometry is the one part no jest suite reaches.

## Additional Notes

**What a reviewer should check hardest**

1. **Index alignment between each adapter's walk and `layer.data`.** This is the entire contract. amCharts: `extractCloudMarks` must stay the same loop as `extractScatterPoints`/`extractVolcanoPoints` — it is kept in the same file so a drift is visible in a side-by-side read. Chart.js: `buildPointTargets` must stay the same `dsIndices` walk with the same `isPointValue` filter as `datasetToScatterPoints`. If either pair drifts, the overlay outlines a confidently wrong point, which is worse than the blank it replaces.
2. **The model-side index arithmetic.** `flatPoints` is `data.map(...)`, so `pointModeIndex` is already a data index. `buildStackedIndices(data, 'x')` sorts (x asc, y asc) and groups on x — exactly how the constructor builds `xPoints` — so `xPointIndices[col]` is parallel to `xPoints[col]`.
3. **The `-1` position.** `pointIndices` arrives with `row`/`col` set to `-1` rather than the fields being made optional, keeping `NavigateCallback`'s two required fields intact for third-party consumers. Every consumer in the tree already bounds-checks the pair before indexing, so an integration that has not learned about the new field degrades to *no* highlight — never to a box on an arbitrary mark. This is the one design decision worth arguing about.
4. **Blast radius.** `VolcanoTrace` is the only `ScatterTrace` subclass (SCATTER/VOLCANO/MANHATTAN); `SmoothTrace` extends `LineTrace` and is untouched; `isPointCloudType` in the Chart.js adapter is scoped to the same three. No line or smooth layer starts demanding `pointIndices` it will never receive.

**Test approach.** Every new test was proven to fail without the fix by mutating the source rather than trusting the diff: gutting `highlightedPointIndices` to `[]` fails 9 model/controller tests; reverting `createNavigateObserver` to the old `!state.braille.empty` gate fails 3 controller tests; un-registering the amCharts cloud resolver and short-circuiting the Chart.js branch fails 5 adapter tests. Both controller specs previously hand-copied the observer out of `Controller`, so reverting `src/controller.ts` would have failed nothing — they now point at the shipped code.

Two tests are deliberate control arms that pass with *and* without the fix, flagged rather than silently kept: `leaves a non-cloud trace emitting exactly what it emitted before` (the no-regression proof for the bar/braille path) and `clears rather than guesses when a cloud carries no point indices` (the honest blank survives for a consumer that has not learned about `pointIndices`).

**Left undone**

- **No e2e Playwright spec for the canvas overlay actually drawing on a point.** The jest suites cover the chain up to and including the resolved `{datasetIndex, index}` / `{series, dataItem}` targets, but the overlay rectangle geometry itself needs a real browser. `e2e_tests/` has no canvas-chart harness — amCharts and Chart.js are bound from live JS objects, not from a static page MAIDR loads — so building one is a larger piece of work than this PR should carry. Worth noting that `.claude/rules/testing.md` asks for an e2e spec per new trace type; this adds no trace type, as all three cloud types already shipped.
- **No SVG-adapter e2e proof**, argued structurally instead: an SVG adapter never sets `maidr.onNavigate` (the only consumers in the tree are `src/adapters/chartjs/plugin.tsx` and `src/adapters/amcharts/binder.tsx`), so nothing here can reach one. The one genuine SVG risk was the `buildStackedSvg` → `buildStackedIndices` refactor, pinned by two model tests: one asserts the exact `cy` outlined before and after `moveToNextIntersection`, the other that the index channel and the SVG channel never name different points.
- **Manual verification against a live amCharts/Chart.js page** was not performed.

**Gate**, re-run on the final tree after the rebase onto the moved `main` (the Observable Plot adapter from #887/#898 is in the base and is unaffected — it is an SVG adapter and registers no navigate callback):

- `npm run lint:fix` — clean.
- `npm run type-check` — clean (`tsc --noEmit` and `tsconfig.ci.json`).
- `npm run build` — all 13 builds complete.
- `npm test` — 283/283 unit suites (4067 tests) and 7/7 esm suites (73 tests), fully green.
- `npx commitlint --from origin/main --to HEAD` — clean, zero warnings.
- Commits 1 and 2 type-check in isolation, so the branch is bisectable rather than only green at the tip.

One honest note on flakiness, not on this change: an earlier `npm test` run had two suites (`test/model/moveToNearestOverride.test.ts`, `test/state/viewModel/textViewModelAnnounce.test.ts`) killed with `SIGKILL` — jest worker OOM under concurrent load on the build machine, not an assertion failure. Both pass in isolation and the re-run was fully green. Neither touches anything in this change.

Separately, a bare `npx jest` (rather than `npm test`) reports 7 pre-existing ESM-project failures out of `rehype-sanitize`; that is the documented reason `scripts/test.js` spawns one process per project, and it reproduces on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_