### PR TITLE
fix(focus): check that the host actually took focus before calling it done

### DIFF
--- a/src/service/frameFocus.ts
+++ b/src/service/frameFocus.ts
@@ -259,37 +259,80 @@ export class FrameFocusService implements Disposable {
    */
   private focusHostContainer(): void {
     const frame = FrameFocusService.hostFrameElement();
-    const container = frame === null
-      ? null
-      : frame.closest(HOST_CONTAINER_SELECTOR) ?? frame.parentElement ?? frame.ownerDocument.body;
-
-    if (container === null || !FrameFocusService.isFocusable(container)) {
-      // Nothing more this side can do. Blurring means the next Shift + Tab
-      // behaves as it would have without this service, so the reader is
-      // left no worse off than before — never trapped.
-      (document.activeElement as HTMLElement | null)?.blur();
-      return;
+    if (frame !== null) {
+      for (const candidate of FrameFocusService.hostCandidates(frame)) {
+        if (FrameFocusService.takeFocus(candidate)) {
+          return;
+        }
+      }
     }
 
-    // `tabindex="-1"` makes the container focusable without adding a tab stop
-    // to the host's own order.
-    if (!container.hasAttribute('tabindex')) {
-      container.setAttribute('tabindex', '-1');
-    }
-    container.focus();
+    // Nothing in the host would take it. Blurring means the next Shift + Tab
+    // behaves as it would have without this service, so the reader is left no
+    // worse off than before — never trapped.
+    (document.activeElement as HTMLElement | null)?.blur();
   }
 
   /**
-   * Whether a host element can be told to take focus.
+   * The host elements worth handing focus to, nearest meaningful first.
    *
-   * Duck-typed on purpose: everything reached through `frameElement` lives in
-   * the host's realm, where `instanceof HTMLElement` — which resolves to *this*
-   * frame's constructor — is false for every element the host owns.
-   * @param {Element} element - An element belonging to the host document
-   * @returns {boolean} True when the element exposes `focus()`
+   * The whole ancestor chain follows the sectioning element, because the
+   * nearest wrapper is not always able to hold focus: Shiny wraps every output
+   * in a `display: contents` div, which has no box for focus to land in, and
+   * the chart's frame sits directly inside one.
+   * @param {Element} frame - This document's frame, in the host's DOM
+   * @returns {Element[]} Candidates in the order they should be tried
    */
-  private static isFocusable(element: Element): element is HTMLElement {
-    return typeof (element as HTMLElement).focus === 'function';
+  private static hostCandidates(frame: Element): Element[] {
+    const section = frame.closest(HOST_CONTAINER_SELECTOR);
+    const candidates = section === null ? [] : [section];
+    for (let element = frame.parentElement; element !== null; element = element.parentElement) {
+      if (element !== section) {
+        candidates.push(element);
+      }
+    }
+    return candidates;
+  }
+
+  /**
+   * Gives a host element focus, and reports whether it actually took it.
+   *
+   * Asking is not enough: `focus()` on an element with no rendered box — a
+   * `display: contents` wrapper, most of all — is a silent no-op, so a caller
+   * that only checked the call went through would leave the reader inside the
+   * frame with nothing to show for the keypress. Reading `activeElement` back
+   * is what tells the two apart.
+   *
+   * A `tabindex` this added is removed again when the element refuses, so a
+   * host that cannot hold focus is not left carrying an attribute that says it
+   * can.
+   * @param {Element} element - An element belonging to the host document
+   * @returns {boolean} True when the element now holds focus
+   */
+  private static takeFocus(element: Element): boolean {
+    // Duck-typed: everything reached through `frameElement` lives in the host's
+    // realm, where `instanceof HTMLElement` — which resolves to *this* frame's
+    // constructor — is false for every element the host owns.
+    if (typeof (element as HTMLElement).focus !== 'function') {
+      return false;
+    }
+
+    // `tabindex="-1"` makes the element focusable without adding a tab stop to
+    // the host's own order.
+    const added = !element.hasAttribute('tabindex');
+    if (added) {
+      element.setAttribute('tabindex', '-1');
+    }
+
+    (element as HTMLElement).focus();
+    if (element.ownerDocument.activeElement === element) {
+      return true;
+    }
+
+    if (added) {
+      element.removeAttribute('tabindex');
+    }
+    return false;
   }
 
   /**

--- a/test/service/frameFocus.test.ts
+++ b/test/service/frameFocus.test.ts
@@ -138,6 +138,35 @@ describe('in a frame the host has nothing before', () => {
   });
 });
 
+describe('when the host element holding the frame cannot take focus', () => {
+  it('walks past it rather than leaving the reader in the frame', () => {
+    // Shiny's shape: every output is wrapped in a `display: contents` div, and
+    // the chart's frame sits directly inside one with no sectioning element
+    // anywhere above it. `focus()` on a box that is not rendered is a silent
+    // no-op, so a handoff that only made the call would leave the reader in
+    // the chart with nothing to show for the keypress.
+    hostDocument.body.innerHTML
+      = '<div id="page"><div id="wrapper"><span id="frame"></span></div></div>';
+    hostFrame = hostDocument.getElementById('frame')!;
+    const page = hostDocument.getElementById('page')!;
+    const wrapper = hostDocument.getElementById('wrapper')!;
+    wrapper.style.display = 'contents';
+    // jsdom has no layout, so it would focus an element a browser refuses.
+    // Stubbing the call is what reproduces the browser: the call goes through
+    // and focus does not move.
+    wrapper.focus = (): void => {};
+
+    pretendFramedBy(hostFrame);
+    service = new FrameFocusService();
+
+    expect(pressShiftTab().defaultPrevented).toBe(true);
+
+    expect(hostDocument.activeElement).toBe(page);
+    // And nothing is left behind on the element that refused.
+    expect(wrapper.hasAttribute('tabindex')).toBe(false);
+  });
+});
+
 describe('in a frame the host has something before', () => {
   it('leaves the native tab order alone', () => {
     hostDocument.body.insertBefore(


### PR DESCRIPTION
# Pull Request

## Description

`FrameFocusService` (#1111) assumed that calling `focus()` on a host element moved focus there. It does not always: an element with no rendered box refuses silently, and `display: contents` is the case that bites.

Shiny wraps **every** output in a `display: contents` div, and a chart's frame sits directly inside one with no sectioning element above it. So the handoff picked that wrapper, called `focus()`, got nothing, and returned as though it had succeeded — leaving the reader inside the chart with nothing to show for the keypress. That is the very failure the service exists to prevent, reproduced in a different host.

It was also slightly worse than doing nothing there: the old native behaviour at least moved focus out of the page, whereas the intercepted keypress moved it nowhere at all.

## Related Issues

Follow-up to #1111, which introduced the handoff. The Shiny case was not among the hosts checked before that merged — this is the gap.

## Changes Made

- `focusHostContainer()` now reads the outcome back (`ownerDocument.activeElement === element`) instead of trusting the call, and walks up the ancestor chain until one actually takes focus. The sectioning element is still tried first; the whole chain follows it rather than only `parentElement`.
- A `tabindex` the handoff added is **removed again** when the element refuses, so a wrapper that cannot hold focus is not left carrying an attribute claiming it can. That also shrinks the change's footprint on host pages generally.
- `isFocusable()` folded into the new `takeFocus()`, which is where the duck-typing note now lives; `hostCandidates()` builds the list.

## Screenshots (if applicable)

Not visual. A real py-shiny app driven in Chromium, sampling the host document after one Shift + Tab out of the chart:

```
before                                    after
t=  50ms  top=iframe#…  frameHasFocus=1   t=  50ms  top=div.container-fluid  frameHasFocus=0
t= 300ms  top=iframe#…  frameHasFocus=1   t= 300ms  top=div.container-fluid  frameHasFocus=0
t=2000ms  top=iframe#…  frameHasFocus=1   t=2000ms  top=div.container-fluid  frameHasFocus=0

tabindex written on: div.shiny-html-output    tabindex written on: div.container-fluid
                     (display:contents,                            (the one that took it)
                      never took focus)
```

Walking the ancestor chain in that page, measured rather than assumed:

```
div#first_chart.shiny-html-output   display=contents   takesFocus=false
div.container-fluid                 display=block      takesFocus=true
body                                display=block      takesFocus=true
```

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**The regression test earns its place.** jsdom has no layout, so it happily focuses an element a browser refuses — a first attempt at this test passed against the unfixed code and pinned nothing. The committed case reproduces Shiny's actual shape (a `display: contents` wrapper with no sectioning ancestor) and stubs `focus()` to the no-op a browser performs; it fails against `main` and passes here, which was checked both ways.

**Verification.** `npm run lint:fix`, `npm run type-check` and `npm run build` clean; `npm test` green at 5389 tests across 384 suites. Then driven in Chromium against four hosts, since the point of this fix is that one host had been missed:

| host | before | after |
| --- | --- | --- |
| py-shiny, chart first | stuck in the chart | focus on `div.container-fluid` |
| Quarto `revealjs` (R and Python) | lands on the slide, Space advances | unchanged |
| JupyterLab, live notebook | native tab order kept, nothing written | unchanged |
| nbconvert HTML export | native tab order kept, nothing written | unchanged |
| bare page, chart first | focus on `body` | unchanged |

Both notebook hosts give every cell wrapper a `tabindex`, so something focusable always precedes the frame and the service correctly leaves them alone — confirmed by checking that no ancestor of the chart's frame gains a `tabindex` from us (the two that carry one in JupyterLab already carry it before any chart is touched).

**Related.** [`xability/r-maidr#213`](https://github.com/xability/r-maidr/pull/213) carries the same fix for the parent-side copies of the listener.