### PR TITLE
fix(docs): give built pages heading ids so in-page links jump

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -271,10 +271,31 @@
       background: rgba(255, 255, 255, 0.2);
     }
 
+    /* Skip link: first thing in the tab order, offscreen until focused. */
+    .skip-link {
+      position: absolute;
+      left: -10000px;
+      top: 0;
+      z-index: 1100;
+      padding: 0.75rem 1rem;
+      background: white;
+      color: #1a1a1a;
+      font-weight: 600;
+    }
+
+    .skip-link:focus {
+      left: 0;
+    }
+
     main {
       max-width: 1200px;
       margin: 0 auto;
       padding: 2rem;
+    }
+
+    /* Focused only to move the reading position from the skip link. */
+    main:focus {
+      outline: none;
     }
 
     /* Markdown content styles */
@@ -407,6 +428,7 @@
 </head>
 
 <body>
+  <a class="skip-link" href="#main-content">Skip to content</a>
   <nav>
     <div class="container">
       <a href="{{BASE_PATH}}index.html" class="logo">
@@ -456,7 +478,7 @@
     </div>
   </nav>
 
-  <main>
+  <main id="main-content" tabindex="-1">
     {{CONTENT}}
   </main>
 

--- a/docs/vegalite.md
+++ b/docs/vegalite.md
@@ -53,7 +53,7 @@ Load Vega, Vega-Lite, vega-embed, MAIDR core, and the Vega-Lite adapter, then ca
 
 `embed()` returns a `Promise<{ view }>` — `await` it (or use `.then()` / `.catch()`) when you need the underlying Vega view or want to handle render failures.
 
