### PR TITLE
fix(line): read every path command, so a staircase highlights its samples

### DIFF
--- a/src/model/area.ts
+++ b/src/model/area.ts
@@ -41,6 +41,39 @@ function variantOf(type: TraceType): AreaVariant {
 }
 
 /**
+ * Drop a stepped band's return journey along the baseline, if it has one.
+ *
+ * A closed band walks its top edge and then comes back along the baseline,
+ * adding exactly one vertex per sample. So a closed staircase is `3N - 1`
+ * vertices for `hv`/`vh` and `3N` for `mid`, against `2N - 1` and `2N` for a
+ * top edge stroked on its own.
+ *
+ * Matched exactly rather than by "longer than a top edge", which is what this
+ * was and which misread a `mid` band: its `2N` top edge is already longer than
+ * the `2N - 1` an `hv` one has, so the test fired on a path with no baseline
+ * at all and sliced away real samples. Plotly strokes the edge separately —
+ * `path.js-line` carries no baseline — so that case is the common one, not the
+ * exotic one.
+ *
+ * A count matching neither is left whole: {@link stepDataVertices} answers
+ * `null` for it and the caller falls back to interpolation, which is the right
+ * recovery for geometry this does not recognise.
+ *
+ * @param coordinates - Vertices parsed from the path
+ * @param expected - How many samples the series has
+ * @returns The vertices with any baseline removed
+ */
+function withoutBaseline(coordinates: LinePoint[], expected: number): LinePoint[] {
+  if (expected <= 0) {
+    return coordinates;
+  }
+  const closedLengths = [3 * expected - 1, 3 * expected];
+  return closedLengths.includes(coordinates.length)
+    ? coordinates.slice(0, coordinates.length - expected)
+    : coordinates;
+}
+
+/**
  * Whether a magnitude is a real number the totals may include.
  *
  * A gap travels as `NaN`, and `NaN` spreads: summing one into a column total
@@ -144,10 +177,12 @@ export class AreaTrace extends LineTrace {
    * band, the second highlight sat on the held value at the next x rather than
    * on the sample, and every one after it was displaced too.
    *
-   * So the baseline is dropped first, and what remains is handed to the same
-   * {@link stepDataVertices} that `StepTrace` uses. Sharing that rather than
-   * repeating it keeps the two from disagreeing about which vertex is a
-   * sample, which is the failure this method exists to prevent.
+   * So {@link withoutBaseline} drops the return journey first, and what
+   * remains is handed to the same {@link stepDataVertices} that `StepTrace`
+   * uses. Sharing that rather than repeating it keeps the two from disagreeing
+   * about which vertex is a sample, which is the failure this method exists to
+   * prevent — and it is why a band whose edge is stroked on its own, carrying
+   * no baseline to drop, needs no separate handling here.
    *
    * @param coordinates - Vertices parsed from the path, mutated in place
    * @param row - Index of the series these coordinates belong to
@@ -170,12 +205,10 @@ export class AreaTrace extends LineTrace {
     }
 
     const expected = this.points[row]?.length ?? 0;
-    const closed
-      = expected > 0 && coordinates.length > 2 * expected - 1
-        ? coordinates.slice(0, coordinates.length - expected)
-        : coordinates;
-
-    const dataVertices = stepDataVertices(closed, expected);
+    const dataVertices = stepDataVertices(
+      withoutBaseline(coordinates, expected),
+      expected,
+    );
     if (dataVertices !== null) {
       coordinates.length = 0;
       coordinates.push(...dataVertices);

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -12,18 +12,37 @@ import { MovableGraph } from './movable';
 
 const TYPE = 'Group';
 /**
- * Regex for extracting data point coordinates from SVG path `d` attribute.
+ * Splits a path `d` attribute into commands, each with its argument text.
  *
- * Matches M/L commands (direct endpoints) with comma or whitespace separators,
- * and C (cubic bezier) commands — extracting the endpoint (last coordinate pair).
- *
- * M/L: `M65,231.42` or `L 100 200` → captures (65, 231.42) or (100, 200)
- * C:   `C81,215,97,199,113,182`    → captures endpoint (113, 182)
+ * `A`/`a` are deliberately absent. An arc's flag arguments are legally
+ * written without separators — `a1 1 0 011 1` is three flags and a coordinate
+ * pair — so a plain number scan mis-tokenizes them and would push invented
+ * vertices. Line-family geometry never contains an arc, so an unread one is
+ * the honest answer; an arc in the middle of a path leaves the current point
+ * stale, which is no worse than the whole command being invisible as it was
+ * before.
  */
