### PR TITLE
docs(observable): say what the adapter reads, and check that it keeps saying it

### DIFF
--- a/src/adapters/observable/index.ts
+++ b/src/adapters/observable/index.ts
@@ -16,10 +16,22 @@
  *
  * ### Marks it reads
  *
- * `barX` / `barY` (plain and stacked), `rectX` / `rectY` including binned
- * histograms, `dot` (as a scatter, or as a Cleveland dot plot on a categorical
- * axis), `line` and `area` (one series per drawn path), and any of those split
- * into facets with `fx` / `fy`, which become MAIDR subplots.
+ * `barX` / `barY` (plain, stacked, and 100% stacked), `rectX` / `rectY`
+ * including binned histograms, `dot` (a scatter, a Cleveland dot plot on a
+ * categorical axis, or a hexbin lattice when the caller declares one), `tick`
+ * given a categorical axis (a strip plot, read as a dot plot), `line` and
+ * `area` (one series per drawn path, with the step curves read as steps),
+ * `linearRegressionX` / `linearRegressionY` (the fitted line, as a smooth),
+ * `waffle` (counted from the cells rather than inverted from a colour),
+ * `link` / `arrow`, `rule`, `vector` (which is also what `Plot.spike` draws),
+ * and `boxX` / `boxY`, which Plot draws as four separate marks that are
+ * recognised and read as one distribution. Any of them split into facets with
+ * `fx` / `fy` become MAIDR subplots.
+ *
+ * A `link`, an `arrow` and a `rule` each draw a segment between two points,
+ * which is a span in a lane when its ends share the other coordinate — read as
+ * a gantt. A spike stands a magnitude at a place, read as a scatter carrying
+ * `z`, which the trace speaks and sounds alongside the position.
  *
  * ### Marks it does not
  *
@@ -28,11 +40,15 @@
  * Announcing an approximation to a reader who cannot check it against the
  * picture is worse than announcing nothing, so those marks are skipped.
  *
