### PR TITLE
docs(examples): add hand-authored pages for chord, normalized and polar area

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -123,16 +123,20 @@ Use the following to define the object properties:
 
 - `type`: the type of plot. The declarable types are `alluvial`, `area`, `bar`, `box`, `boxen`, `bump`, `candlestick`, `chord`, `choropleth`, `contour`, `diverging_bar`, `dodged_bar`, `dot`, `dumbbell`, `error_bar`, `forest`, `funnel`, `gantt`, `gauge`, `heat`, `hexbin`, `hist`, `icicle`, `line`, `lollipop`, `manhattan`, `mosaic`, `network`, `parallel_coordinates`, `pie`, `point`, `polar_area`, `radar`, `ridgeline`, `sankey`, `smooth`, `stacked_area`, `stacked_bar`, `stacked_normalized_area`, `stacked_normalized_bar`, `step`, `sunburst`, `survival`, `treemap`, `violin_box`, `violin_kde`, `volcano`, `waterfall`, `word_cloud`. `TraceType` in `src/type/grammar.ts` is the source of truth; `candlestick_delta` appears there but is built at runtime from a candlestick and a reference line, so it is not something a page declares.
 
-> **`candlestick_delta` has no example page, on purpose.** Every declarable
-> trace type above has a hand-authored example under `examples/` that carries
-> its schema literally in a `maidr='{...}'` attribute. `candlestick_delta` has
-> none and should never be given one: it is a reading mode the model derives at
-> runtime from a `candlestick` layer (`src/model/candlestickDelta.ts`, reached
-> with Alt+L), not a value a page declares. `TraceFactory.create` in
-> `src/model/factory.ts` has no case for it, so a layer declaring it throws
+> **`candlestick_delta` has no example page, on purpose.** It should never be
+> given one: it is a reading mode the model derives at runtime from a
+> `candlestick` layer (`src/model/candlestickDelta.ts`, reached with Alt+L), not
+> a value a page declares. `TraceFactory.create` in `src/model/factory.ts` has
+> no case for it, so a layer declaring it throws
 > `Invalid trace type: candlestick_delta` and the figure never binds — an
 > example would document something that does not exist. An audit of example
 > coverage that finds this gap has found the correct state of affairs.
+>
+> It is the only deliberate gap. Other declarable types that lack a
+> hand-authored example are genuinely missing one, and adding it is a normal
+> contribution — at the time of writing that is `alluvial`, `area` and
+> `manhattan`, which appear under `examples/` only as adapter-bound pages where
+> a chart library emits the schema at runtime.
 
 - `id`: the id that you added as an attribute of your main SVG.
 - `title`: the title of the plot. (optional)

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -121,11 +121,19 @@ Or multiple plots:
 
 Use the following to define the object properties:
 
-<<<<<<< HEAD
 - `type`: the type of plot. The declarable types are `alluvial`, `area`, `bar`, `box`, `boxen`, `bump`, `candlestick`, `chord`, `choropleth`, `contour`, `diverging_bar`, `dodged_bar`, `dot`, `dumbbell`, `error_bar`, `forest`, `funnel`, `gantt`, `gauge`, `heat`, `hexbin`, `hist`, `icicle`, `line`, `lollipop`, `manhattan`, `mosaic`, `network`, `parallel_coordinates`, `pie`, `point`, `polar_area`, `radar`, `ridgeline`, `sankey`, `smooth`, `stacked_area`, `stacked_bar`, `stacked_normalized_area`, `stacked_normalized_bar`, `step`, `sunburst`, `survival`, `treemap`, `violin_box`, `violin_kde`, `volcano`, `waterfall`, `word_cloud`. `TraceType` in `src/type/grammar.ts` is the source of truth; `candlestick_delta` appears there but is built at runtime from a candlestick and a reference line, so it is not something a page declares.
-=======
-- `type`: the type of plot. The declarable types are `alluvial`, `area`, `bar`, `box`, `boxen`, `bump`, `candlestick`, `chord`, `choropleth`, `contour`, `diverging_bar`, `dodged_bar`, `dot`, `dumbbell`, `error_bar`, `forest`, `funnel`, `gantt`, `gauge`, `heat`, `hexbin`, `hist`, `icicle`, `line`, `lollipop`, `manhattan`, `mosaic`, `parallel_coordinates`, `pie`, `point`, `polar_area`, `radar`, `ridgeline`, `sankey`, `smooth`, `stacked_area`, `stacked_bar`, `stacked_normalized_area`, `stacked_normalized_bar`, `step`, `sunburst`, `survival`, `treemap`, `violin_box`, `violin_kde`, `volcano`, `waterfall`, `word_cloud`. `TraceType` in `src/type/grammar.ts` is the source of truth; `candlestick_delta` appears there but is built at runtime from a candlestick and a reference line, so it is not something a page declares.
->>>>>>> 97ef5574 (fix(choropleth): let the border walk be entered leftwards)
+
+> **`candlestick_delta` has no example page, on purpose.** Every declarable
+> trace type above has a hand-authored example under `examples/` that carries
+> its schema literally in a `maidr='{...}'` attribute. `candlestick_delta` has
+> none and should never be given one: it is a reading mode the model derives at
+> runtime from a `candlestick` layer (`src/model/candlestickDelta.ts`, reached
+> with Alt+L), not a value a page declares. `TraceFactory.create` in
+> `src/model/factory.ts` has no case for it, so a layer declaring it throws
+> `Invalid trace type: candlestick_delta` and the figure never binds — an
+> example would document something that does not exist. An audit of example
+> coverage that finds this gap has found the correct state of affairs.
+
 - `id`: the id that you added as an attribute of your main SVG.
 - `title`: the title of the plot. (optional)
 - `axes`: axes info for your plot. Each axis is a per-axis object: `maidr.axes.x`, `maidr.axes.y`, and (when used) `maidr.axes.z`. Supported properties per axis: `label` (string), `min` / `max` (number bounds), `tickStep` (number), and `format` (an `AxisFormat` object controlling numeric / categorical rendering). `label` is optional and defaults to `X`, `Y`, or `Level` for the respective axis. Bare string values for axes are no longer accepted.

