### PR TITLE
fix(docs): resolve the committed conflict markers and guard against more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,37 @@ jobs:
       - name: Check generated instruction files
         run: npm run sync:copilot:check
 
+  # Three unresolved conflict regions sat on `main` for weeks and shipped to
+  # maidr.ai (#917). They passed commitlint, the linter, the type check, the
+  # build and the whole test suite, because none of those read prose — and one
+  # `=======` inside a fenced code block silently swallowed the last ninety
+  # lines of docs/BRAILLE.md.
+  #
+  # Every tracked file rather than markdown: the same mistake in a .ts file
+  # would at least fail the type check, but in .html or .json it would sail
+  # through exactly as this one did.
+  #
+  # Pure Node and git with no dependencies, so it skips npm ci, and it gates
+  # nothing for the same reason commitlint below does not.
+  conflict-markers:
+    name: No Conflict Markers
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Check tracked files for conflict markers
+        run: npm run check:conflicts
+
   # Gates nothing, and must not: `needs` does not just order jobs, it *skips*
   # them when the dependency fails, so a commit subject that does not parse
   # used to take the build, the type check, the whole unit suite and every e2e

--- a/docs/BRAILLE.md
+++ b/docs/BRAILLE.md
@@ -835,7 +835,6 @@ Contours use one line per level on a multiline display, which is the case where
 braille gives back what the announcement carries: two fingers on adjacent rows
 feel exactly where the curves crowd together and where they open out.
 
-<<<<<<< HEAD
 ## Sankey, alluvial and chord
 
 One row per **stage** -- one column of the drawing -- with one cell per node in
@@ -867,7 +866,14 @@ Stage   Cells
 0       ⣿⠶
 1       ⠂⣿⡶
 2       ⣿⡖
-=======
+```
+
+### Multiline Displays
+
+One line per stage, so a hand across the display holds the whole chart and the
+narrowing from source to sink is felt directly -- the one thing here braille
+conveys better than it conveys the ribbons.
+
 ## Network
 
 One row per **connected group**, one cell per node in it, ordered most
@@ -890,20 +896,13 @@ data, so there is nothing there to put in a cell.
 Group   Cells
 1       ⣿⡶⡶⠆⠆
 2       ⡶⡶⡶
->>>>>>> eae4da3f (feat(network): reach every node, which following links cannot)
 ```
 
 ### Multiline Displays
 
-<<<<<<< HEAD
-One line per stage, so a hand across the display holds the whole chart and the
-narrowing from source to sink is felt directly -- the one thing here braille
-conveys better than it conveys the ribbons.
-=======
 One line per group, so the split into groups -- the structure a reader
 following links can never discover, because links do not cross between them --
 is felt directly as separate rows of different lengths.
->>>>>>> eae4da3f (feat(network): reach every node, which following links cannot)
 
 ## Treemap
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "check-models": "node scripts/check-model-catalog.mjs",
+    "check:conflicts": "node scripts/conflictMarkers.js",
     "sync:copilot": "node scripts/sync-copilot-instructions.mjs",
     "sync:copilot:check": "node scripts/sync-copilot-instructions.mjs --check",
     "semantic-release": "semantic-release",

--- a/scripts/conflictMarkers.d.ts
+++ b/scripts/conflictMarkers.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Hand-written declarations for `scripts/conflictMarkers.js`.
+ *
+ * The same arrangement as `scripts/markdown.d.ts`: the module is plain ESM run
+ * directly by node, and `tsconfig.json` sets `allowJs: false`, so a test can
+ * only import it with declarations beside it.
+ * `test/scripts/conflictMarkers.esm-test.ts` checks these against what the
+ * module actually returns, since `tsc` never sees the JavaScript.
+ */
+
+/** One marker line, as found in a file. */
+export interface ConflictMarker {
+  /** 1-based line number. */
+  line: number;
+  /** Which of the four markers this is. */
+  name: 'ours' | 'base' | 'separator' | 'theirs';
+  /** The line itself, without any trailing carriage return. */
+  text: string;
+}
+
+/** One marker line, with the file it was found in. */
+export interface ConflictMarkerHit extends ConflictMarker {
+  /** Repository-relative path. */
+  file: string;
+}
+
+/** Find the conflict markers in one file's text, in file order. */
+export declare function conflictMarkersIn(text: string): ConflictMarker[];
+
+/** List the repository's tracked files, as `git ls-files` reports them. */
+export declare function trackedFiles(root?: string): string[];
+
+/** Scan every tracked file for conflict markers, skipping binary files. */
+export declare function findConflictMarkers(root?: string): ConflictMarkerHit[];

