### PR TITLE
fix(model): give every grid cell a subplot number, not only the drawn ones

### DIFF
--- a/src/util/subplotLayout.ts
+++ b/src/util/subplotLayout.ts
@@ -84,7 +84,7 @@ export function resolveSubplotLayout(subplots: Subplot[][]): SubplotLayout {
   }
 
   const sorted = sortByVisualPosition(positions);
-  const visualOrderMap = buildOrderMap(sorted);
+  const visualOrderMap = buildOrderMap(sorted, subplots);
   const topLeftRow = sorted[0].row;
   const invertVertical = detectInversion(positions, subplots.length);
 
@@ -181,12 +181,90 @@ function sortByVisualPosition(entries: AxesPosition[]): AxesPosition[] {
 }
 
 /**
- * Creates a 1-based visual index map from a sorted array of positions.
+ * Orders the indices of one axis by the screen coordinate its cells report.
+ *
+ * Only the *direction* is read from the measurements, not the individual
+ * positions, so an index nothing could be measured for still lands where it
+ * belongs: an empty cell has a place in the grid even when it has none on
+ * the screen, and interpolating a coordinate for it would be inventing a
+ * measurement rather than using one.
+ *
+ * @param count - How many indices this axis has.
+ * @param coordOf - The axis coordinate of an index, or undefined if nothing
+ *   at that index could be measured.
+ * @returns The indices, in visual order.
  */
