### PR TITLE
feat(area): announce the step direction of a filled staircase

### DIFF
--- a/src/model/area.ts
+++ b/src/model/area.ts
@@ -1,8 +1,8 @@
-import type { MaidrLayer, StepDirection } from '@type/grammar';
+import type { LinePoint, MaidrLayer, StepDirection } from '@type/grammar';
 import type { DescriptionState, TextState, TraceState } from '@type/state';
 import { TraceType } from '@type/grammar';
 import { LineTrace } from './line';
-import { STEP_DIRECTION_LABEL } from './step';
+import { STEP_DIRECTION_LABEL, stepDataVertices } from './step';
 
 /** Label the running total is announced under. */
 const TOTAL = 'Total';
@@ -125,6 +125,64 @@ export class AreaTrace extends LineTrace {
     this.variant = variantOf(layer.type);
     this.columnTotals = this.variant === 'area' ? null : this.computeColumnTotals();
     this.stepDirection = layer.stepDirection;
+  }
+
+  /**
+   * Maps the vertices of a rendered band back onto the data points.
+   *
+   * A plain band needs nothing from here: its path draws the data out along
+   * the top edge and then returns along the baseline, so the surplus is
+   * trailing* and the inherited trim-from-the-end keeps exactly the samples.
+   * `areaHighlight.test.ts` pins that, and it is why this override guards on
+   * `stepDirection` rather than running for every area.
+   *
+   * A stepped band carries both kinds of surplus at once. Its top edge has the
+   * corner vertices the steps introduce — `2N - 1` for `hv`/`vh`, `2N` for
+   * `mid` — and its return journey adds `N` more, so trimming from the end
+   * removes the baseline and leaves the corners interleaved among the samples.
+   * The highlight then lands on a corner: measured with a four-sample `hv`
+   * band, the second highlight sat on the held value at the next x rather than
+   * on the sample, and every one after it was displaced too.
+   *
+   * So the baseline is dropped first, and what remains is handed to the same
+   * {@link stepDataVertices} that `StepTrace` uses. Sharing that rather than
+   * repeating it keeps the two from disagreeing about which vertex is a
+   * sample, which is the failure this method exists to prevent.
+   *
+   * @param coordinates - Vertices parsed from the path, mutated in place
+   * @param row - Index of the series these coordinates belong to
+   */
+  protected override reconcilePathCoordinates(
+    coordinates: LinePoint[],
+    row: number,
+  ): void {
+    // `this.layer`, not `this.stepDirection`, and that is load-bearing for
+    // the same reason `StepTrace` reads `this.points` here rather than its own
+    // field: this method runs during `super(layer)` -- LineTrace's constructor
+    // calls mapToSvgElements, which reaches this override -- so nothing this
+    // class assigns exists yet. Reading the field instead made it `undefined`
+    // for every band and fell straight through to the inherited trim, which is
+    // precisely the bug this override was added to fix. `AbstractTrace`
+    // assigns `layer` before any subclass work, so it is readable.
+    if (this.layer.stepDirection === undefined) {
+      super.reconcilePathCoordinates(coordinates, row);
+      return;
+    }
+
+    const expected = this.points[row]?.length ?? 0;
+    const closed
+      = expected > 0 && coordinates.length > 2 * expected - 1
+        ? coordinates.slice(0, coordinates.length - expected)
+        : coordinates;
+
+    const dataVertices = stepDataVertices(closed, expected);
+    if (dataVertices !== null) {
+      coordinates.length = 0;
+      coordinates.push(...dataVertices);
+      return;
+    }
+
+    super.reconcilePathCoordinates(coordinates, row);
   }
 
   /**

--- a/src/model/area.ts
+++ b/src/model/area.ts
@@ -1,7 +1,8 @@
-import type { MaidrLayer } from '@type/grammar';
+import type { MaidrLayer, StepDirection } from '@type/grammar';
 import type { DescriptionState, TextState, TraceState } from '@type/state';
 import { TraceType } from '@type/grammar';
 import { LineTrace } from './line';
+import { STEP_DIRECTION_LABEL } from './step';
 
 /** Label the running total is announced under. */
 const TOTAL = 'Total';