- * Box plots are skipped too, and for the same reason. `Plot.boxY` is not one
- * mark but four, and nothing in the DOM says they belong together: read
- * individually its interquartile box is an ordinary bar whose height is
- * `q3 - q1`, a number that appears nowhere in the data, while the median and
- * the whiskers go unannounced.
+ * A mark of a kind listed above is handed back when reading it would mean
+ * announcing something the drawing does not state: a `vector` that points
+ * somewhere, since the grammar has no field for a bearing; an `area` whose
+ * floor follows the data, which is an interval rather than a magnitude; a
+ * `rule` whose lines all share an end, which is a reference line or a
+ * lollipop's stem rather than a measurement; a `tick` with no cross-channel,
+ * which has no category to announce; a line drawn through control points that
+ * are not data points; and a line or area broken by a gap. `docs/observable.md`
+ * gives each case and the reasoning behind it.
  *
  * @example
  * ```html

--- a/test/adapters/observable/markList.test.ts
+++ b/test/adapters/observable/markList.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The adapter's own summary of what it reads, checked against what it reads.
+ *
+ * `src/adapters/observable/index.ts` opens with a `@packageDocumentation` block
+ * naming the marks the adapter handles, and that block is what a reader of the
+ * generated API docs sees first. It drifted: five marks were added over #1069,
+ * #1081, #1093, #1094, #1098 and #1100 without it moving, and it still said box
+ * plots were skipped a release after they were read. Nothing failed, because
+ * prose is not compiled.
+ *
+ * So compile it here. Every label `convertMark` dispatches has to be named in
+ * the "Marks it reads" section, and so does the box plot — which is assembled
+ * before the switch rather than dispatched by it, and is therefore exactly the
+ * kind of reading a check on the switch alone would keep missing.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+
+const ADAPTER = join(__dirname, '../../../src/adapters/observable');
+
+function source(file: string): string {
+  return readFileSync(join(ADAPTER, file), 'utf8');
+}
+
+/** The mark labels `convertMark`'s switch has a branch for. */
+function dispatchedLabels(): string[] {
+  const converters = source('converters.ts');
+  const start = converters.indexOf('function convertMark(');
+  expect(start).toBeGreaterThan(-1);
+
+  const body = converters.slice(start, converters.indexOf('\n}', start));
+  return [...body.matchAll(/case '([^']+)':/g)].map(([, label]) => label);
+}
+
+/**
+ * The backticked names in the module documentation's "Marks it reads" section.
+ *
+ * Sliced to that section so a mark named only among the refusals below it does
+ * not count as read — several are named in both, for opposite reasons.
+ */
+function namesRead(): string[] {
+  const documentation = source('index.ts');
+  const start = documentation.indexOf('### Marks it reads');
+  const end = documentation.indexOf('### Marks it does not');
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  const section = documentation.slice(start, end);
+  return [...section.matchAll(/`([^`]+)`/g)]
+    .map(([, name]) => name.toLowerCase().replace(/[^a-z0-9]/g, ''));
+}
+
+/** Whether the prose names a mark: `linear-regression` is `linearRegressionY`. */
+function isNamed(label: string, names: string[]): boolean {
+  const wanted = label.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return names.some(name => name.startsWith(wanted));
+}
+
+describe('the observable adapter\'s documented mark list', () => {
+  it('names every mark the converter dispatches', () => {
+    const names = namesRead();
+    const missing = dispatchedLabels().filter(label => !isNamed(label, names));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('is checking a list that is actually there', () => {
+    // Both halves of the check read text, and text that moved out from under
+    // the slice would leave the assertion above passing over nothing.
+    expect(dispatchedLabels().length).toBeGreaterThanOrEqual(10);
+    expect(namesRead().length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('names the box plot, which is read without a branch of its own', () => {
+    // `boxComposites` claims the four groups a box plot is drawn with before
+    // the dispatch loop runs, so no `case 'box'` exists to be counted. The
+    // documentation said box plots were skipped for a release after they were
+    // read, and a check on the switch alone would not have noticed.
+    expect(source('converters.ts')).toContain('TraceType.BOX');
+    expect(isNamed('box', namesRead())).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1102.

The `@packageDocumentation` block at the top of `src/adapters/observable/index.ts` is the first thing a reader of the generated API docs meets. It had not moved since #898 while eight readings landed underneath it.

## What it said

| Landed in | Reading | Named in the block |
|---|---|---|
| #1082 | 100% stacked bar and area | no |
| #1087 | `dot` under `hexbin` → hexbin | no |
| #1070 | `tick` → strip plot | no |
| #1083 | `linear-regression` → smooth | no |
| #1089 | `boxX` / `boxY` → box | **documented as skipped** |
| #1096 | `waffle` → bar | no |
| #1097 | `link` / `arrow` → gantt | no |
| #1099 | `vector` (`Plot.spike`) → scatter with `z` | no |
| #1101 | `rule` → gantt | no |

The box entry is the one that costs something. It told a maintainer the composite detection does not exist, in the paragraph explaining why building it would be hard — a year after #1089 built and tested it. `docs/observable.md` was correct throughout, so the two disagreed and nothing said which to believe.

## The fix, and the part that keeps it fixed

The block now lists what the adapter reads, and a short paragraph says what a `link`, an `arrow`, a `rule` and a spike each become, since those four are not obvious from the mark name. The "Marks it does not" half keeps `cell` — still true, still for the reason given — and replaces the box paragraph with the refusals that are actually live: a `vector` that points somewhere, an `area` whose floor follows the data, a `rule` whose lines all share an end, a `tick` with no cross-channel, a smoothed curve, a gappy path.

The rewrite alone would drift again next time, because prose is not compiled — every one of those nine pull requests changed `converters.ts` and its tests, all checked, and left a doc comment in a neighbouring file that nothing reads. So `test/adapters/observable/markList.test.ts` compiles it: every label `convertMark` has a branch for must be named in the "Marks it reads" section, matched on the mark name so `linear-regression` is satisfied by `linearRegressionY` and `bar` by `barX`.

The box plot is asserted **separately**, and that is the point rather than an afterthought. `boxComposites` claims the four groups before the dispatch loop runs, so there is no `case 'box'` to count — a check on the switch alone would have gone on missing exactly the entry that was wrong.

## Verification

`eslint 0 / type-check 0 / build 0`, full `npm test` green — 3 projects, 137 + 186 + the rest, exit 0.

Every assertion falsified by applying each mutation alone:

| mutation | result |
|---|---|
| restore the old (pre-change) reads section | **3 failed** — all three |
| remove both `rule` mentions from the reads section | 1 failed |
| remove `boxX` / `boxY` from the reads section | 1 failed (the box test) |
| add an undocumented `case 'contour':` to `convertMark` | 1 failed |
| rename the `### Marks it reads` heading | 3 failed |

The first row is the check that matters: the test would have caught this drift, in all three of its assertions.

One mutation **passed** and is worth recording. Deleting `` `rule` `` from the mark list left the test green, because the paragraph below still says "a `link`, an `arrow` and a `rule` each draw a segment" — both mentions are inside the reads section, and the doc does still name it. Removing both reddens. That same run also confirmed the section slice earns its place: `rule` remains named in the "Marks it does not" half, and the test failed anyway.

## Not doing

`docs/observable.md`'s own "What it reads" table is missing rows for `waffle`, `link` / `arrow`, `vector` and `rule` — each has a full prose section further down, so nothing there is wrong or absent, only the summary table is short. That is a separate edit to a separate file and does not belong in a commit about the module's API documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_