-If you already drive `vegaEmbed` yourself (e.g. you need the `view` for additional logic before MAIDR mounts), use [`bindVegaLite`](#bindvegalite-view-spec-options) instead. **You must `await result.view.runAsync()`** between embedding and binding so the SVG is in the DOM by the time MAIDR mounts:
+If you already drive `vegaEmbed` yourself (e.g. you need the `view` for additional logic before MAIDR mounts), use [`bindVegaLite`](#bindvegaliteview-spec-options) instead. **You must `await result.view.runAsync()`** between embedding and binding so the SVG is in the DOM by the time MAIDR mounts:
 
 ```js
 // renderer must be 'svg' — MAIDR navigates the SVG output, not canvas.
@@ -574,7 +574,7 @@ Lower-level entry point that mounts MAIDR on the SVG produced by an existing `ve
 | `options.id` | `string` (optional) | Unique ID for the MAIDR instance. Defaults to the view container's `id`, or a timestamp fallback. |
 | `options.title` | `string` (optional) | Override for the chart title used in announcements. |
 
-**Callers must `await view.runAsync()` before calling `bindVegaLite()`.** `vegaEmbed(...)` resolves when the view is *constructed*, not when it has *rendered* — calling `bindVegaLite()` immediately after `vegaEmbed()` resolves can race the first paint and produce a "No SVG found" error on slow or aggregated specs (histograms, complex transforms). The view must also be created with `renderer: 'svg'`; MAIDR cannot navigate canvas output. **Prefer [`embed()`](#embed-target-spec-options)** which performs both steps for you.
+**Callers must `await view.runAsync()` before calling `bindVegaLite()`.** `vegaEmbed(...)` resolves when the view is *constructed*, not when it has *rendered* — calling `bindVegaLite()` immediately after `vegaEmbed()` resolves can race the first paint and produce a "No SVG found" error on slow or aggregated specs (histograms, complex transforms). The view must also be created with `renderer: 'svg'`; MAIDR cannot navigate canvas output. **Prefer [`embed()`](#embedtarget-spec-options)** which performs both steps for you.
 
 ### `vegaLiteToMaidr(spec, view?, options?)`
 

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -12,8 +12,8 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { marked } from 'marked';
 import { buildGallery, listExamplePages, renderGallery } from './examplesGallery.js';
+import { renderMarkdown } from './markdown.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -30,21 +30,18 @@ if (!fs.existsSync(SITE_DIR)) {
 // Read template
 const template = fs.readFileSync(TEMPLATE_PATH, 'utf-8');
 
-// Configure marked for safe HTML output
-marked.setOptions({
-  gfm: true,
-  breaks: false,
-});
-
 /**
- * Convert markdown to HTML using marked library
+ * Convert markdown to HTML for the site.
+ *
+ * `renderMarkdown` carries the marked configuration and the heading ids the
+ * table-of-contents links need; see `scripts/markdown.js` for why the ids are
+ * not marked's own.
  */
 function markdownToHtml(md) {
   // Remove the centered logo div at the top of README
   const content = md.replace(/<div align="center">[\s\S]*?<\/div>\s*/, '');
 
-  // Convert markdown to HTML
-  return marked.parse(content);
+  return renderMarkdown(content);
 }
 
 // Per-page SEO descriptions.
@@ -191,7 +188,7 @@ if (fs.existsSync(reactMdPath)) {
   const reactMd = fs.readFileSync(reactMdPath, 'utf-8');
   const reactHtml = `
 <div class="content">
-  ${marked.parse(reactMd)}
+  ${renderMarkdown(reactMd)}
 </div>
 `;
   const reactPage = generatePage({ title: 'React', content: reactHtml, activePage: 'react', slug: 'react.html', ogType: 'article' });
@@ -205,7 +202,7 @@ if (fs.existsSync(rechartsMdPath)) {
   const rechartsMd = fs.readFileSync(rechartsMdPath, 'utf-8');
   const rechartsHtml = `
 <div class="content">
-  ${marked.parse(rechartsMd)}
+  ${renderMarkdown(rechartsMd)}
 </div>
 `;
   const rechartsPage = generatePage({ title: 'Recharts', content: rechartsHtml, activePage: 'recharts', slug: 'recharts.html', ogType: 'article' });
@@ -219,7 +216,7 @@ if (fs.existsSync(plotlyMdPath)) {
   const plotlyMd = fs.readFileSync(plotlyMdPath, 'utf-8');
   const plotlyHtml = `
 <div class="content">
-  ${marked.parse(plotlyMd)}
+  ${renderMarkdown(plotlyMd)}
 </div>
 `;
   const plotlyPage = generatePage({ title: 'Plotly', content: plotlyHtml, activePage: 'plotly', slug: 'plotly.html', ogType: 'article' });
@@ -233,7 +230,7 @@ if (fs.existsSync(googleChartsMdPath)) {
   const googleChartsMd = fs.readFileSync(googleChartsMdPath, 'utf-8');
   const googleChartsHtml = `
 <div class="content">
-  ${marked.parse(googleChartsMd)}
+  ${renderMarkdown(googleChartsMd)}
 </div>
 `;
   const googleChartsPage = generatePage({ title: 'Google Charts', content: googleChartsHtml, activePage: 'google-charts', slug: 'google-charts.html', ogType: 'article' });
@@ -247,7 +244,7 @@ if (fs.existsSync(d3MdPath)) {
   const d3Md = fs.readFileSync(d3MdPath, 'utf-8');
   const d3Html = `
 <div class="content">
-  ${marked.parse(d3Md)}
+  ${renderMarkdown(d3Md)}
 </div>
 `;
   const d3Page = generatePage({ title: 'D3.js', content: d3Html, activePage: 'd3', slug: 'd3.html', ogType: 'article' });
@@ -261,7 +258,7 @@ if (fs.existsSync(vegaliteMdPath)) {
   const vegaliteMd = fs.readFileSync(vegaliteMdPath, 'utf-8');
   const vegaliteHtml = `
 <div class="content">
-  ${marked.parse(vegaliteMd)}
+  ${renderMarkdown(vegaliteMd)}
 </div>
 `;
   const vegalitePage = generatePage({ title: 'Vega-Lite', content: vegaliteHtml, activePage: 'vegalite', slug: 'vegalite.html', ogType: 'article' });
@@ -275,7 +272,7 @@ if (fs.existsSync(chartjsMdPath)) {
   const chartjsMd = fs.readFileSync(chartjsMdPath, 'utf-8');
   const chartjsHtml = `
 <div class="content">
-  ${marked.parse(chartjsMd)}
+  ${renderMarkdown(chartjsMd)}
 </div>
 `;
   const chartjsPage = generatePage({ title: 'Chart.js', content: chartjsHtml, activePage: 'chartjs', slug: 'chartjs.html', ogType: 'article' });
@@ -289,7 +286,7 @@ if (fs.existsSync(amchartsMdPath)) {
   const amchartsMd = fs.readFileSync(amchartsMdPath, 'utf-8');
   const amchartsHtml = `
 <div class="content">
-  ${marked.parse(amchartsMd)}
+  ${renderMarkdown(amchartsMd)}
 </div>
 `;
   const amchartsPage = generatePage({ title: 'amCharts', content: amchartsHtml, activePage: 'amcharts', slug: 'amcharts.html', ogType: 'article' });
@@ -303,7 +300,7 @@ if (fs.existsSync(observableMdPath)) {
   const observableMd = fs.readFileSync(observableMdPath, 'utf-8');
   const observableHtml = `
 <div class="content">
-  ${marked.parse(observableMd)}
+  ${renderMarkdown(observableMd)}
 </div>
 `;
   const observablePage = generatePage({ title: 'Observable Plot', content: observableHtml, activePage: 'observable', slug: 'observable.html', ogType: 'article' });
@@ -317,7 +314,7 @@ if (fs.existsSync(frappeMdPath)) {
   const frappeMd = fs.readFileSync(frappeMdPath, 'utf-8');
   const frappeHtml = `
 <div class="content">
-  ${marked.parse(frappeMd)}
+  ${renderMarkdown(frappeMd)}
 </div>
 `;
   const frappePage = generatePage({ title: 'Frappe Charts', content: frappeHtml, activePage: 'frappe', slug: 'frappe.html', ogType: 'article' });
@@ -331,7 +328,7 @@ if (fs.existsSync(victoryMdPath)) {
   const victoryMd = fs.readFileSync(victoryMdPath, 'utf-8');
   const victoryHtml = `
 <div class="content">
-  ${marked.parse(victoryMd)}
+  ${renderMarkdown(victoryMd)}
 </div>
 `;
   const victoryPage = generatePage({ title: 'Victory', content: victoryHtml, activePage: 'victory', slug: 'victory.html', ogType: 'article' });
@@ -345,7 +342,7 @@ if (fs.existsSync(anychartMdPath)) {
   const anychartMd = fs.readFileSync(anychartMdPath, 'utf-8');
   const anychartHtml = `
 <div class="content">
-  ${marked.parse(anychartMd)}
+  ${renderMarkdown(anychartMd)}
 </div>
 `;
   const anychartPage = generatePage({ title: 'AnyChart', content: anychartHtml, activePage: 'anychart', slug: 'anychart.html', ogType: 'article' });
@@ -359,7 +356,7 @@ if (fs.existsSync(highchartsMdPath)) {
   const highchartsMd = fs.readFileSync(highchartsMdPath, 'utf-8');
   const highchartsHtml = `
 <div class="content">
-  ${marked.parse(highchartsMd)}
+  ${renderMarkdown(highchartsMd)}
 </div>
 `;
   const highchartsPage = generatePage({ title: 'Highcharts', content: highchartsHtml, activePage: 'highcharts', slug: 'highcharts.html', ogType: 'article' });

--- a/scripts/markdown.d.ts
+++ b/scripts/markdown.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Hand-written declarations for `scripts/markdown.js`.
+ *
+ * The same arrangement as `scripts/testArgs.d.ts`: the module is plain ESM run
+ * directly by node from `scripts/build-site.js`, and `tsconfig.json` sets
+ * `allowJs: false`, so a test can only import it with declarations beside it.
+ * `test/scripts/siteAnchors.esm-test.ts` checks these against what the module
+ * actually returns, since `tsc` never sees the JavaScript.
+ */
+
+/** Convert heading text to a GitHub heading slug. */
+export declare function slugify(text: string): string;
+
+/** Create a slug allocator that disambiguates repeats within one document. */
+export declare function createHeadingSlugger(): (text: string) => string;
+
+/** Render a markdown document to HTML, giving each heading its GitHub slug as `id`. */
+export declare function renderMarkdown(markdown: string): string;

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -1,0 +1,127 @@
+/**
+ * Markdown rendering for the documentation site, with GitHub-compatible
+ * heading ids.
+ *
+ * **Why this file exists.** marked v15 emits no heading `id` attributes: the
+ * `headerIds` option left marked core for the `marked-gfm-heading-id`
+ * extension, which this repository does not depend on. `scripts/build-site.js`
+ * upgraded across that boundary and nothing failed, because a link to a missing
+ * fragment is not an error — the browser simply does not move. Every
+ * table-of-contents link in `README.md` and `docs/` had been pointing at
+ * nothing on maidr.ai (#913).
+ *
+ * It is split out of the build script rather than living beside the rest of it
+ * because `build-site.js` writes files on import: nothing can load it to ask
+ * what a heading turns into. This module is inert, so the slug rule and the
+ * anchors it has to satisfy are testable — see
+ * `test/scripts/siteAnchors.esm-test.ts`.
+ *
+ * **Why the rule has to be GitHub's.** The same files are read on github.com
+ * and on maidr.ai, and they carry one set of `[…](#…)` links for both. A slug
+ * rule of our own would work in one place and not the other, so the target is
+ * `github-slugger`'s output rather than anything more principled — including
+ * the parts of it that look like bugs, which are relied on by links that
+ * already exist.
+ */
+
+import { Marked } from 'marked';
+
+/**
+ * Everything GitHub drops from a slug: anything that is not a letter, a number,
+ * a combining mark, a space, an underscore or an ASCII hyphen.
+ *
+ * The hyphen is spelled out rather than taken from `\p{Pd}` on purpose. That
+ * category also holds the em dash, and `docs/` uses em dashes in nine
+ * headings — `## 4. KDE Layer — \`violin_kde\`` among them — where GitHub drops
+ * the dash and keeps the two spaces around it, giving the doubled hyphen in
+ * `#4-kde-layer--violin_kde`. Keeping `\p{Pd}` would produce a single hyphen
+ * and break that link.
+ */
+const DISCARDED = /[^\p{L}\p{N}\p{M} _-]/gu;
+
+/**
+ * Convert heading text to a GitHub heading slug.
+ *
+ * Lower-case, drop everything in {@link DISCARDED}, then turn each remaining
+ * space into a hyphen — each, not each run, which is why `## Live & Streaming
+ * Data` is `#live--streaming-data` and not `#live-streaming-data`.
+ *
+ * Characters are dropped rather than replaced, so `` `embed(target, spec)` ``
+ * slugs to `embedtarget-spec`: the bracket vanishes and closes the gap while
+ * the comma leaves its following space behind. That reads like a mistake and
+ * is what GitHub does, so it is what links have to be written against.
+ * @param {string} text - Heading text, with markdown already resolved to plain
+ * text (a code span contributes its contents, not its backticks).
+ * @returns {string} The slug, which is empty when the heading holds nothing
+ * that survives — a heading of one emoji, say.
+ */
+export function slugify(text) {
+  return text.toLowerCase().replace(DISCARDED, '').replace(/ /g, '-');
+}
+
+/**
+ * Create a slug allocator that disambiguates repeats within one document.
+ *
+ * GitHub numbers repeats in document order — `setup`, `setup-1`, `setup-2` —
+ * and keeps searching when the numbered form is itself taken, so a document
+ * with two `Bar Chart` headings and a literal `Bar Chart 1` produces
+ * `bar-chart`, `bar-chart-1`, then `bar-chart-1-1` rather than silently
+ * colliding. `docs/BRAILLE.md` alone repeats `### Multiline Displays` thirty
+ * times, so this is the common case here rather than an edge one.
+ *
+ * One allocator per document: ids only have to be unique within a page, and
+ * sharing one across pages would number the second page's headings as though
+ * they were repeats.
+ * @returns {(text: string) => string} Allocator, to be called once per heading
+ * in document order.
+ */
+export function createHeadingSlugger() {
+  /** Every slug handed out, and for each base the highest suffix used. */
+  const used = new Map();
+
+  return (text) => {
+    const base = slugify(text);
+    let slug = base;
+    while (used.has(slug)) {
+      const next = (used.get(base) ?? 0) + 1;
+      used.set(base, next);
+      slug = `${base}-${next}`;
+    }
+    used.set(slug, 0);
+    return slug;
+  };
+}
+
+/**
+ * Render a markdown document to HTML for the site, giving each heading an id.
+ *
+ * A fresh `Marked` instance per call rather than the shared `marked` export,
+ * because the heading renderer closes over a slug allocator that must not
+ * outlive the document.
+ * @param {string} markdown - The markdown source.
+ * @returns {string} HTML, with every heading carrying its GitHub slug as `id`.
+ */
+export function renderMarkdown(markdown) {
+  const nextSlug = createHeadingSlugger();
+  const marked = new Marked({ gfm: true, breaks: false });
+
+  marked.use({
+    renderer: {
+      heading({ tokens, depth }) {
+        // `textRenderer` flattens the inline tokens to their text content, which
+        // is what GitHub slugs: a code span gives up its backticks, a link its
+        // URL, and `&` arrives as itself rather than as `&amp;`. Slugging the
+        // raw markdown instead would turn `## Live & Streaming Data` into
+        // `live-amp-streaming-data` once the entity had been escaped.
+        const id = nextSlug(this.parser.parseInline(tokens, this.parser.textRenderer));
+        const body = this.parser.parseInline(tokens);
+        // A heading whose text is entirely dropped — one emoji, say — gets no
+        // id rather than `id=""`, which is not a thing a fragment can address.
+        return `<h${depth}${id ? ` id="${id}"` : ''}>${body}</h${depth}>\n`;
+      },
+    },
+  });
+
+  // `parse` is synchronous unless an async extension is registered, and none is.
+  return /** @type {string} */ (marked.parse(markdown));
+}

--- a/test/scripts/siteAnchors.esm-test.ts
+++ b/test/scripts/siteAnchors.esm-test.ts
@@ -1,0 +1,273 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+import { createHeadingSlugger, renderMarkdown, slugify } from '../../scripts/markdown';
+
+/**
+ * Tests for `scripts/markdown.js` — the heading ids every in-page link on
+ * maidr.ai depends on.
+ *
+ * marked v15 dropped `headerIds` from core, so for as long as the site has been
+ * built with it every table-of-contents link has pointed at a fragment that did
+ * not exist (#913). Nothing failed: an unresolvable fragment is not an error,
+ * the browser just does not move, and a screen-reader user gets no announcement
+ * to say so. Fifty links across `README.md` and `docs/` were dead.
+ *
+ * The last `describe` is the part that stops it coming back, and it is the
+ * reason this file is worth more than a slug unit test: it walks the pages the
+ * build actually produces, collects every `href="#…"` in them, and asks the DOM
+ * whether that id is there. It fails on a broken slug rule, on a renamed
+ * heading, and on a link written against a slug GitHub would never generate —
+ * three ways for this to break that a test of `slugify` alone would miss.
+ *
+ * It runs in the `esm` project because the module under test is ESM (the repo
+ * is `"type": "module"`) and the CommonJS project cannot require it — the same
+ * arrangement, and the same reasoning, as `testArgs.esm-test.ts`.
+ */
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const TEMPLATE = readFileSync(resolve(ROOT, 'docs/template.html'), 'utf-8');
+
+/**
+ * `docs/BRAILLE.md` carries committed merge-conflict markers (#917). One lands
+ * inside a fenced code block, which flips the fence parity and swallows the
+ * last ninety lines of the file — including the `## Multiline Braille Display
+ * Support` heading that line 14 links to. No slug rule can fix that; the
+ * heading is not a heading any more. Pinned below rather than skipped, so the
+ * day #917 lands this turns red and the pin can go.
+ */
+const CONFLICTED_PAGE = 'docs/BRAILLE.md';
+
+/** Every markdown source the site builds into a page, in build order. */
+function markdownSources(): string[] {
+  const docs = readdirSync(resolve(ROOT, 'docs'))
+    .filter(file => file.endsWith('.md'))
+    .sort()
+    .map(file => `docs/${file}`);
+  return ['README.md', ...docs];
+}
+
+/**
+ * Build the page for a markdown source the way `scripts/build-site.js` does:
+ * render the markdown, then drop it into the real template.
+ *
+ * The template matters rather than being ceremony — it carries ids of its own
+ * and the skip link's `href="#main-content"`, so composing the two is what
+ * checks that the skip link resolves. The build script is not called directly
+ * because it writes `_site/` and shells out to `npm run build:react-example` on
+ * import; this reuses the one function that decides what a heading becomes.
+ */
+function buildPage(source: string): Document {
+  const markdown = readFileSync(resolve(ROOT, source), 'utf-8');
+  // The build strips the centred logo div off the top of the README.
+  const stripped = markdown.replace(/<div align="center">[\s\S]*?<\/div>\s*/, '');
+  const content = `<div class="content">${renderMarkdown(stripped)}</div>`;
+  return new JSDOM(TEMPLATE.replace('{{CONTENT}}', () => content)).window.document;
+}
+
+/** In-page links on a page that resolve to no element. */
+function deadAnchors(source: string): string[] {
+  const document = buildPage(source);
+  return [...document.querySelectorAll('a[href^="#"]')]
+    .map(anchor => anchor.getAttribute('href') ?? '')
+    // `href="#"` is the top of the page and always resolves; the examples
+    // gallery uses it for its onclick handlers.
+    .filter(href => href.length > 1)
+    .map(href => decodeURIComponent(href.slice(1)))
+    .filter(id => document.getElementById(id) === null)
+    .map(id => `#${id}`);
+}
+
+describe('the declarations beside the module', () => {
+  it('should describe what the module actually returns', () => {
+    // `markdown.d.ts` is hand-written and `tsc` never sees the JavaScript, so
+    // nothing else catches the two disagreeing. The annotations are half the
+    // check — a declared type that no longer fits stops compiling here — and
+    // the assertions are the other half.
+    const slug: string = slugify('Quick Start');
+    const allocator: (text: string) => string = createHeadingSlugger();
+    const html: string = renderMarkdown('# Quick Start\n');
+
+    expect(typeof slug).toBe('string');
+    expect(typeof allocator('Quick Start')).toBe('string');
+    expect(typeof html).toBe('string');
+  });
+});
+
+describe('slugify', () => {
+  it('should lower-case the text and hyphenate its spaces', () => {
+    expect(slugify('Quick Start')).toBe('quick-start');
+  });
+
+  it('should drop punctuation without closing the gap it leaves', () => {
+    // GitHub deletes the character and hyphenates whatever spaces survive, so
+    // the space that followed the comma becomes the hyphen and the one the
+    // bracket never had does not appear. `docs/vegalite.md` links to both of
+    // these, and they read like typos precisely because this is the rule.
+    expect(slugify('bindVegaLite(view, spec, options?)')).toBe('bindvegaliteview-spec-options');
+    expect(slugify('embed(target, spec, options?)')).toBe('embedtarget-spec-options');
+  });
+
+  it('should hyphenate each space rather than each run of them', () => {
+    // Dropping the `&` leaves two adjacent spaces, and both become hyphens.
+    // Collapsing them is the single most tempting simplification here and it
+    // breaks `README.md`'s link to this very heading.
+    expect(slugify('Live & Streaming Data')).toBe('live--streaming-data');
+  });
+
+  it('should drop an em dash but keep the ASCII hyphen', () => {
+    // Both are `\p{Pd}`. Slugging by that category would give a single hyphen
+    // and break `docs/VIOLIN_PLOT_SPEC.md`'s table of contents.
+    expect(slugify('4. KDE Layer — `violin_kde`'.replace(/`/g, ''))).toBe('4-kde-layer--violin_kde');
+    expect(slugify('Multi-Panel (Faceted) Charts')).toBe('multi-panel-faceted-charts');
+  });
+
+  it('should keep numbers and underscores', () => {
+    expect(slugify('16. Checklist for Backend Implementation')).toBe('16-checklist-for-backend-implementation');
+    expect(slugify('5. Box Layer — violin_box')).toBe('5-box-layer--violin_box');
+  });
+
+  it('should keep letters that are not ASCII', () => {
+    // GitHub slugs Unicode letters rather than transliterating or dropping
+    // them, so a heading in any language still gets a usable anchor.
+    expect(slugify('Café Crème')).toBe('café-crème');
+    expect(slugify('日本語の見出し')).toBe('日本語の見出し');
+  });
+
+  it('should drop emoji, leaving the hyphen their trailing space becomes', () => {
+    // An emoji is a symbol rather than a letter, so it goes and its space
+    // stays — which is why GitHub anchors for decorated headings start with a
+    // hyphen. Surprising, and matching it is the whole point.
+    expect(slugify('🎯 Goals')).toBe('-goals');
+    expect(slugify('🎯')).toBe('');
+  });
+});
+
+describe('createHeadingSlugger', () => {
+  it('should number repeated headings in document order', () => {
+    const slug = createHeadingSlugger();
+
+    const slugs = ['Setup', 'Setup', 'Setup'].map(slug);
+
+    expect(slugs).toEqual(['setup', 'setup-1', 'setup-2']);
+  });
+
+  it('should keep searching when the numbered form is itself taken', () => {
+    // By the time the literal `Bar Chart 1` heading arrives, the second
+    // `Bar Chart` has already been given `bar-chart-1`, so it has to settle for
+    // `bar-chart-1-1`. Stopping at the first suffix instead would put two
+    // elements on one id and send the link to whichever came first — and the
+    // numbering carries on from where it was, so the last one is `bar-chart-3`
+    // rather than `bar-chart-2`.
+    const slug = createHeadingSlugger();
+
+    const slugs = ['Bar Chart', 'Bar Chart', 'Bar Chart', 'Bar Chart 1', 'Bar Chart'].map(slug);
+
+    expect(slugs).toEqual(['bar-chart', 'bar-chart-1', 'bar-chart-2', 'bar-chart-1-1', 'bar-chart-3']);
+  });
+
+  it('should give each document its own numbering', () => {
+    const first = createHeadingSlugger();
+    const second = createHeadingSlugger();
+
+    first('Setup');
+
+    expect(second('Setup')).toBe('setup');
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('should give a heading the id its own table of contents links to', () => {
+    // The reproduction from #913, verbatim.
+    const html = renderMarkdown(
+      '- [Declaring What a Chart Means](#declaring-what-a-chart-means)\n\n'
+      + '## Declaring What a Chart Means\n',
+    );
+
+    expect(html).toContain('<h2 id="declaring-what-a-chart-means">');
+  });
+
+  it('should slug the text a code span renders to, not its backticks', () => {
+    const html = renderMarkdown('### `MaidrLayer`\n');
+
+    expect(html).toContain('id="maidrlayer"');
+    expect(html).toContain('<code>MaidrLayer</code>');
+  });
+
+  it('should slug an ampersand rather than the entity it escapes to', () => {
+    // The heading body is escaped to `&amp;`. Slugging that string instead of
+    // the text would give `live-amp-streaming-data`.
+    const html = renderMarkdown('## Live & Streaming Data\n');
+
+    expect(html).toContain('<h2 id="live--streaming-data">');
+    expect(html).toContain('Live &amp; Streaming Data');
+  });
+
+  it('should give every heading level an id', () => {
+    const html = renderMarkdown('# One\n\n## Two\n\n### Three\n\n#### Four\n\n##### Five\n\n###### Six\n');
+
+    expect(html.match(/<h[1-6] id="/g)).toHaveLength(6);
+  });
+
+  it('should emit no id attribute when nothing survives the slug', () => {
+    // `id=""` is not something a fragment can address, so an emoji-only
+    // heading is better off without the attribute than with an empty one. The
+    // second heading is here so this cannot pass by nothing having ids at all,
+    // which is exactly the state the fix is against.
+    const html = renderMarkdown('## 🎯\n\n## Goals\n');
+
+    expect(html).toContain('<h2>🎯</h2>');
+    expect(html).toContain('<h2 id="goals">');
+    expect(html).not.toContain('id=""');
+  });
+
+  it('should restart numbering for each document it renders', () => {
+    renderMarkdown('## Setup\n');
+    const html = renderMarkdown('## Setup\n');
+
+    expect(html).toContain('<h2 id="setup">');
+  });
+});
+
+describe('in-page anchors in every built page', () => {
+  const pages = markdownSources().filter(source => source !== CONFLICTED_PAGE);
+
+  it('should be checking the pages this bug was reported against', () => {
+    // A glob that quietly stopped matching would turn every case below green
+    // while checking nothing, which is the failure mode this whole file exists
+    // to close. #913 counted the links; assert the sources are still here.
+    expect(pages).toContain('README.md');
+    expect(pages).toContain('docs/amcharts.md');
+    expect(pages).toContain('docs/VIOLIN_PLOT_SPEC.md');
+    expect(pages.length).toBeGreaterThanOrEqual(18);
+  });
+
+  it.each(pages)('should resolve every in-page anchor in %s', (source) => {
+    expect(deadAnchors(source)).toEqual([]);
+  });
+
+  // Pinned rather than skipped — see CONFLICTED_PAGE and #917.
+  it.failing(`should resolve every in-page anchor in ${CONFLICTED_PAGE}`, () => {
+    expect(deadAnchors(CONFLICTED_PAGE)).toEqual([]);
+  });
+
+  it('should point the skip link at the main landmark', () => {
+    // The template's own anchor, and the one a keyboard user reaches first.
+    const document = buildPage('README.md');
+    const skipLink = document.querySelector('a.skip-link');
+
+    expect(skipLink?.getAttribute('href')).toBe('#main-content');
+    expect(document.getElementById('main-content')?.tagName).toBe('MAIN');
+  });
+
+  it('should put the skip link before everything else focusable', () => {
+    // Offscreen-until-focused only helps if it is the first stop, and it is
+    // ordinary source order that makes it one — nothing here sets tabindex.
+    const document = buildPage('README.md');
+    const focusable = document.querySelectorAll('a[href], button, [tabindex]:not([tabindex="-1"])');
+
+    expect(focusable[0]?.className).toBe('skip-link');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Every in-page anchor link on maidr.ai was dead.

`marked` v15 emits no heading `id` attributes — the `headerIds` option left marked core for the `marked-gfm-heading-id` extension, which this repository does not depend on. `scripts/build-site.js` crossed that boundary and nothing failed, because an unresolvable fragment is not an error: the browser simply does not move. Reproduced before changing anything:

```console
$ node -e "…marked.parse('- [Declaring What a Chart Means](#declaring-what-a-chart-means)\n\n## Declaring What a Chart Means\n')"
<li><a href="#declaring-what-a-chart-means">Declaring What a Chart Means</a></li>
<h2>Declaring What a Chart Means</h2>          ← no id
```

That is worse here than on most sites. A sighted user who clicks a dead table-of-contents link sees the page not move and scrolls manually. A screen-reader user gets no announcement, no focus move, and no signal that anything failed — the reading position simply stays put, and skipping to a section is the whole reason the table of contents exists.

## Related Issues

Closes #913.

Surfaced #917 — see "Additional Notes".

## Changes Made

### The slug rule, and why it is GitHub's

New `scripts/markdown.js` renders the site's markdown and gives every heading its GitHub slug as an `id`.

`marked-gfm-heading-id` is not installed and could not be added, so this is a small explicit renderer — which the issue notes is the better answer anyway, since it makes the rule testable, and the GitHub-compatibility requirement is exactly the kind of thing worth pinning.

The rule has to be GitHub's rather than a tidier one of our own: these files are read on github.com *and* on maidr.ai, and they carry one set of `[…](#…)` links for both. Anything else would work in one place and not the other.

1. Lower-case.
2. Drop anything that is not a letter, a number, a combining mark, a space, `_`, or an ASCII hyphen.
3. Turn **each** remaining space into a hyphen — each, not each run.
4. Number repeats in document order, and keep searching when the numbered form is itself taken.

Three details are load-bearing, and each is the kind of thing a naive slugifier gets wrong. All three are pinned by tests against real headings in this repository:

| Heading | Slug | Why it is easy to get wrong |
|---|---|---|
| `## Live & Streaming Data` | `live--streaming-data` | Dropping `&` leaves two spaces, and **both** become hyphens. Collapsing runs is the most tempting simplification here and it breaks the README's link to this heading. |
| ``## 4. KDE Layer — `violin_kde` `` | `4-kde-layer--violin_kde` | The em dash and the ASCII hyphen are both `\p{Pd}`. Slugging by that category drops the wrong one and gives a single hyphen. `docs/` has nine em-dashed headings. |
| ``### `embed(target, spec, options?)` `` | `embedtarget-spec-options` | Characters are **deleted**, not replaced — the bracket closes the gap while the comma leaves its following space behind. Reads like a typo; is what GitHub does. |

Code spans, links and `&` are slugged from the heading's rendered *text* rather than its raw markdown, so backticks and URLs never reach the slug and `&` arrives as itself rather than as the escaped `&amp;` (which would give `live-amp-streaming-data`).

The rule was verified character for character against `github-slugger` — the library GitHub's own pipeline uses — across **all 579 headings** in `README.md` and `docs/`, plus adversarial cases (emoji, CJK, accented letters, `C++ / C#`, `100%`, padding). Zero mismatches, including the duplicate-numbering path where a literal `Bar Chart 1` heading forces `bar-chart-1-1`. `github-slugger` is only present transitively, so it is **not** used by the shipped code or the tests — it was a one-off oracle.

The module is separate from `build-site.js` because that script writes files and shells out to `npm run build:react-example` on import, so nothing could load it to ask what a heading becomes. `scripts/markdown.d.ts` sits beside it, the same arrangement as `scripts/testArgs.d.ts`.

### The regression test

`test/scripts/siteAnchors.esm-test.ts` is the criterion that stops this coming back — the bug survived precisely because nothing checked it. For every page the site builds, it collects every `href="#…"` and asks the DOM whether an element with that id exists. It catches a broken slug rule, a renamed heading, **and** a link written against a slug GitHub would never generate; a unit test of `slugify` alone would miss the last two.

It lives in `test/scripts/` per the convention that directory documents, and in the `esm` project because the module under test is ESM and the CommonJS project cannot require it — the same split, and the same reasoning, as `testArgs.esm-test.ts`. It reuses the real template so the skip link is checked too, and does not shell out to the full build.

### Skip-to-content link

`docs/template.html` had a `<main>` but no skip link. Added: first focusable element in the body, offscreen until focused, targeting `<main id="main-content" tabindex="-1">`. Two CSS rules and one line of markup.

### Two links that were wrong on GitHub too

`docs/vegalite.md` pointed at `#bindvegalite-view-spec-options` and `#embed-target-spec-options`. GitHub deletes `(` without closing the gap, so the real slugs are `#bindvegaliteview-spec-options` and `#embedtarget-spec-options`. Those two links were dead on github.com as well, and no heading-id change could have fixed them.

## Screenshots (if applicable)

Not a visual change; the browser verification below is the equivalent evidence.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Verified in a real browser

The whole bug is "the page does not move", which no unit test fully captures. Built the site and drove it in Chromium (`/opt/pw-browsers/chromium-1194/chrome-linux/chrome`) via Playwright:

| Page | TOC link clicked | `scrollY` | Result |
|---|---|---|---|
| `index.html` | `#braille-generation` | 0 → 4164 | `<h2>` "Braille Generation" at top of viewport |
| `index.html` | `#live--streaming-data` | 0 → 3932 | `<h2>` "Live & Streaming Data" at top of viewport |
| `amcharts.html` | `#declaring-what-a-chart-means` | 0 → 6581 | `<h2>` "Declaring What a Chart Means" at top of viewport |
| `amcharts.html` | `#multi-panel-charts` | 0 → 9826 | `<h2>` "Multi-Panel Charts" at top of viewport |

In every case the viewport actually moved, `location.hash` updated, and the target heading landed at `top: 0px`. Pressing <kbd>Tab</kbd> immediately after each click moved focus to an element *below the heading* (y = 127, 152, 502, 283) rather than back to the top of the document — so the browser set the sequential focus navigation starting point at the heading, which is the correct behaviour for a non-focusable fragment target and the thing a screen reader follows.

Skip link: from a fresh load, the first <kbd>Tab</kbd> focuses `<a class="skip-link">` and it becomes visible (`left: 0`); <kbd>Enter</kbd> sets `#main-content` and moves focus to `<main id="main-content">`.

Full sweep in the browser across all 20 built pages: **70 in-page anchors, 1 dead** — the pinned `docs/BRAILLE.md` case below. Before this change, 50 of them were dead.

### One anchor is left dead, deliberately

`docs/BRAILLE.md` carries **unresolved merge-conflict markers committed on `main`** (filed separately as #917, along with a third in `docs/SCHEMA.md`). One `=======` marker lands inside a fenced code block, flipping the fence parity so the last ~90 lines of the file are swallowed into an unterminated code block. `marked`'s lexer stops seeing headings after `Sankey, alluvial and chord`, which means the `## Multiline Braille Display Support` heading that line 14 links to no longer exists as a heading at all.

No slug rule can fix that, and resolving it is a content decision — the two sides look like two sections that should both survive — so it belongs to a different change. Per the repo's testing rule it is pinned with `it.failing` and the issue number rather than skipped: the case keeps running, the suite stays green while the bug stands, and the day #917 lands it turns red as the reminder to remove the pin.

### Checks

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass — `unit` 4288/4288, `esm` 112/112.

Each new test was verified to fail without the fix: reverting the renderer hunk fails 17 of them. The slug rule was additionally mutation-tested — collapsing space runs fails 6, slugging by `\p{Pd}` fails 3, dropping duplicate numbering fails 2 — and the skip-link cases fail when the template hunk is reverted. Three tests pass either way by design and are disclosed as such: the hand-written-declarations guard (the convention `testArgs.esm-test.ts` establishes), the guard asserting the page list has not silently emptied, and the per-page cases for the six docs that currently contain no table-of-contents anchors — those are generated by `it.each` over the real `docs/` listing so a newly added anchor is covered without hand-maintaining a list.

### Note on #911

#911 also touches `scripts/build-site.js`, replacing the hardcoded examples gallery with a generated one. This change is deliberately confined to the `marked` configuration and the markdown-to-HTML path (the import, `markdownToHtml`, and the 13 per-page `marked.parse(…)` → `renderMarkdown(…)` call sites). It does not touch the examples-gallery section at all, so the two should merge cleanly.

Squash title is `fix(...)` on purpose: this is a user-facing defect on the published site, so it should cut a patch release rather than the no-op a `docs(...)` title would give.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_