### PR TITLE
feat(tableau): add tableau embedding api adapter

### DIFF
--- a/docs/tableau.md
+++ b/docs/tableau.md
@@ -1,0 +1,327 @@
+# Tableau Integration
+
+MAIDR ships a Tableau *binder* for the [Tableau Embedding API v3](https://help.tableau.com/current/api/embedding_api/en-us/index.html). One call — `bindTableau(viz)` — reads the summary data out of an embedded `<tableau-viz>` worksheet or dashboard and mounts MAIDR's accessible layer beside it, adding audio sonification, text descriptions, braille output, keyboard navigation, and a description modal to a visualization that a screen reader otherwise reaches only as a static image with a tooltip.
+
+> **What this adapter is not.** It does **not** run inside Tableau as a dashboard extension, and it does **not** draw a highlight box. A `<tableau-viz>` is a cross-origin `<iframe>`: the host page cannot read its SVG, cannot inject ARIA into it, and cannot style anything inside it. Everything the adapter knows comes from the asynchronous data API, and the only visual feedback it can produce is Tableau's **own mark selection**, driven from the keyboard as the reader navigates. See [Limitations](#limitations) before you plan around it.
+
+## Quick Start
+
+Load the Embedding API v3 library, MAIDR core, and the MAIDR Tableau adapter; place a `<tableau-viz>` pointing at a view; then bind once the viz reports that it is interactive.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>My Tableau View</title>
+    <!-- 1. The Tableau Embedding API v3 — must be type="module". -->
+    <script
+      type="module"
+      src="https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.min.js"
+    ></script>
+    <!-- 2. MAIDR core, then the MAIDR Tableau adapter (UMD; exposes maidrTableau). -->
+    <script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/maidr/dist/tableau.js"></script>
+  </head>
+  <body>
+    <tableau-viz
+      id="tableauViz"
+      src="https://public.tableau.com/views/Superstore_embedded_800x800/Overview"
+      toolbar="bottom"
+      hide-tabs
+    ></tableau-viz>
+
+    <script type="module">
+      // 3. Wait for FirstInteractive — nothing in the workbook is readable
+      //    before it, and the data API rejects if you ask early.
+      const viz = document.getElementById('tableauViz');
+      viz.addEventListener('firstinteractive', () => {
+        maidrTableau.bindTableau(viz, { title: 'Superstore Overview' });
+      });
+    </script>
+  </body>
+</html>
+```
+
+The binder inserts a focusable block **immediately before** the viz element. Tab to it (it is ahead of the iframe in DOM order, so a keyboard user reaches it before Tableau's own controls swallow focus), press <kbd>Enter</kbd>, and MAIDR activates with:
+
+- **Audio sonification** — tones representing data values
+- **Text descriptions** — announced through the screen reader
+- **Braille output** — refreshable braille display support
+- **Keyboard navigation** — arrow keys through data points, Page Up / Page Down between dashboard worksheets
+- **Mark selection** — the mark under the cursor is selected in the Tableau view itself, which is what a sighted colleague sees highlight
+
+Two hosting notes, both from Tableau's own documentation:
+
+- **The page must be served over `http(s)`, not opened from `file://`.** The Embedding API is an ES module; loading it from the file system fails CORS with `Access to script at 'file:///…' from origin 'null' has been blocked`. Any static server (`npx serve`, `python3 -m http.server`) is enough — no application server is involved.
+- **Tableau Public views need no authentication.** Tableau Cloud and Tableau Server do; see [Limitations](#limitations).
+
+## How It Works
+
+The adapter never imports a Tableau package. It duck-types the live `<tableau-viz>` element the page already created, so it stays independent of the Embedding library's version.
+
+1. **Find the worksheets.** `viz.workbook.activeSheet` is read once. A `worksheet` sheet is a single worksheet; a `dashboard` contributes `dashboard.worksheets`, in the order the author added them — which is also the order Tableau's own documentation says a screen reader narrates a dashboard. A `story` sheet is skipped with a warning (see [Limitations](#limitations)).
+2. **Read the summary data.** For each worksheet the adapter calls `getSummaryColumnsInfoAsync()` for the columns *in view order*, then opens a `getSummaryDataReaderAsync()` and pages through it. The reader hands its columns back **alphabetically**, so the adapter builds a view-order-to-alphabetical index map by `fieldId` and remaps every row; every index downstream is a view index. The reader is always released in a `finally` block, and every read goes through a per-viz promise chain, because Tableau supports **only one active summary-data reader at a time** and a leaked one blocks the next read.
+3. **Classify the columns.** Each column becomes a measure or a dimension — see [Supported Chart Types](#supported-chart-types).
+4. **Decide the trace type and build the layer.** One worksheet produces exactly **one** MAIDR layer inside its own subplot; a dashboard of four worksheets is a four-row, one-column subplot grid.
+5. **Mount.** A wrapper `<div>` is inserted before the viz element and a React root renders MAIDR into it. The viz element itself is never moved — `<tableau-viz>` is a custom element and re-parenting re-runs its `connectedCallback`, with undocumented consequences for the iframe.
+
+### Highlighting
+
+There is no overlay, and that is a consequence of the embedding surface rather than a gap. The marks live inside a cross-origin iframe, so their geometry is unreachable; a box drawn on the host page would be drawn from guessed coordinates.
+
+Instead, as the reader moves, the adapter calls `selectMarksByValueAsync()` on the owning worksheet with the field values of the row under the cursor, using Tableau's `select-replace` update type. Tableau then highlights that mark with its own selection styling, exactly as a mouse click would. Leaving the figure, and disposing the binding, clears the selection so MAIDR never leaves a stale one behind in the workbook.
+
+Three honest consequences:
+
+- **A cell MAIDR invented has nothing to select.** A grouped bar chart is rectangularized so every series has the same categories (see [Supported Chart Types](#supported-chart-types)); a filler cell carries no criteria, and navigating onto it *clears* the selection rather than selecting a neighbouring mark.
+- **A point cloud selects only what it can name exactly.** When MAIDR reports several points at once, the adapter emits a multi-value selection only if those points differ in exactly one field. Otherwise it clears — passing two fields with two values each selects the four-way cross product, not the two marks the reader is on.
+- **A rejected selection disables selection for that layer permanently.** `selectMarksByValueAsync` throws on a field name or value it does not accept. The first rejection logs one console warning naming the worksheet and the field, clears the selection, and stops calling for that layer. Audio, text, braille, autoplay and review keep working — a chart that is readable but not highlighted is far better than one that throws on every keypress.
+
+Selection is one-directional. Clicking a mark in Tableau does **not** move the MAIDR cursor; see [Limitations](#limitations).
+
+## Installation
+
+### CDN (script tags)
+
+```html
+<script
+  type="module"
+  src="https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.min.js"
+></script>
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/tableau.js"></script>
+<script type="module">
+  // Global: maidrTableau
+  document.getElementById('tableauViz').addEventListener('firstinteractive', (event) => {
+    maidrTableau.bindTableau(event.target);
+  });
+</script>
+```
+
+`tableau.embedding.3.latest.min.js` is served from your own Tableau host — `public.tableau.com` for Tableau Public, `https://your-server/javascripts/api/…` for Tableau Server, `https://<pod>.online.tableau.com/javascripts/api/…` for Tableau Cloud. The version-pinned Tableau CDN build at `https://embedding.tableauusercontent.com/tableau.embedding.3.N.N.min.js` works too, and is the only one where the version is under your control.
+
+Unlike the other MAIDR adapters, this one cannot be demonstrated from a `file://` URL, because the Embedding API refuses to load there.
+
+### ESM (modern build tooling / bundlers)
+
+```html
+<script type="module">
+  import { TableauEventType } from 'https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.min.js';
+  import { bindTableau } from 'https://cdn.jsdelivr.net/npm/maidr/dist/tableau.mjs';
+
+  const viz = document.getElementById('tableauViz');
+  viz.addEventListener(TableauEventType.FirstInteractive, () => bindTableau(viz));
+</script>
+```
+
+### npm
+
+```bash
+npm install maidr
+```
+
+```ts
+import type { TableauAdapterOptions } from 'maidr/tableau';
+import { bindTableau } from 'maidr/tableau';
+
+const binding = bindTableau(viz, { title: 'Regional sales' });
+// later: binding?.dispose();
+```
+
+No `@tableau/*` package is required or installed. The adapter's Tableau types are its own minimal structural interfaces describing only the members it reads, which is what keeps it version-independent — and what lets the same extraction code serve a future Dashboard Extensions binder unchanged.
+
+## Supported Chart Types
+
+Tableau does not tell the Embedding API what mark type it drew. `getVisualSpecificationAsync()` — the call that reports the mark type, the shelves and the encodings — exists on the **Extensions** surface only. The adapter feature-detects it and uses it when it is there, but on the embedding surface today it is absent, so the chart type is read from the **shape of the summary data**.
+
+Every column is first classified as a measure or a dimension:
+
+| Column | Read as |
+|---|---|
+| `isReferenced: false` (a tooltip-only passenger) | dropped |
+| `dataType` of `spatial` or `unknown` | dropped — nothing sonifiable |
+| `SUM(Sales)`, `AVG(Profit)`, `CNTD(Order ID)`, … on a numeric type | **measure**, captioned `Sales`, `Profit`, `Order ID` |
+| `YEAR(Order Date)`, `MONTH(Ship Date)`, `WEEKDAY(…)`, … | **dimension**, temporal |
+| any other numeric column | **measure** |
+| anything else | **dimension**, temporal when its type is a date |
+
+The aggregation wrapper is matched by name, and Tableau documents `fieldName` as **not stable across languages** — a French workbook yields `SOMME(Ventes)`, which no wrapper list will match. That is why the numeric `dataType` is the backstop rather than the regex being the only test: such a column is still read as a measure, and the only thing that degrades is the caption, which keeps its wrapper. Nothing is ever assigned the wrong role because of a localized name.
+
+With `D` the dimensions and `M` the measures, both in view order:
+
+| Condition | MAIDR trace | Data shape |
+|---|---|---|
+| No measure at all | **worksheet skipped**, with a warning | — |
+| No dimension at all | **worksheet skipped**, with a warning — a single aggregate has nothing to navigate | — |
+| Two or more measures, and every dimension is a detail dimension (as many distinct values as there are rows) | **Scatter** (`point`) | flat points, `x` = first measure, `y` = second, `z` = third when present |
+| The first dimension is temporal, or is an unaggregated numeric field | **Line** (`line`) | nested series, one per group; a missing sample is a `null` gap, never a zero |
+| One dimension | **Bar** (`bar`) | flat points, one per row in view order |
+| Two or more dimensions | **Dodged bar** (`dodged_bar`) | nested segments, grouped by the second dimension |
+
+A third and further dimension is ignored, with one warning naming them. Grouping always uses the second dimension.
+
+When a visual specification *is* available — inside a future Extensions binder, or a future Embedding release that adds the call — the mark type outranks the ladder above: `bar` reads as a bar or dodged bar, `line` as a line, `area` as an area, `pie` as a pie, `square`/`heatmap` as a heatmap when the grid is complete, and `circle`/`shape` as a scatter when there are two measures to put on the axes.
+
+### What the adapter refuses to guess
+
+Four readings are reachable only by declaring them (see [When The Heuristics Are Wrong](#when-the-heuristics-are-wrong)), and each refusal has a reason worth knowing:
+
+- **Stacked versus side-by-side bars cannot be distinguished at all.** Tableau's summary data gives each segment's own value in both layouts; nothing in the numbers says whether they were drawn on top of one another or beside one another. `dodged_bar` is the default because it announces each group's own value and never claims a total the view may not have drawn. MAIDR's segmented trace appends its synthetic *Total* summary row either way, so the totals are still there for a stacked view — they are simply not asserted as the drawing.
+- **A heatmap is never inferred.** Two dimensions and one measure is *equally* the signature of a highlight table and of a grouped bar chart. Reading it as a dodged bar announces exactly the same numbers, needs no complete grid, and does not silently reverse the y axis the way a heatmap layer does.
+- **Normalized and 100%-stacked readings are never inferred**, for the same reason as the stacking above.
+- **Box plots, histograms, gantt charts, treemaps and choropleths are skipped, not approximated.** Tableau's summary data for a box plot is the disaggregated marks, not the quartiles — a quartile MAIDR computed itself is not the quartile Tableau drew. A gantt needs a start and an end, which the summary reports as a duration measure. A choropleth needs centroid latitude/longitude and a neighbour list, which the API does not expose. In every case a wrong reading is worse than no reading, so those worksheets contribute nothing and warn.
+
+A worksheet that yields no layer contributes **no subplot**, so a skipped worksheet never shifts the numbering of the ones that survive. If *every* worksheet is skipped, `bindTableau` warns once, mounts nothing, and returns `null`, leaving the page exactly as it was.
+
+## When The Heuristics Are Wrong
+
+Everything above can be overridden per worksheet, by name, through the options object. There is one configuration channel and it is plain JavaScript — the Embedding API exposes no settings store, and a second channel before a second host exists would be an abstraction with one caller.
+
+```js
+maidrTableau.bindTableau(viz, {
+  title: 'Regional performance',
+  worksheets: ['Sales by Region', 'Trend'],   // include-list, honoured in this order
+  overrides: {
+    'Sales by Region': {
+      traceType: 'stacked_bar',               // the data cannot reveal this — say so
+      x: 'Region',                            // Column.fieldName, or fieldId
+      y: 'SUM(Sales)',
+      z: 'Segment',
+      axes: { x: 'Region', y: 'Sales (USD)', z: 'Customer segment' },
+    },
+    'Trend': { title: 'Sales over time', orientation: 'vertical' },
+    'Scratch sheet': { skip: true },
+  },
+});
+```
+
+Three rules govern how an override is honoured:
+
+- **Precedence.** `overrides[name].traceType` outranks the visual specification, which outranks the heuristic ladder.
+- **A name that resolves to nothing degrades rather than throws.** `x` / `y` / `z` are matched against `Column.fieldName` first and `Column.fieldId` second. An unmatched name logs one warning that lists the columns the worksheet actually has, and the heuristic pick is used instead.
+- **An override that cannot be honoured degrades too.** `traceType: 'heat'` on a worksheet whose grid is incomplete falls back to the ladder's answer and warns. A truthful smaller reading, never a confident wrong one.
+
+Two things the summary data never reveals, and which therefore have no default:
+
+- **`orientation`** — nothing says whether Tableau drew the bars horizontally, so the field is emitted only when you set it.
+- **`stepDirection`** — likewise for a step chart's convention.
+
+## Refresh and Filters
+
+The binder listens on the `<tableau-viz>` element, which is an ordinary DOM `EventTarget` (the Tableau payload arrives in `event.detail`):
+
+| Event | String | Why it matters |
+|---|---|---|
+| `FirstInteractive` | `firstinteractive` | the gate — nothing is readable before it |
+| `FilterChanged` | `filterchanged` | quick filters and dashboard actions change the rows |
+| `ParameterChanged` | `parameterchanged` | a parameter control can reshape the whole view |
+| `SummaryDataChanged` | `summarydatachanged` | a data source refresh or extract update |
+
+All three change events funnel into a single **trailing-debounced** re-read, 250 ms after the last one, because one dashboard filter fires several events across several worksheets and only one re-read is wanted. Each re-read clears the mark selection first, so MAIDR's own selection cannot bias the data that comes back, then re-reads every bound worksheet through the same one-reader-at-a-time chain and rebuilds the figure. A refresh that throws is logged and **leaves the previous figure mounted** — a stale but correct figure beats a dead one.
+
+**By default the refresh is not applied while the reader is inside the chart.** It is stored and picked up on the next focus-in, which is far less disruptive than rebuilding the figure under someone who is mid-navigation, and it means an idle dashboard on an auto-refreshing extract never interrupts anyone. Pass `live: true` to opt into in-place updating with cursor preservation instead:
+
+```js
+maidrTableau.bindTableau(viz, { live: true });
+```
+
+The figure's id is captured once at bind time and reused across every refresh, so the same MAIDR instance is updated rather than replaced.
+
+## API Reference
+
+### `bindTableau(viz, options?)`
+
+Mounts MAIDR beside a `<tableau-viz>` element. Call it after the viz has fired `firstinteractive`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `viz` | `TableauViz` | The live `<tableau-viz>` element (`document.getElementById(...)`, or `event.target` in a `firstinteractive` handler). |
+| `options` | `TableauAdapterOptions?` | Everything below. |
+
+Returns a binding handle whose `dispose()` unregisters every listener, cancels the pending debounce, clears each bound worksheet's mark selection, unmounts the React root and removes the wrapper element. Returns **`null`** when no worksheet produced a layer — the page is left untouched, so always null-check before calling `dispose()`.
+
+### `TableauAdapterOptions`
+
+| Option | Type | Description |
+|---|---|---|
+| `id` | `string?` | Stable figure id, kept across refreshes. Defaults to `maidr-tableau-<n>`. |
+| `title` | `string?` | Figure title announced for the whole view. |
+| `live` | `boolean?` | Apply refreshes in place while the reader is inside the chart. Default `false` — see [Refresh and Filters](#refresh-and-filters). |
+| `worksheets` | `string[]?` | Worksheet names to include, honoured in the order written. Default: every worksheet of the active sheet. |
+| `overrides` | `Record<string, TableauWorksheetOverride>?` | Per-worksheet configuration, keyed by worksheet name. |
+| `anchorLabel` | `string?` | Text on the keyboard entry point rendered beside the viz. Defaults to `Accessible chart view — press Enter, then use arrow keys`. Style it with the `[data-maidr-tableau-anchor]` attribute selector. |
+
+Every field is JSON-serializable by design, so the same object can be stored and parsed back by a future Dashboard Extensions binder.
+
+### `TableauWorksheetOverride`
+
+| Option | Type | Description |
+|---|---|---|
+| `skip` | `boolean?` | Leave this worksheet out of the figure entirely. |
+| `traceType` | `TraceType?` | Force the reading. Outranks both the visual specification and the ladder; falls back with a warning if it cannot be honoured. |
+| `title` | `string?` | Layer title. Defaults to the worksheet name. |
+| `x` | `string?` | `Column.fieldName` (or `fieldId`) to use as the category / x axis. |
+| `y` | `string?` | The measure to use as the value. |
+| `z` | `string?` | The dimension to group series by. |
+| `orientation` | `Orientation?` | Emitted only when set — the summary data does not reveal it. |
+| `stepDirection` | `StepDirection?` | Emitted only when set, for a step reading. |
+| `axes` | `{ x?: string; y?: string; z?: string }?` | Axis labels. Default to the resolved columns' captions. |
+
+### `extractTableau(snapshots, options?)`
+
+The pure half of the adapter: it takes the worksheet snapshots the reader produced and returns `{ maidr, selection }` — the MAIDR schema, plus the map from every navigable position back to the Tableau selection criteria that address it. No DOM, no React, no `await`, and the returned `maidr` carries no `onNavigate` (the binder attaches that). Exported for tooling and tests; a page that just wants an accessible chart wants `bindTableau`.
+
+### Type exports
+
+```ts
+import type {
+  TableauAdapterOptions,
+  TableauColumn,
+  TableauSelectionCriteria,
+  TableauViz,
+  TableauWorksheet,
+  TableauWorksheetOverride,
+} from 'maidr/tableau';
+```
+
+These are **minimal structural types** describing only the subset of the Tableau API the adapter actually reads. Nothing here depends on a `@tableau/*` package.
+
+## Keyboard Controls
+
+Once the figure is focused, the standard MAIDR shortcuts apply:
+
+| Function | Key (Windows) | Key (Mac) |
+|----------|--------------|-----------|
+| Move between data points | Arrow keys | Arrow keys |
+| Go to extremes | Ctrl + Arrow | Cmd + Arrow |
+| Move between worksheets (subplots) | Page Up / Page Down | Page Up / Page Down |
+| Toggle Sonification | S | S |
+| Toggle Braille Mode | B | B |
+| Toggle Text Mode | T | T |
+| Toggle Review Mode | R | R |
+| Auto-play | Ctrl + Shift + Arrow | Cmd + Shift + Arrow |
+| Stop Auto-play | Ctrl | Cmd |
+
+For the full list, see the [Keyboard Controls](CONTROLS.html) reference.
+
+## Limitations
+
+Stated plainly, because every one of these is a place where a plausible-looking feature would have had to be guessed:
+
+- **No highlight overlay.** The marks are inside a cross-origin iframe. The only visual feedback is Tableau's own mark selection, described under [How It Works](#how-it-works).
+- **Selection is one-directional.** Clicking a mark in the Tableau view does not move the MAIDR cursor. The API gives no way to tell a programmatic selection from a user one, and a mark carries no stable id, so the reverse lookup would have to reconstruct a position from field values and would be ambiguous wherever two rows share them.
+- **Stacked and side-by-side bars are indistinguishable**, as are normalized ones. Set `overrides[name].traceType` to say which it is.
+- **Box plots, histograms, gantt charts, treemaps and choropleths are skipped**, with a warning, rather than approximated. See [Supported Chart Types](#supported-chart-types).
+- **Story sheets are skipped.** The Embedding API has a listed known issue: a worksheet inside a story throws *operation not allowed on non-active sheet*.
+- **A dashboard becomes an N×1 subplot column**, in the order the worksheets were added to the dashboard — the order Tableau documents a screen reader as narrating them. Geometry-aware two-dimensional layout is not attempted, because the Embedding API's dashboard objects are not documented to carry position and size.
+- **Summary data only.** Underlying data (`getUnderlyingTableDataReaderAsync`) is gated to Explorer and Creator roles and would fail silently for Viewer-role users, so it is never requested.
+- **Nothing is written back into the workbook.** No annotations, no filters, no parameter changes; the only write is the mark selection, which is cleared on blur and on dispose.
+- **Authentication is the host page's job.** Tableau Public needs none. Tableau Cloud and Tableau Server do: a connected-app JWT must be minted **by your server** — the connected-app secret must never reach the browser — and handed to the component through the `token` attribute or `viz.token` before you bind. The adapter neither mints, refreshes, nor inspects a token.
+- **Dashboard extensions are a separate surface.** Running MAIDR *inside* a Tableau dashboard requires a `.trex` manifest, a hosted origin, and per-site admin safe-listing for anything network-enabled. The extraction code here is written against structural interfaces both surfaces satisfy, so that binder is future work rather than a rewrite — but it is not in this release.
+
+A runnable page is at [tableau-bar.html](examples/tableau-bar.html); remember that it must be served over `http(s)` and needs a live connection to Tableau Public.
+
+## API Documentation
+
+For the complete TypeScript API reference, see the [API Documentation](api/index.html).

--- a/docs/tableau.md
+++ b/docs/tableau.md
@@ -48,8 +48,10 @@ The binder inserts a focusable block **immediately before** the viz element. Tab
 - **Audio sonification** — tones representing data values
 - **Text descriptions** — announced through the screen reader
 - **Braille output** — refreshable braille display support
-- **Keyboard navigation** — arrow keys through data points, Page Up / Page Down between dashboard worksheets
+- **Keyboard navigation** — arrow keys through data points; <kbd>Escape</kbd> back out to the worksheet list, <kbd>Up</kbd>/<kbd>Down</kbd> to choose another worksheet, <kbd>Enter</kbd> to open it
 - **Mark selection** — the mark under the cursor is selected in the Tableau view itself, which is what a sighted colleague sees highlight
+
+A dashboard of several worksheets opens in MAIDR's *subplot lobby* rather than inside a chart: on activation MAIDR announces how many subplots the figure has and tells you to use the arrow keys and <kbd>Enter</kbd>. See [Keyboard Controls](#keyboard-controls) for the exact keys.
 
 Two hosting notes, both from Tableau's own documentation:
 
@@ -60,7 +62,7 @@ Two hosting notes, both from Tableau's own documentation:
 
 The adapter never imports a Tableau package. It duck-types the live `<tableau-viz>` element the page already created, so it stays independent of the Embedding library's version.
 
-1. **Find the worksheets.** `viz.workbook.activeSheet` is read once. A `worksheet` sheet is a single worksheet; a `dashboard` contributes `dashboard.worksheets`, in the order the author added them — which is also the order Tableau's own documentation says a screen reader narrates a dashboard. A `story` sheet is skipped with a warning (see [Limitations](#limitations)).
+1. **Find the worksheets.** `viz.workbook.activeSheet` is read at bind time, and again on every refresh — a `tabswitched` event changes which sheet the worksheets come from. A `worksheet` sheet is a single worksheet; a `dashboard` contributes `dashboard.worksheets`, in the order the author added them — which is also the order Tableau's own documentation says a screen reader narrates a dashboard. A `story` sheet is skipped with a warning (see [Limitations](#limitations)).
 2. **Read the summary data.** For each worksheet the adapter calls `getSummaryColumnsInfoAsync()` for the columns *in view order*, then opens a `getSummaryDataReaderAsync()` and pages through it. The reader hands its columns back **alphabetically**, so the adapter builds a view-order-to-alphabetical index map by `fieldId` and remaps every row; every index downstream is a view index. The reader is always released in a `finally` block, and every read goes through a per-viz promise chain, because Tableau supports **only one active summary-data reader at a time** and a leaked one blocks the next read.
 3. **Classify the columns.** Each column becomes a measure or a dimension — see [Supported Chart Types](#supported-chart-types).
 4. **Decide the trace type and build the layer.** One worksheet produces exactly **one** MAIDR layer inside its own subplot; a dashboard of four worksheets is a four-row, one-column subplot grid.
@@ -70,13 +72,19 @@ The adapter never imports a Tableau package. It duck-types the live `<tableau-vi
 
 There is no overlay, and that is a consequence of the embedding surface rather than a gap. The marks live inside a cross-origin iframe, so their geometry is unreachable; a box drawn on the host page would be drawn from guessed coordinates.
 
-Instead, as the reader moves, the adapter calls `selectMarksByValueAsync()` on the owning worksheet with the field values of the row under the cursor, using Tableau's `select-replace` update type. Tableau then highlights that mark with its own selection styling, exactly as a mouse click would. Leaving the figure, and disposing the binding, clears the selection so MAIDR never leaves a stale one behind in the workbook.
+Instead, as the reader moves, the adapter calls `selectMarksByValueAsync()` on the owning worksheet with the field values of the row under the cursor, using Tableau's `select-replace` update type. Tableau then highlights that mark with its own selection styling, exactly as a mouse click would.
+
+The selection is cleared again in three places, so a highlight never outlives the cursor that put it there:
+
+- **When focus leaves MAIDR's block.** The adapter listens for `focusout` on its own wrapper and, one task later, re-checks whether the focused element is still inside it — the same test MAIDR's controller uses to decide a reading session has ended. Tabbing on into the Tableau iframe, or away to the rest of the page, clears every bound worksheet. The adapter has to do this itself: disposing the controller notifies nothing, so without the listener the mark would stay highlighted in the workbook with nothing explaining why.
+- **Before every re-read.** A filter or parameter change clears first, so MAIDR's own selection cannot bias the data that comes back.
+- **On `dispose()`.** Every bound worksheet is cleared as the binding is torn down.
 
 Three honest consequences:
 
 - **A cell MAIDR invented has nothing to select.** A grouped bar chart is rectangularized so every series has the same categories (see [Supported Chart Types](#supported-chart-types)); a filler cell carries no criteria, and navigating onto it *clears* the selection rather than selecting a neighbouring mark.
 - **A point cloud selects only what it can name exactly.** When MAIDR reports several points at once, the adapter emits a multi-value selection only if those points differ in exactly one field. Otherwise it clears — passing two fields with two values each selects the four-way cross product, not the two marks the reader is on.
-- **A rejected selection disables selection for that layer permanently.** `selectMarksByValueAsync` throws on a field name or value it does not accept. The first rejection logs one console warning naming the worksheet and the field, clears the selection, and stops calling for that layer. Audio, text, braille, autoplay and review keep working — a chart that is readable but not highlighted is far better than one that throws on every keypress.
+- **A rejected selection disables selection for that worksheet permanently.** `selectMarksByValueAsync` throws on a field name or value it does not accept. The first rejection logs one console warning naming the worksheet and the field, clears the selection, and stops calling for that worksheet. The latch is keyed by worksheet *name*, not by layer id, because a refresh that drops a worksheet renumbers the ids after it. Audio, text, braille, autoplay and review keep working — a chart that is readable but not highlighted is far better than one that throws on every keypress.
 
 Selection is one-directional. Clicking a mark in Tableau does **not** move the MAIDR cursor; see [Limitations](#limitations).
 
@@ -125,7 +133,12 @@ npm install maidr
 import type { TableauAdapterOptions } from 'maidr/tableau';
 import { bindTableau } from 'maidr/tableau';
 
-const binding = bindTableau(viz, { title: 'Regional sales' });
+const options: TableauAdapterOptions = { title: 'Regional sales' };
+
+// `bindTableau` is async — it can only tell you whether any worksheet produced
+// a navigable layer after the first read has finished. Top-level `await` is
+// valid in an ES module, so no wrapping IIFE is needed.
+const binding = await bindTableau(viz, options);
 // later: binding?.dispose();
 ```
 
@@ -148,16 +161,20 @@ Every column is first classified as a measure or a dimension:
 
 The aggregation wrapper is matched by name, and Tableau documents `fieldName` as **not stable across languages** — a French workbook yields `SOMME(Ventes)`, which no wrapper list will match. That is why the numeric `dataType` is the backstop rather than the regex being the only test: such a column is still read as a measure, and the only thing that degrades is the caption, which keeps its wrapper. Nothing is ever assigned the wrong role because of a localized name.
 
-With `D` the dimensions and `M` the measures, both in view order:
+With `D` the dimensions and `M` the measures, both in view order, the rungs are tried **in this order** — and the order is load-bearing:
 
 | Condition | MAIDR trace | Data shape |
 |---|---|---|
 | No measure at all | **worksheet skipped**, with a warning | — |
-| No dimension at all | **worksheet skipped**, with a warning — a single aggregate has nothing to navigate | — |
 | Two or more measures, and every dimension is a detail dimension (as many distinct values as there are rows) | **Scatter** (`point`) | flat points, `x` = first measure, `y` = second, `z` = third when present |
-| The first dimension is temporal, or is an unaggregated numeric field | **Line** (`line`) | nested series, one per group; a missing sample is a `null` gap, never a zero |
+| No dimension at all | **worksheet skipped**, with a warning — a single aggregate has nothing to navigate | — |
+| The first dimension is temporal | **Line** (`line`) | nested series, one per group; a missing sample is a `null` gap, never a zero |
 | One dimension | **Bar** (`bar`) | flat points, one per row in view order |
 | Two or more dimensions | **Dodged bar** (`dodged_bar`) | nested segments, grouped by the second dimension |
+
+The scatter rung is tested **before** the "no dimension" skip on purpose. A worksheet with a continuous field on an axis — an unaggregated `Discount`, or a `Sales (bin)` field — has that field classified as a second *measure*, because every numeric column goes to the measure rung above. Such a worksheet reaches the ladder with no dimensions at all, where "every dimension is a detail dimension" is vacuously true, and numeric-x-against-numeric-y is exactly what it is. Tested the other way round, a perfectly readable view would vanish from the figure.
+
+For the same reason the line rung asks only whether the first dimension is *temporal*: a continuous numeric field never arrives as a dimension, so a date-part wrapper such as `YEAR(Order Date)` is the only dimension that can be numeric, and it is already temporal.
 
 A third and further dimension is ignored, with one warning naming them. Grouping always uses the second dimension.
 
@@ -165,14 +182,26 @@ When a visual specification *is* available — inside a future Extensions binder
 
 ### What the adapter refuses to guess
 
-Four readings are reachable only by declaring them (see [When The Heuristics Are Wrong](#when-the-heuristics-are-wrong)), and each refusal has a reason worth knowing:
+Three readings are reachable only by declaring them (see [When The Heuristics Are Wrong](#when-the-heuristics-are-wrong)), and each refusal has a reason worth knowing:
 
 - **Stacked versus side-by-side bars cannot be distinguished at all.** Tableau's summary data gives each segment's own value in both layouts; nothing in the numbers says whether they were drawn on top of one another or beside one another. `dodged_bar` is the default because it announces each group's own value and never claims a total the view may not have drawn. MAIDR's segmented trace appends its synthetic *Total* summary row either way, so the totals are still there for a stacked view — they are simply not asserted as the drawing.
 - **A heatmap is never inferred.** Two dimensions and one measure is *equally* the signature of a highlight table and of a grouped bar chart. Reading it as a dodged bar announces exactly the same numbers, needs no complete grid, and does not silently reverse the y axis the way a heatmap layer does.
 - **Normalized and 100%-stacked readings are never inferred**, for the same reason as the stacking above.
-- **Box plots, histograms, gantt charts, treemaps and choropleths are skipped, not approximated.** Tableau's summary data for a box plot is the disaggregated marks, not the quartiles — a quartile MAIDR computed itself is not the quartile Tableau drew. A gantt needs a start and an end, which the summary reports as a duration measure. A choropleth needs centroid latitude/longitude and a neighbour list, which the API does not expose. In every case a wrong reading is worse than no reading, so those worksheets contribute nothing and warn.
 
-A worksheet that yields no layer contributes **no subplot**, so a skipped worksheet never shifts the numbering of the ones that survive. If *every* worksheet is skipped, `bindTableau` warns once, mounts nothing, and returns `null`, leaving the page exactly as it was.
+### Box plots, histograms, gantt charts, treemaps and choropleths
+
+None of these are ever *inferred as themselves*, and — this is the part worth planning around — **on the embedding surface they are not refused either.**
+
+The reasons they are never inferred are real: Tableau's summary data for a box plot is the disaggregated marks, not the quartiles, and a quartile MAIDR computed itself is not the quartile Tableau drew; a gantt needs a start and an end, which the summary reports as a duration measure; a choropleth needs centroid latitude/longitude and a neighbour list the API does not expose. Nothing in a table of numbers says which of these the author drew.
+
+Refusal, however, needs the mark type, and the mark type needs a visual specification:
+
+- **With a visual specification** (the Extensions surface, or a future Embedding release that adds `getVisualSpecificationAsync`), the mark types `gantt-bar`, `text`, `map`, `polygon` and `viz-extension` skip the worksheet with a warning. Note that this list does **not** cover every shape named above: a treemap draws `square` marks, which read as a heatmap on a complete grid and otherwise fall to the ladder; a histogram draws `bar` marks, which read as a bar chart.
+- **On the embedding surface today there is no visual specification**, so none of that runs. These worksheets fall straight to the heuristic ladder and are announced as whatever their column shape looks like: a box plot as a bar or grouped bar chart of its disaggregated marks (one bar per underlying record, with the category label repeated), a treemap as a bar chart, a gantt as a grouped bar chart, a choropleth as a scatter of latitude against longitude, and a histogram as a scatter of bin against count. Most of those readings are produced **without a warning**, because from the ladder's point of view nothing went wrong. The reading will be wrong, and MAIDR has no way to know it.
+
+**The remedy is to name the worksheet.** Set `overrides['<worksheet>'].skip = true` to leave a distribution or a geographic view out of the figure, or `overrides['<worksheet>'].traceType` to declare what it really is — see [When The Heuristics Are Wrong](#when-the-heuristics-are-wrong).
+
+A worksheet that yields no layer contributes **no subplot**, so a skipped worksheet never shifts the numbering of the ones that survive. If *every* worksheet is skipped, `bindTableau` warns once, mounts nothing, and resolves to `null`, leaving the page exactly as it was.
 
 ## When The Heuristics Are Wrong
 
@@ -188,9 +217,13 @@ maidrTableau.bindTableau(viz, {
       x: 'Region',                            // Column.fieldName, or fieldId
       y: 'SUM(Sales)',
       z: 'Segment',
-      axes: { x: 'Region', y: 'Sales (USD)', z: 'Customer segment' },
+      orientation: 'horz',                    // 'horz' or 'vert' — the summary
+                                              // data cannot reveal which
+      // A horizontal bar puts the magnitude on x and the category on y, and an
+      // explicit caption names the axis as the layer emits it.
+      axes: { x: 'Sales (USD)', y: 'Region', z: 'Customer segment' },
     },
-    'Trend': { title: 'Sales over time', orientation: 'vertical' },
+    'Trend': { title: 'Sales over time' },
     'Scratch sheet': { skip: true },
   },
 });
@@ -204,8 +237,8 @@ Three rules govern how an override is honoured:
 
 Two things the summary data never reveals, and which therefore have no default:
 
-- **`orientation`** — nothing says whether Tableau drew the bars horizontally, so the field is emitted only when you set it.
-- **`stepDirection`** — likewise for a step chart's convention.
+- **`orientation`** — `'horz'` or `'vert'`, the grammar's own values rather than the words they abbreviate. Read only by the bar family; a line, scatter, heatmap or pie layer ignores it. Nothing in the summary data says whether Tableau drew the bars horizontally, so the field is emitted only when you set it. Setting `'horz'` transposes the payload the adapter builds — magnitude on `x`, category on `y`, which is what MAIDR's bar model reads for an oriented layer — and swaps the default axis captions with it, so an explicit `axes` caption still names the axis it is written for. A value outside those two strings is not the same as leaving it unset: the model compares it against `'vert'` and treats anything else as horizontal, so the payload and the flag disagree and every bar sonifies as a non-number.
+- **`stepDirection`** — likewise for a step chart's convention: `'hv'`, `'vh'` or `'mid'`.
 
 ## Refresh and Filters
 
@@ -217,8 +250,9 @@ The binder listens on the `<tableau-viz>` element, which is an ordinary DOM `Eve
 | `FilterChanged` | `filterchanged` | quick filters and dashboard actions change the rows |
 | `ParameterChanged` | `parameterchanged` | a parameter control can reshape the whole view |
 | `SummaryDataChanged` | `summarydatachanged` | a data source refresh or extract update |
+| `TabSwitched` | `tabswitched` | the active sheet changed, so which worksheets exist changed too |
 
-All three change events funnel into a single **trailing-debounced** re-read, 250 ms after the last one, because one dashboard filter fires several events across several worksheets and only one re-read is wanted. Each re-read clears the mark selection first, so MAIDR's own selection cannot bias the data that comes back, then re-reads every bound worksheet through the same one-reader-at-a-time chain and rebuilds the figure. A refresh that throws is logged and **leaves the previous figure mounted** — a stale but correct figure beats a dead one.
+All four change events funnel into a single **trailing-debounced** re-read, 250 ms after the last one, because one dashboard filter fires several events across several worksheets and only one re-read is wanted. Each re-read re-discovers the worksheets from the active sheet (`tabswitched` arrives on the same path and can change which sheet they come from), clears the mark selection first so MAIDR's own selection cannot bias the data that comes back, then re-reads every bound worksheet through the same one-reader-at-a-time chain and rebuilds the figure. A refresh that throws is logged and **leaves the previous figure mounted** — a stale but correct figure beats a dead one.
 
 **By default the refresh is not applied while the reader is inside the chart.** It is stored and picked up on the next focus-in, which is far less disruptive than rebuilding the figure under someone who is mid-navigation, and it means an idle dashboard on an auto-refreshing extract never interrupts anyone. Pass `live: true` to opt into in-place updating with cursor preservation instead:
 
@@ -239,7 +273,15 @@ Mounts MAIDR beside a `<tableau-viz>` element. Call it after the viz has fired `
 | `viz` | `TableauViz` | The live `<tableau-viz>` element (`document.getElementById(...)`, or `event.target` in a `firstinteractive` handler). |
 | `options` | `TableauAdapterOptions?` | Everything below. |
 
-Returns a binding handle whose `dispose()` unregisters every listener, cancels the pending debounce, clears each bound worksheet's mark selection, unmounts the React root and removes the wrapper element. Returns **`null`** when no worksheet produced a layer — the page is left untouched, so always null-check before calling `dispose()`.
+**Returns `Promise<TableauBinding | null>` — `await` it.** The call is asynchronous by necessity: whether any worksheet yields a navigable layer is only knowable once the first read has finished. It resolves to **`null`** when no worksheet produced a layer, in which case the page is left exactly as it was found and there is nothing to tab to. Null-check the **awaited** value, never the call itself: a promise is always truthy, so `bindTableau(viz)?.dispose()` neither short-circuits nor works — it throws `TypeError: binding.dispose is not a function`.
+
+The resolved handle carries three members:
+
+| Member | Type | Description |
+|---|---|---|
+| `maidr` | `Maidr` | Getter for the MAIDR data currently mounted, including the `onNavigate` callback. A getter rather than a snapshot, because every successful refresh replaces the object wholesale. |
+| `refresh` | `() => Promise<void>` | Re-read every bound worksheet and re-render, on demand. Never rejects: a read failure is logged and the previously mounted figure is left in place. Calls are serialized behind any refresh already running. |
+| `dispose` | `() => void` | Unregisters every listener, cancels the pending debounce, clears each bound worksheet's mark selection, unmounts the React root and removes the wrapper element. The `<tableau-viz>` element is left exactly as it was found. |
 
 ### `TableauAdapterOptions`
 
@@ -264,24 +306,29 @@ Every field is JSON-serializable by design, so the same object can be stored and
 | `x` | `string?` | `Column.fieldName` (or `fieldId`) to use as the category / x axis. |
 | `y` | `string?` | The measure to use as the value. |
 | `z` | `string?` | The dimension to group series by. |
-| `orientation` | `Orientation?` | Emitted only when set — the summary data does not reveal it. |
-| `stepDirection` | `StepDirection?` | Emitted only when set, for a step reading. |
-| `axes` | `{ x?: string; y?: string; z?: string }?` | Axis labels. Default to the resolved columns' captions. |
+| `orientation` | `Orientation?` — `'horz'` or `'vert'` | Emitted only when set — the summary data does not reveal it. Read only by the bar family. Any other string is treated as horizontal by the model, not ignored. |
+| `stepDirection` | `StepDirection?` — `'hv'`, `'vh'` or `'mid'` | Emitted only when set, for a step reading. |
+| `axes` | `{ x?: string; y?: string; z?: string }?` | Axis labels. Default to the resolved columns' captions — swapped along with the payload on a horizontal bar layer. An explicit caption always wins, and names the axis as the layer emits it. |
 
 ### `extractTableau(snapshots, options?)`
 
-The pure half of the adapter: it takes the worksheet snapshots the reader produced and returns `{ maidr, selection }` — the MAIDR schema, plus the map from every navigable position back to the Tableau selection criteria that address it. No DOM, no React, no `await`, and the returned `maidr` carries no `onNavigate` (the binder attaches that). Exported for tooling and tests; a page that just wants an accessible chart wants `bindTableau`.
+The pure half of the adapter: it takes the worksheet snapshots the reader produced and returns a `TableauExtraction` — `{ maidr, selection }`, the MAIDR schema plus a `SelectionIndex` mapping every navigable position back to the Tableau selection criteria that address it (`cells` for grid positions, `points` for point clouds, and `worksheets` for which worksheet each layer id came from). Synchronous: no DOM, no React, no `await`. The returned `maidr` carries no `onNavigate` — the binder attaches that. Exported for tooling and tests; a page that just wants an accessible chart wants `bindTableau`.
 
 ### Type exports
 
 ```ts
 import type {
+  SelectionIndex,
   TableauAdapterOptions,
+  TableauBinding,
   TableauColumn,
+  TableauDataType,
+  TableauExtraction,
   TableauSelectionCriteria,
   TableauViz,
   TableauWorksheet,
   TableauWorksheetOverride,
+  WorksheetSnapshot,
 } from 'maidr/tableau';
 ```
 
@@ -295,13 +342,20 @@ Once the figure is focused, the standard MAIDR shortcuts apply:
 |----------|--------------|-----------|
 | Move between data points | Arrow keys | Arrow keys |
 | Go to extremes | Ctrl + Arrow | Cmd + Arrow |
-| Move between worksheets (subplots) | Page Up / Page Down | Page Up / Page Down |
+| Leave a worksheet for the dashboard's worksheet list | Escape (or Backspace) | Escape (or Delete) |
+| Move between worksheets in that list | Up / Down arrows | Up / Down arrows |
+| Open the selected worksheet | Enter | Enter |
 | Toggle Sonification | S | S |
 | Toggle Braille Mode | B | B |
 | Toggle Text Mode | T | T |
 | Toggle Review Mode | R | R |
 | Auto-play | Ctrl + Shift + Arrow | Cmd + Shift + Arrow |
 | Stop Auto-play | Ctrl | Cmd |
+
+Two notes specific to this adapter:
+
+- **Up and Down, not Left and Right, move between worksheets.** A dashboard becomes an N×1 subplot column (see [Limitations](#limitations)), so Left and Right in the worksheet list are always out of bounds.
+- **<kbd>Page Up</kbd> and <kbd>Page Down</kbd> do nothing here.** Those keys switch between *layers* of one subplot, and a Tableau worksheet always produces exactly one layer. There is nothing for them to switch to.
 
 For the full list, see the [Keyboard Controls](CONTROLS.html) reference.
 
@@ -312,11 +366,11 @@ Stated plainly, because every one of these is a place where a plausible-looking 
 - **No highlight overlay.** The marks are inside a cross-origin iframe. The only visual feedback is Tableau's own mark selection, described under [How It Works](#how-it-works).
 - **Selection is one-directional.** Clicking a mark in the Tableau view does not move the MAIDR cursor. The API gives no way to tell a programmatic selection from a user one, and a mark carries no stable id, so the reverse lookup would have to reconstruct a position from field values and would be ambiguous wherever two rows share them.
 - **Stacked and side-by-side bars are indistinguishable**, as are normalized ones. Set `overrides[name].traceType` to say which it is.
-- **Box plots, histograms, gantt charts, treemaps and choropleths are skipped**, with a warning, rather than approximated. See [Supported Chart Types](#supported-chart-types).
+- **Box plots, histograms, gantt charts, treemaps and choropleths are never inferred, and on the embedding surface they are not skipped either.** Refusing a worksheet by its mark type needs a visual specification, which only the Extensions surface provides; without one these views fall to the heuristic ladder and are announced as bars, grouped bars or a scatter, usually with no warning. Exclude them by name with `overrides['<worksheet>'].skip`, or declare what they are with `overrides['<worksheet>'].traceType`. See [Supported Chart Types](#supported-chart-types).
 - **Story sheets are skipped.** The Embedding API has a listed known issue: a worksheet inside a story throws *operation not allowed on non-active sheet*.
 - **A dashboard becomes an N×1 subplot column**, in the order the worksheets were added to the dashboard — the order Tableau documents a screen reader as narrating them. Geometry-aware two-dimensional layout is not attempted, because the Embedding API's dashboard objects are not documented to carry position and size.
 - **Summary data only.** Underlying data (`getUnderlyingTableDataReaderAsync`) is gated to Explorer and Creator roles and would fail silently for Viewer-role users, so it is never requested.
-- **Nothing is written back into the workbook.** No annotations, no filters, no parameter changes; the only write is the mark selection, which is cleared on blur and on dispose.
+- **Nothing is written back into the workbook.** No annotations, no filters, no parameter changes; the only write is the mark selection, and that is cleared when focus leaves MAIDR's block, before every re-read, and on `dispose()` — see [How It Works](#how-it-works).
 - **Authentication is the host page's job.** Tableau Public needs none. Tableau Cloud and Tableau Server do: a connected-app JWT must be minted **by your server** — the connected-app secret must never reach the browser — and handed to the component through the `token` attribute or `viz.token` before you bind. The adapter neither mints, refreshes, nor inspects a token.
 - **Dashboard extensions are a separate surface.** Running MAIDR *inside* a Tableau dashboard requires a `.trex` manifest, a hosted origin, and per-site admin safe-listing for anything network-enabled. The extraction code here is written against structural interfaces both surfaces satisfy, so that binder is future work rather than a rewrite — but it is not in this release.
 

--- a/docs/template.html
+++ b/docs/template.html
@@ -469,6 +469,7 @@
             <a href="{{BASE_PATH}}victory.html" class="{{VICTORY_ACTIVE}}" role="menuitem">Victory</a>
             <a href="{{BASE_PATH}}anychart.html" class="{{ANYCHART_ACTIVE}}" role="menuitem">AnyChart</a>
             <a href="{{BASE_PATH}}highcharts.html" class="{{HIGHCHARTS_ACTIVE}}" role="menuitem">Highcharts</a>
+            <a href="{{BASE_PATH}}tableau.html" class="{{TABLEAU_ACTIVE}}" role="menuitem">Tableau</a>
           </div>
         </li>
         <li><a href="{{BASE_PATH}}examples.html" class="{{EXAMPLES_ACTIVE}}">Examples</a></li>

--- a/examples/tableau-bar.html
+++ b/examples/tableau-bar.html
@@ -58,10 +58,10 @@
     <p>
       A view embedded from Tableau Public and made accessible by the MAIDR
       Tableau adapter. Tab to the "Accessible chart view" block above the viz,
-      press Enter, then use the arrow keys to move between bars. Page Up and
-      Page Down move between worksheets when the embedded sheet is a dashboard.
-      Toggle B for Braille, T for Text, S for Sonification, and R for Review
-      mode.
+      press Enter, then use the arrow keys to move between bars. When the
+      embedded sheet is a dashboard, press Escape to return to the worksheet
+      list, Up and Down to choose a worksheet, and Enter to open it. Toggle B
+      for Braille, T for Text, S for Sonification, and R for Review mode.
     </p>
 
     <div class="note">
@@ -108,14 +108,25 @@
       to announce from its shape: one dimension and one measure read as a bar
       chart, a date dimension reads as a line, two dimensions read as a grouped
       bar chart, and two measures over a detail dimension read as a scatter
-      plot. Worksheets it cannot read honestly (a box plot, a map, a gantt) are
-      skipped with a console warning rather than approximated.
+      plot. A worksheet is skipped, with a console warning, only when it has no
+      measure to sonify, no dimension to navigate, or no rows at all.
+    </p>
+    <p>
+      That shape test is all the adapter has here, so it cannot recognise a
+      distribution or a map and step aside: a box plot is read as a bar chart of
+      its disaggregated marks, and a filled map as a scatter of latitude against
+      longitude — usually without a warning, because nothing looks wrong from
+      the data's side. Exclude such worksheets by name with
+      <code>overrides['&lt;worksheet&gt;'].skip</code>, or declare what they are
+      with <code>overrides['&lt;worksheet&gt;'].traceType</code>.
     </p>
     <p>
       There is no highlight box. The marks live inside a cross-origin iframe,
       so the host page cannot measure them; instead the mark under the cursor is
       <em>selected</em> in the Tableau view itself, which is what a sighted
-      colleague sees light up. Leaving the chart clears the selection again.
+      colleague sees light up. Tabbing out of the accessible chart block clears
+      the selection again, so no mark is left highlighted once you have moved
+      on.
     </p>
     <p>
       Changing a filter or a parameter in the view re-reads the data and
@@ -131,10 +142,22 @@
 
       // Nothing in the workbook is readable before `firstinteractive`; the data
       // API rejects if asked earlier.
-      viz.addEventListener('firstinteractive', () => {
-        const binding = maidrTableau.bindTableau(viz, {
-          title: 'Superstore Overview',
-        });
+      //
+      // `bindTableau` is async — it can only report whether any worksheet
+      // produced a navigable layer once the first read has finished — so the
+      // handler must await it. Branching on the un-awaited call would branch on
+      // a promise, which is always truthy, and this status region would claim
+      // success even when nothing was mounted.
+      viz.addEventListener('firstinteractive', async () => {
+        let binding = null;
+        try {
+          binding = await maidrTableau.bindTableau(viz, {
+            title: 'Superstore Overview',
+          });
+        } catch (error) {
+          status.textContent = `MAIDR could not bind to the Tableau view: ${error?.message ?? 'unknown error'}`;
+          return;
+        }
 
         status.textContent = binding
           ? 'Tableau view loaded and bound. Tab to the accessible chart view above the viz, then press Enter.'

--- a/examples/tableau-bar.html
+++ b/examples/tableau-bar.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MAIDR + Tableau Bar Chart</title>
+
+    <!-- 1. The Tableau Embedding API v3. It is an ES module, so `type="module"`
+         is mandatory and the page must be served over http(s) — see the note
+         in the body. This copy is served by Tableau Public itself. -->
+    <script
+      type="module"
+      src="https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.min.js"
+    ></script>
+
+    <!-- 2. MAIDR core, then the MAIDR Tableau adapter (UMD, exposing the
+         `maidrTableau` global). -->
+    <script type="text/javascript" src="../dist/maidr.js"></script>
+    <script type="text/javascript" src="../dist/tableau.js"></script>
+
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      .note {
+        border-left: 4px solid #4682b4;
+        background: #f4f8fb;
+        padding: 12px 16px;
+        margin: 16px 0;
+      }
+      #status {
+        font-family: monospace;
+        padding: 8px 12px;
+        border: 1px solid #999;
+        margin: 16px 0;
+      }
+      [data-maidr-tableau-anchor] {
+        display: inline-block;
+        padding: 8px 12px;
+        margin-bottom: 8px;
+        border: 2px solid #4682b4;
+        border-radius: 4px;
+      }
+      tableau-viz {
+        display: block;
+        width: 800px;
+        max-width: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>MAIDR + Tableau Bar Chart</h1>
+    <p>
+      A view embedded from Tableau Public and made accessible by the MAIDR
+      Tableau adapter. Tab to the "Accessible chart view" block above the viz,
+      press Enter, then use the arrow keys to move between bars. Page Up and
+      Page Down move between worksheets when the embedded sheet is a dashboard.
+      Toggle B for Braille, T for Text, S for Sonification, and R for Review
+      mode.
+    </p>
+
+    <div class="note">
+      <strong>This page needs two things the other examples do not.</strong>
+      <ul>
+        <li>
+          <strong>A web server.</strong> The Embedding API is an ES module and
+          browsers block module loads from <code>file://</code>. Run something
+          like <code>npx serve</code> or <code>python3 -m http.server</code> in
+          the repository root and open this page over <code>http://</code>.
+        </li>
+        <li>
+          <strong>A live connection to Tableau Public.</strong> The view below
+          is rendered by <code>public.tableau.com</code> inside a cross-origin
+          iframe, and its data is fetched over that connection. Offline, the
+          viz never becomes interactive, MAIDR is never bound, and this page
+          shows nothing but the text you are reading.
+        </li>
+      </ul>
+      No Tableau account, token or backend is involved — Tableau Public views
+      need no authentication.
+    </div>
+
+    <div id="status" role="status">Waiting for the Tableau view to load…</div>
+
+    <h2>Embedded view</h2>
+    <p>
+      The MAIDR entry point is inserted <em>immediately before</em> the viz, so
+      a keyboard user reaches it before focus enters Tableau's own iframe
+      controls. The viz element itself is never moved.
+    </p>
+
+    <tableau-viz
+      id="tableauViz"
+      src="https://public.tableau.com/views/DeveloperSuperstore/Overview"
+      toolbar="bottom"
+      hide-tabs
+    ></tableau-viz>
+
+    <h2>What you are hearing</h2>
+    <p>
+      The adapter reads each worksheet's <em>summary data</em> — the same
+      aggregated table Tableau's own "View Data" pane shows — and decides what
+      to announce from its shape: one dimension and one measure read as a bar
+      chart, a date dimension reads as a line, two dimensions read as a grouped
+      bar chart, and two measures over a detail dimension read as a scatter
+      plot. Worksheets it cannot read honestly (a box plot, a map, a gantt) are
+      skipped with a console warning rather than approximated.
+    </p>
+    <p>
+      There is no highlight box. The marks live inside a cross-origin iframe,
+      so the host page cannot measure them; instead the mark under the cursor is
+      <em>selected</em> in the Tableau view itself, which is what a sighted
+      colleague sees light up. Leaving the chart clears the selection again.
+    </p>
+    <p>
+      Changing a filter or a parameter in the view re-reads the data and
+      rebuilds the figure. See the
+      <a href="https://maidr.ai/tableau.html">Tableau Integration Guide</a> for the
+      configuration options, including how to override a chart type the data
+      cannot reveal.
+    </p>
+
+    <script type="module">
+      const status = document.getElementById('status');
+      const viz = document.getElementById('tableauViz');
+
+      // Nothing in the workbook is readable before `firstinteractive`; the data
+      // API rejects if asked earlier.
+      viz.addEventListener('firstinteractive', () => {
+        const binding = maidrTableau.bindTableau(viz, {
+          title: 'Superstore Overview',
+        });
+
+        status.textContent = binding
+          ? 'Tableau view loaded and bound. Tab to the accessible chart view above the viz, then press Enter.'
+          : 'Tableau view loaded, but no worksheet produced a readable layer. See the console for which ones were skipped and why.';
+
+        // Nothing on this page disposes the binding; a single-page app would
+        // call binding.dispose() when the viz is torn down.
+        window.__maidrTableauBinding = binding;
+      });
+
+      viz.addEventListener('vizloaderror', (event) => {
+        status.textContent = `Tableau could not load the view: ${event.detail?.message ?? 'unknown error'}`;
+      });
+
+      // Say so rather than leaving an empty page when Tableau Public is
+      // unreachable — the failure is silent otherwise.
+      setTimeout(() => {
+        if (status.textContent.startsWith('Waiting')) {
+          status.textContent
+            = 'The Tableau view has still not become interactive. Check that this page is served over http(s) and that public.tableau.com is reachable.';
+        }
+      }, 20000);
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
       "types": "./dist/victory.d.mts",
       "import": "./dist/victory.mjs",
       "default": "./dist/victory.mjs"
+    },
+    "./tableau": {
+      "types": "./dist/tableau.d.mts",
+      "import": "./dist/tableau.mjs",
+      "default": "./dist/tableau.js"
     }
   },
   "main": "dist/maidr.js",

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -62,6 +62,7 @@ const PAGE_DESCRIPTIONS = {
   'victory': 'How to make Victory charts accessible with MAIDR — support for bar, line, scatter, stacked, histogram, box plot, candlestick, and pie chart types.',
   'anychart': 'How to make AnyChart charts accessible with MAIDR — support for bar, line, step, scatter, box, heatmap, candlestick, and pie chart types via a one-line binder.',
   'highcharts': 'How to make Highcharts charts accessible with MAIDR — support for bar, line, scatter, box, heatmap, histogram, candlestick, stacked, dodged, normalized, and pie chart types.',
+  'tableau': 'How to make embedded Tableau dashboards accessible with MAIDR — sonification, braille and screen-reader navigation for bar, line, scatter and pie worksheets via a one-line binder.',
   'examples': 'Interactive examples of accessible bar plots, line charts, heatmaps, scatter plots, box plots, and more using MAIDR.',
   'Data Schema': 'MAIDR data schema specification for defining accessible chart data structures.',
   'Braille Generation': 'Documentation for MAIDR braille output generation for tactile data exploration.',
@@ -155,6 +156,7 @@ function generatePage({ title, content, activePage, basePath = '', slug = '', og
     .replace(/\{\{VICTORY_ACTIVE\}\}/g, () => activePage === 'victory' ? 'active' : '')
     .replace(/\{\{ANYCHART_ACTIVE\}\}/g, () => activePage === 'anychart' ? 'active' : '')
     .replace(/\{\{HIGHCHARTS_ACTIVE\}\}/g, () => activePage === 'highcharts' ? 'active' : '')
+    .replace(/\{\{TABLEAU_ACTIVE\}\}/g, () => activePage === 'tableau' ? 'active' : '')
     .replace(/\{\{EXAMPLES_ACTIVE\}\}/g, () => activePage === 'examples' ? 'active' : '')
     .replace(/\{\{API_ACTIVE\}\}/g, () => activePage === 'api' ? 'active' : '')
     .replace(/\{\{BASE_PATH\}\}/g, () => basePath);
@@ -361,6 +363,20 @@ if (fs.existsSync(highchartsMdPath)) {
 `;
   const highchartsPage = generatePage({ title: 'Highcharts', content: highchartsHtml, activePage: 'highcharts', slug: 'highcharts.html', ogType: 'article' });
   fs.writeFileSync(path.join(SITE_DIR, 'highcharts.html'), highchartsPage);
+}
+
+// Build tableau.html from docs/tableau.md
+console.log('Building tableau.html from docs/tableau.md...');
+const tableauMdPath = path.join(ROOT, 'docs', 'tableau.md');
+if (fs.existsSync(tableauMdPath)) {
+  const tableauMd = fs.readFileSync(tableauMdPath, 'utf-8');
+  const tableauHtml = `
+<div class="content">
+  ${renderMarkdown(tableauMd)}
+</div>
+`;
+  const tableauPage = generatePage({ title: 'Tableau', content: tableauHtml, activePage: 'tableau', slug: 'tableau.html', ogType: 'article' });
+  fs.writeFileSync(path.join(SITE_DIR, 'tableau.html'), tableauPage);
 }
 
 // Build examples.html (inline gallery content — no middle iframe)
@@ -573,7 +589,7 @@ const docsSiteDest = path.join(SITE_DIR, 'docs');
 if (fs.existsSync(docsSource)) {
   const files = fs.readdirSync(docsSource);
   for (const file of files) {
-    if (file === 'template.html' || file === 'examples' || file === 'react.md' || file === 'recharts.md' || file === 'plotly.md' || file === 'google-charts.md' || file === 'd3.md' || file === 'vegalite.md' || file === 'chartjs.md' || file === 'amcharts.md' || file === 'frappe.md' || file === 'observable.md' || file === 'victory.md' || file === 'anychart.md' || file === 'highcharts.md')
+    if (file === 'template.html' || file === 'examples' || file === 'react.md' || file === 'recharts.md' || file === 'plotly.md' || file === 'google-charts.md' || file === 'd3.md' || file === 'vegalite.md' || file === 'chartjs.md' || file === 'amcharts.md' || file === 'frappe.md' || file === 'observable.md' || file === 'victory.md' || file === 'anychart.md' || file === 'highcharts.md' || file === 'tableau.md')
       continue;
 
     const src = path.join(docsSource, file);
@@ -640,6 +656,7 @@ const sitemapUrls = [
   { loc: 'https://maidr.ai/victory.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'victory.md')) },
   { loc: 'https://maidr.ai/anychart.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'anychart.md')) },
   { loc: 'https://maidr.ai/highcharts.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'highcharts.md')) },
+  { loc: 'https://maidr.ai/tableau.html', priority: '0.8', lastmod: fileMod(path.join(ROOT, 'docs', 'tableau.md')) },
   { loc: 'https://maidr.ai/examples.html', priority: '0.8', lastmod: today },
   { loc: 'https://maidr.ai/api/index.html', priority: '0.7', lastmod: today },
 ];
@@ -647,7 +664,7 @@ const sitemapUrls = [
 // Add all doc .md files that were built into _site/docs/
 if (fs.existsSync(docsSource)) {
   for (const f of fs.readdirSync(docsSource)) {
-    if (f === 'template.html' || f === 'react.md' || f === 'recharts.md' || f === 'plotly.md' || f === 'google-charts.md' || f === 'd3.md' || f === 'vegalite.md' || f === 'chartjs.md' || f === 'amcharts.md' || f === 'frappe.md' || f === 'observable.md' || f === 'victory.md' || f === 'anychart.md' || f === 'highcharts.md' || !f.endsWith('.md'))
+    if (f === 'template.html' || f === 'react.md' || f === 'recharts.md' || f === 'plotly.md' || f === 'google-charts.md' || f === 'd3.md' || f === 'vegalite.md' || f === 'chartjs.md' || f === 'amcharts.md' || f === 'frappe.md' || f === 'observable.md' || f === 'victory.md' || f === 'anychart.md' || f === 'highcharts.md' || f === 'tableau.md' || !f.endsWith('.md'))
       continue;
     const base = path.basename(f, '.md');
     sitemapUrls.push({

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -330,6 +330,23 @@ export const builds = [
       '@type': path.resolve(rootDir, 'src/type'),
     },
   },
+  {
+    name: 'tableau',
+    entry: 'src/tableau-entry.ts',
+    libName: 'maidrTableau',
+    formats: ['es', 'umd'],
+    fileName: format => format === 'es' ? 'tableau.mjs' : 'tableau.js',
+    emptyOutDir: false,
+    // `bindTableau` mounts the MAIDR React UI beside the embedded viz, so React
+    // is bundled in (mirrors chartjs/amcharts) and the UMD build (tableau.js)
+    // exposes the `maidrTableau` global for classic <script> use. Tableau's
+    // Embedding API is loaded by the host page and is only duck-typed off the
+    // live viz element, so there is nothing to externalize.
+    external: [],
+    useReact: true,
+    useDts: true,
+    aliases: adapterAliases,
+  },
 ];
 
 export function createViteConfig(config) {

--- a/scripts/examplesGallery.js
+++ b/scripts/examplesGallery.js
@@ -344,6 +344,13 @@ export const GROUPS = [
     headingPrefix: 'Highcharts',
     note: 'See the <a href="highcharts.html">Highcharts Integration Guide</a> for setup instructions and code examples for all chart types.',
   },
+  {
+    id: 'tableau',
+    heading: 'Tableau',
+    prefixes: ['tableau-'],
+    headingPrefix: 'Tableau',
+    note: 'See the <a href="tableau.html">Tableau Integration Guide</a> for setup instructions and configuration options.',
+  },
 ];
 
 /**

--- a/src/adapters/tableau/binder.tsx
+++ b/src/adapters/tableau/binder.tsx
@@ -3,10 +3,10 @@
  *
  * Every other module in this adapter is either pure or a thin wrapper over one
  * Tableau call. This file is the only one that owns *state*: the React root,
- * the DOM listeners, the debounce, and the selection bridge whose contents are
- * replaced wholesale on every re-read.
+ * the DOM listeners, the debounce, the bound worksheets, and the selection
+ * bridge that is rebuilt on every re-read.
  *
- * Three decisions here are load-bearing and are not free to change:
+ * Four decisions here are load-bearing and are not free to change:
  *
  * 1. **The `<tableau-viz>` element is never re-parented.** It is a custom
  *    element, and moving it re-runs `connectedCallback`; whether that reloads
@@ -17,11 +17,19 @@
  *    marks live inside the iframe and the only visual feedback channel is
  *    Tableau's own selection, which {@link applySelection} drives.
  * 2. **One re-read per burst.** A single dashboard filter fires several change
- *    events across several worksheets, so all three funnel into one trailing
+ *    events across several worksheets, so they all funnel into one trailing
  *    debounce; and because Tableau supports only one active summary-data reader,
- *    the reads themselves are serialized by the queue in `reader.ts`.
+ *    the reads themselves are serialized by the queue in `reader.ts`. Every
+ *    re-read also re-discovers the worksheets, because `tabswitched` arrives on
+ *    the same path and changes which sheet they come from.
  * 3. **A failed refresh keeps the previous figure mounted.** A stale-but-correct
  *    figure is still fully navigable; an unmounted one is nothing at all.
+ * 4. **The selection bridge never runs ahead of the mounted figure.** Unless
+ *    `live` is set, MAIDR adopts new data only once the reader has left and
+ *    come back, so a bridge built from a newer read is staged until then —
+ *    otherwise MAIDR would announce one mark while Tableau highlighted another.
+ *    Leaving the figure also clears the selection, so no highlight outlives the
+ *    cursor that put it there.
  *
  * @example
  * ```html
@@ -41,6 +49,7 @@ import type { SelectionIndex } from './extractor';
 import type { SelectionBridge } from './selection';
 import type {
   TableauAdapterOptions,
+  TableauSheet,
   TableauViz,
   TableauWorksheet,
 } from './types';
@@ -53,13 +62,38 @@ import { applySelection, clearAllSelections, createSelectionGuard } from './sele
 const ADAPTER_PREFIX = '[MAIDR tableau]';
 
 /**
- * The gate. Nothing may be read before Tableau fires this: `viz.workbook` is
- * only guaranteed to exist afterwards.
+ * The gate. Nothing may be read before Tableau fires this: the workbook behind
+ * the viz is only readable afterwards.
  */
 const FIRST_INTERACTIVE_EVENT = 'firstinteractive';
 
 /**
- * The three events that mean the numbers on screen may have changed.
+ * Tableau's "this viz will not load" signal — a bad `src`, an expired token, a
+ * site that does not allowlist the host domain.
+ *
+ * It is not a terminal state: a page that answers an `unknown-auth-error` by
+ * switching to `iframeAuth` gets a `firstinteractive` afterwards. The adapter
+ * therefore treats it only as "stop waiting", never as "fail".
+ */
+const VIZ_LOAD_ERROR_EVENT = 'vizloaderror';
+
+/**
+ * How long to wait for a viz to become interactive before giving up on it.
+ *
+ * A viz can fail to load without ever firing {@link VIZ_LOAD_ERROR_EVENT} —
+ * an unreachable host, or an embedding library older than the release that
+ * added the event — so the wait needs a floor of its own. Reaching it is
+ * reported as "nothing to read" and the caller gets its documented `null`,
+ * which is what a caller can act on; hanging forever is not.
+ */
+const FIRST_INTERACTIVE_TIMEOUT_MS = 30_000;
+
+/**
+ * The four events that mean what MAIDR read may no longer be what is on screen.
+ *
+ * The first three are data changes. `tabswitched` is a *sheet* change: the
+ * worksheets are re-discovered from the newly active sheet, because the ones
+ * captured on the previous tab describe a view the reader can no longer see.
  *
  * They are ordinary DOM events on the `<tableau-viz>` element — the Tableau
  * payload rides in `event.detail`, which this adapter never needs to read
@@ -69,6 +103,7 @@ const CHANGE_EVENTS: readonly string[] = [
   'filterchanged',
   'parameterchanged',
   'summarydatachanged',
+  'tabswitched',
 ];
 
 /**
@@ -134,25 +169,77 @@ export interface TableauBinding {
 }
 
 /**
- * Resolve once the viz is interactive enough to have a workbook.
+ * Read the active sheet, or `null` when the viz is not interactive yet.
  *
- * Resolves immediately when `viz.workbook` is already populated, which is the
- * normal case for a page that calls `bindTableau` from its own
- * `firstinteractive` handler.
+ * `viz.workbook` is **not** a readiness signal: the custom element builds a
+ * fresh wrapper object on every read, so it is defined from the moment the
+ * element starts loading, and both it and `activeSheet` throw while the
+ * machinery behind them is still unset. A successful read of the active sheet
+ * is the only readiness signal that can actually be verified from here, and it
+ * is exactly what the adapter needs next.
  *
  * @param viz - The `<tableau-viz>` element.
- * @returns A promise that settles when the workbook is readable.
+ * @returns The active sheet, or `null` when it cannot be read.
+ */
+function readActiveSheet(viz: TableauViz): TableauSheet | null {
+  try {
+    return viz.workbook?.activeSheet ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve once the viz is interactive enough to have a readable active sheet.
+ *
+ * Resolves immediately when the active sheet already reads, which is the normal
+ * case for a page that calls `bindTableau` from its own `firstinteractive`
+ * handler.
+ *
+ * Otherwise it waits — but it **always settles**, on whichever of three things
+ * happens first: the viz becomes interactive, it reports a load error, or
+ * {@link FIRST_INTERACTIVE_TIMEOUT_MS} passes. The two failure paths resolve
+ * rather than reject so that the caller reaches the adapter's ordinary
+ * "nothing to read" path (one warning, then `null`) instead of an unhandled
+ * rejection or a promise that never settles. Every listener and the timer are
+ * removed on the way out, whichever path settles it.
+ *
+ * @param viz - The `<tableau-viz>` element.
+ * @returns A promise that settles when the workbook is readable, or when it has
+ * become clear that it will not be.
  */
 function waitForFirstInteractive(viz: TableauViz): Promise<void> {
-  if (viz.workbook !== undefined) {
+  if (readActiveSheet(viz) !== null) {
     return Promise.resolve();
   }
   return new Promise<void>((resolve) => {
-    const handle = (): void => {
-      viz.removeEventListener(FIRST_INTERACTIVE_EVENT, handle);
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const settle = (event?: Event): void => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      viz.removeEventListener(FIRST_INTERACTIVE_EVENT, settle);
+      viz.removeEventListener(VIZ_LOAD_ERROR_EVENT, settle);
+      if (event?.type === VIZ_LOAD_ERROR_EVENT) {
+        const detail = (event as CustomEvent<{
+          errorCode?: string;
+          message?: string;
+        } | null>).detail;
+        warn(
+          `the viz reported a load error (${detail?.errorCode ?? 'unknown'}); `
+          + `there is nothing to bind. If the page recovers the load, bind `
+          + `again from its own 'firstinteractive' handler.`,
+          detail?.message,
+        );
+      }
       resolve();
     };
-    viz.addEventListener(FIRST_INTERACTIVE_EVENT, handle);
+
+    timer = setTimeout(settle, FIRST_INTERACTIVE_TIMEOUT_MS);
+    viz.addEventListener(FIRST_INTERACTIVE_EVENT, settle);
+    viz.addEventListener(VIZ_LOAD_ERROR_EVENT, settle);
   });
 }
 
@@ -164,19 +251,26 @@ function waitForFirstInteractive(viz: TableauViz): Promise<void> {
  * paging through MAIDR's subplots follows the order the reader already knows.
  *
  * A story yields nothing: reading a worksheet inside one is a documented known
- * issue ("operation not allowed on non-active sheet").
+ * issue ("operation not allowed on non-active sheet"). A viz that is not
+ * interactive yields nothing either, rather than throwing.
  *
- * @param viz - The `<tableau-viz>` element, already interactive.
+ * Called again on every refresh, not only at bind time: `tabswitched` changes
+ * which sheet is active, and the worksheets of the sheet the reader has left
+ * describe a view that is no longer on screen.
+ *
+ * @param viz - The `<tableau-viz>` element.
  * @returns The worksheets, or an empty list when there is nothing to read.
  */
 function discoverWorksheets(viz: TableauViz): readonly TableauWorksheet[] {
-  const workbook = viz.workbook;
-  if (workbook === undefined) {
-    warn('the viz reported no workbook; nothing to read.');
+  const sheet = readActiveSheet(viz);
+  if (sheet === null) {
+    warn(
+      'the viz has no readable active sheet — it never became interactive, or '
+      + 'its load failed; nothing to read.',
+    );
     return [];
   }
 
-  const sheet = workbook.activeSheet;
   if (sheet.sheetType === 'worksheet') {
     return [sheet];
   }
@@ -263,9 +357,9 @@ function resolveBridgeWorksheets(
  * Waits for the viz to become interactive, reads every worksheet on the active
  * sheet, builds one MAIDR subplot per worksheet, and renders the accessible
  * figure into a wrapper inserted immediately before the `<tableau-viz>`
- * element. Filter, parameter and data changes re-read the worksheets and
- * re-render; MAIDR's cursor is mirrored back into the viz as a Tableau mark
- * selection.
+ * element. Filter, parameter, data and tab changes re-discover and re-read the
+ * worksheets and re-render; MAIDR's cursor is mirrored back into the viz as a
+ * Tableau mark selection, which is cleared again when focus leaves the figure.
  *
  * Asynchronous because the first read is: whether *any* worksheet yields a
  * navigable layer is a property of the data, not of the DOM, and a binder that
@@ -277,9 +371,11 @@ function resolveBridgeWorksheets(
  * @param options - Figure id and title, the include-list, per-worksheet
  * overrides, and the live-update opt-in.
  * @returns A binding, or `null` when there was nothing to mount — a detached
- * element, a story sheet, an empty include-list, or worksheets that yielded no
- * navigable layer. In every `null` case the page is left exactly as it was
- * found, with one warning explaining why.
+ * element, a viz that failed to load or never became interactive, a story
+ * sheet, an empty include-list, or worksheets that yielded no navigable layer.
+ * In every `null` case the page is left exactly as it was found, with one
+ * warning explaining why. It always settles: a viz that never loads resolves to
+ * `null` rather than leaving the caller waiting.
  */
 export async function bindTableau(
   viz: TableauViz,
@@ -292,7 +388,10 @@ export async function bindTableau(
 
   await waitForFirstInteractive(viz);
 
-  const worksheets = selectWorksheets(discoverWorksheets(viz), options);
+  // Reassigned by every refresh: `tabswitched` makes a different sheet active,
+  // and the worksheets discovered here belong to the sheet that was active at
+  // bind time.
+  let worksheets = selectWorksheets(discoverWorksheets(viz), options);
   if (worksheets.length === 0) {
     warn('no worksheet to read on the active sheet; the page is unchanged.');
     return null;
@@ -317,14 +416,28 @@ export async function bindTableau(
   // The guard and the disable latch outlive every refresh: a worksheet whose
   // `selectMarksByValueAsync` rejects will reject again on the next read of the
   // same fields, and re-enabling it on refresh would restore the warning storm
-  // the latch exists to stop.
+  // the latch exists to stop. The latch is keyed by worksheet *name* for the
+  // same reason it survives — a layer id is only meaningful within one
+  // extraction — and is dropped wholesale when a tab switch replaces the set of
+  // worksheets it was earned on.
   const guard = createSelectionGuard();
   const disabled = new Set<string>();
 
   const state: { data: MaidrData | null } = { data: null };
   let bridge: SelectionBridge | null = null;
+  let pendingBridge: SelectionBridge | null = null;
   let disposed = false;
   let warnedEmpty = false;
+
+  /**
+   * Put a freshly built bridge into service.
+   *
+   * @param next - The bridge built from the read that is now on screen.
+   */
+  const adopt = (next: SelectionBridge): void => {
+    bridge = next;
+    pendingBridge = null;
+  };
 
   const onNavigate: NavigateCallback = (info) => {
     if (disposed || bridge === null) {
@@ -349,6 +462,33 @@ export async function bindTableau(
     // would have done to the read.
     await enqueueTableauRead(() => clearAllSelections(worksheets, guard));
 
+    // Re-discovered rather than reused: `tabswitched` is one of the events that
+    // brings us here, and the worksheets captured on the previous tab describe
+    // a view that is no longer on screen. The clear above deliberately ran on
+    // the *old* list first, so a selection is never stranded in the sheet the
+    // reader has just left.
+    const current = selectWorksheets(discoverWorksheets(viz), options);
+    if (current.length === 0) {
+      warn(
+        state.data === null
+          ? 'no worksheet to read on the active sheet; the page is unchanged.'
+          : 'no worksheet to read on the active sheet; keeping whatever was '
+            + 'already mounted.',
+      );
+      return;
+    }
+    const sameWorksheets = current.length === worksheets.length
+      && current.every((sheet, index) => sheet.name === worksheets[index].name);
+    if (!sameWorksheets) {
+      // Layer ids are indices among the worksheets that survived extraction, so
+      // a latch earned on the previous set would silence a different worksheet
+      // here. The names it holds belong to a sheet we are no longer reading.
+      disabled.clear();
+    }
+    // Always take the fresh handles, even when the names are unchanged: the
+    // sheet may have handed out new worksheet objects.
+    worksheets = current;
+
     // Each `readWorksheet` enqueues its own pagination, so these resolve in
     // whatever order Tableau answers while still opening exactly one reader at
     // a time. `Promise.all` keeps the snapshots in figure order regardless.
@@ -371,12 +511,24 @@ export async function bindTableau(
       return;
     }
 
-    bridge = {
+    const nextBridge: SelectionBridge = {
       index: selection,
       worksheets: resolveBridgeWorksheets(selection, worksheets),
       guard,
       disabled,
     };
+    // A `{layerId, row, col}` address only means anything against the read it
+    // was built from. `useMaidrController` rebuilds the model from new data
+    // immediately only when `live` is set; otherwise the running controller
+    // keeps navigating the previous figure until the reader leaves and comes
+    // back. Swapping the index underneath it would make MAIDR announce one mark
+    // while Tableau highlighted another — so the new index is staged and only
+    // takes over once the controller that cannot see it is gone.
+    if (options.live === true || !wrapper.contains(document.activeElement)) {
+      adopt(nextBridge);
+    } else {
+      pendingBridge = nextBridge;
+    }
 
     // A brand-new object every time. `LiveDataManager.setData` stores the
     // reference without cloning and the model may mutate the arrays it is
@@ -435,6 +587,35 @@ export async function bindTableau(
     viz.addEventListener(type, handleChange);
   }
 
+  // `focusout` bubbles out of the mounted figure, which is what tells this
+  // adapter that the reader's session ended: `useMaidrController` disposes the
+  // controller on the same signal, and nothing downstream of that disposal
+  // emits a final `onNavigate(null)`, so the mark MAIDR selected would stay
+  // highlighted in the workbook with nothing explaining why.
+  //
+  // Deferred by a task and re-checked against `document.activeElement`, exactly
+  // as `useMaidrController.onFocusOut` does, rather than reading
+  // `event.relatedTarget`: `relatedTarget` is null both when focus moves into
+  // the cross-origin viz iframe *and* when it goes to browser chrome, and only
+  // the former ends the session.
+  const handleFocusOut = (): void => {
+    if (disposed) {
+      return;
+    }
+    setTimeout(() => {
+      if (disposed || wrapper.contains(document.activeElement)) {
+        return;
+      }
+      // The controller that could not see a staged index is gone now, so the
+      // newest read can take over without the two disagreeing.
+      if (pendingBridge !== null) {
+        adopt(pendingBridge);
+      }
+      void clearAllSelections(worksheets, guard);
+    }, 0);
+  };
+  wrapper.addEventListener('focusout', handleFocusOut);
+
   return {
     get maidr(): MaidrData {
       // Replaced by every successful refresh; the fallback is unreachable,
@@ -454,6 +635,10 @@ export async function bindTableau(
       for (const type of CHANGE_EVENTS) {
         viz.removeEventListener(type, handleChange);
       }
+      wrapper.removeEventListener('focusout', handleFocusOut);
+      // A staged index has nothing left to be adopted into, and dropping it
+      // releases the read it holds.
+      pendingBridge = null;
       // Never leave a selection behind in a workbook this adapter no longer
       // drives; the marks would stay highlighted with nothing explaining why.
       void clearAllSelections(worksheets, guard);

--- a/src/adapters/tableau/binder.tsx
+++ b/src/adapters/tableau/binder.tsx
@@ -1,0 +1,464 @@
+/**
+ * Mounts MAIDR beside an embedded Tableau view.
+ *
+ * Every other module in this adapter is either pure or a thin wrapper over one
+ * Tableau call. This file is the only one that owns *state*: the React root,
+ * the DOM listeners, the debounce, and the selection bridge whose contents are
+ * replaced wholesale on every re-read.
+ *
+ * Three decisions here are load-bearing and are not free to change:
+ *
+ * 1. **The `<tableau-viz>` element is never re-parented.** It is a custom
+ *    element, and moving it re-runs `connectedCallback`; whether that reloads
+ *    the iframe is undocumented. The accessible layer is inserted *immediately
+ *    before* the viz instead, which also puts the keyboard entry point ahead of
+ *    the iframe in DOM order — a keyboard user reaches MAIDR before focus is
+ *    swallowed by Tableau's own UI. There is nothing to overlay anyway: the
+ *    marks live inside the iframe and the only visual feedback channel is
+ *    Tableau's own selection, which {@link applySelection} drives.
+ * 2. **One re-read per burst.** A single dashboard filter fires several change
+ *    events across several worksheets, so all three funnel into one trailing
+ *    debounce; and because Tableau supports only one active summary-data reader,
+ *    the reads themselves are serialized by the queue in `reader.ts`.
+ * 3. **A failed refresh keeps the previous figure mounted.** A stale-but-correct
+ *    figure is still fully navigable; an unmounted one is nothing at all.
+ *
+ * @example
+ * ```html
+ * <tableau-viz id="viz" src="https://public.tableau.com/views/..."></tableau-viz>
+ * <script type="module">
+ *   import { bindTableau } from 'maidr/tableau';
+ *
+ *   const binding = await bindTableau(document.getElementById('viz'));
+ *   // later: binding?.dispose();
+ * </script>
+ * ```
+ */
+
+import type { Root as ReactRoot } from 'react-dom/client';
+import type { Maidr as MaidrData, NavigateCallback } from '../../type/grammar';
+import type { SelectionIndex } from './extractor';
+import type { SelectionBridge } from './selection';
+import type {
+  TableauAdapterOptions,
+  TableauViz,
+  TableauWorksheet,
+} from './types';
+import { createRoot } from 'react-dom/client';
+import { Maidr as MaidrComponent } from '../../maidr-component';
+import { extractTableau } from './extractor';
+import { enqueueTableauRead, readWorksheet } from './reader';
+import { applySelection, clearAllSelections, createSelectionGuard } from './selection';
+
+const ADAPTER_PREFIX = '[MAIDR tableau]';
+
+/**
+ * The gate. Nothing may be read before Tableau fires this: `viz.workbook` is
+ * only guaranteed to exist afterwards.
+ */
+const FIRST_INTERACTIVE_EVENT = 'firstinteractive';
+
+/**
+ * The three events that mean the numbers on screen may have changed.
+ *
+ * They are ordinary DOM events on the `<tableau-viz>` element — the Tableau
+ * payload rides in `event.detail`, which this adapter never needs to read
+ * because a change of any kind is answered the same way: re-read everything.
+ */
+const CHANGE_EVENTS: readonly string[] = [
+  'filterchanged',
+  'parameterchanged',
+  'summarydatachanged',
+];
+
+/**
+ * Trailing debounce window for a burst of change events.
+ *
+ * One dashboard filter can fire `filterchanged` once per affected worksheet,
+ * plus a `summarydatachanged`, in the space of a few milliseconds. Reading once
+ * at the end of the burst is both cheaper and more truthful than reading each
+ * intermediate state.
+ */
+const REFRESH_DEBOUNCE_MS = 250;
+
+/** Label on the keyboard entry point when the page supplies none. */
+const DEFAULT_ANCHOR_LABEL
+  = 'Accessible chart view — press Enter, then use arrow keys';
+
+/** Figure ids when the caller supplies none. One id per binding, for its life. */
+let nextBindingId = 0;
+
+/**
+ * Log an adapter-prefixed warning.
+ *
+ * @param message - What happened, and what the adapter did about it.
+ * @param error - The underlying error, when there is one.
+ */
+function warn(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.warn(`${ADAPTER_PREFIX} ${message}`);
+  } else {
+    console.warn(`${ADAPTER_PREFIX} ${message}`, error);
+  }
+}
+
+/**
+ * Handle returned by {@link bindTableau}.
+ */
+export interface TableauBinding {
+  /**
+   * The MAIDR data currently mounted, including the `onNavigate` callback.
+   *
+   * A getter rather than a snapshot: every successful refresh replaces the
+   * object wholesale, and a caller holding the one from bind time would be
+   * inspecting a figure that is no longer on the page.
+   */
+  readonly maidr: MaidrData;
+  /**
+   * Re-read every bound worksheet and re-render.
+   *
+   * Never rejects: a read failure is logged and the previously mounted figure
+   * is left in place. Calls are serialized, so invoking it while a refresh is
+   * already running queues behind that one rather than opening a second reader.
+   */
+  refresh: () => Promise<void>;
+  /**
+   * Unregister every listener, clear the marks MAIDR selected in every bound
+   * worksheet, unmount the React tree, and remove the wrapper.
+   *
+   * Disposing the MAIDR controller and its services is **not** done here —
+   * `<Maidr>` owns that through `useMaidrController`, and unmounting is what
+   * triggers it. The `<tableau-viz>` element is left exactly as it was found.
+   */
+  dispose: () => void;
+}
+
+/**
+ * Resolve once the viz is interactive enough to have a workbook.
+ *
+ * Resolves immediately when `viz.workbook` is already populated, which is the
+ * normal case for a page that calls `bindTableau` from its own
+ * `firstinteractive` handler.
+ *
+ * @param viz - The `<tableau-viz>` element.
+ * @returns A promise that settles when the workbook is readable.
+ */
+function waitForFirstInteractive(viz: TableauViz): Promise<void> {
+  if (viz.workbook !== undefined) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    const handle = (): void => {
+      viz.removeEventListener(FIRST_INTERACTIVE_EVENT, handle);
+      resolve();
+    };
+    viz.addEventListener(FIRST_INTERACTIVE_EVENT, handle);
+  });
+}
+
+/**
+ * Find every worksheet the active sheet exposes.
+ *
+ * A dashboard's `worksheets` is in the order the author added them, which is
+ * also the order Tableau documents a screen reader as narrating them in — so
+ * paging through MAIDR's subplots follows the order the reader already knows.
+ *
+ * A story yields nothing: reading a worksheet inside one is a documented known
+ * issue ("operation not allowed on non-active sheet").
+ *
+ * @param viz - The `<tableau-viz>` element, already interactive.
+ * @returns The worksheets, or an empty list when there is nothing to read.
+ */
+function discoverWorksheets(viz: TableauViz): readonly TableauWorksheet[] {
+  const workbook = viz.workbook;
+  if (workbook === undefined) {
+    warn('the viz reported no workbook; nothing to read.');
+    return [];
+  }
+
+  const sheet = workbook.activeSheet;
+  if (sheet.sheetType === 'worksheet') {
+    return [sheet];
+  }
+  if (sheet.sheetType === 'dashboard') {
+    return sheet.worksheets;
+  }
+
+  warn(
+    `the active sheet "${sheet.name}" is a story, and reading a worksheet `
+    + `inside a story is a documented Tableau limitation; skipping it.`,
+  );
+  return [];
+}
+
+/**
+ * Apply the page's include-list and per-worksheet `skip` flags.
+ *
+ * `options.worksheets` is honoured **in the order the page wrote it**, so a
+ * dashboard can be re-ordered for a reader without touching the workbook.
+ * The extractor applies the same filters again — it must, because it is also
+ * callable on its own — and doing so twice changes nothing.
+ *
+ * @param all - Every worksheet on the active sheet.
+ * @param options - The page's adapter options.
+ * @returns The worksheets to bind, in figure order.
+ */
+function selectWorksheets(
+  all: readonly TableauWorksheet[],
+  options: TableauAdapterOptions,
+): readonly TableauWorksheet[] {
+  const overrides = options.overrides ?? {};
+  let chosen: readonly TableauWorksheet[] = all;
+
+  if (options.worksheets !== undefined) {
+    const byName = new Map(all.map(worksheet => [worksheet.name, worksheet]));
+    const picked: TableauWorksheet[] = [];
+    for (const name of options.worksheets) {
+      const worksheet = byName.get(name);
+      if (worksheet === undefined) {
+        warn(
+          `no worksheet named "${name}" on the active sheet. Available: `
+          + `${all.map(sheet => `"${sheet.name}"`).join(', ')}.`,
+        );
+        continue;
+      }
+      picked.push(worksheet);
+    }
+    chosen = picked;
+  }
+
+  return chosen.filter(worksheet => overrides[worksheet.name]?.skip !== true);
+}
+
+/**
+ * Turn the extractor's layer-id → worksheet *name* map into a layer-id →
+ * worksheet map the selection bridge can call.
+ *
+ * The indirection is deliberate: the extractor is pure and holds no Tableau
+ * objects, and a layer id is an index among the worksheets that *survived*
+ * extraction, which only the extractor knows.
+ *
+ * @param index - The selection index from the extractor.
+ * @param worksheets - The bound worksheets.
+ * @returns Layer id → the worksheet that layer was built from.
+ */
+function resolveBridgeWorksheets(
+  index: SelectionIndex,
+  worksheets: readonly TableauWorksheet[],
+): Map<string, TableauWorksheet> {
+  const byName = new Map(worksheets.map(worksheet => [worksheet.name, worksheet]));
+  const resolved = new Map<string, TableauWorksheet>();
+  for (const [layerId, name] of index.worksheets) {
+    const worksheet = byName.get(name);
+    if (worksheet !== undefined) {
+      resolved.set(layerId, worksheet);
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Mount MAIDR beside an embedded Tableau view and keep it in step with it.
+ *
+ * Waits for the viz to become interactive, reads every worksheet on the active
+ * sheet, builds one MAIDR subplot per worksheet, and renders the accessible
+ * figure into a wrapper inserted immediately before the `<tableau-viz>`
+ * element. Filter, parameter and data changes re-read the worksheets and
+ * re-render; MAIDR's cursor is mirrored back into the viz as a Tableau mark
+ * selection.
+ *
+ * Asynchronous because the first read is: whether *any* worksheet yields a
+ * navigable layer is a property of the data, not of the DOM, and a binder that
+ * returned before finding out could only report failure by mounting an empty
+ * figure.
+ *
+ * @param viz - The `<tableau-viz>` element. It must already be in the document,
+ * and it is never moved, restyled or otherwise modified.
+ * @param options - Figure id and title, the include-list, per-worksheet
+ * overrides, and the live-update opt-in.
+ * @returns A binding, or `null` when there was nothing to mount — a detached
+ * element, a story sheet, an empty include-list, or worksheets that yielded no
+ * navigable layer. In every `null` case the page is left exactly as it was
+ * found, with one warning explaining why.
+ */
+export async function bindTableau(
+  viz: TableauViz,
+  options: TableauAdapterOptions = {},
+): Promise<TableauBinding | null> {
+  if (viz.parentElement === null) {
+    warn('the <tableau-viz> element must be in the document before binding.');
+    return null;
+  }
+
+  await waitForFirstInteractive(viz);
+
+  const worksheets = selectWorksheets(discoverWorksheets(viz), options);
+  if (worksheets.length === 0) {
+    warn('no worksheet to read on the active sheet; the page is unchanged.');
+    return null;
+  }
+
+  const parent = viz.parentElement;
+  if (parent === null) {
+    warn('the <tableau-viz> element left the document while it was loading.');
+    return null;
+  }
+
+  // Captured once and reused by every refresh, so the live registry and the
+  // DOM ids keep pointing at the same figure instance across a re-render.
+  const figureId = options.id ?? `maidr-tableau-${nextBindingId++}`;
+  const anchorLabel = options.anchorLabel ?? DEFAULT_ANCHOR_LABEL;
+
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('data-maidr-tableau', figureId);
+  parent.insertBefore(wrapper, viz);
+  const root: ReactRoot = createRoot(wrapper, { identifierPrefix: figureId });
+
+  // The guard and the disable latch outlive every refresh: a worksheet whose
+  // `selectMarksByValueAsync` rejects will reject again on the next read of the
+  // same fields, and re-enabling it on refresh would restore the warning storm
+  // the latch exists to stop.
+  const guard = createSelectionGuard();
+  const disabled = new Set<string>();
+
+  const state: { data: MaidrData | null } = { data: null };
+  let bridge: SelectionBridge | null = null;
+  let disposed = false;
+  let warnedEmpty = false;
+
+  const onNavigate: NavigateCallback = (info) => {
+    if (disposed || bridge === null) {
+      return;
+    }
+    // Fire-and-forget: `applySelection` never rejects, and MAIDR's own
+    // announcement must not wait on a round trip into the iframe.
+    void applySelection(bridge, info);
+  };
+
+  const refresh = async (): Promise<void> => {
+    if (disposed) {
+      return;
+    }
+
+    // The clear is enqueued as its own task rather than wrapped around the
+    // reads: the queue is a strict serial chain and is not re-entrant, so
+    // nesting `readWorksheet` inside a held slot would deadlock. Awaiting the
+    // clear here is enough to guarantee it lands first, which is what matters —
+    // `ignoreSelection` is documented backwards on both Tableau API surfaces,
+    // so the adapter removes the selection instead of guessing what the flag
+    // would have done to the read.
+    await enqueueTableauRead(() => clearAllSelections(worksheets, guard));
+
+    // Each `readWorksheet` enqueues its own pagination, so these resolve in
+    // whatever order Tableau answers while still opening exactly one reader at
+    // a time. `Promise.all` keeps the snapshots in figure order regardless.
+    const snapshots = await Promise.all(
+      worksheets.map(async worksheet => readWorksheet(worksheet)),
+    );
+    if (disposed) {
+      return;
+    }
+
+    const { maidr, selection } = extractTableau(snapshots, options);
+    if (maidr.subplots.length === 0) {
+      if (!warnedEmpty) {
+        warnedEmpty = true;
+        warn(
+          'no worksheet yielded a navigable layer; keeping whatever was '
+          + 'already mounted.',
+        );
+      }
+      return;
+    }
+
+    bridge = {
+      index: selection,
+      worksheets: resolveBridgeWorksheets(selection, worksheets),
+      guard,
+      disabled,
+    };
+
+    // A brand-new object every time. `LiveDataManager.setData` stores the
+    // reference without cloning and the model may mutate the arrays it is
+    // handed, so a refresh must never hand back anything the previous figure
+    // still holds.
+    const next: MaidrData = {
+      ...maidr,
+      id: figureId,
+      ...(options.live === true ? { live: true } : {}),
+      onNavigate,
+    };
+    state.data = next;
+
+    root.render(
+      <MaidrComponent data={next}>
+        <div data-maidr-tableau-anchor="">{anchorLabel}</div>
+      </MaidrComponent>,
+    );
+  };
+
+  // Refreshes run one at a time and absorb their own failures, so a rejected
+  // read never becomes an unhandled rejection and never stalls the next one.
+  let pending: Promise<void> = Promise.resolve();
+  const runRefresh = (): Promise<void> => {
+    pending = pending.then(refresh).catch((error: unknown) => {
+      warn('a refresh failed; the previously mounted figure is unchanged.', error);
+    });
+    return pending;
+  };
+
+  await runRefresh();
+  if (state.data === null) {
+    // Nothing was ever rendered: take the wrapper back out so the page is left
+    // exactly as it was found.
+    root.unmount();
+    wrapper.remove();
+    return null;
+  }
+  const initial = state.data;
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const handleChange = (): void => {
+    if (disposed) {
+      return;
+    }
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      void runRefresh();
+    }, REFRESH_DEBOUNCE_MS);
+  };
+
+  for (const type of CHANGE_EVENTS) {
+    viz.addEventListener(type, handleChange);
+  }
+
+  return {
+    get maidr(): MaidrData {
+      // Replaced by every successful refresh; the fallback is unreachable,
+      // since a binding is only returned once the first render succeeded.
+      return state.data ?? initial;
+    },
+    refresh: runRefresh,
+    dispose: (): void => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      if (debounceTimer !== null) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      for (const type of CHANGE_EVENTS) {
+        viz.removeEventListener(type, handleChange);
+      }
+      // Never leave a selection behind in a workbook this adapter no longer
+      // drives; the marks would stay highlighted with nothing explaining why.
+      void clearAllSelections(worksheets, guard);
+      root.unmount();
+      wrapper.remove();
+    },
+  };
+}

--- a/src/adapters/tableau/extractor.ts
+++ b/src/adapters/tableau/extractor.ts
@@ -50,7 +50,7 @@ import type {
   TableauWorksheetOverride,
   WorksheetSnapshot,
 } from './types';
-import { TraceType } from '../../type/grammar';
+import { Orientation, TraceType } from '../../type/grammar';
 import { classifyColumns, toCategoryKey, toDateValue, toFiniteNumber } from './fields';
 
 const ADAPTER_PREFIX = '[MAIDR tableau]';
@@ -161,10 +161,18 @@ interface BuiltLayer {
   readonly points?: (readonly TableauSelectionCriteria[] | null)[];
 }
 
-/** A flat category/magnitude pair, assignable to both `BarPoint` and `PiePoint`. */
+/**
+ * A flat category/magnitude pair, assignable to `BarPoint`.
+ *
+ * Which field holds which depends on the layer's orientation: a vertical bar
+ * carries its category in `x` and its magnitude in `y`, and a horizontal one
+ * carries them the other way round, because that is how `AbstractBarPlot` reads
+ * an oriented layer. A `pie` layer is never oriented, so the pie path only ever
+ * builds the vertical form and stays assignable to `PiePoint` as well.
+ */
 interface FlatPoint {
-  readonly x: string;
-  readonly y: number;
+  readonly x: string | number;
+  readonly y: number | string;
 }
 
 // ---------------------------------------------------------------------------
@@ -390,19 +398,37 @@ function planColumns(
     warned,
   );
 
-  const category = requestedCategory ?? dimensions.find(d => d !== requestedGroup) ?? null;
+  let category = requestedCategory ?? dimensions.find(d => d !== requestedGroup) ?? null;
+  let groupRequest = requestedGroup;
+
   // One column cannot be both the category axis and the series: that would
   // build a grouped chart of one category per group, which is a shape the page
   // cannot have meant.
-  if (requestedGroup !== null && requestedGroup === category) {
+  if (groupRequest !== null && groupRequest === category) {
     warnOnce(
       warned,
-      `worksheet "${snapshot.name}": "${requestedGroup.column.fieldName}" is already `
+      `worksheet "${snapshot.name}": "${groupRequest.column.fieldName}" is already `
       + `the category axis, so it cannot also group the series; ignoring the group.`,
     );
+    groupRequest = null;
   }
-  const seriesOverride = requestedGroup === category ? null : requestedGroup;
-  const group = seriesOverride ?? dimensions.find(d => d !== category) ?? null;
+
+  // ...and it cannot be the series when it is the only dimension there is. The
+  // search above excludes the requested group from the category candidates, so
+  // a one-dimension worksheet would otherwise leave the category unset, and the
+  // ladder would drop the worksheet reporting that it has no dimension to
+  // navigate — which is false, and never names the override that caused it.
+  if (groupRequest !== null && category === null) {
+    warnOnce(
+      warned,
+      `worksheet "${snapshot.name}": "${groupRequest.column.fieldName}" is the only `
+      + `dimension, so it cannot group the series; reading it as the category axis.`,
+    );
+    category = groupRequest;
+    groupRequest = null;
+  }
+
+  const group = groupRequest ?? dimensions.find(d => d !== category) ?? null;
   const extras = dimensions.filter(d => d !== category && d !== group);
   if (extras.length > 0) {
     warnOnce(
@@ -641,7 +667,27 @@ function ladderTraceType(
     return null;
   }
 
-  // C1. A single aggregate has nothing to navigate between — one number is a
+  // C1. Several measures, and every dimension is a detail dimension (one
+  //     distinct value per row): the rows are observations rather than
+  //     categories, which is a point cloud.
+  //
+  //     This is tested *before* the "nothing to navigate" skip below, and the
+  //     order is load-bearing. A worksheet with a continuous field on an axis —
+  //     an unaggregated `Discount`, or a `Sales (bin)` field — has that field
+  //     classified as a second *measure*, because `classifyColumn` routes every
+  //     numeric column to the measure rung. Such a worksheet therefore arrives
+  //     here with no dimensions at all, where `every` is vacuously true, and
+  //     reading it as numeric x against numeric y is exactly what it is. Tested
+  //     the other way round it would be skipped for having no category, and a
+  //     perfectly readable view would vanish from the figure.
+  const everyDimensionIsDetail = plan.dimensions.every(
+    dimension => distinctKeys(rows, dimension.viewIndex).length === rows.length,
+  );
+  if (plan.measures.length >= 2 && everyDimensionIsDetail) {
+    return TraceType.SCATTER;
+  }
+
+  // C2. A single aggregate has nothing to navigate between — one number is a
   //     sentence, not a chart, and MAIDR would announce a one-cell figure.
   if (plan.category === null) {
     warnOnce(
@@ -651,19 +697,15 @@ function ladderTraceType(
     return null;
   }
 
-  // C2. Several measures, and every dimension is a detail dimension (one
-  //     distinct value per row): the rows are observations rather than
-  //     categories, which is a point cloud.
-  const everyDimensionIsDetail = plan.dimensions.every(
-    dimension => distinctKeys(rows, dimension.viewIndex).length === rows.length,
-  );
-  if (plan.measures.length >= 2 && everyDimensionIsDetail) {
-    return TraceType.SCATTER;
-  }
-
-  // C3. A temporal category, or an unaggregated continuous one, is an ordered
-  //     axis: the marks are samples along it rather than separate bars.
-  if (plan.category.temporal || plan.category.numeric) {
+  // C3. A temporal category is an ordered axis: the marks are samples along it
+  //     rather than separate bars.
+  //
+  //     Only a *temporal* one: a continuous numeric field never reaches here as
+  //     a dimension. `classifyColumn` sends every numeric column to the measure
+  //     rung, so the only dimension that can carry `numeric: true` is a
+  //     date-part wrapper such as `YEAR(Order Date)`, which is already
+  //     `temporal`. The continuous-axis case is C1's, above.
+  if (plan.category.temporal) {
     return TraceType.LINE;
   }
 
@@ -755,6 +797,9 @@ function decideTraceType(
  * @param category - The category dimension.
  * @param value - The measure.
  * @param rows - The worksheet's rows, in view order.
+ * @param horizontal - Whether the layer is horizontal, in which case the
+ * category goes on `y` and the magnitude on `x`, which is the payload
+ * `AbstractBarPlot` reads for an oriented layer.
  * @returns The points and their single-row cell index, or `null` when nothing
  * survived.
  */
@@ -762,6 +807,7 @@ function buildFlatData(
   category: TableauDimensionColumn,
   value: TableauMeasureColumn,
   rows: readonly TableauRow[],
+  horizontal: boolean,
 ): LayerBuild | null {
   const data: FlatPoint[] = [];
   const cells: (readonly TableauSelectionCriteria[] | null)[] = [];
@@ -771,7 +817,12 @@ function buildFlatData(
     if (magnitude === null) {
       continue;
     }
-    data.push({ x: toCategoryKey(row[category.viewIndex]), y: magnitude });
+    const categoryKey = toCategoryKey(row[category.viewIndex]);
+    data.push(
+      horizontal
+        ? { x: magnitude, y: categoryKey }
+        : { x: categoryKey, y: magnitude },
+    );
     cells.push(rowCriteria([category], row));
   }
 
@@ -782,16 +833,26 @@ function buildFlatData(
  * Build a rectangular grouped series, for the `dodged_bar` family.
  *
  * `SegmentedTrace.createSummaryLevel()` sums across rows by index, so every
- * inner array must hold the same categories in the same order. A `(group,
- * category)` pair with no row is therefore filled with `y: 0` — and its cell
- * criteria are `null`, because that zero is the adapter's scaffolding rather
- * than a mark, and selecting a mark that was never drawn is worse than
- * selecting nothing.
+ * inner array must hold the same categories in the same order. What it needs is
+ * equal *length*, not values: it filters the segments it sums with `isMeasured`
+ * and yields a gap for a category every series is missing. A `(group,
+ * category)` pair with no row is therefore padded with a magnitude of `NaN` —
+ * MAIDR's gap sentinel, kept out of the pitch range, announced as "missing",
+ * and left silent — and never with a `0`, which would sonify as a real reading
+ * at the bottom of the range, be reachable as the row's minimum, and pull the
+ * scale every other bar's pitch is measured against. Its cell criteria are
+ * `null` for the same reason: the pad is the adapter's scaffolding rather than
+ * a mark, and selecting a mark that was never drawn is worse than selecting
+ * nothing.
  *
  * @param category - The category dimension (`D[0]`).
  * @param group - The series dimension (`D[1]`).
  * @param value - The measure.
  * @param rows - The worksheet's rows, in view order.
+ * @param horizontal - Whether the layer is horizontal, in which case the
+ * category goes on `y` and the magnitude on `x`. The `[group][category]`
+ * iteration order is unchanged: `SegmentedTrace.createSummaryLevel()` already
+ * reads the category off `y` when the trace is horizontal.
  * @returns The nested points and their `[group][category]` cell index, or
  * `null` when the view is empty.
  */
@@ -800,6 +861,7 @@ function buildSegmentedData(
   group: TableauDimensionColumn,
   value: TableauMeasureColumn,
   rows: readonly TableauRow[],
+  horizontal: boolean,
 ): LayerBuild | null {
   const categories = distinctKeys(rows, category.viewIndex);
   const groups = distinctKeys(rows, group.viewIndex);
@@ -832,7 +894,12 @@ function buildSegmentedData(
       const magnitude = source === undefined
         ? null
         : toFiniteNumber(source[value.viewIndex]);
-      series.push({ x: categoryKey, y: magnitude ?? 0, z: groupKey });
+      const magnitudeOrGap = magnitude ?? Number.NaN;
+      series.push(
+        horizontal
+          ? { x: magnitudeOrGap, y: categoryKey, z: groupKey }
+          : { x: categoryKey, y: magnitudeOrGap, z: groupKey },
+      );
       seriesCells.push(
         source === undefined || magnitude === null
           ? null
@@ -958,7 +1025,8 @@ function buildScatterData(
  * `points.length === y.length` and `points[r].length === x.length`. Callers
  * check {@link isCompleteGrid} first, so a hole here is a duplicated pair
  * rather than a missing one; it is filled with `0` and given `null` criteria,
- * the same contract the segmented builder uses for its filler.
+ * so the pad names no mark — the same criteria contract the segmented builder
+ * uses for its own padding.
  *
  * @param category - The category dimension, laid along x.
  * @param group - The series dimension, laid along y.
@@ -1024,12 +1092,15 @@ function buildHeatData(
  * @param type - The decided trace type.
  * @param plan - The worksheet's column plan.
  * @param rows - The worksheet's rows, in view order.
+ * @param horizontal - Whether the layer is horizontal. Only the bar families
+ * are oriented, so only they read it; the rest ignore it.
  * @returns The built payload, or `null` when the worksheet yields no data.
  */
 function buildData(
   type: TraceType,
   plan: ColumnPlan,
   rows: readonly TableauRow[],
+  horizontal: boolean,
 ): LayerBuild | null {
   const { category, group, value, measures, dimensions } = plan;
 
@@ -1038,11 +1109,11 @@ function buildData(
     case 'pie':
       return category === null || value === null
         ? null
-        : buildFlatData(category, value, rows);
+        : buildFlatData(category, value, rows, horizontal);
     case 'segmented':
       return category === null || group === null || value === null
         ? null
-        : buildSegmentedData(category, group, value, rows);
+        : buildSegmentedData(category, group, value, rows, horizontal);
     case 'line':
       return category === null || value === null
         ? null
@@ -1072,11 +1143,15 @@ function buildData(
  *
  * @param family - The family the layer belongs to.
  * @param plan - The worksheet's column plan.
+ * @param horizontal - Whether the layer is horizontal, in which case a bar
+ * family's captions are swapped with its payload: the magnitude is on x and the
+ * category on y.
  * @returns The captions, each absent when the family has no such axis.
  */
 function defaultAxisLabels(
   family: TraceFamily,
   plan: ColumnPlan,
+  horizontal: boolean,
 ): { x?: string; y?: string; z?: string } {
   if (family === 'scatter') {
     return {
@@ -1094,6 +1169,17 @@ function defaultAxisLabels(
       z: plan.value?.caption,
     };
   }
+  if (horizontal) {
+    // A horizontal bar carries its magnitude on x and its category on y, so the
+    // captions travel with the payload. Naming them the other way round would
+    // announce the category label over the number and the measure label over
+    // the category name.
+    return {
+      x: plan.value?.caption,
+      y: plan.category?.caption,
+      z: plan.group?.caption,
+    };
+  }
   return {
     x: plan.category?.caption,
     y: plan.value?.caption,
@@ -1108,9 +1194,15 @@ function defaultAxisLabels(
  * Axes are always `AxisConfig` objects: a bare string is not accepted by the
  * grammar and silently degrades the label to `'X'` at runtime.
  *
+ * An explicit `override.axes` caption always wins, including on a horizontal
+ * layer: a page that hand-writes a caption is writing it for the axis as the
+ * layer will actually emit it.
+ *
  * @param family - The family the layer belongs to.
  * @param plan - The worksheet's column plan.
  * @param override - The page's overrides for this worksheet.
+ * @param horizontal - Whether the layer is horizontal, which swaps a bar
+ * family's default captions along with its payload.
  * @returns The axis configuration, with an axis omitted only when neither an
  * override nor a column names it.
  */
@@ -1118,8 +1210,9 @@ function buildAxes(
   family: TraceFamily,
   plan: ColumnPlan,
   override: TableauWorksheetOverride,
+  horizontal: boolean,
 ): { x?: AxisConfig; y?: AxisConfig; z?: AxisConfig } {
-  const defaults = defaultAxisLabels(family, plan);
+  const defaults = defaultAxisLabels(family, plan, horizontal);
   const axes: { x?: AxisConfig; y?: AxisConfig; z?: AxisConfig } = {};
 
   const x = override.axes?.x ?? defaults.x;
@@ -1177,7 +1270,18 @@ function buildLayer(
     return null;
   }
 
-  const build = buildData(type, plan, snapshot.rows);
+  // `orientation: 'horz'` is a claim about the payload, not a decoration on it.
+  // `AbstractBarPlot` reads an oriented layer's magnitude off `point.x` and its
+  // category off `point.y`, so a horizontal bar family has to be *built*
+  // transposed; stamping the flag onto the vertical shape would hand every bar
+  // `Number('<category>')`, i.e. `NaN`, and leave the chart silent with an empty
+  // braille display. Only the bar families are oriented — `IS_ORIENTED` is
+  // false for line, scatter, heat and pie, whose models ignore the field
+  // entirely — so nothing else transposes.
+  const horizontal = override.orientation === Orientation.HORIZONTAL
+    && (family === 'bar' || family === 'segmented');
+
+  const build = buildData(type, plan, snapshot.rows, horizontal);
   if (build === null) {
     warnOnce(
       warned,
@@ -1190,7 +1294,7 @@ function buildLayer(
     id: layerId,
     type,
     title: override.title ?? snapshot.name,
-    axes: buildAxes(family, plan, override),
+    axes: buildAxes(family, plan, override, horizontal),
     data: build.data,
   };
   // Nothing in the summary data says which way Tableau drew the bars, or where

--- a/src/adapters/tableau/extractor.ts
+++ b/src/adapters/tableau/extractor.ts
@@ -1,0 +1,1313 @@
+/**
+ * Turns worksheet snapshots into a MAIDR figure — purely.
+ *
+ * This is the half of the Tableau adapter that decides *what a worksheet is*.
+ * Tableau's summary data is a flat table: it says what the numbers are and
+ * never what was drawn with them. The Extensions API can answer that directly
+ * (`getVisualSpecificationAsync`), the Embedding API cannot, so the answer is
+ * assembled from three sources in a fixed order of authority — an explicit
+ * override, then the visual specification when the host has one, then a
+ * heuristic ladder over the columns themselves.
+ *
+ * Two properties of this file are load-bearing:
+ *
+ * 1. **It is pure.** No DOM, no React, no promises, no Tableau calls. Given the
+ *    same snapshots it produces the same figure, which is what lets the whole
+ *    classifier be tested with plain object literals and what lets a future
+ *    Dashboard Extensions binder reuse it unchanged.
+ * 2. **It never invents a reading it cannot support.** Where the evidence is
+ *    ambiguous the extractor picks the *smaller* truthful answer — a two
+ *    dimensional grid is read as grouped bars rather than guessed to be a
+ *    highlight table, and side-by-side bars are never announced as a stack —
+ *    and where there is no answer at all the worksheet is skipped with a
+ *    warning rather than rendered as something it is not. Each such omission
+ *    carries its reasoning at the point it is made.
+ *
+ * The {@link SelectionIndex} is built alongside the figure, from the same rows,
+ * so every navigable position remembers the dimension values of the row it came
+ * from. That is what `selection.ts` turns back into a Tableau mark selection at
+ * runtime; extraction itself performs no selection and sets no `onNavigate`.
+ */
+
+import type {
+  AxisConfig,
+  HeatmapData,
+  LinePoint,
+  Maidr,
+  MaidrLayer,
+  MaidrSubplot,
+  ScatterPoint,
+  SegmentedPoint,
+} from '../../type/grammar';
+import type {
+  TableauAdapterOptions,
+  TableauClassifiedColumn,
+  TableauDimensionColumn,
+  TableauMeasureColumn,
+  TableauRow,
+  TableauSelectionCriteria,
+  TableauVisualSpecification,
+  TableauWorksheetOverride,
+  WorksheetSnapshot,
+} from './types';
+import { TraceType } from '../../type/grammar';
+import { classifyColumns, toCategoryKey, toDateValue, toFiniteNumber } from './fields';
+
+const ADAPTER_PREFIX = '[MAIDR tableau]';
+
+/** Separator for composite map keys. A NUL cannot occur in a rendered cell. */
+const KEY_SEPARATOR = '\u0000';
+
+/** Figure ids when the caller supplies none. The binder pins one per binding. */
+let nextFigureId = 0;
+
+/**
+ * Everything the runtime needs to turn a MAIDR navigation position back into a
+ * Tableau mark selection.
+ *
+ * Positions are addressed exactly as MAIDR addresses them, so a lookup is an
+ * index rather than a search:
+ *
+ * - a **bar** or **pie** layer is one row, so its cells live at `[0][col]`;
+ * - a **grouped** layer (dodged/stacked bars, multi-series lines and areas) is
+ *   one row per series, in the same order as the layer's outer data array —
+ *   note that `SegmentedTrace` appends a synthetic "Total" row of its own, and
+ *   that row deliberately has no entry here: a total is not a mark;
+ *   the lookup misses and the runtime clears the selection instead;
+ * - a **heat** layer's rows are reversed to match `Heatmap`'s own constructor,
+ *   which flips `y` and `points` so row 0 is the bottom of the drawn grid;
+ * - a **point** cloud is addressed by `pointIndices` rather than by row/column,
+ *   so it lives in {@link SelectionIndex.points} instead.
+ *
+ * A `null` entry means the position is not addressable — a rectangularized
+ * filler cell that no mark was ever drawn for, or a row whose dimension value
+ * is missing. The runtime clears the selection for those rather than selecting
+ * something adjacent.
+ */
+export interface SelectionIndex {
+  /** Layer id → `[row][col]` → criteria for that cell, or `null`. */
+  readonly cells: Map<string, (readonly TableauSelectionCriteria[] | null)[][]>;
+  /** Layer id → per-data-index criteria, for point clouds only. */
+  readonly points: Map<string, (readonly TableauSelectionCriteria[] | null)[]>;
+  /**
+   * Layer id → the name of the worksheet that layer was built from.
+   *
+   * A worksheet that yields no layer contributes no subplot, so a layer id is
+   * the index among the survivors and does not line up with the caller's own
+   * worksheet list.
+   * The binder needs the correspondence to route a selection to the right
+   * worksheet, and only the extractor knows which snapshots survived.
+   */
+  readonly worksheets: Map<string, string>;
+}
+
+/**
+ * The result of extracting a set of worksheets.
+ *
+ * Mirrors the Chart.js adapter's `{ maidr, layerDatasetIndices }` contract: the
+ * schema plus the bookkeeping needed to route navigation back into the host
+ * library. `maidr.onNavigate` is deliberately **not** set — wiring it is the
+ * binder's job, and leaving extraction pure is what makes it testable.
+ */
+export interface TableauExtraction {
+  /** The MAIDR data object, ready for `<Maidr data={...}>`. */
+  readonly maidr: Maidr;
+  /** Where each navigable position came from, for the selection bridge. */
+  readonly selection: SelectionIndex;
+}
+
+/**
+ * The shapes MAIDR trace types collapse into for the purpose of building data.
+ *
+ * Several trace types are byte-for-byte the same payload and differ only in how
+ * the model announces them — `dodged_bar`, `stacked_bar` and
+ * `stacked_normalized_bar` are all `SegmentedPoint[][]`, and the whole line
+ * family is `LinePoint[][]` — so the builders are keyed by shape rather than by
+ * trace type.
+ */
+type TraceFamily = 'bar' | 'segmented' | 'line' | 'scatter' | 'heat' | 'pie';
+
+/** What a mark type resolves to, or what to do when it resolves to nothing. */
+type MarkTypeDecision
+  = | { readonly kind: 'trace'; readonly type: TraceType }
+    | { readonly kind: 'ladder' }
+    | { readonly kind: 'skip' };
+
+/** Which columns play which role in one worksheet, after overrides. */
+interface ColumnPlan {
+  /** Dimensions in read order: category, then group, then the ignored rest. */
+  readonly dimensions: readonly TableauDimensionColumn[];
+  /** Measures in read order: the value first, then the rest in view order. */
+  readonly measures: readonly TableauMeasureColumn[];
+  /** `D[0]`: what a reader navigates between. */
+  readonly category: TableauDimensionColumn | null;
+  /** `D[1]`: what a series is. */
+  readonly group: TableauDimensionColumn | null;
+  /** `M[0]`: the magnitude, except on a point cloud where it is the x axis. */
+  readonly value: TableauMeasureColumn | null;
+}
+
+/** A built payload plus the position index that addresses it. */
+interface LayerBuild {
+  readonly data: MaidrLayer['data'];
+  readonly cells?: (readonly TableauSelectionCriteria[] | null)[][];
+  readonly points?: (readonly TableauSelectionCriteria[] | null)[];
+}
+
+/** One worksheet's finished layer, with its position index. */
+interface BuiltLayer {
+  readonly layer: MaidrLayer;
+  readonly cells?: (readonly TableauSelectionCriteria[] | null)[][];
+  readonly points?: (readonly TableauSelectionCriteria[] | null)[];
+}
+
+/** A flat category/magnitude pair, assignable to both `BarPoint` and `PiePoint`. */
+interface FlatPoint {
+  readonly x: string;
+  readonly y: number;
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+/**
+ * Log an adapter-prefixed warning at most once per extraction.
+ *
+ * Every warning here describes a property of the *worksheet*, not of a row, so
+ * it would otherwise repeat once per row and drown the console. The latch is
+ * per call rather than per module so a refresh still reports a condition that
+ * is still true, and so a test never depends on what an earlier test logged.
+ *
+ * @param warned - Messages already logged during this extraction.
+ * @param message - What was ambiguous, and what the extractor did about it.
+ */
+function warnOnce(warned: Set<string>, message: string): void {
+  if (warned.has(message)) {
+    return;
+  }
+  warned.add(message);
+  console.warn(`${ADAPTER_PREFIX} ${message}`);
+}
+
+// ---------------------------------------------------------------------------
+// Row helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose a composite map key from category and group keys.
+ *
+ * @param first - First component.
+ * @param second - Second component.
+ * @returns The two joined by a separator no rendered cell can contain.
+ */
+function cellKey(first: string, second: string): string {
+  return `${first}${KEY_SEPARATOR}${second}`;
+}
+
+/**
+ * Every distinct value of one column, in first-appearance order.
+ *
+ * First-appearance rather than sorted, because summary data arrives in the
+ * order the view laid the marks out and that is the order a reader sees.
+ *
+ * @param rows - The worksheet's rows, in view order.
+ * @param viewIndex - The column to read.
+ * @returns The distinct rendered values, in the order they first occur.
+ */
+function distinctKeys(rows: readonly TableauRow[], viewIndex: number): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const row of rows) {
+    const key = toCategoryKey(row[viewIndex]);
+    if (!seen.has(key)) {
+      seen.add(key);
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Build the selection criterion addressing one dimension value of one row.
+ *
+ * `fieldName` is `Column.fieldName` **verbatim**. A date-part column such as
+ * `YEAR(Order Date)` is not unwrapped into a base field plus a range: what
+ * `SelectionCriteria.fieldName` means for a date part is undocumented, and a
+ * guessed transform would select the wrong marks confidently.
+ *
+ * @param dimension - The dimension to address.
+ * @param row - The source row, in view order.
+ * @returns The criterion, or `null` when the cell is a gap and therefore names
+ * no mark.
+ */
+function criterionFor(
+  dimension: TableauDimensionColumn,
+  row: TableauRow,
+): TableauSelectionCriteria | null {
+  const cell = row[dimension.viewIndex];
+  const fieldName = dimension.column.fieldName;
+
+  // A real date takes the documented single-date range form. `min === max ===
+  // the same Date` is how Tableau's own examples address one day.
+  const date = toDateValue(cell);
+  if (date !== null) {
+    return { fieldName, value: { min: date, max: date } };
+  }
+
+  const key = toCategoryKey(cell);
+  if (key === '') {
+    return null;
+  }
+  return { fieldName, value: key };
+}
+
+/**
+ * Build the criteria addressing one row across several dimensions.
+ *
+ * @param dimensions - Every dimension that participates in the address.
+ * @param row - The source row, in view order.
+ * @returns One criterion per dimension, or `null` when any of them is a gap —
+ * a partial address would select a whole band of marks instead of one.
+ */
+function rowCriteria(
+  dimensions: readonly TableauDimensionColumn[],
+  row: TableauRow,
+): readonly TableauSelectionCriteria[] | null {
+  const criteria: TableauSelectionCriteria[] = [];
+  for (const dimension of dimensions) {
+    const criterion = criterionFor(dimension, row);
+    if (criterion === null) {
+      return null;
+    }
+    criteria.push(criterion);
+  }
+  return criteria.length === 0 ? null : criteria;
+}
+
+// ---------------------------------------------------------------------------
+// Column planning
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an override's column name against the classified columns.
+ *
+ * `Column.fieldName` is tried first because it is what a page author sees in
+ * Tableau; `fieldId` second because it is what survives a rename.
+ *
+ * @param name - The name the page asked for.
+ * @param candidates - The columns of the matching role.
+ * @returns The column, or `null` when nothing matches.
+ */
+function resolveColumn<T extends TableauClassifiedColumn>(
+  name: string,
+  candidates: readonly T[],
+): T | null {
+  const byName = candidates.find(candidate => candidate.column.fieldName === name);
+  if (byName !== undefined) {
+    return byName;
+  }
+  return candidates.find(candidate => candidate.column.fieldId === name) ?? null;
+}
+
+/**
+ * Resolve one override name, warning when it names nothing.
+ *
+ * An unresolved name is a page bug, and a silent fallback would leave the
+ * author looking at a chart built from the wrong column with no clue why, so
+ * the warning names every column that *was* available.
+ *
+ * @param name - The requested column, or `undefined` when unset.
+ * @param candidates - The columns of the matching role.
+ * @param role - What the name was asked for, for the message.
+ * @param worksheet - The worksheet name, for the message.
+ * @param warned - Per-extraction warning latch.
+ * @returns The resolved column, or `null` to fall back to the heuristic pick.
+ */
+function resolveOverride<T extends TableauClassifiedColumn>(
+  name: string | undefined,
+  candidates: readonly T[],
+  role: string,
+  worksheet: string,
+  warned: Set<string>,
+): T | null {
+  if (name === undefined) {
+    return null;
+  }
+  const resolved = resolveColumn(name, candidates);
+  if (resolved !== null) {
+    return resolved;
+  }
+  const available = candidates.map(candidate => candidate.column.fieldName).join(', ');
+  warnOnce(
+    warned,
+    `worksheet "${worksheet}": no ${role} column named "${name}". `
+    + `Available: ${available === '' ? '(none)' : available}. `
+    + `Falling back to the heuristic pick.`,
+  );
+  return null;
+}
+
+/**
+ * Decide which column plays which role in one worksheet.
+ *
+ * Only `D[0]` and `D[1]` are read. Further dimensions cannot be expressed by
+ * any MAIDR trace — a third grouping level has nowhere to go in a
+ * `SegmentedPoint[][]` — so they are ignored, and named in a warning so the
+ * author can see which facts the reading leaves out.
+ *
+ * @param snapshot - The worksheet snapshot.
+ * @param override - The page's overrides for this worksheet.
+ * @param warned - Per-extraction warning latch.
+ * @returns The resolved plan; any role may be `null` when nothing fills it.
+ */
+function planColumns(
+  snapshot: WorksheetSnapshot,
+  override: TableauWorksheetOverride,
+  warned: Set<string>,
+): ColumnPlan {
+  const { dimensions, measures } = classifyColumns(snapshot.columns);
+
+  const requestedCategory = resolveOverride(
+    override.x,
+    dimensions,
+    'dimension',
+    snapshot.name,
+    warned,
+  );
+  const requestedGroup = resolveOverride(
+    override.z,
+    dimensions,
+    'dimension',
+    snapshot.name,
+    warned,
+  );
+  const requestedValue = resolveOverride(
+    override.y,
+    measures,
+    'measure',
+    snapshot.name,
+    warned,
+  );
+
+  const category = requestedCategory ?? dimensions.find(d => d !== requestedGroup) ?? null;
+  // One column cannot be both the category axis and the series: that would
+  // build a grouped chart of one category per group, which is a shape the page
+  // cannot have meant.
+  if (requestedGroup !== null && requestedGroup === category) {
+    warnOnce(
+      warned,
+      `worksheet "${snapshot.name}": "${requestedGroup.column.fieldName}" is already `
+      + `the category axis, so it cannot also group the series; ignoring the group.`,
+    );
+  }
+  const seriesOverride = requestedGroup === category ? null : requestedGroup;
+  const group = seriesOverride ?? dimensions.find(d => d !== category) ?? null;
+  const extras = dimensions.filter(d => d !== category && d !== group);
+  if (extras.length > 0) {
+    warnOnce(
+      warned,
+      `worksheet "${snapshot.name}": only the first two dimensions are read; `
+      + `ignoring ${extras.map(d => `"${d.column.fieldName}"`).join(', ')}.`,
+    );
+  }
+
+  const orderedDimensions = [category, group, ...extras].filter(
+    (d): d is TableauDimensionColumn => d !== null,
+  );
+  const value = requestedValue ?? measures[0] ?? null;
+  const orderedMeasures = value === null
+    ? []
+    : [value, ...measures.filter(measure => measure !== value)];
+
+  return {
+    dimensions: orderedDimensions,
+    measures: orderedMeasures,
+    category,
+    group,
+    value,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Trace-type decision
+// ---------------------------------------------------------------------------
+
+/**
+ * The data shape a trace type is built from.
+ *
+ * The inferable set is small on purpose (§2.3): everything else is reachable
+ * only through `overrides.traceType`, and a type this does not know is refused
+ * rather than approximated.
+ *
+ * @param type - The trace type to place.
+ * @returns Its family, or `null` when the extractor cannot build that type.
+ */
+function traceFamily(type: TraceType): TraceFamily | null {
+  switch (type) {
+    case TraceType.BAR:
+      return 'bar';
+    case TraceType.DODGED:
+    case TraceType.STACKED:
+    case TraceType.NORMALIZED:
+      return 'segmented';
+    case TraceType.LINE:
+    case TraceType.STEP:
+    case TraceType.AREA:
+    case TraceType.STACKED_AREA:
+    case TraceType.NORMALIZED_AREA:
+      return 'line';
+    case TraceType.SCATTER:
+      return 'scatter';
+    case TraceType.HEATMAP:
+      return 'heat';
+    case TraceType.PIE:
+      return 'pie';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Whether every row of the view fills exactly one cell of the `D[0] × D[1]`
+ * grid.
+ *
+ * `HeatmapData` is a rectangle: `points[r].length` must equal `x.length` for
+ * every row. A view whose row count does not match the product has holes, and a
+ * hole filled with a zero is a value the viz never drew.
+ *
+ * @param plan - The worksheet's column plan.
+ * @param rows - The worksheet's rows.
+ * @returns Whether a complete grid can be built.
+ */
+function isCompleteGrid(plan: ColumnPlan, rows: readonly TableauRow[]): boolean {
+  if (plan.category === null || plan.group === null || rows.length === 0) {
+    return false;
+  }
+  const columns = distinctKeys(rows, plan.category.viewIndex).length;
+  const bands = distinctKeys(rows, plan.group.viewIndex).length;
+  return rows.length === columns * bands;
+}
+
+/**
+ * Whether a trace type can actually be built from this worksheet.
+ *
+ * @param type - The requested trace type.
+ * @param plan - The worksheet's column plan.
+ * @param rows - The worksheet's rows.
+ * @returns Whether the required columns (and, for `heat`, the complete grid)
+ * are present.
+ */
+function canBuild(
+  type: TraceType,
+  plan: ColumnPlan,
+  rows: readonly TableauRow[],
+): boolean {
+  switch (traceFamily(type)) {
+    case 'bar':
+    case 'pie':
+    case 'line':
+      return plan.category !== null && plan.value !== null;
+    case 'segmented':
+      return plan.category !== null && plan.group !== null && plan.value !== null;
+    case 'scatter':
+      return plan.measures.length >= 2;
+    case 'heat':
+      return plan.value !== null && isCompleteGrid(plan, rows);
+    default:
+      return false;
+  }
+}
+
+/**
+ * Map a Tableau mark type onto a MAIDR trace type.
+ *
+ * Used only when a visual specification is available — the Extensions API
+ * today, and any future Embedding release that adds it. The mark type is the
+ * only *direct* evidence of what the author drew, so it outranks the heuristic
+ * ladder; it does not outrank an explicit override.
+ *
+ * @param markType - `MarksSpecification.primitiveType`, as Tableau spells it.
+ * @param plan - The worksheet's column plan.
+ * @param rows - The worksheet's rows.
+ * @param worksheet - The worksheet name, for warnings.
+ * @param warned - Per-extraction warning latch.
+ * @returns The trace type, or an instruction to fall through to the ladder, or
+ * to skip the worksheet entirely.
+ */
+function markTypeToTrace(
+  markType: string,
+  plan: ColumnPlan,
+  rows: readonly TableauRow[],
+  worksheet: string,
+  warned: Set<string>,
+): MarkTypeDecision {
+  switch (markType) {
+    case 'bar':
+      // A second dimension is a second series, whichever way Tableau laid the
+      // bars out. `dodged_bar` rather than `stacked_bar` for the reason the
+      // ladder gives below: the data cannot tell them apart.
+      return { kind: 'trace', type: plan.group === null ? TraceType.BAR : TraceType.DODGED };
+    case 'line':
+      return { kind: 'trace', type: TraceType.LINE };
+    case 'area':
+      // Never `stacked_area`: summary data gives each band its own value for
+      // both layouts, so the stack is not recoverable. `overrides.traceType`
+      // is the only way to declare one.
+      return { kind: 'trace', type: TraceType.AREA };
+    case 'circle':
+    case 'shape':
+      // A categorical dot plot is drawn with the same primitive as a scatter,
+      // and MAIDR's `point` demands numeric x and y. Without two measures to
+      // put on those axes this is not a point cloud, so the ladder decides.
+      return plan.measures.length >= 2
+        ? { kind: 'trace', type: TraceType.SCATTER }
+        : { kind: 'ladder' };
+    case 'square':
+    case 'heatmap':
+      if (isCompleteGrid(plan, rows)) {
+        return { kind: 'trace', type: TraceType.HEATMAP };
+      }
+      warnOnce(
+        warned,
+        `worksheet "${worksheet}" is drawn with ${markType} marks but its rows do `
+        + `not fill a complete grid; reading it as grouped bars instead.`,
+      );
+      return { kind: 'ladder' };
+    case 'pie':
+      return { kind: 'trace', type: TraceType.PIE };
+    case 'gantt-bar':
+    case 'text':
+    case 'map':
+    case 'polygon':
+    case 'viz-extension':
+      // Refused rather than approximated: a gantt needs a start and an end
+      // where the summary gives a duration, a map needs centroids and a
+      // neighbour list Tableau does not expose, and a text table has no
+      // magnitude to sonify at all.
+      return { kind: 'skip' };
+    default:
+      // There is no `Automatic` member in `MarkType` — Tableau resolves it to
+      // whatever primitive it drew — but the docs never say the enum is closed,
+      // so an unrecognised mark falls through to the ladder rather than
+      // throwing away a worksheet the columns can still describe.
+      return { kind: 'ladder' };
+  }
+}
+
+/**
+ * The mark type of the active marks card, when the host reported one.
+ *
+ * `activeMarksSpecificationIndex` selects the card focused in the authoring UI
+ * and is undocumented in view mode, so the first card is the fallback rather
+ * than an error.
+ *
+ * @param spec - The worksheet's visual specification, when it has one.
+ * @returns The primitive type, or `undefined`.
+ */
+function activeMarkType(spec: TableauVisualSpecification | undefined): string | undefined {
+  const cards = spec?.marksSpecifications;
+  if (cards === undefined || cards.length === 0) {
+    return undefined;
+  }
+  const index = spec?.activeMarksSpecificationIndex;
+  const active = typeof index === 'number' ? cards[index] : undefined;
+  return (active ?? cards[0])?.primitiveType;
+}
+
+/**
+ * The heuristic ladder: what the columns alone say the worksheet is.
+ *
+ * Runs only when neither an override nor a visual specification settled it.
+ *
+ * @param plan - The worksheet's column plan.
+ * @param rows - The worksheet's rows.
+ * @param worksheet - The worksheet name, for warnings.
+ * @param warned - Per-extraction warning latch.
+ * @returns The trace type, or `null` to skip the worksheet.
+ */
+function ladderTraceType(
+  plan: ColumnPlan,
+  rows: readonly TableauRow[],
+  worksheet: string,
+  warned: Set<string>,
+): TraceType | null {
+  // C0. Nothing to sonify: every trace MAIDR has pitches a magnitude.
+  if (plan.measures.length === 0 || plan.value === null) {
+    warnOnce(
+      warned,
+      `worksheet "${worksheet}" has no measure to sonify; skipping it.`,
+    );
+    return null;
+  }
+
+  // C1. A single aggregate has nothing to navigate between — one number is a
+  //     sentence, not a chart, and MAIDR would announce a one-cell figure.
+  if (plan.category === null) {
+    warnOnce(
+      warned,
+      `worksheet "${worksheet}" has no dimension to navigate; skipping it.`,
+    );
+    return null;
+  }
+
+  // C2. Several measures, and every dimension is a detail dimension (one
+  //     distinct value per row): the rows are observations rather than
+  //     categories, which is a point cloud.
+  const everyDimensionIsDetail = plan.dimensions.every(
+    dimension => distinctKeys(rows, dimension.viewIndex).length === rows.length,
+  );
+  if (plan.measures.length >= 2 && everyDimensionIsDetail) {
+    return TraceType.SCATTER;
+  }
+
+  // C3. A temporal category, or an unaggregated continuous one, is an ordered
+  //     axis: the marks are samples along it rather than separate bars.
+  if (plan.category.temporal || plan.category.numeric) {
+    return TraceType.LINE;
+  }
+
+  // C4. Otherwise: categories, with a second dimension read as series.
+  //
+  // Two deliberate omissions live here, both for the same reason — the summary
+  // data does not contain the fact that would settle them:
+  //
+  // - **`heat` is never inferred.** Two dimensions and one measure is equally
+  //   the signature of a highlight table and of a grouped bar chart. Reading it
+  //   as `dodged_bar` announces exactly the same numbers, needs no complete
+  //   grid, and does not reverse the y axis the way `Heatmap` does. A heat map
+  //   requires the mark type or `overrides.traceType`.
+  // - **`stacked_bar` is never inferred.** Summary data gives each segment its
+  //   own value whether the segments were stacked or set side by side, so
+  //   nothing distinguishes them. `dodged_bar` is the honest default: it
+  //   announces each group's own value and never claims a total the viz may not
+  //   have drawn. (`SegmentedTrace` appends its synthetic "Total" row either
+  //   way, so no total is lost by choosing it.)
+  return plan.group === null ? TraceType.BAR : TraceType.DODGED;
+}
+
+/**
+ * Decide what one worksheet is, in the fixed order of authority.
+ *
+ * A → an explicit `overrides.traceType`; B → the visual specification's mark
+ * type; C → the heuristic ladder. An override that cannot be honoured — `heat`
+ * on a view with holes in its grid, say — degrades to the ladder's answer with
+ * a warning, because a truthful smaller reading beats a confident wrong one.
+ *
+ * @param snapshot - The worksheet snapshot.
+ * @param plan - The worksheet's column plan.
+ * @param override - The page's overrides for this worksheet.
+ * @param warned - Per-extraction warning latch.
+ * @returns The trace type, or `null` to skip the worksheet.
+ */
+function decideTraceType(
+  snapshot: WorksheetSnapshot,
+  plan: ColumnPlan,
+  override: TableauWorksheetOverride,
+  warned: Set<string>,
+): TraceType | null {
+  const rows = snapshot.rows;
+
+  // A. The page said so.
+  if (override.traceType !== undefined) {
+    if (canBuild(override.traceType, plan, rows)) {
+      return override.traceType;
+    }
+    warnOnce(
+      warned,
+      `worksheet "${snapshot.name}": cannot build a "${override.traceType}" layer `
+      + `from these columns; falling back to the inferred type.`,
+    );
+  }
+
+  // B. Tableau said so.
+  const markType = activeMarkType(snapshot.spec);
+  if (markType !== undefined) {
+    const decision = markTypeToTrace(markType, plan, rows, snapshot.name, warned);
+    if (decision.kind === 'trace') {
+      return decision.type;
+    }
+    if (decision.kind === 'skip') {
+      warnOnce(
+        warned,
+        `worksheet "${snapshot.name}" is drawn with ${markType} marks, which MAIDR `
+        + `has no equivalent for; skipping it.`,
+      );
+      return null;
+    }
+  }
+
+  // C. The columns say so.
+  return ladderTraceType(plan, rows, snapshot.name, warned);
+}
+
+// ---------------------------------------------------------------------------
+// Data builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a flat category/magnitude series, for `bar` and `pie`.
+ *
+ * A row whose measure is a gap is **skipped**, not emitted as a zero: a zero is
+ * a bar the viz drew at the baseline, and inventing one puts a mark where the
+ * view has none.
+ *
+ * @param category - The category dimension.
+ * @param value - The measure.
+ * @param rows - The worksheet's rows, in view order.
+ * @returns The points and their single-row cell index, or `null` when nothing
+ * survived.
+ */
+function buildFlatData(
+  category: TableauDimensionColumn,
+  value: TableauMeasureColumn,
+  rows: readonly TableauRow[],
+): LayerBuild | null {
+  const data: FlatPoint[] = [];
+  const cells: (readonly TableauSelectionCriteria[] | null)[] = [];
+
+  for (const row of rows) {
+    const magnitude = toFiniteNumber(row[value.viewIndex]);
+    if (magnitude === null) {
+      continue;
+    }
+    data.push({ x: toCategoryKey(row[category.viewIndex]), y: magnitude });
+    cells.push(rowCriteria([category], row));
+  }
+
+  return data.length === 0 ? null : { data, cells: [cells] };
+}
+
+/**
+ * Build a rectangular grouped series, for the `dodged_bar` family.
+ *
+ * `SegmentedTrace.createSummaryLevel()` sums across rows by index, so every
+ * inner array must hold the same categories in the same order. A `(group,
+ * category)` pair with no row is therefore filled with `y: 0` — and its cell
+ * criteria are `null`, because that zero is the adapter's scaffolding rather
+ * than a mark, and selecting a mark that was never drawn is worse than
+ * selecting nothing.
+ *
+ * @param category - The category dimension (`D[0]`).
+ * @param group - The series dimension (`D[1]`).
+ * @param value - The measure.
+ * @param rows - The worksheet's rows, in view order.
+ * @returns The nested points and their `[group][category]` cell index, or
+ * `null` when the view is empty.
+ */
+function buildSegmentedData(
+  category: TableauDimensionColumn,
+  group: TableauDimensionColumn,
+  value: TableauMeasureColumn,
+  rows: readonly TableauRow[],
+): LayerBuild | null {
+  const categories = distinctKeys(rows, category.viewIndex);
+  const groups = distinctKeys(rows, group.viewIndex);
+  if (categories.length === 0 || groups.length === 0) {
+    return null;
+  }
+
+  // First row wins for a repeated pair. Summing would fabricate a total the
+  // view may not have drawn — the extra dimensions that produce duplicates are
+  // the ones `planColumns` already warned it is ignoring.
+  const sourceRows = new Map<string, TableauRow>();
+  for (const row of rows) {
+    const key = cellKey(
+      toCategoryKey(row[group.viewIndex]),
+      toCategoryKey(row[category.viewIndex]),
+    );
+    if (!sourceRows.has(key)) {
+      sourceRows.set(key, row);
+    }
+  }
+
+  const data: SegmentedPoint[][] = [];
+  const cells: (readonly TableauSelectionCriteria[] | null)[][] = [];
+
+  for (const groupKey of groups) {
+    const series: SegmentedPoint[] = [];
+    const seriesCells: (readonly TableauSelectionCriteria[] | null)[] = [];
+    for (const categoryKey of categories) {
+      const source = sourceRows.get(cellKey(groupKey, categoryKey));
+      const magnitude = source === undefined
+        ? null
+        : toFiniteNumber(source[value.viewIndex]);
+      series.push({ x: categoryKey, y: magnitude ?? 0, z: groupKey });
+      seriesCells.push(
+        source === undefined || magnitude === null
+          ? null
+          : rowCriteria([category, group], source),
+      );
+    }
+    data.push(series);
+    cells.push(seriesCells);
+  }
+
+  return { data, cells };
+}
+
+/**
+ * Build a nested series, for the whole line family (`line`, `step`, `area`).
+ *
+ * Nested **even for a single series**, which is what the grammar demands. A
+ * missing magnitude becomes `y: null` and never `0`: `Number(null)` is `0`,
+ * which would sound like a real low reading, be reachable as the row's minimum,
+ * and pull the range every other point's pitch is scaled against.
+ *
+ * Unlike the segmented builder this is deliberately **not** rectangularized —
+ * a line with fewer samples than its neighbour is a real chart, and padding it
+ * would draw points the view does not have.
+ *
+ * @param category - The category dimension (`D[0]`), read in view order.
+ * @param group - The series dimension (`D[1]`), or `null` for one series.
+ * @param value - The measure.
+ * @param rows - The worksheet's rows, in view order.
+ * @returns The nested points and their `[series][sample]` cell index, or `null`
+ * when the view is empty.
+ */
+function buildLineData(
+  category: TableauDimensionColumn,
+  group: TableauDimensionColumn | null,
+  value: TableauMeasureColumn,
+  rows: readonly TableauRow[],
+): LayerBuild | null {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const seriesIndex = new Map<string, number>();
+  const data: LinePoint[][] = [];
+  const cells: (readonly TableauSelectionCriteria[] | null)[][] = [];
+  const address = group === null ? [category] : [category, group];
+
+  for (const row of rows) {
+    const groupKey = group === null ? '' : toCategoryKey(row[group.viewIndex]);
+    let index = seriesIndex.get(groupKey);
+    if (index === undefined) {
+      index = data.length;
+      seriesIndex.set(groupKey, index);
+      data.push([]);
+      cells.push([]);
+    }
+
+    const point: LinePoint = {
+      x: toCategoryKey(row[category.viewIndex]),
+      y: toFiniteNumber(row[value.viewIndex]),
+    };
+    if (group !== null) {
+      point.z = groupKey;
+    }
+    data[index].push(point);
+    cells[index].push(rowCriteria(address, row));
+  }
+
+  return { data, cells };
+}
+
+/**
+ * Build a point cloud, for `point`.
+ *
+ * `ScatterPoint.x` and `.y` are strictly numeric, so a row missing either
+ * coordinate is dropped — there is no position to place it at. A third measure
+ * becomes `z`, which the grammar defines as a third numeric channel and not a
+ * series name.
+ *
+ * The address of a point is **every** dimension of the row, not just `D[0]` and
+ * `D[1]`: on a point cloud the dimensions are detail fields whose combination
+ * is what identifies the mark.
+ *
+ * @param measures - Measures in read order; `[0]` is x, `[1]` is y, `[2]` is z.
+ * @param dimensions - Every dimension, used to address the mark.
+ * @param rows - The worksheet's rows, in view order.
+ * @returns The points and their per-index criteria, or `null` when none had
+ * both coordinates.
+ */
+function buildScatterData(
+  measures: readonly TableauMeasureColumn[],
+  dimensions: readonly TableauDimensionColumn[],
+  rows: readonly TableauRow[],
+): LayerBuild | null {
+  const xMeasure = measures[0];
+  const yMeasure = measures[1];
+  if (xMeasure === undefined || yMeasure === undefined) {
+    return null;
+  }
+  const zMeasure = measures[2];
+
+  const data: ScatterPoint[] = [];
+  const points: (readonly TableauSelectionCriteria[] | null)[] = [];
+
+  for (const row of rows) {
+    const x = toFiniteNumber(row[xMeasure.viewIndex]);
+    const y = toFiniteNumber(row[yMeasure.viewIndex]);
+    if (x === null || y === null) {
+      continue;
+    }
+    const z = zMeasure === undefined ? null : toFiniteNumber(row[zMeasure.viewIndex]);
+    data.push(z === null ? { x, y } : { x, y, z });
+    points.push(rowCriteria(dimensions, row));
+  }
+
+  return data.length === 0 ? null : { data, points };
+}
+
+/**
+ * Build a complete grid, for `heat`.
+ *
+ * `HeatmapData` is an object rather than an array and demands a rectangle:
+ * `points.length === y.length` and `points[r].length === x.length`. Callers
+ * check {@link isCompleteGrid} first, so a hole here is a duplicated pair
+ * rather than a missing one; it is filled with `0` and given `null` criteria,
+ * the same contract the segmented builder uses for its filler.
+ *
+ * @param category - The category dimension, laid along x.
+ * @param group - The series dimension, laid along y.
+ * @param value - The measure the cells are shaded by.
+ * @param rows - The worksheet's rows, in view order.
+ * @returns The grid and its cell index — **row-reversed**, to match
+ * `Heatmap`'s own constructor, which reverses `y` and `points` so that row 0 is
+ * the bottom of the drawn grid. Without the reversal, arrow-key row N would
+ * select the marks of a different row.
+ */
+function buildHeatData(
+  category: TableauDimensionColumn,
+  group: TableauDimensionColumn,
+  value: TableauMeasureColumn,
+  rows: readonly TableauRow[],
+): LayerBuild | null {
+  const x = distinctKeys(rows, category.viewIndex);
+  const y = distinctKeys(rows, group.viewIndex);
+  if (x.length === 0 || y.length === 0) {
+    return null;
+  }
+
+  const sourceRows = new Map<string, TableauRow>();
+  for (const row of rows) {
+    const key = cellKey(
+      toCategoryKey(row[group.viewIndex]),
+      toCategoryKey(row[category.viewIndex]),
+    );
+    if (!sourceRows.has(key)) {
+      sourceRows.set(key, row);
+    }
+  }
+
+  const points: number[][] = [];
+  const cells: (readonly TableauSelectionCriteria[] | null)[][] = [];
+
+  for (const bandKey of y) {
+    const magnitudes: number[] = [];
+    const bandCells: (readonly TableauSelectionCriteria[] | null)[] = [];
+    for (const columnKey of x) {
+      const source = sourceRows.get(cellKey(bandKey, columnKey));
+      const magnitude = source === undefined
+        ? null
+        : toFiniteNumber(source[value.viewIndex]);
+      magnitudes.push(magnitude ?? 0);
+      bandCells.push(
+        source === undefined || magnitude === null
+          ? null
+          : rowCriteria([category, group], source),
+      );
+    }
+    points.push(magnitudes);
+    cells.push(bandCells);
+  }
+
+  const data: HeatmapData = { x, y, points };
+  return { data, cells: [...cells].reverse() };
+}
+
+/**
+ * Dispatch to the builder for a trace type's family.
+ *
+ * @param type - The decided trace type.
+ * @param plan - The worksheet's column plan.
+ * @param rows - The worksheet's rows, in view order.
+ * @returns The built payload, or `null` when the worksheet yields no data.
+ */
+function buildData(
+  type: TraceType,
+  plan: ColumnPlan,
+  rows: readonly TableauRow[],
+): LayerBuild | null {
+  const { category, group, value, measures, dimensions } = plan;
+
+  switch (traceFamily(type)) {
+    case 'bar':
+    case 'pie':
+      return category === null || value === null
+        ? null
+        : buildFlatData(category, value, rows);
+    case 'segmented':
+      return category === null || group === null || value === null
+        ? null
+        : buildSegmentedData(category, group, value, rows);
+    case 'line':
+      return category === null || value === null
+        ? null
+        : buildLineData(category, group, value, rows);
+    case 'scatter':
+      return buildScatterData(measures, dimensions, rows);
+    case 'heat':
+      return category === null || group === null || value === null
+        ? null
+        : buildHeatData(category, group, value, rows);
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Layer assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * The default axis captions for one trace family.
+ *
+ * Which column an axis names depends on what the chart is: a point cloud puts
+ * two *measures* on x and y, and a heat map puts the second *dimension* on y
+ * and the measure on the colour axis. Naming them by position alone would
+ * announce the wrong field, which is a defect a reader cannot see past.
+ *
+ * @param family - The family the layer belongs to.
+ * @param plan - The worksheet's column plan.
+ * @returns The captions, each absent when the family has no such axis.
+ */
+function defaultAxisLabels(
+  family: TraceFamily,
+  plan: ColumnPlan,
+): { x?: string; y?: string; z?: string } {
+  if (family === 'scatter') {
+    return {
+      x: plan.measures[0]?.caption,
+      y: plan.measures[1]?.caption,
+      z: plan.measures[2]?.caption,
+    };
+  }
+  if (family === 'heat') {
+    // `z` names what the cells are shaded by, which is the measure — the two
+    // dimensions are already spoken for by x and y.
+    return {
+      x: plan.category?.caption,
+      y: plan.group?.caption,
+      z: plan.value?.caption,
+    };
+  }
+  return {
+    x: plan.category?.caption,
+    y: plan.value?.caption,
+    // `z` names what a *series is*, per the grammar, not the values it carries.
+    z: plan.group?.caption,
+  };
+}
+
+/**
+ * Build a layer's axis configuration.
+ *
+ * Axes are always `AxisConfig` objects: a bare string is not accepted by the
+ * grammar and silently degrades the label to `'X'` at runtime.
+ *
+ * @param family - The family the layer belongs to.
+ * @param plan - The worksheet's column plan.
+ * @param override - The page's overrides for this worksheet.
+ * @returns The axis configuration, with an axis omitted only when neither an
+ * override nor a column names it.
+ */
+function buildAxes(
+  family: TraceFamily,
+  plan: ColumnPlan,
+  override: TableauWorksheetOverride,
+): { x?: AxisConfig; y?: AxisConfig; z?: AxisConfig } {
+  const defaults = defaultAxisLabels(family, plan);
+  const axes: { x?: AxisConfig; y?: AxisConfig; z?: AxisConfig } = {};
+
+  const x = override.axes?.x ?? defaults.x;
+  if (x !== undefined) {
+    axes.x = { label: x };
+  }
+  const y = override.axes?.y ?? defaults.y;
+  if (y !== undefined) {
+    axes.y = { label: y };
+  }
+  const z = override.axes?.z ?? defaults.z;
+  if (z !== undefined) {
+    axes.z = { label: z };
+  }
+
+  return axes;
+}
+
+/**
+ * Build the single layer one worksheet contributes.
+ *
+ * One worksheet is exactly one layer, and one layer is exactly one subplot, so
+ * `layerId` is the subplot index and is figure-unique by construction.
+ *
+ * @param snapshot - The worksheet snapshot.
+ * @param override - The page's overrides for this worksheet.
+ * @param layerId - The layer id to stamp, i.e. the survivor index.
+ * @param warned - Per-extraction warning latch.
+ * @returns The layer and its position index, or `null` when the worksheet
+ * contributes nothing — in which case it contributes no subplot either.
+ */
+function buildLayer(
+  snapshot: WorksheetSnapshot,
+  override: TableauWorksheetOverride,
+  layerId: string,
+  warned: Set<string>,
+): BuiltLayer | null {
+  if (snapshot.rows.length === 0) {
+    warnOnce(warned, `worksheet "${snapshot.name}" returned no rows; skipping it.`);
+    return null;
+  }
+
+  const plan = planColumns(snapshot, override, warned);
+  const type = decideTraceType(snapshot, plan, override, warned);
+  if (type === null) {
+    return null;
+  }
+
+  const family = traceFamily(type);
+  if (family === null) {
+    warnOnce(
+      warned,
+      `worksheet "${snapshot.name}": no builder for a "${type}" layer; skipping it.`,
+    );
+    return null;
+  }
+
+  const build = buildData(type, plan, snapshot.rows);
+  if (build === null) {
+    warnOnce(
+      warned,
+      `worksheet "${snapshot.name}" produced no sonifiable data; skipping it.`,
+    );
+    return null;
+  }
+
+  const layer: MaidrLayer = {
+    id: layerId,
+    type,
+    title: override.title ?? snapshot.name,
+    axes: buildAxes(family, plan, override),
+    data: build.data,
+  };
+  // Nothing in the summary data says which way Tableau drew the bars, or where
+  // a step jumps, so both are emitted only when the page declared them.
+  if (override.orientation !== undefined) {
+    layer.orientation = override.orientation;
+  }
+  if (override.stepDirection !== undefined) {
+    layer.stepDirection = override.stepDirection;
+  }
+
+  // `selectors` is never emitted: there is no DOM to select, and highlighting
+  // goes through the selection bridge instead. A layer without them keeps
+  // audio, text, braille, autoplay, review and the description modal.
+  return { layer, cells: build.cells, points: build.points };
+}
+
+/**
+ * Apply the page's include-list and per-worksheet `skip` flags.
+ *
+ * `options.worksheets` is honoured **in the order the page wrote it**, which is
+ * the only order the page can express a preference in; without it the order is
+ * `dashboard.worksheets`, i.e. the order the author added them, which is also
+ * the order a screen reader already narrates the dashboard in.
+ *
+ * @param snapshots - Every snapshot that was read.
+ * @param options - The adapter options.
+ * @param warned - Per-extraction warning latch.
+ * @returns The snapshots to build layers from, in figure order.
+ */
+function selectSnapshots(
+  snapshots: readonly WorksheetSnapshot[],
+  options: TableauAdapterOptions,
+  warned: Set<string>,
+): WorksheetSnapshot[] {
+  let included: WorksheetSnapshot[];
+  if (options.worksheets === undefined) {
+    included = [...snapshots];
+  } else {
+    included = [];
+    for (const name of options.worksheets) {
+      const match = snapshots.find(snapshot => snapshot.name === name);
+      if (match === undefined) {
+        warnOnce(warned, `no worksheet named "${name}" was read; ignoring it.`);
+        continue;
+      }
+      included.push(match);
+    }
+  }
+
+  return included.filter(
+    snapshot => options.overrides?.[snapshot.name]?.skip !== true,
+  );
+}
+
+/**
+ * Build a MAIDR figure, and its selection index, from worksheet snapshots.
+ *
+ * The figure is laid out as **N rows × 1 column**: one worksheet per subplot,
+ * in the order the snapshots arrive. Tableau documents that "screen readers
+ * read views or objects in a dashboard in the order in which they were added",
+ * and `dashboard.worksheets` is that order — so paging through the subplots
+ * matches the order a reader is already narrated the dashboard in.
+ *
+ * A worksheet that yields no layer contributes **no subplot**: `Figure` crashes
+ * on a subplot with zero layers, and the controller refuses to construct itself
+ * when no subplot has any. When every worksheet is skipped the result has an
+ * empty `subplots` array, which the binder reads as "leave the page alone".
+ *
+ * `maidr.onNavigate` is not set here. Extraction is pure; the binder spreads
+ * its own callback on.
+ *
+ * @param snapshots - One snapshot per worksheet, in figure order.
+ * @param options - The page's adapter options.
+ * @returns The MAIDR data object and the selection index that addresses it.
+ */
+export function extractTableau(
+  snapshots: readonly WorksheetSnapshot[],
+  options: TableauAdapterOptions = {},
+): TableauExtraction {
+  const warned = new Set<string>();
+  const subplots: MaidrSubplot[][] = [];
+  const cells = new Map<string, (readonly TableauSelectionCriteria[] | null)[][]>();
+  const points = new Map<string, (readonly TableauSelectionCriteria[] | null)[]>();
+  const worksheets = new Map<string, string>();
+
+  for (const snapshot of selectSnapshots(snapshots, options, warned)) {
+    // The survivor index, not the input index: a skipped worksheet must not
+    // shift the ids every later lookup is keyed by.
+    const layerId = String(subplots.length);
+    const built = buildLayer(
+      snapshot,
+      options.overrides?.[snapshot.name] ?? {},
+      layerId,
+      warned,
+    );
+    if (built === null) {
+      continue;
+    }
+
+    subplots.push([{ layers: [built.layer] }]);
+    worksheets.set(layerId, snapshot.name);
+    if (built.cells !== undefined) {
+      cells.set(layerId, built.cells);
+    }
+    if (built.points !== undefined) {
+      points.set(layerId, built.points);
+    }
+  }
+
+  const maidr: Maidr = {
+    id: options.id ?? `maidr-tableau-${nextFigureId++}`,
+    subplots,
+  };
+  if (options.title !== undefined) {
+    maidr.title = options.title;
+  }
+
+  return { maidr, selection: { cells, points, worksheets } };
+}

--- a/src/adapters/tableau/fields.ts
+++ b/src/adapters/tableau/fields.ts
@@ -1,0 +1,318 @@
+/**
+ * Column classification and value coercion for the Tableau adapter.
+ *
+ * Tableau's summary data does not say which columns are measures and which are
+ * dimensions. The Extensions API exposes `Field.role`, but the Embedding API's
+ * `Worksheet` does not list `getDataSourcesAsync` at all, so role is derived
+ * here from the two things every summary column carries on both surfaces: the
+ * aggregation wrapper in `fieldName`, and `dataType`.
+ *
+ * **The honest limit.** `Column.fieldName` is documented as "not stable across
+ * languages". A French workbook yields `SOMME(Ventes)`, whose wrapper is not a
+ * known aggregation, so the ladder falls through to the `dataType` test —
+ * which still classifies it as a measure, because the column is a `float`. Only
+ * the *caption* degrades: it keeps the wrapper and a reader hears
+ * "SOMME(Ventes)" instead of "Ventes". Nothing is read as the wrong role. That
+ * is exactly why `dataType` is the backstop rather than the regex being the
+ * only test — a regex-only classifier would silently demote every measure in
+ * every non-English workbook to a category.
+ *
+ * Everything in this file is pure: no DOM, no promises, no Tableau calls.
+ */
+
+import type {
+  TableauClassifiedColumn,
+  TableauColumn,
+  TableauColumnClassification,
+  TableauDataValue,
+  TableauDimensionColumn,
+  TableauMeasureColumn,
+  TableauRow,
+} from './types';
+
+/**
+ * Aggregation wrappers Tableau writes around a measure in `fieldName`.
+ *
+ * Matched case-insensitively against the wrapper the regex captured, so
+ * `Sum(Sales)` and `SUM(Sales)` classify alike.
+ */
+const MEASURE_AGGS = new Set([
+  'SUM',
+  'AVG',
+  'MIN',
+  'MAX',
+  'CNT',
+  'CNTD',
+  'MEDIAN',
+  'STDEV',
+  'STDEVP',
+  'VAR',
+  'VARP',
+  'ATTR',
+  'AGG',
+  'PCT',
+  'TOTAL',
+  'COLLECT',
+]);
+
+/**
+ * Date-part wrappers. `YEAR(Order Date)` is a *dimension* — one category per
+ * year — even though the wrapped field is continuous, which is why this is
+ * tested before the plain numeric test below.
+ */
+const DATE_PARTS = new Set([
+  'YEAR',
+  'QUARTER',
+  'MONTH',
+  'WEEK',
+  'DAY',
+  'HOUR',
+  'MINUTE',
+  'SECOND',
+  'MDY',
+  'WEEKDAY',
+]);
+
+/** Tableau `DataType` *enum values* that carry a number. */
+const NUMERIC = new Set(['int', 'float']);
+
+/** `WRAPPER(field)`, e.g. `SUM(Sales)` or `YEAR(Order Date)`. */
+const WRAPPER_PATTERN = /^([a-z]+)\((.+)\)$/i;
+
+/**
+ * Classify one column, or drop it.
+ *
+ * The ladder runs in exactly this order; each rung is commented with the case
+ * it exists for.
+ *
+ * @param column - A summary column, in view order.
+ * @param viewIndex - Its position in the view-order column list.
+ * @returns The classified column, or `null` when it carries nothing sonifiable.
+ */
+function classifyColumn(
+  column: TableauColumn,
+  viewIndex: number,
+): TableauClassifiedColumn | null {
+  // 0. Tooltip-only passengers. Tableau still returns them; the viz does not
+  //    draw them, so navigating them would announce data nobody plotted.
+  if (column.isReferenced === false) {
+    return null;
+  }
+
+  // 1. No sonifiable value: geometry has no magnitude, and `unknown` is a
+  //    column Tableau itself declines to describe.
+  const { dataType } = column;
+  if (dataType === 'spatial' || dataType === 'unknown') {
+    return null;
+  }
+
+  const numeric = NUMERIC.has(dataType);
+  const temporal = dataType === 'date' || dataType === 'date-time';
+  const match = WRAPPER_PATTERN.exec(column.fieldName);
+  const wrapper = match === null ? null : match[1].toUpperCase();
+
+  // 2/3. An aggregated numeric: the caption is the field inside the wrapper,
+  //      which is the name a reader knows the quantity by.
+  if (match !== null && wrapper !== null && MEASURE_AGGS.has(wrapper) && numeric) {
+    return {
+      role: 'measure',
+      column,
+      viewIndex,
+      caption: match[2],
+      agg: match[1],
+      numeric,
+      temporal,
+    };
+  }
+
+  // 4. A date part. The caption keeps the wrapper because `YEAR(Order Date)`
+  //    and `MONTH(Order Date)` are different categories of the same field, and
+  //    unwrapping both to "Order Date" would make them indistinguishable.
+  if (match !== null && wrapper !== null && DATE_PARTS.has(wrapper)) {
+    return {
+      role: 'dimension',
+      column,
+      viewIndex,
+      caption: column.fieldName,
+      numeric,
+      temporal: true,
+    };
+  }
+
+  // 5. A bare numeric column. This is the rung a non-English workbook lands on,
+  //    and it is why the wrong locale costs a caption rather than a role.
+  if (numeric) {
+    return {
+      role: 'measure',
+      column,
+      viewIndex,
+      caption: column.fieldName,
+      numeric,
+      temporal,
+    };
+  }
+
+  // 6. Everything else is a category: strings, booleans, and unwrapped dates.
+  return {
+    role: 'dimension',
+    column,
+    viewIndex,
+    caption: column.fieldName,
+    numeric,
+    temporal,
+  };
+}
+
+/**
+ * Classify a worksheet's columns into measures and dimensions.
+ *
+ * @param columns - Summary columns **in view order**, i.e. exactly what
+ * `getSummaryColumnsInfoAsync` returned. Order is preserved in every returned
+ * list, and `viewIndex` keeps pointing at the original position even when
+ * earlier columns were dropped.
+ * @returns The surviving columns, split by role.
+ */
+export function classifyColumns(
+  columns: readonly TableauColumn[],
+): TableauColumnClassification {
+  const classified: TableauClassifiedColumn[] = [];
+  const dimensions: TableauDimensionColumn[] = [];
+  const measures: TableauMeasureColumn[] = [];
+
+  columns.forEach((column, viewIndex) => {
+    const field = classifyColumn(column, viewIndex);
+    if (field === null) {
+      return;
+    }
+    classified.push(field);
+    if (field.role === 'measure') {
+      measures.push(field);
+    } else {
+      dimensions.push(field);
+    }
+  });
+
+  return { columns: classified, dimensions, measures };
+}
+
+/**
+ * Map view-order column positions onto the data table's alphabetical ones.
+ *
+ * `DataTableReader` sorts its columns alphabetically and offers no way to ask
+ * for view order, while `getSummaryColumnsInfoAsync` is in view order and
+ * carries no data. Matching them by `fieldId` — as Tableau's own snippet does —
+ * is the only bridge. `fieldName` is tried second so a host that omits
+ * `fieldId` degrades to a working read rather than to no columns at all.
+ *
+ * @param viewColumns - Columns in view order.
+ * @param tableColumns - Columns of a data table page, alphabetically sorted.
+ * @returns One entry per view column: the alphabetical index to read it from,
+ * or `-1` when the column has no counterpart in the table.
+ */
+export function buildIndexMap(
+  viewColumns: readonly TableauColumn[],
+  tableColumns: readonly TableauColumn[],
+): number[] {
+  return viewColumns.map((viewColumn) => {
+    const byId = tableColumns.findIndex(
+      candidate => candidate.fieldId === viewColumn.fieldId,
+    );
+    if (byId !== -1) {
+      return byId;
+    }
+    return tableColumns.findIndex(
+      candidate => candidate.fieldName === viewColumn.fieldName,
+    );
+  });
+}
+
+/**
+ * Reorder one raw data row into view order.
+ *
+ * @param row - A row as the reader gave it, in alphabetical column order.
+ * @param indexMap - The map from {@link buildIndexMap}.
+ * @returns The row in view order; an unmatched column reads `undefined`.
+ */
+export function remapRow(
+  row: readonly TableauDataValue[],
+  indexMap: readonly number[],
+): TableauRow {
+  return indexMap.map(alphabeticalIndex =>
+    alphabeticalIndex < 0 ? undefined : row[alphabeticalIndex],
+  );
+}
+
+/**
+ * Read a cell as a finite number, or report that it is a gap.
+ *
+ * `DataValue` has no `isNull` flag: Tableau turns its special values into a
+ * `null` `nativeValue`. A gap is therefore `null`/`undefined`/`NaN`, and this
+ * returns `null` for all three. Callers must not substitute a zero — a zero is
+ * a value a chart drew, and inventing one puts a bar where the viz has none.
+ *
+ * A `Date` is deliberately *not* converted: its epoch milliseconds are not a
+ * number the chart drew. Use {@link toDateValue} for temporal cells.
+ *
+ * @param value - The cell, or `undefined` for an unmatched column.
+ * @returns The number, or `null` for a gap.
+ */
+export function toFiniteNumber(value: TableauDataValue | undefined): number | null {
+  const native = value?.nativeValue;
+  if (typeof native === 'number') {
+    return Number.isFinite(native) ? native : null;
+  }
+  // Some hosts hand a measure back as its digits; a strictly numeric string is
+  // unambiguous, and anything else stays a gap.
+  if (typeof native === 'string' && native.trim() !== '') {
+    const parsed = Number(native);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * Read a cell as the text a reader should hear, and as the key a category is
+ * grouped by.
+ *
+ * `formattedValue` wins because it carries the worksheet's own number and date
+ * formatting, which is what a sighted reader sees on the axis.
+ *
+ * @param value - The cell, or `undefined` for an unmatched column.
+ * @returns The category key; the empty string for a gap, never a fabricated
+ * label such as `"null"`.
+ */
+export function toCategoryKey(value: TableauDataValue | undefined): string {
+  const formatted = value?.formattedValue;
+  if (typeof formatted === 'string') {
+    return formatted;
+  }
+  const native = value?.nativeValue;
+  if (native === null || native === undefined) {
+    return '';
+  }
+  if (native instanceof Date) {
+    // ISO rather than `String(date)`: a locale- and timezone-dependent string
+    // would make the same cell read differently on two machines.
+    return Number.isNaN(native.getTime()) ? '' : native.toISOString();
+  }
+  return String(native);
+}
+
+/**
+ * Read a cell as a date.
+ *
+ * Only a real `Date` is accepted. Parsing a string into a calendar is the kind
+ * of confident guess this adapter refuses: a date-part column's text is
+ * `"Q3 2021"` as often as it is an ISO stamp, and a wrong parse would select
+ * the wrong marks in the viz.
+ *
+ * @param value - The cell, or `undefined` for an unmatched column.
+ * @returns The date, or `null` when the cell is a gap or is not a date.
+ */
+export function toDateValue(value: TableauDataValue | undefined): Date | null {
+  const native = value?.nativeValue;
+  if (native instanceof Date && !Number.isNaN(native.getTime())) {
+    return native;
+  }
+  return null;
+}

--- a/src/adapters/tableau/index.ts
+++ b/src/adapters/tableau/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Tableau integration for MAIDR.
+ *
+ * Makes an embedded Tableau view — a single worksheet or a whole dashboard —
+ * available non-visually through audio sonification, text descriptions, braille
+ * output and keyboard navigation, and mirrors MAIDR's cursor back into the view
+ * as a Tableau mark selection.
+ *
+ * @remarks
+ * The Tableau Embedding API v3 library is loaded by the host page, exactly as
+ * Tableau documents; this module takes **no dependency on any `@tableau/*`
+ * package** and only duck-types the live `<tableau-viz>` element. `react` and
+ * `react-dom` are bundled, since the accessible figure is a React tree mounted
+ * beside the viz.
+ *
+ * One worksheet becomes one MAIDR subplot, in dashboard add-order — the order
+ * Tableau documents a screen reader as narrating a dashboard in. Filter,
+ * parameter and data-source changes re-read the worksheets automatically.
+ *
+ * @example
+ * ```html
+ * <script type="module"
+ *   src="https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.min.js"></script>
+ * <tableau-viz id="viz" src="https://public.tableau.com/views/Book/Sheet"></tableau-viz>
+ *
+ * <script type="module">
+ *   import { bindTableau } from 'maidr/tableau';
+ *
+ *   const viz = document.getElementById('viz');
+ *   const binding = await bindTableau(viz, {
+ *     title: 'Sales by region',
+ *     overrides: { 'Sales by Region': { traceType: 'bar' } },
+ *   });
+ *
+ *   // later, when the page tears the view down:
+ *   binding?.dispose();
+ * </script>
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { bindTableau } from './binder';
+export type { TableauBinding } from './binder';
+export { extractTableau } from './extractor';
+export type { SelectionIndex, TableauExtraction } from './extractor';
+export type {
+  TableauAdapterOptions,
+  TableauColumn,
+  TableauDataType,
+  TableauSelectionCriteria,
+  TableauViz,
+  TableauWorksheet,
+  TableauWorksheetOverride,
+  WorksheetSnapshot,
+} from './types';

--- a/src/adapters/tableau/reader.ts
+++ b/src/adapters/tableau/reader.ts
@@ -1,0 +1,188 @@
+/**
+ * The only module in the Tableau adapter that awaits Tableau.
+ *
+ * Everything downstream — classification, trace-type inference, layer
+ * construction, selection criteria — is pure and works off the
+ * {@link WorksheetSnapshot} this file produces. That split is what lets the
+ * extractor be tested with plain object mocks, and what will let a future
+ * Dashboard Extensions binder reuse the whole pipeline unchanged: the
+ * Extensions `Worksheet` satisfies the same structural interface.
+ *
+ * Three documented traps drive the shape of the code here:
+ *
+ * 1. **Column order.** `DataTableReader` sorts its columns alphabetically;
+ *    `getSummaryColumnsInfoAsync` is in view order. Rows are remapped once, on
+ *    the way out, so every index downstream is a view index.
+ * 2. **One reader at a time.** "Only one active `DataTableReader` for summary
+ *    data is supported", and a released reader throws on further use. Reads are
+ *    serialized through {@link enqueueTableauRead}, and `releaseAsync` runs in
+ *    a `finally` on every path.
+ * 3. **`ignoreSelection` is undecidable.** Its documented description is the
+ *    inverse of its name on both API surfaces, so the adapter never passes it —
+ *    {@link TableauGetSummaryDataOptions} does not even declare it. The binder
+ *    clears the selection before a re-read instead. The only option passed is
+ *    `{ maxRows: 0 }`, meaning all rows.
+ */
+
+import type {
+  TableauColumn,
+  TableauDataTableReader,
+  TableauRow,
+  TableauVisualSpecification,
+  TableauWorksheet,
+  WorksheetSnapshot,
+} from './types';
+import { buildIndexMap, remapRow } from './fields';
+
+const ADAPTER = 'tableau';
+
+/**
+ * Log an adapter-prefixed warning.
+ *
+ * @param message - What went wrong, and what the adapter did about it.
+ * @param error - The underlying error, when there is one.
+ */
+function warn(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.warn(`[MAIDR ${ADAPTER}] ${message}`);
+  } else {
+    console.warn(`[MAIDR ${ADAPTER}] ${message}`, error);
+  }
+}
+
+/**
+ * Tail of the serial read queue. Always settled-or-pending, never rejected:
+ * every task's outcome is absorbed before it becomes the next task's gate.
+ */
+let readQueue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Run a task with exclusive access to Tableau's summary-data reader.
+ *
+ * Tableau supports only one active `DataTableReader` for summary data, so a
+ * filter storm that fires several change events must not open a second one
+ * while the first is still paginating. Tasks run in the order they were
+ * enqueued, and a task that throws does not stall the ones behind it.
+ *
+ * Exported so the binder shares this one queue rather than starting a second:
+ * its pre-read `clearSelectedMarksAsync` has to land before the reads it is
+ * meant to precede.
+ *
+ * **Not re-entrant.** The queue is a strict serial chain, so calling this from
+ * inside a task that is already running on it waits forever. The binder
+ * enqueues its clear as its own task and then calls {@link readWorksheet},
+ * which enqueues itself — it never wraps the two together.
+ *
+ * @param task - The work to run while holding the queue.
+ * @returns Whatever the task resolves to; rejects with whatever it throws.
+ */
+export function enqueueTableauRead<T>(task: () => Promise<T>): Promise<T> {
+  const run = readQueue.then(task, task);
+  readQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
+ * Page through a worksheet's summary data and return its rows in view order.
+ *
+ * Must be called while holding the read queue.
+ *
+ * @param worksheet - The worksheet to read.
+ * @param viewColumns - Its columns in view order.
+ * @returns Every row, remapped into view order.
+ */
+async function readRows(
+  worksheet: TableauWorksheet,
+  viewColumns: readonly TableauColumn[],
+): Promise<TableauRow[]> {
+  const reader: TableauDataTableReader = await worksheet.getSummaryDataReaderAsync(
+    undefined,
+    { maxRows: 0 },
+  );
+
+  try {
+    const rows: TableauRow[] = [];
+    const pageCount = Number.isFinite(reader.pageCount) ? reader.pageCount : 0;
+    // Column order is a property of the reader, not of a page, so the map is
+    // built once from the first page and reused for the rest.
+    let indexMap: number[] | null = null;
+
+    for (let page = 0; page < pageCount; page++) {
+      const table = await reader.getPageAsync(page);
+      if (indexMap === null) {
+        indexMap = buildIndexMap(viewColumns, table.columns);
+      }
+      for (const row of table.data) {
+        rows.push(remapRow(row, indexMap));
+      }
+    }
+
+    return rows;
+  } finally {
+    // Never let a release failure replace the error that got us here: a leaked
+    // reader blocks every later read, so the failure is reported, not thrown.
+    await reader.releaseAsync().catch((error: unknown) => {
+      warn(`failed to release the summary data reader for "${worksheet.name}".`, error);
+    });
+  }
+}
+
+/**
+ * Read the worksheet's visual specification, when the host has one.
+ *
+ * `getVisualSpecificationAsync` is an Extensions API method (1.11+ / Tableau
+ * 2024.1+) and is absent from the Embedding API today, so it is feature-detected
+ * rather than assumed. When it is missing the extractor falls back to its
+ * heuristic ladder; when a future release adds it, mark-type classification
+ * lights up with no further change here.
+ *
+ * @param worksheet - The worksheet to inspect.
+ * @returns The specification, or `undefined` when unavailable or unreadable.
+ */
+async function readVisualSpecification(
+  worksheet: TableauWorksheet,
+): Promise<TableauVisualSpecification | undefined> {
+  const getSpec = worksheet.getVisualSpecificationAsync;
+  if (typeof getSpec !== 'function') {
+    return undefined;
+  }
+
+  try {
+    return await getSpec.call(worksheet);
+  } catch (error) {
+    // A spec is evidence, not a requirement. Losing it costs the mark type,
+    // which the ladder can stand in for; throwing would cost the whole figure.
+    warn(
+      `could not read the visual specification for "${worksheet.name}"; `
+      + `falling back to the heuristics.`,
+      error,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Read everything one worksheet contributes to the figure.
+ *
+ * The column info call is made first and outside the queue — it opens no
+ * reader — so the view order is known before any pagination starts.
+ *
+ * @param worksheet - The worksheet to read.
+ * @returns A snapshot: name, view-order columns, view-order rows, and the
+ * visual specification when the host exposes one.
+ * @throws Whatever `getSummaryColumnsInfoAsync` or `getPageAsync` throws. The
+ * reader is always released first; the caller decides whether a failed read
+ * means keeping the previous figure.
+ */
+export async function readWorksheet(
+  worksheet: TableauWorksheet,
+): Promise<WorksheetSnapshot> {
+  const columns = await worksheet.getSummaryColumnsInfoAsync();
+  const rows = await enqueueTableauRead(() => readRows(worksheet, columns));
+  const spec = await readVisualSpecification(worksheet);
+
+  return { name: worksheet.name, columns, rows, spec };
+}

--- a/src/adapters/tableau/selection.ts
+++ b/src/adapters/tableau/selection.ts
@@ -76,7 +76,17 @@ export interface SelectionBridge {
   readonly worksheets: Map<string, TableauWorksheet>;
   /** Shared re-entrancy flag. */
   readonly guard: SelectionGuard;
-  /** Layers whose selection has been permanently disabled by a rejection. */
+  /**
+   * Worksheets, **by name**, whose selection has been permanently disabled by
+   * a rejection.
+   *
+   * Keyed by name and not by layer id: a layer id is an index among the
+   * worksheets that survived one extraction, so a refresh that drops a
+   * worksheet re-points every id after it at a different worksheet, and a latch
+   * earned by one worksheet would silence another. A worksheet name is stable
+   * across refreshes — it is already how {@link SelectionBridge.worksheets} is
+   * rebuilt.
+   */
   readonly disabled: Set<string>;
 }
 
@@ -111,7 +121,7 @@ function withGuard(guard: SelectionGuard, call: () => Promise<void>): Promise<vo
 }
 
 /**
- * Disable a layer's selection after a rejection, once and for good.
+ * Disable a worksheet's selection after a rejection, once and for good.
  *
  * `selectMarksByValueAsync` rejects on an invalid field name or an invalid
  * value, and neither becomes valid by being retried — a wrong `fieldName` is
@@ -119,27 +129,28 @@ function withGuard(guard: SelectionGuard, call: () => Promise<void>): Promise<vo
  * arrow key. Guessing a different field to try instead is worse still: it would
  * highlight marks chosen by the adapter rather than by the data.
  *
+ * The latch is keyed by worksheet name rather than by layer id, because it
+ * outlives the refresh that can renumber the layer ids underneath it.
+ *
  * @param bridge - The selection bridge.
- * @param layerId - The layer whose selection failed.
- * @param worksheetName - The worksheet, for the message.
+ * @param worksheetName - The worksheet whose selection failed, and the latch key.
  * @param criteria - The criteria that were rejected, for the message.
  * @param error - The rejection.
  */
-function disableLayer(
+function disableWorksheetSelection(
   bridge: SelectionBridge,
-  layerId: string,
   worksheetName: string,
   criteria: readonly TableauSelectionCriteria[],
   error: unknown,
 ): void {
-  if (bridge.disabled.has(layerId)) {
+  if (bridge.disabled.has(worksheetName)) {
     return;
   }
-  bridge.disabled.add(layerId);
+  bridge.disabled.add(worksheetName);
   const fields = criteria.map(criterion => `"${criterion.fieldName}"`).join(', ');
   console.warn(
     `${ADAPTER_PREFIX} could not select marks in worksheet "${worksheetName}" `
-    + `by ${fields}; mark selection is now disabled for this layer. `
+    + `by ${fields}; mark selection is now disabled for this worksheet. `
     + `Audio, text and braille are unaffected.`,
     error,
   );
@@ -172,8 +183,9 @@ export function clearSelection(
 /**
  * Clear every worksheet MAIDR may have selected marks in.
  *
- * Used on blur and on dispose, so the adapter never leaves a selection behind
- * in a workbook it no longer drives.
+ * Used when focus leaves the figure, before every re-read, and on dispose, so
+ * the adapter never leaves a selection behind in a workbook it no longer
+ * drives.
  *
  * @param worksheets - The bound worksheets.
  * @param guard - The shared guard.
@@ -327,7 +339,7 @@ export function applySelection(
 
   const { layerId } = info;
   const worksheet = bridge.worksheets.get(layerId);
-  if (worksheet === undefined || bridge.disabled.has(layerId)) {
+  if (worksheet === undefined || bridge.disabled.has(worksheet.name)) {
     return Promise.resolve();
   }
 
@@ -344,7 +356,7 @@ export function applySelection(
   return withGuard(bridge.guard, () =>
     worksheet.selectMarksByValueAsync(criteria, SELECT_REPLACE)).catch(
     (error: unknown) => {
-      disableLayer(bridge, layerId, worksheet.name, criteria, error);
+      disableWorksheetSelection(bridge, worksheet.name, criteria, error);
       return clearSelection(worksheet, bridge.guard);
     },
   );

--- a/src/adapters/tableau/selection.ts
+++ b/src/adapters/tableau/selection.ts
@@ -1,0 +1,351 @@
+/**
+ * The runtime half of the Tableau selection bridge.
+ *
+ * A MAIDR figure built from an embedded viz has no DOM to highlight: the marks
+ * live inside Tableau's own iframe and are not reachable with a CSS selector.
+ * The only visual feedback channel the Embedding API affords is Tableau's own
+ * mark selection, so MAIDR's cursor is mirrored into the viz by asking the
+ * worksheet to select the marks the cursor is on.
+ *
+ * The extractor already recorded, for every navigable position, the dimension
+ * values of the row it came from ({@link SelectionIndex}). This module turns
+ * one of those addresses into a `selectMarksByValueAsync` call, and — just as
+ * importantly — decides when *not* to make one:
+ *
+ * - a position with no address (a rectangularized filler cell, a row with a
+ *   missing dimension value, the synthetic "Total" row a segmented trace adds)
+ *   **clears** the selection rather than selecting something adjacent;
+ * - a multi-point selection that cannot be expressed exactly clears too,
+ *   because the criteria are combined as a cross product and an inexact one
+ *   would highlight marks the reader is not on;
+ * - a worksheet whose first selection call rejects has selection disabled
+ *   **permanently**, with one warning. Everything else about MAIDR — audio,
+ *   text, braille, autoplay, review — is untouched. Degrading quietly is the
+ *   contract; retrying a call that is known to reject is not.
+ */
+
+import type { NavigateCallback } from '../../type/grammar';
+import type { SelectionIndex } from './extractor';
+import type { TableauSelectionCriteria, TableauWorksheet } from './types';
+
+/**
+ * The navigation position MAIDR reports, exactly as the grammar defines it.
+ *
+ * Taken from {@link NavigateCallback} rather than restated, so a change to the
+ * callback's payload is a compile error here instead of a silent mismatch.
+ */
+type NavigationInfo = Parameters<NavigateCallback>[0];
+
+const ADAPTER_PREFIX = '[MAIDR tableau]';
+
+/**
+ * `SelectionUpdateType.Replace`.
+ *
+ * The Embedding API library is loaded by the host page and never imported by
+ * this bundle, so the enum object is not reachable from here — but its declared
+ * value is documented and stable
+ * (help.tableau.com/current/api/embedding_api/en-us/reference/enums/SelectionUpdateType.html).
+ * Note the value is prefixed: `'select-replace'`, not `'replace'`. It lives in
+ * one named constant rather than being inlined at the call site, so there is
+ * exactly one place to correct if Tableau ever changes it.
+ */
+const SELECT_REPLACE = 'select-replace';
+
+/**
+ * Guards the adapter against reacting to its own writes.
+ *
+ * Programmatic selection fires Tableau's `MarkSelectionChanged`. This adapter
+ * does not listen for that event — syncing MAIDR's cursor from a user click is
+ * a separate piece of work — so there is no loop to break today. The flag
+ * exists because the binder also clears the selection before every re-read, and
+ * whatever comes to listen must be able to tell that clear apart from a user
+ * action.
+ */
+export interface SelectionGuard {
+  /** True while a selection change originated from MAIDR rather than a user. */
+  programmatic: boolean;
+}
+
+/**
+ * Everything {@link applySelection} needs, gathered once at bind time.
+ */
+export interface SelectionBridge {
+  /** Where every navigable position came from, from the extractor. */
+  readonly index: SelectionIndex;
+  /** Layer id → the worksheet that layer was built from. */
+  readonly worksheets: Map<string, TableauWorksheet>;
+  /** Shared re-entrancy flag. */
+  readonly guard: SelectionGuard;
+  /** Layers whose selection has been permanently disabled by a rejection. */
+  readonly disabled: Set<string>;
+}
+
+/**
+ * Create an empty guard.
+ *
+ * @returns A guard with no programmatic write in flight.
+ */
+export function createSelectionGuard(): SelectionGuard {
+  return { programmatic: false };
+}
+
+/**
+ * Run a Tableau call with the programmatic flag raised.
+ *
+ * The flag is lowered in a microtask rather than synchronously: the promise a
+ * selection call returns may resolve when the action was *initiated* rather
+ * than completed, so lowering it in the same turn would race the event the flag
+ * exists to classify.
+ *
+ * @param guard - The shared guard.
+ * @param call - The Tableau call to make.
+ * @returns The call's promise, with the flag lowered once it settles.
+ */
+function withGuard(guard: SelectionGuard, call: () => Promise<void>): Promise<void> {
+  guard.programmatic = true;
+  return call().finally(() => {
+    queueMicrotask(() => {
+      guard.programmatic = false;
+    });
+  });
+}
+
+/**
+ * Disable a layer's selection after a rejection, once and for good.
+ *
+ * `selectMarksByValueAsync` rejects on an invalid field name or an invalid
+ * value, and neither becomes valid by being retried — a wrong `fieldName` is
+ * wrong on every navigation step, so an un-latched adapter would log once per
+ * arrow key. Guessing a different field to try instead is worse still: it would
+ * highlight marks chosen by the adapter rather than by the data.
+ *
+ * @param bridge - The selection bridge.
+ * @param layerId - The layer whose selection failed.
+ * @param worksheetName - The worksheet, for the message.
+ * @param criteria - The criteria that were rejected, for the message.
+ * @param error - The rejection.
+ */
+function disableLayer(
+  bridge: SelectionBridge,
+  layerId: string,
+  worksheetName: string,
+  criteria: readonly TableauSelectionCriteria[],
+  error: unknown,
+): void {
+  if (bridge.disabled.has(layerId)) {
+    return;
+  }
+  bridge.disabled.add(layerId);
+  const fields = criteria.map(criterion => `"${criterion.fieldName}"`).join(', ');
+  console.warn(
+    `${ADAPTER_PREFIX} could not select marks in worksheet "${worksheetName}" `
+    + `by ${fields}; mark selection is now disabled for this layer. `
+    + `Audio, text and braille are unaffected.`,
+    error,
+  );
+}
+
+/**
+ * Clear the marks MAIDR selected in one worksheet.
+ *
+ * @param worksheet - The worksheet to clear.
+ * @param guard - The shared guard, so the clear is not read as a user action.
+ * @returns A promise that settles once the clear has been requested. A failure
+ * is logged rather than thrown: a stale highlight is a cosmetic problem inside
+ * the viz, and nothing MAIDR announces depends on it.
+ */
+export function clearSelection(
+  worksheet: TableauWorksheet,
+  guard: SelectionGuard,
+): Promise<void> {
+  return withGuard(guard, () => worksheet.clearSelectedMarksAsync()).catch(
+    (error: unknown) => {
+      console.warn(
+        `${ADAPTER_PREFIX} could not clear the mark selection in worksheet `
+        + `"${worksheet.name}".`,
+        error,
+      );
+    },
+  );
+}
+
+/**
+ * Clear every worksheet MAIDR may have selected marks in.
+ *
+ * Used on blur and on dispose, so the adapter never leaves a selection behind
+ * in a workbook it no longer drives.
+ *
+ * @param worksheets - The bound worksheets.
+ * @param guard - The shared guard.
+ * @returns A promise that settles once every clear has been requested.
+ */
+export function clearAllSelections(
+  worksheets: Iterable<TableauWorksheet>,
+  guard: SelectionGuard,
+): Promise<void> {
+  const pending: Promise<void>[] = [];
+  for (const worksheet of worksheets) {
+    pending.push(clearSelection(worksheet, guard));
+  }
+  return Promise.all(pending).then(() => undefined);
+}
+
+/**
+ * Combine several points' criteria into one exact selection.
+ *
+ * A point cloud's selection is a *set of points* rather than a cell, so a
+ * highlight may cover many marks at once. Tableau combines criteria as a **cross
+ * product**: `[{A: [a1, a2]}, {B: [b1, b2]}]` selects four marks, not two. So a
+ * multi-point selection is expressible exactly only when the points differ in
+ * exactly one field — then that field's values become the array and every other
+ * field is a shared constant, which is precise because a detail dimension
+ * identifies a row.
+ *
+ * Anything else returns `null` and the caller clears instead. Over-selecting
+ * would tell the reader that marks are highlighted which their cursor is not
+ * on, which is worse than highlighting nothing.
+ *
+ * @param points - The layer's per-index criteria, from the extractor.
+ * @param indices - The data indices the highlight covers.
+ * @returns Criteria selecting exactly those points, or `null` when no exact
+ * selection exists.
+ */
+export function mergePointCriteria(
+  points: readonly (readonly TableauSelectionCriteria[] | null)[] | undefined,
+  indices: readonly number[],
+): readonly TableauSelectionCriteria[] | null {
+  if (points === undefined || indices.length === 0) {
+    return null;
+  }
+
+  const selected: (readonly TableauSelectionCriteria[])[] = [];
+  for (const index of indices) {
+    const criteria = points[index];
+    // An out-of-range index or an unaddressable point makes the *set*
+    // inexpressible, not just that one point: selecting the rest would claim a
+    // selection the reader is not on.
+    if (criteria === undefined || criteria === null || criteria.length === 0) {
+      return null;
+    }
+    selected.push(criteria);
+  }
+
+  const first = selected[0];
+  if (selected.length === 1) {
+    return first;
+  }
+
+  // Every point must address the same fields, in the same order, for "differ in
+  // exactly one field" to be a question that can be asked at all.
+  const fieldNames = first.map(criterion => criterion.fieldName);
+  const sameFields = selected.every(
+    criteria =>
+      criteria.length === fieldNames.length
+      && criteria.every((criterion, i) => criterion.fieldName === fieldNames[i]),
+  );
+  if (!sameFields) {
+    return null;
+  }
+
+  const varying: number[] = [];
+  for (let i = 0; i < fieldNames.length; i++) {
+    const values = new Set(selected.map(criteria => valueKey(criteria[i].value)));
+    if (values.size > 1) {
+      varying.push(i);
+    }
+  }
+  if (varying.length > 1) {
+    return null;
+  }
+  if (varying.length === 0) {
+    // Every point carries the same address, so one of them selects them all.
+    return first;
+  }
+
+  const varyingIndex = varying[0];
+  const values: string[] = [];
+  for (const criteria of selected) {
+    const value = criteria[varyingIndex].value;
+    // Only a plain string can join a multi-value list: a range cannot be one of
+    // several values, and an already-multi-valued criterion would have to be
+    // flattened, which loses which point contributed what.
+    if (typeof value !== 'string') {
+      return null;
+    }
+    if (!values.includes(value)) {
+      values.push(value);
+    }
+  }
+
+  return first.map((criterion, i) =>
+    i === varyingIndex ? { fieldName: criterion.fieldName, value: values } : criterion,
+  );
+}
+
+/**
+ * A comparable key for a criterion's value.
+ *
+ * `SelectionCriteria.value` is a union of a string, a list of strings and a
+ * range, so equality has to be structural. A `Date` is compared by its epoch
+ * milliseconds rather than by identity, since two reads of the same cell are
+ * two `Date` objects.
+ *
+ * @param value - The criterion's value.
+ * @returns A string that is equal exactly when the values are.
+ */
+function valueKey(value: TableauSelectionCriteria['value']): string {
+  if (typeof value === 'string') {
+    return `s:${value}`;
+  }
+  if (Array.isArray(value)) {
+    return `a:${value.join(' ')}`;
+  }
+  const bound = (edge: number | Date): string =>
+    edge instanceof Date ? String(edge.getTime()) : String(edge);
+  return `r:${bound(value.min)}:${bound(value.max)}`;
+}
+
+/**
+ * Mirror MAIDR's cursor into the viz as a Tableau mark selection.
+ *
+ * @param bridge - The selection bridge built at bind time.
+ * @param info - The navigation position, or `null` when the cursor left the
+ * chart — which clears every bound worksheet, since nothing else signals that
+ * the selection ended and a stale highlight would follow the reader to another
+ * panel.
+ * @returns A promise that settles once the selection (or clear) has been
+ * requested. It never rejects: a selection failure disables the layer and
+ * clears, and a clear failure is logged.
+ */
+export function applySelection(
+  bridge: SelectionBridge,
+  info: NavigationInfo,
+): Promise<void> {
+  if (info === null) {
+    return clearAllSelections(bridge.worksheets.values(), bridge.guard);
+  }
+
+  const { layerId } = info;
+  const worksheet = bridge.worksheets.get(layerId);
+  if (worksheet === undefined || bridge.disabled.has(layerId)) {
+    return Promise.resolve();
+  }
+
+  // `pointIndices` present means `row` and `col` are both `-1` and name no
+  // position: a point cloud's selection is a set of points, not a cell.
+  const criteria = info.pointIndices !== undefined
+    ? mergePointCriteria(bridge.index.points.get(layerId), info.pointIndices)
+    : bridge.index.cells.get(layerId)?.[info.row]?.[info.col] ?? null;
+
+  if (criteria === null || criteria.length === 0) {
+    return clearSelection(worksheet, bridge.guard);
+  }
+
+  return withGuard(bridge.guard, () =>
+    worksheet.selectMarksByValueAsync(criteria, SELECT_REPLACE)).catch(
+    (error: unknown) => {
+      disableLayer(bridge, layerId, worksheet.name, criteria, error);
+      return clearSelection(worksheet, bridge.guard);
+    },
+  );
+}

--- a/src/adapters/tableau/types.ts
+++ b/src/adapters/tableau/types.ts
@@ -1,0 +1,358 @@
+/**
+ * Structural type definitions for the Tableau surface MAIDR duck-types against.
+ *
+ * MAIDR deliberately takes **no compile-time dependency on any `@tableau/*`
+ * package**. The Embedding API v3 library is loaded by the host page (from
+ * `public.tableau.com`, a Tableau Server/Cloud origin, or the Tableau CDN) and
+ * the adapter only ever sees the live `<tableau-viz>` element that library
+ * upgraded. Shipping the vendor's typings would add a dependency that buys
+ * nothing at runtime and pins us to one library version, so the members the
+ * adapter actually reads are mirrored here instead — nothing more.
+ *
+ * Everything below is intentionally a *subset*. A member is present only
+ * because some module in `src/adapters/tableau/` reads or calls it, and a
+ * member is optional whenever the running library may not provide it (an older
+ * Embedding release, or the Extensions API's `Worksheet`, which satisfies the
+ * same shared `DataTable` contract). The one member that is optional for a
+ * different reason is {@link TableauWorksheet.getVisualSpecificationAsync}:
+ * it exists on the Extensions surface only, and `reader.ts` feature-detects it.
+ */
+
+import type { Orientation, StepDirection, TraceType } from '../../type/grammar';
+
+/**
+ * Values of Tableau's `DataType` enum, as they appear on `Column.dataType`.
+ *
+ * These are the enum's *values*, not the prose names used in the reference
+ * tables — `date-time` rather than "datetime", `int` rather than "integer".
+ * `fields.ts` compares against them directly, so the distinction matters.
+ */
+export type TableauDataType
+  = | 'bool'
+    | 'date'
+    | 'date-time'
+    | 'float'
+    | 'int'
+    | 'spatial'
+    | 'string'
+    | 'unknown';
+
+/**
+ * One column of a worksheet's summary data.
+ *
+ * `fieldName` carries the aggregation wrapper (`SUM(Sales)`) and is documented
+ * as **not stable across languages**; `fieldId` carries it too and is not
+ * stable across data-source replacement. Both are read: `fieldId` keys the
+ * view-order↔alphabetical remap, `fieldName` is what selection criteria are
+ * addressed by.
+ */
+export interface TableauColumn {
+  /** Display name including the aggregation wrapper, e.g. `SUM(Sales)`. */
+  readonly fieldName: string;
+  /** Stable-within-a-session identifier used to match columns across calls. */
+  readonly fieldId: string;
+  readonly dataType: TableauDataType;
+  /** Position of this column in the table it came from. */
+  readonly index: number;
+  /**
+   * Whether the column is referenced by the visualization. Optional because
+   * older libraries omit it; `false` means a tooltip-only passenger, which
+   * `fields.ts` drops.
+   */
+  readonly isReferenced?: boolean;
+}
+
+/**
+ * One cell of summary data.
+ *
+ * Both value members are optional and typed `unknown`: `IncludeDataValuesOption`
+ * lets a caller ask for only one of them, and Tableau turns special values
+ * (`%null%`, `%no-access%`) into `null` on `nativeValue`. Narrowing happens in
+ * the coercion helpers in `fields.ts`, never at a call site.
+ */
+export interface TableauDataValue {
+  /** Raw value; special values arrive as the sentinel strings, not as null. */
+  readonly value?: unknown;
+  /** Native JS value (`string | number | boolean | Date`), or `null`. */
+  readonly nativeValue?: unknown;
+  /** Worksheet-formatted text — what a reader should hear. */
+  readonly formattedValue?: string;
+  readonly aliasValue?: string;
+  readonly hasAlias?: boolean;
+}
+
+/**
+ * A row of summary data **already remapped into view order**.
+ *
+ * An entry is `undefined` when the view column at that position had no
+ * counterpart in the (alphabetically sorted) data table, which is the only
+ * honest reading of a column we cannot locate. The coercion helpers treat it
+ * exactly as they treat a null value: a gap.
+ */
+export type TableauRow = readonly (TableauDataValue | undefined)[];
+
+/**
+ * A page of summary data. `data` is indexed `[rowIndex][columnIndex]`, and its
+ * columns are sorted **alphabetically** — never in view order.
+ */
+export interface TableauDataTable {
+  readonly columns: readonly TableauColumn[];
+  readonly data: readonly (readonly TableauDataValue[])[];
+  readonly name?: string;
+  readonly totalRowCount?: number;
+  readonly isSummaryData?: boolean;
+}
+
+/**
+ * Options accepted by `getSummaryDataReaderAsync`.
+ *
+ * Only `maxRows` is declared, and that is deliberate: Tableau documents
+ * `ignoreSelection` with a description that is the exact inverse of its name
+ * ("Only return data for the currently selected marks"), on both API surfaces.
+ * Leaving it out of this interface makes passing it a **compile error**, so no
+ * call site can quietly guess which way it means. The adapter clears the
+ * selection before every read instead.
+ */
+export interface TableauGetSummaryDataOptions {
+  /** `0` means all rows, and is the only value the adapter passes. */
+  readonly maxRows?: number;
+}
+
+/**
+ * Paginated reader over a worksheet's summary data.
+ *
+ * Only one active reader for summary data is supported per viz, and
+ * `releaseAsync` must be called — later calls on a released reader throw. Both
+ * facts are why `reader.ts` owns a serial queue and a `finally`.
+ */
+export interface TableauDataTableReader {
+  readonly pageCount: number;
+  readonly totalRowCount: number;
+  getPageAsync: (pageNumber: number) => Promise<TableauDataTable>;
+  /**
+   * Documented convenience that concatenates every page. Not used — it caps at
+   * 400 pages and hides which page a failure came from — but declared because
+   * a real reader has it.
+   */
+  getAllPagesAsync?: (maxRows?: number) => Promise<TableauDataTable>;
+  releaseAsync: () => Promise<void>;
+}
+
+/** A quantitative or temporal range, as `SelectionCriteria.value` accepts it. */
+export interface TableauRangeValue {
+  readonly min: number | Date;
+  readonly max: number | Date;
+}
+
+/**
+ * One clause of `selectMarksByValueAsync`.
+ *
+ * Note `value` is **singular** even when it carries a list of values — that is
+ * Tableau's spelling, and getting it wrong silently selects nothing.
+ */
+export interface TableauSelectionCriteria {
+  readonly fieldName: string;
+  readonly value: string | string[] | TableauRangeValue;
+}
+
+/** One marks card of a worksheet's visual specification. */
+export interface TableauMarksSpecification {
+  /**
+   * The primitive Tableau actually drew — `'bar'`, `'line'`, `'pie'`, … There
+   * is no `Automatic` member: "Automatic" resolves to whatever was drawn.
+   */
+  readonly primitiveType?: string;
+}
+
+/**
+ * A worksheet's visual specification.
+ *
+ * Available on the Extensions API (1.11+ / Tableau 2024.1+) and absent from the
+ * Embedding API today, which is why every member is optional and why
+ * `reader.ts` feature-detects the method that returns it. When present it is
+ * the only *direct* evidence of what chart the author drew; without it the
+ * extractor falls back to its heuristic ladder.
+ */
+export interface TableauVisualSpecification {
+  readonly activeMarksSpecificationIndex?: number;
+  readonly marksSpecifications?: readonly TableauMarksSpecification[];
+}
+
+/** Values of Tableau's `SheetType` enum. */
+export type TableauSheetType = 'worksheet' | 'dashboard' | 'story';
+
+/** Members every sheet carries, whatever kind it is. */
+export interface TableauSheetBase {
+  readonly name: string;
+  readonly sheetType: TableauSheetType;
+}
+
+/**
+ * A worksheet: the only sheet kind that owns data and selection.
+ *
+ * The signatures match both the Embedding and the Extensions `Worksheet`, so
+ * every pure module downstream works unchanged under either host.
+ */
+export interface TableauWorksheet extends TableauSheetBase {
+  readonly sheetType: 'worksheet';
+  /** Columns in **view order** — the reader's own columns are alphabetical. */
+  getSummaryColumnsInfoAsync: () => Promise<TableauColumn[]>;
+  getSummaryDataReaderAsync: (
+    pageRowCount?: number,
+    options?: TableauGetSummaryDataOptions,
+  ) => Promise<TableauDataTableReader>;
+  selectMarksByValueAsync: (
+    selections: readonly TableauSelectionCriteria[],
+    updateType: string,
+  ) => Promise<void>;
+  clearSelectedMarksAsync: () => Promise<void>;
+  /** Extensions-only, Tableau 2024.1+. Feature-detected, never assumed. */
+  getVisualSpecificationAsync?: () => Promise<TableauVisualSpecification>;
+}
+
+/** A dashboard. `worksheets` is in the order the author added them. */
+export interface TableauDashboard extends TableauSheetBase {
+  readonly sheetType: 'dashboard';
+  readonly worksheets: readonly TableauWorksheet[];
+}
+
+/**
+ * A story. Carries nothing the adapter can use: reading a worksheet inside a
+ * story is a documented known issue ("operation not allowed on non-active
+ * sheet"), so stories are skipped with a warning.
+ */
+export interface TableauStory extends TableauSheetBase {
+  readonly sheetType: 'story';
+}
+
+/** Discriminated union of the three sheet kinds, keyed by `sheetType`. */
+export type TableauSheet = TableauWorksheet | TableauDashboard | TableauStory;
+
+/** The workbook behind a viz. */
+export interface TableauWorkbook {
+  readonly name?: string;
+  readonly activeSheet: TableauSheet;
+}
+
+/**
+ * The live `<tableau-viz>` custom element.
+ *
+ * It is an ordinary `HTMLElement` and an ordinary `EventTarget` — Tableau
+ * events arrive as `CustomEvent`s whose payload is in `event.detail` — which is
+ * why the adapter needs no vendor event API at all. `workbook` is optional
+ * because it is only guaranteed once the element has fired `firstinteractive`.
+ */
+export interface TableauViz extends HTMLElement {
+  readonly workbook?: TableauWorkbook;
+}
+
+/** Whether a classified column is read as a value or as a category. */
+export type TableauColumnRole = 'measure' | 'dimension';
+
+/** Members shared by both classified column roles. */
+export interface TableauClassifiedColumnBase {
+  readonly column: TableauColumn;
+  /**
+   * Index into a {@link TableauRow} — i.e. the column's position in the
+   * original view-order column list, dropped columns included. Dropping a
+   * column never shifts the columns after it.
+   */
+  readonly viewIndex: number;
+  /** Human-facing name: the aggregation wrapper unwrapped where possible. */
+  readonly caption: string;
+  /** Whether `dataType` is one of Tableau's numeric types. */
+  readonly numeric: boolean;
+  /** Whether the column carries a date or date-time. */
+  readonly temporal: boolean;
+}
+
+/** A column read as a value: what the pitch and the numbers come from. */
+export interface TableauMeasureColumn extends TableauClassifiedColumnBase {
+  readonly role: 'measure';
+  /** Aggregation wrapper as written, e.g. `SUM`. Absent on a bare numeric. */
+  readonly agg?: string;
+}
+
+/** A column read as a category: what a reader navigates between. */
+export interface TableauDimensionColumn extends TableauClassifiedColumnBase {
+  readonly role: 'dimension';
+}
+
+/** A column that survived classification, discriminated by `role`. */
+export type TableauClassifiedColumn = TableauMeasureColumn | TableauDimensionColumn;
+
+/** Result of classifying a worksheet's columns, all lists in view order. */
+export interface TableauColumnClassification {
+  /** Every surviving column, in view order. */
+  readonly columns: readonly TableauClassifiedColumn[];
+  readonly dimensions: readonly TableauDimensionColumn[];
+  readonly measures: readonly TableauMeasureColumn[];
+}
+
+/**
+ * Everything one worksheet contributes, read once and then never awaited again.
+ *
+ * This is the boundary between the async half of the adapter (`reader.ts`) and
+ * the pure half (`fields.ts`, `extractor.ts`): the extractor is handed
+ * snapshots and produces a figure with no I/O of its own.
+ */
+export interface WorksheetSnapshot {
+  readonly name: string;
+  /** Columns in view order, exactly as `getSummaryColumnsInfoAsync` gave them. */
+  readonly columns: readonly TableauColumn[];
+  /** Every row, already remapped into view order. */
+  readonly rows: readonly TableauRow[];
+  /** Present only when the host exposes `getVisualSpecificationAsync`. */
+  readonly spec?: TableauVisualSpecification;
+}
+
+/**
+ * What a page can tell the adapter about a single worksheet when the
+ * heuristics read it wrong.
+ *
+ * Every field is JSON-serializable on purpose: a future Extensions binder can
+ * read the same object straight out of `tableau.extensions.settings` without a
+ * second configuration format existing.
+ */
+export interface TableauWorksheetOverride {
+  /** Leave this worksheet out of the figure entirely. */
+  skip?: boolean;
+  /** What the worksheet is. Outranks the visual specification and the ladder. */
+  traceType?: TraceType;
+  /** Layer title; defaults to the worksheet name. */
+  title?: string;
+  /** `Column.fieldName` (or `fieldId`) to use as the category / x axis. */
+  x?: string;
+  /** Measure to use as the value. */
+  y?: string;
+  /** Dimension to group series by. */
+  z?: string;
+  /** Nothing in summary data says which way the bars were drawn. */
+  orientation?: Orientation;
+  /** Nothing in summary data says where a step jumps. */
+  stepDirection?: StepDirection;
+  /** Axis labels, when the field captions are not what a reader should hear. */
+  axes?: { x?: string; y?: string; z?: string };
+}
+
+/**
+ * Options for `bindTableau`. The adapter's only configuration channel.
+ */
+export interface TableauAdapterOptions {
+  /** Stable figure id. Defaults to `maidr-tableau-<n>`; kept across refreshes. */
+  id?: string;
+  /** Figure title. */
+  title?: string;
+  /**
+   * Opt in to in-place refresh while the user is inside the chart. Default
+   * `false`, so a filter change is picked up on the next focus-in rather than
+   * rebuilding the figure under a reader who is mid-navigation.
+   */
+  live?: boolean;
+  /** Worksheet names to include, in this order. Default: every worksheet. */
+  worksheets?: string[];
+  /** Per-worksheet overrides, keyed by worksheet name. */
+  overrides?: Record<string, TableauWorksheetOverride>;
+  /** Text on the keyboard entry point rendered beside the viz. */
+  anchorLabel?: string;
+}

--- a/src/tableau-entry.ts
+++ b/src/tableau-entry.ts
@@ -1,0 +1,76 @@
+/**
+ * Tableau adapter entry point for MAIDR.
+ *
+ * Re-exports the adapter's API and exposes it as `window.maidrTableau` for
+ * script-tag usage. For what the adapter does and how a page wires it up, see
+ * {@link bindTableau}.
+ *
+ * @remarks
+ * The Tableau Embedding API v3 library is loaded by the host page — this bundle
+ * has no compile-time or runtime dependency on any `@tableau/*` package, and
+ * only duck-types the live `<tableau-viz>` element.
+ *
+ * @example
+ * ```html
+ * <script type="module"
+ *   src="https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.min.js"></script>
+ * <script src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.js"></script>
+ * <script src="https://cdn.jsdelivr.net/npm/maidr/dist/tableau.js"></script>
+ *
+ * <tableau-viz id="viz" src="https://public.tableau.com/views/Book/Sheet"></tableau-viz>
+ *
+ * <script>
+ *   const viz = document.getElementById('viz');
+ *   viz.addEventListener('firstinteractive', () => {
+ *     window.maidrTableau.bindTableau(viz);
+ *   });
+ * </script>
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import { bindTableau, extractTableau } from './adapters/tableau';
+
+export { bindTableau, extractTableau } from './adapters/tableau';
+export type {
+  SelectionIndex,
+  TableauAdapterOptions,
+  TableauBinding,
+  TableauColumn,
+  TableauDataType,
+  TableauExtraction,
+  TableauSelectionCriteria,
+  TableauViz,
+  TableauWorksheet,
+  TableauWorksheetOverride,
+  WorksheetSnapshot,
+} from './adapters/tableau';
+
+// Re-export core types that consumers may need alongside the adapter.
+export type {
+  Maidr as MaidrData,
+  MaidrLayer,
+  MaidrSubplot,
+  StepDirection,
+} from './type/grammar';
+export { Orientation, TraceType } from './type/grammar';
+
+declare global {
+  interface Window {
+    maidrTableau?: {
+      bindTableau: typeof bindTableau;
+      extractTableau: typeof extractTableau;
+    };
+  }
+}
+
+if (typeof window !== 'undefined') {
+  // Merged, not assigned. The UMD build has already put every export on this
+  // global; replacing it would drop the ones not named here — the enums a
+  // script-tag consumer needs to read a layer's `type`, among them.
+  window.maidrTableau = Object.assign(window.maidrTableau ?? {}, {
+    bindTableau,
+    extractTableau,
+  });
+}

--- a/test/adapters/tableau/binder.test.tsx
+++ b/test/adapters/tableau/binder.test.tsx
@@ -2,11 +2,17 @@
  * @jest-environment jsdom
  */
 
-import type { TableauViz } from '@adapters/tableau/types';
+import type { TableauSheet, TableauViz } from '@adapters/tableau/types';
 import type { ReactNode } from 'react';
-import type { FakeWorksheet } from './helpers';
+import type { FakeCell, FakeWorksheet } from './helpers';
 import { bindTableau } from '@adapters/tableau/binder';
-import { fakeColumn, fakeDashboardViz, fakeWorksheet } from './helpers';
+import {
+  fakeColumn,
+  fakeDashboard,
+  fakeDashboardViz,
+  fakeViz,
+  fakeWorksheet,
+} from './helpers';
 
 /**
  * `<Maidr>` stands in for itself here, for a reason that is about module
@@ -25,7 +31,7 @@ jest.mock('../../../src/maidr-component', () => ({
 /**
  * The Tableau binder: what it does to the host page, and when it re-reads.
  *
- * Four of its behaviours are contracts rather than conveniences, and each has a
+ * These behaviours are contracts rather than conveniences, and each has a
  * failure mode that is invisible until someone is using a screen reader:
  *
  * 1. **The `<tableau-viz>` element is never moved.** It is a custom element, so
@@ -41,6 +47,18 @@ jest.mock('../../../src/maidr-component', () => ({
  *    unbias.
  * 4. **A failed refresh keeps the previous figure.** A stale-but-correct figure
  *    is still fully navigable; an unmounted one is nothing at all.
+ * 5. **The wait for the viz always ends.** A viz that fails to load, or never
+ *    says anything at all, resolves to `null` — the one outcome a page can act
+ *    on. A promise that never settles leaves the page with no chart and no
+ *    error.
+ * 6. **A tab switch re-discovers the worksheets.** The sheet the reader left
+ *    describes a view that is no longer on screen, and the selection it holds
+ *    has to be cleared before it stops being reachable.
+ * 7. **The selection bridge never runs ahead of the mounted figure.** Without
+ *    `live`, MAIDR keeps navigating the previous read until focus leaves, so a
+ *    bridge built from a newer read is staged until then — otherwise MAIDR
+ *    announces one mark while Tableau highlights another. Leaving the figure
+ *    also clears the selection.
  *
  * The debounce is driven with fake timers so the burst is expressed as the
  * milliseconds between two events rather than as a sleep. `queueMicrotask` is
@@ -118,6 +136,27 @@ function mountViz(worksheets: readonly FakeWorksheet[]): {
   return { host, marker, viz };
 }
 
+/**
+ * Put a viz on the page whose active sheet the test decides, and can change.
+ *
+ * Starting with no sheet models a viz that has not become interactive: reading
+ * `workbook` throws, exactly as the real element does before `firstinteractive`.
+ *
+ * @param active - The sheet to start active, or `null` for a loading viz.
+ * @returns The viz and the setter that switches its active sheet.
+ */
+function mountControlledViz(active: TableauSheet | null = null): {
+  viz: TableauViz;
+  setActiveSheet: (sheet: TableauSheet | null) => void;
+} {
+  const host = document.createElement('div');
+  const { viz, setActiveSheet } = fakeViz(active);
+  host.append(viz);
+  document.body.append(host);
+
+  return { viz, setActiveSheet };
+}
+
 /** Every element on the page the binder claims as its own. */
 function wrappers(): NodeListOf<Element> {
   return document.querySelectorAll('[data-maidr-tableau]');
@@ -126,6 +165,31 @@ function wrappers(): NodeListOf<Element> {
 /** How many summary-data readers a worksheet has been asked for. */
 function reads(worksheet: FakeWorksheet): number {
   return worksheet.calls.log.filter(entry => entry.startsWith('open:')).length;
+}
+
+/**
+ * The wrapper the binder mounted, as an element a test can focus.
+ *
+ * Focus is asked about with `wrapper.contains(document.activeElement)`, and a
+ * node contains itself, so making the wrapper itself focusable puts the test
+ * inside the figure without depending on anything React rendered into it.
+ *
+ * @returns The wrapper.
+ * @throws When nothing is mounted.
+ */
+function mountedWrapper(): HTMLElement {
+  const wrapper = document.querySelector<HTMLElement>('[data-maidr-tableau]');
+  if (wrapper === null) {
+    throw new Error('expected a mounted wrapper');
+  }
+  wrapper.tabIndex = -1;
+  return wrapper;
+}
+
+/** Every field/value pair the worksheet was last asked to select. */
+function lastSelection(worksheet: FakeWorksheet): unknown {
+  const call = worksheet.calls.selections.at(-1);
+  return call === undefined ? null : call.criteria;
 }
 
 describe('tableau binder', () => {
@@ -141,6 +205,73 @@ describe('tableau binder', () => {
 
   afterAll(() => {
     warn.mockRestore();
+  });
+
+  describe('waiting for the viz', () => {
+    it('should read nothing until the viz becomes interactive', async () => {
+      const sales = salesWorksheet('Sales');
+      const { viz, setActiveSheet } = mountControlledViz();
+
+      const pending = bindTableau(viz);
+      await flush();
+
+      // `workbook` is an accessor that throws before the viz is interactive, so
+      // a binder that took the property's existence for readiness would already
+      // have read — or crashed — by now.
+      expect(sales.calls.log).toEqual([]);
+      expect(wrappers()).toHaveLength(0);
+
+      setActiveSheet(fakeDashboard([sales]));
+      viz.dispatchEvent(new Event('firstinteractive'));
+      const binding = await pending;
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure once interactive');
+      }
+      expect(reads(sales)).toBe(1);
+
+      binding.dispose();
+    });
+
+    it('should resolve null, not hang, when the viz reports a load error', async () => {
+      const { viz } = mountControlledViz();
+
+      const pending = bindTableau(viz);
+      await flush();
+      viz.dispatchEvent(new CustomEvent('vizloaderror', {
+        detail: { errorCode: 'unknown-auth-error', message: 'not authorised' },
+      }));
+
+      // A caller can act on `null`; it cannot act on a promise that never
+      // settles, which is what a page gets if the wait only listens for
+      // `firstinteractive`.
+      await expect(pending).resolves.toBeNull();
+      expect(wrappers()).toHaveLength(0);
+      expect(warn.mock.calls.map(call => String(call[0])).join('\n'))
+        .toContain('unknown-auth-error');
+    });
+
+    it('should resolve null after a timeout when the viz says nothing at all', async () => {
+      const { viz } = mountControlledViz();
+
+      let settled = false;
+      const pending = bindTableau(viz).then((binding) => {
+        settled = true;
+        return binding;
+      });
+
+      // A viz too old to fire `vizloaderror`, or pointed at an unreachable
+      // host, never speaks at all — so the wait needs a floor of its own. It is
+      // a floor and not a poll: nothing has given up a moment before it.
+      await jest.advanceTimersByTimeAsync(29_000);
+
+      expect(settled).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(1_000);
+
+      await expect(pending).resolves.toBeNull();
+      expect(wrappers()).toHaveLength(0);
+    });
   });
 
   describe('mounting', () => {
@@ -200,7 +331,10 @@ describe('tableau binder', () => {
       expect(reads(sales)).toBe(1);
       // `ignoreSelection` is documented backwards on both Tableau surfaces, so
       // the adapter removes the selection instead of guessing — which is only
-      // true if the clear actually lands before the read.
+      // true if the clear actually lands before the read. Its presence is
+      // asserted first on purpose: comparing indices alone passes when the
+      // clear never happens at all, since `indexOf` then returns -1.
+      expect(sales.calls.log).toContain('clear:Sales');
       expect(sales.calls.log.indexOf('clear:Sales'))
         .toBeLessThan(sales.calls.log.indexOf('open:Sales'));
 
@@ -254,6 +388,173 @@ describe('tableau binder', () => {
 
       binding.dispose();
     });
+
+    it('should re-discover the worksheets when the reader switches tabs', async () => {
+      const log: string[] = [];
+      const sales = salesWorksheet('Sales', log);
+      const profit = salesWorksheet('Profit', log);
+      const { viz, setActiveSheet } = mountControlledViz(fakeDashboard([sales]));
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      log.length = 0;
+
+      setActiveSheet(fakeDashboard([profit], 'Dashboard 2'));
+      viz.dispatchEvent(new Event('tabswitched'));
+      await settle();
+
+      // The figure describes the tab that is now on screen, not the one the
+      // reader left — the worksheets are re-discovered, not reused.
+      expect(binding.maidr.subplots[0][0].layers[0].title).toBe('Profit');
+      expect(log).toContain('open:Profit');
+      // The sheet left behind is cleared and never read again: a selection
+      // stranded in a tab nobody is looking at can no longer be taken back.
+      expect(log.filter(entry => entry.includes('Sales'))).toEqual(['clear:Sales']);
+      expect(log.indexOf('clear:Sales')).toBeLessThan(log.indexOf('open:Profit'));
+
+      binding.dispose();
+    });
+
+    it('should keep the previous figure when the new tab has nothing to read', async () => {
+      const sales = salesWorksheet('Sales');
+      const { viz, setActiveSheet } = mountControlledViz(fakeDashboard([sales]));
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      const mounted = binding.maidr;
+      const wrapper = wrappers()[0];
+      warn.mockClear();
+
+      // Reading a worksheet inside a story is a documented Tableau limitation,
+      // so switching to one leaves nothing to discover.
+      setActiveSheet({ name: 'Story 1', sheetType: 'story' });
+      viz.dispatchEvent(new Event('tabswitched'));
+      await settle();
+
+      expect([...wrappers()]).toEqual([wrapper]);
+      expect(binding.maidr).toBe(mounted);
+      expect(warn.mock.calls.map(call => String(call[0])).join('\n'))
+        .toContain('keeping whatever was already mounted');
+
+      binding.dispose();
+    });
+  });
+
+  describe('keeping the bridge in step with the mounted figure', () => {
+    /**
+     * Mount a figure over rows the test can change under it.
+     *
+     * @param live - Whether to opt into in-place refresh.
+     * @returns The worksheet, its mutable rows, the viz to fire change events
+     * at, the focusable wrapper, and the binding.
+     */
+    async function mountOverMutableRows(live = false): Promise<{
+      sales: FakeWorksheet;
+      rows: FakeCell[][];
+      viz: TableauViz;
+      wrapper: HTMLElement;
+      binding: NonNullable<Awaited<ReturnType<typeof bindTableau>>>;
+    }> {
+      const rows: FakeCell[][] = [['East', 10], ['West', 20]];
+      const sales = fakeWorksheet({ name: 'Sales', columns: [REGION, SALES], rows });
+      const { viz } = mountViz([sales]);
+      const binding = await bindTableau(viz, live ? { live: true } : {});
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      return { sales, rows, viz, wrapper: mountedWrapper(), binding };
+    }
+
+    /**
+     * Navigate to the first cell and wait for the selection it fires.
+     *
+     * @param binding - The mounted binding.
+     * @param sales - The worksheet the selection lands in.
+     * @returns The criteria Tableau was last asked to select by.
+     */
+    async function navigateToFirstCell(
+      binding: NonNullable<Awaited<ReturnType<typeof bindTableau>>>,
+      sales: FakeWorksheet,
+    ): Promise<unknown> {
+      sales.calls.selections.length = 0;
+      binding.maidr.onNavigate?.({ layerId: '0', row: 0, col: 0 });
+      await flush();
+      return lastSelection(sales);
+    }
+
+    it('should keep serving the mounted read while the reader is inside the figure', async () => {
+      const { sales, rows, viz, wrapper, binding } = await mountOverMutableRows();
+
+      wrapper.focus();
+      rows[0] = ['North', 30];
+      rows[1] = ['South', 40];
+      viz.dispatchEvent(new Event('filterchanged'));
+      await settle();
+
+      expect(reads(sales)).toBe(2);
+      // Without `live`, `useMaidrController` keeps the reader on the figure it
+      // is already navigating. A `{layerId, row, col}` only addresses the read
+      // it was built from, so adopting the new index here would highlight
+      // `North` while MAIDR announced `East`.
+      await expect(navigateToFirstCell(binding, sales)).resolves.toEqual([
+        { fieldName: 'Region', value: 'East' },
+      ]);
+
+      binding.dispose();
+    });
+
+    it('should adopt the newest read, and clear the selection, once focus leaves', async () => {
+      const { sales, rows, viz, wrapper, binding } = await mountOverMutableRows();
+
+      wrapper.focus();
+      rows[0] = ['North', 30];
+      rows[1] = ['South', 40];
+      viz.dispatchEvent(new Event('filterchanged'));
+      await settle();
+      const clearsBeforeLeaving = sales.calls.clears;
+
+      // A real blur, not a synthesised event: `focusout` is what the browser
+      // fires as focus leaves, and it has to arrive on its own for the adapter
+      // to hear the reader go.
+      wrapper.blur();
+      await settle();
+
+      // Nothing downstream of the controller's disposal emits a final
+      // `onNavigate(null)`, so the mark MAIDR selected would stay highlighted
+      // in the workbook with nothing explaining why.
+      expect(sales.calls.clears).toBe(clearsBeforeLeaving + 1);
+      // The controller that could not see the staged index is gone, so the
+      // newest read takes over — and the next visit addresses it.
+      await expect(navigateToFirstCell(binding, sales)).resolves.toEqual([
+        { fieldName: 'Region', value: 'North' },
+      ]);
+
+      binding.dispose();
+    });
+
+    it('should adopt the newest read immediately when the page asked for live', async () => {
+      const { sales, rows, viz, wrapper, binding } = await mountOverMutableRows(true);
+
+      wrapper.focus();
+      rows[0] = ['North', 30];
+      rows[1] = ['South', 40];
+      viz.dispatchEvent(new Event('filterchanged'));
+      await settle();
+
+      // `live` means the model is rebuilt in place, so the index the reader is
+      // navigating is the new one and staging it would strand the bridge a
+      // refresh behind.
+      await expect(navigateToFirstCell(binding, sales)).resolves.toEqual([
+        { fieldName: 'Region', value: 'North' },
+      ]);
+
+      binding.dispose();
+    });
   });
 
   describe('disposing', () => {
@@ -267,7 +568,10 @@ describe('tableau binder', () => {
       if (binding === null) {
         throw new Error('expected bindTableau to mount a figure');
       }
-      const clearedByBind = [sales.calls.clears, profit.calls.clears];
+      // Pinned rather than captured as a baseline: a delta of one is satisfied
+      // by 0 → 1 as happily as by 1 → 2, so a binder that stopped clearing
+      // before its reads would slip through here too.
+      expect([sales.calls.clears, profit.calls.clears]).toEqual([1, 1]);
 
       binding.dispose();
       await flush();
@@ -275,10 +579,7 @@ describe('tableau binder', () => {
       expect(wrappers()).toHaveLength(0);
       // The viz itself is left exactly as it was found.
       expect([...host.children]).toEqual([marker, viz]);
-      expect([sales.calls.clears, profit.calls.clears]).toEqual([
-        clearedByBind[0] + 1,
-        clearedByBind[1] + 1,
-      ]);
+      expect([sales.calls.clears, profit.calls.clears]).toEqual([2, 2]);
 
       const readsAtDispose = [reads(sales), reads(profit)];
       viz.dispatchEvent(new Event('filterchanged'));

--- a/test/adapters/tableau/binder.test.tsx
+++ b/test/adapters/tableau/binder.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { TableauViz } from '@adapters/tableau/types';
+import type { ReactNode } from 'react';
+import type { FakeWorksheet } from './helpers';
+import { bindTableau } from '@adapters/tableau/binder';
+import { fakeColumn, fakeDashboardViz, fakeWorksheet } from './helpers';
+
+/**
+ * `<Maidr>` stands in for itself here, for a reason that is about module
+ * systems rather than about scope: it reaches `react-markdown` and
+ * `rehype-sanitize` through the chat panel, both of which are ESM-only, and
+ * this project compiles to CommonJS. Everything this file asserts — where the
+ * wrapper lands, when a read happens, what dispose takes back out — is the
+ * binder's own DOM and scheduling work rather than React's, and the component's
+ * behaviour is covered by `test/ui/`. The stub renders its children so the
+ * keyboard anchor still ends up inside the wrapper.
+ */
+jest.mock('../../../src/maidr-component', () => ({
+  Maidr: (props: { children: ReactNode }): ReactNode => props.children,
+}));
+
+/**
+ * The Tableau binder: what it does to the host page, and when it re-reads.
+ *
+ * Four of its behaviours are contracts rather than conveniences, and each has a
+ * failure mode that is invisible until someone is using a screen reader:
+ *
+ * 1. **The `<tableau-viz>` element is never moved.** It is a custom element, so
+ *    re-parenting re-runs `connectedCallback` and may reload the iframe. The
+ *    accessible layer is inserted immediately *before* it, which also puts the
+ *    keyboard entry point ahead of the iframe in DOM order.
+ * 2. **Nothing is mounted when there is nothing to navigate.** `Figure` crashes
+ *    on a subplot with no layers, so a figure that would be empty is not
+ *    rendered at all and the page is left byte-identical.
+ * 3. **One re-read per burst.** A single dashboard filter fires several change
+ *    events; reading once at the end of the burst is both cheaper and more
+ *    truthful, and the pre-read clear has to land before the read it exists to
+ *    unbias.
+ * 4. **A failed refresh keeps the previous figure.** A stale-but-correct figure
+ *    is still fully navigable; an unmounted one is nothing at all.
+ *
+ * The debounce is driven with fake timers so the burst is expressed as the
+ * milliseconds between two events rather than as a sleep. `queueMicrotask` is
+ * left real: the selection guard lowers its flag through it, and faking it
+ * would park that behind a timer that a test never advances.
+ */
+
+const REGION = fakeColumn('Region', 'string', 0);
+const SALES = fakeColumn('SUM(Sales)', 'float', 1);
+
+const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+/** The debounce window, plus enough to cross it. */
+const AFTER_DEBOUNCE_MS = 300;
+
+/**
+ * Drain the microtask queue.
+ *
+ * Once the debounce has fired, a refresh is a chain of `await`s over promises
+ * that resolve immediately — no timer is involved — so yielding repeatedly lets
+ * it run to completion without the test having to know how many `await`s deep
+ * the implementation happens to be.
+ *
+ * @returns A promise that settles once the queue has been drained.
+ */
+async function flush(): Promise<void> {
+  for (let turn = 0; turn < 50; turn++) {
+    await Promise.resolve();
+  }
+}
+
+/**
+ * Let a burst of change events settle and the refresh they triggered finish.
+ *
+ * @returns A promise that settles once the debounced refresh has run.
+ */
+async function settle(): Promise<void> {
+  await jest.advanceTimersByTimeAsync(AFTER_DEBOUNCE_MS);
+  await flush();
+}
+
+/**
+ * Build a worksheet holding two rows of one dimension and one measure.
+ *
+ * @param name - The worksheet name.
+ * @param log - A shared call log, so several worksheets record into one order.
+ * @returns The worksheet.
+ */
+function salesWorksheet(name: string, log?: string[]): FakeWorksheet {
+  return fakeWorksheet({
+    name,
+    columns: [REGION, SALES],
+    rows: [['East', 10], ['West', 20]],
+    ...(log === undefined ? {} : { log }),
+  });
+}
+
+/**
+ * Put a viz on the page, preceded by a sibling so its position is observable.
+ *
+ * @param worksheets - The dashboard's worksheets, in add-order.
+ * @returns The host, the marker sibling and the viz.
+ */
+function mountViz(worksheets: readonly FakeWorksheet[]): {
+  host: HTMLElement;
+  marker: HTMLElement;
+  viz: TableauViz;
+} {
+  const host = document.createElement('div');
+  const marker = document.createElement('span');
+  const viz = fakeDashboardViz(worksheets);
+  host.append(marker, viz);
+  document.body.append(host);
+
+  return { host, marker, viz };
+}
+
+/** Every element on the page the binder claims as its own. */
+function wrappers(): NodeListOf<Element> {
+  return document.querySelectorAll('[data-maidr-tableau]');
+}
+
+/** How many summary-data readers a worksheet has been asked for. */
+function reads(worksheet: FakeWorksheet): number {
+  return worksheet.calls.log.filter(entry => entry.startsWith('open:')).length;
+}
+
+describe('tableau binder', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask'] });
+    warn.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  afterAll(() => {
+    warn.mockRestore();
+  });
+
+  describe('mounting', () => {
+    it('should insert its wrapper immediately before the viz without moving it', async () => {
+      const sales = salesWorksheet('Sales');
+      const { host, marker, viz } = mountViz([sales]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      // The viz keeps its parent and its position: the wrapper is a new sibling
+      // in front of it, not a new home for it.
+      expect(viz.parentElement).toBe(host);
+      expect([...host.children]).toEqual([marker, viz.previousElementSibling, viz]);
+      expect(viz.previousElementSibling?.getAttribute('data-maidr-tableau'))
+        .toBe(binding.maidr.id);
+
+      binding.dispose();
+    });
+
+    it('should mount nothing and return null when every worksheet is skipped', async () => {
+      const sales = salesWorksheet('Sales');
+      const { host, marker, viz } = mountViz([sales]);
+
+      const binding = await bindTableau(viz, {
+        overrides: { Sales: { skip: true } },
+      });
+
+      expect(binding).toBeNull();
+      expect(wrappers()).toHaveLength(0);
+      expect([...host.children]).toEqual([marker, viz]);
+      // Nothing was read either: a skipped worksheet is skipped before it costs
+      // a reader, not after.
+      expect(sales.calls.log).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('refreshing', () => {
+    it('should re-read once for a burst of change events, after clearing the selection', async () => {
+      const sales = salesWorksheet('Sales');
+      const { viz } = mountViz([sales]);
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      sales.calls.log.length = 0;
+
+      viz.dispatchEvent(new Event('filterchanged'));
+      await jest.advanceTimersByTimeAsync(50);
+      viz.dispatchEvent(new Event('filterchanged'));
+      await settle();
+
+      expect(reads(sales)).toBe(1);
+      // `ignoreSelection` is documented backwards on both Tableau surfaces, so
+      // the adapter removes the selection instead of guessing — which is only
+      // true if the clear actually lands before the read.
+      expect(sales.calls.log.indexOf('clear:Sales'))
+        .toBeLessThan(sales.calls.log.indexOf('open:Sales'));
+
+      binding.dispose();
+    });
+
+    it('should still re-read for a second burst after the first has settled', async () => {
+      const sales = salesWorksheet('Sales');
+      const { viz } = mountViz([sales]);
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      sales.calls.log.length = 0;
+
+      // The debounce collapses a burst; it is not a one-shot latch, and a
+      // dashboard the reader keeps filtering has to keep being re-read.
+      viz.dispatchEvent(new Event('filterchanged'));
+      await settle();
+      viz.dispatchEvent(new Event('parameterchanged'));
+      await settle();
+
+      expect(reads(sales)).toBe(2);
+
+      binding.dispose();
+    });
+
+    it('should keep the previously mounted figure when a refresh fails', async () => {
+      const sales = salesWorksheet('Sales');
+      const { viz } = mountViz([sales]);
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      const mounted = binding.maidr;
+      const wrapper = wrappers()[0];
+      warn.mockClear();
+
+      sales.getSummaryColumnsInfoAsync = async (): Promise<never> => {
+        throw new Error('the view went away');
+      };
+      viz.dispatchEvent(new Event('filterchanged'));
+      await settle();
+
+      expect([...wrappers()]).toEqual([wrapper]);
+      expect(binding.maidr).toBe(mounted);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('a refresh failed');
+
+      binding.dispose();
+    });
+  });
+
+  describe('disposing', () => {
+    it('should remove the wrapper, clear every worksheet, and stop re-reading', async () => {
+      const log: string[] = [];
+      const sales = salesWorksheet('Sales', log);
+      const profit = salesWorksheet('Profit', log);
+      const { host, marker, viz } = mountViz([sales, profit]);
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      const clearedByBind = [sales.calls.clears, profit.calls.clears];
+
+      binding.dispose();
+      await flush();
+
+      expect(wrappers()).toHaveLength(0);
+      // The viz itself is left exactly as it was found.
+      expect([...host.children]).toEqual([marker, viz]);
+      expect([sales.calls.clears, profit.calls.clears]).toEqual([
+        clearedByBind[0] + 1,
+        clearedByBind[1] + 1,
+      ]);
+
+      const readsAtDispose = [reads(sales), reads(profit)];
+      viz.dispatchEvent(new Event('filterchanged'));
+      await settle();
+
+      expect([reads(sales), reads(profit)]).toEqual(readsAtDispose);
+    });
+  });
+});

--- a/test/adapters/tableau/extractor.test.ts
+++ b/test/adapters/tableau/extractor.test.ts
@@ -104,7 +104,7 @@ describe('tableau extractor', () => {
       expect(layerOf(extraction).type).toBe(TraceType.DODGED);
     });
 
-    it('rectangularizes grouped bars, filling a missing cell with zero', () => {
+    it('rectangularizes grouped bars, padding a missing cell with a gap and never a zero', () => {
       const extraction = extractTableau([
         fakeSnapshot({
           columns: [category(), region(), measure()],
@@ -118,7 +118,12 @@ describe('tableau extractor', () => {
 
       const data = layerOf(extraction).data as SegmentedPoint[][];
       // `SegmentedTrace.createSummaryLevel()` sums across rows by index, so
-      // every series must hold the same categories in the same order.
+      // every series must hold the same categories in the same order — but it
+      // filters the segments it sums with `isMeasured`, so equal *length* is
+      // all it needs. The pad is therefore `NaN`, MAIDR's gap sentinel: a `0`
+      // would sonify as a real reading at the bottom of the range, be reachable
+      // as the row's minimum, and pull the scale every other bar is pitched
+      // against — for a bar the view never drew.
       expect(data).toEqual([
         [
           { x: 'Chairs', y: 1, z: 'East' },
@@ -126,9 +131,10 @@ describe('tableau extractor', () => {
         ],
         [
           { x: 'Chairs', y: 3, z: 'West' },
-          { x: 'Tables', y: 0, z: 'West' },
+          { x: 'Tables', y: Number.NaN, z: 'West' },
         ],
       ]);
+      expect(Number.isNaN(data[1][1].y as number)).toBe(true);
       expect(new Set(data.map(series => series.length)).size).toBe(1);
       expect(data.every(series => series.every(point => point.z !== undefined))).toBe(true);
     });
@@ -158,7 +164,7 @@ describe('tableau extractor', () => {
       ]);
     });
 
-    it('reads a numeric dimension as a line too, since it is an ordered axis', () => {
+    it('reads a numeric date-part dimension as a line too, since it is an ordered axis', () => {
       const extraction = extractTableau([
         fakeSnapshot({
           columns: [fakeColumn('YEAR(Order Date)', 'int', 0), measure()],
@@ -167,6 +173,32 @@ describe('tableau extractor', () => {
       ]);
 
       expect(layerOf(extraction).type).toBe(TraceType.LINE);
+    });
+
+    it('reads a continuous axis as a point cloud rather than dropping the worksheet', () => {
+      // A continuous field on an axis — an unaggregated `Discount`, or a
+      // `Sales (bin)` field — is classified as a second *measure*, because every
+      // numeric column goes to the measure rung. The worksheet therefore has no
+      // dimension at all, and the point-cloud rung has to be tested before the
+      // "nothing to navigate" skip or a perfectly readable view vanishes.
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Profit by Discount',
+          columns: [fakeColumn('Discount', 'float', 0), fakeColumn('SUM(Profit)', 'float', 1)],
+          rows: [[0.1, 5], [0.2, 9], [0.3, 2]],
+        }),
+      ]);
+
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.SCATTER);
+      expect(layer.data as ScatterPoint[]).toEqual([
+        { x: 0.1, y: 5 },
+        { x: 0.2, y: 9 },
+        { x: 0.3, y: 2 },
+      ]);
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no dimension to navigate'),
+      );
     });
 
     it('gives every point of a grouped line a z, and does not pad the shorter series', () => {
@@ -557,6 +589,144 @@ describe('tableau extractor', () => {
       expect(declared.orientation).toBe(Orientation.HORIZONTAL);
       expect(declared.stepDirection).toBe('hv');
     });
+
+    it('transposes a horizontal bar, so the magnitude is the value the model reads', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), measure()],
+            rows: [['Chairs', 3], ['Tables', 1]],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { orientation: Orientation.HORIZONTAL } } },
+      );
+
+      const layer = layerOf(extraction);
+      expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+      // `AbstractBarPlot` reads an oriented layer's magnitude off `point.x`.
+      // Stamping the flag onto the vertical payload would give it
+      // `Number('Chairs')`, i.e. `NaN` for every bar: no tone, no braille, and
+      // "Min value: missing".
+      expect(layer.data as BarPoint[]).toEqual([
+        { x: 3, y: 'Chairs' },
+        { x: 1, y: 'Tables' },
+      ]);
+      // The captions travel with the payload.
+      expect(layer.axes).toEqual({ x: { label: 'Sales' }, y: { label: 'Category' } });
+    });
+
+    it('transposes a horizontal grouped bar, keeping the series order and the pad', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), region(), measure()],
+            rows: [
+              ['Chairs', 'East', 1],
+              ['Tables', 'East', 2],
+              ['Chairs', 'West', 3],
+            ],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { orientation: Orientation.HORIZONTAL } } },
+      );
+
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.DODGED);
+      // `[group][category]` is unchanged: `SegmentedTrace.createSummaryLevel()`
+      // already reads the category off `y` when the trace is horizontal.
+      expect(layer.data as SegmentedPoint[][]).toEqual([
+        [
+          { x: 1, y: 'Chairs', z: 'East' },
+          { x: 2, y: 'Tables', z: 'East' },
+        ],
+        [
+          { x: 3, y: 'Chairs', z: 'West' },
+          { x: Number.NaN, y: 'Tables', z: 'West' },
+        ],
+      ]);
+      expect(layer.axes).toEqual({
+        x: { label: 'Sales' },
+        y: { label: 'Category' },
+        z: { label: 'Region' },
+      });
+    });
+
+    it('leaves an explicit axis caption alone on a horizontal layer', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), measure()],
+            rows: [['Chairs', 3]],
+          }),
+        ],
+        {
+          overrides: {
+            'Sheet 1': {
+              orientation: Orientation.HORIZONTAL,
+              axes: { x: 'Revenue', y: 'Product' },
+            },
+          },
+        },
+      );
+
+      // A page that hand-writes a caption is writing it for the axis as the
+      // layer will actually emit it.
+      expect(layerOf(extraction).axes).toEqual({
+        x: { label: 'Revenue' },
+        y: { label: 'Product' },
+      });
+    });
+
+    it('does not transpose a family the model never orients', () => {
+      const january = fakeValue(new Date('2021-01-01T00:00:00Z'), 'January 2021');
+
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [month(), measure()],
+            rows: [[january, 10]],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { orientation: Orientation.HORIZONTAL } } },
+      );
+
+      // `IS_ORIENTED` is false for the line family, so `LineTrace` never reads
+      // `layer.orientation`; transposing here would only mislabel the axes.
+      const layer = layerOf(extraction);
+      expect(layer.data as LinePoint[][]).toEqual([[{ x: 'January 2021', y: 10 }]]);
+      expect(layer.axes).toEqual({ x: { label: 'MONTH(Order Date)' }, y: { label: 'Sales' } });
+    });
+
+    it('reads a z override that names the only dimension as the category axis', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sales by Region',
+            columns: [category('Region'), measure()],
+            rows: [['East', 3], ['West', 1]],
+          }),
+        ],
+        { overrides: { 'Sales by Region': { z: 'Region' } } },
+      );
+
+      // Grouping the only dimension away would leave nothing to navigate, and
+      // the ladder would drop the worksheet reporting that it has no dimension
+      // — which is false, and never names the override that caused it.
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.BAR);
+      expect(layer.data as BarPoint[]).toEqual([
+        { x: 'East', y: 3 },
+        { x: 'West', y: 1 },
+      ]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('is the only dimension'));
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no dimension to navigate'),
+      );
+    });
   });
 
   describe('the subplot grid', () => {
@@ -804,7 +974,7 @@ describe('tableau extractor', () => {
         { fieldName: 'Category', value: 'Chairs' },
         { fieldName: 'Region', value: 'East' },
       ]);
-      // The `y: 0` at `[West][Tables]` is the adapter's scaffolding, not a mark.
+      // The pad at `[West][Tables]` is the adapter's scaffolding, not a mark.
       expect(cells?.[1][1]).toBeNull();
     });
 

--- a/test/adapters/tableau/extractor.test.ts
+++ b/test/adapters/tableau/extractor.test.ts
@@ -1,0 +1,878 @@
+import type { TableauExtraction } from '@adapters/tableau/extractor';
+import type { TableauColumn } from '@adapters/tableau/types';
+import type {
+  BarPoint,
+  HeatmapData,
+  LinePoint,
+  MaidrLayer,
+  PiePoint,
+  ScatterPoint,
+  SegmentedPoint,
+} from '@type/grammar';
+import { extractTableau } from '@adapters/tableau/extractor';
+import { Orientation, TraceType } from '@type/grammar';
+import { fakeColumn, fakeSnapshot, fakeValue } from './helpers';
+
+/** A plain categorical dimension. */
+const category = (name = 'Category'): TableauColumn => fakeColumn(name, 'string', 0);
+
+/** A second categorical dimension, the one read as the series. */
+const region = (name = 'Region'): TableauColumn => fakeColumn(name, 'string', 1);
+
+/** An aggregated numeric measure. */
+const measure = (name = 'SUM(Sales)'): TableauColumn => fakeColumn(name, 'float', 2);
+
+/** A date-part dimension, which the ladder reads as an ordered axis. */
+const month = (): TableauColumn => fakeColumn('MONTH(Order Date)', 'date', 0);
+
+/**
+ * The only layer of one subplot.
+ *
+ * One worksheet is exactly one layer and one layer is exactly one subplot, so
+ * every lookup in this file is by subplot index.
+ *
+ * @param extraction - What {@link extractTableau} returned.
+ * @param index - The subplot index.
+ * @returns That subplot's layer.
+ */
+function layerOf(extraction: TableauExtraction, index = 0): MaidrLayer {
+  return extraction.maidr.subplots[index][0].layers[0];
+}
+
+describe('tableau extractor', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  describe('the heuristic ladder', () => {
+    it('reads one dimension and one measure as a bar chart in view order', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Sales by Category',
+          columns: [category(), measure()],
+          rows: [['Chairs', 3], ['Tables', 1], ['Phones', 2]],
+        }),
+      ]);
+
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.BAR);
+      // View order, not sorted: summary data arrives in the order the view laid
+      // the marks out, and that is the order a reader hears them in.
+      expect(layer.data as BarPoint[]).toEqual([
+        { x: 'Chairs', y: 3 },
+        { x: 'Tables', y: 1 },
+        { x: 'Phones', y: 2 },
+      ]);
+    });
+
+    it('skips a bar row whose measure is a gap instead of drawing it at zero', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [['Chairs', 3], ['Tables', null], ['Phones', 2]],
+        }),
+      ]);
+
+      expect(layerOf(extraction).data as BarPoint[]).toEqual([
+        { x: 'Chairs', y: 3 },
+        { x: 'Phones', y: 2 },
+      ]);
+    });
+
+    it('reads two dimensions and one measure as grouped bars, never as a stack or a heat map', () => {
+      // Summary data gives each segment its own value whether Tableau stacked
+      // the bars or set them side by side, and two dimensions is equally the
+      // signature of a highlight table, so the honest reading is the grouped
+      // one.
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+          ],
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.DODGED);
+    });
+
+    it('rectangularizes grouped bars, filling a missing cell with zero', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+          ],
+        }),
+      ]);
+
+      const data = layerOf(extraction).data as SegmentedPoint[][];
+      // `SegmentedTrace.createSummaryLevel()` sums across rows by index, so
+      // every series must hold the same categories in the same order.
+      expect(data).toEqual([
+        [
+          { x: 'Chairs', y: 1, z: 'East' },
+          { x: 'Tables', y: 2, z: 'East' },
+        ],
+        [
+          { x: 'Chairs', y: 3, z: 'West' },
+          { x: 'Tables', y: 0, z: 'West' },
+        ],
+      ]);
+      expect(new Set(data.map(series => series.length)).size).toBe(1);
+      expect(data.every(series => series.every(point => point.z !== undefined))).toBe(true);
+    });
+
+    it('reads a temporal dimension as a line, nested even for a single series', () => {
+      const january = fakeValue(new Date('2021-01-01T00:00:00Z'), 'January 2021');
+      const february = fakeValue(new Date('2021-02-01T00:00:00Z'), 'February 2021');
+      const march = fakeValue(new Date('2021-03-01T00:00:00Z'), 'March 2021');
+
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [month(), measure()],
+          rows: [[january, 10], [february, null], [march, 30]],
+        }),
+      ]);
+
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.LINE);
+      const data = layer.data as LinePoint[][];
+      expect(data).toHaveLength(1);
+      // `null`, never `0`: `Number(null)` is zero, which would sound like a real
+      // low reading and pull the range every other pitch is scaled against.
+      expect(data[0]).toEqual([
+        { x: 'January 2021', y: 10 },
+        { x: 'February 2021', y: null },
+        { x: 'March 2021', y: 30 },
+      ]);
+    });
+
+    it('reads a numeric dimension as a line too, since it is an ordered axis', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [fakeColumn('YEAR(Order Date)', 'int', 0), measure()],
+          rows: [[2020, 10], [2021, 20]],
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.LINE);
+    });
+
+    it('gives every point of a grouped line a z, and does not pad the shorter series', () => {
+      const january = fakeValue(new Date('2021-01-01T00:00:00Z'), 'January 2021');
+      const february = fakeValue(new Date('2021-02-01T00:00:00Z'), 'February 2021');
+
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [month(), region(), measure()],
+          rows: [
+            [january, 'East', 10],
+            [february, 'East', 20],
+            [january, 'West', 5],
+          ],
+        }),
+      ]);
+
+      const data = layerOf(extraction).data as LinePoint[][];
+      // A line with fewer samples than its neighbour is a real chart; padding
+      // it would draw points the view does not have.
+      expect(data).toEqual([
+        [
+          { x: 'January 2021', y: 10, z: 'East' },
+          { x: 'February 2021', y: 20, z: 'East' },
+        ],
+        [{ x: 'January 2021', y: 5, z: 'West' }],
+      ]);
+    });
+
+    it('reads several measures over detail dimensions as a numeric point cloud', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [
+            fakeColumn('Customer', 'string', 0),
+            fakeColumn('SUM(Sales)', 'float', 1),
+            fakeColumn('AVG(Profit)', 'float', 2),
+          ],
+          rows: [
+            ['Alice', 10, 1],
+            ['Bob', 20, 2],
+            ['Cara', 30, null],
+          ],
+        }),
+      ]);
+
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.SCATTER);
+      // `ScatterPoint.x` and `.y` are strictly numeric, so a row missing either
+      // coordinate has no position to be placed at.
+      expect(layer.data as ScatterPoint[]).toEqual([
+        { x: 10, y: 1 },
+        { x: 20, y: 2 },
+      ]);
+    });
+
+    it('puts a third measure on a point cloud’s z channel', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [
+            fakeColumn('Customer', 'string', 0),
+            fakeColumn('SUM(Sales)', 'float', 1),
+            fakeColumn('AVG(Profit)', 'float', 2),
+            fakeColumn('SUM(Quantity)', 'float', 3),
+          ],
+          rows: [['Alice', 10, 1, 7], ['Bob', 20, 2, 8]],
+        }),
+      ]);
+
+      expect(layerOf(extraction).data as ScatterPoint[]).toEqual([
+        { x: 10, y: 1, z: 7 },
+        { x: 20, y: 2, z: 8 },
+      ]);
+    });
+
+    it('reads several measures over a repeating category as bars, not a point cloud', () => {
+      // The dimension is not a detail field — it has fewer distinct values than
+      // rows — so the rows are categories rather than observations.
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [
+            category(),
+            fakeColumn('SUM(Sales)', 'float', 1),
+            fakeColumn('AVG(Profit)', 'float', 2),
+          ],
+          rows: [['Chairs', 10, 1], ['Chairs', 20, 2], ['Tables', 30, 3]],
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.BAR);
+    });
+  });
+
+  describe('the visual specification', () => {
+    it('reads pie marks as a pie chart, outranking the ladder’s bar', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [['Chairs', 3], ['Tables', 1]],
+          spec: { marksSpecifications: [{ primitiveType: 'pie' }] },
+        }),
+      ]);
+
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.PIE);
+      expect(layer.data as PiePoint[]).toEqual([
+        { x: 'Chairs', y: 3 },
+        { x: 'Tables', y: 1 },
+      ]);
+    });
+
+    it('reads line marks as a line even when the category is a plain string', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [['Chairs', 3], ['Tables', 1]],
+          spec: { marksSpecifications: [{ primitiveType: 'line' }] },
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.LINE);
+    });
+
+    it('reads heatmap marks over a complete grid as a heat map', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+            ['Tables', 'West', 4],
+          ],
+          spec: { marksSpecifications: [{ primitiveType: 'heatmap' }] },
+        }),
+      ]);
+
+      const layer = layerOf(extraction);
+      expect(layer.type).toBe(TraceType.HEATMAP);
+      const data = layer.data as HeatmapData;
+      expect(data.x).toEqual(['Chairs', 'Tables']);
+      expect(data.y).toEqual(['East', 'West']);
+      expect(data.points).toEqual([[1, 2], [3, 4]]);
+      // `HeatmapData` is a rectangle, and the model indexes it as one.
+      expect(data.points).toHaveLength(data.y.length);
+      expect(data.points.every(row => row.length === data.x.length)).toBe(true);
+    });
+
+    it('falls back to grouped bars, with a warning, when the grid has holes', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Highlight Table',
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+          ],
+          spec: { marksSpecifications: [{ primitiveType: 'heatmap' }] },
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.DODGED);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('complete grid'));
+    });
+
+    it('reads circle marks as a point cloud only when there are two measures', () => {
+      const asPoints = extractTableau([
+        fakeSnapshot({
+          columns: [
+            fakeColumn('Customer', 'string', 0),
+            fakeColumn('SUM(Sales)', 'float', 1),
+            fakeColumn('AVG(Profit)', 'float', 2),
+          ],
+          rows: [['Alice', 10, 1], ['Bob', 20, 2]],
+          spec: { marksSpecifications: [{ primitiveType: 'circle' }] },
+        }),
+      ]);
+      const asBars = extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [['Chairs', 3], ['Tables', 1]],
+          spec: { marksSpecifications: [{ primitiveType: 'circle' }] },
+        }),
+      ]);
+
+      expect(layerOf(asPoints).type).toBe(TraceType.SCATTER);
+      // A categorical dot plot uses the same primitive but has no numeric x.
+      expect(layerOf(asBars).type).toBe(TraceType.BAR);
+    });
+
+    it('skips a worksheet drawn with marks MAIDR has no equivalent for', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Map',
+          columns: [category(), measure()],
+          rows: [['Chairs', 3]],
+          spec: { marksSpecifications: [{ primitiveType: 'map' }] },
+        }),
+      ]);
+
+      expect(extraction.maidr.subplots).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no equivalent'));
+    });
+
+    it('falls through to the ladder for a mark type it does not recognise', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [['Chairs', 3]],
+          spec: { marksSpecifications: [{ primitiveType: 'something-new' }] },
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.BAR);
+    });
+
+    it('reads the marks card the specification says is active', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [['Chairs', 3]],
+          spec: {
+            activeMarksSpecificationIndex: 1,
+            marksSpecifications: [{ primitiveType: 'bar' }, { primitiveType: 'pie' }],
+          },
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.PIE);
+    });
+  });
+
+  describe('overrides', () => {
+    it('lets the page’s trace type outrank the visual specification', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), measure()],
+            rows: [['Chairs', 3], ['Tables', 1]],
+            spec: { marksSpecifications: [{ primitiveType: 'bar' }] },
+          }),
+        ],
+        { overrides: { 'Sheet 1': { traceType: TraceType.LINE } } },
+      );
+
+      expect(layerOf(extraction).type).toBe(TraceType.LINE);
+    });
+
+    it('reaches a stacked bar, which is never inferred, only through the override', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), region(), measure()],
+            rows: [
+              ['Chairs', 'East', 1],
+              ['Tables', 'East', 2],
+              ['Chairs', 'West', 3],
+              ['Tables', 'West', 4],
+            ],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { traceType: TraceType.STACKED } } },
+      );
+
+      expect(layerOf(extraction).type).toBe(TraceType.STACKED);
+      expect(layerOf(extraction).data as SegmentedPoint[][]).toHaveLength(2);
+    });
+
+    it('degrades an unbuildable override to the inferred type, with a warning', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), region(), measure()],
+            rows: [
+              ['Chairs', 'East', 1],
+              ['Tables', 'East', 2],
+              ['Chairs', 'West', 3],
+            ],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { traceType: TraceType.HEATMAP } } },
+      );
+
+      // A truthful smaller reading beats a confident wrong one.
+      expect(layerOf(extraction).type).toBe(TraceType.DODGED);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('cannot build'));
+    });
+
+    it('honours explicit x, y and z column choices', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [
+              category(),
+              region(),
+              fakeColumn('SUM(Sales)', 'float', 2),
+              fakeColumn('SUM(Profit)', 'float', 3),
+            ],
+            rows: [
+              ['Chairs', 'East', 1, 100],
+              ['Chairs', 'West', 2, 200],
+            ],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { x: 'Region', y: 'SUM(Profit)', z: 'Category' } } },
+      );
+
+      const layer = layerOf(extraction);
+      expect(layer.axes).toEqual({
+        x: { label: 'Region' },
+        y: { label: 'Profit' },
+        z: { label: 'Category' },
+      });
+      expect(layer.data as SegmentedPoint[][]).toEqual([
+        [
+          { x: 'East', y: 100, z: 'Chairs' },
+          { x: 'West', y: 200, z: 'Chairs' },
+        ],
+      ]);
+    });
+
+    it('warns and falls back when an override names no column', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), measure()],
+            rows: [['Chairs', 3]],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { y: 'SUM(Nope)' } } },
+      );
+
+      expect(layerOf(extraction).axes?.y).toEqual({ label: 'Sales' });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('no measure column named "SUM(Nope)"'),
+      );
+    });
+
+    it('overrides the axis labels without touching which columns are read', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({
+            name: 'Sheet 1',
+            columns: [category(), measure()],
+            rows: [['Chairs', 3]],
+          }),
+        ],
+        { overrides: { 'Sheet 1': { axes: { x: 'Product', y: 'Revenue' } } } },
+      );
+
+      const layer = layerOf(extraction);
+      expect(layer.axes).toEqual({ x: { label: 'Product' }, y: { label: 'Revenue' } });
+      expect(layer.data as BarPoint[]).toEqual([{ x: 'Chairs', y: 3 }]);
+    });
+
+    it('titles a layer by the worksheet name unless the page renames it', () => {
+      const snapshots = [
+        fakeSnapshot({ name: 'Sales', columns: [category(), measure()], rows: [['Chairs', 3]] }),
+      ];
+
+      expect(layerOf(extractTableau(snapshots)).title).toBe('Sales');
+      expect(
+        layerOf(extractTableau(snapshots, { overrides: { Sales: { title: 'Revenue' } } })).title,
+      ).toBe('Revenue');
+    });
+
+    it('emits orientation and step direction only when the page declares them', () => {
+      const snapshots = [
+        fakeSnapshot({ name: 'Sheet 1', columns: [category(), measure()], rows: [['Chairs', 3]] }),
+      ];
+
+      const inferred = layerOf(extractTableau(snapshots));
+      expect(inferred.orientation).toBeUndefined();
+      expect(inferred.stepDirection).toBeUndefined();
+
+      const declared = layerOf(
+        extractTableau(snapshots, {
+          overrides: {
+            'Sheet 1': { orientation: Orientation.HORIZONTAL, stepDirection: 'hv' },
+          },
+        }),
+      );
+      expect(declared.orientation).toBe(Orientation.HORIZONTAL);
+      expect(declared.stepDirection).toBe('hv');
+    });
+  });
+
+  describe('the subplot grid', () => {
+    it('lays worksheets out one per row, in the order they were read', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({ name: 'A', columns: [category(), measure()], rows: [['Chairs', 1]] }),
+        fakeSnapshot({ name: 'B', columns: [category(), measure()], rows: [['Tables', 2]] }),
+        fakeSnapshot({ name: 'C', columns: [category(), measure()], rows: [['Phones', 3]] }),
+      ]);
+
+      expect(extraction.maidr.subplots).toHaveLength(3);
+      expect(extraction.maidr.subplots.every(row => row.length === 1)).toBe(true);
+      expect([0, 1, 2].map(index => layerOf(extraction, index).id)).toEqual(['0', '1', '2']);
+      expect([0, 1, 2].map(index => layerOf(extraction, index).title)).toEqual(['A', 'B', 'C']);
+    });
+
+    it('skips a worksheet with no measure and contributes no subplot for it', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Text Table',
+          columns: [category(), region()],
+          rows: [['Chairs', 'East'], ['Tables', 'West']],
+        }),
+      ]);
+
+      expect(extraction.maidr.subplots).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no measure to sonify'));
+    });
+
+    it('skips a worksheet with no dimension to navigate', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({ name: 'KPI', columns: [measure()], rows: [[42]] }),
+      ]);
+
+      expect(extraction.maidr.subplots).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no dimension to navigate'));
+    });
+
+    it('skips a worksheet that returned no rows', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({ name: 'Filtered Out', columns: [category(), measure()], rows: [] }),
+      ]);
+
+      expect(extraction.maidr.subplots).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no rows'));
+    });
+
+    it('keeps layer ids contiguous when a worksheet in the middle is skipped', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({ name: 'A', columns: [category(), measure()], rows: [['Chairs', 1]] }),
+        fakeSnapshot({ name: 'B', columns: [category(), region()], rows: [['Tables', 'East']] }),
+        fakeSnapshot({ name: 'C', columns: [category(), measure()], rows: [['Phones', 3]] }),
+      ]);
+
+      expect(extraction.maidr.subplots).toHaveLength(2);
+      expect([0, 1].map(index => layerOf(extraction, index).id)).toEqual(['0', '1']);
+      // The survivor index is what every selection lookup is keyed by, so the
+      // map back to a worksheet has to come from the extractor.
+      expect(extraction.selection.worksheets.get('0')).toBe('A');
+      expect(extraction.selection.worksheets.get('1')).toBe('C');
+    });
+
+    it('emits no subplots at all when every worksheet is skipped', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({ name: 'A', columns: [category(), measure()], rows: [['Chairs', 1]] }),
+          fakeSnapshot({ name: 'B', columns: [category(), measure()], rows: [['Tables', 2]] }),
+        ],
+        { overrides: { A: { skip: true }, B: { skip: true } } },
+      );
+
+      expect(extraction.maidr.subplots).toEqual([]);
+      expect(extraction.selection.worksheets.size).toBe(0);
+    });
+
+    it('honours an include-list in the order the page wrote it', () => {
+      const extraction = extractTableau(
+        [
+          fakeSnapshot({ name: 'A', columns: [category(), measure()], rows: [['Chairs', 1]] }),
+          fakeSnapshot({ name: 'B', columns: [category(), measure()], rows: [['Tables', 2]] }),
+          fakeSnapshot({ name: 'C', columns: [category(), measure()], rows: [['Phones', 3]] }),
+        ],
+        { worksheets: ['C', 'A'] },
+      );
+
+      expect([0, 1].map(index => layerOf(extraction, index).title)).toEqual(['C', 'A']);
+    });
+
+    it('warns about an include-list entry that names no worksheet that was read', () => {
+      const extraction = extractTableau(
+        [fakeSnapshot({ name: 'A', columns: [category(), measure()], rows: [['Chairs', 1]] })],
+        { worksheets: ['A', 'Ghost'] },
+      );
+
+      expect(extraction.maidr.subplots).toHaveLength(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no worksheet named "Ghost"'));
+    });
+  });
+
+  describe('the figure', () => {
+    it('never sets onNavigate: extraction is pure and the binder owns the callback', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({ columns: [category(), measure()], rows: [['Chairs', 1]] }),
+      ]);
+
+      expect(extraction.maidr.onNavigate).toBeUndefined();
+    });
+
+    it('generates a figure id, and uses the page’s when it supplies one', () => {
+      const snapshots = [
+        fakeSnapshot({ columns: [category(), measure()], rows: [['Chairs', 1]] }),
+      ];
+
+      expect(extractTableau(snapshots).maidr.id).toMatch(/^maidr-tableau-\d+$/);
+      expect(extractTableau(snapshots, { id: 'pinned' }).maidr.id).toBe('pinned');
+    });
+
+    it('emits a title only when the page supplies one', () => {
+      const snapshots = [
+        fakeSnapshot({ columns: [category(), measure()], rows: [['Chairs', 1]] }),
+      ];
+
+      expect(extractTableau(snapshots).maidr.title).toBeUndefined();
+      expect(extractTableau(snapshots, { title: 'Superstore' }).maidr.title).toBe('Superstore');
+    });
+
+    it('always describes an axis as an object with a label, never as a bare string', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [['Chairs', 'East', 1], ['Tables', 'West', 2]],
+        }),
+      ]);
+
+      // A bare string is not accepted by the grammar and degrades the label to
+      // `'X'` at runtime.
+      expect(layerOf(extraction).axes).toEqual({
+        x: { label: 'Category' },
+        y: { label: 'Sales' },
+        z: { label: 'Region' },
+      });
+    });
+
+    it('names a point cloud’s axes after its measures, not after its dimension', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [
+            fakeColumn('Customer', 'string', 0),
+            fakeColumn('SUM(Sales)', 'float', 1),
+            fakeColumn('AVG(Profit)', 'float', 2),
+            fakeColumn('SUM(Quantity)', 'float', 3),
+          ],
+          rows: [['Alice', 10, 1, 7], ['Bob', 20, 2, 8]],
+        }),
+      ]);
+
+      expect(layerOf(extraction).axes).toEqual({
+        x: { label: 'Sales' },
+        y: { label: 'Profit' },
+        z: { label: 'Quantity' },
+      });
+    });
+
+    it('names a heat map’s z after the measure the cells are shaded by', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+            ['Tables', 'West', 4],
+          ],
+          spec: { marksSpecifications: [{ primitiveType: 'heatmap' }] },
+        }),
+      ]);
+
+      expect(layerOf(extraction).axes).toEqual({
+        x: { label: 'Category' },
+        y: { label: 'Region' },
+        z: { label: 'Sales' },
+      });
+    });
+
+    it('never emits selectors: there is no DOM inside the viz to highlight', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({ columns: [category(), measure()], rows: [['Chairs', 1]] }),
+      ]);
+
+      expect(layerOf(extraction).selectors).toBeUndefined();
+    });
+
+    it('warns once, naming them, about dimensions beyond the first two', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Sheet 1',
+          columns: [
+            category(),
+            region(),
+            fakeColumn('Segment', 'string', 2),
+            fakeColumn('SUM(Sales)', 'float', 3),
+          ],
+          rows: [
+            ['Chairs', 'East', 'Consumer', 1],
+            ['Tables', 'West', 'Corporate', 2],
+          ],
+        }),
+      ]);
+
+      expect(layerOf(extraction).type).toBe(TraceType.DODGED);
+      const messages = warn.mock.calls.map(call => String(call[0]));
+      expect(messages.filter(message => message.includes('"Segment"'))).toHaveLength(1);
+    });
+  });
+
+  describe('the selection index', () => {
+    it('addresses a bar layer as a single row of cells', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), measure()],
+          rows: [['Chairs', 1], ['Tables', 2]],
+        }),
+      ]);
+
+      const cells = extraction.selection.cells.get('0');
+      expect(cells).toHaveLength(1);
+      expect(cells?.[0][0]).toEqual([{ fieldName: 'Category', value: 'Chairs' }]);
+      expect(cells?.[0][1]).toEqual([{ fieldName: 'Category', value: 'Tables' }]);
+    });
+
+    it('addresses a grouped cell by both dimensions, and a filler cell by nothing', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+          ],
+        }),
+      ]);
+
+      const cells = extraction.selection.cells.get('0');
+      expect(cells?.[0][0]).toEqual([
+        { fieldName: 'Category', value: 'Chairs' },
+        { fieldName: 'Region', value: 'East' },
+      ]);
+      // The `y: 0` at `[West][Tables]` is the adapter's scaffolding, not a mark.
+      expect(cells?.[1][1]).toBeNull();
+    });
+
+    it('addresses a date dimension as a single-day range', () => {
+      const january = new Date('2021-01-01T00:00:00Z');
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [month(), measure()],
+          rows: [[fakeValue(january, 'January 2021'), 10]],
+        }),
+      ]);
+
+      expect(extraction.selection.cells.get('0')?.[0][0]).toEqual([
+        { fieldName: 'MONTH(Order Date)', value: { min: january, max: january } },
+      ]);
+    });
+
+    it('reverses a heat map’s rows to match how the model indexes the grid', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [category(), region(), measure()],
+          rows: [
+            ['Chairs', 'East', 1],
+            ['Tables', 'East', 2],
+            ['Chairs', 'West', 3],
+            ['Tables', 'West', 4],
+          ],
+          spec: { marksSpecifications: [{ primitiveType: 'heatmap' }] },
+        }),
+      ]);
+
+      // `Heatmap`'s constructor reverses `y` and `points`, so row 0 is the
+      // bottom band: an un-reversed index would select another row's marks.
+      expect(extraction.selection.cells.get('0')?.[0][0]).toEqual([
+        { fieldName: 'Category', value: 'Chairs' },
+        { fieldName: 'Region', value: 'West' },
+      ]);
+    });
+
+    it('addresses a point cloud by data index, using every dimension of the row', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          columns: [
+            fakeColumn('Customer', 'string', 0),
+            fakeColumn('SUM(Sales)', 'float', 1),
+            fakeColumn('AVG(Profit)', 'float', 2),
+          ],
+          rows: [['Alice', 10, 1], ['Bob', 20, 2]],
+        }),
+      ]);
+
+      expect(extraction.selection.cells.has('0')).toBe(false);
+      expect(extraction.selection.points.get('0')).toEqual([
+        [{ fieldName: 'Customer', value: 'Alice' }],
+        [{ fieldName: 'Customer', value: 'Bob' }],
+      ]);
+    });
+
+    it('maps every layer id back to the worksheet it was built from', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({ name: 'A', columns: [category(), measure()], rows: [['Chairs', 1]] }),
+        fakeSnapshot({ name: 'B', columns: [category(), measure()], rows: [['Tables', 2]] }),
+      ]);
+
+      expect([...extraction.selection.worksheets]).toEqual([
+        ['0', 'A'],
+        ['1', 'B'],
+      ]);
+    });
+  });
+});

--- a/test/adapters/tableau/fields.test.ts
+++ b/test/adapters/tableau/fields.test.ts
@@ -1,0 +1,210 @@
+import {
+  buildIndexMap,
+  classifyColumns,
+  remapRow,
+  toCategoryKey,
+  toDateValue,
+  toFiniteNumber,
+} from '@adapters/tableau/fields';
+import { fakeColumn, fakeDataTable, fakeValue } from './helpers';
+
+describe('tableau column classification', () => {
+  it('reads an aggregated numeric as a measure captioned by the wrapped field', () => {
+    const { measures, dimensions } = classifyColumns([
+      fakeColumn('SUM(Sales)', 'float', 0),
+    ]);
+
+    expect(dimensions).toHaveLength(0);
+    expect(measures).toHaveLength(1);
+    expect(measures[0]).toMatchObject({
+      role: 'measure',
+      caption: 'Sales',
+      agg: 'SUM',
+      numeric: true,
+      temporal: false,
+      viewIndex: 0,
+    });
+  });
+
+  it('matches the aggregation wrapper case-insensitively', () => {
+    const { measures } = classifyColumns([fakeColumn('Sum(Sales)', 'float', 0)]);
+
+    expect(measures[0].caption).toBe('Sales');
+    expect(measures[0].agg).toBe('Sum');
+  });
+
+  it('reads a date part as a temporal dimension that keeps its wrapper', () => {
+    // `int` on purpose: a date part is a category even though the value Tableau
+    // hands back is a number, so this proves the date-part rung is tested
+    // before the bare-numeric one.
+    const { dimensions, measures } = classifyColumns([
+      fakeColumn('YEAR(Order Date)', 'int', 0),
+    ]);
+
+    expect(measures).toHaveLength(0);
+    expect(dimensions[0]).toMatchObject({
+      role: 'dimension',
+      caption: 'YEAR(Order Date)',
+      temporal: true,
+    });
+  });
+
+  it('still reads a non-English aggregation as a measure, losing only the caption', () => {
+    // `fieldName` is documented as not stable across languages, so `SOMME` is
+    // not a wrapper this adapter knows. `dataType` is the backstop: the role
+    // survives, the caption keeps the wrapper.
+    const { measures } = classifyColumns([fakeColumn('SOMME(Ventes)', 'float', 0)]);
+
+    expect(measures).toHaveLength(1);
+    expect(measures[0].caption).toBe('SOMME(Ventes)');
+    expect(measures[0].agg).toBeUndefined();
+  });
+
+  it('reads a bare numeric column as a measure', () => {
+    const { measures } = classifyColumns([fakeColumn('Profit Ratio', 'float', 0)]);
+
+    expect(measures[0]).toMatchObject({ role: 'measure', caption: 'Profit Ratio' });
+    expect(measures[0].agg).toBeUndefined();
+  });
+
+  it('reads a string column as a dimension', () => {
+    const { dimensions } = classifyColumns([fakeColumn('Category', 'string', 0)]);
+
+    expect(dimensions[0]).toMatchObject({
+      role: 'dimension',
+      caption: 'Category',
+      numeric: false,
+      temporal: false,
+    });
+  });
+
+  it('reads an unwrapped date column as a temporal dimension', () => {
+    const { dimensions } = classifyColumns([fakeColumn('Order Date', 'date-time', 0)]);
+
+    expect(dimensions[0]).toMatchObject({ role: 'dimension', temporal: true });
+  });
+
+  it('drops spatial and unknown columns, which carry nothing sonifiable', () => {
+    const { columns } = classifyColumns([
+      fakeColumn('Geometry', 'spatial', 0),
+      fakeColumn('Mystery', 'unknown', 1),
+    ]);
+
+    expect(columns).toHaveLength(0);
+  });
+
+  it('drops a column the visualization does not reference', () => {
+    const { columns } = classifyColumns([
+      fakeColumn('Tooltip Only', 'string', 0, { isReferenced: false }),
+      fakeColumn('Category', 'string', 1, { isReferenced: true }),
+    ]);
+
+    expect(columns.map(column => column.column.fieldName)).toEqual(['Category']);
+  });
+
+  it('keeps viewIndex pointing at the original position when a column is dropped', () => {
+    const { dimensions, measures } = classifyColumns([
+      fakeColumn('Geometry', 'spatial', 0),
+      fakeColumn('Category', 'string', 1),
+      fakeColumn('SUM(Sales)', 'float', 2),
+    ]);
+
+    expect(dimensions[0].viewIndex).toBe(1);
+    expect(measures[0].viewIndex).toBe(2);
+  });
+});
+
+describe('tableau view↔alphabetical column remap', () => {
+  const viewColumns = [
+    fakeColumn('Region', 'string', 0),
+    fakeColumn('SUM(Sales)', 'float', 1),
+    fakeColumn('Category', 'string', 2),
+  ];
+
+  it('recovers view order from an alphabetically sorted data table', () => {
+    const table = fakeDataTable(viewColumns, [['West', 42, 'Chairs']]);
+
+    // The fake sorts as a real `DataTableReader` does, so the table is nothing
+    // like view order until the map is applied.
+    expect(table.columns.map(column => column.fieldName)).toEqual([
+      'Category',
+      'Region',
+      'SUM(Sales)',
+    ]);
+
+    const indexMap = buildIndexMap(viewColumns, table.columns);
+    expect(indexMap).toEqual([1, 2, 0]);
+
+    const row = remapRow(table.data[0], indexMap);
+    expect(row.map(cell => cell?.nativeValue)).toEqual(['West', 42, 'Chairs']);
+  });
+
+  it('falls back to fieldName when the table reports no matching fieldId', () => {
+    const table = fakeDataTable(
+      [
+        fakeColumn('Region', 'string', 0, { fieldId: 'renamed-region' }),
+        fakeColumn('SUM(Sales)', 'float', 1, { fieldId: 'renamed-sales' }),
+      ],
+      [['West', 42]],
+    );
+
+    const indexMap = buildIndexMap(viewColumns.slice(0, 2), table.columns);
+
+    expect(indexMap).toEqual([0, 1]);
+  });
+
+  it('reads an unmatched view column as a gap instead of shifting the row', () => {
+    const table = fakeDataTable([viewColumns[0], viewColumns[1]], [['West', 42]]);
+
+    const indexMap = buildIndexMap(viewColumns, table.columns);
+    expect(indexMap).toEqual([0, 1, -1]);
+
+    const row = remapRow(table.data[0], indexMap);
+    expect(row[2]).toBeUndefined();
+    expect(row[0]?.nativeValue).toBe('West');
+  });
+});
+
+describe('tableau value coercion', () => {
+  it('reads a numeric cell, and a numeric string, as a number', () => {
+    expect(toFiniteNumber(fakeValue(42))).toBe(42);
+    expect(toFiniteNumber(fakeValue('42.5'))).toBe(42.5);
+  });
+
+  it('reads every kind of gap as null rather than as a zero', () => {
+    // A zero is a bar the viz drew at the baseline. Inventing one would put a
+    // mark where the view has none.
+    expect(toFiniteNumber(fakeValue(null))).toBeNull();
+    expect(toFiniteNumber(undefined)).toBeNull();
+    expect(toFiniteNumber(fakeValue(Number.NaN))).toBeNull();
+    expect(toFiniteNumber(fakeValue('Chairs'))).toBeNull();
+  });
+
+  it('does not read a date as its epoch milliseconds', () => {
+    expect(toFiniteNumber(fakeValue(new Date('2021-03-04T00:00:00Z')))).toBeNull();
+  });
+
+  it('prefers the worksheet formatting for a category key', () => {
+    expect(toCategoryKey(fakeValue(1234.5, '$1,234.50'))).toBe('$1,234.50');
+    expect(toCategoryKey(fakeValue('Chairs'))).toBe('Chairs');
+  });
+
+  it('reads a gap as the empty string, never as the word null', () => {
+    expect(toCategoryKey(fakeValue(null))).toBe('');
+    expect(toCategoryKey(undefined)).toBe('');
+  });
+
+  it('renders an unformatted date as an ISO stamp, not a locale string', () => {
+    expect(toCategoryKey(fakeValue(new Date('2021-03-04T00:00:00Z')))).toBe(
+      '2021-03-04T00:00:00.000Z',
+    );
+  });
+
+  it('accepts only a real Date as a date, never a parsed string', () => {
+    const date = new Date('2021-03-04T00:00:00Z');
+
+    expect(toDateValue(fakeValue(date))).toBe(date);
+    expect(toDateValue(fakeValue('2021-03-04'))).toBeNull();
+    expect(toDateValue(fakeValue(new Date('nonsense')))).toBeNull();
+  });
+});

--- a/test/adapters/tableau/helpers.ts
+++ b/test/adapters/tableau/helpers.ts
@@ -1,0 +1,405 @@
+/**
+ * Duck-typed Tableau fakes shared by the Tableau adapter tests.
+ *
+ * The adapter takes no dependency on any `@tableau/*` package — every Tableau
+ * object it touches is described by a structural interface in
+ * `src/adapters/tableau/types.ts` — so a plain object satisfies it and no
+ * network, no live viz and no vendor bundle are needed here.
+ *
+ * The factories deliberately reproduce the two traps the real API sets, because
+ * a fake that is tidier than the thing it stands in for proves nothing:
+ *
+ * - {@link fakeDataTable} sorts its columns **alphabetically**, exactly as a
+ *   real `DataTableReader` does, while {@link fakeWorksheet} keeps
+ *   `getSummaryColumnsInfoAsync` in view order. A test that writes its columns
+ *   in view order and reads its rows back in view order is therefore proving
+ *   the view↔alphabetical remap works, not assuming it away.
+ * - {@link fakeWorksheet} counts the readers it opens and the releases it is
+ *   given and records the order of every call in a shared log, so a leaked
+ *   reader or a read that started before the previous one finished is a failed
+ *   assertion rather than an invisible bug.
+ *
+ * Not a test file: jest's `*.test.ts` glob does not match this name.
+ */
+
+import type {
+  TableauColumn,
+  TableauDashboard,
+  TableauDataTable,
+  TableauDataTableReader,
+  TableauDataType,
+  TableauDataValue,
+  TableauGetSummaryDataOptions,
+  TableauRow,
+  TableauSelectionCriteria,
+  TableauVisualSpecification,
+  TableauViz,
+  TableauWorkbook,
+  TableauWorksheet,
+  WorksheetSnapshot,
+} from '@adapters/tableau/types';
+
+/**
+ * A cell as a test writes it.
+ *
+ * Either a ready-made {@link TableauDataValue} — for the cases where the
+ * formatted text has to differ from the native value — or the native value on
+ * its own, which {@link fakeValue} wraps.
+ */
+export type FakeCell = TableauDataValue | string | number | boolean | Date | null;
+
+/** One recorded `selectMarksByValueAsync` call. */
+export interface FakeSelectionCall {
+  readonly criteria: readonly TableauSelectionCriteria[];
+  readonly updateType: string;
+}
+
+/** One recorded `getSummaryDataReaderAsync` call, arguments verbatim. */
+export interface FakeReaderCall {
+  readonly pageRowCount: number | undefined;
+  readonly options: TableauGetSummaryDataOptions | undefined;
+}
+
+/** Everything a {@link FakeWorksheet} records about how it was used. */
+export interface FakeWorksheetCalls {
+  /**
+   * Ordered log of every Tableau call, as `verb:worksheet[:detail]`.
+   *
+   * Shared between fakes when they are given the same array, which is how a
+   * test proves that one worksheet's reader was released before the next one
+   * was opened.
+   */
+  readonly log: string[];
+  /** Arguments of every `getSummaryDataReaderAsync` call, in order. */
+  readonly readers: FakeReaderCall[];
+  /** Every `selectMarksByValueAsync` call, in order. */
+  readonly selections: FakeSelectionCall[];
+  /** How many readers were released. */
+  releases: number;
+  /** How many `clearSelectedMarksAsync` calls were made. */
+  clears: number;
+}
+
+/** A worksheet fake, plus the record of how the adapter drove it. */
+export interface FakeWorksheet extends TableauWorksheet {
+  readonly calls: FakeWorksheetCalls;
+}
+
+/** How a {@link fakeWorksheet} behaves, including how it fails. */
+export interface FakeWorksheetConfig {
+  /** Worksheet name; also the label used in {@link FakeWorksheetCalls.log}. */
+  name?: string;
+  /** Columns in **view order**, as `getSummaryColumnsInfoAsync` returns them. */
+  columns: readonly TableauColumn[];
+  /** Rows in view order; the reader serves them alphabetically remapped. */
+  rows: readonly (readonly FakeCell[])[];
+  /**
+   * The visual specification to report. When omitted the worksheet has **no**
+   * `getVisualSpecificationAsync` at all, which is the Embedding API today.
+   */
+  spec?: TableauVisualSpecification;
+  /** Rows per page. Defaults to every row on a single page. */
+  pageSize?: number;
+  /** A shared call log, so several fakes record into one ordering. */
+  log?: string[];
+  /** Reject `getPageAsync` for this page index. */
+  failPage?: number;
+  /** What {@link failPage} rejects with. */
+  pageError?: unknown;
+  /** Reject `releaseAsync`. */
+  failRelease?: boolean;
+  /** Reject `selectMarksByValueAsync`. */
+  failSelect?: boolean;
+  /** What {@link failSelect} rejects with. */
+  selectError?: unknown;
+  /** Reject `clearSelectedMarksAsync`. */
+  failClear?: boolean;
+  /**
+   * Declare `getVisualSpecificationAsync` and have it reject with this, which
+   * is the "the host has the method but the call failed" path.
+   */
+  specError?: unknown;
+  /**
+   * Awaited inside `getPageAsync` for page 0, so a test can hold a reader open
+   * while it starts a second read and observe whether the two overlap.
+   */
+  holdFirstPage?: Promise<unknown>;
+}
+
+/**
+ * Build one summary column.
+ *
+ * @param fieldName - Display name including any aggregation wrapper, e.g.
+ * `SUM(Sales)`. This is also what selection criteria are addressed by.
+ * @param dataType - The Tableau `DataType` *value*, e.g. `float`.
+ * @param index - The column's position in the table it came from.
+ * @param overrides - Anything else to set, such as `isReferenced: false` or a
+ * `fieldId` that differs from the name.
+ * @returns The column.
+ */
+export function fakeColumn(
+  fieldName: string,
+  dataType: TableauDataType,
+  index = 0,
+  overrides: Partial<TableauColumn> = {},
+): TableauColumn {
+  return {
+    fieldName,
+    fieldId: `[${fieldName}]`,
+    dataType,
+    index,
+    ...overrides,
+  };
+}
+
+/**
+ * Build one summary cell.
+ *
+ * `formattedValue` is omitted unless asked for, so the coercion helpers take
+ * their documented fallback path (`String(nativeValue)`) by default and a test
+ * that cares about the worksheet's own formatting has to say so.
+ *
+ * @param native - The native JS value, or `null` for one of Tableau's special
+ * values.
+ * @param formatted - The worksheet-formatted text, when it differs.
+ * @returns The data value.
+ */
+export function fakeValue(native: unknown, formatted?: string): TableauDataValue {
+  return {
+    value: native,
+    nativeValue: native,
+    ...(formatted === undefined ? {} : { formattedValue: formatted }),
+  };
+}
+
+/**
+ * Wrap a cell written the short way.
+ *
+ * @param cell - A ready-made value, or the native value on its own.
+ * @returns The data value.
+ */
+function toDataValue(cell: FakeCell): TableauDataValue {
+  if (cell !== null && typeof cell === 'object' && !(cell instanceof Date)) {
+    return cell;
+  }
+  return fakeValue(cell);
+}
+
+/**
+ * Build a page of summary data with its columns **alphabetically sorted**.
+ *
+ * This is the whole point of the helper: `DataTableReader` offers no way to ask
+ * for view order, so a fake that served view order would hide every remap bug
+ * the adapter exists to avoid. `fieldId` is preserved across the sort — it is
+ * what the index map matches on — while each column's `index` is re-stamped to
+ * its position in *this* table, as a real one's is.
+ *
+ * @param viewColumns - Columns in view order.
+ * @param rows - Rows in view order.
+ * @returns The table, columns and cells both alphabetically ordered.
+ */
+export function fakeDataTable(
+  viewColumns: readonly TableauColumn[],
+  rows: readonly (readonly FakeCell[])[],
+): TableauDataTable {
+  const order = viewColumns
+    .map((column, viewIndex) => ({ column, viewIndex }))
+    .sort((a, b) => a.column.fieldName.localeCompare(b.column.fieldName));
+
+  return {
+    columns: order.map(({ column }, index) => ({ ...column, index })),
+    data: rows.map(row => order.map(({ viewIndex }) => toDataValue(row[viewIndex]))),
+    isSummaryData: true,
+    totalRowCount: rows.length,
+  };
+}
+
+/**
+ * Split rows into pages the way a reader does.
+ *
+ * @param rows - Every row, in view order.
+ * @param pageSize - Rows per page, or `undefined` for one page.
+ * @returns The pages, in order. Empty when there are no rows, which is what a
+ * real reader reports as `pageCount: 0`.
+ */
+function paginate(
+  rows: readonly (readonly FakeCell[])[],
+  pageSize: number | undefined,
+): (readonly FakeCell[])[][] {
+  if (rows.length === 0) {
+    return [];
+  }
+  const size = pageSize === undefined ? rows.length : pageSize;
+  const pages: (readonly FakeCell[])[][] = [];
+  for (let start = 0; start < rows.length; start += size) {
+    pages.push(rows.slice(start, start + size));
+  }
+  return pages;
+}
+
+/**
+ * Build a worksheet that records how it was used.
+ *
+ * @param config - What the worksheet holds and how it misbehaves.
+ * @returns The worksheet, with its {@link FakeWorksheet.calls} record attached.
+ */
+export function fakeWorksheet(config: FakeWorksheetConfig): FakeWorksheet {
+  const name = config.name ?? 'Sheet 1';
+  const calls: FakeWorksheetCalls = {
+    log: config.log ?? [],
+    readers: [],
+    selections: [],
+    releases: 0,
+    clears: 0,
+  };
+  const pages = paginate(config.rows, config.pageSize);
+
+  const openReader = (): TableauDataTableReader => ({
+    pageCount: pages.length,
+    totalRowCount: config.rows.length,
+    getPageAsync: async (pageNumber: number): Promise<TableauDataTable> => {
+      if (pageNumber === 0 && config.holdFirstPage !== undefined) {
+        await config.holdFirstPage;
+      }
+      calls.log.push(`page:${name}:${pageNumber}`);
+      if (pageNumber === config.failPage) {
+        throw config.pageError ?? new Error(`page ${pageNumber} of "${name}" failed`);
+      }
+      return fakeDataTable(config.columns, pages[pageNumber] ?? []);
+    },
+    releaseAsync: async (): Promise<void> => {
+      calls.releases++;
+      calls.log.push(`release:${name}`);
+      if (config.failRelease === true) {
+        throw new Error(`release of "${name}" failed`);
+      }
+    },
+  });
+
+  const worksheet: FakeWorksheet = {
+    name,
+    sheetType: 'worksheet',
+    calls,
+    getSummaryColumnsInfoAsync: async (): Promise<TableauColumn[]> => {
+      calls.log.push(`columns:${name}`);
+      return config.columns.map(column => ({ ...column }));
+    },
+    getSummaryDataReaderAsync: async (
+      pageRowCount?: number,
+      options?: TableauGetSummaryDataOptions,
+    ): Promise<TableauDataTableReader> => {
+      calls.readers.push({ pageRowCount, options });
+      calls.log.push(`open:${name}`);
+      return openReader();
+    },
+    selectMarksByValueAsync: async (
+      selections: readonly TableauSelectionCriteria[],
+      updateType: string,
+    ): Promise<void> => {
+      calls.selections.push({ criteria: selections, updateType });
+      calls.log.push(`select:${name}`);
+      if (config.failSelect === true) {
+        throw config.selectError ?? new Error(`selection in "${name}" failed`);
+      }
+    },
+    clearSelectedMarksAsync: async (): Promise<void> => {
+      calls.clears++;
+      calls.log.push(`clear:${name}`);
+      if (config.failClear === true) {
+        throw new Error(`clear of "${name}" failed`);
+      }
+    },
+  };
+
+  // Absent unless the test asks for it: `getVisualSpecificationAsync` is an
+  // Extensions API method, and the adapter feature-detects it precisely because
+  // the Embedding API does not have it.
+  if (config.spec !== undefined || config.specError !== undefined) {
+    worksheet.getVisualSpecificationAsync = async (): Promise<TableauVisualSpecification> => {
+      calls.log.push(`spec:${name}`);
+      if (config.specError !== undefined) {
+        throw config.specError;
+      }
+      return config.spec ?? {};
+    };
+  }
+
+  return worksheet;
+}
+
+/** What one worksheet contributes, as a test writes it. */
+export interface FakeSnapshotConfig {
+  /** Worksheet name, which is also the key overrides are looked up by. */
+  name?: string;
+  /** Columns in view order. */
+  columns: readonly TableauColumn[];
+  /**
+   * Rows in view order. A cell written as `undefined` stays `undefined`, which
+   * models a view column with no counterpart in the data table.
+   */
+  rows: readonly (readonly (FakeCell | undefined)[])[];
+  /** The visual specification, when the test exercises mark-type classification. */
+  spec?: TableauVisualSpecification;
+}
+
+/**
+ * Build the snapshot the pure half of the adapter consumes.
+ *
+ * `readWorksheet` produces these; the extractor only ever sees them, so its
+ * tests skip the async half entirely and hand one over directly.
+ *
+ * @param config - What the worksheet holds.
+ * @returns The snapshot, with every cell wrapped as a data value.
+ */
+export function fakeSnapshot(config: FakeSnapshotConfig): WorksheetSnapshot {
+  const rows: TableauRow[] = config.rows.map(row =>
+    row.map(cell => (cell === undefined ? undefined : toDataValue(cell))),
+  );
+  return {
+    name: config.name ?? 'Sheet 1',
+    columns: config.columns,
+    rows,
+    ...(config.spec === undefined ? {} : { spec: config.spec }),
+  };
+}
+
+/**
+ * Build a dashboard sheet over a set of worksheets, in add-order.
+ *
+ * @param worksheets - The worksheets, in the order the author added them.
+ * @param name - The dashboard's name.
+ * @returns The dashboard.
+ */
+export function fakeDashboard(
+  worksheets: readonly TableauWorksheet[],
+  name = 'Dashboard 1',
+): TableauDashboard {
+  return { name, sheetType: 'dashboard', worksheets };
+}
+
+/**
+ * Build a live `<tableau-viz>` element whose active sheet is a dashboard.
+ *
+ * A real one is a custom element the Embedding library upgraded, so this uses a
+ * genuine element rather than a cast: the binder inserts a sibling next to it
+ * and must never re-parent it, and only a real node can show that.
+ *
+ * @param worksheets - The dashboard's worksheets, in add-order.
+ * @param name - The dashboard's name.
+ * @returns The viz element, already carrying a workbook.
+ * @throws When there is no DOM — add `@jest-environment jsdom` to the test.
+ */
+export function fakeDashboardViz(
+  worksheets: readonly TableauWorksheet[],
+  name = 'Dashboard 1',
+): TableauViz {
+  if (typeof document === 'undefined') {
+    throw new TypeError(
+      'fakeDashboardViz needs a DOM; add a `@jest-environment jsdom` docblock.',
+    );
+  }
+  const element = document.createElement('tableau-viz');
+  const workbook: TableauWorkbook = { name, activeSheet: fakeDashboard(worksheets, name) };
+  Object.defineProperty(element, 'workbook', { value: workbook, configurable: true });
+  return element;
+}

--- a/test/adapters/tableau/helpers.ts
+++ b/test/adapters/tableau/helpers.ts
@@ -6,18 +6,24 @@
  * `src/adapters/tableau/types.ts` — so a plain object satisfies it and no
  * network, no live viz and no vendor bundle are needed here.
  *
- * The factories deliberately reproduce the two traps the real API sets, because
- * a fake that is tidier than the thing it stands in for proves nothing:
+ * The factories deliberately reproduce the traps the real API sets, because a
+ * fake that is tidier than the thing it stands in for proves nothing:
  *
  * - {@link fakeDataTable} sorts its columns **alphabetically**, exactly as a
  *   real `DataTableReader` does, while {@link fakeWorksheet} keeps
  *   `getSummaryColumnsInfoAsync` in view order. A test that writes its columns
- *   in view order and reads its rows back in view order is therefore proving
- *   the view↔alphabetical remap works, not assuming it away.
+ *   so that the two orders differ, and reads its rows back in view order, is
+ *   therefore proving the view↔alphabetical remap works rather than assuming it
+ *   away — a fixture whose names happen to be alphabetical already proves
+ *   nothing, since the remap is then the identity.
  * - {@link fakeWorksheet} counts the readers it opens and the releases it is
  *   given and records the order of every call in a shared log, so a leaked
  *   reader or a read that started before the previous one finished is a failed
  *   assertion rather than an invisible bug.
+ * - {@link fakeViz} exposes `workbook` as an accessor that **throws** until the
+ *   viz is interactive, rather than leaving the property undefined, because
+ *   that is what the real custom element does and it is the difference between
+ *   waiting for `firstinteractive` and appearing to be ready.
  *
  * Not a test file: jest's `*.test.ts` glob does not match this name.
  */
@@ -32,6 +38,7 @@ import type {
   TableauGetSummaryDataOptions,
   TableauRow,
   TableauSelectionCriteria,
+  TableauSheet,
   TableauVisualSpecification,
   TableauViz,
   TableauWorkbook,
@@ -91,7 +98,14 @@ export interface FakeWorksheetConfig {
   name?: string;
   /** Columns in **view order**, as `getSummaryColumnsInfoAsync` returns them. */
   columns: readonly TableauColumn[];
-  /** Rows in view order; the reader serves them alphabetically remapped. */
+  /**
+   * Rows in view order; the reader serves them alphabetically remapped.
+   *
+   * Read when a reader is *opened*, not when the worksheet is built, exactly as
+   * a real one snapshots the view at that moment. A test that keeps a mutable
+   * reference to this array can therefore change what the next read returns,
+   * which is how a filter change is expressed here.
+   */
   rows: readonly (readonly FakeCell[])[];
   /**
    * The visual specification to report. When omitted the worksheet has **no**
@@ -252,29 +266,33 @@ export function fakeWorksheet(config: FakeWorksheetConfig): FakeWorksheet {
     releases: 0,
     clears: 0,
   };
-  const pages = paginate(config.rows, config.pageSize);
-
-  const openReader = (): TableauDataTableReader => ({
-    pageCount: pages.length,
-    totalRowCount: config.rows.length,
-    getPageAsync: async (pageNumber: number): Promise<TableauDataTable> => {
-      if (pageNumber === 0 && config.holdFirstPage !== undefined) {
-        await config.holdFirstPage;
-      }
-      calls.log.push(`page:${name}:${pageNumber}`);
-      if (pageNumber === config.failPage) {
-        throw config.pageError ?? new Error(`page ${pageNumber} of "${name}" failed`);
-      }
-      return fakeDataTable(config.columns, pages[pageNumber] ?? []);
-    },
-    releaseAsync: async (): Promise<void> => {
-      calls.releases++;
-      calls.log.push(`release:${name}`);
-      if (config.failRelease === true) {
-        throw new Error(`release of "${name}" failed`);
-      }
-    },
-  });
+  // Paginated per reader rather than once per worksheet: the rows are whatever
+  // `config.rows` holds when the reader is opened, so a test can change the
+  // data between two reads the way a filter change does.
+  const openReader = (): TableauDataTableReader => {
+    const pages = paginate(config.rows, config.pageSize);
+    return {
+      pageCount: pages.length,
+      totalRowCount: config.rows.length,
+      getPageAsync: async (pageNumber: number): Promise<TableauDataTable> => {
+        if (pageNumber === 0 && config.holdFirstPage !== undefined) {
+          await config.holdFirstPage;
+        }
+        calls.log.push(`page:${name}:${pageNumber}`);
+        if (pageNumber === config.failPage) {
+          throw config.pageError ?? new Error(`page ${pageNumber} of "${name}" failed`);
+        }
+        return fakeDataTable(config.columns, pages[pageNumber] ?? []);
+      },
+      releaseAsync: async (): Promise<void> => {
+        calls.releases++;
+        calls.log.push(`release:${name}`);
+        if (config.failRelease === true) {
+          throw new Error(`release of "${name}" failed`);
+        }
+      },
+    };
+  };
 
   const worksheet: FakeWorksheet = {
     name,
@@ -377,29 +395,79 @@ export function fakeDashboard(
   return { name, sheetType: 'dashboard', worksheets };
 }
 
+/** A viz element whose active sheet the test can change, or take away. */
+export interface FakeVizHandle {
+  /** The element itself. */
+  readonly viz: TableauViz;
+  /**
+   * Make this sheet the active one, or `null` to make the viz unreadable again.
+   *
+   * Setting a sheet is what a `tabswitched` means; `null` is a viz that has not
+   * become interactive.
+   */
+  readonly setActiveSheet: (sheet: TableauSheet | null) => void;
+}
+
 /**
- * Build a live `<tableau-viz>` element whose active sheet is a dashboard.
+ * Build a live `<tableau-viz>` element whose active sheet a test controls.
  *
  * A real one is a custom element the Embedding library upgraded, so this uses a
  * genuine element rather than a cast: the binder inserts a sibling next to it
  * and must never re-parent it, and only a real node can show that.
  *
+ * `workbook` is an accessor that **throws** until a sheet is set, which is what
+ * a real viz does before it is interactive — the property exists from the
+ * moment the element is upgraded, and reading through it is what fails. An
+ * adapter that treats `workbook !== undefined` as readiness therefore breaks
+ * here rather than passing by accident.
+ *
+ * @param active - The sheet to start active, or `null` for a viz that is still
+ * loading.
+ * @param name - The workbook's name.
+ * @returns The element and the setter that changes its active sheet.
+ * @throws When there is no DOM — add `@jest-environment jsdom` to the test.
+ */
+export function fakeViz(
+  active: TableauSheet | null = null,
+  name = 'Workbook 1',
+): FakeVizHandle {
+  if (typeof document === 'undefined') {
+    throw new TypeError('fakeViz needs a DOM; add a `@jest-environment jsdom` docblock.');
+  }
+  const element = document.createElement('tableau-viz');
+  let sheet = active;
+  Object.defineProperty(element, 'workbook', {
+    configurable: true,
+    get(): TableauWorkbook {
+      if (sheet === null) {
+        throw new Error('the viz is not interactive yet');
+      }
+      // A fresh wrapper per read, as the custom element builds one.
+      return { name, activeSheet: sheet };
+    },
+  });
+
+  return {
+    viz: element,
+    setActiveSheet: (next: TableauSheet | null): void => {
+      sheet = next;
+    },
+  };
+}
+
+/**
+ * Build a live `<tableau-viz>` element whose active sheet is a dashboard.
+ *
+ * The common case of {@link fakeViz}, for a test that never changes the sheet.
+ *
  * @param worksheets - The dashboard's worksheets, in add-order.
  * @param name - The dashboard's name.
- * @returns The viz element, already carrying a workbook.
+ * @returns The viz element, already carrying a readable workbook.
  * @throws When there is no DOM — add `@jest-environment jsdom` to the test.
  */
 export function fakeDashboardViz(
   worksheets: readonly TableauWorksheet[],
   name = 'Dashboard 1',
 ): TableauViz {
-  if (typeof document === 'undefined') {
-    throw new TypeError(
-      'fakeDashboardViz needs a DOM; add a `@jest-environment jsdom` docblock.',
-    );
-  }
-  const element = document.createElement('tableau-viz');
-  const workbook: TableauWorkbook = { name, activeSheet: fakeDashboard(worksheets, name) };
-  Object.defineProperty(element, 'workbook', { value: workbook, configurable: true });
-  return element;
+  return fakeViz(fakeDashboard(worksheets, name), name).viz;
 }

--- a/test/adapters/tableau/reader.test.ts
+++ b/test/adapters/tableau/reader.test.ts
@@ -17,9 +17,19 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
-/** The columns every worksheet in this file reports, in view order. */
+/**
+ * The columns every worksheet in this file reports, in view order.
+ *
+ * The names are chosen so that view order and alphabetical order **disagree**:
+ * `'SUM(Sales)'` sorts before `'Zone'`, so `fakeDataTable` serves the measure
+ * first while `getSummaryColumnsInfoAsync` reports the dimension first. Every
+ * assertion below that reads `row[0]` as the zone and `row[1]` as the measure
+ * therefore fails unless the reader really applies its index map — with an
+ * already-alphabetical fixture the remap would be the identity and prove
+ * nothing.
+ */
 const columns = [
-  fakeColumn('Category', 'string', 0),
+  fakeColumn('Zone', 'string', 0),
   fakeColumn('SUM(Sales)', 'float', 1),
 ];
 
@@ -52,7 +62,8 @@ describe('tableau worksheet reader', () => {
 
     expect(snapshot.name).toBe('Sales');
     expect(snapshot.rows).toHaveLength(5);
-    // View order, not the alphabetical order the reader's own columns are in.
+    // View order, not the alphabetical order the reader's own columns are in:
+    // the table serves `SUM(Sales)` first, and these come back as the zones.
     expect(snapshot.rows.map(row => row[0]?.nativeValue)).toEqual([
       'Chairs',
       'Tables',

--- a/test/adapters/tableau/reader.test.ts
+++ b/test/adapters/tableau/reader.test.ts
@@ -1,0 +1,205 @@
+import { readWorksheet } from '@adapters/tableau/reader';
+import { fakeColumn, fakeWorksheet } from './helpers';
+
+/**
+ * A promise a test can settle on demand.
+ *
+ * Used to hold a worksheet's first page open while a second read is started,
+ * which is the only way to observe whether the two overlap.
+ *
+ * @returns The promise and the function that resolves it.
+ */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => {};
+  const promise = new Promise<void>((settle) => {
+    resolve = (): void => settle();
+  });
+  return { promise, resolve };
+}
+
+/** The columns every worksheet in this file reports, in view order. */
+const columns = [
+  fakeColumn('Category', 'string', 0),
+  fakeColumn('SUM(Sales)', 'float', 1),
+];
+
+describe('tableau worksheet reader', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('concatenates every page in page order, remapped into view order', async () => {
+    const worksheet = fakeWorksheet({
+      name: 'Sales',
+      columns,
+      rows: [
+        ['Chairs', 1],
+        ['Tables', 2],
+        ['Phones', 3],
+        ['Copiers', 4],
+        ['Binders', 5],
+      ],
+      pageSize: 2,
+    });
+
+    const snapshot = await readWorksheet(worksheet);
+
+    expect(snapshot.name).toBe('Sales');
+    expect(snapshot.rows).toHaveLength(5);
+    // View order, not the alphabetical order the reader's own columns are in.
+    expect(snapshot.rows.map(row => row[0]?.nativeValue)).toEqual([
+      'Chairs',
+      'Tables',
+      'Phones',
+      'Copiers',
+      'Binders',
+    ]);
+    expect(snapshot.rows.map(row => row[1]?.nativeValue)).toEqual([1, 2, 3, 4, 5]);
+    expect(worksheet.calls.log).toEqual([
+      'columns:Sales',
+      'open:Sales',
+      'page:Sales:0',
+      'page:Sales:1',
+      'page:Sales:2',
+      'release:Sales',
+    ]);
+  });
+
+  it('asks for all rows and nothing else, leaving the page size at the default', async () => {
+    const worksheet = fakeWorksheet({ columns, rows: [['Chairs', 1]] });
+
+    await readWorksheet(worksheet);
+
+    // `ignoreSelection` is documented backwards on both API surfaces, so it is
+    // never passed — the binder clears the selection before a read instead.
+    expect(worksheet.calls.readers).toEqual([
+      { pageRowCount: undefined, options: { maxRows: 0 } },
+    ]);
+  });
+
+  it('releases the reader even when a page rejects, and reports the page error', async () => {
+    const worksheet = fakeWorksheet({
+      name: 'Sales',
+      columns,
+      rows: [['Chairs', 1], ['Tables', 2]],
+      pageSize: 1,
+      failPage: 1,
+      pageError: new Error('boom'),
+    });
+
+    await expect(readWorksheet(worksheet)).rejects.toThrow('boom');
+
+    // A leaked reader would block every later read: only one is supported.
+    expect(worksheet.calls.releases).toBe(1);
+    expect(worksheet.calls.log).toContain('release:Sales');
+  });
+
+  it('never lets a release failure replace the error that caused it', async () => {
+    const worksheet = fakeWorksheet({
+      columns,
+      rows: [['Chairs', 1]],
+      failPage: 0,
+      pageError: new Error('boom'),
+      failRelease: true,
+    });
+
+    await expect(readWorksheet(worksheet)).rejects.toThrow('boom');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to release'),
+      expect.anything(),
+    );
+  });
+
+  it('still returns the rows when only the release fails', async () => {
+    const worksheet = fakeWorksheet({
+      columns,
+      rows: [['Chairs', 1]],
+      failRelease: true,
+    });
+
+    const snapshot = await readWorksheet(worksheet);
+
+    expect(snapshot.rows).toHaveLength(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes concurrent reads, opening the second reader only after the first is released', async () => {
+    const log: string[] = [];
+    const gate = deferred();
+    const first = fakeWorksheet({
+      name: 'A',
+      columns,
+      rows: [['Chairs', 1]],
+      log,
+      holdFirstPage: gate.promise,
+    });
+    const second = fakeWorksheet({ name: 'B', columns, rows: [['Tables', 2]], log });
+
+    const both = Promise.all([readWorksheet(first), readWorksheet(second)]);
+    gate.resolve();
+    await both;
+
+    // Only one active `DataTableReader` for summary data is supported, so B's
+    // reader must not exist while A's is still paginating.
+    expect(log.filter(entry => /^(?:open|release):/.test(entry))).toEqual([
+      'open:A',
+      'release:A',
+      'open:B',
+      'release:B',
+    ]);
+  });
+
+  it('reports no visual specification when the host has no such method', async () => {
+    const worksheet = fakeWorksheet({ columns, rows: [['Chairs', 1]] });
+
+    expect(worksheet.getVisualSpecificationAsync).toBeUndefined();
+
+    const snapshot = await readWorksheet(worksheet);
+
+    expect(snapshot.spec).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('carries the visual specification through when the host does expose one', async () => {
+    const worksheet = fakeWorksheet({
+      columns,
+      rows: [['Chairs', 1]],
+      spec: { marksSpecifications: [{ primitiveType: 'bar' }] },
+    });
+
+    const snapshot = await readWorksheet(worksheet);
+
+    expect(snapshot.spec).toEqual({ marksSpecifications: [{ primitiveType: 'bar' }] });
+  });
+
+  it('degrades to no specification, with one warning, when reading it throws', async () => {
+    const worksheet = fakeWorksheet({
+      columns,
+      rows: [['Chairs', 1]],
+      specError: new Error('not supported'),
+    });
+
+    const snapshot = await readWorksheet(worksheet);
+
+    // A spec is evidence, not a requirement: losing it costs the mark type,
+    // which the heuristic ladder stands in for.
+    expect(snapshot.spec).toBeUndefined();
+    expect(snapshot.rows).toHaveLength(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads an empty worksheet as no rows, still opening and releasing a reader', async () => {
+    const worksheet = fakeWorksheet({ name: 'Empty', columns, rows: [] });
+
+    const snapshot = await readWorksheet(worksheet);
+
+    expect(snapshot.rows).toEqual([]);
+    expect(worksheet.calls.log).toEqual(['columns:Empty', 'open:Empty', 'release:Empty']);
+  });
+});

--- a/test/adapters/tableau/selection.test.ts
+++ b/test/adapters/tableau/selection.test.ts
@@ -1,0 +1,302 @@
+import type { SelectionBridge } from '@adapters/tableau/selection';
+import type {
+  TableauRangeValue,
+  TableauSelectionCriteria,
+  TableauWorksheet,
+  WorksheetSnapshot,
+} from '@adapters/tableau/types';
+import type { FakeWorksheet } from './helpers';
+import { extractTableau } from '@adapters/tableau/extractor';
+import { applySelection, createSelectionGuard } from '@adapters/tableau/selection';
+import { fakeColumn, fakeSnapshot, fakeWorksheet } from './helpers';
+
+/**
+ * The Tableau selection bridge: MAIDR's cursor mirrored into the viz.
+ *
+ * An embedded viz gives the adapter no DOM to highlight — the marks are inside
+ * Tableau's iframe — so the only visual feedback channel is Tableau's own mark
+ * selection. Everything here is therefore about *addressing*: whether a
+ * navigation position names marks exactly, and what happens when it does not.
+ *
+ * The index is never hand-written. Every case runs the real extractor over a
+ * worksheet snapshot and drives {@link applySelection} with the result, because
+ * the interesting failures are disagreements between the two — a cell index
+ * that addresses the wrong row, or a filler cell the extractor invented and the
+ * bridge then tries to select.
+ */
+
+const REGION = fakeColumn('Region', 'string', 0);
+const SEGMENT = fakeColumn('Segment', 'string', 1);
+const SALES = fakeColumn('SUM(Sales)', 'float', 2);
+
+const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+/** A worksheet snapshot plus the fake worksheet a selection is applied to. */
+interface Bound {
+  readonly bridge: SelectionBridge;
+  readonly worksheet: FakeWorksheet;
+}
+
+/**
+ * Extract a snapshot and wire its selection index to a recording worksheet.
+ *
+ * @param snapshot - The worksheet snapshot to extract.
+ * @param config - How the worksheet misbehaves.
+ * @param config.failSelect - Whether `selectMarksByValueAsync` should reject.
+ * @returns The bridge {@link applySelection} takes, and the worksheet it drives.
+ */
+function bind(
+  snapshot: WorksheetSnapshot,
+  config: { failSelect?: boolean } = {},
+): Bound {
+  const worksheet = fakeWorksheet({
+    name: snapshot.name,
+    columns: snapshot.columns,
+    rows: [],
+    ...config,
+  });
+
+  const { selection } = extractTableau([snapshot]);
+  const worksheets = new Map<string, TableauWorksheet>();
+  for (const layerId of selection.worksheets.keys()) {
+    worksheets.set(layerId, worksheet);
+  }
+
+  return {
+    bridge: {
+      index: selection,
+      worksheets,
+      guard: createSelectionGuard(),
+      disabled: new Set<string>(),
+    },
+    worksheet,
+  };
+}
+
+/**
+ * Read a criterion's value as a range.
+ *
+ * `SelectionCriteria.value` is a union, so a test that means to assert on the
+ * documented single-date form has to narrow first rather than cast.
+ *
+ * @param criterion - The criterion to read.
+ * @returns Its range value.
+ * @throws When the criterion carries a string or a list instead.
+ */
+function asRange(criterion: TableauSelectionCriteria): TableauRangeValue {
+  const { value } = criterion;
+  if (typeof value === 'string' || Array.isArray(value)) {
+    throw new TypeError(`expected a range, got ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/** Two dimensions and a measure: the grouped-bar reading of a worksheet. */
+function groupedSnapshot(
+  rows: readonly (readonly (string | number)[])[],
+): WorksheetSnapshot {
+  return fakeSnapshot({
+    name: 'Sales by Region',
+    columns: [REGION, SEGMENT, SALES],
+    rows,
+  });
+}
+
+/**
+ * A point cloud: two measures, and dimensions that are distinct per row.
+ *
+ * @param dimensions - The detail dimensions, in view order.
+ * @param rows - Eight rows, in view order.
+ * @returns The snapshot.
+ */
+function cloudSnapshot(
+  dimensions: readonly string[],
+  rows: readonly (readonly (string | number)[])[],
+): WorksheetSnapshot {
+  return fakeSnapshot({
+    name: 'Customers',
+    columns: [
+      ...dimensions.map((name, index) => fakeColumn(name, 'string', index)),
+      fakeColumn('SUM(Sales)', 'float', dimensions.length),
+      fakeColumn('SUM(Profit)', 'float', dimensions.length + 1),
+    ],
+    rows,
+  });
+}
+
+describe('tableau selection bridge', () => {
+  beforeEach(() => {
+    warn.mockClear();
+  });
+
+  afterAll(() => {
+    warn.mockRestore();
+  });
+
+  describe('addressing a cell', () => {
+    it('should address a grouped cell by both of its dimensions', async () => {
+      const { bridge, worksheet } = bind(groupedSnapshot([
+        ['East', 'Consumer', 10],
+        ['East', 'Corporate', 20],
+        ['West', 'Consumer', 30],
+        ['West', 'Corporate', 40],
+      ]));
+
+      // Row 1 is the second group (`Corporate`), column 1 the second category
+      // (`West`) — the cell holding 40.
+      await applySelection(bridge, { layerId: '0', row: 1, col: 1 });
+
+      expect(worksheet.calls.selections).toEqual([{
+        criteria: [
+          { fieldName: 'Region', value: 'West' },
+          { fieldName: 'Segment', value: 'Corporate' },
+        ],
+        updateType: 'select-replace',
+      }]);
+    });
+
+    it('should spell the criterion key `value`, singular, on every clause', async () => {
+      const { bridge, worksheet } = bind(groupedSnapshot([
+        ['East', 'Consumer', 10],
+        ['East', 'Corporate', 20],
+        ['West', 'Consumer', 30],
+        ['West', 'Corporate', 40],
+      ]));
+
+      await applySelection(bridge, { layerId: '0', row: 0, col: 0 });
+
+      // `values` would be silently ignored by Tableau and select nothing, so
+      // the key itself is asserted rather than only the criteria's contents.
+      const [call] = worksheet.calls.selections;
+      expect(call.criteria.map(criterion => Object.keys(criterion).sort()))
+        .toEqual([['fieldName', 'value'], ['fieldName', 'value']]);
+    });
+
+    it('should address a date dimension as a range whose ends are the same day', async () => {
+      const march = new Date('2021-03-01T00:00:00.000Z');
+      const april = new Date('2021-04-01T00:00:00.000Z');
+      const { bridge, worksheet } = bind(fakeSnapshot({
+        name: 'Sales over time',
+        columns: [fakeColumn('Order Date', 'date-time', 0), SALES],
+        rows: [[march, 10], [april, 20]],
+      }));
+
+      // A temporal category is read as a line, so the cells are
+      // `[series][sample]` and column 1 is April.
+      await applySelection(bridge, { layerId: '0', row: 0, col: 1 });
+
+      const [call] = worksheet.calls.selections;
+      expect(call.criteria).toHaveLength(1);
+      expect(call.criteria[0].fieldName).toBe('Order Date');
+      const range = asRange(call.criteria[0]);
+      expect(range.min).toBe(april);
+      expect(range.max).toBe(april);
+    });
+
+    it('should clear rather than select a rectangularized filler cell', async () => {
+      // `(Consumer, West)` was never drawn; the extractor fills it with `y: 0`
+      // so the segmented rows stay equal length, and gives it `null` criteria.
+      const { bridge, worksheet } = bind(groupedSnapshot([
+        ['East', 'Consumer', 10],
+        ['West', 'Corporate', 40],
+      ]));
+
+      await applySelection(bridge, { layerId: '0', row: 0, col: 1 });
+
+      expect(worksheet.calls.selections).toHaveLength(0);
+      expect(worksheet.calls.clears).toBe(1);
+    });
+  });
+
+  describe('addressing a set of points', () => {
+    const CUSTOMERS = Array.from({ length: 8 }, (_, index) => index);
+
+    it('should select the single point a highlight covers', async () => {
+      const { bridge, worksheet } = bind(cloudSnapshot(
+        ['Customer'],
+        CUSTOMERS.map(index => [`C${index}`, index * 10, index]),
+      ));
+
+      // `pointIndices` means `row` and `col` name no position and are `-1`.
+      await applySelection(bridge, {
+        layerId: '0',
+        row: -1,
+        col: -1,
+        pointIndices: [3],
+      });
+
+      expect(worksheet.calls.selections).toEqual([{
+        criteria: [{ fieldName: 'Customer', value: 'C3' }],
+        updateType: 'select-replace',
+      }]);
+    });
+
+    it('should merge points differing in one field into one array-valued clause', async () => {
+      const { bridge, worksheet } = bind(cloudSnapshot(
+        ['Customer'],
+        CUSTOMERS.map(index => [`C${index}`, index * 10, index]),
+      ));
+
+      await applySelection(bridge, {
+        layerId: '0',
+        row: -1,
+        col: -1,
+        pointIndices: [3, 7],
+      });
+
+      // One clause, not two: `[{Customer: 'C3'}, {Customer: 'C7'}]` would be
+      // read as a cross product and select nothing.
+      expect(worksheet.calls.selections).toEqual([{
+        criteria: [{ fieldName: 'Customer', value: ['C3', 'C7'] }],
+        updateType: 'select-replace',
+      }]);
+    });
+
+    it('should clear rather than over-select points differing in two fields', async () => {
+      const { bridge, worksheet } = bind(cloudSnapshot(
+        ['Customer', 'Territory'],
+        CUSTOMERS.map(index => [`C${index}`, `T${index}`, index * 10, index]),
+      ));
+
+      await applySelection(bridge, {
+        layerId: '0',
+        row: -1,
+        col: -1,
+        pointIndices: [3, 7],
+      });
+
+      // `{Customer: [C3, C7]}` and `{Territory: [T3, T7]}` together select the
+      // four-way cross product — two marks the reader is not on.
+      expect(worksheet.calls.selections).toHaveLength(0);
+      expect(worksheet.calls.clears).toBe(1);
+    });
+  });
+
+  describe('when tableau refuses the selection', () => {
+    it('should disable that layer permanently and warn exactly once', async () => {
+      const { bridge, worksheet } = bind(
+        groupedSnapshot([
+          ['East', 'Consumer', 10],
+          ['East', 'Corporate', 20],
+          ['West', 'Consumer', 30],
+          ['West', 'Corporate', 40],
+        ]),
+        { failSelect: true },
+      );
+
+      await applySelection(bridge, { layerId: '0', row: 0, col: 0 });
+
+      expect(worksheet.calls.selections).toHaveLength(1);
+      expect(worksheet.calls.clears).toBe(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('mark selection is now disabled');
+
+      await applySelection(bridge, { layerId: '0', row: 1, col: 1 });
+
+      // A rejected field name is wrong on every arrow key, so the second
+      // navigation must not retry it — nor log a second time.
+      expect(worksheet.calls.selections).toHaveLength(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/adapters/tableau/selection.test.ts
+++ b/test/adapters/tableau/selection.test.ts
@@ -194,8 +194,10 @@ describe('tableau selection bridge', () => {
     });
 
     it('should clear rather than select a rectangularized filler cell', async () => {
-      // `(Consumer, West)` was never drawn; the extractor fills it with `y: 0`
-      // so the segmented rows stay equal length, and gives it `null` criteria.
+      // `(Consumer, West)` was never drawn; the extractor pads it with a gap so
+      // the segmented rows stay equal length, and gives it `null` criteria —
+      // the pad is scaffolding, and selecting a mark nobody drew is worse than
+      // selecting nothing.
       const { bridge, worksheet } = bind(groupedSnapshot([
         ['East', 'Consumer', 10],
         ['West', 'Corporate', 40],
@@ -273,7 +275,7 @@ describe('tableau selection bridge', () => {
   });
 
   describe('when tableau refuses the selection', () => {
-    it('should disable that layer permanently and warn exactly once', async () => {
+    it('should disable that worksheet permanently and warn exactly once', async () => {
       const { bridge, worksheet } = bind(
         groupedSnapshot([
           ['East', 'Consumer', 10],
@@ -296,6 +298,66 @@ describe('tableau selection bridge', () => {
       // A rejected field name is wrong on every arrow key, so the second
       // navigation must not retry it — nor log a second time.
       expect(worksheet.calls.selections).toHaveLength(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should follow the worksheet that refused, not the layer id it sat at', async () => {
+      const rows = [
+        ['East', 'Consumer', 10],
+        ['East', 'Corporate', 20],
+        ['West', 'Consumer', 30],
+        ['West', 'Corporate', 40],
+      ];
+      const columns = [REGION, SEGMENT, SALES];
+      const refused = fakeWorksheet({
+        name: 'Sales by Region',
+        columns,
+        rows: [],
+        failSelect: true,
+      });
+      const willing = fakeWorksheet({ name: 'Profit by Region', columns, rows: [] });
+      // Two layers, so both `'0'` and `'1'` address a real cell and a latch can
+      // be asked which of the two it followed.
+      const { selection } = extractTableau([
+        fakeSnapshot({ name: refused.name, columns, rows }),
+        fakeSnapshot({ name: willing.name, columns, rows }),
+      ]);
+      // Shared across the bridges, as the binder shares one set across every
+      // refresh: a worksheet that rejects once rejects on every later read of
+      // the same fields.
+      const disabled = new Set<string>();
+      const guard = createSelectionGuard();
+      const bridgeOver = (
+        layers: Record<string, TableauWorksheet>,
+      ): SelectionBridge => ({
+        index: selection,
+        worksheets: new Map(Object.entries(layers)),
+        guard,
+        disabled,
+      });
+
+      await applySelection(
+        bridgeOver({ 0: refused, 1: willing }),
+        { layerId: '0', row: 0, col: 0 },
+      );
+
+      expect(refused.calls.selections).toHaveLength(1);
+      expect(warn.mock.calls[0][0]).toContain('"Sales by Region"');
+
+      // A refresh that drops a worksheet renumbers every layer after it, so the
+      // id the rejection happened at now belongs to a worksheet that never
+      // refused anything. Latching by position would silence it.
+      await applySelection(bridgeOver({ 0: willing }), { layerId: '0', row: 0, col: 0 });
+
+      expect(willing.calls.selections).toHaveLength(1);
+
+      // And the worksheet that did refuse stays disabled wherever it lands.
+      await applySelection(
+        bridgeOver({ 0: willing, 1: refused }),
+        { layerId: '1', row: 1, col: 1 },
+      );
+
+      expect(refused.calls.selections).toHaveLength(1);
       expect(warn).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
# Pull Request

## Description

Adds a Tableau adapter, so an embedded Tableau viz becomes navigable with sonification, text descriptions and braille.

A Tableau viz renders inside a cross-origin iframe MAIDR cannot reach, which makes this the first adapter with **no selectors at all**. It reads each worksheet's summary data through the Embedding API v3 and drives highlighting back through Tableau's own `selectMarksByValueAsync`, wired to the `onNavigate` callback the canvas adapters already use. Everything else — audio, text, braille, autoplay, review, the description modal — works exactly as it does elsewhere.

Put a `tableau-viz` element on the page, load `dist/tableau.js`, and bind once the viz is interactive:

```js
const viz = document.getElementById('viz');

viz.addEventListener('firstinteractive', async () => {
  const binding = await maidrTableau.bindTableau(viz);
  if (binding === null) {
    // No worksheet in the dashboard could be read.
  }
});
```

`bindTableau` is async — nothing in the workbook is readable before `firstinteractive`, and it can only report whether any worksheet produced a layer after it has read them.

**The Embedding API ships here; the Dashboard Extensions API does not.** An extension needs a `.trex` manifest and per-site admin safe-listing before it will run at all, so it cannot carry a reviewable demo or a working example page. The shared modules (`reader`, `fields`, `extractor`, `selection`) are written against a structural worksheet interface that both surfaces satisfy, so that follow-up is a second binder rather than a rewrite. `getVisualSpecificationAsync` is already feature-detected and consumed when present, so it lights up for free under that binder.

No new runtime dependency: every Tableau type is our own structural interface.

**Live preview:** https://pr-932.maidr-preview.pages.dev/examples/tableau-bar.html

## Related Issues

None — this is new integration work. Six follow-ups are listed under *Additional Notes*.

## Changes Made

**New — `src/adapters/tableau/`**

| File | Purpose |
|---|---|
| `types.ts` | Structural interfaces for the Tableau surface we duck-type against, plus the public options types |
| `fields.ts` | Column classification (measure vs dimension), the view↔alphabetical index remap, value coercion |
| `reader.ts` | The only module that awaits Tableau: paginated reads, guaranteed `releaseAsync`, a single-reader mutex |
| `extractor.ts` | Pure worksheet-snapshots → `Maidr` schema + a `SelectionIndex` |
| `selection.ts` | The `onNavigate` → Tableau selection bridge |
| `binder.tsx` | `bindTableau` — mount, event wiring, debounced refresh, dispose |
| `index.ts`, `src/tableau-entry.ts` | Barrel and bundle entry (`maidrTableau` UMD global) |

**Registration** — a `tableau` bundle in `scripts/build.js`, a `./tableau` export, and the docs-site nav, page, sitemap and examples-gallery entries.

**Docs** — `docs/tableau.md` and `examples/tableau-bar.html` (a Tableau Public view, so it needs no auth).

**Reading smaller rather than guessing.** Summary data cannot distinguish a stacked bar from a side-by-side one, so `dodged_bar` is the default and `stacked_bar` is reachable only through an explicit override. `heat` requires the mark type. Box, histogram, gantt, treemap and choropleth are not approximated — Tableau's summary data for a box plot is the disaggregated marks, and a quartile MAIDR computed itself is not the quartile Tableau drew.

## Screenshots (if applicable)

Not applicable — the change is non-visual by nature. The preview link above is the demonstration.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

Locally: `npm run type-check`, `npx eslint`, `npm test` (296 suites / 4450 tests + 10 / 137 ESM), `npm run build` (14 bundles) and `node scripts/build-site.js` all pass. E2E was not run locally; CI ran it and it passed.

## Additional Notes

### The second commit is the interesting one

The adapter was reviewed adversarially before this PR was opened: 35 findings raised, each one then handed to a separate verifier asked to *refute* it. 12 were refuted and left alone; 23 survived and are fixed in `1cd5ffa`. The ones worth flagging to a reviewer were all **silent-failure** bugs, where the chart kept announcing text while the parts a blind user actually depends on went quiet:

- `orientation: 'horz'` stamped the layer without transposing the points, so the bar model read a category string as its magnitude — every tone, the braille grid and extrema navigation lost, text still perfect.
- A refresh swapped the selection bridge before the mounted figure adopted the new data, so MAIDR announced one mark while Tableau highlighted another.
- The per-layer disable latch was keyed by a positional layer id that outlived a refresh, so it could silently disable a *different* worksheet.
- Two tests passed vacuously — one asserted an ordering that a missing call satisfied, the other exercised the column remap with a fixture already in the target order.

### Follow-ups worth filing

1. **Dashboard Extensions API binder** — a second entry reusing the shared modules, plus the `.trex` manifest and a settings-backed config dialog.
2. **Use `getVisualSpecificationAsync` for mark-type classification** — verify the real payload against the mapping table, especially dual-axis vizzes.
3. **Establish extension-iframe focus and screen-reader behaviour** — undocumented by Tableau; needs empirical testing on NVDA/JAWS/VoiceOver before the Extensions binder ships.
4. **Geometry-aware dashboard subplot grid** — currently N×1 in add-order.
5. **Stacked vs dodged detection** — or a conclusion that it is undecidable and the override is the only answer.
6. **Sync the MAIDR cursor from user mark selection** — blocked on a re-entrancy design.