### PR TITLE
fix(adapters): close the declaration-foundation gaps the adapters reported

### DIFF
--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -4065,8 +4065,9 @@ function convertChoroplethSeries(
 
   // The name and the value are read off the point Highcharts already resolved
   // them onto, and the declaration only renames them. The default fallback
-  // chain is deliberately not walked for either: `value`'s chain includes `x`,
-  // which on a map row is as likely to be the region's own name.
+  // chain is not walked for either: a `map` series states both for itself, and
+  // a chain consulted over the top of that could only disagree with what
+  // Highcharts drew.
   const names = declaration?.region === undefined
     ? undefined
     : readSeriesField(series, declaration.region, 'region');

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -917,9 +917,12 @@ function buildHexbinLayer(
   data.forEach((item, index) => {
     // The hexbin's own chain, so a bin spelling its centre `x0`/`cx` — as a
     // d3-hexbin bin does — is read rather than dropped for want of a centre.
+    // The type is passed on all three reads, `count` included: it has no
+    // hexbin-specific chain today, so this resolves exactly as before, and
+    // adding one later reaches every field rather than two of the three.
     const x = toOptionalNumber(resolveFieldRef(item, binXKey ?? xKey, 'x', TraceType.HEXBIN));
     const y = toOptionalNumber(resolveFieldRef(item, binYKey ?? yKey, 'y', TraceType.HEXBIN));
-    const count = toOptionalNumber(resolveFieldRef(item, countKey, 'count'));
+    const count = toOptionalNumber(resolveFieldRef(item, countKey, 'count', TraceType.HEXBIN));
     // A bin is its centre and its count. Missing any of the three, there is
     // nothing to announce and nowhere to announce it from.
     if (x === undefined || y === undefined || count === undefined) {

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -915,8 +915,10 @@ function buildHexbinLayer(
 
   const bins: HexbinBin[] = [];
   data.forEach((item, index) => {
-    const x = toOptionalNumber(resolveFieldRef(item, binXKey ?? xKey, 'x'));
-    const y = toOptionalNumber(resolveFieldRef(item, binYKey ?? yKey, 'y'));
+    // The hexbin's own chain, so a bin spelling its centre `x0`/`cx` — as a
+    // d3-hexbin bin does — is read rather than dropped for want of a centre.
+    const x = toOptionalNumber(resolveFieldRef(item, binXKey ?? xKey, 'x', TraceType.HEXBIN));
+    const y = toOptionalNumber(resolveFieldRef(item, binYKey ?? yKey, 'y', TraceType.HEXBIN));
     const count = toOptionalNumber(resolveFieldRef(item, countKey, 'count'));
     // A bin is its centre and its count. Missing any of the three, there is
     // nothing to announce and nowhere to announce it from.
@@ -1090,10 +1092,14 @@ function toLetterValueLevels(value: unknown): LetterValueLevel[] {
     if (entry === null || typeof entry !== 'object') {
       continue;
     }
-    const rung = entry as Record<string, unknown>;
-    const p = toOptionalNumber(rung.p);
-    const lo = toOptionalNumber(rung.lo);
-    const hi = toOptionalNumber(rung.hi);
+    // A rung is a row of its own, so it is read through the same resolver the
+    // top-level fields are: `lo` also answers to `lower`, `low`, `min` or
+    // `y0`, exactly as it does in the d3 boxen binder. Reading only the
+    // literal three dropped every ladder written any other way, which left a
+    // boxen with a median and nothing to walk out to.
+    const p = toOptionalNumber(resolveFieldRef(entry, undefined, 'p', TraceType.BOXEN));
+    const lo = toOptionalNumber(resolveFieldRef(entry, undefined, 'lo', TraceType.BOXEN));
+    const hi = toOptionalNumber(resolveFieldRef(entry, undefined, 'hi', TraceType.BOXEN));
     // A rung is a labelled pair of positions on the distribution. One missing
     // any of its three numbers would be announced as a percentile the sample
     // was never asked for.

--- a/src/adapters/shared/traceDeclaration.ts
+++ b/src/adapters/shared/traceDeclaration.ts
@@ -30,7 +30,7 @@
  * option blocks would become a second grammar that can drift from the first.
  */
 
-import type { AlluvialDeclaration, BoxenDeclaration, ChoroplethDeclaration, ErrorBarDeclaration, FieldRef, ForestDeclaration, HexbinDeclaration, MaidrTraceDeclaration, ManhattanDeclaration, MosaicDeclaration, ParallelDeclaration, RidgelineDeclaration, ScatterDeclaration, SurvivalDeclaration, VolcanoDeclaration } from '../../type/declaration';
+import type { AlluvialDeclaration, BoxenDeclaration, ChoroplethDeclaration, ErrorBarDeclaration, FieldRef, ForestDeclaration, GanttDeclaration, HexbinDeclaration, MaidrTraceDeclaration, ManhattanDeclaration, MosaicDeclaration, ParallelDeclaration, RidgelineDeclaration, ScatterDeclaration, SurvivalDeclaration, VolcanoDeclaration } from '../../type/declaration';
 import { Orientation, TraceType } from '../../type/grammar';
 
 /** The `type` values {@link MaidrTraceDeclaration} covers. */
@@ -148,6 +148,22 @@ export const FIELD_REF_FALLBACKS: Readonly<Record<string, readonly string[]>> = 
  * right way round: `x` is the **last** name a region answers to and `y` the
  * **first** a value does.
  *
+ * The other entries are here for the milder reason: a canonical name so
+ * generic that no chain could be shared. `x` on a hexbin is a bin centre, on a
+ * gantt a lane; `label` on a gantt is the interval's name and everywhere else
+ * the Manhattan identifier. Each chain is the shipped d3 binder's for that
+ * chart, so a column that already worked there works through a declaration
+ * too.
+ *
+ * The boxen entry is the one that is not a top-level field at all. `p`, `lo`
+ * and `hi` are the fields of a **rung** — the `{ p, lo, hi }` entries inside
+ * whatever `BoxenDeclaration.levels` names — and their spellings vary exactly
+ * as the top-level ones do (`prob`, `lower`, `y1`). An adapter reading only
+ * the literal three drops every ladder written any other way, which leaves a
+ * boxen with a median and no rungs to walk. Nothing new is needed to reach
+ * them: a rung **is** a row, so passing one to {@link resolveFieldRef} under
+ * `TraceType.BOXEN` reads it.
+ *
  * A chain here replaces the shared one rather than extending it. Extending
  * would keep exactly the entry the type is here to disown.
  */
@@ -157,6 +173,24 @@ export const DECLARED_FIELD_REF_FALLBACKS: Readonly<
   [TraceType.CHOROPLETH]: {
     region: ['name', 'NAME', 'name_long', 'admin', 'state', 'id', 'label', 'x'],
     value: ['y', 'rate', 'density', 'count'],
+  },
+  [TraceType.HEXBIN]: {
+    x: ['x0', 'cx'],
+    y: ['y0', 'cy'],
+  },
+  [TraceType.GANTT]: {
+    x: ['lane', 'category', 'label', 'name', 'key', 'group', 'task'],
+    start: ['from', 'begin', 'x0', 'startDate'],
+    end: ['to', 'finish', 'x1', 'endDate'],
+    // Not the `label` chain every other type shares — that one is the
+    // Manhattan/volcano identifier's (`snp`, `gene`, `probe`), which names
+    // nothing on a schedule.
+    label: ['name', 'task', 'title', 'activity'],
+  },
+  [TraceType.BOXEN]: {
+    p: ['prob', 'probability', 'depth'],
+    lo: ['lower', 'low', 'min', 'y0'],
+    hi: ['upper', 'high', 'max', 'y1'],
   },
 };
 
@@ -580,6 +614,18 @@ const DECLARATION_KEYS: Readonly<Record<DeclaredType, Readonly<Record<string, Ke
     upperOutliers: 'field',
     orientation: 'orientation',
   } satisfies FieldKeySet<BoxenDeclaration>,
+  [TraceType.GANTT]: {
+    title: 'text',
+    name: 'text',
+    x: 'field',
+    start: 'field',
+    end: 'field',
+    label: 'field',
+    // Text, not a field: a unit belongs to the chart and not to any row, and
+    // per-row units would let a producer emit intervals disagreeing about what
+    // their numbers measure.
+    unit: 'text',
+  } satisfies FieldKeySet<GanttDeclaration>,
 };
 
 /**

--- a/src/adapters/shared/traceDeclaration.ts
+++ b/src/adapters/shared/traceDeclaration.ts
@@ -17,12 +17,27 @@
  * called, so both keep the readers they shipped and neither is bound by the
  * table below.
  *
+ * The same argument covers the two things a reader hears rather than a column
+ * name: the sentence an adapter prints when a declaration names a construct
+ * the library does not draw ({@link warnUndrawnType},
+ * {@link warnWrongConstruct}), and the rule that each distinct problem is said
+ * once per binding rather than once per pass over the chart — an adapter that
+ * walks the chart twice, once for the payload and once for the highlight,
+ * otherwise says everything twice. That is settled here by keying every
+ * warning on the author's own block, so no caller has to arrange it.
+ *
  * Nothing else belongs in this file. Anything that mirrors `MaidrLayer`'s
  * option blocks would become a second grammar that can drift from the first.
  */
 
 import type { AlluvialDeclaration, BoxenDeclaration, ChoroplethDeclaration, ErrorBarDeclaration, FieldRef, ForestDeclaration, HexbinDeclaration, MaidrTraceDeclaration, ManhattanDeclaration, MosaicDeclaration, ParallelDeclaration, RidgelineDeclaration, ScatterDeclaration, SurvivalDeclaration, VolcanoDeclaration } from '../../type/declaration';
 import { Orientation, TraceType } from '../../type/grammar';
+
+/** The `type` values {@link MaidrTraceDeclaration} covers. */
+export type DeclaredType = MaidrTraceDeclaration['type'];
+
+/** The declaration variant a declared type names. */
+export type DeclarationOf<T extends DeclaredType> = Extract<MaidrTraceDeclaration, { type: T }>;
 
 /**
  * Who is reading a declaration, and what they are reading it off.
@@ -41,6 +56,23 @@ export interface DeclarationContext {
    * phrase — `'series "sales"'`, `'dataset 2'` — rather than a bare number.
    */
   seriesRef: string;
+  /**
+   * The binding this reading belongs to, for saying each distinct problem
+   * once.
+   *
+   * The spec allows each warning at most once per chart per binding, and an
+   * adapter that resolves declarations at two entry points — the payload pass
+   * and the highlight pass both re-walk the chart — otherwise says everything
+   * twice. Pass any object that lives as long as the binding and no longer:
+   * the author's own block, the slot it was read from, the series. Every
+   * warning raised against a context carrying one is said once per object.
+   *
+   * {@link validateDeclaration} needs none, and ignores this when the block it
+   * was handed is itself an object: keying on the author's block is what stops
+   * a *corrected* block from being silenced, since rewriting it produces a new
+   * object that is reported afresh.
+   */
+  binding?: object;
 }
 
 /**
@@ -59,16 +91,26 @@ export interface DeclarationContext {
  *
  * Consulted **only** when the author named no field: an explicit
  * {@link FieldRef} is used verbatim, per {@link resolveFieldRef}. A canonical
- * name with no entry here — `width`, `x`, `y`, `region` — resolves under its
- * own name and nothing else.
+ * name with no entry here — `width`, `x`, `y` — resolves under its own name
+ * and nothing else.
  *
- * The chains are keyed by canonical name across every declared type, so a name
- * borrowed by two of them is shared: `value` carries the ridgeline chain and a
- * choropleth's `value` therefore also answers to `x`, which is called out on
- * {@link ChoroplethDeclaration.value}.
+ * The chains here are keyed by canonical name across every declared type, so a
+ * name borrowed by two of them is shared. Where that sharing would resolve the
+ * wrong column, the type says so for itself in
+ * {@link DECLARED_FIELD_REF_FALLBACKS}, which replaces the entry below for
+ * that type.
  *
  * `censored` is deliberately not aliased to `event`, which most survival
  * datasets carry with the opposite meaning.
+ *
+ * `error` has **no chain at all**, and that is deliberate rather than an
+ * omission: it is an *offset* whose every common spelling is either
+ * axis-specific (`yerr`, `xerr` — a row carrying both says nothing about which
+ * axis this chart draws its intervals on) or a dispersion statistic a chart
+ * commonly draws a multiple of (`sd`, `sem`, `err` — ±1.96 SEM is as ordinary
+ * as ±1). Reading one of those as the drawn offset resizes every interval on
+ * the figure without saying so, which is the failure this table exists to
+ * avoid, so an offset column is named explicitly or spelled exactly `error`.
  */
 export const FIELD_REF_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
   censored: ['censor', 'isCensored'],
@@ -88,14 +130,123 @@ export const FIELD_REF_FALLBACKS: Readonly<Record<string, readonly string[]>> = 
 };
 
 /**
+ * Chains that belong to one declared type, replacing
+ * {@link FIELD_REF_FALLBACKS} for it.
+ *
+ * A canonical name is shared across variants and a chain sometimes cannot be:
+ * `value` on a ridgeline is a position on the value axis, so `x` is a fair
+ * reading of it, while `value` on a choropleth is the number a region is
+ * shaded by and a map's rows routinely put the *place name* in an `x` column.
+ * Shared, that chain announces "Texas" as the shaded value of Texas — the one
+ * failure mode worse than announcing nothing, since a reader has no way to
+ * tell it from a number.
+ *
+ * So a choropleth reads its own two chains, and they are the shipped d3
+ * binder's (`d3/binders/choropleth.ts`), which the same maps have been read
+ * through since before this table existed. They are ordered so that the
+ * ordinary region table — `{ x: 'Texas', y: 12.4 }` — resolves both halves the
+ * right way round: `x` is the **last** name a region answers to and `y` the
+ * **first** a value does.
+ *
+ * A chain here replaces the shared one rather than extending it. Extending
+ * would keep exactly the entry the type is here to disown.
+ */
+export const DECLARED_FIELD_REF_FALLBACKS: Readonly<
+  Partial<Record<DeclaredType, Readonly<Record<string, readonly string[]>>>>
+> = {
+  [TraceType.CHOROPLETH]: {
+    region: ['name', 'NAME', 'name_long', 'admin', 'state', 'id', 'label', 'x'],
+    value: ['y', 'rate', 'density', 'count'],
+  },
+};
+
+/**
+ * The chain a canonical name is defaulted through, for the type being read.
+ *
+ * @param canonical - The grammar field name being filled.
+ * @param type      - The declared type reading it, when the caller knows it.
+ * @returns The alternative names to try, in order.
+ */
+function fallbacksFor(canonical: string, type: DeclaredType | undefined): readonly string[] {
+  const scoped = type === undefined ? undefined : DECLARED_FIELD_REF_FALLBACKS[type]?.[canonical];
+  return scoped ?? FIELD_REF_FALLBACKS[canonical] ?? [];
+}
+
+/**
+ * Reads a name off one lookup surface: the key itself, or the dotted path it
+ * spells.
+ *
+ * The literal key is tried first, so a column genuinely named `a.b` is read as
+ * itself before the name is taken apart.
+ *
+ * @param record - The surface to read.
+ * @param name   - The key, or a dotted path through nested objects.
+ * @returns The value read, or `undefined` when the surface does not carry it.
+ */
+function readName<T>(record: Record<string, unknown>, name: string): T | undefined {
+  const own = record[name];
+  if (own !== undefined) {
+    return own as T;
+  }
+  if (!name.includes('.')) {
+    return undefined;
+  }
+
+  let step: unknown = record;
+  for (const segment of name.split('.')) {
+    if (step === null || typeof step !== 'object') {
+      return undefined;
+    }
+    step = (step as Record<string, unknown>)[segment];
+  }
+  return step as T | undefined;
+}
+
+/**
+ * Reads a name off a row and, failing that, off the row's `properties`.
+ *
+ * The second surface is what makes a **map** readable. `element.__data__` on a
+ * choropleth is a GeoJSON or TopoJSON feature, which keeps only `type`, `id`,
+ * `geometry` and `properties` at the top level: the region's name and the
+ * value joined onto it live in `properties`, every time. An author writing
+ * `region: 'NAME'` can only mean the property, so making them spell
+ * `properties.NAME` would be ceremony over a shape the format fixes — though
+ * that path resolves too, per {@link readName}.
+ *
+ * Second, never first: the row's own key always wins, so this can fill a gap
+ * but never overrule what the row itself says.
+ *
+ * @param row  - The row the charting library bound to the mark.
+ * @param name - The key, or a dotted path through nested objects.
+ * @returns The value read, or `undefined` when neither surface carries it.
+ */
+function readFromRow<T>(row: Record<string, unknown>, name: string): T | undefined {
+  const own = readName<T>(row, name);
+  if (own !== undefined) {
+    return own;
+  }
+  const properties = row.properties;
+  return properties === null || typeof properties !== 'object'
+    ? undefined
+    : readName<T>(properties as Record<string, unknown>, name);
+}
+
+/**
  * Reads one declared fact off an author's row.
  *
  * An explicit `ref` is used verbatim with **no fallback**: a name the author
  * wrote that misses is their error, and reporting it — with
  * {@link warnUnresolvedRef}, once the series is read — beats papering over it
- * with a column they did not name. Only the defaulted path walks
- * {@link FIELD_REF_FALLBACKS}, trying `canonical` first and then each
- * alternative in order.
+ * with a column they did not name. Only the defaulted path walks the chain,
+ * trying `canonical` first and then each alternative in order — the type's own
+ * chain from {@link DECLARED_FIELD_REF_FALLBACKS} where it has one, and
+ * {@link FIELD_REF_FALLBACKS} otherwise.
+ *
+ * Every name, explicit or defaulted, is looked for in three places in turn:
+ * the row's own key, the dotted path it spells, and the row's `properties` —
+ * see {@link readFromRow}. Name priority dominates: `properties.name` beats a
+ * top-level `id` on a GeoJSON feature, because a region is called by its name
+ * rather than by its FIPS code.
  *
  * `undefined` and `null` both mean "no ref given" here, exactly as they do in
  * {@link validateDeclaration}: the slots this rides in are frequently untyped
@@ -121,12 +272,16 @@ export const FIELD_REF_FALLBACKS: Readonly<Record<string, readonly string[]>> = 
  *                    that is not an object resolves to nothing.
  * @param ref       - The field the author named, or `undefined` to default.
  * @param canonical - The grammar field name being filled, e.g. `'yMin'`.
+ * @param type      - The declared type being read, where one of its fields
+ *                    defaults differently from the shared chain — `'value'` on
+ *                    a choropleth. Omitted, the shared chain applies.
  * @returns The value read, or `undefined` when nothing resolves.
  */
 export function resolveFieldRef<T>(
   row: unknown,
   ref: FieldRef | undefined,
   canonical: string,
+  type?: DeclaredType,
 ): T | undefined {
   if (row === null || typeof row !== 'object') {
     return undefined;
@@ -136,17 +291,17 @@ export function resolveFieldRef<T>(
   // bag of the author's own columns, and the names are resolved from data.
   const record = row as Record<string, unknown>;
   if (typeof ref === 'string') {
-    return record[ref] as T | undefined;
+    return readFromRow<T>(record, ref);
   }
 
-  const canonicalValue = record[canonical];
+  const canonicalValue = readFromRow<T>(record, canonical);
   if (canonicalValue !== undefined) {
-    return canonicalValue as T;
+    return canonicalValue;
   }
-  for (const alternative of FIELD_REF_FALLBACKS[canonical] ?? []) {
-    const value = record[alternative];
+  for (const alternative of fallbacksFor(canonical, type)) {
+    const value = readFromRow<T>(record, alternative);
     if (value !== undefined) {
-      return value as T;
+      return value;
     }
   }
   return undefined;
@@ -162,9 +317,11 @@ export function resolveFieldRef<T>(
  * row of it. The field is then left out of the payload, and the author is told
  * why rather than being handed a chart quietly missing what they declared.
  *
- * The message lives here so all eight adapters print the same sentence; the
+ * The message lives here so all eight adapters print the same sentence. The
  * "at most once per chart per binding" contract is satisfied by calling this
- * once per series per field, since it holds no state of its own.
+ * once per series per field; an adapter that reads a series at two entry
+ * points calls it twice and passes {@link DeclarationContext.binding} — the
+ * declaration it is reading — to have the second one swallowed.
  *
  * @param context   - Who is reading, and what they are reading it off.
  * @param ref       - The field name the author wrote.
@@ -175,10 +332,59 @@ export function warnUnresolvedRef(
   ref: FieldRef,
   canonical: string,
 ): void {
-  warn(
-    context.adapter,
+  report(
+    context,
     `maidr declaration on ${context.seriesRef} names "${ref}" for ${canonical}, `
     + `which no row carries; ${canonical} is left out.`,
+  );
+}
+
+/**
+ * Reports a declared type this adapter has no reading for — spec §7.1.
+ *
+ * The declaration is honoured where the library can back it and degrades to
+ * the undeclared chart where it cannot, so this is the sentence every adapter
+ * needs and none should spell for itself: eight hand-rolled wordings for one
+ * fact is eight things an author has to recognise as the same fact.
+ *
+ * @param context - Who is reading, and what they are reading it off.
+ * @param type    - The declared type, printed as the author wrote it.
+ */
+export function warnUndrawnType(context: DeclarationContext, type: string): void {
+  report(
+    context,
+    `maidr declaration for "${type}" on ${context.seriesRef} names no construct `
+    + `this library draws; reading it as the undeclared chart.`,
+  );
+}
+
+/**
+ * Reports a declaration the construct it was written on cannot back — the
+ * other half of spec §7.1.
+ *
+ * Distinct from {@link warnUndrawnType}: the adapter reads this type, but not
+ * off *this* series. A survival curve read off a pie is not a degraded
+ * announcement, it is a wrong one, so the reading falls through to the
+ * undeclared chart and says which construct the declaration wanted.
+ *
+ * @param context - Who is reading, and what they are reading it off.
+ * @param type    - The declared type, printed as the author wrote it.
+ * @param needs   - What the type needs, phrased to follow "needs" — `'a "map"
+ *                  series'`, `'a bar or line dataset'`.
+ * @param drawn   - What the library actually draws this series as, when the
+ *                  adapter can name it.
+ */
+export function warnWrongConstruct(
+  context: DeclarationContext,
+  type: string,
+  needs: string,
+  drawn?: string,
+): void {
+  const found = drawn === undefined ? '' : ` and this one is drawn as "${drawn}"`;
+  report(
+    context,
+    `maidr declaration for "${type}" on ${context.seriesRef} needs ${needs}${found}; `
+    + `reading it as the undeclared chart.`,
   );
 }
 
@@ -212,9 +418,6 @@ export function isFlagValue(value: unknown): boolean {
   }
   return false;
 }
-
-/** The `type` values {@link MaidrTraceDeclaration} covers. */
-type DeclaredType = MaidrTraceDeclaration['type'];
 
 /**
  * What a key's value has to look like for the declaration to keep it.
@@ -567,6 +770,11 @@ function describeValue(value: unknown): string {
  *   parallel plot, `group` on a ridgeline — is rejected. The alternative is
  *   returning a block typed as if the field were there, which is an invitation
  *   to the throw this function exists to prevent.
+ * - A variant outside the `reads` set — a choropleth declared on a library
+ *   that draws no map — is reported with {@link warnUndrawnType} and rejected.
+ *   Every adapter reads some subset and each was otherwise hand-writing the
+ *   same narrowing predicate after this returned, along with its own wording
+ *   for the one sentence spec §7.1 fixes.
  *
  * `undefined` and `null` are "not given" wherever they appear, both as the
  * block and as any key's value.
@@ -576,24 +784,31 @@ function describeValue(value: unknown): string {
  * never mutated.
  *
  * This is the only place an `unknown` from a chart config is narrowed; `any`
- * must not escape it. Calling it once per series per binding is what satisfies
- * the "each distinct warning at most once per chart per binding" contract —
- * this function holds no state of its own.
+ * must not escape it. The "each distinct warning at most once per chart per
+ * binding" contract holds however often this is called, since every warning it
+ * raises is keyed on the author's own block — an adapter that resolves
+ * declarations at two entry points per binding needs to arrange nothing.
  *
  * @param raw     - The value at the library's `maidr` slot.
  * @param context - Who is reading, and what they are reading it off.
+ * @param reads   - The declared types this adapter has a reading for. Omitted,
+ *                  every variant is accepted and the caller narrows for
+ *                  itself.
  * @returns The validated declaration, or `null` when there is none to read.
  */
-export function validateDeclaration(
+export function validateDeclaration<T extends DeclaredType = DeclaredType>(
   raw: unknown,
   context: DeclarationContext,
-): MaidrTraceDeclaration | null {
+  reads?: readonly T[],
+): DeclarationOf<T> | null {
   if (raw === undefined || raw === null) {
     return null;
   }
 
   const { adapter, seriesRef } = context;
   if (typeof raw !== 'object' || Array.isArray(raw)) {
+    // No object to key a once-per-binding gate on, and none needed: a block
+    // this shape carries no fields to go on and report a second problem about.
     warn(adapter, `maidr declaration on ${seriesRef} is not an object; ignored.`);
     return null;
   }
@@ -601,16 +816,22 @@ export function validateDeclaration(
   const block = raw as Record<string, unknown>;
   const type = block.type;
   if (typeof type !== 'string' || !isDeclaredType(type)) {
-    warn(
-      adapter,
+    report(
+      context,
       `maidr declaration on ${seriesRef} has unknown type "${String(type)}"; `
       + `reading it as the undeclared chart.`,
+      block,
     );
     return null;
   }
 
+  if (reads !== undefined && !(reads as readonly string[]).includes(type)) {
+    warnUndrawnType({ ...context, binding: context.binding ?? block }, type);
+    return null;
+  }
+
   const located = (message: string): void =>
-    warn(adapter, `maidr declaration for "${type}" on ${seriesRef} ${message}`);
+    report(context, `maidr declaration for "${type}" on ${seriesRef} ${message}`, block);
 
   const accepted = DECLARATION_KEYS[type];
   const dropped: string[] = [];
@@ -652,13 +873,13 @@ export function validateDeclaration(
   }
 
   if (dropped.length === 0) {
-    return block as unknown as MaidrTraceDeclaration;
+    return block as unknown as DeclarationOf<T>;
   }
   const kept = { ...block };
   for (const key of dropped) {
     delete kept[key];
   }
-  return kept as unknown as MaidrTraceDeclaration;
+  return kept as unknown as DeclarationOf<T>;
 }
 
 /**
@@ -676,16 +897,55 @@ export function validateDeclaration(
  * @param container - The library's slot — `series.options.custom`,
  *                    `series.get('userData')`, `trace.meta`, `usermeta`.
  * @param context   - Who is reading, and what they are reading it off.
+ * @param reads     - The declared types this adapter has a reading for, as
+ *                    {@link validateDeclaration} takes them.
  * @returns The validated declaration, or `null` when there is none to read.
  */
-export function readDeclarationSlot(
+export function readDeclarationSlot<T extends DeclaredType = DeclaredType>(
   container: unknown,
   context: DeclarationContext,
-): MaidrTraceDeclaration | null {
+  reads?: readonly T[],
+): DeclarationOf<T> | null {
+  const written = declarationIn(container);
+  return written === undefined ? null : validateDeclaration(written, context, reads);
+}
+
+/**
+ * Whether the author wrote a block in this slot at all, readable or not.
+ *
+ * `null` from {@link readDeclarationSlot} answers two different questions with
+ * one word — "nothing was written here" and "something was written and this
+ * module rejected it" — and spec §6(b)'s precedence turns on which: a block
+ * that was written and rejected is still the author saying something *about
+ * this series*, so the reading falls through to the heuristic rather than on
+ * to a chart-level declaration meant for the series that said nothing.
+ *
+ * Shares its guard with {@link readDeclarationSlot} rather than restating it,
+ * so the two cannot come to disagree about what a slot is.
+ *
+ * @param container - The library's slot.
+ * @returns True when a `maidr` block was written on it.
+ */
+export function hasDeclarationSlot(container: unknown): boolean {
+  return declarationIn(container) !== undefined;
+}
+
+/**
+ * The block written in a library's slot, if any.
+ *
+ * A container that is not an object, that carries no `maidr` key, or whose
+ * `maidr` is `null` is no declaration: Plotly's `meta` is very often a plain
+ * string that has nothing to do with MAIDR, and `null` is how an author writes
+ * "not set".
+ *
+ * @param container - The library's slot.
+ * @returns The block, or `undefined` when none was written.
+ */
+function declarationIn(container: unknown): unknown {
   if (typeof container !== 'object' || container === null || !('maidr' in container)) {
-    return null;
+    return undefined;
   }
-  return validateDeclaration(container.maidr, context);
+  return container.maidr ?? undefined;
 }
 
 /**
@@ -696,4 +956,54 @@ export function readDeclarationSlot(
  */
 function warn(adapter: string, message: string): void {
   console.warn(`[MAIDR ${adapter}] ${message}`);
+}
+
+/**
+ * Sentences already said, keyed by the binding they were said against.
+ *
+ * A `WeakMap` so a chart that is thrown away takes its warning history with
+ * it, and keyed on the author's own object so a *corrected* block is reported
+ * afresh: rewriting a declaration produces a new object, which has said
+ * nothing yet. The sentence itself is the key, which makes "each distinct
+ * warning" exactly what it says — a second problem on the same block is a
+ * different sentence and is still reported.
+ */
+const said = new WeakMap<object, Set<string>>();
+
+/**
+ * Emits one adapter-prefixed warning, at most once per binding.
+ *
+ * The gate lives here rather than in each adapter because every adapter needs
+ * it and only some have noticed: a chart walked twice per binding — once for
+ * the payload, once for the highlight — says everything twice, and a reader
+ * turning on the console to find out why their chart is silent should not have
+ * to read it double.
+ *
+ * With no binding to key on, the warning is emitted every time. That is the
+ * honest default: swallowing a warning on a key that outlives the chart would
+ * silence a genuinely new problem.
+ *
+ * @param context - Who is reading, and the binding to say it once per.
+ * @param message - The sentence following the `[MAIDR <Adapter>]` prefix.
+ * @param block   - The author's own block, when the caller holds one. Used as
+ *                  the binding where the context names none.
+ */
+function report(context: DeclarationContext, message: string, block?: object): void {
+  const binding = context.binding ?? block;
+  if (binding === undefined) {
+    warn(context.adapter, message);
+    return;
+  }
+
+  let seen = said.get(binding);
+  if (seen === undefined) {
+    seen = new Set<string>();
+    said.set(binding, seen);
+  }
+  const sentence = `${context.adapter}: ${message}`;
+  if (seen.has(sentence)) {
+    return;
+  }
+  seen.add(sentence);
+  warn(context.adapter, message);
 }

--- a/src/type/declaration.ts
+++ b/src/type/declaration.ts
@@ -41,7 +41,14 @@
  * explicit name that misses is a mistake worth reporting rather than papering
  * over. The fallback lists live in `src/adapters/shared/traceDeclaration.ts`
  * so a column that works in one adapter reading this block works in all of
- * them.
+ * them. Most are shared by canonical name across the variants; a few belong to
+ * one chart, because the same name means different things on different ones —
+ * see {@link ChoroplethDeclaration.value}.
+ *
+ * A name is resolved against the row itself and against the row's
+ * `properties`, in that order, and a dotted name walks the path it spells. A
+ * GeoJSON feature keeps everything joined onto it one level down, so a map
+ * needs no declaration to say so.
  *
  * ## What a declaration is worth
  *
@@ -276,6 +283,14 @@ export interface ErrorBarDeclaration extends DeclarationBase {
    *
    * Normalised to absolute bounds on the way into the payload. Loses to
    * `yMin`/`yMax` where both are declared, since those need no arithmetic.
+   *
+   * Alone among the field refs here, this one has **no fallback chain**: an
+   * offset column is named explicitly or spelled exactly `error`. Every common
+   * spelling is either axis-specific (`yerr`, `xerr`, and a row carrying both
+   * says nothing about which axis this chart draws its intervals on) or a
+   * dispersion statistic a chart commonly draws a multiple of (`sd`, `sem`,
+   * `err` — ±1.96 SEM is as ordinary as ±1). Read as the drawn offset, one of
+   * those resizes every interval on the figure without saying so.
    */
   error?: FieldRef;
   /**
@@ -588,19 +603,29 @@ export interface ChoroplethDeclaration extends DeclarationBase {
   /**
    * Field holding the region's name. Maps to `ChoroplethPoint.x`.
    *
-   * @default 'region'
+   * The chain is a map's own, not the one every other declaration shares: the
+   * names a place answers to on a GeoJSON or TopoJSON feature, ending in `x`
+   * so the ordinary region table — `{ x: 'Texas', y: 12.4 }` — is read the
+   * right way round. Resolved against the row **and** against its
+   * `properties`, which is where a feature keeps everything joined onto it, so
+   * `region: 'NAME'` finds `properties.NAME` without being spelled as a path.
+   *
+   * @default 'region', falling back to `name`, `NAME`, `name_long`, `admin`,
+   * `state`, `id`, `label` or `x`
    */
   region?: FieldRef;
   /**
    * Field holding the value the region is shaded by. Maps to
    * `ChoroplethPoint.y`.
    *
-   * The fallback chain is shared with {@link RidgelineDeclaration.value},
-   * where `x` genuinely is the position on the value axis. On a map whose rows
-   * put the region name in an `x` column, that chain would resolve the name as
-   * the value — so name the field, on any row shaped that way.
+   * A map's own chain, deliberately **not** the one
+   * {@link RidgelineDeclaration.value} carries: `x` is a position on the value
+   * axis of a ridgeline and the place's own name on a map, and announcing
+   * "Texas" as the value of Texas is a wrong reading a listener cannot tell
+   * from a right one. Read off the row's `properties` as well, exactly as
+   * {@link ChoroplethDeclaration.region} is.
    *
-   * @default 'value', falling back to `x`, `t` or `position`
+   * @default 'value', falling back to `y`, `rate`, `density` or `count`
    */
   value?: FieldRef;
   /**

--- a/src/type/declaration.ts
+++ b/src/type/declaration.ts
@@ -150,7 +150,8 @@ export type MaidrTraceDeclaration
     | ParallelDeclaration
     | RidgelineDeclaration
     | HexbinDeclaration
-    | BoxenDeclaration;
+    | BoxenDeclaration
+    | GanttDeclaration;
 
 /**
  * A Kaplan-Meier survival curve drawn as a step line.
@@ -753,14 +754,19 @@ export interface HexbinDeclaration extends DeclarationBase {
    *
    * Screen coordinates would announce every bin's position in pixels.
    *
-   * @default 'x'
+   * The chain is a hexbin's own: `x` names a bin centre here and a category, a
+   * lane or a quantile on other charts, so no chain could be shared. It is the
+   * shipped d3 hexbin binder's, which is where these bins are already read
+   * from.
+   *
+   * @default 'x', falling back to `x0` or `cx`
    */
   x?: FieldRef;
   /**
    * Field holding the bin's centre along the y axis, in **data units**. Maps
    * to `HexbinPoint.y`.
    *
-   * @default 'y'
+   * @default 'y', falling back to `y0` or `cy`
    */
   y?: FieldRef;
   /**
@@ -814,6 +820,12 @@ export interface BoxenDeclaration extends DeclarationBase {
    * The trace sorts them outward from the median rather than trusting the
    * order they arrive in.
    *
+   * This names the *column*; the rungs inside it are not declared field by
+   * field. A rung is read as a row of its own, so its three numbers answer to
+   * the same spread of spellings a top-level field does: `p` also to `prob`,
+   * `probability` or `depth`; `lo` to `lower`, `low`, `min` or `y0`; `hi` to
+   * `upper`, `high`, `max` or `y1`.
+   *
    * @default 'levels', falling back to `letterValues`, `letter_values`,
    * `quantiles` or `ladder`
    */
@@ -829,4 +841,77 @@ export interface BoxenDeclaration extends DeclarationBase {
    * words they abbreviate, exactly as {@link ErrorBarDeclaration.orientation}.
    */
   orientation?: Orientation;
+}
+
+/**
+ * A schedule drawn as intervals along a shared axis — a gantt chart, a
+ * timeline, a swimlane diagram.
+ *
+ * What separates this from a bar chart is that both coordinates are positions
+ * on the same axis rather than a position and a magnitude. A bar has one
+ * number and a baseline; an interval has two numbers and no baseline, and the
+ * fact a reader is listening for — how *long* the interval is — is a
+ * difference between them that has to be announced rather than heard as a
+ * height.
+ *
+ * That difference is also why {@link GanttDeclaration.unit} matters more here
+ * than a unit does elsewhere: no charting library carries what a step of the
+ * axis is called, so without it a task is announced as "7 long" rather than
+ * "7 days".
+ *
+ * @example
+ * // Highcharts, a schedule whose rows name their ends the ordinary way
+ * { custom: { maidr: { type: 'gantt', x: 'resource', unit: 'days' } } }
+ */
+export interface GanttDeclaration extends DeclarationBase {
+  /** `TraceType.GANTT` — the string `'gantt'`. */
+  type: TraceType.GANTT;
+  /**
+   * Field holding the lane the interval belongs to — a task, a resource, a
+   * phase. Maps to `GanttPoint.x`.
+   *
+   * A lane commonly holds several intervals, and grouping is by this field's
+   * value, so a row that resolves nothing here is its own lane rather than
+   * joining another.
+   *
+   * @default 'x', falling back to `lane`, `category`, `label`, `name`, `key`,
+   * `group` or `task`
+   */
+  x?: FieldRef;
+  /**
+   * Field holding where the interval begins. Maps to `GanttPoint.start`.
+   *
+   * @default 'start', falling back to `from`, `begin`, `x0` or `startDate`
+   */
+  start?: FieldRef;
+  /**
+   * Field holding where the interval ends. Maps to `GanttPoint.end`.
+   *
+   * @default 'end', falling back to `to`, `finish`, `x1` or `endDate`
+   */
+  end?: FieldRef;
+  /**
+   * Field holding what this interval is called, when the lane is not already
+   * its name. Maps to `GanttPoint.label`.
+   *
+   * The chain is a schedule's own rather than the `label` chain every other
+   * declaration shares, which is the Manhattan identifier's (`snp`, `gene`,
+   * `probe`) and names nothing on a schedule.
+   *
+   * A label that resolves to the lane's own name is dropped rather than
+   * emitted: an interval labelled with its own lane says the same thing twice.
+   *
+   * @default 'label', falling back to `name`, `task`, `title` or `activity`
+   */
+  label?: FieldRef;
+  /**
+   * What a unit of the axis is called: `'days'`, `'hours'`, `'weeks'`. Maps to
+   * `GanttData.unit`.
+   *
+   * A literal word, not a field: the unit belongs to the chart and not to any
+   * row, and a per-row unit would let a producer emit intervals that disagree
+   * about what their numbers measure. Omitted, the trace announces a length
+   * without a unit rather than guessing one.
+   */
+  unit?: string;
 }

--- a/src/type/declaration.ts
+++ b/src/type/declaration.ts
@@ -859,8 +859,13 @@ export interface BoxenDeclaration extends DeclarationBase {
  * axis is called, so without it a task is announced as "7 long" rather than
  * "7 days".
  *
+ * The variant is the schema an adapter reads a schedule through; no adapter
+ * reads a gantt block yet, so a chart declaring one today is read as the
+ * undeclared chart and told so. Adoption is a per-adapter change.
+ *
  * @example
- * // Highcharts, a schedule whose rows name their ends the ordinary way
+ * // The block a Highcharts adapter reading schedules would take, on a series
+ * // whose rows name their ends the ordinary way
  * { custom: { maidr: { type: 'gantt', x: 'resource', unit: 'days' } } }
  */
 export interface GanttDeclaration extends DeclarationBase {
@@ -898,8 +903,12 @@ export interface GanttDeclaration extends DeclarationBase {
    * declaration shares, which is the Manhattan identifier's (`snp`, `gene`,
    * `probe`) and names nothing on a schedule.
    *
-   * A label that resolves to the lane's own name is dropped rather than
-   * emitted: an interval labelled with its own lane says the same thing twice.
+   * The `x` chain includes `label`, so a row that names its interval but not
+   * its lane resolves both fields to the same word. An adapter adopting this
+   * declaration should drop a label equal to the lane it sits in rather than
+   * emit it — an interval labelled with its own lane says the same thing
+   * twice. {@link resolveFieldRef} resolves the two names independently and
+   * does not compare them, so the drop belongs to the adopting adapter.
    *
    * @default 'label', falling back to `name`, `task`, `title` or `activity`
    */

--- a/test/adapters/recharts/converters.test.ts
+++ b/test/adapters/recharts/converters.test.ts
@@ -2012,6 +2012,24 @@ describe('convertRechartsToMaidr', () => {
         data: [{ cx: 0.5, cy: 1000 }],
       })).toThrow('RechartsAdapter');
     });
+
+    it('reads a y centre a d3-hexbin bin spells `y0`, with no key named', () => {
+      // `yKeys` is what names the vertical centre, and a hexbin is the one
+      // chart type that can be built without it — the bin carries its own
+      // centre. Undefaulted, every such bin resolved no y and was dropped, and
+      // a lattice of dropped bins throws rather than announcing anything.
+      const layer = convertRechartsToMaidr({
+        ...hexbinConfig,
+        data: [{ cx: 0.5, y0: 1000, count: 12 }, { cx: 1.5, y0: 1000, count: 30 }],
+        yKeys: undefined,
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as HexbinPoint[][];
+      expect(data).toEqual([[
+        { x: 0.5, y: 1000, count: 12 },
+        { x: 1.5, y: 1000, count: 30 },
+      ]]);
+    });
   });
 
   describe('boxen plot', () => {
@@ -2081,6 +2099,30 @@ describe('convertRechartsToMaidr', () => {
       // was never asked for.
       const data = layer.data as BoxenPoint[];
       expect(data[0].levels).toEqual([{ p: 0.25, lo: 150, hi: 240 }]);
+    });
+
+    it('reads a rung that spells its three numbers the way the d3 binder allows', () => {
+      // The column holding the ladder was resolved through the shared chains
+      // and the rungs inside it were not: only the literal `p`/`lo`/`hi` were
+      // read, so a ladder written any other way produced a distribution with a
+      // median and nothing around it — a boxen with no boxen in it.
+      const layer = convertRechartsToMaidr({
+        ...boxenConfig,
+        data: [{
+          region: 'East',
+          median: 180,
+          levels: [
+            { prob: 0.25, lower: 150, upper: 240 },
+            { depth: 0.125, y0: 130, y1: 310 },
+          ],
+        }],
+      }).subplots[0][0].layers[0];
+
+      const data = layer.data as BoxenPoint[];
+      expect(data[0].levels).toEqual([
+        { p: 0.25, lo: 150, hi: 240 },
+        { p: 0.125, lo: 130, hi: 310 },
+      ]);
     });
 
     it('reads the ladder from a letterValues column when no key is declared', () => {

--- a/test/adapters/shared/traceDeclaration.test.ts
+++ b/test/adapters/shared/traceDeclaration.test.ts
@@ -1,11 +1,15 @@
 import type { MaidrTraceDeclaration } from '@type/declaration';
 import {
+  DECLARED_FIELD_REF_FALLBACKS,
   FIELD_REF_FALLBACKS,
+  hasDeclarationSlot,
   isFlagValue,
   readDeclarationSlot,
   resolveFieldRef,
   validateDeclaration,
+  warnUndrawnType,
   warnUnresolvedRef,
+  warnWrongConstruct,
 } from '@adapters/shared/traceDeclaration';
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { Orientation, TraceType } from '@type/grammar';
@@ -101,6 +105,125 @@ describe('resolveFieldRef — the defaulted path walks the fallback chain', () =
   });
 });
 
+describe('resolveFieldRef — a type whose chain cannot be the shared one', () => {
+  /** The region table every map tutorial writes: the place in x, the number in y. */
+  const REGION_ROW = { x: 'Texas', y: 12.4 };
+
+  test('a map does not announce the place name as the value it is shaded by', () => {
+    // The chain `value` carries for a ridgeline is `x`, `t`, `position`, where
+    // `x` genuinely is the position on the value axis. Shared with a map, it
+    // reads "Texas" as the shaded value of Texas — and a listener has no way
+    // to tell that from a right answer.
+    expect(resolveFieldRef(REGION_ROW, undefined, 'value', TraceType.CHOROPLETH)).toBe(12.4);
+  });
+
+  test('a map reads the same row\'s x as the region it names', () => {
+    expect(resolveFieldRef(REGION_ROW, undefined, 'region', TraceType.CHOROPLETH)).toBe('Texas');
+  });
+
+  test('the ridgeline keeps the chain it was written for', () => {
+    expect(resolveFieldRef({ x: 3.2 }, undefined, 'value', TraceType.RIDGELINE)).toBe(3.2);
+    expect(resolveFieldRef({ x: 3.2 }, undefined, 'value')).toBe(3.2);
+  });
+
+  test('a scoped chain replaces the shared one rather than extending it', () => {
+    // Keeping `x`, `t` and `position` as well would keep exactly the entry a
+    // map is here to disown.
+    expect(DECLARED_FIELD_REF_FALLBACKS[TraceType.CHOROPLETH]?.value).not.toContain('x');
+    expect(resolveFieldRef({ t: 5 }, undefined, 'value', TraceType.CHOROPLETH)).toBeUndefined();
+  });
+
+  test('a region answers to its name before it answers to an x column', () => {
+    expect(
+      resolveFieldRef({ name: 'Texas', x: 'TX' }, undefined, 'region', TraceType.CHOROPLETH),
+    ).toBe('Texas');
+  });
+
+  test('a canonical name the type does not scope falls back to the shared chain', () => {
+    expect(resolveFieldRef({ longitude: -99 }, undefined, 'lon', TraceType.CHOROPLETH)).toBe(-99);
+  });
+
+  test.each(
+    Object.entries(DECLARED_FIELD_REF_FALLBACKS).flatMap(([type, chains]) =>
+      Object.entries(chains ?? {}).flatMap(([canonical, alternatives]) =>
+        alternatives.map(alternative => [type, canonical, alternative] as const),
+      ),
+    ),
+  )('a %s reads %s from a row carrying only `%s`', (type, canonical, alternative) => {
+    expect(
+      resolveFieldRef({ [alternative]: 'read' }, undefined, canonical, type as TraceType.CHOROPLETH),
+    ).toBe('read');
+  });
+
+  test('an offset column is spelled `error` or named, and never guessed at', () => {
+    // `yerr` names one axis, `sem` is a statistic a chart draws a multiple of;
+    // read as the drawn offset either one silently resizes every interval.
+    expect(FIELD_REF_FALLBACKS.error).toBeUndefined();
+    expect(resolveFieldRef({ yerr: 0.2 }, undefined, 'error')).toBeUndefined();
+    expect(resolveFieldRef({ sem: 0.2 }, undefined, 'error')).toBeUndefined();
+    expect(resolveFieldRef({ error: 0.2 }, undefined, 'error')).toBe(0.2);
+    expect(resolveFieldRef({ yerr: 0.2 }, 'yerr', 'error')).toBe(0.2);
+  });
+});
+
+describe('resolveFieldRef — a row whose fields are one level down', () => {
+  /** What `d3.geoPath()` binds: a feature, with everything joined into `properties`. */
+  const FEATURE = {
+    type: 'Feature',
+    id: '48',
+    properties: { name: 'Texas', NAME: 'TEXAS', rate: 5.2 },
+    geometry: { type: 'Polygon', coordinates: [] },
+  };
+
+  test('a GeoJSON feature names its region without a declaration', () => {
+    expect(resolveFieldRef(FEATURE, undefined, 'region', TraceType.CHOROPLETH)).toBe('Texas');
+  });
+
+  test('a GeoJSON feature carries its value in properties too', () => {
+    expect(resolveFieldRef(FEATURE, undefined, 'value', TraceType.CHOROPLETH)).toBe(5.2);
+  });
+
+  test('name priority beats surface priority, so a place is not called by its code', () => {
+    // `id` is a region candidate the feature carries at the top level, and
+    // `name` is one level down. Reading the row's own keys first for every
+    // name in the chain would announce Texas as "48".
+    expect(resolveFieldRef(FEATURE, undefined, 'region', TraceType.CHOROPLETH)).not.toBe('48');
+  });
+
+  test('an explicit ref reads the property the author can only have meant', () => {
+    // A feature keeps `type`, `id`, `geometry` and `properties` and nothing
+    // else at the top level, so `NAME` is unambiguous.
+    expect(resolveFieldRef(FEATURE, 'NAME', 'region')).toBe('TEXAS');
+  });
+
+  test('a dotted ref walks the path it spells', () => {
+    expect(resolveFieldRef(FEATURE, 'properties.name', 'region')).toBe('Texas');
+    expect(resolveFieldRef(FEATURE, 'geometry.type', 'region')).toBe('Polygon');
+  });
+
+  test('a dotted ref that walks off the row resolves to nothing', () => {
+    expect(resolveFieldRef(FEATURE, 'properties.missing', 'region')).toBeUndefined();
+    expect(resolveFieldRef(FEATURE, 'id.name', 'region')).toBeUndefined();
+  });
+
+  test('a column genuinely named with a dot is read as itself first', () => {
+    expect(resolveFieldRef({ 'a.b': 1, 'a': { b: 2 } }, 'a.b', 'value')).toBe(1);
+  });
+
+  test('the row\'s own key wins over the same key in properties', () => {
+    expect(resolveFieldRef({ value: 1, properties: { value: 2 } }, undefined, 'value')).toBe(1);
+  });
+
+  test('a properties that is not an object is not a second surface', () => {
+    expect(resolveFieldRef({ properties: 'none' }, 'name', 'region')).toBeUndefined();
+    expect(resolveFieldRef({ properties: null }, 'name', 'region')).toBeUndefined();
+  });
+
+  test('a falsy property is a present value, exactly as a falsy column is', () => {
+    expect(resolveFieldRef({ properties: { value: 0 } }, undefined, 'value')).toBe(0);
+  });
+});
+
 describe('warnUnresolvedRef — an explicit name that misses is reported', () => {
   test('the message names the field, the canonical it filled and the series', () => {
     warnUnresolvedRef(CONTEXT, 'cens', 'censored');
@@ -117,6 +240,79 @@ describe('warnUnresolvedRef — an explicit name that misses is reported', () =>
       '[MAIDR Chart.js] maidr declaration on dataset 2 names "wgt" for weight, '
       + 'which no row carries; weight is left out.',
     );
+  });
+
+  test('a binding says it once, however many entry points read the series', () => {
+    // An adapter that resolves declarations for the payload and again for the
+    // highlight reads every series twice; without this it says everything
+    // twice, which is what amCharts had to arrange for itself.
+    const declaration = { type: TraceType.FOREST, weight: 'wgt' };
+    const context = { ...CONTEXT, binding: declaration };
+
+    warnUnresolvedRef(context, 'wgt', 'weight');
+    warnUnresolvedRef(context, 'wgt', 'weight');
+
+    expect(warnings).toHaveLength(1);
+  });
+
+  test('a second field missing on the same binding is still reported', () => {
+    const context = { ...CONTEXT, binding: { type: TraceType.FOREST } };
+
+    warnUnresolvedRef(context, 'wgt', 'weight');
+    warnUnresolvedRef(context, 'lo', 'yMin');
+
+    expect(warnings).toHaveLength(2);
+  });
+
+  test('with no binding to key on, every caller is heard', () => {
+    warnUnresolvedRef(CONTEXT, 'wgt', 'weight');
+    warnUnresolvedRef(CONTEXT, 'wgt', 'weight');
+
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe('the sentence for a declaration the library cannot back — spec §7.1', () => {
+  test('a type this adapter draws no construct for is one sentence, not eight', () => {
+    warnUndrawnType(CONTEXT, TraceType.CHOROPLETH);
+
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "choropleth" on series "sales" '
+      + 'names no construct this library draws; reading it as the undeclared chart.',
+    ]);
+  });
+
+  test('a construct that cannot back the type names both halves', () => {
+    warnWrongConstruct(CONTEXT, TraceType.SURVIVAL, 'a line series', 'pie');
+
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "survival" on series "sales" needs '
+      + 'a line series and this one is drawn as "pie"; reading it as the undeclared chart.',
+    ]);
+  });
+
+  test('an adapter that cannot name what was drawn still says what was needed', () => {
+    warnWrongConstruct(
+      { adapter: 'Chart.js', seriesRef: 'dataset 2' },
+      TraceType.MOSAIC,
+      'a stacked bar dataset',
+    );
+
+    expect(warnings).toEqual([
+      '[MAIDR Chart.js] maidr declaration for "mosaic" on dataset 2 needs a stacked '
+      + 'bar dataset; reading it as the undeclared chart.',
+    ]);
+  });
+
+  test('both sentences are said once per binding', () => {
+    const context = { ...CONTEXT, binding: { type: TraceType.CHOROPLETH } };
+
+    warnUndrawnType(context, TraceType.CHOROPLETH);
+    warnUndrawnType(context, TraceType.CHOROPLETH);
+    warnWrongConstruct(context, TraceType.CHOROPLETH, 'a "map" series', 'pie');
+    warnWrongConstruct(context, TraceType.CHOROPLETH, 'a "map" series', 'pie');
+
+    expect(warnings).toHaveLength(2);
   });
 });
 
@@ -635,6 +831,115 @@ describe('readDeclarationSlot — the container is narrowed once, here', () => {
     expect(warnings).toEqual([
       '[MAIDR Highcharts] maidr declaration on series "sales" is not an object; ignored.',
     ]);
+  });
+
+  test('a slot reads only the types the adapter has a reading for', () => {
+    const slot = { maidr: { type: TraceType.CHOROPLETH, region: 'state' } };
+
+    expect(readDeclarationSlot(slot, CONTEXT, [TraceType.SURVIVAL])).toBeNull();
+    expect(warnings[0]).toContain('names no construct this library draws');
+  });
+});
+
+describe('validateDeclaration — an adapter reads a subset, and says so once', () => {
+  test('a type outside the subset degrades to the undeclared chart', () => {
+    const declaration = validateDeclaration(
+      { type: TraceType.CHOROPLETH, region: 'state' },
+      CONTEXT,
+      [TraceType.SURVIVAL, TraceType.FOREST],
+    );
+
+    expect(declaration).toBeNull();
+    expect(warnings).toEqual([
+      '[MAIDR Highcharts] maidr declaration for "choropleth" on series "sales" '
+      + 'names no construct this library draws; reading it as the undeclared chart.',
+    ]);
+  });
+
+  test('a type inside the subset is narrowed to the variant it names', () => {
+    const block = { type: TraceType.RIDGELINE, group: 'month', density: 'kde' };
+    const declaration = validateDeclaration(block, CONTEXT, [TraceType.RIDGELINE]);
+
+    expect(declaration).toBe(block);
+    // The line the eight adapters no longer hand-write a predicate for: the
+    // narrowed type carries the variant's own fields without a second check.
+    expect(declaration?.group).toBe('month');
+    expect(warnings).toEqual([]);
+  });
+
+  test('an omitted subset accepts every variant, as it always did', () => {
+    expect(validateDeclaration({ type: TraceType.ALLUVIAL }, CONTEXT)).not.toBeNull();
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('validateDeclaration — each distinct problem is said once per block', () => {
+  test('a chart walked twice per binding does not say everything twice', () => {
+    // amCharts resolves declarations at two entry points — the payload pass
+    // and the highlight pass both re-walk the chart — and had to key a
+    // WeakMap on the author's own object to keep the console readable.
+    const block = { type: TraceType.VOLCANO, significanse: 7.3 };
+
+    validateDeclaration(block, CONTEXT);
+    validateDeclaration(block, CONTEXT);
+
+    expect(warnings).toHaveLength(1);
+  });
+
+  test('a second problem on the same block is a second sentence', () => {
+    const block = { type: TraceType.ALLUVIAL, of: 'x', unit: 'days' };
+
+    validateDeclaration(block, CONTEXT);
+    validateDeclaration(block, CONTEXT);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('unknown key "of"');
+    expect(warnings[1]).toContain('unknown key "unit"');
+  });
+
+  test('a corrected block is reported afresh rather than silenced', () => {
+    validateDeclaration({ type: TraceType.VOLCANO, significanse: 7.3 }, CONTEXT);
+    validateDeclaration({ type: TraceType.VOLCANO, significanse: 7.3 }, CONTEXT);
+
+    // Rewriting a declaration produces a new object, which has said nothing
+    // yet — otherwise a live-updating chart would fall silent about a fault it
+    // still has.
+    expect(warnings).toHaveLength(2);
+  });
+
+  test('the same block read by two adapters is heard from both', () => {
+    const block = { type: TraceType.VOLCANO, significanse: 7.3 };
+
+    validateDeclaration(block, CONTEXT);
+    validateDeclaration(block, { adapter: 'Chart.js', seriesRef: 'dataset 2' });
+
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe('hasDeclarationSlot — a block written and rejected is not a block absent', () => {
+  test('a slot the validator rejected still carries what the author wrote', () => {
+    // Spec §6(b)'s precedence turns on this: a rejected block is the author
+    // saying something about *this* series, so the reading falls through to
+    // the heuristic rather than on to a chart-level declaration.
+    const slot = { maidr: { type: 'survivl' } };
+
+    expect(readDeclarationSlot(slot, CONTEXT)).toBeNull();
+    expect(hasDeclarationSlot(slot)).toBe(true);
+  });
+
+  test.each([
+    ['no container', undefined],
+    ['a container that is a string', 'quarterly'],
+    ['a container with no maidr key', { legend: 'right' }],
+    ['a maidr key written as null', { maidr: null }],
+    ['a maidr key written as undefined', { maidr: undefined }],
+  ])('%s is no block written', (_label, container) => {
+    expect(hasDeclarationSlot(container)).toBe(false);
+  });
+
+  test('a readable declaration is written too', () => {
+    expect(hasDeclarationSlot({ maidr: { type: TraceType.ALLUVIAL } })).toBe(true);
   });
 });
 

--- a/test/adapters/shared/traceDeclaration.test.ts
+++ b/test/adapters/shared/traceDeclaration.test.ts
@@ -1,3 +1,4 @@
+import type { DeclaredType } from '@adapters/shared/traceDeclaration';
 import type { MaidrTraceDeclaration } from '@type/declaration';
 import {
   DECLARED_FIELD_REF_FALLBACKS,
@@ -151,8 +152,55 @@ describe('resolveFieldRef — a type whose chain cannot be the shared one', () =
     ),
   )('a %s reads %s from a row carrying only `%s`', (type, canonical, alternative) => {
     expect(
-      resolveFieldRef({ [alternative]: 'read' }, undefined, canonical, type as TraceType.CHOROPLETH),
+      resolveFieldRef({ [alternative]: 'read' }, undefined, canonical, type as DeclaredType),
     ).toBe('read');
+  });
+
+  test('a hexbin bin keeps its centre when it spells it the d3-hexbin way', () => {
+    // A d3-hexbin bin carries `x`/`y` on the bin and `x0`/`y0` on the lattice
+    // cell, and a Recharts-style bin uses `cx`/`cy`. Read under the shared
+    // chain, `x` and `y` have none, so such a bin resolved no centre at all —
+    // and a bin with no centre is dropped, which is a hole in the lattice a
+    // reader navigates straight past.
+    const bin = { x0: 0.5, y0: 1000, length: 12 };
+
+    expect(resolveFieldRef(bin, undefined, 'x', TraceType.HEXBIN)).toBe(0.5);
+    expect(resolveFieldRef(bin, undefined, 'y', TraceType.HEXBIN)).toBe(1000);
+    expect(resolveFieldRef(bin, undefined, 'x')).toBeUndefined();
+  });
+
+  test('a boxen rung is a row, and its three numbers spread as widely', () => {
+    // The ladder is the fact a boxen exists to carry. The foundation resolved
+    // only top-level fields, so a rung spelled any way but `{ p, lo, hi }` was
+    // dropped and the distribution announced a median with nothing around it.
+    const rung = { prob: 0.125, lower: 130, upper: 310 };
+
+    expect(resolveFieldRef(rung, undefined, 'p', TraceType.BOXEN)).toBe(0.125);
+    expect(resolveFieldRef(rung, undefined, 'lo', TraceType.BOXEN)).toBe(130);
+    expect(resolveFieldRef(rung, undefined, 'hi', TraceType.BOXEN)).toBe(310);
+  });
+
+  test('a rung\'s names belong to the rung and not to every row', () => {
+    // `lo` and `hi` are alternatives for `yMin`/`yMax` on the shared chain, not
+    // canonicals of their own, so nothing reads them outside a boxen.
+    expect(resolveFieldRef({ lower: 130 }, undefined, 'lo')).toBeUndefined();
+    expect(resolveFieldRef({ upper: 310 }, undefined, 'hi')).toBeUndefined();
+  });
+
+  test('a schedule reads the ends of its intervals', () => {
+    const interval = { lane: 'Design', from: 3, to: 9 };
+
+    expect(resolveFieldRef(interval, undefined, 'x', TraceType.GANTT)).toBe('Design');
+    expect(resolveFieldRef(interval, undefined, 'start', TraceType.GANTT)).toBe(3);
+    expect(resolveFieldRef(interval, undefined, 'end', TraceType.GANTT)).toBe(9);
+  });
+
+  test('a schedule does not label an interval from the Manhattan chain', () => {
+    // The shared `label` chain is `snp`, `id`, `name`, `gene`, `probe` — a
+    // genomic identifier. An `id` column on a schedule row is a database key,
+    // and announcing it as the interval's name says nothing a listener can use.
+    expect(resolveFieldRef({ id: 4171 }, undefined, 'label', TraceType.GANTT)).toBeUndefined();
+    expect(resolveFieldRef({ task: 'Wiring' }, undefined, 'label', TraceType.GANTT)).toBe('Wiring');
   });
 
   test('an offset column is spelled `error` or named, and never guessed at', () => {
@@ -524,6 +572,16 @@ const FULL_DECLARATIONS: readonly MaidrTraceDeclaration[] = [
     upperOutliers: 'highOut',
     orientation: Orientation.VERTICAL,
   },
+  {
+    type: TraceType.GANTT,
+    title: 't',
+    name: 'n',
+    x: 'resource',
+    start: 'from',
+    end: 'to',
+    label: 'activity',
+    unit: 'days',
+  },
 ];
 
 describe('validateDeclaration — a valid block passes through untouched', () => {
@@ -534,8 +592,8 @@ describe('validateDeclaration — a valid block passes through untouched', () =>
     expect(warnings).toEqual([]);
   });
 
-  test('all thirteen variants are covered by the fixtures above', () => {
-    expect(new Set(FULL_DECLARATIONS.map(d => d.type)).size).toBe(13);
+  test('all fourteen variants are covered by the fixtures above', () => {
+    expect(new Set(FULL_DECLARATIONS.map(d => d.type)).size).toBe(14);
   });
 
   test('a survival curve may say its siblings are further arms of it', () => {
@@ -545,6 +603,36 @@ describe('validateDeclaration — a valid block passes through untouched', () =>
       .not
       .toBeNull();
     expect(warnings).toEqual([]);
+  });
+});
+
+describe('validateDeclaration — a schedule can be declared at all', () => {
+  test('a gantt is a variant, so an adapter that draws one can be told so', () => {
+    // There was no GANTT variant, so a library drawing a schedule its adapter
+    // could not detect had no way for the author to say what it was — the
+    // intervals were read as bars, which announces a length as a height and
+    // loses the axis the two ends share.
+    const block = { type: TraceType.GANTT, x: 'resource', unit: 'days' };
+
+    expect(validateDeclaration(block, CONTEXT)).toBe(block);
+    expect(warnings).toEqual([]);
+  });
+
+  test('the unit is a word, and a number written there is dropped', () => {
+    // `'7'` is not what a step of the axis is called, and announcing "7 7" is
+    // worse than announcing the length alone. The word/column distinction the
+    // key set draws is documentation — both kinds accept a string — so what is
+    // pinned here is that a non-string never reaches the payload.
+    const declaration = validateDeclaration({ type: TraceType.GANTT, unit: 7 }, CONTEXT);
+
+    expect(declaration).toEqual({ type: TraceType.GANTT });
+    expect(warnings[0]).toContain('unit');
+  });
+
+  test('a misspelt schedule key is reported like any other', () => {
+    validateDeclaration({ type: TraceType.GANTT, finish: 'to' }, CONTEXT);
+
+    expect(warnings[0]).toContain('unknown key "finish"');
   });
 });
 

--- a/test/type/declaration.test.ts
+++ b/test/type/declaration.test.ts
@@ -29,9 +29,9 @@ describe('the declaration union is keyed on TraceType string values', () => {
     expect(unknown).toEqual([]);
   });
 
-  test('the union covers the thirteen declarable types, each exactly once', () => {
-    expect(members).toHaveLength(13);
-    expect(new Set(members).size).toBe(13);
+  test('the union covers the fourteen declarable types, each exactly once', () => {
+    expect(members).toHaveLength(14);
+    expect(new Set(members).size).toBe(14);
   });
 
   test('the two spellings that surprise authors are the ones that ship', () => {


### PR DESCRIPTION
## Description

The trace-declaration foundation landed in #886 and was then built on by eight adapters in parallel (#888–#895). Each implementer was asked to report gaps rather than change the foundation under its seven siblings. This is the single follow-up PR against the foundation files that those reports asked for.

The one gap that produced a *wrong* announcement rather than a missing one is closed first. `ChoroplethDeclaration.value` shared its fallback chain with the ridgeline, and that chain leads with `x`. On the ordinary region table `{ x: 'Texas', y: 12.4 }` a map therefore announced **"Texas" as the number Texas is shaded by** — a reading a listener has no way to tell from a right one. Everything else here is a reading that was missing, not one that was wrong.

Foundation files only. No adapter's reading of a chart changes except Recharts, which reported two of the gaps and whose call sites already resolve the fields those gaps concern.

## Related Issues

Closes #896

## Changes Made

### 1. Per-type fallback chains — `value` was the ridgeline's and is wrong on a map (§1)

`DECLARED_FIELD_REF_FALLBACKS` in `src/adapters/shared/traceDeclaration.ts` keys a chain by declared type, and **replaces** the shared `FIELD_REF_FALLBACKS` entry for that type rather than extending it — extending would keep exactly the entry the type is there to disown. A choropleth now reads two chains of its own, both the shipped d3 binder's, ordered so the ordinary region table resolves both halves the right way round (`x` is the *last* name a region answers to, `y` the *first* a value does):

- `region` → `name`, `NAME`, `name_long`, `admin`, `state`, `id`, `label`, `x` (there was no `region` chain at all before)
- `value` → `y`, `rate`, `density`, `count`

`resolveFieldRef` takes an optional `type` argument for this; omitted, the shared chain applies exactly as before, so no existing caller changes behaviour.

### 2. A row whose fields are one level down (§2)

`resolveFieldRef` did a flat `row[name]`. It now looks in three places, in order: the row's own key, the dotted path the name spells, and the row's `properties`. That is what makes a **map** readable — `element.__data__` on a choropleth is a GeoJSON or TopoJSON feature that keeps the region's name and the joined value under `properties`, every time.

- The row's own key always wins, so `properties` can fill a gap but never overrule the row.
- A column genuinely named `a.b` is read as itself before the name is taken apart.
- Name priority dominates surface priority: `properties.name` beats a top-level `id`, because a region is called by its name and not by its FIPS code.

### 3. One spelling for the §7.1 sentence, and a subset an adapter can declare (§3)

- `warnUndrawnType(context, type)` — this declared type names no construct the library draws.
- `warnWrongConstruct(context, type, needs, drawn?)` — the adapter reads the type, but not off *this* series.
- `validateDeclaration` and `readDeclarationSlot` take an optional `reads` subset and narrow their return to the variant that subset names, via a new `DeclarationOf` helper type. That replaces the narrowing predicate each adapter was hand-writing after the call. Omitted, every variant is accepted, as before.

### 4. Warn-once, arranged centrally (§4)

A module-level `WeakMap` keyed on the **author's own block** gates every warning this module emits, so an adapter with two entry points per binding (a payload pass and a highlight pass both re-walking the chart) says each distinct sentence once. Keying on the author's object is what keeps a *corrected* block audible — rewriting a declaration produces a new object that has said nothing yet — and two adapters reading one block are both heard. A distinct second problem on the same block is a different sentence and is still reported. With no binding to key on, the warning is emitted every time, which is the honest default.

### 5. The smaller items

- **`error` has no chain, deliberately.** Documented as such on both `FIELD_REF_FALLBACKS` and `ErrorBarDeclaration.error`, with a test pinning that `yerr`/`sem` resolve nothing. Every common spelling is either axis-specific (`yerr`, `xerr`) or a dispersion statistic a chart commonly draws a multiple of (`sd`, `sem` — ±1.96 SEM is as ordinary as ±1); read as the drawn offset, one of those silently resizes every interval on the figure.
- **`GanttDeclaration` added** to `MaidrTraceDeclaration` and `DECLARATION_KEYS`: `x`, `start`, `end`, `label`, `unit`. `unit` is a literal word rather than a field — the unit belongs to the chart, and per-row units would let a producer emit intervals that disagree about what their numbers measure. `label` gets a schedule's own chain (`name`, `task`, `title`, `activity`) rather than the shared one, which is the Manhattan identifier's (`snp`, `gene`, `probe`) and names nothing on a schedule.
- **Hexbin `x`/`y` chains** (`x0`/`cx`, `y0`/`cy`), matching the shipped d3 hexbin binder. Recharts now passes `TraceType.HEXBIN` at its bin-centre call sites, so a bin spelling its centre the d3 way is read rather than dropped for want of a centre — a hole in the lattice a reader navigates straight past.
- **The interior of a payload array.** A boxen ladder is a list of `{ p, lo, hi }` rungs and only those literal three were read, so a ladder written `{ prob, lower, upper }` left a distribution with a median and nothing to walk out to. No new resolver was needed — a rung **is** a row — so `BOXEN` gets rung chains (`p` → `prob`/`probability`/`depth`; `lo` → `lower`/`low`/`min`/`y0`; `hi` → `upper`/`high`/`max`/`y1`) and Recharts' `toLetterValueLevels` passes each rung through the existing resolver.
- **"No block written" vs "block written and rejected."** `hasDeclarationSlot(container)` answers spec §6(b)'s precedence question, sharing its guard with `readDeclarationSlot` via a common `declarationIn` so the two cannot come to disagree about what a slot is.

### Tests

46 test cases added across `test/adapters/shared/traceDeclaration.test.ts` and `test/adapters/recharts/converters.test.ts`. `test/type/declaration.test.ts` parses `declaration.ts` for its discriminants and asserted thirteen; adding the gantt variant makes it fourteen, so that count and the `FULL_DECLARATIONS` fixture assertion were updated — the only pre-existing test this changes.

Each added test was checked against a deliberate mutation of the source hunk it covers, and each fails without it. One did not pin what its name claimed: "the unit is a word, not a column name" passed with `unit`'s rule flipped from `text` to `field`, because `FieldRef` *is* `string` and the two are indistinguishable at runtime. It was renamed to "the unit is a word, and a number written there is dropped", which is what it actually pins; the word/column split is documentation, not a runtime check. No test was deleted and none passes both ways.

## Screenshots (if applicable)

Not applicable — no visual change. The failure this fixes is audible: a map announcing a place name where a number belongs.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The manual-testing box is left unticked deliberately: the automated gate was run in full and is green (below), but the `ManualTestingProcess.md` walkthrough in a browser was not performed. The declaration path is exercised by adapters that have no example page for the shapes this touches — a GeoJSON-backed choropleth, a d3-hexbin bin, a boxen ladder spelled the other way — so a reviewer confirming a real map announces its values is worth more than a tick here.

Documentation: the reference for this API is the TSDoc in `src/type/declaration.ts` and `src/adapters/shared/traceDeclaration.ts`, and both are updated — every chain, and the reasoning for each one that is scoped or deliberately absent. Nothing under `docs/` enumerates declaration variants, so no page there needed changing.

## Additional Notes

**Gate**, run in this order after the rebase onto the moved `main`, not carried over from before it:

| Step | Result |
| --- | --- |
| `npm run lint:fix` | clean, no files rewritten |
| `npm run type-check` | clean (`tsc --noEmit` and `tsconfig.ci.json`) |
| `npm run build` | all 13 builds complete |
| `npm test` | 281/281 suites, 4146/4146 tests, then 7/7 suites, 73/73 tests — green |

One honest note on the test run: an earlier full run of the same commit reported `test/util/deepMerge.test.ts` as a failed *suite* with no failed test (4138 of 4138 passing — exactly the 8 tests that suite contains, lost to the suite not loading). It passes alone, and the clean re-run above passes it in place. Neither `src/util/deepMerge.ts` nor its test is touched by this branch, and nothing here is imported by either, so this reads as an intermittent worker-level flake in the runner rather than anything this diff causes. Flagged rather than buried in case it recurs in CI.

**Adoption is not in this PR.** `warnUndrawnType`, `warnWrongConstruct`, `hasDeclarationSlot` and the `reads` subset are now available to every adapter, but no adapter is switched over to them here — Highcharts still carries its own local `warnWrongConstruct`, and no caller passes `reads` yet. That follows the issue's own scoping ("one PR against the foundation files, not eight"); adopting them is a per-adapter change with its own review surface. The §1, §2, §4 and §5 fixes need no adoption and are live for every adapter the moment this lands, since they sit inside `resolveFieldRef`, `validateDeclaration` and `readDeclarationSlot`.

One nuance on §4 worth a reviewer's eye: the type-level warnings dedupe automatically because `validateDeclaration` holds the author's block and keys on it. `warnUnresolvedRef` is raised after the block is out of scope, so it dedupes only when the adapter sets `DeclarationContext.binding`. That is documented on the field, and the honest default when nothing is passed is to warn every time rather than risk silencing a genuinely new problem.

**Deliberately not closed**, each with its reason:

- **`ChoroplethPoint.y` being required with no null** — a region drawn but carrying no value, the ordinary "no data" colour on a real map. The issue itself files this under "Not a foundation gap" and calls it a `grammar.ts` question. Making it nullable would touch the trace, the audio mapping and the text service; that is a separate change with its own accessibility surface, and doing it here would bury it.
- **Threading the declared `type` through the other choropleth-reading adapters** — none of them walks a chain for region or value today, and each has a reason: Highcharts states both off the point it already resolved (its comment is corrected here to say so), Vega-Lite reads them off the spec channel, and Chart.js draws no map. Passing a type where nothing defaults would be inert. Recharts was wired because it reported the hexbin and boxen gaps and its call sites already resolve those fields.
- **A generic nested-payload resolver for array-valued declaration fields** — no second caller exists (CLAUDE.md principle 1). The boxen ladder is the only such payload and it needed no resolver at all: a rung is already a row the existing one reads, so three chain entries closed the gap.

**Release note.** The branch contains a `feat:` commit (the gantt variant is new API surface). If this is squash-merged, the squashed title decides the release, so `feat(adapters):` rather than `fix(adapters):` is what puts the new variant in the notes.