### PR TITLE
feat(amcharts): read flow, hierarchy, map and gauge charts

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -91,6 +91,7 @@ Series are classified by their amCharts class name and field configuration:
 - `am5wc.WordCloud` → **word cloud**
 - `am5flow.Sankey` → **sankey**; `Chord`, `ChordDirected` and `ChordNonRibbon` → **chord**; `ArcDiagram` → **sankey**, because it carries weights and a network has nowhere to put one
 - `am5hierarchy.ForceDirected` → **network**
+- `am5map.MapPolygonSeries` bound to a `valueField` (or carrying `heatRules`) → **choropleth**; a polygon series with neither, and every `MapLineSeries`, `MapPointSeries` or `GraticuleSeries`, is the base geography and is skipped
 - `LineSeries` on a value axis whose renderer is `inversed`, carrying a genuine ranking → **bump** (rank over time); the `bump` option settles the cases the axis cannot
 
 ### Visual Highlighting
@@ -131,6 +132,7 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Sankey † | `am5flow.Sankey`, `ArcDiagram` | series class (requires `flow.js`) |
 | Chord † | `am5flow.Chord`, `ChordDirected`, `ChordNonRibbon` | series class (requires `flow.js`) |
 | Network † | `am5hierarchy.ForceDirected` | series class (requires `hierarchy.js`) |
+| Choropleth | `am5map.MapPolygonSeries` inside a `MapChart` | series class + a bound `valueField` or `heatRules` (requires `map.js`) |
 | Bump (rank over time) | `LineSeries` | value axis renderer `inversed: true` **and** values that are a ranking; or the `bump` option |
 | Gauge | *no series* — an `am5radar.ClockHand` on a `RadarChart` axis | chart class `RadarChart` + a `ClockHand` bullet, asked only when the chart's series produced no layer (requires `radar.js`) |
 | Survival (Kaplan-Meier) | `StepLineSeries` | **declared** — `userData: { maidr: { type: "survival" } }` |
@@ -140,6 +142,7 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Manhattan | the same, one series per chromosome | **declared** — `{ type: "manhattan" }` |
 | Scatter | the same | **declared** — `{ type: "point" }` |
 | Alluvial † | `am5flow.Sankey` | **declared** — `{ type: "alluvial" }` |
+| Choropleth (renamed fields) | `am5map.MapPolygonSeries` | **declared** — `{ type: "choropleth", value: "…" }` |
 
 † Read, announced, brailled and navigated — but **not outlined**. See [Flow and network are not outlined](#flow-and-network-are-not-outlined).
 
@@ -191,6 +194,9 @@ A field you leave out falls back to its canonical name and then to a short list 
 | `"volcano"` | the same, with `merge` defaulting to `false` |
 | `"point"` | `label`, `merge` (default `false`) — note the value is `"point"`, not `"scatter"` |
 | `"alluvial"` | nothing — the block is the whole declaration |
+| `"choropleth"` | `region`, `value`, `lon`, `lat` |
+
+`"choropleth"` is the one declared type the adapter also detects on its own. A `MapPolygonSeries` bound to a `valueField` needs no block; the block is for a map whose region name, shaded value or centroid pair lives in a column amCharts was never told about — which is also the only way to get the centroids, and so the arrow keys walking north and south, out of a table that spells them `east`/`north` or keeps them beside the value. It is accepted only on a `MapPolygonSeries`; a block on anything else is reported and the chart is read as what it was drawn as.
 
 `"alluvial"` takes no fields at all, and that is the point: an alluvial is the same weighted flow a sankey carries, drawn without a left-to-right budget, so the nodes, the links and their weights are already in the drawing and the only thing missing is which of the two readings it stands for. It is accepted only on an `am5flow` series that carries at least one readable link — a block on anything else is reported and the chart is read as what it was drawn as.
 
@@ -620,6 +626,45 @@ This is a deliberate refusal rather than an oversight, and the reason is worth s
 Turning either back into a node means reimplementing, inside this adapter, the model's own first-appearance node ordering *together with* its stage layering — longest-distance-from-a-source, with a fallback that collapses a cyclic graph into one stage — or, for a network, its connected-component discovery, member sort and component sort. Those are **derived graph structures**, not orderings over data the adapter emitted. This adapter already mirrors an ordering where one exists (a heatmap's row reversal, a word cloud's weight order), and already refuses to mirror a derived structure (a scatter's binning). A copy would drift from the model silently and then outline a confidently wrong node while the announcement said something else — and nothing about the announcement would look wrong. An empty outline is truthful; that is not.
 
 The fix is small and lives in the model rather than here: both traces already compute the right answer internally, so publishing it as point indices would make all four types highlightable by registering resolvers and changing nothing else. That is tracked as a follow-up.
