### PR TITLE
feat(tableau): lay dashboard worksheets into a geometry-aware subplot grid

### DIFF
--- a/docs/tableau.md
+++ b/docs/tableau.md
@@ -65,8 +65,35 @@ The adapter never imports a Tableau package. It duck-types the live `<tableau-vi
 1. **Find the worksheets.** `viz.workbook.activeSheet` is read at bind time, and again on every refresh — a `tabswitched` event changes which sheet the worksheets come from. A `worksheet` sheet is a single worksheet; a `dashboard` contributes `dashboard.worksheets`, in the order the author added them — which is also the order Tableau's own documentation says a screen reader narrates a dashboard. A `story` sheet is skipped with a warning (see [Limitations](#limitations)).
 2. **Read the summary data.** For each worksheet the adapter calls `getSummaryColumnsInfoAsync()` for the columns *in view order*, then opens a `getSummaryDataReaderAsync()` and pages through it. The reader hands its columns back **alphabetically**, so the adapter builds a view-order-to-alphabetical index map by `fieldId` and remaps every row; every index downstream is a view index. The reader is always released in a `finally` block, and every read goes through a per-viz promise chain, because Tableau supports **only one active summary-data reader at a time** and a leaked one blocks the next read.
 3. **Classify the columns.** Each column becomes a measure or a dimension — see [Supported Chart Types](#supported-chart-types).
-4. **Decide the trace type and build the layer.** One worksheet produces exactly **one** MAIDR layer inside its own subplot; a dashboard of four worksheets is a four-row, one-column subplot grid.
+4. **Decide the trace type and build the layer.** One worksheet produces exactly **one** MAIDR layer inside its own subplot. How those subplots are arranged depends on what the dashboard reports about itself — see [Dashboard Layout](#dashboard-layout).
 5. **Mount.** A wrapper `<div>` is inserted before the viz element and a React root renders MAIDR into it. The viz element itself is never moved — `<tableau-viz>` is a custom element and re-parenting re-runs its `connectedCallback`, with undocumented consequences for the iframe.
+
+### Dashboard Layout
+
+A dashboard's worksheets become a **two-dimensional subplot grid that follows the dashboard's own layout** when the layout is readable and unambiguous, and a **one-worksheet-per-row column** whenever it is not. Both paths are always available and nothing on the page has to opt in.
+
+The geometry comes from `dashboard.objects`: each object reports a `position`, a `size`, and — for a worksheet object — the worksheet inside it. The binder reads it once per re-read and hands four numbers and two flags per worksheet to the extractor, which stays pure.
+
+**How the grid is worked out.** Worksheets are swept top to bottom into *bands*. A worksheet joins the band being built when its vertical extent overlaps the band's by at least **half of the shorter of the two**, and starts a new band otherwise; within a band the order is left to right. The threshold is a ratio rather than a pixel tolerance on purpose — ten pixels is generous on a 600px dashboard and meaningless on a 4000px one, and it moves again under browser zoom. Real tiled dashboards miss perfect alignment by the few pixels of an object's padding and border, which is an overlap of about 98%, so the threshold only bites on layouts that are genuinely ambiguous.
+
+Rows are **ragged by design**: a dashboard with two worksheets over one wide one is a two-then-one grid, not a padded 2×2.
+
+**The bottom row of the dashboard is row 0 of the figure**, so <kbd>↑</kbd> moves up the dashboard and <kbd>↓</kbd> moves down it. This is a consequence of there being no DOM to measure: MAIDR resolves a figure's visual ordering from the rendered SVG, the adapter emits no selectors because the marks are inside a cross-origin iframe, and the layout it falls back to numbers rows from the bottom. One honest cost comes with it: the *ordinal* in the announcement is counted in data order, so the bottom-left subplot is announced as "Subplot 1 of 6". The subplot's own title — the worksheet name — is what identifies it, and the arrows are the part that had to be spatially true.
+
+**When the column is used instead.** Any one of these is enough, and each one applies to the *whole* figure — a partly-guessed grid is worse than an honest column:
+
+- the embedding library on the page reports no dashboard geometry at all (an older build), or reports none for even one worksheet in the figure;
+- the active sheet is a single worksheet or a story, so there is no layout to read;
+- any worksheet **floats** rather than sitting in the tiled layout — a floating object is positioned independently and routinely sits on top of a tiled one, so its coordinates do not place it in a row;
+- any worksheet is **hidden** on the dashboard — dropping it would silently remove data the page may have named explicitly, and placing it in the grid would claim it is on screen;
+- any worksheet reports a zero or negative size;
+- the worksheets form a **staircase** that only chains into a row through a third worksheet in the middle;
+- two worksheets in the same band overlap horizontally by more than half the narrower one, so there is no left-to-right order between them;
+- the page passed `layout: 'column'`.
+
+Every case except the last two logs nothing when there was no geometry to judge; a dashboard that *did* report geometry and still got a column says why in one console warning.
+
+The layout is computed when the worksheets are read. A window resize does not recompute it — the adapter re-reads on filter, parameter, data and tab changes, not on `resize` — for the same reason refreshes are deferred by default: rebuilding the figure under someone who is mid-navigation is worse than a layout that reflects the dashboard as it was read.
 
 ### Highlighting
 
@@ -295,6 +322,7 @@ The resolved handle carries three members:
 | `title` | `string?` | Figure title announced for the whole view. |
 | `live` | `boolean?` | Apply refreshes in place while the reader is inside the chart. Default `false` — see [Refresh and Filters](#refresh-and-filters). |
 | `worksheets` | `string[]?` | Worksheet names to include, honoured in the order written. Default: every worksheet of the active sheet. |
+| `layout` | `'grid' \| 'column'?` | How a dashboard's worksheets are arranged into subplots. Default `'grid'`: follow the dashboard's own geometry when it is readable and unambiguous, and fall back to one worksheet per row otherwise. `'column'` always uses the column. See [Dashboard Layout](#dashboard-layout). |
 | `overrides` | `Record<string, TableauWorksheetOverride>?` | Per-worksheet configuration, keyed by worksheet name. |
 | `anchorLabel` | `string?` | Text on the keyboard entry point rendered beside the viz. Defaults to `Accessible chart view — press Enter, then use arrow keys`. Style it with the `[data-maidr-tableau-anchor]` attribute selector. |
 
@@ -358,7 +386,7 @@ Once the figure is focused, the standard MAIDR shortcuts apply:
 
 Two notes specific to this adapter:
 
-- **Up and Down, not Left and Right, move between worksheets.** A dashboard becomes an N×1 subplot column (see [Limitations](#limitations)), so Left and Right in the worksheet list are always out of bounds.
+- **Which arrows move between worksheets depends on the dashboard.** In the geometry-aware grid, Up and Down move between the dashboard's rows and Left and Right move along one — in the direction the dashboard is laid out, since its bottom row is the figure's row 0. In the column fallback there is one worksheet per row, so Left and Right are always out of bounds. See [Dashboard Layout](#dashboard-layout).
 - **<kbd>Page Up</kbd> and <kbd>Page Down</kbd> do nothing here.** Those keys switch between *layers* of one subplot, and a Tableau worksheet always produces exactly one layer. There is nothing for them to switch to.
 
 For the full list, see the [Keyboard Controls](CONTROLS.html) reference.
@@ -373,7 +401,8 @@ Stated plainly, because every one of these is a place where a plausible-looking 
 - **Box plots, histograms and treemaps are never inferred as themselves, and are not skipped either.** Their mark primitives — `circle`, `bar`, `square` — are the same ones a scatter, a bar chart and a heatmap are drawn with, so the mark type cannot separate them and they are announced as those instead, with no warning. (Gantt charts and choropleths *are* skipped: `gantt-bar` and `map` are theirs alone.) Exclude a view by name with `overrides['<worksheet>'].skip`, or declare what it is with `overrides['<worksheet>'].traceType`. See [Supported Chart Types](#supported-chart-types).
 - **A dual-axis worksheet is read as one of its axes.** Tableau reports a marks card per measure but nothing that says which axis a card belongs to, whether the axes are synchronized, or which summary-data column came from which card. The active card is read and the others are named in a warning.
 - **Story sheets are skipped.** The Embedding API has a listed known issue: a worksheet inside a story throws *operation not allowed on non-active sheet*.
-- **A dashboard becomes an N×1 subplot column**, in the order the worksheets were added to the dashboard — the order Tableau documents a screen reader as narrating them. Geometry-aware two-dimensional layout is not attempted, because the Embedding API's dashboard objects are not documented to carry position and size.
+- **A dashboard layout is followed only when it is unambiguous.** The grid is built from `dashboard.objects`' positions and sizes; a floating or hidden worksheet, a staircase, an overlap inside a row, or an embedding library that reports no geometry all fall the *whole* figure back to one worksheet per row, in the order the worksheets were added — the order Tableau documents a screen reader as narrating them. The full list is under [Dashboard Layout](#dashboard-layout).
+- **A grid's subplot ordinals are not its positions.** "Subplot 1 of 6" counts in data order, which starts at the bottom-left, because MAIDR derives visual ordering from the rendered SVG and a `<tableau-viz>`'s marks are inside a cross-origin iframe. The arrow keys *are* spatially true; only the number is not, and the announcement carries the worksheet's name with it.
 - **Summary data only.** Underlying data (`getUnderlyingTableDataReaderAsync`) is gated to Explorer and Creator roles and would fail silently for Viewer-role users, so it is never requested.
 - **Nothing is written back into the workbook.** No annotations, no filters, no parameter changes; the only write is the mark selection, and that is cleared when focus leaves MAIDR's block, before every re-read, and on `dispose()` — see [How It Works](#how-it-works).
 - **Authentication is the host page's job.** Tableau Public needs none. Tableau Cloud and Tableau Server do: a connected-app JWT must be minted **by your server** — the connected-app secret must never reach the browser — and handed to the component through the `token` attribute or `viz.token` before you bind. The adapter neither mints, refreshes, nor inspects a token.

--- a/src/adapters/tableau/binder.tsx
+++ b/src/adapters/tableau/binder.tsx
@@ -309,6 +309,12 @@ function readDashboardGeometry(
     if (![x, y, width, height].every(Number.isFinite)) {
       continue;
     }
+    // Keyed by worksheet name, which `Dashboard.worksheets` is documented to
+    // correspond to one-for-one with the `worksheet`-typed objects — so a name
+    // collision cannot arise from authoring, and a later object overwriting an
+    // earlier one's entry is a case the API's own contract rules out. Note this
+    // is `object.worksheet.name`, never `object.name`: the latter is the zone's
+    // authoring name and can differ from the sheet it holds.
     geometry.set(object.worksheet.name, {
       x,
       y,
@@ -490,6 +496,14 @@ export async function bindTableau(
   // Reassigned by every refresh: `tabswitched` makes a different sheet active,
   // and the worksheets discovered here belong to the sheet that was active at
   // bind time.
+  //
+  // `refresh()` discovers again rather than reusing this, so discovery runs
+  // twice on a bind. That is deliberate, not a leftover: this call exists so an
+  // empty sheet returns `null` *before* a wrapper is mounted, leaving the page
+  // untouched, while the call inside `refresh()` has to re-read because a
+  // `tabswitched` refresh describes a different sheet entirely. Both are a
+  // synchronous property walk over `dashboard.objects`, so the second read
+  // costs nothing worth restructuring for.
   let worksheets = selectWorksheets(discoverWorksheets(viz).worksheets, options);
   if (worksheets.length === 0) {
     warn('no worksheet to read on the active sheet; the page is unchanged.');

--- a/src/adapters/tableau/binder.tsx
+++ b/src/adapters/tableau/binder.tsx
@@ -49,9 +49,11 @@ import type { SelectionIndex } from './extractor';
 import type { SelectionBridge } from './selection';
 import type {
   TableauAdapterOptions,
+  TableauDashboardObject,
   TableauSheet,
   TableauViz,
   TableauWorksheet,
+  TableauWorksheetGeometry,
 } from './types';
 import { createRoot } from 'react-dom/client';
 import { Maidr as MaidrComponent } from '../../maidr-component';
@@ -244,11 +246,101 @@ function waitForFirstInteractive(viz: TableauViz): Promise<void> {
 }
 
 /**
- * Find every worksheet the active sheet exposes.
+ * Read each worksheet's place on the dashboard, keyed by worksheet name.
+ *
+ * `Dashboard.objects` and every member of a `DashboardObject` are **required**
+ * in Tableau's shipped declarations and none of them carries an `@since` tag,
+ * so the contract sets no version floor — which is exactly why none of it is
+ * trusted here. The host page loads whichever build of the Embedding library it
+ * likes, and the real case this covers is an older one: a library that predates
+ * the dashboard-object surface simply has no `objects`, and a partial one could
+ * hand back an object with no `position`. Every access below is therefore
+ * guarded, and any failure to read a worksheet's geometry leaves that worksheet
+ * out of the map rather than inventing a place for it. The extractor requires
+ * geometry for *every* surviving worksheet before it will build a grid, so a
+ * gap here is a whole-figure fall back to the N×1 column — never a half-grid.
+ *
+ * Only worksheet objects are considered. Legends, titles, filters and blanks
+ * are furniture: they hold no data, contribute no subplot, and their positions
+ * would only distort the banding.
+ *
+ * Matching is by `object.worksheet.name`, never by `object.name` — the latter
+ * is the *object's* authoring name, which an author can change without
+ * renaming the sheet inside it. Tableau documents `dashboard.worksheets` as
+ * exactly the worksheets of the objects whose type is `worksheet`, so the names
+ * line up by construction.
+ *
+ * @param sheet - The active sheet. Anything but a dashboard yields nothing.
+ * @returns Worksheet name → geometry, empty when the sheet reported none.
+ */
+function readDashboardGeometry(
+  sheet: TableauSheet,
+): Map<string, TableauWorksheetGeometry> {
+  const geometry = new Map<string, TableauWorksheetGeometry>();
+  if (sheet.sheetType !== 'dashboard') {
+    return geometry;
+  }
+
+  let objects: readonly TableauDashboardObject[] | undefined;
+  try {
+    objects = sheet.objects;
+  } catch {
+    // A property that throws is a property this library does not really have.
+    return geometry;
+  }
+  if (!Array.isArray(objects)) {
+    return geometry;
+  }
+
+  for (const object of objects) {
+    if (object === null || typeof object !== 'object') {
+      continue;
+    }
+    if (object.type !== 'worksheet' || object.worksheet === undefined) {
+      continue;
+    }
+    const position = object.position;
+    const size = object.size;
+    if (position === undefined || size === undefined) {
+      continue;
+    }
+    const { x, y } = position;
+    const { width, height } = size;
+    if (![x, y, width, height].every(Number.isFinite)) {
+      continue;
+    }
+    geometry.set(object.worksheet.name, {
+      x,
+      y,
+      width,
+      height,
+      // Both flags default to the shape a tiled, on-screen dashboard has, so a
+      // library that reports geometry but not these two is still usable. Each
+      // of them, when true and false respectively, disqualifies the grid
+      // outright in the extractor — see `layOutByGeometry`.
+      isFloating: object.isFloating === true,
+      isVisible: object.isVisible !== false,
+    });
+  }
+  return geometry;
+}
+
+/** What the active sheet contributes: its worksheets, and where they sit. */
+interface DiscoveredSheet {
+  /** The worksheets, in the order the author added them. */
+  readonly worksheets: readonly TableauWorksheet[];
+  /** Worksheet name → geometry. Empty whenever geometry is unavailable. */
+  readonly geometry: ReadonlyMap<string, TableauWorksheetGeometry>;
+}
+
+/**
+ * Find every worksheet the active sheet exposes, and where each one sits.
  *
  * A dashboard's `worksheets` is in the order the author added them, which is
  * also the order Tableau documents a screen reader as narrating them in — so
- * paging through MAIDR's subplots follows the order the reader already knows.
+ * paging through MAIDR's subplots follows the order the reader already knows,
+ * unless the dashboard's own geometry says something more truthful (see
+ * {@link readDashboardGeometry}).
  *
  * A story yields nothing: reading a worksheet inside one is a documented known
  * issue ("operation not allowed on non-active sheet"). A viz that is not
@@ -256,33 +348,40 @@ function waitForFirstInteractive(viz: TableauViz): Promise<void> {
  *
  * Called again on every refresh, not only at bind time: `tabswitched` changes
  * which sheet is active, and the worksheets of the sheet the reader has left
- * describe a view that is no longer on screen.
+ * describe a view that is no longer on screen. The geometry is re-read on the
+ * same path, because a different sheet is laid out differently.
  *
  * @param viz - The `<tableau-viz>` element.
- * @returns The worksheets, or an empty list when there is nothing to read.
+ * @returns The worksheets and their geometry; the worksheets are empty when
+ * there is nothing to read.
  */
-function discoverWorksheets(viz: TableauViz): readonly TableauWorksheet[] {
+function discoverWorksheets(viz: TableauViz): DiscoveredSheet {
+  const empty = new Map<string, TableauWorksheetGeometry>();
   const sheet = readActiveSheet(viz);
   if (sheet === null) {
     warn(
       'the viz has no readable active sheet — it never became interactive, or '
       + 'its load failed; nothing to read.',
     );
-    return [];
+    return { worksheets: [], geometry: empty };
   }
 
   if (sheet.sheetType === 'worksheet') {
-    return [sheet];
+    // A single worksheet is the whole sheet; it has no place *on* anything.
+    return { worksheets: [sheet], geometry: empty };
   }
   if (sheet.sheetType === 'dashboard') {
-    return sheet.worksheets;
+    return {
+      worksheets: sheet.worksheets,
+      geometry: readDashboardGeometry(sheet),
+    };
   }
 
   warn(
     `the active sheet "${sheet.name}" is a story, and reading a worksheet `
     + `inside a story is a documented Tableau limitation; skipping it.`,
   );
-  return [];
+  return { worksheets: [], geometry: empty };
 }
 
 /**
@@ -391,7 +490,7 @@ export async function bindTableau(
   // Reassigned by every refresh: `tabswitched` makes a different sheet active,
   // and the worksheets discovered here belong to the sheet that was active at
   // bind time.
-  let worksheets = selectWorksheets(discoverWorksheets(viz), options);
+  let worksheets = selectWorksheets(discoverWorksheets(viz).worksheets, options);
   if (worksheets.length === 0) {
     warn('no worksheet to read on the active sheet; the page is unchanged.');
     return null;
@@ -467,7 +566,8 @@ export async function bindTableau(
     // a view that is no longer on screen. The clear above deliberately ran on
     // the *old* list first, so a selection is never stranded in the sheet the
     // reader has just left.
-    const current = selectWorksheets(discoverWorksheets(viz), options);
+    const discovered = discoverWorksheets(viz);
+    const current = selectWorksheets(discovered.worksheets, options);
     if (current.length === 0) {
       warn(
         state.data === null
@@ -492,8 +592,19 @@ export async function bindTableau(
     // Each `readWorksheet` enqueues its own pagination, so these resolve in
     // whatever order Tableau answers while still opening exactly one reader at
     // a time. `Promise.all` keeps the snapshots in figure order regardless.
+    //
+    // Geometry is attached here rather than inside `readWorksheet`, because it
+    // is a *sheet*-level fact: it lives on `dashboard.objects`, and the reader
+    // is handed one worksheet at a time and never sees the sheet those objects
+    // belong to. A worksheet the dashboard reported no usable geometry for gets
+    // no `geometry` at all, which is what the extractor reads as "lay this
+    // figure out as a column".
     const snapshots = await Promise.all(
-      worksheets.map(async worksheet => readWorksheet(worksheet)),
+      worksheets.map(async (worksheet) => {
+        const snapshot = await readWorksheet(worksheet);
+        const geometry = discovered.geometry.get(worksheet.name);
+        return geometry === undefined ? snapshot : { ...snapshot, geometry };
+      }),
     );
     if (disposed) {
       return;

--- a/src/adapters/tableau/extractor.ts
+++ b/src/adapters/tableau/extractor.ts
@@ -49,6 +49,7 @@ import type {
   TableauRow,
   TableauSelectionCriteria,
   TableauVisualSpecification,
+  TableauWorksheetGeometry,
   TableauWorksheetOverride,
   WorksheetSnapshot,
 } from './types';
@@ -1368,6 +1369,299 @@ function buildLayer(
   return { layer, cells: build.cells, points: build.points };
 }
 
+// ---------------------------------------------------------------------------
+// Dashboard layout
+// ---------------------------------------------------------------------------
+
+/**
+ * How much of two objects' extents must overlap along one axis before they are
+ * read as sharing a row (vertically), or as being stacked rather than side by
+ * side (horizontally).
+ *
+ * Measured as a **fraction of the shorter extent**, never as a pixel tolerance.
+ * A fixed tolerance is the wrong shape of rule: ten pixels is generous on a
+ * 600px dashboard and meaningless on a 4000px one, and it moves again under
+ * browser zoom and device-pixel ratio. A ratio is scale-free, which also means
+ * it cannot be invalidated by the one thing about the units that the
+ * declarations do not pin down.
+ *
+ * A half is not a tuned constant. It is the point where "these two sit side by
+ * side" stops being more true than "one is above the other": below half, most
+ * of each object's extent is unshared, which is exactly when a sighted reader
+ * reads them as stacked. It is also nowhere near the case it exists to absorb —
+ * the real cause of imperfect alignment in a tiled dashboard is per-object
+ * padding and borders, a few pixels on objects hundreds of pixels tall, an
+ * overlap ratio of about 0.98. The threshold therefore only bites on layouts
+ * that are genuinely ambiguous, which is precisely where the grid is abandoned.
+ */
+const BAND_OVERLAP_RATIO = 0.5;
+
+/**
+ * One subplot that survived extraction, still paired with what it came from.
+ *
+ * Built in snapshot order and numbered before any layout happens, so that the
+ * layer ids and the {@link SelectionIndex} keyed by them are identical whether
+ * the figure ends up a grid or a column.
+ */
+interface BuiltSubplot {
+  /** The layer id — the index among survivors. Never derived from position. */
+  readonly layerId: string;
+  /** The snapshot the subplot was built from, geometry included. */
+  readonly snapshot: WorksheetSnapshot;
+  /** The one-layer subplot itself. */
+  readonly subplot: MaidrSubplot;
+}
+
+/** A survivor whose geometry passed the gates, ready to be banded. */
+interface PlacedSubplot {
+  /** Position among the survivors; the tie-break that makes sorting total. */
+  readonly order: number;
+  readonly subplot: MaidrSubplot;
+  readonly geometry: TableauWorksheetGeometry;
+}
+
+/** The outcome of trying to lay a figure out from its dashboard geometry. */
+interface LayoutAttempt {
+  /** The subplot grid, or `null` when the geometry did not support one. */
+  readonly rows: MaidrSubplot[][] | null;
+  /**
+   * Why a grid was rejected, when the page is likely to want to know.
+   *
+   * `null` when there was no geometry to reject in the first place — a single
+   * worksheet, a story, an older embedding library, the `'column'` option —
+   * which is the ordinary case and not worth a word. A dashboard that *did*
+   * report geometry and still got a column is the surprising case, so that one
+   * says why.
+   */
+  readonly reason: string | null;
+}
+
+/**
+ * The shared fraction of two one-dimensional intervals, against the shorter.
+ *
+ * @param aStart - Start of the first interval.
+ * @param aLength - Length of the first interval; must be positive.
+ * @param bStart - Start of the second interval.
+ * @param bLength - Length of the second interval; must be positive.
+ * @returns `0` when they do not overlap, up to `1` when one contains the other.
+ */
+function overlapRatio(
+  aStart: number,
+  aLength: number,
+  bStart: number,
+  bLength: number,
+): number {
+  const shared
+    = Math.min(aStart + aLength, bStart + bLength) - Math.max(aStart, bStart);
+  if (shared <= 0) {
+    return 0;
+  }
+  // Both lengths are positive — degenerate extents are rejected before any
+  // banding starts — so this never divides by zero.
+  return shared / Math.min(aLength, bLength);
+}
+
+/**
+ * Order two placed subplots top-to-bottom, then left-to-right.
+ *
+ * @param a - One subplot.
+ * @param b - The other.
+ * @returns Negative when `a` comes first, positive when `b` does.
+ */
+function compareTopThenLeft(a: PlacedSubplot, b: PlacedSubplot): number {
+  if (a.geometry.y !== b.geometry.y) {
+    return a.geometry.y - b.geometry.y;
+  }
+  if (a.geometry.x !== b.geometry.x) {
+    return a.geometry.x - b.geometry.x;
+  }
+  // Two objects at the same point cannot be separated by geometry. Falling back
+  // to survivor order keeps the comparator total, so the result is the same on
+  // every engine rather than depending on the sort's stability.
+  return a.order - b.order;
+}
+
+/**
+ * Order two placed subplots left-to-right, then top-to-bottom.
+ *
+ * @param a - One subplot.
+ * @param b - The other.
+ * @returns Negative when `a` comes first, positive when `b` does.
+ */
+function compareLeftThenTop(a: PlacedSubplot, b: PlacedSubplot): number {
+  if (a.geometry.x !== b.geometry.x) {
+    return a.geometry.x - b.geometry.x;
+  }
+  if (a.geometry.y !== b.geometry.y) {
+    return a.geometry.y - b.geometry.y;
+  }
+  return a.order - b.order;
+}
+
+/**
+ * Lay the survivors out as a grid using the dashboard's own geometry, or
+ * decline.
+ *
+ * Survivors are swept top-to-bottom into **bands**: a worksheet joins the band
+ * being built when its vertical extent overlaps the band's by at least
+ * {@link BAND_OVERLAP_RATIO} of the shorter of the two, and starts a new band
+ * otherwise. Within a band the order is left-to-right. That is the whole rule.
+ *
+ * Bands are emitted **bottom-most first**, so the bottom row of the dashboard
+ * becomes row 0 of the figure. That is not a preference; it is what makes the
+ * arrows true. The Tableau extractor emits no `selectors` — there is no DOM to
+ * select — so `resolveSubplotLayout` cannot measure anything and every Tableau
+ * figure takes its fallback layout, which sets `invertVertical: false`. With
+ * that flag clear, `MovableGrid` maps *Move Up* to `row + 1`, i.e. row 0 is
+ * navigationally the bottom of the figure — the same convention `Heatmap`
+ * follows when it reverses its rows. Emitting the top band first would leave a
+ * reader at the top-left of the dashboard told that Down is unavailable while
+ * Up carried them downwards. A wrong direction under a key named "Move Up" is
+ * worse than a wrong ordinal.
+ *
+ * The ordinal is the accepted cost: `buildFallbackLayout` numbers its
+ * `visualOrderMap` in data-array order, so the bottom-left subplot is announced
+ * as "Subplot 1". Naming it correctly means teaching `resolveSubplotLayout` to
+ * accept caller-supplied positions, which is a shared-utility change affecting
+ * every DOM-less adapter. The announcement still carries the worksheet's own
+ * title, which is what identifies it; the number is not a spatial claim.
+ *
+ * A grid is declined outright — no partial grids, ever — when:
+ *
+ * 1. **any** survivor has no geometry (an older library, a lone worksheet, a
+ *    story, or a worksheet no dashboard object named);
+ * 2. any extent is degenerate, which would make the overlap ratio meaningless;
+ * 3. any survivor floats or is invisible (see below);
+ * 4. a band turns out to be *chained* — the sweep is single-linkage, so it
+ *    would happily merge A with B and B with C while A and C barely touch, so
+ *    every pair inside a closed band is re-checked against the same ratio. A
+ *    staircase is not a row;
+ * 5. two members of a band overlap horizontally by more than the same ratio,
+ *    which means they are stacked within the band and "left to right" does not
+ *    order them.
+ *
+ * A floating worksheet disqualifies the *whole* figure rather than being woven
+ * in: floating objects are positioned independently of the tiled layout and
+ * routinely sit on top of tiled ones, so their coordinates do not place them in
+ * a row. An invisible one likewise — dropping it would silently remove data the
+ * page may have named explicitly, and placing it in the grid would be a claim
+ * about something that is not on screen. The column makes no spatial claim at
+ * all and includes everything in author order, which is the honest answer to
+ * both.
+ *
+ * All-singleton bands are *not* a failure: a genuinely vertical dashboard read
+ * in geometry order is more truthful than one read in the order its worksheets
+ * happened to be added. Nor is a single band holding everything, which is a
+ * genuine 1×N dashboard.
+ *
+ * Pure, like everything else in this file: the geometry arrives on the
+ * snapshots, captured once by the binder from `dashboard.objects`. It follows
+ * that the grid is computed at read time and is not recomputed when the window
+ * is merely resized — the refresh events are filter, parameter, data and tab
+ * changes, not `resize` — which is the same trade `options.live` makes
+ * elsewhere: rebuilding the figure under a navigating reader is worse than a
+ * layout that reflects the dashboard as it was read.
+ *
+ * @param built - Every survivor, in figure order, already numbered.
+ * @returns The grid and no reason, or no grid and a reason worth reporting.
+ */
+function layOutByGeometry(built: readonly BuiltSubplot[]): LayoutAttempt {
+  const placed: PlacedSubplot[] = [];
+  for (const [order, entry] of built.entries()) {
+    const geometry = entry.snapshot.geometry;
+    if (geometry === undefined) {
+      return { rows: null, reason: null };
+    }
+    if (geometry.isFloating) {
+      return {
+        rows: null,
+        reason: `worksheet "${entry.snapshot.name}" floats above the dashboard `
+          + `layout, so its position does not place it in a row`,
+      };
+    }
+    if (!geometry.isVisible) {
+      return {
+        rows: null,
+        reason: `worksheet "${entry.snapshot.name}" is hidden on the dashboard, `
+          + `so placing it in the layout would claim it is on screen`,
+      };
+    }
+    if (!(geometry.width > 0) || !(geometry.height > 0)) {
+      return {
+        rows: null,
+        reason: `worksheet "${entry.snapshot.name}" reported a zero or negative `
+          + `size (${geometry.width}×${geometry.height})`,
+      };
+    }
+    placed.push({ order, subplot: entry.subplot, geometry });
+  }
+  if (placed.length === 0) {
+    return { rows: null, reason: null };
+  }
+
+  placed.sort(compareTopThenLeft);
+
+  const bands: PlacedSubplot[][] = [];
+  // The running union of the band being built, as a half-open interval.
+  let top = 0;
+  let bottom = 0;
+  for (const member of placed) {
+    const { y, height } = member.geometry;
+    const current = bands.at(-1);
+    const joins = current !== undefined
+      && overlapRatio(top, bottom - top, y, height) >= BAND_OVERLAP_RATIO;
+    if (current === undefined || !joins) {
+      bands.push([member]);
+      top = y;
+      bottom = y + height;
+      continue;
+    }
+    current.push(member);
+    top = Math.min(top, y);
+    bottom = Math.max(bottom, y + height);
+  }
+
+  for (const band of bands) {
+    band.sort(compareLeftThenTop);
+    for (let i = 0; i < band.length; i++) {
+      for (let j = i + 1; j < band.length; j++) {
+        const a = band[i].geometry;
+        const b = band[j].geometry;
+        if (overlapRatio(a.y, a.height, b.y, b.height) < BAND_OVERLAP_RATIO) {
+          return {
+            rows: null,
+            reason: 'the worksheets form a staircase rather than rows — two of '
+              + 'them were chained into the same band by a third without '
+              + 'sharing a row themselves',
+          };
+        }
+        if (overlapRatio(a.x, a.width, b.x, b.width) > BAND_OVERLAP_RATIO) {
+          return {
+            rows: null,
+            reason: 'two worksheets in the same row overlap horizontally, so '
+              + 'there is no left-to-right order between them',
+          };
+        }
+      }
+    }
+  }
+
+  // Bottom-most band first: with `invertVertical` clear, row 0 is the bottom of
+  // the figure, so this is what makes Up move up the dashboard.
+  const rows: MaidrSubplot[][] = [];
+  for (let index = bands.length - 1; index >= 0; index--) {
+    const band = bands[index];
+    // Unreachable: a band is created around a member and only ever grows. It is
+    // dropped rather than trusted because an empty row is the one shape that
+    // crashes the model — `Figure.activeSubplot` reads `subplots[r][0]`.
+    if (band.length === 0) {
+      continue;
+    }
+    rows.push(band.map(member => member.subplot));
+  }
+  return rows.length === 0 ? { rows: null, reason: null } : { rows, reason: null };
+}
+
 /**
  * Apply the page's include-list and per-worksheet `skip` flags.
  *
@@ -1409,16 +1703,40 @@ function selectSnapshots(
 /**
  * Build a MAIDR figure, and its selection index, from worksheet snapshots.
  *
- * The figure is laid out as **N rows × 1 column**: one worksheet per subplot,
- * in the order the snapshots arrive. Tableau documents that "screen readers
- * read views or objects in a dashboard in the order in which they were added",
- * and `dashboard.worksheets` is that order — so paging through the subplots
- * matches the order a reader is already narrated the dashboard in.
+ * One worksheet becomes one subplot holding one layer. How those subplots are
+ * arranged has two answers, and the fallback is always available:
+ *
+ * - **A geometry-aware grid**, when the snapshots carry the dashboard geometry
+ *   the binder read off `dashboard.objects` *and* that geometry is
+ *   unambiguous. Worksheets that share a row of the dashboard share a row of
+ *   the figure, left to right, and the dashboard's bottom row is row 0 — see
+ *   {@link layOutByGeometry} for the banding rule, for why the bottom comes
+ *   first, and for the five ways a grid is declined.
+ * - **N rows × 1 column** otherwise: one worksheet per subplot, in the order
+ *   the snapshots arrive. This is what an older embedding library gets, since
+ *   it reports no geometry at all; it is also what a single worksheet, a
+ *   `layout: 'column'` option, and every ambiguous dashboard get. Tableau
+ *   documents that "screen readers read views or objects in a dashboard in the
+ *   order in which they were added", and `dashboard.worksheets` is that order,
+ *   so this ordering is one a reader has already been narrated.
+ *
+ * **Layer ids are assigned before any layout happens**, as the running count of
+ * survivors, and are never derived from a grid position. That is load-bearing:
+ * `SelectionIndex.cells`, `.points` and `.worksheets` are keyed by them, and
+ * the binder turns those keys into live worksheets. Numbering after banding
+ * would hand out duplicate ids the moment a row held more than one subplot and
+ * would route highlights to the wrong worksheet. Banding is only ever a
+ * permutation of an already-numbered list, so the ids — and the whole selection
+ * index — are identical for the same input whichever layout is chosen. Nothing
+ * downstream reads a row or a column out of a layer id; the model stores it and
+ * echoes it back.
  *
  * A worksheet that yields no layer contributes **no subplot**: `Figure` crashes
  * on a subplot with zero layers, and the controller refuses to construct itself
- * when no subplot has any. When every worksheet is skipped the result has an
- * empty `subplots` array, which the binder reads as "leave the page alone".
+ * when no subplot has any. It is therefore never a band member either, so a
+ * skipped worksheet leaves no hole in the grid. When every worksheet is skipped
+ * the result has an empty `subplots` array, which the binder reads as "leave
+ * the page alone".
  *
  * `maidr.onNavigate` is not set here. Extraction is pure; the binder spreads
  * its own callback on.
@@ -1432,34 +1750,48 @@ export function extractTableau(
   options: TableauAdapterOptions = {},
 ): TableauExtraction {
   const warned = new Set<string>();
-  const subplots: MaidrSubplot[][] = [];
+  const built: BuiltSubplot[] = [];
   const cells = new Map<string, (readonly TableauSelectionCriteria[] | null)[][]>();
   const points = new Map<string, (readonly TableauSelectionCriteria[] | null)[]>();
   const worksheets = new Map<string, string>();
 
   for (const snapshot of selectSnapshots(snapshots, options, warned)) {
     // The survivor index, not the input index: a skipped worksheet must not
-    // shift the ids every later lookup is keyed by.
-    const layerId = String(subplots.length);
-    const built = buildLayer(
+    // shift the ids every later lookup is keyed by. Counted here, before the
+    // layout exists, so the ids cannot depend on where a subplot lands.
+    const layerId = String(built.length);
+    const layer = buildLayer(
       snapshot,
       options.overrides?.[snapshot.name] ?? {},
       layerId,
       warned,
     );
-    if (built === null) {
+    if (layer === null) {
       continue;
     }
 
-    subplots.push([{ layers: [built.layer] }]);
+    built.push({ layerId, snapshot, subplot: { layers: [layer.layer] } });
     worksheets.set(layerId, snapshot.name);
-    if (built.cells !== undefined) {
-      cells.set(layerId, built.cells);
+    if (layer.cells !== undefined) {
+      cells.set(layerId, layer.cells);
     }
-    if (built.points !== undefined) {
-      points.set(layerId, built.points);
+    if (layer.points !== undefined) {
+      points.set(layerId, layer.points);
     }
   }
+
+  const attempt: LayoutAttempt = options.layout === 'column'
+    ? { rows: null, reason: null }
+    : layOutByGeometry(built);
+  if (attempt.reason !== null) {
+    warnOnce(
+      warned,
+      `${attempt.reason}; laying the dashboard out as one worksheet per row `
+      + `instead. Pass layout: 'column' to ask for that without the check.`,
+    );
+  }
+  const subplots: MaidrSubplot[][]
+    = attempt.rows ?? built.map(entry => [entry.subplot]);
 
   const maidr: Maidr = {
     id: options.id ?? `maidr-tableau-${nextFigureId++}`,

--- a/src/adapters/tableau/types.ts
+++ b/src/adapters/tableau/types.ts
@@ -465,10 +465,108 @@ export interface TableauWorksheet extends TableauSheetBase {
   getVisualSpecificationAsync: () => Promise<TableauVisualSpecification>;
 }
 
+/**
+ * An x/y coordinate in pixels.
+ *
+ * Mirrors `Point` in `ExternalContract/Embedding/SheetInterfaces.d.ts`
+ * (`@tableau/embedding-api@3.12.1`, which vendors
+ * `@tableau/api-external-contract-js@1.211.0`), whose own doc comment reads
+ * "Represents an x/y coordinate in pixels". Note that the declaration lives in
+ * the Embedding file rather than in `Shared/`, unlike {@link TableauSize} — the
+ * Extensions contract declares a `Point` of its own.
+ */
+export interface TableauPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * A width and a height in pixels.
+ *
+ * Mirrors `Size` in `ExternalContract/Shared/SheetInterfaces.d.ts`
+ * (`@tableau/api-external-contract-js@1.211.0`), documented as "Represents a
+ * width and height in pixels" — the same space {@link TableauPoint} is in, so
+ * a position and a size on the same object are directly comparable.
+ *
+ * Declared `height` first, as the vendor does.
+ */
+export interface TableauSize {
+  readonly height: number;
+  readonly width: number;
+}
+
+/**
+ * One object placed on a dashboard: a worksheet, a legend, a title, a blank.
+ *
+ * Mirrors `DashboardObject` in
+ * `ExternalContract/Embedding/SheetInterfaces.d.ts`
+ * (`@tableau/api-external-contract-js@1.211.0`), member for member, minus the
+ * `dashboard` back-reference — that member exists, and is omitted here only
+ * because nothing reads it and mirroring it would make this file's two
+ * dashboard types mutually recursive for no gain.
+ *
+ * Every member is **required and non-optional** in the declarations, and none
+ * carries an `@since` tag, so the contract sets no version floor: presence at
+ * runtime is the only test that means anything. See
+ * {@link TableauDashboard.objects}.
+ */
+export interface TableauDashboardObject {
+  /**
+   * What the object represents.
+   *
+   * The vendor types this as the `DashboardObjectType` enum, whose values are
+   * `'blank'`, `'worksheet'`, `'quick-filter'`, `'parameter-control'`,
+   * `'page-filter'`, `'legend'`, `'title'`, `'text'`, `'image'`, `'web-page'`
+   * and `'extension'`. It is widened to `string` here deliberately: the enum is
+   * closed in *this* contract version, the host page loads whichever Embedding
+   * build it likes, and the adapter only ever asks whether the value is
+   * `'worksheet'` — a union would invite an exhaustive `switch` over a set that
+   * is not actually closed at runtime.
+   */
+  readonly type: string;
+  /** Coordinates relative to the top-left corner of the containing dashboard. */
+  readonly position: TableauPoint;
+  /** The object's own size, in the same pixel space as {@link position}. */
+  readonly size: TableauSize;
+  /** The worksheet when `type` is `'worksheet'`, `undefined` otherwise. */
+  readonly worksheet: TableauWorksheet | undefined;
+  /**
+   * The name given to the *object* during authoring.
+   *
+   * **Not** a worksheet name, even for a worksheet object: an author can rename
+   * the container without renaming the sheet inside it. Matching geometry to a
+   * worksheet goes through `object.worksheet.name`, never through this.
+   */
+  readonly name: string;
+  /** True when the object floats rather than sitting in the tiled layout. */
+  readonly isFloating: boolean;
+  /** True when the object is visible. */
+  readonly isVisible: boolean;
+  /** The dashboard object's id. */
+  readonly id: number;
+}
+
 /** A dashboard. `worksheets` is in the order the author added them. */
 export interface TableauDashboard extends TableauSheetBase {
   readonly sheetType: 'dashboard';
   readonly worksheets: readonly TableauWorksheet[];
+  /**
+   * Every object on the dashboard, worksheets and furniture alike.
+   *
+   * The contract declares this **required** — `readonly objects:
+   * Array<DashboardObject>` on `Dashboard`, with no `@since` tag — and it is
+   * nonetheless declared optional here, following this file's rule that a
+   * member is optional whenever the running library may not provide it. The
+   * real case is an older Embedding build on the host page: absence is exactly
+   * what that looks like from here, and making it a type-level fact keeps the
+   * feature detection in `binder.tsx` an ordinary check rather than a cast that
+   * asserts away the very thing being tested.
+   *
+   * Read for one purpose only: the per-worksheet geometry that lets the
+   * extractor lay a dashboard out as a grid instead of a column. When it is
+   * missing, the figure is an N×1 column and nothing else changes.
+   */
+  readonly objects?: readonly TableauDashboardObject[];
 }
 
 /**
@@ -545,6 +643,32 @@ export interface TableauColumnClassification {
 }
 
 /**
+ * Where a worksheet sits on its dashboard, in the dashboard's own pixel space.
+ *
+ * Flattened out of {@link TableauPoint} and {@link TableauSize} rather than
+ * holding them, for the same reason every other field of a snapshot is a
+ * primitive: the snapshot is a plain JSON-serializable value that a future
+ * Dashboard Extensions binder can fill in unchanged, and the extractor that
+ * reads it must never be handed a live Tableau object.
+ *
+ * All four numbers come from the *same* object's `position` and `size`, so they
+ * are mutually comparable whatever the units turn out to be; the extractor uses
+ * the extents only inside ratios, never against a fixed pixel tolerance.
+ */
+export interface TableauWorksheetGeometry {
+  /** Left edge, relative to the top-left corner of the dashboard. */
+  readonly x: number;
+  /** Top edge, relative to the top-left corner of the dashboard. */
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  /** True when the object floats above the tiled layout instead of within it. */
+  readonly isFloating: boolean;
+  /** True when the object is visible on the dashboard. */
+  readonly isVisible: boolean;
+}
+
+/**
  * Everything one worksheet contributes, read once and then never awaited again.
  *
  * This is the boundary between the async half of the adapter (`reader.ts`) and
@@ -559,6 +683,16 @@ export interface WorksheetSnapshot {
   readonly rows: readonly TableauRow[];
   /** Present only when the host exposes `getVisualSpecificationAsync`. */
   readonly spec?: TableauVisualSpecification;
+  /**
+   * Where this worksheet sits on the dashboard.
+   *
+   * Present only when the active sheet is a dashboard whose objects reported
+   * usable geometry — so absence covers an older Embedding library, a lone
+   * worksheet sheet, a story, and a worksheet no dashboard object named. The
+   * extractor needs it on **every** surviving worksheet before it will lay the
+   * figure out as a grid; one gap and the whole figure is a column again.
+   */
+  readonly geometry?: TableauWorksheetGeometry;
 }
 
 /**
@@ -610,4 +744,17 @@ export interface TableauAdapterOptions {
   overrides?: Record<string, TableauWorksheetOverride>;
   /** Text on the keyboard entry point rendered beside the viz. */
   anchorLabel?: string;
+  /**
+   * How a dashboard's worksheets are arranged into subplots.
+   *
+   * - `'grid'` (default) — follow the dashboard's own geometry when it is
+   *   readable *and* unambiguous, so Left and Right move along a row of the
+   *   dashboard and Up and Down move between its rows. Every other case,
+   *   including an older embedding library that reports no geometry at all,
+   *   falls back to the column below without the page doing anything.
+   * - `'column'` — always one worksheet per row, in the order the worksheets
+   *   were added. The escape hatch for a dashboard whose geometry is readable
+   *   but whose reading order the page knows better than the layout does.
+   */
+  layout?: 'grid' | 'column';
 }

--- a/test/adapters/tableau/binder.test.tsx
+++ b/test/adapters/tableau/binder.test.tsx
@@ -2,13 +2,19 @@
  * @jest-environment jsdom
  */
 
-import type { TableauSheet, TableauViz } from '@adapters/tableau/types';
+import type { TableauBinding } from '@adapters/tableau/binder';
+import type {
+  TableauDashboardObject,
+  TableauSheet,
+  TableauViz,
+} from '@adapters/tableau/types';
 import type { ReactNode } from 'react';
 import type { FakeCell, FakeWorksheet } from './helpers';
 import { bindTableau } from '@adapters/tableau/binder';
 import {
   fakeColumn,
   fakeDashboard,
+  fakeDashboardObject,
   fakeDashboardViz,
   fakeViz,
   fakeWorksheet,
@@ -120,16 +126,23 @@ function salesWorksheet(name: string, log?: string[]): FakeWorksheet {
  * Put a viz on the page, preceded by a sibling so its position is observable.
  *
  * @param worksheets - The dashboard's worksheets, in add-order.
+ * @param objects - Every object on the dashboard, when the test lays one out.
+ * Left off, the dashboard reports no `objects` at all — an embedding library
+ * older than the dashboard-object surface — which is what keeps the default
+ * fixture proving the N×1 column.
  * @returns The host, the marker sibling and the viz.
  */
-function mountViz(worksheets: readonly FakeWorksheet[]): {
+function mountViz(
+  worksheets: readonly FakeWorksheet[],
+  objects?: readonly TableauDashboardObject[],
+): {
   host: HTMLElement;
   marker: HTMLElement;
   viz: TableauViz;
 } {
   const host = document.createElement('div');
   const marker = document.createElement('span');
-  const viz = fakeDashboardViz(worksheets);
+  const viz = fakeDashboardViz(worksheets, 'Dashboard 1', objects);
   host.append(marker, viz);
   document.body.append(host);
 
@@ -439,6 +452,315 @@ describe('tableau binder', () => {
       expect(binding.maidr).toBe(mounted);
       expect(warn.mock.calls.map(call => String(call[0])).join('\n'))
         .toContain('keeping whatever was already mounted');
+
+      binding.dispose();
+    });
+  });
+
+  /**
+   * Getting the dashboard's own geometry to the extractor.
+   *
+   * The extractor is pure and never touches a Tableau object, so the binder is
+   * the only place `dashboard.objects` is read. What it produces is only ever
+   * observable through the shape of the mounted figure, which is what these
+   * assert: a 1×2 grid means the geometry arrived, an N×1 column means it did
+   * not. The column is the outcome for every failure, so a test that only
+   * proved the fallback would pass against a binder that read nothing at all —
+   * hence the first case, which has to see a grid.
+   */
+  describe('reading the dashboard layout', () => {
+    /**
+     * The worksheet titles of the mounted figure, row by row.
+     *
+     * @param binding - The binding under test.
+     * @returns One array of titles per row, in row order.
+     */
+    function layout(binding: TableauBinding): (string | undefined)[][] {
+      return binding.maidr.subplots.map(row =>
+        row.map(subplot => subplot.layers[0].title),
+      );
+    }
+
+    /**
+     * The same dashboard object with one member taken away.
+     *
+     * A partial embedding library — one new enough to expose `objects` but not
+     * to populate every member of one — is exactly this, and the cast is the
+     * only way to describe it: the mirror in `types.ts` declares both members
+     * required, because Tableau's own declarations do.
+     *
+     * @param object - The complete object.
+     * @param member - The member to remove.
+     * @returns The object without it.
+     */
+    function without(
+      object: TableauDashboardObject,
+      member: 'position' | 'size',
+    ): TableauDashboardObject {
+      const copy: Record<string, unknown> = { ...object };
+      delete copy[member];
+      return copy as unknown as TableauDashboardObject;
+    }
+
+    it('should lay two side-by-side worksheets into one row of two subplots', async () => {
+      const left = salesWorksheet('Left');
+      const right = salesWorksheet('Right');
+      const { viz } = mountViz([left, right], [
+        fakeDashboardObject({ worksheet: left, x: 0, y: 0, width: 100, height: 100, id: 1 }),
+        fakeDashboardObject({ worksheet: right, x: 100, y: 0, width: 100, height: 100, id: 2 }),
+      ]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      expect(layout(binding)).toEqual([['Left', 'Right']]);
+
+      binding.dispose();
+    });
+
+    it('should still bind, as an N×1 column, against a dashboard with no objects', async () => {
+      const sales = salesWorksheet('Sales');
+      const profit = salesWorksheet('Profit');
+      // No `objects` at all: the property is missing, not empty, which is what
+      // an embedding library older than the dashboard-object surface looks
+      // like from here. This is the regression proof that geometry is
+      // feature-detected rather than assumed.
+      const { viz } = mountViz([sales, profit]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      expect(layout(binding)).toEqual([['Sales'], ['Profit']]);
+      expect(warn).not.toHaveBeenCalled();
+
+      binding.dispose();
+    });
+
+    it('should fall back to the column when reading objects throws', async () => {
+      const sales = salesWorksheet('Sales');
+      const profit = salesWorksheet('Profit');
+      const dashboard = fakeDashboard([sales, profit]);
+      Object.defineProperty(dashboard, 'objects', {
+        get(): never {
+          throw new Error('not supported by this build');
+        },
+      });
+      const { viz } = mountControlledViz(dashboard);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      // A property that throws is a property this library does not really
+      // have, and the figure is unchanged rather than unbuilt.
+      expect(layout(binding)).toEqual([['Sales'], ['Profit']]);
+
+      binding.dispose();
+    });
+
+    it('should take a worksheet’s place from its own object, never from its legend', async () => {
+      const left = salesWorksheet('Left');
+      const right = salesWorksheet('Right');
+      const { viz } = mountViz([left, right], [
+        // A title strip: furniture proper, carrying no worksheet at all.
+        fakeDashboardObject({ type: 'title', x: 0, y: 0, width: 200, height: 40, id: 1 }),
+        fakeDashboardObject({ worksheet: left, x: 0, y: 40, width: 100, height: 100, id: 2 }),
+        fakeDashboardObject({ worksheet: right, x: 100, y: 40, width: 100, height: 100, id: 3 }),
+        // A colour legend *for* `Left`, parked at the bottom of the dashboard.
+        // Tableau documents `worksheet` as `undefined` unless `type` is
+        // `worksheet`, but a library that fills it in anyway would overwrite
+        // `Left`'s real place with the legend's — it comes later — and the two
+        // worksheets would land on different rows. The type check is what stops
+        // that, and this is the fixture that can tell.
+        fakeDashboardObject({
+          type: 'legend',
+          worksheet: left,
+          x: 0,
+          y: 300,
+          width: 40,
+          height: 40,
+          id: 4,
+        }),
+      ]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      expect(layout(binding)).toEqual([['Left', 'Right']]);
+
+      binding.dispose();
+    });
+
+    it('should match geometry on the worksheet name, not on the object name', async () => {
+      const left = salesWorksheet('Left');
+      const right = salesWorksheet('Right');
+      // An author can rename the container without renaming the sheet inside
+      // it, so `object.name` names neither worksheet here. A binder that
+      // matched on it would find nothing and lay out a column.
+      const { viz } = mountViz([left, right], [
+        fakeDashboardObject({
+          worksheet: left,
+          name: 'Sheet 1 Container',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          id: 1,
+        }),
+        fakeDashboardObject({
+          worksheet: right,
+          name: 'Sheet 2 Container',
+          x: 100,
+          y: 0,
+          width: 100,
+          height: 100,
+          id: 2,
+        }),
+      ]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      expect(layout(binding)).toEqual([['Left', 'Right']]);
+
+      binding.dispose();
+    });
+
+    it('should carry a floating worksheet through to the extractor’s refusal', async () => {
+      const tiled = salesWorksheet('Tiled');
+      const floater = salesWorksheet('Floater');
+      const { viz } = mountViz([tiled, floater], [
+        fakeDashboardObject({ worksheet: tiled, x: 0, y: 0, width: 100, height: 100, id: 1 }),
+        fakeDashboardObject({
+          worksheet: floater,
+          x: 20,
+          y: 20,
+          width: 100,
+          height: 100,
+          isFloating: true,
+          id: 2,
+        }),
+      ]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      // The flag is read here and judged there: the binder never decides a
+      // layout, it only reports what the dashboard said.
+      expect(layout(binding)).toEqual([['Tiled'], ['Floater']]);
+      expect(warn.mock.calls.map(call => String(call[0])).join('\n'))
+        .toContain('floats above the dashboard');
+
+      binding.dispose();
+    });
+
+    it('should leave a worksheet unplaced when its object reported no position', async () => {
+      const left = salesWorksheet('Left');
+      const right = salesWorksheet('Right');
+      const { viz } = mountViz([left, right], [
+        without(
+          fakeDashboardObject({ worksheet: left, x: 0, y: 0, width: 100, height: 100, id: 1 }),
+          'position',
+        ),
+        fakeDashboardObject({ worksheet: right, x: 100, y: 0, width: 100, height: 100, id: 2 }),
+      ]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      // One gap is a whole-figure fall back: a partial grid is a wrong grid.
+      expect(layout(binding)).toEqual([['Left'], ['Right']]);
+
+      binding.dispose();
+    });
+
+    it('should leave a worksheet unplaced when its coordinates are not finite', async () => {
+      const left = salesWorksheet('Left');
+      const right = salesWorksheet('Right');
+      const { viz } = mountViz([left, right], [
+        fakeDashboardObject({
+          worksheet: left,
+          x: Number.NaN,
+          y: 0,
+          width: 100,
+          height: 100,
+          id: 1,
+        }),
+        fakeDashboardObject({ worksheet: right, x: 100, y: 0, width: 100, height: 100, id: 2 }),
+      ]);
+
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      expect(layout(binding)).toEqual([['Left'], ['Right']]);
+
+      binding.dispose();
+    });
+
+    it('should re-read the geometry when the reader switches to another tab', async () => {
+      const left = salesWorksheet('Left');
+      const right = salesWorksheet('Right');
+      const top = salesWorksheet('Top');
+      const bottom = salesWorksheet('Bottom');
+      const { viz, setActiveSheet } = mountControlledViz(fakeDashboard(
+        [left, right],
+        'Dashboard 1',
+        [
+          fakeDashboardObject({ worksheet: left, x: 0, y: 0, width: 100, height: 100, id: 1 }),
+          fakeDashboardObject({ worksheet: right, x: 100, y: 0, width: 100, height: 100, id: 2 }),
+        ],
+      ));
+      const binding = await bindTableau(viz);
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      expect(layout(binding)).toEqual([['Left', 'Right']]);
+
+      setActiveSheet(fakeDashboard([top, bottom], 'Dashboard 2', [
+        fakeDashboardObject({ worksheet: top, x: 0, y: 0, width: 100, height: 100, id: 1 }),
+        fakeDashboardObject({ worksheet: bottom, x: 0, y: 100, width: 100, height: 100, id: 2 }),
+      ]));
+      viz.dispatchEvent(new Event('tabswitched'));
+      await settle();
+
+      // A different sheet is laid out differently, so the geometry has to come
+      // from the sheet that is now on screen. Row 0 is the bottom of the
+      // figure, so the dashboard's lower worksheet comes first.
+      expect(layout(binding)).toEqual([['Bottom'], ['Top']]);
+
+      binding.dispose();
+    });
+
+    it('should let the page ask for a column over a grid-shaped dashboard', async () => {
+      const left = salesWorksheet('Left');
+      const right = salesWorksheet('Right');
+      const { viz } = mountViz([left, right], [
+        fakeDashboardObject({ worksheet: left, x: 0, y: 0, width: 100, height: 100, id: 1 }),
+        fakeDashboardObject({ worksheet: right, x: 100, y: 0, width: 100, height: 100, id: 2 }),
+      ]);
+
+      const binding = await bindTableau(viz, { layout: 'column' });
+
+      if (binding === null) {
+        throw new Error('expected bindTableau to mount a figure');
+      }
+      expect(layout(binding)).toEqual([['Left'], ['Right']]);
 
       binding.dispose();
     });

--- a/test/adapters/tableau/extractor.test.ts
+++ b/test/adapters/tableau/extractor.test.ts
@@ -13,6 +13,7 @@ import type {
   ScatterPoint,
   SegmentedPoint,
 } from '@type/grammar';
+import type { FakeGeometryConfig } from './helpers';
 import { extractTableau } from '@adapters/tableau/extractor';
 import { Orientation, TraceType } from '@type/grammar';
 import {
@@ -1161,6 +1162,360 @@ describe('tableau extractor', () => {
 
       expect(extraction.maidr.subplots).toHaveLength(1);
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('no worksheet named "Ghost"'));
+    });
+  });
+
+  /**
+   * Laying a dashboard's worksheets out from the dashboard's own geometry.
+   *
+   * Two things are asserted throughout, and both are invariants rather than
+   * conveniences:
+   *
+   * 1. **Row 0 is the bottom of the dashboard.** The extractor emits no
+   *    `selectors` — there is no DOM inside the viz to select — so every
+   *    Tableau figure takes `resolveSubplotLayout`'s fallback, which leaves
+   *    `invertVertical` clear, and `MovableGrid` then maps *Move Up* to
+   *    `row + 1`. Emitting the top band as row 0 would leave a reader at the
+   *    top of the dashboard told that Down is unavailable while Up carried them
+   *    downwards. Every ordering assertion below is written bottom-up for that
+   *    reason, and is wrong if it is ever "fixed" to read top-down.
+   * 2. **A layer id is the survivor index and never a grid position.** It is
+   *    what `selection.cells`, `.points` and `.worksheets` are keyed by and
+   *    what the binder turns back into a live worksheet, so the moment a row
+   *    holds two subplots an id derived from the layout would start repeating
+   *    and highlights would land in the wrong worksheet. That failure is
+   *    completely silent, so the id and the worksheet it resolves to are
+   *    asserted together in every reordering case here.
+   */
+  describe('the dashboard layout', () => {
+    /**
+     * A one-bar worksheet, optionally placed on the dashboard.
+     *
+     * The single category is the worksheet's own name, so the criteria the
+     * selection index holds identify the worksheet they came from and a grid
+     * that shuffled the subplots without shuffling the index is visible.
+     *
+     * @param name - The worksheet name.
+     * @param geometry - Where it sits, or nothing for a snapshot with no
+     * geometry at all — an older embedding library, or a lone worksheet sheet.
+     * @returns The snapshot.
+     */
+    function tile(name: string, geometry?: FakeGeometryConfig): WorksheetSnapshot {
+      return fakeSnapshot({
+        name,
+        columns: [category(), measure()],
+        rows: [[name, 1]],
+        ...(geometry === undefined ? {} : { geometry }),
+      });
+    }
+
+    /**
+     * The worksheet titles of every subplot, row by row.
+     *
+     * @param extraction - What {@link extractTableau} returned.
+     * @returns One array of titles per row, in row order.
+     */
+    function titleGrid(extraction: TableauExtraction): (string | undefined)[][] {
+      return extraction.maidr.subplots.map(row =>
+        row.map(subplot => subplot.layers[0].title),
+      );
+    }
+
+    /**
+     * The layer ids of every subplot, row by row.
+     *
+     * @param extraction - What {@link extractTableau} returned.
+     * @returns One array of ids per row, in row order.
+     */
+    function idGrid(extraction: TableauExtraction): string[][] {
+      return extraction.maidr.subplots.map(row =>
+        row.map(subplot => subplot.layers[0].id),
+      );
+    }
+
+    it('reads two worksheets side by side as one row of two subplots', () => {
+      const extraction = extractTableau([
+        tile('Left', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Right', { x: 100, y: 0, width: 100, height: 100 }),
+      ]);
+
+      expect(titleGrid(extraction)).toEqual([['Left', 'Right']]);
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('reads two stacked worksheets as two rows, the lower one first', () => {
+      const extraction = extractTableau([
+        tile('Top', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Bottom', { x: 0, y: 100, width: 100, height: 100 }),
+      ]);
+
+      // Row 0 is navigationally the bottom, so the dashboard's lower worksheet
+      // is the one Move Down reaches from the other.
+      expect(titleGrid(extraction)).toEqual([['Bottom'], ['Top']]);
+      // The ids did not follow the subplots: `Top` was read first and keeps 0.
+      expect(idGrid(extraction)).toEqual([['1'], ['0']]);
+    });
+
+    it('lays a 2×2 dashboard out as two rows of two, left to right within each', () => {
+      const extraction = extractTableau([
+        tile('TopLeft', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('TopRight', { x: 100, y: 0, width: 100, height: 100 }),
+        tile('BottomLeft', { x: 0, y: 100, width: 100, height: 100 }),
+        tile('BottomRight', { x: 100, y: 100, width: 100, height: 100 }),
+      ]);
+
+      expect(titleGrid(extraction)).toEqual([
+        ['BottomLeft', 'BottomRight'],
+        ['TopLeft', 'TopRight'],
+      ]);
+      expect(idGrid(extraction)).toEqual([['2', '3'], ['0', '1']]);
+    });
+
+    it('bands worksheets that are near-aligned rather than pixel-aligned', () => {
+      // Per-object padding and borders are the real cause of imperfect
+      // alignment in a tiled dashboard, and they are worth a few pixels on
+      // objects hundreds of pixels tall. This overlaps by 60% of the shorter
+      // extent, which is far coarser than that and still one row.
+      const extraction = extractTableau([
+        tile('Left', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Right', { x: 100, y: 40, width: 100, height: 100 }),
+      ]);
+
+      expect(titleGrid(extraction)).toEqual([['Left', 'Right']]);
+    });
+
+    it('splits worksheets whose overlap falls below the banding threshold', () => {
+      // 40% of the shorter extent: below half, most of each worksheet's height
+      // is unshared, which is when a sighted reader reads them as stacked.
+      const extraction = extractTableau([
+        tile('Upper', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Lower', { x: 100, y: 60, width: 100, height: 100 }),
+      ]);
+
+      expect(titleGrid(extraction)).toEqual([['Lower'], ['Upper']]);
+    });
+
+    it('allows a ragged grid: two worksheets over one', () => {
+      const extraction = extractTableau([
+        tile('TopLeft', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('TopRight', { x: 100, y: 0, width: 100, height: 100 }),
+        tile('Footer', { x: 0, y: 100, width: 200, height: 100 }),
+      ]);
+
+      // `MovableGrid` re-clamps the column after every row change and every
+      // consumer iterates `subplots[row].length`, so rows of different widths
+      // are navigable; only an *empty* row would crash `Figure`.
+      expect(titleGrid(extraction)).toEqual([['Footer'], ['TopLeft', 'TopRight']]);
+      expect(extraction.maidr.subplots.every(row => row.length > 0)).toBe(true);
+    });
+
+    it('orders a band by geometry, not by the order the worksheets were read', () => {
+      const extraction = extractTableau([
+        tile('Right', { x: 200, y: 0, width: 100, height: 100 }),
+        tile('Left', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Middle', { x: 100, y: 0, width: 100, height: 100 }),
+      ]);
+
+      expect(titleGrid(extraction)).toEqual([['Left', 'Middle', 'Right']]);
+      // Read order still owns the ids: `Right` was read first and is still 0.
+      expect(idGrid(extraction)).toEqual([['1', '2', '0']]);
+      expect([...extraction.selection.worksheets]).toEqual([
+        ['0', 'Right'],
+        ['1', 'Left'],
+        ['2', 'Middle'],
+      ]);
+    });
+
+    it('keeps the selection index addressing the right worksheet after a reorder', () => {
+      const extraction = extractTableau([
+        tile('TopLeft', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('TopRight', { x: 100, y: 0, width: 100, height: 100 }),
+        tile('BottomLeft', { x: 0, y: 100, width: 100, height: 100 }),
+        tile('BottomRight', { x: 100, y: 100, width: 100, height: 100 }),
+      ]);
+
+      // The whole point of the invariant: walk the grid as a reader does, and
+      // every position's cells have to name the worksheet that is actually
+      // sitting there. Each tile's single bar carries its own name as the
+      // category, so a mismatch is legible rather than an index that happens to
+      // resolve.
+      for (const row of extraction.maidr.subplots) {
+        for (const subplot of row) {
+          const layer = subplot.layers[0];
+          expect(extraction.selection.worksheets.get(layer.id)).toBe(layer.title);
+          expect(extraction.selection.cells.get(layer.id)?.[0][0]).toEqual([
+            { fieldName: 'Category', value: layer.title },
+          ]);
+        }
+      }
+      // And no id was handed out twice, which is how numbering after the
+      // banding would fail.
+      expect(idGrid(extraction).flat().sort()).toEqual(['0', '1', '2', '3']);
+    });
+
+    it('leaves no hole in a row when a worksheet in the middle yields no layer', () => {
+      const extraction = extractTableau([
+        tile('Left', { x: 0, y: 0, width: 100, height: 100 }),
+        // No measure, so it is skipped before it is ever a band member.
+        fakeSnapshot({
+          name: 'Text Table',
+          columns: [category(), region()],
+          rows: [['Chairs', 'East']],
+          geometry: { x: 100, y: 0, width: 100, height: 100 },
+        }),
+        tile('Right', { x: 200, y: 0, width: 100, height: 100 }),
+      ]);
+
+      expect(titleGrid(extraction)).toEqual([['Left', 'Right']]);
+      expect(idGrid(extraction)).toEqual([['0', '1']]);
+      expect([...extraction.selection.worksheets]).toEqual([
+        ['0', 'Left'],
+        ['1', 'Right'],
+      ]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('no measure to sonify'));
+    });
+
+    it('emits no row at all for a band whose every worksheet was skipped', () => {
+      const extraction = extractTableau([
+        fakeSnapshot({
+          name: 'Filtered Out',
+          columns: [category(), measure()],
+          rows: [],
+          geometry: { x: 0, y: 0, width: 200, height: 100 },
+        }),
+        tile('Left', { x: 0, y: 100, width: 100, height: 100 }),
+        tile('Right', { x: 100, y: 100, width: 100, height: 100 }),
+      ]);
+
+      // An empty row is the one grid shape that crashes the model —
+      // `Figure.activeSubplot` reads `subplots[row][0]`. It cannot arise,
+      // because banding runs over the survivors and a skipped worksheet never
+      // becomes a band member in the first place; this pins that, rather than
+      // the emptiness being caught afterwards.
+      expect(titleGrid(extraction)).toEqual([['Left', 'Right']]);
+      expect(idGrid(extraction)).toEqual([['0', '1']]);
+    });
+
+    it('falls back to the N×1 column when the library reported no geometry', () => {
+      const extraction = extractTableau([tile('A'), tile('B'), tile('C')]);
+
+      // Byte-identical to the behaviour before dashboard layout existed: an
+      // older embedding library has no `dashboard.objects` at all.
+      expect(titleGrid(extraction)).toEqual([['A'], ['B'], ['C']]);
+      expect(idGrid(extraction)).toEqual([['0'], ['1'], ['2']]);
+      // Not worth a word: geometry-less is the ordinary case, not a surprise.
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the column when only some worksheets reported geometry', () => {
+      const extraction = extractTableau([
+        tile('Left', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Unplaced'),
+        tile('Right', { x: 100, y: 0, width: 100, height: 100 }),
+      ]);
+
+      // All or nothing: a partial grid is a wrong grid, and a wrong grid is
+      // worse than a flat column.
+      expect(titleGrid(extraction)).toEqual([['Left'], ['Unplaced'], ['Right']]);
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the column, with a reason, for a floating worksheet', () => {
+      const extraction = extractTableau([
+        tile('Tiled', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Floater', { x: 20, y: 20, width: 100, height: 100, isFloating: true }),
+      ]);
+
+      // A floating object is positioned independently of the tiled layout and
+      // routinely sits on top of one, so its coordinates do not place it in a
+      // row. It disqualifies the whole figure rather than being woven in.
+      expect(titleGrid(extraction)).toEqual([['Tiled'], ['Floater']]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('floats above the dashboard'));
+    });
+
+    it('falls back to the column, with a reason, for a hidden worksheet', () => {
+      const extraction = extractTableau([
+        tile('Shown', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Hidden', { x: 100, y: 0, width: 100, height: 100, isVisible: false }),
+      ]);
+
+      // Dropping it would silently remove data the page may have named
+      // explicitly; placing it in the grid would claim it is on screen. The
+      // column includes it and makes no spatial claim at all.
+      expect(titleGrid(extraction)).toEqual([['Shown'], ['Hidden']]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('hidden on the dashboard'));
+    });
+
+    it('falls back to the column, with a reason, for a degenerate extent', () => {
+      const extraction = extractTableau([
+        tile('Sized', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('Collapsed', { x: 100, y: 0, width: 100, height: 0 }),
+      ]);
+
+      // A zero-height interval makes the overlap ratio meaningless.
+      expect(titleGrid(extraction)).toEqual([['Sized'], ['Collapsed']]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('zero or negative size'));
+    });
+
+    it('falls back to the column, with a reason, for a staircase of chained bands', () => {
+      // The sweep is single-linkage: A joins B at exactly the threshold and B
+      // joins the widened band, but A and C do not overlap at all. Three steps
+      // of a staircase are not a row.
+      const extraction = extractTableau([
+        tile('A', { x: 0, y: 0, width: 100, height: 100 }),
+        tile('B', { x: 100, y: 50, width: 100, height: 100 }),
+        tile('C', { x: 200, y: 100, width: 100, height: 100 }),
+      ]);
+
+      expect(titleGrid(extraction)).toEqual([['A'], ['B'], ['C']]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('staircase rather than rows'));
+    });
+
+    it('falls back to the column, with a reason, when a band overlaps horizontally', () => {
+      const extraction = extractTableau([
+        tile('Under', { x: 0, y: 0, width: 200, height: 100 }),
+        tile('Over', { x: 50, y: 10, width: 200, height: 80 }),
+      ]);
+
+      // They share a band vertically but overlap by three quarters of the
+      // narrower width, so "left to right" does not order them.
+      expect(titleGrid(extraction)).toEqual([['Under'], ['Over']]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlap horizontally'));
+    });
+
+    it('gives a single worksheet one row whether or not it reported geometry', () => {
+      const placed = extractTableau([tile('Only', { x: 40, y: 80, width: 100, height: 100 })]);
+      const unplaced = extractTableau([tile('Only')]);
+
+      expect(titleGrid(placed)).toEqual([['Only']]);
+      expect(titleGrid(unplaced)).toEqual([['Only']]);
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('lets the page ask for the column even when the geometry is unambiguous', () => {
+      const extraction = extractTableau(
+        [
+          tile('Left', { x: 0, y: 0, width: 100, height: 100 }),
+          tile('Right', { x: 100, y: 0, width: 100, height: 100 }),
+        ],
+        { layout: 'column' },
+      );
+
+      expect(titleGrid(extraction)).toEqual([['Left'], ['Right']]);
+      // The page asked for it, so there is nothing to report.
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('builds the grid by default, without the page asking for it', () => {
+      const extraction = extractTableau(
+        [
+          tile('Left', { x: 0, y: 0, width: 100, height: 100 }),
+          tile('Right', { x: 100, y: 0, width: 100, height: 100 }),
+        ],
+        { layout: 'grid' },
+      );
+
+      expect(titleGrid(extraction)).toEqual([['Left', 'Right']]);
     });
   });
 

--- a/test/adapters/tableau/helpers.ts
+++ b/test/adapters/tableau/helpers.ts
@@ -31,6 +31,7 @@
 import type {
   TableauColumn,
   TableauDashboard,
+  TableauDashboardObject,
   TableauDataTable,
   TableauDataTableReader,
   TableauDataType,
@@ -48,6 +49,7 @@ import type {
   TableauViz,
   TableauWorkbook,
   TableauWorksheet,
+  TableauWorksheetGeometry,
   WorksheetSnapshot,
 } from '@adapters/tableau/types';
 
@@ -502,6 +504,52 @@ export interface FakeSnapshotConfig {
   rows: readonly (readonly (FakeCell | undefined)[])[];
   /** The visual specification, when the test exercises mark-type classification. */
   spec?: TableauVisualSpecification;
+  /**
+   * Where the worksheet sits on its dashboard, when the test exercises layout.
+   *
+   * Absent by default, which is what a snapshot read off an older embedding
+   * library — or off a sheet that is a lone worksheet rather than a dashboard —
+   * really looks like, so every fixture that says nothing about geometry keeps
+   * proving the N×1 column.
+   */
+  geometry?: FakeGeometryConfig;
+}
+
+/**
+ * A worksheet's place on a dashboard, as a test writes it.
+ *
+ * The two flags default to the shape a plain tiled worksheet has, so a test
+ * about banding writes four numbers and a test about floating or hidden
+ * worksheets writes the one flag it is actually about.
+ */
+export interface FakeGeometryConfig {
+  /** Left edge, relative to the dashboard's top-left corner. */
+  x: number;
+  /** Top edge, relative to the dashboard's top-left corner. */
+  y: number;
+  width: number;
+  height: number;
+  /** Defaults to `false` — a tiled object. */
+  isFloating?: boolean;
+  /** Defaults to `true` — an object that is on screen. */
+  isVisible?: boolean;
+}
+
+/**
+ * Fill in the flags a {@link FakeGeometryConfig} left off.
+ *
+ * @param config - The geometry a test wrote.
+ * @returns The complete geometry the adapter's types describe.
+ */
+export function fakeGeometry(config: FakeGeometryConfig): TableauWorksheetGeometry {
+  return {
+    x: config.x,
+    y: config.y,
+    width: config.width,
+    height: config.height,
+    isFloating: config.isFloating ?? false,
+    isVisible: config.isVisible ?? true,
+  };
 }
 
 /**
@@ -522,21 +570,85 @@ export function fakeSnapshot(config: FakeSnapshotConfig): WorksheetSnapshot {
     columns: config.columns,
     rows,
     ...(config.spec === undefined ? {} : { spec: config.spec }),
+    ...(config.geometry === undefined
+      ? {}
+      : { geometry: fakeGeometry(config.geometry) }),
+  };
+}
+
+/** One object on a dashboard, as a test writes it. */
+export interface FakeDashboardObjectConfig extends FakeGeometryConfig {
+  /**
+   * The worksheet inside the object, when there is one.
+   *
+   * `undefined` is what a real `DashboardObject` carries for every piece of
+   * dashboard furniture — the key is present, the value is not a worksheet —
+   * so it is written out below rather than left off.
+   */
+  worksheet?: TableauWorksheet;
+  /**
+   * The object type. Defaults to `'worksheet'` when a worksheet is given and to
+   * `'legend'` otherwise, so a test only names it to make a point.
+   */
+  type?: string;
+  /**
+   * The *object's* authoring name, which is not the worksheet's name.
+   *
+   * Deliberately defaulted to something no worksheet in these tests is called,
+   * so a binder that matched geometry on this instead of on
+   * `object.worksheet.name` would find nothing and fall back to the column.
+   */
+  name?: string;
+  /** The dashboard object's id. */
+  id?: number;
+}
+
+/**
+ * Build one entry of `dashboard.objects`.
+ *
+ * @param config - Where the object sits and what is inside it.
+ * @returns The object, with every member the contract declares required.
+ */
+export function fakeDashboardObject(
+  config: FakeDashboardObjectConfig,
+): TableauDashboardObject {
+  const geometry = fakeGeometry(config);
+  return {
+    type: config.type ?? (config.worksheet === undefined ? 'legend' : 'worksheet'),
+    position: { x: geometry.x, y: geometry.y },
+    size: { width: geometry.width, height: geometry.height },
+    worksheet: config.worksheet,
+    name: config.name ?? `Container ${config.id ?? 0}`,
+    isFloating: geometry.isFloating,
+    isVisible: geometry.isVisible,
+    id: config.id ?? 0,
   };
 }
 
 /**
  * Build a dashboard sheet over a set of worksheets, in add-order.
  *
+ * `objects` is left **off entirely** unless a test supplies it, because that is
+ * what an older embedding library looks like from the adapter's side: the
+ * property is missing, not empty. A dashboard built without it therefore keeps
+ * proving that geometry is feature-detected rather than assumed.
+ *
  * @param worksheets - The worksheets, in the order the author added them.
  * @param name - The dashboard's name.
+ * @param objects - Every object on the dashboard, when the test lays one out.
  * @returns The dashboard.
  */
 export function fakeDashboard(
   worksheets: readonly TableauWorksheet[],
   name = 'Dashboard 1',
+  objects?: readonly TableauDashboardObject[],
 ): TableauDashboard {
-  return { name, sheetType: 'dashboard', worksheets };
+  return {
+    name,
+    sheetType: 'dashboard',
+    worksheets,
+    ...(objects === undefined ? {} : { objects }),
+  };
 }
 
 /** A viz element whose active sheet the test can change, or take away. */
@@ -606,12 +718,16 @@ export function fakeViz(
  *
  * @param worksheets - The dashboard's worksheets, in add-order.
  * @param name - The dashboard's name.
+ * @param objects - Every object on the dashboard, when the test lays one out.
+ * Left off, the dashboard reports no `objects` at all, which is the older
+ * embedding library the binder has to keep working against.
  * @returns The viz element, already carrying a readable workbook.
  * @throws When there is no DOM — add `@jest-environment jsdom` to the test.
  */
 export function fakeDashboardViz(
   worksheets: readonly TableauWorksheet[],
   name = 'Dashboard 1',
+  objects?: readonly TableauDashboardObject[],
 ): TableauViz {
-  return fakeViz(fakeDashboard(worksheets, name), name).viz;
+  return fakeViz(fakeDashboard(worksheets, name, objects), name).viz;
 }


### PR DESCRIPTION
# Pull Request

## Description

Closes #936.

A Tableau dashboard's worksheets were laid into an **N×1** subplot column in add-order. That order was defensible — it matches the order a screen reader already narrates the dashboard — but it discarded the layout the author actually drew: two worksheets side by side were announced as if one were below the other.

This reads each dashboard object's `position` and `size`, bands the worksheets into rows by vertical position, and orders them by horizontal position within a band, so paging through the subplots follows the drawn layout.

## Related Issues

Closes #936.

## Changes Made

**Geometry is captured in the binder, not the reader.** `reader.ts` reads one worksheet at a time and never sees the dashboard; geometry is a sheet-level fact on `dashboard.objects`, and the binder already owns sheet discovery and already re-runs it on `tabswitched`. `WorksheetSnapshot` gains an optional `geometry` of six primitives (x, y, width, height, isFloating, isVisible) — flattened rather than holding `Point`/`Size` so the snapshot stays plain JSON, which is what will let an Extensions binder fill it in unchanged. The extractor stays pure: it receives four numbers and two booleans, never a Tableau object.

**Banding is a vertical-overlap ratio, not a pixel threshold.** Two worksheets join a band when their vertical intervals overlap by at least half of the shorter extent. A fixed pixel tolerance is the wrong shape of rule — 10px is generous on a 600px dashboard and meaningless on a 4000px one, and it moves again under browser zoom and device-pixel-ratio. The ratio is scale-free, and 0.5 is not a tuned constant: it is the point where "these sit side by side" stops being more true than "one is above the other". It is nowhere near the case it exists to absorb — per-object padding on objects hundreds of px tall gives an overlap ratio around 0.98 — so it only bites on layouts that are genuinely ambiguous, which is exactly where falling back is right.

**It falls back rather than guessing.** Any survivor without geometry (an older host library), anything floating or invisible, or a banding that does not come out confident, and the layout reverts to the previous N×1 column. A wrong grid is worse than a flat one, because Page Up / Page Down would then move in an order that contradicts what the reader was told.

## Screenshots (if applicable)

Not applicable — the change is in navigation order, which is non-visual.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

Locally: `npm run type-check`, `npx eslint`, `npm test` (297 suites / 4531 tests — 30 new — plus 10 / 137 ESM), `npm run build` (14 bundles) and `node scripts/build-site.js` all pass, re-run after the rebase onto `main`.

## Additional Notes

### The invariant this change could have broken silently

`layer.id` was `String(subplots.length)` — the count of surviving subplots — and it keys the `SelectionIndex` that maps a layer back to its live worksheet. That worked only because survivor count and row count were the same number under an N×1 layout. **The moment a row holds two subplots, that identity breaks and the ids collide**, which would send a highlight to the wrong worksheet without any error. The id is now the survivor index explicitly, never derived from grid position, and a test pins it. Nothing in the model derives row/col from `layer.id` (it is stored opaquely and echoed into `NavigateCallback`), so keeping it flat while the grid reorders around it is sound.

### Verified rather than assumed

- **Ragged rows are supported.** `MovableGrid.moveOnce`/`.moveToExtreme` re-clamp the column after a row change, `isMovable` bounds-checks per row, and every service that walks subplots iterates `subplots[r].length`. Nothing requires rectangularity. An *empty* row, by contrast, crashes `Figure.state`, so the banding never emits one.
- **Row 0 is the bottom of the figure** for navigation. Tableau layers emit no `selectors`, so `resolveSubplotLayout` cannot read geometry from the DOM and every Tableau figure takes `buildFallbackLayout` (`invertVertical: false`). The banding is ordered to match.

### Two things the declarations could not settle

- `Size` carries no "pixels" wording where `Point` does. `size` is therefore used only inside ratios, so a unit mismatch could change a confidence verdict but never produce a wrong ordering.
- Whether `object.worksheet` is reference-identical to the matching entry in `dashboard.worksheets` is not stated, so worksheets are matched by `name` — which the `worksheets` doc comment does guarantee. Note this is deliberately *not* `DashboardObject.name`, which is the object's authoring name and can differ.

---
_Generated by [Claude Code](https://claude.ai/code/session_01661Y35cni4efW36rCQNkfL)_