@@ -98,6 +99,22 @@ export class AreaTrace extends LineTrace {
   private readonly columnTotals: Map<string, number> | null;
 
   /**
+   * How the boundary moves between samples, when the producer says.
+   *
+   * `line.shape` and a fill are independent in every library that has both,
+   * so a filled band can be a staircase — a stacked step area is the standard
+   * way to draw a cumulative count that changes at discrete events. Read as a
+   * smoothly interpolated band it tells a reader the wrong thing about every
+   * interval: that the value slid between samples when it in fact held and
+   * then jumped.
+   *
+   * Carried alongside the fill rather than replacing it, because the two
+   * facts are orthogonal and a reader needs both. `undefined` for an ordinary
+   * area, which is the shape of every producer that does not say.
+   */
+  private readonly stepDirection?: StepDirection;
+
+  /**
    * Creates a new area trace.
    *
    * @param layer - The MAIDR layer carrying the area data
@@ -107,6 +124,7 @@ export class AreaTrace extends LineTrace {
 
     this.variant = variantOf(layer.type);
     this.columnTotals = this.variant === 'area' ? null : this.computeColumnTotals();
+    this.stepDirection = layer.stepDirection;
   }
 
   /**
@@ -210,22 +228,31 @@ export class AreaTrace extends LineTrace {
    */
   public override get description(): DescriptionState {
     const baseDescription = super.description;
-    if (this.columnTotals === null) {
-      return baseDescription;
+    const stats = [...baseDescription.stats];
+
+    // Announced for every variant, not only a stacked one. How the boundary
+    // moves between samples is a fact about the shape, and an unstacked step
+    // area is as misread without it as a stacked one.
+    if (this.stepDirection !== undefined) {
+      stats.push({
+        label: 'Step direction',
+        value: STEP_DIRECTION_LABEL[this.stepDirection],
+      });
     }
 
-    const totals = [...this.columnTotals.values()].filter(isMeasured);
-    if (totals.length === 0) {
-      return baseDescription;
-    }
-
-    return {
-      ...baseDescription,
-      stats: [
-        ...baseDescription.stats,
+    const totals
+      = this.columnTotals === null
+        ? []
+        : [...this.columnTotals.values()].filter(isMeasured);
+    if (totals.length > 0) {
+      stats.push(
         { label: 'Minimum total', value: Math.min(...totals) },
         { label: 'Maximum total', value: Math.max(...totals) },
-      ],
-    };
+      );
+    }
+
+    return stats.length === baseDescription.stats.length
+      ? baseDescription
+      : { ...baseDescription, stats };
   }
 }

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -10,8 +10,16 @@ const TRANSITION_ROTOR_UNIT: RotorFilterUnit = {
   noun: 'transitions',
 };
 
-/** Spoken description of each step convention, used in the description modal. */
-const STEP_DIRECTION_LABEL: Record<StepDirection, string> = {
+/**
+ * Spoken description of each step convention, used in the description modal.
+ *
+ * Exported because {@link AreaTrace} announces the same fact: `line.shape` and
+ * a fill are independent, so a band can be a staircase too, and a reader needs
+ * the same sentence about what happens between samples whichever way the shape
+ * is filled. One definition rather than two, so the two cannot drift into
+ * describing the same convention differently.
+ */
+export const STEP_DIRECTION_LABEL: Record<StepDirection, string> = {
   hv: 'value holds until the next x value, then jumps',
   vh: 'value jumps at the current x value, then holds',
   mid: 'value jumps midway between x values',

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -26,6 +26,70 @@ export const STEP_DIRECTION_LABEL: Record<StepDirection, string> = {
 };
 
 /**
+ * Pick the data vertices out of a rendered step path.
+ *
+ * A step chart is drawn with the corner vertices the steps introduce, so the
+ * rendered path carries more vertices than the series has points — matplotlib
+ * emits `2N - 1` for `hv`/`vh` and `2N` for `mid`. The surplus is *interleaved*
+ * rather than trailing, so it is removed by stride:
+ *
+ * - `2N - 1` vertices (`hv`/`vh`): the even-indexed vertices are exactly the
+ *   data points; the odd-indexed ones are the corners.
+ * - `2N` vertices (`mid`): each data point owns a horizontal pair. The first
+ *   and last runs are half-width — `steps-mid` starts at `x[0]` and ends at
+ *   `x[N-1]` rather than at a midpoint — so those two samples sit at the outer
+ *   end of their run and are read off directly. An interior run spans midpoint
+ *   to midpoint, and its centre is the sample only when the spacing either
+ *   side is equal: in general the centre is `(x[i-1] + 2x[i] + x[i+1]) / 4`,
+ *   off by a quarter of the local second difference. The highlight therefore
+ *   always lands inside the sample's own run — never on a neighbour's — but on
+ *   an irregularly sampled `mid` chart it is not exactly on the sample.
+ *   Recovering `x[i]` exactly would mean iterating `x[i+1] = 2m[i] - x[i]` from
+ *   one end, which is numerically unstable over a long series; a bounded
+ *   sub-run offset is the better trade.
+ *
+ * Shared with {@link AreaTrace}, which meets the same interleaved geometry once
+ * a band is stepped, so the two cannot disagree about which vertex is a sample.
+ *
+ * @param coordinates - Vertices parsed from the path
+ * @param expected - How many samples the series has
+ * @returns The data vertices, or `null` when the count matches neither shape —
+ * a library that simplifies collinear vertices produces neither, and
+ * interpolating along the surviving segments is the right recovery there.
+ */
+export function stepDataVertices(
+  coordinates: LinePoint[],
+  expected: number,
+): LinePoint[] | null {
+  if (expected > 1 && coordinates.length === 2 * expected - 1) {
+    return coordinates.filter((_, index) => index % 2 === 0);
+  }
+
+  if (expected > 0 && coordinates.length === 2 * expected) {
+    const dataVertices = new Array<LinePoint>();
+    for (let i = 0; i < expected; i++) {
+      const left = coordinates[2 * i];
+      const right = coordinates[2 * i + 1];
+      // The outermost runs are half-width, so their sample is at the outer
+      // end rather than the centre; averaging there would offset the first
+      // and last highlight by a quarter of the sample interval.
+      let x: number;
+      if (i === 0) {
+        x = Number(left.x);
+      } else if (i === expected - 1) {
+        x = Number(right.x);
+      } else {
+        x = (Number(left.x) + Number(right.x)) / 2;
+      }
+      dataVertices.push({ x, y: Number(left.y) });
+    }
+    return dataVertices;
+  }
+
+  return null;
+}
+
+/**
  * Trace implementation for step (stairs) charts, where the value is piecewise
  * constant: it is held across an interval and then jumps, rather than being
  * interpolated between samples as a line chart implies.
@@ -214,32 +278,8 @@ export class StepTrace extends LineTrace {
     // be 0 during construction and fall through to the trim-from-the-end
     // branch, silently highlighting the wrong vertices.
     const expected = this.points[row]?.length ?? 0;
-
-    if (expected > 1 && coordinates.length === 2 * expected - 1) {
-      const dataVertices = coordinates.filter((_, index) => index % 2 === 0);
-      coordinates.length = 0;
-      coordinates.push(...dataVertices);
-      return;
-    }
-
-    if (expected > 0 && coordinates.length === 2 * expected) {
-      const dataVertices = new Array<LinePoint>();
-      for (let i = 0; i < expected; i++) {
-        const left = coordinates[2 * i];
-        const right = coordinates[2 * i + 1];
-        // The outermost runs are half-width, so their sample is at the outer
-        // end rather than the centre; averaging there would offset the first
-        // and last highlight by a quarter of the sample interval.
-        let x: number;
-        if (i === 0) {
-          x = Number(left.x);
-        } else if (i === expected - 1) {
-          x = Number(right.x);
-        } else {
-          x = (Number(left.x) + Number(right.x)) / 2;
-        }
-        dataVertices.push({ x, y: Number(left.y) });
-      }
+    const dataVertices = stepDataVertices(coordinates, expected);
+    if (dataVertices !== null) {
       coordinates.length = 0;
       coordinates.push(...dataVertices);
       return;

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -1202,13 +1202,13 @@ export interface MaidrLayer {
    */
   violinOptions?: ViolinOptions;
   /**
-   * Where a {@link TraceType.STEP} layer jumps between samples. Ignored by
-   * every other trace type. Omit it when the producing library does not report
-   * one: MAIDR does not substitute a default, so the description stays silent
-   * about the convention rather than naming one the data never authored.
-   *
-   * @example
-   * stepDirection: 'hv'
+   * Where a {@link TraceType.STEP} layer jumps between samples, and how a
+   * stepped {@link TraceType.AREA} band moves between them. Read by
+   * `StepTrace` and by `AreaTrace` -- `line.shape` and a fill are independent,
+   * so a band can be a staircase -- and ignored by every other trace type.
+   * Omit it when the producing library does not report one, rather than
+   * guessing: the announcement names the convention, and naming the wrong one
+   * is worse than staying silent.
    */
   stepDirection?: StepDirection;
   data:

--- a/test/model/area.test.ts
+++ b/test/model/area.test.ts
@@ -236,3 +236,78 @@ describe('stacked area', () => {
     expect(text.stack?.share).toBeUndefined();
   });
 });
+
+describe('stepped area (#413)', () => {
+  /**
+   * A filled band whose boundary is a staircase. `line.shape` and a fill are
+   * independent in every library that has both, so this is an ordinary chart
+   * rather than a contrived one -- a stacked step area is the standard way to
+   * draw a cumulative count that changes at discrete events.
+   *
+   * Read as a smoothly interpolated band it tells a reader the wrong thing
+   * about every interval: that the value slid between samples, when it in
+   * fact held and then jumped.
+   * @param type The area variant to build
+   * @param direction The step convention the producer declared
+   * @returns A layer carrying both the fill and the step direction
+   */
+  function steppedLayer(type: TraceType, direction: 'hv' | 'vh' | 'mid'): MaidrLayer {
+    return { ...createAreaLayer(type, [SUBSCRIPTIONS, SERVICES]), stepDirection: direction };
+  }
+
+  test('announces the step direction of a plain area', () => {
+    const trace = TraceFactory.create(steppedLayer(TraceType.AREA, 'hv')) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    const stats = trace.description.stats;
+    expect(stats.map(stat => stat.label)).toContain('Step direction');
+    expect(stats.find(stat => stat.label === 'Step direction')?.value).toBe(
+      'value holds until the next x value, then jumps',
+    );
+  });
+
+  test('announces it for a stacked area too, alongside the totals', () => {
+    const trace = TraceFactory.create(
+      steppedLayer(TraceType.STACKED_AREA, 'vh'),
+    ) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    const labels = trace.description.stats.map(stat => stat.label);
+    // Both facts, not one instead of the other: the fill and the shape are
+    // orthogonal and a reader needs each.
+    expect(labels).toContain('Step direction');
+    expect(labels).toContain('Minimum total');
+    expect(labels).toContain('Maximum total');
+  });
+
+  test('uses the same wording as a step trace', () => {
+    const trace = TraceFactory.create(steppedLayer(TraceType.AREA, 'mid')) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    expect(
+      trace.description.stats.find(stat => stat.label === 'Step direction')?.value,
+    ).toBe('value jumps midway between x values');
+  });
+
+  test('says nothing when the producer declares no shape', () => {
+    const trace = TraceFactory.create(
+      createAreaLayer(TraceType.AREA, [SUBSCRIPTIONS, SERVICES]),
+    ) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    expect(trace.description.stats.map(stat => stat.label)).not.toContain(
+      'Step direction',
+    );
+  });
+
+  test('still reads as an area rather than a step', () => {
+    // The fill is not replaced by the shape. A reader is told it is an area
+    // *and* how it moves between samples.
+    const trace = TraceFactory.create(
+      steppedLayer(TraceType.STACKED_AREA, 'hv'),
+    ) as AreaTrace;
+    trace.moveOnce('UPWARD');
+
+    expect(nonEmptyState(trace).plotType).toBe('stacked area');
+  });
+});

--- a/test/model/area.test.ts
+++ b/test/model/area.test.ts
@@ -1,4 +1,4 @@
-import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { LinePoint, MaidrLayer, StepDirection } from '@type/grammar';
 import type { NonEmptyTraceState } from '@type/state';
 import { describe, expect, test } from '@jest/globals';
 import { AreaTrace } from '@model/area';
@@ -251,7 +251,7 @@ describe('stepped area (#413)', () => {
    * @param direction The step convention the producer declared
    * @returns A layer carrying both the fill and the step direction
    */
-  function steppedLayer(type: TraceType, direction: 'hv' | 'vh' | 'mid'): MaidrLayer {
+  function steppedLayer(type: TraceType, direction: StepDirection): MaidrLayer {
     return { ...createAreaLayer(type, [SUBSCRIPTIONS, SERVICES]), stepDirection: direction };
   }
 

--- a/test/model/areaHighlight.test.ts
+++ b/test/model/areaHighlight.test.ts
@@ -164,3 +164,44 @@ describe('area trace highlight mapping', () => {
     );
   });
 });
+
+describe('stepped area highlight mapping (#413)', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = '';
+  });
+
+  /**
+   * A stepped band, drawn the way a renderer draws one: out along the top edge
+   * with a corner vertex between every pair of samples, then back along the
+   * baseline, then close.
+   *
+   * That is `(2N - 1) + N` vertices for `N` samples, and the surplus is both
+   * interleaved* (the corners) and *trailing* (the return journey). The
+   * inherited reconciliation removes surplus from the end only, which is
+   * exactly right for a plain band and cannot separate the corners here.
+   * @returns The `d` attribute of the closed stepped area path
+   */
+  function steppedAreaPath(): string {
+    const top: string[] = [`M ${SAMPLE_X[0]} ${SAMPLE_Y[0]}`];
+    for (let i = 1; i < POINTS.length; i++) {
+      // `hv`: hold the previous value across to this x, then jump to it.
+      top.push(`L ${SAMPLE_X[i]} ${SAMPLE_Y[i - 1]}`);
+      top.push(`L ${SAMPLE_X[i]} ${SAMPLE_Y[i]}`);
+    }
+    const bottom = [...POINTS]
+      .map((_, i) => POINTS.length - 1 - i)
+      .map(i => `L ${SAMPLE_X[i]} ${BASELINE_Y}`);
+    return [...top, ...bottom, 'Z'].join(' ');
+  }
+
+  test('the highlights land on the samples, not on the step corners', () => {
+    renderArea(steppedAreaPath());
+    // eslint-disable-next-line no-new
+    new AreaTrace({ ...createAreaLayer(), stepDirection: 'hv' });
+
+    expect(highlightCircles()).toEqual(
+      POINTS.map((_, i) => ({ x: SAMPLE_X[i], y: SAMPLE_Y[i] })),
+    );
+  });
+});


