### PR TITLE
feat(vegalite): read a rule spanning two bounds as the range chart it draws

### DIFF
--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -2887,9 +2887,14 @@ function warnCompositeDeclaration(spec: VegaLiteSpec): void {
  *
  * Vega-Lite has no lollipop mark and no dumbbell mark: both are authored as
  * a `layer:` of a segment and its dots. Read layer by layer, the segment is
- * dropped — a bare `rule` resolves to no trace type — and the dots are
- * announced as a scatter, so the chart loses the thing it is drawn to show:
- * the stem's magnitude, or the gap between the pair.
+ * dropped — a `rule` with one positional field resolves to no trace type,
+ * which is every stem this pairs — and the dots are announced as a scatter,
+ * so the chart loses the thing it is drawn to show: the stem's magnitude, or
+ * the gap between the pair.
+ *
+ * This pass runs *before* per-layer conversion, which is what keeps a genuine
+ * ranged dot plot reading as a dumbbell now that a `rule` spanning two bounds
+ * has a reading of its own (#1122).
  *
  * The two are told apart by the data. Two values at every category, told
  * apart by a grouping field, is a dumbbell; one value at each is a

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -699,8 +699,10 @@ function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
  * Some marks produce different MAIDR types depending on encoding:
  *   - `bar` with `bin` on x/y          → HISTOGRAM
  *   - `bar` with color/fill + stack    → STACKED / NORMALIZED / DODGED
- *   - `bar` spanning x–x2 / y–y2       → GANTT, or WATERFALL when the
+ *   - `bar` or `rule` spanning x–x2 / y–y2 → GANTT, or WATERFALL when the
  *     bounds are consecutive running totals
+ *   - `rule` with one positional field → nothing: a reference line or a
+ *     lollipop's stem states no interval of its own
  *   - `rect`                           → HEATMAP
  *   - `point` / `circle` / `square` / `tick` → SCATTER, or DOT when one
  *     positional channel is a category
@@ -913,18 +915,26 @@ function resolveFoldedAxes(
 }
 
 /**
- * Classify a bar that spans a range on one axis instead of standing on a
+ * Classify a mark that spans a range on one axis instead of standing on a
  * baseline.
  *
- * Both shapes draw a floating bar from a positional channel to its `2`
+ * Both shapes draw a floating span from a positional channel to its `2`
  * counterpart, with the remaining axis naming the row: a gantt lane, a
  * waterfall step. They are told apart by {@link hasRunningSumTransform}.
  *
+ * `bar` and `rule` both reach this. Which of the two an author writes is a
+ * choice about how thick the span is drawn, not about what it means — the
+ * same two bounds on the same two channels — and reading only one of them
+ * left an ordinary range chart unread for the sake of its mark's name
+ * (#1122).
+ *
+ * @param mark - The mark being classified, named only for the warning
  * @param encoding - The layer's encoding, merged with any parent's
  * @param transform - The transforms in scope for the layer
- * @returns The trace type, or `null` when the bar is an ordinary one
+ * @returns The trace type, or `null` when the mark spans no range
  */
 function resolveRangedBarType(
+  mark: string,
   encoding?: VegaLiteEncoding,
   transform?: VegaLiteTransform[],
 ): TraceType | null {
@@ -939,15 +949,20 @@ function resolveRangedBarType(
   }
   // Both bounds are there but the axis opposite them left its type to
   // Vega-Lite's inference, which the spec alone cannot recover — see
-  // `isCategorical`. The bar then reads as an ordinary one, whose magnitude
-  // is the lower bound by itself: a silent misread rather than an
-  // unsupported chart, so say which one line of the spec would fix it.
+  // `isCategorical`. Say which one line of the spec would fix it, and say
+  // what the mark falls back to, which is not the same for the two: a `bar`
+  // reads as an ordinary one whose magnitude is the lower bound by itself —
+  // a silent misread — while a `rule` has no other reading and is left out
+  // of the figure altogether.
   if ((hasField(encoding?.y) && hasField(encoding?.y2))
     || (hasField(encoding?.x) && hasField(encoding?.x2))) {
+    const fallback = mark === 'bar'
+      ? 'reading it as an ordinary bar.'
+      : `leaving the ${mark} unread.`;
     console.warn(
-      '[maidr/vegalite] A bar spanning two positional bounds needs an explicit '
+      `[maidr/vegalite] A ${mark} spanning two positional bounds needs an explicit `
       + '"nominal" or "ordinal" type on the axis opposite them to read as a gantt '
-      + 'or a waterfall; reading it as an ordinary bar.',
+      + `or a waterfall; ${fallback}`,
     );
   }
   return null;
@@ -964,7 +979,7 @@ function resolveTraceType(
       // Before the binning and stacking tests: a bar drawn between two
       // positions on one axis carries no magnitude for either of them to
       // read.
-      const ranged = resolveRangedBarType(encoding, transform);
+      const ranged = resolveRangedBarType(mark, encoding, transform);
       if (ranged) {
         return ranged;
       }
@@ -1056,6 +1071,21 @@ function resolveTraceType(
       }
       return TraceType.SCATTER;
     }
+    // A `rule` draws a segment, and `x`–`x2` (or `y`–`y2`) makes that segment
+    // an interval per row — the same chart `bar` draws with the same two
+    // channels, differing only in how thick it is painted. Vega-Lite's own
+    // gallery reaches for `rule` to draw one, and the mark resolved to
+    // nothing, so the chart went unread for the sake of its mark's name
+    // (#1122).
+    //
+    // Only when both bounds are there. A `rule` with one positional field is
+    // a reference line drawn across the frame, and one with `x` and `y` is a
+    // lollipop's stem running up from the baseline — neither carries an
+    // interval any row of the data states, and both keep resolving to `null`
+    // here. A stem under a dot layer is collapsed into the lollipop or
+    // dumbbell it draws before this runs, by `convertPairedLayers`.
+    case 'rule':
+      return resolveRangedBarType(mark, encoding, transform);
     case 'rect':
       return TraceType.HEATMAP;
     case 'boxplot':

--- a/test/adapters/vegalite/rangedRule.test.ts
+++ b/test/adapters/vegalite/rangedRule.test.ts
@@ -117,6 +117,35 @@ describe('vega-Lite rules that span a range', () => {
     expect(layer.selectors).not.toContain('path');
   });
 
+  it('reads a rule over a running total as the waterfall a bar would be', () => {
+    // `resolveRangedBarType` separates the two by `hasRunningSumTransform`,
+    // and that branch is reachable from this mark now. Nobody draws a
+    // waterfall with a `rule`, which is exactly why it is pinned: the
+    // mark's name reaches only the warning string, and a future change that
+    // gave it its own branch would be silent otherwise.
+    const layer = onlyLayer({
+      data: {
+        values: [
+          { label: 'Begin', amount: 4000 },
+          { label: 'Jan', amount: 1707 },
+          { label: 'Feb', amount: -1425 },
+        ],
+      },
+      transform: [
+        { window: [{ op: 'sum', field: 'amount', as: 'sum' }] },
+        { calculate: 'datum.sum - datum.amount', as: 'previous_sum' },
+      ],
+      mark: 'rule',
+      encoding: {
+        x: { field: 'label', type: 'ordinal', title: 'Month' },
+        y: { field: 'previous_sum', type: 'quantitative', title: 'Amount' },
+        y2: { field: 'sum' },
+      },
+    });
+
+    expect(layer.type).toBe(TraceType.WATERFALL);
+  });
+
   it('leaves a reference line unread', () => {
     // One positional field: Vega-Lite draws it across the whole frame
     // because it was given the frame, not because a row said so.

--- a/test/adapters/vegalite/rangedRule.test.ts
+++ b/test/adapters/vegalite/rangedRule.test.ts
@@ -1,0 +1,207 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { GanttData, MaidrLayer } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { Orientation, TraceType } from '@type/grammar';
+
+/**
+ * A range chart read or dropped on its mark's name alone (#1122).
+ *
+ * `resolveTraceType` had cases for `bar`, `line`, `area`, `point`, `rect`,
+ * `arc`, `errorbar` and the rest, and none for `rule`, so a spec spanning
+ * `x`–`x2` fell to `default: return null` and the figure came back with no
+ * layers. The identical spec written with `mark: 'bar'` read as a gantt.
+ *
+ * Which of the two an author writes is a choice about how thick the span is
+ * painted, not about what it means, and Vega-Lite's own gallery reaches for
+ * `rule` to draw a range chart.
+ *
+ * The three other charts that wear this mark keep resolving to nothing, and
+ * the spec separates them cleanly — a reference line and a lollipop's stem
+ * each carry **one** positional field, so neither states an interval any row
+ * of the data contains. That is what makes this cheaper than the same
+ * reading on the Observable side (#1100), where the shapes had to be told
+ * apart by measuring the drawn geometry.
+ */
+
+const SCHEDULE = {
+  values: [
+    { task: 'Design', start: 0, end: 3 },
+    { task: 'Build', start: 3, end: 8 },
+    { task: 'Ship', start: 8, end: 10 },
+  ],
+};
+
+/** The lanes-on-y spelling, which is how a schedule is ordinarily drawn. */
+function lanesOnY(mark: string): VegaLiteSpec {
+  return {
+    data: SCHEDULE,
+    mark,
+    encoding: {
+      y: { field: 'task', type: 'ordinal', title: 'Task' },
+      x: { field: 'start', type: 'quantitative', title: 'Day' },
+      x2: { field: 'end' },
+    },
+  } as VegaLiteSpec;
+}
+
+function layersOf(spec: VegaLiteSpec): MaidrLayer[] {
+  return vegaLiteToMaidr(spec).subplots[0][0].layers;
+}
+
+function onlyLayer(spec: VegaLiteSpec): MaidrLayer {
+  const layers = layersOf(spec);
+  expect(layers).toHaveLength(1);
+  return layers[0];
+}
+
+describe('vega-Lite rules that span a range', () => {
+  it('reads a rule spanning x–x2 as the gantt it draws', () => {
+    const layer = onlyLayer(lanesOnY('rule'));
+
+    expect(layer.type).toBe(TraceType.GANTT);
+    expect(layer.orientation).toBe(Orientation.HORIZONTAL);
+    expect(layer.data as GanttData).toEqual({
+      // One lane per task, in first-seen row order, and the lane list beside
+      // them — the nested payload a schedule needs so a lane nothing books
+      // is still a row the reader can land on.
+      lanes: ['Design', 'Build', 'Ship'],
+      points: [
+        [{ x: 'Design', start: 0, end: 3 }],
+        [{ x: 'Build', start: 3, end: 8 }],
+        [{ x: 'Ship', start: 8, end: 10 }],
+      ],
+    });
+  });
+
+  it('reads it exactly as the same chart written with a bar', () => {
+    // The heart of it: the two specs differ in one string, and differed in
+    // whether the chart was read at all. Compared field by field rather than
+    // both being asserted against a literal, so the two cannot drift apart
+    // while each still matches something written down.
+    const asRule = onlyLayer(lanesOnY('rule'));
+    const asBar = onlyLayer(lanesOnY('bar'));
+
+    expect(asRule.type).toBe(asBar.type);
+    expect(asRule.data).toEqual(asBar.data);
+    expect(asRule.axes).toEqual(asBar.axes);
+    expect(asRule.orientation).toBe(asBar.orientation);
+  });
+
+  it('reads the lanes-on-x spelling too', () => {
+    const layer = onlyLayer({
+      data: SCHEDULE,
+      mark: 'rule',
+      encoding: {
+        x: { field: 'task', type: 'ordinal', title: 'Task' },
+        y: { field: 'start', type: 'quantitative', title: 'Day' },
+        y2: { field: 'end' },
+      },
+    });
+
+    expect(layer.type).toBe(TraceType.GANTT);
+    // Lanes down x is the vertical spelling, so no orientation is emitted —
+    // the same thing the bar case does, and the reason it is asserted is
+    // that the two axes are read from different channels either way.
+    expect(layer.orientation).toBeUndefined();
+  });
+
+  it('highlights through the element Vega draws a rule as', () => {
+    // A `rule` renders as `<line>` where a `bar` renders as `<path>`, and a
+    // selector naming the wrong tag matches nothing — which costs the layer
+    // its highlighting without costing it anything else, so no other
+    // assertion in this file would notice.
+    const layer = onlyLayer(lanesOnY('rule'));
+
+    expect(layer.selectors).toContain('mark-rule');
+    expect(layer.selectors).toContain('line');
+    expect(layer.selectors).not.toContain('path');
+  });
+
+  it('leaves a reference line unread', () => {
+    // One positional field: Vega-Lite draws it across the whole frame
+    // because it was given the frame, not because a row said so.
+    expect(layersOf({
+      data: SCHEDULE,
+      mark: 'rule',
+      encoding: { y: { field: 'start', type: 'quantitative' } },
+    })).toHaveLength(0);
+  });
+
+  it('leaves a lollipop stem unread', () => {
+    // `x` and `y` with no second bound: the stem runs from the baseline to
+    // the value, so reading it as a span would announce "0 to 8" where the
+    // chart means "8".
+    expect(layersOf({
+      data: SCHEDULE,
+      mark: 'rule',
+      encoding: {
+        x: { field: 'task', type: 'ordinal' },
+        y: { field: 'start', type: 'quantitative' },
+      },
+    })).toHaveLength(0);
+  });
+
+  it('leaves a rule whose second bound is a constant unread', () => {
+    // `x2: { datum: 0 }` is the baseline an ordinary lollipop already stands
+    // on, not a bound taken from the data — the distinction `hasField`
+    // exists for, asserted here because this mark now reaches it.
+    expect(layersOf({
+      data: SCHEDULE,
+      mark: 'rule',
+      encoding: {
+        y: { field: 'task', type: 'ordinal' },
+        x: { field: 'start', type: 'quantitative' },
+        x2: { datum: 0 },
+      },
+    })).toHaveLength(0);
+  });
+
+  it('leaves a rule unread when the lane axis has no declared type', () => {
+    // Vega-Lite would infer the type at compile time; the spec alone cannot,
+    // so there is nothing to name the lanes with. Refused rather than
+    // guessed, the same as the bar case.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(layersOf({
+        data: SCHEDULE,
+        mark: 'rule',
+        encoding: {
+          y: { field: 'task' },
+          x: { field: 'start', type: 'quantitative' },
+          x2: { field: 'end' },
+        },
+      })).toHaveLength(0);
+
+      // And the advice names what actually became of this mark. A `bar` in
+      // the same position still reads as an ordinary bar, so the two
+      // sentences cannot be the same one.
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('leaving the rule unread'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('still tells a bar what a bar falls back to', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const layer = onlyLayer({
+        data: SCHEDULE,
+        mark: 'bar',
+        encoding: {
+          y: { field: 'task' },
+          x: { field: 'start', type: 'quantitative' },
+          x2: { field: 'end' },
+        },
+      });
+
+      expect(layer.type).toBe(TraceType.BAR);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('reading it as an ordinary bar'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Closes #1122.

## What was wrong

Two specs, same data, same channels, differing only in the mark's name:

```js
{ data: SCHEDULE, mark: 'bar', encoding: {
    y: { field: 'task', type: 'ordinal' },
    x: { field: 'start', type: 'quantitative' },
    x2: { field: 'end' } } }
// -> [ 'gantt' ]

// mark: 'rule', everything else identical
// -> []
```

`[]` is a figure with no layers: the chart is unread. `resolveTraceType` had a case for `bar`, `line`, `trail`, `area`, `point`, `circle`, `square`, `tick`, `rect`, `boxplot`, `arc`, `errorbar`, `errorband` and `geoshape`, and none for `rule`, so it fell to `default: return null`. The adapter already said so out loud, in a comment at `convertPairedLayers`: *"a bare `rule` resolves to no trace type"*.

Which of the two an author writes is a choice about how thick the span is painted, not about what it means — the same two bounds on the same two channels — and `rule` is what Vega-Lite's own gallery reaches for to draw a range chart.

## What changed

`rule` goes through `resolveRangedBarType`, the helper `bar` already uses. Nothing else had to move: `extractGanttData` reads the spec rather than the geometry, and the selector machinery already knew this mark — `markToCssClass` gives `mark-rule`, and `markToChildElement` already returned `line` for it, since the `errorbar` whip is a rule.

The three other charts that wear this mark keep resolving to nothing, and the spec separates them **without measuring anything**:

| spec | reads as |
| --- | --- |
| `rule` + `x`/`x2` + ordinal `y` | `gantt` — was `[]` |
| `rule` + `y`/`y2` + ordinal `x` | `gantt` — was `[]` |
| `rule` + `y` only (a reference line) | `[]` |
| `rule` + `x` ordinal + `y` (lollipop stems) | `[]` |
| `rule` + `x`/`x2` where `x2` is a `datum` constant | `[]` |
| `rule` + `x`/`x2` under a dot layer (ranged dot plot) | `dumbbell`, unchanged — `convertPairedLayers` consumes both layers first |

A reference line and a lollipop's stem each carry **one** positional field, so neither states an interval any row of the data contains. That is what makes this cheaper than the same reading on the Observable side (#1100), where the three shapes had to be told apart by measuring the drawn geometry and asking whether every line shared an end.

## One thing the shared helper could not keep saying

It warns, when both bounds are present but the opposite axis' type was left to Vega-Lite's inference, that it is *"reading it as an ordinary bar"*. True of a bar — whose magnitude then becomes the lower bound by itself, a silent misread — and false of a rule, which has no other reading and is simply left out of the figure. The sentence now names the mark it is about and what actually became of it. Both halves are asserted.

## Tests

`test/adapters/vegalite/rangedRule.test.ts`, 9 cases.

The one carrying the most weight is **"reads it exactly as the same chart written with a bar"**: the two specs differ in one string, and differed in whether the chart was read at all, so type, data, axes and orientation are compared field by field between them rather than both being asserted against a literal — they cannot drift apart while each still matches something written down.

**"highlights through the element Vega draws a rule as"** is there because a `rule` renders as `<line>` where a `bar` renders as `<path>`, and a selector naming the wrong tag matches nothing — costing the layer its highlighting without costing it anything else, which no other assertion in the file would notice.

Falsified — each mutation applied alone against the fixed baseline:

| mutation | result |
| --- | --- |
| `case 'rule'` removed | 5 failures |
| `rule` returns `GANTT` unconditionally | 4 failures — the reference line, the stem, the constant bound, and the untyped lane axis |
| the warning always says "ordinary bar" | "leaves a rule unread when the lane axis has no declared type" fails |
| `markToChildElement` returns `path` for `rule` | the selector test fails |

`npm run lint:fix && npm run type-check && npm run build && npm test`: all clean, `385 passed` suites / `5397 passed` tests plus `10` / `137` on the ESM project. `lint:fix` changed nothing.

## Recorded in the issue, not fixed here

The same sweep found **`text`** has no case either. The Observable adapter reads a standalone `Plot.text` as a labelled scatter (#1106); the Vega-Lite `text` mark with `x`, `y` and `text` is the same chart and is unread. It needs its own reading decision. **`image`** has no case and correctly so — it places pictures at positions and carries no magnitude to announce.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_