+
+### Choropleth
+
+A choropleth is an `am5map.MapPolygonSeries` shaded by a value, inside a `MapChart`. It needs `map.js` and a geodata file on top of `index.js`. A runnable page is at [`examples/amcharts-choropleth.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-choropleth.html).
+
+```js
+var chart = root.container.children.push(am5map.MapChart.new(root, {
+  projection: am5map.geoAlbersUsa(),
+}));
+var series = chart.series.push(am5map.MapPolygonSeries.new(root, {
+  geoJSON: am5geodata_region_usa_low,
+  valueField: "value",
+  calculateAggregates: true,
+}));
+series.set("heatRules", [{
+  target: series.mapPolygons.template, dataField: "value",
+  key: "fill", min: am5.color(0xeeeeee), max: am5.color(0x203080),
+}]);
+series.data.setAll([
+  { id: "US-WA", value: 12.1 },
+  { id: "US-OR", value: 16.4 },
+  { id: "US-NV", value: 38.9 },
+]);
+```
+
+A `MapChart` is a `SerialChart`: it has a series list and no axes, so the adapter recognises it by its class name, exactly as it does a `PieChart`. Only a **shaded** polygon series becomes a layer — one bound to a `valueField`, or carrying `heatRules`. The base geography drawn underneath, the graticule, route lines and city pins are all skipped: announcing the base map would offer a list of every shape on it with nothing to say about any of them. A region amCharts drew but joined no value onto is left out of the layer too, which is the ordinary case for the shapes drawn in the no-data colour.
+
+The map is bound to no axis — the value runs along a colour ramp and the regions along nothing at all — so its dimensions are named `Region` and `Value`; the `axisLabels` option overrides both.
+
+**The centroids are what make this a map** rather than a bar chart whose categories happen to be places. MAIDR's choropleth trace bands the regions by latitude and reads each band west to east, so Up is north and Right is east — and it does that out of a longitude and a latitude in **degrees** and out of nothing else. The adapter reads them from two places, in this order:
+
+1. your own row, from `lon`/`longitude`/`long` and `lat`/`latitude`, or from whatever a [declaration](#declaring-what-a-chart-means) renames them to;
+2. the drawn polygon's `geoCentroid()`.
+
+A pair that resolves to neither is **omitted**, never converted. A projected or normalised coordinate announced as a degree is a wrong compass direction, which is worse than what the omission costs: without the pair the regions are read as one band in declared order — a region list, which is a poorer reading but the one the data supports. Values outside ±180 / ±90 are refused for the same reason, and half a pair is treated as none.
+
+`neighbors` is not emitted at all. Adjacency is not recoverable from rendered geometry, and centroids do not answer it either — two regions can have near centroids and no shared border. The trace keeps its spatial walk and is told nothing about borders rather than something guessed, so the "bordering regions" rotor is simply empty on an amCharts map.
+
+**Highlighting** outlines the drawn polygon's axis-aligned box. That is coarse for a long thin country, but it hugs the shape and says which way navigation moved, which is what the overlay is for — the same call the word cloud's rotated glyphs make. A polygon that reports no box with area clears the overlay rather than drawing a hairline somewhere plausible.
 
 ### Bump (Rank Over Time)
 

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -89,11 +89,15 @@ Series are classified by their amCharts class name and field configuration:
 - `LineSeries` with its stroke switched off and bullets pushed on, on a category axis → **dot** (a Cleveland dot plot)
 - `ColumnSeries` whose columns are narrowed to a hairline, with bullets → **lollipop**
 - `am5wc.WordCloud` → **word cloud**
+- `am5flow.Sankey` → **sankey**; `Chord`, `ChordDirected` and `ChordNonRibbon` → **chord**; `ArcDiagram` → **sankey**, because it carries weights and a network has nowhere to put one
+- `am5hierarchy.ForceDirected` → **network**
 - `LineSeries` on a value axis whose renderer is `inversed`, carrying a genuine ranking → **bump** (rank over time); the `bump` option settles the cases the axis cannot
 
 ### Visual Highlighting
 
 amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes for MAIDR's usual highlighting. `bindAmCharts` instead draws an absolutely-positioned outline box over the canvas at the active data point's pixel geometry (computed via am5's `sprite.toGlobal()`) — the same overlay approach the Chart.js adapter uses. The overlay re-anchors on resize. Call the returned `dispose()` to unmount MAIDR, remove the overlay, and restore the chart. Highlighting is unavailable on the `fromAmCharts` JSON/attribute path.
+
+**Four types are read but not outlined**: sankey, alluvial, chord and network. They sonify, describe, braille and navigate correctly, and the overlay simply clears as the cursor moves. This is deliberate, and [the reason is written out below](#flow-and-network-are-not-outlined) — an empty outline is truthful, and a box drawn around a guessed node is not.
 
 ## Supported Chart Types
 
@@ -124,6 +128,9 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Dot Plot (Cleveland) | `LineSeries` | category axis + `strokes.template` hidden + bullets |
 | Lollipop | `ColumnSeries` | category axis + hairline `columns.template` width + bullets |
 | Word Cloud | `am5wc.WordCloud` | series class (requires `wc.js`) |
+| Sankey † | `am5flow.Sankey`, `ArcDiagram` | series class (requires `flow.js`) |
+| Chord † | `am5flow.Chord`, `ChordDirected`, `ChordNonRibbon` | series class (requires `flow.js`) |
+| Network † | `am5hierarchy.ForceDirected` | series class (requires `hierarchy.js`) |
 | Bump (rank over time) | `LineSeries` | value axis renderer `inversed: true` **and** values that are a ranking; or the `bump` option |
 | Gauge | *no series* — an `am5radar.ClockHand` on a `RadarChart` axis | chart class `RadarChart` + a `ClockHand` bullet, asked only when the chart's series produced no layer (requires `radar.js`) |
 | Survival (Kaplan-Meier) | `StepLineSeries` | **declared** — `userData: { maidr: { type: "survival" } }` |
@@ -132,6 +139,9 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Volcano | hidden-stroke `LineSeries` with bullets, two value axes | **declared** — `{ type: "volcano" }` |
 | Manhattan | the same, one series per chromosome | **declared** — `{ type: "manhattan" }` |
 | Scatter | the same | **declared** — `{ type: "point" }` |
+| Alluvial † | `am5flow.Sankey` | **declared** — `{ type: "alluvial" }` |
+
+† Read, announced, brailled and navigated — but **not outlined**. See [Flow and network are not outlined](#flow-and-network-are-not-outlined).
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
@@ -141,13 +151,13 @@ A `FunnelSeries` lives in the same `percent.js` module, inside a `SlicedChart` r
 
 `RadarLineSeries` and `RadarColumnSeries` need `radar.js` on top of `xy.js`; a `RadarChart` extends `XYChart`, so the binder finds it with the rest.
 
-The last seven rows are **declared** rather than detected — see [Declaring What a Chart Means](#declaring-what-a-chart-means) below.
+The **declared** rows are declared rather than detected — see [Declaring What a Chart Means](#declaring-what-a-chart-means) below.
 
-> Box plots, candlestick, violin, and smooth/regression layers are **not** supported by the amCharts binder, and neither are sankey, alluvial or chord diagrams (`am5flow`).
+> Box plots, candlestick, violin, and smooth/regression layers are **not** supported by the amCharts binder.
 
 ## Declaring What a Chart Means
 
-Some readings amCharts leaves no signature for. A Kaplan-Meier curve and a step line are one series class. An error bar is a second series of floating columns, which is also how a waterfall and a dumbbell are drawn. A volcano, a Manhattan and a plain scatter are all a `LineSeries` with its stroke switched off and bullets pushed on, and so is a dot plot. Every one of those configurations is worn by an ordinary chart, so the adapter's heuristics cannot separate them and do not try: a step line read as a survival curve announces censoring the chart never carried, which is worse than reading it as the step line it is.
+Some readings amCharts leaves no signature for. A Kaplan-Meier curve and a step line are one series class. An error bar is a second series of floating columns, which is also how a waterfall and a dumbbell are drawn. A volcano, a Manhattan and a plain scatter are all a `LineSeries` with its stroke switched off and bullets pushed on, and so is a dot plot. An alluvial is an `am5flow.Sankey`. Every one of those configurations is worn by an ordinary chart, so the adapter's heuristics cannot separate them and do not try: a step line read as a survival curve announces censoring the chart never carried, which is worse than reading it as the step line it is.
 
 What separates them is the author saying so, in the `userData` slot amCharts documents as *"a storage for any custom user data"*:
 
@@ -180,6 +190,9 @@ A field you leave out falls back to its canonical name and then to a short list 
 | `"manhattan"` | `label`, `group`, `significance`, `significanceDirection`, `effect`, `merge` (default `true`) |
 | `"volcano"` | the same, with `merge` defaulting to `false` |
 | `"point"` | `label`, `merge` (default `false`) — note the value is `"point"`, not `"scatter"` |
+| `"alluvial"` | nothing — the block is the whole declaration |
+
+`"alluvial"` takes no fields at all, and that is the point: an alluvial is the same weighted flow a sankey carries, drawn without a left-to-right budget, so the nodes, the links and their weights are already in the drawing and the only thing missing is which of the two readings it stands for. It is accepted only on an `am5flow` series that carries at least one readable link — a block on anything else is reported and the chart is read as what it was drawn as.
 
 Every variant also accepts `title` (what the chart is called) and `name` (what this layer is called among its siblings). Any other key is reported and ignored, which is what catches a `significanse: 7.3` in plain JavaScript, where nothing else would.
 
@@ -559,6 +572,54 @@ series.data.setAll([
 ```
 
 A cloud's arrangement is chosen to pack glyphs and encodes nothing, so MAIDR walks the terms **heaviest first** rather than in layout order, and each term announces the weight the chart prints nowhere. The layer declares the terms in data order; the reading order is derived from the weights themselves, so it cannot disagree with them. The highlight box is drawn around the active term's glyph, rotated words included.
+
+### Sankey / Alluvial / Chord / Network
+
+An `am5flow` diagram is a standalone series like an `am5hierarchy` layout: pushed straight into a container, with no chart around it. It needs `flow.js` on top of `index.js`; a force-directed network needs `hierarchy.js` instead. A runnable page covering all four is at [`examples/amcharts-flow.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-flow.html).
+
+```js
+var series = root.container.children.push(am5flow.Sankey.new(root, {
+  sourceIdField: "from", targetIdField: "to", valueField: "value",
+}));
+series.data.setAll([
+  { from: "Coal", to: "Electricity", value: 34 },
+  { from: "Gas", to: "Electricity", value: 21 },
+  { from: "Electricity", to: "Homes", value: 40 },
+]);
+```
+
+The payload is **one point per link**. The nodes are derived from the ends, so `series.nodes` is deliberately not read — a second node list would be a second source of truth for something the links already say, and the two could then disagree. A link missing an end, or carrying no weight, is dropped rather than kept as a gap: amCharts draws no ribbon for it, and a mark MAIDR counted but the chart never drew would slide every later position onto its neighbour.
+
+An `ArcDiagram` is announced as a **sankey**, not as a network. It extends `FlowSeries` and carries a weight per link, and MAIDR's network payload has nowhere to put one, so reading it as a network would silently drop the magnitudes.
+
+All three `Chord` classes — `Chord`, `ChordDirected`, `ChordNonRibbon` — are announced as a **chord**. One honesty note: a chord graph is cyclic, and MAIDR's flow trace lays nodes out by their longest distance from a source. A cyclic graph has no such layering, so every node collapses into a single stage by design. Navigation and sonification are correct; there is simply no left-to-right ordering to announce, and the trace does not claim one.
+
+An **alluvial** has no amCharts class at all — it is an `am5flow.Sankey` with the nodes repeated across stages — so it is [declared](#declaring-what-a-chart-means) rather than detected:
+
+```js
+series.set("userData", { maidr: { type: "alluvial" } });
+```
+
+A **network** comes from `am5hierarchy.ForceDirected`, which is a *hierarchy* series rather than a link list: its data is a tree of `children`, and the links are that tree's parent-child edges plus whatever cross-links each row names in the column `linkWithField` points at.
+
+```js
+var series = root.container.children.push(am5hierarchy.ForceDirected.new(root, {
+  categoryField: "name", childDataField: "children",
+  idField: "name", linkWithField: "linkWith",
+}));
+```
+
+The container root is dropped, as it is for a treemap. A `linkWith` entry naming something the walk never saw is skipped rather than turned into a node: amCharts draws no link for it either, and inventing the node would announce a participant the chart does not have. A pair that names itself from both ends yields one link, because a link is undirected. **Nothing about the layout is read** — where the force solver dropped a node is a fact about its seed rather than about the data, and MAIDR's network point has nowhere to put a position for exactly that reason.
+
+#### Flow and network are not outlined
+
+Sankey, alluvial, chord and network layers get **no highlight**. As the cursor moves the overlay clears; audio, the text description, braille and keyboard navigation all work normally.
+
+This is a deliberate refusal rather than an oversight, and the reason is worth stating. MAIDR hands a canvas adapter one of two things: an explicit list of point indices, for traces that publish which marks they mean, or the **braille** position for everything else. A flow trace is in the second group, and its braille position is `(stage, index within that stage)` — the stage being a column of the drawing, which is the only thing a braille line can be. A network trace's is `(component, index within that component)`.
+
+Turning either back into a node means reimplementing, inside this adapter, the model's own first-appearance node ordering *together with* its stage layering — longest-distance-from-a-source, with a fallback that collapses a cyclic graph into one stage — or, for a network, its connected-component discovery, member sort and component sort. Those are **derived graph structures**, not orderings over data the adapter emitted. This adapter already mirrors an ordering where one exists (a heatmap's row reversal, a word cloud's weight order), and already refuses to mirror a derived structure (a scatter's binning). A copy would drift from the model silently and then outline a confidently wrong node while the announcement said something else — and nothing about the announcement would look wrong. An empty outline is truthful; that is not.
+
+The fix is small and lives in the model rather than here: both traces already compute the right answer internally, so publishing it as point indices would make all four types highlightable by registering resolvers and changing nothing else. That is tracked as a follow-up.
 
 ### Bump (Rank Over Time)
 

--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -84,7 +84,7 @@ Series are classified by their amCharts class name and field configuration:
 - `am5percent.FunnelSeries` (and `PyramidSeries`, `PictorialStackedSeries`) → **funnel**
 - `ColumnSeries` with `openValueYField` on a category X axis → **waterfall** when the bars chain (each opens where the previous one closed), **dumbbell** when they do not
 - `ColumnSeries` with `openValueXField` on a category Y axis → **gantt**
-- `am5hierarchy.Treemap` → **treemap**; `am5hierarchy.Partition` → **icicle**
+- `am5hierarchy.Treemap` → **treemap**; `am5hierarchy.Partition` → **icicle**; `am5hierarchy.Sunburst` → **sunburst**
 - two `ColumnSeries` on one category axis, one side's values all negative and the other's all positive → **diverging bar** (a population pyramid); any other unstacked group stays **dodged**
 - `LineSeries` with its stroke switched off and bullets pushed on, on a category axis → **dot** (a Cleveland dot plot)
 - `ColumnSeries` whose columns are narrowed to a hairline, with bullets → **lollipop**
@@ -119,11 +119,13 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Gantt / Timeline | `ColumnSeries` | category Y axis + `openValueXField` (or `openDateXField`) |
 | Treemap | `am5hierarchy.Treemap` | series class (requires `hierarchy.js`) |
 | Icicle | `am5hierarchy.Partition` | series class (requires `hierarchy.js`) |
+| Sunburst | `am5hierarchy.Sunburst` | series class (requires `hierarchy.js`) |
 | Diverging Bar / Population Pyramid | two `ColumnSeries` | shared categories, one series entirely negative and the other entirely positive |
 | Dot Plot (Cleveland) | `LineSeries` | category axis + `strokes.template` hidden + bullets |
 | Lollipop | `ColumnSeries` | category axis + hairline `columns.template` width + bullets |
 | Word Cloud | `am5wc.WordCloud` | series class (requires `wc.js`) |
 | Bump (rank over time) | `LineSeries` | value axis renderer `inversed: true` **and** values that are a ranking; or the `bump` option |
+| Gauge | *no series* — an `am5radar.ClockHand` on a `RadarChart` axis | chart class `RadarChart` + a `ClockHand` bullet, asked only when the chart's series produced no layer (requires `radar.js`) |
 | Survival (Kaplan-Meier) | `StepLineSeries` | **declared** — `userData: { maidr: { type: "survival" } }` |
 | Error bar | any XY series, with a floating column behind it | **declared** — `{ type: "error_bar" }` |
 | Forest (meta-analysis) | horizontal `openValueXField` columns plus estimate marks | **declared** — `{ type: "forest" }` |
@@ -448,9 +450,9 @@ The lanes come from the **category axis**, not from the bars, so a lane with not
 
 A `DateAxis` stores positions as epoch milliseconds, which no reader can hear a length in, so the adapter rescales them to the axis' own `baseInterval` time unit, measured from the earliest interval: a schedule reads as "day 0 to day 30, length 30 days". The absolute dates are dropped by that, and everything a schedule is drawn to answer — what overlaps what, what hands over to what, where the slack is — survives it. A plain `ValueAxis` is passed through untouched and named with no unit.
 
-### Treemap / Icicle
+### Treemap / Icicle / Sunburst
 
-An `am5hierarchy` layout is **not** a chart: it is a series pushed straight into a container, with no series list and no axes, so the adapter recognises the series itself and treats it as one panel. A treemap and an icicle (amCharts calls it a `Partition`) draw the same tree with different marks and are read identically — as a tree, not a grid: Left and Right move between siblings, Down steps into a node's children, Up returns to its parent. A runnable page is at [`examples/amcharts-treemap.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-treemap.html).
+An `am5hierarchy` layout is **not** a chart: it is a series pushed straight into a container, with no series list and no axes, so the adapter recognises the series itself and treats it as one panel. A treemap, an icicle (amCharts calls it a `Partition`) and a sunburst draw the same tree with different marks and are read identically — as a tree, not a grid: Left and Right move between siblings, Down steps into a node's children, Up returns to its parent. A runnable page covering all three is at [`examples/amcharts-treemap.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-treemap.html).
 
 ```js
 var series = root.container.children.push(am5hierarchy.Treemap.new(root, {
@@ -466,6 +468,32 @@ series.data.setAll([{
 ```
 
 The single root object amCharts requires is dropped: it is a container for the chart rather than a finding, and keeping it would add a level that always holds one node worth 100% of the total. A branch is emitted without a value unless it declares one of its own, so its total is derived from what is under it and cannot disagree with its own children.
+
+A `Sunburst` extends `Partition` but carries its own class name, so it is recognised in its own right rather than inherited — which is also what keeps it from being announced as an icicle. The one thing the mark does change is the highlight: a treemap block and an icicle bar are rectangles, and a sunburst node is a `Slice`, which reports a degenerate box at its own centre and is therefore measured from its radius and sweep instead (the same reading a pie wedge gets).
+
+### Gauge
+
+A gauge is the one chart in this adapter whose reading is not in a series at all. amCharts draws the needle as an `AxisBullet` on an **axis** data item, so a `ClockHand` gauge commonly carries zero series and there is nothing for the per-series conversion to find. The adapter therefore asks the chart directly — but only after the series loop produced no layer, which is what keeps an ordinary radar or polar-area chart, drawn in the very same `RadarChart`, from ever reaching this path. A runnable page is at [`examples/amcharts-gauge.html`](https://github.com/xability/maidr/blob/main/examples/amcharts-gauge.html).
+
+```js
+var chart = root.container.children.push(am5radar.RadarChart.new(root, { startAngle: 160, endAngle: 380 }));
+var axis = chart.xAxes.push(am5xy.ValueAxis.new(root, {
+  min: 0, max: 100, strictMinMax: true,
+  renderer: am5radar.AxisRendererCircular.new(root, {}),
+}));
+// A band: MAIDR carries its UPPER edge only, since bands partition the range.
+axis.createAxisRange(axis.makeDataItem({ value: 50, endValue: 80 }));
+// The needle, and the value MAIDR reads.
+var handItem = axis.makeDataItem({ value: 73 });
+handItem.set("bullet", am5xy.AxisBullet.new(root, { sprite: am5radar.ClockHand.new(root, {}) }));
+axis.createAxisRange(handItem);
+```
+
+The payload is a **single object**, not an array of one: the chart draws exactly one measure, and an array would describe a shape it does not have. The dial's ends come from the axis' `min`/`max` settings, falling back to the extremes amCharts computed when the author fixed neither — never from the axis' `start`/`end`, which are relative zoom positions and would quietly report every gauge as a 0-to-1 dial. **A dial with no finite ends emits no layer at all.** `GaugeTrace` pitches its tone against the range rather than against the value, so a reading with no range behind it is not a reading, and a chart left with no layers is dropped rather than announced as a dial of `NaN`s.
+
+Bands are read from the axis' ranges: any range with a finite `endValue` becomes one, sorted ascending, and a band amCharts leaves unnamed is numbered by its position (`Band 1`, `Band 2`). The needle's own range carries a value and no end, which is exactly what keeps it out of the band list. A chart carrying several hands is read as its first, with a console warning.
+
+Two things are **not** read. A bullet chart's `target` marker is omitted: amCharts has no unambiguous construct for one, and a guessed target is a number the chart never stated. And the highlight outlines the `ClockHand` sprite itself — if that sprite reports no measurable box, the overlay **clears** rather than falling back to the chart, because a box drawn around the whole dial says nothing about where the needle is.
 
 ### Diverging Bar / Population Pyramid
 

--- a/examples/amcharts-choropleth.html
+++ b/examples/amcharts-choropleth.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Choropleth</title>
+
+    <!-- 1. Load amCharts 5. `map.js` carries the MapChart and its polygon
+         series; the geodata file carries the shapes themselves. A MapChart is
+         a SerialChart: a series list and no axes, which is why the adapter
+         recognises it by its class name the way it does a PieChart. -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/map.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/geodata/usaLow.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over the chart, so the core maidr.js
+         script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 720px;
+        height: 440px;
+      }
+      .note {
+        background: #f4f4f4;
+        border-left: 4px solid #666;
+        padding: 12px 16px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Choropleth</h1>
+    <p>
+      A choropleth shades places by a value. What a reader gets from one is
+      <strong>spatial</strong> — where the high values sit, which way the
+      gradient runs — so MAIDR bands the regions by latitude and reads each band
+      west to east: Up is north, Right is east.
+    </p>
+    <p class="note">
+      <strong>That walk comes out of centroids in degrees, and out of nothing
+      else.</strong> The adapter reads them from your own row first and from the
+      drawn polygon's <code>geoCentroid()</code> second, and
+      <strong>omits the pair</strong> when neither answers in degrees — a
+      projected coordinate announced as a degree would be a wrong compass
+      direction. Without the pair the map is still read, still navigable and
+      still outlined; it is simply a region list in declared order.
+    </p>
+
+    <h2>Detected: a polygon series bound to a value</h2>
+    <p>
+      No declaration needed. A <code>MapPolygonSeries</code> with a
+      <code>valueField</code> (or <code>heatRules</code>) is a choropleth; the
+      base geography drawn under it, and any lines or pins, are skipped.
+    </p>
+    <div id="detected-chart" class="chart"></div>
+
+    <h2>Declared: the centroids stated on the row</h2>
+    <p>
+      The same map, with the coordinates and the state's own name read off
+      columns amCharts was never bound to. This is what guarantees the north /
+      south / east / west walk rather than leaving it to
+      <code>geoCentroid()</code>.
+    </p>
+    <div id="declared-chart" class="chart"></div>
+
+    <script>
+      // Age-adjusted rate per 100,000 -- illustrative figures, not real ones.
+      // `id` is what amCharts joins the row to a shape by; every other column
+      // is the author's own and reaches MAIDR through the declaration.
+      var STATES = [
+        { id: "US-WA", state: "Washington", rate: 12.1, east: -120.5, north: 47.4 },
+        { id: "US-OR", state: "Oregon", rate: 16.4, east: -120.6, north: 43.9 },
+        { id: "US-ID", state: "Idaho", rate: 21.7, east: -114.6, north: 44.4 },
+        { id: "US-NV", state: "Nevada", rate: 38.9, east: -116.6, north: 39.3 },
+        { id: "US-UT", state: "Utah", rate: 19.2, east: -111.7, north: 39.3 },
+        { id: "US-CA", state: "California", rate: 27.5, east: -119.4, north: 37.2 },
+        { id: "US-AZ", state: "Arizona", rate: 31.4, east: -111.7, north: 34.3 },
+        { id: "US-NM", state: "New Mexico", rate: 24.8, east: -106.1, north: 34.4 },
+      ];
+
+      /**
+       * One MapChart with a shaded polygon series.
+       *
+       * `valueField` is what makes the series a reading rather than a drawing:
+       * with neither it nor `heatRules`, the adapter treats it as the base
+       * geography and skips it.
+       */
+      function mapChart(divId, userData) {
+        var root = am5.Root.new(divId);
+        var chart = root.container.children.push(
+          am5map.MapChart.new(root, {
+            projection: am5map.geoAlbersUsa(),
+            panX: "none",
+            panY: "none",
+            wheelY: "none",
+          })
+        );
+
+        var series = chart.series.push(
+          am5map.MapPolygonSeries.new(root, {
+            geoJSON: am5geodata_usaLow,
+            valueField: "rate",
+            calculateAggregates: true,
+            // The block below names the author's own columns. Omitted, the
+            // adapter reads what amCharts resolved and the polygons' own
+            // centroids -- see the second panel's comment.
+            userData: userData,
+          })
+        );
+
+        series.mapPolygons.template.setAll({
+          tooltipText: "{name}: {rate}",
+          stroke: am5.color(0xffffff),
+          strokeWidth: 0.5,
+        });
+        series.set("heatRules", [{
+          target: series.mapPolygons.template,
+          dataField: "value",
+          key: "fill",
+          min: am5.color(0xe8eef8),
+          max: am5.color(0x1f3f8f),
+        }]);
+
+        series.data.setAll(STATES);
+        return root;
+      }
+
+      var detectedRoot = mapChart("detected-chart");
+
+      // `region`, `lon` and `lat` name columns of the rows above. `value` is
+      // left out: the series is already bound to `rate`, so the chart itself
+      // says what the shading is.
+      var declaredRoot = mapChart("declared-chart", {
+        maidr: {
+          type: "choropleth",
+          region: "state",
+          lon: "east",
+          lat: "north",
+        },
+      });
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR on each panel via the
+         `maidrAmCharts` UMD global. In production, prefer listening to the
+         series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      setTimeout(function () {
+        var panels = [
+          [detectedRoot, "Rate per 100,000, Western States"],
+          [declaredRoot, "Rate per 100,000, Western States (declared centroids)"],
+        ];
+        panels.forEach(function (panel) {
+          try {
+            maidrAmCharts.bindAmCharts(panel[0], {
+              title: panel[1],
+              // A map is bound to no axis; drop these and the adapter falls
+              // back to "Region" and "Value".
+              axisLabels: { x: "State", y: "Rate per 100,000" },
+            });
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed for ' + panel[1] + ':', err);
+          }
+        });
+      }, 1200);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-flow.html
+++ b/examples/amcharts-flow.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Flow &amp; Network</title>
+
+    <!-- 1. Load amCharts 5. `flow.js` carries the sankey and the chord;
+         `hierarchy.js` carries the force-directed network, which amCharts
+         builds as a hierarchy series rather than as a link list. Like a
+         treemap, none of these is a chart: each is a series pushed straight
+         into the root container. -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/flow.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/hierarchy.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over the chart, so the core maidr.js
+         script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 720px;
+        height: 460px;
+      }
+      .note {
+        background: #f4f4f4;
+        border-left: 4px solid #666;
+        padding: 12px 16px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Flow &amp; Network</h1>
+    <p>
+      Four readings of one idea: a weighted graph. A <strong>sankey</strong>
+      budgets it left to right, an <strong>alluvial</strong> re-divides the same
+      quantity between categories that stay put, a <strong>chord</strong> draws
+      it as a circle, and a <strong>network</strong> drops the weights and keeps
+      only who is connected to whom.
+    </p>
+    <p class="note">
+      <strong>These four types are read but not outlined.</strong> They sonify,
+      describe, braille and navigate correctly; the canvas highlight simply
+      clears as the cursor moves. Recovering which node the cursor is on would
+      mean reimplementing MAIDR's own node ordering and stage layering inside
+      the adapter, and a copy of that would drift silently and then outline a
+      confidently wrong node. See <code>docs/amcharts.md</code>.
+    </p>
+
+    <h2>Sankey</h2>
+    <p>
+      One point per link, and the nodes are derived from the ends — the node
+      list amCharts keeps separately is deliberately not read.
+    </p>
+    <div id="sankey-chart" class="chart"></div>
+
+    <h2>Alluvial (declared)</h2>
+    <p>
+      amCharts has no alluvial class: an alluvial <em>is</em> a sankey, drawn
+      with the nodes repeated across stages. Only the author can say which of
+      the two the drawing stands for, so this one carries a
+      <code>userData.maidr</code> block and nothing else changes.
+    </p>
+    <div id="alluvial-chart" class="chart"></div>
+
+    <h2>Chord</h2>
+    <p>
+      A chord graph is cyclic, and MAIDR lays a flow's nodes out by their
+      longest distance from a source. A cycle has no such layering, so every
+      node collapses into one stage by design — navigation and sonification are
+      correct, and the trace claims no left-to-right order it does not have.
+    </p>
+    <div id="chord-chart" class="chart"></div>
+
+    <h2>Network (force-directed)</h2>
+    <p>
+      A hierarchy series rather than a link list: the links are the tree's own
+      parent-child edges plus whatever cross-links each row names in
+      <code>linkWith</code>. Where the solver put each node is a fact about its
+      seed rather than about the data, so nothing about the layout is read.
+    </p>
+    <div id="network-chart" class="chart"></div>
+
+    <script>
+      var ENERGY = [
+        { from: "Coal", to: "Electricity", value: 34 },
+        { from: "Gas", to: "Electricity", value: 21 },
+        { from: "Nuclear", to: "Electricity", value: 18 },
+        { from: "Wind", to: "Electricity", value: 12 },
+        { from: "Electricity", to: "Homes", value: 40 },
+        { from: "Electricity", to: "Industry", value: 33 },
+        { from: "Gas", to: "Homes", value: 15 },
+      ];
+
+      // An alluvial re-divides one quantity between categories that persist,
+      // so the same names appear at every stage.
+      var BUDGET = [
+        { from: "2022 Housing", to: "2023 Housing", value: 40 },
+        { from: "2022 Housing", to: "2023 Savings", value: 8 },
+        { from: "2022 Travel", to: "2023 Housing", value: 6 },
+        { from: "2022 Travel", to: "2023 Travel", value: 14 },
+        { from: "2022 Savings", to: "2023 Savings", value: 22 },
+        { from: "2022 Savings", to: "2023 Travel", value: 5 },
+      ];
+
+      var TRADE = [
+        { from: "Europe", to: "Asia", value: 31 },
+        { from: "Asia", to: "Americas", value: 24 },
+        { from: "Americas", to: "Europe", value: 19 },
+        { from: "Asia", to: "Africa", value: 11 },
+        { from: "Africa", to: "Europe", value: 9 },
+      ];
+
+      var PEOPLE = [{
+        name: "Computing",
+        children: [
+          {
+            name: "Ada",
+            linkWith: ["Grace"],
+            children: [
+              { name: "Alan" },
+              { name: "Grace" },
+            ],
+          },
+          { name: "Edsger", linkWith: ["Alan"] },
+          { name: "Barbara", linkWith: ["Grace", "Edsger"] },
+        ],
+      }];
+
+      /** A flow series of the given class, pushed straight into its own root. */
+      function flowChart(divId, Kind, data, userData) {
+        var root = am5.Root.new(divId);
+        var series = root.container.children.push(
+          Kind.new(root, {
+            sourceIdField: "from",
+            targetIdField: "to",
+            valueField: "value",
+            // The block below is what separates an alluvial from the sankey it
+            // is drawn as. Omitted, the same chart reads as a sankey.
+            userData: userData,
+          })
+        );
+        series.data.setAll(data);
+        return root;
+      }
+
+      var sankeyRoot = flowChart("sankey-chart", am5flow.Sankey, ENERGY);
+      var alluvialRoot = flowChart("alluvial-chart", am5flow.Sankey, BUDGET, {
+        maidr: { type: "alluvial" },
+      });
+      var chordRoot = flowChart("chord-chart", am5flow.ChordDirected, TRADE);
+
+      var networkRoot = am5.Root.new("network-chart");
+      var network = networkRoot.container.children.push(
+        am5hierarchy.ForceDirected.new(networkRoot, {
+          categoryField: "name",
+          childDataField: "children",
+          // `idField` names the column a cross-link refers to; `linkWithField`
+          // names the column holding those references.
+          idField: "name",
+          linkWithField: "linkWith",
+          manyBodyStrength: -12,
+          centerStrength: 0.5,
+        })
+      );
+      network.data.setAll(PEOPLE);
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR on each panel via the
+         `maidrAmCharts` UMD global. In production, prefer listening to the
+         series' "datavalidated" event instead of a fixed timeout. -->
+    <script>
+      setTimeout(function () {
+        var panels = [
+          [sankeyRoot, "Energy Flow", { x: "Node", y: "Terawatt-hours" }],
+          [alluvialRoot, "Where the Budget Moved", { x: "Category", y: "Thousands" }],
+          [chordRoot, "Trade Between Regions", { x: "Region", y: "Billions" }],
+          // A network is bound to no axis and carries no weight; drop these and
+          // the adapter falls back to "Node" and "Links".
+          [networkRoot, "Who Worked With Whom", { x: "Person", y: "Connections" }],
+        ];
+        panels.forEach(function (panel) {
+          try {
+            maidrAmCharts.bindAmCharts(panel[0], {
+              title: panel[1],
+              axisLabels: panel[2],
+            });
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed for ' + panel[1] + ':', err);
+          }
+        });
+      }, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-gauge.html
+++ b/examples/amcharts-gauge.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + amCharts 5 Gauge</title>
+
+    <!-- 1. Load amCharts 5 (core + xy + radar). A gauge is a RadarChart with a
+         circular value axis and a ClockHand pinned to an axis data item. -->
+    <script src="https://cdn.amcharts.com/lib/5/index.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/xy.js"></script>
+    <script src="https://cdn.amcharts.com/lib/5/radar.js"></script>
+
+    <!-- 2. Load the MAIDR amCharts adapter (UMD). `bindAmCharts` mounts the
+         full MAIDR app (React bundled in) over each chart, so the core
+         maidr.js script is not needed here. -->
+    <script type="text/javascript" src="../dist/amcharts.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .chart {
+        width: 640px;
+        height: 420px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + amCharts 5 Gauge</h1>
+    <p>
+      A gauge is the one amCharts chart whose reading is not in a series at
+      all: the needle is an <code>AxisBullet</code> on an <em>axis</em> data
+      item, so the chart commonly carries zero series. MAIDR reads it from the
+      chart instead.
+    </p>
+    <p>
+      "73" on its own is not a reading. The announcement carries the dial's
+      ends and the band the needle landed in, because neither is written
+      anywhere a screen reader can reach on a drawn gauge. The tone is pitched
+      against the range rather than against the value, so where the needle sits
+      on the dial is what you hear.
+    </p>
+
+    <h2>Server load, banded</h2>
+    <div id="gauge-chart" class="chart"></div>
+
+    <script>
+      window.__amBindings = [];
+
+      var root = am5.Root.new("gauge-chart");
+
+      var chart = root.container.children.push(
+        am5radar.RadarChart.new(root, {
+          panX: false,
+          panY: false,
+          startAngle: 160,
+          endAngle: 380,
+        })
+      );
+
+      // The dial. `min` and `max` are what MAIDR reads the range from; leave
+      // them out and the adapter falls back to the extremes amCharts computes.
+      var axis = chart.xAxes.push(
+        am5xy.ValueAxis.new(root, {
+          min: 0,
+          max: 100,
+          strictMinMax: true,
+          renderer: am5radar.AxisRendererCircular.new(root, { minGridDistance: 30 }),
+        })
+      );
+      axis.set("title", am5.Label.new(root, { text: "Load, percent" }));
+
+      // Qualitative bands. MAIDR carries each band's UPPER edge only -- a band
+      // starts where the previous one ended -- and numbers the ones nothing
+      // names, so give them labels if the reader should hear them.
+      var BANDS = [
+        { from: 0, to: 50, label: "healthy", color: 0x33aa33 },
+        { from: 50, to: 80, label: "busy", color: 0xddaa22 },
+        { from: 80, to: 100, label: "saturated", color: 0xcc3333 },
+      ];
+      BANDS.forEach(function (band) {
+        var range = axis.createAxisRange(
+          axis.makeDataItem({ value: band.from, endValue: band.to })
+        );
+        range.get("axisFill").setAll({ visible: true, fill: am5.color(band.color) });
+        range.set("label", am5.Label.new(root, { text: band.label }));
+        range.get("label").setAll({ visible: false });
+      });
+
+      // The needle. A ClockHand is a Container of primitives, so unlike a Slice
+      // it reports a real box -- which is what the MAIDR overlay outlines.
+      var handItem = axis.makeDataItem({ value: 73 });
+      var hand = handItem.set(
+        "bullet",
+        am5xy.AxisBullet.new(root, {
+          sprite: am5radar.ClockHand.new(root, {
+            radius: am5.percent(80),
+          }),
+        })
+      );
+      axis.createAxisRange(handItem);
+
+      window.__amBindings.push({
+        root: root,
+        options: { title: "Server Load" },
+      });
+    </script>
+
+    <!-- After amCharts finishes rendering, mount MAIDR (with canvas highlight)
+         on each chart via the `maidrAmCharts` UMD global. In production, prefer
+         listening to the chart's "frameended" event instead of a fixed timeout. -->
+    <script>
+      function bindAll() {
+        for (const b of (window.__amBindings || [])) {
+          try {
+            maidrAmCharts.bindAmCharts(b.root, b.options);
+          } catch (err) {
+            console.error('MAIDR amCharts bind failed:', err);
+          }
+        }
+      }
+
+      setTimeout(bindAll, 1500);
+    </script>
+  </body>
+</html>

--- a/examples/amcharts-treemap.html
+++ b/examples/amcharts-treemap.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>MAIDR + amCharts 5 Treemap and Icicle</title>
+    <title>MAIDR + amCharts 5 Treemap, Icicle and Sunburst</title>
 
     <!-- 1. Load amCharts 5 (core + hierarchy charts). A hierarchy layout is not
          a chart: it is a series pushed straight into the root container. -->
@@ -31,12 +31,13 @@
   </head>
 
   <body>
-    <h1>MAIDR + amCharts 5 Treemap and Icicle</h1>
+    <h1>MAIDR + amCharts 5 Treemap, Icicle and Sunburst</h1>
     <p>
-      A treemap and an icicle draw the same tree with different marks — nested
-      rectangles against stacked bands — so MAIDR reads them the same way: as a
-      tree rather than as a grid. Left and Right move between siblings, Down
-      steps into a node's children, and Up returns to its parent.
+      A treemap, an icicle and a sunburst draw the same tree with different
+      marks — nested rectangles, stacked bands, and the same bands bent into
+      rings — so MAIDR reads all three the same way: as a tree rather than as a
+      grid. Left and Right move between siblings, Down steps into a node's
+      children, and Up returns to its parent.
     </p>
     <p>
       Only the leaves carry a value here. Every branch total is derived from
@@ -49,6 +50,9 @@
 
     <h2>Icicle: the same tree, drawn as bands</h2>
     <div id="icicle-chart" class="chart"></div>
+
+    <h2>Sunburst: the same bands, bent into rings</h2>
+    <div id="sunburst-chart" class="chart"></div>
 
     <script>
       // Collects { root, options } for each chart so the block below can mount
@@ -136,6 +140,15 @@
         "World Population by Region, as an Icicle",
         am5hierarchy.Partition,
         { orientation: "vertical" }
+      );
+      // A Sunburst extends Partition but carries its own class name, which is
+      // why the adapter names it in its own right rather than inheriting the
+      // icicle's reading. Its nodes are drawn as wedges, so the highlight
+      // measures them the way it measures a pie slice.
+      makeHierarchy(
+        "sunburst-chart",
+        "World Population by Region, as a Sunburst",
+        am5hierarchy.Sunburst
       );
     </script>
 

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -26,6 +26,7 @@
 import type {
   BarPoint,
   DumbbellData,
+  FlowPoint,
   GanttData,
   GaugePoint,
   HeatmapData,
@@ -34,6 +35,7 @@ import type {
   Maidr,
   MaidrLayer,
   MaidrSubplot,
+  NetworkPoint,
   PiePoint,
   SegmentedPoint,
   TreemapPoint,
@@ -62,12 +64,14 @@ import {
   classifySeriesKind,
   extractBarPoints,
   extractDumbbellPoints,
+  extractFlowPoints,
   extractGanttData,
   extractGaugePoint,
   extractHeatmapData,
   extractHierarchyPoints,
   extractHistogramPoints,
   extractLinePoints,
+  extractNetworkPoints,
   extractPiePoints,
   extractSegmentedPoints,
   extractWaterfallPoints,
@@ -293,7 +297,7 @@ function buildChartLayers(
     }
     const declared = plan.declared.get(series);
     if (declared) {
-      const layer = buildDeclaredLayer(declared, xLabel, yLabel, containerEl);
+      const layer = buildDeclaredLayer(declared, xLabel, yLabel, containerEl, options);
       if (layer) {
         layers.push(layer);
       }
@@ -402,6 +406,25 @@ function buildChartLayers(
         if (data.length === 0)
           break;
         layers.push(buildWordCloudLayer(series, data, options));
+        break;
+      }
+      case 'sankey':
+      case 'chord': {
+        // One weighted graph drawn two ways; only the announced type differs.
+        // An `ArcDiagram` lands here as a sankey — it carries weights, which a
+        // network payload has nowhere to put.
+        const data = extractFlowPoints(series);
+        if (data.length === 0)
+          break;
+        const type = kind === 'chord' ? TraceType.CHORD : TraceType.SANKEY;
+        layers.push(buildFlowLayer(series, type, data, options));
+        break;
+      }
+      case 'network': {
+        const data = extractNetworkPoints(series);
+        if (data.length === 0)
+          break;
+        layers.push(buildNetworkLayer(series, data, options));
         break;
       }
       default:
@@ -521,7 +544,7 @@ function areaTraceType(areaSeriesList: AmXYSeries[]): MergedTraceType {
 /**
  * Builds the layer one co-located `maidr` declaration describes.
  *
- * These are the six readings amCharts leaves no signature for: a survival curve
+ * These are the readings amCharts leaves no signature for: a survival curve
  * and a step line are one series class, an error bar is a floating column
  * behind another series, and a volcano, a Manhattan and a plain scatter are all
  * a `LineSeries` with the stroke switched off. Nothing here is guessed — every
@@ -537,6 +560,7 @@ function buildDeclaredLayer(
   xLabel: string,
   yLabel: string,
   containerEl: HTMLElement,
+  options?: AmChartsBinderOptions,
 ): MaidrLayer | null {
   const declaration = declared.declaration;
   const axes = { x: { label: xLabel }, y: { label: yLabel } };
@@ -546,6 +570,26 @@ function buildDeclaredLayer(
   };
 
   switch (declaration.type) {
+    // The one declared type whose payload is a graph rather than a series of
+    // marks — and the one the chart already carries whole. An alluvial IS an
+    // `am5flow.Sankey`; what the author declared is which of the two readings
+    // the drawing stands for, so nothing beyond the type is taken from the
+    // block. Bound to no axis, so it names its own dimensions rather than
+    // taking the chart's — and it emits no selectors and gets no highlight,
+    // exactly as an undeclared sankey does.
+    case TraceType.ALLUVIAL: {
+      const data = extractFlowPoints(declared.series);
+      if (data.length === 0) {
+        return null;
+      }
+      return {
+        ...named,
+        type: TraceType.ALLUVIAL,
+        title: declaration.title ?? seriesName(declared.series),
+        axes: flowAxes(options),
+        data,
+      };
+    }
     case TraceType.SURVIVAL: {
       const { data } = extractSurvivalArms(declared);
       if (data.length === 0) {
@@ -615,7 +659,7 @@ function buildDeclaredLayer(
         data,
       };
     }
-    // Named rather than defaulted, so that a seventh member of `AmDeclaration`
+    // Named rather than defaulted, so that a further member of `AmDeclaration`
     // fails to compile here instead of being read out as a plain scatter.
     case TraceType.SCATTER: {
       const data = extractScatterPoints(declared);
@@ -895,6 +939,85 @@ function buildHierarchyLayer(
     axes: {
       x: { label: options?.axisLabels?.x ?? HIERARCHY_NODE_AXIS },
       y: { label: options?.axisLabels?.y ?? HIERARCHY_VALUE_AXIS },
+    },
+    data,
+  };
+}
+
+/**
+ * What a flow diagram's two dimensions are called. A sankey, an alluvial, a
+ * chord and an arc diagram are all bound to no axis, and what a reader is
+ * after at a node is how much moves through it.
+ */
+const FLOW_NODE_AXIS = 'Node';
+const FLOW_WEIGHT_AXIS = 'Weight';
+
+/** The axes every flow layer names, with the figure-wide override applied. */
+function flowAxes(options?: AmChartsBinderOptions): MaidrLayer['axes'] {
+  return {
+    x: { label: options?.axisLabels?.x ?? FLOW_NODE_AXIS },
+    y: { label: options?.axisLabels?.y ?? FLOW_WEIGHT_AXIS },
+  };
+}
+
+/**
+ * Builds the layer for one am5flow series — a `Sankey`, one of the three
+ * `Chord` variants, or the `ArcDiagram` that draws the same weighted links
+ * along a line.
+ *
+ * All of them are one weighted graph declared as one point per link, so they
+ * differ here only in which trace type they announce; MAIDR reads all of them
+ * with the same `FlowTrace`. The arc diagram is announced as a sankey because
+ * it carries weights, and MAIDR's network payload has nowhere to put one.
+ *
+ * No `selectors`, for the reason a pie and a treemap emit none — amCharts
+ * paints the ribbons into a canvas. **And no highlight either**: the position
+ * MAIDR hands back for a flow trace is a braille one, `(stage, index within
+ * stage)`, and turning that back into a node would mean reimplementing the
+ * model's own node ordering and stage layering here. See `docs/amcharts.md`;
+ * the overlay clears rather than outlining a guessed node.
+ */
+function buildFlowLayer(
+  series: AmXYSeries,
+  type: TraceType.SANKEY | TraceType.CHORD,
+  data: FlowPoint[],
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  return {
+    id: layerId(series),
+    type,
+    ...(seriesName(series) ? { title: seriesName(series) } : {}),
+    axes: flowAxes(options),
+    data,
+  };
+}
+
+/**
+ * What a network's two dimensions are called. A force-directed graph is bound
+ * to no axis either, and what a reader is after at a node is its degree.
+ */
+const NETWORK_NODE_AXIS = 'Node';
+const NETWORK_LINK_AXIS = 'Links';
+
+/**
+ * Builds the layer for one `am5hierarchy.ForceDirected` series.
+ *
+ * Nothing about where the solver put the nodes is carried: the position is a
+ * fact about its seed rather than about the data. No selectors and no
+ * highlight, for the same reasons the flow layer has none.
+ */
+function buildNetworkLayer(
+  series: AmXYSeries,
+  data: NetworkPoint[],
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  return {
+    id: layerId(series),
+    type: TraceType.NETWORK,
+    ...(seriesName(series) ? { title: seriesName(series) } : {}),
+    axes: {
+      x: { label: options?.axisLabels?.x ?? NETWORK_NODE_AXIS },
+      y: { label: options?.axisLabels?.y ?? NETWORK_LINK_AXIS },
     },
     data,
   };

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -25,6 +25,7 @@
 
 import type {
   BarPoint,
+  ChoroplethPoint,
   DumbbellData,
   FlowPoint,
   GanttData,
@@ -50,6 +51,7 @@ import type {
 } from './types';
 import { Orientation, TraceType } from '@type/grammar';
 import {
+  choroplethFields,
   extractErrorBarSamples,
   extractForestSamples,
   extractScatterPoints,
@@ -63,6 +65,7 @@ import {
 import {
   classifySeriesKind,
   extractBarPoints,
+  extractChoroplethPoints,
   extractDumbbellPoints,
   extractFlowPoints,
   extractGanttData,
@@ -427,6 +430,16 @@ function buildChartLayers(
         layers.push(buildNetworkLayer(series, data, options));
         break;
       }
+      case 'choropleth': {
+        // A polygon series whose regions all missed their join carries no
+        // reading at all; the panel is then dropped rather than emitted as a
+        // map of nothing.
+        const data = extractChoroplethPoints(series);
+        if (data.length === 0)
+          break;
+        layers.push(buildChoroplethLayer(series, data, options));
+        break;
+      }
       default:
         // Skip unsupported series types.
         break;
@@ -587,6 +600,23 @@ function buildDeclaredLayer(
         type: TraceType.ALLUVIAL,
         title: declaration.title ?? seriesName(declared.series),
         axes: flowAxes(options),
+        data,
+      };
+    }
+    // A map amCharts already draws as regions, declared so the author can say
+    // which of their own columns each fact lives in. Bound to no axis, so it
+    // names its own dimensions; no selectors, because the polygons are painted
+    // into a canvas and the overlay outlines them instead.
+    case TraceType.CHOROPLETH: {
+      const data = extractChoroplethPoints(declared.series, choroplethFields(declaration));
+      if (data.length === 0) {
+        return null;
+      }
+      return {
+        ...named,
+        type: TraceType.CHOROPLETH,
+        title: declaration.title ?? seriesName(declared.series),
+        axes: choroplethAxes(options),
         data,
       };
     }
@@ -993,6 +1023,45 @@ function buildFlowLayer(
 }
 
 /**
+ * What a choropleth's two dimensions are called. A map is bound to no axis a
+ * title could be read from — the value runs along a colour ramp and the
+ * regions along nothing at all — so the chart-level fallback would name them
+ * after coordinates the chart does not have. The same two names the Highcharts
+ * adapter gives a `map` series.
+ */
+const CHOROPLETH_REGION_AXIS = 'Region';
+const CHOROPLETH_VALUE_AXIS = 'Value';
+
+/** The axes every choropleth layer names, with the figure-wide override applied. */
+function choroplethAxes(options?: AmChartsBinderOptions): MaidrLayer['axes'] {
+  return {
+    x: { label: options?.axisLabels?.x ?? CHOROPLETH_REGION_AXIS },
+    y: { label: options?.axisLabels?.y ?? CHOROPLETH_VALUE_AXIS },
+  };
+}
+
+/**
+ * Builds the layer for one am5map `MapPolygonSeries` shaded by a value.
+ *
+ * No `selectors`, for the reason a pie emits none — amCharts paints the
+ * polygons into a canvas. The binder's overlay outlines the active region
+ * instead, from the box the drawn polygon reports.
+ */
+function buildChoroplethLayer(
+  series: AmXYSeries,
+  data: ChoroplethPoint[],
+  options?: AmChartsBinderOptions,
+): MaidrLayer {
+  return {
+    id: layerId(series),
+    type: TraceType.CHOROPLETH,
+    ...(seriesName(series) ? { title: seriesName(series) } : {}),
+    axes: choroplethAxes(options),
+    data,
+  };
+}
+
+/**
  * What a network's two dimensions are called. A force-directed graph is bound
  * to no axis either, and what a reader is after at a node is its degree.
  */
@@ -1352,6 +1421,11 @@ function collectCharts(node: unknown, found: AmChart[]): void {
       found.push(child);
       continue;
     }
+    const map = asMapPanel(child);
+    if (map) {
+      found.push(map);
+      continue;
+    }
     const standalone = asStandalonePanel(child);
     if (standalone) {
       found.push(standalone);
@@ -1402,6 +1476,60 @@ function isPercentChartLike(candidate: unknown): candidate is AmChart {
   return typeof c.className === 'string'
     && PERCENT_CHART_CLASSES.has(c.className)
     && Boolean(c.series);
+}
+
+/**
+ * The am5map chart class a choropleth is drawn in.
+ *
+ * A `MapChart` is a `SerialChart`: it has a series list and no axes, which is
+ * the same signature an am5percent chart carries — so the class name is what
+ * separates them, exactly as it does there.
+ */
+const MAP_CHART_CLASSES = new Set([
+  'MapChart',
+]);
+
+/**
+ * Wrap an am5map `MapChart` as a panel.
+ *
+ * The one chart in the library that discovery could not see. It answers to
+ * neither {@link isXYChartLike} (no axes) nor {@link isPercentChartLike} (a
+ * class name of its own), so `collectCharts` used to recurse straight past it
+ * into its own containers and surface nothing.
+ *
+ * The wrapper exists for one read: `plotContainer`. A `MapChart` has none —
+ * that is an `XYChart` notion — but it IS a `Container`, so pointing the slot
+ * at the chart itself answers `globalBounds()` / `toGlobal()` / `width()` /
+ * `height()`, which is all {@link readPlotBounds} asks for. That keeps
+ * multi-panel highlight clipping and {@link computeChartGrid} working on the
+ * same reads every other panel uses; without it a map beside another chart
+ * would have its highlight suppressed outright.
+ *
+ * The same trick {@link asStandalonePanel} uses to give a bare series the
+ * shape of a chart, and the `children` list is carried across so the panel
+ * keeps its title.
+ *
+ * @returns The wrapped panel, or `null` for anything that is not one.
+ */
+function asMapPanel(candidate: unknown): AmChart | null {
+  if (candidate == null || typeof candidate !== 'object')
+    return null;
+
+  const chart = candidate as AmChart;
+  if (typeof chart.className !== 'string' || !MAP_CHART_CLASSES.has(chart.className))
+    return null;
+  if (!Array.isArray(chart.series?.values))
+    return null;
+
+  const children = (candidate as { children?: unknown }).children;
+  return {
+    className: chart.className,
+    uid: chart.uid,
+    get: key => chart.get(key),
+    series: chart.series,
+    ...(children != null ? { children } : {}),
+    plotContainer: chart as AmChart['plotContainer'],
+  } as AmChart;
 }
 
 /**

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -27,6 +27,7 @@ import type {
   BarPoint,
   DumbbellData,
   GanttData,
+  GaugePoint,
   HeatmapData,
   HistogramPoint,
   LinePoint,
@@ -62,6 +63,7 @@ import {
   extractBarPoints,
   extractDumbbellPoints,
   extractGanttData,
+  extractGaugePoint,
   extractHeatmapData,
   extractHierarchyPoints,
   extractHistogramPoints,
@@ -69,6 +71,7 @@ import {
   extractPiePoints,
   extractSegmentedPoints,
   extractWaterfallPoints,
+  findGaugeHand,
   hasRankAxis,
   holdsRanks,
   isColumnSeries,
@@ -384,7 +387,8 @@ function buildChartLayers(
         break;
       }
       case 'treemap':
-      case 'icicle': {
+      case 'icicle':
+      case 'sunburst': {
         const data = extractHierarchyPoints(series);
         if (data.length === 0)
           break;
@@ -428,6 +432,19 @@ function buildChartLayers(
   pushMerged(layers, merged.area, areaTraceType(areaSeriesList), xLabel, yLabel);
   pushMerged(layers, merged.radar, TraceType.RADAR, xLabel, yLabel);
   pushMerged(layers, merged.polar, TraceType.POLAR_AREA, xLabel, yLabel);
+
+  // A ClockHand gauge is the one chart whose reading is not in a series at
+  // all: the needle is an `AxisBullet` on an *axis* data item, so a gauge
+  // commonly carries zero series and the loop above found nothing to convert.
+  // Asked last, and only of a chart that produced no layer, which is what
+  // keeps an ordinary radar or polar chart — drawn in the same `RadarChart` —
+  // from ever reaching this path.
+  if (layers.length === 0) {
+    const gauge = buildGaugeLayer(chart, options);
+    if (gauge) {
+      layers.push(gauge);
+    }
+  }
 
   return layers;
 }
@@ -848,21 +865,26 @@ const HIERARCHY_VALUE_AXIS = 'Value';
 const HIERARCHY_TRACE_TYPES = {
   treemap: TraceType.TREEMAP,
   icicle: TraceType.ICICLE,
+  sunburst: TraceType.SUNBURST,
 } as const;
 
 /**
- * Builds the layer for one am5hierarchy series — a treemap, or the icicle
- * amCharts calls a `Partition`.
+ * Builds the layer for one am5hierarchy series — a treemap, the icicle
+ * amCharts calls a `Partition`, or the `Sunburst` that bends that icicle into
+ * a ring.
  *
- * The two draw the same tree with different marks, so they differ here only in
- * which trace type they name; MAIDR navigates both as a tree either way.
+ * The three draw the same tree with different marks, so they differ here only
+ * in which trace type they name; MAIDR navigates all three as a tree either
+ * way. What the mark does change is the highlight: a treemap block and an
+ * icicle bar are rectangles, and a sunburst node is a wedge, which the overlay
+ * has to measure differently — see `buildHierarchyResolver`.
  *
  * No `selectors`, for the reason a pie emits none — amCharts paints the nodes
- * into a canvas. The binder's overlay highlights the active node's rectangle.
+ * into a canvas. The binder's overlay highlights the active node's mark.
  */
 function buildHierarchyLayer(
   series: AmXYSeries,
-  kind: 'treemap' | 'icicle',
+  kind: 'treemap' | 'icicle' | 'sunburst',
   data: TreemapPoint[],
   options?: AmChartsBinderOptions,
 ): MaidrLayer {
@@ -873,6 +895,56 @@ function buildHierarchyLayer(
     axes: {
       x: { label: options?.axisLabels?.x ?? HIERARCHY_NODE_AXIS },
       y: { label: options?.axisLabels?.y ?? HIERARCHY_VALUE_AXIS },
+    },
+    data,
+  };
+}
+
+/**
+ * What a gauge's two dimensions are called.
+ *
+ * A gauge is bound to an axis, but the axis is the *dial* — the range the
+ * reading sits in — and the thing being measured is named nowhere on it. The
+ * same split Highcharts' gauge converter makes.
+ */
+const GAUGE_MEASURE_AXIS = 'Measure';
+const GAUGE_DIAL_AXIS = 'Value';
+
+/**
+ * Builds the layer for an am5radar gauge, or `null` for any other chart.
+ *
+ * The only layer in this adapter built from a chart rather than from a series.
+ * amCharts draws a gauge's needle as an `AxisBullet` on an axis data item, so
+ * a ClockHand gauge carries no series at all and there is nothing for the
+ * series loop to find; `buildChartLayers` therefore asks this last, of a chart
+ * that produced no layer.
+ *
+ * `null` rather than a layer of `NaN`s when the dial has no finite ends: the
+ * caller drops a chart with no layers, which is the right degradation for a
+ * dial whose range cannot be read.
+ */
+function buildGaugeLayer(
+  chart: AmChart,
+  options?: AmChartsBinderOptions,
+): MaidrLayer | null {
+  const hand = findGaugeHand(chart);
+  if (!hand) {
+    return null;
+  }
+
+  const title = readChartTitle(chart);
+  const data: GaugePoint | null = extractGaugePoint(hand, title);
+  if (!data) {
+    return null;
+  }
+
+  return {
+    id: `amcharts-gauge-${chart.uid ?? counter()}`,
+    type: TraceType.GAUGE,
+    ...(title ? { title } : {}),
+    axes: {
+      x: { label: options?.axisLabels?.x ?? GAUGE_MEASURE_AXIS },
+      y: { label: options?.axisLabels?.y ?? readAxisLabel(hand.axis, GAUGE_DIAL_AXIS) },
     },
     data,
   };

--- a/src/adapters/amcharts/binder.tsx
+++ b/src/adapters/amcharts/binder.tsx
@@ -24,7 +24,7 @@
 import type { Maidr as MaidrData, NavigateCallback } from '@type/grammar';
 import type { JSX } from 'react';
 import type { Root as ReactRoot } from 'react-dom/client';
-import type { NavMap, SeriesGroups } from './navmap';
+import type { NavMap } from './navmap';
 import type {
   AmChart,
   AmChartsBinderOptions,
@@ -34,11 +34,9 @@ import { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
 import { convertCharts, findCharts } from './adapter';
-import { planDeclarations } from './declaration';
-import { classifySeriesKind } from './extractor';
 import { readPlotBounds, readSliceBounds } from './geometry';
 import { getHighlightColor } from './highlightColor';
-import { buildNavigationMap } from './navmap';
+import { buildNavigationMap, groupSeries } from './navmap';
 import { dataItemToOverlayRect, HighlightOverlay } from './overlay';
 
 /**
@@ -185,117 +183,6 @@ function createHighlightCallback(
       // Ignore highlight errors (e.g., during teardown or before layout).
     }
   };
-}
-
-// ---------------------------------------------------------------------------
-// Series grouping (mirrors fromXYChart in adapter.ts)
-// ---------------------------------------------------------------------------
-
-function groupSeries(chart: AmChart): SeriesGroups {
-  const groups: SeriesGroups = {
-    barSeriesList: [],
-    dotSeriesList: [],
-    lollipopSeriesList: [],
-    lineSeriesList: [],
-    stepSeriesList: [],
-    areaSeriesList: [],
-    radarSeriesList: [],
-    polarSeriesList: [],
-    histogramSeries: [],
-    heatmapSeries: [],
-    pieSeriesList: [],
-    funnelSeriesList: [],
-    waterfallSeriesList: [],
-    dumbbellSeriesList: [],
-    ganttSeriesList: [],
-    hierarchySeriesList: [],
-    wordCloudSeriesList: [],
-    declaredList: [],
-  };
-
-  // The same plan `buildChartLayers` builds, asked of the same chart: a
-  // declared series is never also classified, and an absorbed one is never a
-  // layer of its own — so the layer a reader hears and the mark the overlay
-  // outlines are always the same series.
-  const plan = planDeclarations(chart);
-
-  for (const series of chart.series.values) {
-    if (plan.absorbed.has(series)) {
-      continue;
-    }
-    const declared = plan.declared.get(series);
-    if (declared) {
-      groups.declaredList.push(declared);
-      continue;
-    }
-
-    switch (classifySeriesKind(series)) {
-      case 'bar':
-        groups.barSeriesList.push(series);
-        break;
-      // A dot and a lollipop read as a bar chart but are drawn with different
-      // marks, so the highlight measures different sprites and they keep
-      // buckets of their own.
-      case 'dot':
-        groups.dotSeriesList.push(series);
-        break;
-      case 'lollipop':
-        groups.lollipopSeriesList.push(series);
-        break;
-      // A bump chart's competitors are line series too. Whether the layer they
-      // merge into is read as ranks is a property of the group, decided where
-      // the layer is built, so the highlight path has one bucket for both.
-      case 'line':
-        groups.lineSeriesList.push(series);
-        break;
-      case 'step':
-        groups.stepSeriesList.push(series);
-        break;
-      case 'area':
-        groups.areaSeriesList.push(series);
-        break;
-      case 'radar':
-        groups.radarSeriesList.push(series);
-        break;
-      case 'polar':
-        groups.polarSeriesList.push(series);
-        break;
-      case 'histogram':
-        groups.histogramSeries.push(series);
-        break;
-      case 'heatmap':
-        groups.heatmapSeries.push(series);
-        break;
-      case 'pie':
-        groups.pieSeriesList.push(series);
-        break;
-      case 'funnel':
-        groups.funnelSeriesList.push(series);
-        break;
-      case 'waterfall':
-        groups.waterfallSeriesList.push(series);
-        break;
-      case 'dumbbell':
-        groups.dumbbellSeriesList.push(series);
-        break;
-      case 'gantt':
-        groups.ganttSeriesList.push(series);
-        break;
-      // A treemap and an icicle draw one tree two ways; the highlight walks
-      // the same nodes either way, so they share a bucket.
-      case 'treemap':
-      case 'icicle':
-        groups.hierarchySeriesList.push(series);
-        break;
-      case 'wordcloud':
-        groups.wordCloudSeriesList.push(series);
-        break;
-      default:
-        break;
-    }
-  }
-
-  return groups;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/amcharts/declaration.ts
+++ b/src/adapters/amcharts/declaration.ts
@@ -28,6 +28,7 @@
  */
 
 import type {
+  AlluvialDeclaration,
   ErrorBarDeclaration,
   ForestDeclaration,
   MaidrTraceDeclaration,
@@ -52,7 +53,14 @@ import {
   warnUnresolvedRef,
 } from '@adapters/shared/traceDeclaration';
 import { Orientation, TraceType } from '@type/grammar';
-import { classifySeriesKind, readXValue, toNumber, toStringOrNumber } from './extractor';
+import {
+  classifySeriesKind,
+  extractFlowPoints,
+  isFlowSeries,
+  readXValue,
+  toNumber,
+  toStringOrNumber,
+} from './extractor';
 
 /** How this adapter names itself in every warning it raises. */
 const ADAPTER = 'amCharts';
@@ -62,11 +70,20 @@ const ADAPTER = 'amCharts';
  *
  * The union is smaller than `MaidrTraceDeclaration` because a declaration is
  * still a claim about a drawing: there is no amCharts construct behind a
- * `hexbin` or a `choropleth`, and a block declaring one is reported rather than
- * read into a layer with nothing in it.
+ * `hexbin` or a `choropleth`, and a block declaring one is reported rather
+ * than read into a layer with nothing in it.
+ *
+ * `alluvial` is the odd member. Every other entry names a reading amCharts
+ * draws with a series class worn by something else; an alluvial has no class
+ * of its own at all, because it IS an `am5flow.Sankey` — the same weighted
+ * flow, drawn with the nodes repeated across stages rather than budgeted left
+ * to right. So the drawing cannot separate the two and the author has to, and
+ * the declaration carries nothing but which of the two it is: the nodes, the
+ * links and their weights are already in the chart.
  */
 export type AmDeclaration
-  = | ErrorBarDeclaration
+  = | AlluvialDeclaration
+    | ErrorBarDeclaration
     | ForestDeclaration
     | ManhattanDeclaration
     | ScatterDeclaration
@@ -241,6 +258,7 @@ function readDeclaration(series: AmXYSeries): MaidrTraceDeclaration | null {
 /** Whether a validated declaration is one an amCharts series can back. */
 function isDeclarable(declaration: MaidrTraceDeclaration): declaration is AmDeclaration {
   switch (declaration.type) {
+    case TraceType.ALLUVIAL:
     case TraceType.ERROR_BAR:
     case TraceType.FOREST:
     case TraceType.MANHATTAN:
@@ -437,6 +455,13 @@ function readMain(item: AmDataItem, series: AmXYSeries, horizontal: boolean): un
  */
 function backsDeclaration(series: AmXYSeries, declaration: AmDeclaration): boolean {
   switch (declaration.type) {
+    // Both halves are required. The class name is what says the chart drew a
+    // weighted flow at all — `type: 'alluvial'` on a pie series is the mistake
+    // this check exists to report — and the links are what say there is one to
+    // read: a flow series whose ends or weights the adapter cannot resolve
+    // would otherwise emit an alluvial layer with nothing in it.
+    case TraceType.ALLUVIAL:
+      return isFlowSeries(series) && extractFlowPoints(series).length > 0;
     case TraceType.SURVIVAL:
       return series.dataItems.some(item =>
         readXValue(item, series) != null && item.get('valueY') != null

--- a/src/adapters/amcharts/declaration.ts
+++ b/src/adapters/amcharts/declaration.ts
@@ -29,6 +29,7 @@
 
 import type {
   AlluvialDeclaration,
+  ChoroplethDeclaration,
   ErrorBarDeclaration,
   ForestDeclaration,
   MaidrTraceDeclaration,
@@ -45,6 +46,7 @@ import type {
   ThresholdOptions,
   VolcanoPoint,
 } from '@type/grammar';
+import type { ChoroplethFields } from './extractor';
 import type { AmChart, AmDataItem, AmXYSeries } from './types';
 import {
   isFlagValue,
@@ -55,8 +57,10 @@ import {
 import { Orientation, TraceType } from '@type/grammar';
 import {
   classifySeriesKind,
+  extractChoroplethPoints,
   extractFlowPoints,
   isFlowSeries,
+  isMapPolygonSeries,
   readXValue,
   toNumber,
   toStringOrNumber,
@@ -70,8 +74,14 @@ const ADAPTER = 'amCharts';
  *
  * The union is smaller than `MaidrTraceDeclaration` because a declaration is
  * still a claim about a drawing: there is no amCharts construct behind a
- * `hexbin` or a `choropleth`, and a block declaring one is reported rather
- * than read into a layer with nothing in it.
+ * `hexbin`, and a block declaring one is reported rather than read into a
+ * layer with nothing in it.
+ *
+ * `choropleth` is here for the ordinary reason and `alluvial` for a strange
+ * one. An `am5map.MapPolygonSeries` bound to a `valueField` is already read as
+ * a map with no declaration at all; declaring one says which of the author's
+ * own columns carries the region, the value or the centroid pair, for a map
+ * that hangs them somewhere amCharts was never told about.
  *
  * `alluvial` is the odd member. Every other entry names a reading amCharts
  * draws with a series class worn by something else; an alluvial has no class
@@ -83,6 +93,7 @@ const ADAPTER = 'amCharts';
  */
 export type AmDeclaration
   = | AlluvialDeclaration
+    | ChoroplethDeclaration
     | ErrorBarDeclaration
     | ForestDeclaration
     | ManhattanDeclaration
@@ -259,6 +270,7 @@ function readDeclaration(series: AmXYSeries): MaidrTraceDeclaration | null {
 function isDeclarable(declaration: MaidrTraceDeclaration): declaration is AmDeclaration {
   switch (declaration.type) {
     case TraceType.ALLUVIAL:
+    case TraceType.CHOROPLETH:
     case TraceType.ERROR_BAR:
     case TraceType.FOREST:
     case TraceType.MANHATTAN:
@@ -437,6 +449,30 @@ function readMain(item: AmDataItem, series: AmXYSeries, horizontal: boolean): un
   return item.get('categoryY') ?? item.get('valueY');
 }
 
+/**
+ * The four column names a choropleth declaration renames a region's facts to.
+ *
+ * Narrowed to plain strings here so that `extractor.ts` — which reads what
+ * amCharts drew — never has to know what a declaration is. A slot the author
+ * left out stays `undefined`, and the extractor then walks its own chain for
+ * that fact rather than treating the omission as a name.
+ *
+ * Exported because the highlight path needs the same four: they decide which
+ * regions the layer kept, and a resolver filtering by a different rule would
+ * index a list of a different length.
+ *
+ * @param declaration - The declared map.
+ * @returns The named columns, each omitted when the author named none.
+ */
+export function choroplethFields(declaration: ChoroplethDeclaration): ChoroplethFields {
+  return {
+    ...(declaration.region != null ? { region: declaration.region } : {}),
+    ...(declaration.value != null ? { value: declaration.value } : {}),
+    ...(declaration.lon != null ? { lon: declaration.lon } : {}),
+    ...(declaration.lat != null ? { lat: declaration.lat } : {}),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Planning a chart
 // ---------------------------------------------------------------------------
@@ -462,6 +498,14 @@ function backsDeclaration(series: AmXYSeries, declaration: AmDeclaration): boole
     // would otherwise emit an alluvial layer with nothing in it.
     case TraceType.ALLUVIAL:
       return isFlowSeries(series) && extractFlowPoints(series).length > 0;
+    // Both halves again, and for the same reason. The class name says amCharts
+    // drew regions at all — `type: 'choropleth'` on a column series is the
+    // mistake this reports — and the regions say the named columns resolve to
+    // something: a map whose `value` ref names nothing would otherwise emit a
+    // layer with no regions in it.
+    case TraceType.CHOROPLETH:
+      return isMapPolygonSeries(series)
+        && extractChoroplethPoints(series, choroplethFields(declaration)).length > 0;
     case TraceType.SURVIVAL:
       return series.dataItems.some(item =>
         readXValue(item, series) != null && item.get('valueY') != null

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -5,6 +5,7 @@
 
 import type {
   BarPoint,
+  ChoroplethPoint,
   DumbbellPoint,
   FlowPoint,
   GanttData,
@@ -21,6 +22,8 @@ import type {
   WaterfallPoint,
 } from '@type/grammar';
 import type { AmAxis, AmChart, AmDataItem, AmSprite, AmXYSeries } from './types';
+import { resolveFieldRef } from '@adapters/shared/traceDeclaration';
+import { TraceType } from '@type/grammar';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1364,6 +1367,256 @@ function readAxisTitle(axis: AmAxis): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Choropleth (am5map MapPolygonSeries)
+// ---------------------------------------------------------------------------
+
+/**
+ * The am5map series class that draws regions. A choropleth is one of these
+ * shaded by a value; the base geography underneath is another one that carries
+ * none, which is why the class alone is not the signature.
+ */
+const MAP_POLYGON_CLASS = 'MapPolygonSeries';
+
+/**
+ * Every am5map series class, so the ones that are not regions are *skipped*
+ * rather than defaulted.
+ *
+ * {@link classifySeriesKind} answers `'bar'` for anything it does not know, so
+ * an unlisted map series would be announced as a bar chart of its shapes. A
+ * graticule read as a row of bars is the failure this list prevents; naming
+ * them all is what makes "not a choropleth" mean "not a layer".
+ */
+const MAP_SERIES_CLASSES = new Set([
+  MAP_POLYGON_CLASS,
+  'MapLineSeries',
+  'MapPointSeries',
+  'ClusteredPointSeries',
+  'GraticuleSeries',
+]);
+
+/** Whether a series is the class an am5map choropleth is drawn with. */
+export function isMapPolygonSeries(series: AmXYSeries): boolean {
+  return series.className === MAP_POLYGON_CLASS;
+}
+
+/**
+ * Whether a polygon series is shaded by a value — a choropleth — rather than
+ * being the base geography under one.
+ *
+ * A map routinely carries two `MapPolygonSeries`: the countries, drawn once in
+ * a flat colour, and the ones a value was joined onto. Only the second is a
+ * chart; announcing the first would offer the reader a list of every country
+ * on earth with nothing to say about any of them.
+ *
+ * `valueField` is what binds the shading, and `heatRules` is how the shading is
+ * declared, so either one says the author meant this series to carry a reading.
+ */
+function isShadedPolygonSeries(series: AmXYSeries): boolean {
+  if (!isMapPolygonSeries(series))
+    return false;
+  const field = series.get('valueField');
+  if (typeof field === 'string' && field.length > 0)
+    return true;
+  const rules = series.get('heatRules');
+  return Array.isArray(rules) && rules.length > 0;
+}
+
+/**
+ * The declared field names a choropleth's four facts may be renamed to.
+ *
+ * Spelled here as plain strings rather than as a `ChoroplethDeclaration`, so
+ * that this module stays the reader of what amCharts drew and `declaration.ts`
+ * stays the reader of what the author said. Both paths land in the same
+ * function because a map's regions are read the same way either way — the
+ * declaration only says which column each fact is in.
+ */
+export interface ChoroplethFields {
+  region?: string;
+  value?: string;
+  lon?: string;
+  lat?: string;
+}
+
+/**
+ * What a region is called.
+ *
+ * An explicit `region` ref wins outright and with no fallback, exactly as
+ * {@link resolveFieldRef} treats every named ref: a name the author wrote that
+ * misses is their mistake to see, not one to paper over with a column they did
+ * not name.
+ *
+ * Undeclared, amCharts' own reading comes first — `dataItem.get('name')` is
+ * the name it resolved the polygon to — and the row's chain second. That chain
+ * reaches `properties.NAME` on a GeoJSON feature, which is where a map's names
+ * actually live, and ends at the `id` an am5map row is ordinarily keyed by.
+ */
+function readRegionName(
+  item: AmDataItem,
+  fields: ChoroplethFields | undefined,
+): string | number | null {
+  const row = rowOf(item);
+  if (fields?.region != null) {
+    return asNodeName(resolveFieldRef(row, fields.region, 'region', TraceType.CHOROPLETH));
+  }
+  const drawn = asNodeName(item.get('name'));
+  if (drawn != null)
+    return drawn;
+  return asNodeName(resolveFieldRef(row, undefined, 'region', TraceType.CHOROPLETH));
+}
+
+/**
+ * The number a region is shaded by.
+ *
+ * Read strictly, never through `toNumber`: `Number(null)` is `0`, and a region
+ * amCharts drew in the no-data colour would then be announced as a region
+ * whose value is zero — a reading a listener cannot tell from a true one.
+ *
+ * The series' own `valueField` is consulted before the shared chain, because
+ * it is the column the author actually bound the shading to.
+ */
+function readRegionValue(
+  item: AmDataItem,
+  series: AmXYSeries,
+  fields: ChoroplethFields | undefined,
+): number | null {
+  const row = rowOf(item);
+  if (fields?.value != null) {
+    return asFiniteNumber(resolveFieldRef(row, fields.value, 'value', TraceType.CHOROPLETH));
+  }
+
+  const drawn = asFiniteNumber(item.get('value'));
+  if (drawn != null)
+    return drawn;
+
+  const field = series.get('valueField');
+  if (typeof field === 'string' && field.length > 0) {
+    const bound = asFiniteNumber(row?.[field]);
+    if (bound != null)
+      return bound;
+  }
+  return asFiniteNumber(resolveFieldRef(row, undefined, 'value', TraceType.CHOROPLETH));
+}
+
+/**
+ * A coordinate in degrees, or `null` for anything that is not one.
+ *
+ * The whole point of the guard. `ChoroplethTrace` walks north, south, east and
+ * west out of this pair, so a projected or normalised coordinate accepted here
+ * is a wrong compass direction — worse than the declared-order region list the
+ * grammar explicitly sanctions when the pair is missing.
+ */
+function asDegrees(value: unknown, limit: number): number | null {
+  const number = asFiniteNumber(value);
+  return number != null && Math.abs(number) <= limit ? number : null;
+}
+
+/**
+ * The geographic centroid of the polygon a region was drawn as.
+ *
+ * **Unverified against the library.** `MapPolygon.geoCentroid()` is documented
+ * to answer an `IGeoPoint` — `{ longitude, latitude }` in degrees — but
+ * amCharts is commercial and not installed here, so every read is guarded and
+ * a build answering with anything else falls through to `null`. The pair is
+ * then omitted, and the map degrades to a region list in declared order rather
+ * than to a compass pointing the wrong way.
+ */
+function readGeoCentroid(item: AmDataItem): { lon: number; lat: number } | null {
+  const polygon = item.get('mapPolygon');
+  if (polygon == null || typeof polygon !== 'object')
+    return null;
+  const centroid = (polygon as { geoCentroid?: () => unknown }).geoCentroid;
+  if (typeof centroid !== 'function')
+    return null;
+
+  let point: unknown;
+  try {
+    point = centroid.call(polygon);
+  } catch {
+    return null;
+  }
+  if (point == null || typeof point !== 'object')
+    return null;
+
+  const geo = point as { longitude?: unknown; latitude?: unknown };
+  const lon = asDegrees(geo.longitude, 180);
+  const lat = asDegrees(geo.latitude, 90);
+  return lon != null && lat != null ? { lon, lat } : null;
+}
+
+/**
+ * The data items a choropleth layer was built from, in the order it emitted
+ * them.
+ *
+ * Kept as its own function so the highlight path indexes exactly the list the
+ * payload was built from. A region the layer dropped must not stay in this
+ * list: it would slide every later position onto its neighbour, which is the
+ * same call the pie, funnel and flow conversions already make.
+ */
+export function filterChoroplethItems(
+  series: AmXYSeries,
+  fields?: ChoroplethFields,
+): AmDataItem[] {
+  return series.dataItems.filter(item =>
+    readRegionName(item, fields) != null && readRegionValue(item, series, fields) != null);
+}
+
+/**
+ * Convert an am5map `MapPolygonSeries` into {@link ChoroplethPoint} data.
+ *
+ * A region amCharts drew but joined no value onto is left out. It is the
+ * ordinary case on a real map — the shapes with no data, drawn in a flat
+ * colour — and a layer's value is a number, so there is nothing to announce
+ * for one.
+ *
+ * **The centroids are what make this a map rather than a bar chart whose
+ * categories happen to be places.** They are read in degrees or not at all:
+ * from the author's own row first, where a table of `{ region, value, lon, lat }`
+ * states them outright, and from the drawn polygon's `geoCentroid()` second.
+ * A pair that resolves to neither is omitted — `ChoroplethTrace` then keeps
+ * the regions in declared order in one band, which is a poorer reading but the
+ * one the data supports.
+ *
+ * `neighbors` is not emitted at all. Adjacency is not recoverable from
+ * rendered geometry, and not from centroids either, so the trace keeps its
+ * spatial walk and is told nothing about borders rather than something
+ * guessed — the same call the Highcharts adapter makes.
+ */
+export function extractChoroplethPoints(
+  series: AmXYSeries,
+  fields?: ChoroplethFields,
+): ChoroplethPoint[] {
+  const points: ChoroplethPoint[] = [];
+
+  for (const item of series.dataItems) {
+    const x = readRegionName(item, fields);
+    if (x == null)
+      continue;
+    const y = readRegionValue(item, series, fields);
+    if (y == null)
+      continue;
+
+    const row = rowOf(item);
+    const centroid = readGeoCentroid(item);
+    const lon = asDegrees(resolveFieldRef(row, fields?.lon, 'lon', TraceType.CHOROPLETH), 180)
+      ?? centroid?.lon ?? null;
+    const lat = asDegrees(resolveFieldRef(row, fields?.lat, 'lat', TraceType.CHOROPLETH), 90)
+      ?? centroid?.lat ?? null;
+
+    points.push({
+      x,
+      y,
+      // Both or neither: a longitude alone places nothing, and a region
+      // carrying half a coordinate would drop the whole map back to declared
+      // order anyway — `ChoroplethTrace` bands only when every region is
+      // placed. Emitting one half would look like a placement and be none.
+      ...(lon != null && lat != null ? { lon, lat } : {}),
+    });
+  }
+
+  return points;
+}
+
+// ---------------------------------------------------------------------------
 // Series type detection
 // ---------------------------------------------------------------------------
 
@@ -1620,6 +1873,7 @@ export type SeriesKind
     | 'sankey'
     | 'chord'
     | 'network'
+    | 'choropleth'
     | 'unknown';
 
 /**
@@ -1669,6 +1923,14 @@ export function classifySeriesKind(series: AmXYSeries): SeriesKind {
   const standalone = STANDALONE_KINDS[className];
   if (standalone) {
     return standalone;
+  }
+
+  // Every am5map series, answered together. A polygon series shaded by a value
+  // is a choropleth; the base geography under it, the graticule, the lines and
+  // the pins are drawings rather than readings, and are skipped outright —
+  // which they would not be if they fell through to the `'bar'` default below.
+  if (MAP_SERIES_CLASSES.has(className)) {
+    return isShadedPolygonSeries(series) ? 'choropleth' : 'unknown';
   }
 
   if (COLUMN_CLASSES.has(className)) {

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -7,6 +7,8 @@ import type {
   BarPoint,
   DumbbellPoint,
   GanttData,
+  GaugeBand,
+  GaugePoint,
   HeatmapData,
   HistogramPoint,
   LinePoint,
@@ -16,7 +18,7 @@ import type {
   WaterfallKind,
   WaterfallPoint,
 } from '@type/grammar';
-import type { AmAxis, AmDataItem, AmSprite, AmXYSeries } from './types';
+import type { AmAxis, AmChart, AmDataItem, AmSprite, AmXYSeries } from './types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -898,6 +900,246 @@ export function extractHierarchyPoints(series: AmXYSeries): TreemapPoint[] {
 }
 
 // ---------------------------------------------------------------------------
+// Gauge (am5radar ClockHand)
+// ---------------------------------------------------------------------------
+
+/**
+ * The chart class an am5radar gauge is drawn in. It extends `XYChart`, so the
+ * adapter's discovery has always found it; what it has never had is a series
+ * to convert.
+ */
+const RADAR_CHART_CLASS = 'RadarChart';
+
+/**
+ * The class name amCharts gives a gauge's needle. Nothing else in the library
+ * draws one, which is what makes this the whole of the signature: a gauge is
+ * recognised by the mark it has, not by the series it lacks.
+ */
+const CLOCK_HAND_CLASS = 'ClockHand';
+
+/**
+ * The needle of an am5radar gauge, with the axis it is pinned to.
+ *
+ * A gauge is the one layer in this adapter whose source is the *chart* rather
+ * than a series: amCharts draws the hand as an `AxisBullet` on an axis data
+ * item, so a ClockHand gauge routinely carries no series at all. Both the
+ * extraction and the highlight need the same three things, so they are found
+ * once and shared.
+ */
+export interface AmGaugeHand {
+  /** The axis the hand is pinned to, which carries the dial's range. */
+  axis: AmAxis;
+  /** The axis data item the hand's value is read from. */
+  dataItem: AmDataItem;
+  /** The `ClockHand` sprite itself, which is what the overlay outlines. */
+  sprite: AmSprite;
+}
+
+/** A duck-typed `values` list, or `[]` for anything that is not one. */
+function listValues<T>(candidate: unknown): T[] {
+  if (candidate == null || typeof candidate !== 'object')
+    return [];
+  const values = (candidate as { values?: unknown }).values;
+  return Array.isArray(values) ? (values as T[]) : [];
+}
+
+/** Read a setting only when it really is a finite number. */
+function finiteSetting(entity: { get: (key: string) => unknown }, key: string): number | null {
+  const value = entity.get(key);
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Every data item an axis carries a bullet on.
+ *
+ * A gauge's hand hangs on a data item created with `axis.createAxisRange()`,
+ * which amCharts keeps in `axisRanges` — but the raw `dataItems` list is read
+ * too, because the range and the tick lists are the same kind of object and
+ * which one a given build files a made data item under is not something this
+ * adapter can verify without the library.
+ */
+function axisMarkerItems(axis: AmAxis): AmDataItem[] {
+  const ranges = listValues<AmDataItem>((axis as unknown as { axisRanges?: unknown }).axisRanges);
+  const items = Array.isArray(axis.dataItems) ? axis.dataItems : [];
+  return [...ranges, ...items];
+}
+
+/**
+ * The sprites a data item's bullets draw.
+ *
+ * Read through both the settings accessor and the plain property, and through
+ * both the singular `bullet` an axis data item carries and the `bullets` list
+ * a series data item does, because which of them answers is exactly the shape
+ * that cannot be checked here.
+ */
+function bulletSprites(item: AmDataItem): AmSprite[] {
+  const sprites: AmSprite[] = [];
+  const push = (value: unknown): void => {
+    if (value != null && typeof value === 'object')
+      sprites.push(value as AmSprite);
+  };
+  const readBullet = (bullet: unknown): void => {
+    if (bullet == null || typeof bullet !== 'object')
+      return;
+    const b = bullet as { get?: (key: string) => unknown; sprite?: unknown };
+    if (typeof b.get === 'function')
+      push(b.get('sprite'));
+    push(b.sprite);
+  };
+
+  readBullet(item.get('bullet'));
+  for (const bullet of item.bullets ?? []) {
+    readBullet(bullet);
+  }
+  return sprites;
+}
+
+/** Whether a sprite is the needle amCharts draws a gauge's reading with. */
+function isClockHand(sprite: AmSprite): boolean {
+  return (sprite as { className?: string }).className === CLOCK_HAND_CLASS;
+}
+
+/**
+ * Find the needle of an am5radar gauge, or `null` for any other chart.
+ *
+ * The signature is deliberately narrow, because a `RadarChart` is also what a
+ * radar and a polar area are drawn in: the class name has to match *and* an
+ * axis has to carry a `ClockHand`. The caller adds the third condition — this
+ * is asked only of a chart whose series produced no layer at all — so an
+ * ordinary radar chart never reaches it even if someone pins a hand to one.
+ *
+ * A chart with several hands is read as its first, with a warning: MAIDR's
+ * gauge is one measure against one range, and there is no shape here for a
+ * second.
+ */
+export function findGaugeHand(chart: AmChart): AmGaugeHand | null {
+  if (chart.className !== RADAR_CHART_CLASS)
+    return null;
+
+  const axes = [...(chart.xAxes?.values ?? []), ...(chart.yAxes?.values ?? [])];
+  const hands: AmGaugeHand[] = [];
+  for (const axis of axes) {
+    for (const dataItem of axisMarkerItems(axis)) {
+      for (const sprite of bulletSprites(dataItem)) {
+        if (isClockHand(sprite)) {
+          hands.push({ axis, dataItem, sprite });
+        }
+      }
+    }
+  }
+
+  const hand = hands[0];
+  if (!hand)
+    return null;
+  if (hands.length > 1) {
+    console.warn(
+      `[MAIDR amCharts] Gauge carries ${hands.length} hands; reading the first. `
+      + `A gauge layer carries one measure.`,
+    );
+  }
+  return hand;
+}
+
+/**
+ * The qualitative bands an axis partitions its dial into.
+ *
+ * Only a range with a finite `endValue` is a band: MAIDR carries the upper
+ * edge alone, because bands partition the range and a band starts where the
+ * previous one ended. That also excludes the hand's own range, which carries a
+ * value and no end — the reading is not one of the bands it lands in.
+ *
+ * Sorted ascending, since an unsorted list would describe a partition the
+ * chart does not draw, and a band amCharts leaves unnamed is numbered by its
+ * position: that says where in the partition the reading landed, which is what
+ * a band is read for, without inventing a meaning the chart never gave it.
+ */
+export function extractGaugeBands(axis: AmAxis): GaugeBand[] {
+  const ranges = axisMarkerItems(axis);
+  const found: { to: number; label?: string }[] = [];
+
+  for (const range of ranges) {
+    const to = finiteSetting(range, 'endValue');
+    if (to == null)
+      continue;
+    const label = readRangeLabel(range);
+    found.push({ to, ...(label != null ? { label } : {}) });
+  }
+
+  return found
+    .sort((a, b) => a.to - b.to)
+    .map((band, index) => ({ to: band.to, label: band.label ?? `Band ${index + 1}` }));
+}
+
+/** What an axis range calls itself, when it says. */
+function readRangeLabel(range: AmDataItem): string | undefined {
+  const label = range.get('label');
+  if (typeof label === 'string' && label.length > 0)
+    return label;
+  if (label != null && typeof label === 'object') {
+    const text = (label as { get?: (key: string) => unknown }).get?.('text');
+    if (typeof text === 'string' && text.length > 0)
+      return text;
+  }
+  const category = range.get('category');
+  return typeof category === 'string' && category.length > 0 ? category : undefined;
+}
+
+/**
+ * Convert an am5radar gauge into the single {@link GaugePoint} it draws.
+ *
+ * A single object rather than an array, because the chart draws exactly one
+ * measure — an array of one would describe a shape the chart does not have.
+ *
+ * `null` when the dial has no finite ends. `GaugeTrace` pitches its tone
+ * against the range rather than against the value, so a reading with no range
+ * behind it is not a reading at all; emitting no layer is the honest answer,
+ * and the caller then leaves the panel out rather than announcing a dial of
+ * `NaN`s.
+ *
+ * The range is read from the axis' own `min`/`max` settings, falling back to
+ * the private values amCharts computes when the author did not fix them. It is
+ * NOT read from the axis' `start`/`end`, which on an am5 axis are the relative
+ * zoom positions (0 to 1) and would silently answer with a 0-to-1 dial for
+ * every gauge whose extremes are computed.
+ */
+export function extractGaugePoint(hand: AmGaugeHand, label?: string): GaugePoint | null {
+  const min = axisExtreme(hand.axis, 'min');
+  const max = axisExtreme(hand.axis, 'max');
+  if (min == null || max == null)
+    return null;
+
+  const value = finiteSetting(hand.dataItem, 'value');
+  if (value == null)
+    return null;
+
+  const bands = extractGaugeBands(hand.axis);
+  const name = label ?? readAxisTitle(hand.axis);
+
+  return {
+    value,
+    min,
+    max,
+    ...(name != null ? { label: name } : {}),
+    ...(bands.length > 0 ? { bands } : {}),
+  };
+}
+
+/** An axis extreme: the author's setting, else the one amCharts computed. */
+function axisExtreme(axis: AmAxis, key: 'min' | 'max'): number | null {
+  const declared = finiteSetting(axis, key);
+  if (declared != null)
+    return declared;
+  const computed = (axis as unknown as { getPrivate?: (k: string) => unknown }).getPrivate?.(key);
+  return typeof computed === 'number' && Number.isFinite(computed) ? computed : null;
+}
+
+/** An axis' own title, when it has one — never a fallback. */
+function readAxisTitle(axis: AmAxis): string | undefined {
+  const label = readAxisLabel(axis, '');
+  return label.length > 0 ? label : undefined;
+}
+
+// ---------------------------------------------------------------------------
 // Series type detection
 // ---------------------------------------------------------------------------
 
@@ -970,9 +1212,13 @@ const RADAR_COLUMN_CLASSES = new Set([
  *
  * An am5hierarchy layout and an am5wc word cloud are `am5.Series` pushed
  * straight into a plain container, with no chart object around them, which is
- * why the adapter's discovery has to recognise the series itself. `Sunburst`
- * is deliberately absent — it extends `Partition` but carries its own class
- * name, so leaving it out keeps it out rather than reading it as an icicle.
+ * why the adapter's discovery has to recognise the series itself.
+ *
+ * `Sunburst` is named here in its own right rather than inherited. It extends
+ * `Partition` but carries its own class name, so listing it is what makes it a
+ * sunburst instead of nothing at all — and naming it separately is also what
+ * keeps it from being announced as an icicle, which is the same tree drawn
+ * with an entirely different mark.
  *
  * One record rather than one set per module: discovery asks a single question
  * ("is this series a panel of its own?"), and a per-module set would have to
@@ -981,6 +1227,7 @@ const RADAR_COLUMN_CLASSES = new Set([
 const STANDALONE_KINDS: Record<string, SeriesKind> = {
   Treemap: 'treemap',
   Partition: 'icicle',
+  Sunburst: 'sunburst',
   WordCloud: 'wordcloud',
 };
 
@@ -1126,6 +1373,7 @@ export type SeriesKind
     | 'gantt'
     | 'treemap'
     | 'icicle'
+    | 'sunburst'
     | 'wordcloud'
     | 'unknown';
 

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -6,12 +6,14 @@
 import type {
   BarPoint,
   DumbbellPoint,
+  FlowPoint,
   GanttData,
   GaugeBand,
   GaugePoint,
   HeatmapData,
   HistogramPoint,
   LinePoint,
+  NetworkPoint,
   PiePoint,
   SegmentedPoint,
   TreemapPoint,
@@ -900,6 +902,228 @@ export function extractHierarchyPoints(series: AmXYSeries): TreemapPoint[] {
 }
 
 // ---------------------------------------------------------------------------
+// Flow (am5flow) and network (am5hierarchy.ForceDirected)
+// ---------------------------------------------------------------------------
+
+/**
+ * What am5flow binds a link's two ends to when the author names no field.
+ *
+ * amCharts' own examples author a link as `{ from, to, value }` and set
+ * `sourceIdField` / `targetIdField` / `valueField` to match, so these are the
+ * defaults for the last resort in {@link readFlowEnd} — reading the author's
+ * own row when neither the resolved id nor the node data item answered.
+ */
+const FLOW_SOURCE_FIELD_DEFAULT = 'from';
+const FLOW_TARGET_FIELD_DEFAULT = 'to';
+const FLOW_VALUE_FIELD_DEFAULT = 'value';
+
+/**
+ * A value usable as a node's name: a non-empty string, or a finite number.
+ *
+ * Stricter than {@link toStringOrNumber}, which renders `null` as `''` — an
+ * empty name is not a node, and a link with one is a link to nowhere.
+ */
+function asNodeName(value: unknown): string | number | null {
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string')
+    return value.length > 0 ? value : null;
+  return null;
+}
+
+/** A finite number, from a number or from the numeric string a CSV row carries. */
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/** The author's own record behind a data item, when it kept one. */
+function rowOf(item: AmDataItem): Record<string, unknown> | null {
+  const row = item.dataContext;
+  return row != null && typeof row === 'object' ? (row as Record<string, unknown>) : null;
+}
+
+/**
+ * What one end of a flow link is called.
+ *
+ * Three reads, in falling order of how directly amCharts states the answer,
+ * because which of them a given build answers with is exactly the shape that
+ * cannot be checked without the library:
+ *
+ * 1. `sourceId` / `targetId` — the id amCharts resolved the end to, which is
+ *    the name if it answers at all.
+ * 2. `source` / `target` — the *node* data item the link was joined to, asked
+ *    for its own `name` and then its `id`.
+ * 3. The author's row, keyed by the field the series was told to read ends
+ *    from. This is the one that survives a build answering with neither.
+ *
+ * `null` when no read answers, which drops the link: a ribbon with one end is
+ * not a flow, and naming the missing end anything at all would invent a node.
+ */
+function readFlowEnd(
+  item: AmDataItem,
+  series: AmXYSeries,
+  end: 'source' | 'target',
+): string | number | null {
+  const resolved = asNodeName(item.get(`${end}Id`));
+  if (resolved != null)
+    return resolved;
+
+  const node = item.get(end);
+  if (node != null && typeof node === 'object') {
+    const get = (node as { get?: (key: string) => unknown }).get;
+    if (typeof get === 'function') {
+      const named = asNodeName(get.call(node, 'name')) ?? asNodeName(get.call(node, 'id'));
+      if (named != null)
+        return named;
+    }
+  }
+
+  const field = series.get(`${end}IdField`);
+  const key = typeof field === 'string' && field.length > 0
+    ? field
+    : (end === 'source' ? FLOW_SOURCE_FIELD_DEFAULT : FLOW_TARGET_FIELD_DEFAULT);
+  return asNodeName(rowOf(item)?.[key]);
+}
+
+/**
+ * How much flows along one link.
+ *
+ * Read from the data item's own `value` first and from the author's row after,
+ * both strictly: `toNumber` would answer `0` for a link carrying no value at
+ * all, because `Number(null)` is `0`, and a zero is a weight the chart never
+ * stated rather than an absent one.
+ */
+function readFlowValue(item: AmDataItem, series: AmXYSeries): number | null {
+  const declared = asFiniteNumber(item.get('value'));
+  if (declared != null)
+    return declared;
+
+  const field = series.get('valueField');
+  const key = typeof field === 'string' && field.length > 0 ? field : FLOW_VALUE_FIELD_DEFAULT;
+  return asFiniteNumber(rowOf(item)?.[key]);
+}
+
+/**
+ * Convert an am5flow series — a `Sankey`, a `Chord` or an `ArcDiagram` — into
+ * {@link FlowPoint} data.
+ *
+ * One point per **link**, which is the whole payload: MAIDR derives the nodes
+ * from the links by design, so `series.nodes` is deliberately not read. A
+ * second list would be a second source of truth for something the links
+ * already say, and the two could then disagree.
+ *
+ * A link missing an end, or carrying no weight, is dropped rather than kept as
+ * a gap — the same call the pie, funnel and waterfall conversions make. A link
+ * amCharts draws no ribbon for but MAIDR still counts would slide every later
+ * position onto its neighbour.
+ */
+export function extractFlowPoints(series: AmXYSeries): FlowPoint[] {
+  const points: FlowPoint[] = [];
+
+  for (const item of series.dataItems) {
+    const source = readFlowEnd(item, series, 'source');
+    const target = readFlowEnd(item, series, 'target');
+    if (source == null || target == null)
+      continue;
+
+    const value = readFlowValue(item, series);
+    if (value == null || value === 0)
+      continue;
+
+    points.push({ source, target, value });
+  }
+
+  return points;
+}
+
+/**
+ * The field an `am5hierarchy.ForceDirected` names each row's cross-links in.
+ *
+ * Unlike the flow fields there is no default worth guessing: amCharts draws no
+ * cross-link at all unless the author sets `linkWithField`, so an unset one
+ * means the graph really is the tree.
+ */
+const LINK_WITH_FIELD_SETTING = 'linkWithField';
+
+/**
+ * Convert an `am5hierarchy.ForceDirected` series into {@link NetworkPoint}
+ * links.
+ *
+ * The awkward one. A force-directed graph is a **hierarchy** series in
+ * amCharts, not a link list: its data is a tree of `children`, and the links a
+ * reader sees are the parent-child edges of that tree plus whatever cross-links
+ * each row named. So the same walk the treemap uses supplies the tree — each
+ * node's parent is the last name on its path — and the cross-links are read
+ * off the authors' own rows afterwards.
+ *
+ * Nothing about the layout is read. Where the solver dropped a node is a fact
+ * about its seed rather than about the data, which is why `NetworkPoint` has
+ * nowhere to put one.
+ *
+ * A cross-link naming something the walk never saw is skipped rather than
+ * turned into a node: amCharts draws no link for it either, and inventing the
+ * node would announce a participant the chart does not have. Each pair is
+ * emitted once — a link is undirected, and two rows naming each other draw one
+ * line.
+ */
+export function extractNetworkPoints(series: AmXYSeries): NetworkPoint[] {
+  const nodes = extractHierarchyNodes(series);
+
+  // Every name a cross-link may legitimately reach: the node's own category,
+  // and the id the author keyed it by when that is a different column.
+  const idField = series.get('idField');
+  const byRef = new Map<string | number, string | number>();
+  for (const node of nodes) {
+    if (!byRef.has(node.name))
+      byRef.set(node.name, node.name);
+    if (typeof idField === 'string' && idField.length > 0) {
+      const id = asNodeName(rowOf(node.dataItem)?.[idField]);
+      if (id != null && !byRef.has(id))
+        byRef.set(id, node.name);
+    }
+  }
+
+  const links: NetworkPoint[] = [];
+  const seen = new Set<string>();
+  const add = (source: string | number, target: string | number): void => {
+    const key = [String(source), String(target)].sort().join(' ');
+    if (seen.has(key))
+      return;
+    seen.add(key);
+    links.push({ source, target });
+  };
+
+  for (const node of nodes) {
+    const parent = node.path[node.path.length - 1];
+    if (parent !== undefined)
+      add(parent, node.name);
+  }
+
+  const linkWithField = series.get(LINK_WITH_FIELD_SETTING);
+  if (typeof linkWithField === 'string' && linkWithField.length > 0) {
+    for (const node of nodes) {
+      const refs = rowOf(node.dataItem)?.[linkWithField];
+      if (!Array.isArray(refs))
+        continue;
+      for (const ref of refs) {
+        const name = asNodeName(ref);
+        const target = name != null ? byRef.get(name) : undefined;
+        if (target !== undefined)
+          add(node.name, target);
+      }
+    }
+  }
+
+  return links;
+}
+
+// ---------------------------------------------------------------------------
 // Gauge (am5radar ClockHand)
 // ---------------------------------------------------------------------------
 
@@ -1210,15 +1434,27 @@ const RADAR_COLUMN_CLASSES = new Set([
 /**
  * Series that are not inside a chart at all, and what each one draws.
  *
- * An am5hierarchy layout and an am5wc word cloud are `am5.Series` pushed
- * straight into a plain container, with no chart object around them, which is
- * why the adapter's discovery has to recognise the series itself.
+ * An am5hierarchy layout, an am5flow diagram and an am5wc word cloud are
+ * `am5.Series` pushed straight into a plain container, with no chart object
+ * around them, which is why the adapter's discovery has to recognise the
+ * series itself.
  *
  * `Sunburst` is named here in its own right rather than inherited. It extends
  * `Partition` but carries its own class name, so listing it is what makes it a
  * sunburst instead of nothing at all — and naming it separately is also what
  * keeps it from being announced as an icicle, which is the same tree drawn
- * with an entirely different mark.
+ * with an entirely different mark. The same reasoning names all three chord
+ * variants: each extends the last, and each carries its own class name.
+ *
+ * `ArcDiagram` is a sankey rather than a network. It extends `FlowSeries` and
+ * carries a weight per link, and MAIDR's `NetworkPoint` has nowhere to put
+ * one — so reading it as a network would silently drop the magnitudes. The
+ * same call the Highcharts adapter makes for `arcdiagram`.
+ *
+ * Listing a class here is also what keeps it from being read as something
+ * else: {@link classifySeriesKind} answers `'bar'` for anything it does not
+ * know, so an unlisted flow series would be announced as a bar chart of its
+ * links rather than skipped.
  *
  * One record rather than one set per module: discovery asks a single question
  * ("is this series a panel of its own?"), and a per-module set would have to
@@ -1229,6 +1465,12 @@ const STANDALONE_KINDS: Record<string, SeriesKind> = {
   Partition: 'icicle',
   Sunburst: 'sunburst',
   WordCloud: 'wordcloud',
+  Sankey: 'sankey',
+  ArcDiagram: 'sankey',
+  Chord: 'chord',
+  ChordDirected: 'chord',
+  ChordNonRibbon: 'chord',
+  ForceDirected: 'network',
 };
 
 /** The class names {@link STANDALONE_KINDS} covers, for discovery to probe. */
@@ -1375,6 +1617,9 @@ export type SeriesKind
     | 'icicle'
     | 'sunburst'
     | 'wordcloud'
+    | 'sankey'
+    | 'chord'
+    | 'network'
     | 'unknown';
 
 /**
@@ -1388,6 +1633,21 @@ export type SeriesKind
  */
 export function isColumnSeries(series: AmXYSeries): boolean {
   return COLUMN_CLASSES.has(series.className ?? '');
+}
+
+/**
+ * Whether a series is one of am5flow's weighted graphs.
+ *
+ * Asked only by the alluvial declaration, which is the one reading amCharts
+ * has no class for at all: an alluvial IS a sankey — the same weighted flow
+ * drawn without a left-to-right budget — so the only thing separating them is
+ * the author saying which they drew. This is the "wrong construct" half of
+ * that check: a block declaring an alluvial on a pie series is a mistake worth
+ * reporting, not a layer to emit with nothing in it.
+ */
+export function isFlowSeries(series: AmXYSeries): boolean {
+  const kind = STANDALONE_KINDS[series.className ?? ''];
+  return kind === 'sankey' || kind === 'chord';
 }
 
 /**

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -630,6 +630,18 @@ export function groupSeries(chart: AmChart): SeriesGroups {
       case 'wordcloud':
         groups.wordCloudSeriesList.push(series);
         break;
+      // A flow diagram and a force-directed network are read, described,
+      // brailled and navigated, and deliberately get no bucket: MAIDR hands a
+      // flow trace's position back as a *braille* one — the stage, and the
+      // index within it — and recovering the node from that would mean
+      // reimplementing the model's own node ordering and stage layering here.
+      // That is a derived graph structure rather than an ordering, which is
+      // the line `buildCloudResolver` refuses to cross, so no resolver is
+      // registered and the overlay clears. See `docs/amcharts.md`.
+      case 'sankey':
+      case 'chord':
+      case 'network':
+        break;
       default:
         break;
     }
@@ -878,6 +890,32 @@ function addEntryResolvers(
         }
         break;
       }
+      // Named rather than left to the default, because their absence is a
+      // decision rather than an omission — the failure mode this whole file
+      // exists to make visible is a type that reads correctly while its
+      // highlight silently vanishes.
+      //
+      // `createNavigateObserver` hands a flow or network layer the *braille*
+      // position, which `FlowTrace.braille` transposes to (stage, index within
+      // stage) and `NetworkTrace.braille` to (component, index within
+      // component). Inverting either means reimplementing the model's node
+      // ordering together with its stage layering — or its component
+      // discovery, ordering and sorting — inside the adapter. That is a
+      // derived graph structure, not an ordering over data this adapter
+      // emitted, and `buildCloudResolver` already refuses exactly that: a copy
+      // drifts silently and then outlines a confidently wrong node.
+      //
+      // So no resolver is registered, `NavMap.resolve` answers `[]`, and
+      // `applyHighlight` clears the overlay. An empty outline is truthful; a
+      // box drawn from a guessed layering is not. Both traces already compute
+      // the right answer internally (`edge.at`, `node.linkAt[0]`), so a
+      // `highlightedPointIndices` getter on each — a `src/model/` change —
+      // makes all four resolvable by registering resolvers and nothing else.
+      case TraceType.SANKEY:
+      case TraceType.CHORD:
+      case TraceType.ALLUVIAL:
+      case TraceType.NETWORK:
+        break;
       default:
         break;
     }

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -18,11 +18,14 @@ import {
   extractErrorBarSamples,
   extractForestSamples,
   extractSurvivalArms,
+  planDeclarations,
 } from './declaration';
 import {
+  classifySeriesKind,
   extractGanttItems,
   extractHierarchyNodes,
   extractSpanItems,
+  findGaugeHand,
   isColumnSeries,
 } from './extractor';
 
@@ -117,7 +120,14 @@ export interface SeriesGroups {
   dumbbellSeriesList: AmXYSeries[];
   /** One GANTT layer each, in series order. */
   ganttSeriesList: AmXYSeries[];
-  /** One TREEMAP or ICICLE layer each, in series order. */
+  /**
+   * One TREEMAP, ICICLE or SUNBURST layer each, in series order.
+   *
+   * One bucket for three layouts because they are one tree drawn three ways
+   * and the highlight walks the same nodes whichever it is. Which *mark* to
+   * measure is decided from the layer's trace type where the resolver is
+   * built, since that is the part that differs.
+   */
   hierarchySeriesList: AmXYSeries[];
   /** One WORD_CLOUD layer each, in series order. */
   wordCloudSeriesList: AmXYSeries[];
@@ -280,24 +290,69 @@ function buildGanttResolver(series: AmXYSeries | undefined): Resolver {
 }
 
 /**
- * Build a resolver for a treemap or icicle layer.
+ * Build a resolver for a treemap, icicle or sunburst layer.
  *
  * MAIDR addresses a tree node by depth and by its position within that depth,
  * taking the position from the order the nodes were declared in — which is the
  * order the walk emitted them, so gathering the walk by depth rebuilds exactly
- * the grid the reader is navigating.
+ * the grid the reader is navigating. That is true of all three layouts: they
+ * are one tree drawn three ways.
+ *
+ * What is not the same is the mark. A treemap block and an icicle bar are
+ * rectangles, which the overlay measures as it measures a column; a sunburst
+ * node is a `Slice`, which reports a degenerate box at its own centre and has
+ * to be measured from its radius and sweep instead. Hence the `kind` — the one
+ * thing the caller has to say.
  */
-function buildHierarchyResolver(series: AmXYSeries | undefined): Resolver {
+function buildHierarchyResolver(
+  series: AmXYSeries | undefined,
+  kind: NavTarget['kind'],
+): Resolver {
   const levels: AmDataItem[][] = [];
   for (const node of series ? extractHierarchyNodes(series) : []) {
     (levels[node.depth] ??= []).push(node.dataItem);
   }
   return (row, col) => {
     const dataItem = levels[row]?.[col];
-    // A node is drawn as a rectangle, which the overlay measures the same way
-    // it measures a column.
-    return series && dataItem ? [{ series, dataItem, kind: 'column' }] : [];
+    return series && dataItem ? [{ series, dataItem, kind }] : [];
   };
+}
+
+/**
+ * Build a resolver for a gauge layer.
+ *
+ * Structurally the simplest resolver there is: `GaugeTrace` is a 1x1 grid and
+ * its position is always `(0, 0)`, so there is no ordering to mirror and no
+ * index to invert — every position is the needle.
+ *
+ * The plumbing is the only wrinkle. A {@link NavTarget} names a series and a
+ * data item, and a ClockHand has neither: it is a bullet on an *axis*. Rather
+ * than widen the target for one layer, the hand is handed to the overlay
+ * through a data item that answers `graphics` with it — which is exactly the
+ * read `kind: 'column'` already makes — and a stand-in series that nothing on
+ * that path asks anything of. The same trick `asStandalonePanel` uses to give
+ * a bare series the shape of a chart.
+ *
+ * If the hand reports no usable box the overlay clears rather than falling
+ * back to the chart. An outline around the whole dial would say nothing about
+ * where the needle is.
+ */
+function buildGaugeResolver(chart: AmChart): Resolver {
+  const hand = findGaugeHand(chart);
+  if (!hand) {
+    return () => [];
+  }
+
+  const dataItem = {
+    get: (key: string) => (key === 'graphics' ? hand.sprite : undefined),
+  } as AmDataItem;
+  const series = {
+    className: 'ClockHand',
+    get: () => undefined,
+    dataItems: [],
+  } as unknown as AmXYSeries;
+
+  return () => [{ series, dataItem, kind: 'column' }];
 }
 
 /**
@@ -446,6 +501,141 @@ export function buildNavigationMap(entries: readonly NavMapEntry[]): NavMap {
     chartFor: layerId => owners.get(layerId),
     chartCount: new Set(entries.map(entry => entry.chart)).size,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Series grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Group a chart's live series exactly as `buildChartLayers` groups them when
+ * it builds the layers.
+ *
+ * The one place in the adapter that deliberately duplicates a decision: the
+ * layer a reader hears and the mark the overlay outlines have to be the same
+ * series, so this asks the same two questions of the same chart —
+ * {@link planDeclarations} first, since a declared series is never also
+ * classified and an absorbed one is never a layer of its own, then
+ * `classifySeriesKind`. A kind added to one side and forgotten on the other is
+ * the failure this shape exists to make visible: audio and text keep working
+ * while the highlight silently vanishes.
+ *
+ * It lives here rather than beside the binder that calls it because
+ * {@link SeriesGroups} is defined here and the resolvers that consume it are
+ * here — and because the binder's own module cannot be loaded without React,
+ * which left this untested for as long as it sat there.
+ *
+ * @param chart - The live chart whose series to group.
+ * @returns The same buckets `addEntryResolvers` walks.
+ */
+export function groupSeries(chart: AmChart): SeriesGroups {
+  const groups: SeriesGroups = {
+    barSeriesList: [],
+    dotSeriesList: [],
+    lollipopSeriesList: [],
+    lineSeriesList: [],
+    stepSeriesList: [],
+    areaSeriesList: [],
+    radarSeriesList: [],
+    polarSeriesList: [],
+    histogramSeries: [],
+    heatmapSeries: [],
+    pieSeriesList: [],
+    funnelSeriesList: [],
+    waterfallSeriesList: [],
+    dumbbellSeriesList: [],
+    ganttSeriesList: [],
+    hierarchySeriesList: [],
+    wordCloudSeriesList: [],
+    declaredList: [],
+  };
+
+  // The same plan `buildChartLayers` builds, asked of the same chart: a
+  // declared series is never also classified, and an absorbed one is never a
+  // layer of its own — so the layer a reader hears and the mark the overlay
+  // outlines are always the same series.
+  const plan = planDeclarations(chart);
+
+  for (const series of chart.series.values) {
+    if (plan.absorbed.has(series)) {
+      continue;
+    }
+    const declared = plan.declared.get(series);
+    if (declared) {
+      groups.declaredList.push(declared);
+      continue;
+    }
+
+    switch (classifySeriesKind(series)) {
+      case 'bar':
+        groups.barSeriesList.push(series);
+        break;
+      // A dot and a lollipop read as a bar chart but are drawn with different
+      // marks, so the highlight measures different sprites and they keep
+      // buckets of their own.
+      case 'dot':
+        groups.dotSeriesList.push(series);
+        break;
+      case 'lollipop':
+        groups.lollipopSeriesList.push(series);
+        break;
+      // A bump chart's competitors are line series too. Whether the layer they
+      // merge into is read as ranks is a property of the group, decided where
+      // the layer is built, so the highlight path has one bucket for both.
+      case 'line':
+        groups.lineSeriesList.push(series);
+        break;
+      case 'step':
+        groups.stepSeriesList.push(series);
+        break;
+      case 'area':
+        groups.areaSeriesList.push(series);
+        break;
+      case 'radar':
+        groups.radarSeriesList.push(series);
+        break;
+      case 'polar':
+        groups.polarSeriesList.push(series);
+        break;
+      case 'histogram':
+        groups.histogramSeries.push(series);
+        break;
+      case 'heatmap':
+        groups.heatmapSeries.push(series);
+        break;
+      case 'pie':
+        groups.pieSeriesList.push(series);
+        break;
+      case 'funnel':
+        groups.funnelSeriesList.push(series);
+        break;
+      case 'waterfall':
+        groups.waterfallSeriesList.push(series);
+        break;
+      case 'dumbbell':
+        groups.dumbbellSeriesList.push(series);
+        break;
+      case 'gantt':
+        groups.ganttSeriesList.push(series);
+        break;
+      // A treemap, an icicle and a sunburst draw one tree three ways; the
+      // highlight walks the same nodes whichever it is, so they share a
+      // bucket. Which *mark* to measure is decided from the layer's trace type
+      // where the resolver is built, since that is what differs.
+      case 'treemap':
+      case 'icicle':
+      case 'sunburst':
+        groups.hierarchySeriesList.push(series);
+        break;
+      case 'wordcloud':
+        groups.wordCloudSeriesList.push(series);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return groups;
 }
 
 /** Register the resolvers (and owning chart) for one subplot's layers. */
@@ -630,11 +820,22 @@ function addEntryResolvers(
         break;
       }
       case TraceType.TREEMAP:
-      case TraceType.ICICLE: {
+      case TraceType.ICICLE:
+      case TraceType.SUNBURST: {
+        // One tree, three marks: a treemap block and an icicle bar are
+        // rectangles, a sunburst node is a wedge.
+        const kind: NavTarget['kind']
+          = layer.type === TraceType.SUNBURST ? 'slice' : 'column';
         register(
           layer.id,
-          buildHierarchyResolver(groups.hierarchySeriesList[hierarchyIdx++]),
+          buildHierarchyResolver(groups.hierarchySeriesList[hierarchyIdx++], kind),
         );
+        break;
+      }
+      case TraceType.GAUGE: {
+        // The one layer whose source is the chart rather than a series — a
+        // ClockHand gauge has no series for `groupSeries` to have bucketed.
+        register(layer.id, buildGaugeResolver(chart));
         break;
       }
       case TraceType.WORD_CLOUD: {

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -9,11 +9,13 @@
  * chart so highlights clip against the correct panel's plot area.
  */
 
-import type { HeatmapData, MaidrLayer } from '@type/grammar';
+import type { ChoroplethPoint, HeatmapData, MaidrLayer } from '@type/grammar';
 import type { AmDeclaredLayer } from './declaration';
+import type { ChoroplethFields } from './extractor';
 import type { AmChart, AmDataItem, AmXYSeries } from './types';
 import { TraceType } from '@type/grammar';
 import {
+  choroplethFields,
   extractCloudMarks,
   extractErrorBarSamples,
   extractForestSamples,
@@ -25,6 +27,7 @@ import {
   extractGanttItems,
   extractHierarchyNodes,
   extractSpanItems,
+  filterChoroplethItems,
   findGaugeHand,
   isColumnSeries,
 } from './extractor';
@@ -33,12 +36,12 @@ import {
  * The am5 entities to highlight for a navigation position.
  * `kind` tells the overlay which geometry to read: a column's box, a line
  * point, the wedge-shaped sprite of a pie slice, funnel stage or polar column,
- * or the glyph of a word cloud's term.
+ * the glyph of a word cloud's term, or the drawn polygon of a map region.
  */
 export interface NavTarget {
   series: AmXYSeries;
   dataItem: AmDataItem;
-  kind: 'column' | 'point' | 'slice' | 'label';
+  kind: 'column' | 'point' | 'slice' | 'label' | 'region';
 }
 
 /**
@@ -78,6 +81,22 @@ export interface NavMapEntry {
   layers: MaidrLayer[];
   groups: SeriesGroups;
   chart: AmChart;
+}
+
+/**
+ * Where one choropleth layer came from: the polygon series amCharts drew, and
+ * the field names a declaration renamed its facts to, when the author gave
+ * one.
+ *
+ * The fields have to travel with the series because they change *which
+ * regions the layer kept*: a map whose value hangs on a column amCharts was
+ * never bound to reads as no regions at all without them, and the highlight
+ * would then index a list of a different length from the one the reader is
+ * walking.
+ */
+export interface AmChoroplethSource {
+  series: AmXYSeries;
+  fields?: ChoroplethFields;
 }
 
 /**
@@ -131,6 +150,18 @@ export interface SeriesGroups {
   hierarchySeriesList: AmXYSeries[];
   /** One WORD_CLOUD layer each, in series order. */
   wordCloudSeriesList: AmXYSeries[];
+  /**
+   * One CHOROPLETH layer each, in series order.
+   *
+   * The one bucket that carries a declaration alongside the series, because a
+   * map is the one type this adapter reads BOTH ways: an `am5map`
+   * `MapPolygonSeries` bound to a `valueField` is a choropleth on its own, and
+   * one whose value hangs on a column amCharts was never told about is a
+   * choropleth the author declared. Both emit `TraceType.CHOROPLETH`, so one
+   * ordered bucket keeps the layers and their sources in step — which two
+   * buckets could not, since the layers interleave in series order.
+   */
+  choroplethSeriesList: AmChoroplethSource[];
   /**
    * One layer each for the series that declared what they mean, in series
    * order — a survival curve, an error bar, a forest plot, a cloud.
@@ -454,6 +485,99 @@ function buildCloudResolver(
 }
 
 /**
+ * Lay the regions out the way `ChoroplethTrace` does, as indices into the
+ * layer's own `data` array.
+ *
+ * **This mirrors model logic, deliberately, and the line it sits on is worth
+ * stating.** What the codebase refuses to copy is a *derived structure* — a
+ * scatter's binning, a flow's stage layering — because a copy of one drifts
+ * silently and then outlines a confidently wrong mark. `arrange`
+ * (`src/model/choropleth.ts`) is not that: it is a pure sort-and-chunk over
+ * exactly the numbers this adapter emitted, with no graph in it, the same kind
+ * of ordering {@link buildHeatmapResolver} already mirrors for the model's
+ * y-reversal and `filterWordCloudItems` for its weight order.
+ *
+ * Two things keep it honest rather than optimistic. A layer that declared no
+ * centroids arranges to one band in declared order, so the mirror degenerates
+ * to the identity map — which is the common case here, since the centroid read
+ * is unverified. And the contract is pinned by a test that constructs the real
+ * `ChoroplethTrace` and asks it, at every position, which region it just
+ * named.
+ *
+ * Sorted with the model's own comparisons on a stable sort, so regions of
+ * equal latitude keep their declared order in both.
+ *
+ * @param points - The regions the layer declared.
+ * @returns Their `data` indices, banded south-first and west-to-east.
+ */
+function arrangeRegions(points: readonly ChoroplethPoint[]): number[][] {
+  const placed = points.map((point, at) => ({
+    at,
+    lat: typeof point.lat === 'number' ? point.lat : Number.NaN,
+    lon: typeof point.lon === 'number' ? point.lon : Number.NaN,
+  }));
+  if (placed.length === 0) {
+    return [];
+  }
+  if (!placed.every(region => Number.isFinite(region.lat) && Number.isFinite(region.lon))) {
+    return [placed.map(region => region.at)];
+  }
+
+  const bands = Math.max(1, Math.round(Math.sqrt(placed.length)));
+  const perBand = Math.ceil(placed.length / bands);
+  const southFirst = [...placed].sort((a, b) => a.lat - b.lat);
+
+  const arranged: number[][] = [];
+  for (let start = 0; start < southFirst.length; start += perBand) {
+    arranged.push(
+      southFirst
+        .slice(start, start + perBand)
+        .sort((a, b) => a.lon - b.lon)
+        .map(region => region.at),
+    );
+  }
+  return arranged;
+}
+
+/**
+ * Build a resolver for a choropleth layer.
+ *
+ * A map is the one layer whose navigation grid is neither the declared order
+ * nor a filtered view of it: the regions are banded by latitude and read west
+ * to east inside each band, so `(row, col)` names a place on the map rather
+ * than a position in the data. {@link arrangeRegions} rebuilds that banding
+ * over the layer's own points and hands back the declared index, which then
+ * indexes the drawn polygons.
+ *
+ * The alignment guard is what makes it safe: the polygons are re-filtered with
+ * the same rule the extraction used, and a list of a different length from
+ * `layer.data` means the chart moved underneath the conversion. The resolver
+ * then answers nothing, the overlay clears, and no stale index gets outlined —
+ * the same call {@link buildCloudResolver} makes.
+ */
+function buildChoroplethResolver(
+  source: AmChoroplethSource | undefined,
+  layer: MaidrLayer,
+): Resolver {
+  const points = layer.data as ChoroplethPoint[];
+  if (!source || !Array.isArray(points)) {
+    return () => [];
+  }
+
+  const items = filterChoroplethItems(source.series, source.fields);
+  if (items.length !== points.length) {
+    return () => [];
+  }
+
+  const bands = arrangeRegions(points);
+  return (row, col) => {
+    const at = bands[row]?.[col];
+    const dataItem = at === undefined ? undefined : items[at];
+    return dataItem ? [{ series: source.series, dataItem, kind: 'region' }] : [];
+  };
+}
+
+/**
  * Build a resolver for a heatmap layer. amCharts heatmap dataItems are a flat,
  * insertion-ordered list, so we index them by `categoryX`/`categoryY` value.
  * MAIDR's Heatmap model reverses the Y axis (`src/model/heatmap.ts`), so we
@@ -547,6 +671,7 @@ export function groupSeries(chart: AmChart): SeriesGroups {
     ganttSeriesList: [],
     hierarchySeriesList: [],
     wordCloudSeriesList: [],
+    choroplethSeriesList: [],
     declaredList: [],
   };
 
@@ -562,7 +687,18 @@ export function groupSeries(chart: AmChart): SeriesGroups {
     }
     const declared = plan.declared.get(series);
     if (declared) {
-      groups.declaredList.push(declared);
+      // A declared choropleth goes to the map bucket rather than the declared
+      // one: its layer is a CHOROPLETH like any other, and keeping both kinds
+      // in one ordered bucket is what lets the resolver find the source of the
+      // n-th map layer without depending on generated ids.
+      if (declared.declaration.type === TraceType.CHOROPLETH) {
+        groups.choroplethSeriesList.push({
+          series,
+          fields: choroplethFields(declared.declaration),
+        });
+      } else {
+        groups.declaredList.push(declared);
+      }
       continue;
     }
 
@@ -629,6 +765,13 @@ export function groupSeries(chart: AmChart): SeriesGroups {
         break;
       case 'wordcloud':
         groups.wordCloudSeriesList.push(series);
+        break;
+      // A map region IS addressable — the polygon amCharts drew reports a box
+      // — so unlike the flow family below, a choropleth gets a bucket and a
+      // resolver. The banding the model navigates it by is rebuilt from the
+      // layer's own centroids; see `buildChoroplethResolver`.
+      case 'choropleth':
+        groups.choroplethSeriesList.push({ series });
         break;
       // A flow diagram and a force-directed network are read, described,
       // brailled and navigated, and deliberately get no bucket: MAIDR hands a
@@ -718,6 +861,7 @@ function addEntryResolvers(
   let ganttIdx = 0;
   let hierarchyIdx = 0;
   let wordCloudIdx = 0;
+  let choroplethIdx = 0;
 
   const register = (layerId: string, resolver: Resolver): void => {
     resolvers.set(layerId, resolver);
@@ -881,6 +1025,13 @@ function addEntryResolvers(
         // position on offer was the braille one, which for a scatter is a cell
         // of a *binned grid* rather than a point.
         register(layer.id, buildCloudResolver(nextDeclared(layer.type), layer));
+        break;
+      }
+      case TraceType.CHOROPLETH: {
+        register(
+          layer.id,
+          buildChoroplethResolver(groups.choroplethSeriesList[choroplethIdx++], layer),
+        );
         break;
       }
       case TraceType.HEATMAP: {

--- a/src/adapters/amcharts/overlay.ts
+++ b/src/adapters/amcharts/overlay.ts
@@ -149,9 +149,46 @@ function readRect(target: NavTarget): OverlayRect | null {
       return sliceRect(target);
     case 'label':
       return labelRect(target);
+    case 'region':
+      return regionRect(target);
     case 'column':
       return columnRect(target);
   }
+}
+
+/**
+ * Rectangle for a map region — the polygon an am5map `MapPolygonSeries` drew,
+ * which it keeps on the data item's `mapPolygon`.
+ *
+ * Measured from the reported bounds first, for the reason a word cloud's glyph
+ * is: a region is an irregular shape at whatever angle the projection put it,
+ * and its local width and height describe a box it does not fill. The
+ * axis-aligned box `globalBounds()` maps is the honest outline for one — coarse
+ * for a long thin country, but it hugs the shape and says which way navigation
+ * moved, which is what the highlight is for.
+ *
+ * A polygon reporting no box with area answers `null` rather than a hairline:
+ * an am5 `Graphics` painted through a draw callback can report a degenerate
+ * point (the `Slice` problem of #774), and there is no radius or sweep to
+ * measure a region from instead. The overlay then clears, which says nothing
+ * rather than pointing a one-pixel mark at the wrong place.
+ */
+function regionRect(target: NavTarget): OverlayRect | null {
+  const polygon = target.dataItem.get('mapPolygon') as AmSprite | undefined;
+  if (!polygon) {
+    return null;
+  }
+
+  const bounds = polygon.globalBounds?.();
+  if (bounds) {
+    const box = boundsToRect(bounds);
+    if (box.width > 0 && box.height > 0) {
+      return box;
+    }
+  }
+
+  const box = spriteBoxRect(polygon);
+  return box && box.width > 0 && box.height > 0 ? box : null;
 }
 
 /**

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -3,6 +3,7 @@ import type {
   BarPoint,
   DumbbellData,
   GanttData,
+  GaugePoint,
   LinePoint,
   MaidrLayer,
   PiePoint,
@@ -23,6 +24,7 @@ import {
   fakeFloatingColumnSeries,
   fakeFunnelSeries,
   fakeGanttSeries,
+  fakeGaugeChart,
   fakeHierarchySeries,
   fakeHorizontalBarSeries,
   fakeLineSeries,
@@ -898,6 +900,175 @@ describe('fromAmCharts (hierarchy)', () => {
 
     expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].selectors)
       .toBeUndefined();
+  });
+});
+
+describe('fromAmCharts (sunburst)', () => {
+  const TREE = {
+    category: 'Root',
+    children: [
+      {
+        category: 'Asia',
+        children: [
+          { category: 'China', value: 1425 },
+          { category: 'India', value: 1428 },
+        ],
+      },
+      { category: 'Africa', children: [{ category: 'Nigeria', value: 224 }] },
+    ],
+  };
+
+  it('finds a standalone Sunburst, which like a treemap is no chart at all', () => {
+    // A `Sunburst` extends `Partition` but carries its own class name, so it is
+    // discovered only because it is named in its own right.
+    const series = fakeHierarchySeries('Population', TREE, 'Sunburst');
+    const root = fakeRoot([fakeContainer([series])]);
+
+    const found = findCharts(root);
+    expect(found).toHaveLength(1);
+    expect(found[0].series.values).toEqual([series]);
+  });
+
+  it('reads a Sunburst as a sunburst, not as the icicle it extends', () => {
+    const series = fakeHierarchySeries('Population', TREE, 'Sunburst');
+
+    const layer = fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.SUNBURST);
+    expect(layer.title).toBe('Population');
+    // A tree is bound to no axis, so the dimensions name what they hold.
+    expect(layer.axes).toEqual({ x: { label: 'Node' }, y: { label: 'Value' } });
+    // The same walk the treemap and the icicle emit: one tree, three marks.
+    expect(layer.data as TreemapPoint[]).toEqual([
+      { x: 'Asia', path: [] },
+      { x: 'China', y: 1425, path: ['Asia'] },
+      { x: 'India', y: 1428, path: ['Asia'] },
+      { x: 'Africa', path: [] },
+      { x: 'Nigeria', y: 224, path: ['Africa'] },
+    ]);
+  });
+
+  it('emits no selectors: amCharts paints the wedges to canvas, not to SVG', () => {
+    const series = fakeHierarchySeries('Population', TREE, 'Sunburst');
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].selectors)
+      .toBeUndefined();
+  });
+});
+
+describe('fromAmCharts (gauge)', () => {
+  function gaugeLayer(config: Parameters<typeof fakeGaugeChart>[0] = {}): MaidrLayer {
+    return fromAmCharts(fakeRoot([fakeGaugeChart(config)])).subplots[0][0].layers[0];
+  }
+
+  it('reads a RadarChart with a ClockHand and no series at all as a gauge', () => {
+    // The whole point of the shape: the needle is a bullet on an AXIS data
+    // item, so the series loop finds nothing and the chart-level fallback is
+    // the only thing that can see the reading.
+    const layer = gaugeLayer({ value: 73, min: 0, max: 120, axisLabel: 'km/h' });
+
+    expect(layer.type).toBe(TraceType.GAUGE);
+    // A single object, not an array of one: the chart draws exactly one measure.
+    expect(layer.data).toEqual({ value: 73, min: 0, max: 120, label: 'km/h' });
+    expect(Array.isArray(layer.data)).toBe(false);
+    expect(layer.axes).toEqual({ x: { label: 'Measure' }, y: { label: 'km/h' } });
+  });
+
+  it('names the measure after the chart when the chart is titled', () => {
+    const layer = gaugeLayer({ value: 40, title: 'Server load', axisLabel: 'percent' });
+
+    expect(layer.title).toBe('Server load');
+    expect((layer.data as GaugePoint).label).toBe('Server load');
+  });
+
+  it('reads the dial from the extremes amCharts computed when none were set', () => {
+    const layer = gaugeLayer({ min: 10, max: 90, value: 55, privateExtremes: true });
+
+    expect(layer.data).toMatchObject({ min: 10, max: 90, value: 55 });
+  });
+
+  it('finds a hand filed under the axis dataItems as well as under its ranges', () => {
+    // Which list a made axis data item lands in is not checkable without the
+    // library, so both are read.
+    expect(gaugeLayer({ viaDataItems: true, value: 12 }).data)
+      .toMatchObject({ value: 12 });
+  });
+
+  it('finds a hand whose bullet exposes its sprite as a plain property', () => {
+    expect(gaugeLayer({ bulletProperty: true, value: 12 }).data)
+      .toMatchObject({ value: 12 });
+  });
+
+  it('carries the dial bands ascending, numbering the ones nothing names', () => {
+    const layer = gaugeLayer({
+      value: 73,
+      bands: [
+        { endValue: 100 },
+        { endValue: 40, label: 'poor' },
+        { endValue: 70 },
+      ],
+    });
+
+    // Upper edges only: a band starts where the previous one ended, which is
+    // why an unsorted list would describe a partition the chart does not draw.
+    expect((layer.data as GaugePoint).bands).toEqual([
+      { to: 40, label: 'poor' },
+      { to: 70, label: 'Band 2' },
+      { to: 100, label: 'Band 3' },
+    ]);
+  });
+
+  it('leaves the hand out of the bands: a reading is not one of them', () => {
+    // The hand's own axis range carries a value and no end, which is exactly
+    // what separates it from a band.
+    const layer = gaugeLayer({ value: 73, bands: [{ endValue: 100 }] });
+
+    expect((layer.data as GaugePoint).bands).toEqual([{ to: 100, label: 'Band 1' }]);
+  });
+
+  it('emits no layer for a dial with no finite ends, rather than one of NaNs', () => {
+    // GaugeTrace pitches its tone against the range, so a reading with no
+    // range behind it is not a reading -- and a chart with no layers is
+    // dropped, which is the honest degradation.
+    const chart = fakeGaugeChart({ privateExtremes: true, min: Number.NaN, max: Number.NaN });
+
+    expect(() => fromAmCharts(fakeRoot([chart]))).toThrow();
+  });
+
+  it('emits no layer when the hand points at no value', () => {
+    expect(() => fromAmCharts(fakeRoot([fakeGaugeChart({ value: null })]))).toThrow();
+  });
+
+  it('reads the first of several hands, and says so', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(gaugeLayer({ hands: 2, value: 73 }).data).toMatchObject({ value: 73 });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('2 hands'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('leaves an ordinary radar chart a radar, hand or no hand', () => {
+    // RADAR and POLAR_AREA are drawn in the same `RadarChart`, so the gauge
+    // path runs only when the series produced no layer at all.
+    const chart = fakeGaugeChart({
+      series: [fakeRadarSeries('Speed', [
+        { categoryX: 'Mon', valueY: 10 },
+        { categoryX: 'Tue', valueY: 20 },
+      ])],
+    });
+
+    const layers = fromAmCharts(fakeRoot([chart])).subplots[0][0].layers;
+    expect(layers).toHaveLength(1);
+    expect(layers[0].type).toBe(TraceType.RADAR);
+  });
+
+  it('ignores a chart that is not a RadarChart, and a sprite that is no hand', () => {
+    expect(() => fromAmCharts(fakeRoot([fakeGaugeChart({ className: 'XYChart' })])))
+      .toThrow();
+    expect(() => fromAmCharts(fakeRoot([fakeGaugeChart({ handClassName: 'Bullet' })])))
+      .toThrow();
   });
 });
 

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -2,10 +2,12 @@ import type { AmChartsBinderOptions, AmXYSeries } from '@adapters/amcharts/types
 import type {
   BarPoint,
   DumbbellData,
+  FlowPoint,
   GanttData,
   GaugePoint,
   LinePoint,
   MaidrLayer,
+  NetworkPoint,
   PiePoint,
   SegmentedPoint,
   TreemapPoint,
@@ -22,6 +24,8 @@ import {
   fakeContainerEl,
   fakeDotSeries,
   fakeFloatingColumnSeries,
+  fakeFlowSeries,
+  fakeForceDirectedSeries,
   fakeFunnelSeries,
   fakeGanttSeries,
   fakeGaugeChart,
@@ -950,6 +954,215 @@ describe('fromAmCharts (sunburst)', () => {
 
   it('emits no selectors: amCharts paints the wedges to canvas, not to SVG', () => {
     const series = fakeHierarchySeries('Population', TREE, 'Sunburst');
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].selectors)
+      .toBeUndefined();
+  });
+});
+
+describe('fromAmCharts (flow: sankey, chord, arc diagram)', () => {
+  const LINKS = [
+    { sourceId: 'Coal', targetId: 'Electricity', value: 34 },
+    { sourceId: 'Gas', targetId: 'Electricity', value: 21 },
+    { sourceId: 'Electricity', targetId: 'Homes', value: 40 },
+  ];
+
+  it('finds a standalone Sankey, which like a treemap is no chart at all', () => {
+    // An am5flow series is an `am5.Series` pushed straight into a container,
+    // so discovery has to recognise the series itself or recurse past it.
+    const series = fakeFlowSeries('Energy', LINKS);
+    const root = fakeRoot([fakeContainer([series])]);
+
+    const found = findCharts(root);
+    expect(found).toHaveLength(1);
+    expect(found[0].series.values).toEqual([series]);
+  });
+
+  it('converts a Sankey into one point per link, nodes derived from the ends', () => {
+    const series = fakeFlowSeries('Energy', LINKS);
+
+    const layer = fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.SANKEY);
+    expect(layer.title).toBe('Energy');
+    // A flow is bound to no axis, so the dimensions name what they hold.
+    expect(layer.axes).toEqual({ x: { label: 'Node' }, y: { label: 'Weight' } });
+    expect(layer.data as FlowPoint[]).toEqual([
+      { source: 'Coal', target: 'Electricity', value: 34 },
+      { source: 'Gas', target: 'Electricity', value: 21 },
+      { source: 'Electricity', target: 'Homes', value: 40 },
+    ]);
+  });
+
+  it('reads an end off the node data item when no id was resolved', () => {
+    // The second of the three probes: amCharts joined the link to a node
+    // object, and the id setting answered with nothing.
+    const series = fakeFlowSeries('Energy', [{
+      sourceNode: { name: 'Coal' },
+      targetNode: { id: 'Electricity' },
+      value: 34,
+    }]);
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].data)
+      .toEqual([{ source: 'Coal', target: 'Electricity', value: 34 }]);
+  });
+
+  it('reads an end and a weight off the author\'s own row as a last resort', () => {
+    // The third probe. Neither the resolved id nor a node object answered, so
+    // the row the author supplied is all there is — keyed by the fields the
+    // series was told to read, which amCharts defaults to `from`/`to`/`value`.
+    const series = fakeFlowSeries('Energy', [
+      { row: { from: 'Coal', to: 'Electricity', value: 34 } },
+      { row: { origin: 'Gas', dest: 'Electricity', mwh: 21 } },
+    ], 'Sankey');
+    const named = fakeFlowSeries('Energy', [
+      { row: { origin: 'Gas', dest: 'Electricity', mwh: 21 } },
+    ], 'Sankey', { sourceIdField: 'origin', targetIdField: 'dest', valueField: 'mwh' });
+
+    // Default field names: only the first row reads.
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].data)
+      .toEqual([{ source: 'Coal', target: 'Electricity', value: 34 }]);
+    // The author's own field names: the same row now reads.
+    expect(fromAmCharts(fakeRoot([named])).subplots[0][0].layers[0].data)
+      .toEqual([{ source: 'Gas', target: 'Electricity', value: 21 }]);
+  });
+
+  it('drops a link with no end, and one carrying no weight', () => {
+    // A ribbon amCharts does not draw but MAIDR still counts would slide every
+    // later position onto its neighbour. `Number(null)` is 0 and finite, so a
+    // missing weight has to be refused rather than coerced.
+    const series = fakeFlowSeries('Energy', [
+      { sourceId: 'Coal', targetId: 'Electricity', value: 34 },
+      { sourceId: 'Gas', value: 21 },
+      { sourceId: 'Oil', targetId: 'Electricity' },
+      { sourceId: 'Wind', targetId: 'Electricity', value: 0 },
+      { sourceId: 'Sun', targetId: 'Electricity', value: Number.NaN },
+    ]);
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].data)
+      .toEqual([{ source: 'Coal', target: 'Electricity', value: 34 }]);
+  });
+
+  it('reads every Chord variant as a chord, and an ArcDiagram as a sankey', () => {
+    // The three chord classes each extend the last and each carry their own
+    // class name, so each has to be listed. An arc diagram is a sankey rather
+    // than a network: it extends `FlowSeries` and carries weights, and a
+    // network payload has nowhere to put one.
+    const typeOf = (className: string): TraceType =>
+      fromAmCharts(fakeRoot([fakeFlowSeries('Trade', LINKS, className)]))
+        .subplots[0][0]
+        .layers[0]
+        .type;
+
+    expect(typeOf('Chord')).toBe(TraceType.CHORD);
+    expect(typeOf('ChordDirected')).toBe(TraceType.CHORD);
+    expect(typeOf('ChordNonRibbon')).toBe(TraceType.CHORD);
+    expect(typeOf('ArcDiagram')).toBe(TraceType.SANKEY);
+  });
+
+  it('emits no selectors: amCharts paints the ribbons to canvas, not to SVG', () => {
+    const series = fakeFlowSeries('Energy', LINKS);
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].selectors)
+      .toBeUndefined();
+  });
+
+  it('leaves a flow series whose links none resolve out of the figure', () => {
+    // A layer of nothing is worse than no layer: `convertCharts` drops a chart
+    // with none and says so, rather than announcing an empty graph.
+    const series = fakeFlowSeries('Energy', [{ value: 34 }, { sourceId: 'Coal' }]);
+
+    expect(() => fromAmCharts(fakeRoot([series]))).toThrow(/no supported series with data/);
+  });
+});
+
+describe('fromAmCharts (network)', () => {
+  const TREE = {
+    category: 'Root',
+    children: [
+      {
+        category: 'Ada',
+        row: { name: 'Ada', linkWith: ['Grace'] },
+        children: [
+          { category: 'Alan', row: { name: 'Alan' } },
+          { category: 'Grace', row: { name: 'Grace' } },
+        ],
+      },
+      { category: 'Edsger', row: { name: 'Edsger', linkWith: ['Alan', 'Nobody'] } },
+    ],
+  };
+
+  it('finds a standalone ForceDirected, which is no chart either', () => {
+    const series = fakeForceDirectedSeries('People', TREE);
+    const root = fakeRoot([fakeContainer([series])]);
+
+    const found = findCharts(root);
+    expect(found).toHaveLength(1);
+    expect(found[0].series.values).toEqual([series]);
+  });
+
+  it('reads the tree as links: one per parent-child edge, root dropped', () => {
+    // A force-directed graph is a HIERARCHY series in amCharts, not a link
+    // list, so the edges are the tree's own and the container root is not one
+    // of the participants.
+    const series = fakeForceDirectedSeries('People', TREE);
+
+    const layer = fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0];
+
+    expect(layer.type).toBe(TraceType.NETWORK);
+    expect(layer.title).toBe('People');
+    expect(layer.axes).toEqual({ x: { label: 'Node' }, y: { label: 'Links' } });
+    expect(layer.data as NetworkPoint[]).toEqual([
+      { source: 'Ada', target: 'Alan' },
+      { source: 'Ada', target: 'Grace' },
+    ]);
+  });
+
+  it('adds the cross-links a row names, and skips one naming no node', () => {
+    // `linkWith` is the only place a force-directed graph's non-tree edges
+    // live. An entry the walk never saw names nothing amCharts drew either, so
+    // inventing the node would announce a participant the chart does not have.
+    const series = fakeForceDirectedSeries('People', TREE, { linkWithField: 'linkWith' });
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].data).toEqual([
+      { source: 'Ada', target: 'Alan' },
+      { source: 'Ada', target: 'Grace' },
+      { source: 'Edsger', target: 'Alan' },
+    ]);
+  });
+
+  it('resolves a cross-link named by id when that is not the node label', () => {
+    // `idField` and `categoryField` are the same column in amCharts' own
+    // examples, but they need not be — and a reference by id is still a
+    // reference to a node the walk saw.
+    const series = fakeForceDirectedSeries('People', {
+      category: 'Root',
+      children: [
+        { category: 'Ada Lovelace', row: { key: 'ada', linkWith: ['grace'] } },
+        { category: 'Grace Hopper', row: { key: 'grace' } },
+      ],
+    }, { linkWithField: 'linkWith', idField: 'key' });
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].data)
+      .toEqual([{ source: 'Ada Lovelace', target: 'Grace Hopper' }]);
+  });
+
+  it('emits one link for a pair that names itself from both ends', () => {
+    // A link is undirected, so two rows naming each other draw one line.
+    const series = fakeForceDirectedSeries('People', {
+      category: 'Root',
+      children: [
+        { category: 'Ada', row: { linkWith: ['Grace'] } },
+        { category: 'Grace', row: { linkWith: ['Ada'] } },
+      ],
+    }, { linkWithField: 'linkWith' });
+
+    expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].data)
+      .toEqual([{ source: 'Ada', target: 'Grace' }]);
+  });
+
+  it('emits no selectors: amCharts paints the links to canvas, not to SVG', () => {
+    const series = fakeForceDirectedSeries('People', TREE);
 
     expect(fromAmCharts(fakeRoot([series])).subplots[0][0].layers[0].selectors)
       .toBeUndefined();

--- a/test/adapters/amcharts/adapter.test.ts
+++ b/test/adapters/amcharts/adapter.test.ts
@@ -1,6 +1,7 @@
 import type { AmChartsBinderOptions, AmXYSeries } from '@adapters/amcharts/types';
 import type {
   BarPoint,
+  ChoroplethPoint,
   DumbbellData,
   FlowPoint,
   GanttData,
@@ -33,6 +34,9 @@ import {
   fakeHorizontalBarSeries,
   fakeLineSeries,
   fakeLollipopSeries,
+  fakeMapChart,
+  fakeMapPolygon,
+  fakeMapPolygonSeries,
   fakePieChart,
   fakePieSeries,
   fakePolarSeries,
@@ -1282,6 +1286,245 @@ describe('fromAmCharts (gauge)', () => {
       .toThrow();
     expect(() => fromAmCharts(fakeRoot([fakeGaugeChart({ handClassName: 'Bullet' })])))
       .toThrow();
+  });
+});
+
+describe('fromAmCharts (choropleth)', () => {
+  /** Three western states, shaded, with the value amCharts resolved. */
+  const WEST = [
+    { name: 'Washington', value: 12.1 },
+    { name: 'Oregon', value: 16.4 },
+    { name: 'Nevada', value: 38.9 },
+  ];
+
+  it('finds a MapChart, which neither chart gate could see', () => {
+    // A `MapChart` is a `SerialChart`: a series list, no axes, and a class name
+    // of its own — so `isXYChartLike` and `isPercentChartLike` both miss it and
+    // discovery used to recurse straight past into its own containers.
+    const series = fakeMapPolygonSeries('Rate', WEST);
+    const chart = fakeMapChart({ series: [series] });
+    const root = fakeRoot([fakeContainer([chart])]);
+
+    const found = findCharts(root);
+    expect(found).toHaveLength(1);
+    expect(found[0].series.values).toEqual([series]);
+    // Not an XY chart: the narrower entry point must not claim it.
+    expect(findXYCharts(root)).toEqual([]);
+  });
+
+  it('measures the panel from the MapChart itself, which is its own container', () => {
+    // A `MapChart` has no `plotContainer` — that is an `XYChart` notion — so
+    // the wrapper points the slot at the chart, which IS a `Container`. Without
+    // it `readPlotBounds` answers nothing and a map beside another panel has
+    // its highlight suppressed outright.
+    const bounds = { left: 0, top: 0, right: 400, bottom: 300 };
+    const chart = fakeMapChart({
+      series: [fakeMapPolygonSeries('Rate', WEST)],
+      bounds,
+    });
+
+    const found = findCharts(fakeRoot([chart]));
+    expect(found[0].plotContainer?.globalBounds?.()).toEqual(bounds);
+  });
+
+  it('converts a shaded MapPolygonSeries into one point per region', () => {
+    const series = fakeMapPolygonSeries('Rate', WEST);
+
+    const layer = fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0]
+      .layers[0];
+
+    expect(layer.type).toBe(TraceType.CHOROPLETH);
+    expect(layer.title).toBe('Rate');
+    // A map is bound to no axis: the value runs along a colour ramp and the
+    // regions along nothing at all.
+    expect(layer.axes).toEqual({ x: { label: 'Region' }, y: { label: 'Value' } });
+    expect(layer.data as ChoroplethPoint[]).toEqual([
+      { x: 'Washington', y: 12.1 },
+      { x: 'Oregon', y: 16.4 },
+      { x: 'Nevada', y: 38.9 },
+    ]);
+  });
+
+  it('skips the base geography, the graticule, the lines and the pins', () => {
+    // A map routinely carries a polygon series with no values under the shaded
+    // one. Announcing it would offer a list of every country with nothing to
+    // say about any of them — and `classifySeriesKind` answers `'bar'` for
+    // anything it does not know, so without the map classes each of these
+    // would have been read as a bar chart of its shapes rather than skipped.
+    const base = fakeMapPolygonSeries('World', WEST, {});
+    const lines = fakeMapPolygonSeries('Routes', WEST, { valueField: 'value' }, 'MapLineSeries');
+    const pins = fakeMapPolygonSeries('Cities', WEST, { valueField: 'value' }, 'MapPointSeries');
+    const grid = fakeMapPolygonSeries('Grid', WEST, { valueField: 'value' }, 'GraticuleSeries');
+
+    for (const series of [base, lines, pins, grid]) {
+      expect(() => fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })])))
+        .toThrow(/no supported series with data/);
+    }
+  });
+
+  it('reads a polygon series shaded through heatRules alone', () => {
+    // `heatRules` is how the shading is declared; either it or a bound
+    // `valueField` says the author meant this series to carry a reading.
+    const series = fakeMapPolygonSeries('Rate', WEST, {
+      heatRules: [{ target: 'polygon', dataField: 'value' }],
+    });
+
+    expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0].layers[0].type).toBe(TraceType.CHOROPLETH);
+  });
+
+  it('leaves out a region amCharts drew but joined no value onto', () => {
+    // The ordinary case on a real map — the shapes drawn in the no-data
+    // colour. `Number(null)` is 0 and finite, so an absent value has to be
+    // refused rather than coerced into a region worth nothing.
+    const series = fakeMapPolygonSeries('Rate', [
+      { name: 'Washington', value: 12.1 },
+      { name: 'California' },
+      { name: 'Nevada', value: 38.9 },
+    ]);
+
+    expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0]
+      .layers[0]
+      .data as ChoroplethPoint[])
+      .toEqual([{ x: 'Washington', y: 12.1 }, { x: 'Nevada', y: 38.9 }]);
+  });
+
+  it('names a region from the row when amCharts resolved no name', () => {
+    // A GeoJSON feature keeps everything joined onto it under `properties`,
+    // and an am5map row is ordinarily keyed by `id`. Both are on the chain,
+    // names ahead of codes: a region is called by its name, not by its FIPS.
+    const series = fakeMapPolygonSeries('Rate', [
+      { value: 12.1, row: { id: '53', properties: { NAME: 'Washington' } } },
+      { value: 38.9, row: { id: '32' } },
+    ]);
+
+    expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0]
+      .layers[0]
+      .data as ChoroplethPoint[])
+      .toEqual([{ x: 'Washington', y: 12.1 }, { x: '32', y: 38.9 }]);
+  });
+
+  it('reads the value off the column the series was bound to', () => {
+    // amCharts resolved nothing onto the data item, so the author's own row —
+    // keyed by the field the series names — is what carries the shading.
+    const series = fakeMapPolygonSeries('Rate', [
+      { name: 'Washington', row: { deaths: 12.1 } },
+      { name: 'Nevada', row: { deaths: 38.9 } },
+    ], { valueField: 'deaths' });
+
+    expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0]
+      .layers[0]
+      .data as ChoroplethPoint[])
+      .toEqual([{ x: 'Washington', y: 12.1 }, { x: 'Nevada', y: 38.9 }]);
+  });
+
+  it('places the regions from the drawn polygons\' geographic centroids', () => {
+    // The centroids are what make this a map rather than a bar chart whose
+    // categories happen to be places: `ChoroplethTrace` walks north, south,
+    // east and west out of this pair and out of nothing else.
+    const series = fakeMapPolygonSeries('Rate', [
+      {
+        name: 'Washington',
+        value: 12.1,
+        polygon: fakeMapPolygon({ centroid: { longitude: -120.5, latitude: 47.4 } }),
+      },
+      {
+        name: 'Nevada',
+        value: 38.9,
+        polygon: fakeMapPolygon({ centroid: { longitude: -116.6, latitude: 39.3 } }),
+      },
+    ]);
+
+    expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0]
+      .layers[0]
+      .data as ChoroplethPoint[])
+      .toEqual([
+        { x: 'Washington', y: 12.1, lon: -120.5, lat: 47.4 },
+        { x: 'Nevada', y: 38.9, lon: -116.6, lat: 39.3 },
+      ]);
+  });
+
+  it('omits the pair rather than believing a centroid that is not in degrees', () => {
+    // The highest-consequence read in the batch, and the one that cannot be
+    // checked without the library. A projected coordinate accepted here is a
+    // wrong compass direction; omitted, the map degrades to a region list in
+    // declared order, which the grammar explicitly sanctions.
+    const projected = fakeMapPolygon({ centroid: { longitude: 1340221, latitude: 5621880 } });
+    const absent = fakeMapPolygon({});
+    const broken = fakeMapPolygon({ centroidThrows: true });
+    const half = fakeMapPolygon({ centroid: { longitude: -116.6, latitude: null } });
+
+    for (const polygon of [projected, absent, broken, half]) {
+      const series = fakeMapPolygonSeries('Rate', [
+        { name: 'Nevada', value: 38.9, polygon },
+      ]);
+      expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+        .subplots[0][0]
+        .layers[0]
+        .data as ChoroplethPoint[])
+        .toEqual([{ x: 'Nevada', y: 38.9 }]);
+    }
+  });
+
+  it('prefers a centroid the author stated to the one the polygon reports', () => {
+    // A table of `{ region, value, lon, lat }` states the pair outright, and a
+    // stated degree pair beats a derived one — the same order the Highcharts
+    // adapter reads a map in.
+    const series = fakeMapPolygonSeries('Rate', [{
+      name: 'Nevada',
+      value: 38.9,
+      polygon: fakeMapPolygon({ centroid: { longitude: -1, latitude: -1 } }),
+      row: { longitude: -116.6, latitude: 39.3 },
+    }]);
+
+    expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0]
+      .layers[0]
+      .data as ChoroplethPoint[])
+      .toEqual([{ x: 'Nevada', y: 38.9, lon: -116.6, lat: 39.3 }]);
+  });
+
+  it('emits no selectors: amCharts paints the polygons to canvas, not to SVG', () => {
+    const series = fakeMapPolygonSeries('Rate', WEST);
+
+    expect(fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })]))
+      .subplots[0][0].layers[0].selectors).toBeUndefined();
+  });
+
+  it('drops a map whose regions all missed their join', () => {
+    // Not a layer of NaNs, and not an empty subplot either: `convertCharts`
+    // drops a chart yielding no layer and says so, which is the difference
+    // between an actionable error and a crash inside the core model.
+    const series = fakeMapPolygonSeries('Rate', [{ name: 'Washington' }, { name: 'Nevada' }]);
+
+    expect(() => fromAmCharts(fakeRoot([fakeMapChart({ series: [series] })])))
+      .toThrow(/no supported series with data/);
+  });
+
+  it('places a map beside another panel in the grid', () => {
+    // The wrapper's whole point: with a plot container to measure, a map takes
+    // its place in `computeChartGrid` like any other panel.
+    const map = fakeMapChart({
+      series: [fakeMapPolygonSeries('Rate', WEST)],
+      bounds: { left: 0, top: 0, right: 300, bottom: 200 },
+    });
+    const bars = fakeChart({
+      series: [fakeBarSeries('Sales', [{ categoryX: 'Q1', valueY: 5 }])],
+      bounds: { left: 0, top: 300, right: 300, bottom: 500 },
+    });
+
+    const maidr = fromAmCharts(fakeRoot([map, bars]));
+
+    // Rows are emitted bottom-first, so the lower panel — the bar chart — is
+    // row 0 and the map sits above it.
+    expect(maidr.subplots).toHaveLength(2);
+    expect(maidr.subplots[0][0].layers[0].type).toBe(TraceType.BAR);
+    expect(maidr.subplots[1][0].layers[0].type).toBe(TraceType.CHOROPLETH);
   });
 });
 

--- a/test/adapters/amcharts/declaration.test.ts
+++ b/test/adapters/amcharts/declaration.test.ts
@@ -9,13 +9,15 @@ import type {
 } from '@type/grammar';
 import { findCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
 import { planDeclarations } from '@adapters/amcharts/declaration';
-import { buildNavigationMap } from '@adapters/amcharts/navmap';
+import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
 import { Orientation, TraceType } from '@type/grammar';
 import {
   fakeChart,
   fakeContainer,
   fakeContainerEl,
   fakeFlowSeries,
+  fakeMapChart,
+  fakeMapPolygonSeries,
   fakePieSeries,
   fakeRoot,
   fakeSeries,
@@ -285,6 +287,126 @@ describe('declared alluvials', () => {
 
     expect(layersOf([declared, sibling]).map(layer => layer.type))
       .toEqual([TraceType.ALLUVIAL, TraceType.SANKEY]);
+  });
+});
+
+describe('declared choropleths', () => {
+  /** The layer a one-map figure produces. */
+  function mapLayer(series: AmXYSeries): MaidrLayer {
+    const layers = fromXYChart(fakeMapChart({ series: [series] }), CONTAINER)
+      .subplots[0][0]
+      .layers;
+    expect(layers).toHaveLength(1);
+    return layers[0];
+  }
+
+  it('reads a map whose value amCharts was never bound to', () => {
+    // The reason the declaration is worth having at all. With no `valueField`
+    // the series is the base geography as far as the heuristics can tell, and
+    // the whole map is skipped; the block says which column the shading is in.
+    const undeclared = fakeMapPolygonSeries('Rate', [
+      { name: 'Nevada', row: { deaths: 38.9 } },
+      { name: 'Oregon', row: { deaths: 16.4 } },
+    ], {});
+    const declared = fakeMapPolygonSeries('Rate', [
+      { name: 'Nevada', row: { deaths: 38.9 } },
+      { name: 'Oregon', row: { deaths: 16.4 } },
+    ], { userData: { maidr: { type: 'choropleth', value: 'deaths' } } });
+
+    expect(() => fromXYChart(fakeMapChart({ series: [undeclared] }), CONTAINER))
+      .toThrow(/no supported series with data/);
+
+    const layer = mapLayer(declared);
+    expect(layer.type).toBe(TraceType.CHOROPLETH);
+    expect(layer.axes).toEqual({ x: { label: 'Region' }, y: { label: 'Value' } });
+    expect(layer.data).toEqual([{ x: 'Nevada', y: 38.9 }, { x: 'Oregon', y: 16.4 }]);
+  });
+
+  it('renames the region and the centroid pair too', () => {
+    // All four facts of a map are renameable, and the two that matter most are
+    // the coordinates: named wrong the map reads as a region list, named right
+    // it is walked as a map.
+    const series = fakeMapPolygonSeries('Rate', [
+      { row: { place: 'Nevada', deaths: 38.9, east: -116.6, north: 39.3 } },
+    ], {
+      userData: {
+        maidr: {
+          type: 'choropleth',
+          region: 'place',
+          value: 'deaths',
+          lon: 'east',
+          lat: 'north',
+        },
+      },
+    });
+
+    expect(mapLayer(series).data)
+      .toEqual([{ x: 'Nevada', y: 38.9, lon: -116.6, lat: 39.3 }]);
+  });
+
+  it('keeps the name and title the block declared', () => {
+    const series = fakeMapPolygonSeries('Rate', [{ name: 'Nevada', value: 38.9 }], {
+      valueField: 'value',
+      userData: {
+        maidr: { type: 'choropleth', name: 'rates', title: 'Deaths per 100,000' },
+      },
+    });
+
+    const layer = mapLayer(series);
+
+    expect(layer.name).toBe('rates');
+    expect(layer.title).toBe('Deaths per 100,000');
+  });
+
+  it('refuses the block on a series that draws no regions', () => {
+    // The "wrong construct" check: `type: 'choropleth'` on a column series is
+    // a mistake worth reporting, not a map to emit with nothing in it.
+    const declared = fakeSeries({
+      className: 'ColumnSeries',
+      name: 'Rate',
+      userData: { maidr: { type: 'choropleth' } },
+      settings: { categoryXField: 'category' },
+      data: [{ categoryX: 'Nevada', valueY: 38.9, value: 38.9, name: 'Nevada' }],
+    });
+
+    expect(layerOf([declared]).type).toBe(TraceType.BAR);
+    expect(warnings()).toContain('no mark of it carries the values');
+  });
+
+  it('falls back when the named column reaches no region', () => {
+    const series = fakeMapPolygonSeries('Rate', [{ name: 'Nevada', row: { deaths: 38.9 } }], {
+      userData: { maidr: { type: 'choropleth', value: 'fatalities' } },
+    });
+
+    expect(() => fromXYChart(fakeMapChart({ series: [series] }), CONTAINER))
+      .toThrow(/no supported series with data/);
+    expect(warnings()).toContain('no mark of it carries the values');
+  });
+
+  it('keeps the declared map and its highlight in step', () => {
+    // A declared map lands in the same ordered bucket an undeclared one does,
+    // carrying the field names with it — because the fields decide which
+    // regions the layer KEPT, and a resolver filtering by a different rule
+    // would index a list of a different length and clear.
+    const declared = fakeMapPolygonSeries('Rate', [
+      { name: 'Nevada', polygon: { globalBounds: () => ({ left: 0, top: 0, right: 8, bottom: 8 }) }, row: { deaths: 38.9 } },
+      { name: 'Oregon', row: { note: 'no data' } },
+    ], { userData: { maidr: { type: 'choropleth', value: 'deaths' } } });
+    const chart = fakeMapChart({ series: [declared] });
+    const layer = fromXYChart(chart, CONTAINER).subplots[0][0].layers[0];
+
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [layer],
+      groups: groupSeries(chart),
+    }]);
+
+    const [target] = navMap.resolve(layer.id, 0, 0);
+    expect(target).toBeDefined();
+    expect(target.kind).toBe('region');
+    // Oregon carried no `deaths` column and was left out of the layer, so the
+    // one announced region is Nevada and the outline is Nevada's polygon.
+    expect(layer.data).toEqual([{ x: 'Nevada', y: 38.9 }]);
   });
 });
 
@@ -781,6 +903,7 @@ describe('declared layers and the highlight', () => {
         ganttSeriesList: [],
         hierarchySeriesList: [],
         wordCloudSeriesList: [],
+        choroplethSeriesList: [],
         declaredList: [...plan.declared.values()],
       },
     }]);

--- a/test/adapters/amcharts/declaration.test.ts
+++ b/test/adapters/amcharts/declaration.test.ts
@@ -7,11 +7,19 @@ import type {
   SurvivalPoint,
   VolcanoPoint,
 } from '@type/grammar';
-import { fromXYChart } from '@adapters/amcharts/adapter';
+import { findCharts, fromAmCharts, fromXYChart } from '@adapters/amcharts/adapter';
 import { planDeclarations } from '@adapters/amcharts/declaration';
 import { buildNavigationMap } from '@adapters/amcharts/navmap';
 import { Orientation, TraceType } from '@type/grammar';
-import { fakeChart, fakeContainerEl, fakePieSeries, fakeSeries } from './helpers';
+import {
+  fakeChart,
+  fakeContainer,
+  fakeContainerEl,
+  fakeFlowSeries,
+  fakePieSeries,
+  fakeRoot,
+  fakeSeries,
+} from './helpers';
 
 /**
  * The declared reading is opt-in, so every case here is really two charts: the
@@ -159,6 +167,124 @@ describe('declaration precedence', () => {
     expect(layer.type).toBe(TraceType.SURVIVAL);
     expect(layer.stepDirection).toBe('hv');
     expect(warnings()).toContain('unknown key "significanse"');
+  });
+});
+
+describe('declared alluvials', () => {
+  const LINKS = [
+    { sourceId: 'Rent', targetId: 'Housing', value: 40 },
+    { sourceId: 'Loan', targetId: 'Housing', value: 25 },
+  ];
+
+  /** The layer a bare am5flow series produces, found the way discovery finds it. */
+  function standaloneLayer(series: AmXYSeries): MaidrLayer {
+    const layers = fromAmCharts(fakeRoot([series])).subplots[0][0].layers;
+    expect(layers).toHaveLength(1);
+    return layers[0];
+  }
+
+  it('reads an undeclared Sankey as a sankey', () => {
+    expect(standaloneLayer(fakeFlowSeries('Budget', LINKS)).type).toBe(TraceType.SANKEY);
+  });
+
+  it('reads the same series as an alluvial once it declares one', () => {
+    // amCharts has no alluvial class: an alluvial IS a sankey, drawn with the
+    // nodes repeated across stages, so only the author can separate the two.
+    const series = fakeFlowSeries('Budget', LINKS, 'Sankey', {
+      userData: { maidr: { type: 'alluvial' } },
+    });
+
+    const layer = standaloneLayer(series);
+
+    expect(layer.type).toBe(TraceType.ALLUVIAL);
+    expect(layer.axes).toEqual({ x: { label: 'Node' }, y: { label: 'Weight' } });
+    // The payload is the same weighted graph either way — what the author
+    // declared is which of the two readings the drawing stands for.
+    expect(layer.data).toEqual([
+      { source: 'Rent', target: 'Housing', value: 40 },
+      { source: 'Loan', target: 'Housing', value: 25 },
+    ]);
+  });
+
+  it('is visible through the panel discovery wraps a bare series in', () => {
+    // `planDeclarations` iterates `chart.series.values`, and a bare am5flow
+    // series has no chart at all — it reaches the plan only through the
+    // one-series panel `asStandalonePanel` synthesises around it.
+    const series = fakeFlowSeries('Budget', LINKS, 'Sankey', {
+      userData: { maidr: { type: 'alluvial' } },
+    });
+    const chart = findCharts(fakeRoot([fakeContainer([series])]))[0];
+
+    const plan = planDeclarations(chart);
+
+    expect(plan.declared.get(series)?.declaration.type).toBe(TraceType.ALLUVIAL);
+  });
+
+  it('keeps the name and title the block declared', () => {
+    const series = fakeFlowSeries('Budget', LINKS, 'Sankey', {
+      userData: { maidr: { type: 'alluvial', name: 'flows', title: 'Where the money goes' } },
+    });
+
+    const layer = standaloneLayer(series);
+
+    expect(layer.name).toBe('flows');
+    expect(layer.title).toBe('Where the money goes');
+  });
+
+  it('falls back to the undeclared reading on a series that draws no flow', () => {
+    // The "wrong construct" check: `type: 'alluvial'` on a pie series is a
+    // mistake worth reporting, not a layer to emit with nothing in it.
+    const declared = fakeSeries({
+      className: 'PieSeries',
+      name: 'Share',
+      userData: { maidr: { type: 'alluvial' } },
+      settings: { categoryField: 'category', valueField: 'value' },
+      data: [{ category: 'A', value: 3 }],
+    });
+
+    expect(layerOf([declared]).type).toBe(TraceType.PIE);
+    expect(warnings()).toContain('no mark of it carries the values');
+  });
+
+  it('refuses the block on a column series whose rows merely look like links', () => {
+    // The class name is the half of the check the data cannot supply: a bar
+    // chart authored from rows with `from`/`to`/`value` columns reads as a
+    // perfectly good link list, and reading it as one would announce a graph
+    // nobody drew. amCharts drawing a weighted flow is what makes the claim
+    // about the DRAWING true, which is what a declaration is.
+    const declared = fakeSeries({
+      className: 'ColumnSeries',
+      name: 'Transfers',
+      userData: { maidr: { type: 'alluvial' } },
+      settings: { categoryXField: 'category' },
+      data: [{ categoryX: 'Rent', from: 'Rent', to: 'Housing', value: 40, valueY: 40 }],
+    });
+
+    expect(layerOf([declared]).type).toBe(TraceType.BAR);
+    expect(warnings()).toContain('no mark of it carries the values');
+  });
+
+  it('falls back when the flow series carries no link the adapter can read', () => {
+    const series = fakeFlowSeries('Budget', [{ sourceId: 'Rent' }], 'Sankey', {
+      userData: { maidr: { type: 'alluvial' } },
+    });
+
+    // No readable link means no flow of any kind, declared or not — so the
+    // figure has no layer at all rather than an alluvial of nothing.
+    expect(() => fromAmCharts(fakeRoot([series]))).toThrow(/no supported series with data/);
+    expect(warnings()).toContain('no mark of it carries the values');
+  });
+
+  it('does not absorb the siblings that follow it', () => {
+    // An alluvial declares nothing but which reading the drawing stands for,
+    // so a second flow beside it is a second figure, not a further arm of one.
+    const declared = fakeFlowSeries('Budget', LINKS, 'Sankey', {
+      userData: { maidr: { type: 'alluvial' } },
+    });
+    const sibling = fakeFlowSeries('Energy', LINKS);
+
+    expect(layersOf([declared, sibling]).map(layer => layer.type))
+      .toEqual([TraceType.ALLUVIAL, TraceType.SANKEY]);
   });
 });
 

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -405,6 +405,17 @@ export interface FakeNode {
   children?: FakeNode[];
   /** Stands in for the rectangle sprite the overlay measures. */
   rectangle?: unknown;
+  /**
+   * Stands in for the wedge a `Sunburst` draws a node with, which the overlay
+   * measures the way it measures a pie slice.
+   */
+  slice?: unknown;
+  /**
+   * The same wedge hung on `graphics` instead — the other slot `sliceRect`
+   * probes, since which of the two an am5hierarchy build uses is exactly the
+   * shape that cannot be checked without the library.
+   */
+  graphics?: unknown;
 }
 
 function fakeHierarchyItem(node: FakeNode): AmDataItem {
@@ -414,15 +425,18 @@ function fakeHierarchyItem(node: FakeNode): AmDataItem {
     ...(node.value != null ? { value: node.value } : {}),
     ...(children != null ? { children } : {}),
     ...(node.rectangle != null ? { rectangle: node.rectangle } : {}),
+    ...(node.slice != null ? { slice: node.slice } : {}),
+    ...(node.graphics != null ? { graphics: node.graphics } : {}),
   };
   return { get: (key: string) => settings[key] } as unknown as AmDataItem;
 }
 
 /**
- * An am5hierarchy series — a `Treemap`, or the `Partition` amCharts draws an
- * icicle with. Unlike every other series here it is not inside a chart: it is
- * pushed straight into a container, and its nodes hang off the single root
- * data item rather than off the series.
+ * An am5hierarchy series — a `Treemap`, the `Partition` amCharts draws an
+ * icicle with, or the `Sunburst` that bends that icicle into a ring. Unlike
+ * every other series here it is not inside a chart: it is pushed straight into
+ * a container, and its nodes hang off the single root data item rather than
+ * off the series.
  */
 export function fakeHierarchySeries(
   name: string,
@@ -436,6 +450,146 @@ export function fakeHierarchySeries(
     get: (key: string) => settings[key],
     dataItems: [fakeHierarchyItem(root)],
   } as unknown as AmXYSeries;
+}
+
+/**
+ * One qualitative band of a gauge's dial: an axis range with an upper edge and
+ * (usually) nothing that names it.
+ */
+export interface FakeGaugeBand {
+  endValue: number;
+  /** A `Label` entity, as amCharts hangs one on a range. */
+  label?: string;
+  /** The same name as a plain string, the other slot the reader probes. */
+  labelText?: string;
+}
+
+export interface FakeGaugeConfig {
+  /** The reading the hand points at. `null` leaves the data item valueless. */
+  value?: number | null;
+  /** The dial's ends, as settings on the value axis. */
+  min?: number;
+  max?: number;
+  /**
+   * Report the ends through `axis.getPrivate()` instead — what amCharts does
+   * when the author fixed neither and let it compute them.
+   */
+  privateExtremes?: boolean;
+  /** The axis title, which is what names the dial. */
+  axisLabel?: string;
+  /** The chart title, exposed as a `Label` child like amCharts does. */
+  title?: string;
+  bands?: FakeGaugeBand[];
+  /** Stands in for the `ClockHand` sprite the overlay measures. */
+  hand?: unknown;
+  /** How many hands to pin to the axis. Defaults to one. */
+  hands?: number;
+  /**
+   * File the hand's data item under `axis.dataItems` rather than under
+   * `axis.axisRanges` — the other list a made axis data item may land in.
+   */
+  viaDataItems?: boolean;
+  /**
+   * Expose the bullet's sprite as a plain `.sprite` property rather than
+   * through `bullet.get('sprite')`.
+   */
+  bulletProperty?: boolean;
+  /** Series on the chart. A ClockHand gauge ordinarily has none. */
+  series?: AmXYSeries[];
+  /** Overrides the `RadarChart` class name, for the negative cases. */
+  className?: string;
+  /** Overrides the hand sprite's `ClockHand` class name. */
+  handClassName?: string;
+}
+
+/** A `ClockHand` as amCharts reports one: a `Container` with a laid-out box. */
+export function fakeClockHand(
+  box: { left: number; top: number; width: number; height: number },
+  className = 'ClockHand',
+): unknown {
+  return {
+    className,
+    width: () => box.width,
+    height: () => box.height,
+    toGlobal: (point: { x: number; y: number }) => ({
+      x: box.left + point.x,
+      y: box.top + point.y,
+    }),
+    get: () => undefined,
+  };
+}
+
+function fakeAxisRange(settings: Record<string, unknown>): AmDataItem {
+  return { get: (key: string) => settings[key] } as unknown as AmDataItem;
+}
+
+/**
+ * An am5radar gauge: a `RadarChart` whose reading is a `ClockHand` pinned to
+ * an axis data item, and — the point of the whole shape — no series at all.
+ */
+export function fakeGaugeChart(config: FakeGaugeConfig = {}): AmChart {
+  const handSprite = config.hand
+    ?? fakeClockHand({ left: 40, top: 60, width: 12, height: 80 }, config.handClassName);
+
+  const handItems: AmDataItem[] = [];
+  for (let at = 0; at < (config.hands ?? 1); at++) {
+    const bullet = config.bulletProperty
+      ? { get: () => undefined, sprite: handSprite }
+      : { get: (key: string) => (key === 'sprite' ? handSprite : undefined) };
+    handItems.push(fakeAxisRange({
+      ...(config.value !== null ? { value: config.value ?? 73 } : {}),
+      bullet,
+    }));
+  }
+
+  const bandItems = (config.bands ?? []).map(band => fakeAxisRange({
+    endValue: band.endValue,
+    ...(band.label != null
+      ? { label: { get: (key: string) => (key === 'text' ? band.label : undefined) } }
+      : {}),
+    ...(band.labelText != null ? { label: band.labelText } : {}),
+  }));
+
+  const title = config.axisLabel != null
+    ? { get: (key: string) => (key === 'text' ? config.axisLabel : undefined) }
+    : undefined;
+  const settings: Record<string, unknown> = {
+    ...(title != null ? { title } : {}),
+    ...(config.privateExtremes ? {} : { min: config.min ?? 0, max: config.max ?? 100 }),
+  };
+  const privates: Record<string, unknown> = config.privateExtremes
+    ? { min: config.min ?? 0, max: config.max ?? 100 }
+    : {};
+
+  const axis = {
+    className: 'ValueAxis',
+    get: (key: string) => settings[key],
+    getPrivate: (key: string) => privates[key],
+    dataItems: config.viaDataItems ? handItems : [],
+    axisRanges: { values: config.viaDataItems ? bandItems : [...handItems, ...bandItems] },
+  } as unknown as AmAxis;
+
+  const chart: Record<string, unknown> = {
+    className: config.className ?? 'RadarChart',
+    uid: nextUid++,
+    get: () => undefined,
+    series: { values: config.series ?? [] },
+    xAxes: { values: [axis] },
+    yAxes: { values: [] },
+    plotContainer: {
+      globalBounds: () => ({ left: 0, top: 0, right: 400, bottom: 400 }),
+    },
+  };
+  if (config.title != null) {
+    const chartTitle = config.title;
+    chart.children = {
+      values: [{
+        className: 'Label',
+        get: (key: string) => (key === 'text' ? chartTitle : undefined),
+      }],
+    };
+  }
+  return chart as unknown as AmChart;
 }
 
 /** A step-line series, drawn as a staircase rather than an interpolated line. */

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -416,6 +416,14 @@ export interface FakeNode {
    * shape that cannot be checked without the library.
    */
   graphics?: unknown;
+  /**
+   * The author's own row behind the node, as `dataItem.dataContext`.
+   *
+   * Where an `am5hierarchy.ForceDirected`'s cross-links live: amCharts binds
+   * them through `linkWithField`, which names a column on the row rather than
+   * anything the chart itself resolves.
+   */
+  row?: Record<string, unknown>;
 }
 
 function fakeHierarchyItem(node: FakeNode): AmDataItem {
@@ -428,7 +436,10 @@ function fakeHierarchyItem(node: FakeNode): AmDataItem {
     ...(node.slice != null ? { slice: node.slice } : {}),
     ...(node.graphics != null ? { graphics: node.graphics } : {}),
   };
-  return { get: (key: string) => settings[key] } as unknown as AmDataItem;
+  return {
+    get: (key: string) => settings[key],
+    ...(node.row != null ? { dataContext: node.row } : {}),
+  } as unknown as AmDataItem;
 }
 
 /**
@@ -442,13 +453,93 @@ export function fakeHierarchySeries(
   name: string,
   root: FakeNode,
   className = 'Treemap',
+  extraSettings: Record<string, unknown> = {},
 ): AmXYSeries {
-  const settings: Record<string, unknown> = { name };
+  const settings: Record<string, unknown> = { name, ...extraSettings };
   return {
     className,
     uid: nextUid++,
     get: (key: string) => settings[key],
     dataItems: [fakeHierarchyItem(root)],
+  } as unknown as AmXYSeries;
+}
+
+/**
+ * An `am5hierarchy.ForceDirected` series — a network, and a hierarchy series
+ * rather than a link list: its graph is a tree of `children` plus whatever
+ * cross-links each row names in the column `linkWithField` points at.
+ */
+export function fakeForceDirectedSeries(
+  name: string,
+  root: FakeNode,
+  settings: Record<string, unknown> = {},
+): AmXYSeries {
+  return fakeHierarchySeries(name, root, 'ForceDirected', settings);
+}
+
+/**
+ * One link of a fake am5flow series, with a knob for each of the three ways
+ * the adapter probes for an end.
+ *
+ * All three exist because none can be checked without the library: a build may
+ * answer with the resolved id, with the node data item the link was joined to,
+ * or with neither — leaving the author's own row as the only thing that says
+ * what the link connects.
+ */
+export interface FakeLink {
+  /** `dataItem.get('sourceId')` — the id amCharts resolved the end to. */
+  sourceId?: string | number;
+  /** `dataItem.get('targetId')`. */
+  targetId?: string | number;
+  /** `dataItem.get('source')` — the *node* data item, asked for name then id. */
+  sourceNode?: { name?: string | number; id?: string | number };
+  /** `dataItem.get('target')`. */
+  targetNode?: { name?: string | number; id?: string | number };
+  /** `dataItem.get('value')` — how much flows. */
+  value?: number;
+  /** The author's own row, reached only when the reads above answer nothing. */
+  row?: Record<string, unknown>;
+}
+
+function fakeNodeItem(node: { name?: string | number; id?: string | number }): unknown {
+  return { get: (key: string) => (node as Record<string, unknown>)[key] };
+}
+
+function fakeLinkItem(link: FakeLink): AmDataItem {
+  const settings: Record<string, unknown> = {
+    ...(link.sourceId != null ? { sourceId: link.sourceId } : {}),
+    ...(link.targetId != null ? { targetId: link.targetId } : {}),
+    ...(link.sourceNode != null ? { source: fakeNodeItem(link.sourceNode) } : {}),
+    ...(link.targetNode != null ? { target: fakeNodeItem(link.targetNode) } : {}),
+    ...(link.value !== undefined ? { value: link.value } : {}),
+  };
+  return {
+    get: (key: string) => settings[key],
+    ...(link.row != null ? { dataContext: link.row } : {}),
+  } as unknown as AmDataItem;
+}
+
+/**
+ * An am5flow series — a `Sankey`, one of the three `Chord` variants, or the
+ * `ArcDiagram` that draws the same weighted links along a line.
+ *
+ * Like an am5hierarchy layout it is not inside a chart: it is pushed straight
+ * into a container. Its `dataItems` are the **links**; the nodes amCharts
+ * derives from them live on a separate series, which the adapter deliberately
+ * does not read.
+ */
+export function fakeFlowSeries(
+  name: string,
+  links: FakeLink[],
+  className = 'Sankey',
+  extraSettings: Record<string, unknown> = {},
+): AmXYSeries {
+  const settings: Record<string, unknown> = { name, ...extraSettings };
+  return {
+    className,
+    uid: nextUid++,
+    get: (key: string) => settings[key],
+    dataItems: links.map(fakeLinkItem),
   } as unknown as AmXYSeries;
 }
 

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -683,6 +683,111 @@ export function fakeGaugeChart(config: FakeGaugeConfig = {}): AmChart {
   return chart as unknown as AmChart;
 }
 
+/**
+ * The polygon an am5map `MapPolygonSeries` drew a region as.
+ *
+ * `globalBounds()` is the axis-aligned box the overlay outlines; `geoCentroid`
+ * is the degree pair the payload's `lon`/`lat` come from when the author's own
+ * row carries none. Both are unverifiable without the library, so both are
+ * knobs: pass no `centroid` for a build that answers nothing, and a
+ * `degenerate` box for one that reports a point rather than a shape.
+ */
+export function fakeMapPolygon(config: {
+  box?: { left: number; top: number; right: number; bottom: number };
+  centroid?: { longitude: unknown; latitude: unknown };
+  /** Make `geoCentroid()` throw, as a half-built polygon may. */
+  centroidThrows?: boolean;
+} = {}): unknown {
+  const box = config.box ?? { left: 10, top: 20, right: 60, bottom: 70 };
+  const polygon: Record<string, unknown> = {
+    className: 'MapPolygon',
+    globalBounds: () => box,
+  };
+  if (config.centroidThrows) {
+    polygon.geoCentroid = (): never => {
+      throw new Error('not laid out');
+    };
+  } else if (config.centroid !== undefined) {
+    polygon.geoCentroid = (): unknown => config.centroid;
+  }
+  return polygon;
+}
+
+/** One region of a fake choropleth. */
+export interface FakeRegion {
+  /** `dataItem.get('name')` — the name amCharts resolved the polygon to. */
+  name?: string;
+  /** `dataItem.get('value')` — the number the region is shaded by. */
+  value?: number;
+  /** The drawn polygon, on `dataItem.get('mapPolygon')`. */
+  polygon?: unknown;
+  /** The author's own row, as `dataItem.dataContext`. */
+  row?: Record<string, unknown>;
+}
+
+/**
+ * An am5map `MapPolygonSeries`.
+ *
+ * Bound to a `valueField` by default, which is what separates a choropleth
+ * from the base geography drawn under one: pass `settings: {}` for a series
+ * carrying no values at all.
+ */
+export function fakeMapPolygonSeries(
+  name: string,
+  regions: FakeRegion[],
+  settings: Record<string, unknown> = { valueField: 'value' },
+  className = 'MapPolygonSeries',
+): AmXYSeries {
+  const seriesSettings: Record<string, unknown> = { name, ...settings };
+  return {
+    className,
+    uid: nextUid++,
+    get: (key: string) => seriesSettings[key],
+    dataItems: regions.map((region) => {
+      const itemSettings: Record<string, unknown> = {
+        ...(region.name != null ? { name: region.name } : {}),
+        ...(region.value != null ? { value: region.value } : {}),
+        ...(region.polygon != null ? { mapPolygon: region.polygon } : {}),
+      };
+      return {
+        get: (key: string) => itemSettings[key],
+        ...(region.row != null ? { dataContext: region.row } : {}),
+      } as unknown as AmDataItem;
+    }),
+  } as unknown as AmXYSeries;
+}
+
+/**
+ * An am5map `MapChart`: a `SerialChart` with a series list, no axes, and a
+ * class name of its own — the signature the adapter's other two chart gates
+ * both miss. It is its own `Container`, so it answers the geometry reads a
+ * panel is measured by.
+ */
+export function fakeMapChart(
+  config: { series?: AmXYSeries[]; title?: string; bounds?: AmBounds } = {},
+): AmChart {
+  const chart: Record<string, unknown> = {
+    className: 'MapChart',
+    uid: nextUid++,
+    get: () => undefined,
+    series: { values: config.series ?? [] },
+  };
+  if (config.bounds) {
+    const bounds = config.bounds;
+    chart.globalBounds = (): AmBounds => bounds;
+  }
+  if (config.title != null) {
+    const title = config.title;
+    chart.children = {
+      values: [{
+        className: 'Label',
+        get: (key: string) => (key === 'text' ? title : undefined),
+      }],
+    };
+  }
+  return chart as unknown as AmChart;
+}
+
 /** A step-line series, drawn as a staircase rather than an interpolated line. */
 export function fakeStepSeries(
   name: string,

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -1,16 +1,19 @@
 import type { SeriesGroups } from '@adapters/amcharts/navmap';
 import type { AmXYChart, AmXYSeries } from '@adapters/amcharts/types';
 import type { MaidrLayer } from '@type/grammar';
-import { buildNavigationMap } from '@adapters/amcharts/navmap';
+import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
+import { dataItemToOverlayRect } from '@adapters/amcharts/overlay';
 import { TraceType } from '@type/grammar';
 import {
   fakeAreaSeries,
   fakeBarSeries,
   fakeChart,
+  fakeClockHand,
   fakeDotSeries,
   fakeFloatingColumnSeries,
   fakeFunnelSeries,
   fakeGanttSeries,
+  fakeGaugeChart,
   fakeHierarchySeries,
   fakeLineSeries,
   fakeLollipopSeries,
@@ -306,6 +309,97 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     expect(navMap.resolve('tree', 2, 0)).toEqual([]);
   });
 
+  it('measures a sunburst node as a wedge, not as a rectangle', () => {
+    // A treemap block and an icicle bar are rectangles; a sunburst node is a
+    // `Slice`, which reports a degenerate box and has to be measured from its
+    // radius and sweep instead. Getting this wrong outlines nothing at all.
+    const series = fakeHierarchySeries('Population', {
+      category: 'Root',
+      children: [
+        { category: 'Asia', children: [{ category: 'China', value: 1425 }] },
+        { category: 'Africa', children: [{ category: 'Nigeria', value: 224 }] },
+      ],
+    }, 'Sunburst');
+    const chart = fakeChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'ring', type: TraceType.SUNBURST, data: [] }],
+      groups: { ...emptyGroups(), hierarchySeriesList: [series] },
+    }]);
+
+    expect(navMap.resolve('ring', 0, 1)[0].dataItem.get('category')).toBe('Africa');
+    expect(navMap.resolve('ring', 1, 1)[0].dataItem.get('category')).toBe('Nigeria');
+    expect(navMap.resolve('ring', 1, 1)[0].kind).toBe('slice');
+    expect(navMap.resolve('ring', 2, 0)).toEqual([]);
+  });
+
+  it('reaches a sunburst wedge on `slice` and on `graphics` alike', () => {
+    // Which slot an am5hierarchy build hangs the wedge on cannot be checked
+    // without the library, so both are probed -- and a `Slice` reports a
+    // degenerate point, so the box has to come from its radius and sweep.
+    const wedge = {
+      globalBounds: () => ({ left: 100, top: 100, right: 100, bottom: 100 }),
+      width: () => 0,
+      height: () => 0,
+      // 0..90 is the bottom-right quarter; y grows down.
+      get: (key: string) => ({ radius: 50, startAngle: 0, arc: 90 } as Record<string, unknown>)[key],
+    };
+    const box = { left: 100, top: 100, width: 50, height: 50 };
+
+    for (const slot of ['slice', 'graphics'] as const) {
+      const series = fakeHierarchySeries('Population', {
+        category: 'Root',
+        children: [{ category: 'Asia', value: 3000, [slot]: wedge }],
+      }, 'Sunburst');
+      const navMap = buildNavigationMap([{
+        chart: fakeChart({ series: [series] }),
+        layers: [{ id: 'ring', type: TraceType.SUNBURST, data: [] }],
+        groups: { ...emptyGroups(), hierarchySeriesList: [series] },
+      }]);
+
+      expect(dataItemToOverlayRect(navMap.resolve('ring', 0, 0)[0], null)).toEqual(box);
+    }
+  });
+
+  it('resolves a gauge to its needle, from every position there is', () => {
+    // `GaugeTrace` is a 1x1 grid whose position is always (0, 0), so there is
+    // nothing to invert -- and the hand is a bullet on an AXIS, so it reaches
+    // the overlay through a data item that answers `graphics` with it.
+    const hand = fakeClockHand({ left: 40, top: 60, width: 12, height: 80 });
+    const chart = fakeGaugeChart({ value: 73, hand });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'dial', type: TraceType.GAUGE, data: [] }],
+      groups: emptyGroups(),
+    }]);
+
+    const [target] = navMap.resolve('dial', 0, 0);
+    expect(target.kind).toBe('column');
+    expect(target.dataItem.get('graphics')).toBe(hand);
+    // The overlay reads the hand's own laid-out box, not the whole dial.
+    expect(dataItemToOverlayRect(target, null))
+      .toEqual({ left: 40, top: 60, width: 12, height: 80 });
+  });
+
+  it('clears rather than boxing the dial when the hand reports no geometry', () => {
+    // A hand that answers with nothing measurable must draw nothing. An
+    // outline around the whole gauge would say nothing about where the needle
+    // is, which is the kind of confidently-uninformative mark to avoid.
+    const chart = fakeGaugeChart({
+      value: 73,
+      hand: { className: 'ClockHand', get: () => undefined },
+    });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'dial', type: TraceType.GAUGE, data: [] }],
+      groups: emptyGroups(),
+    }]);
+
+    const [target] = navMap.resolve('dial', 0, 0);
+    expect(target).toBeDefined();
+    expect(dataItemToOverlayRect(target, null)).toBeNull();
+  });
+
   it('resolves a diverging layer as it resolves a dodged one, one row per side', () => {
     const men = fakeBarSeries('Men', [
       { categoryX: '0-14', valueY: -1200 },
@@ -434,5 +528,21 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     expect(targets[0].dataItem.get('valueY')).toBe(1);
     expect(targets[0].kind).toBe('point');
     expect(navMap.resolve('places', 2, 0)).toEqual([]);
+  });
+});
+
+describe('groupSeries', () => {
+  it('buckets a sunburst with the trees it is one of', () => {
+    // The fourth edit every new type needs, and the one whose omission is
+    // silent: the layer would still be built, announced and navigated, and
+    // only the highlight would vanish. `hierarchySeriesList` is what the
+    // resolver indexes, so an unbucketed sunburst resolves to nothing.
+    const series = fakeHierarchySeries('Population', {
+      category: 'Root',
+      children: [{ category: 'Asia', value: 3000 }],
+    }, 'Sunburst');
+
+    expect(groupSeries(fakeChart({ series: [series] })).hierarchySeriesList)
+      .toEqual([series]);
   });
 });

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -1,14 +1,18 @@
 import type { SeriesGroups } from '@adapters/amcharts/navmap';
 import type { AmXYChart, AmXYSeries } from '@adapters/amcharts/types';
