### PR TITLE
feat(chartjs): read a word cloud plugin chart as the terms it draws

### DIFF
--- a/docs/chartjs.md
+++ b/docs/chartjs.md
@@ -94,6 +94,7 @@ MAIDR's Chart.js adapter is a standard Chart.js plugin:
 | Heatmap | `'matrix'` | `chartjs-chart-matrix` | [Heatmap](examples.html) |
 | Treemap | `'treemap'` | `chartjs-chart-treemap` | [Treemap](examples.html) |
 | Sankey | `'sankey'` | `chartjs-chart-sankey` | [Sankey](examples.html) |
+| Word Cloud | `'wordCloud'` | `chartjs-chart-wordcloud` | [Word cloud](examples.html) |
 | Pie / Doughnut | `'pie'`, `'doughnut'` | — | [Pie chart](examples.html) |
 | Gauge | `'doughnut'` with `circumference` under 360 and two values | — | [Gauge](examples.html) |
 
@@ -566,6 +567,35 @@ Requires [`chartjs-chart-sankey`](https://github.com/kurkle/chartjs-chart-sankey
 `labels` maps a node key to the name the chart displays, and MAIDR announces the label rather than the key.
 
 > **Sankey note:** a sankey is the one supported Chart.js type MAIDR does **not** outline. A flow diagram is navigated by *node* while the chart's elements are *flows*, and nothing in the navigation event names the node — so the adapter declines rather than outlining a ribbon chosen by position. Audio, text and braille are unaffected.
+
+### Word Cloud
+
+Requires [`chartjs-chart-wordcloud`](https://github.com/sgratzl/chartjs-chart-wordcloud). The terms go in `data.labels` and their weights in the dataset, which is the ordinary Chart.js split — and it is the reading, so a word's weight is announced as the number the author gave rather than recovered from how large it was drawn.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-wordcloud@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/maidr/dist/chartjs.js"></script>
+
+<div style="width: 700px; height: 400px">
+  <canvas id="wordcloud-chart"></canvas>
+</div>
+<script>
+  Chart.register(maidrChartjs.maidrPlugin);
+
+  new Chart(document.getElementById('wordcloud-chart'), {
+    type: 'wordCloud',
+    data: {
+      labels: ['accessible', 'chart', 'audio', 'braille'],
+      datasets: [{ label: 'Terms', data: [40, 25, 12, 8] }],
+    },
+  });
+</script>
+```
+
+Terms are read in the order they were declared, not in the order the layout happened to place them — the largest word is drawn first on screen, but a reader sweeping left and right gets the author's order.
+
+A term whose weight is `null` is skipped rather than announced as zero: a weight is what terms are compared by, and a zero would make the term look like the least common one rather than one the chart has no count for.
 
 ### Heatmap (Matrix)
 

--- a/src/adapters/chartjs/extractor.ts
+++ b/src/adapters/chartjs/extractor.ts
@@ -7,18 +7,17 @@
  *   waterfall, dumbbell), line (plain, stepped, area, stacked and normalized
  *   area, bump, dot, survival), scatter, bubble, pie, doughnut, gauge, radar,
  *   polarArea
- * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap), treemap
+ * - Plugin: boxplot, candlestick/ohlc, matrix (heatmap), treemap, sankey,
+ *   wordCloud
  *
  * A type with no MAIDR trace behind it is rejected with an explicit error
- * rather than silently mapped to a bar chart. That list keeps shrinking:
- * `treemap` and `sankey` are read here now that `TraceType.TREEMAP` and
- * `TraceType.SANKEY` carry the navigation they need (#1108). The word cloud
- * plugin has a trace too and is still refused — it needs its own pass over a
- * running chart, and a reading written from published types alone is a guess.
+ * rather than silently mapped to a bar chart. The three plugins #1108 named
+ * are all read now that `TraceType.TREEMAP`, `SANKEY` and `WORD_CLOUD` carry
+ * the navigation they need.
  */
 
 import type { FieldRef, MaidrTraceDeclaration, ManhattanDeclaration, ScatterDeclaration, VolcanoDeclaration } from '../../type/declaration';
-import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, FlowPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, ThresholdOptions, TreemapPoint, ViolinKdePoint, VolcanoPoint, WaterfallKind, WaterfallPoint } from '../../type/grammar';
+import type { BarPoint, BoxPoint, CandlestickPoint, DumbbellData, DumbbellPoint, FlowPoint, GanttData, GanttPoint, GaugePoint, HeatmapData, LinePoint, Maidr, MaidrLayer, MaidrSubplot, NavigateCallback, PiePoint, ScatterPoint, SegmentedPoint, StepDirection, SurvivalPoint, ThresholdOptions, TreemapPoint, ViolinKdePoint, VolcanoPoint, WaterfallKind, WaterfallPoint, WordCloudPoint } from '../../type/grammar';
 import type { DeclarationContext } from '../shared/traceDeclaration';
 import type { ChartJsChart, ChartJsDataset, ChartJsDataValue, ChartJsPointValue, ChartJsRangeBound, ChartJsSankeyValue, ChartJsTreemapValue, MaidrPluginOptions } from './types';
 import { Orientation, TraceType } from '../../type/grammar';
@@ -820,11 +819,14 @@ function extractLayers(
       return extractTreemapLayers(chart, pluginOptions);
     case 'sankey':
       return extractSankeyLayers(chart);
+    case 'wordCloud':
+      return extractWordCloudLayers(chart);
     default:
       throw new Error(
         `MAIDR Chart.js adapter: unsupported chart type "${chartType}". `
         + 'Supported types: bar, line, scatter, bubble, pie, doughnut, radar, '
-        + 'polarArea, boxplot, violin, candlestick, ohlc, matrix, treemap, sankey.',
+        + 'polarArea, boxplot, violin, candlestick, ohlc, matrix, treemap, sankey, '
+        + 'wordCloud.',
       );
   }
 }
@@ -2837,6 +2839,59 @@ function extractSankeyLayers(chart: ChartJsChart): MaidrLayer[] {
     {
       id: '0',
       type: TraceType.SANKEY,
+      title: dataset.label,
+      data,
+    },
+  ];
+}
+
+/**
+ * Read a `chartjs-chart-wordcloud` dataset as the terms it draws.
+ *
+ * The plugin puts the words in `data.labels` and their weights in
+ * `dataset.data` -- the ordinary Chart.js split, kept untouched through
+ * `chart.update()`, so this is the same reading a bar chart gets. Measured on
+ * `chartjs-chart-wordcloud@4` under jsdom (the controller measures text and so
+ * needs a real DOM, unlike the treemap and sankey ones): three terms in,
+ * `labels` back verbatim, `data` back verbatim, and `meta.data[i].text` equal
+ * to `labels[i]`.
+ *
+ * The drawn geometry is never read. A word cloud encodes its weight as glyph
+ * size, and recovering it from `scale` would be inverting a rendering when the
+ * number is sitting in the dataset -- the same reason the treemap's rectangles
+ * go unread.
+ *
+ * A word with no weight is dropped rather than announced as zero: `y` is what
+ * a reader compares terms by, and inventing one makes a term look like the
+ * least common rather than like a term the chart has no count for.
+ *
+ * @param chart - The Chart.js chart instance
+ * @returns A single word-cloud layer, or none when the dataset drew nothing
+ */
+function extractWordCloudLayers(chart: ChartJsChart): MaidrLayer[] {
+  const dataset = chart.data.datasets[0];
+  if (!dataset)
+    return [];
+
+  const labels = chart.data.labels ?? [];
+  const data: WordCloudPoint[] = [];
+  dataset.data.forEach((weight, index) => {
+    const word = labels[index];
+    const value = toFiniteNumber(weight);
+    if (typeof word !== 'string' || word === '' || value === null)
+      return;
+    data.push({ x: word, y: value });
+  });
+
+  if (data.length === 0)
+    return [];
+
+  // No `axes`: a word cloud has no scales, and `WordCloudTrace` names its own
+  // term and weight. Same reasoning as the treemap and sankey branches.
+  return [
+    {
+      id: '0',
+      type: TraceType.WORD_CLOUD,
       title: dataset.label,
       data,
     },

--- a/test/adapters/chartjs/sankey.test.ts
+++ b/test/adapters/chartjs/sankey.test.ts
@@ -188,10 +188,14 @@ describe('chart.js sankey', () => {
     }
   });
 
-  it('still refuses the word cloud plugin', () => {
+  it('still refuses a type nothing reads', () => {
+    // This named `wordCloud` when it was written, one PR before the word
+    // cloud was read -- so it expired immediately, which is the fourth time
+    // this assertion has broken by naming a real-but-not-yet-supported type.
+    // A name no plugin registers is the only version that cannot.
     const chart = sankeyChart({ label: 'x', data: [] } as unknown as ChartJsDataset);
-    (chart as unknown as { config: { type: string } }).config.type = 'wordCloud';
+    (chart as unknown as { config: { type: string } }).config.type = 'notAChartType';
 
-    expect(() => extractChartData(chart)).toThrow(/unsupported chart type "wordCloud"/);
+    expect(() => extractChartData(chart)).toThrow(/unsupported chart type "notAChartType"/);
   });
 });

--- a/test/adapters/chartjs/wordCloud.test.ts
+++ b/test/adapters/chartjs/wordCloud.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The Chart.js adapter refuses word clouds, though the trace exists (#1108).
+ *
+ * `TraceType.WORD_CLOUD` landed in #796 -- a word cloud being the canonical
+ * chart that carries real data while being readable only by eye, its weights
+ * encoded as glyph size and written down nowhere -- and AnyChart, amCharts and
+ * d3 all read one. Only a Chart.js word cloud raised.
+ *
+ * Measured on `chartjs-chart-wordcloud@4` with `chart.js@4`. This plugin needs
+ * a **real DOM**, unlike the treemap and sankey controllers: it measures text
+ * to lay the words out, so the bare headless harness threw `document is not
+ * defined` and the probe had to run under jsdom. What it showed is that the
+ * reading is the ordinary Chart.js split, kept untouched through `update()`:
+ *
+ *     data.labels        ["accessible", "chart", "audio"]   (verbatim)
+ *     dataset.data       [40, 25, 12]                       (verbatim)
+ *     meta.data[i].text  === data.labels[i]
+ *
+ * So the drawn geometry is never read. Recovering a weight from the element's
+ * `scale` would be inverting a rendering when the number is sitting in the
+ * dataset -- the same reason the treemap's rectangles go unread.
+ */
+import type { ChartJsChart, ChartJsDataset } from '@adapters/chartjs/types';
+import type { WordCloudPoint } from '@type/grammar';
+import { extractChartData } from '@adapters/chartjs/extractor';
+import { computeTargetMaps, resolveActiveTargets } from '@adapters/chartjs/highlightTargets';
+import { describe, expect, it } from '@jest/globals';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A word cloud chart as Chart.js leaves it after `update()`.
+ *
+ * @param labels - The terms
+ * @param dataset - The dataset carrying their weights
+ * @returns The chart
+ */
+function wordCloudChart(labels: unknown[], dataset: ChartJsDataset): ChartJsChart {
+  return {
+    canvas: {} as HTMLCanvasElement,
+    data: { labels, datasets: [dataset] },
+    options: { plugins: {} },
+    config: { type: 'wordCloud' },
+    getDatasetMeta: () => ({ data: [], type: 'wordCloud' }),
+    setActiveElements: () => {},
+  } as unknown as ChartJsChart;
+}
+
+/** The three terms the probe measured. */
+function termsChart(): ChartJsChart {
+  return wordCloudChart(
+    ['accessible', 'chart', 'audio'],
+    { label: 'Terms', data: [40, 25, 12] } as unknown as ChartJsDataset,
+  );
+}
+
+/** The single word-cloud layer of a chart. */
+function wordCloudLayer(chart: ChartJsChart): { data: WordCloudPoint[]; layer: any } {
+  const layer = extractChartData(chart).maidr.subplots[0][0].layers[0];
+  return { data: layer.data as WordCloudPoint[], layer };
+}
+
+describe('chart.js word cloud', () => {
+  it('is read rather than refused', () => {
+    const { layer } = wordCloudLayer(termsChart());
+
+    expect(layer.type).toBe(TraceType.WORD_CLOUD);
+    expect(layer.title).toBe('Terms');
+  });
+
+  it('pairs each term with the weight beside it', () => {
+    const { data } = wordCloudLayer(termsChart());
+
+    expect(data).toEqual([
+      { x: 'accessible', y: 40 },
+      { x: 'chart', y: 25 },
+      { x: 'audio', y: 12 },
+    ]);
+  });
+
+  it('keeps the declared order rather than sorting by weight', () => {
+    // The layout reorders on screen -- the largest word is placed first -- but
+    // the dataset is the reading, and a reader sweeping the terms gets the
+    // order the author wrote. Pinned because "biggest first" is the tempting
+    // wrong answer for a chart whose whole point is relative size.
+    const chart = wordCloudChart(
+      ['small', 'large', 'middling'],
+      { label: 'Unsorted', data: [1, 99, 50] } as unknown as ChartJsDataset,
+    );
+
+    expect(wordCloudLayer(chart).data.map(p => p.x)).toEqual([
+      'small',
+      'large',
+      'middling',
+    ]);
+  });
+
+  it('drops a term with no weight rather than calling it zero', () => {
+    // `y` is what a reader compares terms by. Inventing a zero makes a term
+    // look like the least common one, rather than one the chart has no count
+    // for -- the difference `toFiniteNumber` exists to keep.
+    const chart = wordCloudChart(
+      ['kept', 'gap', 'also kept'],
+      { label: 'Gappy', data: [5, null, 3] } as unknown as ChartJsDataset,
+    );
+
+    expect(wordCloudLayer(chart).data).toEqual([
+      { x: 'kept', y: 5 },
+      { x: 'also kept', y: 3 },
+    ]);
+  });
+
+  it('drops a weight with no term beside it', () => {
+    // A dataset longer than its labels. Emitting the weight anyway would put
+    // `undefined` where the term goes, and `WordCloudPoint.x` is what the
+    // trace announces.
+    const chart = wordCloudChart(
+      ['only'],
+      { label: 'Short labels', data: [5, 3] } as unknown as ChartJsDataset,
+    );
+
+    expect(wordCloudLayer(chart).data).toEqual([{ x: 'only', y: 5 }]);
+  });
+
+  it('emits no layer for a chart with nothing readable in it', () => {
+    const chart = wordCloudChart(
+      [],
+      { label: 'Empty', data: [] } as unknown as ChartJsDataset,
+    );
+
+    expect(extractChartData(chart).maidr.subplots[0][0].layers).toEqual([]);
+  });
+
+  it('outlines the word the cursor is on', () => {
+    // `WordCloudTrace` is one row of one column per term, and the points are
+    // emitted in element order -- so `col` *is* the Chart.js element index and
+    // the generic bar/line branch resolves it correctly. Asserted rather than
+    // assumed, because it is a fallback rather than a branch written for this
+    // trace: the sankey reading had to decline that same fallback because it
+    // would have outlined the wrong element.
+    const chart = termsChart();
+    const extraction = extractChartData(chart);
+    const layers = extraction.maidr.subplots[0][0].layers;
+    const maps = computeTargetMaps(chart, layers, extraction.layerDatasetIndices);
+
+    const at = (col: number): number[] =>
+      resolveActiveTargets(
+        layers,
+        maps,
+        extraction.layerDatasetIndices,
+        layers[0].id,
+        0,
+        col,
+      ).map(t => t.index);
+
+    expect(at(0)).toEqual([0]);
+    expect(at(1)).toEqual([1]);
+    expect(at(2)).toEqual([2]);
+  });
+
+  it('still refuses a type nothing reads', () => {
+    const chart = termsChart();
+    (chart as unknown as { config: { type: string } }).config.type = 'notAChartType';
+
+    expect(() => extractChartData(chart)).toThrow(/unsupported chart type "notAChartType"/);
+  });
+});


### PR DESCRIPTION
Closes #1108 — the third and last plugin it named, after the treemap in #1112 and the sankey in #1113.

## What happens

`TraceType.WORD_CLOUD` landed in #796 — a word cloud being the canonical chart that carries real data while being readable only by eye, its weights encoded as glyph size and written down nowhere on the page — and AnyChart, amCharts and d3 all read one. Only a Chart.js word cloud raised.

## Measured

`chartjs-chart-wordcloud@4` on `chart.js@4`. **This plugin needs a real DOM**, unlike the treemap and sankey controllers: it measures text to lay the words out, so the headless harness that served the other two threw `document is not defined` and the probe had to run under jsdom.

What it showed is that the reading is the ordinary Chart.js split, kept untouched through `update()`:

```
data.labels        ["accessible", "chart", "audio"]   (verbatim)
dataset.data       [40, 25, 12]                       (verbatim)
meta.data[i].text  === data.labels[i]
```

So the drawn geometry is never read. Recovering a weight from the element's `scale` would be inverting a rendering when the number is sitting in the dataset — the same reason the treemap's rectangles go unread.

## Two judgment calls

- **Terms keep the order they were declared in**, not the order the layout placed them. The largest word is drawn first on screen, and "biggest first" is the tempting wrong answer for a chart whose whole point is relative size — but the dataset is the reading, and a reader sweeping the terms should get the author's order. Pinned by a test.
- **A term with no weight is dropped, not called zero.** A weight is what terms are compared by, so a zero makes a term look like the least common one rather than one the chart has no count for.

## Highlighting needs no branch

`WordCloudTrace` is one row of one column per term, and the points are emitted in element order — so `col` *is* the Chart.js element index and the generic bar/line resolution is already correct. Asserted rather than assumed, because it is a fallback rather than a branch written for this trace: the sankey reading in #1113 had to **decline** that same fallback, since it would have outlined a ribbon chosen by position.

## Tests

`test/adapters/chartjs/wordCloud.test.ts`, 8 cases: the reading, term/weight pairing, declared order kept, a weightless term dropped, a weight with no term dropped, an empty chart emitting no layer, highlighting at each term, and the surviving refusal.

Falsified with four mutations, each applied alone — sort by weight (1 fail), announce a missing weight as zero (1), emit a weight with no term (1), read the weight off the drawn position (3). Baseline restored at 8/8.

## The refusal test, one last time

The sankey suite's refusal test named `wordCloud` when it was written **one PR ago**, and expired immediately — which is the fourth time this assertion has broken by naming a real-but-not-yet-supported type (`radar`, then `treemap`, then `sankey`, then this). I flagged the pattern in #1113 and fixed two of the three occurrences, leaving exactly the one that was about to break. It now names a type no plugin registers, like the other two.

`npm run lint:fix`, `npm run type-check`, `npm run build` and `npm test` all clean — **375 suites / 5323 tests**, plus the 10 ESM suites. `docs/chartjs.md` gains the type and a worked example.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_