### PR TITLE
fix(docs): generate the examples gallery so it cannot miss a page

### DIFF
--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { marked } from 'marked';
+import { buildGallery, listExamplePages, renderGallery } from './examplesGallery.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -366,7 +367,19 @@ if (fs.existsSync(highchartsMdPath)) {
 }
 
 // Build examples.html (inline gallery content — no middle iframe)
+//
+// The gallery is read off `examples/` rather than listed here. The list that
+// used to live in this file named 88 of the 199 pages in that directory, and
+// nothing failed when the two drifted apart, so the other 111 shipped with the
+// site and were reachable from nothing on it. See scripts/examplesGallery.js.
 console.log('Building examples.html...');
+const { sections, unclaimed } = buildGallery(listExamplePages(path.join(ROOT, 'examples')));
+for (const page of unclaimed) {
+  console.warn(`Warning: examples/${page} is in no gallery group. Add a group for its directory in scripts/examplesGallery.js.`);
+}
+const gallery = renderGallery(sections);
+console.log(`  ${sections.reduce((n, section) => n + section.items.length, 0)} gallery entries in ${sections.length} groups`);
+
 const examplesContent = `
 <style>
   .examples-gallery { padding: 20px; }
@@ -377,166 +390,7 @@ const examplesContent = `
   <h1>MAIDR Examples</h1>
   <h2>Click on one of the examples below to see a demonstration</h2>
 
