### PR TITLE
feat(candlestick): announce the shape a candle is drawn in

### DIFF
--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -12,6 +12,7 @@ import type { AudioState, BrailleState, DescriptionState, TextState, TraceState 
 import { AbstractTrace } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Orientation } from '@type/grammar';
+import { candleShape } from '@util/candlePattern';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { MovableGrid } from './movable';
@@ -22,6 +23,13 @@ import { MovableGrid } from './movable';
 type HighlightValue = SVGElement | SVGElement[];
 
 const TREND = 'trend';
+/**
+ * What the candle's own shape is announced as -- a doji, a marubozu, a
+ * spinning top. It is the half of a candlestick chart a sighted reader takes
+ * in at a glance and a listener would otherwise have to reconstruct from four
+ * numbers (#731, #732, #733).
+ */
+const SHAPE = 'shape';
 const VOLATILITY_PRECISION_MULTIPLIER = 100;
 
 /** Rotor unit that walks only bullish (close > open) candles. */
@@ -797,6 +805,14 @@ export class Candlestick extends AbstractTrace {
       crossValue = point.open;
     }
 
+    // The shape is a fact about the candle rather than about the price the
+    // cursor is on, so it travels as an aside -- `section` fuses onto the
+    // cross-axis label and `z` is taken by the trend. It repeats across the
+    // five segments of one candle for the same reason the trend does: both
+    // describe the candle, and which segment you happen to be reading does
+    // not change either.
+    const shape = candleShape(point);
+
     return {
       main: {
         label: isHorizontal ? this.yAxis : this.xAxis,
@@ -808,6 +824,7 @@ export class Candlestick extends AbstractTrace {
       },
       section: this.currentSegmentType ?? 'open',
       z: { label: TREND, value: point.trend },
+      ...(shape === null ? {} : { asides: [{ label: SHAPE, value: shape }] }),
       mainAxis: isHorizontal ? 'y' : 'x',
       crossAxis: isHorizontal ? 'x' : 'y',
     };

--- a/src/util/candlePattern.ts
+++ b/src/util/candlePattern.ts
@@ -1,0 +1,170 @@
+/**
+ * The shape of a single candle, read off its own four numbers.
+ *
+ * A candlestick chart says two things at every session. The first is the four
+ * prices, which the trace already announces. The second is the *shape* the
+ * candle is drawn in — a cross, a solid block, a small body between two long
+ * wicks — and that is the half a sighted reader gets from the picture at a
+ * glance and a screen-reader user has to reconstruct by holding four numbers
+ * in their head and dividing.
+ *
+ * Nothing here is a forecast. Every name below describes the drawing: a doji
+ * is a candle whose open and close are level, a marubozu is one drawn with
+ * (almost) no wicks. What such a candle is supposed to *mean* is the reader's
+ * to decide, exactly as it is for someone looking at the chart.
+ *
+ * The thresholds are the ones the requests specify (#731, #732, #733), and
+ * they are parameters rather than literals because strictness is a matter of
+ * trading style. There is no way to set them from a chart yet; when there is,
+ * it passes {@link CandleShapeThresholds} and nothing else changes.
+ *
+ * @packageDocumentation
+ */
+
+/** A candle's four prices, the only input any shape test needs. */
+export interface Ohlc {
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+/**
+ * The shapes told apart here, which are the ones a single candle can carry.
+ *
+ * Patterns that need a neighbour — engulfing, piercing, the star and soldier
+ * families — are not shapes of one candle and are not decided here.
+ */
+export type CandleShape
+  = | 'marubozu'
+    | 'doji'
+    | 'dragonfly doji'
+    | 'gravestone doji'
+    | 'spinning top';
+
+/** How strict each test is, as fractions of the candle's own range. */
+export interface CandleShapeThresholds {
+  /** A marubozu's body must be at least this much of the range (#731). */
+  marubozuBody: number;
+  /** A doji's body may be at most this much of the range (#733). */
+  dojiBody: number;
+  /** A doji variant's short shadow may be at most this much (#733). */
+  dojiShortShadow: number;
+  /** A doji variant's long shadow must be at least this much (#733). */
+  dojiLongShadow: number;
+  /** A spinning top's body may be at most this much of the range (#732). */
+  spinningBody: number;
+  /** How far a spinning top's two shadows may differ (#732). */
+  spinningShadowGap: number;
+}
+
+/** The thresholds each request names, and what applies when none are given. */
+export const DEFAULT_CANDLE_SHAPE_THRESHOLDS: CandleShapeThresholds = {
+  marubozuBody: 0.95,
+  dojiBody: 0.05,
+  dojiShortShadow: 0.05,
+  dojiLongShadow: 0.6,
+  spinningBody: 0.33,
+  spinningShadowGap: 0.15,
+};
+
+/** The four quantities every test below is written in terms of. */
+interface CandleParts {
+  range: number;
+  body: number;
+  upper: number;
+  lower: number;
+}
+
+/**
+ * Splits a candle into the parts the shape tests are written in terms of.
+ *
+ * @param candle - The candle's four prices
+ * @returns Its range, body height and the length of each shadow
+ */
+function partsOf(candle: Ohlc): CandleParts {
+  const top = Math.max(candle.open, candle.close);
+  const bottom = Math.min(candle.open, candle.close);
+  return {
+    range: candle.high - candle.low,
+    body: Math.abs(candle.close - candle.open),
+    upper: candle.high - top,
+    lower: bottom - candle.low,
+  };
+}
+
+/**
+ * Which doji variant a level-bodied candle is, if it is one at all.
+ *
+ * @param parts      - The candle's measured parts
+ * @param thresholds - How strict to be
+ * @returns The variant's name
+ */
+function dojiVariant(
+  parts: CandleParts,
+  thresholds: CandleShapeThresholds,
+): CandleShape {
+  // A candle with no range at all opened, closed, rose and fell at one price.
+  // It is a doji — open level with close is the whole of the definition — but
+  // it is not a *dragonfly* or a *gravestone*, both of which name a long
+  // shadow that this candle does not have. Every proportion below is a
+  // fraction of a range of zero and so is trivially satisfied, which would
+  // otherwise report a rejection of lows that never happened.
+  if (parts.range === 0) {
+    return 'doji';
+  }
+
+  const short = thresholds.dojiShortShadow * parts.range;
+  const long = thresholds.dojiLongShadow * parts.range;
+
+  if (parts.upper <= short && parts.lower >= long) {
+    return 'dragonfly doji';
+  }
+  if (parts.lower <= short && parts.upper >= long) {
+    return 'gravestone doji';
+  }
+  return 'doji';
+}
+
+/**
+ * Names the shape a candle is drawn in, or nothing when it is an ordinary one.
+ *
+ * The tests are asked most specific first, because they overlap by
+ * construction: every doji also satisfies the spinning top's body condition
+ * (0.05 of a range is under 0.33), and a doji with two even wicks satisfies
+ * all of it. Doji is the narrower statement and so the one worth making.
+ * Marubozu cannot collide with either — a body at 95% of the range and one at
+ * 5% are the two ends of the same measurement.
+ *
+ * @param candle     - The candle's four prices
+ * @param thresholds - How strict to be; the requests' figures by default
+ * @returns The shape's name, or `null` for a candle that is none of them
+ */
+export function candleShape(
+  candle: Ohlc,
+  thresholds: CandleShapeThresholds = DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+): CandleShape | null {
+  const parts = partsOf(candle);
+
+  // Not `>= 0`: a candle drawn at a single price has a body of zero, and
+  // `0 >= 0.95 * 0` would call it the most one-directional candle on the
+  // chart. It reaches the doji test below instead, which is what it is.
+  if (parts.range > 0 && parts.body >= thresholds.marubozuBody * parts.range) {
+    return 'marubozu';
+  }
+
+  if (parts.body <= thresholds.dojiBody * parts.range) {
+    return dojiVariant(parts, thresholds);
+  }
+
+  if (
+    parts.body <= thresholds.spinningBody * parts.range
+    && parts.upper >= parts.body
+    && parts.lower >= parts.body
+    && Math.abs(parts.upper - parts.lower) <= thresholds.spinningShadowGap * parts.range
+  ) {
+    return 'spinning top';
+  }
+
+  return null;
+}

--- a/test/model/candlestickShape.test.ts
+++ b/test/model/candlestickShape.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The candle's shape reaches the announcement (#731, #732, #733).
+ *
+ * `candleShape` decides the name; these cases are about where it lands. It
+ * travels as an **aside** rather than in `z` or `section`, because those two
+ * are taken and neither would carry it correctly: `z` is the candle's trend,
+ * and `section` fuses onto the cross-axis label, so a shape put there would
+ * read as though the price were the shape.
+ *
+ * The shape repeats across the five segments of one candle. That is the same
+ * choice the trend already makes, and for the same reason: both are facts
+ * about the candle, and which of its prices the cursor is reading does not
+ * change either of them.
+ */
+
+import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import { describe, expect, it } from '@jest/globals';
+import { Candlestick } from '@model/candlestick';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A candle carrying whatever prices a case needs.
+ *
+ * `trend` and `volatility` are placeholders: the model recomputes both.
+ *
+ * @param value - The x label
+ * @param ohlc  - The four prices
+ * @returns A candlestick point
+ */
+function candle(
+  value: string,
+  ohlc: { open: number; high: number; low: number; close: number },
+): CandlestickPoint {
+  return { value, ...ohlc, trend: 'Neutral', volatility: 0 };
+}
+
+/** One doji, one marubozu, one spinning top and one ordinary candle. */
+const CANDLES = [
+  candle('d0', { open: 100, high: 105, low: 95, close: 100.2 }),
+  candle('d1', { open: 10, high: 20, low: 10, close: 20 }),
+  candle('d2', { open: 100, high: 106, low: 96, close: 102 }),
+  candle('d3', { open: 100, high: 105, low: 99, close: 104 }),
+];
+
+/**
+ * The trace over {@link CANDLES}.
+ *
+ * @returns A candlestick trace positioned on its first candle
+ */
+function trace(): Candlestick {
+  const layer: MaidrLayer = {
+    id: 'candle',
+    type: TraceType.CANDLESTICK,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: CANDLES,
+  };
+  return new Candlestick(layer);
+}
+
+/**
+ * What a trace announces as asides where it sits.
+ *
+ * @param subject - The trace to read
+ * @returns The aside label/value pairs, or undefined when there are none
+ */
+function asidesOf(subject: Candlestick): { label: string; value: string }[] | undefined {
+  const state = subject.state as Extract<TraceState, { empty: false }>;
+  return state.text.asides;
+}
+
+/**
+ * Walks the cursor forward by `steps` candles.
+ *
+ * The first `FORWARD` is the trace's initial entry and lands on the candle
+ * the cursor already reports, so it is spent before any stepping begins.
+ *
+ * @param subject - The trace to move
+ * @param steps   - How many candles to advance
+ */
+function forward(subject: Candlestick, steps: number): void {
+  subject.moveOnce('FORWARD');
+  for (let i = 0; i < steps; i++) {
+    subject.moveOnce('FORWARD');
+  }
+}
+
+describe('a candlestick announces the shape it is drawn in', () => {
+  it('names the doji it opens on', () => {
+    expect(asidesOf(trace())).toEqual([{ label: 'shape', value: 'doji' }]);
+  });
+
+  it('names each candle as the cursor reaches it', () => {
+    const subject = trace();
+
+    forward(subject, 1);
+    expect(asidesOf(subject)).toEqual([{ label: 'shape', value: 'marubozu' }]);
+
+    subject.moveOnce('FORWARD');
+    expect(asidesOf(subject)).toEqual([{ label: 'shape', value: 'spinning top' }]);
+  });
+
+  it('says nothing at all about an ordinary candle', () => {
+    // The half that keeps the announcement worth listening to: most candles
+    // on most charts are no named shape, and a trailing clause on every one
+    // of them would bury the ones that are.
+    const subject = trace();
+
+    forward(subject, 3);
+    expect(asidesOf(subject)).toBeUndefined();
+  });
+
+  it('keeps saying it as the cursor moves between the candle\'s prices', () => {
+    // The same choice the trend already makes. A reader who arrows down from
+    // the close to the low has not moved to a different candle.
+    const subject = trace();
+    const named = [{ label: 'shape', value: 'doji' }];
+
+    // Named outright rather than compared against whatever the previous
+    // reading was: two `undefined`s are equal too, and this case has to fail
+    // when the shape stops being announced at all.
+    expect(asidesOf(subject)).toEqual(named);
+
+    subject.moveOnce('DOWNWARD');
+    expect(asidesOf(subject)).toEqual(named);
+  });
+
+  it('leaves the prices and the trend where they were', () => {
+    // An aside is an addition, not a replacement: nothing that was announced
+    // before stops being announced.
+    const state = trace().state as Extract<TraceState, { empty: false }>;
+
+    expect(state.text.main.value).toBe('d0');
+    expect(state.text.z).toEqual({ label: 'trend', value: 'Bull' });
+  });
+});

--- a/test/util/candlePattern.test.ts
+++ b/test/util/candlePattern.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The shape a single candle is drawn in (#731, #732, #733).
+ *
+ * A candlestick chart carries two things at every session: the four prices,
+ * which the trace already announces, and the shape they draw — a cross, a
+ * solid block, a small body between two long wicks. The second is what a
+ * sighted reader takes in at a glance and a listener would otherwise have to
+ * reconstruct by holding four numbers in their head and dividing.
+ *
+ * Every case below is worked from the request's own arithmetic:
+ *
+ *   range = high - low        body  = |close - open|
+ *   upper = high - max(o, c)  lower = min(o, c) - low
+ *
+ * Three of them are decisions rather than transcriptions, and each is
+ * asserted so it cannot drift:
+ *
+ * - **The tests overlap, and the narrower one wins.** Every doji satisfies the
+ *   spinning top's body condition by construction (0.05 of a range is inside
+ *   0.33), and a doji with two even wicks satisfies all of it. "Doji" is the
+ *   stronger statement about the same candle.
+ * - **A candle drawn at one price is a doji, not a dragonfly.** Its range is
+ *   zero, so every proportional test is trivially true and the variant rules
+ *   would report a rejection of lows that never happened. Open level with
+ *   close is the whole of the doji definition, and that much is real.
+ * - **It is not a marubozu either**, for the mirror-image reason: `body >=
+ *   0.95 * range` reads `0 >= 0` and would call the flattest candle on the
+ *   chart the most one-directional one.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { candleShape, DEFAULT_CANDLE_SHAPE_THRESHOLDS } from '@util/candlePattern';
+
+describe('the shape a candle is drawn in', () => {
+  it('names a marubozu drawn with no wicks at all', () => {
+    // high === close and low === open: the request's "perfect" bullish case.
+    expect(candleShape({ open: 10, high: 20, low: 10, close: 20 })).toBe('marubozu');
+    // And bearish, which is the same body with open and close swapped.
+    expect(candleShape({ open: 20, high: 20, low: 10, close: 10 })).toBe('marubozu');
+  });
+
+  it('names a marubozu inside the wick tolerance', () => {
+    // range 10.5, body 10, and 10 >= 0.95 * 10.5 = 9.975.
+    expect(candleShape({ open: 10, high: 20.3, low: 9.8, close: 20 })).toBe('marubozu');
+  });
+
+  it('declines a body that misses the tolerance', () => {
+    // range 11.5, body 10, and 0.95 * 11.5 = 10.925. A candle 87% body is a
+    // strong one and not a marubozu, and it is nothing else either.
+    expect(candleShape({ open: 10, high: 21, low: 9.5, close: 20 })).toBeNull();
+  });
+
+  it('names a doji whose wicks reach both ways', () => {
+    // range 10, body 0.2; both shadows near 5, so neither variant applies.
+    expect(candleShape({ open: 100, high: 105, low: 95, close: 100.2 })).toBe('doji');
+  });
+
+  it('names a dragonfly by its one long lower wick', () => {
+    // range 8.4, upper 0.4 (<= 0.42), lower 8 (>= 5.04).
+    expect(candleShape({ open: 100, high: 100.4, low: 92, close: 100 }))
+      .toBe('dragonfly doji');
+  });
+
+  it('names a gravestone by its one long upper wick', () => {
+    expect(candleShape({ open: 100, high: 108, low: 99.6, close: 100 }))
+      .toBe('gravestone doji');
+  });
+
+  it('names a spinning top by its small body between even wicks', () => {
+    // range 10, body 2 (<= 3.3), both shadows 4 (>= 2), and no gap between
+    // them at all.
+    expect(candleShape({ open: 100, high: 106, low: 96, close: 102 }))
+      .toBe('spinning top');
+  });
+
+  it('declines a small body whose wicks are lopsided', () => {
+    // The clause that separates a spinning top from a hammer-shaped candle:
+    // body 2, upper 6, lower 2, and |6 - 2| = 4 is past 0.15 * 10.
+    expect(candleShape({ open: 100, high: 108, low: 98, close: 102 })).toBeNull();
+  });
+
+  it('calls an overlapping candle a doji rather than a spinning top', () => {
+    // Satisfies every spinning-top clause -- body 0.2 <= 3.234, both shadows
+    // 4.8, no gap -- and is a doji, which says more about the same candle.
+    expect(candleShape({ open: 100, high: 105, low: 95.2, close: 100.2 }))
+      .toBe('doji');
+  });
+
+  it('calls a candle drawn at a single price a plain doji', () => {
+    // Range zero. Not a dragonfly and not a gravestone, which each name a
+    // long shadow this candle has none of, and not a marubozu.
+    expect(candleShape({ open: 50, high: 50, low: 50, close: 50 })).toBe('doji');
+  });
+
+  it('leaves an ordinary candle unnamed', () => {
+    // range 6, body 4: too small for a marubozu, far too large for a doji or
+    // a spinning top. Most candles on most charts are this.
+    expect(candleShape({ open: 100, high: 105, low: 99, close: 104 })).toBeNull();
+  });
+
+  it('answers by the thresholds it is given', () => {
+    const candle = { open: 10, high: 21, low: 9.5, close: 20 };
+
+    // The same candle the tolerance rejected above, accepted once the
+    // strictness is relaxed -- which is the whole point of the figures being
+    // parameters rather than literals.
+    expect(candleShape(candle)).toBeNull();
+    expect(candleShape(candle, { ...DEFAULT_CANDLE_SHAPE_THRESHOLDS, marubozuBody: 0.85 }))
+      .toBe('marubozu');
+  });
+});


### PR DESCRIPTION
Closes #731. Closes #732. Closes #733.

## Why

A candlestick chart carries two things at every session. The first is the four prices, which the trace already announces. The second is the **shape** they draw — a cross, a solid block, a small body between two long wicks — and that is the half a sighted reader takes in at a glance while a listener would have to hold four numbers in their head and divide.

Nothing here is a forecast. Every name describes the drawing; what such a candle is supposed to *mean* stays the reader's to decide, exactly as it is for someone looking at the chart.

## What is read

`src/util/candlePattern.ts`, from each request's own arithmetic:

```
range = high - low        body  = |close - open|
upper = high - max(o, c)  lower = min(o, c) - low
```

| shape | condition | from |
| --- | --- | --- |
| marubozu | `body >= 0.95 * range` | #731 |
| doji | `body <= 0.05 * range` | #733 |
| dragonfly doji | doji, `upper <= 0.05 * range`, `lower >= 0.6 * range` | #733 |
| gravestone doji | doji, `lower <= 0.05 * range`, `upper >= 0.6 * range` | #733 |
| spinning top | `body <= 0.33 * range`, both shadows `>= body`, `\|upper - lower\| <= 0.15 * range` | #732 |

#731's "perfect" marubozu (`high = close and low = open`) is the zero-tolerance case of the practical rule and needs no branch of its own.

## Three decisions, measured rather than assumed

- **The tests overlap, and the narrower one wins.** Every doji satisfies the spinning top's body condition by construction — 0.05 of a range is inside 0.33 — and a doji with two even wicks satisfies all of it. Doji is the stronger statement about the same candle, so it is asked first. Asserted directly: a candle at `o=100 h=105 l=95.2 c=100.2` meets every spinning-top clause and comes back `doji`.
- **A candle drawn at one price is a plain doji, not a dragonfly.** Its range is zero, so every proportional test is trivially true and the variant rules would report a rejection of lows that never happened. Open level with close is the whole of the doji definition, and that much is real.
- **It is not a marubozu either**, for the mirror-image reason: `body >= 0.95 * range` reads `0 >= 0` and would call the flattest candle on the chart the most one-directional one.

## Where it is announced

As an **aside**, which is the field for "facts the point carries that sit on neither axis". The two nearby alternatives do not work:

- `z` is taken by the candle's trend.
- `section` fuses onto the cross-axis label whenever `z` is present, so a shape put there reads as though the price were the shape — the same trap `TextState.asides` was added for.

It repeats across the candle's five segments, which is the choice the **trend already makes** and for the same reason: both describe the candle, and which of its prices the cursor is reading does not change either. An ordinary candle — most of them — says nothing at all, so the clause stays worth hearing.

## Thresholds

Parameters rather than literals, because strictness is a matter of trading style as all three requests say. There is no way to set them from a chart yet, and inventing a grammar field before anything can send one would be guessing at the shape of that option; when it exists it passes `CandleShapeThresholds` and nothing else changes. A case pins that the parameter is real: the candle the 5% tolerance rejects is accepted at 15%.

`Body / Range` is not returned. #731 asks for it so users can sort by "how perfect" a marubozu is, and there is nowhere to sort or display it yet; it is one subtraction from the four prices when there is.

**No producer has to send anything.** The shape is derived from prices the payload already carries, so `docs/SCHEMA.md` is untouched.

## Tests

17 cases across `test/util/candlePattern.test.ts` (12) and `test/model/candlestickShape.test.ts` (5). Every expected value in the first file was worked by hand from the arithmetic above rather than recorded from a run.

Falsified with four mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| trace drops the aside | 3 |
| spinning top tested before doji | 4 |
| marubozu without the zero-range guard | 1 |
| doji variants without the zero-range guard | 1 |

One case was strengthened after falsification exposed it as weak: "keeps saying it as the cursor moves between the candle's prices" compared the aside against whatever the previous reading had been, which passes when two `undefined`s are compared. It names the expected value outright now, and the first mutation went from 2 failures to 3.

`npm run lint:fix`, `npm run type-check` and `npm run build` clean; full suite **5344 passing** (378 suites) plus **137** ESM.

## Not in scope

The nine multi-candle patterns (#734–#742) are not shapes of one candle — engulfing, piercing, the star and soldier families all need a neighbour and a prior trend — and none is decided here. `CandleShape` and `candleShape` are deliberately named for the single-candle case so that work can sit beside them rather than inside them.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_