### PR TITLE
feat(line): let a fitted curve carry its confidence band

### DIFF
--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -58,6 +58,29 @@ const SVG_PATH_ARITY: Record<string, number> = {
 };
 
 /**
+ * Read the uncertainty band a sample carries, when it carries one.
+ *
+ * Spread into the text state rather than assigned, so a point with no bounds
+ * produces no `interval` key at all — the text service branches on the field
+ * being present, and an `{}` would announce an empty clause.
+ *
+ * Only finite bounds count. A producer that fills the columns with `NaN` for
+ * the samples outside its fit is describing a curve with no band there, and
+ * announcing "interval NaN to NaN" would be worse than saying nothing.
+ *
+ * @param point - The sample under the cursor
+ * @returns A spreadable `{ interval }`, or nothing
+ */
+function intervalOf(point: LinePoint): { interval?: { min?: number; max?: number } } {
+  const min = Number.isFinite(point.yMin) ? point.yMin : undefined;
+  const max = Number.isFinite(point.yMax) ? point.yMax : undefined;
+  if (min === undefined && max === undefined) {
+    return {};
+  }
+  return { interval: { min, max } };
+}
+
+/**
  * Represents a line trace plot with support for single and multi-line navigation
  */
 export class LineTrace extends AbstractTrace {
@@ -275,6 +298,22 @@ export class LineTrace extends AbstractTrace {
       stats.push({ label: labels.names, value: lineNames });
     }
 
+    // How wide the uncertainty gets, when the chart draws any. That is what
+    // the per-sample statistics above cannot show: `Min value` and `Max value`
+    // describe the fitted curve, not the band around it, so a reader opening
+    // the description of a regression chart would otherwise learn nothing
+    // about how well determined it is.
+    const widths = this.points
+      .flat()
+      .map(point => Number(point.yMax) - Number(point.yMin))
+      .filter(width => Number.isFinite(width));
+    if (widths.length > 0) {
+      stats.push(
+        { label: 'Narrowest interval', value: MathUtil.safeMin(widths) },
+        { label: 'Widest interval', value: MathUtil.safeMax(widths) },
+      );
+    }
+
     let headers: string[];
     let rows: (string | number)[][];
 
@@ -467,6 +506,7 @@ export class LineTrace extends AbstractTrace {
       main: { label: this.xAxis, value: this.points[this.row][this.col].x },
       cross: { label: this.yAxis, value: crossValue },
       ...zData,
+      ...intervalOf(point),
     };
   }
 

--- a/src/service/text.ts
+++ b/src/service/text.ts
@@ -620,6 +620,38 @@ export class TextService implements Observer<PlotState>, Disposable {
       }
     }
 
+    // The uncertainty around the value, after it rather than instead of it —
+    // a band is a second fact about a real reading, not a replacement for it
+    // the way a histogram bin's extent is. Each bound is announced only when
+    // the chart drew it, so a one-sided interval reads as one.
+    if (state.interval !== undefined) {
+      const { min, max } = state.interval;
+      if (min !== undefined && max !== undefined) {
+        verbose.push(
+          Constant.COMMA_SPACE,
+          'interval',
+          Constant.SPACE,
+          this.formatSingleValue(min, crossAxisType),
+          Constant.THROUGH,
+          this.formatSingleValue(max, crossAxisType),
+        );
+      } else if (min !== undefined) {
+        verbose.push(
+          Constant.COMMA_SPACE,
+          'interval from',
+          Constant.SPACE,
+          this.formatSingleValue(min, crossAxisType),
+        );
+      } else if (max !== undefined) {
+        verbose.push(
+          Constant.COMMA_SPACE,
+          'interval up to',
+          Constant.SPACE,
+          this.formatSingleValue(max, crossAxisType),
+        );
+      }
+    }
+
     return verbose.join(Constant.EMPTY);
   }
 

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -727,6 +727,26 @@ export interface LinePoint {
    * { x: 1.5, y: 3, label: 'REM' }
    */
   label?: string;
+  /**
+   * Lower bound of the uncertainty around `y`, when the chart draws one.
+   *
+   * A fitted curve almost always comes with a band, and it is the reason the
+   * curve is drawn rather than a plain line: `geom_smooth(se = TRUE)` and
+   * `sns.regplot` both default to one. Carried on the sample rather than in a
+   * layer of its own so a reader hears the value and its interval at the same
+   * x — the comparison a band exists for is whether the trend is
+   * distinguishable from flat, and that cannot be made by navigating two
+   * layers in turn.
+   *
+   * Named to match {@link ErrorBarPoint}, so a producer that already computes
+   * an interval emits the same keys wherever it puts them.
+   *
+   * Both bounds are optional and independent: a one-sided interval is a real
+   * chart, and a sample missing its bounds still carries its value.
+   */
+  yMin?: number;
+  /** Upper bound of the uncertainty around `y`. See {@link LinePoint.yMin}. */
+  yMax?: number;
 }
 
 /**

--- a/src/type/state.ts
+++ b/src/type/state.ts
@@ -386,6 +386,19 @@ export interface TextState {
    * shape.
    */
   stack?: { label: string; value: number; share?: number };