-  <h3 id="react-examples">React</h3>
-  <ul>
-    <li><a href="#" onclick="loadReact(); return false;">React Examples (Bar, Line, Smooth, D3 Bar, D3 Scatter)</a></li>
-  </ul>
-  <p>See the <a href="react.html">React Integration Guide</a> for setup instructions, TypeScript types, and code examples for all plot types. The D3 examples show how to use <a href="d3.html">the D3 adapter</a> with the <code>&lt;MaidrD3&gt;</code> wrapper.</p>
-
-  <h3>HTML / Vanilla JS</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('barplot.html', 'Barplot'); return false;">Barplot</a></li>
-    <li><a href="#" onclick="loadHTML('candlestick_multilayer.html', 'Candlestick multilayer'); return false;">Candlestick multilayer</a></li>
-    <li><a href="#" onclick="loadHTML('dodged_barplot.html', 'Dodged Barplot'); return false;">Dodged Barplot</a></li>
-    <li><a href="#" onclick="loadHTML('facet_barplot.html', 'Faceted Bar plots'); return false;">Faceted Bar plots</a></li>
-    <li><a href="#" onclick="loadHTML('heatmap.html', 'Heatmap'); return false;">Heatmap</a></li>
-    <li><a href="#" onclick="loadHTML('histogram.html', 'Histogram'); return false;">Histogram</a></li>
-    <li><a href="#" onclick="loadHTML('horizontal-boxplot.html', 'Horizontal box plot'); return false;">Horizontal box plot</a></li>
-    <li><a href="#" onclick="loadHTML('lineplot.html', 'Single Line plot'); return false;">Single Line plot</a></li>
-    <li><a href="#" onclick="loadHTML('multiline_plot.html', 'Multi line plot'); return false;">Multi line plot</a></li>
-    <li><a href="#" onclick="loadHTML('multilayer_plot.html', 'Multi layered plot'); return false;">Multi layered plot</a></li>
-    <li><a href="#" onclick="loadHTML('multipanel.html', 'Multi panel plot'); return false;">Multi panel plot</a></li>
-    <li><a href="#" onclick="loadHTML('scatter_plot.html', 'Scatter plot'); return false;">Scatter plot</a></li>
-    <li><a href="#" onclick="loadHTML('smooth_plot.html', 'Smooth plot'); return false;">Smooth plot</a></li>
-    <li><a href="#" onclick="loadHTML('stacked_bar.html', 'Stacked Bar plot'); return false;">Stacked Bar plot</a></li>
-    <li><a href="#" onclick="loadHTML('stepplot.html', 'Step plot (hypnogram)'); return false;">Step plot (hypnogram)</a></li>
-    <li><a href="#" onclick="loadHTML('vertical-boxplot.html', 'Vertical box plot'); return false;">Vertical box plot</a></li>
-    <li><a href="#" onclick="loadHTML('vertical-candlestick.html', 'Vertical candle stick plot'); return false;">Vertical candle stick plot</a></li>
-    <li><a href="#" onclick="loadHTML('violin.html', 'Violin plot'); return false;">Violin plot</a></li>
-  </ul>
-
-  <h3>Plotly.js</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('plotly-bar.html', 'Plotly Bar Chart'); return false;">Bar Chart</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-scatter.html', 'Plotly Scatter Plot'); return false;">Scatter Plot</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-line.html', 'Plotly Line Chart'); return false;">Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-box.html', 'Plotly Box Plot'); return false;">Box Plot</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-violin.html', 'Plotly Violin Plot'); return false;">Violin Plot</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-heatmap.html', 'Plotly Heatmap'); return false;">Heatmap</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-histogram.html', 'Plotly Histogram'); return false;">Histogram</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-candlestick.html', 'Plotly Candlestick'); return false;">Candlestick</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-grouped-bar.html', 'Plotly Grouped Bar'); return false;">Grouped Bar</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-stacked-bar.html', 'Plotly Stacked Bar'); return false;">Stacked Bar</a></li>
-    <li><a href="#" onclick="loadHTML('plotly-pie.html', 'Plotly Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="plotly.html">Plotly.js Integration Guide</a> for setup instructions and code examples for all chart types.</p>
-
-  <h3>Recharts</h3>
-  <ul>
-    <li><a href="#" onclick="loadRecharts(); return false;">Recharts Examples (Bar, Line, Scatter, Stacked, Histogram)</a></li>
-  </ul>
-  <p>See the <a href="recharts.html">Recharts Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.</p>
-
-  <h3>Google Charts</h3>
-  <ul>
-    <li><a href="#" onclick="loadGoogleCharts(); return false;">Google Charts Examples (Bar, Line, Scatter, Stacked, Dodged, Candlestick)</a></li>
-    <li><a href="#" onclick="loadHTML('google-charts-pie.html', 'Google Charts Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="google-charts.html">Google Charts Integration Guide</a> for setup instructions and code examples for all chart types.</p>
-
-  <h3>Chart.js</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('chartjs/bar.html', 'Chart.js Bar Chart'); return false;">Bar Chart</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/line.html', 'Chart.js Line Chart'); return false;">Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/scatter.html', 'Chart.js Scatter Plot'); return false;">Scatter Plot</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/bar-stacked.html', 'Chart.js Stacked Bar'); return false;">Stacked Bar</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/bar-dodged.html', 'Chart.js Dodged Bar'); return false;">Dodged Bar</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/boxplot.html', 'Chart.js Box Plot'); return false;">Box Plot</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/candlestick.html', 'Chart.js Candlestick'); return false;">Candlestick</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/heatmap.html', 'Chart.js Heatmap'); return false;">Heatmap (Matrix)</a></li>
-    <li><a href="#" onclick="loadHTML('chartjs/pie.html', 'Chart.js Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="chartjs.html">Chart.js Integration Guide</a> for setup instructions and code examples for all chart types.</p>
-
-  <h3>Observable Plot &amp; Quarto</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('observable-plain.html', 'Observable Plot on a plain page'); return false;">Plain page &mdash; bar, scatter, stacked bar, and a chart redrawn on demand</a></li>
-    <li><a href="#" onclick="loadHTML('observable-quarto.html', 'Observable Plot in a Quarto document'); return false;">Quarto OJS cells (bar, scatter, line, histogram, facets)</a></li>
-  </ul>
-  <p>The two differ only in how the scripts reach the page &mdash; the adapter is the same and neither asks you to change the code that draws the chart. See the <a href="observable.html">Observable Plot &amp; Quarto Integration Guide</a> for both, including the Quarto extension.</p>
-
-  <h3>Frappe Charts</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('frappe-bar.html', 'Frappe Bar Chart'); return false;">Bar Chart</a></li>
-    <li><a href="#" onclick="loadHTML('frappe-line.html', 'Frappe Line Chart'); return false;">Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('frappe-multiline.html', 'Frappe Multi-Line Chart'); return false;">Multi-Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('frappe-scatter.html', 'Frappe Scatter Plot'); return false;">Scatter Plot</a></li>
-    <li><a href="#" onclick="loadHTML('frappe-mixed.html', 'Frappe Mixed Axis Chart'); return false;">Mixed Axis (Bar + Line)</a></li>
-    <li><a href="#" onclick="loadHTML('frappe-pie.html', 'Frappe Pie Chart'); return false;">Pie / Donut</a></li>
-  </ul>
-  <p>See the <a href="frappe.html">Frappe Charts Integration Guide</a> for setup instructions and code examples for all chart types.</p>
-
-  <h3>D3.js</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('d3-bindbar.html', 'D3 Bar Chart'); return false;">Bar Chart</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindline.html', 'D3 Line Chart'); return false;">Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindscatter.html', 'D3 Scatter Plot'); return false;">Scatter Plot</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindbox.html', 'D3 Box Plot'); return false;">Box Plot</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindheatmap.html', 'D3 Heatmap'); return false;">Heatmap</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindhistogram.html', 'D3 Histogram'); return false;">Histogram</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindcandlestick.html', 'D3 Candlestick'); return false;">Candlestick</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindstacked.html', 'D3 Stacked Bar'); return false;">Stacked Bar</a></li>
-    <li><a href="#" onclick="loadHTML('d3-binddodged.html', 'D3 Dodged Bar'); return false;">Dodged Bar</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindsmooth.html', 'D3 Smooth Curve'); return false;">Smooth Curve</a></li>
-    <li><a href="#" onclick="loadHTML('d3-bindpie.html', 'D3 Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="d3.html">D3.js Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.</p>
-
-  <h3>Vega-Lite</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('vegalite-bindbar.html', 'Vega-Lite Bar Chart'); return false;">Bar Chart</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-bindstacked.html', 'Vega-Lite Stacked Bar'); return false;">Stacked Bar</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-binddodged.html', 'Vega-Lite Dodged Bar'); return false;">Dodged Bar</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-bindnormalized.html', 'Vega-Lite Normalized Bar'); return false;">Normalized Bar</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-bindhistogram.html', 'Vega-Lite Histogram'); return false;">Histogram</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-bindline.html', 'Vega-Lite Line Chart'); return false;">Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-bindscatter.html', 'Vega-Lite Scatter Plot'); return false;">Scatter Plot</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-bindheatmap.html', 'Vega-Lite Heatmap'); return false;">Heatmap</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-bindbox.html', 'Vega-Lite Box Plot'); return false;">Box Plot</a></li>
-    <li><a href="#" onclick="loadHTML('vegalite-pie.html', 'Vega-Lite Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="vegalite.html">Vega-Lite Integration Guide</a> for setup instructions and code examples for all chart types.</p>
-
-  <h3>amCharts 5</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('amcharts.html', 'amCharts 5 Examples'); return false;">amCharts 5 Examples (Bar, Dodged, Stacked, Normalized, Line, Histogram, Heatmap)</a></li>
-    <li><a href="#" onclick="loadHTML('amcharts-pie.html', 'amCharts 5 Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="amcharts.html">amCharts 5 Integration Guide</a> for setup instructions and code examples for all chart types.</p>
-
-  <h3>Victory</h3>
-  <ul>
-    <li><a href="#" onclick="loadVictory(); return false;">Victory Examples (Bar, Line, Scatter, Stacked, Histogram, Box, Candlestick)</a></li>
-  </ul>
-  <p>See the <a href="victory.html">Victory Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.</p>
-
-  <h3>AnyChart</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('anychart/bar.html', 'AnyChart Bar Chart'); return false;">Bar Chart</a></li>
-    <li><a href="#" onclick="loadHTML('anychart/line.html', 'AnyChart Line Chart'); return false;">Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('anychart/scatter.html', 'AnyChart Scatter Plot'); return false;">Scatter Plot</a></li>
-    <li><a href="#" onclick="loadHTML('anychart/box.html', 'AnyChart Box Plot'); return false;">Box Plot</a></li>
-    <li><a href="#" onclick="loadHTML('anychart/heatmap.html', 'AnyChart Heatmap'); return false;">Heatmap</a></li>
-    <li><a href="#" onclick="loadHTML('anychart/candlestick.html', 'AnyChart Candlestick'); return false;">Candlestick</a></li>
-    <li><a href="#" onclick="loadHTML('anychart/pie.html', 'AnyChart Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="anychart.html">AnyChart Integration Guide</a> for setup instructions and code examples for all chart types.</p>
-
-  <h3>Highcharts</h3>
-  <ul>
-    <li><a href="#" onclick="loadHTML('highcharts-bar.html', 'Highcharts Bar Chart'); return false;">Bar Chart</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-line.html', 'Highcharts Line Chart'); return false;">Line Chart</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-scatter.html', 'Highcharts Scatter Plot'); return false;">Scatter Plot</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-box.html', 'Highcharts Box Plot'); return false;">Box Plot</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-heatmap.html', 'Highcharts Heatmap'); return false;">Heatmap</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-histogram.html', 'Highcharts Histogram'); return false;">Histogram</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-candlestick.html', 'Highcharts Candlestick'); return false;">Candlestick</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-stacked.html', 'Highcharts Stacked Bar'); return false;">Stacked Bar</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-dodged.html', 'Highcharts Dodged Bar'); return false;">Dodged Bar</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-normalized.html', 'Highcharts Normalized Bar'); return false;">Normalized Bar</a></li>
-    <li><a href="#" onclick="loadHTML('highcharts-pie.html', 'Highcharts Pie Chart'); return false;">Pie Chart</a></li>
-  </ul>
-  <p>See the <a href="highcharts.html">Highcharts Integration Guide</a> for setup instructions and code examples for all chart types.</p>
+${gallery}
 
   <div id="content" hidden="true">Select an example above.</div>
 </div>
