### PR TITLE
docs(observable): give the guide's table the five marks it was missing

### DIFF
--- a/docs/observable.md
+++ b/docs/observable.md
@@ -195,8 +195,14 @@ That is why the adapter needs no configuration and works on charts written befor
 | `line` | Line | One series per drawn path |
 | `area` / `areaY` | Area | |
 | `areaY` under `stackY({offset: 'normalize'})` | 100% stacked area | Announced as percentages |
+| `line` under `curveStep` / `curveStepAfter` / `curveStepBefore` | Step | Which side the value is held on is announced; see below |
 | `linearRegressionY` / `linearRegressionX` | Smooth | The fitted line; see below |
 | `dot` under `hexbin` | Hexbin | Only when declared — see below |
+| `spike`, and `vector` with a `length` | Scatter carrying `z` | The magnitude is said and heard; a vector that points somewhere is refused — see below |
+| `link` / `arrow` whose ends share a coordinate | Gantt | An interval in a lane; see below |
+| `ruleX` / `ruleY` carrying an interval | Gantt | The same reading off a `<line>`; a rule that agrees with itself is refused — see below |
+| `waffleY` / `waffleX` | Bar | Counted from the cells rather than inverted from a colour; see below |
+| `waffleY` / `waffleX` with `fill` | Stacked bar | One path per segment in a band |
 | `boxY` / `boxX` | Box | Four marks read as one distribution; see below |
 | any of the above with `fx` / `fy` | Subplots | One MAIDR panel per facet, named after it |
 

--- a/test/adapters/observable/markList.test.ts
+++ b/test/adapters/observable/markList.test.ts
@@ -18,7 +18,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from '@jest/globals';
 
-const ADAPTER = join(__dirname, '../../../src/adapters/observable');
+const ROOT = join(__dirname, '../../..');
+const ADAPTER = join(ROOT, 'src/adapters/observable');
 
 function source(file: string): string {
   return readFileSync(join(ADAPTER, file), 'utf8');
@@ -52,6 +53,24 @@ function namesRead(): string[] {
     .map(([, name]) => name.toLowerCase().replace(/[^a-z0-9]/g, ''));
 }
 
+/**
+ * The backticked names in the guide's "What it reads" table.
+ *
+ * Sliced to the table rather than searched for in the whole file, because
+ * every mark below it has a prose section that mentions it by name -- a
+ * file-wide search would pass on a table that lists none of them.
+ */
+function namesTabulated(): string[] {
+  const guide = readFileSync(join(ROOT, 'docs/observable.md'), 'utf8');
+  const start = guide.indexOf('## What it reads');
+  const end = guide.indexOf('## Hexbins');
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  return [...guide.slice(start, end).matchAll(/`([^`]+)`/g)]
+    .map(([, name]) => name.toLowerCase().replace(/[^a-z0-9]/g, ''));
+}
+
 /** Whether the prose names a mark: `linear-regression` is `linearRegressionY`. */
 function isNamed(label: string, names: string[]): boolean {
   const wanted = label.toLowerCase().replace(/[^a-z0-9]/g, '');
@@ -71,6 +90,17 @@ describe('the observable adapter\'s documented mark list', () => {
     // the slice would leave the assertion above passing over nothing.
     expect(dispatchedLabels().length).toBeGreaterThanOrEqual(10);
     expect(namesRead().length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('is matched by the guide\'s own summary table', () => {
+    // The two are maintained separately and drifted separately. Held to the
+    // same list so a new reading has to reach the table as well as the module
+    // documentation, which is the half a reader is most likely to scan.
+    const tabulated = namesTabulated();
+    const missing = dispatchedLabels().filter(label => !isNamed(label, tabulated));
+
+    expect(missing).toEqual([]);
+    expect(isNamed('box', tabulated)).toBe(true);
   });
 
   it('names the box plot, which is read without a branch of its own', () => {


### PR DESCRIPTION
Closes #1104. The drift I recorded as "Not doing" in #1103, now closed.

`docs/observable.md` is the maintained reference for the adapter, and the table at the top of **What it reads** is the part a reader scans to answer "does my chart work?". Five marks had a full prose section further down the same file and no row in it:

| Mark | Section in the guide | Row before | Row now |
|---|---|---|---|
| `line` under `curveStep*` | ## Step curves | — | Step |
| `spike` / `vector` with a `length` | ## Spike and vector marks | — | Scatter carrying `z` |
| `link` / `arrow` sharing a coordinate | ## Link and arrow marks | — | Gantt |
| `ruleX` / `ruleY` carrying an interval | ## Rule marks | — | Gantt |
| `waffleY` / `waffleX` | ## Waffle charts | — | Bar, and Stacked bar with a `fill` |

Nothing in the file was wrong — every one of those sections is accurate. The summary just stopped short of them, which is the worst place to stop: a reader who checks the table and moves on gets a **no** for five marks that work.

## Why #1103's check did not catch it

It reads `src/adapters/observable/index.ts` alone, and the guide drifted independently of it. Widening it to a file-wide search would have been no help either — every one of those marks *is* named in `docs/observable.md`, in the very section the table fails to point at, so a whole-file search passes on a table that lists none of them.

So the check slices the table (`## What it reads` up to `## Hexbins`) and holds *that* to the labels `convertMark` dispatches, plus the box plot. Being mentioned below the table does not count, which is the whole point.

## Verification

`eslint 0 / type-check 0`, full `npm test` green — 368 suites, 5,277 tests, plus the 137 of the ESM project.

The new assertion falsified by applying each mutation alone:

| mutation | result |
|---|---|
| restore the old table (five marks missing) | the table test failed |
| drop only the `ruleX` / `ruleY` row | failed |
| drop the `boxY` / `boxX` row | failed |
| rename the `## What it reads` heading | failed |

Each reddens the new assertion and leaves the three from #1103 green, which is the separation worth having: the module documentation and the guide are maintained apart and now fail apart.

The slice earns its place in the second row above. With `ruleX` / `ruleY` gone from the table, `rule` is still named twice in the guide's own **## Rule marks** section a few screens down — and the test fails anyway.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_