### PR TITLE
feat(candlestick): name a hammer by the run of closes it stands on

### DIFF
--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -12,7 +12,7 @@ import type { AudioState, BrailleState, DescriptionState, TextState, TraceState 
 import { AbstractTrace } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Orientation } from '@type/grammar';
-import { candlePairPatterns, candleShape } from '@util/candlePattern';
+import { candlePairPatterns, candleShape, candleTrendPattern } from '@util/candlePattern';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { MovableGrid } from './movable';
@@ -824,9 +824,16 @@ export class Candlestick extends AbstractTrace {
     const pairs = previous === undefined
       ? []
       : candlePairPatterns(previous, point);
+    // A hammer and a hanging man are one shape read two ways, and only the
+    // run of closes before the candle separates them (#734).
+    const run = this.candles
+      .slice(0, this.currentPointIndex)
+      .map(earlier => earlier.close);
+    const named = candleTrendPattern(run, point);
     const asides = [
       ...(shape === null ? [] : [{ label: SHAPE, value: shape }]),
       ...pairs.map(pattern => ({ label: PATTERN, value: pattern })),
+      ...(named === null ? [] : [{ label: PATTERN, value: named }]),
     ];
 
     return {

--- a/src/util/candlePattern.ts
+++ b/src/util/candlePattern.ts
@@ -15,7 +15,9 @@
  *
  * {@link candlePairPatterns} does the same for the two-candle patterns, which
  * describe how a candle sits against the one before it rather than how it is
- * drawn on its own (#735, #736, #737, #738).
+ * drawn on its own (#735, #736, #737, #738), and {@link candleTrendPattern}
+ * for the one pair of names that a run of earlier closes decides between
+ * (#734).
  *
  * The thresholds are the ones the requests specify, and they are parameters
  * rather than literals because strictness is a matter of trading style. There
@@ -65,6 +67,14 @@ export interface CandleShapeThresholds {
    * fraction of the two ranges' mean (#737).
    */
   tweezerLevel: number;
+  /** A hammer's lower shadow must be at least this many bodies (#734). */
+  hammerLowerShadow: number;
+  /** A hammer's upper shadow may be at most this much of the range (#734). */
+  hammerUpperShadow: number;
+  /** A hammer's body must sit at least this far up the range (#734). */
+  hammerBodyFloor: number;
+  /** How many earlier closes a hammer's run is read from (#734). */
+  trendLookback: number;
 }
 
 /** The thresholds each request names, and what applies when none are given. */
@@ -76,6 +86,10 @@ export const DEFAULT_CANDLE_SHAPE_THRESHOLDS: CandleShapeThresholds = {
   spinningBody: 0.33,
   spinningShadowGap: 0.15,
   tweezerLevel: 0.1,
+  hammerLowerShadow: 2,
+  hammerUpperShadow: 0.1,
+  hammerBodyFloor: 0.66,
+  trendLookback: 3,
 };
 
 /** The four quantities every test below is written in terms of. */
@@ -321,4 +335,102 @@ export function candlePairPatterns(
   }
 
   return found;
+}
+
+/**
+ * The two names one candle shape carries, told apart by what came before it.
+ */
+export type CandleTrendPattern = 'hammer' | 'hanging man';
+
+/**
+ * Whether a candle is drawn in the hammer shape: a small body high in the
+ * range, over a long lower shadow, with next to nothing above it.
+ *
+ * @param candle     - The candle's four prices
+ * @param thresholds - How strict to be
+ * @returns True when the candle is that shape
+ */
+function isHammerShape(
+  candle: Ohlc,
+  thresholds: CandleShapeThresholds,
+): boolean {
+  const parts = partsOf(candle);
+
+  // A candle drawn at a single price satisfies every clause below -- a lower
+  // shadow of zero is `2 * 0`, an upper shadow of zero is under a tenth of
+  // zero, and its body sits at the low, which is also two thirds of the way
+  // up a range of nothing. It has no long lower shadow, which is the whole of
+  // what a hammer names, so it is turned away before any of that is asked.
+  if (parts.range === 0) {
+    return false;
+  }
+
+  return parts.lower >= thresholds.hammerLowerShadow * parts.body
+    && parts.upper <= thresholds.hammerUpperShadow * parts.range
+    && Math.min(candle.open, candle.close)
+    >= candle.low + thresholds.hammerBodyFloor * parts.range;
+}
+
+/**
+ * Whether a run of closes moves one way throughout.
+ *
+ * @param closes    - The closes, oldest first
+ * @param direction - Whether they must fall or rise
+ * @returns True when every step goes that way
+ */
+function runsOneWay(closes: readonly number[], direction: 'down' | 'up'): boolean {
+  for (let i = 1; i < closes.length; i++) {
+    const fell = closes[i] < closes[i - 1];
+    if (direction === 'down' ? !fell : !(closes[i] > closes[i - 1])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Names a hammer or a hanging man, which are one shape under two readings.
+ *
+ * The shape does not decide it: an identical candle is a hammer at the bottom
+ * of a fall and a hanging man at the top of a rise. So this is the one place
+ * where the run of earlier closes has to be read, and it is read by the rule
+ * #734 gives -- the last {@link CandleShapeThresholds.trendLookback} closes
+ * before the candle, each strictly under or over the one before it.
+ *
+ * That is a narrow rule and deliberately so. It is the request's own, it can
+ * be stated to a reader in one sentence, and a candle that meets the shape
+ * after an unsteady run is left unnamed rather than given whichever name the
+ * last two closes happen to suggest. Nothing here forecasts anything: the
+ * name says what the drawing is, and a reader who wants to know whether the
+ * fall really was a downtrend can navigate back through it.
+ *
+ * A run shorter than the lookback -- the first few candles of any chart --
+ * establishes nothing, and gets no name.
+ *
+ * @param previousCloses - Every close before this candle, oldest first
+ * @param candle         - The candle's four prices
+ * @param thresholds     - How strict to be; the request's figures by default
+ * @returns The name, or `null` when the shape or the run does not hold
+ */
+export function candleTrendPattern(
+  previousCloses: readonly number[],
+  candle: Ohlc,
+  thresholds: CandleShapeThresholds = DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+): CandleTrendPattern | null {
+  if (!isHammerShape(candle, thresholds)) {
+    return null;
+  }
+
+  const run = previousCloses.slice(-thresholds.trendLookback);
+  if (run.length < thresholds.trendLookback) {
+    return null;
+  }
+
+  if (runsOneWay(run, 'down')) {
+    return 'hammer';
+  }
+  if (runsOneWay(run, 'up')) {
+    return 'hanging man';
+  }
+  return null;
 }

--- a/test/model/candlestickTrendPattern.test.ts
+++ b/test/model/candlestickTrendPattern.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The hammer reaches the announcement, and only where the run supports it
+ * (#734).
+ *
+ * `candleTrendPattern` decides the name; these cases are about the trace
+ * handing it the right closes. That is the part a unit test of the rule
+ * cannot check: the run has to be the closes *before* the candle the cursor
+ * is on, in chart order, and a hammer near the start of a chart has too few
+ * of them to be named.
+ */
+
+import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import type { Ohlc } from '@util/candlePattern';
+import { describe, expect, it } from '@jest/globals';
+import { Candlestick } from '@model/candlestick';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A candle carrying whatever prices a case needs.
+ *
+ * `trend` and `volatility` are placeholders: the model recomputes both.
+ *
+ * @param value - The x label
+ * @param ohlc  - The four prices
+ * @returns A candlestick point
+ */
+function candle(value: string, ohlc: Ohlc): CandlestickPoint {
+  return { value, ...ohlc, trend: 'Neutral', volatility: 0 };
+}
+
+/**
+ * The trace over a series of candles, positioned on the first.
+ *
+ * @param prices - The candles' prices in x order
+ * @returns A candlestick trace
+ */
+function trace(prices: Ohlc[]): Candlestick {
+  const layer: MaidrLayer = {
+    id: 'candle',
+    type: TraceType.CANDLESTICK,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: prices.map((ohlc, index) => candle(`d${index}`, ohlc)),
+  };
+  return new Candlestick(layer);
+}
+
+/**
+ * What a trace announces as asides after stepping `steps` candles forward.
+ *
+ * The first `FORWARD` is the trace's initial entry and lands on the candle
+ * the cursor already reports.
+ *
+ * @param subject - The trace to read
+ * @param steps   - How many candles to advance
+ * @returns The aside label/value pairs, or undefined when there are none
+ */
+function asidesAt(
+  subject: Candlestick,
+  steps: number,
+): { label: string; value: string }[] | undefined {
+  subject.moveOnce('FORWARD');
+  for (let i = 0; i < steps; i++) {
+    subject.moveOnce('FORWARD');
+  }
+  const state = subject.state as Extract<TraceState, { empty: false }>;
+  return state.text.asides;
+}
+
+/** Three ordinary candles closing 130, 120, 112 — a run of falls. */
+const FALLING: Ohlc[] = [
+  { open: 132, high: 133, low: 129, close: 130 },
+  { open: 130, high: 131, low: 119, close: 120 },
+  { open: 120, high: 121, low: 111, close: 112 },
+];
+
+/** The same three reversed, so the closes run 112, 120, 130 — a rise. */
+const RISING: Ohlc[] = [...FALLING].reverse();
+
+/** The hammer shape: body 2 high in a range of 10.5, over a shadow of 8. */
+const SHAPED: Ohlc = { open: 108, high: 110.5, low: 100, close: 110 };
+
+describe('a candlestick announces a hammer for the run it stands on', () => {
+  it('names a hammer after three falling closes', () => {
+    expect(asidesAt(trace([...FALLING, SHAPED]), 3))
+      .toEqual([{ label: 'pattern', value: 'hammer' }]);
+  });
+
+  it('names the same candle a hanging man after three rising ones', () => {
+    expect(asidesAt(trace([...RISING, SHAPED]), 3))
+      .toEqual([{ label: 'pattern', value: 'hanging man' }]);
+  });
+
+  it('names nothing when there are too few candles before it', () => {
+    // The identical hammer, one candle into the chart. The run is what is
+    // missing, not the shape.
+    expect(asidesAt(trace([FALLING[2], SHAPED]), 1)).toBeUndefined();
+  });
+
+  it('announces the candle\'s own shape beside the name', () => {
+    // A dragonfly doji *is* the hammer shape -- body at the top of the range,
+    // nothing above it, a long wick below. The two names come from different
+    // vocabularies and say different things: one describes the candle, the
+    // other says what standing at the end of a fall makes of it. Both are
+    // true, so both are said.
+    const dragonfly: Ohlc = { open: 100, high: 100.4, low: 92, close: 100 };
+
+    expect(asidesAt(trace([...FALLING, dragonfly]), 3)).toEqual([
+      { label: 'shape', value: 'dragonfly doji' },
+      { label: 'pattern', value: 'hammer' },
+    ]);
+  });
+});

--- a/test/util/candleTrendPattern.test.ts
+++ b/test/util/candleTrendPattern.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The one shape whose name is decided by what came before it (#734).
+ *
+ * A hammer and a hanging man are the *same candle* — a small body high in the
+ * range, over a long lower shadow, with next to nothing above it. Which of
+ * the two it is depends entirely on whether the market had been falling or
+ * rising into it, so this is the one place in the family where a run of
+ * earlier closes has to be read.
+ *
+ * The shape, from the request:
+ *
+ *   lower >= 2 * body
+ *   upper <= 0.1 * range
+ *   min(open, close) >= low + 0.66 * range
+ *
+ * The run, also the request's: the last three closes before the candle, each
+ * strictly under (hammer) or over (hanging man) the one before it.
+ *
+ * That rule is narrow on purpose. It can be stated to a reader in one
+ * sentence, and a candle that meets the shape after an unsteady run is left
+ * unnamed rather than given whichever name the last two closes happen to
+ * suggest. A chart's first few candles establish no run and so get no name.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import {
+  candleTrendPattern,
+  DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+} from '@util/candlePattern';
+
+/**
+ * The shape both names share: body 2 high in a range of 10.5, a lower shadow
+ * of 8 under it and 0.5 above.
+ */
+const SHAPED = { open: 108, high: 110.5, low: 100, close: 110 };
+
+/** Three closes, each under the last. */
+const FELL = [130, 120, 112];
+/** Three closes, each over the last. */
+const ROSE = [100, 105, 112];
+
+describe('a hammer and a hanging man, told apart by the run before them', () => {
+  it('names a hammer after a run of falling closes', () => {
+    expect(candleTrendPattern(FELL, SHAPED)).toBe('hammer');
+  });
+
+  it('names a hanging man after a run of rising closes', () => {
+    // The identical candle. Only the three numbers before it changed.
+    expect(candleTrendPattern(ROSE, SHAPED)).toBe('hanging man');
+  });
+
+  it('reads only the last few closes, not the whole chart', () => {
+    // A long history that wandered before settling into its fall.
+    expect(candleTrendPattern([50, 90, 60, 130, 120, 112], SHAPED)).toBe('hammer');
+  });
+
+  it('leaves the shape unnamed after an unsteady run', () => {
+    // Down then up. Neither name is earned, and picking one from the last
+    // step would be reading a trend the closes do not show.
+    expect(candleTrendPattern([120, 110, 115], SHAPED)).toBeNull();
+  });
+
+  it('does not count a flat step as part of a run', () => {
+    // "Each strictly under the one before" -- a close that held is not a fall.
+    expect(candleTrendPattern([120, 115, 115], SHAPED)).toBeNull();
+  });
+
+  it('names nothing at the start of a chart', () => {
+    // Two closes cannot establish a three-close run, however they moved.
+    expect(candleTrendPattern([120, 112], SHAPED)).toBeNull();
+    expect(candleTrendPattern([], SHAPED)).toBeNull();
+  });
+
+  it('leaves an ordinary candle unnamed however the run moved', () => {
+    // A lower shadow of 1 against a body of 4 is not a hammer, and a falling
+    // run does not make it one.
+    const ordinary = { open: 100, high: 105, low: 99, close: 104 };
+
+    expect(candleTrendPattern(FELL, ordinary)).toBeNull();
+    expect(candleTrendPattern(ROSE, ordinary)).toBeNull();
+  });
+
+  it('leaves a candle drawn at a single price unnamed', () => {
+    // Every clause of the shape is trivially true of a range of zero -- a
+    // lower shadow of 0 is "at least twice a body of 0" -- and it has none of
+    // the long lower shadow the name is about.
+    expect(candleTrendPattern(FELL, { open: 50, high: 50, low: 50, close: 50 }))
+      .toBeNull();
+  });
+
+  it('answers by the lookback it is given', () => {
+    // The unsteady run above, read two closes deep instead of three: 110 then
+    // 115 is a rise, so the shape gets a name it did not have. Which is the
+    // point of the window being a parameter -- and of it being visible.
+    const wandering = [120, 110, 115];
+
+    expect(candleTrendPattern(wandering, SHAPED)).toBeNull();
+    expect(candleTrendPattern(wandering, SHAPED, {
+      ...DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+      trendLookback: 2,
+    })).toBe('hanging man');
+  });
+});


### PR DESCRIPTION
Closes #734.

Third in the family, after #1117 (a candle's own shape) and #1118 (what it makes of the one before it).

## Why this one is different

A hammer and a hanging man are the **same candle** — a small body high in the range, over a long lower shadow, with next to nothing above it. Which of the two it is depends entirely on whether the market had been falling or rising into it. So unlike every pattern so far, the shape alone decides nothing, and a run of earlier closes has to be read.

#1118 deliberately set that question aside: #735 and #736 raised a prior-trend check as a *desirable extra* and gave no rule for it, so applying one would have silenced real patterns by a rule the reader could not see. Here it is not optional — without it there is no name at all — and #734 **does** give the rule.

## What is read

```
shape (shared)   lower >= 2 * body
                 upper <= 0.1 * range
                 min(open, close) >= low + 0.66 * range

hammer           the last three closes, each strictly under the one before
hanging man      the last three closes, each strictly over the one before
```

Both are the request's own figures. The rule is narrow on purpose: it can be stated to a reader in one sentence, and a candle that meets the shape after an unsteady run is left **unnamed** rather than given whichever name the last two closes happen to suggest. The lookback is a parameter so that narrowness is visible rather than assumed — pinned by a case where the wandering run `[120, 110, 115]` is nameless at three closes and a hanging man at two.

Nothing here forecasts anything. The name says what the drawing is; a reader who wants to know whether the fall really was a downtrend can navigate back through it.

## Three things the arithmetic gets wrong if left alone

Each guarded, each asserted:

- **A candle drawn at one price meets every clause of the shape.** A lower shadow of zero is "at least twice a body of zero"; an upper shadow of zero is under a tenth of zero; and its body sits at the low, which is also two thirds of the way up a range of nothing. It has none of the long lower shadow the name is about, so it is turned away before any of that is asked.
- **A close that held is not a fall.** The run is strict, so `[120, 115, 115]` breaks rather than extends it.
- **A chart's first few candles establish no run**, and get no name however they are drawn.

## An overlap worth seeing

A dragonfly doji **is** the hammer shape — body at the top of the range, nothing above it, a long wick below. So a chart can announce:

```
shape is dragonfly doji, pattern is hammer
```

Both are true and they say different things: one describes the candle, the other says what standing at the end of a fall makes of it. Asserted rather than left to chance.

## Tests

13 cases across `test/util/candleTrendPattern.test.ts` (9) and `test/model/candlestickTrendPattern.test.ts` (4). Every expected value was worked by hand.

The model-level cases carry the part a unit test of the rule cannot: that the trace hands over the closes **before** the candle, in chart order. Falsified with six mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| the run handed over reversed | 3 |
| the run taken from *after* the candle | 3 |
| the run includes the candle's own close | 1 |
| no minimum run length | 2 |
| a run that may hold flat | 1 |
| hammer shape without the zero-range guard | 1 |

`npm run lint:fix`, `npm run type-check` and `npm run build` clean; full suite **5372 passing** (382 suites) plus **137** ESM.

## What remains of the family

#739 (morning / evening star), #740 (three white soldiers / black crows), #741 (Tasuki gap), #742 (three inside/outside down) — all three-candle. Two of them ask for thresholds the request leaves open: #739 wants "large" and "small" bodies relative to recent candle size, and #740 wants a numeric figure for "small shadows". Those are choices to make explicitly rather than to smuggle in as literals, which is the next thing to do rather than something this PR should have guessed at.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_