### PR TITLE
fix(highlight): let a flow or network trace publish the ribbon it highlighted

### DIFF
--- a/docs/amcharts.md
+++ b/docs/amcharts.md
@@ -98,7 +98,7 @@ Series are classified by their amCharts class name and field configuration:
 
 amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes for MAIDR's usual highlighting. `bindAmCharts` instead draws an absolutely-positioned outline box over the canvas at the active data point's pixel geometry (computed via am5's `sprite.toGlobal()`) — the same overlay approach the Chart.js adapter uses. The overlay re-anchors on resize. Call the returned `dispose()` to unmount MAIDR, remove the overlay, and restore the chart. Highlighting is unavailable on the `fromAmCharts` JSON/attribute path.
 
-**Four types are read but not outlined**: sankey, alluvial, chord and network. They sonify, describe, braille and navigate correctly, and the overlay simply clears as the cursor moves. This is deliberate, and [the reason is written out below](#flow-and-network-are-not-outlined) — an empty outline is truthful, and a box drawn around a guessed node is not.
+A sankey, alluvial, chord or network layer is outlined one **ribbon** at a time — the band or line the cursor's node is read through — rather than by a box around the node itself; see [Flow and network highlighting](#flow-and-network-highlighting).
 
 ## Supported Chart Types
 
@@ -129,9 +129,9 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Dot Plot (Cleveland) | `LineSeries` | category axis + `strokes.template` hidden + bullets |
 | Lollipop | `ColumnSeries` | category axis + hairline `columns.template` width + bullets |
 | Word Cloud | `am5wc.WordCloud` | series class (requires `wc.js`) |
-| Sankey † | `am5flow.Sankey`, `ArcDiagram` | series class (requires `flow.js`) |
-| Chord † | `am5flow.Chord`, `ChordDirected`, `ChordNonRibbon` | series class (requires `flow.js`) |
-| Network † | `am5hierarchy.ForceDirected` | series class (requires `hierarchy.js`) |
+| Sankey | `am5flow.Sankey`, `ArcDiagram` | series class (requires `flow.js`) |
+| Chord | `am5flow.Chord`, `ChordDirected`, `ChordNonRibbon` | series class (requires `flow.js`) |
+| Network | `am5hierarchy.ForceDirected` | series class (requires `hierarchy.js`) |
 | Choropleth | `am5map.MapPolygonSeries` inside a `MapChart` | series class + a bound `valueField` or `heatRules` (requires `map.js`) |
 | Bump (rank over time) | `LineSeries` | value axis renderer `inversed: true` **and** values that are a ranking; or the `bump` option |
 | Gauge | *no series* — an `am5radar.ClockHand` on a `RadarChart` axis | chart class `RadarChart` + a `ClockHand` bullet, asked only when the chart's series produced no layer (requires `radar.js`) |
@@ -141,10 +141,8 @@ amCharts 5 renders to an HTML5 `<canvas>`, so there are no per-element SVG nodes
 | Volcano | hidden-stroke `LineSeries` with bullets, two value axes | **declared** — `{ type: "volcano" }` |
 | Manhattan | the same, one series per chromosome | **declared** — `{ type: "manhattan" }` |
 | Scatter | the same | **declared** — `{ type: "point" }` |
-| Alluvial † | `am5flow.Sankey` | **declared** — `{ type: "alluvial" }` |
+| Alluvial | `am5flow.Sankey` | **declared** — `{ type: "alluvial" }` |
 | Choropleth (renamed fields) | `am5map.MapPolygonSeries` | **declared** — `{ type: "choropleth", value: "…" }` |
-
-† Read, announced, brailled and navigated — but **not outlined**. See [Flow and network are not outlined](#flow-and-network-are-not-outlined).
 
 A `StepLineSeries` is piecewise constant — the value is held and then jumps — so it maps to MAIDR's step trace rather than to a line, and is announced and navigated as a step plot. amCharts positions the staircase from the axis cell rather than reporting a step convention, so the adapter emits no `stepDirection` and MAIDR's description does not name one.
 
@@ -617,15 +615,17 @@ var series = root.container.children.push(am5hierarchy.ForceDirected.new(root, {
 
 The container root is dropped, as it is for a treemap. A `linkWith` entry naming something the walk never saw is skipped rather than turned into a node: amCharts draws no link for it either, and inventing the node would announce a participant the chart does not have. A pair that names itself from both ends yields one link, because a link is undirected. **Nothing about the layout is read** — where the force solver dropped a node is a fact about its seed rather than about the data, and MAIDR's network point has nowhere to put a position for exactly that reason.
 
-#### Flow and network are not outlined
+#### Flow and network highlighting
 
-Sankey, alluvial, chord and network layers get **no highlight**. As the cursor moves the overlay clears; audio, the text description, braille and keyboard navigation all work normally.
+A sankey, alluvial, chord or network layer **is** outlined, and what it outlines is one ribbon: the band amCharts drew for a flow link, or the line it drew between two nodes. Not a box around the node the cursor is on — amCharts paints its nodes into the same canvas as everything else, and a node's own extent is not what the reading is about.
 
-This is a deliberate refusal rather than an oversight, and the reason is worth stating. MAIDR hands a canvas adapter one of two things: an explicit list of point indices, for traces that publish which marks they mean, or the **braille** position for everything else. A flow trace is in the second group, and its braille position is `(stage, index within that stage)` — the stage being a column of the drawing, which is the only thing a braille line can be. A network trace's is `(component, index within that component)`.
+The route is worth stating, because the obvious one is wrong. MAIDR hands a canvas adapter either an explicit list of point indices, for traces that publish which marks they mean, or the **braille** position for everything else. A flow trace's braille position is `(stage, index within that stage)` and a network trace's is `(component, index within that component)`, and turning either back into a node would mean reimplementing, inside this adapter, the model's own first-appearance node ordering *together with* its stage layering — or, for a network, its connected-component discovery, member sort and component sort. Those are **derived graph structures**, not orderings over data the adapter emitted, and a copy of one drifts from the model silently and then outlines a confidently wrong node while the announcement says something else. Both types shipped with no highlight at all rather than that.
 
-Turning either back into a node means reimplementing, inside this adapter, the model's own first-appearance node ordering *together with* its stage layering — longest-distance-from-a-source, with a fallback that collapses a cyclic graph into one stage — or, for a network, its connected-component discovery, member sort and component sort. Those are **derived graph structures**, not orderings over data the adapter emitted. This adapter already mirrors an ordering where one exists (a heatmap's row reversal, a word cloud's weight order), and already refuses to mirror a derived structure (a scatter's binning). A copy would drift from the model silently and then outline a confidently wrong node while the announcement said something else — and nothing about the announcement would look wrong. An empty outline is truthful; that is not.
+They are in the first group now: `FlowTrace` and `NetworkTrace` publish the mark they highlighted as an index into the `data` this adapter supplied, and the adapter inverts that index against its own extraction walk. The n-th flow point was read from the n-th readable link, so a flow index reaches its ribbon directly; a network's links are not data items at all, so the index names two nodes and the drawn line joining that pair is found by name, in either direction. The binning, the layering and the component walk all stay in the model.
 
-The fix is small and lives in the model rather than here: both traces already compute the right answer internally, so publishing it as point indices would make all four types highlightable by registering resolvers and changing nothing else. That is tracked as a follow-up.
+The published set is exactly **one** mark, the same one an SVG renderer outlines for the same trace at the same cursor position, so a chart read on amCharts and a chart read on Vega-Lite light up the same ribbon. A node in a sankey touches every flow on either side of it, and outlining all of them would have been the wider, wrong-looking-right answer.
+
+The outline is the ribbon's axis-aligned box — coarse for a long curved band, but it hugs the mark and says which way navigation moved. A link drawn perfectly straight reports a box with no thickness and is padded to a hairline rather than dropped. A build that hands back no geometry at all, or a pair no drawn line joins, clears the overlay instead of outlining something nearby.
 
 ### Choropleth
 

--- a/src/adapters/amcharts/adapter.ts
+++ b/src/adapters/amcharts/adapter.ts
@@ -588,8 +588,8 @@ function buildDeclaredLayer(
     // `am5flow.Sankey`; what the author declared is which of the two readings
     // the drawing stands for, so nothing beyond the type is taken from the
     // block. Bound to no axis, so it names its own dimensions rather than
-    // taking the chart's — and it emits no selectors and gets no highlight,
-    // exactly as an undeclared sankey does.
+    // taking the chart's — and it emits no selectors, exactly as an undeclared
+    // sankey does; the overlay outlines its ribbons instead.
     case TraceType.ALLUVIAL: {
       const data = extractFlowPoints(declared.series);
       if (data.length === 0) {
@@ -1001,11 +1001,12 @@ function flowAxes(options?: AmChartsBinderOptions): MaidrLayer['axes'] {
  * it carries weights, and MAIDR's network payload has nowhere to put one.
  *
  * No `selectors`, for the reason a pie and a treemap emit none — amCharts
- * paints the ribbons into a canvas. **And no highlight either**: the position
- * MAIDR hands back for a flow trace is a braille one, `(stage, index within
- * stage)`, and turning that back into a node would mean reimplementing the
- * model's own node ordering and stage layering here. See `docs/amcharts.md`;
- * the overlay clears rather than outlining a guessed node.
+ * paints the ribbons into a canvas, so the binder's overlay outlines the active
+ * one instead. It can, because `FlowTrace` publishes the ribbon it highlighted
+ * as an index into this `data`: the position MAIDR hands back for a flow trace
+ * is otherwise a braille one, `(stage, index within stage)`, and turning that
+ * into a node would have meant reimplementing the model's node ordering and
+ * stage layering here. See `navmap.ts`'s `buildFlowResolver`.
  */
 function buildFlowLayer(
   series: AmXYSeries,
@@ -1072,8 +1073,9 @@ const NETWORK_LINK_AXIS = 'Links';
  * Builds the layer for one `am5hierarchy.ForceDirected` series.
  *
  * Nothing about where the solver put the nodes is carried: the position is a
- * fact about its seed rather than about the data. No selectors and no
- * highlight, for the same reasons the flow layer has none.
+ * fact about its seed rather than about the data. No selectors either, for the
+ * reason the flow layer emits none — and the overlay outlines the active link
+ * the same way, from what `NetworkTrace` publishes.
  */
 function buildNetworkLayer(
   series: AmXYSeries,

--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -1027,7 +1027,41 @@ function readFlowValue(item: AmDataItem, series: AmXYSeries): number | null {
  * position onto its neighbour.
  */
 export function extractFlowPoints(series: AmXYSeries): FlowPoint[] {
-  const points: FlowPoint[] = [];
+  return extractFlowLinks(series).map(link => link.point);
+}
+
+/**
+ * One readable link of an am5flow series: the reading MAIDR was given, and the
+ * data item amCharts drew the ribbon from.
+ */
+export interface AmFlowLink {
+  /** The link's data item, which carries the drawn ribbon. */
+  item: AmDataItem;
+  /** The point emitted for it, at the same position in `layer.data`. */
+  point: FlowPoint;
+}
+
+/**
+ * The links of an am5flow series, each paired with the data item it was read
+ * from.
+ *
+ * {@link extractFlowPoints} is this list with the data items dropped, so the
+ * n-th point of a flow layer was read from the n-th entry here **by
+ * construction** rather than by two walks agreeing. That is what lets the
+ * highlight invert an index: `FlowTrace` publishes the ribbon it outlined as a
+ * position in `layer.data`, and the adapter reads that position back off this
+ * list to reach the sprite amCharts drew.
+ *
+ * A parallel walk would have done the same job until one of the two learned
+ * about a link the other kept — the drop rules above are exactly where that
+ * would happen — and the highlight would then sit one ribbon off with nothing
+ * about the announcement looking wrong.
+ *
+ * @param series - The flow series to read.
+ * @returns One entry per readable link, in chart order.
+ */
+export function extractFlowLinks(series: AmXYSeries): AmFlowLink[] {
+  const links: AmFlowLink[] = [];
 
   for (const item of series.dataItems) {
     const source = readFlowEnd(item, series, 'source');
@@ -1039,10 +1073,26 @@ export function extractFlowPoints(series: AmXYSeries): FlowPoint[] {
     if (value == null || value === 0)
       continue;
 
-    points.push({ source, target, value });
+    links.push({ item, point: { source, target, value } });
   }
 
-  return points;
+  return links;
+}
+
+/**
+ * The ribbon amCharts drew for one flow link.
+ *
+ * An am5flow data item keeps its band on `link` — a `SankeyLink`, a
+ * `ChordLink` or the straight `ArcDiagram` line — which is the mark the
+ * overlay measures. Unverifiable without the library, like every other sprite
+ * read here, so an absent one answers `undefined` and the caller clears the
+ * overlay rather than outlining something else.
+ *
+ * @param item - The link's data item.
+ * @returns Its drawn ribbon, or `undefined` when the build keeps none.
+ */
+export function flowRibbonOf(item: AmDataItem): AmSprite | undefined {
+  return item.get('link') as AmSprite | undefined;
 }
 
 /**
@@ -1095,7 +1145,7 @@ export function extractNetworkPoints(series: AmXYSeries): NetworkPoint[] {
   const links: NetworkPoint[] = [];
   const seen = new Set<string>();
   const add = (source: string | number, target: string | number): void => {
-    const key = [String(source), String(target)].sort().join(' ');
+    const key = networkLinkKey(source, target);
     if (seen.has(key))
       return;
     seen.add(key);
@@ -1124,6 +1174,79 @@ export function extractNetworkPoints(series: AmXYSeries): NetworkPoint[] {
   }
 
   return links;
+}
+
+/**
+ * How one undirected link is named, from the two nodes it joins.
+ *
+ * **One expression, two readers.** {@link extractNetworkPoints} keys its
+ * de-duplication with this — two rows naming each other draw one line, so the
+ * pair has to name the same link whichever end it is read from — and
+ * {@link findNetworkLink} matches a drawn line against the emitted payload with
+ * it. A second spelling of "the same pair" is how the highlight would come to
+ * miss exactly the links a `linkWith` authored backwards.
+ *
+ * @param source - One end of the link.
+ * @param target - The other end.
+ * @returns A key equal for both orderings of the pair.
+ */
+export function networkLinkKey(
+  source: string | number,
+  target: string | number,
+): string {
+  return [String(source), String(target)].sort().join(' ');
+}
+
+/**
+ * The line an `am5hierarchy.ForceDirected` drew between two nodes.
+ *
+ * A network is the one reading whose payload is not a walk over data items: its
+ * links are the tree's parent-child edges plus the cross-links the rows named,
+ * and amCharts draws them from a list of its own. So a published index is
+ * inverted against the emitted point — `layer.data[i]` names two nodes — and
+ * the line is then found by asking each drawn link which two nodes it joins,
+ * with {@link networkLinkKey} settling the direction the payload does not
+ * carry.
+ *
+ * `series.links` and a link's `source` / `target` node data items are
+ * unverifiable without the library, like every other sprite read here. A build
+ * that answers with neither leaves every link unfound, the resolver answers
+ * nothing, and the overlay clears — which is what a network did in full before
+ * this existed, rather than a line drawn somewhere plausible.
+ *
+ * @param series - The force-directed series that drew the graph.
+ * @param link - The emitted point naming the two ends.
+ * @returns The drawn line, or `undefined` when none of them joins that pair.
+ */
+export function findNetworkLink(
+  series: AmXYSeries,
+  link: NetworkPoint,
+): AmSprite | undefined {
+  const wanted = networkLinkKey(link.source, link.target);
+  for (const drawn of series.links?.values ?? []) {
+    const source = readLinkEndName(drawn, 'source');
+    const target = readLinkEndName(drawn, 'target');
+    if (source != null && target != null && networkLinkKey(source, target) === wanted) {
+      return drawn;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The name of one end of a drawn hierarchy link.
+ *
+ * The end is a *node data item*, so it is asked for its category — the same
+ * read {@link extractHierarchyNodes} names a node by, which is what makes the
+ * two sides comparable at all.
+ */
+function readLinkEndName(link: AmSprite, end: 'source' | 'target'): string | number | null {
+  const node = link.get?.(end);
+  if (node == null || typeof node !== 'object') {
+    return null;
+  }
+  const get = (node as { get?: (key: string) => unknown }).get;
+  return typeof get === 'function' ? asNodeName(get.call(node, 'category')) : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/amcharts/navmap.ts
+++ b/src/adapters/amcharts/navmap.ts
@@ -9,10 +9,10 @@
  * chart so highlights clip against the correct panel's plot area.
  */
 
-import type { ChoroplethPoint, HeatmapData, MaidrLayer } from '@type/grammar';
+import type { ChoroplethPoint, HeatmapData, MaidrLayer, NetworkPoint } from '@type/grammar';
 import type { AmDeclaredLayer } from './declaration';
 import type { ChoroplethFields } from './extractor';
-import type { AmChart, AmDataItem, AmXYSeries } from './types';
+import type { AmChart, AmDataItem, AmSprite, AmXYSeries } from './types';
 import { TraceType } from '@type/grammar';
 import {
   choroplethFields,
@@ -24,25 +24,49 @@ import {
 } from './declaration';
 import {
   classifySeriesKind,
+  extractFlowLinks,
   extractGanttItems,
   extractHierarchyNodes,
+  extractNetworkPoints,
   extractSpanItems,
   filterChoroplethItems,
   findGaugeHand,
+  findNetworkLink,
+  flowRibbonOf,
   isColumnSeries,
 } from './extractor';
 
 /**
- * The am5 entities to highlight for a navigation position.
+ * A mark reached through the data item it hangs on.
+ *
  * `kind` tells the overlay which geometry to read: a column's box, a line
  * point, the wedge-shaped sprite of a pie slice, funnel stage or polar column,
  * the glyph of a word cloud's term, or the drawn polygon of a map region.
  */
-export interface NavTarget {
+export interface NavItemTarget {
   series: AmXYSeries;
   dataItem: AmDataItem;
   kind: 'column' | 'point' | 'slice' | 'label' | 'region';
 }
+
+/**
+ * A ribbon: the band a sankey, chord or alluvial link is drawn as, or the line
+ * between two nodes of a force-directed network.
+ *
+ * The one target named by its sprite rather than by a data item, because a
+ * network's lines are not data items at all — amCharts derives them from the
+ * tree and keeps them in a list of its own. The resolver has already done the
+ * inversion by the time this is built, so the overlay measures what it is
+ * handed instead of learning where each library hangs a link.
+ */
+export interface NavRibbonTarget {
+  series: AmXYSeries;
+  sprite: AmSprite;
+  kind: 'ribbon';
+}
+
+/** The am5 entities to highlight for a navigation position. */
+export type NavTarget = NavItemTarget | NavRibbonTarget;
 
 /**
  * Resolves a MAIDR navigation position to the am5 targets to highlight.
@@ -52,9 +76,11 @@ export interface NavMap {
    * @param layerId - The layer the position belongs to
    * @param row - The MAIDR row, or `-1` when `pointIndices` is given
    * @param col - The MAIDR column, or `-1` when `pointIndices` is given
-   * @param pointIndices - For a point cloud, the `layer.data` indices to
-   *   outline. A cloud's selection is a set of points that no row/column pair
-   *   can name, so it is addressed by data index instead.
+   * @param pointIndices - For a layer that names its own marks, the
+   *   `layer.data` indices to outline. A cloud's selection is a set of points
+   *   that no row/column pair can name, and a flow or network position names a
+   *   node rather than the ribbon drawn for it, so both are addressed by data
+   *   index instead.
    */
   resolve: (
     layerId: string,
@@ -150,6 +176,18 @@ export interface SeriesGroups {
   hierarchySeriesList: AmXYSeries[];
   /** One WORD_CLOUD layer each, in series order. */
   wordCloudSeriesList: AmXYSeries[];
+  /**
+   * One SANKEY or CHORD layer each, in series order.
+   *
+   * One bucket for both because they are one weighted graph drawn two ways —
+   * the same `extractFlowLinks` walk, the same ribbon per link — and only the
+   * announced type differs. An `ArcDiagram` lands here too, as a sankey. A
+   * declared **alluvial** does not: it is the same am5flow series read a third
+   * way, so it travels in {@link declaredList} with the other declared layers.
+   */
+  flowSeriesList: AmXYSeries[];
+  /** One NETWORK layer each, in series order. */
+  networkSeriesList: AmXYSeries[];
   /**
    * One CHOROPLETH layer each, in series order.
    *
@@ -337,7 +375,7 @@ function buildGanttResolver(series: AmXYSeries | undefined): Resolver {
  */
 function buildHierarchyResolver(
   series: AmXYSeries | undefined,
-  kind: NavTarget['kind'],
+  kind: NavItemTarget['kind'],
 ): Resolver {
   const levels: AmDataItem[][] = [];
   for (const node of series ? extractHierarchyNodes(series) : []) {
@@ -420,7 +458,7 @@ function buildIntervalResolver(declared: AmDeclaredLayer | undefined): Resolver 
   const { items, owners } = declared.declaration.type === TraceType.FOREST
     ? extractForestSamples(declared)
     : extractErrorBarSamples(declared);
-  const kind: NavTarget['kind'] = isColumnSeries(declared.series) ? 'column' : 'point';
+  const kind: NavItemTarget['kind'] = isColumnSeries(declared.series) ? 'column' : 'point';
 
   return (_row, col) => {
     const dataItem = items[col];
@@ -478,6 +516,104 @@ function buildCloudResolver(
       const mark = marks[index];
       if (mark) {
         targets.push({ series: mark.series, dataItem: mark.item, kind: 'point' });
+      }
+    }
+    return targets;
+  };
+}
+
+/**
+ * Build a resolver for a flow layer — a sankey, a chord, or the alluvial an
+ * author declares on the same am5flow series.
+ *
+ * The second family to be addressed by data index rather than by position, and
+ * for the same reason as {@link buildCloudResolver}: what MAIDR hands back for
+ * a flow trace is its *braille* position, `(stage, index within stage)`, and
+ * turning that into a node would mean reimplementing the model's own
+ * first-appearance node ordering together with its longest-path stage layering
+ * here. That is a derived graph structure rather than an ordering over data
+ * this adapter emitted, and a copy of it drifts silently — #895 and #903 both
+ * refused to ship one, and left this unregistered instead.
+ *
+ * `FlowTrace` now publishes the one ribbon it outlined as an index into the
+ * `data` this adapter supplied, so the inversion is a lookup: `layer.data[i]`
+ * was read from `extractFlowLinks(series)[i]` by construction, and that entry
+ * carries the data item amCharts drew the band from. **One ribbon, not every
+ * flow touching the node** — the model publishes exactly what its own
+ * `mapToSvgElements` selects, so this overlay and an SVG renderer outline the
+ * same band at the same cursor position.
+ *
+ * @param series - The am5flow series that drew the ribbons, if one matched.
+ * @param layer - The emitted layer, whose `data` the indices address.
+ * @returns A resolver mapping data indices to the ribbons that drew them.
+ */
+function buildFlowResolver(series: AmXYSeries | undefined, layer: MaidrLayer): Resolver {
+  if (!series || !Array.isArray(layer.data)) {
+    return () => [];
+  }
+  const links = extractFlowLinks(series);
+  // The alignment guard {@link buildCloudResolver} makes: an index only means
+  // anything if this list and `layer.data` are the same list. A mismatch means
+  // the chart moved underneath the extraction, and resolving to nothing then
+  // clears the overlay — the honest blank these four types shipped with, and
+  // strictly better than a band picked by a stale index.
+  if (links.length !== layer.data.length) {
+    return () => [];
+  }
+  return (_row, _col, pointIndices) => {
+    if (!pointIndices) {
+      return [];
+    }
+    const targets: NavTarget[] = [];
+    for (const index of pointIndices) {
+      const link = links[index];
+      const sprite = link ? flowRibbonOf(link.item) : undefined;
+      if (sprite) {
+        targets.push({ series, sprite, kind: 'ribbon' });
+      }
+    }
+    return targets;
+  };
+}
+
+/**
+ * Build a resolver for a force-directed network layer.
+ *
+ * The same inversion as {@link buildFlowResolver}, with the model's connected
+ * component walk in the place of its stage layering, and one difference that
+ * belongs to amCharts rather than to MAIDR: a network's links are not data
+ * items. `ForceDirected` is a *hierarchy* series, so `extractNetworkPoints`
+ * derives the links from the tree and from the rows' `linkWith` columns, and
+ * the drawn lines live in a list of the series' own. A published index
+ * therefore names a point first — two node names — and {@link findNetworkLink}
+ * finds the line joining that pair.
+ *
+ * The re-extraction is the alignment guard: a list of a different length from
+ * `layer.data` means the graph changed under the map, and the resolver then
+ * answers nothing rather than pairing an index with whatever now sits at it.
+ *
+ * @param series - The `ForceDirected` series that drew the graph, if one matched.
+ * @param layer - The emitted layer, whose `data` the indices address.
+ * @returns A resolver mapping data indices to the lines that drew them.
+ */
+function buildNetworkResolver(series: AmXYSeries | undefined, layer: MaidrLayer): Resolver {
+  const points = layer.data as NetworkPoint[];
+  if (!series || !Array.isArray(points)) {
+    return () => [];
+  }
+  if (extractNetworkPoints(series).length !== points.length) {
+    return () => [];
+  }
+  return (_row, _col, pointIndices) => {
+    if (!pointIndices) {
+      return [];
+    }
+    const targets: NavTarget[] = [];
+    for (const index of pointIndices) {
+      const point = points[index];
+      const sprite = point ? findNetworkLink(series, point) : undefined;
+      if (sprite) {
+        targets.push({ series, sprite, kind: 'ribbon' });
       }
     }
     return targets;
@@ -671,6 +807,8 @@ export function groupSeries(chart: AmChart): SeriesGroups {
     ganttSeriesList: [],
     hierarchySeriesList: [],
     wordCloudSeriesList: [],
+    flowSeriesList: [],
+    networkSeriesList: [],
     choroplethSeriesList: [],
     declaredList: [],
   };
@@ -767,23 +905,26 @@ export function groupSeries(chart: AmChart): SeriesGroups {
         groups.wordCloudSeriesList.push(series);
         break;
       // A map region IS addressable — the polygon amCharts drew reports a box
-      // — so unlike the flow family below, a choropleth gets a bucket and a
-      // resolver. The banding the model navigates it by is rebuilt from the
-      // layer's own centroids; see `buildChoroplethResolver`.
+      // — so a choropleth gets a bucket and a resolver. The banding the model
+      // navigates it by is rebuilt from the layer's own centroids; see
+      // `buildChoroplethResolver`.
       case 'choropleth':
         groups.choroplethSeriesList.push({ series });
         break;
-      // A flow diagram and a force-directed network are read, described,
-      // brailled and navigated, and deliberately get no bucket: MAIDR hands a
-      // flow trace's position back as a *braille* one — the stage, and the
-      // index within it — and recovering the node from that would mean
-      // reimplementing the model's own node ordering and stage layering here.
-      // That is a derived graph structure rather than an ordering, which is
-      // the line `buildCloudResolver` refuses to cross, so no resolver is
-      // registered and the overlay clears. See `docs/amcharts.md`.
+      // A sankey and a chord are one weighted graph drawn two ways, so they
+      // share a bucket the way a treemap and an icicle do. Both had none at
+      // all until #904: the only position on offer was the *braille* one — a
+      // stage and an index within it — and recovering the node from that would
+      // have meant reimplementing the model's stage layering here. The trace
+      // now names the ribbon it outlined instead, as an index into the data
+      // this adapter emitted, which is an inversion rather than a copy.
       case 'sankey':
       case 'chord':
+        groups.flowSeriesList.push(series);
+        break;
+      // The same story with the component walk in place of the layering.
       case 'network':
+        groups.networkSeriesList.push(series);
         break;
       default:
         break;
@@ -861,6 +1002,8 @@ function addEntryResolvers(
   let ganttIdx = 0;
   let hierarchyIdx = 0;
   let wordCloudIdx = 0;
+  let flowIdx = 0;
+  let networkIdx = 0;
   let choroplethIdx = 0;
 
   const register = (layerId: string, resolver: Resolver): void => {
@@ -918,7 +1061,7 @@ function addEntryResolvers(
         // A polar area draws its values as wedges rather than as points on a
         // line, so the sprite the overlay measures differs even though the
         // navigable grid is the same.
-        const kind: NavTarget['kind']
+        const kind: NavItemTarget['kind']
           = layer.type === TraceType.POLAR_AREA ? 'slice' : 'point';
         register(layer.id, (row, col) => {
           const entry = seriesList[row];
@@ -980,7 +1123,7 @@ function addEntryResolvers(
       case TraceType.SUNBURST: {
         // One tree, three marks: a treemap block and an icicle bar are
         // rectangles, a sunburst node is a wedge.
-        const kind: NavTarget['kind']
+        const kind: NavItemTarget['kind']
           = layer.type === TraceType.SUNBURST ? 'slice' : 'column';
         register(
           layer.id,
@@ -1041,32 +1184,30 @@ function addEntryResolvers(
         }
         break;
       }
-      // Named rather than left to the default, because their absence is a
-      // decision rather than an omission — the failure mode this whole file
-      // exists to make visible is a type that reads correctly while its
-      // highlight silently vanishes.
-      //
-      // `createNavigateObserver` hands a flow or network layer the *braille*
-      // position, which `FlowTrace.braille` transposes to (stage, index within
-      // stage) and `NetworkTrace.braille` to (component, index within
-      // component). Inverting either means reimplementing the model's node
-      // ordering together with its stage layering — or its component
-      // discovery, ordering and sorting — inside the adapter. That is a
-      // derived graph structure, not an ordering over data this adapter
-      // emitted, and `buildCloudResolver` already refuses exactly that: a copy
-      // drifts silently and then outlines a confidently wrong node.
-      //
-      // So no resolver is registered, `NavMap.resolve` answers `[]`, and
-      // `applyHighlight` clears the overlay. An empty outline is truthful; a
-      // box drawn from a guessed layering is not. Both traces already compute
-      // the right answer internally (`edge.at`, `node.linkAt[0]`), so a
-      // `highlightedPointIndices` getter on each — a `src/model/` change —
-      // makes all four resolvable by registering resolvers and nothing else.
+      // A sankey and a chord are one weighted graph drawn two ways, and were
+      // collected together for that reason; an `ArcDiagram` is announced as a
+      // sankey and lands with them.
       case TraceType.SANKEY:
-      case TraceType.CHORD:
-      case TraceType.ALLUVIAL:
-      case TraceType.NETWORK:
+      case TraceType.CHORD: {
+        register(layer.id, buildFlowResolver(groups.flowSeriesList[flowIdx++], layer));
         break;
+      }
+      // The same am5flow series, read a third way — so its resolver is the
+      // flow one, taken from the declared queue rather than from the bucket.
+      case TraceType.ALLUVIAL: {
+        register(
+          layer.id,
+          buildFlowResolver(nextDeclared(TraceType.ALLUVIAL)?.series, layer),
+        );
+        break;
+      }
+      case TraceType.NETWORK: {
+        register(
+          layer.id,
+          buildNetworkResolver(groups.networkSeriesList[networkIdx++], layer),
+        );
+        break;
+      }
       default:
         break;
     }

--- a/src/adapters/amcharts/overlay.ts
+++ b/src/adapters/amcharts/overlay.ts
@@ -17,7 +17,7 @@
  * navigation.
  */
 
-import type { NavTarget } from './navmap';
+import type { NavItemTarget, NavRibbonTarget, NavTarget } from './navmap';
 import type { AmBounds, AmPoint, AmSprite } from './types';
 import { sliceExtent } from './geometry';
 
@@ -33,6 +33,17 @@ export interface OverlayRect {
 
 /** Side length of the box drawn around a line/scatter point. */
 const POINT_BOX_SIZE = 14;
+
+/**
+ * How thin a ribbon's box is allowed to get before it is padded out.
+ *
+ * A sankey band and a chord ribbon always enclose area, but a network line
+ * between two nodes at the same height reports a box of zero height — real
+ * geometry rather than the degenerate point a `Slice` reports (#774). Left as
+ * it is, `intersectRect` would collapse it and the overlay would clear on a
+ * link that is drawn perfectly straight.
+ */
+const RIBBON_MIN_THICKNESS = 2;
 
 /**
  * Manages DOM rectangles drawn over an amCharts 5 chart to provide
@@ -124,10 +135,10 @@ export class HighlightOverlay {
 }
 
 /**
- * Convert a navigation target (an am5 series + dataItem) into an overlay
- * rectangle in root-container pixels, clipped to the plot area. Returns `null`
- * when geometry is unavailable or fully outside the plot, in which case the
- * caller should clear the overlay.
+ * Convert a navigation target — the mark hanging off an am5 dataItem, or the
+ * sprite a ribbon was resolved to — into an overlay rectangle in root-container
+ * pixels, clipped to the plot area. Returns `null` when geometry is unavailable
+ * or fully outside the plot, in which case the caller should clear the overlay.
  */
 export function dataItemToOverlayRect(
   target: NavTarget,
@@ -153,7 +164,58 @@ function readRect(target: NavTarget): OverlayRect | null {
       return regionRect(target);
     case 'column':
       return columnRect(target);
+    case 'ribbon':
+      return ribbonRect(target);
   }
+}
+
+/**
+ * Rectangle for a ribbon — the band a flow link is drawn as, or the line
+ * between two nodes of a force-directed network.
+ *
+ * The sprite arrives already resolved, because where a link hangs differs by
+ * series family and that is the navigation map's business; here it is only
+ * measured. Measured from the reported box first, for the reason a map region
+ * is: a ribbon is a curved band and a link is a diagonal, and neither fills the
+ * box its local width and height describe, while `globalBounds()` maps all four
+ * corners of the shape as drawn.
+ *
+ * The box is coarse — a sankey's widest band spans most of the chart — but the
+ * overlay draws rectangles onto a canvas that has no path to outline, and a box
+ * hugging the active ribbon still says which way navigation moved.
+ *
+ * A sprite reporting no extent in either direction answers `null` rather than a
+ * mark at its centre: an am5 `Graphics` painted through a draw callback can
+ * report a degenerate point (#774), and a link carries no radius or sweep to be
+ * measured from instead.
+ */
+function ribbonRect(target: NavRibbonTarget): OverlayRect | null {
+  const bounds = target.sprite.globalBounds?.();
+  const reported = bounds ? boundsToRect(bounds) : null;
+  const box = reported && hasExtent(reported) ? reported : spriteBoxRect(target.sprite);
+  if (!box || !hasExtent(box)) {
+    return null;
+  }
+
+  // A straight link has extent along one axis only, and a hairline is what it
+  // is; pad the other so the box survives the clip and stays visible.
+  return {
+    left: box.width > 0 ? box.left : box.left - RIBBON_MIN_THICKNESS / 2,
+    top: box.height > 0 ? box.top : box.top - RIBBON_MIN_THICKNESS / 2,
+    width: Math.max(box.width, RIBBON_MIN_THICKNESS),
+    height: Math.max(box.height, RIBBON_MIN_THICKNESS),
+  };
+}
+
+/**
+ * Whether a box measures anything at all.
+ *
+ * One dimension is enough, which is where a ribbon parts company with a region:
+ * a link drawn horizontally is a real mark with a real length, while a shape
+ * reporting nothing in either direction is the degenerate point of #774.
+ */
+function hasExtent(box: OverlayRect): boolean {
+  return box.width > 0 || box.height > 0;
 }
 
 /**
@@ -173,7 +235,7 @@ function readRect(target: NavTarget): OverlayRect | null {
  * measure a region from instead. The overlay then clears, which says nothing
  * rather than pointing a one-pixel mark at the wrong place.
  */
-function regionRect(target: NavTarget): OverlayRect | null {
+function regionRect(target: NavItemTarget): OverlayRect | null {
   const polygon = target.dataItem.get('mapPolygon') as AmSprite | undefined;
   if (!polygon) {
     return null;
@@ -195,7 +257,7 @@ function regionRect(target: NavTarget): OverlayRect | null {
  * Rectangle for a column-shaped data point (bar / segmented / histogram /
  * heatmap cell), read directly from the column graphics sprite's global box.
  */
-function columnRect(target: NavTarget): OverlayRect | null {
+function columnRect(target: NavItemTarget): OverlayRect | null {
   const sprite = readColumnSprite(target);
   if (!sprite) {
     return null;
@@ -252,7 +314,7 @@ function spriteBoxRect(sprite: AmSprite): OverlayRect | null {
  * {@link sliceExtent} to measure — but it is laid out with a width and a
  * height of its own, which is what the sprite box answers with.
  */
-function sliceRect(target: NavTarget): OverlayRect | null {
+function sliceRect(target: NavItemTarget): OverlayRect | null {
   const slice = (target.dataItem.get('slice') ?? target.dataItem.get('graphics')) as
     | AmSprite
     | undefined;
@@ -281,7 +343,7 @@ function sliceRect(target: NavTarget): OverlayRect | null {
  * glyph however it is turned. The sprite's own corners stay as the fallback
  * for a build that reports no bounds.
  */
-function labelRect(target: NavTarget): OverlayRect | null {
+function labelRect(target: NavItemTarget): OverlayRect | null {
   const label = target.dataItem.get('label') as AmSprite | undefined;
   if (!label) {
     return null;
@@ -302,7 +364,7 @@ function labelRect(target: NavTarget): OverlayRect | null {
 /**
  * Rectangle for a line/scatter point: a small box centered on the point.
  */
-function pointRect(target: NavTarget): OverlayRect | null {
+function pointRect(target: NavItemTarget): OverlayRect | null {
   const center = readPointGlobal(target);
   if (!center) {
     return null;
@@ -352,7 +414,7 @@ function intersectRect(rect: OverlayRect, bounds: AmBounds): OverlayRect | null 
  * rectangles laid out with a width and a height, which is what the box read
  * above needs; only the property they hang on differs.
  */
-function readColumnSprite(target: NavTarget): AmSprite | undefined {
+function readColumnSprite(target: NavItemTarget): AmSprite | undefined {
   const graphics = target.dataItem.get('graphics')
     ?? target.dataItem.get('column')
     ?? target.dataItem.get('rectangle');
@@ -364,7 +426,7 @@ function readColumnSprite(target: NavTarget): AmSprite | undefined {
  * Prefers the first bullet sprite's bounds center, falling back to the
  * dataItem's `point` converted via the series.
  */
-function readPointGlobal(target: NavTarget): AmPoint | null {
+function readPointGlobal(target: NavItemTarget): AmPoint | null {
   // Proven path: the dataItem's series-local point mapped via the series.
   const point = target.dataItem.get('point') as AmPoint | undefined;
   if (point && target.series.toGlobal) {

--- a/src/adapters/amcharts/types.ts
+++ b/src/adapters/amcharts/types.ts
@@ -132,6 +132,17 @@ export interface AmXYSeries extends AmEntity {
    * thing that tells an area from a line.
    */
   fills?: { template?: AmSprite };
+  /**
+   * The lines an `am5hierarchy.ForceDirected` draws between its nodes, as an
+   * am5 `ListTemplate`.
+   *
+   * A network is the one reading whose marks hang off neither a data item nor
+   * the series' own data: its links are derived from the tree and from the
+   * rows' `linkWith` columns, and amCharts keeps the drawn lines here. Each
+   * carries the two node data items it joins on `source` / `target`, which is
+   * how `findNetworkLink` tells them apart.
+   */
+  links?: AmListLike<AmSprite>;
   /** Converts a series-local point to root-container coordinates. */
   toGlobal?: (point: AmPoint) => AmPoint;
   /**

--- a/src/model/flow.ts
+++ b/src/model/flow.ts
@@ -1,5 +1,6 @@
 import type { FlowPoint, MaidrLayer } from '@type/grammar';
 import type { Coordinate, MovableDirection, Node } from '@type/movable';
+import type { PointCloudHighlightable } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint, RotorFilterUnit } from './abstract';
 import { MathUtil } from '@util/math';
@@ -107,7 +108,7 @@ function asPercent(fraction: number): string {
  * a separate node list would be a second source of truth for something the
  * edges already say -- the treemap's reasoning about paths, applied to a graph.
  */
-export class FlowTrace extends AbstractTrace {
+export class FlowTrace extends AbstractTrace implements PointCloudHighlightable {
   /**
    * No go-to-extrema dialog. Every node is one arrow from its neighbours and
    * the largest flows are named in the description; leaving this true without
@@ -747,14 +748,71 @@ export class FlowTrace extends AbstractTrace {
     // and nothing about the announcement would look wrong.
     return this.grid.map(row =>
       row.map((node) => {
-        if (node === null) {
-          return Svg.createEmptyElement();
-        }
-        const touching = [...node.out, ...node.in]
-          .map(edge => flat[edge.at])
-          .filter((element): element is SVGElement => element !== undefined);
-        return touching[0] ?? Svg.createEmptyElement();
+        const at = FlowTrace.ribbonOf(node);
+        const element = at === undefined ? undefined : flat[at];
+        return element ?? Svg.createEmptyElement();
       }));
+  }
+
+  /**
+   * The one ribbon a node's highlight covers, as its position in the declared
+   * flow array.
+   *
+   * **This is the single expression both highlight channels read.** A node
+   * touches every flow on either side of it, but the chart is not asked to
+   * outline all of them: `mapToSvgElements` takes one element per cell, and
+   * {@link highlightedPointIndices} names one index. Writing the rule twice is
+   * how the two would come to disagree -- an adapter publishing
+   * `[...out, ...in]` while the SVG path outlined `out[0]` puts a canvas
+   * highlight and an SVG highlight on different ribbons for the same trace at
+   * the same cursor position, which reads as correct and is not.
+   *
+   * Outgoing first, because that is the direction the chart is drawn in and the
+   * ribbon the FORWARD arrow follows; a sink has no outgoing flow, so it falls
+   * back to the widest one arriving. Both lists are sorted largest first, so
+   * this is the widest ribbon touching the node -- the one an eye goes to.
+   *
+   * @param node - The node under the cursor, or null where the grid is empty
+   * @returns Its ribbon's index into the declared flows, or undefined when the
+   *   node draws no ribbon at all
+   */
+  private static ribbonOf(node: FlowNode | null): number | undefined {
+    if (node === null) {
+      return undefined;
+    }
+    return node.out[0]?.at ?? node.in[0]?.at;
+  }
+
+  /**
+   * The ribbon the highlight currently covers, as an index into this layer's
+   * `data` array.
+   *
+   * This is `highlight` answered in a renderer-neutral currency. A flow chart
+   * drawn on a canvas has no SVG elements for `selectors` to reach, and an
+   * adapter that rebuilt the stage layering to find the node itself would drift
+   * from {@link assignStages} silently -- so the trace names the ribbon by the
+   * position it occupies in the flow array the adapter supplied, and the
+   * adapter inverts that against its own extraction walk.
+   *
+   * Derived from {@link ribbonOf}, the same expression `mapToSvgElements`
+   * indexes its elements with, so the canvas highlight and the SVG highlight
+   * cannot name different ribbons.
+   *
+   * Deliberately not gated on SVG availability: a canvas chart has no elements
+   * by definition, and that is the case this exists to serve.
+   *
+   * @returns One index into `layer.data`, or nothing when the cursor is on no
+   *   node or on a node no ribbon was drawn for.
+   */
+  public get highlightedPointIndices(): readonly number[] {
+    if (this.isInitialEntry) {
+      // The inherited `highlight` reports out of bounds until the cursor has
+      // entered the trace; an empty array is how this channel says the same
+      // thing, so the two agree at every position including this one.
+      return [];
+    }
+    const at = FlowTrace.ribbonOf(this.current);
+    return at === undefined ? [] : [at];
   }
 
   protected findNearestPoint(): NearestPoint | null {

--- a/src/model/network.ts
+++ b/src/model/network.ts
@@ -556,7 +556,7 @@ export class NetworkTrace extends AbstractTrace implements PointCloudHighlightab
    * @returns Its line's index into the declared links, or undefined when the
    *   node has no line drawn for it
    */
-  private static lineOf(node: NetworkNode | null | undefined): number | undefined {
+  private static lineOf(node: NetworkNode | null): number | undefined {
     const at = node?.linkAt[0];
     return at === undefined || at < 0 ? undefined : at;
   }

--- a/src/model/network.ts
+++ b/src/model/network.ts
@@ -1,5 +1,6 @@
 import type { MaidrLayer, NetworkPoint } from '@type/grammar';
 import type { Coordinate, Node } from '@type/movable';
+import type { PointCloudHighlightable } from '@type/navigation';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint, RotorFilterUnit } from './abstract';
 import { MathUtil } from '@util/math';
@@ -70,7 +71,7 @@ interface NetworkNode {
  * have equal status, so there is no "the" edge for an arrow to take, unlike a
  * sankey where the widest ribbon is the one an eye follows.
  */
-export class NetworkTrace extends AbstractTrace {
+export class NetworkTrace extends AbstractTrace implements PointCloudHighlightable {
   /**
    * No go-to-extrema dialog. The arrows already reach every node, and the
    * most connected are named in the description; see `extremaContract`.
@@ -526,10 +527,70 @@ export class NetworkTrace extends AbstractTrace {
     // line belonging to somebody else.
     return this.grid.map(row =>
       row.map((node) => {
-        const at = node?.linkAt[0];
-        const element = at === undefined || at < 0 ? undefined : flat[at];
+        const at = NetworkTrace.lineOf(node);
+        const element = at === undefined ? undefined : flat[at];
         return element ?? Svg.createEmptyElement();
       }));
+  }
+
+  /**
+   * The one line a node's highlight covers, as its position in the declared
+   * link array.
+   *
+   * **This is the single expression both highlight channels read.** A node
+   * touches every link on it, but the chart is not asked to outline all of
+   * them: `mapToSvgElements` takes one element per cell, and
+   * {@link highlightedPointIndices} names one index. Writing the rule twice is
+   * how the two would come to disagree -- an adapter publishing every link
+   * while the SVG path outlined `linkAt[0]` puts a canvas highlight and an SVG
+   * highlight on different lines for the same trace at the same cursor
+   * position, which reads as correct and is not.
+   *
+   * `linkAt` runs parallel to `links`, which is sorted most-connected first, so
+   * this is the line to the node's biggest neighbour -- and the line the
+   * rotor's first step from here travels. A `-1` marks a neighbour no declared
+   * link was found for, and an isolated node has no entry at all; both mean
+   * "no line", which is honest rather than pointing at somebody else's.
+   *
+   * @param node - The node under the cursor, or null where the grid is empty
+   * @returns Its line's index into the declared links, or undefined when the
+   *   node has no line drawn for it
+   */
+  private static lineOf(node: NetworkNode | null | undefined): number | undefined {
+    const at = node?.linkAt[0];
+    return at === undefined || at < 0 ? undefined : at;
+  }
+
+  /**
+   * The line the highlight currently covers, as an index into this layer's
+   * `data` array.
+   *
+   * This is `highlight` answered in a renderer-neutral currency. A network
+   * drawn on a canvas has no SVG elements for `selectors` to reach, and an
+   * adapter that rebuilt the component walk to find the node itself would drift
+   * from {@link findComponents} silently -- so the trace names the line by the
+   * position it occupies in the link array the adapter supplied, and the
+   * adapter inverts that against its own extraction walk.
+   *
+   * Derived from {@link lineOf}, the same expression `mapToSvgElements` indexes
+   * its elements with, so the canvas highlight and the SVG highlight cannot
+   * name different lines.
+   *
+   * Deliberately not gated on SVG availability: a canvas chart has no elements
+   * by definition, and that is the case this exists to serve.
+   *
+   * @returns One index into `layer.data`, or nothing when the cursor is on no
+   *   node or on an isolated one.
+   */
+  public get highlightedPointIndices(): readonly number[] {
+    if (this.isInitialEntry) {
+      // The inherited `highlight` reports out of bounds until the cursor has
+      // entered the trace; an empty array is how this channel says the same
+      // thing, so the two agree at every position including this one.
+      return [];
+    }
+    const at = NetworkTrace.lineOf(this.current);
+    return at === undefined ? [] : [at];
   }
 
   protected findNearestPoint(): NearestPoint | null {

--- a/test/adapters/amcharts/declaration.test.ts
+++ b/test/adapters/amcharts/declaration.test.ts
@@ -21,6 +21,7 @@ import {
   fakePieSeries,
   fakeRoot,
   fakeSeries,
+  itemOf,
 } from './helpers';
 
 /**
@@ -903,6 +904,8 @@ describe('declared layers and the highlight', () => {
         ganttSeriesList: [],
         hierarchySeriesList: [],
         wordCloudSeriesList: [],
+        flowSeriesList: [],
+        networkSeriesList: [],
         choroplethSeriesList: [],
         declaredList: [...plan.declared.values()],
       },
@@ -925,7 +928,7 @@ describe('declared layers and the highlight', () => {
 
     expect(targets).toHaveLength(1);
     expect(targets[0].series).toBe(control);
-    expect(targets[0].dataItem).toBe(control.dataItems[1]);
+    expect(itemOf(targets[0])).toBe(control.dataItems[1]);
   });
 
   it('points every section of an error bar at the sample it belongs to', () => {
@@ -941,8 +944,8 @@ describe('declared layers and the highlight', () => {
     const lower = navMap.resolve(layerId, 0, 1);
     const upper = navMap.resolve(layerId, 2, 1);
 
-    expect(lower[0].dataItem).toBe(estimate.dataItems[1]);
-    expect(upper[0].dataItem).toBe(estimate.dataItems[1]);
+    expect(itemOf(lower[0])).toBe(estimate.dataItems[1]);
+    expect(itemOf(upper[0])).toBe(estimate.dataItems[1]);
     expect(lower[0].kind).toBe('column');
   });
 
@@ -963,9 +966,9 @@ describe('declared layers and the highlight', () => {
     const first = navMap.resolve(layerId, -1, -1, [0]);
     const second = navMap.resolve(layerId, -1, -1, [1]);
 
-    expect(first[0].dataItem).toBe(cloud.dataItems[0]);
+    expect(itemOf(first[0])).toBe(cloud.dataItems[0]);
     expect(first[0].kind).toBe('point');
-    expect(second[0].dataItem).toBe(cloud.dataItems[1]);
+    expect(itemOf(second[0])).toBe(cloud.dataItems[1]);
   });
 
   it('resolves every point of a multi-point cloud selection', () => {
@@ -982,7 +985,7 @@ describe('declared layers and the highlight', () => {
 
     const both = navMap.resolve(layerId, -1, -1, [0, 1]);
 
-    expect(both.map(target => target.dataItem)).toEqual([
+    expect(both.map(target => itemOf(target))).toEqual([
       cloud.dataItems[0],
       cloud.dataItems[1],
     ]);

--- a/test/adapters/amcharts/helpers.ts
+++ b/test/adapters/amcharts/helpers.ts
@@ -6,16 +6,42 @@
  * enough — no amCharts import and no DOM required.
  */
 
+import type { NavTarget } from '@adapters/amcharts/navmap';
 import type {
   AmAxis,
   AmBounds,
   AmChart,
   AmDataItem,
   AmRoot,
+  AmSprite,
   AmXYSeries,
 } from '@adapters/amcharts/types';
 
 let nextUid = 1;
+
+/**
+ * The data item a resolved target names.
+ *
+ * `NavTarget` is a union because a ribbon is not addressed like the other
+ * marks: a network's lines are not data items at all, so a flow or network
+ * target names the sprite amCharts drew instead. A test that asks a ribbon for
+ * a data item has resolved something other than what it meant to, so this says
+ * so rather than narrowing with a cast.
+ */
+export function itemOf(target: NavTarget): AmDataItem {
+  if (target.kind === 'ribbon') {
+    throw new Error('Expected a target naming a data item, got a ribbon');
+  }
+  return target.dataItem;
+}
+
+/** The sprite a resolved ribbon names, with the same guard the other way. */
+export function spriteOf(target: NavTarget): AmSprite {
+  if (target.kind !== 'ribbon') {
+    throw new Error(`Expected a ribbon target, got a ${target.kind}`);
+  }
+  return target.sprite;
+}
 
 export interface FakeSeriesConfig {
   /** amCharts series class name. Defaults to `ColumnSeries`. */
@@ -473,8 +499,49 @@ export function fakeForceDirectedSeries(
   name: string,
   root: FakeNode,
   settings: Record<string, unknown> = {},
+  links: unknown[] = [],
 ): AmXYSeries {
-  return fakeHierarchySeries(name, root, 'ForceDirected', settings);
+  const series = fakeHierarchySeries(name, root, 'ForceDirected', settings);
+  // The drawn lines, which hang off the series rather than off any data item:
+  // amCharts derives them from the tree and from the rows' `linkWith` columns,
+  // and keeps them in a list of its own. Absent for a build that exposes none,
+  // which is how the highlight's fallback to nothing is exercised.
+  return { ...series, links: { values: links } } as unknown as AmXYSeries;
+}
+
+/**
+ * One line an `am5hierarchy.ForceDirected` drew between two nodes.
+ *
+ * Its ends are *node data items*, asked for the category that names them —
+ * the same read the tree walk names a node by, which is what lets the highlight
+ * match a drawn line to an emitted link. `globalBounds()` is the box the
+ * overlay outlines; pass a flat one for a line drawn perfectly straight.
+ */
+export function fakeHierarchyLink(config: {
+  source: string | number;
+  target: string | number;
+  box?: AmBounds;
+}): unknown {
+  const ends: Record<string, unknown> = {
+    source: { get: (key: string) => (key === 'category' ? config.source : undefined) },
+    target: { get: (key: string) => (key === 'category' ? config.target : undefined) },
+  };
+  const box = config.box ?? { left: 0, top: 0, right: 10, bottom: 10 };
+  return {
+    className: 'HierarchyLink',
+    get: (key: string) => ends[key],
+    globalBounds: () => box,
+  };
+}
+
+/**
+ * The band an am5flow series drew for one link, as the overlay measures it.
+ *
+ * Nothing but a box: a `SankeyLink` is a `Graphics` painted from a path, so
+ * what the highlight reads off it is the axis-aligned box it reports.
+ */
+export function fakeRibbon(box: AmBounds): unknown {
+  return { className: 'SankeyLink', globalBounds: () => box };
 }
 
 /**
@@ -499,6 +566,12 @@ export interface FakeLink {
   value?: number;
   /** The author's own row, reached only when the reads above answer nothing. */
   row?: Record<string, unknown>;
+  /**
+   * `dataItem.get('link')` — the band amCharts drew for the link, which the
+   * overlay measures. Unverifiable without the library, so it is a knob: leave
+   * it out for a build that keeps none.
+   */
+  link?: unknown;
 }
 
 function fakeNodeItem(node: { name?: string | number; id?: string | number }): unknown {
@@ -512,6 +585,7 @@ function fakeLinkItem(link: FakeLink): AmDataItem {
     ...(link.sourceNode != null ? { source: fakeNodeItem(link.sourceNode) } : {}),
     ...(link.targetNode != null ? { target: fakeNodeItem(link.targetNode) } : {}),
     ...(link.value !== undefined ? { value: link.value } : {}),
+    ...(link.link != null ? { link: link.link } : {}),
   };
   return {
     get: (key: string) => settings[key],

--- a/test/adapters/amcharts/navmap.test.ts
+++ b/test/adapters/amcharts/navmap.test.ts
@@ -1,7 +1,10 @@
-import type { SeriesGroups } from '@adapters/amcharts/navmap';
+import type { NavTarget, SeriesGroups } from '@adapters/amcharts/navmap';
 import type { AmXYChart, AmXYSeries } from '@adapters/amcharts/types';
 import type { ChoroplethTrace } from '@model/choropleth';
+import type { FlowTrace } from '@model/flow';
+import type { NetworkTrace } from '@model/network';
 import type { MaidrLayer } from '@type/grammar';
+import type { FakeNode } from './helpers';
 import { fromXYChart } from '@adapters/amcharts/adapter';
 import { buildNavigationMap, groupSeries } from '@adapters/amcharts/navmap';
 import { dataItemToOverlayRect } from '@adapters/amcharts/overlay';
@@ -20,6 +23,7 @@ import {
   fakeFunnelSeries,
   fakeGanttSeries,
   fakeGaugeChart,
+  fakeHierarchyLink,
   fakeHierarchySeries,
   fakeLineSeries,
   fakeLollipopSeries,
@@ -31,8 +35,11 @@ import {
   fakePolarSeries,
   fakeRadarSeries,
   fakeRankSeries,
+  fakeRibbon,
   fakeSlicedChart,
   fakeWordCloudSeries,
+  itemOf,
+  spriteOf,
 } from './helpers';
 
 function emptyGroups(): SeriesGroups {
@@ -54,6 +61,8 @@ function emptyGroups(): SeriesGroups {
     ganttSeriesList: [],
     hierarchySeriesList: [],
     wordCloudSeriesList: [],
+    flowSeriesList: [],
+    networkSeriesList: [],
     choroplethSeriesList: [],
     declaredList: [],
   };
@@ -103,13 +112,13 @@ describe('buildNavigationMap (multi-panel)', () => {
     const targetsA = navMap.resolve('layer-a', 0, 1);
     expect(targetsA).toHaveLength(1);
     expect(targetsA[0].series).toBe(seriesA);
-    expect(targetsA[0].dataItem.get('valueY')).toBe(76);
+    expect(itemOf(targetsA[0]).get('valueY')).toBe(76);
     expect(targetsA[0].kind).toBe('column');
 
     const targetsB = navMap.resolve('layer-b', 0, 0);
     expect(targetsB).toHaveLength(1);
     expect(targetsB[0].series).toBe(seriesB);
-    expect(targetsB[0].dataItem.get('valueY')).toBe(10);
+    expect(itemOf(targetsB[0]).get('valueY')).toBe(10);
   });
 
   it('records the owning chart per layer', () => {
@@ -136,7 +145,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     const targets = navMap.resolve('bar', 0, 1);
     expect(targets).toHaveLength(1);
     // col 1 is the SECOND kept item, i.e. category C (the gap is skipped).
-    expect(targets[0].dataItem.get('categoryX')).toBe('C');
+    expect(itemOf(targets[0]).get('categoryX')).toBe('C');
   });
 
   it('resolves a pie layer to slice targets, skipping valueless slices', () => {
@@ -155,7 +164,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     const targets = navMap.resolve('pie', 0, 1);
     expect(targets).toHaveLength(1);
     // col 1 is the SECOND kept slice, i.e. Cherries (the gap is skipped).
-    expect(targets[0].dataItem.get('category')).toBe('Cherries');
+    expect(itemOf(targets[0]).get('category')).toBe('Cherries');
     expect(targets[0].kind).toBe('slice');
   });
 
@@ -180,7 +189,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     const targets = navMap.resolve('bands', 0, 1);
     expect(targets).toHaveLength(1);
     expect(targets[0].series).toBe(band);
-    expect(targets[0].dataItem.get('valueY')).toBe(14);
+    expect(itemOf(targets[0]).get('valueY')).toBe(14);
     expect(targets[0].kind).toBe('point');
   });
 
@@ -204,7 +213,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     }]);
 
     const spoke = navMap.resolve('radar', 0, 1);
-    expect(spoke[0].dataItem.get('valueY')).toBe(4);
+    expect(itemOf(spoke[0]).get('valueY')).toBe(4);
     expect(spoke[0].kind).toBe('point');
 
     // A polar column is a wedge sprite, so the overlay measures it as one.
@@ -229,7 +238,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     const targets = navMap.resolve('funnel', 0, 1);
     expect(targets).toHaveLength(1);
     // col 1 is the SECOND kept stage, i.e. Purchased (the gap is skipped).
-    expect(targets[0].dataItem.get('category')).toBe('Purchased');
+    expect(itemOf(targets[0]).get('category')).toBe('Purchased');
     expect(targets[0].kind).toBe('slice');
   });
 
@@ -249,7 +258,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     const targets = navMap.resolve('bridge', 0, 1);
     expect(targets).toHaveLength(1);
     // col 1 is the SECOND kept step, i.e. Sales (the partial column is skipped).
-    expect(targets[0].dataItem.get('categoryX')).toBe('Sales');
+    expect(itemOf(targets[0]).get('categoryX')).toBe('Sales');
     expect(targets[0].kind).toBe('column');
   });
 
@@ -269,8 +278,8 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     // connector per category, so both resolve to the same mark.
     const start = navMap.resolve('pairs', 0, 1);
     const end = navMap.resolve('pairs', 1, 1);
-    expect(start[0].dataItem.get('categoryX')).toBe('Latvia');
-    expect(end[0].dataItem).toBe(start[0].dataItem);
+    expect(itemOf(start[0]).get('categoryX')).toBe('Latvia');
+    expect(itemOf(end[0])).toBe(itemOf(start[0]));
   });
 
   it('resolves a gantt layer by [lane, interval], the grouping the layer holds', () => {
@@ -287,10 +296,10 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     }]);
 
     const second = navMap.resolve('schedule', 0, 1);
-    expect(second[0].dataItem.get('openValueX')).toBe(60);
+    expect(itemOf(second[0]).get('openValueX')).toBe(60);
     expect(second[0].kind).toBe('column');
 
-    expect(navMap.resolve('schedule', 1, 0)[0].dataItem.get('valueX')).toBe(100);
+    expect(itemOf(navMap.resolve('schedule', 1, 0)[0]).get('valueX')).toBe(100);
     // A lane with nothing booked is navigable and highlights nothing.
     expect(navMap.resolve('schedule', 2, 0)).toEqual([]);
   });
@@ -311,9 +320,9 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     }]);
 
     // Row 0 is the top level below the (dropped) root.
-    expect(navMap.resolve('tree', 0, 1)[0].dataItem.get('category')).toBe('Africa');
+    expect(itemOf(navMap.resolve('tree', 0, 1)[0]).get('category')).toBe('Africa');
     // Row 1 holds the leaves, in the order the walk reached them.
-    expect(navMap.resolve('tree', 1, 1)[0].dataItem.get('category')).toBe('Nigeria');
+    expect(itemOf(navMap.resolve('tree', 1, 1)[0]).get('category')).toBe('Nigeria');
     // A node is a rectangle, which the overlay measures as it measures a column.
     expect(navMap.resolve('tree', 1, 1)[0].kind).toBe('column');
     expect(navMap.resolve('tree', 2, 0)).toEqual([]);
@@ -337,8 +346,8 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
       groups: { ...emptyGroups(), hierarchySeriesList: [series] },
     }]);
 
-    expect(navMap.resolve('ring', 0, 1)[0].dataItem.get('category')).toBe('Africa');
-    expect(navMap.resolve('ring', 1, 1)[0].dataItem.get('category')).toBe('Nigeria');
+    expect(itemOf(navMap.resolve('ring', 0, 1)[0]).get('category')).toBe('Africa');
+    expect(itemOf(navMap.resolve('ring', 1, 1)[0]).get('category')).toBe('Nigeria');
     expect(navMap.resolve('ring', 1, 1)[0].kind).toBe('slice');
     expect(navMap.resolve('ring', 2, 0)).toEqual([]);
   });
@@ -385,7 +394,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
 
     const [target] = navMap.resolve('dial', 0, 0);
     expect(target.kind).toBe('column');
-    expect(target.dataItem.get('graphics')).toBe(hand);
+    expect(itemOf(target).get('graphics')).toBe(hand);
     // The overlay reads the hand's own laid-out box, not the whole dial.
     expect(dataItemToOverlayRect(target, null))
       .toEqual({ left: 40, top: 60, width: 12, height: 80 });
@@ -428,7 +437,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
 
     const target = navMap.resolve('pyramid', 1, 1);
     expect(target[0].series).toBe(women);
-    expect(target[0].dataItem.get('valueY')).toBe(1100);
+    expect(itemOf(target[0]).get('valueY')).toBe(1100);
     expect(target[0].kind).toBe('column');
   });
 
@@ -454,7 +463,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     // A dot's mark is the bullet, so the overlay measures a point.
     const dot = navMap.resolve('dots', 0, 1);
     expect(dot[0].series).toBe(dots);
-    expect(dot[0].dataItem.get('valueY')).toBe(318);
+    expect(itemOf(dot[0]).get('valueY')).toBe(318);
     expect(dot[0].kind).toBe('point');
 
     // A stem is still a column, thin as it is.
@@ -480,10 +489,10 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
       groups: { ...emptyGroups(), wordCloudSeriesList: [series] },
     }]);
 
-    expect(navMap.resolve('cloud', 0, 0)[0].dataItem.get('category')).toBe('machine');
-    expect(navMap.resolve('cloud', 0, 1)[0].dataItem.get('category')).toBe('neural');
+    expect(itemOf(navMap.resolve('cloud', 0, 0)[0]).get('category')).toBe('machine');
+    expect(itemOf(navMap.resolve('cloud', 0, 1)[0]).get('category')).toBe('neural');
     // The weightless term is skipped, exactly as the extraction skips it.
-    expect(navMap.resolve('cloud', 0, 2)[0].dataItem.get('category')).toBe('gradient');
+    expect(itemOf(navMap.resolve('cloud', 0, 2)[0]).get('category')).toBe('gradient');
     expect(navMap.resolve('cloud', 0, 3)).toEqual([]);
     // A term is a glyph, which the overlay measures as neither a box nor a wedge.
     expect(navMap.resolve('cloud', 0, 0)[0].kind).toBe('label');
@@ -508,7 +517,7 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     const targets = navMap.resolve('lines', 1, 1);
     expect(targets).toHaveLength(1);
     expect(targets[0].series).toBe(lineB);
-    expect(targets[0].dataItem.get('valueY')).toBe(60);
+    expect(itemOf(targets[0]).get('valueY')).toBe(60);
     expect(targets[0].kind).toBe('point');
     expect(navMap.chartFor('lines')).toBe(chart);
   });
@@ -535,44 +544,275 @@ describe('buildNavigationMap (behavior preserved from single-panel)', () => {
     const targets = navMap.resolve('places', 1, 1);
     expect(targets).toHaveLength(1);
     expect(targets[0].series).toBe(birch);
-    expect(targets[0].dataItem.get('valueY')).toBe(1);
+    expect(itemOf(targets[0]).get('valueY')).toBe(1);
     expect(targets[0].kind).toBe('point');
     expect(navMap.resolve('places', 2, 0)).toEqual([]);
   });
 });
 
-describe('buildNavigationMap (flow and network: no highlight, on purpose)', () => {
-  const LINKS = [
-    { sourceId: 'Coal', targetId: 'Electricity', value: 34 },
-    { sourceId: 'Electricity', targetId: 'Homes', value: 40 },
+describe('buildNavigationMap (flow and network)', () => {
+  /**
+   * Five flows through six nodes, declared out of value order, each with the
+   * band amCharts drew for it.
+   *
+   * `Electricity` is the node the whole of #904 turns on: it receives the
+   * chart's widest ribbon (34) and sends two narrower ones, so a resolver
+   * indexing anything other than what the trace published — the first flow
+   * declared, the widest one touching, every one touching — lands somewhere
+   * else. The same five flows the model-side test walks, so the two halves read
+   * together.
+   */
+  const RIBBONS = [0, 1, 2, 3, 4].map(at => fakeRibbon({
+    left: at * 10,
+    top: 0,
+    right: at * 10 + 6,
+    bottom: 20,
+  }));
+
+  const FLOWS = [
+    { sourceId: 'Coal', targetId: 'Losses', value: 8, link: RIBBONS[0] },
+    { sourceId: 'Coal', targetId: 'Electricity', value: 34, link: RIBBONS[1] },
+    { sourceId: 'Coal', targetId: 'Heat', value: 14, link: RIBBONS[2] },
+    { sourceId: 'Electricity', targetId: 'Homes', value: 20, link: RIBBONS[3] },
+    { sourceId: 'Electricity', targetId: 'Industry', value: 14, link: RIBBONS[4] },
   ];
 
   /**
-   * Asserted positively, because the absence is a decision. MAIDR hands a flow
-   * or network layer its BRAILLE position — a stage and an index within it, or
-   * a component and an index within it — and recovering the node from that
-   * would mean reimplementing the model's node ordering together with its
-   * stage layering, which is a derived graph structure rather than an ordering
-   * over data this adapter emitted. So `resolve` answers `[]` and the binder
-   * clears the overlay; a resolver added later without a position that says
-   * which node it means would outline a confidently wrong one, and this is
-   * what would notice.
+   * A hub, its three neighbours, and a node linked only to itself.
+   *
+   * The cross-links are read off the rows, which is where a force-directed
+   * graph keeps everything that is not the tree — and these rows ARE the whole
+   * graph, since amCharts hands the walk one container root whose children are
+   * therefore all top level.
    */
-  it.each([
-    ['a sankey', TraceType.SANKEY],
-    ['a chord', TraceType.CHORD],
-    ['an alluvial', TraceType.ALLUVIAL],
-    ['a network', TraceType.NETWORK],
-  ])('registers no resolver for %s, so the overlay clears', (_name, type) => {
-    const series = fakeFlowSeries('Energy', LINKS);
+  const PEOPLE: FakeNode = {
+    category: 'Root',
+    children: [
+      { category: 'Ada', row: { name: 'Ada', linkWith: ['Edsger', 'Grace', 'Alan'] } },
+      { category: 'Grace', row: { name: 'Grace', linkWith: ['Alan'] } },
+      { category: 'Alan', row: { name: 'Alan' } },
+      { category: 'Edsger', row: { name: 'Edsger' } },
+    ],
+  };
+
+  /** The layer, the map and the chart for one standalone series. */
+  function panelFor(series: AmXYSeries): {
+    navMap: ReturnType<typeof buildNavigationMap>;
+    layer: MaidrLayer;
+  } {
+    const chart = fakeChart({ series: [series] });
+    const layer = fromXYChart(chart, fakeContainerEl()).subplots[0][0].layers[0];
     const navMap = buildNavigationMap([{
-      chart: fakeChart({ series: [series] }),
-      layers: [{ id: 'flow', type, data: [] }],
-      groups: emptyGroups(),
+      chart,
+      layers: [layer],
+      groups: groupSeries(chart),
+    }]);
+    return { navMap, layer };
+  }
+
+  /** What the adapter outlines where the trace's cursor currently sits. */
+  function outlined(
+    navMap: ReturnType<typeof buildNavigationMap>,
+    layer: MaidrLayer,
+    trace: FlowTrace | NetworkTrace,
+  ): NavTarget[] {
+    return navMap.resolve(layer.id, -1, -1, trace.highlightedPointIndices);
+  }
+
+  it('outlines the one ribbon a sankey trace says it highlighted', () => {
+    // The contract, end to end: the real `FlowTrace` walks to a node, publishes
+    // the band it outlined as a position in the data this adapter emitted, and
+    // the adapter inverts it against its own extraction walk. Nothing here
+    // reconstructs the stage layering that put the cursor on Electricity.
+    const { navMap, layer } = panelFor(fakeFlowSeries('Energy', FLOWS));
+    const trace = TraceFactory.create(layer) as FlowTrace;
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('Expected a non-empty trace state');
+    }
+    expect(state.text.main.value).toBe('Electricity');
+
+    const targets = outlined(navMap, layer, trace);
+
+    // Electricity touches three ribbons. One is outlined — the one the SVG path
+    // would outline — and it is neither the first declared nor the widest.
+    expect(targets).toHaveLength(1);
+    expect(targets[0].kind).toBe('ribbon');
+    expect(spriteOf(targets[0])).toBe(RIBBONS[3]);
+  });
+
+  it('measures the outlined ribbon as the box it reports', () => {
+    const { navMap, layer } = panelFor(fakeFlowSeries('Energy', FLOWS));
+    const trace = TraceFactory.create(layer) as FlowTrace;
+    trace.moveOnce('FORWARD');
+
+    const [target] = outlined(navMap, layer, trace);
+
+    // Coal's widest outgoing flow is Coal-Electricity, drawn by ribbon 1.
+    expect(dataItemToOverlayRect(target, null))
+      .toEqual({ left: 10, top: 0, width: 6, height: 20 });
+  });
+
+  it('outlines a chord the same way, since it is the same weighted graph', () => {
+    // A `Chord` is announced as its own type but drawn from the same links, so
+    // it shares the bucket a sankey is collected into — and a bucket a type is
+    // missing from is exactly how a highlight silently vanishes.
+    const { navMap, layer } = panelFor(fakeFlowSeries('Trade', FLOWS, 'ChordDirected'));
+    expect(layer.type).toBe(TraceType.CHORD);
+    const trace = TraceFactory.create(layer) as FlowTrace;
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    expect(spriteOf(outlined(navMap, layer, trace)[0])).toBe(RIBBONS[3]);
+  });
+
+  it('outlines a declared alluvial, which reaches the resolver another way', () => {
+    // An alluvial has no amCharts class: it IS a sankey the author declared as
+    // one, so `planDeclarations` takes the series out of the flow bucket and
+    // into the declared queue. Same series, same ribbons, different route to
+    // the same resolver — and the route is the part that would rot unnoticed.
+    const series = fakeFlowSeries('Budget', FLOWS, 'Sankey', {
+      userData: { maidr: { type: 'alluvial' } },
+    });
+    const { navMap, layer } = panelFor(series);
+    expect(layer.type).toBe(TraceType.ALLUVIAL);
+    const trace = TraceFactory.create(layer) as FlowTrace;
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    expect(spriteOf(outlined(navMap, layer, trace)[0])).toBe(RIBBONS[3]);
+  });
+
+  it('outlines the links it can reach and clears on the ones it cannot', () => {
+    // The sprite read is unverifiable without the library, so a build that
+    // keeps no band answers nothing rather than reaching for a neighbouring
+    // one. Asserted beside a link that does resolve, or the blank would prove
+    // only that the resolver had not been registered at all.
+    const { navMap, layer } = panelFor(fakeFlowSeries('Energy', [
+      { sourceId: 'Coal', targetId: 'Electricity', value: 34, link: RIBBONS[1] },
+      { sourceId: 'Electricity', targetId: 'Homes', value: 20 },
+    ]));
+
+    expect(spriteOf(navMap.resolve(layer.id, -1, -1, [0])[0])).toBe(RIBBONS[1]);
+    expect(navMap.resolve(layer.id, -1, -1, [1])).toEqual([]);
+  });
+
+  it('clears rather than guessing when a flow carries no point indices', () => {
+    // A consumer that has not learned about `pointIndices` sends the -1 pair
+    // through, and a braille position for a flow layer names a stage rather
+    // than a ribbon. Answering nothing keeps the honest blank #903 shipped.
+    const { navMap, layer } = panelFor(fakeFlowSeries('Energy', FLOWS));
+
+    expect(navMap.resolve(layer.id, -1, -1, [3])).toHaveLength(1);
+    expect(navMap.resolve(layer.id, 0, 0)).toEqual([]);
+    expect(navMap.resolve(layer.id, -1, -1)).toEqual([]);
+  });
+
+  it('clears when the drawn links and the layer have drifted apart', () => {
+    // An index only means something if the ribbons and `layer.data` are the
+    // same list. A layer built from a chart that has since changed would
+    // otherwise outline a band picked at random — worse than no outline.
+    const series = fakeFlowSeries('Energy', FLOWS);
+    const chart = fakeChart({ series: [series] });
+    const stale: MaidrLayer = {
+      id: 'stale',
+      type: TraceType.SANKEY,
+      data: [{ source: 'Coal', target: 'Losses', value: 8 }],
+    };
+    const live = fromXYChart(chart, fakeContainerEl()).subplots[0][0].layers[0];
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [live, stale],
+      groups: { ...groupSeries(chart), flowSeriesList: [series, series] },
     }]);
 
-    expect(navMap.resolve('flow', 0, 0)).toEqual([]);
-    expect(navMap.resolve('flow', 1, 1)).toEqual([]);
+    expect(navMap.resolve(live.id, -1, -1, [3])).toHaveLength(1);
+    expect(navMap.resolve('stale', -1, -1, [0])).toEqual([]);
+  });
+
+  it('outlines the line a network trace says it highlighted', () => {
+    // The same inversion with the model's component walk in the place of the
+    // stage layering — and one difference of amCharts': a force-directed
+    // graph's links are not data items, so the payload's two node names are
+    // matched against the lines the series drew. Those are declared here in
+    // another order, and the matching one with its ends the other way round,
+    // so a resolver pairing by ordinal or by direction resolves elsewhere.
+    const drawn = [
+      fakeHierarchyLink({ source: 'Grace', target: 'Alan' }),
+      fakeHierarchyLink({ source: 'Ada', target: 'Alan' }),
+      fakeHierarchyLink({ source: 'Grace', target: 'Ada' }),
+      fakeHierarchyLink({ source: 'Ada', target: 'Edsger' }),
+    ];
+    const series = fakeForceDirectedSeries(
+      'People',
+      PEOPLE,
+      { linkWithField: 'linkWith' },
+      drawn,
+    );
+    const { navMap, layer } = panelFor(series);
+    const trace = TraceFactory.create(layer) as NetworkTrace;
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('Expected a non-empty trace state');
+    }
+    expect(state.text.main.value).toBe('Ada');
+
+    const targets = outlined(navMap, layer, trace);
+
+    // Ada is linked to three people; sorted by degree her first neighbour is
+    // Grace, so one line is outlined and it is the Ada-Grace one.
+    expect(targets).toHaveLength(1);
+    expect(spriteOf(targets[0])).toBe(drawn[2]);
+  });
+
+  it('clears when the graph has changed under a network layer', () => {
+    // The re-extraction is the network's alignment guard: names alone would
+    // happily match an index against a layer built from a different graph, and
+    // the outline would then be one the reader is not standing on.
+    const drawn = [fakeHierarchyLink({ source: 'Ada', target: 'Grace' })];
+    const series = fakeForceDirectedSeries(
+      'People',
+      PEOPLE,
+      { linkWithField: 'linkWith' },
+      drawn,
+    );
+    const chart = fakeChart({ series: [series] });
+    const live = fromXYChart(chart, fakeContainerEl()).subplots[0][0].layers[0];
+    const stale: MaidrLayer = {
+      id: 'stale',
+      type: TraceType.NETWORK,
+      data: [{ source: 'Ada', target: 'Grace' }],
+    };
+    const navMap = buildNavigationMap([{
+      chart,
+      layers: [live, stale],
+      groups: { ...groupSeries(chart), networkSeriesList: [series, series] },
+    }]);
+
+    expect(spriteOf(navMap.resolve(live.id, -1, -1, [1])[0])).toBe(drawn[0]);
+    expect(navMap.resolve('stale', -1, -1, [0])).toEqual([]);
+  });
+
+  it('clears on a pair the chart drew no line for', () => {
+    // A build exposing no lines at all — or one short of the pair asked for —
+    // leaves the overlay empty rather than outlining the nearest line it has.
+    const drawn = [fakeHierarchyLink({ source: 'Ada', target: 'Edsger' })];
+    const series = fakeForceDirectedSeries(
+      'People',
+      PEOPLE,
+      { linkWithField: 'linkWith' },
+      drawn,
+    );
+    const { navMap, layer } = panelFor(series);
+
+    // Ada-Edsger is the first link the walk emits, and Ada-Grace the second.
+    expect(spriteOf(navMap.resolve(layer.id, -1, -1, [0])[0])).toBe(drawn[0]);
+    expect(navMap.resolve(layer.id, -1, -1, [1])).toEqual([]);
   });
 });
 
@@ -643,7 +883,7 @@ describe('buildNavigationMap (choropleth)', () => {
         const [target] = navMap.resolve(layer.id, row, col);
         expect(target).toBeDefined();
         expect(target.kind).toBe('region');
-        expect(target.dataItem.get('mapPolygon')).toBe(shapes[boxOf.get(named) as number]);
+        expect(itemOf(target).get('mapPolygon')).toBe(shapes[boxOf.get(named) as number]);
       }
     }
   });
@@ -658,11 +898,11 @@ describe('buildNavigationMap (choropleth)', () => {
     // The two southernmost are Nevada (39.3N) and Oregon (43.9N), read west to
     // east — so Oregon (-120.6) comes before Nevada (-116.6), which is neither
     // their declared order nor their order by latitude.
-    expect(navMap.resolve(layer.id, 0, 0)[0].dataItem.get('mapPolygon')).toBe(shapes[2]);
-    expect(navMap.resolve(layer.id, 0, 1)[0].dataItem.get('mapPolygon')).toBe(shapes[1]);
+    expect(itemOf(navMap.resolve(layer.id, 0, 0)[0]).get('mapPolygon')).toBe(shapes[2]);
+    expect(itemOf(navMap.resolve(layer.id, 0, 1)[0]).get('mapPolygon')).toBe(shapes[1]);
     // Northern band: Washington (-120.5) is west of Idaho (-114.6).
-    expect(navMap.resolve(layer.id, 1, 0)[0].dataItem.get('mapPolygon')).toBe(shapes[0]);
-    expect(navMap.resolve(layer.id, 1, 1)[0].dataItem.get('mapPolygon')).toBe(shapes[3]);
+    expect(itemOf(navMap.resolve(layer.id, 1, 0)[0]).get('mapPolygon')).toBe(shapes[0]);
+    expect(itemOf(navMap.resolve(layer.id, 1, 1)[0]).get('mapPolygon')).toBe(shapes[3]);
   });
 
   it('degenerates to declared order when the map placed no region', () => {
@@ -679,7 +919,7 @@ describe('buildNavigationMap (choropleth)', () => {
     const { navMap, layer } = navMapFor(series);
 
     for (let col = 0; col < STATES.length; col++) {
-      expect(navMap.resolve(layer.id, 0, col)[0].dataItem.get('mapPolygon')).toBe(shapes[col]);
+      expect(itemOf(navMap.resolve(layer.id, 0, col)[0]).get('mapPolygon')).toBe(shapes[col]);
     }
   });
 
@@ -742,12 +982,13 @@ describe('groupSeries (choropleth)', () => {
 });
 
 describe('groupSeries', () => {
-  it('leaves an am5flow series and a force-directed network in no bucket', () => {
-    // Not an oversight, and not a no-op either: `classifySeriesKind` answers
-    // `'bar'` for a class it does not know, so before these classes were named
-    // a sankey landed in `barSeriesList` — where it would have shifted every
-    // real bar layer's resolver index and outlined the wrong column on a chart
-    // carrying both. Recognising them is what puts them in NO bucket.
+  it('buckets an am5flow series and a network by the marks they draw', () => {
+    // `classifySeriesKind` answers `'bar'` for a class it does not know, so
+    // before these classes were named a sankey landed in `barSeriesList` —
+    // where it would have shifted every real bar layer's resolver index and
+    // outlined the wrong column on a chart carrying both. And a series in no
+    // bucket at all is how a type reads correctly with no highlight, which is
+    // what these two shipped with until the traces published their ribbons.
     const sankey = fakeFlowSeries('Energy', [
       { sourceId: 'Coal', targetId: 'Electricity', value: 34 },
     ]);
@@ -758,8 +999,9 @@ describe('groupSeries', () => {
 
     const groups = groupSeries(fakeChart({ series: [sankey, network] }));
 
+    expect(groups.flowSeriesList).toEqual([sankey]);
+    expect(groups.networkSeriesList).toEqual([network]);
     expect(groups.barSeriesList).toEqual([]);
-    expect(Object.values(groups).every(bucket => bucket.length === 0)).toBe(true);
   });
 
   it('buckets a sunburst with the trees it is one of', () => {

--- a/test/adapters/amcharts/overlay.test.ts
+++ b/test/adapters/amcharts/overlay.test.ts
@@ -1,4 +1,4 @@
-import type { NavTarget } from '@adapters/amcharts/navmap';
+import type { NavItemTarget, NavTarget } from '@adapters/amcharts/navmap';
 import type { AmDataItem, AmSprite, AmXYSeries } from '@adapters/amcharts/types';
 import { dataItemToOverlayRect } from '@adapters/amcharts/overlay';
 import { describe, expect, it } from '@jest/globals';
@@ -29,7 +29,10 @@ function stageSprite(left: number, top: number, width: number, height: number): 
   };
 }
 
-function target(properties: Record<string, unknown>, kind: NavTarget['kind'] = 'slice'): NavTarget {
+function target(
+  properties: Record<string, unknown>,
+  kind: NavItemTarget['kind'] = 'slice',
+): NavTarget {
   const dataItem = { get: (key: string) => properties[key] } as unknown as AmDataItem;
   return { series: {} as AmXYSeries, dataItem, kind };
 }
@@ -101,5 +104,54 @@ describe('dataItemToOverlayRect (wedge-shaped marks)', () => {
       target({ slice }),
       { left: 0, top: 80, right: 130, bottom: 200 },
     )).toEqual({ left: 100, top: 80, width: 30, height: 20 });
+  });
+});
+
+describe('dataItemToOverlayRect (ribbons)', () => {
+  /** A ribbon target: the sprite is resolved before the overlay ever sees it. */
+  function ribbon(sprite: AmSprite): NavTarget {
+    return { series: {} as AmXYSeries, sprite, kind: 'ribbon' };
+  }
+
+  it('measures a flow band from the box it reports', () => {
+    // A `SankeyLink` is a curved band, and its local width and height describe
+    // a box it does not fill; the reported box is the shape as drawn.
+    const band: AmSprite = {
+      globalBounds: () => ({ left: 40, top: 12, right: 190, bottom: 60 }),
+      width: () => 150,
+      height: () => 8,
+      toGlobal: point => ({ x: 40 + point.x, y: 12 + point.y }),
+    };
+
+    expect(dataItemToOverlayRect(ribbon(band), null))
+      .toEqual({ left: 40, top: 12, width: 150, height: 48 });
+  });
+
+  it('keeps a straight link visible instead of collapsing it away', () => {
+    // A network line between two nodes at the same height reports a box of
+    // zero height. That is real geometry rather than the degenerate point of
+    // #774, so it is padded to a hairline band — left as it was, the clip
+    // would drop it and a perfectly straight link would outline nothing.
+    const line: AmSprite = {
+      globalBounds: () => ({ left: 20, top: 50, right: 120, bottom: 50 }),
+    };
+
+    expect(dataItemToOverlayRect(ribbon(line), { left: 0, top: 0, right: 200, bottom: 200 }))
+      .toEqual({ left: 20, top: 49, width: 100, height: 2 });
+  });
+
+  it('falls back to a link\'s own corners, and clears when it has neither', () => {
+    const laidOut: AmSprite = {
+      width: () => 90,
+      height: () => 4,
+      toGlobal: point => ({ x: 5 + point.x, y: 70 + point.y }),
+    };
+    const unlaid: AmSprite = {
+      globalBounds: () => ({ left: 30, top: 30, right: 30, bottom: 30 }),
+    };
+
+    expect(dataItemToOverlayRect(ribbon(laidOut), null))
+      .toEqual({ left: 5, top: 70, width: 90, height: 4 });
+    expect(dataItemToOverlayRect(ribbon(unlaid), null)).toBeNull();
   });
 });

--- a/test/controller/navigateCallbackFlowNetwork.test.ts
+++ b/test/controller/navigateCallbackFlowNetwork.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { FlowPoint, Maidr, NavigateCallback, NetworkPoint } from '@type/grammar';
+import type { MovableDirection } from '@type/movable';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { Context } from '@model/context';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+import { createNavigateObserver } from '@util/navigateObserver';
+import { resolveSubplotLayout } from '@util/subplotLayout';
+
+/**
+ * The navigate callback carries a flow or network highlight (#904).
+ *
+ * A canvas chart has no SVG elements for `selectors` to reach, so this callback
+ * is its only path to an overlay — and until now a sankey, chord, alluvial or
+ * network layer sent it the *braille* position. For a flow trace that position
+ * is deliberately transposed (`row` is the stage, `col` the node within it),
+ * and for neither trace does it name the ribbon or line the chart actually
+ * outlines. An adapter reading it would have had to rebuild `assignStages` or
+ * `findComponents` to get back to a node, which is the copy #895 and #903 both
+ * refused to ship.
+ *
+ * Now both traces publish the mark itself, by its index in the `data` array the
+ * adapter supplied. This drives the moves through `Context` exactly as a
+ * keypress does, and registers `createNavigateObserver` — the observer
+ * `Controller` registers, imported rather than re-implemented — so what runs
+ * here is the shipped wiring.
+ */
+
+/** What the callback is handed, mirroring `NavigateCallback`'s parameter. */
+type NavEvent = {
+  layerId: string;
+  row: number;
+  col: number;
+  pointIndices?: readonly number[];
+} | null;
+
+const FORWARD: MovableDirection = 'FORWARD';
+
+/** Flows declared out of value order, with a junction in the middle. */
+const FLOWS: FlowPoint[] = [
+  { source: 'Coal', target: 'Losses', value: 8 },
+  { source: 'Coal', target: 'Electricity', value: 34 },
+  { source: 'Coal', target: 'Heat', value: 14 },
+  { source: 'Electricity', target: 'Homes', value: 20 },
+];
+
+/** A hub whose most connected neighbour is not the first link authored. */
+const LINKS: NetworkPoint[] = [
+  { source: 'Ada', target: 'Edsger' },
+  { source: 'Ada', target: 'Grace' },
+  { source: 'Ada', target: 'Alan' },
+  { source: 'Grace', target: 'Alan' },
+];
+
+/**
+ * A sankey and a network, in one panel each, carrying no selectors.
+ *
+ * The missing selectors are the reported case rather than an omission: a canvas
+ * chart has nothing to select, so the element channel is unavailable and the
+ * published indices are the only thing an overlay can act on.
+ *
+ * @returns The figure definition
+ */
+function figureData(): Maidr {
+  return {
+    id: 'flow-and-network',
+    subplots: [
+      [
+        {
+          layers: [{
+            id: 'sankey',
+            type: TraceType.SANKEY,
+            axes: { x: { label: 'Node' }, y: { label: 'Petajoules' } },
+            data: FLOWS,
+          }],
+        },
+        {
+          layers: [{
+            id: 'network',
+            type: TraceType.NETWORK,
+            axes: { x: { label: 'Person' }, y: { label: 'Links' } },
+            data: LINKS,
+          }],
+        },
+      ],
+    ],
+  } as Maidr;
+}
+
+describe('the navigate callback reaches a flow or network trace', () => {
+  let figure: Figure;
+  let context: Context;
+  let seen: NavEvent[];
+
+  /** Registers what `Controller.registerNavigateCallback` registers. */
+  function register(callback: NavigateCallback): void {
+    figure.subplots.forEach(row => row.forEach((subplot) => {
+      subplot.traces.forEach(traceRow => traceRow.forEach((trace) => {
+        trace.addObserver(createNavigateObserver(trace, callback));
+      }));
+    }));
+  }
+
+  beforeEach(() => {
+    figure = new Figure(figureData());
+    figure.applyLayout(resolveSubplotLayout(figure.subplots));
+    context = new Context(figure);
+    seen = [];
+    register(event => void seen.push(event));
+  });
+
+  /** Steps the lobby cursor onto the second panel and enters it. */
+  function enterNetworkPanel(): void {
+    context.enterSubplot();
+    context.exitSubplot();
+    // The lobby cursor starts before the first panel, so the first move lands
+    // on panel 1 and the second is what reaches the network panel.
+    context.moveOnce(FORWARD);
+    context.moveOnce(FORWARD);
+    context.enterSubplot();
+  }
+
+  it('names the ribbon a flow node highlighted, not the braille position', () => {
+    context.enterSubplot();
+    seen.length = 0;
+
+    context.moveOnce(FORWARD);
+
+    // Coal's widest flow is `Coal-Electricity`, declared at index 1. The
+    // braille pair this used to send was `{ row: 0, col: 0 }` — the stage and
+    // the node within it, which names no ribbon at all.
+    expect(seen.at(-1)).toEqual({
+      layerId: 'sankey',
+      row: -1,
+      col: -1,
+      pointIndices: [1],
+    });
+  });
+
+  it('names one ribbon at a junction rather than every ribbon touching it', () => {
+    context.enterSubplot();
+    seen.length = 0;
+
+    context.moveOnce(FORWARD);
+    context.moveOnce(FORWARD);
+
+    // Electricity receives flow 1 and sends flow 3. `[...out, ...in]` would
+    // publish `[3, 1]` here, and an overlay would light both bands while an
+    // SVG renderer lit one — the disagreement #904 exists to prevent.
+    expect(seen.at(-1)?.pointIndices).toEqual([3]);
+  });
+
+  it('names the line a network node highlighted', () => {
+    enterNetworkPanel();
+    seen.length = 0;
+
+    context.moveOnce(FORWARD);
+
+    // Ada's neighbours by degree are Grace and Alan (2 each) then Edsger (1),
+    // so the first is Grace — link 1, not the link 0 a pairing by rank takes.
+    expect(seen.at(-1)).toEqual({
+      layerId: 'network',
+      row: -1,
+      col: -1,
+      pointIndices: [1],
+    });
+  });
+
+  it('sends -1 for the position, so an un-updated consumer clears', () => {
+    context.enterSubplot();
+    seen.length = 0;
+    context.moveOnce(FORWARD);
+
+    const event = seen.at(-1);
+    // Every consumer in the tree bounds-checks the pair before indexing with
+    // it, so an integration that has not learned about `pointIndices` degrades
+    // to no highlight — never to a box on an arbitrary ribbon.
+    expect(event?.row).toBe(-1);
+    expect(event?.col).toBe(-1);
+  });
+});

--- a/test/model/flowNetworkPointIndices.test.ts
+++ b/test/model/flowNetworkPointIndices.test.ts
@@ -1,0 +1,320 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { FlowPoint, MaidrLayer, NetworkPoint } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { FlowTrace } from '@model/flow';
+import { NetworkTrace } from '@model/network';
+import { TraceType } from '@type/grammar';
+import { isPointCloudHighlightable } from '@type/navigation';
+
+/**
+ * A flow and a network trace name the mark they highlighted (#904).
+ *
+ * amCharts renders to canvas, so a sankey, chord, alluvial or network layer has
+ * no SVG elements for `selectors` to reach and its only path to an overlay is
+ * the navigate callback. Reconstructing the node from `{row, col}` would mean
+ * copying `FlowTrace`'s stage layering or `NetworkTrace`'s component walk into
+ * an adapter, where it drifts silently — so the trace publishes the mark
+ * instead, as an index into the `data` array the adapter supplied.
+ *
+ * **The whole risk is that it publishes a wider set than the SVG path
+ * outlines.** A node touches every flow on either side of it, but
+ * `mapToSvgElements` outlines exactly one of them. Publishing
+ * `[...node.out, ...node.in]` would put amCharts' overlay on every ribbon
+ * touching a node while Vega-Lite outlined one — the two renderers disagreeing
+ * about the same trace at the same cursor position, which looks right and is
+ * not. Every test below compares the two channels rather than either alone.
+ */
+
+/**
+ * Five flows through six nodes, declared out of value order.
+ *
+ * The declared order matters twice over. Every node sorts its edges by value on
+ * construction, so a chart authored largest-first could not tell a correct
+ * pairing from one that re-derived a position from the sorted list. And
+ * `Electricity` carries flows on *both* sides — one arriving, two leaving — so
+ * it is the node where the wider set and the outlined ribbon differ.
+ */
+const FLOWS: FlowPoint[] = [
+  { source: 'Coal', target: 'Losses', value: 8 },
+  { source: 'Coal', target: 'Electricity', value: 34 },
+  { source: 'Coal', target: 'Heat', value: 14 },
+  { source: 'Electricity', target: 'Homes', value: 20 },
+  { source: 'Electricity', target: 'Industry', value: 14 },
+];
+
+/**
+ * A hub, its three neighbours, and a node linked to nobody.
+ *
+ * Declared so that the hub's most connected neighbour is not the first link
+ * authored, for the same reason the flows are.
+ */
+const LINKS: NetworkPoint[] = [
+  { source: 'Ada', target: 'Edsger' },
+  { source: 'Ada', target: 'Grace' },
+  { source: 'Ada', target: 'Alan' },
+  { source: 'Grace', target: 'Alan' },
+  { source: 'Ida', target: 'Ida' },
+];
+
+/** How a ribbon or a line is named in the DOM, from the record that drew it. */
+function nameOf(point: FlowPoint | NetworkPoint): string {
+  return `${String(point.source)}-${String(point.target)}`;
+}
+
+/**
+ * Create a flow layer whose selectors name each ribbon by its own flow.
+ * @returns Flow layer definition
+ */
+function flowLayer(): MaidrLayer {
+  return {
+    id: 'flow-indices',
+    type: TraceType.SANKEY,
+    title: 'Energy flow',
+    axes: { x: { label: 'Node' }, y: { label: 'Petajoules' } },
+    selectors: FLOWS.map((_, index) => `#ribbon-${index}`),
+    data: FLOWS,
+  };
+}
+
+/**
+ * Create a network layer whose selectors name each line by its own link.
+ * @returns Network layer definition
+ */
+function networkLayer(): MaidrLayer {
+  return {
+    id: 'network-indices',
+    type: TraceType.NETWORK,
+    title: 'Collaborations',
+    axes: { x: { label: 'Person' }, y: { label: 'Links' } },
+    selectors: LINKS.map((_, index) => `#link-${index}`),
+    data: LINKS,
+  };
+}
+
+/** Paint the ribbons and lines the two layers declare selectors for. */
+function paintChart(): void {
+  const ribbons = FLOWS
+    .map((flow, index) => `<path id="ribbon-${index}" data-mark="${nameOf(flow)}" />`)
+    .join('');
+  const lines = LINKS
+    .map((link, index) => `<line id="link-${index}" data-mark="${nameOf(link)}" />`)
+    .join('');
+  document.body.innerHTML
+    = `<svg xmlns="http://www.w3.org/2000/svg">${ribbons}${lines}</svg>`;
+}
+
+/**
+ * What the SVG channel outlines, named by the record each mark was drawn for.
+ *
+ * The elements are MAIDR's hidden clones rather than the originals, so they are
+ * read by the attribute they carry rather than by identity — which is also how
+ * a reader would tell which ribbon lit up.
+ *
+ * @param trace - The trace to read
+ * @returns One name per outlined mark, in the order the state lists them
+ */
+function svgMarks(trace: FlowTrace | NetworkTrace): string[] {
+  const state = trace.state;
+  if (state.empty || state.highlight.empty) {
+    return [];
+  }
+  const { elements } = state.highlight;
+  const flat = Array.isArray(elements) ? elements.flat() : [elements];
+  return flat
+    .map(element => element?.getAttribute('data-mark'))
+    .filter((name): name is string => name !== null && name !== undefined);
+}
+
+/**
+ * What the canvas channel publishes, named the same way.
+ *
+ * This is the inversion an adapter performs: an index arrives, and the adapter
+ * looks it up in the `data` array it supplied. Doing it here rather than
+ * reaching for the DOM is the point — the index has to mean something against
+ * `layer.data`, not against a selector list a canvas chart does not have.
+ *
+ * @param trace - The trace to read
+ * @param data - The records the layer was built from
+ * @returns One name per published index, in the order they were published
+ */
+function canvasMarks(
+  trace: FlowTrace | NetworkTrace,
+  data: readonly (FlowPoint | NetworkPoint)[],
+): string[] {
+  return [...trace.highlightedPointIndices].map((index) => {
+    const record = data[index];
+    if (record === undefined) {
+      throw new Error(`Published index ${index} is not a record of this layer`);
+    }
+    return nameOf(record);
+  });
+}
+
+/**
+ * Walk every addressable cell of a trace, comparing the two channels at each.
+ *
+ * @param trace - The trace to walk
+ * @param data - The records the layer was built from
+ * @param rows - How many rows to try
+ * @param cols - How many columns to try
+ * @returns The cells that were reachable, so a caller can assert it walked some
+ */
+function walkAgreeing(
+  trace: FlowTrace | NetworkTrace,
+  data: readonly (FlowPoint | NetworkPoint)[],
+  rows: number,
+  cols: number,
+): { row: number; col: number; marks: string[] }[] {
+  const visited: { row: number; col: number; marks: string[] }[] = [];
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      if (!trace.moveToIndex(row, col)) {
+        continue;
+      }
+      const svg = svgMarks(trace);
+      // The claim of #904, at one cursor position: the canvas overlay and the
+      // SVG outline cover the same marks. A wider published set passes every
+      // assertion that reads one channel and fails only this one.
+      expect(canvasMarks(trace, data)).toEqual(svg);
+      visited.push({ row, col, marks: svg });
+    }
+  }
+  return visited;
+}
+
+describe('a flow trace publishes the ribbon it highlighted', () => {
+  beforeEach(paintChart);
+
+  test('it announces itself as naming its own marks', () => {
+    const trace = new FlowTrace(flowLayer());
+
+    // The guard is what `createNavigateObserver` feature-tests on, so failing
+    // it means the trace is silently back on the braille-position path.
+    expect(isPointCloudHighlightable(trace)).toBe(true);
+  });
+
+  test('the canvas and the SVG channels agree at every position', () => {
+    const trace = new FlowTrace(flowLayer());
+
+    // Six nodes over three stages, so the grid is larger than either.
+    const visited = walkAgreeing(trace, FLOWS, 6, 6);
+
+    // The walk has to have gone somewhere, or the comparison above proved
+    // nothing at all.
+    expect(visited.length).toBe(6);
+    expect(visited.every(cell => cell.marks.length === 1)).toBe(true);
+  });
+
+  test('a node with flows on both sides publishes one ribbon, not all of them', () => {
+    // Electricity receives Coal-Electricity (34, the widest ribbon on the
+    // chart) and sends Electricity-Homes (20) and Electricity-Industry (14).
+    // `[...node.out, ...node.in]` would publish all three, and an adapter
+    // reading it would light the whole junction up while an SVG renderer lit
+    // one band — the disagreement #904 exists to prevent.
+    const trace = new FlowTrace(flowLayer());
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('Expected a non-empty trace state');
+    }
+    expect(state.text.main.value).toBe('Electricity');
+
+    expect(canvasMarks(trace, FLOWS)).toEqual(['Electricity-Homes']);
+    expect(canvasMarks(trace, FLOWS)).toEqual(svgMarks(trace));
+  });
+
+  test('a sink publishes the ribbon that reaches it', () => {
+    // A node with nothing leaving it falls back to the widest thing arriving,
+    // which is what the SVG path settles on too.
+    const trace = new FlowTrace(flowLayer());
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('Expected a non-empty trace state');
+    }
+    expect(state.text.main.value).toBe('Homes');
+
+    expect(canvasMarks(trace, FLOWS)).toEqual(['Electricity-Homes']);
+    expect(canvasMarks(trace, FLOWS)).toEqual(svgMarks(trace));
+  });
+
+  test('nothing is published before the cursor has entered', () => {
+    const trace = new FlowTrace(flowLayer());
+
+    // The inherited `highlight` reports out of bounds until the first move, so
+    // publishing a ribbon here would outline one before the reader arrived.
+    expect(svgMarks(trace)).toEqual([]);
+    expect(canvasMarks(trace, FLOWS)).toEqual([]);
+  });
+});
+
+describe('a network trace publishes the line it highlighted', () => {
+  beforeEach(paintChart);
+
+  test('it announces itself as naming its own marks', () => {
+    const trace = new NetworkTrace(networkLayer());
+
+    expect(isPointCloudHighlightable(trace)).toBe(true);
+  });
+
+  test('the canvas and the SVG channels agree at every position', () => {
+    const trace = new NetworkTrace(networkLayer());
+
+    // Four linked nodes in one component and Ida alone in another.
+    const visited = walkAgreeing(trace, LINKS, 4, 4);
+
+    expect(visited.length).toBe(5);
+    // Ida is isolated, so exactly one visited cell names no line — and it must
+    // name none on both channels rather than borrowing somebody else's.
+    expect(visited.filter(cell => cell.marks.length === 0).length).toBe(1);
+  });
+
+  test('a hub publishes one line, not every line it touches', () => {
+    // Ada is linked to Edsger, Grace and Alan. Publishing all three would
+    // light the hub's whole neighbourhood while an SVG renderer lit the single
+    // line `mapToSvgElements` chose — the same disagreement as the sankey's.
+    const trace = new NetworkTrace(networkLayer());
+    trace.moveOnce('FORWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('Expected a non-empty trace state');
+    }
+    expect(state.text.main.value).toBe('Ada');
+
+    // Sorted by degree, Ada's first neighbour is Grace, drawn by link 1 — not
+    // link 0, which a pairing by rank would have taken.
+    expect(canvasMarks(trace, LINKS)).toEqual(['Ada-Grace']);
+    expect(canvasMarks(trace, LINKS)).toEqual(svgMarks(trace));
+  });
+
+  test('an isolated node publishes nothing rather than somebody else’s line', () => {
+    const trace = new NetworkTrace(networkLayer());
+    trace.moveOnce('FORWARD');
+    trace.moveOnce('UPWARD');
+
+    const state = trace.state;
+    if (state.empty) {
+      throw new Error('Expected a non-empty trace state');
+    }
+    expect(state.text.main.value).toBe('Ida');
+
+    expect(canvasMarks(trace, LINKS)).toEqual([]);
+    expect(svgMarks(trace)).toEqual([]);
+  });
+
+  test('nothing is published before the cursor has entered', () => {
+    const trace = new NetworkTrace(networkLayer());
+
+    expect(svgMarks(trace)).toEqual([]);
+    expect(canvasMarks(trace, LINKS)).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

A sankey, chord, alluvial or network layer drawn on a canvas library produced **no visual highlight at all**. A canvas chart has no SVG elements for `selectors` to reach, so its only path to an overlay is the navigate callback — and that callback carried the *braille* position. For `FlowTrace` that position is deliberately transposed (`row` is the stage, `col` the node within it), and for neither trace does it name the ribbon or line the chart actually outlines. Turning it back into an am5 node meant re-implementing `FlowTrace`'s longest-path stage layering (`assignStages`/`buildNodes`, plus the cyclic-graph fallback) or `NetworkTrace`'s component walk inside an adapter, where a copy drifts and the failure mode is an outline confidently on the wrong node. #895 refused to ship that and #903 kept the same line.

#899 landed the mechanism that makes it cheap: `PointCloudHighlightable` / `highlightedPointIndices` lets a trace **publish** the marks it highlighted, so the adapter never reconstructs them. `FlowTrace` and `NetworkTrace` implementing the same interface is the model-side fix; registering four resolvers that invert those published indices is the adapter-side one. Both halves are here, so all four types now outline.

**The correction the issue asks for is the substance of this change.** The obvious shape —

```ts
[...node.out, ...node.in].map(e => e.at)   // do not ship this
```

— is **wider** than what the SVG path outlines. Verified against the code rather than taken on trust: `FlowTrace.mapToSvgElements` builds `touching = [...node.out, ...node.in]` and then returns `touching[0]`, and `NetworkTrace.mapToSvgElements` reads `node.linkAt[0]`. One ribbon per node, not all of them. Publishing the wider set would make amCharts outline every ribbon touching a junction while Vega-Lite outlined one — the two renderers disagreeing about the same trace at the same cursor position, which is worse than the old honest blank because it looks correct.

So both channels are derived from **one shared expression** — `FlowTrace.ribbonOf` and `NetworkTrace.lineOf` — rather than from two parallel ones. `mapToSvgElements` indexes its element list with it, and `highlightedPointIndices` returns it. They cannot name different marks without the shared function being wrong for both at once.

## Related Issues

Closes #904

All five acceptance criteria are covered: the model change, the agreement test, the SVG-unaffected proof, the four amCharts resolvers, and the docs caveat. The branch has since been rebased onto `main` with #903 in it, so the flow and network readings the adapter half needs — the declaration cases, the series kinds, `extractFlowPoints` / `extractNetworkPoints` — exist here now, and the `docs/amcharts.md` subsection that said these four are not outlined exists to be removed.

## Changes Made

**Model** (`src/model/flow.ts`, `src/model/network.ts`)

- Both classes now `implements PointCloudHighlightable` and expose `highlightedPointIndices`. Each gains one private static — `FlowTrace.ribbonOf(node)` / `NetworkTrace.lineOf(node)` — that answers "which declared record drew this node's mark", and `mapToSvgElements` is rewritten to read it instead of open-coding the selection. That rewrite is behaviour-preserving: the old flow branch filtered `undefined` out of the mapped elements before taking `[0]`, but `flat` comes from `Array.from(querySelectorAll(...)).map(...)` and the method has already returned `null` unless `flat.length === declared`, so every `edge.at` is in range and the filter could never drop anything.
- **No type change.** `PointCloudHighlightable`, its guard and `NavigateCallback.pointIndices` all shipped in #899 unchanged.
- **No wiring change.** `createNavigateObserver` feature-tests the trace it is handed, so both traces move onto the cloud branch by implementing the interface. `src/controller.ts` is untouched.

**Ordering, and why it is that way.** `ribbonOf` prefers `out[0]` and falls back to `in[0]`, which is the order `touching` was built in — outgoing is the direction the chart is drawn in and the ribbon `FORWARD` follows, and a sink has nothing leaving it. Both edge lists are sorted largest-first at construction, so this is the widest ribbon touching the node. `lineOf` reads `linkAt[0]`, parallel to the degree-sorted `links`, so it is the line to the biggest neighbour — and the line the rotor's first step travels, which is the agreement `networkHighlight.test.ts` already pinned. Both statics take the same `Node | null` the grid holds, so they read as the one expression they are.

**The `isInitialEntry` gate.** `highlightedPointIndices` returns `[]` until the cursor has entered the trace, because the inherited `AbstractTrace.highlight` reports out-of-bounds there. Without it the two channels genuinely disagree at one position — the freshly-constructed one — and the agreement claim would be true only *almost* everywhere. It is deliberately **not** gated on SVG availability: a canvas chart has no elements by definition, and that is the case this exists to serve.

**Adapter** (`src/adapters/amcharts/`)

- `navmap.ts` registers resolvers for SANKEY, CHORD, ALLUVIAL and NETWORK, consuming the published indices exactly the way `buildCloudResolver` (#899) does: a build-time alignment guard, an index lookup at resolve time, and an **empty answer rather than a guess** when either fails. No model logic — no stage layering, no component walk — is reconstructed in the adapter; the resolver only inverts an index against the list this adapter itself emitted.
- New `flowSeriesList` and `networkSeriesList` buckets in `SeriesGroups`/`groupSeries`. Sankey and chord share one bucket because they are one weighted graph drawn two ways, the way treemap and icicle already share theirs. A **declared** alluvial is never classified, so it keeps travelling in `declaredList` and reaches the same `buildFlowResolver` through `nextDeclared(ALLUVIAL)`.
- `extractor.ts`: `extractFlowLinks` is now the single walk over an am5flow series and `extractFlowPoints` is that list with the data items dropped — so the n-th emitted point and the n-th ribbon are aligned **by construction** rather than by two walks agreeing about the same drop rules. `flowRibbonOf` reads the drawn band off the link data item.
- `extractor.ts`: `networkLinkKey` is extracted as the one expression both `extractNetworkPoints`' de-duplication and the new `findNetworkLink` use, so a line drawn with its ends the other way round still matches. `findNetworkLink` walks `series.links` and matches by node category name, because a `ForceDirected`'s links are **not** data items — it is a hierarchy series, and amCharts keeps the drawn lines in a list of its own.
- `NavTarget` became a discriminated union (`NavItemTarget | NavRibbonTarget`): every other mark is named by the data item it hangs on, a ribbon by the sprite. `overlay.ts` gained a `'ribbon'` kind and `ribbonRect`, which measures the reported box, falls back to the sprite's own corners, and pads a perfectly straight link whose box has zero thickness — otherwise `intersectRect` collapses it. A sprite reporting nothing in either direction still clears.
- `types.ts`: `AmXYSeries` gains the optional `links` list.
- `adapter.ts`: the now-false "no highlight, on purpose" comments on `buildFlowLayer`, `buildNetworkLayer` and the declared-alluvial case are corrected.

**Docs.** `docs/amcharts.md`'s `#### Flow and network are not outlined` subsection is replaced by `#### Flow and network highlighting`, the summary sentence near line 101 is rewritten, and the four `†` markers on the Sankey/Chord/Network/Alluvial table rows and their footnote are removed. `grep -n 'not outlined\|un-outlined' docs/amcharts.md` returns nothing and no dangling anchor to the old section remains.

**Still no service, ViewModel or React change**, and the model still only calls `notifyStateUpdate()`, imports no service, and touches no DOM beyond the existing `Svg` helpers.

## Screenshots (if applicable)

N/A — no UI surface of its own. The overlay is the existing amCharts highlight rectangle, now drawn on four more types.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

The third box is unticked deliberately: the automated gate is fully green (below), but `ManualTestingProcess.md` was not walked by hand and no live canvas page was driven. amCharts is commercial and is not installed in this environment, so the adapter is duck-typed throughout and tested against plain fakes.

## Additional Notes

**What a reviewer should check hardest**

1. **That `ribbonOf` and `lineOf` really are the single source both channels read.** This is the point of the model half. If a later edit reintroduces a second expression on either side, the canvas and SVG highlights can diverge again and nothing about either announcement will look wrong. The two are adjacent to `mapToSvgElements` in each file so a drift is visible in a side-by-side read.
2. **That `mapToSvgElements` still outlines exactly what it outlined before.** The refactor is the one place an SVG regression could hide. Argued above from `Svg.selectAllElements` being dense plus the `flat.length !== declared` guard, and pinned by the existing `flowHighlight.test.ts` / `networkHighlight.test.ts` plus a new walk over *every* addressable cell of both traces.
3. **The two amCharts reads that cannot be verified here** — `dataItem.get('link')` for a flow band, and `series.links` with each link's `source`/`target` node data items for a network line. These are in the same class as every other sprite read in this adapter (`mapPolygon`, `geoCentroid`, `slice`/`graphics`): amCharts is commercial and not installed, so neither can be checked against the real library. Both are duck-typed and both degrade to `undefined` → empty resolve → cleared overlay, which is exactly the behaviour these four types shipped with. If a real build hangs them elsewhere, the failure mode is the old honest blank rather than a wrong outline. **Worth confirming against a live chart before release.**
4. **Whether `highlightedPointIndices` should follow the rotor.** It does not: it is derived from the grid position alone, exactly as `highlightValues[row][col]` is. Following `arrivedVia` or `flowWalk` would put the index channel somewhere the element channel is not, which is the bug this change exists to prevent — but it is the decision most worth arguing about.
5. **The alignment guards.** Each resolver re-extracts at build time and refuses to resolve at all if its list is a different length from `layer.data`. A mismatch means the chart moved underneath the extraction, and clearing is strictly better than a band picked by a stale index. Both guards have a dedicated drift test.

**Two design decisions worth naming**

- **`NavTarget` is a union now.** A flow ribbon hangs on the link's own data item, but a force-directed network's lines are not data items at all, so a ribbon target names a sprite instead. Keeping a single interface would have meant either an optional `dataItem` — breaking every existing assertion with a possibly-undefined error — or passing a data item the target has nothing to do with. The union costs ~37 mechanical narrowings in existing tests, all routed through one `itemOf()` helper in `helpers.ts`; type-only, no assertion changed meaning.
- **The ribbon padding rule.** A network link drawn perfectly horizontally or vertically reports a box with zero thickness, which `intersectRect` would collapse to nothing; it is padded to a 2px hairline band instead. That is real geometry, and it is distinct from the degenerate point of #774, which still clears.

**Test approach.** Every new test was proven to fail without the fix by mutating the source, not by trusting the diff:

- Reverting `src/model/flow.ts` and `src/model/network.ts` to their pre-change state fails **all 14** new model tests.
- Replacing the getters with the wider set the issue warns against — `[...node.out, ...node.in].map(e => e.at)` and `node.linkAt.filter(at => at >= 0)` — fails **5**, including both `the canvas and the SVG channels agree at every position` cases and both junction/hub cases. That is the specific disagreement, pinned specifically.
- Deleting the `isInitialEntry` gate alone fails the two `nothing is published before the cursor has entered` cases, so the gate is load-bearing rather than defensive.
- On the adapter side: unregistering the four resolvers fails **9** of the new navmap tests; dropping the flow bucket fails **6**; unsorting `networkLinkKey` fails the network test; neutering either alignment guard fails exactly its drift test; requiring area in `hasExtent` fails the straight-link test.

Every blank-answer assertion is paired with a positive control in the same test, so no test in this PR passes with *and* without the change.

**How the agreement is asserted.** `test/model/flowNetworkPointIndices.test.ts` walks every addressable cell of both traces and, at each, compares the *names* of the marks the two channels select: the SVG channel via the `data-mark` attribute on the outlined element, the canvas channel by inverting each published index against `layer.data` — which is exactly the inversion the adapter performs. Both traces are given a chart authored out of value/degree order, so a pairing by rank rather than by declared position fails too. `test/controller/navigateCallbackFlowNetwork.test.ts` runs the same claim through the shipped `createNavigateObserver` and `Context`, on layers carrying **no selectors at all** — the reported canvas case. `test/adapters/amcharts/navmap.test.ts` then drives a real `FlowTrace` and a real `NetworkTrace` end to end into the resolvers, with the network's drawn lines declared out of order and one pair reversed.

**Left undone, and why**

- **No e2e Playwright spec.** `e2e_tests/` has no canvas-chart harness — amCharts is bound from live JS objects, not from a static page MAIDR loads — and this adds no trace type, so `.claude/rules/testing.md`'s per-trace-type e2e requirement is not triggered.
- **No manual verification against a live page**, for the reason in point 3 above.

**Gate**, run on the final tree:

- `npm run lint:fix` — clean, no files changed.
- `npm run type-check` — clean (`tsc --noEmit` and `tsconfig.ci.json`).
- `npm run build` — all 13 builds complete.
- `npm test` — 285/285 unit suites (4266 tests) and 7/7 esm suites (73 tests), fully green.
