### PR TITLE
feat(line): let a sample carry a position with no reading

### DIFF
--- a/src/adapters/amcharts/extractor.ts
+++ b/src/adapters/amcharts/extractor.ts
@@ -736,19 +736,24 @@ export function holdsRanks(seriesList: AmXYSeries[]): boolean {
 
   for (const series of seriesList) {
     for (const point of extractLinePoints(series)) {
-      if (!Number.isInteger(point.y) || point.y < 1 || point.y > competitors)
+      // A rank is a whole number in `1..competitors`, so a gap disqualifies
+      // the series exactly as a fractional or out-of-range value does --
+      // `Number.isInteger(null)` was already false, this only lets the
+      // compiler see it.
+      const rank = point.y;
+      if (rank === null || !Number.isInteger(rank) || rank < 1 || rank > competitors)
         return false;
 
       const period = String(point.x);
       const taken = takenAt.get(period);
       if (taken == null)
-        takenAt.set(period, new Set([point.y]));
-      else if (taken.has(point.y))
+        takenAt.set(period, new Set([rank]));
+      else if (taken.has(rank))
         return false;
       else
-        taken.add(point.y);
+        taken.add(rank);
 
-      best = Math.min(best, point.y);
+      best = Math.min(best, rank);
       ranks++;
     }
   }

--- a/src/adapters/victory/converters.ts
+++ b/src/adapters/victory/converters.ts
@@ -855,9 +855,12 @@ function isNormalizedStack(series: LinePoint[][]): boolean {
   const totals = new Map<string, number>();
   for (const band of series) {
     for (const point of band) {
-      if (!Number.isFinite(point.y))
+      // A band with a gap is not a normalized stack: its column cannot sum to
+      // the whole. `Number.isFinite(null)` was already false here.
+      const value = point.y;
+      if (value === null || !Number.isFinite(value))
         return false;
-      totals.set(String(point.x), (totals.get(String(point.x)) ?? 0) + point.y);
+      totals.set(String(point.x), (totals.get(String(point.x)) ?? 0) + value);
     }
   }
   if (totals.size < 2)

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -8,6 +8,7 @@ import { Constant } from '@util/constant';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace, named } from './abstract';
+import { isMeasured, toBarValue } from './bar';
 import { MovableGraph } from './movable';
 
 const TYPE = 'Group';
@@ -138,11 +139,25 @@ export class LineTrace extends AbstractTrace {
 
     this.points = layer.data as LinePoint[][];
 
+    // `toBarValue` rather than `Number`, for the reason its own docstring
+    // gives: `Number(null)` is `0`, which makes a gap indistinguishable from a
+    // point genuinely measured at zero. It would sound like a real low
+    // reading, be reachable as the row's minimum, and pull the range every
+    // other point's pitch is scaled against. `NaN` keeps it absent, which is
+    // what the audio and text services already read as missing (#925).
+    //
+    // Imported from `bar.ts` because that is where the convention lives and
+    // where it is documented; `PieTrace`, `FunnelTrace`, `DivergingTrace` and
+    // `SegmentedTrace` all reach for it the same way.
     this.lineValues = this.points.map(row =>
-      row.map(point => Number(point.y)),
+      row.map(point => toBarValue(point.y)),
     );
-    this.min = this.lineValues.map(row => MathUtil.safeMin(row));
-    this.max = this.lineValues.map(row => MathUtil.safeMax(row));
+    // Gaps are filtered out of the range rather than filtered in: `Math.min`
+    // of anything containing `NaN` is `NaN`, which would leave every point in
+    // the row with a non-finite range to be scaled against and silence the
+    // whole series rather than the one gap.
+    this.min = this.lineValues.map(row => MathUtil.safeMin(row.filter(isMeasured)));
+    this.max = this.lineValues.map(row => MathUtil.safeMax(row.filter(isMeasured)));
 
     // `layer.selectors` is `string | string[] | ...` per the schema. When a
     // single-line binder (e.g. the D3 smooth/line binders) emits a bare
@@ -321,11 +336,13 @@ export class LineTrace extends AbstractTrace {
       headers = [this.xAxis, this.yAxis, labels.column];
       rows = this.points.flatMap((line, i) => {
         const lineName = this.groupNameAt(i);
-        return line.map(p => [p.x, p.y, lineName]);
+        // A gap prints as an empty cell rather than as a number it does
+        // not have; `TextService` names it "missing" when spoken.
+        return line.map(p => [p.x, p.y ?? '', lineName]);
       });
     } else {
       headers = [this.xAxis, this.yAxis];
-      rows = this.points[0].map(p => [p.x, p.y]);
+      rows = this.points[0].map(p => [p.x, p.y ?? '']);
     }
 
     return {
@@ -370,7 +387,14 @@ export class LineTrace extends AbstractTrace {
         continue;
       }
 
-      const sortedPoints = [...pointsAtCol].sort((a, b) => a.y - b.y);
+      // Gaps take no part in the ordering: there is no magnitude to rank
+      // them by, and `null - null` would sort them somewhere arbitrary and
+      // then report one as the column's top or bottom.
+      const measured = pointsAtCol.filter(p => p.y !== null);
+      if (measured.length === 0) {
+        continue;
+      }
+      const sortedPoints = [...measured].sort((a, b) => a.y! - b.y!);
       const bottom = { row: sortedPoints[0].row, col: c };
       const top = { row: sortedPoints[sortedPoints.length - 1].row, col: c };
       for (let i = 0; i < sortedPoints.length; i++) {
@@ -499,8 +523,15 @@ export class LineTrace extends AbstractTrace {
     // so the human-readable name rides alongside as `label`. Announce the name
     // when there is one, and the number otherwise — which is the right reading
     // for the continuous y that most line charts have.
+    // `lineValues`, not `point.y`: identical for every measured point, and
+    // `NaN` for a gap, which `TextService.formatSingleValue` already announces
+    // as "missing". Reading `point.y` here would hand it a `null` instead —
+    // which it also names correctly, but only because the text layer is
+    // tolerant, and the two would then disagree with what audio and braille
+    // were given.
     const label = point.label;
-    const crossValue = label === undefined || label === '' ? point.y : label;
+    const value = this.lineValues[this.row][this.col];
+    const crossValue = label === undefined || label === '' ? value : label;
 
     return {
       main: { label: this.xAxis, value: this.points[this.row][this.col].x },
@@ -633,7 +664,7 @@ export class LineTrace extends AbstractTrace {
             freq: {
               min: this.min[r],
               max: this.max[r],
-              raw: currentY,
+              raw: toBarValue(currentY),
             },
             // The cursor's own cell, not series `r`'s -- an intersection is
             // one point that several series share, so every tone in the chord
@@ -713,13 +744,21 @@ export class LineTrace extends AbstractTrace {
       }
 
       const lineY = this.points[row][matchingPointIndex].y;
+      const cursorY = this.points[this.row][this.col].y;
+
+      // Neither end of the comparison can be a gap. "The nearest line above
+      // this one" is a question about two magnitudes, and a sample with no
+      // reading is not above or below anything -- `null > n` is false and
+      // `null < n` is true, so leaving it in would make every gap look like a
+      // candidate in one direction and rank it at distance `n` from nothing.
+      if (lineY === null || cursorY === null) {
+        continue;
+      }
 
       // Check if this line's y value is in the desired direction
       const isValidDirection
-        = direction === 'UPWARD'
-          ? lineY > this.points[this.row][this.col].y
-          : lineY < this.points[this.row][this.col].y;
-      const distance = Math.abs(lineY - this.points[this.row][this.col].y);
+        = direction === 'UPWARD' ? lineY > cursorY : lineY < cursorY;
+      const distance = Math.abs(lineY - cursorY);
 
       if (!isValidDirection) {
         continue;
@@ -852,12 +891,18 @@ export class LineTrace extends AbstractTrace {
       const linePointElements: SVGElement[] = [];
       let lineFailed = false;
       for (const coordinate of coordinates) {
-        if (Number.isNaN(Number(coordinate.x)) || Number.isNaN(coordinate.y)) {
+        // `toBarValue` so a gap reaches the same branch a NaN already did:
+        // there is no y to put a marker at. A series carrying one therefore
+        // gets no synthesized highlight at all, which is the existing
+        // behaviour for an unusable coordinate rather than a new limitation --
+        // and only affects charts whose highlight maidr draws itself.
+        const markerY = toBarValue(coordinate.y);
+        if (Number.isNaN(Number(coordinate.x)) || !Number.isFinite(markerY)) {
           lineFailed = true;
           break;
         }
         linePointElements.push(
-          Svg.createCircleElement(coordinate.x, coordinate.y, lineElement),
+          Svg.createCircleElement(coordinate.x, markerY, lineElement),
         );
       }
       if (lineFailed) {

--- a/src/model/survival.ts
+++ b/src/model/survival.ts
@@ -236,7 +236,10 @@ export class SurvivalTrace extends StepTrace {
   private medianSurvivalOf(arm: number): number | string | null {
     const curve = this.survivalPoints[arm] ?? [];
     for (const point of curve) {
-      if (Number.isFinite(point.y) && point.y <= 0.5) {
+      // A gap is not a crossing: the curve has no value there to compare
+      // against a half. `Number.isFinite(null)` was already false.
+      const survival = point.y;
+      if (survival !== null && Number.isFinite(survival) && survival <= 0.5) {
         return point.x;
       }
     }

--- a/src/service/braille.ts
+++ b/src/service/braille.ts
@@ -770,7 +770,14 @@ implements BrailleEncoder<T> {
   protected encodeCell(state: T, row: number, col: number): string {
     const { low, medium, mediumHigh, high } = this.getThresholds(row, state);
     const currentValue = state.values[row][col];
-    const prevValue = col > 0 ? state.values[row][col - 1] : null;
+    // A gap behind the cursor becomes `null` rather than staying `NaN`: there
+    // is no trend to draw from a reading that does not exist, and `null` is
+    // already how this encoder spells "nothing before this". Leaving the NaN
+    // in reaches the same glyph today only because it loses every comparison.
+    const previous = col > 0 ? state.values[row][col - 1] : null;
+    const prevValue = previous !== null && Number.isFinite(previous)
+      ? previous
+      : null;
 
     return this.getBrailleChar(
       currentValue,
@@ -843,6 +850,15 @@ implements BrailleEncoder<T> {
   ): string {
     if (mediumHigh === undefined) {
       mediumHigh = high;
+    }
+    // A gap arrives as NaN, which loses every comparison below and falls all
+    // the way through to `return ''` — an empty *string*, not a blank cell.
+    // That is worse than a wrong glyph: the encoded line comes out one
+    // character shorter than the row has cells, so every cursor position past
+    // the gap maps to the wrong point. It reads as blank, which is what the
+    // bar encoder already does with one (#925).
+    if (!Number.isFinite(current)) {
+      return ' ';
     }
     if (current <= low && prev !== null && prev > low) {
       if (prev <= medium)

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -710,7 +710,23 @@ export interface HistogramPoint extends BarPoint {
  */
 export interface LinePoint {
   x: number | string;
-  y: number;
+  /**
+   * The magnitude at this x, or `null` where the series has a position but no
+   * reading.
+   *
+   * A gap is not a zero. `seaborn.pointplot` pads a hue level missing from one
+   * category so its estimate lines stay the same length, and a producer that
+   * meets a break in a series has nowhere else to put it. `Number(null)` is
+   * `0`, which would make the gap sound like a real low point, let it be
+   * reached as the row's minimum, and pull the range every other point's pitch
+   * is scaled against — the same trap `toBarValue` was written for (#925).
+   *
+   * `null` rather than a non-finite number because the payload has to survive
+   * `JSON.parse`: `json.dumps` writes `NaN` and `Infinity` as bare tokens that
+   * are legal JavaScript and invalid JSON, and a producer emitting one stops
+   * the chart initialising at all (xability/py-maidr#427).
+   */
+  y: number | null;
   z?: string;
   /**
    * Ordinal level name announced in place of the raw numeric `y`, for a chart

--- a/test/adapters/vegalite/lineSeriesNames.test.ts
+++ b/test/adapters/vegalite/lineSeriesNames.test.ts
@@ -74,7 +74,7 @@ describe('vega-Lite merged multi-series line layers', () => {
       // which is worse for a screen reader user than no name at all.
       const series = onlyLayer(densitySpec, view).data as LinePoint[][];
       const peakX = series.map(points =>
-        points.reduce((best, p) => (p.y > best.y ? p : best)).x,
+        points.reduce((best, p) => (p.y! > best.y! ? p : best)).x,
       );
 
       expect(new Set(peakX).size).toBe(3);

--- a/test/model/lineGaps.test.ts
+++ b/test/model/lineGaps.test.ts
@@ -1,0 +1,184 @@
+import type { NotificationService } from '@service/notification';
+import type { LinePoint, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, jest, test } from '@jest/globals';
+import { LineTrace } from '@model/line';
+import { TextService } from '@service/text';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A line sample that has a position but no reading (#925).
+ *
+ * `BarTrace` has had this since #112: a producer sends `null`, `toBarValue`
+ * turns it into `NaN` so it stays distinguishable from a measured zero, and
+ * every modality already knows what to do with a non-finite magnitude —
+ * `AudioService` plays the empty tone, `TextService.formatSingleValue` returns
+ * "missing", the bar braille encoder writes a blank cell.
+ *
+ * `LineTrace` never adopted it. It read `Number(point.y)`, and `Number(null)`
+ * is `0`, so a gap arrived as a real measurement at the bottom of the range.
+ * Measured before this change, on a three-point series whose middle y is null:
+ *
+ *     index 1: audio.freq.raw = 0, text.cross.value = null
+ *
+ * — a floor tone and the word "null", for data that does not exist.
+ *
+ * `null` rather than a non-finite number is what the *producer* sends, and
+ * that part is load-bearing rather than stylistic: `NaN` and `Infinity` are
+ * legal JavaScript literals but not JSON, and `JSON.parse` — which the core
+ * runs on the SVG's `maidr` attribute — rejects them outright, so a producer
+ * emitting one stops the chart initialising at all (xability/py-maidr#427).
+ */
+
+function lineLayer(rows: LinePoint[][]): MaidrLayer {
+  return {
+    id: 'l',
+    type: TraceType.LINE,
+    title: 'Series',
+    axes: { x: { label: 'X' }, y: { label: 'Y' } },
+    data: rows,
+  } as MaidrLayer;
+}
+
+/** A series whose middle sample was never measured. */
+function withGap(): LineTrace {
+  return new LineTrace(lineLayer([[
+    { x: 'a', y: 1 },
+    { x: 'b', y: null },
+    { x: 'c', y: 3 },
+  ]]));
+}
+
+function announce(state: TraceState): string {
+  const text = new TextService({ notify: jest.fn() } as unknown as NotificationService);
+  const listener = jest.fn();
+  const disposable = text.onChange(listener);
+
+  text.update(state);
+  disposable.dispose();
+  return (listener.mock.calls[0][0] as { value: string }).value;
+}
+
+function stateAt(trace: LineTrace, col: number): TraceState {
+  return trace.getStateAt(0, col);
+}
+
+describe('a line sample with no reading', () => {
+  test('is announced as missing rather than as a number', () => {
+    expect(announce(stateAt(withGap(), 1))).toBe('X is b, Y is missing');
+  });
+
+  test('still says where it is', () => {
+    // The whole reason the point is kept rather than dropped. An announcement
+    // that named only the absence would be the out-of-bounds message, which is
+    // what makes reusing `outOfBoundsState` for this wrong.
+    expect(announce(stateAt(withGap(), 1))).toContain('X is b');
+  });
+
+  test('carries no magnitude for the audio service to pitch', () => {
+    // `AudioService` already branches on a non-finite `raw` and plays the
+    // empty tone there, so the model's job is only to stop turning the gap
+    // into a number. Asserted on the state rather than the service to keep
+    // this a model test.
+    const audio = (stateAt(withGap(), 1) as { audio: { freq: { raw: number } } }).audio;
+
+    expect(Number.isFinite(audio.freq.raw)).toBe(false);
+  });
+
+  test('is not confusable with a sample measured at zero', () => {
+    // The defect exactly: `Number(null)` is `0`. A chart that really does read
+    // zero in the middle has to sound and read differently from one that has
+    // no reading there at all.
+    const zero = new LineTrace(lineLayer([[
+      { x: 'a', y: 1 },
+      { x: 'b', y: 0 },
+      { x: 'c', y: 3 },
+    ]]));
+
+    expect(announce(stateAt(zero, 1))).toBe('X is b, Y is 0');
+    expect(announce(stateAt(withGap(), 1))).toBe('X is b, Y is missing');
+  });
+});
+
+describe('what the gap must not drag down with it', () => {
+  test('the measured samples either side are unaffected', () => {
+    const trace = withGap();
+
+    expect(announce(stateAt(trace, 0))).toBe('X is a, Y is 1');
+    expect(announce(stateAt(trace, 2))).toBe('X is c, Y is 3');
+  });
+
+  test('the row keeps a usable range', () => {
+    // `Math.min` of anything containing NaN is NaN. Without filtering the gap
+    // out of the range, every point in the row would be scaled against a
+    // non-finite min and max — one gap silencing the whole series rather than
+    // itself.
+    const audio = (stateAt(withGap(), 0) as {
+      audio: { freq: { min: number; max: number } };
+    }).audio;
+
+    expect(audio.freq.min).toBe(1);
+    expect(audio.freq.max).toBe(3);
+  });
+
+  test('a series with no gaps is unchanged', () => {
+    const plain = new LineTrace(lineLayer([[
+      { x: 'a', y: 1 },
+      { x: 'b', y: 2 },
+    ]]));
+
+    expect(announce(stateAt(plain, 0))).toBe('X is a, Y is 1');
+    expect(announce(stateAt(plain, 1))).toBe('X is b, Y is 2');
+  });
+
+  test('a row of nothing but gaps does not claim a range', () => {
+    const allGaps = new LineTrace(lineLayer([[
+      { x: 'a', y: null },
+      { x: 'b', y: null },
+    ]]));
+
+    expect(announce(stateAt(allGaps, 0))).toBe('X is a, Y is missing');
+  });
+});
+
+describe('navigating between series across a gap', () => {
+  test('a gap is not a candidate for the nearest line below', () => {
+    // `null` coerces to `0` in a relational comparison, so an unguarded gap
+    // does not merely sort oddly — it presents itself as a line sitting at
+    // zero. Whether that looks like a candidate depends on which side of zero
+    // the cursor is, which is why both directions are covered and why the
+    // fixtures straddle it.
+    //
+    // The distances matter as much as the directions. `Math.abs(0 - 9)` is 9
+    // and the real line below is 14 away, so without the guard the gap wins
+    // on distance and the cursor lands on a sample with nothing to announce.
+    // An earlier version of this test used a cursor at y = 2, where
+    // `null > 2` is false and UPWARD skipped the gap by accident: it passed
+    // with the guard removed.
+    const trace = new LineTrace(lineLayer([
+      [{ x: 'a', y: 9 }, { x: 'b', y: 9 }],
+      [{ x: 'a', y: 5 }, { x: 'b', y: null }],
+      [{ x: 'a', y: -5 }, { x: 'b', y: -5 }],
+    ]));
+    trace.moveToIndex(0, 1);
+
+    trace.moveOnce('DOWNWARD');
+
+    expect(announce(trace.state)).toBe('X is b, Y is -5');
+  });
+
+  test('and not for the nearest line above either', () => {
+    // The mirror image, with the cursor below zero so the phantom line at
+    // zero is genuinely "above" it.
+    const trace = new LineTrace(lineLayer([
+      [{ x: 'a', y: -5 }, { x: 'b', y: -5 }],
+      [{ x: 'a', y: 5 }, { x: 'b', y: null }],
+      [{ x: 'a', y: 9 }, { x: 'b', y: 9 }],
+    ]));
+    trace.moveToIndex(0, 1);
+
+    trace.moveOnce('UPWARD');
+
+    expect(announce(trace.state)).toBe('X is b, Y is 9');
+  });
+});

--- a/test/model/stepHighlight.test.ts
+++ b/test/model/stepHighlight.test.ts
@@ -30,11 +30,11 @@ const PIXEL_FOR_SAMPLE = [10, 20, 30, 40];
  * @returns The `d` attribute of the staircase path
  */
 function staircasePath(): string {
-  const commands = [`M ${PIXEL_FOR_SAMPLE[0]} ${PIXEL_FOR_LEVEL[POINTS[0].y]}`];
+  const commands = [`M ${PIXEL_FOR_SAMPLE[0]} ${PIXEL_FOR_LEVEL[POINTS[0].y!]}`];
   for (let i = 1; i < POINTS.length; i++) {
     // Horizontal to the next x at the old level, then vertical to the new one.
-    commands.push(`L ${PIXEL_FOR_SAMPLE[i]} ${PIXEL_FOR_LEVEL[POINTS[i - 1].y]}`);
-    commands.push(`L ${PIXEL_FOR_SAMPLE[i]} ${PIXEL_FOR_LEVEL[POINTS[i].y]}`);
+    commands.push(`L ${PIXEL_FOR_SAMPLE[i]} ${PIXEL_FOR_LEVEL[POINTS[i - 1].y!]}`);
+    commands.push(`L ${PIXEL_FOR_SAMPLE[i]} ${PIXEL_FOR_LEVEL[POINTS[i].y!]}`);
   }
   return commands.join(' ');
 }
@@ -57,8 +57,8 @@ function midStaircasePath(): string {
   xs.push(PIXEL_FOR_SAMPLE[POINTS.length - 1]);
 
   const ys = POINTS.flatMap(point => [
-    PIXEL_FOR_LEVEL[point.y],
-    PIXEL_FOR_LEVEL[point.y],
+    PIXEL_FOR_LEVEL[point.y!],
+    PIXEL_FOR_LEVEL[point.y!],
   ]);
 
   return xs.map((x, i) => `${i === 0 ? 'M' : 'L'} ${x} ${ys[i]}`).join(' ');
@@ -151,7 +151,7 @@ describe('step trace highlight mapping', () => {
     expect(circles).toEqual(
       POINTS.map((point, i) => ({
         x: PIXEL_FOR_SAMPLE[i],
-        y: PIXEL_FOR_LEVEL[point.y],
+        y: PIXEL_FOR_LEVEL[point.y!],
       })),
     );
 
@@ -176,7 +176,7 @@ describe('step trace highlight mapping', () => {
     expect(circles).toEqual(
       POINTS.map((point, i) => ({
         x: PIXEL_FOR_SAMPLE[i],
-        y: PIXEL_FOR_LEVEL[point.y],
+        y: PIXEL_FOR_LEVEL[point.y!],
       })),
     );
 
@@ -196,8 +196,8 @@ describe('step trace highlight mapping', () => {
     }
     xs.push(unevenX[unevenX.length - 1]);
     const ys = POINTS.flatMap(point => [
-      PIXEL_FOR_LEVEL[point.y],
-      PIXEL_FOR_LEVEL[point.y],
+      PIXEL_FOR_LEVEL[point.y!],
+      PIXEL_FOR_LEVEL[point.y!],
     ]);
     renderStaircase(xs.map((x, i) => `${i === 0 ? 'M' : 'L'} ${x} ${ys[i]}`).join(' '));
 
@@ -214,7 +214,7 @@ describe('step trace highlight mapping', () => {
       const runEnd = i === POINTS.length - 1 ? unevenX[unevenX.length - 1] : midpoints[i];
       expect(circle.x).toBeGreaterThanOrEqual(runStart);
       expect(circle.x).toBeLessThanOrEqual(runEnd);
-      expect(circle.y).toBe(PIXEL_FOR_LEVEL[POINTS[i].y]);
+      expect(circle.y).toBe(PIXEL_FOR_LEVEL[POINTS[i].y!]);
     });
 
     trace.dispose();

--- a/test/service/braille.test.ts
+++ b/test/service/braille.test.ts
@@ -423,6 +423,67 @@ function createBrailleServiceWithSettingsTrigger(displaySize: number): {
   return { service, triggerDisplaySizeChange, setContextState };
 }
 
+/**
+ * A line sample with a position and no reading, on the braille display (#925).
+ *
+ * A gap reaches the encoder as `NaN`, and every threshold comparison in
+ * `getBrailleChar` loses against it — so before this it fell all the way
+ * through to `return ''`. Not a wrong glyph but *no* glyph: the encoded row
+ * came out one character shorter than the row has cells, which slides every
+ * cursor position past the gap onto the wrong point. The bar encoder has
+ * always written a blank for one.
+ */
+describe('a line gap on the braille display', () => {
+  /** A three-sample row whose middle value was never measured. */
+  function rowWithGap(): TraceState {
+    const state = createLineTraceState([[1, Number.NaN, 3]], 0, 0);
+    // `createLineTraceState` derives the range with `Math.min(...items)`,
+    // which is NaN once a gap is in the row. `LineTrace` filters gaps out of
+    // its range for exactly that reason, so the state is corrected to match
+    // what the model really emits.
+    (state as { braille: { min: number[]; max: number[] } }).braille.min = [1];
+    (state as { braille: { min: number[]; max: number[] } }).braille.max = [3];
+    return state;
+  }
+
+  function encode(state: TraceState): string {
+    const { service } = createBrailleService(10);
+    let emitted = '';
+    const disposable = service.onChange((event) => {
+      emitted = event.value;
+    });
+
+    service.toggle(state);
+    disposable.dispose();
+    service.dispose();
+    return emitted.split('\n')[0];
+  }
+
+  test('takes a cell of its own rather than none', () => {
+    // The assertion that matters is the length: a missing character is what
+    // desynchronises the cursor mapping, and it is invisible in the output.
+    expect(encode(rowWithGap())).toHaveLength(3);
+  });
+
+  test('reads as blank', () => {
+    expect(encode(rowWithGap())[1]).toBe(' ');
+  });
+
+  test('leaves the measured samples with their own glyphs', () => {
+    const encoded = encode(rowWithGap());
+
+    expect(encoded[0]).not.toBe(' ');
+    expect(encoded[2]).not.toBe(' ');
+  });
+
+  test('a row with no gaps is unchanged', () => {
+    const encoded = encode(createLineTraceState([[1, 2, 3]], 0, 0));
+
+    expect(encoded).toHaveLength(3);
+    expect(encoded).not.toContain(' ');
+  });
+});
+
 describe('BrailleService display-size encoding', () => {
   test('encodes one newline when row length is less than display size', () => {
     const { service } = createBrailleService(10);


### PR DESCRIPTION
Closes #925.

## The defect

`BarTrace` has had this since #112 — a producer sends `null`, `toBarValue` turns it into `NaN` so it stays distinguishable from a measured zero, and every modality already knows what a non-finite magnitude means. `LineTrace` never adopted it and read `Number(point.y)`; `Number(null)` is `0`.

Measured on a three-point series whose middle `y` is `null`:

```
index 0: audio.freq.raw = 1, text.cross.value = 1
index 1: audio.freq.raw = 0, text.cross.value = null      ← the gap
index 2: audio.freq.raw = 3, text.cross.value = 3
```

A floor tone and the word "null", for data that does not exist. A reader hears a value at the bottom of the range, which is a confident claim about a sample that was never measured.

## What was already there, and what was not

Most of the machinery existed. `AudioService` already branches on a non-finite `freq.raw` and plays the empty tone; `TextService.formatSingleValue` already returns `"missing"` for a non-finite number. The model was simply never handing them one.

The **cheap fix does not work**, and it is worth recording since it is the obvious one. `isEmptyAtCursor` is `protected` and overridable, and the `state.empty` path is wired end to end — so a per-point override looks like two lines. Measured what that path actually says:

```
EMPTY STATE announces: "No more data to display"
EMPTY STATE keys:      empty, type, traceType, audio
```

That is the **out-of-bounds** message. A gap is not "no more data" — there is plenty more, and the cursor is on a position the reader navigated to deliberately. It also discards `xAxis`/`yAxis` and the point's own x, so the reader could not tell *where* the gap is. A gap needs the position announced as usual and the value named as absent, which is what this does.

## Four consequences, each its own decision

- **The range filters gaps out rather than in.** `Math.min` of anything containing `NaN` is `NaN`, so leaving one in scales every point in the row against a non-finite range — one gap silencing the whole series rather than itself.
- **The up/down search skips a gap.** `null` coerces to `0` in a relational comparison, so an unguarded gap does not merely sort oddly: it presents itself as a line sitting at zero, and can win on distance.
- **The braille encoder writes a blank.** A `NaN` lost every threshold comparison and fell through to `return ''` — *no* glyph rather than a wrong one. The row then encodes one character shorter than it has cells, sliding every cursor position past the gap onto the wrong point.
- **The data table prints an empty cell** rather than a number it does not have.

## `null` on the wire, `NaN` inside

Load-bearing rather than stylistic. `NaN` and `Infinity` are legal JavaScript literals and invalid JSON, and `JSON.parse` — which the core runs on the SVG's `maidr` attribute — rejects them, so a producer emitting one stops the chart initialising at all (xability/py-maidr#427). `null` survives the wire; the trace converts it at the boundary.

## Widening the type did its job

`LinePoint.y: number | null` surfaced **32 errors across 6 files** — every site that had assumed a numeric y. The three outside this trace were already *behaviourally* correct, since `Number.isFinite(null)` and `Number.isInteger(null)` are both false; they only needed the compiler to see it:

| site | already right because |
|---|---|
| amcharts bump detector | `!Number.isInteger(null)` → rejects the series |
| victory normalized-stack check | `!Number.isFinite(null)` → rejects the stack |
| survival median | `Number.isFinite(null)` → never a crossing |

## Verification

`npm run lint:fix`, `npm run type-check` and `npm run build` all exit 0. **4343 passed across 291 suites**, plus 136 in the esm/component projects. 12 new cases.

Falsification:

| reverted | failures |
|---|---|
| `lineValues` back to `Number(point.y)` | **5** |
| range no longer filters gaps | **1** |
| braille blank guard removed | **1** |
| up/down gap guard removed | **2** |

### One of these tests was wrong first, and that is the interesting part

My first navigation test **passed with the guard removed**. It put the cursor at `y = 2` and moved UPWARD, where `null > 2` is false — so the gap was skipped by accident, not by the guard.

The rewritten pair straddles zero in both directions, and chooses distances so the accident cannot save it (`Math.abs(0 - 9)` is 9; the real line is 14 away, so an unguarded gap wins). With the guard removed both now fail with the cursor sitting on the gap:

```
Expected: "X is b, Y is -5"
Received: "X is b, Y is missing"
```

Correcting it also corrected the explanation: `null` does not lose every comparison, it coerces to `0` — so whether a gap looks like a candidate depends on which side of zero the cursor is. The test comment says that now, rather than the plausible-sounding thing I first wrote.

## Unblocks

xability/py-maidr#429 and the `seaborn.pointplot` padding case pinned with a strict xfail in xability/py-maidr#430.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_