+import type { ChoroplethTrace } from '@model/choropleth';
 import type { MaidrLayer } from '@type/grammar';
+import { fromXYChart } from '@adapters/amcharts/adapter';
 import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
 import { dataItemToOverlayRect } from '@adapters/amcharts/overlay';
+import { TraceFactory } from '@model/factory';
 import { TraceType } from '@type/grammar';
 import {
   fakeAreaSeries,
   fakeBarSeries,
   fakeChart,
   fakeClockHand,
+  fakeContainerEl,
   fakeDotSeries,
   fakeFloatingColumnSeries,
   fakeFlowSeries,
@@ -19,6 +23,9 @@ import {
   fakeHierarchySeries,
   fakeLineSeries,
   fakeLollipopSeries,
+  fakeMapChart,
+  fakeMapPolygon,
+  fakeMapPolygonSeries,
   fakePieChart,
   fakePieSeries,
   fakePolarSeries,
@@ -47,6 +54,7 @@ function emptyGroups(): SeriesGroups {
     ganttSeriesList: [],
     hierarchySeriesList: [],
     wordCloudSeriesList: [],
+    choroplethSeriesList: [],
     declaredList: [],
   };
 }
@@ -565,6 +573,171 @@ describe('buildNavigationMap (flow and network: no highlight, on purpose)', () =
 
     expect(navMap.resolve('flow', 0, 0)).toEqual([]);
     expect(navMap.resolve('flow', 1, 1)).toEqual([]);
+  });
+});
+
+describe('buildNavigationMap (choropleth)', () => {
+  /**
+   * Four states with real centroids, declared in an order that is neither the
+   * order the map is walked in nor a rotation of it: `arrange` bands them by
+   * latitude and reads each band west to east, so a resolver that had simply
+   * kept declared order would be wrong at every position but one.
+   */
+  const STATES: Array<{ name: string; value: number; lon: number; lat: number }> = [
+    { name: 'Washington', value: 12.1, lon: -120.5, lat: 47.4 },
+    { name: 'Nevada', value: 38.9, lon: -116.6, lat: 39.3 },
+    { name: 'Oregon', value: 16.4, lon: -120.6, lat: 43.9 },
+    { name: 'Idaho', value: 21.7, lon: -114.6, lat: 44.4 },
+  ];
+
+  /** The polygons, kept so a resolved target can be identified by its box. */
+  function polygons(): unknown[] {
+    return STATES.map((_state, at) => fakeMapPolygon({
+      box: { left: at * 10, top: 0, right: at * 10 + 8, bottom: 8 },
+    }));
+  }
+
+  function mapSeries(shapes: unknown[]): AmXYSeries {
+    return fakeMapPolygonSeries('Rate', STATES.map((state, at) => ({
+      name: state.name,
+      value: state.value,
+      polygon: shapes[at],
+      row: { longitude: state.lon, latitude: state.lat },
+    })));
+  }
+
+  function navMapFor(series: AmXYSeries): {
+    navMap: ReturnType<typeof buildNavigationMap>;
+    layer: MaidrLayer;
+  } {
+    const chart = fakeMapChart({ series: [series] });
+    const layer = fromXYChart(chart, fakeContainerEl()).subplots[0][0].layers[0];
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [layer],
+      groups: groupSeries(chart),
+    }]);
+    return { navMap, layer };
+  }
+
+  it('resolves every position to the region the trace names there', () => {
+    // The contract test the mirror is not allowed to ship without. It asks the
+    // REAL `ChoroplethTrace` which region each position announces and checks
+    // the adapter outlines that one — so a change to `arrange` in the model
+    // turns into a red build here rather than into a highlight that quietly
+    // drifts one region east.
+    const shapes = polygons();
+    const { navMap, layer } = navMapFor(mapSeries(shapes));
+    const trace = TraceFactory.create(layer) as ChoroplethTrace;
+    const boxOf = new Map(STATES.map((state, at) => [state.name, at]));
+
+    // Four regions band into a 2x2 grid: two bands of two.
+    for (let row = 0; row < 2; row++) {
+      for (let col = 0; col < 2; col++) {
+        const state = trace.getStateAt(row, col);
+        if (state.empty) {
+          throw new Error(`Expected a populated state at ${row},${col}`);
+        }
+        const named = String(state.text.main.value);
+
+        const [target] = navMap.resolve(layer.id, row, col);
+        expect(target).toBeDefined();
+        expect(target.kind).toBe('region');
+        expect(target.dataItem.get('mapPolygon')).toBe(shapes[boxOf.get(named) as number]);
+      }
+    }
+  });
+
+  it('bands the map the way the trace does, rather than keeping declared order', () => {
+    // Spelled out once, so the test above is readable as a contract rather
+    // than as a tautology: four regions make two bands of two, south first,
+    // and west to east inside each.
+    const shapes = polygons();
+    const { navMap, layer } = navMapFor(mapSeries(shapes));
+
+    // The two southernmost are Nevada (39.3N) and Oregon (43.9N), read west to
+    // east — so Oregon (-120.6) comes before Nevada (-116.6), which is neither
+    // their declared order nor their order by latitude.
+    expect(navMap.resolve(layer.id, 0, 0)[0].dataItem.get('mapPolygon')).toBe(shapes[2]);
+    expect(navMap.resolve(layer.id, 0, 1)[0].dataItem.get('mapPolygon')).toBe(shapes[1]);
+    // Northern band: Washington (-120.5) is west of Idaho (-114.6).
+    expect(navMap.resolve(layer.id, 1, 0)[0].dataItem.get('mapPolygon')).toBe(shapes[0]);
+    expect(navMap.resolve(layer.id, 1, 1)[0].dataItem.get('mapPolygon')).toBe(shapes[3]);
+  });
+
+  it('degenerates to declared order when the map placed no region', () => {
+    // The likely common case, since the centroid read is unverified. With no
+    // coordinates `arrange` returns one band in declared order, so the mirror
+    // is the identity map — and the map is still navigable, still announced,
+    // still outlined, just read as a region list.
+    const shapes = polygons();
+    const series = fakeMapPolygonSeries('Rate', STATES.map((state, at) => ({
+      name: state.name,
+      value: state.value,
+      polygon: shapes[at],
+    })));
+    const { navMap, layer } = navMapFor(series);
+
+    for (let col = 0; col < STATES.length; col++) {
+      expect(navMap.resolve(layer.id, 0, col)[0].dataItem.get('mapPolygon')).toBe(shapes[col]);
+    }
+  });
+
+  it('outlines the polygon\'s reported box', () => {
+    const shapes = polygons();
+    const { navMap, layer } = navMapFor(mapSeries(shapes));
+
+    const [target] = navMap.resolve(layer.id, 0, 0);
+    expect(dataItemToOverlayRect(target, null))
+      .toEqual({ left: 20, top: 0, width: 8, height: 8 });
+  });
+
+  it('clears rather than outlining a polygon that reports no box with area', () => {
+    // An am5 `Graphics` painted through a draw callback can report a
+    // degenerate point (the `Slice` problem of #774), and a region has no
+    // radius or sweep to be measured from instead. A one-pixel mark at the
+    // wrong place says less than nothing.
+    const flat = fakeMapPolygon({ box: { left: 30, top: 30, right: 30, bottom: 30 } });
+    const series = fakeMapPolygonSeries('Rate', [
+      { name: 'Nevada', value: 38.9, polygon: flat },
+    ]);
+    const { navMap, layer } = navMapFor(series);
+
+    const [target] = navMap.resolve(layer.id, 0, 0);
+    expect(target).toBeDefined();
+    expect(dataItemToOverlayRect(target, null)).toBeNull();
+  });
+
+  it('resolves nothing when the polygons and the announced regions disagree', () => {
+    // The alignment guard. A layer whose data no longer matches the series it
+    // was built from means the chart moved underneath the conversion; an empty
+    // answer clears the overlay, which beats outlining a stale index.
+    const shapes = polygons();
+    const series = mapSeries(shapes);
+    const chart = fakeMapChart({ series: [series] });
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [{ id: 'map', type: TraceType.CHOROPLETH, data: [{ x: 'Nevada', y: 38.9 }] }],
+      groups: groupSeries(chart),
+    }]);
+
+    expect(navMap.resolve('map', 0, 0)).toEqual([]);
+  });
+});
+
+describe('groupSeries (choropleth)', () => {
+  it('buckets a shaded polygon series and leaves the base geography out', () => {
+    // The fourth edit every new type needs, and the one whose omission is
+    // silent: audio and text would keep working while the highlight vanished.
+    const shaded = fakeMapPolygonSeries('Rate', [{ name: 'Nevada', value: 38.9 }]);
+    const base = fakeMapPolygonSeries('World', [{ name: 'Nevada', value: 38.9 }], {});
+
+    const groups = groupSeries(fakeMapChart({ series: [base, shaded] }));
+
+    expect(groups.choroplethSeriesList).toEqual([{ series: shaded }]);
+    // And emphatically not read as a bar chart of its shapes, which is what
+    // `classifySeriesKind`'s default would have made of either of them.
+    expect(groups.barSeriesList).toEqual([]);
   });
 });
 

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -11,6 +11,8 @@ import {
   fakeClockHand,
   fakeDotSeries,
   fakeFloatingColumnSeries,
+  fakeFlowSeries,
+  fakeForceDirectedSeries,
   fakeFunnelSeries,
   fakeGanttSeries,
   fakeGaugeChart,
@@ -531,7 +533,62 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
   });
 });
 
