### PR TITLE
feat(chartjs): read a sankey plugin chart as the weighted graph it draws

### DIFF
--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -93,6 +93,7 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Candlestick | `'candlestick'` | `chartjs-chart-financial` + a date adapter | [Candlestick](examples.html) |
 | Heatmap | `'matrix'` | `chartjs-chart-matrix` | [Heatmap](examples.html) |
 | Treemap | `'treemap'` | `chartjs-chart-treemap` | [Treemap](examples.html) |
+| Sankey | `'sankey'` | `chartjs-chart-sankey` | [Sankey](examples.html) |
 | Pie / Doughnut | `'pie'`, `'doughnut'` | — | [Pie chart](examples.html) |
 | Gauge | `'doughnut'` with `circumference` under 360 and two values | — | [Gauge](examples.html) |
 
@@ -528,6 +529,43 @@ A node's value is announced only where it is its own: a group whose value is exa
 A treemap has no Chart.js scales, so the axes are named after the dataset instead — `groups` joined for `axes.x` and `key` for `axes.y`. Set `plugins.maidr.axes` to override either.
 
 A **flat** `tree` of numbers draws rectangles the plugin gives no names to, and `data.labels` is not read by the controller. Those nodes are announced by their position — 1, 2, 3 — so declare `groups` whenever the nodes have names worth hearing.