-function buildOrderMap(sorted: AxesPosition[]): Map<string, number> {
+function axisOrder(
+  count: number,
+  coordOf: (index: number) => number | undefined,
+): number[] {
+  const all = Array.from({ length: count }, (_, index) => index);
+  const measured = all.filter(index => coordOf(index) !== undefined);
+
+  // The first pair that actually differs. Equal coordinates say nothing about
+  // direction, and panels drawn exactly on top of each other report them.
+  let descending = false;
+  for (let k = 1; k < measured.length; k++) {
+    const before = coordOf(measured[k - 1])!;
+    const after = coordOf(measured[k])!;
+    if (before !== after) {
+      descending = before > after;
+      break;
+    }
+  }
+
+  return descending ? all.reverse() : all;
+}
+
+/**
+ * Creates a 1-based visual index map covering **every** cell of the grid.
+ *
+ * Numbering only the cells that could be measured left an empty one with no
+ * entry at all, and `Figure.state` then announced it as subplot 1 -- the
+ * index the top-left panel already claims, so two different cells answered to
+ * the same number and a reader had no way to tell where they were. The total
+ * was meanwhile the whole cell count, so the announced index and the
+ * announced total were counting different things and the last index was
+ * never reachable (#1085).
+ *
+ * Both halves now come from the same set: the indices run 1..cells, and every
+ * one of them is somewhere a reader can stand.
+ *
+ * @param sorted - Measured positions, in visual order.
+ * @param subplots - The full grid, including cells nothing could be measured
+ *   for.
+ * @returns A 1-based index for every cell.
+ */
+function buildOrderMap(
+  sorted: AxesPosition[],
+  subplots: Subplot[][],
+): Map<string, number> {
+  const numCols = subplots.reduce((widest, row) => Math.max(widest, row.length), 0);
+  const first = (
+    entries: AxesPosition[],
+    match: (entry: AxesPosition) => boolean,
+    coord: (entry: AxesPosition) => number,
+  ): number | undefined => {
+    const found = entries.find(match);
+    return found === undefined ? undefined : coord(found);
+  };
+
+  // `sorted` is already in reading order, so the first entry for a row or
+  // column is its topmost or leftmost cell.
+  const rowOrder = axisOrder(subplots.length, row =>
+    first(sorted, entry => entry.row === row, entry => entry.y));
+  const colOrder = axisOrder(numCols, col =>
+    first(sorted, entry => entry.col === col, entry => entry.x));
+
   const map = new Map<string, number>();
-  for (let i = 0; i < sorted.length; i++) {
-    map.set(`${sorted[i].row},${sorted[i].col}`, i + 1);
+  let index = 1;
+  for (const row of rowOrder) {
+    for (const col of colOrder) {
+      // Ragged grids are allowed: a shorter row simply has no cell there.
+      if (col < subplots[row].length) {
+        map.set(`${row},${col}`, index++);
+      }
+    }
   }
   return map;
 }

--- a/src/util/subplotLayout.ts
+++ b/src/util/subplotLayout.ts
@@ -261,6 +261,11 @@ function buildOrderMap(
   for (const row of rowOrder) {
     for (const col of colOrder) {
       // Ragged grids are allowed: a shorter row simply has no cell there.
+      // The length is enough to say which, because a row is left-packed --
+      // a producer fills every position it emits, and a cell with nothing
+      // drawn in it is a `Subplot` carrying `layers: []` rather than a hole
+      // in the array. A row missing its *leading* column is not a shape the
+      // grammar can express.
       if (col < subplots[row].length) {
         map.set(`${row},${col}`, index++);
       }

--- a/test/util/subplotLayout.test.ts
+++ b/test/util/subplotLayout.test.ts
@@ -193,3 +193,100 @@ describe('resolveSubplotLayout axes-group path precedence', () => {
     expect(layout.totalAxesCount).toBe(2);
   });
 });
+
+/**
+ * Numbering only the cells that could be measured left an empty one with no
+ * entry at all. `Figure.state` fell through to `currentIndex ?? 1`, so the
+ * empty cell announced itself as subplot 1 — the index the top-left panel
+ * already claims. Two different cells answered to the same number, and
+ * position announcements are the only way to know where you are in a grid.
+ *
+ * The total was meanwhile the whole cell count, so "N of M" counted two
+ * different sets and the last index was never reachable (#1085).
+ *
+ * These go through the `<g id="axes_*">` path deliberately. The panel
+ * fallback next door demands geometry for *every* subplot and returns
+ * nothing when one is missing, so a grid with an empty cell lands on
+ * data-array order there — which already numbers every cell and would make
+ * these tests pass without exercising the change at all.
+ */
+describe('resolveSubplotLayout numbers cells nothing could be measured for', () => {
+  /**
+   * Builds a grid through the axes-group path, where `null` marks a cell
+   * with nothing to measure.
+   */
+  function axesGrid(rows: ({ top: number; left: number } | null)[][]): Subplot[][] {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    document.body.appendChild(svg);
+    let axesIndex = 1;
+
+    return rows.map(row =>
+      row.map((rect) => {
+        if (!rect) {
+          return {
+            getHighlightElement: () => null,
+            getLayerSelector: () => null,
+          } as unknown as Subplot;
+        }
+        const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        g.setAttribute('id', `axes_${axesIndex++}`);
+        svg.appendChild(g);
+        mockRect(g, rect);
+
+        const inner = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        g.appendChild(inner);
+        mockRect(inner, rect);
+
+        return {
+          getHighlightElement: () => inner,
+          getLayerSelector: () => null,
+        } as unknown as Subplot;
+      }),
+    );
+  }
+
+  /** A 2x2 whose top row is one spanning panel, so (0,1) holds nothing. */
+  function spanningTopRow() {
+    return resolveSubplotLayout(axesGrid([
+      [{ top: 0, left: 0 }, null],
+      [{ top: 100, left: 0 }, { top: 100, left: 100 }],
+    ]));
+  }
+
+  it('gives the empty cell an index of its own', () => {
+    const layout = spanningTopRow();
+
+    expect(layout.visualOrderMap.get('0,1')).toBe(2);
+    expect(layout.visualOrderMap.get('0,1')).not.toBe(
+      layout.visualOrderMap.get('0,0'),
+    );
+  });
+
+  it('numbers every cell exactly once, 1 through the cell count', () => {
+    const indices = [...spanningTopRow().visualOrderMap.values()].sort();
+
+    expect(indices).toEqual([1, 2, 3, 4]);
+  });
+
+  it('keeps the drawn panels in reading order around it', () => {
+    const layout = spanningTopRow();
+
+    expect(layout.visualOrderMap.get('0,0')).toBe(1);
+    expect(layout.visualOrderMap.get('1,0')).toBe(3);
+    expect(layout.visualOrderMap.get('1,1')).toBe(4);
+  });
+
+  it('places an empty cell by its position, not at the end', () => {
+    // Data row 1 renders *above* data row 0, so the empty cell is in the row
+    // a reader meets first. Appending unmeasured cells would put it last.
+    const layout = resolveSubplotLayout(axesGrid([
+      [{ top: 100, left: 0 }, { top: 100, left: 100 }],
+      [{ top: 0, left: 0 }, null],
+    ]));
+
+    expect(layout.visualOrderMap.get('1,0')).toBe(1);
+    expect(layout.visualOrderMap.get('1,1')).toBe(2);
+    expect(layout.visualOrderMap.get('0,0')).toBe(3);
+    expect(layout.visualOrderMap.get('0,1')).toBe(4);
+  });
+});


### PR DESCRIPTION
Closes #1085.

## What a reader hears

A figure with an unoccupied grid position announced two different cells as the same one. Driving a 2×2 whose top row is a single spanning panel (so `(0,1)` holds nothing) in Chromium:

| key | before | after |
|---|---|---|
| `→` | Subplot **1** of 4, Top | Subplot **1** of 4, Top |
| `→` | Subplot **1** of 4 is empty | Subplot **2** of 4 is empty |
| `↓` | Subplot **3** of 4, Right | Subplot **4** of 4, Right |
| `←` | Subplot **2** of 4, Left | Subplot **3** of 4, Left |
| `↑` | Subplot **1** of 4, Top | Subplot **1** of 4, Top |
| console | `[Figure] Visual order map missing key "0,1"` | *(silent)* |

Position announcements are the only way to know where you are in a grid, and two cells answered to the same number. The total meanwhile counted every cell while the index counted only drawn panels, so "Subplot 4 of 4" was never reachable and a reader had no way to tell they had seen everything.

## Root cause

`collectAxesPositions` yields nothing for a cell with no axes element, so `buildOrderMap` left it out of the map entirely. `Figure.state` then fell through its own guard:

```ts
const currentIndex = this.visualOrderMap.get(key);
if (currentIndex === undefined) {
  console.warn(`[Figure] Visual order map missing key "${key}". Was applyLayout() called?`);
}
...
index: currentIndex ?? 1,
```

`applyLayout()` *was* called. The key is missing because the cell has nothing to measure, which is a supported state — `isFigureLevel`, `MovableGrid` and `getActiveTrace` all handle an empty subplot, and #1076 made a malformed one degrade to the same thing. `?? 1` turned a missing index into a confidently wrong one.

## The change

`buildOrderMap` now covers every cell. Only the **direction** of each axis is read from the measurements, not the individual positions, so a cell nothing could be measured for still lands where it belongs — interpolating a coordinate for it would be inventing a measurement rather than using one.

Both halves of "N of M" now come from the same set: the indices run 1..cells, and every one of them is somewhere a reader can stand.

Ragged grids are handled (a shorter row simply has no cell at that column), and the existing `?? 1` fallback becomes unreachable for grid positions — left in place rather than removed, since it still guards a `Figure` used before `applyLayout()`.

## Behaviour change worth naming

For a figure **with** an empty cell, the drawn panels renumber: in the example above Left goes from 2 to 3 and Right from 3 to 4. That is the point — the old numbers were a sequence that skipped positions while the total counted them. A figure with no empty cells is numbered exactly as before, which is what the eight pre-existing tests pin.

## Tests

Four added, and all twelve pass. Against a build with the old measured-only `buildOrderMap`, the four new ones fail and the eight old ones pass.

They go through the `<g id="axes_*">` path **deliberately**, and the test docstring says why: the panel fallback next door demands geometry for every subplot and returns nothing when one is missing, so a grid with an empty cell lands on data-array order there — which already numbers every cell. Three of these tests passed in their first draft without exercising the change at all; only the fourth failed, which is what caught it.

```
Test Suites: 357 passed, 357 total
Tests:       5186 passed, 5186 total
lint:fix — clean      type-check — clean
```

Plus the browser run in the table above, against a build of this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_