### PR TITLE
feat(candlestick): announce what a candle makes of the one before it

### DIFF
--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -12,7 +12,7 @@ import type { AudioState, BrailleState, DescriptionState, TextState, TraceState 
 import { AbstractTrace } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Orientation } from '@type/grammar';
-import { candleShape } from '@util/candlePattern';
+import { candlePairPatterns, candleShape } from '@util/candlePattern';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { MovableGrid } from './movable';
@@ -30,6 +30,13 @@ const TREND = 'trend';
  * numbers (#731, #732, #733).
  */
 const SHAPE = 'shape';
+/**
+ * What the candle makes of the one before it -- an engulfing, a piercing
+ * line, a tweezer. Unlike {@link SHAPE} there may be more than one at a time,
+ * because these say different things about the same pair rather than the same
+ * thing at different strictnesses (#735, #736, #737, #738).
+ */
+const PATTERN = 'pattern';
 const VOLATILITY_PRECISION_MULTIPLIER = 100;
 
 /** Rotor unit that walks only bullish (close > open) candles. */
@@ -812,6 +819,15 @@ export class Candlestick extends AbstractTrace {
     // describe the candle, and which segment you happen to be reading does
     // not change either.
     const shape = candleShape(point);
+    // The first candle has nothing before it, so it carries no pair pattern.
+    const previous = this.candles[this.currentPointIndex - 1];
+    const pairs = previous === undefined
+      ? []
+      : candlePairPatterns(previous, point);
+    const asides = [
+      ...(shape === null ? [] : [{ label: SHAPE, value: shape }]),
+      ...pairs.map(pattern => ({ label: PATTERN, value: pattern })),
+    ];
 
     return {
       main: {
@@ -824,7 +840,7 @@ export class Candlestick extends AbstractTrace {
       },
       section: this.currentSegmentType ?? 'open',
       z: { label: TREND, value: point.trend },
-      ...(shape === null ? {} : { asides: [{ label: SHAPE, value: shape }] }),
+      ...(asides.length === 0 ? {} : { asides }),
       mainAxis: isHorizontal ? 'y' : 'x',
       crossAxis: isHorizontal ? 'x' : 'y',
     };

--- a/src/util/candlePattern.ts
+++ b/src/util/candlePattern.ts
@@ -13,10 +13,14 @@
  * (almost) no wicks. What such a candle is supposed to *mean* is the reader's
  * to decide, exactly as it is for someone looking at the chart.
  *
- * The thresholds are the ones the requests specify (#731, #732, #733), and
- * they are parameters rather than literals because strictness is a matter of
- * trading style. There is no way to set them from a chart yet; when there is,
- * it passes {@link CandleShapeThresholds} and nothing else changes.
+ * {@link candlePairPatterns} does the same for the two-candle patterns, which
+ * describe how a candle sits against the one before it rather than how it is
+ * drawn on its own (#735, #736, #737, #738).
+ *
+ * The thresholds are the ones the requests specify, and they are parameters
+ * rather than literals because strictness is a matter of trading style. There
+ * is no way to set them from a chart yet; when there is, it passes
+ * {@link CandleShapeThresholds} and nothing else changes.
  *
  * @packageDocumentation
  */
@@ -56,6 +60,11 @@ export interface CandleShapeThresholds {
   spinningBody: number;
   /** How far a spinning top's two shadows may differ (#732). */
   spinningShadowGap: number;
+  /**
+   * How far two candles' shared level may differ and still be one, as a
+   * fraction of the two ranges' mean (#737).
+   */
+  tweezerLevel: number;
 }
 
 /** The thresholds each request names, and what applies when none are given. */
@@ -66,6 +75,7 @@ export const DEFAULT_CANDLE_SHAPE_THRESHOLDS: CandleShapeThresholds = {
   dojiLongShadow: 0.6,
   spinningBody: 0.33,
   spinningShadowGap: 0.15,
+  tweezerLevel: 0.1,
 };
 
 /** The four quantities every test below is written in terms of. */
@@ -167,4 +177,148 @@ export function candleShape(
   }
 
   return null;
+}
+
+/**
+ * How a candle sits against the one before it.
+ *
+ * These are statements about a *pair*, so they are announced on the second
+ * candle of the two: it is the one whose reading changes because of what came
+ * before. The first candle on a chart has no previous and so carries none.
+ */
+export type CandlePairPattern
+  = | 'bullish engulfing'
+    | 'bearish engulfing'
+    | 'piercing line'
+    | 'dark cloud cover'
+    | 'tweezer bottom'
+    | 'tweezer top';
+
+/**
+ * Whether two candles share a level closely enough to be a tweezer.
+ *
+ * The tolerance is a fraction of the two ranges' mean rather than of either
+ * one, so a quiet session beside a wild one does not get the wild one's
+ * slack — which is what "the same level, twice" is supposed to mean.
+ *
+ * @param first      - The earlier candle's level
+ * @param second     - The later candle's level
+ * @param ranges     - Both candles' high-to-low extents
+ * @param thresholds - How strict to be
+ * @returns True when the two levels count as one
+ */
+function sharesLevel(
+  first: number,
+  second: number,
+  ranges: [number, number],
+  thresholds: CandleShapeThresholds,
+): boolean {
+  const tolerance = thresholds.tweezerLevel * ((ranges[0] + ranges[1]) / 2);
+  return Math.abs(first - second) <= tolerance;
+}
+
+/**
+ * Names every two-candle pattern a pair satisfies.
+ *
+ * An **array**, because unlike the single-candle shapes these do not compete.
+ * A doji and a spinning top are the same statement at two strictnesses, so
+ * only the narrower is worth making; an engulfing and a tweezer bottom are
+ * two different facts — one about the bodies, one about the shared low — and
+ * a pair can honestly be both. They are returned in a fixed order so the
+ * announcement does not depend on how the tests happen to be written.
+ *
+ * What the pairs cannot collide on is direction: bullish engulfing needs the
+ * close above the previous open and piercing needs it below, which is #735's
+ * "does not fully engulf" written as arithmetic, and the bearish two mirror
+ * it. A tweezer bottom and a tweezer top would need the earlier candle to be
+ * both bearish and bullish.
+ *
+ * The prior-trend qualifier #735 and #736 mention as desirable is **not**
+ * applied. "After a downtrend" needs a definition of trend — how many candles
+ * back, and how much of a fall counts — that the chart does not state, and
+ * inventing one would silence real patterns on a reader's behalf by a rule
+ * they cannot see. The geometry each request specifies is what is tested.
+ *
+ * @param previous   - The candle before
+ * @param candle     - The candle the cursor is on
+ * @param thresholds - How strict to be; the requests' figures by default
+ * @returns Every pattern the pair satisfies, possibly none
+ */
+export function candlePairPatterns(
+  previous: Ohlc,
+  candle: Ohlc,
+  thresholds: CandleShapeThresholds = DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+): CandlePairPattern[] {
+  const found = new Array<CandlePairPattern>();
+
+  const wasBearish = previous.close < previous.open;
+  const wasBullish = previous.close > previous.open;
+  const midpoint = (previous.open + previous.close) / 2;
+  const ranges: [number, number] = [
+    previous.high - previous.low,
+    candle.high - candle.low,
+  ];
+
+  // #738: the later body swallows the earlier one whole, in the opposite
+  // direction. Deliberately two candles rather than three, as the request
+  // notes.
+  if (
+    wasBearish
+    && candle.close > candle.open
+    && candle.open < previous.close
+    && candle.close > previous.open
+  ) {
+    found.push('bullish engulfing');
+  }
+  if (
+    wasBullish
+    && candle.close < candle.open
+    && candle.open > previous.close
+    && candle.close < previous.open
+  ) {
+    found.push('bearish engulfing');
+  }
+
+  // #735 and #736: opens past the earlier candle's extreme, then closes back
+  // through the middle of its body without reaching the far end of it. The
+  // direction of the second candle follows from the other clauses rather than
+  // being tested again -- an open below the previous low and a close above
+  // the previous body's midpoint is a rising candle by arithmetic.
+  if (
+    wasBearish
+    && candle.open < previous.low
+    && candle.close > midpoint
+    && candle.close < previous.open
+  ) {
+    found.push('piercing line');
+  }
+  if (
+    wasBullish
+    && candle.open > previous.high
+    && candle.close < midpoint
+    && candle.close > previous.open
+  ) {
+    found.push('dark cloud cover');
+  }
+
+  // #737: the same low tested twice and held, or the same high twice and
+  // rejected. A run of three or more candles sharing a level is this rule
+  // over each consecutive pair, which announces the level on every candle
+  // that retested it rather than only on the last.
+  if (
+    previous.close <= previous.open
+    && candle.close > candle.open
+    && sharesLevel(previous.low, candle.low, ranges, thresholds)
+  ) {
+    found.push('tweezer bottom');
+  }
+  if (
+    previous.close >= previous.open
+    && candle.close < candle.open
+    && sharesLevel(previous.high, candle.high, ranges, thresholds)
+  ) {
+    found.push('tweezer top');
+  }
+
+  return found;
 }

--- a/test/model/candlestickPairPattern.test.ts
+++ b/test/model/candlestickPairPattern.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The two-candle patterns reach the announcement (#735, #736, #737, #738).
+ *
+ * `candlePairPatterns` decides the names; these cases are about where they
+ * land and what they sit beside. They travel as asides alongside the candle's
+ * own shape, which is the field for facts that are neither axis — and unlike
+ * the shape there may be more than one at a time, because two of these can be
+ * true of one pair without either being the other said more precisely.
+ *
+ * The first candle of a chart has nothing before it, so it carries none.
+ */
+
+import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import type { Ohlc } from '@util/candlePattern';
+import { describe, expect, it } from '@jest/globals';
+import { Candlestick } from '@model/candlestick';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A candle carrying whatever prices a case needs.
+ *
+ * `trend` and `volatility` are placeholders: the model recomputes both.
+ *
+ * @param value - The x label
+ * @param ohlc  - The four prices
+ * @returns A candlestick point
+ */
+function candle(value: string, ohlc: Ohlc): CandlestickPoint {
+  return { value, ...ohlc, trend: 'Neutral', volatility: 0 };
+}
+
+/**
+ * The trace over a series of candles, positioned on the first.
+ *
+ * @param prices - The candles' prices in x order
+ * @returns A candlestick trace
+ */
+function trace(prices: Ohlc[]): Candlestick {
+  const layer: MaidrLayer = {
+    id: 'candle',
+    type: TraceType.CANDLESTICK,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: prices.map((ohlc, index) => candle(`d${index}`, ohlc)),
+  };
+  return new Candlestick(layer);
+}
+
+/**
+ * What a trace announces as asides after stepping `steps` candles forward.
+ *
+ * The first `FORWARD` is the trace's initial entry and lands on the candle
+ * the cursor already reports, so it is spent before any stepping begins.
+ *
+ * @param subject - The trace to read
+ * @param steps   - How many candles to advance
+ * @returns The aside label/value pairs, or undefined when there are none
+ */
+function asidesAt(
+  subject: Candlestick,
+  steps: number,
+): { label: string; value: string }[] | undefined {
+  subject.moveOnce('FORWARD');
+  for (let i = 0; i < steps; i++) {
+    subject.moveOnce('FORWARD');
+  }
+  const state = subject.state as Extract<TraceState, { empty: false }>;
+  return state.text.asides;
+}
+
+/** A bearish candle, no named shape of its own. */
+const FELL: Ohlc = { open: 110, high: 112, low: 98, close: 100 };
+/** Swallows {@link FELL}'s body whole, with its low well clear of it. */
+const ENGULFS: Ohlc = { open: 99, high: 112, low: 90, close: 111 };
+/** An unremarkable candle after it. */
+const ORDINARY: Ohlc = { open: 111, high: 115, low: 110, close: 114 };
+
+describe('a candlestick announces what a candle makes of the one before it', () => {
+  it('says nothing about the first candle, which has no previous', () => {
+    expect(asidesAt(trace([FELL, ENGULFS, ORDINARY]), 0)).toBeUndefined();
+  });
+
+  it('names the engulfing on the candle that does it', () => {
+    expect(asidesAt(trace([FELL, ENGULFS, ORDINARY]), 1))
+      .toEqual([{ label: 'pattern', value: 'bullish engulfing' }]);
+  });
+
+  it('says nothing about an ordinary pair', () => {
+    expect(asidesAt(trace([FELL, ENGULFS, ORDINARY]), 2)).toBeUndefined();
+  });
+
+  it('announces the shape and the pattern together when both hold', () => {
+    // A doji whose low sits on the previous candle's: its own shape, and what
+    // it makes of the one before it. Two different facts, both true, and the
+    // shape is named first because it is about the candle the cursor is on.
+    const doji: Ohlc = { open: 105, high: 112, low: 98, close: 105.2 };
+
+    expect(asidesAt(trace([FELL, doji]), 1)).toEqual([
+      { label: 'shape', value: 'doji' },
+      { label: 'pattern', value: 'tweezer bottom' },
+    ]);
+  });
+});

--- a/test/model/candlestickShape.test.ts
+++ b/test/model/candlestickShape.test.ts
@@ -15,6 +15,7 @@
 
 import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
 import type { TraceState } from '@type/state';
+import type { Ohlc } from '@util/candlePattern';
 import { describe, expect, it } from '@jest/globals';
 import { Candlestick } from '@model/candlestick';
 import { Orientation, TraceType } from '@type/grammar';
@@ -28,10 +29,7 @@ import { Orientation, TraceType } from '@type/grammar';
  * @param ohlc  - The four prices
  * @returns A candlestick point
  */
-function candle(
-  value: string,
-  ohlc: { open: number; high: number; low: number; close: number },
-): CandlestickPoint {
+function candle(value: string, ohlc: Ohlc): CandlestickPoint {
   return { value, ...ohlc, trend: 'Neutral', volatility: 0 };
 }
 

--- a/test/util/candlePairPattern.test.ts
+++ b/test/util/candlePairPattern.test.ts
@@ -1,0 +1,145 @@
+/**
+ * How a candle sits against the one before it (#735, #736, #737, #738).
+ *
+ * These say something the single-candle shapes cannot: a candle that swallows
+ * the previous one whole, or opens past its extreme and closes back through
+ * it, or retests the low it set. All of it is in the two candles' eight
+ * numbers, and none of it is a forecast — what a reversal signal is supposed
+ * to *mean* stays the reader's to decide.
+ *
+ * Every expected value below is worked from the requests' own arithmetic
+ * rather than recorded from a run, with `1` the earlier candle and `2` the
+ * later:
+ *
+ *   bullish engulfing  C1<O1, C2>O2, O2<C1, C2>O1
+ *   bearish engulfing  C1>O1, C2<O2, O2>C1, C2<O1
+ *   piercing line      C1<O1, O2<L1, C2>(O1+C1)/2, C2<O1
+ *   dark cloud cover   C1>O1, O2>H1, C2<(O1+C1)/2, C2>O1
+ *   tweezer bottom     |L1-L2| <= 0.1*mean(R1,R2), C1<=O1, C2>O2
+ *   tweezer top        |H1-H2| <= 0.1*mean(R1,R2), C1>=O1, C2<O2
+ *
+ * Two things here are decisions rather than transcriptions:
+ *
+ * - **A pair can honestly be more than one of these.** Unlike a doji and a
+ *   spinning top, which are the same statement at two strictnesses, an
+ *   engulfing and a tweezer bottom are different facts about the same pair —
+ *   one about the bodies, one about the shared low. So the answer is a list,
+ *   in a fixed order.
+ * - **The prior-trend qualifier is not applied.** #735 and #736 both note that
+ *   pairing the geometry with a preceding down- or uptrend would cut false
+ *   positives. "After a downtrend" needs a definition of trend the chart does
+ *   not state — how far back, and how much of a fall counts — and inventing
+ *   one would silence real patterns by a rule the reader cannot see.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import {
+  candlePairPatterns,
+  DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+} from '@util/candlePattern';
+
+/** A bearish candle: opens at 110, closes at 100, ranging 98 to 112. */
+const FELL = { open: 110, high: 112, low: 98, close: 100 };
+/** Its mirror: opens at 100, closes at 110, over the same extent. */
+const ROSE = { open: 100, high: 112, low: 98, close: 110 };
+
+describe('how a candle sits against the one before it', () => {
+  it('names a bullish engulfing', () => {
+    // Opens under the fall's close and closes over its open. The low is put
+    // well clear of the previous one so nothing else is claimed here.
+    expect(candlePairPatterns(FELL, { open: 99, high: 112, low: 90, close: 111 }))
+      .toEqual(['bullish engulfing']);
+  });
+
+  it('names a bearish engulfing', () => {
+    expect(candlePairPatterns(ROSE, { open: 111, high: 120, low: 99, close: 99 }))
+      .toEqual(['bearish engulfing']);
+  });
+
+  it('names a piercing line', () => {
+    // Opens at 97, under the previous low of 98; closes at 107, over the
+    // body's midpoint of 105 but short of its open at 110.
+    expect(candlePairPatterns(FELL, { open: 97, high: 108, low: 96, close: 107 }))
+      .toEqual(['piercing line']);
+  });
+
+  it('names a dark cloud cover', () => {
+    // The mirror: opens at 113 over the previous high of 112, closes at 102,
+    // under the midpoint of 105 and over the open at 100.
+    expect(candlePairPatterns(ROSE, { open: 113, high: 114, low: 101, close: 102 }))
+      .toEqual(['dark cloud cover']);
+  });
+
+  it('names a tweezer bottom', () => {
+    // Lows of 98 and 98.2, inside 0.1 of the two ranges' mean; the second
+    // candle closes up, which is the low holding.
+    expect(candlePairPatterns(FELL, { open: 101, high: 106, low: 98.2, close: 105 }))
+      .toEqual(['tweezer bottom']);
+  });
+
+  it('names a tweezer top', () => {
+    expect(candlePairPatterns(ROSE, { open: 109, high: 111.8, low: 104, close: 105 }))
+      .toEqual(['tweezer top']);
+  });
+
+  it('names every pattern a pair really is', () => {
+    // The same engulfing as above with its low moved onto the previous one,
+    // which makes it a tweezer bottom as well. Both are true, and neither is
+    // the other said more precisely.
+    expect(candlePairPatterns(FELL, { open: 99, high: 112, low: 98, close: 111 }))
+      .toEqual(['bullish engulfing', 'tweezer bottom']);
+  });
+
+  it('cannot call one pair both an engulfing and a piercing', () => {
+    // #735's "does not fully engulf", written as arithmetic: engulfing needs
+    // the close over the previous open and piercing needs it under.
+    //
+    // Both candles here open at 97 -- under the previous low of 98, so under
+    // its close of 100 as well -- which satisfies the opening clause of each
+    // pattern. The *only* thing left to tell them apart is where they close,
+    // at 111 over the previous open of 110 or at 107 under it. A fixture that
+    // separated them some other way would pass whatever these two clauses
+    // said.
+    const closesOver = candlePairPatterns(FELL, { open: 97, high: 112, low: 90, close: 111 });
+    const closesUnder = candlePairPatterns(FELL, { open: 97, high: 108, low: 90, close: 107 });
+
+    expect(closesOver).toEqual(['bullish engulfing']);
+    expect(closesUnder).toEqual(['piercing line']);
+  });
+
+  it('scales the tweezer tolerance by both candles, not one', () => {
+    // The same gap of 1 between the two lows, twice. Against two wide candles
+    // it is well inside the tolerance; against two quiet ones it is not --
+    // which is what stops a wild session lending its slack to a still one.
+    const wide = candlePairPatterns(
+      { open: 110, high: 120, low: 98, close: 100 },
+      { open: 101, high: 120, low: 99, close: 110 },
+    );
+    const narrow = candlePairPatterns(
+      { open: 101, high: 101.5, low: 98, close: 100 },
+      { open: 100.2, high: 101, low: 99, close: 100.8 },
+    );
+
+    expect(wide).toEqual(['tweezer bottom']);
+    expect(narrow).toEqual([]);
+  });
+
+  it('answers by the thresholds it is given', () => {
+    const earlier = { open: 101, high: 101.5, low: 98, close: 100 };
+    const later = { open: 100.2, high: 101, low: 99, close: 100.8 };
+
+    expect(candlePairPatterns(earlier, later)).toEqual([]);
+    expect(candlePairPatterns(earlier, later, {
+      ...DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+      tweezerLevel: 0.4,
+    })).toEqual(['tweezer bottom']);
+  });
+
+  it('says nothing about an ordinary pair', () => {
+    // Two unremarkable rising candles, which is most of any chart.
+    expect(candlePairPatterns(
+      { open: 100, high: 105, low: 99, close: 104 },
+      { open: 104, high: 108, low: 103, close: 107 },
+    )).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #735. Closes #736. Closes #737. Closes #738.

Follows #1117, which announced how a candle is drawn on its own. These say how it sits **against the candle before it** — swallowing its body whole, opening past its extreme and closing back through it, or retesting the low it set. That is a second thing a sighted reader takes straight from the picture and a listener cannot get from four numbers read one candle at a time.

## What is read

`candlePairPatterns` in `src/util/candlePattern.ts`, from each request's own arithmetic (`1` the earlier candle, `2` the later):

| pattern | condition | from |
| --- | --- | --- |
| bullish engulfing | `C1<O1`, `C2>O2`, `O2<C1`, `C2>O1` | #738 |
| bearish engulfing | `C1>O1`, `C2<O2`, `O2>C1`, `C2<O1` | #738 |
| piercing line | `C1<O1`, `O2<L1`, `C2>(O1+C1)/2`, `C2<O1` | #735 |
| dark cloud cover | `C1>O1`, `O2>H1`, `C2<(O1+C1)/2`, `C2>O1` | #736 |
| tweezer bottom | `\|L1-L2\| <= 0.1 * mean(R1,R2)`, `C1<=O1`, `C2>O2` | #737 |
| tweezer top | `\|H1-H2\| <= 0.1 * mean(R1,R2)`, `C1>=O1`, `C2<O2` | #737 |

The second candle's direction is not tested again for piercing and dark cloud: an open below the previous low and a close above the previous body's midpoint **is** a rising candle by arithmetic, so a separate clause would be a restatement.

## It returns a list, and that is the difference from the shapes

#1117's shapes compete — a doji and a spinning top are the same statement at two strictnesses, so only the narrower is worth making. These do not. An engulfing is about the bodies and a tweezer bottom is about the shared low, and a pair can honestly be both:

```
FELL   = { open: 110, high: 112, low: 98, close: 100 }
+ next = { open:  99, high: 112, low: 98, close: 111 }
→ ['bullish engulfing', 'tweezer bottom']
```

What they cannot collide on is direction. Engulfing needs the close above the previous open and piercing needs it below — which is #735's "does not fully engulf" written as arithmetic — and the bearish two mirror it. A tweezer bottom and top would need the earlier candle to be both bearish and bullish.

## Two decisions

- **The prior-trend qualifier is not applied.** #735 and #736 both note that requiring a preceding down- or uptrend would cut false positives, and they are right that it would. But "after a downtrend" needs a definition of trend the chart does not state — how far back to look, and how much of a fall counts — and inventing one would silence real patterns on a reader's behalf by a rule they cannot see or adjust. The geometry each request specifies is what is tested.
- **A run of three or more candles sharing a level** is #737's "two or more" case, and it falls out of the pair rule over each consecutive pair: the level gets announced on every candle that retested it, rather than only on the last. The tolerance is a fraction of the two ranges' **mean** rather than of either one, so a wild session does not lend its slack to a still one — pinned by a case where the same gap of 1 is inside the tolerance for two wide candles and outside it for two quiet ones.

## Where it is announced

As asides beside the candle's own shape, so a doji whose low sits on the previous candle's says both:

```
shape is doji, pattern is tweezer bottom
```

The first candle of a chart has nothing before it and carries none. An ordinary pair — most pairs — says nothing.

## Tests

15 cases across `test/util/candlePairPattern.test.ts` (11) and `test/model/candlestickPairPattern.test.ts` (4). Every expected value was worked by hand from the arithmetic above rather than recorded from a run.

Falsified with five mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| trace never looks at the previous candle | 2 |
| trace reads the **next** candle instead | 3 |
| tweezer tolerance taken from the later range only | 1 |
| piercing drops its does-not-engulf clause | 1 |
| the returned order reversed | 1 |

**One case was rewritten because falsification found it weak.** The engulfing and piercing fixtures had been separated by their *opening* prices as well as their closes, so no mutation to the clause that actually distinguishes them could have failed it. Both now open at 97 — under the previous low, satisfying the opening clause of each — leaving the close as the only thing telling them apart.

`npm run lint:fix`, `npm run type-check` and `npm run build` clean; full suite **5359 passing** (380 suites) plus **137** ESM.

## What remains of the family

#734 (hammer / hanging man), #739 (morning / evening star), #740 (three white soldiers / black crows), #741 (Tasuki gap), #742 (three inside/outside down). The star and soldier families need three candles; hammer and hanging man are the case where the prior trend is not an optional qualifier but the *only* thing separating two names for one shape, so it needs the trend question answered first rather than set aside.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_