### PR TITLE
feat(vegalite): read a text mark as the labelled scatter it draws

### DIFF
--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -2940,6 +2940,12 @@ function warnCompositeDeclaration(spec: VegaLiteSpec): void {
  * or after the mark it labels, and a `text` layer over *different* channels
  * is a chart of its own rather than an annotation.
  *
+ * Any non-`text` sibling counts, not only one that would itself read as a
+ * scatter. A `line` with per-point annotations over the same two channels is
+ * the same double-announcement -- the coordinates are the line's, and the
+ * text is written on top of them -- so what matters is that another mark
+ * already draws those positions, not what that mark resolved to.
+ *
  * @param specs - The layered spec's children
  * @param index - Position of the candidate label layer
  * @param parentEncoding - Encoding hoisted onto the layered parent

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -164,6 +164,12 @@ export function vegaLiteToMaidr(
         i += 2;
         continue;
       }
+      // A `text` layer written over the mark it labels is not a second
+      // chart -- see `labelsAnotherLayer`.
+      if (labelsAnotherLayer(layerSpecs, i, spec.encoding)) {
+        i += 1;
+        continue;
+      }
       const layer = convertLayerSpec(
         layerSpecs[i],
         i,
@@ -703,6 +709,9 @@ function getStepDirection(spec: VegaLiteSpec): StepDirection | undefined {
  *     bounds are consecutive running totals
  *   - `rule` with one positional field → nothing: a reference line or a
  *     lollipop's stem states no interval of its own
+ *   - `text` on two continuous axes    → SCATTER whose points carry `label`
+ *   - `text` on a categorical axis, or with no `text` channel → nothing:
+ *     a value written over a bar, which the bar already announces
  *   - `rect`                           → HEATMAP
  *   - `point` / `circle` / `square` / `tick` → SCATTER, or DOT when one
  *     positional channel is a category
@@ -1086,6 +1095,28 @@ function resolveTraceType(
     // dumbbell it draws before this runs, by `convertPairedLayers`.
     case 'rule':
       return resolveRangedBarType(mark, encoding, transform);
+    // A `text` mark writes a name at a position, and on two continuous axes
+    // that is a labelled scatter -- the country-names-against-GDP chart
+    // `ScatterPoint.label` exists for. It resolved to nothing, so such a
+    // figure came back with no layers at all (#1124).
+    //
+    // Only on two continuous scales, which is the rule #1106 settled for the
+    // Observable side and settles here for the same reason: a `text` on a
+    // categorical axis is a value written over a bar or into a heatmap cell,
+    // and the mark beside it already announces that number. Reading it here
+    // would announce every count twice, once as a bar and once as a point
+    // standing at the same place.
+    //
+    // A `text` with no `text` channel draws nothing to read, and a `text`
+    // layer that labels another layer is declined before this runs -- see
+    // `labelsAnotherLayer`.
+    case 'text':
+      if (!hasField(encoding?.text))
+        return null;
+      return hasField(encoding?.x) && hasField(encoding?.y)
+        && !isCategorical(encoding?.x) && !isCategorical(encoding?.y)
+        ? TraceType.SCATTER
+        : null;
     case 'rect':
       return TraceType.HEATMAP;
     case 'boxplot':
@@ -1872,11 +1903,21 @@ function extractScatterData(
 ): ScatterPoint[] {
   const xField = encoding.x?.field ?? 'x';
   const yField = encoding.y?.field ?? 'y';
+  // What the `text` mark writes at each position, which is the thing that
+  // mark is drawn for. Absent on every other mark that reaches here, and an
+  // empty string counts as absent per `ScatterPoint.label` (#1124).
+  const labelField = hasField(encoding.text) ? encoding.text?.field : undefined;
 
-  return rows.map(row => ({
-    x: Number(row[xField] ?? 0),
-    y: Number(row[yField] ?? 0),
-  }));
+  return rows.map((row) => {
+    const point: ScatterPoint = {
+      x: Number(row[xField] ?? 0),
+      y: Number(row[yField] ?? 0),
+    };
+    const label = labelField === undefined ? undefined : row[labelField];
+    if (label !== undefined && label !== null && String(label) !== '')
+      point.label = String(label);
+    return point;
+  });
 }
 
 /**
@@ -2879,6 +2920,49 @@ function warnCompositeDeclaration(spec: VegaLiteSpec): void {
     + `names no one layer; move it onto the layer, concat or facet child it `
     + `describes. Ignored.`,
   );
+}
+
+/**
+ * Whether a layer is a `text` mark written over the mark it labels.
+ *
+ * Vega-Lite's way of labelling points is a `layer:` of the mark and a `text`
+ * on the same two positional channels. Both halves then satisfy the labelled
+ * scatter test in {@link resolveTraceType}, and the figure would come back
+ * with two scatters over one set of points -- the same numbers announced
+ * twice, once with names and once without.
+ *
+ * The labels belong *on* the points rather than beside them, which is what
+ * the Observable adapter's `labelOverlays` does. Declining is the smaller
+ * half of that: the layered chart reads exactly as it did before #1124,
+ * while a standalone `text` gains the reading it never had.
+ *
+ * Told by the fields, not by the order: a label layer may be written before
+ * or after the mark it labels, and a `text` layer over *different* channels
+ * is a chart of its own rather than an annotation.
+ *
+ * @param specs - The layered spec's children
+ * @param index - Position of the candidate label layer
+ * @param parentEncoding - Encoding hoisted onto the layered parent
+ * @returns True when this layer only names another layer's marks
+ */
+function labelsAnotherLayer(
+  specs: VegaLiteSpec[],
+  index: number,
+  parentEncoding: VegaLiteEncoding | undefined,
+): boolean {
+  if (getMarkType(specs[index]) !== 'text')
+    return false;
+
+  const labels: VegaLiteEncoding = { ...parentEncoding, ...specs[index].encoding };
+  if (!hasField(labels.x) || !hasField(labels.y))
+    return false;
+
+  return specs.some((sibling, at) => {
+    if (at === index || getMarkType(sibling) === 'text')
+      return false;
+    const drawn: VegaLiteEncoding = { ...parentEncoding, ...sibling.encoding };
+    return drawn.x?.field === labels.x?.field && drawn.y?.field === labels.y?.field;
+  });
 }
 
 /**

--- a/src/adapters/vegalite/selectors.ts
+++ b/src/adapters/vegalite/selectors.ts
@@ -67,13 +67,24 @@ export function markToCssClass(mark: string): string {
  * The SVG element Vega draws one of each mark's instances as.
  *
  * Vega's SVG renderer gives `rule` marks — and the `errorbar` whip, which
- * is a rule — a `<line>` each, while every other mark this adapter reaches
- * is drawn as a `<path>`. Selecting the wrong tag matches nothing, which
- * costs the layer its highlighting without costing it anything else, so the
- * failure is invisible from every other channel.
+ * is a rule — a `<line>` each, and a `text` mark a `<text>` each, while
+ * every other mark this adapter reaches is drawn as a `<path>`. Selecting
+ * the wrong tag matches nothing, which costs the layer its highlighting
+ * without costing it anything else, so the failure is invisible from every
+ * other channel.
+ *
+ * `text` reached here for the first time in #1124, which gave the mark a
+ * trace type; before that `buildSelector` was never called with it, and the
+ * default branch's `<path>` was a guess nothing exercised. What it renders
+ * as is not in doubt — `facets.ts` reads a facet's header out of
+ * `g.mark-text.role-title-text text`.
  */
 function markToChildElement(mark: string): string {
-  return mark === 'rule' || mark === 'errorbar' ? 'line' : 'path';
+  if (mark === 'rule' || mark === 'errorbar')
+    return 'line';
+  if (mark === 'text')
+    return 'text';
+  return 'path';
 }
 
 /**

--- a/src/adapters/vegalite/types.ts
+++ b/src/adapters/vegalite/types.ts
@@ -207,6 +207,14 @@ export interface VegaLiteEncoding {
    * Everywhere else the positional channels already say what a point is, and
    * the tooltip repeats them.
    */
+  /**
+   * What a `text` mark writes at each position.
+   *
+   * The mark's whole payload: a labelled scatter's point is a country or a
+   * gene, and the two coordinates are what the reader can already see the
+   * shape of. Read into `ScatterPoint.label` (#1124).
+   */
+  text?: VegaLiteChannelDef;
   tooltip?: VegaLiteChannelDef | VegaLiteChannelDef[];
   row?: VegaLiteChannelDef;
   column?: VegaLiteChannelDef;

--- a/test/adapters/vegalite/labelledText.test.ts
+++ b/test/adapters/vegalite/labelledText.test.ts
@@ -2,6 +2,7 @@ import type { VegaLiteSpec } from '@adapters/vegalite/types';
 import type { MaidrLayer, ScatterPoint } from '@type/grammar';
 import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
 import { TraceType } from '@type/grammar';
+import { JSDOM } from 'jsdom';
 
 /**
  * A `text` mark read as nothing, so a labelled scatter announced nothing
@@ -74,9 +75,25 @@ describe('vega-Lite text marks', () => {
   });
 
   it('highlights through the element Vega draws a text mark as', () => {
+    // Asserted against a rendered group rather than against the selector
+    // string. Vega draws a `text` mark as a `<text>` each, where every mark
+    // this adapter reached before is a `<path>` -- and a selector naming the
+    // wrong tag matches nothing, which costs the layer its highlighting and
+    // nothing else, so `toContain('mark-text')` passed either way.
+    //
+    // The shape is the codebase's own: `facets.ts` reads a facet header out
+    // of `g.mark-text.role-title-text text`.
     const layer = onlyLayer(labelledScatter);
 
-    expect(layer.selectors).toContain('mark-text');
+    const dom = new JSDOM(
+      '<svg><g class="mark-text role-mark marks">'
+      + '<text>Aa</text><text>Bb</text><text>Cc</text>'
+      + '</g></svg>',
+    );
+
+    const drawn = dom.window.document.querySelectorAll(layer.selectors as string);
+    expect(Array.from(drawn).map(node => node.textContent))
+      .toEqual(['Aa', 'Bb', 'Cc']);
   });
 
   it('leaves a text mark with nothing written in it unread', () => {

--- a/test/adapters/vegalite/labelledText.test.ts
+++ b/test/adapters/vegalite/labelledText.test.ts
@@ -1,0 +1,241 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A `text` mark read as nothing, so a labelled scatter announced nothing
+ * (#1124).
+ *
+ * `resolveTraceType` had no `text` case, so the mark fell to
+ * `default: return null` and the figure came back with no layers. That is
+ * the country-names-against-GDP chart, and the one shape where the mark
+ * carries something no other mark can -- which is what `ScatterPoint.label`
+ * exists for, and what its own doc names `Plot.text` as the reason for.
+ *
+ * The rule is #1106's, settled for the Observable side and for the same
+ * reason here: only on two continuous scales. A `text` on a categorical
+ * axis is a value written over a bar or into a heatmap cell, and the mark
+ * beside it already announces that number; reading it would announce every
+ * count twice.
+ *
+ * The layered case is the one that needed a second rule. Vega-Lite labels a
+ * scatter with `layer: [{mark: 'point'}, {mark: 'text'}]` on the same two
+ * channels, and both halves pass the test above -- so the label layer is
+ * declined, leaving that chart reading exactly as it did before.
+ */
+
+const CITIES = {
+  values: [
+    { city: 'Aa', pop: 3, area: 10 },
+    { city: 'Bb', pop: 5, area: 20 },
+    { city: 'Cc', pop: 2, area: 30 },
+  ],
+};
+
+function layersOf(spec: VegaLiteSpec): MaidrLayer[] {
+  return vegaLiteToMaidr(spec).subplots[0][0].layers;
+}
+
+function onlyLayer(spec: VegaLiteSpec): MaidrLayer {
+  const layers = layersOf(spec);
+  expect(layers).toHaveLength(1);
+  return layers[0];
+}
+
+/** A labelled scatter: two continuous axes and a name at each point. */
+const labelledScatter: VegaLiteSpec = {
+  data: CITIES,
+  mark: 'text',
+  encoding: {
+    x: { field: 'area', type: 'quantitative', title: 'Area' },
+    y: { field: 'pop', type: 'quantitative', title: 'Population' },
+    text: { field: 'city', type: 'nominal' },
+  },
+};
+
+describe('vega-Lite text marks', () => {
+  it('reads a standalone text mark as the labelled scatter it draws', () => {
+    const layer = onlyLayer(labelledScatter);
+
+    expect(layer.type).toBe(TraceType.SCATTER);
+    expect(layer.data as ScatterPoint[]).toEqual([
+      { x: 10, y: 3, label: 'Aa' },
+      { x: 20, y: 5, label: 'Bb' },
+      { x: 30, y: 2, label: 'Cc' },
+    ]);
+  });
+
+  it('names the axes the two coordinates were drawn against', () => {
+    const layer = onlyLayer(labelledScatter);
+
+    expect(layer.axes?.x?.label).toBe('Area');
+    expect(layer.axes?.y?.label).toBe('Population');
+  });
+
+  it('highlights through the element Vega draws a text mark as', () => {
+    const layer = onlyLayer(labelledScatter);
+
+    expect(layer.selectors).toContain('mark-text');
+  });
+
+  it('leaves a text mark with nothing written in it unread', () => {
+    // Vega-Lite draws empty strings without a `text` channel, so there is
+    // no name to carry and nothing the point mark would not say better.
+    expect(layersOf({
+      data: CITIES,
+      mark: 'text',
+      encoding: {
+        x: { field: 'area', type: 'quantitative' },
+        y: { field: 'pop', type: 'quantitative' },
+      },
+    })).toHaveLength(0);
+  });
+
+  it('leaves a value written over a bar unread', () => {
+    // One categorical positional channel: this is a bar's own count printed
+    // at the top of it. The bar mark announces that number already.
+    expect(layersOf({
+      data: CITIES,
+      mark: 'text',
+      encoding: {
+        x: { field: 'city', type: 'nominal' },
+        y: { field: 'pop', type: 'quantitative' },
+        text: { field: 'pop', type: 'quantitative' },
+      },
+    })).toHaveLength(0);
+  });
+
+  it('leaves a heatmap cell label unread', () => {
+    // Both channels categorical -- the number in a cell, which the `rect`
+    // layer beside it carries as the cell's value.
+    expect(layersOf({
+      data: CITIES,
+      mark: 'text',
+      encoding: {
+        x: { field: 'city', type: 'nominal' },
+        y: { field: 'city', type: 'nominal' },
+        text: { field: 'pop', type: 'quantitative' },
+      },
+    })).toHaveLength(0);
+  });
+
+  it('reads a labelled scatter as one layer, not two', () => {
+    // The layered spelling: a `point` and the `text` that names it, over the
+    // same two channels. Both pass the labelled-scatter test on their own,
+    // so without the decline this figure gains a second scatter announcing
+    // the same three points.
+    const layers = layersOf({
+      data: CITIES,
+      layer: [
+        {
+          mark: 'point',
+          encoding: {
+            x: { field: 'area', type: 'quantitative' },
+            y: { field: 'pop', type: 'quantitative' },
+          },
+        },
+        {
+          mark: 'text',
+          encoding: {
+            x: { field: 'area', type: 'quantitative' },
+            y: { field: 'pop', type: 'quantitative' },
+            text: { field: 'city', type: 'nominal' },
+          },
+        },
+      ],
+    });
+
+    expect(layers.map(layer => layer.type)).toEqual([TraceType.SCATTER]);
+  });
+
+  it('declines the label layer wherever it is written', () => {
+    // Drawn first rather than last, which is how a spec puts labels behind
+    // their marks. Told by the fields, so the order cannot matter.
+    const layers = layersOf({
+      data: CITIES,
+      layer: [
+        {
+          mark: 'text',
+          encoding: {
+            x: { field: 'area', type: 'quantitative' },
+            y: { field: 'pop', type: 'quantitative' },
+            text: { field: 'city', type: 'nominal' },
+          },
+        },
+        {
+          mark: 'point',
+          encoding: {
+            x: { field: 'area', type: 'quantitative' },
+            y: { field: 'pop', type: 'quantitative' },
+          },
+        },
+      ],
+    });
+
+    expect(layers.map(layer => layer.type)).toEqual([TraceType.SCATTER]);
+  });
+
+  it('keeps a text layer that charts something of its own', () => {
+    // Different channels from the layer beside it, so it annotates nothing:
+    // it is a chart stacked on another chart, and both are read.
+    const layers = layersOf({
+      data: CITIES,
+      layer: [
+        {
+          mark: 'point',
+          encoding: {
+            x: { field: 'area', type: 'quantitative' },
+            y: { field: 'pop', type: 'quantitative' },
+          },
+        },
+        {
+          mark: 'text',
+          encoding: {
+            x: { field: 'pop', type: 'quantitative' },
+            y: { field: 'area', type: 'quantitative' },
+            text: { field: 'city', type: 'nominal' },
+          },
+        },
+      ],
+    });
+
+    expect(layers.map(layer => layer.type)).toEqual([
+      TraceType.SCATTER,
+      TraceType.SCATTER,
+    ]);
+  });
+
+  it('leaves an ordinary scatter without labels it never had', () => {
+    // `label` is emitted only when a `text` channel names a field, so a
+    // `point` mark is unchanged -- the field is read from the encoding both
+    // marks share an extractor for.
+    const layer = onlyLayer({
+      data: CITIES,
+      mark: 'point',
+      encoding: {
+        x: { field: 'area', type: 'quantitative' },
+        y: { field: 'pop', type: 'quantitative' },
+      },
+    });
+
+    expect(layer.data as ScatterPoint[]).toEqual([
+      { x: 10, y: 3 },
+      { x: 20, y: 5 },
+      { x: 30, y: 2 },
+    ]);
+  });
+
+  it('leaves an image mark unread', () => {
+    // A picture at a position carries no magnitude to announce, so `null`
+    // is the right answer and this pins that the sweep did not give it one.
+    expect(layersOf({
+      data: CITIES,
+      mark: 'image',
+      encoding: {
+        x: { field: 'area', type: 'quantitative' },
+        y: { field: 'pop', type: 'quantitative' },
+      },
+    })).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1124. The second half of the mark sweep whose first half was #1122.

## What was wrong

`resolveTraceType` had no `text` case, so the mark fell to `default: return null` and a figure drawn entirely of it came back with **no layers at all**:

```js
{ data: CITIES, mark: 'text', encoding: {
    x: { field: 'area', type: 'quantitative' },
    y: { field: 'pop', type: 'quantitative' },
    text: { field: 'city', type: 'nominal' } } }
// -> []
```

That is the country-names-against-GDP chart, and the one shape where the mark carries something no other mark can. The grammar already had the field for it — `ScatterPoint.label`'s own documentation names `Plot.text` as the reason it exists:

> A reader told "x is 2.3, y is 14.1" has been given the two numbers they can see the shape of already and withheld the one thing they came for.

## The rule

#1106's, settled for the Observable side and holding here for the same reason: **only on two continuous scales**. A `text` on a categorical axis is a value written over a bar or into a heatmap cell, and the mark beside it already announces that number — reading it would say every count twice, once as a bar and once as a point standing at the same place.

| spec | before | after |
| --- | --- | --- |
| `text` + `x`/`y` quantitative + `text` field | `[]` | `scatter`, each point carrying `label` |
| `text` + `x`/`y` quantitative, no `text` field | `[]` | `[]` — empty strings carry no name |
| `text` + one categorical positional channel | `[]` | `[]` — a bar's own count |
| `text` + both categorical | `[]` | `[]` — a heatmap cell's value |
| `layer: [point, text]` on the same channels | `scatter` | `scatter` — unchanged |
| `layer: [point, text]` on *different* channels | `scatter` | `scatter`, `scatter` |
| `image` | `[]` | `[]` |

## The layered spelling needed a second rule

Vega-Lite labels a scatter with `layer: [{mark: 'point'}, {mark: 'text'}]` over the same two channels, and **both halves pass the test above** — so such a figure would have gained a second scatter announcing the same three points, once with names and once without.

`labelsAnotherLayer` declines the overlay. That leaves the layered chart reading exactly as it did before, while the standalone case gains the reading it never had. It is told by the **fields, not the order**: a label layer may be written either side of the mark it labels, and a `text` over different channels is a chart of its own rather than an annotation — both asserted.

Moving those names *onto* the points they label — what the Observable adapter's `labelOverlays` does — is the natural follow-up and is deliberately not here. It is the difference between "a labelled scatter is read" and "every scatter with labels beside it is named", and only the first reads as nothing today.

## Tests

`test/adapters/vegalite/labelledText.test.ts`, 11 cases, covering all seven rows of the table above plus the axis titles and the selector.

The one doing quiet work is **"leaves an ordinary scatter without labels it never had"**: `extractScatterData` is shared with `point`, `circle`, `square` and `tick`, and it now reads a `text` channel, so a mark that never had one must come back exactly as before.

Falsified — each mutation applied alone against the fixed baseline:

| mutation | result |
| --- | --- |
| `case 'text'` removed | 4 failures |
| `text` always `SCATTER` (categorical axes accepted) | the bar-label and heatmap-label cases fail |
| the label overlay is not declined | both layered cases fail |
| any sibling counts as the labelled mark | "keeps a text layer that charts something of its own" fails |
| the label is never read onto the point | the labelled-scatter case fails |

`npm run lint:fix && npm run type-check && npm run build && npm test`: all clean, `386 passed` suites / `5410 passed` tests plus `10` / `137` on the ESM project. `lint:fix` changed nothing.

## Not changed, and pinned so

`image` places pictures at positions and carries no magnitude to announce, so `null` is the right answer — the same conclusion py-maidr reached for `ax.imshow` of an RGB array (xability/py-maidr#564). Asserted here so the sweep cannot be read later as having missed it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_