### PR TITLE
test(model): pin how a histogram binned up the y axis is read

### DIFF
--- a/test/model/histogramOrientation.test.ts
+++ b/test/model/histogramOrientation.test.ts
@@ -1,0 +1,123 @@
+import type { MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, it } from '@jest/globals';
+import { Histogram } from '@model/histogram';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A histogram turned on its side reads its bins off the axis they run along.
+ *
+ * `Histogram` branches on `orientation` in both `description` and `text`:
+ * vertical takes the bin bounds from `xMin`/`xMax` and the count from `y`,
+ * horizontal takes them from `yMin`/`yMax` and the count from `x`. Nothing
+ * exercised the second branch — every histogram test in the suite built a
+ * vertical layer — while two producers now emit horizontal ones:
+ * `seaborn`'s `histplot(y=)` through xability/py-maidr#401, and a ggplot2
+ * dot plot binned up the y axis through xability/r-maidr#201.
+ *
+ * The failure that branch protects against is the one
+ * {@link MaidrLayer.orientation} was documented for: a layer that declares
+ * `horz` and is read as though it were vertical announces the bin *position*
+ * where the count belongs and the count where the range belongs. Every number
+ * is present and every number is in the wrong place, so nothing throws and
+ * nothing is missing — the reader is simply told a different chart.
+ */
+
+/** Three bins running up the y axis, with counts on x. */
+const HORIZONTAL: MaidrLayer = {
+  id: 'sideways',
+  type: TraceType.HISTOGRAM,
+  orientation: Orientation.HORIZONTAL,
+  axes: { x: { label: 'Count' }, y: { label: 'Petal Length' } },
+  data: [
+    { x: 4, y: 1, xMin: 0, xMax: 4, yMin: 0, yMax: 2 },
+    { x: 33, y: 3, xMin: 0, xMax: 33, yMin: 2, yMax: 4 },
+    { x: 12, y: 5, xMin: 0, xMax: 12, yMin: 4, yMax: 6 },
+  ],
+};
+
+/** The same distribution the ordinary way up, for the contrast. */
+const VERTICAL: MaidrLayer = {
+  id: 'upright',
+  type: TraceType.HISTOGRAM,
+  axes: { x: { label: 'Petal Length' }, y: { label: 'Count' } },
+  data: [
+    { x: 1, y: 4, xMin: 0, xMax: 2, yMin: 0, yMax: 4 },
+    { x: 3, y: 33, xMin: 2, xMax: 4, yMin: 0, yMax: 33 },
+    { x: 5, y: 12, xMin: 4, xMax: 6, yMin: 0, yMax: 12 },
+  ],
+};
+
+/**
+ * The trace's state at its starting cell.
+ * @param layer The layer to read
+ * @returns Whatever the trace announces there
+ */
+function announced(layer: MaidrLayer): TraceState {
+  const trace = new Histogram(layer);
+  trace.moveToIndex(0, 0);
+  return trace.state as TraceState;
+}
+
+describe('a histogram binned up the y axis', () => {
+  it('takes its bin range from the axis the bins run along', () => {
+    // `yMin`/`yMax`, not `xMin`/`xMax`. Read the vertical way this would
+    // announce "0 through 4" for the first bin -- which is the count's own
+    // extent, a number that is on the chart and means nothing here.
+    const state = announced(HORIZONTAL);
+
+    expect(state.empty).toBe(false);
+    if (state.empty) {
+      return;
+    }
+    expect(state.text.range).toEqual({ min: 0, max: 2 });
+  });
+
+  it('announces the count as the value and the bin as the position', () => {
+    const state = announced(HORIZONTAL);
+
+    expect(state.empty).toBe(false);
+    if (state.empty) {
+      return;
+    }
+    // The main axis is the one the reader moves along, which is the bins.
+    expect(state.text.main).toEqual({ label: 'Petal Length', value: 1 });
+    expect(state.text.cross).toEqual({ label: 'Count', value: 4 });
+    expect(state.text.mainAxis).toBe('y');
+    expect(state.text.crossAxis).toBe('x');
+  });
+
+  it('describes the whole bin range from first bin to last', () => {
+    // The summary reads the *first* bin's lower bound against the *last*
+    // bin's upper one, so a branch that took them off x would report the
+    // count axis's extent as the data's range: "0 to 12" for a variable that
+    // runs 0 to 6.
+    const stats = new Histogram(HORIZONTAL).description.stats;
+
+    expect(stats.find(stat => stat.label === 'Bin range')?.value).toBe('0 to 6');
+  });
+
+  it('puts the bins first in its data table, as the reader walks them', () => {
+    const table = new Histogram(HORIZONTAL).description.dataTable;
+
+    expect(table.headers).toEqual(['Petal Length', 'Count', 'Bin Min', 'Bin Max']);
+    expect(table.rows[1]).toEqual([3, 33, 2, 4]);
+  });
+
+  it('leaves the upright reading alone', () => {
+    // The other half of every orientation fix: the branch that was already
+    // right has to stay right. Same three counts, same three bins, read the
+    // ordinary way up.
+    const state = announced(VERTICAL);
+    const stats = new Histogram(VERTICAL).description.stats;
+
+    expect(state.empty).toBe(false);
+    if (state.empty) {
+      return;
+    }
+    expect(state.text.range).toEqual({ min: 0, max: 2 });
+    expect(state.text.main).toEqual({ label: 'Petal Length', value: 1 });
+    expect(state.text.cross).toEqual({ label: 'Count', value: 4 });
+    expect(stats.find(stat => stat.label === 'Bin range')?.value).toBe('0 to 6');
+  });
+});