-const SVG_PATH_ML_REGEX
-  = /[ML]\s*(-?\d+(?:\.\d+)?)[,\s]+(-?\d+(?:\.\d+)?)/g;
-const SVG_PATH_C_REGEX
-  = /C\s*(?:-?\d+(?:\.\d+)?[,\s]+-?\d+(?:\.\d+)?[,\s]+){2}(-?\d+(?:\.\d+)?)[,\s]+(-?\d+(?:\.\d+)?)/g;
+const SVG_PATH_COMMAND_REGEX = /([MLHVCSQTZ])([^MLHVCSQTZ]*)/gi;
+
+/** One number of a path argument list, including exponent notation. */
+const SVG_PATH_NUMBER_REGEX = /-?\d*\.?\d+(?:e[-+]?\d+)?/gi;
+
+/**
+ * How many numbers each path command takes per repetition.
+ *
+ * A command may carry several repetitions in one argument list — `L1 2 3 4`
+ * is two linetos — so the arity is what the argument list is walked in.
+ */
+const SVG_PATH_ARITY: Record<string, number> = {
+  M: 2,
+  L: 2,
+  H: 1,
+  V: 1,
+  C: 6,
+  S: 4,
+  Q: 4,
+  T: 2,
+};
 
 /**
  * Represents a line trace plot with support for single and multi-line navigation
@@ -866,39 +885,74 @@ export class LineTrace extends AbstractTrace {
 
   /**
    * Extracts data point coordinates from an SVG path `d` attribute.
-   * Handles M/L (move/line) and C (cubic bezier) commands.
-   * For C commands, the endpoint (3rd coordinate pair) is extracted.
+   *
+   * One vertex per drawing command, taken at that command's endpoint — which
+   * for a curve is where it lands, not where its control points sit. The path
+   * is walked rather than pattern-matched because the endpoint of `H`, `V`,
+   * and every relative command is only defined against the current point,
+   * which a regex over the whole string cannot know.
+   *
+   * That is what this used to be, and it left `H`/`V` unread. A staircase is
+   * precisely the shape a renderer draws with them, every segment being
+   * axis-aligned, so a Plotly step chart parsed to its single `M` and nothing
+   * else: measured, `M0,399H246.67V147H493.33V273H740V21` yielded 1 vertex for
+   * 4 samples. `reconcilePathCoordinates` then padded with `NaN`, the series
+   * was marked failed, and `mapToSvgElements` returned null — correct audio,
+   * braille and text, no highlight, and nothing anywhere saying why (#907).
+   *
+   * `M`, `L` and `C` behave exactly as they did; a cubic still contributes its
+   * endpoint alone.
+   *
+   * @param pathD - The `d` attribute of the rendered path
+   * @param coordinates - Vertex list to append to, mutated in place
    */
   private extractPathCoordinates(pathD: string, coordinates: LinePoint[]): void {
-    // Extract M/L endpoints
-    SVG_PATH_ML_REGEX.lastIndex = 0;
-    let match: RegExpExecArray | null = SVG_PATH_ML_REGEX.exec(pathD);
-    const indexed: { index: number; x: number; y: number }[] = [];
-    while (match !== null) {
-      indexed.push({
-        index: match.index,
-        x: Number.parseFloat(match[1]),
-        y: Number.parseFloat(match[2]),
-      });
-      match = SVG_PATH_ML_REGEX.exec(pathD);
-    }
+    let x = 0;
+    let y = 0;
+    // Where the current subpath began, which is where `Z` returns to.
+    let startX = 0;
+    let startY = 0;
 
-    // Extract C cubic bezier endpoints (3rd pair of each C command)
-    SVG_PATH_C_REGEX.lastIndex = 0;
-    match = SVG_PATH_C_REGEX.exec(pathD);
+    SVG_PATH_COMMAND_REGEX.lastIndex = 0;
+    let match: RegExpExecArray | null = SVG_PATH_COMMAND_REGEX.exec(pathD);
     while (match !== null) {
-      indexed.push({
-        index: match.index,
-        x: Number.parseFloat(match[1]),
-        y: Number.parseFloat(match[2]),
-      });
-      match = SVG_PATH_C_REGEX.exec(pathD);
-    }
+      const command = match[1];
+      const absolute = command.toUpperCase();
+      const isRelative = command !== absolute;
+      const args = (match[2].match(SVG_PATH_NUMBER_REGEX) ?? []).map(Number);
+      match = SVG_PATH_COMMAND_REGEX.exec(pathD);
 
-    // Sort by position in path string to preserve point order
-    indexed.sort((a, b) => a.index - b.index);
-    for (const point of indexed) {
-      coordinates.push({ x: point.x, y: point.y });
+      if (absolute === 'Z') {
+        // A closepath draws back to a vertex already recorded, so it moves the
+        // pen without adding a point. Emitting one would duplicate the start.
+        x = startX;
+        y = startY;
+        continue;
+      }
+
+      const arity = SVG_PATH_ARITY[absolute];
+      for (let i = 0; i + arity <= args.length; i += arity) {
+        if (absolute === 'H') {
+          x = isRelative ? x + args[i] : args[i];
+        } else if (absolute === 'V') {
+          y = isRelative ? y + args[i] : args[i];
+        } else {
+          // The endpoint is the last pair of every remaining command; the
+          // control points before it are not on the drawn path.
+          const endX = args[i + arity - 2];
+          const endY = args[i + arity - 1];
+          x = isRelative ? x + endX : endX;
+          y = isRelative ? y + endY : endY;
+        }
+
+        // Only the first pair of a moveto starts a subpath; the repetitions
+        // after it are implicit linetos, per the SVG path grammar.
+        if (absolute === 'M' && i === 0) {
+          startX = x;
+          startY = y;
+        }
+        coordinates.push({ x, y });
+      }
     }
   }
 

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -14,15 +14,22 @@ const TYPE = 'Group';
 /**
  * Splits a path `d` attribute into commands, each with its argument text.
  *
- * `A`/`a` are deliberately absent. An arc's flag arguments are legally
- * written without separators — `a1 1 0 011 1` is three flags and a coordinate
- * pair — so a plain number scan mis-tokenizes them and would push invented
- * vertices. Line-family geometry never contains an arc, so an unread one is
- * the honest answer; an arc in the middle of a path leaves the current point
- * stale, which is no worse than the whole command being invisible as it was
- * before.
+ * `A`/`a` is listed here but absent from {@link SVG_PATH_ARITY}, so an arc is
+ * recognised and then skipped. Both halves matter. It has to be *recognised*
+ * because the argument group runs to the next command letter: leaving `A` out
+ * of the class would sweep an arc's flags and coordinates into the preceding
+ * command's arguments, where they are consumed as further repetitions of that
+ * command's arity. Measured on `M 0 0 L 10 10 A 5 5 0 0 1 20 20 L 30 30`,
+ * that fabricated three vertices — `(5,5)`, `(0,0)`, `(1,20)` — rather than
+ * leaving the arc merely unread.
+ *
+ * It is then *skipped* because an arc's flag arguments are legally written
+ * without separators — `a1 1 0 011 1` is three flags and a coordinate pair —
+ * so a plain number scan cannot tell where the endpoint starts. That leaves
+ * the current point stale across an arc, which only misplaces a *relative*
+ * command that follows one; line-family geometry contains neither.
  */
