### PR TITLE
fix(model): stop one malformed subplot from taking down the whole figure

### DIFF
--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -79,6 +79,25 @@ export function focusedSubplotTitle(state: PlotState): string {
 }
 
 /**
+ * Whether a subplot cell arrived with a `layers` array we can iterate.
+ *
+ * `layers` is required in `MaidrSubplot`, but that is a claim about
+ * TypeScript callers and the schema arrives at runtime as JSON -- from
+ * py-maidr, from r-maidr, from a hand-authored `maidr` attribute. Any of
+ * them can emit a cell the type says is impossible.
+ *
+ * Checked with `Array.isArray` rather than for truthiness, because the
+ * shapes that break are not only the falsy ones: `{ layers: {} }` passes
+ * `?? []` untouched and then throws `layers.map is not a function`, which
+ * is the same failure as a missing key wearing a different hat.
+ *
+ * One predicate for both callers below, so the two cannot drift apart.
+ */
+function hasLayerArray(subplot: MaidrSubplot | undefined): subplot is MaidrSubplot {
+  return Array.isArray(subplot?.layers);
+}
+
+/**
  * Represents a figure containing one or more subplots
  */
 export class Figure extends AbstractPlot<FigureState> implements Movable, Observable<FigureState>, Disposable {
@@ -141,17 +160,14 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
     const subplots = maidr.subplots as MaidrSubplot[][];
     this.subplots = subplots.map((row, r) =>
       row.map((subplot, c) => {
-        // `layers` is required in `MaidrSubplot`, but that is a claim about
-        // TypeScript callers and the schema arrives as JSON -- from Python,
-        // from R, from a hand-authored `maidr` attribute. Reporting the
-        // position is the only signal a producer author ever gets, and
-        // treating the cell as empty silently would trade a loud failure
-        // for an invisible one.
-        if (!subplot?.layers) {
+        // Reporting the position is the only signal a producer author ever
+        // gets, and reading the cell as empty in silence would trade a loud
+        // failure for an invisible one.
+        if (!hasLayerArray(subplot)) {
           console.warn(
-            `[Figure] Subplot [${r}][${c}] has no \`layers\`; reading it as `
-            + `an empty subplot. The producer of this schema should emit `
-            + `\`{ id, layers: [] }\` for positions no chart occupies.`,
+            `[Figure] Subplot [${r}][${c}] has no \`layers\` array; reading `
+            + `it as an empty subplot. The producer of this schema should `
+            + `emit \`{ id, layers: [] }\` for positions no chart occupies.`,
           );
         }
         return new Subplot(subplot);
@@ -406,7 +422,7 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
     // An empty subplot is already a supported state (`isFigureLevel`,
     // `MovableGrid`, `getActiveTrace` all handle one), so degrading to it
     // costs the rest of the figure nothing. `Figure` warns about the cell.
-    const layers = subplot?.layers ?? [];
+    const layers = hasLayerArray(subplot) ? subplot.layers : [];
     this.size = layers.length;
     this.primaryTitle = layers[0]?.title ?? '';
 

--- a/src/model/plot.ts
+++ b/src/model/plot.ts
@@ -139,8 +139,23 @@ export class Figure extends AbstractPlot<FigureState> implements Movable, Observ
     this.yLabel = maidr.axes?.y?.label ?? DEFAULT_FIGURE_AXIS;
 
     const subplots = maidr.subplots as MaidrSubplot[][];
-    this.subplots = subplots.map(row =>
-      row.map(subplot => new Subplot(subplot)),
+    this.subplots = subplots.map((row, r) =>
+      row.map((subplot, c) => {
+        // `layers` is required in `MaidrSubplot`, but that is a claim about
+        // TypeScript callers and the schema arrives as JSON -- from Python,
+        // from R, from a hand-authored `maidr` attribute. Reporting the
+        // position is the only signal a producer author ever gets, and
+        // treating the cell as empty silently would trade a loud failure
+        // for an invisible one.
+        if (!subplot?.layers) {
+          console.warn(
+            `[Figure] Subplot [${r}][${c}] has no \`layers\`; reading it as `
+            + `an empty subplot. The producer of this schema should emit `
+            + `\`{ id, layers: [] }\` for positions no chart occupies.`,
+          );
+        }
+        return new Subplot(subplot);
+      }),
     );
     this.size = this.subplots.reduce((sum, row) => sum + row.length, 0);
 
@@ -385,7 +400,13 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
   public constructor(subplot: MaidrSubplot) {
     super();
 
-    const layers = subplot.layers;
+    // Tolerated rather than trusted: `Figure` maps every cell through this
+    // eagerly, so throwing here aborts the whole figure -- every well-formed
+    // subplot with it -- and leaves a chart that draws but cannot be driven.
+    // An empty subplot is already a supported state (`isFigureLevel`,
+    // `MovableGrid`, `getActiveTrace` all handle one), so degrading to it
+    // costs the rest of the figure nothing. `Figure` warns about the cell.
+    const layers = subplot?.layers ?? [];
     this.size = layers.length;
     this.primaryTitle = layers[0]?.title ?? '';
 
@@ -412,7 +433,7 @@ export class Subplot extends AbstractPlot<SubplotState> implements Movable, Obse
     // on every construction (including every live-data rebuild).
     this.traceTypes = this.traces.flat().map(trace => trace.traceType);
 
-    this.highlightValue = this.mapToSvgElement(subplot.selector);
+    this.highlightValue = this.mapToSvgElement(subplot?.selector);
     this.movable = new MovableGrid<Trace>(this.traces);
   }
 

--- a/test/model/emptySubplot.test.ts
+++ b/test/model/emptySubplot.test.ts
@@ -139,3 +139,96 @@ describe('TextService wording for a panel with no layers', () => {
     expect(text.emptySubplotText(1, 2, '')).toBeNull();
   });
 });
+
+/**
+ * The stricter cousin of the case above: a subplot with no `layers` *key*
+ * at all, rather than an empty array.
+ *
+ * `layers` is required in `MaidrSubplot`, but that is a claim about
+ * TypeScript callers and the schema arrives at runtime as JSON — from
+ * py-maidr, from r-maidr, from a hand-authored `maidr` attribute. Any of
+ * them can emit a cell the type says is impossible; py-maidr did, for
+ * every unoccupied position of a sparse subplot grid
+ * (xability/py-maidr#512).
+ *
+ * This one failed earlier and harder than #749 did. `Figure`'s constructor
+ * maps every cell through `new Subplot`, which read `layers.length`
+ * unguarded — so one bare cell threw during construction and *no* part of
+ * the chart initialised. The SVG still drew, so the page looked finished
+ * and the key that starts navigation did nothing at all.
+ */
+describe('subplot with no layers key', () => {
+  /** A cell as a producer emits it when it forgets the contract. */
+  const BARE_SUBPLOT = {} as unknown as MaidrSubplot;
+
+  function createFigureWithABareCell(): Figure {
+    const maidr: Maidr = {
+      id: 'bare-cell',
+      subplots: [[barSubplot('sp-1', 1), BARE_SUBPLOT, barSubplot('sp-3', 3)]],
+    } as Maidr;
+    return new Figure(maidr);
+  }
+
+  test('constructing the figure does not throw', () => {
+    expect(() => createFigureWithABareCell()).not.toThrow();
+  });
+
+  test('the well-formed cells either side are still built', () => {
+    const [row] = createFigureWithABareCell().subplots;
+
+    expect(row).toHaveLength(3);
+    expect(row[0].activeTrace).not.toBeNull();
+    expect(row[2].activeTrace).not.toBeNull();
+  });
+
+  test('the bare cell reads as empty rather than as something broken', () => {
+    const bare = createFigureWithABareCell().subplots[0][1];
+
+    expect(bare.activeTrace).toBeNull();
+    expect(bare.state).toEqual({ empty: true, type: 'subplot' });
+  });
+
+  test('the figure is navigable, which is the whole point', () => {
+    const figure = createFigureWithABareCell();
+    const context = new Context(figure);
+
+    expect(context.state.type).toBe('figure');
+    // Past the bare cell and into the far one.
+    expect(figure.moveToIndex(0, 2)).toBe(true);
+    expect(context.enterSubplot()).toBe(true);
+    expect(context.state.type).toBe('trace');
+  });
+
+  test('the position is named on the console, so a producer can find it', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      createFigureWithABareCell();
+
+      const messages = warn.mock.calls.map(call => String(call[0]));
+      const reported = messages.filter(m => m.includes('has no `layers`'));
+
+      expect(reported).toHaveLength(1);
+      // The coordinates matter more than the wording: without them the
+      // warning cannot be acted on in a grid of any size.
+      expect(reported[0]).toContain('[0][1]');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('a well-formed figure says nothing', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const figure = new Figure({
+        id: 'all-well-formed',
+        subplots: [[barSubplot('sp-1', 1), EMPTY_SUBPLOT]],
+      } as Maidr);
+      expect(figure.subplots[0]).toHaveLength(2);
+
+      const messages = warn.mock.calls.map(call => String(call[0]));
+      expect(messages.filter(m => m.includes('has no `layers`'))).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/test/model/emptySubplot.test.ts
+++ b/test/model/emptySubplot.test.ts
@@ -158,16 +158,41 @@ describe('TextService wording for a panel with no layers', () => {
  * and the key that starts navigation did nothing at all.
  */
 describe('subplot with no layers key', () => {
-  /** A cell as a producer emits it when it forgets the contract. */
-  const BARE_SUBPLOT = {} as unknown as MaidrSubplot;
+  /**
+   * The shapes a producer actually emits when it forgets the contract.
+   *
+   * The non-array cases are not hypothetical padding: `{ layers: {} }` is
+   * truthy, so a guard written for the missing key alone lets it through and
+   * `layers.map` throws one line later — the same abort, wearing a different
+   * hat.
+   */
+  const MALFORMED: ReadonlyArray<readonly [string, MaidrSubplot]> = [
+    ['no layers key', {} as unknown as MaidrSubplot],
+    ['a null cell', null as unknown as MaidrSubplot],
+    ['layers as an object', { layers: {} } as unknown as MaidrSubplot],
+    ['layers as a string', { layers: 'bar' } as unknown as MaidrSubplot],
+  ];
 
-  function createFigureWithABareCell(): Figure {
+  function createFigureWith(cell: MaidrSubplot): Figure {
     const maidr: Maidr = {
       id: 'bare-cell',
-      subplots: [[barSubplot('sp-1', 1), BARE_SUBPLOT, barSubplot('sp-3', 3)]],
+      subplots: [[barSubplot('sp-1', 1), cell, barSubplot('sp-3', 3)]],
     } as Maidr;
     return new Figure(maidr);
   }
+
+  function createFigureWithABareCell(): Figure {
+    return createFigureWith(MALFORMED[0][1]);
+  }
+
+  test.each(MALFORMED)('a cell with %s does not abort the figure', (_name, cell) => {
+    expect(() => createFigureWith(cell)).not.toThrow();
+
+    const [row] = createFigureWith(cell).subplots;
+    expect(row[0].activeTrace).not.toBeNull();
+    expect(row[1].activeTrace).toBeNull();
+    expect(row[2].activeTrace).not.toBeNull();
+  });
 
   test('constructing the figure does not throw', () => {
     expect(() => createFigureWithABareCell()).not.toThrow();
@@ -205,12 +230,24 @@ describe('subplot with no layers key', () => {
       createFigureWithABareCell();
 
       const messages = warn.mock.calls.map(call => String(call[0]));
-      const reported = messages.filter(m => m.includes('has no `layers`'));
+      const reported = messages.filter(m => m.includes('has no `layers` array'));
 
       expect(reported).toHaveLength(1);
       // The coordinates matter more than the wording: without them the
       // warning cannot be acted on in a grid of any size.
       expect(reported[0]).toContain('[0][1]');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test.each(MALFORMED)('a cell with %s is reported, not just survived', (_name, cell) => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      createFigureWith(cell);
+
+      const messages = warn.mock.calls.map(call => String(call[0]));
+      expect(messages.filter(m => m.includes('has no `layers` array'))).toHaveLength(1);
     } finally {
       warn.mockRestore();
     }
@@ -226,7 +263,7 @@ describe('subplot with no layers key', () => {
       expect(figure.subplots[0]).toHaveLength(2);
 
       const messages = warn.mock.calls.map(call => String(call[0]));
-      expect(messages.filter(m => m.includes('has no `layers`'))).toHaveLength(0);
+      expect(messages.filter(m => m.includes('has no `layers` array'))).toHaveLength(0);
     } finally {
       warn.mockRestore();
     }


### PR DESCRIPTION
Closes #1076.

## What breaks

`Subplot`'s constructor read `subplot.layers.length` unguarded, and `Figure`'s constructor maps every cell through it eagerly:

```ts
this.subplots = subplots.map(row => row.map(subplot => new Subplot(subplot)));
```

So one cell arriving without a `layers` key threw `TypeError: Cannot read properties of undefined (reading 'length')` during figure construction, the map aborted, and **no** part of the chart initialised — every well-formed subplot with it.

Measured in Chromium against a 4.4.0 bundle, one figure with a bare cell versus the same figure without:

| | uncaught error on activation | runtime UI built |
|---|---|---|
| one bare cell | `Cannot read properties of undefined (reading 'length')` | no |
| no bare cells | none | yes |

The SVG is already in the DOM by then, so the page looks finished, the chart is visibly a chart, and the key that starts navigation does nothing at all. No message, no degraded mode — a screen-reader user gets a decorative image and no way to know why.

## Why the type does not prevent it

`layers` being required in `MaidrSubplot` is a compile-time claim about TypeScript callers. The schema arrives at runtime as JSON — from py-maidr, from r-maidr, from a hand-authored `maidr` attribute. Any of them can emit a cell the type says is impossible, and py-maidr did, for every unoccupied position of a sparse subplot grid (xability/py-maidr#512, now fixed on the producer side).

That producer fix does not close this. The next producer to get it wrong takes the same figure down.

## The change

Degrade to the empty subplot rather than throwing. That is already a supported state — `isFigureLevel()`, `MovableGrid` and `getActiveTrace()` all document and handle a subplot with no layers (#749) — so the rest of the figure costs nothing. The surrounding lines were already written defensively; `layers.length` was the odd one out between `maidr.axes?.x?.label ?? DEFAULT_FIGURE_AXIS` and `layers[0]?.title ?? ''`.

Silently reading a malformed cell as empty would trade a loud failure for an invisible one, so `Figure` names the position on the console:

```
[Figure] Subplot [0][1] has no `layers`; reading it as an empty subplot.
The producer of this schema should emit `{ id, layers: [] }` for positions
no chart occupies.
```

The coordinates are the point — without them the warning cannot be acted on in a grid of any size, and they are the only signal a producer author ever gets. There is no schema validation on this path today; this is the first.

`subplot?.selector` picked up the same guard, since a cell can be `null` as easily as `{}`.

## Tests

Six added to `test/model/emptySubplot.test.ts`, next to the #749 cases they are the stricter cousin of — that issue was an empty `layers` *array* failing later, in `activeTrace`; this one is a missing `layers` *key* failing earlier, at construction.

Both halves were mutation-checked independently:

- guard reverted → **5 of the 6 fail** (the sixth is the well-formed control for the warning, which correctly still passes)
- `console.warn` removed, guard kept → **exactly 1 fails**, the one asserting the position is named

```
Test Suites: 355 passed, 355 total     Tests: 5143 passed    # unit + component
Test Suites:  10 passed,  10 total     Tests:  137 passed    # esm
lint:fix — clean       type-check — clean
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_