### PR DESCRIPTION
## The gap

`Histogram` branches on `orientation` in **both** `description` and `text`:

```ts
const binRangeMin = isVertical ? firstPoint.xMin : firstPoint.yMin;
const binRangeMax = isVertical ? lastPoint.xMax : lastPoint.yMax;

const headers = isVertical
  ? [this.xAxis, this.yAxis, 'Bin Min', 'Bin Max']
  : [this.yAxis, this.xAxis, 'Bin Min', 'Bin Max'];
```

Nothing exercised the second branch. Every histogram test in the suite builds a vertical layer — `test/model/barGaps.test.ts` and `test/adapters/observable/traceContract.test.ts` are the only two that construct one, and both are upright.

Meanwhile two producers emit horizontal histograms:

- `seaborn.histplot(y=)`, through xability/py-maidr#401;
- a ggplot2 dot plot binned up the y axis, through xability/r-maidr#201, which is in review now and emits `hist` + `horz` with the bin bounds on `yMin`/`yMax`.

## Why it matters that nothing pins it

This is the failure `MaidrLayer.orientation` was documented for in #947. A `horz` layer read as though it were vertical announces the bin **position** where the count belongs, and the count's own extent where the data's range belongs:

- the first bin's range comes out `0 through 4` for a bin that runs `0` to `2`;
- the summary reports `0 to 12` for a variable that runs `0` to `6`.

Every number is present and every number is in the wrong place. Nothing throws, nothing is missing, and no assertion about "did it announce something" would notice — the reader is simply told a different chart.

## What the test asserts

One assertion per thing the branch decides, over three bins running up the y axis with counts on x:

| assertion | what a wrong branch would give |
|---|---|
| announced range is `{min: 0, max: 2}` | `{min: 0, max: 4}` — the count's extent |
| `main` is `Petal Length` / `1`, `cross` is `Count` / `4` | the two swapped |
| `mainAxis` is `y`, `crossAxis` is `x` | `x` / `y` |
| summary bin range is `0 to 6` | `0 to 12` |
| table headers lead with the binned axis | the count column first |

and the vertical reading is asserted alongside, because the half that was already right has to stay right — that is the other half of every orientation fix in this repo.

## Falsification

| mutation | result |
|---|---|
| `text` reads `xMin`/`xMax` unconditionally | 1 red |
| `description`'s bin range reads `xMin`/`xMax` unconditionally | 1 red |
| headers never swap | 1 red |

Each mutation turns exactly one assertion red, so none of them is carrying another's weight.

## Checks

`npm run type-check`, `eslint`, and `npm test` all pass: 370 suites / 5284 tests in the unit+component projects, 10 / 137 in the ESM project.

No source change — this is coverage for a branch that was already correct and unguarded.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_