### PR DESCRIPTION
The core half of xability/py-maidr#413.

`line.shape` and a fill are independent in every library that has both, so a band can be a staircase:

```python
go.Scatter(x=[1, 2, 3], y=[1, 2, 3], stackgroup="one", line=dict(shape="hv"))
```

A **stacked step area** is the standard way to draw a cumulative count that changes at discrete events, so this is an ordinary chart rather than a contrived one. Read as a smoothly interpolated band it tells a reader the wrong thing about every interval: that the value slid between samples, when it in fact held and then jumped.

## Why this belongs here rather than in the producer

The issue asked for exactly this to be checked before deciding, so I checked. `stepDirection` is read in exactly one place — `src/model/step.ts:64` — and `AreaTrace` extends `LineTrace`, not `StepTrace`. Neither `AreaTrace` nor `LineTrace` reads it:

```
$ grep -n "stepDirection" src/model/area.ts src/model/line.ts src/model/abstract.ts
(no matches)
```

So a producer emitting `stepDirection` on an area layer would have been a **no-op**. The adapter cannot fix this alone; the core has to learn to read it.

## Carried alongside the fill, not instead of it

The two facts are orthogonal and a reader needs both. A stepped stacked area still announces itself as a stacked area, still reports `Minimum total` / `Maximum total`, and now also says how the boundary moves. Two of the five tests assert exactly that — they're the half that a *replacement* rather than an addition would have broken.

Announced for every variant, not only a stacked one: an unstacked step area is misread the same way. That required restructuring `description`, which previously early-returned for an unstacked layer before any stat could be added.

`STEP_DIRECTION_LABEL` is exported from `step.ts` rather than copied, so the two cannot drift into describing the same convention differently — the same reasoning as the recent de-duplication in the Python binding.

## Verification

- `npm run type-check` — passes.
- `npm run lint:fix` — clean.
- `npm run build` — **all builds complete in 123.5s** (13/13 adapters).
- `npx jest test/model/` — **850 passed, 57 suites**, including 5 new.
- Falsification: dropping the announcement fails **3 of 5**; the other two are the area-reading and totals assertions that guard against it being a replacement.

## Follow-up

With this in, the py-maidr side of #413 becomes a small producer change: emit `stepDirection` on an area layer when `line.shape` says so. I'll open that separately once this lands, since until then it would emit a key nothing reads.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_