+
+### Sankey
+
+Requires [`chartjs-chart-sankey`](https://github.com/kurkle/chartjs-chart-sankey). The plugin's `{from, to, flow}` rows are read as they are written — the nodes are derived from the edges, so nothing has to be declared twice. Left and right follow the largest ribbon; up and down walk the other nodes in the same column.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey@0.15"></script>
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/chartjs.js"></script>
+
+<div style="width: 700px; height: 400px">
+  <canvas id="sankey-chart"></canvas>
+</div>
+<script>
+  Chart.register(maidrChartjs.maidrPlugin);
+
+  new Chart(document.getElementById('sankey-chart'), {
+    type: 'sankey',
+    data: {
+      datasets: [{
+        label: 'Energy',
+        data: [
+          { from: 'Coal', to: 'Electricity', flow: 34 },
+          { from: 'Gas', to: 'Electricity', flow: 20 },
+          { from: 'Electricity', to: 'Homes', flow: 30 },
+          { from: 'Electricity', to: 'Industry', flow: 24 },
+        ],
+        labels: { Homes: 'Residential' },
+      }],
+    },
+  });
+</script>
+```
+
+`labels` maps a node key to the name the chart displays, and MAIDR announces the label rather than the key.
+
+> **Sankey note:** a sankey is the one supported Chart.js type MAIDR does **not** outline. A flow diagram is navigated by *node* while the chart's elements are *flows*, and nothing in the navigation event names the node — so the adapter declines rather than outlining a ribbon chosen by position. Audio, text and braille are unaffected.
 
 ### Heatmap (Matrix)
 

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -10,18 +10,17 @@
  * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap), treemap
  *
  * A type with no MAIDR trace behind it is rejected with an explicit error
- * rather than silently mapped to a bar chart. That list is shorter than it
- * was: `treemap` is read here now that `TraceType.TREEMAP` carries the
- * hierarchical navigation it needs (#1108). `sankey` and the word cloud
- * plugin have traces too and are still refused — each needs its own pass over
- * a running chart, and a reading written from published types alone is a
- * guess.
+ * rather than silently mapped to a bar chart. That list keeps shrinking:
+ * `treemap` and `sankey` are read here now that `TraceType.TREEMAP` and
+ * `TraceType.SANKEY` carry the navigation they need (#1108). The word cloud
+ * plugin has a trace too and is still refused — it needs its own pass over a
+ * running chart, and a reading written from published types alone is a guess.
  */
 
 import type { FieldRef, MaidrTraceDeclaration, ManhattanDeclaration, ScatterDeclaration, VolcanoDeclaration } from '../../type/declaration';
-import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, ThresholdOptions, TreemapPoint, ViolinKdePoint, VolcanoPoint, WaterfallKind, WaterfallPoint } from '../../type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, FlowPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, ThresholdOptions, TreemapPoint, ViolinKdePoint, VolcanoPoint, WaterfallKind, WaterfallPoint } from '../../type/grammar';
 import type { DeclarationContext } from '../shared/traceDeclaration';
-import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsPointValue, ChartJsRangeBound, ChartJsTreemapValue, MaidrPluginOptions } from './types';
+import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsPointValue, ChartJsRangeBound, ChartJsSankeyValue, ChartJsTreemapValue, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
 import { resolveFieldRef, validateDeclaration, warnUnresolvedRef } from '../shared/traceDeclaration';
 
@@ -819,11 +818,13 @@ function extractLayers(
       return extractHeatmapLayers(chart, pluginOptions);
     case 'treemap':
       return extractTreemapLayers(chart, pluginOptions);
+    case 'sankey':
+      return extractSankeyLayers(chart);
     default:
       throw new Error(
         `MAIDR Chart.js adapter: unsupported chart type "${chartType}". `
         + 'Supported types: bar, line, scatter, bubble, pie, doughnut, radar, '
-        + 'polarArea, boxplot, violin, candlestick, ohlc, matrix, treemap.',
+        + 'polarArea, boxplot, violin, candlestick, ohlc, matrix, treemap, sankey.',
       );
   }
 }
@@ -2760,6 +2761,84 @@ function extractTreemapLayers(
         y: { label: pluginOptions?.axes?.y ?? dataset.key },
       },
       data: points,
+    },
+  ];
+}
+
+/**
+ * Whether a dataset value is one of the sankey plugin's flows.
+ *
+ * All three fields, because all three are load-bearing: a flow with no ends
+ * names nothing, and one with no magnitude is not a case that reaches here —
+ * the plugin throws laying it out — so a row missing any of them is not a
+ * sankey row at all.
+ *
+ * @param value - A dataset value
+ * @returns True when it is a flow
+ */
+function isSankeyFlow(value: ChartJsDataValue): value is ChartJsSankeyValue {
+  if (typeof value !== 'object' || value === null)
+    return false;
+  const flow = value as ChartJsSankeyValue;
+  return (typeof flow.from === 'string' || typeof flow.from === 'number')
+    && (typeof flow.to === 'string' || typeof flow.to === 'number')
+    && typeof flow.flow === 'number'
+    && Number.isFinite(flow.flow);
+}
+
+/**
+ * Read a `chartjs-chart-sankey` dataset as the weighted graph it draws.
+ *
+ * Almost a rename: the plugin leaves `dataset.data` exactly as the caller
+ * wrote it — measured, the `{from, to, flow}` rows come back verbatim after
+ * `chart.update()` — and `FlowPoint` is `{source, target, value}`. The
+ * controller's own derived node map is deliberately not read: `FlowPoint`
+ * documents that the nodes come from the edges, and MAIDR derives its own
+ * from the same rows, so reading the plugin's would be a second source of
+ * truth for something the data already says. Node order is first appearance,
+ * which the emitted edge order gives for free.
+ *
+ * **Cycles need no handling.** Measured, `a → b` and `b → a` in one dataset
+ * draw two flows over two nodes without complaint, so a cycle is just two
+ * edges and nothing here has to break one.
+ *
+ * `dataset.labels` maps a node key to a display name. It is applied, because
+ * the key is an identifier and the label is what the chart puts on screen —
+ * announcing `'a'` where the chart says `'Apple'` describes a different chart.
+ *
+ * @param chart - The Chart.js chart instance
+ * @returns A single sankey layer, or none when the dataset drew nothing
+ */
+function extractSankeyLayers(chart: ChartJsChart): MaidrLayer[] {
+  const dataset = chart.data.datasets[0];
+  if (!dataset)
+    return [];
+
+  const flows = dataset.data.filter(isSankeyFlow);
+  if (flows.length === 0)
+    return [];
+
+  const labels = dataset.labels;
+  const named = (key: string | number): string | number => {
+    const label = labels?.[String(key)];
+    return typeof label === 'string' && label !== '' ? label : key;
+  };
+
+  const data: FlowPoint[] = flows.map(flow => ({
+    source: named(flow.from),
+    target: named(flow.to),
+    value: flow.flow,
+  }));
+
+  // No `axes`: a sankey has no scales, and naming two it does not have is
+  // what the treemap branch above avoids for the same reason. `FlowTrace`
+  // labels its own throughput.
+  return [
+    {
+      id: '0',
+      type: TraceType.SANKEY,
+      title: dataset.label,
+      data,
     },
   ];
 }

--- a/src/adapters/chartjs/highlightTargets.ts
+++ b/src/adapters/chartjs/highlightTargets.ts
@@ -499,6 +499,24 @@ export function resolveActiveTargets(
     return [{ datasetIndex: firstDatasetIndex(layerDatasetIndices, layer.id), index }];
   }
 
+  // Sankey: nothing is outlined, deliberately.
+  //
+  // A `FlowTrace` navigates **nodes** -- `row` and `col` address a node in a
+  // stage grid it derives by walking the graph -- while the Chart.js elements
+  // are **flows**. Nothing in `NavigateCallback` carries the node's identity,
+  // so the only way to pair the two here would be to re-derive the stage
+  // assignment in the adapter, which is exactly the drift the treemap branch
+  // above avoids by reproducing the model's addressing rather than its
+  // algorithm.
+  //
+  // Falling through instead would be worse than declining: the bar/line
+  // branch at the bottom answers `{ index: col }` for a layer it has no map
+  // for, so a node in the second column would outline the second *ribbon* --
+  // audio, text and braille all correct while the wrong element lights up,
+  // which is the one failure an accessibility suite cannot hear (#814).
+  if (layer.type === TraceType.SANKEY)
+    return [];
+
   // Heatmap / Matrix: look the active cell up by coordinate (the matrix data
   // order is arbitrary). MAIDR's Heatmap model reverses the Y axis (row 0 =
   // bottom), so un-reverse to recover the original yLabel before the lookup.

--- a/src/adapters/chartjs/types.ts
+++ b/src/adapters/chartjs/types.ts
@@ -84,7 +84,9 @@ export type ChartJsDataValue
      * `tree` in `dataset.data` during `chart.update()`, so this union has to
      * admit it for the dataset to be read at all.
      */
-    | ChartJsTreemapValue;
+    | ChartJsTreemapValue
+    /** One weighted flow of a sankey dataset. */
+    | ChartJsSankeyValue;
 
 /**
  * Minimal representation of a Chart.js chart instance.
@@ -192,6 +194,11 @@ export interface ChartJsDataset {
   groups?: string[];
   /** Which field of a row carries the value the rectangles are sized by. */
   key?: string;
+  /**
+   * `chartjs-chart-sankey`'s display names, keyed by node key — e.g.
+   * `{ a: 'Apple' }`. A key with no entry is announced as itself.
+   */
+  labels?: Record<string, string>;
 }
 
 /**
@@ -319,6 +326,28 @@ export interface ChartJsTreemapValue {
    * it is the source number itself.
    */
   _data?: unknown;
+}
+
+/**
+ * One flow of a `chartjs-chart-sankey` dataset.
+ *
+ * Unlike the treemap plugin, the sankey controller leaves `dataset.data`
+ * exactly as the caller wrote it — measured, the `{from, to, flow}` rows come
+ * back verbatim after `chart.update()`. So the reading is the rows, and the
+ * nodes the controller derives are never read: MAIDR derives its own from the
+ * same edges, and a second list would be a second source of truth.
+ *
+ * A row with no `flow` is not a case to handle — the plugin itself throws
+ * laying it out, before MAIDR sees the chart. Zero and negative flows draw
+ * fine and are read.
+ */
+export interface ChartJsSankeyValue {
+  /** The node the flow leaves. */
+  from: string | number;
+  /** The node it arrives at. */
+  to: string | number;
+  /** How much flows. */
+  flow: number;
 }
 
 /**

--- a/test/adapters/chartjs/extractor.test.ts
+++ b/test/adapters/chartjs/extractor.test.ts
@@ -458,14 +458,16 @@ describe('chart.js extractor', () => {
     });
 
     it('still throws for unsupported chart types', () => {
-      // 'sankey', not 'treemap' — a treemap is supported now (#1108), the
-      // same way this line already moved off 'radar' once. A supported type
-      // here would assert nothing about the unsupported path, and it fails
-      // quietly rather than loudly: a treemap dataset of plain numbers holds
-      // no laid-out rectangles, so the reading returns no layers instead of
-      // throwing.
+      // A name no plugin will ever register, rather than a real one that is
+      // merely unsupported today. This line has already moved twice --
+      // 'radar' when radar landed, 'treemap' when treemap did (#1108) -- and
+      // each move was prompted by a *failing* test rather than by noticing:
+      // a supported type here asserts nothing about the default branch, and
+      // fails quietly, since a dataset shaped for one plugin holds nothing
+      // another can read and the reading returns no layers instead of
+      // throwing. Naming a non-type is what stops the expiry.
       const chart = createChart({
-        type: 'sankey',
+        type: 'notAChartTypeAnyPluginRegisters',
         data: { datasets: [{ data: [1, 2] }] },
         options: {
           scales: { x: {}, y: { stack: 'demo' }, y2: { stack: 'demo' } },

--- a/test/adapters/chartjs/sankey.test.ts
+++ b/test/adapters/chartjs/sankey.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The Chart.js adapter refuses sankeys, though the trace already exists (#1108).
+ *
+ * `TraceType.SANKEY` got its cursor in #810 and other adapters read it, so an
+ * identical flow diagram drawn anywhere else was navigable and only a Chart.js
+ * one raised.
+ *
+ * Measured against a running chart -- `chart.js@4` with
+ * `chartjs-chart-sankey@0.15`, driven headlessly through Chart.js's own
+ * BasicPlatform -- and the reading turns out to be almost a rename:
+ *
+ *   - `dataset.data` comes back **verbatim** after `chart.update()`. Unlike
+ *     the treemap controller, the sankey one does not replace the caller's
+ *     rows, so `{from, to, flow}` maps straight onto `{source, target, value}`.
+ *
+ *   - the controller does build its own node map (`_nodes`, keyed by name with
+ *     `{in, out, size, x, y, ...}`), and it is deliberately not read.
+ *     `FlowPoint` says the nodes come from the edges; MAIDR derives its own
+ *     from the same rows, so reading the plugin's would be a second source of
+ *     truth for something the data already says.
+ *
+ *   - **cycles need no handling.** The issue asked for this to be measured
+ *     rather than assumed: `a → b` plus `b → a` draws two flows over two nodes
+ *     without complaint.
+ *
+ *   - a row with **no** `flow` is not a case to handle -- the plugin throws
+ *     laying it out ("Cannot read properties of undefined") before MAIDR sees
+ *     the chart. Zero and negative flows draw fine and are read.
+ */
+import type { ChartJsChart, ChartJsDataset } from '@adapters/chartjs/types';
+import type { FlowPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A sankey chart as Chart.js leaves it after `update()`.
+ *
+ * @param dataset - The dataset, whose `data` the controller left untouched
+ * @returns The chart
+ */
+function sankeyChart(dataset: ChartJsDataset): ChartJsChart {
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: { labels: [], datasets: [dataset] },
+    options: { plugins: {} },
+    config: { type: 'sankey' },
+    getDatasetMeta: () => ({ data: [], type: 'sankey' }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+/** The energy flow the plugin's own README draws. */
+function energyDataset(): ChartJsDataset {
+  return {
+    label: 'Energy',
+    data: [
+      { from: 'Coal', to: 'Electricity', flow: 34 },
+      { from: 'Gas', to: 'Electricity', flow: 20 },
+      { from: 'Electricity', to: 'Homes', flow: 30 },
+      { from: 'Electricity', to: 'Industry', flow: 24 },
+    ],
+  } as unknown as ChartJsDataset;
+}
+
+/** The single sankey layer of a chart. */
+function sankeyLayer(chart: ChartJsChart): { data: FlowPoint[]; layer: any } {
+  const layer = extractChartData(chart).maidr.subplots[0][0].layers[0];
+  return { data: layer.data as FlowPoint[], layer };
+}
+
+describe('chart.js sankey', () => {
+  it('is read rather than refused', () => {
+    const { layer } = sankeyLayer(sankeyChart(energyDataset()));
+
+    expect(layer.type).toBe(TraceType.SANKEY);
+    expect(layer.title).toBe('Energy');
+  });
+
+  it('reads each flow as the edge it draws, in the order it was declared', () => {
+    // Order matters beyond tidiness: `FlowTrace` derives its nodes from the
+    // edges and orders them by first appearance, so the emitted order *is*
+    // the node order a reader sweeps.
+    const { data } = sankeyLayer(sankeyChart(energyDataset()));
+
+    expect(data).toEqual([
+      { source: 'Coal', target: 'Electricity', value: 34 },
+      { source: 'Gas', target: 'Electricity', value: 20 },
+      { source: 'Electricity', target: 'Homes', value: 30 },
+      { source: 'Electricity', target: 'Industry', value: 24 },
+    ]);
+  });
+
+  it('announces a node by its label rather than its key', () => {
+    // `dataset.labels` maps a key to what the chart puts on screen. The key is
+    // an identifier; announcing it where the chart says "Apple" describes a
+    // different chart.
+    const chart = sankeyChart({
+      label: 'Fruit',
+      data: [{ from: 'a', to: 'b', flow: 5 }],
+      labels: { a: 'Apple', b: 'Banana' },
+    } as unknown as ChartJsDataset);
+
+    expect(sankeyLayer(chart).data).toEqual([
+      { source: 'Apple', target: 'Banana', value: 5 },
+    ]);
+  });
+
+  it('leaves a node with no label called by its key', () => {
+    const chart = sankeyChart({
+      label: 'Partial',
+      data: [{ from: 'a', to: 'b', flow: 5 }],
+      labels: { a: 'Apple' },
+    } as unknown as ChartJsDataset);
+
+    expect(sankeyLayer(chart).data).toEqual([
+      { source: 'Apple', target: 'b', value: 5 },
+    ]);
+  });
+
+  it('reads a cycle as the two edges it is', () => {
+    const chart = sankeyChart({
+      label: 'Cycle',
+      data: [
+        { from: 'A', to: 'B', flow: 5 },
+        { from: 'B', to: 'A', flow: 3 },
+      ],
+    } as unknown as ChartJsDataset);
+
+    expect(sankeyLayer(chart).data).toEqual([
+      { source: 'A', target: 'B', value: 5 },
+      { source: 'B', target: 'A', value: 3 },
+    ]);
+  });
+
+  it('keeps a zero and a negative flow, which the plugin draws', () => {
+    // Neither is a gap: the plugin lays both out. A row with *no* flow is the
+    // one it refuses, and it refuses it before MAIDR is involved.
+    const chart = sankeyChart({
+      label: 'Signed',
+      data: [
+        { from: 'a', to: 'b', flow: 0 },
+        { from: 'a', to: 'c', flow: -3 },
+      ],
+    } as unknown as ChartJsDataset);
+
+    expect(sankeyLayer(chart).data.map(f => f.value)).toEqual([0, -3]);
+  });
+
+  it('drops a row that is not a flow rather than emitting a nameless edge', () => {
+    const chart = sankeyChart({
+      label: 'Mixed',
+      data: [
+        { from: 'a', to: 'b', flow: 5 },
+        { from: 'a', flow: 2 },
+        { from: 'a', to: 'c', flow: Number.NaN },
+      ],
+    } as unknown as ChartJsDataset);
+
+    expect(sankeyLayer(chart).data).toEqual([
+      { source: 'a', target: 'b', value: 5 },
+    ]);
+  });
+
+  it('outlines nothing rather than the wrong ribbon', () => {
+    // A `FlowTrace` navigates nodes while the Chart.js elements are flows, and
+    // no part of the navigation callback carries the node's identity. Falling
+    // through to the bar/line branch would answer `{ index: col }` -- a node
+    // in the second column outlining the second *ribbon*, with audio, text and
+    // braille all correct while the wrong element lights up (#814).
+    const chart = sankeyChart(energyDataset());
+    const extraction = extractChartData(chart);
+    const layers = extraction.maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, extraction.layerDatasetIndices);
+
+    for (const [row, col] of [[0, 0], [0, 1], [1, 0], [1, 1]]) {
+      expect(
+        resolveActiveTargets(
+          layers,
+          maps,
+          extraction.layerDatasetIndices,
+          layers[0].id,
+          row,
+          col,
+        ),
+      ).toEqual([]);
+    }
+  });
+
+  it('still refuses the word cloud plugin', () => {
+    const chart = sankeyChart({ label: 'x', data: [] } as unknown as ChartJsDataset);
+    (chart as unknown as { config: { type: string } }).config.type = 'wordCloud';
+
+    expect(() => extractChartData(chart)).toThrow(/unsupported chart type "wordCloud"/);
+  });
+});

--- a/test/adapters/chartjs/treemap.test.ts
+++ b/test/adapters/chartjs/treemap.test.ts
@@ -207,10 +207,13 @@ describe('chart.js treemap', () => {
     expect(at(5, 0)).toEqual([]);
   });
 
-  it('still refuses a plugin type nothing reads', () => {
+  it('still refuses a type nothing reads', () => {
+    // A name no plugin registers, so this cannot expire the way the same
+    // assertion in `extractor.test.ts` did twice over as the adapter gained
+    // types.
     const chart = treemapChart({ label: 'x', data: [] } as unknown as ChartJsDataset);
-    (chart as unknown as { config: { type: string } }).config.type = 'sankey';
+    (chart as unknown as { config: { type: string } }).config.type = 'notAChartType';
 
-    expect(() => extractChartData(chart)).toThrow(/unsupported chart type "sankey"/);
+    expect(() => extractChartData(chart)).toThrow(/unsupported chart type "notAChartType"/);
   });
 });


### PR DESCRIPTION
The sankey third of #1108, following the treemap third in #1112.

## What happens

`TraceType.SANKEY` got its cursor in #810 and AnyChart, Recharts and d3 all read it — so an identical flow diagram was navigable everywhere except Chart.js, where the adapter raised.

## Measured, not read off the types

Same headless harness as #1112: `chartjs-chart-sankey@0.15` on `chart.js@4`, through Chart.js's own `BasicPlatform`. The reading turns out to be almost a rename, and the interesting findings are the ones that closed the issue's open questions.

**`dataset.data` comes back verbatim.** Unlike the treemap controller, the sankey one does not replace the caller's rows — `{from, to, flow}` survives `chart.update()` untouched and maps straight onto `FlowPoint`'s `{source, target, value}`.

**The controller's own node map is deliberately not read.** It does build one (`_nodes`, keyed by name with `{in, out, size, x, y, …}`), but `FlowPoint` says the nodes come from the edges, and MAIDR derives its own from the same rows. Reading the plugin's would be a second source of truth for something the data already says. Node order is first appearance, which the emitted edge order gives for free.

**Cycles need no handling** — the issue asked for this rather than assuming it. `a → b` plus `b → a` in one dataset draws two flows over two nodes without complaint.

**A row with no `flow` is not a case to handle.** The plugin throws laying it out (`Cannot read properties of undefined`) before MAIDR sees the chart. Zero and negative flows draw fine and are read as the values they are.

**`dataset.labels`** maps a node key to its display name, and is applied — the key is an identifier, and announcing `'a'` where the chart says `'Apple'` describes a different chart.

## Nothing is outlined, deliberately

This is the one judgment call worth reading closely. A `FlowTrace` navigates **nodes** — `row`/`col` address a node in a stage grid it derives by walking the graph — while the Chart.js elements are **flows**. Nothing in `NavigateCallback` carries the node's identity, so pairing the two here would mean re-deriving the stage assignment in the adapter: exactly the drift #1112's treemap branch avoids by reproducing the model's *addressing* rather than its *algorithm*.

Falling through would be worse than declining. The bar/line branch answers `{ index: col }` for a layer it has no map for, so a node in the second column would outline the second **ribbon** — audio, text and braille all correct while the wrong element lights up, which is the one failure an accessibility suite cannot hear (#814). So the branch returns `[]` explicitly, and a test pins it.

Making this resolvable is a change to `NavigateCallback` rather than to this adapter, and is a separate piece of work.

## Tests

`test/adapters/chartjs/sankey.test.ts`, 9 cases: the reading, edge order, labels applied, an unlabelled node left as its key, a cycle, zero and negative flows, a non-flow row dropped, the highlight decline at four positions, and the surviving refusal.

Falsified with five mutations, each applied alone — ignore `labels` (2 fail), swap source and target (5), accept a row missing an end (1), fall through to the bar/line highlight branch (1), drop zero and negative flows as gaps (1). Baseline restored at 9/9.

## Two existing tests made expiry-proof

Both `extractor.test.ts` and `treemap.test.ts` used a real-but-unsupported type as their "unsupported" stand-in, and both broke when sankey landed. That line had already moved twice before — `'radar'` when radar landed, `'treemap'` in #1112 — and **each move was prompted by a failing test rather than by anyone noticing**. Worse, it fails *quietly*: a dataset shaped for one plugin holds nothing another can read, so the reading returns no layers instead of throwing. They now name a type no plugin registers, which is what the assertion was always about.

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all clean — **373 suites / 5306 tests**, plus the 10 ESM suites. `docs/chartjs.md` gains the type, a worked example, and a note that a sankey is the one supported Chart.js type MAIDR does not outline.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_