### PR TITLE
feat(candlestick): announce the formation three candles make

### DIFF
--- a/src/model/candlestick.ts
+++ b/src/model/candlestick.ts
@@ -12,7 +12,12 @@ import type { AudioState, BrailleState, DescriptionState, TextState, TraceState 
 import { AbstractTrace } from '@model/abstract';
 import { NavigationService } from '@service/navigation';
 import { Orientation } from '@type/grammar';
-import { candlePairPatterns, candleShape, candleTrendPattern } from '@util/candlePattern';
+import {
+  candlePairPatterns,
+  candleShape,
+  candleTrendPattern,
+  candleTrioPatterns,
+} from '@util/candlePattern';
 import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { MovableGrid } from './movable';
@@ -830,10 +835,17 @@ export class Candlestick extends AbstractTrace {
       .slice(0, this.currentPointIndex)
       .map(earlier => earlier.close);
     const named = candleTrendPattern(run, point);
+    // The three-candle formations need two candles behind the cursor, so the
+    // first two of any chart carry none (#739, #740, #741, #742).
+    const earlier = this.candles[this.currentPointIndex - 2];
+    const trios = earlier === undefined || previous === undefined
+      ? []
+      : candleTrioPatterns(earlier, previous, point);
     const asides = [
       ...(shape === null ? [] : [{ label: SHAPE, value: shape }]),
       ...pairs.map(pattern => ({ label: PATTERN, value: pattern })),
       ...(named === null ? [] : [{ label: PATTERN, value: named }]),
+      ...trios.map(pattern => ({ label: PATTERN, value: pattern })),
     ];
 
     return {

--- a/src/util/candlePattern.ts
+++ b/src/util/candlePattern.ts
@@ -17,7 +17,8 @@
  * describe how a candle sits against the one before it rather than how it is
  * drawn on its own (#735, #736, #737, #738), and {@link candleTrendPattern}
  * for the one pair of names that a run of earlier closes decides between
- * (#734).
+ * (#734). {@link candleTrioPatterns} covers the three-candle formations
+ * (#739, #740, #741, #742).
  *
  * The thresholds are the ones the requests specify, and they are parameters
  * rather than literals because strictness is a matter of trading style. There
@@ -75,6 +76,12 @@ export interface CandleShapeThresholds {
   hammerBodyFloor: number;
   /** How many earlier closes a hammer's run is read from (#734). */
   trendLookback: number;
+  /** A star's outer candles fill at least this much of their range (#739). */
+  starLargeBody: number;
+  /** A star's middle candle fills at most this much of its range (#739). */
+  starSmallBody: number;
+  /** A soldier's or crow's shadow, at most this much of its range (#740). */
+  soldierShadow: number;
 }
 
 /** The thresholds each request names, and what applies when none are given. */
@@ -90,6 +97,15 @@ export const DEFAULT_CANDLE_SHAPE_THRESHOLDS: CandleShapeThresholds = {
   hammerUpperShadow: 0.1,
   hammerBodyFloor: 0.66,
   trendLookback: 3,
+  // #739 asks for "large" and "small" relative to recent candle size, and
+  // suggests an ATR. That needs a lookback window the chart does not state
+  // and would leave the first candles of any chart unreadable; a body against
+  // its own range says the same thing about each candle -- decisive, or not
+  // -- and needs nothing beyond the three the pattern is about. #740 leaves
+  // "small shadows" without a figure at all and asks for one to be chosen.
+  starLargeBody: 0.6,
+  starSmallBody: 0.3,
+  soldierShadow: 0.15,
 };
 
 /** The four quantities every test below is written in terms of. */
@@ -433,4 +449,188 @@ export function candleTrendPattern(
     return 'hanging man';
   }
   return null;
+}
+
+/** The three-candle formations. */
+export type CandleTrioPattern
+  = | 'morning star'
+    | 'evening star'
+    | 'three white soldiers'
+    | 'three black crows'
+    | 'upside tasuki gap'
+    | 'upside tasuki gap filled'
+    | 'three inside down'
+    | 'three outside down';
+
+/**
+ * Whether a candle's body fills enough of its range to be a decisive one.
+ *
+ * @param candle - The candle's four prices
+ * @param share  - The fraction of the range the body must reach
+ * @returns True when the body is at least that much of the range
+ */
+function bodyFills(candle: Ohlc, share: number): boolean {
+  const parts = partsOf(candle);
+  return parts.range > 0 && parts.body >= share * parts.range;
+}
+
+/**
+ * Whether a candle's body is small enough against its range to be a star.
+ *
+ * A candle drawn at one price counts: it has no body at all, which is the
+ * indecision a star's middle candle stands for, and unlike the hammer shape
+ * there is no long shadow being claimed that it does not have.
+ *
+ * @param candle - The candle's four prices
+ * @param share  - The fraction of the range the body must stay under
+ * @returns True when the body is at most that much of the range
+ */
+function bodyStaysUnder(candle: Ohlc, share: number): boolean {
+  const parts = partsOf(candle);
+  return parts.body <= share * parts.range;
+}
+
+/**
+ * Whether three candles all run one way, each closing past the last and
+ * opening inside the body before it, with short shadows on the leading side.
+ *
+ * @param candles    - The three candles, oldest first
+ * @param direction  - Whether they rise (soldiers) or fall (crows)
+ * @param thresholds - How strict to be
+ * @returns True when all three march that way
+ */
+function marchesOneWay(
+  candles: readonly [Ohlc, Ohlc, Ohlc],
+  direction: 'up' | 'down',
+  thresholds: CandleShapeThresholds,
+): boolean {
+  const rising = direction === 'up';
+
+  for (const candle of candles) {
+    if (rising ? candle.close <= candle.open : candle.close >= candle.open) {
+      return false;
+    }
+    // The shadow that matters is the one ahead of the march: a soldier that
+    // rose and left a long wick above it gave the gain back before the close,
+    // which is the opposite of the steady control the name is about.
+    const parts = partsOf(candle);
+    const leading = rising ? parts.upper : parts.lower;
+    if (parts.range === 0 || leading > thresholds.soldierShadow * parts.range) {
+      return false;
+    }
+  }
+
+  const [one, two, three] = candles;
+  const closesOn = rising
+    ? one.close < two.close && two.close < three.close
+    : one.close > two.close && two.close > three.close;
+  if (!closesOn) {
+    return false;
+  }
+
+  // "Opens within the prior body", written from the body's own ends rather
+  // than by flipping the inequalities: a rising candle's body runs open to
+  // close, a falling one's runs close to open.
+  const insideFirst = rising
+    ? two.open >= one.open && two.open <= one.close
+    : two.open <= one.open && two.open >= one.close;
+  const insideSecond = rising
+    ? three.open >= two.open && three.open <= two.close
+    : three.open <= two.open && three.open >= two.close;
+
+  return insideFirst && insideSecond;
+}
+
+/**
+ * Names every three-candle formation a trio satisfies.
+ *
+ * An array for the reason {@link candlePairPatterns} returns one: these are
+ * separate statements rather than one statement at several strictnesses. Most
+ * of them cannot co-occur — a formation that needs its first candle bullish
+ * excludes every one that needs it bearish — but a filled Tasuki gap and an
+ * evening star can both describe the same three candles, and neither is the
+ * other said more precisely.
+ *
+ * @param first      - The earliest of the three
+ * @param second     - The middle one
+ * @param third      - The candle the cursor is on
+ * @param thresholds - How strict to be; the requests' figures by default
+ * @returns Every formation the trio satisfies, possibly none
+ */
+export function candleTrioPatterns(
+  first: Ohlc,
+  second: Ohlc,
+  third: Ohlc,
+  thresholds: CandleShapeThresholds = DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+): CandleTrioPattern[] {
+  const found = new Array<CandleTrioPattern>();
+
+  const firstTop = Math.max(first.open, first.close);
+  const firstBottom = Math.min(first.open, first.close);
+  const midpoint = (first.open + first.close) / 2;
+  const secondTop = Math.max(second.open, second.close);
+  const secondBottom = Math.min(second.open, second.close);
+
+  const large = (candle: Ohlc): boolean => bodyFills(candle, thresholds.starLargeBody);
+  const small = (candle: Ohlc): boolean => bodyStaysUnder(candle, thresholds.starSmallBody);
+
+  // #739: decisive, then a pause clear of it, then decisive back through the
+  // middle of the first candle's body.
+  if (
+    first.close < first.open && large(first)
+    && small(second) && secondTop < firstBottom
+    && third.close > third.open && large(third) && third.close > midpoint
+  ) {
+    found.push('morning star');
+  }
+  if (
+    first.close > first.open && large(first)
+    && small(second) && secondBottom > firstTop
+    && third.close < third.open && large(third) && third.close < midpoint
+  ) {
+    found.push('evening star');
+  }
+
+  // #740: three steady steps the same way.
+  if (marchesOneWay([first, second, third], 'up', thresholds)) {
+    found.push('three white soldiers');
+  }
+  if (marchesOneWay([first, second, third], 'down', thresholds)) {
+    found.push('three black crows');
+  }
+
+  // #741: two rising candles with a gap between them, then a fall back into
+  // the gap. Whether the gap survives is the whole of what the two names say,
+  // so both are returned rather than a flag on one.
+  if (
+    first.close > first.open
+    && second.close > second.open && second.low > first.high
+    && third.close < third.open
+    && third.open >= second.open && third.open <= second.close
+  ) {
+    found.push(
+      third.close > first.high ? 'upside tasuki gap' : 'upside tasuki gap filled',
+    );
+  }
+
+  // #742: a rise, then a turn either tucked inside it or swallowing it, then
+  // a lower close confirming the turn.
+  if (
+    first.close > first.open
+    && second.close < second.open
+    && first.open <= second.close && second.open <= first.close
+    && third.close < second.close
+  ) {
+    found.push('three inside down');
+  }
+  if (
+    first.close > first.open
+    && second.close < second.open
+    && second.open > first.close && second.close < first.open
+    && third.close < second.close
+  ) {
+    found.push('three outside down');
+  }
+
+  return found;
 }

--- a/test/model/candlestickTrioPattern.test.ts
+++ b/test/model/candlestickTrioPattern.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The three-candle formations reach the announcement (#739, #740, #741,
+ * #742).
+ *
+ * `candleTrioPatterns` decides the names; these cases are about the trace
+ * handing it the right three candles, in the right order, and only where
+ * there are three to hand.
+ */
+
+import type { CandlestickPoint, MaidrLayer } from '@type/grammar';
+import type { TraceState } from '@type/state';
+import type { Ohlc } from '@util/candlePattern';
+import { describe, expect, it } from '@jest/globals';
+import { Candlestick } from '@model/candlestick';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A candle carrying whatever prices a case needs.
+ *
+ * `trend` and `volatility` are placeholders: the model recomputes both.
+ *
+ * @param value - The x label
+ * @param ohlc  - The four prices
+ * @returns A candlestick point
+ */
+function candle(value: string, ohlc: Ohlc): CandlestickPoint {
+  return { value, ...ohlc, trend: 'Neutral', volatility: 0 };
+}
+
+/**
+ * The trace over a series of candles, positioned on the first.
+ *
+ * @param prices - The candles' prices in x order
+ * @returns A candlestick trace
+ */
+function trace(prices: Ohlc[]): Candlestick {
+  const layer: MaidrLayer = {
+    id: 'candle',
+    type: TraceType.CANDLESTICK,
+    orientation: Orientation.VERTICAL,
+    axes: { x: { label: 'Date' }, y: { label: 'Price' } },
+    data: prices.map((ohlc, index) => candle(`d${index}`, ohlc)),
+  };
+  return new Candlestick(layer);
+}
+
+/**
+ * What a trace announces as asides after stepping `steps` candles forward.
+ *
+ * The first `FORWARD` is the trace's initial entry and lands on the candle
+ * the cursor already reports.
+ *
+ * @param subject - The trace to read
+ * @param steps   - How many candles to advance
+ * @returns The aside label/value pairs, or undefined when there are none
+ */
+function asidesAt(
+  subject: Candlestick,
+  steps: number,
+): { label: string; value: string }[] | undefined {
+  subject.moveOnce('FORWARD');
+  for (let i = 0; i < steps; i++) {
+    subject.moveOnce('FORWARD');
+  }
+  const state = subject.state as Extract<TraceState, { empty: false }>;
+  return state.text.asides;
+}
+
+/** A morning star: decisive fall, pause below it, decisive rise back through. */
+const MORNING: Ohlc[] = [
+  { open: 120, high: 121, low: 99, close: 100 },
+  { open: 95, high: 96, low: 90, close: 94 },
+  { open: 100, high: 116, low: 99, close: 115 },
+];
+
+describe('a candlestick announces the formation three candles make', () => {
+  it('names the morning star on its third candle', () => {
+    expect(asidesAt(trace(MORNING), 2))
+      .toContainEqual({ label: 'pattern', value: 'morning star' });
+  });
+
+  it('names nothing about it on the second, which has only one behind it', () => {
+    // The formation is real by the time the third candle is drawn and not
+    // before; announcing it early would name a chart that does not exist yet.
+    const asides = asidesAt(trace(MORNING), 1) ?? [];
+
+    expect(asides.map(aside => aside.value)).not.toContain('morning star');
+  });
+
+  it('reads the three in chart order', () => {
+    // The same three candles reversed are no formation at all -- a decisive
+    // rise, a pause *below* rather than after it, a decisive fall. If the
+    // trace handed them over in any other order this would still find one.
+    expect(asidesAt(trace([...MORNING].reverse()), 2) ?? [])
+      .not
+      .toContainEqual({ label: 'pattern', value: 'morning star' });
+  });
+
+  it('announces a formation beside whatever else the candle carries', () => {
+    // Three white soldiers whose last candle is itself a marubozu -- a body
+    // filling 10 of its 10.4 range. The two are different statements about
+    // different things, one about how this candle is drawn and one about what
+    // the three of them did, so both are made.
+    const soldiers: Ohlc[] = [
+      { open: 100, high: 110.5, low: 99, close: 110 },
+      { open: 105, high: 115.5, low: 104, close: 115 },
+      { open: 112, high: 122.2, low: 111.8, close: 122 },
+    ];
+
+    expect(asidesAt(trace(soldiers), 2)).toEqual([
+      { label: 'shape', value: 'marubozu' },
+      { label: 'pattern', value: 'three white soldiers' },
+    ]);
+  });
+});

--- a/test/util/candleTrioPattern.test.ts
+++ b/test/util/candleTrioPattern.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The three-candle formations (#739, #740, #741, #742).
+ *
+ * These are the last of the family and the only ones that need two candles
+ * behind the cursor. Each is the request's own arithmetic, with `1` the
+ * earliest of the three and `3` the candle the cursor is on.
+ *
+ * Two thresholds had to be chosen rather than transcribed, and both are
+ * choices worth seeing:
+ *
+ * - **#739's "large" and "small" bodies.** The request suggests measuring them
+ *   against recent candle size, ATR-style. That needs a lookback window the
+ *   chart does not state, and would leave the first candles of any chart
+ *   unreadable. A body against its **own range** says the same thing about
+ *   each candle — decisive, or not — and needs nothing beyond the three the
+ *   pattern is about. 0.6 of the range for the outer two, 0.3 for the middle.
+ * - **#740's "small shadows throughout"**, which the request leaves without a
+ *   figure and asks for one. 0.15 of the range, and only on the *leading*
+ *   side: a soldier that rose and left a long wick above it gave the gain
+ *   back before the close, which is the opposite of the steady control the
+ *   name is about.
+ *
+ * Both travel in {@link CandleShapeThresholds} so a caller can disagree.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import {
+  candleTrioPatterns,
+  DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+} from '@util/candlePattern';
+
+describe('the three-candle formations', () => {
+  it('names a morning star', () => {
+    // A decisive fall, a pause clear below it, then a decisive rise back
+    // through the middle of the first candle's body at 110.
+    expect(candleTrioPatterns(
+      { open: 120, high: 121, low: 99, close: 100 },
+      { open: 95, high: 96, low: 90, close: 94 },
+      { open: 100, high: 116, low: 99, close: 115 },
+    )).toEqual(['morning star']);
+  });
+
+  it('names an evening star', () => {
+    expect(candleTrioPatterns(
+      { open: 100, high: 121, low: 99, close: 120 },
+      { open: 125, high: 130, low: 124, close: 126 },
+      { open: 120, high: 121, low: 104, close: 105 },
+    )).toEqual(['evening star']);
+  });
+
+  it('names three white soldiers', () => {
+    // Each closes higher, each opens inside the body before it, and none
+    // leaves more than a token wick above.
+    expect(candleTrioPatterns(
+      { open: 100, high: 110.5, low: 99, close: 110 },
+      { open: 105, high: 115.5, low: 104, close: 115 },
+      { open: 112, high: 122.5, low: 111, close: 122 },
+    )).toEqual(['three white soldiers']);
+  });
+
+  it('names three black crows', () => {
+    expect(candleTrioPatterns(
+      { open: 110, high: 111, low: 99.5, close: 100 },
+      { open: 105, high: 106, low: 94.5, close: 95 },
+      { open: 100, high: 101, low: 89.5, close: 90 },
+    )).toEqual(['three black crows']);
+  });
+
+  it('declines soldiers that gave the gain back before the close', () => {
+    // The same three, with a wick of 3 over the last one against a range of
+    // 14. It still closed highest; it did not hold the high while doing it.
+    expect(candleTrioPatterns(
+      { open: 100, high: 110.5, low: 99, close: 110 },
+      { open: 105, high: 115.5, low: 104, close: 115 },
+      { open: 112, high: 125, low: 111, close: 122 },
+    )).toEqual([]);
+  });
+
+  it('names an upside Tasuki gap that held', () => {
+    // Two rising candles with a gap from 111 to 114 between them, then a fall
+    // that opens inside the second body and closes at 113 — inside the gap,
+    // but above the first candle's high, so the gap survives.
+    expect(candleTrioPatterns(
+      { open: 100, high: 111, low: 99, close: 110 },
+      { open: 115, high: 126, low: 114, close: 125 },
+      { open: 120, high: 121, low: 112, close: 113 },
+    )).toEqual(['upside tasuki gap']);
+  });
+
+  it('names the same gap as filled when the fall closes through it', () => {
+    // Identical but for the close: 108 is under the first candle's high of
+    // 111, so nothing of the gap is left. Both names are returned by the same
+    // rule rather than one being a flag on the other, because which of the
+    // two it is *is* the finding.
+    expect(candleTrioPatterns(
+      { open: 100, high: 111, low: 99, close: 110 },
+      { open: 115, high: 126, low: 114, close: 125 },
+      { open: 120, high: 121, low: 107, close: 108 },
+    )).toEqual(['upside tasuki gap filled']);
+  });
+
+  it('names three inside down', () => {
+    // The turn is tucked inside the rise's body, then confirmed lower.
+    expect(candleTrioPatterns(
+      { open: 100, high: 121, low: 99, close: 120 },
+      { open: 115, high: 116, low: 104, close: 105 },
+      { open: 105, high: 106, low: 97, close: 98 },
+    )).toEqual(['three inside down']);
+  });
+
+  it('names three outside down', () => {
+    // The turn swallows the rise instead of hiding in it.
+    expect(candleTrioPatterns(
+      { open: 100, high: 111, low: 99, close: 110 },
+      { open: 112, high: 113, low: 97, close: 98 },
+      { open: 98, high: 99, low: 89, close: 90 },
+    )).toEqual(['three outside down']);
+  });
+
+  it('cannot call one trio both inside and outside down', () => {
+    // Inside needs the turn's open at or under the rise's close; outside
+    // needs it above. Checked rather than assumed.
+    const inside = candleTrioPatterns(
+      { open: 100, high: 121, low: 99, close: 120 },
+      { open: 115, high: 116, low: 104, close: 105 },
+      { open: 105, high: 106, low: 97, close: 98 },
+    );
+    const outside = candleTrioPatterns(
+      { open: 100, high: 111, low: 99, close: 110 },
+      { open: 112, high: 113, low: 97, close: 98 },
+      { open: 98, high: 99, low: 89, close: 90 },
+    );
+
+    expect(inside).not.toContain('three outside down');
+    expect(outside).not.toContain('three inside down');
+  });
+
+  it('answers by the thresholds it is given', () => {
+    // The morning star's middle candle, fattened to a body of 2.5 against a
+    // range of 6. Past the default 0.3, inside a caller's 0.5.
+    const trio = [
+      { open: 120, high: 121, low: 99, close: 100 },
+      { open: 95, high: 96, low: 90, close: 92.5 },
+      { open: 100, high: 116, low: 99, close: 115 },
+    ] as const;
+
+    expect(candleTrioPatterns(...trio)).toEqual([]);
+    expect(candleTrioPatterns(...trio, {
+      ...DEFAULT_CANDLE_SHAPE_THRESHOLDS,
+      starSmallBody: 0.5,
+    })).toEqual(['morning star']);
+  });
+
+  it('says nothing about three ordinary candles', () => {
+    expect(candleTrioPatterns(
+      { open: 100, high: 105, low: 99, close: 104 },
+      { open: 104, high: 108, low: 103, close: 102 },
+      { open: 102, high: 106, low: 101, close: 105 },
+    )).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #739. Closes #740. Closes #741. Closes #742.

The last of the family, after #1117 (a candle's own shape), #1118 (what it makes of the one before it) and #1119 (the run of closes a hammer stands on). With this the twelve candlestick-pattern requests are all read.

## What is read

Eight formations over three consecutive candles, each the request's own arithmetic:

| formation | shape of the rule | from |
| --- | --- | --- |
| morning star / evening star | decisive, a pause clear of it, decisive back through the first body's midpoint | #739 |
| three white soldiers / three black crows | three steady steps the same way, each opening inside the body before it, short shadows on the leading side | #740 |
| upside Tasuki gap — **held** or **filled** | two rising candles with a gap between them, then a fall back into it | #741 |
| three inside down / three outside down | a rise, a turn tucked inside it or swallowing it, then a lower close confirming | #742 |

#741 asks for a strength label rather than a boolean, since both variants share their first two candles — so which of the two it is *is* the finding, and the two names come out of the same rule rather than one being a flag on the other.

## Two thresholds had to be chosen

Both are stated in the code where they are made, not buried as literals:

- **#739's "large" and "small" bodies.** The request suggests measuring them against recent candle size, ATR-style. That needs a lookback window the chart does not state, and would leave the first candles of any chart unreadable. A body against its **own range** says the same thing about each candle — decisive, or not — and needs nothing beyond the three the pattern is about. **0.6** of the range for the outer two, **0.3** for the middle.
- **#740's "small shadows throughout"**, which the request leaves without a figure and explicitly asks for one. **0.15** of the range, and only on the **leading** side: a soldier that rose and left a long wick above it gave the gain back before the close, which is the opposite of the steady control the name is about. A case pins that — the same three soldiers with a wick of 3 on a range of 14 are declined.

Both travel in `CandleShapeThresholds`, so a caller can disagree, and a case pins that the parameter is real (a star's middle candle at 2.5/6 is nameless by default and a morning star at `starSmallBody: 0.5`).

## One detail worth flagging

"Opens within the prior body" is written from the body's own ends rather than by flipping the inequalities — a rising candle's body runs open to close, a falling one's runs close to open. That is what keeps the crows a true mirror of the soldiers rather than an approximation of one.

Likewise, `three inside down` and `three outside down` cannot both fire: inside needs the turn's open at or under the rise's close and outside needs it above. Checked rather than assumed.

## Tests

16 cases across `test/util/candleTrioPattern.test.ts` (12) and `test/model/candlestickTrioPattern.test.ts` (4). Every expected value worked by hand.

The model-level cases carry what a unit test of the rule cannot: that the trace hands over the two candles **behind** the cursor, in chart order, and only where there are two. Falsified with six mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| trace hands the trio over reversed | 3 |
| trace reads the previous candle twice | 2 |
| soldiers ignore the leading shadow | 1 |
| Tasuki always reports the gap as held | 1 |
| inside-down drops its containment test | 2 |
| a star's middle candle may be any size | 1 |

`npm run lint:fix`, `npm run type-check` and `npm run build` clean; full suite **5388 passing** (384 suites) plus **137** ESM.

## What a reader hears now

A candle can carry its own shape and what it takes part in at once, and they are different statements:

```
shape is marubozu, pattern is three white soldiers
shape is dragonfly doji, pattern is hammer
shape is doji, pattern is tweezer bottom
```

None of it is a forecast, and none of it needs anything new from a producer — every name is derived from prices the payload already carries, so `docs/SCHEMA.md` is untouched across all four PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_