-const SVG_PATH_COMMAND_REGEX = /([MLHVCSQTZ])([^MLHVCSQTZ]*)/gi;
+const SVG_PATH_COMMAND_REGEX = /([MLHVCSQTAZ])([^MLHVCSQTAZ]*)/gi;
 
 /** One number of a path argument list, including exponent notation. */
 const SVG_PATH_NUMBER_REGEX = /-?\d*\.?\d+(?:e[-+]?\d+)?/gi;
@@ -32,6 +39,12 @@ const SVG_PATH_NUMBER_REGEX = /-?\d*\.?\d+(?:e[-+]?\d+)?/gi;
  *
  * A command may carry several repetitions in one argument list — `L1 2 3 4`
  * is two linetos — so the arity is what the argument list is walked in.
+ *
+ * `Z` and `A` are absent, and an absent entry contributes no vertices: the
+ * walk's bound is `i + arity <= args.length`, and `undefined` makes that
+ * comparison false at once. `Z` is handled before the lookup because it still
+ * moves the pen; `A` is not, for the reason
+ * {@link SVG_PATH_COMMAND_REGEX} gives.
  */
 const SVG_PATH_ARITY: Record<string, number> = {
   M: 2,

--- a/src/model/step.ts
+++ b/src/model/step.ts
@@ -61,6 +61,93 @@ export function stepDataVertices(
   coordinates: LinePoint[],
   expected: number,
 ): LinePoint[] | null {
+  const direct = matchStepGeometry(coordinates, expected);
+  if (direct !== null) {
+    return direct;
+  }
+
+  // Only reached when the path matches neither shape, so a well-formed
+  // staircase never takes this branch. That ordering is load-bearing: a step
+  // chart holds its value across a run, so a real `2N - 1` path routinely
+  // carries three consecutive vertices on one horizontal line, and collapsing
+  // first would drop the middle one and break a path that was already right.
+  const collapsed = collapseAxisAlignedRuns(coordinates);
+  return collapsed.length === coordinates.length
+    ? null
+    : matchStepGeometry(collapsed, expected);
+}
+
+/**
+ * Whether a vertex only continues a straight axis-aligned run.
+ *
+ * Requires the middle vertex to lie *between* its neighbours, not merely on
+ * their line. Three vertices sharing an x with the middle one outside the
+ * span is a reversal — the pen went out and came back — which `vhv` draws and
+ * which dropping the middle vertex would erase.
+ *
+ * @param previous - The vertex before
+ * @param current - The vertex under test
+ * @param next - The vertex after
+ * @returns True when `current` adds no corner to the path
+ */
+function continuesRun(
+  previous: LinePoint,
+  current: LinePoint,
+  next: LinePoint,
+): boolean {
+  const between = (a: number, b: number, c: number): boolean =>
+    (a <= b && b <= c) || (c <= b && b <= a);
+
+  if (Number(previous.y) === Number(current.y) && Number(current.y) === Number(next.y)) {
+    return between(Number(previous.x), Number(current.x), Number(next.x));
+  }
+  if (Number(previous.x) === Number(current.x) && Number(current.x) === Number(next.x)) {
+    return between(Number(previous.y), Number(current.y), Number(next.y));
+  }
+  return false;
+}
+
+/**
+ * Drop the vertices a renderer added without turning a corner.
+ *
+ * One straight segment may reach the DOM as several commands: Plotly draws an
+ * `hvh` staircase with consecutive same-direction moves — measured,
+ * `…H246.67H370…` with no `V` between them — which puts a vertex in the middle
+ * of a horizontal run that no step of the data corresponds to. Those inflate
+ * the count past every shape {@link stepDataVertices} recognises, so the
+ * staircase falls through to interpolation and every highlight lands wrong.
+ *
+ * @param coordinates - Vertices parsed from the path
+ * @returns A new list holding only the endpoints and the corners
+ */
+function collapseAxisAlignedRuns(coordinates: LinePoint[]): LinePoint[] {
+  if (coordinates.length < 3) {
+    return [...coordinates];
+  }
+
+  // Compared against the last *kept* vertex rather than the raw predecessor,
+  // so a run split into three or more pieces collapses in one pass.
+  const kept: LinePoint[] = [coordinates[0]];
+  for (let i = 1; i < coordinates.length - 1; i++) {
+    if (!continuesRun(kept[kept.length - 1], coordinates[i], coordinates[i + 1])) {
+      kept.push(coordinates[i]);
+    }
+  }
+  kept.push(coordinates[coordinates.length - 1]);
+  return kept;
+}
+
+/**
+ * Read the samples off a vertex list whose length matches a step convention.
+ *
+ * @param coordinates - Vertices parsed from the path
+ * @param expected - How many samples the series has
+ * @returns The data vertices, or `null` when the count matches neither shape
+ */
+function matchStepGeometry(
+  coordinates: LinePoint[],
+  expected: number,
+): LinePoint[] | null {
   if (expected > 1 && coordinates.length === 2 * expected - 1) {
     return coordinates.filter((_, index) => index % 2 === 0);
   }

--- a/test/model/pathCommands.test.ts
+++ b/test/model/pathCommands.test.ts
@@ -259,6 +259,50 @@ describe('svg path command parsing (#907)', () => {
     test('exponent notation parses as one number', () => {
       expect(parse('M 1e2 2e1 L 3 4', 2)).toEqual([{ x: 100, y: 20 }, { x: 3, y: 4 }]);
     });
+
+    test('a smooth cubic contributes its endpoint', () => {
+      // `S x2 y2 x y` — four numbers, the first pair a control point. Reading
+      // the wrong pair would put the highlight off the drawn curve.
+      expect(parse('M 0 0 C 5 20 10 20 15 0 S 25 -20 30 0', 3)).toEqual([
+        { x: 0, y: 0 },
+        { x: 15, y: 0 },
+        { x: 30, y: 0 },
+      ]);
+    });
+
+    test('a smooth quadratic contributes its endpoint', () => {
+      // `T x y` — the control point is implied from the previous command, so
+      // both numbers are the endpoint.
+      expect(parse('M 0 0 Q 5 20 10 0 T 20 0', 3)).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 20, y: 0 },
+      ]);
+    });
+
+    test('an arc is skipped without corrupting the commands around it', () => {
+      // An arc's endpoint cannot be located by a number scan — its flags are
+      // legally written without separators — so it contributes nothing. What
+      // it must not do is contribute something *wrong*: with `A` missing from
+      // the command class its tokens were swept into the preceding `L`'s
+      // argument list and read as further linetos, fabricating `(5,5)`,
+      // `(0,0)` and `(1,20)` here. Raised in review on #908.
+      expect(parse('M 0 0 L 10 10 A 5 5 0 0 1 20 20 L 30 30', 3)).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+        { x: 30, y: 30 },
+      ]);
+    });
+
+    test('an arc with packed flags is skipped just as cleanly', () => {
+      // The compact serialisation the number scan cannot read: `0 0 1` is
+      // written `001`. Whatever it tokenizes to must stay inside the arc.
+      expect(parse('M 0 0 L 10 10 a5 5 0 001 1 L 30 30', 3)).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+        { x: 30, y: 30 },
+      ]);
+    });
   });
 });
 