+describe('buildNavigationMap (flow and network: no highlight, on purpose)', () => {
+  const LINKS = [
+    { sourceId: 'Coal', targetId: 'Electricity', value: 34 },
+    { sourceId: 'Electricity', targetId: 'Homes', value: 40 },
+  ];
+
+  /**
+   * Asserted positively, because the absence is a decision. MAIDR hands a flow
+   * or network layer its BRAILLE position — a stage and an index within it, or
+   * a component and an index within it — and recovering the node from that
+   * would mean reimplementing the model's node ordering together with its
+   * stage layering, which is a derived graph structure rather than an ordering
+   * over data this adapter emitted. So `resolve` answers `[]` and the binder
+   * clears the overlay; a resolver added later without a position that says
+   * which node it means would outline a confidently wrong one, and this is
+   * what would notice.
+   */
+  it.each([
+    ['a sankey', TraceType.SANKEY],
+    ['a chord', TraceType.CHORD],
+    ['an alluvial', TraceType.ALLUVIAL],
+    ['a network', TraceType.NETWORK],
+  ])('registers no resolver for %s, so the overlay clears', (_name, type) => {
+    const series = fakeFlowSeries('Energy', LINKS);
+    const navMap = buildNavigationMap([{
+      chart: fakeChart({ series: [series] }),
+      layers: [{ id: 'flow', type, data: [] }],
+      groups: emptyGroups(),
+    }]);
+
+    expect(navMap.resolve('flow', 0, 0)).toEqual([]);
+    expect(navMap.resolve('flow', 1, 1)).toEqual([]);
+  });
+});
+
 describe('groupSeries', () => {
+  it('leaves an am5flow series and a force-directed network in no bucket', () => {
+    // Not an oversight, and not a no-op either: `classifySeriesKind` answers
+    // `'bar'` for a class it does not know, so before these classes were named
+    // a sankey landed in `barSeriesList` — where it would have shifted every
+    // real bar layer's resolver index and outlined the wrong column on a chart
+    // carrying both. Recognising them is what puts them in NO bucket.
+    const sankey = fakeFlowSeries('Energy', [
+      { sourceId: 'Coal', targetId: 'Electricity', value: 34 },
+    ]);
+    const network = fakeForceDirectedSeries('People', {
+      category: 'Root',
+      children: [{ category: 'Ada' }],
+    });
+
+    const groups = groupSeries(fakeChart({ series: [sankey, network] }));
+
+    expect(groups.barSeriesList).toEqual([]);
+    expect(Object.values(groups).every(bucket => bucket.length === 0)).toBe(true);
+  });
+
   it('buckets a sunburst with the trees it is one of', () => {
     // The fourth edit every new type needs, and the one whose omission is
     // silent: the layer would still be built, announced and navigated, and


### PR DESCRIPTION
# Pull Request

## Description

Adds the seven amCharts trace types [#901](https://github.com/xability/maidr/issues/901) found missing — `SANKEY`, `CHORD`, `ALLUVIAL`, `NETWORK`, `SUNBURST`, `CHOROPLETH` and `GAUGE`. All seven are now detected, extracted to the payload shape `src/type/grammar.ts` declares, documented and exercised by unit tests. Three of them are highlighted; four ship deliberately **without** a highlight, for a reason stated below and in `docs/amcharts.md` rather than papered over with a guessed outline.

The change is confined to `src/adapters/amcharts/`, `test/adapters/amcharts/`, `examples/` and `docs/amcharts.md`. **No core change was made** — nothing under `src/model/`, `src/service/`, `src/state/`, `src/ui/`, `src/command/`, `src/type/` or `src/adapters/shared/` is touched.

## Related Issues

Refs #901 — deliberately **not** `Closes`.

All seven types are accounted for and none is silently dropped, which is the accounting failure #901 exists to correct. But #901's own acceptance criterion says a type that sonifies and does not highlight "is not done", with an escape only where a highlight genuinely *cannot* be addressed. For `SANKEY`, `CHORD`, `ALLUVIAL` and `NETWORK` the honest position is narrower than that escape: the highlight *can* be addressed, but only by a `src/model/` change outside this PR's scope. So those four are shipped as reading-without-outline with the shortfall documented, and the issue is left open for a maintainer to close once the follow-up lands. Auto-closing it here would overclaim.

### Reconciliation — all seven, individually

| TraceType | Detection + payload | Highlight | Notes |
|---|---|---|---|
| `SUNBURST` | ✅ landed | ✅ wired | `am5hierarchy.Sunburst`. Wedge measured from radius/sweep, not the degenerate box a `Slice` reports (#774). |
| `GAUGE` | ✅ landed | ✅ wired | `RadarChart` + `ClockHand`. Payload is a **single `GaugePoint` object**, not an array, per the acceptance criterion. |
| `CHOROPLETH` | ✅ landed | ✅ wired | `am5map.MapChart` + `MapPolygonSeries`. Both detected and declarable. |
| `SANKEY` | ✅ landed | ❌ **not wired** | Reading is complete; overlay clears as the cursor moves. Reason below. |
| `CHORD` | ✅ landed | ❌ **not wired** | Same. All three `Chord` classes plus `ArcDiagram`. |
| `ALLUVIAL` | ✅ landed | ❌ **not wired** | Same. Declared (`{ type: "alluvial" }`), as no amCharts class distinguishes it. |
| `NETWORK` | ✅ landed | ❌ **not wired** | Same. `am5hierarchy.ForceDirected`. |

**Why the four flow/network types have no highlight.** #901 hoped #899's `highlightedPointIndices` had removed this class of problem. It has — but only from the *model* side, and the getter does not yet exist on `FlowTrace` or `NetworkTrace`. Without it the adapter would have to re-implement the longest-path stage layering in `src/model/flow.ts` and the component walk in `src/model/network.ts`, and a copy of model logic drifts and then outlines a confidently wrong node. So no resolver is registered: `NavMap.resolve` answers `[]` and the overlay clears. Audio, text, braille and keyboard navigation all work normally. An empty outline is truthful; a box drawn from a guessed layering is not — that is the failure #895 refused, and this PR refuses it too.

The follow-up is a small `highlightedPointIndices` getter on each trace, after which these four are resolvable by registering resolvers and nothing else. **It still needs filing by hand** — I had no issue-filing tool in the sessions that produced this work. One correction it must carry: the shape originally proposed (`[...node.out, ...node.in].map(e => e.at)`) is **wider** than what the SVG path actually highlights — `FlowTrace.mapToSvgElements` takes `touching[0]` and `NetworkTrace.mapToSvgElements` uses `node.linkAt[0]`, i.e. one ribbon per node. Shipping the wider shape verbatim would make the canvas highlight disagree with the SVG highlight for the same trace.

## Changes Made

**Detection and extraction** (`extractor.ts`, `adapter.ts`)
- `STANDALONE_KINDS` gains `Sunburst`, `Sankey`, `ArcDiagram`, the three `Chord` classes and `ForceDirected`; `SeriesKind` gains `sunburst`, `sankey`, `chord`, `network`, `choropleth`.
- New extractors: `extractFlowPoints`, `extractNetworkPoints`, `extractGaugePoint`/`extractGaugeBands`, `extractChoroplethPoints`. New layer builders for each, wired into `buildChartLayers`.
- New chart gate `asMapPanel` for `am5map.MapChart`, alongside the existing XY and percent gates.
- Gauge is asked for only when the series loop produced **zero** layers, so it can never steal a `RADAR` or `POLAR_AREA` reading.

**Highlight** (`navmap.ts`, `overlay.ts`)
- `buildHierarchyResolver` gains a `kind` parameter; sunburst passes `slice`, treemap and icicle keep `column`.
- `buildGaugeResolver` synthesises a duck-typed data item so the `ClockHand` reaches the existing column path with no `overlay.ts` change.
- `buildChoroplethResolver` mirrors `ChoroplethTrace.arrange`'s lat/lon banding, registered only when the filtered polygon count matches the layer, and **pinned by a contract test against the real trace** built through `TraceFactory` — the first mirror in this adapter shipped with one.
- New `kind: 'region'` + `regionRect` in `overlay.ts`: prefers `globalBounds()` for an irregular projected shape and returns `null` when neither source reports a box **with area**, so a degenerate `Graphics` clears the overlay instead of drawing a confident 1px mark.
- `groupSeries` moved from `binder.tsx` to `navmap.ts` and **exported**, so it is unit-testable for the first time — it is the edit site whose omission is silent (audio and text keep working; only the highlight vanishes).

**Declarations** (`declaration.ts`) — `AlluvialDeclaration` and `ChoroplethDeclaration` join the `AmDeclaration` union. `backsDeclaration` (not `isDeclarable`) carries the series-class check, so the failure message matches the actual failure.

**Correction to the original design, worth a reviewer's eye:** the gauge's min/max were specified to fall back to the axis' `start`/`end`. On an am5 `Axis` those are **relative zoom positions** (0–1), not extremes — that fallback would have reported every computed-extreme gauge as a confident 0-to-1 dial, and `GaugeTrace` pitches its tone against the range. `getPrivate('min')`/`getPrivate('max')` is used instead. A dial with no finite ends emits no layer rather than a dial of `NaN`s.

**Tests** — 249 amCharts tests pass. Each new test was verified to fail without its hunk by reverting the source and re-running, except a small set of deliberate absence-guards (e.g. "an ordinary radar chart stays a radar, hand or no hand"; "no resolver is registered for a sankey, so the overlay clears") which are non-discriminating by construction but are what turns a future regression into a red build. Those are called out in the batch notes rather than passed off as discriminating.

**Docs and examples** — `docs/amcharts.md` gains classification bullets, a support-table row per type, declared-field rows, sections for Gauge, Sunburst, the flow family and Choropleth, and a `#### Flow and network are not outlined` subsection stating the shortfall and its mechanism. New `examples/amcharts-flow.html`, `amcharts-gauge.html`, `amcharts-choropleth.html`; `amcharts-treemap.html` gains a sunburst panel.

## Screenshots (if applicable)

Not applicable — amCharts is commercial and not installed in this repo, so the example pages cannot be rendered here. They load amCharts from CDN and are intended to be opened by a reviewer who has access.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass. — *Unit tests pass (see below); the manual process was **not** run, because amCharts is not installed here and the example pages cannot be exercised in this environment.*
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

Gate, run in order on this branch, all passing:

| Check | Result |
|---|---|
| `npm run lint:fix` | ✅ clean, no files changed |
| `npm run type-check` | ✅ clean (`tsc --noEmit` + `tsconfig.ci.json`) |
| `npm run build` | ✅ all 13 bundles built |
| `npm test` | ✅ 4237 passed / 4237 (283 suites) + 73 passed / 73 (ESM), 0 failures |

No SIGKILL and no flake occurred; the suite was run twice with identical results.

## Additional Notes

**amCharts is commercial and is not installed in this repository, so none of the following could be verified against the real library.** The adapter is duck-typed throughout for exactly this reason. A reviewer with amCharts access should check these specifically — they are listed roughly worst-consequence first.

*Assumptions where a wrong guess produces a **wrong reading** (highest priority):*

1. **The class-name lists are exhaustive and literal** — `Sankey`, `ArcDiagram`, `Chord`, `ChordDirected`, `ChordNonRibbon`, `ForceDirected`, `Sunburst`, and the five map classes (`MapPolygonSeries`, `MapLineSeries`, `MapPointSeries`, `ClusteredPointSeries`, `GraticuleSeries`). This is the sharpest risk in the PR: `classifySeriesKind` answers `'bar'` for anything it does not recognise, so a **misspelled or missing class name is announced as a bar chart of its links or shapes**, not skipped. Each name is pinned by a test, but a test cannot know the real spelling.
2. **`MapPolygon.geoCentroid()` returns `{ longitude, latitude }` in degrees.** A wrong unit would reverse the compass. Mitigated three ways: the call is wrapped in `try`/`catch`, both numbers must be finite *and* within ±180/±90, and the author's own row is read **first**, so a table stating its coordinates never depends on this.
3. **An `am5flow` series' `dataItems` are the links (one per ribbon), not the nodes.** The whole flow payload rests on this. If a build files nodes there too they are dropped for want of a resolvable end — quiet and in the safe direction, but the link count would then be right only by luck.

*Assumptions where a wrong guess degrades to silence or a poorer reading (still worth checking):*

4. `am5radar.ClockHand`'s `className` is literally `'ClockHand'` — the entire discriminating half of the gauge signature. A miss means no gauge is ever detected (silent no-op). It cannot steal `RADAR`/`POLAR_AREA`, because zero layers is required first.
5. The hand is reachable as `axisDataItem.get('bullet').get('sprite')`, and its value is `get('value')` on that same item. Four probes cover the sprite (accessor and property, plus `item.bullets[]` both ways); the value is unmitigated — if it lives elsewhere the layer is dropped.
6. A made axis data item lands in `axis.axisRanges.values` or `axis.dataItems`. Both are read, ranges first.
7. Gauge band ranges expose `get('endValue')`, with a name via `get('label')` (a `Label` with `get('text')`, or a plain string) or `get('category')`. Unnamed bands fall back to `Band n`.
8. `ClockHand.globalBounds()` reports a box **with area**. A `ClockHand` is a `Container`, so unlike a `Slice` it should — but if it does not, the overlay clears rather than boxing the whole dial. Pinned by a test.
9. A `Sunburst` node hangs its wedge on `slice` or `graphics`, and that `Slice` carries `radius`/`innerRadius`/`startAngle`/`arc` as a pie's does. Both slots are probed; if the settings are absent the chain falls back and ultimately clears.
10. Flow link ends answer `get('sourceId')`/`get('targetId')`, then `get('source')`/`get('target')` as node items with `name`/`id`, then `dataContext[sourceIdField ?? 'from']` — three probes in order. A link no probe resolves is dropped, never guessed.
11. The link weight is `item.get('value')`, else `dataContext[valueField ?? 'value']`; and `'from'`/`'to'` are amCharts' default end-field names.
12. `am5hierarchy.ForceDirected` exposes its graph as a hierarchy (a root whose `children` are the nodes), as `Treemap` and `Partition` do; and `linkWithField` names a `dataContext` column holding an **array** of node references. Non-arrays are ignored and unresolvable entries skipped, leaving the parent-child edges — a correct if smaller network.
13. A polygon data item exposes its shape as `item.get('mapPolygon')`, and `MapPolygon.globalBounds()` reports a box with area. The latter is doubtful — a `MapPolygon` is a `Graphics` painted through a draw callback, exactly the shape that reports a degenerate point in #774 — so `regionRect` clears rather than drawing a hairline. Pinned by a test.
14. The default am5map row is `{ id: 'US-NV', value: N }`. If a build keeps the place name out of the chain's reach, regions are announced by code rather than name — poorer, not wrong, and what the `region` declaration exists to fix.
15. `series.get('heatRules')` answers with an array. Only used to widen the shaded-series gate; if not, a map shaded by heat rules alone is skipped and is fixable by declaring `{ type: "choropleth" }`.

**Deliberate omissions** (decisions, not oversights, each documented in `docs/amcharts.md`): the gauge's `target` field — amCharts has no duck-typable construct separating a bullet-chart target from a second hand, and a guessed target is a number the chart never stated; choropleth `neighbors` — adjacency is not recoverable from rendered geometry or from centroids, and the grammar sanctions the absence; and `MapPointSeries`/`MapLineSeries` as readings — a bubble map and a route map are different charts, and reading either through `ChoroplethPoint` would announce a region list the chart does not draw.

**One follow-up is outstanding and unfiled:** the `highlightedPointIndices` getter on `FlowTrace` and `NetworkTrace`, described under Related Issues. It needs filing by hand alongside this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_