### PR TITLE
fix(ci): size the e2e report's code fence so its content cannot close it

### DIFF
--- a/scripts/ci/e2eReport.cjs
+++ b/scripts/ci/e2eReport.cjs
@@ -136,6 +136,31 @@ function results() {
 }
 
 /**
+ * A code fence long enough that the given content cannot close it (#715).
+ *
+ * The report's one job is to be a faithful transcript, and a bare three-tick
+ * fence is not one: the capture is `2>&1`, so it carries everything the suite
+ * and the app print, and a failing assertion prints the values involved. A
+ * line of three backticks anywhere in there closes the fence early — the rest
+ * renders as Markdown and the closing fence shows up as stray text.
+ *
+ * CommonMark lets a fence be longer than three and lets the content hold
+ * shorter runs, so one tick past the longest run present cannot be closed by
+ * anything inside. Measured on the whole content rather than line-starts
+ * alone: that is a longer fence than strictly required for an inline run, and
+ * cheaper than reasoning about which runs are indented into a position where
+ * they would count.
+ * @param {string} content - What will sit inside the fence.
+ * @returns {string} The fence to open and close it with.
+ */
+function fenceFor(content) {
+  const longest = (content.match(/`+/g) ?? [])
+    .reduce((max, run) => Math.max(max, run.length), 0);
+
+  return '`'.repeat(Math.max(3, longest + 1));
+}
+
+/**
  * Files or updates this run's report issue, and retires stale failures.
  * @param {object} api - The github-script bindings.
  * @param {Github} api.github - The authenticated octokit client.
@@ -147,6 +172,14 @@ module.exports = async function report({ github, context, core }) {
   const { repo, owner } = context.repo;
   const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
 
+  // Read once, and pick the fence from what is actually embedded. Calling
+  // `results()` a second time for the fence would size it against the whole
+  // capture, and truncation keeps the *tail* — so a run whose discarded head
+  // held a long run of backticks would get a fence far longer than its content
+  // needs, for no reason a reader of the body could see.
+  const testResults = results();
+  const fence = fenceFor(testResults);
+
   const reportContent = [
     '## Test Execution Report',
     `Date: ${new Date().toISOString()}`,
@@ -155,9 +188,9 @@ module.exports = async function report({ github, context, core }) {
     `Commit: ${context.sha}`,
     '',
     '### Test Results',
-    '```',
-    results(),
-    '```',
+    fence,
+    testResults,
+    fence,
     '',
     `[View Workflow Run](${runUrl})`,
   ].join('\n');

--- a/test/scripts/e2eReportWorkflow.test.ts
+++ b/test/scripts/e2eReportWorkflow.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 /**
@@ -36,6 +37,8 @@ interface RunResult {
   commented: number[];
   /** Labels passed to `issues.create`, if it filed a new report. */
   created: string[][];
+  /** Bodies passed to `issues.create`, in the same order as `created`. */
+  createdBodies: string[];
   /** True if any lookup bypassed `paginate`. */
   usedUnpaginatedList: boolean;
   /** Warnings the script emitted instead of throwing. */
@@ -80,6 +83,7 @@ async function runScript(
     closed: [],
     commented: [],
     created: [],
+    createdBodies: [],
     usedUnpaginatedList: false,
     warnings: [],
     adopted: [],
@@ -104,8 +108,9 @@ async function runScript(
           result.usedUnpaginatedList = true;
           return { data: matching(params).slice(0, 30) };
         },
-        create: async (params: { labels: string[] }) => {
+        create: async (params: { labels: string[]; body: string }) => {
           result.created.push(params.labels);
+          result.createdBodies.push(params.body);
         },
         createComment: async (params: { issue_number: number }) => {
           if (failingComments.has(params.issue_number)) {
@@ -160,6 +165,51 @@ async function runScript(
   }
 
   return result;
+}
+
+/**
+ * Runs `fn` with `output` standing in for the Playwright reporter capture.
+ *
+ * The module reads `test-results.txt` relative to the working directory, the
+ * way the test step leaves it there, so the fixture is supplied by running
+ * from a directory that has one. Stubbing `fs` would test a seam production
+ * does not have — and this file also reads the workflow YAML through the real
+ * `fs`, so a module mock would have to be unpicked again for those cases.
+ * @param output - What the reporter is to have printed.
+ * @param fn - The run to make against it.
+ * @returns Whatever `fn` resolves to.
+ */
+async function withResults<T>(output: string, fn: () => Promise<T>): Promise<T> {
+  const directory = mkdtempSync(join(tmpdir(), 'maidr-e2e-report-'));
+  const previous = process.cwd();
+
+  writeFileSync(join(directory, 'test-results.txt'), output);
+  process.chdir(directory);
+
+  try {
+    return await fn();
+  } finally {
+    process.chdir(previous);
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+/** The fence the body opened its Test Results block with. */
+function openingFence(body: string): string {
+  const opened = /^### Test Results\n(`+)$/m.exec(body);
+
+  expect(opened).not.toBeNull();
+  return (opened as RegExpExecArray)[1];
+}
+
+/** What the body put inside its Test Results block. */
+function fencedContent(body: string): string {
+  const fence = openingFence(body);
+  const block = new RegExp(`^### Test Results\\n${fence}\\n([\\s\\S]*?)\\n${fence}$`, 'm');
+  const matched = block.exec(body);
+
+  expect(matched).not.toBeNull();
+  return (matched as RegExpExecArray)[1];
 }
 
 /** A report as this workflow files it. */
@@ -392,6 +442,98 @@ describe('the scheduled e2e report step', () => {
       const result = await runScript(undefined, []);
 
       expect(result.created).toEqual([['test-failure']]);
+    });
+  });
+
+  /**
+   * The body's shape, which nothing above covers (#715).
+   *
+   * A report that renders is not the same as a report that is faithful, and
+   * the labels and lifecycle cases pass either way. The capture is
+   * `npm run e2e 2>&1`, so it carries whatever the suite and the app print,
+   * and a failing assertion prints the values involved — which in this repo
+   * can be Markdown, since `TypingEffect`, `markdownSanitize` and
+   * `markdownPipeline` all have fenced blocks in flight.
+   */
+  describe('when it embeds the reporter output', () => {
+    it('should keep a triple-backtick line inside the block', async () => {
+      // The reported defect exactly: the fence closes on this line, and
+      // everything after it renders as Markdown while the closing fence
+      // becomes stray text.
+      const output = [
+        'Running 3 tests using 1 worker',
+        '  1) bar.spec.ts:12 › announces the value',
+        '',
+        'Error: expected the description to contain',
+        '```',
+        '# A heading, not a heading',
+        '```',
+        '',
+        '3 failed',
+      ].join('\n');
+
+      const result = await withResults(output, () => runScript('failure', []));
+
+      expect(fencedContent(result.createdBodies[0])).toBe(output);
+    });
+
+    it('should leave a fence-free capture on a plain three-tick fence', async () => {
+      // The longer fence is for the content that needs it. Widening every
+      // report would be a change to output nobody asked for.
+      const result = await withResults(
+        '3 passed (4.2s)',
+        () => runScript('failure', []),
+      );
+
+      expect(openingFence(result.createdBodies[0])).toBe('```');
+    });
+
+    it('should outrun the longest run of backticks, not just three of them', async () => {
+      // A four-tick fence is closed by a four-tick line, so "longer than
+      // three" is not the rule — "longer than anything inside" is.
+      const output = ['before', '`````', 'after'].join('\n');
+
+      const result = await withResults(output, () => runScript('failure', []));
+
+      expect(openingFence(result.createdBodies[0])).toBe('``````');
+      expect(fencedContent(result.createdBodies[0])).toBe(output);
+    });
+
+    it('should size the fence from the tail it keeps, not the head it drops', async () => {
+      // `results()` keeps the last 60000 characters, so the backticks at the
+      // front are not in the body at all. Sizing the fence before truncating
+      // would open the block with eleven ticks around content holding none.
+      const dropped = `${'`'.repeat(10)}\n`;
+      const kept = 'x'.repeat(60000);
+
+      const result = await withResults(
+        dropped + kept,
+        () => runScript('failure', []),
+      );
+      const body = result.createdBodies[0];
+
+      expect(body).toContain('… (truncated, full output in the workflow run)');
+      expect(body).not.toContain('`'.repeat(10));
+      expect(openingFence(body)).toBe('```');
+    });
+
+    it('should embed the capture verbatim when it fits', async () => {
+      // Nothing is escaped, indented or re-wrapped on the way in: the point
+      // of the block is that the transcript survives it.
+      const output = 'Running 1 test using 1 worker\n\n  ✓  bar.spec.ts:12\n\n1 passed';
+
+      const result = await withResults(output, () => runScript('failure', []));
+
+      expect(fencedContent(result.createdBodies[0])).toBe(output);
+    });
+
+    it('should say so rather than embed nothing when no capture exists', async () => {
+      // The test step not running is itself the report, and an empty block
+      // reads as a suite that printed nothing.
+      const result = await runScript('failure', []);
+
+      expect(fencedContent(result.createdBodies[0]))
+        .toBe('No test output was captured (the test step did not run).');
     });
   });
 });


### PR DESCRIPTION
Closes #715.

## The defect

`scripts/ci/e2eReport.cjs` wrapped the Playwright capture in a bare three-backtick fence. The capture is `npm run e2e 2>&1`, so it carries whatever the suite *and the app* print, and a failing assertion prints the values involved — a line of three backticks anywhere in there closes the fence early. Everything after it renders as Markdown, the closing fence becomes stray text, and the report stops being a faithful transcript, which is the one job it has.

The fence is now one tick past the longest run of backticks in the content, which CommonMark permits and which nothing inside can then close.

## Sized after truncation, not before

The acceptance list calls this out and it is the part worth explaining. `results()` keeps the **tail** when the capture exceeds 60000 characters, so the head is not in the body at all. Sizing the fence against the raw capture would open the block with a fence as long as something the reader cannot see:

```
raw:  ``````````\n + 60000 x's      →  dropped head holds a 10-tick run
body: … (truncated, …)\nxxxx…       →  content holds no backticks
```

Before-truncation sizing opens that with eleven ticks; after-truncation sizing opens it with three. `results()` is also now called **once** rather than twice, which is what makes the two agree by construction instead of by coincidence.

## Deliberately measured on the whole content

`fenceFor` takes the longest run anywhere, not the longest run at a line start. That is a longer fence than a bare inline run strictly requires, and it is cheaper than reasoning about which runs are indented into a position where they would count as a closing fence. The cost is a few extra backticks on a body nobody diffs.

## Verification

`npm run lint:fix`, `npm run type-check` and `npm run build` all exit 0. Full suite **4329 passed, 290 suites**. 6 new cases, in a new `describe` — as the issue notes, there was no coverage of the body's *shape* at all, only its labels and lifecycle.

The harness gained two things: `create` now captures the body, and `withResults()` runs the script from a temp directory holding a `test-results.txt`. That last is deliberate — the module reads the file relative to cwd, exactly as the workflow leaves it, so stubbing `fs` would have tested a seam production does not have (and this file reads the workflow YAML through the real `fs`, so a module mock would have to be unpicked again).

Falsification — the two failures are disjoint, so neither test is carrying the other:

| reverted | failures |
|---|---|
| fence hardcoded back to ` ``` ` | **2** — the triple-backtick line, and the five-tick run |
| fence sized from the raw capture instead of the truncated tail | **1** — the tail/head case |

```
✕ should keep a triple-backtick line inside the block          ← falsify A
✕ should outrun the longest run of backticks, not just three   ← falsify A
✕ should size the fence from the tail it keeps, not the head   ← falsify B
```

The remaining three cases pin what must *not* change: a capture with no backticks still gets a plain ` ``` `, the capture is embedded verbatim, and a run where the test step never produced output still says so rather than showing an empty block.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_