--- a/scripts/conflictMarkers.js
+++ b/scripts/conflictMarkers.js
@@ -1,0 +1,165 @@
+/**
+ * Fails when a tracked file still contains a merge-conflict marker.
+ *
+ * **Why this exists.** Three unresolved conflict regions sat on `main` for
+ * weeks in `docs/BRAILLE.md` and `docs/SCHEMA.md` (#917). They passed
+ * commitlint, eslint, the type check, the build, the whole test suite and
+ * every CI job, and shipped to maidr.ai — because none of those read markdown
+ * content. One `=======` landed inside a fenced code block, flipped the fence
+ * parity, and swallowed the last ninety lines of the document, so two headings
+ * stopped existing and an in-page link stopped resolving. Nothing was red.
+ *
+ * **Why every tracked file rather than markdown.** The same mistake in a `.ts`
+ * file would at least fail the type check, but in `.html`, `.json`, `.yml` or
+ * a snapshot it would sail through exactly as this one did. The cost of
+ * reading every tracked file is a fraction of a second, so there is no reason
+ * to narrow it.
+ *
+ * **Why the markers are built rather than written.** This file, and its test,
+ * have to talk about the markers without containing them — a guard that
+ * matches its own source is a guard nobody can keep. `'<'.repeat(7)` puts the
+ * run of characters in memory instead of on disk, so `git grep` for a marker
+ * finds real conflicts and not the check that looks for them. The test proves
+ * it by running the check over the repository, which includes this file.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The four lines `git merge` writes into a conflicted file.
+ *
+ * The separator is anchored at both ends because a bare run of `=` is also a
+ * setext heading underline; the other three carry a label after the space, so
+ * a trailing space is part of what identifies them. The diff3 base marker only
+ * appears under `merge.conflictStyle = diff3`, which is not the default — it
+ * is here because a contributor who has set it produces conflicts this would
+ * otherwise half-detect.
+ *
+ * The runs are escaped on the way into the pattern, not just repeated: the
+ * base marker's character is regular-expression alternation, and `^||||||| `
+ * unescaped is seven empty alternatives, which matches every line of every
+ * file. That is not hypothetical — the first run of this check reported all
+ * 1120 tracked files as conflicted.
+ */
+const MARKERS = [
+  { name: 'ours', pattern: markerPattern('<', ' ') },
+  { name: 'base', pattern: markerPattern('|', ' ') },
+  { name: 'separator', pattern: markerPattern('=', '$') },
+  { name: 'theirs', pattern: markerPattern('>', ' ') },
+];
+
+/**
+ * Build the pattern for one marker without writing the marker down.
+ *
+ * @param {string} character The character git repeats seven times
+ * @param {string} tail What follows the run: a literal space, or `$` for the
+ * separator, which has nothing after it
+ * @returns {RegExp} The anchored pattern
+ */
+function markerPattern(character, tail) {
+  const escaped = character.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+  return new RegExp(`^${escaped.repeat(7)}${tail}`);
+}
+
+/**
+ * Find the conflict markers in one file's text.
+ *
+ * @param {string} text The file contents
+ * @returns {{ line: number, name: string, text: string }[]} One entry per
+ * marker line found, in file order, with 1-based line numbers
+ */
+export function conflictMarkersIn(text) {
+  const found = [];
+
+  for (const [index, line] of text.split('\n').entries()) {
+    // `\r` would otherwise stop a CRLF file's separator from matching its
+    // end-anchored pattern, which is the one marker with nothing after it.
+    const candidate = line.replace(/\r$/, '');
+    const marker = MARKERS.find(({ pattern }) => pattern.test(candidate));
+    if (marker) {
+      found.push({ line: index + 1, name: marker.name, text: candidate });
+    }
+  }
+
+  return found;
+}
+
+/**
+ * List the repository's tracked files.
+ *
+ * `git ls-files` rather than a directory walk: it is the definition of
+ * "tracked", so it already excludes `node_modules`, `_site`, `dist` and
+ * anything else `.gitignore` covers, without this file having to keep a list
+ * of them in step.
+ *
+ * @param {string} [root] The repository to list, defaulting to this one
+ * @returns {string[]} Repository-relative paths
+ */
+export function trackedFiles(root = ROOT) {
+  const listed = execFileSync('git', ['ls-files', '-z'], {
+    cwd: root,
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+  return listed.split('\0').filter(Boolean);
+}
+
+/**
+ * Scan every tracked file for conflict markers.
+ *
+ * Binary files are read and skipped rather than filtered by extension: a NUL
+ * byte is what makes a file unreadable as lines, and it needs no list of
+ * extensions to keep current. A file that is tracked but missing from the
+ * working tree is skipped too, so a half-applied checkout reports nothing
+ * rather than crashing.
+ *
+ * @param {string} [root] The repository to scan, defaulting to this one
+ * @returns {{ file: string, line: number, name: string, text: string }[]} One
+ * entry per marker line found, grouped by file in `git ls-files` order
+ */
+export function findConflictMarkers(root = ROOT) {
+  const found = [];
+
+  for (const file of trackedFiles(root)) {
+    let buffer;
+    try {
+      buffer = readFileSync(resolve(root, file));
+    } catch {
+      continue;
+    }
+
+    if (buffer.includes(0)) {
+      continue;
+    }
+
+    for (const marker of conflictMarkersIn(buffer.toString('utf-8'))) {
+      found.push({ file, ...marker });
+    }
+  }
+
+  return found;
+}
+
+// Run as a script: report every marker and fail, so the whole set is visible
+// from one run rather than one per push.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const found = findConflictMarkers();
+
+  if (found.length > 0) {
+    console.error(`Merge-conflict markers in ${new Set(found.map(one => one.file)).size} tracked file(s):\n`);
+    for (const { file, line, name, text } of found) {
+      console.error(`  ${file}:${line}  ${name}  ${text}`);
+    }
+    console.error('\nResolve the conflict and commit the resolved file.');
+    process.exit(1);
+  }
+
+  console.log(`No merge-conflict markers in ${trackedFiles().length} tracked files.`);
+}

--- a/test/scripts/conflictMarkers.esm-test.ts
+++ b/test/scripts/conflictMarkers.esm-test.ts
@@ -1,0 +1,151 @@
+import { Buffer } from 'node:buffer';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { conflictMarkersIn, findConflictMarkers, trackedFiles } from '../../scripts/conflictMarkers';
+
+/**
+ * Tests for `scripts/conflictMarkers.js` — the check that no tracked file
+ * carries a merge-conflict marker.
+ *
+ * Three conflict regions sat on `main` for weeks (#917) and passed every
+ * existing check, because none of them reads file content that is not code.
+ * The last case here is the one that matters: it runs the check over this
+ * repository and expects nothing, which is the assertion CI makes on every
+ * run.
+ *
+ * The awkward part is that a test for a marker detector has to produce
+ * markers, and would then flag itself. Both this file and the module under
+ * test build the markers from `repeat` instead of writing them out, so the
+ * bytes on disk never contain a run — and the repository-wide case, which
+ * covers both files, is what proves it.
+ *
+ * It runs in the `esm` project because the module under test is ESM, the same
+ * arrangement as `siteAnchors.esm-test.ts`.
+ */
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** Build a marker line the way git writes it, without writing one here. */
+function marker(character: string, label = ''): string {
+  const run = character.repeat(7);
+  return label === '' ? run : `${run} ${label}`;
+}
+
+const OURS = marker('<', 'HEAD');
+const BASE = marker('|', 'merged common ancestors');
+const SEPARATOR = marker('=');
+const THEIRS = marker('>', 'eae4da3f (feat(network): reach every node)');
+
+describe('conflictMarkersIn', () => {
+  it('should find each of the four markers git writes', () => {
+    const text = `one\n${OURS}\ntwo\n${BASE}\nbase\n${SEPARATOR}\nthree\n${THEIRS}\nfour\n`;
+
+    const found = conflictMarkersIn(text);
+
+    expect(found.map(one => one.name)).toEqual(['ours', 'base', 'separator', 'theirs']);
+    expect(found.map(one => one.line)).toEqual([2, 4, 6, 8]);
+  });
+
+  it('should report the marker inside a fenced code block', () => {
+    // The #917 case exactly: the separator landed between the fences, which is
+    // why it flipped the parity and swallowed the rest of the document. A
+    // check that understood markdown blocks would have skipped the one line
+    // that did the damage.
+    const text = `\`\`\`\nStage   Cells\n${SEPARATOR}\nGroup   Cells\n\`\`\`\n`;
+
+    expect(conflictMarkersIn(text)).toEqual([
+      { line: 3, name: 'separator', text: SEPARATOR },
+    ]);
+  });
+
+  it('should find a marker on a CRLF line', () => {
+    // The separator is the one marker anchored at its end, so a stray
+    // carriage return is all it takes to hide it.
+    const text = `one\r\n${SEPARATOR}\r\ntwo\r\n`;
+
+    expect(conflictMarkersIn(text).map(one => one.name)).toEqual(['separator']);
+  });
+
+  it('should ignore lines that only look like markers', () => {
+    // A setext underline of some other length, a marker with no label, an
+    // indented one, and prose about markers — none of which git writes.
+    const text = [
+      'Heading',
+      '='.repeat(6),
+      '='.repeat(8),
+      marker('<'),
+      `  ${OURS}`,
+      `A conflict starts with ${OURS}.`,
+      '',
+    ].join('\n');
+
+    expect(conflictMarkersIn(text)).toEqual([]);
+  });
+
+  it('should return nothing for a file with no markers', () => {
+    expect(conflictMarkersIn('# Title\n\nSome prose.\n')).toEqual([]);
+  });
+});
+
+describe('findConflictMarkers', () => {
+  let repository: string;
+
+  beforeAll(() => {
+    repository = mkdtempSync(join(tmpdir(), 'maidr-conflict-'));
+    execFileSync('git', ['init', '--quiet'], { cwd: repository });
+
+    writeFileSync(join(repository, 'clean.md'), '# Title\n\nProse.\n');
+    writeFileSync(join(repository, 'untracked.md'), `${OURS}\nstray\n${THEIRS}\n`);
+    // Not markdown, and the reason the check is not scoped to markdown: a
+    // marker here fails no linter, no type check and no build.
+    writeFileSync(join(repository, 'page.html'), `<p>a</p>\n${SEPARATOR}\n<p>b</p>\n`);
+    // A NUL byte makes this unreadable as lines; the check skips it rather
+    // than keeping a list of binary extensions in step.
+    writeFileSync(join(repository, 'logo.bin'), Buffer.from([0x89, 0x00, 0x1A, 0x0A]));
+
+    execFileSync('git', ['add', 'clean.md', 'page.html', 'logo.bin'], { cwd: repository });
+  });
+
+  afterAll(() => {
+    rmSync(repository, { recursive: true, force: true });
+  });
+
+  it('should report a marker in a tracked non-markdown file', () => {
+    expect(findConflictMarkers(repository)).toEqual([
+      { file: 'page.html', line: 2, name: 'separator', text: SEPARATOR },
+    ]);
+  });
+
+  it('should look only at tracked files', () => {
+    // `untracked.md` is the noisiest file in the fixture and is deliberately
+    // not added: an editor's `.orig` leftover or a local scratch file is not
+    // something CI should fail on.
+    expect(trackedFiles(repository)).toEqual(['clean.md', 'logo.bin', 'page.html']);
+    expect(findConflictMarkers(repository).map(one => one.file)).not.toContain('untracked.md');
+  });
+});
+
+describe('this repository', () => {
+  it('should track the files the check is meant to cover', () => {
+    // A `git ls-files` that returned nothing would turn the case below green
+    // while reading no files at all, which is the one failure this guard
+    // cannot afford.
+    const tracked = trackedFiles();
+
+    expect(tracked).toContain('docs/BRAILLE.md');
+    expect(tracked).toContain('docs/SCHEMA.md');
+    expect(tracked).toContain('scripts/conflictMarkers.js');
+    expect(tracked).toContain('test/scripts/conflictMarkers.esm-test.ts');
+    expect(tracked.length).toBeGreaterThan(100);
+  });
+
+  it('should contain no merge-conflict markers in any tracked file', () => {
+    // Covers the check's own source and this file with everything else, which
+    // is what proves neither of them contains the runs it looks for.
+    expect(findConflictMarkers(ROOT)).toEqual([]);
+  });
+});

--- a/test/scripts/siteAnchors.esm-test.ts
+++ b/test/scripts/siteAnchors.esm-test.ts
@@ -30,16 +30,6 @@ import { createHeadingSlugger, renderMarkdown, slugify } from '../../scripts/mar
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const TEMPLATE = readFileSync(resolve(ROOT, 'docs/template.html'), 'utf-8');
 
-/**
- * `docs/BRAILLE.md` carries committed merge-conflict markers (#917). One lands
- * inside a fenced code block, which flips the fence parity and swallows the
- * last ninety lines of the file — including the `## Multiline Braille Display
- * Support` heading that line 14 links to. No slug rule can fix that; the
- * heading is not a heading any more. Pinned below rather than skipped, so the
- * day #917 lands this turns red and the pin can go.
- */
-const CONFLICTED_PAGE = 'docs/BRAILLE.md';
-
 /** Every markdown source the site builds into a page, in build order. */
 function markdownSources(): string[] {
   const docs = readdirSync(resolve(ROOT, 'docs'))
@@ -232,7 +222,7 @@ describe('renderMarkdown', () => {
 });
 
 describe('in-page anchors in every built page', () => {
-  const pages = markdownSources().filter(source => source !== CONFLICTED_PAGE);
+  const pages = markdownSources();
 
   it('should be checking the pages this bug was reported against', () => {
     // A glob that quietly stopped matching would turn every case below green
@@ -241,16 +231,17 @@ describe('in-page anchors in every built page', () => {
     expect(pages).toContain('README.md');
     expect(pages).toContain('docs/amcharts.md');
     expect(pages).toContain('docs/VIOLIN_PLOT_SPEC.md');
-    expect(pages.length).toBeGreaterThanOrEqual(18);
+    // `docs/BRAILLE.md` was excluded while #917 stood: a committed `=======`
+    // sat inside a fenced code block, flipped the fence parity, and swallowed
+    // the rest of the file — so `## Multiline Braille Display Support`, which
+    // line 14 links to, was not a heading any more. It is checked like every
+    // other page now, and naming it here keeps it from dropping back out.
+    expect(pages).toContain('docs/BRAILLE.md');
+    expect(pages.length).toBeGreaterThanOrEqual(19);
   });
 
   it.each(pages)('should resolve every in-page anchor in %s', (source) => {
     expect(deadAnchors(source)).toEqual([]);
-  });
-
-  // Pinned rather than skipped — see CONFLICTED_PAGE and #917.
-  it.failing(`should resolve every in-page anchor in ${CONFLICTED_PAGE}`, () => {
-    expect(deadAnchors(CONFLICTED_PAGE)).toEqual([]);
   });
 
   it('should point the skip link at the main landmark', () => {


### PR DESCRIPTION
# Pull Request

## Description

Resolves the two merge-conflict regions committed in `docs/BRAILLE.md`, and adds a check that stops the next one reaching `main`.

The markers were not three stray lines. The `=======` at line 870 landed **between the fences of a code block**, which flipped the fence parity for the rest of the file — so everything after it was swallowed into an unterminated block, on GitHub and on maidr.ai alike. `## Volcano and Manhattan` and `## Multiline Braille Display Support` stopped existing as headings, and `docs/BRAILLE.md:14`'s link to `#multiline-braille-display-support` pointed at nothing.

`docs/SCHEMA.md`, the third region in the report, was already resolved by #912.

## Related Issues

Closes #917

## Changes Made

### The two regions, and what each was checked against

The sides were not competing edits to one passage, so neither was discarded. **Both sections are kept**, each with its own code block and its own `### Multiline Displays` note — which is what the second region turned out to be: one `### Multiline Displays` heading shared between two sections that each needed their own.

| Region | HEAD side | Other side | Resolution |
| --- | --- | --- | --- |
| 838–893 | `## Sankey, alluvial and chord` — prose plus a `Stage / Cells` table whose opening fence is inside the region | `## Network` — prose plus a `Group / Cells` table, sharing HEAD's closing fence | Both sections kept, in that order, each with a complete fenced block of its own |
| 898–906 | The multiline note for sankey ("one line per stage") | The multiline note for network ("one line per group") | Both kept, each under the `### Multiline Displays` of its own section |

Each description was read against the model rather than picked by position:

- **Sankey** — `src/model/flow.ts`. `braille` returns `values` grouped by stage with `min: this.stageMin` / `max: this.stageMax`, and swaps the cursor out as `row: this.col, col: this.row`. That is exactly the "one row per stage, each scaled against its own stage, transposed on its way out" the HEAD prose describes. The arrow geometry it claims (left/right along a ribbon, up/down within a column) is what `buildGraph` wires, and the rotor units it mentions are `OUT_ROTOR_UNIT` / `IN_ROTOR_UNIT`.
- **Network** — `src/model/network.ts`. `braille` returns one row per connected component with `min`/`max` set to the chart-wide `minDegree`/`maxDegree` on *every* row — the whole-chart scaling the prose calls the deliberate opposite of the treemap's, and the reason it gives (a hub of three should not feel like a hub of thirty) matches the comment on `audio`. `findComponents` sorts components largest first and members by degree, so "ordered most connected first" holds; no layout coordinate is read anywhere, so "where a node is drawn is not encoded" holds too.

### Heading counts, before and after

Measured with `marked.lexer` on the file itself:

| | headings in file | headings parsed | last heading parsed |
| --- | --- | --- | --- |
| before | 73 | **64** | `Sankey, alluvial and chord` |
| after | 74 | **74** | `Setup` |

`Volcano and Manhattan` and `Multiline Braille Display Support` are both back. The file's heading count goes 73 → 74 because the resolution gives the network section the `### Multiline Displays` it had been sharing with the sankey one; the point is that parsed now equals present, where it was nine short.

Fences: 21 (odd) → 22 (even).

### The `it.failing` pin

`test/scripts/siteAnchors.esm-test.ts` excluded `docs/BRAILLE.md` from the page loop and pinned it with `it.failing` referencing this issue. Both are gone: the page is now checked by the same `it.each(pages)` case as every other page, asserting positively. `docs/BRAILLE.md` is named explicitly in the "should be checking the pages this bug was reported against" case so it cannot quietly drop out of the list again.

### The guard

`scripts/conflictMarkers.js`, wired to `npm run check:conflicts` and to a `No Conflict Markers` job in `ci.yml`.

- **Every tracked file, not just markdown.** `git ls-files` is the file list, so `.gitignore` keeps itself in step and nothing has to enumerate `node_modules`/`_site`/`dist`. A marker in a `.ts` file would at least fail the type check; in `.html` or `.json` it would sail through exactly as this one did. Binary files are skipped on a NUL byte rather than by an extension list.
- **All four markers**, including the diff3 base marker a contributor with `merge.conflictStyle = diff3` would produce. The separator is anchored at both ends, since a bare run of `=` is also a setext underline.
- **Its own job, gating nothing** — same reasoning as `commitlint` in this workflow (#763): a marker should fail its own check, not grey out the build and the tests. No `npm ci`; it is node and git only, so it costs seconds.
- **It does not match itself.** The check and its test build the marker strings with `repeat` instead of writing them down, so no run of seven ever hits disk. The proof is that the repository-wide case — which reads `scripts/conflictMarkers.js` and `test/scripts/conflictMarkers.esm-test.ts` along with everything else — comes back empty.

One real bug surfaced while proving that: `|` is regular-expression alternation, so the first version's base pattern was seven empty alternatives and reported **all 1120 tracked files as conflicted**. The characters are escaped into the pattern now, and the note is kept in the source.

### Failure evidence

Against `origin/main`'s `docs/BRAILLE.md`, the check finds every region the issue reported and nothing else:

```
origin/main docs/BRAILLE.md -> ["838:ours","870:separator","893:theirs","898:ours","902:separator","906:theirs"]
resolved   docs/BRAILLE.md -> []
```

And reintroduced live, in a scratch `.html` file staged into the index — the non-markdown case the guard exists for:

```
$ npm run check:conflicts
Merge-conflict markers in 1 tracked file(s):

  docs/scratch-guard-demo.html:2  separator  =======

Resolve the conflict and commit the resolved file.
exit=1
```

Scratch file removed, same command:

```
$ npm run check:conflicts
No merge-conflict markers in 1126 tracked files.
exit=0
```

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

The manual-testing box is left unticked deliberately: `ManualTestingProcess.md` walks a chart with a screen reader, and nothing here changes runtime behaviour — the change is prose, a test, a script and a CI job. The automated suites were all run and all passed:

| | result |
| --- | --- |
| `npm run lint:fix` | passes (four `node/prefer-global` errors on the new files were fixed) |
| `npm run type-check` | passes |
| `npm run build` | passes |
| `npm test` | passes — unit 4312/4312, esm 136/136 |
| `npm run sync:copilot:check` | in sync |

Nothing under `src/` is touched.

One judgement call worth flagging for review: the sections are ordered sankey-then-network, which keeps the HEAD section where it already sat and reads into `## Treemap` (the chart the network prose compares its scaling against). If the section owner would rather they ran the other way, it is a block move with no content change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B79ATNMjrXx1FyV4bptw3Q)_