--- a/examples/chord.html
+++ b/examples/chord.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Chord Diagram Example — Trade Between Regions</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A chord diagram is a weighted graph drawn around a circle. It carries
+        exactly what a SANKEY carries -- source, target, value, one entry per
+        ribbon -- and shares its trace class, so following a ribbon works the
+        same way:
+
+          right  follows the largest flow OUT of this node
+          left   follows the largest flow IN, back the other way
+          up/down  walk the other nodes
+
+        What makes it a type of its own is that IT IS CYCLIC. Every region
+        here both sends and receives, and Americas to Europe sits alongside
+        Europe to Americas, so there is no left-to-right budget and no order
+        the nodes could be layered in. A sankey's stage assignment is a longest
+        path from a source, and this graph has no source: the assignment does
+        not sort, so every node goes in ONE STAGE. That is the honest answer --
+        a partial layering would put some ribbons in a direction the data does
+        not support -- and the ribbons still follow, which is what the chart is
+        read for.
+
+        You can hear the cycle. Right takes the widest ribbon out of the node
+        it is on, and here that is Americas to Europe to Asia to Africa and
+        back to the Americas -- four presses and you are where you started,
+        which on a sankey could never happen.
+
+        THE PAIRS ARE THE POINT. Asia sends 28 to Africa and receives 8, a net
+        outflow of 20 that neither number states on its own; a reading that
+        gave only node totals would lose the direction the whole diagram is
+        drawn to show.
+
+        `selectors` is ONE ENTRY PER FLOW, in declared order, because a ribbon
+        is what the chart draws -- the nodes are the gaps between them. Twelve
+        flows, twelve `path` ids. A list of a different length resolves to
+        nothing and the layer silently loses its highlight.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="460pt" viewBox="0 0 720 460" version="1.1"
+        id="chord-trade" maidr='{&#10;  &quot;id&quot;: &quot;chord-trade&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;chord-trade-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;chord-trade-layer&quot;,&#10;            &quot;type&quot;: &quot;chord&quot;,&#10;            &quot;title&quot;: &quot;Trade Between Regions&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Region&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Billions of dollars&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: [&#10;              &quot;path[id=&#x27;chord-ribbon-0&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-1&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-2&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-3&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-4&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-5&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-6&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-7&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-8&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-9&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-10&#x27;]&quot;,&#10;              &quot;path[id=&#x27;chord-ribbon-11&#x27;]&quot;&#10;            ],&#10;            &quot;data&quot;: [&#10;              {&#10;                &quot;source&quot;: &quot;Americas&quot;,&#10;                &quot;target&quot;: &quot;Europe&quot;,&#10;                &quot;value&quot;: 34&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Europe&quot;,&#10;                &quot;target&quot;: &quot;Americas&quot;,&#10;                &quot;value&quot;: 22&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Americas&quot;,&#10;                &quot;target&quot;: &quot;Asia&quot;,&#10;                &quot;value&quot;: 26&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Asia&quot;,&#10;                &quot;target&quot;: &quot;Americas&quot;,&#10;                &quot;value&quot;: 24&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Americas&quot;,&#10;                &quot;target&quot;: &quot;Africa&quot;,&#10;                &quot;value&quot;: 9&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Africa&quot;,&#10;                &quot;target&quot;: &quot;Americas&quot;,&#10;                &quot;value&quot;: 15&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Europe&quot;,&#10;                &quot;target&quot;: &quot;Asia&quot;,&#10;                &quot;value&quot;: 30&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Asia&quot;,&#10;                &quot;target&quot;: &quot;Europe&quot;,&#10;                &quot;value&quot;: 19&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Europe&quot;,&#10;                &quot;target&quot;: &quot;Africa&quot;,&#10;                &quot;value&quot;: 12&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Africa&quot;,&#10;                &quot;target&quot;: &quot;Europe&quot;,&#10;                &quot;value&quot;: 11&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Asia&quot;,&#10;                &quot;target&quot;: &quot;Africa&quot;,&#10;                &quot;value&quot;: 28&#10;              },&#10;              {&#10;                &quot;source&quot;: &quot;Africa&quot;,&#10;                &quot;target&quot;: &quot;Asia&quot;,&#10;                &quot;value&quot;: 8&#10;              }&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 460  L 720 460  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="chord-ribbons">
+          <path id="chord-ribbon-0" d="M 353.5 86.1 A 150.0 150.0 0 0 1 415.7 96.7 Q 360.0 236.0 509.3 250.0 A 150.0 150.0 0 0 1 490.4 310.2 Q 360.0 236.0 353.5 86.1 Z" style="fill: #4c72b0; fill-opacity: 0.45" />
+          <path id="chord-ribbon-1" d="M 490.4 310.2 A 150.0 150.0 0 0 1 465.4 342.7 Q 360.0 236.0 415.7 96.7 A 150.0 150.0 0 0 1 451.3 117.0 Q 360.0 236.0 490.4 310.2 Z" style="fill: #dd8452; fill-opacity: 0.45" />
+          <path id="chord-ribbon-2" d="M 451.3 117.0 A 150.0 150.0 0 0 1 484.5 152.3 Q 360.0 236.0 329.4 382.8 A 150.0 150.0 0 0 1 284.2 365.4 Q 360.0 236.0 451.3 117.0 Z" style="fill: #4c72b0; fill-opacity: 0.45" />
+          <path id="chord-ribbon-3" d="M 284.2 365.4 A 150.0 150.0 0 0 1 249.4 337.3 Q 360.0 236.0 484.5 152.3 A 150.0 150.0 0 0 1 503.6 192.7 Q 360.0 236.0 284.2 365.4 Z" style="fill: #55a868; fill-opacity: 0.45" />
+          <path id="chord-ribbon-4" d="M 503.6 192.7 A 150.0 150.0 0 0 1 507.6 209.0 Q 360.0 236.0 222.1 176.9 A 150.0 150.0 0 0 1 229.6 161.8 Q 360.0 236.0 503.6 192.7 Z" style="fill: #4c72b0; fill-opacity: 0.45" />
+          <path id="chord-ribbon-5" d="M 229.6 161.8 A 150.0 150.0 0 0 1 245.7 138.9 Q 360.0 236.0 507.6 209.0 A 150.0 150.0 0 0 1 510.0 236.9 Q 360.0 236.0 229.6 161.8 Z" style="fill: #c44e52; fill-opacity: 0.45" />
+          <path id="chord-ribbon-6" d="M 465.4 342.7 A 150.0 150.0 0 0 1 419.1 373.9 Q 360.0 236.0 249.4 337.3 A 150.0 150.0 0 0 1 220.0 289.9 Q 360.0 236.0 465.4 342.7 Z" style="fill: #dd8452; fill-opacity: 0.45" />
+          <path id="chord-ribbon-7" d="M 220.0 289.9 A 150.0 150.0 0 0 1 211.3 255.6 Q 360.0 236.0 419.1 373.9 A 150.0 150.0 0 0 1 385.1 383.9 Q 360.0 236.0 220.0 289.9 Z" style="fill: #55a868; fill-opacity: 0.45" />
+          <path id="chord-ribbon-8" d="M 385.1 383.9 A 150.0 150.0 0 0 1 362.8 386.0 Q 360.0 236.0 245.7 138.9 A 150.0 150.0 0 0 1 261.5 122.9 Q 360.0 236.0 385.1 383.9 Z" style="fill: #dd8452; fill-opacity: 0.45" />
+          <path id="chord-ribbon-9" d="M 261.5 122.9 A 150.0 150.0 0 0 1 277.8 110.5 Q 360.0 236.0 362.8 386.0 A 150.0 150.0 0 0 1 342.3 384.9 Q 360.0 236.0 261.5 122.9 Z" style="fill: #c44e52; fill-opacity: 0.45" />
+          <path id="chord-ribbon-10" d="M 211.3 255.6 A 150.0 150.0 0 0 1 213.6 203.5 Q 360.0 236.0 277.8 110.5 A 150.0 150.0 0 0 1 325.7 90.0 Q 360.0 236.0 211.3 255.6 Z" style="fill: #55a868; fill-opacity: 0.45" />
+          <path id="chord-ribbon-11" d="M 325.7 90.0 A 150.0 150.0 0 0 1 340.4 87.3 Q 360.0 236.0 213.6 203.5 A 150.0 150.0 0 0 1 217.5 189.1 Q 360.0 236.0 325.7 90.0 Z" style="fill: #c44e52; fill-opacity: 0.45" />
+            </g>
+            <g id="chord-arcs">
+          <path d="M 353.5 86.1 A 150.0 150.0 0 0 1 510.0 236.9 L 524.0 237.0 A 164.0 164.0 0 0 0 352.8 72.2 Z" style="fill: #4c72b0" />
+          <path d="M 509.3 250.0 A 150.0 150.0 0 0 1 342.3 384.9 L 340.6 398.9 A 164.0 164.0 0 0 0 523.3 251.3 Z" style="fill: #dd8452" />
+          <path d="M 329.4 382.8 A 150.0 150.0 0 0 1 217.5 189.1 L 204.2 184.7 A 164.0 164.0 0 0 0 326.5 396.5 Z" style="fill: #55a868" />
+          <path d="M 222.1 176.9 A 150.0 150.0 0 0 1 340.4 87.3 L 338.6 73.4 A 164.0 164.0 0 0 0 209.3 171.4 Z" style="fill: #c44e52" />
+            </g>
+            <g id="chord-labels">
+          <text x="489.0" y="106.0" style="font: 13px sans-serif; text-anchor: start">Americas</text>
+          <text x="476.9" y="384.7" style="font: 13px sans-serif; text-anchor: start">Europe</text>
+          <text x="198.9" y="333.0" style="font: 13px sans-serif; text-anchor: end">Asia</text>
+          <text x="247.7" y="91.7" style="font: 13px sans-serif; text-anchor: end">Africa</text>
+            </g>
+            <g id="chart-title">
+              <text x="360" y="40" style="font: 16px sans-serif; text-anchor: middle">Trade Between Regions</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/examples/normalized-area.html
+++ b/examples/normalized-area.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR 100% Stacked Area Example — Share of Sessions by Device</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        The same idea as the 100% stacked bar, over a continuous x: each year's
+        bands are SHARES of that year's total, and every column sums to 100.
+
+        Against a plain `stacked_area`, one thing changes and it changes what
+        the chart is for. There the top edge is the running total and carries
+        real information -- revenue grew. Here the top edge is FLAT AT 100 BY
+        CONSTRUCTION and carries none, so all the movement is in the bands: the
+        story is that mobile overtook desktop between 2021 and 2022, not that
+        anything got bigger.
+
+        MAIDR derives the total by summing the series it was given rather than
+        expecting the accumulated edge, so each point announces its own value
+        alongside the stack it sits in -- on a normalized layer the total is
+        100 and the share is the value itself, which is the tell that the
+        columns really do normalise.
+
+        Each band is drawn the way every renderer draws one: out along its top
+        edge through each sample, then back along the edge beneath it, then
+        closed. That is 2N vertices for N samples and only the first N are
+        data; MAIDR keeps those and drops the return journey, so a highlight
+        never lands on a baseline. `selectors` is one entry per band, in
+        declared order, and Desktop -- declared first -- is the band on the
+        BOTTOM of the stack.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="420pt" viewBox="0 0 720 420" version="1.1"
+        id="normalized-area-sessions" maidr='{&#10;  &quot;id&quot;: &quot;normalized-area-sessions&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;normalized-area-sessions-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;normalized-area-sessions-layer&quot;,&#10;            &quot;type&quot;: &quot;stacked_normalized_area&quot;,&#10;            &quot;title&quot;: &quot;Share of Sessions by Device&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Year&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Percent of sessions&quot;&#10;              },&#10;              &quot;z&quot;: {&#10;                &quot;label&quot;: &quot;Device&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: [&#10;              &quot;g[id=&#x27;normalized-area-desktop&#x27;] path&quot;,&#10;              &quot;g[id=&#x27;normalized-area-mobile&#x27;] path&quot;,&#10;              &quot;g[id=&#x27;normalized-area-tablet&#x27;] path&quot;&#10;            ],&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 62,&#10;                  &quot;z&quot;: &quot;Desktop&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2020&quot;,&#10;                  &quot;y&quot;: 55,&#10;                  &quot;z&quot;: &quot;Desktop&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 48,&#10;                  &quot;z&quot;: &quot;Desktop&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2022&quot;,&#10;                  &quot;y&quot;: 42,&#10;                  &quot;z&quot;: &quot;Desktop&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 36,&#10;                  &quot;z&quot;: &quot;Desktop&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2024&quot;,&#10;                  &quot;y&quot;: 31,&#10;                  &quot;z&quot;: &quot;Desktop&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 30,&#10;                  &quot;z&quot;: &quot;Mobile&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2020&quot;,&#10;                  &quot;y&quot;: 37,&#10;                  &quot;z&quot;: &quot;Mobile&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 45,&#10;                  &quot;z&quot;: &quot;Mobile&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2022&quot;,&#10;                  &quot;y&quot;: 52,&#10;                  &quot;z&quot;: &quot;Mobile&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 59,&#10;                  &quot;z&quot;: &quot;Mobile&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2024&quot;,&#10;                  &quot;y&quot;: 65,&#10;                  &quot;z&quot;: &quot;Mobile&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;2019&quot;,&#10;                  &quot;y&quot;: 8,&#10;                  &quot;z&quot;: &quot;Tablet&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2020&quot;,&#10;                  &quot;y&quot;: 8,&#10;                  &quot;z&quot;: &quot;Tablet&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2021&quot;,&#10;                  &quot;y&quot;: 7,&#10;                  &quot;z&quot;: &quot;Tablet&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2022&quot;,&#10;                  &quot;y&quot;: 6,&#10;                  &quot;z&quot;: &quot;Tablet&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2023&quot;,&#10;                  &quot;y&quot;: 5,&#10;                  &quot;z&quot;: &quot;Tablet&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;2024&quot;,&#10;                  &quot;y&quot;: 4,&#10;                  &quot;z&quot;: &quot;Tablet&quot;&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 420  L 720 420  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="grid">
+          <path d="M 90.0 360.0 L 660.0 360.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 90.0 285.0 L 660.0 285.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 90.0 210.0 L 660.0 210.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 90.0 135.0 L 660.0 135.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 90.0 60.0 L 660.0 60.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+            </g>
+            <g id="axis_x">
+          <text x="90.0" y="382.0" style="font: 12px sans-serif; text-anchor: middle">2019</text>
+          <text x="204.0" y="382.0" style="font: 12px sans-serif; text-anchor: middle">2020</text>
+          <text x="318.0" y="382.0" style="font: 12px sans-serif; text-anchor: middle">2021</text>
+          <text x="432.0" y="382.0" style="font: 12px sans-serif; text-anchor: middle">2022</text>
+          <text x="546.0" y="382.0" style="font: 12px sans-serif; text-anchor: middle">2023</text>
+          <text x="660.0" y="382.0" style="font: 12px sans-serif; text-anchor: middle">2024</text>
+            </g>
+            <g id="axis_y">
+          <text x="78.0" y="364.0" style="font: 12px sans-serif; text-anchor: end">0%</text>
+          <text x="78.0" y="289.0" style="font: 12px sans-serif; text-anchor: end">25%</text>
+          <text x="78.0" y="214.0" style="font: 12px sans-serif; text-anchor: end">50%</text>
+          <text x="78.0" y="139.0" style="font: 12px sans-serif; text-anchor: end">75%</text>
+          <text x="78.0" y="64.0" style="font: 12px sans-serif; text-anchor: end">100%</text>
+            </g>
+        <g id="normalized-area-desktop">
+          <path d="M 90.0 174.0 L 204.0 195.0 L 318.0 216.0 L 432.0 234.0 L 546.0 252.0 L 660.0 267.0 L 660.0 360.0 L 546.0 360.0 L 432.0 360.0 L 318.0 360.0 L 204.0 360.0 L 90.0 360.0 Z" style="fill: #4c78a8; fill-opacity: 0.85; stroke: #4c78a8; stroke-width: 1.5" />
+        </g>
+        <g id="normalized-area-mobile">
+          <path d="M 90.0 84.0 L 204.0 84.0 L 318.0 81.0 L 432.0 78.0 L 546.0 75.0 L 660.0 72.0 L 660.0 267.0 L 546.0 252.0 L 432.0 234.0 L 318.0 216.0 L 204.0 195.0 L 90.0 174.0 Z" style="fill: #f58518; fill-opacity: 0.85; stroke: #f58518; stroke-width: 1.5" />
+        </g>
+        <g id="normalized-area-tablet">
+          <path d="M 90.0 60.0 L 204.0 60.0 L 318.0 60.0 L 432.0 60.0 L 546.0 60.0 L 660.0 60.0 L 660.0 72.0 L 546.0 75.0 L 432.0 78.0 L 318.0 81.0 L 204.0 84.0 L 90.0 84.0 Z" style="fill: #54a24b; fill-opacity: 0.85; stroke: #54a24b; stroke-width: 1.5" />
+        </g>
+            <g id="chart-title">
+              <text x="375" y="40" style="font: 16px sans-serif; text-anchor: middle">Share of Sessions by Device</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/examples/normalized-barplot.html
+++ b/examples/normalized-barplot.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR 100% Stacked Bar Example — Share of Signups by Channel</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A 100% stacked bar answers ONE question and deliberately refuses the
+        other. Every column here totals exactly 100, so what a reader can
+        compare is COMPOSITION -- how the mix of channels shifts quarter on
+        quarter -- and what they cannot recover is SIZE. Q1 and Q4 are drawn
+        the same height whether the quarter brought a hundred signups or ten
+        thousand.
+
+        That is the difference from a plain `stacked_bar`, which draws the same
+        segments at their real magnitudes and lets a column's height carry the
+        total. Both are read the same way: a row per series, a column per
+        category, and a SUMMARY ROW MAIDR derives by summing the segments. On a
+        normalized layer that row reads 100 at every column, which is the
+        clearest possible statement of what the chart has normalised away --
+        and a column that does not read 100 is an authoring error the summary
+        row will announce out loud.
+
+        (A mosaic is the type that gives the sizes back: it keeps these
+        proportions and encodes each column's share of the whole in its WIDTH.)
+
+        The rects are emitted BOTTOM SEGMENT FIRST within each column, which is
+        the order a stacked bar's producers draw them and the order MAIDR
+        expects without a `domMapping`: a category's elements are walked from
+        the last data series back to the first. So `Organic`, declared first,
+        is the band at the TOP of each column.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="400pt" viewBox="0 0 720 400" version="1.1"
+        id="normalized-signups" maidr='{&#10;  &quot;id&quot;: &quot;normalized-signups&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;normalized-signups-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;normalized-signups-layer&quot;,&#10;            &quot;type&quot;: &quot;stacked_normalized_bar&quot;,&#10;            &quot;title&quot;: &quot;Share of Signups by Channel&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Quarter&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Percent of signups&quot;&#10;              },&#10;              &quot;z&quot;: {&#10;                &quot;label&quot;: &quot;Channel&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;normalized-segments&#x27;] &gt; rect&quot;,&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;Q1&quot;,&#10;                  &quot;y&quot;: 52,&#10;                  &quot;z&quot;: &quot;Organic&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q2&quot;,&#10;                  &quot;y&quot;: 46,&#10;                  &quot;z&quot;: &quot;Organic&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q3&quot;,&#10;                  &quot;y&quot;: 41,&#10;                  &quot;z&quot;: &quot;Organic&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q4&quot;,&#10;                  &quot;y&quot;: 37,&#10;                  &quot;z&quot;: &quot;Organic&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;Q1&quot;,&#10;                  &quot;y&quot;: 30,&#10;                  &quot;z&quot;: &quot;Referral&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q2&quot;,&#10;                  &quot;y&quot;: 33,&#10;                  &quot;z&quot;: &quot;Referral&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q3&quot;,&#10;                  &quot;y&quot;: 34,&#10;                  &quot;z&quot;: &quot;Referral&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q4&quot;,&#10;                  &quot;y&quot;: 32,&#10;                  &quot;z&quot;: &quot;Referral&quot;&#10;                }&#10;              ],&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;Q1&quot;,&#10;                  &quot;y&quot;: 18,&#10;                  &quot;z&quot;: &quot;Paid&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q2&quot;,&#10;                  &quot;y&quot;: 21,&#10;                  &quot;z&quot;: &quot;Paid&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q3&quot;,&#10;                  &quot;y&quot;: 25,&#10;                  &quot;z&quot;: &quot;Paid&quot;&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;Q4&quot;,&#10;                  &quot;y&quot;: 31,&#10;                  &quot;z&quot;: &quot;Paid&quot;&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 400  L 720 400  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="grid">
+          <path d="M 110.0 340.0 L 660.0 340.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 110.0 270.0 L 660.0 270.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 110.0 200.0 L 660.0 200.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 110.0 130.0 L 660.0 130.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+          <path d="M 110.0 60.0 L 660.0 60.0 " style="stroke: #dddddd; stroke-width: 0.8" />
+            </g>
+            <g id="normalized-segments">
+          <rect x="137.5" y="289.6" width="82.5" height="50.4" style="fill: #55a868" />
+          <rect x="137.5" y="205.6" width="82.5" height="84.0" style="fill: #dd8452" />
+          <rect x="137.5" y="60.0" width="82.5" height="145.6" style="fill: #4c72b0" />
+          <rect x="275.0" y="281.2" width="82.5" height="58.8" style="fill: #55a868" />
+          <rect x="275.0" y="188.8" width="82.5" height="92.4" style="fill: #dd8452" />
+          <rect x="275.0" y="60.0" width="82.5" height="128.8" style="fill: #4c72b0" />
+          <rect x="412.5" y="270.0" width="82.5" height="70.0" style="fill: #55a868" />
+          <rect x="412.5" y="174.8" width="82.5" height="95.2" style="fill: #dd8452" />
+          <rect x="412.5" y="60.0" width="82.5" height="114.8" style="fill: #4c72b0" />
+          <rect x="550.0" y="253.2" width="82.5" height="86.8" style="fill: #55a868" />
+          <rect x="550.0" y="163.6" width="82.5" height="89.6" style="fill: #dd8452" />
+          <rect x="550.0" y="60.0" width="82.5" height="103.6" style="fill: #4c72b0" />
+            </g>
+            <g id="axis_x">
+          <text x="178.8" y="362.0" style="font: 13px sans-serif; text-anchor: middle">Q1</text>
+          <text x="316.2" y="362.0" style="font: 13px sans-serif; text-anchor: middle">Q2</text>
+          <text x="453.8" y="362.0" style="font: 13px sans-serif; text-anchor: middle">Q3</text>
+          <text x="591.2" y="362.0" style="font: 13px sans-serif; text-anchor: middle">Q4</text>
+              <text x="385.0" y="384.0" style="font: 13px sans-serif; text-anchor: middle">Quarter</text>
+            </g>
+            <g id="axis_y">
+          <text x="98.0" y="344.0" style="font: 12px sans-serif; text-anchor: end">0%</text>
+          <text x="98.0" y="274.0" style="font: 12px sans-serif; text-anchor: end">25%</text>
+          <text x="98.0" y="204.0" style="font: 12px sans-serif; text-anchor: end">50%</text>
+          <text x="98.0" y="134.0" style="font: 12px sans-serif; text-anchor: end">75%</text>
+          <text x="98.0" y="64.0" style="font: 12px sans-serif; text-anchor: end">100%</text>
+            </g>
+            <g id="chart-title">
+              <text x="385.0" y="40" style="font: 16px sans-serif; text-anchor: middle">Share of Signups by Channel</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/examples/polar-area.html
+++ b/examples/polar-area.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>MAIDR Polar Area Example — Wind Hours by Direction</title>
+</head>
+
+<body>
+  <div>
+    <link rel="stylesheet" href="../dist/maidr.css" />
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <div>
+      <!--
+        A polar area -- a coxcomb, or a rose -- puts its categories around a
+        circle and draws each value as a WEDGE whose radius is the magnitude.
+        A wind rose is the case the mark is made for: the categories are
+        compass directions, so their arrangement around the circle is the data
+        rather than a layout choice.
+
+        It shares its trace with RADAR, and the difference between the two is
+        entirely in the mark. A radar joins the spoke values into a closed
+        outline; a polar area fills a wedge out to each one. A reader navigates
+        the same thing either way -- a spoke and a value -- so the two differ
+        in what the chart is called and in nothing that is read.
+
+        What both get, and a row of bars does not, is that THE STEREO POSITION
+        FOLLOWS THE SPOKE'S ANGLE rather than its index: 12 o'clock centre, 3
+        o'clock hard right, 6 o'clock centre again, 9 o'clock hard left.
+        Sweeping the eight directions goes out and comes back, which is what a
+        circle sounds like. Here that is literal -- panning right IS wind from
+        the east.
+
+        The data is a multi-line layer's, so it nests: one row per series, one
+        entry per spoke. A coxcomb is usually the single-series case, which is
+        `[[...]]` -- one row -- and not a flat array. `selectors` is one entry
+        per series, and this one selector matches the eight wedges of the one
+        series it names.
+      -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="720pt" height="460pt" viewBox="0 0 720 460" version="1.1"
+        id="polar-area-wind" maidr='{&#10;  &quot;id&quot;: &quot;polar-area-wind&quot;,&#10;  &quot;subplots&quot;: [&#10;    [&#10;      {&#10;        &quot;id&quot;: &quot;polar-area-wind-subplot&quot;,&#10;        &quot;layers&quot;: [&#10;          {&#10;            &quot;id&quot;: &quot;polar-area-wind-layer&quot;,&#10;            &quot;type&quot;: &quot;polar_area&quot;,&#10;            &quot;title&quot;: &quot;Wind Hours by Direction&quot;,&#10;            &quot;axes&quot;: {&#10;              &quot;x&quot;: {&#10;                &quot;label&quot;: &quot;Direction&quot;&#10;              },&#10;              &quot;y&quot;: {&#10;                &quot;label&quot;: &quot;Hours&quot;&#10;              }&#10;            },&#10;            &quot;selectors&quot;: &quot;g[id=&#x27;polar-wedges&#x27;] &gt; path&quot;,&#10;            &quot;data&quot;: [&#10;              [&#10;                {&#10;                  &quot;x&quot;: &quot;N&quot;,&#10;                  &quot;y&quot;: 42&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;NE&quot;,&#10;                  &quot;y&quot;: 28&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;E&quot;,&#10;                  &quot;y&quot;: 15&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;SE&quot;,&#10;                  &quot;y&quot;: 22&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;S&quot;,&#10;                  &quot;y&quot;: 61&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;SW&quot;,&#10;                  &quot;y&quot;: 78&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;W&quot;,&#10;                  &quot;y&quot;: 54&#10;                },&#10;                {&#10;                  &quot;x&quot;: &quot;NW&quot;,&#10;                  &quot;y&quot;: 33&#10;                }&#10;              ]&#10;            ]&#10;          }&#10;        ]&#10;      }&#10;    ]&#10;  ]&#10;}'>
+        <g id="figure_1">
+          <g id="figure-background">
+            <path d="M 0 460  L 720 460  L 720 0  L 0 0  z " style="fill: #ffffff" />
+          </g>
+          <g id="axes_1">
+            <g id="polar-grid">
+            <circle cx="360.0" cy="236.0" r="37.5" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            <circle cx="360.0" cy="236.0" r="75.0" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            <circle cx="360.0" cy="236.0" r="112.5" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            <circle cx="360.0" cy="236.0" r="150.0" style="fill: none; stroke: #d9d9d9; stroke-width: 1" />
+            </g>
+            <g id="polar-wedges">
+          <path d="M 360.0 236.0 L 329.9 163.2 A 78.8 78.8 0 0 1 390.1 163.2 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+          <path d="M 360.0 236.0 L 380.1 187.5 A 52.5 52.5 0 0 1 408.5 215.9 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+          <path d="M 360.0 236.0 L 386.0 225.2 A 28.1 28.1 0 0 1 386.0 246.8 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+          <path d="M 360.0 236.0 L 398.1 251.8 A 41.2 41.2 0 0 1 375.8 274.1 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+          <path d="M 360.0 236.0 L 403.8 341.7 A 114.4 114.4 0 0 1 316.2 341.7 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+          <path d="M 360.0 236.0 L 304.0 371.1 A 146.2 146.2 0 0 1 224.9 292.0 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+          <path d="M 360.0 236.0 L 266.5 274.7 A 101.2 101.2 0 0 1 266.5 197.3 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+          <path d="M 360.0 236.0 L 302.8 212.3 A 61.9 61.9 0 0 1 336.3 178.8 Z" style="fill: #4c72b0; fill-opacity: 0.55; stroke: #ffffff; stroke-width: 1" />
+            </g>
+            <g id="spoke-labels">
+            <text x="360.0" y="64.0" style="font: 12px sans-serif; text-anchor: middle">N</text>
+            <text x="484.5" y="115.5" style="font: 12px sans-serif; text-anchor: middle">NE</text>
+            <text x="536.0" y="240.0" style="font: 12px sans-serif; text-anchor: middle">E</text>
+            <text x="484.5" y="364.5" style="font: 12px sans-serif; text-anchor: middle">SE</text>
+            <text x="360.0" y="416.0" style="font: 12px sans-serif; text-anchor: middle">S</text>
+            <text x="235.5" y="364.5" style="font: 12px sans-serif; text-anchor: middle">SW</text>
+            <text x="184.0" y="240.0" style="font: 12px sans-serif; text-anchor: middle">W</text>
+            <text x="235.5" y="115.5" style="font: 12px sans-serif; text-anchor: middle">NW</text>
+            </g>
+            <g id="chart-title">
+              <text x="360" y="40" style="font: 16px sans-serif; text-anchor: middle">Wind Hours by Direction</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
# Pull Request

## Description

Four trace types had no hand-authored MAIDR JSON example. Their only coverage was adapter-bound — the chart library renders and the adapter emits the type at runtime — so nothing in the page showed an author what the schema looks like. This adds one page each for `chord`, `stacked_normalized_bar`, `stacked_normalized_area` and `polar_area`, following the conventions of the existing hand-authored set (`area.html`, `dot.html`, `forest.html`, `sankey.html`, `radar.html`): an inline SVG whose element ids the layer's `selectors` actually resolve against, the schema carried literally in an HTML-entity-encoded `maidr='{...}'` attribute, and an opening comment saying what the type is *for* and how it differs from its nearest neighbour.

It also writes down why `candlestick_delta` gets no example, so a future audit of example coverage does not close that gap by inventing one.

## Related Issues

Refs #911 (the gallery-generation half of the issue lands separately, and that PR closes it).

## Changes Made

- **`examples/chord.html`** — twelve weighted flows between four regions, every pair drawn in both directions. The nearest neighbour is `sankey`, which shares the trace class and the `FlowPoint` payload; what makes a chord its own type is that it is cyclic, so the stage assignment does not sort and every node lands in one stage. The values are chosen so that following the widest ribbon out walks Americas → Europe → Asia → Africa → Americas — four presses and you are back where you started, which a sankey cannot do. `selectors` is one entry per flow, in declared order.
- **`examples/normalized-barplot.html`** — `stacked_normalized_bar`, four quarters × three channels, every column totalling 100. The derived summary row announces `Sum` = 100 at every column, which is the clearest statement of what the chart has normalised away. Rects are emitted bottom-segment-first within each column, the order MAIDR expects without a `domMapping`.
- **`examples/normalized-area.html`** — the same idea as bands over a continuous x. Against a plain `stacked_area` the top edge is flat at 100 by construction and carries nothing, so all the movement is in the bands. Each band is drawn as top edge out and baseline back, and MAIDR keeps only the first N vertices.
- **`examples/polar-area.html`** — a wind rose, where the arrangement around the circle genuinely is the data. Shares `RadarTrace` with `radar`; the difference is entirely the mark, and the stereo position follows the spoke's angle rather than its index.
- **`docs/SCHEMA.md`** — a short note beside the trace-type list explaining that `candlestick_delta` has no example on purpose: it is derived at runtime from a `candlestick` layer (`src/model/candlestickDelta.ts`, Alt+L), `TraceFactory.create` has no case for it, and a layer declaring it throws `Invalid trace type: candlestick_delta` rather than binding.

### One change beyond the task

`docs/SCHEMA.md` on `main` carries committed merge-conflict markers (`<<<<<<< HEAD` … `>>>>>>> 97ef5574`) around the `type` bullet — exactly where the note belongs. Placing a note inside a broken conflict block would have produced nonsense, so the markers are resolved, keeping the variant whose list includes `network` (a real declarable type with its own example page). The two sides differed only in that entry. Flagging it here because it is not strictly part of the requested change.

## Screenshots (if applicable)

Not attached. The four pages were checked by rendering them in Chromium; what was verified is listed below rather than shown.

## Verification

All four pages were driven in a real browser (Chromium, `file://`, against a fresh `npm run build`). For each: MAIDR binds with no page errors, the layer reports the declared type, every `selectors` entry resolves, and navigation highlights the element the announcement names.

| Page | Announced type | Selectors resolve | Highlight lands where it should |
|---|---|---|---|
| `chord.html` | `chord` | 12 selectors → 12 ribbons | Each node highlights its widest outgoing ribbon (`ribbon-0`, `-6`, `-10`, `-5` for Americas, Europe, Asia, Africa) |
| `normalized-barplot.html` | `vertical stacked_normalized_bar` | 1 selector → 12 rects | Organic → top rect, Referral → middle, Paid → bottom, checked against each rect's geometry |
| `normalized-area.html` | `100% stacked area with 3 groups` | 3 selectors → 1 path each | Marker sits on the band's own cumulative top edge (62% → y 174, 92% → y 84, 100% → y 60 at 2019) |
| `polar-area.html` | `polar area` | 1 selector → 8 wedges | Each direction highlights its own wedge; box geometry matches the wedge's radius and angle |

Also confirmed on each page: braille renders real cells (one row per series; an unregistered encoder is the one failure that is silent), and the announcements are the ones the type exists to give — the normalized bar's summary row reads 100 at all four quarters, and every normalized-area point reads `Total is 100` with its own value as the share.

The `candlestick_delta` claim in `docs/SCHEMA.md` was checked the same way, with a throwaway page that declared the type: it throws `Invalid trace type: candlestick_delta` and the figure never binds. That probe page was not committed.

Not verified: nothing was checked by ear — sonification and stereo panning were not listened to, only the code path that sets them was read. No e2e specs were added for these pages; the existing suite was not run.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable. — no new code paths; the pages exercise existing traces, and the gallery-coverage test belongs to the sibling PR.

## Additional Notes

Checks run on this branch, all passing: `npm run lint:fix`, `npm run type-check`, `npm run build`, `npm test` (286 suites / 4288 tests, plus 7 suites / 73 tests in the second project). `examples/` and `docs/` are both in eslint's ignore list, so lint neither reformatted nor inspected the new files.

These four pages are not linked from `examples.html`, which is built from a hardcoded list — that is the other half of #911 and is fixed by the sibling PR that generates the gallery from the directory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_