@@ -607,31 +461,6 @@ const examplesContent = `
     iframe.tabIndex = 0;
     iframe.title = 'Victory Examples';
     iframe.setAttribute('aria-label', 'Victory example demonstration');
-
-    var contentDiv = document.getElementById('content');
-    contentDiv.innerHTML = '';
-    contentDiv.appendChild(heading);
-    contentDiv.appendChild(iframe);
-    contentDiv.hidden = false;
-
-    setTimeout(function() { heading.focus(); }, 100);
-  }
-
-  function loadGoogleCharts() {
-    var heading = document.createElement('h2');
-    heading.id = 'example-heading';
-    heading.textContent = 'Google Charts Examples';
-    heading.tabIndex = -1;
-    heading.style.marginTop = '0';
-
-    var iframe = document.createElement('iframe');
-    iframe.src = 'examples/google-charts.html';
-    iframe.style.width = '100%';
-    iframe.style.height = '800px';
-    iframe.style.border = 'none';
-    iframe.tabIndex = 0;
-    iframe.title = 'Google Charts Examples';
-    iframe.setAttribute('aria-label', 'Google Charts example demonstration');
 
     var contentDiv = document.getElementById('content');
     contentDiv.innerHTML = '';

--- a/scripts/examplesGallery.d.ts
+++ b/scripts/examplesGallery.d.ts
@@ -1,0 +1,83 @@
+/**
+ * Hand-written declarations for `examplesGallery.js`.
+ *
+ * The module is plain JS so `scripts/build-site.js` (run directly by node) can
+ * import it; `tsconfig.json` sets `allowJs: false`, so a TypeScript test needs
+ * these to import it too. Keep both files in sync.
+ */
+
+/** A page under `examples/` that is deliberately not a gallery entry. */
+export interface ExcludedExample {
+  /** Path relative to `examples/`, e.g. `recharts/index.html`. */
+  page: string;
+  /** Why it is not a gallery entry. */
+  reason: string;
+}
+
+/** One entry in a gallery section. */
+export interface GalleryItem {
+  /** Path relative to `examples/`; absent on a hand-written entry. */
+  page?: string;
+  /** A hand-written entry's click handler, in place of `loadHTML(...)`. */
+  onclick?: string;
+  /** The link text. */
+  label: string;
+  /** The heading the loaded example is announced under. */
+  heading: string;
+}
+
+/** One integration's section of the gallery. */
+export interface GallerySection {
+  id: string;
+  heading: string;
+  headingId?: string;
+  note?: string;
+  items: GalleryItem[];
+}
+
+/** A section's definition, before any page is assigned to it. */
+export interface GalleryGroup {
+  id: string;
+  heading: string;
+  headingId?: string;
+  note?: string;
+  /** Filename prefixes that put a top-level page in this group. */
+  prefixes?: string[];
+  /** Exact filename stems that put a top-level page in this group. */
+  names?: string[];
+  /** A subdirectory of `examples/` whose pages all belong to this group. */
+  dir?: string;
+  /** Dropped from a filename stem before it is turned into a title. */
+  strip?: RegExp;
+  /** Prepended to the link text to form the announced heading. */
+  headingPrefix?: string;
+  /** Entries that are not pages, such as the bundled React example. */
+  statics?: { onclick: string; label: string }[];
+  /** Whether an unprefixed top-level page lands here. At most one group. */
+  fallback?: boolean;
+}
+
+export declare const EXCLUDED_EXAMPLES: ExcludedExample[];
+
+export declare const CHART_TITLES: Record<string, string>;
+
+export declare const TITLES: Record<string, string | { label: string; heading: string }>;
+
+export declare const GROUPS: GalleryGroup[];
+
+/** Every page under `examples/`, two levels deep, relative to it and sorted. */
+export declare function listExamplePages(examplesDir: string): string[];
+
+/**
+ * Sort the given pages into gallery sections.
+ *
+ * `unclaimed` holds pages no group matched, which is how a new subdirectory
+ * shows up rather than being mislabelled.
+ */
+export declare function buildGallery(pages: string[]): {
+  sections: GallerySection[];
+  unclaimed: string[];
+};
+
+/** The gallery's markup. */
+export declare function renderGallery(sections: GallerySection[]): string;

--- a/scripts/examplesGallery.js
+++ b/scripts/examplesGallery.js
@@ -225,6 +225,12 @@ const WORDS = {
  * which charting library they use, not which chart type MAIDR calls what. What
  * changed is only that membership is now decided by the filename rather than by
  * remembering to add a line.
+ *
+ * Order matters: `groupFor` returns the first group whose `dir`, `names` or
+ * `prefixes` match, so a new prefix that is a substring of an earlier one would
+ * quietly claim that group's pages rather than erroring. The prefixes here are
+ * distinct today (`amcharts-` and `anychart-` share only `a`), but a prefix
+ * added below an existing one it extends needs to go above it instead.
  */
 export const GROUPS = [
   {

--- a/scripts/examplesGallery.js
+++ b/scripts/examplesGallery.js
@@ -1,0 +1,548 @@
+/**
+ * The examples gallery on `examples.html`, derived from `examples/`.
+ *
+ * It used to be a hand-written list of `loadHTML(...)` calls inside
+ * `scripts/build-site.js`. That list named 88 pages while the directory held
+ * 199, so 127 examples — most of the chart types added since — shipped with the
+ * site and were reachable from nothing on it. A page nobody can open documents
+ * nothing, and the drift was silent: adding an example never touched the list.
+ *
+ * So the list is read off the directory instead. Adding `examples/foo.html` now
+ * adds a gallery entry, and the only way to keep a page out is to name it in
+ * {@link EXCLUDED_EXAMPLES} with a reason.
+ * `test/scripts/examplesGallery.esm-test.ts` fails if any page is in neither.
+ *
+ * Plain JS with hand-written declarations beside it, the same arrangement as
+ * `scripts/testArgs.js` — `scripts/build-site.js` is run directly by node, and
+ * `tsconfig.json` sets `allowJs: false`, so a `.ts` module could not be
+ * imported there and a `.js` one cannot be typed without the `.d.ts`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Pages under `examples/` that are deliberately not gallery entries.
+ *
+ * Every exclusion is written down rather than filtered out by a pattern,
+ * because a pattern quietly widens: the point of generating the list is that a
+ * page cannot go missing by accident, and a silent skip puts that back.
+ */
+export const EXCLUDED_EXAMPLES = [
+  {
+    page: 'react-app/index.html',
+    reason:
+      'Vite entry point, not a page. It loads ./main.tsx and renders nothing '
+      + 'until bundled; `npm run build:react-example` emits the runnable page at '
+      + 'examples/react/index.html, which the React group links.',
+  },
+  {
+    page: 'recharts/index.html',
+    reason:
+      'Vite entry point, not a page. `npm run build:recharts-example` bundles it '
+      + 'into a single file that build-site.js copies over this path in _site; the '
+      + 'Recharts group links that build.',
+  },
+  {
+    page: 'victory/index.html',
+    reason:
+      'Vite entry point, not a page. `npm run build:victory-example` bundles it '
+      + 'into a single file that build-site.js copies over this path in _site; the '
+      + 'Victory group links that build.',
+  },
+];
+
+/**
+ * Chart vocabulary shared by every integration, keyed by the filename stem
+ * left after a group's prefix is stripped.
+ *
+ * One map rather than one per group: `plotly-bar.html`, `d3-bindbar.html`,
+ * `anychart/bar.html` and `highcharts-bar.html` all want to read "Bar Chart",
+ * and the old hand-written list said exactly that for each of them.
+ */
+export const CHART_TITLES = {
+  'area': 'Area Chart',
+  'bar': 'Bar Chart',
+  'bar-diverging': 'Diverging Bar',
+  'bar-dodged': 'Dodged Bar',
+  'bar-stacked': 'Stacked Bar',
+  'box': 'Box Plot',
+  'boxen': 'Letter-Value Plot (boxen)',
+  'boxplot': 'Box Plot',
+  'bump': 'Bump Chart',
+  'candlestick': 'Candlestick',
+  'chord': 'Chord Diagram',
+  'choropleth': 'Choropleth Map',
+  'contour': 'Contour Plot',
+  'diverging': 'Diverging Bar',
+  'dodged': 'Dodged Bar',
+  'dot': 'Dot Plot',
+  'dotplot': 'Dot Plot',
+  'dumbbell': 'Dumbbell Plot',
+  'errorbar': 'Error Bars',
+  'errorbar-grouped': 'Error Bars, grouped',
+  'facet-bar': 'Faceted Bar Chart',
+  'facets': 'Faceted Charts',
+  'forest': 'Forest Plot',
+  'funnel': 'Funnel Chart',
+  'gantt': 'Gantt Chart',
+  'gauge': 'Gauge',
+  'grouped-bar': 'Grouped Bar',
+  'heatmap': 'Heatmap',
+  'hexbin': 'Hexbin Plot',
+  'histogram': 'Histogram',
+  'icicle': 'Icicle Chart',
+  'line': 'Line Chart',
+  'lollipop': 'Lollipop Chart',
+  'manhattan': 'Manhattan Plot',
+  'mosaic': 'Mosaic Plot',
+  'multiline': 'Multi-Line Chart',
+  'multipanel': 'Multi-Panel Figure',
+  'network': 'Network Graph',
+  'normalized': 'Normalized Bar',
+  'parallel': 'Parallel Coordinates',
+  'pie': 'Pie Chart',
+  'pyramid': 'Population Pyramid',
+  'radar': 'Radar Chart',
+  'ridgeline': 'Ridgeline Plot',
+  'sankey': 'Sankey Diagram',
+  'scatter': 'Scatter Plot',
+  'smooth': 'Smooth Curve',
+  'stacked': 'Stacked Bar',
+  'stacked-bar': 'Stacked Bar',
+  'step': 'Step Plot',
+  'subplots': 'Subplots',
+  'sunburst': 'Sunburst Chart',
+  'survival': 'Survival Curve',
+  'treemap': 'Treemap',
+  'violin': 'Violin Plot',
+  'volcano': 'Volcano Plot',
+  'waterfall': 'Waterfall Chart',
+  'wordcloud': 'Word Cloud',
+};
+
+/**
+ * Per-page titles, for the pages the shared vocabulary cannot name.
+ *
+ * Every title the hand-written gallery carried is here, so generating the list
+ * did not cost the wording someone chose for it. A string is the link text, and
+ * the iframe heading is the group's prefix plus that text; an object sets the
+ * two independently, which is what the pages whose heading is not simply
+ * "<integration> <link text>" need.
+ */
+export const TITLES = {
+  // Hand-authored MAIDR JSON pages: titles carried over from the old list.
+  'barplot.html': 'Barplot',
+  'candlestick_multilayer.html': 'Candlestick multilayer',
+  'dodged_barplot.html': 'Dodged Barplot',
+  'facet_barplot.html': 'Faceted Bar plots',
+  'heatmap.html': 'Heatmap',
+  'histogram.html': 'Histogram',
+  'horizontal-boxplot.html': 'Horizontal box plot',
+  'lineplot.html': 'Single Line plot',
+  'multilayer_plot.html': 'Multi layered plot',
+  'multiline_plot.html': 'Multi line plot',
+  'multipanel.html': 'Multi panel plot',
+  'scatter_plot.html': 'Scatter plot',
+  'smooth_plot.html': 'Smooth plot',
+  'stacked_bar.html': 'Stacked Bar plot',
+  'stepplot.html': 'Step plot (hypnogram)',
+  'vertical-boxplot.html': 'Vertical box plot',
+  'vertical-candlestick.html': 'Vertical candle stick plot',
+  'violin.html': 'Violin plot',
+
+  'live-candlestick.html': 'Live candlestick feed',
+  'live-coinbase.html': 'Live Coinbase feed',
+  'live-line.html': 'Live line feed',
+  'multiline_plot_intersection.html': 'Multi line plot with intersecting lines',
+
+  // `examples/` holds seven charts twice, under a hyphenated and an
+  // underscored filename, and the old gallery listed only one of each pair.
+  // Both are reachable now, so both need a name of their own: two links
+  // reading "Dodged Barplot" are indistinguishable to anyone who hears the
+  // link text rather than seeing which file it points at.
+  'boxplot-horizontal.html': 'Horizontal box plot, second example',
+  'boxplot-vertical.html': 'Vertical box plot, second example',
+  'dodged-barplot.html': 'Dodged Barplot, second example',
+  'multi-lineplot.html': 'Multi line plot, second example',
+  'multi-panel.html': 'Multi panel plot, second example',
+  'smoothplot.html': 'Smooth plot, second example',
+  'stacked-barplot.html': 'Stacked Bar plot, second example',
+
+  // Integration pages whose heading is not "<integration> <link text>".
+  'amcharts.html': {
+    label: 'amCharts 5 Examples (Bar, Dodged, Stacked, Normalized, Line, Histogram, Heatmap)',
+    heading: 'amCharts 5 Examples',
+  },
+  'google-charts.html': {
+    label: 'Google Charts Examples (Bar, Line, Scatter, Stacked, Dodged, Candlestick)',
+    heading: 'Google Charts Examples',
+  },
+  'observable-plain.html': {
+    label: 'Plain page &mdash; bar, scatter, stacked bar, and a chart redrawn on demand',
+    heading: 'Observable Plot on a plain page',
+  },
+  'observable-quarto.html': {
+    label: 'Quarto OJS cells (bar, scatter, line, histogram, facets)',
+    heading: 'Observable Plot in a Quarto document',
+  },
+
+  // Pages holding several charts, or one the shared vocabulary would name
+  // wrongly. Each label follows the page's own heading.
+  'amcharts-declared.html': 'Declared Traces (no SVG scraping)',
+  'amcharts-floating-columns.html': 'Floating-Column Charts',
+  'amcharts-flow.html': 'Flow and Network',
+  'amcharts-marks.html': 'Pyramid, Dot Plot and Lollipop',
+  'anychart-bindable.html': 'Bar Chart (bound with bindAnyChart)',
+  'chartjs/heatmap.html': 'Heatmap (Matrix)',
+  'chartjs/line-stacked-panels.html': 'Stacked Axis Panels',
+  'frappe-mixed.html': 'Mixed Axis (Bar + Line)',
+  'frappe-pie.html': 'Pie / Donut',
+  'google-charts-gauge-map.html': 'Gauges and Maps',
+  'google-charts-marks.html': 'Dot, Lollipop, Funnel, Diverging and Waterfall',
+  'google-charts-relational.html': 'Flows, Hierarchies and Schedules',
+  'google-charts-statistical.html': 'Statistical and Relational Readings',
+  'highcharts-grid.html': 'Small Multiples (2×2 Grid)',
+  'highcharts-panes.html': 'Multi-Pane Chart (Price + Volume)',
+  'plotly-subplots.html': 'Subplots (2×2 Grid)',
+  'vegalite-bindbox-horizontal.html': 'Box Plot (horizontal)',
+  'vegalite-hconcat-box.html': 'Box Plots side by side (hconcat)',
+};
+
+/** Words the de-slugified fallback should not simply capitalise. */
+const WORDS = {
+  d3: 'D3',
+  js: 'JS',
+  kde: 'KDE',
+  ohlc: 'OHLC',
+};
+
+/**
+ * The gallery's sections, in the order they appear on the page.
+ *
+ * The grouping is the one the hand-written list already had — by integration —
+ * and it is kept because it is how someone arrives at the gallery: they know
+ * which charting library they use, not which chart type MAIDR calls what. What
+ * changed is only that membership is now decided by the filename rather than by
+ * remembering to add a line.
+ */
+export const GROUPS = [
+  {
+    id: 'react',
+    heading: 'React',
+    headingId: 'react-examples',
+    statics: [{ onclick: 'loadReact()', label: 'React Examples (Bar, Line, Smooth, D3 Bar, D3 Scatter)' }],
+    note: 'See the <a href="react.html">React Integration Guide</a> for setup instructions, TypeScript types, and code examples for all plot types. The D3 examples show how to use <a href="d3.html">the D3 adapter</a> with the <code>&lt;MaidrD3&gt;</code> wrapper.',
+  },
+  {
+    id: 'html',
+    heading: 'HTML / Vanilla JS',
+    // The fallback: a page matching no integration prefix is a hand-authored
+    // page carrying its MAIDR JSON inline, which is what this group is.
+    fallback: true,
+  },
+  {
+    id: 'plotly',
+    heading: 'Plotly.js',
+    prefixes: ['plotly-'],
+    headingPrefix: 'Plotly',
+    note: 'See the <a href="plotly.html">Plotly.js Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+  {
+    id: 'recharts',
+    heading: 'Recharts',
+    statics: [{ onclick: 'loadRecharts()', label: 'Recharts Examples (Bar, Line, Scatter, Stacked, Histogram)' }],
+    note: 'See the <a href="recharts.html">Recharts Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.',
+  },
+  {
+    id: 'google-charts',
+    heading: 'Google Charts',
+    prefixes: ['google-charts-'],
+    names: ['google-charts'],
+    headingPrefix: 'Google Charts',
+    note: 'See the <a href="google-charts.html">Google Charts Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+  {
+    id: 'chartjs',
+    heading: 'Chart.js',
+    dir: 'chartjs',
+    headingPrefix: 'Chart.js',
+    note: 'See the <a href="chartjs.html">Chart.js Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+  {
+    id: 'observable',
+    heading: 'Observable Plot &amp; Quarto',
+    prefixes: ['observable-'],
+    headingPrefix: 'Observable',
+    note: 'The two differ only in how the scripts reach the page &mdash; the adapter is the same and neither asks you to change the code that draws the chart. See the <a href="observable.html">Observable Plot &amp; Quarto Integration Guide</a> for both, including the Quarto extension.',
+  },
+  {
+    id: 'frappe',
+    heading: 'Frappe Charts',
+    prefixes: ['frappe-'],
+    headingPrefix: 'Frappe',
+    note: 'See the <a href="frappe.html">Frappe Charts Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+  {
+    id: 'd3',
+    heading: 'D3.js',
+    // No hyphen after the prefix: the pages are named `d3-bindbar.html`, and
+    // `bind` is the adapter's verb rather than part of the chart's name.
+    prefixes: ['d3-bind'],
+    headingPrefix: 'D3',
+    note: 'See the <a href="d3.html">D3.js Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.',
+  },
+  {
+    id: 'vegalite',
+    heading: 'Vega-Lite',
+    prefixes: ['vegalite-'],
+    // Same `bind` verb as the D3 pages, but here it follows the group prefix.
+    strip: /^bind/,
+    headingPrefix: 'Vega-Lite',
+    note: 'See the <a href="vegalite.html">Vega-Lite Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+  {
+    id: 'amcharts',
+    heading: 'amCharts 5',
+    prefixes: ['amcharts-'],
+    names: ['amcharts'],
+    headingPrefix: 'amCharts 5',
+    note: 'See the <a href="amcharts.html">amCharts 5 Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+  {
+    id: 'victory',
+    heading: 'Victory',
+    statics: [{ onclick: 'loadVictory()', label: 'Victory Examples (Bar, Line, Scatter, Stacked, Histogram, Box, Candlestick)' }],
+    note: 'See the <a href="victory.html">Victory Integration Guide</a> for setup instructions, TypeScript types, and code examples for all chart types.',
+  },
+  {
+    id: 'anychart',
+    heading: 'AnyChart',
+    prefixes: ['anychart-'],
+    dir: 'anychart',
+    headingPrefix: 'AnyChart',
+    note: 'See the <a href="anychart.html">AnyChart Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+  {
+    id: 'highcharts',
+    heading: 'Highcharts',
+    prefixes: ['highcharts-'],
+    headingPrefix: 'Highcharts',
+    note: 'See the <a href="highcharts.html">Highcharts Integration Guide</a> for setup instructions and code examples for all chart types.',
+  },
+];
+
+/**
+ * Directories under `examples/` holding build output rather than source pages.
+ *
+ * `examples/react/` is written by `npm run build:react-example` and is
+ * gitignored, so it is there after a build and not on a fresh checkout. Listing
+ * it would make the gallery depend on whether anyone had run a build, which is
+ * the one thing a generated list must not do. Nothing is lost by skipping it:
+ * the React group's entry loads `examples/react/index.html` already.
+ */
+const BUILD_OUTPUT_DIRS = new Set(['react', 'dist', 'node_modules']);
+
+/**
+ * Every page under `examples/` that could be a gallery entry.
+ *
+ * Two levels deep, which is as deep as an example page goes: the top level
+ * holds the hand-authored and prefixed pages, and one subdirectory per
+ * integration holds the rest. Anything deeper is build output —
+ * `examples/recharts/dist/index.html` and friends — and is not a source page.
+ */
+export function listExamplePages(examplesDir) {
+  const pages = [];
+
+  for (const entry of fs.readdirSync(examplesDir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith('.html')) {
+      pages.push(entry.name);
+      continue;
+    }
+    if (!entry.isDirectory() || BUILD_OUTPUT_DIRS.has(entry.name)) {
+      continue;
+    }
+    const nested = fs.readdirSync(path.join(examplesDir, entry.name), { withFileTypes: true });
+    for (const file of nested) {
+      if (file.isFile() && file.name.endsWith('.html')) {
+        pages.push(`${entry.name}/${file.name}`);
+      }
+    }
+  }
+
+  return pages.sort();
+}
+
+/** The group a page belongs to, by filename. */
+function groupFor(page) {
+  const slash = page.indexOf('/');
+  const dir = slash === -1 ? null : page.slice(0, slash);
+  const stem = path.posix.basename(page, '.html').toLowerCase();
+
+  for (const group of GROUPS) {
+    if (dir !== null) {
+      if (group.dir === dir) {
+        return group;
+      }
+      continue;
+    }
+    if (group.names?.includes(stem)) {
+      return group;
+    }
+    if (group.prefixes?.some(prefix => stem.startsWith(prefix))) {
+      return group;
+    }
+  }
+
+  // A nested page in a directory no group claims would otherwise land in the
+  // hand-authored group and read as one, so it is left unmatched and the test
+  // reports it rather than the gallery mislabelling it.
+  return dir === null ? GROUPS.find(group => group.fallback) : undefined;
+}
+
+/** The part of a filename that names the chart, with the group's prefix gone. */
+function chartStem(page, group) {
+  let stem = path.posix.basename(page, '.html').toLowerCase().replace(/_/g, '-');
+
+  const prefix = group.prefixes?.find(candidate => stem.startsWith(candidate));
+  if (prefix) {
+    stem = stem.slice(prefix.length);
+  }
+  if (group.strip) {
+    stem = stem.replace(group.strip, '');
+  }
+
+  return stem;
+}
+
+/** Turn a filename stem into words: `bindbox-horizontal` → `Bindbox Horizontal`. */
+function deslugify(stem) {
+  return stem
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map(word => WORDS[word] ?? word[0].toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/** The link text and iframe heading for one page. */
+function titleFor(page, group) {
+  const override = TITLES[page];
+  if (typeof override === 'object') {
+    return { label: override.label, heading: override.heading };
+  }
+
+  const stem = chartStem(page, group);
+  const label = override ?? CHART_TITLES[stem] ?? deslugify(stem);
+  const heading = group.headingPrefix ? `${group.headingPrefix} ${label}` : label;
+
+  return { label, heading };
+}
+
+/**
+ * Give two entries in one section that ended up with the same link text their
+ * filenames back, because two links reading "Dodged Barplot" and going to
+ * different pages leave a screen reader user no way to tell them apart — the
+ * link text is the whole of what is announced. `examples/` holds several pages
+ * that draw the same chart under a second filename, so this is not theoretical.
+ */
+function disambiguate(items) {
+  const counts = new Map();
+  for (const item of items) {
+    counts.set(item.label, (counts.get(item.label) ?? 0) + 1);
+  }
+
+  for (const item of items) {
+    if (item.page && counts.get(item.label) > 1) {
+      const stem = path.posix.basename(item.page, '.html');
+      item.heading = `${item.heading} (${stem})`;
+      item.label = `${item.label} (${stem})`;
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Sort the gallery's sections and their entries.
+ *
+ * Alphabetical by link text within a section. The hand-written list was ordered
+ * by whatever each contributor appended, which was survivable at 88 entries and
+ * is not at 240 — the point of a gallery is that you can find the chart you
+ * came for.
+ */
+function byLabel(a, b) {
+  if (a.label === b.label) {
+    return (a.page ?? '') < (b.page ?? '') ? -1 : 1;
+  }
+  return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : 1;
+}
+
+/**
+ * Build the gallery's sections from a list of example pages.
+ *
+ * Takes the pages rather than reading them so the shape can be checked against
+ * a list the test writes.
+ */
+export function buildGallery(pages) {
+  const excluded = new Set(EXCLUDED_EXAMPLES.map(entry => entry.page));
+  const items = new Map(GROUPS.map(group => [group.id, []]));
+  const unclaimed = [];
+
+  for (const page of pages) {
+    if (excluded.has(page)) {
+      continue;
+    }
+    const group = groupFor(page);
+    if (!group) {
+      unclaimed.push(page);
+      continue;
+    }
+    items.get(group.id).push({ page, ...titleFor(page, group) });
+  }
+
+  const sections = GROUPS.map(group => ({
+    id: group.id,
+    heading: group.heading,
+    headingId: group.headingId,
+    note: group.note,
+    items: [
+      ...(group.statics ?? []).map(item => ({ ...item, heading: item.label })),
+      ...disambiguate(items.get(group.id)).sort(byLabel),
+    ],
+  }));
+
+  return { sections, unclaimed };
+}
+
+/** Escape a string for use inside a double-quoted HTML attribute. */
+function attr(value) {
+  return value.replace(/"/g, '&quot;');
+}
+
+/** Escape a string for use inside a single-quoted JavaScript literal. */
+function js(value) {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'');
+}
+
+/** One `<li>`: the same markup and the same `loadHTML` call as before. */
+function renderItem(item) {
+  const onclick = item.onclick ?? `loadHTML('${js(item.page)}', '${js(item.heading)}')`;
+  return `    <li><a href="#" onclick="${attr(onclick)}; return false;">${item.label}</a></li>`;
+}
+
+/** The gallery's markup, for `scripts/build-site.js` to drop into the page. */
+export function renderGallery(sections) {
+  return sections
+    .filter(section => section.items.length > 0)
+    .map((section) => {
+      const id = section.headingId ? ` id="${section.headingId}"` : '';
+      const note = section.note ? `\n  <p>${section.note}</p>` : '';
+      return [
+        `  <h3${id}>${section.heading}</h3>`,
+        '  <ul>',
+        section.items.map(renderItem).join('\n'),
+        '  </ul>',
+      ].join('\n') + note;
+    })
+    .join('\n\n');
+}

--- a/scripts/examplesGallery.js
+++ b/scripts/examplesGallery.js
@@ -406,7 +406,15 @@ function groupFor(page) {
   return dir === null ? GROUPS.find(group => group.fallback) : undefined;
 }
 
-/** The part of a filename that names the chart, with the group's prefix gone. */
+/**
+ * The part of a filename that names the chart, with the group's prefix gone.
+ *
+ * Only `prefixes` is stripped, not `names`: a page matched by `names` is the
+ * group's own landing page, and both of them (`amcharts.html`,
+ * `google-charts.html`) carry a curated `TITLES` entry, so this never runs for
+ * one. A `names` group added without that entry would be labelled from its full
+ * stem — give it a `TITLES` entry rather than stripping `names` here.
+ */
 function chartStem(page, group) {
   let stem = path.posix.basename(page, '.html').toLowerCase().replace(/_/g, '-');
 

--- a/test/scripts/examplesGallery.esm-test.ts
+++ b/test/scripts/examplesGallery.esm-test.ts
@@ -88,7 +88,7 @@ describe('the examples gallery', () => {
     const dir = mkdtempSync(join(tmpdir(), 'maidr-gallery-'));
     try {
       writeFileSync(join(dir, 'plotly-bar.html'), '');
-      for (const built of ['react', 'dist']) {
+      for (const built of ['react', 'dist', 'node_modules']) {
         mkdirSync(join(dir, built));
         writeFileSync(join(dir, built, 'index.html'), '');
       }

--- a/test/scripts/examplesGallery.esm-test.ts
+++ b/test/scripts/examplesGallery.esm-test.ts
@@ -1,0 +1,185 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { describe, expect, it } from '@jest/globals';
+import {
+  buildGallery,
+  EXCLUDED_EXAMPLES,
+  listExamplePages,
+  renderGallery,
+  TITLES,
+} from '../../scripts/examplesGallery';
+
+/**
+ * Keeps every page in `examples/` reachable from the gallery on `examples.html`.
+ *
+ * The gallery used to be a hand-written list of `loadHTML(...)` calls in
+ * `scripts/build-site.js`. It named 88 pages; the directory held 199. Nothing
+ * failed when someone added the 200th, so 127 examples — the whole amCharts,
+ * Highcharts, Vega-Lite and Google Charts families among them — shipped inside
+ * the site and were reachable from nothing on it. That is the failure this
+ * guards: not a broken link, but a page with no link at all, which no build
+ * step and no browser can notice.
+ *
+ * `scripts/build-site.js` now derives the list from the directory, so the
+ * arithmetic works out on its own. What still needs guarding is the deny-list —
+ * the one place a page can be kept out — and the labels, because a generated
+ * list can go wrong in a way the old one could not: two pages resolving to the
+ * same link text. A link is announced by its text alone, so two links reading
+ * "Dodged Barplot" and opening different charts are, to anyone not looking at
+ * the address bar, the same link twice.
+ *
+ * Jest runs from `rootDir`, so this is the repository root; `import.meta` is
+ * usable in this project but `process.cwd()` is what the other ESM script tests
+ * already use.
+ */
+const ROOT = process.cwd();
+const EXAMPLES = join(ROOT, 'examples');
+
+const pages = listExamplePages(EXAMPLES);
+const { sections, unclaimed } = buildGallery(pages);
+
+/** Every page the gallery links, in section order. */
+function linkedPages(): string[] {
+  return sections.flatMap(section => section.items.map(item => item.page).filter(page => page !== undefined));
+}
+
+describe('the examples gallery', () => {
+  it('should reach every page in examples/', () => {
+    const linked = new Set(linkedPages());
+    const excluded = new Set(EXCLUDED_EXAMPLES.map(entry => entry.page));
+
+    const unreachable = pages.filter(page => !linked.has(page) && !excluded.has(page));
+
+    expect(unreachable).toEqual([]);
+  });
+
+  it('should put every page in a group rather than silently dropping it', () => {
+    expect(unclaimed).toEqual([]);
+  });
+
+  it('should link something for every page it found', () => {
+    // The counts are the assertion the issue was written about: 199 top-level
+    // pages plus the integration subdirectories, minus the three Vite entry
+    // points, all linked.
+    expect(linkedPages()).toHaveLength(pages.length - EXCLUDED_EXAMPLES.length);
+  });
+
+  it('should link each page exactly once', () => {
+    const linked = linkedPages();
+
+    expect(new Set(linked).size).toBe(linked.length);
+  });
+
+  it('should link pages that exist', () => {
+    const missing = linkedPages().filter(page => !existsSync(join(EXAMPLES, page)));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('should list the same pages before and after a build', () => {
+    // `examples/react/` is written by `npm run build:react-example` and
+    // `examples/*/dist/` by the Recharts and Victory builds, so a listing that
+    // included them would give one gallery on a fresh checkout and another on
+    // a built tree. The React entry those would add is the one `loadReact()`
+    // already opens. Checked against a directory this test lays out, so it
+    // holds whether or not a build has run here.
+    const dir = mkdtempSync(join(tmpdir(), 'maidr-gallery-'));
+    try {
+      writeFileSync(join(dir, 'plotly-bar.html'), '');
+      for (const built of ['react', 'dist']) {
+        mkdirSync(join(dir, built));
+        writeFileSync(join(dir, built, 'index.html'), '');
+      }
+      mkdirSync(join(dir, 'chartjs'));
+      writeFileSync(join(dir, 'chartjs', 'bar.html'), '');
+
+      expect(listExamplePages(dir)).toEqual(['chartjs/bar.html', 'plotly-bar.html']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the gallery\'s deny-list', () => {
+  it('should name pages that exist', () => {
+    const missing = EXCLUDED_EXAMPLES
+      .filter(entry => !existsSync(join(EXAMPLES, entry.page)))
+      .map(entry => entry.page);
+
+    // A stale entry is worse than no entry: it reads as a decision someone
+    // made about a page that is no longer there, and hides the next page that
+    // takes its name.
+    expect(missing).toEqual([]);
+  });
+
+  it('should say why each page is excluded', () => {
+    const unexplained = EXCLUDED_EXAMPLES
+      .filter(entry => entry.reason.trim().length === 0)
+      .map(entry => entry.page);
+
+    expect(unexplained).toEqual([]);
+  });
+
+  it('should not exclude a page the gallery also links', () => {
+    const linked = new Set(linkedPages());
+    const both = EXCLUDED_EXAMPLES.filter(entry => linked.has(entry.page)).map(entry => entry.page);
+
+    expect(both).toEqual([]);
+  });
+});
+
+describe('the gallery\'s labels', () => {
+  it('should give every entry in a group its own link text', () => {
+    const collisions = sections.flatMap((section) => {
+      const seen = new Set<string>();
+      return section.items
+        .filter(item => (seen.has(item.label) ? true : (seen.add(item.label), false)))
+        .map(item => `${section.id}: ${item.label}`);
+    });
+
+    expect(collisions).toEqual([]);
+  });
+
+  it('should announce a heading for every entry', () => {
+    const unnamed = sections.flatMap(section =>
+      section.items.filter(item => item.heading.trim().length === 0).map(item => item.page ?? item.label));
+
+    expect(unnamed).toEqual([]);
+  });
+
+  it('should not curate a title for a page that is gone', () => {
+    const stale = Object.keys(TITLES).filter(page => !existsSync(join(EXAMPLES, page)));
+
+    expect(stale).toEqual([]);
+  });
+});
+
+describe('the gallery\'s markup', () => {
+  const html = renderGallery(sections);
+
+  it('should call loadHTML with the page and its heading', () => {
+    expect(html).toContain(
+      '<li><a href="#" onclick="loadHTML(\'barplot.html\', \'Barplot\'); return false;">Barplot</a></li>',
+    );
+    expect(html).toContain(
+      '<li><a href="#" onclick="loadHTML(\'plotly-bar.html\', \'Plotly Bar Chart\'); return false;">Bar Chart</a></li>',
+    );
+  });
+
+  it('should keep the hand-written entries that are not pages', () => {
+    expect(html).toContain('onclick="loadReact(); return false;"');
+    expect(html).toContain('onclick="loadRecharts(); return false;"');
+    expect(html).toContain('onclick="loadVictory(); return false;"');
+  });
+
+  it('should be what build-site.js drops into the page', () => {
+    const script = readFileSync(join(ROOT, 'scripts', 'build-site.js'), 'utf8');
+
+    // The one interpolation stands in for the 88 `loadHTML` calls that used to
+    // be written out here; if it goes, the gallery is hand-listed again.
+    expect(script).toContain(`\${gallery}`);
+    expect(script).toContain('renderGallery(sections)');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The gallery on `examples.html` was a hand-written list of `loadHTML(...)` calls
inside `scripts/build-site.js`. It named **88** pages. `examples/` holds **199**
at the top level. Nothing failed when the two drifted apart, so 127 examples —
`area`, `boxen`, `bump`, `choropleth`, `contour`, `dot`, `dumbbell`, `errorbar`,
`forest`, `funnel`, `gantt`, `gauge`, `hexbin`, and the whole amCharts,
Highcharts, Vega-Lite and Google Charts families — shipped inside the site and
were reachable from nothing on it. A page nobody can open documents nothing.

The list is now read off the directory, so it cannot drift again, and a test
fails if it ever does.

### Before / after

| | links in `_site/examples.html` |
|---|---|
| before | **92** — 88 `loadHTML` calls plus 4 hand-written entries |
| after | **244** — 241 `loadHTML` calls plus 3 hand-written entries |

241 = 244 pages found under `examples/` (199 top level, 21 `anychart/`,
21 `chartjs/`, 3 Vite entry points) − 3 deny-listed. Verified by building the
site with `npm run build:preview` and counting the generated page; every
`loadHTML` target resolves to a real file under `_site/examples/`.

## Related Issues

Closes #911 — the first of the two gaps in that issue (the gallery). The four
missing hand-authored trace-type examples are not part of this change.

## Changes Made

**`scripts/examplesGallery.js`** (new) — enumerates `examples/` two levels deep
and turns it into gallery sections:

- **Grouping** is the one the hand-written list already had, by integration,
  because that is how someone arrives at the gallery: they know which charting
  library they use, not what MAIDR calls the chart type. Membership is derived
  from the filename prefix — `plotly-`, `highcharts-`, `vegalite-`, `amcharts-`,
  `anychart-`, `frappe-`, `google-charts-`, `d3-bind`, `observable-` — plus the
  `anychart/` and `chartjs/` subdirectories, with everything else falling into
  the hand-authored **HTML / Vanilla JS** group.
- **Labels** come from a shared chart vocabulary (`bar` → "Bar Chart",
  `scatter` → "Scatter Plot"), a curated per-page map, or a de-slugified
  filename, in that order. The curated map carries **every** title the old list
  had, so generating the gallery did not cost the wording someone chose:
  "Stacked Bar plot", "Step plot (hypnogram)", "Heatmap (Matrix)",
  "Mixed Axis (Bar + Line)", "Pie / Donut", and the rest.
- A page whose directory no group claims is reported by the build and by the
  test rather than being quietly filed under the hand-authored group.

**`scripts/build-site.js`** — the 88-entry list is replaced by one
`${gallery}` interpolation. The markup, the `loadHTML(page, title)` click
behaviour, the per-group intro paragraphs and the `#react-examples` heading id
are unchanged. `loadGoogleCharts()` is gone: `google-charts.html` is now an
ordinary generated entry, and `loadHTML('google-charts.html', …)` did exactly
what that function did.

**`test/scripts/examplesGallery.esm-test.ts`** (new, 15 cases) — in
`test/scripts/` with the repo's other script tests, in the `esm` Jest project
so it can import the plain-ESM module, with hand-written declarations in
`scripts/examplesGallery.d.ts` beside it (the arrangement `scripts/testArgs.js`
already uses, since `allowJs` is false). It fails when:

- a page under `examples/` is in neither the gallery nor the deny-list;
- a page lands in no group, or is linked twice, or is linked but absent;
- a deny-list entry names a page that no longer exists, or gives no reason;
- a curated title names a page that no longer exists;
- **two entries in one group resolve to the same link text.** A link is
  announced by its text alone, so two links reading "Dodged Barplot" and opening
  different charts are the same link twice to anyone not looking at the address
  bar. `examples/` holds seven charts twice under a hyphenated and an
  underscored filename, and the old gallery listed only one of each pair — now
  that both are reachable, both are named ("Dodged Barplot" and "Dodged
  Barplot, second example"). A collision that slips past the curated map is
  given the filename back automatically, so it cannot become ambiguous silently.

### Deny-list

Three pages are deliberately not gallery entries. Each is named explicitly in
`EXCLUDED_EXAMPLES` with its reason, rather than filtered out by a pattern — the
point of generating the list is that a page cannot go missing by accident, and a
silent skip puts that back:

| Page | Reason |
|---|---|
| `react-app/index.html` | Vite entry point, not a page: loads `./main.tsx` and renders nothing until bundled. `npm run build:react-example` emits the runnable page at `examples/react/index.html`, which the React group's entry loads. |
| `recharts/index.html` | Vite entry point, not a page. `npm run build:recharts-example` bundles it into the single file `build-site.js` copies over this path in `_site`; the Recharts entry loads that build. |
| `victory/index.html` | Vite entry point, not a page. `npm run build:victory-example` bundles it into the single file `build-site.js` copies over this path in `_site`; the Victory entry loads that build. |

Separately, build output under `examples/` — `examples/react/`, `examples/*/dist/`
— is skipped structurally rather than deny-listed, because it exists only after a
build and the gallery must not differ between a fresh checkout and a built tree.
A test lays out a directory and checks that.

### Ordering

Entries are sorted alphabetically by link text within a group. The old list was
ordered by whatever each contributor appended, which was survivable at 88
entries and is not at 244.

## Screenshots (if applicable)

n/a — the markup is byte-identical in shape to what the hand-written list
produced; only the set of entries changed.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Checks run locally, all passing:**

- `npm run lint:fix` — clean
- `npm run type-check` — clean (`tsc --noEmit` and `tsconfig.ci.json`)
- `npm run build` — succeeded
- `npm test` — 286 unit suites / 4288 tests, 8 esm suites / 88 tests, all passing
- `npm run build:preview` — succeeded; generated `_site/examples.html` verified
  to hold 244 links in 14 groups with no dangling target

A sibling PR adds four new hand-authored example pages for `chord`,
`stacked_normalized_bar`, `stacked_normalized_area` and `polar_area` — the
second gap in #911. Nothing needs doing to list them: once both land, the
generated gallery picks them up from the directory, files them into the
hand-authored **HTML / Vanilla JS** group, and names them from the shared chart
vocabulary. That is the whole point of the change, and the new test is what
would have caught them going missing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_