### PR TITLE
fix(focus): give a framed chart a way back to the page that embeds it

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -14,6 +14,7 @@ import { CommandPaletteService } from '@service/commandPalette';
 import { DescriptionService } from '@service/description';
 import { DisplayService } from '@service/display';
 import { FormatterService } from '@service/formatter';
+import { FrameFocusService } from '@service/frameFocus';
 import { GoToExtremaService } from '@service/goToExtrema';
 import { HelpService } from '@service/help';
 import { HighContrastService } from '@service/highContrast';
@@ -55,6 +56,7 @@ export class Controller implements Disposable {
   private readonly notificationService: NotificationService;
   private readonly settingsService: SettingsService;
   private readonly formatterService: FormatterService;
+  private readonly frameFocusService: FrameFocusService;
 
   private readonly audioService: AudioService;
   private readonly brailleService: BrailleService;
@@ -104,6 +106,7 @@ export class Controller implements Disposable {
 
     this.notificationService = new NotificationService();
     this.formatterService = new FormatterService(maidr);
+    this.frameFocusService = new FrameFocusService();
     this.textService = new TextService(this.notificationService, this.formatterService);
     this.displayService = new DisplayService(this.context, plot, this.textService);
     this.settingsService = new SettingsService(
@@ -502,6 +505,7 @@ export class Controller implements Disposable {
     this.brailleService.dispose();
     this.audioService.dispose();
     this.formatterService.dispose();
+    this.frameFocusService.dispose();
 
     this.settingsService.dispose();
     this.notificationService.dispose();

--- a/src/service/frameFocus.ts
+++ b/src/service/frameFocus.ts
@@ -209,21 +209,30 @@ export class FrameFocusService implements Disposable {
   }
 
   /**
-   * Asks the host to take focus, and takes it for the host if it does not.
+   * Moves focus into the host, by whichever channel that host allows.
    */
   private requestHostFocus(): void {
-    // A cooperating host knows its own page and can pick a better landing
-    // place than this frame can, so it gets the first say. It is also the only
-    // channel to a host on another origin, where the fallback cannot reach.
+    if (FrameFocusService.hostFrameElement() !== null) {
+      // The host's DOM is reachable, which is both faster and surer than
+      // asking: focus moves in this same event, with nothing to wait for.
+      this.focusHostContainer();
+      return;
+    }
+
+    // A host on another origin can only be asked. Once a handoff is in flight
+    // there is nothing to add by asking again — which is what a held Shift +
+    // Tab would otherwise do on every auto-repeat, pushing the deadline out
+    // for as long as the key is down.
+    if (this.fallbackTimer !== null) {
+      return;
+    }
+
     try {
       window.parent.postMessage({ type: FRAME_FOCUS_ESCAPE_MESSAGE, direction: 'backward' }, '*');
     } catch {
-      // A host that refuses messages still gets the DOM fallback below.
+      // A host that refuses messages still gets the fallback below.
     }
 
-    if (this.fallbackTimer !== null) {
-      clearTimeout(this.fallbackTimer);
-    }
     this.fallbackTimer = setTimeout(() => {
       this.fallbackTimer = null;
       // The host took focus if this document no longer has it. Checking the
@@ -238,8 +247,15 @@ export class FrameFocusService implements Disposable {
   /**
    * Moves focus to the element that holds this frame in the host document.
    *
-   * Reachable only for a same-origin host: `frameElement` is null across
-   * origins, which is exactly when the message above is the only channel.
+   * Reaches the host's DOM directly, which `rules/service.md` otherwise
+   * reserves for the services that own their own output. The rule's remedy —
+   * fire an event and let a ViewModel render the result — cannot apply here:
+   * the element focus has to land on belongs to another document, which no
+   * ViewModel of ours renders and no React tree of ours contains. Writing to
+   * it is the whole operation, so there is nothing left to delegate.
+   *
+   * Falls back to letting go of focus when the host cannot be reached, which
+   * is the cross-origin case the posted message exists for.
    */
   private focusHostContainer(): void {
     const frame = FrameFocusService.hostFrameElement();

--- a/src/service/frameFocus.ts
+++ b/src/service/frameFocus.ts
@@ -1,0 +1,293 @@
+import type { Disposable } from '@type/disposable';
+
+/**
+ * The message an embedded chart posts to its host when the reader tabs back
+ * out of it and the host must decide where focus goes.
+ *
+ * A host that embeds MAIDR in a cross-origin frame — an `src="data:…"` frame
+ * has an opaque origin, which is what r-maidr's knitr output uses — cannot be
+ * reached through the DOM, so the frame asks for the handoff instead of
+ * performing it. Same-origin hosts need no listener: the fallback below does
+ * the same thing from this side.
+ */
+export const FRAME_FOCUS_ESCAPE_MESSAGE = 'maidr:frame-focus-escape';
+
+/**
+ * How long to wait for the host to answer the message before falling back.
+ *
+ * Only the fallback path pays this, and only in a frame whose host has no
+ * listener: a host that handles the message takes focus in the same event-loop
+ * turn the message is delivered in.
+ */
+const HOST_RESPONSE_TIMEOUT_MS = 50;
+
+/**
+ * Elements that can hold DOM focus by keyboard, as a selector.
+ *
+ * `[tabindex="-1"]` is deliberately absent: those take focus programmatically
+ * but are not tab stops, so they are neither a boundary of this frame nor
+ * somewhere Shift + Tab could land in the host.
+ */
+const TABBABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex^="-"])',
+].join(',');
+
+/**
+ * The kind of host element the reader is handed back to.
+ *
+ * A reveal.js slide is a `<section>`, so a chart on a slide hands focus back to
+ * the slide itself: the reader hears which slide they landed on, and the deck's
+ * own shortcuts work again, because the keydown now reaches the host document
+ * that listens for them.
+ *
+ * Page-level landmarks — `<main>`, `role="main"` — are deliberately absent.
+ * They match in hosts that section nothing else, a notebook among them, and
+ * handing a reader the whole page when they stepped out of one chart tells
+ * them less about where they are than the chart's own wrapper does, which is
+ * what `parentElement` falls back to.
+ */
+const HOST_CONTAINER_SELECTOR = 'section,article,[role="region"]';
+
+/**
+ * Keeps a chart in a frame from stranding the reader when they tab back out.
+ *
+ * A chart in an iframe swallows every key it is sent: keyboard events do not
+ * cross a frame boundary, so while the reader is inside the chart the page
+ * around it hears nothing. That is right while they are reading — MAIDR binds
+ * the arrows, Space, Backspace, Page Up and Page Down itself — which leaves
+ * Shift + Tab as the way back to the page.
+ *
+ * Usually the browser handles that on its own: Shift + Tab at the frame's first
+ * tab stop moves to whatever precedes the frame in the host. But when nothing
+ * usable precedes it, focus leaves the document altogether for the browser's
+ * own UI, and the page cannot be driven from the keyboard until the reader tabs
+ * all the way back in. A chart on a Quarto `revealjs` slide is exactly that
+ * case: the deck's own controls are not rendered, so a chart is the first thing
+ * on the page, and from inside it no key reaches the deck.
+ *
+ * So this service watches for Shift + Tab at the frame's first tab stop, and
+ * steps in *only* when the browser would strand the reader, handing focus to
+ * the element that holds the frame — the slide, in a deck. Where the host has
+ * somewhere real to go, the native tab order is left exactly as it was, and Tab
+ * in the forward direction is never touched.
+ *
+ * Nothing happens outside a frame, and nothing here can trap a reader: if the
+ * handoff cannot be completed, the focused element is blurred so the next
+ * Shift + Tab does what the browser would have done in the first place.
+ */
+export class FrameFocusService implements Disposable {
+  private readonly onKeyDown: (event: KeyboardEvent) => void;
+  private fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Creates the service and, when the document is framed, starts listening.
+   */
+  public constructor() {
+    this.onKeyDown = (event: KeyboardEvent): void => this.handleKeyDown(event);
+    if (FrameFocusService.isFramed()) {
+      // Capture phase: `hotkeys-js` listens on `document` in the bubble phase,
+      // and the modal components listen on their own subtrees. Neither binds
+      // Tab today, but running first keeps this independent of that.
+      document.addEventListener('keydown', this.onKeyDown, true);
+    }
+  }
+
+  /**
+   * Stops listening and cancels a pending fallback.
+   */
+  public dispose(): void {
+    document.removeEventListener('keydown', this.onKeyDown, true);
+    if (this.fallbackTimer !== null) {
+      clearTimeout(this.fallbackTimer);
+      this.fallbackTimer = null;
+    }
+  }
+
+  /**
+   * Whether this document is displayed inside a frame.
+   * @returns {boolean} True when the document has a parent browsing context
+   */
+  private static isFramed(): boolean {
+    try {
+      return window.self !== window.top;
+    } catch {
+      // Reading `window.top` across origins throws in some browsers, and it
+      // only throws when there *is* a cross-origin ancestor — so being here
+      // is itself the answer.
+      return true;
+    }
+  }
+
+  /**
+   * Hands focus back to the host when Shift + Tab would otherwise leave the
+   * document.
+   * @param {KeyboardEvent} event - The keydown being inspected
+   */
+  private handleKeyDown(event: KeyboardEvent): void {
+    if (event.key !== 'Tab' || !event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+    if (event.defaultPrevented || !this.isAtFirstTabStop()) {
+      return;
+    }
+
+    const frame = FrameFocusService.hostFrameElement();
+    if (frame !== null && FrameFocusService.hasTabStopBefore(frame)) {
+      // The host has somewhere real to send them. Leave the tab order alone.
+      return;
+    }
+
+    event.preventDefault();
+    this.requestHostFocus();
+  }
+
+  /**
+   * Whether the focused element is the first thing Tab reaches in this frame.
+   *
+   * Anything inside a modal is excluded: a dialog cycles focus within itself,
+   * so its first element is a boundary of the dialog, not of the frame.
+   * @returns {boolean} True when Shift + Tab from here would leave the frame
+   */
+  private isAtFirstTabStop(): boolean {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement) || active === document.body) {
+      return false;
+    }
+    if (active.closest('[role="dialog"],[aria-modal="true"]') !== null) {
+      return false;
+    }
+
+    const stops = Array.from(document.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR))
+      .filter(element => FrameFocusService.isReachable(element));
+    return stops.length > 0 && stops[0] === active;
+  }
+
+  /**
+   * Whether the host has a tab stop of its own ahead of this frame.
+   *
+   * "Ahead" is document order, which is what Shift + Tab follows. A stop the
+   * reader cannot actually reach does not count, and that distinction is the
+   * whole point in a slide deck: reveal.js leaves the slides on either side of
+   * the current one rendered, so the chart on the previous slide is a tab stop
+   * in document order even though it is marked hidden and is not on screen.
+   * @param {Element} frame - This document's frame, in the host's DOM
+   * @returns {boolean} True when Shift + Tab has somewhere real to land
+   */
+  private static hasTabStopBefore(frame: Element): boolean {
+    const stops = Array.from(frame.ownerDocument.querySelectorAll(TABBABLE_SELECTOR));
+    const index = stops.indexOf(frame);
+    return stops
+      .slice(0, index < 0 ? stops.length : index)
+      .some(stop => FrameFocusService.isReachable(stop));
+  }
+
+  /**
+   * Whether an element is rendered and exposed, and so can be tabbed to.
+   * @param {Element} element - The candidate tab stop
+   * @returns {boolean} True when the element takes part in the tab order
+   */
+  private static isReachable(element: Element): boolean {
+    if (element.closest('[hidden],[aria-hidden="true"],[inert]') !== null) {
+      return false;
+    }
+    const view = element.ownerDocument.defaultView;
+    if (view === null) {
+      return false;
+    }
+    const style = view.getComputedStyle(element);
+    return style.display !== 'none' && style.visibility !== 'hidden';
+  }
+
+  /**
+   * Asks the host to take focus, and takes it for the host if it does not.
+   */
+  private requestHostFocus(): void {
+    // A cooperating host knows its own page and can pick a better landing
+    // place than this frame can, so it gets the first say. It is also the only
+    // channel to a host on another origin, where the fallback cannot reach.
+    try {
+      window.parent.postMessage({ type: FRAME_FOCUS_ESCAPE_MESSAGE, direction: 'backward' }, '*');
+    } catch {
+      // A host that refuses messages still gets the DOM fallback below.
+    }
+
+    if (this.fallbackTimer !== null) {
+      clearTimeout(this.fallbackTimer);
+    }
+    this.fallbackTimer = setTimeout(() => {
+      this.fallbackTimer = null;
+      // The host took focus if this document no longer has it. Checking the
+      // outcome rather than waiting for an acknowledgement keeps hosts that
+      // handle the message without answering it — the common case — working.
+      if (document.hasFocus()) {
+        this.focusHostContainer();
+      }
+    }, HOST_RESPONSE_TIMEOUT_MS);
+  }
+
+  /**
+   * Moves focus to the element that holds this frame in the host document.
+   *
+   * Reachable only for a same-origin host: `frameElement` is null across
+   * origins, which is exactly when the message above is the only channel.
+   */
+  private focusHostContainer(): void {
+    const frame = FrameFocusService.hostFrameElement();
+    const container = frame === null
+      ? null
+      : frame.closest(HOST_CONTAINER_SELECTOR) ?? frame.parentElement ?? frame.ownerDocument.body;
+
+    if (container === null || !FrameFocusService.isFocusable(container)) {
+      // Nothing more this side can do. Blurring means the next Shift + Tab
+      // behaves as it would have without this service, so the reader is
+      // left no worse off than before — never trapped.
+      (document.activeElement as HTMLElement | null)?.blur();
+      return;
+    }
+
+    // `tabindex="-1"` makes the container focusable without adding a tab stop
+    // to the host's own order.
+    if (!container.hasAttribute('tabindex')) {
+      container.setAttribute('tabindex', '-1');
+    }
+    container.focus();
+  }
+
+  /**
+   * Whether a host element can be told to take focus.
+   *
+   * Duck-typed on purpose: everything reached through `frameElement` lives in
+   * the host's realm, where `instanceof HTMLElement` — which resolves to *this*
+   * frame's constructor — is false for every element the host owns.
+   * @param {Element} element - An element belonging to the host document
+   * @returns {boolean} True when the element exposes `focus()`
+   */
+  private static isFocusable(element: Element): element is HTMLElement {
+    return typeof (element as HTMLElement).focus === 'function';
+  }
+
+  /**
+   * The frame element holding this document, when the host is reachable.
+   *
+   * Null across origins — a `src="data:…"` frame has an opaque origin, so this
+   * is exactly where the posted message is the only way through.
+   * @returns {Element | null} The host's `<iframe>`, or null across origins
+   */
+  private static hostFrameElement(): Element | null {
+    try {
+      return window.frameElement;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/test/service/frameFocus.test.ts
+++ b/test/service/frameFocus.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for the frame focus handoff (#…).
+ *
+ * A chart in an iframe hears every key the reader presses and the host page
+ * hears none of them, so Shift + Tab off the chart is the reader's way back to
+ * the page. Usually the browser handles that by itself; the case this service
+ * exists for is the one where it cannot, because nothing reachable precedes
+ * the frame in the host — a chart on a Quarto `revealjs` slide, where the deck
+ * renders no controls of its own, so the chart is the first thing on the page
+ * and from inside it no key reaches the deck.
+ *
+ * The service therefore has to make two decisions, and both are checked here:
+ * whether Shift + Tab is at the frame's own boundary, and whether the host has
+ * anywhere real to send the reader. Getting the second one wrong would rewrite
+ * the tab order of every notebook and article that embeds a chart, so the
+ * "leave it alone" cases matter as much as the fixing one.
+ *
+ * The DOM this builds is inside out on purpose. The service reads the document
+ * it is loaded in as the frame's own, and reaches the host through
+ * `window.frameElement`, so the test document plays the frame, and a real
+ * child iframe — which has a browsing context, and so computed styles and a
+ * live `activeElement` — plays the host.
+ */
+
+import { FrameFocusService } from '@service/frameFocus';
+
+jest.useFakeTimers();
+
+/** The host document, standing in for the page the chart is embedded in. */
+let hostDocument: Document;
+/** The element the host document holds the chart in. */
+let hostFrame: HTMLElement;
+/** The chart, and the only tab stop in the frame's own document. */
+let plot: HTMLElement;
+let service: FrameFocusService | null = null;
+
+/**
+ * Presents the test document as framed, holding the given host element.
+ * @param {HTMLElement | null} frameElement - What `window.frameElement` returns
+ */
+function pretendFramedBy(frameElement: HTMLElement | null): void {
+  // `self`, not `top`: jsdom defines `top` non-configurably, and the service
+  // compares the two, so standing either one up answers the same question.
+  Object.defineProperty(window, 'self', { value: {}, configurable: true });
+  Object.defineProperty(window, 'frameElement', { value: frameElement, configurable: true });
+}
+
+/**
+ * Sends Shift + Tab to the focused element.
+ * @returns {KeyboardEvent} The dispatched event, to read `defaultPrevented` off
+ */
+function pressShiftTab(): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  document.activeElement!.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="plot" tabindex="0"></div>';
+  plot = document.getElementById('plot')!;
+
+  // A real iframe, so the host document has a browsing context: without one
+  // there are no computed styles to read and `focus()` does nothing.
+  const carrier = document.createElement('iframe');
+  document.body.appendChild(carrier);
+  hostDocument = carrier.contentDocument!;
+  hostDocument.body.innerHTML = '<section id="slide"><span id="frame"></span></section>';
+  hostFrame = hostDocument.getElementById('frame')!;
+
+  plot.focus();
+});
+
+afterEach(() => {
+  service?.dispose();
+  service = null;
+});
+
+describe('outside a frame', () => {
+  it('leaves Shift + Tab alone', () => {
+    Object.defineProperty(window, 'self', { value: window.top, configurable: true });
+    service = new FrameFocusService();
+
+    expect(pressShiftTab().defaultPrevented).toBe(false);
+  });
+});
+
+describe('in a frame the host has nothing before', () => {
+  beforeEach(() => {
+    pretendFramedBy(hostFrame);
+    service = new FrameFocusService();
+  });
+
+  it('hands focus to the element holding the frame', () => {
+    expect(pressShiftTab().defaultPrevented).toBe(true);
+
+    jest.advanceTimersByTime(100);
+    const slide = hostDocument.getElementById('slide')!;
+    expect(slide.getAttribute('tabindex')).toBe('-1');
+    expect(hostDocument.activeElement).toBe(slide);
+  });
+
+  it('ignores Tab in the forward direction, which already lands in the host', () => {
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    plot.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('ignores Shift + Tab from anywhere but the frame\'s first tab stop', () => {
+    const second = document.createElement('button');
+    document.body.appendChild(second);
+    second.focus();
+
+    expect(pressShiftTab().defaultPrevented).toBe(false);
+  });
+
+  it('stops listening once disposed', () => {
+    service!.dispose();
+    service = null;
+
+    expect(pressShiftTab().defaultPrevented).toBe(false);
+  });
+});
+
+describe('in a frame the host has something before', () => {
+  it('leaves the native tab order alone', () => {
+    hostDocument.body.insertBefore(
+      Object.assign(hostDocument.createElement('a'), { href: '#earlier' }),
+      hostDocument.body.firstChild,
+    );
+    pretendFramedBy(hostFrame);
+    service = new FrameFocusService();
+
+    expect(pressShiftTab().defaultPrevented).toBe(false);
+  });
+
+  it('steps in anyway when the only thing before it cannot be reached', () => {
+    // The slide deck case: reveal.js leaves the slides on either side of the
+    // current one rendered, so the chart on the previous slide is a tab stop
+    // in document order even though it is marked hidden and is off screen.
+    const previousSlide = hostDocument.createElement('section');
+    previousSlide.hidden = true;
+    previousSlide.setAttribute('aria-hidden', 'true');
+    previousSlide.innerHTML = '<span id="earlier-chart" tabindex="0"></span>';
+    hostDocument.body.insertBefore(previousSlide, hostDocument.body.firstChild);
+
+    pretendFramedBy(hostFrame);
+    service = new FrameFocusService();
+
+    expect(pressShiftTab().defaultPrevented).toBe(true);
+  });
+});
+
+describe('with a host on another origin', () => {
+  it('asks the host to take focus, and does not trap the reader when it will not', () => {
+    // `frameElement` is null across origins — r-maidr embeds charts through a
+    // `data:` URL, whose origin is opaque — so the message is the only channel.
+    pretendFramedBy(null);
+    const posted = jest.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+    service = new FrameFocusService();
+
+    expect(pressShiftTab().defaultPrevented).toBe(true);
+    expect(posted).toHaveBeenCalledWith(
+      { type: 'maidr:frame-focus-escape', direction: 'backward' },
+      '*',
+    );
+
+    // No host answered, and there is no DOM to fall back to: the chart lets go
+    // so the reader's next Shift + Tab does what the browser would have done.
+    jest.advanceTimersByTime(100);
+    expect(document.activeElement).not.toBe(plot);
+
+    posted.mockRestore();
+  });
+});

--- a/test/service/frameFocus.test.ts
+++ b/test/service/frameFocus.test.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * Tests for the frame focus handoff (#…).
+ * Tests for the frame focus handoff.
  *
  * A chart in an iframe hears every key the reader presses and the host page
  * hears none of them, so Shift + Tab off the chart is the reader's way back to

--- a/test/service/frameFocus.test.ts
+++ b/test/service/frameFocus.test.ts
@@ -99,13 +99,20 @@ describe('in a frame the host has nothing before', () => {
     service = new FrameFocusService();
   });
 
-  it('hands focus to the element holding the frame', () => {
+  it('hands focus to the element holding the frame, in the same event', () => {
+    const posted = jest.spyOn(window.parent, 'postMessage');
+
     expect(pressShiftTab().defaultPrevented).toBe(true);
 
-    jest.advanceTimersByTime(100);
+    // Nothing to wait for: a host whose DOM this frame can reach is served
+    // directly, so no message goes out and no deadline is armed.
     const slide = hostDocument.getElementById('slide')!;
     expect(slide.getAttribute('tabindex')).toBe('-1');
     expect(hostDocument.activeElement).toBe(slide);
+    expect(posted).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+
+    posted.mockRestore();
   });
 
   it('ignores Tab in the forward direction, which already lands in the host', () => {
@@ -178,6 +185,23 @@ describe('with a host on another origin', () => {
     // so the reader's next Shift + Tab does what the browser would have done.
     jest.advanceTimersByTime(100);
     expect(document.activeElement).not.toBe(plot);
+
+    posted.mockRestore();
+  });
+
+  it('asks once while a handoff is in flight, however long the key is held', () => {
+    pretendFramedBy(null);
+    const posted = jest.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+    service = new FrameFocusService();
+
+    plot.focus();
+    pressShiftTab();
+    pressShiftTab();
+    pressShiftTab();
+
+    // Re-arming the deadline on every auto-repeat would hold the handoff off
+    // for as long as the reader keeps the key down.
+    expect(posted).toHaveBeenCalledTimes(1);
 
     posted.mockRestore();
   });


### PR DESCRIPTION
# Pull Request

## Description

A chart on a Quarto `revealjs` slide swallows every key and gives the reader no way back to the deck. Tab reaches the chart; from inside it, Space does not advance the slide, the arrows do not go back, and Shift + Tab leaves the document altogether for the browser's own UI.

Keyboard events do not cross a frame boundary, and every binding embeds charts in an iframe (py-maidr through `srcdoc`, r-maidr through a `data:` URL). While the reader is inside the chart the page around it hears nothing — which is *right* while they are reading, since MAIDR binds the arrows, Space, Backspace, Page Up and Page Down itself. That leaves Shift + Tab as the way back.

Usually the browser handles that on its own: Shift + Tab at the frame's first tab stop moves to whatever precedes the frame in the host. It cannot when nothing reachable precedes it — and a Quarto deck is exactly that case, because it renders no controls of its own, so a chart is the first thing on the page.

## Related Issues

The reveal.js half of what was observed — content on non-current slides staying in the tab order — is upstream and already filed as [hakimel/reveal.js#1587](https://github.com/hakimel/reveal.js/issues/1587) (open since 2016). It reproduces in a stock Quarto `revealjs` deck containing nothing but links, with no MAIDR involved, and is not addressed here.

## Changes Made

`FrameFocusService` (`src/service/frameFocus.ts`), constructed and disposed by `src/controller.ts` alongside the other services, so its listener exists exactly while a chart holds focus.

- Watches for **Shift + Tab at the frame's first tab stop**, and steps in **only when the browser would strand the reader** — where the host has somewhere real to go, the native tab order is left exactly as it was. Tab in the forward direction is never touched.
- When it does step in, focus goes to the element holding the frame, which on a slide deck is the slide's section element: the reader hears which slide they landed on, and the deck's own shortcuts work again because the keydown now reaches the host document.
- Reachability is **checked, not assumed**. reveal.js leaves the slides on either side of the current one rendered, so a chart on the previous slide is a tab stop in document order even though it is marked hidden — sending the reader there would land them on an off-screen chart instead of the slide.
- A same-origin host is served directly through `frameElement`, in the same event. A host on another origin — r-maidr's `data:` frames have an opaque origin — is asked by `postMessage` instead (`maidr:frame-focus-escape`), which `xability/r-maidr` answers on the parent side; a handoff already in flight is not asked again, so a held Shift + Tab cannot push its deadline out.
- **Nothing can trap a reader.** If the handoff cannot be completed, the chart blurs so the next Shift + Tab does what the browser would have done. Outside a frame the service adds no listener at all.

Nothing was needed in `xability/py-maidr`: its `srcdoc` frames are same-origin, so the engine reaches the host document directly.

## Screenshots (if applicable)

Not visual. A Chromium (Playwright) trace of the reader's path through a real three-slide Quarto deck, charts drawn by matplotlib through py-maidr:

```
Tab        → chart          role=application, "This is a maidr plot of…"
→ →        → chart          "X is a, Y is 3" / "X is b, Y is 5"
Shift+Tab  → section#slide-1-bar        ← back on the page
Space      → slide-2                    ← the deck responds again
Tab        → chart on slide 2
Shift+Tab  → section#slide-2-line
```

Before this change every step after the first left the reader stuck in the chart, and Shift + Tab put focus in the browser UI.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verification.** `npm run lint:fix`, `npm run type-check` and `npm run build` all clean; `npm test` green at 5286 tests across 369 suites, including eight new cases in `test/service/frameFocus.test.ts`. Both halves of the decision are covered — the fixing case and the leave-it-alone cases, since getting the latter wrong would rewrite the tab order of every notebook and article that embeds a chart. Checked in a browser against Quarto 1.10.18 decks built from both R (ggplot2 via r-maidr) and Python (matplotlib via py-maidr), on every slide, plus a plain Quarto HTML document to confirm its tab order is untouched.

**Reaching users.** Both bindings load maidr 4.4.0 today, from a CDN or a vendored copy, so this arrives with the next engine release.

**Related.** [`xability/r-maidr#208`](https://github.com/xability/r-maidr/pull/208) carries the parent-side half for its cross-origin frames.