### PR TITLE
fix(trace): answer empty rather than throwing when the cursor has no point

### DIFF
--- a/src/model/abstract.ts
+++ b/src/model/abstract.ts
@@ -472,6 +472,23 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
   }
 
   /**
+   * Whether the cursor has no point to report.
+   *
+   * Read from {@link dimension} rather than from any one trace's data,
+   * because that is the one shape every trace already answers in. It is also
+   * evaluated *at the cursor* — `LineTrace` returns the current series'
+   * length as `cols` — so this covers a ragged layer, where one series has
+   * points and another has none, and not only a layer that is empty
+   * throughout.
+   *
+   * @returns True when there is nothing at `(row, col)` to describe
+   */
+  protected get isEmptyAtCursor(): boolean {
+    const { rows, cols } = this.dimension;
+    return rows <= 0 || cols <= 0;
+  }
+
+  /**
    * Gets the current state of the trace including audio, braille, text, and highlight information.
    * @returns The current TraceState
    */
@@ -489,6 +506,21 @@ export abstract class AbstractTrace extends AbstractPlot<TraceState> implements 
         },
         warning: true,
       };
+    }
+    // Answer "nothing here" rather than describing a point that does not
+    // exist. Every populated branch below reaches `points[row][col]` through
+    // one accessor or another -- `LineTrace.text` reads `point.z`,
+    // `BarTrace`'s reads `point.x` -- and none of them guards the point
+    // itself, so an empty series threw a TypeError. That throw leaves trace
+    // construction, propagates out of `new Figure(...)`, and takes the whole
+    // render with it, so one malformed layer silences a figure that is
+    // otherwise fine (#905).
+    //
+    // Guarded here rather than in each accessor because this is the single
+    // funnel they are all reached through, and because a producer can always
+    // emit an empty series -- the core cannot assume otherwise.
+    if (this.isEmptyAtCursor) {
+      return this.outOfBoundsState;
     }
     return {
       empty: false,

--- a/test/model/emptySeriesState.test.ts
+++ b/test/model/emptySeriesState.test.ts
@@ -91,7 +91,7 @@ describe('a ragged layer', () => {
 
   test('the empty series reports empty rather than throwing', () => {
     const trace = raggedTrace();
-    (trace as unknown as { row: number }).row = 1;
+    trace.row = 1;
 
     expect(() => trace.state).not.toThrow();
     expect(trace.state.empty).toBe(true);
@@ -101,12 +101,11 @@ describe('a ragged layer', () => {
     // The guard must not latch: an empty row is a fact about where the
     // cursor is, not about the trace.
     const trace = raggedTrace();
-    const cursor = trace as unknown as { row: number };
 
-    cursor.row = 1;
+    trace.row = 1;
     expect(trace.state.empty).toBe(true);
 
-    cursor.row = 0;
+    trace.row = 0;
     expect(trace.state.empty).toBe(false);
   });
 });

--- a/test/model/emptySeriesState.test.ts
+++ b/test/model/emptySeriesState.test.ts
@@ -1,0 +1,155 @@
+/**
+ * A layer with an empty series threw as soon as its state was read (#905).
+ *
+ * Every populated branch of `AbstractTrace.state` reaches `points[row][col]`
+ * through one accessor or another — `LineTrace.text` reads `point.z`,
+ * `BarTrace`'s reads `point.x` — and none of them guarded the *point* itself.
+ * The optional chaining stopped one step short: `this.points[this.row]?.[this.col]`
+ * yields `undefined` for an empty series, and the property read off it threw.
+ *
+ * The blast radius is what makes it worth a test rather than a shrug. A throw
+ * out of trace construction propagates out of `new Figure(...)`, so one
+ * malformed layer takes the whole render with it rather than degrading to one
+ * silent layer — the same outcome `rules/model.md` describes for an
+ * unregistered trace type.
+ *
+ * A producer can always emit an empty series; py-maidr did, for a subplot
+ * whose only trace had nothing to plot (xability/py-maidr#421). The core
+ * cannot assume the producer got it right.
+ */
+import type { Maidr, MaidrLayer } from '@type/grammar';
+import { describe, expect, jest, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { Figure } from '@model/plot';
+import { TraceType } from '@type/grammar';
+
+jest.mock('hotkeys-js', () => ({
+  __esModule: true,
+  default: { setScope: jest.fn() },
+}));
+
+/**
+ * Build a layer of the given type over the given data.
+ * @param type - The trace type to author
+ * @param data - The layer's data, in that type's own shape
+ * @returns A layer definition
+ */
+function layer(type: TraceType, data: unknown): MaidrLayer {
+  return {
+    id: 'empty-layer',
+    type,
+    title: 'Measurement',
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  } as MaidrLayer;
+}
+
+/** Two points, so a populated series can be told from an empty one. */
+const POINTS = [{ x: 1, y: 1 }, { x: 2, y: 2 }];
+
+describe('a trace with nothing at the cursor', () => {
+  test('the reproduction from the issue answers instead of throwing', () => {
+    const trace = TraceFactory.create(layer(TraceType.LINE, [[]]));
+
+    expect(() => trace.state).not.toThrow();
+    expect(trace.state.empty).toBe(true);
+  });
+
+  test.each([
+    ['line', TraceType.LINE, [[]]],
+    ['smooth', TraceType.SMOOTH, [[]]],
+    ['step', TraceType.STEP, [[]]],
+    ['area', TraceType.AREA, [[]]],
+    // Not a line at all, and it threw on `point.x` rather than `point.z` —
+    // the same defect through a different accessor, which is why the guard
+    // sits at the one funnel they share rather than in `LineTrace`.
+    ['bar', TraceType.BAR, []],
+  ])('a %s layer with no points reports empty', (_name, type, data) => {
+    const trace = TraceFactory.create(layer(type, data));
+
+    expect(() => trace.state).not.toThrow();
+    expect(trace.state.empty).toBe(true);
+  });
+});
+
+describe('a ragged layer', () => {
+  /**
+   * One series with points and one without — the shape a producer emits when
+   * a group has no data for the range, and the reason the guard is read at
+   * the cursor rather than off the layer as a whole.
+   * @returns The trace
+   */
+  function raggedTrace(): ReturnType<typeof TraceFactory.create> {
+    return TraceFactory.create(layer(TraceType.LINE, [POINTS, []]));
+  }
+
+  test('the series with points is still described', () => {
+    const trace = raggedTrace();
+
+    expect(trace.state.empty).toBe(false);
+  });
+
+  test('the empty series reports empty rather than throwing', () => {
+    const trace = raggedTrace();
+    (trace as unknown as { row: number }).row = 1;
+
+    expect(() => trace.state).not.toThrow();
+    expect(trace.state.empty).toBe(true);
+  });
+
+  test('moving back to the populated series describes it again', () => {
+    // The guard must not latch: an empty row is a fact about where the
+    // cursor is, not about the trace.
+    const trace = raggedTrace();
+    const cursor = trace as unknown as { row: number };
+
+    cursor.row = 1;
+    expect(trace.state.empty).toBe(true);
+
+    cursor.row = 0;
+    expect(trace.state.empty).toBe(false);
+  });
+});
+
+describe('a figure carrying one empty layer', () => {
+  /**
+   * Build a single-subplot figure from the given layers.
+   * @param layers - The layers the subplot holds
+   * @returns A Maidr config
+   */
+  function maidr(layers: MaidrLayer[]): Maidr {
+    return { id: 'empty-series-test', subplots: [[{ layers }]] };
+  }
+
+  test('still constructs', () => {
+    // The blast radius: a throw here left MAIDR unmounted and the chart
+    // unusable, rather than costing the one layer that was malformed.
+    expect(() =>
+      new Figure(maidr([layer(TraceType.LINE, [[]])])),
+    ).not.toThrow();
+  });
+
+  test('does not take its healthy neighbour down with it', () => {
+    const figure = new Figure(
+      maidr([
+        layer(TraceType.LINE, [POINTS]),
+        layer(TraceType.LINE, [[]]),
+      ]),
+    );
+
+    expect(figure.state.empty).toBe(false);
+  });
+});
+
+describe('a populated trace is unaffected', () => {
+  test('it still reports a full state', () => {
+    // The guard keys off `dimension`, which every trace already answers, so
+    // this pins that reading it changed nothing for the ordinary case.
+    const trace = TraceFactory.create(layer(TraceType.LINE, [POINTS]));
+    const state = trace.state;
+
+    expect(state.empty).toBe(false);
+    expect(state).toHaveProperty('text');
+    expect(state).toHaveProperty('audio');
+  });
+});


### PR DESCRIPTION
Closes #905.

## The defect

Every populated branch of `AbstractTrace.state` reaches `points[row][col]` through one accessor or another, and none of them guarded the *point*. The optional chaining stops one step short — `this.points[this.row]?.[this.col]` is `undefined` for an empty series, and the property read off it throws:

```
TypeError: Cannot read properties of undefined (reading 'z')
  at LineTrace.text   (src/model/line.ts:423)
  at LineTrace.state  (src/model/abstract.ts:507)
```

The issue asked me to check the siblings while I was in there, and that paid out — it is not a `LineTrace` bug:

| type | before |
|---|---|
| `line` / `smooth` / `step` / `area` | throws on `point.z` |
| `bar` | throws on **`point.x`** — same defect, different accessor |
| `point` (scatter) | no throw |

## Why it is worse than one bad layer

A throw out of trace construction propagates out of `new Figure(...)`, so a single malformed layer takes the whole render with it rather than costing the one layer — the outcome `rules/model.md` describes for an unregistered trace type. And a producer can always emit an empty series; py-maidr did, for a subplot whose only trace had nothing to plot (xability/py-maidr#421, guarded on the producer side in py-maidr#422). The core cannot assume the producer got it right.

## The fix

One guard at the single funnel the accessors are reached through:

```ts
if (this.isEmptyAtCursor) {
  return this.outOfBoundsState;
}
```

Keyed off `dimension` rather than off any one trace's data, because that is the one shape every trace already answers in — which is why it covers `bar` and the line family together without touching either.

**It is evaluated at the cursor, and that is load-bearing.** `LineTrace.dimension` reports the *current series'* length as `cols`, so this covers a **ragged** layer — one series with points, another with none, which is what a producer emits when a group has no data for the range — and not only a layer that is empty throughout. Three tests pin that the populated series is still described, the empty one reports empty, and moving back describes the first again (the guard must not latch).

`outOfBoundsState` is the existing `empty: true` shape, so this reaches an answer the codebase already has rather than inventing one.

## Scatter is deliberately untouched

`ScatterTrace.dimension` floors at `Math.max(1, …)` so out-of-bounds audio panning matches the in-bounds geometry. It therefore never reports `cols: 0` and the guard cannot fire — but it also never threw, so nothing here regresses. It does report `empty: false` with `freq.raw: [null]` for an empty layer, which is inconsistent but is a separate question from this crash, and changing its floor would disturb panning that was set that way on purpose. Flagging rather than folding it in.

## Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` clean; **285 unit suites / 4277 tests** and **7 ESM suites / 73 tests** pass, including 12 new ones in `test/model/emptySeriesState.test.ts`. No existing test depended on the throw or on an empty trace reporting `empty: false`.

Falsification — guard removed: **8 of 12 fail**. The 4 survivors are the populated-trace and populated-row cases, which is what they are there to hold still.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_