### PR TITLE
test(observable): pin what a node-link tree reads, and what it does not

### DIFF
--- a/test/adapters/observable/fixtures.ts
+++ b/test/adapters/observable/fixtures.ts
@@ -417,6 +417,20 @@ export const FIXTURES: Record<string, Fixture> = {
     html: '<svg class="plot-d6a7b5" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60"><g aria-label="x-axis tick label" transform="translate(0.5,9.5)"><text y="0.71em" transform="translate(120,30)">Mon</text><text y="0.71em" transform="translate(320,30)">Tue</text><text y="0.71em" transform="translate(520,30)">Wed</text></g><g aria-label="x-axis label" transform="translate(0.5,27.5)"><text transform="translate(320,30)">day</text></g><g aria-label="rule" stroke="currentColor" transform="translate(0.5,0)"><line x1="120" x2="120" y1="0" y2="30"></line><line x1="320" x2="320" y1="0" y2="30"></line><line x1="520" x2="520" y1="0" y2="30"></line></g></svg>',
     scales: { x: { type: 'point', domain: ['Mon', 'Tue', 'Wed'], range: [20, 620], bandwidth: 0, step: 200, positions: [120, 320, 520] } },
   },
+  hierarchyTree: {
+    // `Plot.tree(['a', 'a/b', 'a/c', 'a/b/d', 'a/b/e'])` -- the first
+    // node-link diagram to reach these tests, and the case #1094's
+    // whole-mark span question exists for. Its `link` mark holds four
+    // curves whose ends differ on both axes, which is what an edge is and
+    // what a span is not.
+    //
+    // Drawn with `axis: null`, and the scales say why: the x domain is
+    // [0, 2] -- tree depth -- and the y domain [-0.5, 1] -- sibling
+    // offset. Neither is anything a reader plotted, which is the other
+    // half of #1106.
+    html: '<svg class="plot-d6a7b5" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400"><g aria-label="link" fill="none" stroke-width="1.5" stroke-opacity="0.5" stroke-miterlimit="1" transform="translate(0.5,0.5)"><path d="M0,266C159.75,266,159.75,133,319.5,133" stroke="#636363"></path><path d="M0,266C159.75,266,159.75,399,319.5,399" stroke="#bdbdbd"></path><path d="M319.5,133C479.25,133,479.25,0,639,0" stroke="#bdbdbd"></path><path d="M319.5,133C479.25,133,479.25,266,639,266" stroke="#bdbdbd"></path></g><g aria-label="dot" transform="translate(0.5,0.5)"><circle cx="0" cy="266.00000000000006" r="3" fill="#636363"><title>/a</title></circle><circle cx="319.5" cy="133.00000000000003" r="3" fill="#636363"><title>/a/b</title></circle><circle cx="319.5" cy="399" r="3" fill="#bdbdbd"><title>/a/c</title></circle><circle cx="639" cy="0" r="3" fill="#bdbdbd"><title>/a/b/d</title></circle><circle cx="639" cy="266.00000000000006" r="3" fill="#bdbdbd"><title>/a/b/e</title></circle></g><g aria-label="text" stroke="var(--plot-background)" stroke-width="3" stroke-linejoin="round" paint-order="stroke" text-anchor="start" transform="translate(6.5,0.5)"><text y="0.32em" transform="translate(319.5,399)">c<title>/a/c</title></text><text y="0.32em" transform="translate(639,0)">d<title>/a/b/d</title></text><text y="0.32em" transform="translate(639,266.00000000000006)">e<title>/a/b/e</title></text></g><g aria-label="text" stroke="var(--plot-background)" stroke-width="3" stroke-linejoin="round" paint-order="stroke" text-anchor="end" transform="translate(-5.5,0.5)"><text y="0.32em" transform="translate(0,266.00000000000006)">a<title>/a</title></text><text y="0.32em" transform="translate(319.5,133.00000000000003)">b<title>/a/b</title></text></g></svg>',
+    scales: { x: { type: 'linear', domain: [0, 2], range: [0, 639] }, y: { type: 'linear', domain: [-0.5, 1], range: [399, 0] } },
+  },
   spikeMap: {
     // `Plot.spike` over magnitudes 5, 12 and 8, on a length scale of
     // [0, 12] -> [0, 18]. Each spike is a triangle reaching 7.5, 18 and 12

--- a/test/adapters/observable/tree.test.ts
+++ b/test/adapters/observable/tree.test.ts
@@ -1,0 +1,56 @@
+/**
+ * A node-link diagram, which is the case the span readings refuse (#1106).
+ *
+ * `Plot.tree` is the first one to reach these tests. It draws three kinds of
+ * mark at once — `link` for the edges, `dot` for the nodes, `text` for their
+ * names — so it exercises two things the adapter already decided and one it
+ * has not.
+ *
+ * The edges are what #1094 and #1100 wrote their whole-mark span test for: a
+ * link whose two ends share a coordinate is an interval in a lane, and one
+ * whose ends share nothing is an edge with no lane to sit in. A tree's links
+ * are the second kind, four of them, and this is the first chart in the suite
+ * where that is true.
+ *
+ * What the chart also shows is a defect, pinned below rather than fixed here.
+ * Its dots read as an ordinary scatter, so the chart binds and navigates —
+ * and what it announces is d3's tree *layout* coordinates, depth against
+ * sibling offset, on scales the chart draws with `axis: null` precisely
+ * because they mean nothing to a reader. Every node's path is sitting in the
+ * `<title>` of the circle being announced, and in a `text` mark beside it,
+ * and both are dropped. Deciding what to do about that needs a hierarchy
+ * reading or a rule for declining a mark whose axes are suppressed, which is
+ * #1106; the pin turns red the day either lands.
+ */
+
+import { observablePlotToMaidr } from '@adapters/observable/converters';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+import { mountFixture } from './helpers';
+
+function layersOf(key: Parameters<typeof mountFixture>[0]): { type: TraceType }[] {
+  const { element } = mountFixture(key);
+  return observablePlotToMaidr(element)?.subplots[0][0].layers ?? [];
+}
+
+describe('a tree\'s edges', () => {
+  it('are not claimed as a gantt', () => {
+    // Four curves running `M0,266C…,319.5,133` — both ends differ on both
+    // axes, so no coordinate is shared and there is no lane. Read as spans
+    // they would announce a schedule whose tasks are tree depths.
+    expect(layersOf('hierarchyTree').some(layer => layer.type === TraceType.GANTT))
+      .toBe(false);
+  });
+});
+
+describe('a tree\'s nodes', () => {
+  it.failing('are not announced as layout coordinates (#1106)', () => {
+    // The dots are read as a scatter of `x = depth`, `y = sibling offset`.
+    // Those are d3's layout output, not anything plotted, and the node names
+    // are in the `<title>` of each circle and in a `text` mark beside them.
+    // Announcing the coordinates and dropping the names describes a chart the
+    // reader does not have.
+    expect(layersOf('hierarchyTree').some(layer => layer.type === TraceType.SCATTER))
+      .toBe(false);
+  });
+});


### PR DESCRIPTION
## What this is

Two tests over one new fixture: a `Plot.tree` node-link diagram. One is a guard on a decision the adapter already made and had never been exercised; the other is an `it.failing` pin on a defect, filed as #1106.

```js
Plot.tree(['a', 'a/b', 'a/c', 'a/b/d', 'a/b/e'])
```

`Plot.tree` draws three kinds of mark at once — `link` for the edges, `dot` for the nodes, `text` for their names — which is why it is worth having in the suite.

## The guard: a tree's links are edges, not spans

#1094 and #1100 gave the adapter a rule for `link` and `rule` marks: a mark whose two ends share a coordinate is an interval in a lane and reads as a gantt; one whose ends share nothing is an edge with no lane to sit in, and is refused.

Every chart in the suite up to now took the first branch. A tree takes the second — measured, its four curves are

```
M0,266C…,266,…,133  …  M319.5,133C…,133,…,66.5
```

both ends differing on both axes, so no coordinate is shared. Nothing in the suite would have caught a widening of that rule that let a node-link diagram be announced as a schedule whose tasks are tree depths.

**Falsified:** with the whole-mark span check removed, this test fails. It is a guard, not a restatement.

## The pin: the nodes read as layout coordinates (#1106)

Measured on the fixture, the adapter emits:

```json
[{"type": "point", "n": 5}]
```

The links are refused, as above. The five dots read as an ordinary scatter — so the chart binds and navigates, and what it announces is d3's tree **layout** output: `x = depth`, `y = sibling offset`. Those are the scales `Plot.tree` draws with `axis: null`, precisely because they mean nothing to a reader.

Meanwhile every node's path is sitting in the `<title>` of the circle being announced, and again in a `text` mark beside it. Both are dropped.

That is pinned with `it.failing` rather than fixed here, because fixing it needs a grammar decision rather than an adapter one — either a hierarchy reading, or a rule for declining a mark whose axes are suppressed. `it.failing` turns red the day either lands, which is the point of writing it now. #1106 carries the decision.

## Fixture

`test/adapters/observable/fixtures.ts` gains a `hierarchyTree` entry: `Plot.plot()` output verbatim, minus the `<style>` block and the `*-axis tick` groups, per the convention already documented in that file. Scales recorded as `plot.scale(name)` minus functions — `x: [0,2] → [0,639]`, `y: [-0.5,1] → [399,0]`.

## Checks

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all pass: 369 suites / 5279 tests in the unit+component projects, 10 / 137 in the ESM project.

Refs #1106

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_