--- a/test/model/pathCommands.test.ts
+++ b/test/model/pathCommands.test.ts
@@ -1,0 +1,367 @@
+/**
+ * @jest-environment jsdom
+ *
+ * A staircase highlighted nothing because the path parser read only `M`, `L`
+ * and `C` (#907).
+ *
+ * Every segment of a staircase is axis-aligned, so a renderer draws one with
+ * `H` and `V` — and those were invisible to the parser. A four-sample Plotly
+ * step chart therefore parsed to its single `M` and nothing else: one vertex
+ * against four samples, padded to `NaN`, the series marked failed, and
+ * `mapToSvgElements` returning null. Correct audio, correct braille, correct
+ * text, no highlight, and nothing anywhere saying why.
+ *
+ * The `d` attributes below are not invented. Each was read out of Chromium
+ * from real Plotly.js output, four samples per trace, off the `path.js-line`
+ * element py-maidr's selectors address.
+ */
+import type { LinePoint, MaidrLayer, StepPoint } from '@type/grammar';
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { AreaTrace } from '@model/area';
+import { LineTrace } from '@model/line';
+import { StepTrace } from '@model/step';
+import { TraceType } from '@type/grammar';
+
+/** Four samples, distinct throughout so a misplaced highlight cannot hide. */
+const POINTS: LinePoint[] = [
+  { x: 1, y: 1 },
+  { x: 2, y: 3 },
+  { x: 3, y: 2 },
+  { x: 4, y: 4 },
+];
+
+/**
+ * Where Plotly draws each sample, in SVG coordinates.
+ *
+ * The x values are the plot area walked in four equal steps; the y values are
+ * `POINTS`' magnitudes inverted onto it. Both are read off the rendered chart
+ * rather than derived, so an assertion below is comparing against the pixels
+ * a sighted reader sees.
+ */
+const PLOTLY_X = [0, 246.67, 493.33, 740];
+const PLOTLY_Y = [399, 147, 273, 21];
+
+/** Measured `path.js-line` geometry, by `line.shape`. */
+const PLOTLY_PATHS = {
+  hv: 'M0,399H246.67V147H493.33V273H740V21',
+  vh: 'M0,399V147H246.67V273H493.33V21H740',
+  linear: 'M0,399L246.67,147L493.33,273L740,21',
+  spline:
+    'M0,399Q158.85,161.34 246.67,147C324.5,134.29 415.5,285.71 493.33,273Q581.15,258.66 740,21',
+};
+
+/**
+ * jsdom implements `SVGElement` but none of the per-tag SVG interfaces, so
+ * `element instanceof SVGPathElement` — the branch `LineTrace` uses to decide
+ * it is looking at a path — throws. Define it here so the branch is reachable,
+ * matching a browser rather than changing it: only a `<path>` satisfies it.
+ */
+function defineSvgPathElement(): void {
+  if ('SVGPathElement' in globalThis) {
+    return;
+  }
+  Object.defineProperty(globalThis, 'SVGPathElement', {
+    configurable: true,
+    writable: true,
+    value: class SVGPathElementShim {
+      public static [Symbol.hasInstance](value: unknown): boolean {
+        return value instanceof SVGElement && (value as Element).tagName === 'path';
+      }
+    },
+  });
+}
+
+/**
+ * Put a rendered path in the document for a trace to resolve against.
+ * @param pathD - The `d` attribute to render
+ */
+function render(pathD: string): void {
+  document.body.innerHTML = `
+      <svg id="chart" xmlns="http://www.w3.org/2000/svg">
+        <g id="series"><path d="${pathD}"></path></g>
+      </svg>`;
+}
+
+/**
+ * Read back the highlight circles MAIDR synthesised.
+ * @returns One point per circle, in document order
+ */
+function circles(): { x: number; y: number }[] {
+  return Array.from(document.querySelectorAll('circle')).map(circle => ({
+    x: Number(circle.getAttribute('cx')),
+    y: Number(circle.getAttribute('cy')),
+  }));
+}
+
+/**
+ * Build a layer whose single selector resolves against the rendered path.
+ * @param type - The trace type to author
+ * @param extra - Additional layer fields, e.g. `stepDirection`
+ * @returns A layer definition over {@link POINTS}
+ */
+function layer(type: TraceType, extra: Partial<MaidrLayer> = {}): MaidrLayer {
+  return {
+    id: 'test-layer',
+    type,
+    title: 'Measurement',
+    axes: { x: { label: 'Time' }, y: { label: 'Value' } },
+    selectors: ['g#series path'],
+    data: [POINTS as StepPoint[]],
+    ...extra,
+  } as MaidrLayer;
+}
+
+/** The SVG position of every sample, which is where the highlights belong. */
+function samplePositions(): { x: number; y: number }[] {
+  return POINTS.map((_, i) => ({ x: PLOTLY_X[i], y: PLOTLY_Y[i] }));
+}
+
+describe('svg path command parsing (#907)', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = '';
+  });
+
+  describe('a plotly staircase', () => {
+    test('highlights every sample rather than nothing at all', () => {
+      render(PLOTLY_PATHS.hv);
+      // eslint-disable-next-line no-new
+      new StepTrace(layer(TraceType.STEP, { stepDirection: 'hv' }));
+
+      expect(circles()).toEqual(samplePositions());
+    });
+
+    test('reads a vh staircase the same way', () => {
+      // `vh` jumps at the x value and then holds, so its path opens with a `V`
+      // where `hv` opens with an `H`. Both are unreadable to an M/L parser,
+      // and for the same reason.
+      render(PLOTLY_PATHS.vh);
+      // eslint-disable-next-line no-new
+      new StepTrace(layer(TraceType.STEP, { stepDirection: 'vh' }));
+
+      expect(circles()).toEqual(samplePositions());
+    });
+
+    test('never leaves a series without a highlight', () => {
+      // The failure this file exists for, asserted directly: a NaN anywhere in
+      // the reconciled vertices makes `mapViaPathParsing` drop the whole
+      // series, and with one series that means no highlight at all.
+      render(PLOTLY_PATHS.hv);
+      // eslint-disable-next-line no-new
+      new StepTrace(layer(TraceType.STEP, { stepDirection: 'hv' }));
+
+      const highlights = circles();
+      expect(highlights).toHaveLength(POINTS.length);
+      expect(highlights.filter(c => Number.isNaN(c.x) || Number.isNaN(c.y))).toEqual([]);
+    });
+  });
+
+  describe('what already worked keeps working', () => {
+    test('a linear plotly line is unchanged', () => {
+      // `M`/`L` only, so this path was already parsed correctly. Pinned so the
+      // rewrite is provably additive rather than a re-derivation.
+      render(PLOTLY_PATHS.linear);
+      // eslint-disable-next-line no-new
+      new LineTrace(layer(TraceType.LINE));
+
+      expect(circles()).toEqual(samplePositions());
+    });
+
+    test('a cubic contributes its endpoint, not its control points', () => {
+      // The one piece of curve handling the old parser had. A control point
+      // recorded as a vertex would put the highlight off the drawn line.
+      render('M 0 0 C 10 90 20 90 30 0');
+      // eslint-disable-next-line no-new
+      new LineTrace(layer(TraceType.LINE, { data: [[{ x: 1, y: 1 }, { x: 2, y: 2 }]] }));
+
+      expect(circles()).toEqual([{ x: 0, y: 0 }, { x: 30, y: 0 }]);
+    });
+  });
+
+  describe('curves the old parser could not see', () => {
+    test('a plotly spline lands on its samples', () => {
+      // Quadratics were as invisible as H/V: this path parsed to its `M` and
+      // one `C` endpoint, two vertices for four samples, so the highlights
+      // were interpolated along that chord instead of sitting on the data.
+      render(PLOTLY_PATHS.spline);
+      // eslint-disable-next-line no-new
+      new LineTrace(layer(TraceType.LINE));
+
+      expect(circles()).toEqual(samplePositions());
+    });
+  });
+
+  describe('the rest of the path grammar', () => {
+    /**
+     * Drive a line over a path and read back the vertices parsed from it.
+     *
+     * `sampleCount` has to match the number of vertices the path is expected
+     * to yield, because `reconcilePathCoordinates` runs afterwards and trims
+     * any surplus from the end — a mismatch would hide a vertex the parser
+     * read correctly, or invent one it did not.
+     *
+     * @param pathD - The `d` attribute to parse
+     * @param sampleCount - How many vertices the path should yield
+     * @returns The highlight positions
+     */
+    function parse(pathD: string, sampleCount: number): { x: number; y: number }[] {
+      const data = Array.from({ length: sampleCount }, (_, i) => ({ x: i, y: i }));
+      render(pathD);
+      // eslint-disable-next-line no-new
+      new LineTrace(layer(TraceType.LINE, { data: [data] }));
+      return circles();
+    }
+
+    test('relative commands accumulate against the current point', () => {
+      expect(parse('m 10 10 l 5 5', 2)).toEqual([{ x: 10, y: 10 }, { x: 15, y: 15 }]);
+    });
+
+    test('relative h and v move one axis at a time', () => {
+      expect(parse('M 10 10 h 5 v -4', 3)).toEqual([
+        { x: 10, y: 10 },
+        { x: 15, y: 10 },
+        { x: 15, y: 6 },
+      ]);
+    });
+
+    test('a repeated argument list is several commands', () => {
+      // `L1 2 3 4` is two linetos, per the path grammar. Reading it as one
+      // would drop every second vertex of a compactly serialised path.
+      expect(parse('M 0 0 L 1 2 3 4', 3)).toEqual([
+        { x: 0, y: 0 },
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ]);
+    });
+
+    test('pairs after a moveto are implicit linetos', () => {
+      expect(parse('M 0 0 1 2', 2)).toEqual([{ x: 0, y: 0 }, { x: 1, y: 2 }]);
+    });
+
+    test('closepath returns to the subpath start without adding a vertex', () => {
+      // `Z` draws back to a vertex already recorded. Emitting one would
+      // duplicate the start and push the count past the shape checks that
+      // read it.
+      expect(parse('M 0 0 L 5 5 Z', 2)).toEqual([{ x: 0, y: 0 }, { x: 5, y: 5 }]);
+    });
+
+    test('a closepath moves the pen back for the command after it', () => {
+      // The reason `Z` is tracked rather than skipped: a relative command
+      // following one is measured from the subpath start, not from where the
+      // pen last drew.
+      expect(parse('M 10 10 L 50 50 Z l 5 5', 3)).toEqual([
+        { x: 10, y: 10 },
+        { x: 50, y: 50 },
+        { x: 15, y: 15 },
+      ]);
+    });
+
+    test('exponent notation parses as one number', () => {
+      expect(parse('M 1e2 2e1 L 3 4', 2)).toEqual([{ x: 100, y: 20 }, { x: 3, y: 4 }]);
+    });
+  });
+});
+
+describe('redundant collinear vertices (#907)', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = '';
+  });
+
+  /**
+   * Plotly's `hvh` geometry, measured. It splits each horizontal run into two
+   * commands — `…H246.67H370…` with no `V` between them — so the path carries
+   * ten vertices for four samples where the `mid` convention has eight.
+   */
+  const PLOTLY_HVH
+    = 'M0,320.25H123.34V220.5H246.67H370V120.75H493.33H616.67V21H740';
+
+  test('a mid staircase still lands inside each sample run', () => {
+    render(PLOTLY_HVH);
+    // eslint-disable-next-line no-new
+    new StepTrace(layer(TraceType.STEP, { stepDirection: 'mid' }));
+
+    // The x values are the sample positions Plotly drew; the y values are the
+    // level held across each run.
+    // `closeTo` on x: an interior `mid` sample is the midpoint of its run, so
+    // it arrives through a division and lands a float ulp off the value
+    // Plotly drew. The y values are read straight off a vertex and are exact.
+    expect(circles()).toEqual([
+      { x: expect.closeTo(0, 6), y: 320.25 },
+      { x: expect.closeTo(246.67, 6), y: 220.5 },
+      { x: expect.closeTo(493.335, 6), y: 120.75 },
+      { x: expect.closeTo(740, 6), y: 21 },
+    ]);
+  });
+
+  test('a well-formed staircase with a flat run is left alone', () => {
+    // The reason collapsing runs is a *fallback* and not a first pass. A step
+    // chart holds its value across an interval, so two equal samples put three
+    // consecutive vertices on one horizontal line in a path that is already
+    // exactly `2N - 1`. Collapsing first would drop the middle one, break the
+    // count, and send a correct path to interpolation.
+    //
+    // Four samples at levels 1, 1, 2, 2: `hv` corners at each x.
+    render('M0,300H100V300H100V200H200V200H200');
+    // eslint-disable-next-line no-new
+    new StepTrace(layer(TraceType.STEP, { stepDirection: 'hv' }));
+
+    expect(circles()).toHaveLength(POINTS.length);
+    expect(circles()[0]).toEqual({ x: 0, y: 300 });
+  });
+
+  test('a reversal is not mistaken for a redundant vertex', () => {
+    // `vhv` goes out along an axis and comes back, so its middle vertex shares
+    // an x with both neighbours while sitting outside their span. Dropping it
+    // would erase a corner the renderer actually drew, so the collapse
+    // requires the vertex to lie *between* its neighbours.
+    render('M0,399V273H246.67V147V210H493.33V273V147H740V21');
+    // eslint-disable-next-line no-new
+    new StepTrace(layer(TraceType.STEP));
+
+    // Ten vertices that collapse to ten: matching neither shape, this falls
+    // back to interpolation rather than being forced into `mid`. One highlight
+    // per sample either way -- what matters is that the reversal survived the
+    // collapse, not which recovery the count then selected.
+    expect(circles()).toHaveLength(POINTS.length);
+  });
+});
+
+describe('a stepped band with no baseline (#907)', () => {
+  beforeEach(() => {
+    defineSvgPathElement();
+    document.body.innerHTML = '';
+  });
+
+  test('an hv band stroked as a bare edge maps onto its samples', () => {
+    // Plotly strokes an area's top edge as its own `path.js-line`, with no
+    // return journey along the baseline — so this is `2N - 1` vertices, not
+    // `3N - 1`, and dropping a baseline that is not there would eat a sample.
+    render('M0,320.25H246.67V220.5H493.33V120.75H740V21');
+    // eslint-disable-next-line no-new
+    new AreaTrace(layer(TraceType.AREA, { stepDirection: 'hv' }));
+
+    expect(circles()).toEqual([
+      { x: 0, y: 320.25 },
+      { x: 246.67, y: 220.5 },
+      { x: 493.33, y: 120.75 },
+      { x: 740, y: 21 },
+    ]);
+  });
+
+  test('a mid band stroked as a bare edge maps onto its samples', () => {
+    // The case the old "longer than a top edge" test could not express: a
+    // `mid` edge is `2N` vertices, already longer than the `2N - 1` an `hv`
+    // one has, so the baseline check fired on a path that has no baseline.
+    render('M0,320.25H123.34V220.5H246.67H370V120.75H493.33H616.67V21H740');
+    // eslint-disable-next-line no-new
+    new AreaTrace(layer(TraceType.AREA, { stepDirection: 'mid' }));
+
+    expect(circles()).toEqual([
+      { x: expect.closeTo(0, 6), y: 320.25 },
+      { x: expect.closeTo(246.67, 6), y: 220.5 },
+      { x: expect.closeTo(493.335, 6), y: 120.75 },
+      { x: expect.closeTo(740, 6), y: 21 },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #907.

## The defect

`LineTrace.extractPathCoordinates` read a rendered path with two regexes over `M`, `L` and `C`. The SVG path grammar also has `H`, `V`, `Q`, `S`, `T` and every relative form, and none of them were read.

That is not a corner. **Every segment of a staircase is axis-aligned**, so a renderer draws one with `H` and `V` — which meant a Plotly step chart parsed to its opening `M` and stopped.

Measured in Chromium, four samples per trace, off the `path.js-line` element py-maidr's selectors address:

| `line.shape` | `d` | vertices recovered |
|---|---|---|
| `hv` | `M0,399H246.67V147H493.33V273H740V21` | **1** |
| `vh` | `M0,399V147H246.67V273H493.33V21H740` | **1** |
| `hvh` | `M0,399H123.34V147H246.67H370V273H493.33H616.67V21H740` | **1** |
| `linear` | `M0,399L246.67,147L493.33,273L740,21` | 4 |
| `spline` | `M0,399Q158.85,161.34 246.67,147C…493.33,273Q581.15,258.66 740,21` | **2** |

With one vertex against four samples, `stepDataVertices` matches neither shape, `reconcilePathCoordinates` pads with `NaN`, `mapViaPathParsing` drops the series, and `mapToSvgElements` returns `null`. Confirmed by driving the real path strings through `StepTrace`:

```
LINEAR  highlightValues: [4]   circles: [(0,399), (246.67,147), (493.33,273), (740,21)]
HV      highlightValues: null  circles: [(0,399)]
```

Correct audio, correct braille, correct text, **no highlight, and nothing anywhere saying why** — the same silent class as py-maidr#400 and #412.

## The fix

Walk the path, tracking the current point, and take each drawing command's endpoint. That reaches `H`/`V`/`Q`/`S`/`T` and the relative forms in one pass, and `M`/`L`/`C` behave exactly as they did — a cubic still contributes its endpoint alone.

Arcs stay unread on purpose. Their flag arguments are legally written without separators (`a1 1 0 011 1` is three flags and a coordinate pair), so a plain number scan mis-tokenizes them and would push invented vertices. Line-family geometry never contains one.

Parsing more surfaced two consequences that had to be handled, or `hvh` would have gone from *no* highlight to a *wrong* one — which is worse, because a wrong highlight is believed:

**Redundant collinear vertices.** Plotly splits a `mid` staircase's horizontal runs into consecutive same-direction moves — `…H246.67H370…` with no `V` between — giving 10 vertices where the convention has `2N = 8`. Collapsing vertices that only continue an axis-aligned run recovers it.

This runs **as a fallback, never as a first pass**, and that ordering is load-bearing. A step chart holds its value across an interval, so two equal samples put three consecutive vertices on one horizontal line in a path that is *already* exactly `2N - 1`; collapsing first would drop the middle one and break a path that was right. `a well-formed staircase with a flat run is left alone` pins it.

The collapse also requires the middle vertex to lie *between* its neighbours, not merely on their line. `vhv` goes out along an axis and comes back, so its middle vertex shares an x with both while sitting outside their span — dropping it would erase a corner the renderer drew.

**The area baseline test.** `AreaTrace` dropped a stepped band's return journey when the path was "longer than a top edge" (`> 2N - 1`). A `mid` edge is `2N`, already longer than an `hv` one, so that fired on a path with **no baseline at all** and sliced away real samples. Since Plotly strokes the edge as its own `path.js-line`, that is the common case, not the exotic one. Now matched by exact count: a closed staircase is `3N - 1` (`hv`/`vh`) or `3N` (`mid`).

## Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass: **284 unit suites / 4187 tests, 7 ESM suites / 73 tests**, plus 18 new tests in `test/model/pathCommands.test.ts`. Every `d` attribute in that file was read out of Chromium from real Plotly.js output rather than hand-written.

Falsification — each mechanism reverted in turn, and the tests that should fail do:

| reverted | failures |
|---|---|
| parser back to the original two regexes | **15 of 18** (the 3 survivors are the `M`/`L`/`C` pins, as intended) |
| collapse fallback removed | **2** — both `mid` cases |
| baseline rule back to `> 2N - 1` | **1** — the `mid` bare-edge band |

## Follow-on

This unblocks the highlight half of py-maidr#413: a stepped area could not have highlighted correctly no matter what the producer emitted, because its geometry never survived parsing. The producer change there is separate and small.

The `spline` row above is fixed as a by-product — quadratics were as invisible as `H`/`V`, so a Plotly spline's highlights were interpolated along a chord instead of sitting on the samples.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_