+  /**
+   * The uncertainty around the value in `cross`, announced as a clause after
+   * it rather than in place of it.
+   *
+   * Deliberately not {@link TextState.range}, which is a *main-axis* extent
+   * that **replaces** the main value — right for a histogram bin ("x is 3
+   * through 5") and wrong here, where the value is a real reading and the
+   * interval is a second fact about it. A band on a fitted curve has to be
+   * heard alongside "y is 3.2", not instead of it.
+   *
+   * Either bound may be absent: a one-sided interval is a real chart.
+   */
+  interval?: { min?: number; max?: number };
   range?: { min: number; max: number };
   /**
    * Facts the point carries that sit on neither axis, announced as their own

--- a/test/model/lineInterval.test.ts
+++ b/test/model/lineInterval.test.ts
@@ -1,0 +1,133 @@
+/**
+ * A fitted curve can now carry its own confidence band (#919).
+ *
+ * A band is the reason a smooth is drawn rather than a plain line — both
+ * `geom_smooth(se = TRUE)` and `sns.regplot` default to one — and until now
+ * `LineTrace` read neither bound, so a producer had nowhere to put it on the
+ * layer that owns the curve.
+ *
+ * Carried on the sample rather than in a layer of its own, so a reader hears
+ * the value and its interval at the same x. The comparison a band exists for
+ * is whether the trend is distinguishable from flat, and that cannot be made
+ * by navigating two layers in turn.
+ */
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { DescriptionStat, TextState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { LineTrace } from '@model/line';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Build a line layer over the given samples.
+ * @param data - The samples, one array per series
+ * @param type - The trace type, defaulting to a plain line
+ * @returns A layer definition
+ */
+function layer(data: LinePoint[][], type: TraceType = TraceType.LINE): MaidrLayer {
+  return {
+    id: 'interval-layer',
+    type,
+    title: 'Fit',
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data,
+  } as MaidrLayer;
+}
+
+/**
+ * The text state at the cursor, which is what carries the interval.
+ * @param trace - The trace to read
+ * @returns The text state
+ */
+function textOf(trace: ReturnType<typeof TraceFactory.create>): TextState {
+  const state = trace.state as { empty: false; text: TextState };
+  return state.text;
+}
+
+describe('a sample carrying an uncertainty band', () => {
+  test('announces the interval alongside the value', () => {
+    const trace = TraceFactory.create(
+      layer([[{ x: 1, y: 3, yMin: 2, yMax: 4 }]]),
+    );
+
+    expect(textOf(trace).interval).toEqual({ min: 2, max: 4 });
+    // The value is still there: the band is a second fact about a real
+    // reading, not a replacement for it.
+    expect(textOf(trace).cross).toEqual({ label: 'Y', value: 3 });
+  });
+
+  test('a smooth inherits it unchanged', () => {
+    // The point of putting it on `LineTrace`: `SmoothTrace` extends it and
+    // overrides only `plotType`, so a fitted curve needs nothing of its own.
+    const trace = TraceFactory.create(
+      layer([[{ x: 1, y: 3, yMin: 2, yMax: 4 }]], TraceType.SMOOTH),
+    );
+
+    expect(textOf(trace).interval).toEqual({ min: 2, max: 4 });
+  });
+});
+
+describe('a sample with no band', () => {
+  test('carries no interval field at all', () => {
+    // Absent rather than empty: the text service branches on the field being
+    // present, so `{}` would announce a clause with nothing in it.
+    const trace = TraceFactory.create(layer([[{ x: 1, y: 3 }]]));
+
+    expect(textOf(trace)).not.toHaveProperty('interval');
+  });
+
+  test('a non-finite bound is treated as no bound', () => {
+    // A producer fills the columns with NaN for samples outside its fit.
+    // "interval NaN through NaN" would be worse than silence.
+    const trace = TraceFactory.create(
+      layer([[{ x: 1, y: 3, yMin: Number.NaN, yMax: Number.NaN }]]),
+    );
+
+    expect(textOf(trace)).not.toHaveProperty('interval');
+  });
+});
+
+describe('a one-sided interval', () => {
+  test('announces only the bound the chart drew', () => {
+    const lower = TraceFactory.create(layer([[{ x: 1, y: 3, yMin: 2 }]]));
+    expect(textOf(lower).interval).toEqual({ min: 2, max: undefined });
+
+    const upper = TraceFactory.create(layer([[{ x: 1, y: 3, yMax: 4 }]]));
+    expect(textOf(upper).interval).toEqual({ min: undefined, max: 4 });
+  });
+});
+
+describe('the description', () => {
+  test('reports how wide the band gets', () => {
+    // `Min value` / `Max value` describe the curve, not the band around it,
+    // so a reader would otherwise learn nothing about how well determined
+    // the fit is.
+    //
+    // Constructed directly rather than through the factory, which types its
+    // result as the navigable `Trace` and does not expose `description`.
+    const trace = new LineTrace(
+      layer([[
+        { x: 1, y: 3, yMin: 2.5, yMax: 3.5 },
+        { x: 2, y: 4, yMin: 2, yMax: 6 },
+      ]]),
+    );
+    const labels = trace.description.stats.map((stat: DescriptionStat) => stat.label);
+
+    expect(labels).toContain('Narrowest interval');
+    expect(labels).toContain('Widest interval');
+
+    const widths = trace.description.stats.filter(
+      (stat: DescriptionStat) =>
+        stat.label === 'Narrowest interval' || stat.label === 'Widest interval',
+    );
+    expect(widths.map((stat: DescriptionStat) => stat.value)).toEqual([1, 4]);
+  });
+
+  test('says nothing about a band on a chart that draws none', () => {
+    const trace = new LineTrace(layer([[{ x: 1, y: 3 }, { x: 2, y: 4 }]]));
+    const labels = trace.description.stats.map((stat: DescriptionStat) => stat.label);
+
+    expect(labels).not.toContain('Narrowest interval');
+    expect(labels).not.toContain('Widest interval');
+  });
+});

--- a/test/service/textInterval.test.ts
+++ b/test/service/textInterval.test.ts
@@ -1,0 +1,117 @@
+import type { NotificationService } from '@service/notification';
+import type { LinePoint, Maidr, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { LineTrace } from '@model/line';
+import { FormatterService } from '@service/formatter';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * How the text layer announces the uncertainty around a value (#919).
+ *
+ * A fitted curve's band is a *second fact about a real reading*, so it is
+ * announced after the value rather than in place of it. That is what separates
+ * it from `state.range`, which replaces the main value — right for a histogram
+ * bin ("X is 5 through 10"), wrong for a reading that also has an interval.
+ *
+ * These cover the rendering rather than the model, so the cross-axis formatter
+ * is exercised on the same path: a chart whose y axis is money has to announce
+ * its bounds as money too, or the interval reads as two bare numbers beside a
+ * formatted value.
+ */
+
+/** Minimal NotificationService stub whose notify is a jest mock. */
+function createMockNotificationService(): NotificationService {
+  return { notify: jest.fn() } as unknown as NotificationService;
+}
+
+/** Builds a line layer over one series. */
+function lineLayer(points: LinePoint[], axes?: MaidrLayer['axes']): MaidrLayer {
+  return {
+    id: 'fit',
+    type: TraceType.LINE,
+    title: 'Fitted trend',
+    axes: axes ?? { x: { label: 'Year' }, y: { label: 'Value' } },
+    data: [points],
+  } as MaidrLayer;
+}
+
+/** A figure carrying one layer, as the formatter service reads it. */
+function figureOf(layer: MaidrLayer): Maidr {
+  return {
+    id: 'figure',
+    title: 'Figure',
+    subplots: [[{ layers: [layer] }]],
+  } as unknown as Maidr;
+}
+
+/** The text a service emits for one trace state, in the current text mode. */
+function announce(text: TextService, state: TraceState): string {
+  const changeListener = jest.fn();
+  const disposable = text.onChange(changeListener);
+
+  text.update(state);
+  disposable.dispose();
+  const event = changeListener.mock.calls[0][0] as { value: string };
+  return event.value;
+}
+
+describe('announcing an interval around a value', () => {
+  test('reads the value first and the band after it', () => {
+    const trace = new LineTrace(lineLayer([{ x: 2020, y: 3, yMin: 2, yMax: 4 }]));
+    const text = new TextService(createMockNotificationService());
+
+    expect(announce(text, trace.getStateAt(0, 0)))
+      .toBe('Year is 2020, Value is 3, interval 2 through 4');
+  });
+
+  test('a chart with no band announces exactly as it did before', () => {
+    // The whole feature has to be invisible to every line chart that draws no
+    // band, which is most of them.
+    const trace = new LineTrace(lineLayer([{ x: 2020, y: 3 }]));
+    const text = new TextService(createMockNotificationService());
+
+    expect(announce(text, trace.getStateAt(0, 0)))
+      .toBe('Year is 2020, Value is 3');
+  });
+
+  test('sends both bounds through the cross-axis formatter', () => {
+    // The reason the bounds travel as two numbers rather than a pre-joined
+    // string: a formatted y axis would otherwise announce a formatted value
+    // beside two raw ones.
+    const layer = lineLayer([{ x: 2020, y: 3, yMin: 2, yMax: 4 }], {
+      x: { label: 'Year' },
+      y: {
+        label: 'Value',
+        // A function *body* the formatter compiles at runtime, so it is
+        // written as concatenation — a template literal here would be
+        // interpolated by our own source instead.
+        format: { function: 'return "$" + Number(value).toFixed(2)' },
+      },
+    });
+    const trace = new LineTrace(layer);
+    const text = new TextService(
+      createMockNotificationService(),
+      new FormatterService(figureOf(layer)),
+    );
+
+    const spoken = announce(text, trace.getStateAt(0, 0));
+
+    expect(spoken).toContain('interval $2.00 through $4.00');
+    expect(spoken).not.toContain('interval 2 through 4');
+  });
+});
+
+describe('a one-sided interval', () => {
+  test('names only the bound the chart drew', () => {
+    const lower = new LineTrace(lineLayer([{ x: 2020, y: 3, yMin: 2 }]));
+    const upper = new LineTrace(lineLayer([{ x: 2020, y: 3, yMax: 4 }]));
+    const text = new TextService(createMockNotificationService());
+
+    expect(announce(text, lower.getStateAt(0, 0)))
+      .toBe('Year is 2020, Value is 3, interval from 2');
+    expect(announce(new TextService(createMockNotificationService()), upper.getStateAt(0, 0)))
+      .toBe('Year is 2020, Value is 3, interval up to 4');
+  });
+});


### PR DESCRIPTION
Closes #919.

## The gap

A band is the reason a smooth is drawn rather than a plain line — `geom_smooth(se = TRUE)` and `sns.regplot` both default to one — and `LineTrace` read neither bound. Both bindings hit the same wall from opposite sides:

| producer | before |
|---|---|
| `sns.regplot` (py-maidr) | `SCATTER` + `SMOOTH` — **band absent entirely** |
| `geom_smooth(se = TRUE)` (r-maidr, xability/r-maidr#166) | `smooth` + a separate `error_bar` layer |

The separate-layer workaround costs three things, all from the band living somewhere other than the curve: the reader cannot hear a value and its interval at one x; a hue-split chart needs one band layer per curve because `ErrorBarPoint` carries no `z`; and r-maidr's facet path cannot express it at all, since a panel holds one layer type by construction. All three dissolve once the curve carries its own bounds.

## The change

`LinePoint` gains optional `yMin` / `yMax`, **named to match `ErrorBarPoint`** so a producer that already computes an interval emits the same keys wherever it puts them. `SmoothTrace` needs nothing beyond inheriting it, which is the point of putting it on `LineTrace`.

The announcement reads after the value rather than instead of it:

```
Year is 2020, Value is 3, interval 2 through 4
```

**`TextState.range` is deliberately not the slot.** `range` is a *main-axis* extent that **replaces** the main value — right for a histogram bin ("X is 5 through 10"), wrong here, where the value is a real reading and the band is a second fact about it. So this adds `TextState.interval`, announced as its own clause.

Both bounds go through the **cross-axis formatter**, pinned by a test: a chart whose y axis is money would otherwise announce a formatted value beside two raw ones.

Details that are choices rather than accidents:

- **Each bound is independent.** A one-sided interval is a real chart, and reads as `interval from 2` / `interval up to 4`.
- **A non-finite bound is no bound.** Producers fill the columns with `NaN` for samples outside the fit; "interval NaN through NaN" would be worse than silence.
- **No bounds means no `interval` key at all**, not an empty one — the text service branches on the field being present, so `{}` would announce a clause with nothing in it.
- **The description gains `Narrowest interval` / `Widest interval`.** `Min value` and `Max value` describe the fitted curve, not the band around it, so a reader opening a regression chart's description would otherwise learn nothing about how well determined it is.

## Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` clean; **290 unit suites / 4323 tests** and **7 ESM suites / 73 tests** pass, including 11 new ones across `test/model/lineInterval.test.ts` and `test/service/textInterval.test.ts`.

A line chart that draws no band announces **exactly** as it did before — pinned, since that is most line charts and the feature has to be invisible to them.

Falsification:

| reverted | failures |
|---|---|
| model stops reading the bounds | **6 of 11** |
| text service stops announcing the clause | **3 of 11** |

## Follow-on for the producers

Neither is blocked on anything else; both were verified to have the data before this was written.

- **r-maidr** already computes `{x, y, yMin, yMax}` for its band. Moving those onto the smooth points drops the second layer, the facet guard, and the per-curve naming.
- **py-maidr**: `sns.regplot`'s band arrives as a `FillBetweenPolyCollection` — measured, 203 vertices for a 100-sample fit, so the upper edge out and the lower edge back. Same ring structure `AreaTrace.withoutBaseline` already reasons about, and the subclass py-maidr's highlight patch already wraps.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_