### PR TITLE
fix(vegalite): give a layered spec's layers the data written above them

### DIFF
--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -3583,10 +3583,10 @@ function buildConcatMaidr(
     if (childSpec.layer) {
       const layers = inheritData(childSpec.layer, childSpec.data)
         .map((layerSpec, j) => {
-        // Vega names this child's mark groups `concat_<i>_layer_<j>_marks`
-        // (local layer index `j`, not the global data index), so drive the
-        // selector off those while keeping `globalLayerIndex` for the data
-        // lookup, which follows Vega's sequential dataset numbering.
+          // Vega names this child's mark groups `concat_<i>_layer_<j>_marks`
+          // (local layer index `j`, not the global data index), so drive the
+          // selector off those while keeping `globalLayerIndex` for the data
+          // lookup, which follows Vega's sequential dataset numbering.
           const layer = convertLayerSpec(
             layerSpec,
             globalLayerIndex,
@@ -4023,7 +4023,14 @@ function buildFacetMaidr(
     warnCompositeDeclaration(spec.spec);
   }
   const isLayered = childSpec.layer != null && childSpec.layer.length > 0;
-  const layerSpecs = isLayered ? childSpec.layer! : [childSpec];
+  // Both branches, not only the layered one: a facet's single child is
+  // itself the spec whose data sits on the enclosing `spec`, so wrapping
+  // only `childSpec.layer` left the unlayered case with none -- measured,
+  // panel enumeration then saw one cell where the chart has three.
+  const layerSpecs = inheritData(
+    isLayered ? childSpec.layer! : [childSpec],
+    childSpec.data ?? spec.data,
+  );
   const facetFields = [
     descriptor.rowChannel?.field,
     descriptor.columnChannel?.field,
@@ -4045,10 +4052,7 @@ function buildFacetMaidr(
   const layerRows = layerSpecs.map((layerSpec, j) => {
     if (perLayerDatasets)
       return perLayerDatasets[j];
-    const specForData: VegaLiteSpec = layerSpec.data != null
-      ? layerSpec
-      : { ...layerSpec, data: childSpec.data ?? spec.data };
-    let rows = resolveData(specForData, j, view);
+    let rows = resolveData(layerSpec, j, view);
     if (rows.length > 0 && !facetFields.every(field => field in rows[0])) {
       const source = resolveSourceRows(spec, view);
       if (source.length > 0 && facetFields.every(field => field in source[0])) {
@@ -4268,15 +4272,15 @@ function buildRepeatMaidr(
     }
     const childName = repeatChildName(cell.mapping);
     const isLayered = cellSpec.layer != null && cellSpec.layer.length > 0;
-    const layerSpecs = isLayered ? cellSpec.layer! : [cellSpec];
+    const layerSpecs = inheritData(
+      isLayered ? cellSpec.layer! : [cellSpec],
+      cellSpec.data,
+    );
     const parentEncoding = isLayered ? cellSpec.encoding : undefined;
 
     const rawLayers = layerSpecs.map((layerSpec, j) => {
-      const specForData: VegaLiteSpec = layerSpec.data != null
-        ? layerSpec
-        : { ...layerSpec, data: cellSpec.data };
       const layer = convertLayerSpec(
-        specForData,
+        layerSpec,
         globalLayerIndex,
         view,
         parentEncoding,
@@ -4285,7 +4289,7 @@ function buildRepeatMaidr(
         { layerIndex: j, markGroupPrefix: `${childName}_` },
       );
       globalLayerIndex++;
-      return layer ? { layer, spec: specForData } : null;
+      return layer ? { layer, spec: layerSpec } : null;
     }).filter(Boolean) as ConvertedLayer[];
     const layers = coalesceSiblingLineLayers(rawLayers, parentEncoding);
     layers.forEach((layer, j) => {

--- a/src/adapters/vegalite/converters.ts
+++ b/src/adapters/vegalite/converters.ts
@@ -155,7 +155,18 @@ export function vegaLiteToMaidr(
     // as a segment layer plus a dot layer, and neither half is the chart.
     // Converting them separately dropped the segment (a `rule` resolves to
     // no trace type at all) and announced the dots as a scatter.
-    const layerSpecs = spec.layer ?? [];
+    // A layer inherits the parent's `data` unless it brings its own, which
+    // is Vega-Lite's own rule and the form every layered example is written
+    // in -- `data` once at the top, `layer:` beneath it. Applied here, to
+    // the specs themselves, so that every downstream `resolveData` sees it
+    // without a parent-data parameter being threaded through each of them.
+    //
+    // Without it the inline-data fallback looked at a child spec that has
+    // no `data` and returned nothing, so a layered chart resolved to empty
+    // layers whenever the compiled view could not supply rows -- and every
+    // spec-only test of one was asserting against no data at all (#1126).
+    // The facet path already did this; the plain layered path did not.
+    const layerSpecs = inheritData(spec.layer ?? [], spec.data);
     const rawLayers: ConvertedLayer[] = [];
     for (let i = 0; i < layerSpecs.length;) {
       const paired = convertPairedLayers(layerSpecs, i, view, spec.encoding);
@@ -1366,6 +1377,30 @@ function rowsCarryFields(
  * caller that knows which columns must be present says so; every other
  * caller keeps the previous first-non-empty behaviour.
  */
+/**
+ * Give each layer of a layered spec its parent's data, where it has none.
+ *
+ * Vega-Lite's own resolution rule: a layer uses its own `data` when it
+ * declares one and the enclosing spec's otherwise. The specs are rewritten
+ * rather than the rule being applied at every point that reads data,
+ * because `resolveData` is reached from several places -- per-layer
+ * conversion, and the paired lollipop/dumbbell pass on either side of it --
+ * and each would otherwise need the parent threaded to it separately.
+ *
+ * @param layers - The layered spec's children
+ * @param parentData - The `data` of the spec enclosing them
+ * @returns The children, each carrying data it can resolve
+ */
+function inheritData(
+  layers: readonly VegaLiteSpec[],
+  parentData: VegaLiteSpec['data'],
+): VegaLiteSpec[] {
+  if (parentData == null)
+    return [...layers];
+  return layers.map(layer =>
+    layer.data == null ? { ...layer, data: parentData } : layer);
+}
+
 function resolveData(
   spec: VegaLiteSpec,
   layerIndex: number,
@@ -3546,27 +3581,29 @@ function buildConcatMaidr(
     // vconcat / wrapped-concat grids — Vega SVGs carry no `axes_*` ids.
     const selector = `g.mark-group.role-scope.concat_${i}_group > g > path.background`;
     if (childSpec.layer) {
-      const layers = childSpec.layer.map((layerSpec, j) => {
+      const layers = inheritData(childSpec.layer, childSpec.data)
+        .map((layerSpec, j) => {
         // Vega names this child's mark groups `concat_<i>_layer_<j>_marks`
         // (local layer index `j`, not the global data index), so drive the
         // selector off those while keeping `globalLayerIndex` for the data
         // lookup, which follows Vega's sequential dataset numbering.
-        const layer = convertLayerSpec(
-          layerSpec,
-          globalLayerIndex,
-          view,
-          childSpec.encoding,
-          true,
-          domOrder,
-          { layerIndex: j, markGroupPrefix: `concat_${i}_` },
-        );
-        // Assign a unique ID that encodes both the concat index and the
-        // layer index within the child to avoid duplicates across subplots.
-        if (layer)
-          layer.id = `${i}_${j}`;
-        globalLayerIndex++;
-        return layer;
-      }).filter(Boolean) as MaidrLayer[];
+          const layer = convertLayerSpec(
+            layerSpec,
+            globalLayerIndex,
+            view,
+            childSpec.encoding,
+            true,
+            domOrder,
+            { layerIndex: j, markGroupPrefix: `concat_${i}_` },
+          );
+          // Assign a unique ID that encodes both the concat index and the
+          // layer index within the child to avoid duplicates across subplots.
+          if (layer)
+            layer.id = `${i}_${j}`;
+          globalLayerIndex++;
+          return layer;
+        })
+        .filter(Boolean) as MaidrLayer[];
       return { layers, selector };
     }
     // A single-view concat child renders under `concat_<i>_marks` (or the

--- a/test/adapters/vegalite/layeredData.test.ts
+++ b/test/adapters/vegalite/layeredData.test.ts
@@ -1,0 +1,131 @@
+import type { VegaLiteSpec } from '@adapters/vegalite/types';
+import type { LinePoint, ScatterPoint } from '@type/grammar';
+import { vegaLiteToMaidr } from '@adapters/vegalite/converters';
+
+/**
+ * A layered spec's inline data never reached its layers (#1126).
+ *
+ * `resolveData`'s inline fallback reads the spec it was handed, and
+ * `convertLayerSpec` is handed the *child*. A layered chart puts `data`
+ * once at the top and `layer:` beneath it -- Vega-Lite's own form, and the
+ * one every example is written in -- so the fallback found nothing and the
+ * layer came back with no rows at all.
+ *
+ * The parent's encoding and transforms were both threaded down already;
+ * its data was not. The facet path had solved this for itself
+ * (`{ ...layerSpec, data: childSpec.data ?? spec.data }`); the plain
+ * layered and concat paths had not.
+ *
+ * What this is and is not: `bindVegaLite` always passes a compiled view,
+ * and the view path runs first, so an ordinary browser chart takes its rows
+ * from the view. This is the fallback -- what a layered chart falls back
+ * to* when the view cannot supply rows, and what every spec-only test of
+ * one was measuring. Those tests asserted layer types only, and passed
+ * whether the data was right, wrong, or absent.
+ */
+
+const CITIES = {
+  values: [
+    { city: 'Aa', pop: 3, area: 10 },
+    { city: 'Bb', pop: 5, area: 20 },
+    { city: 'Cc', pop: 2, area: 30 },
+  ],
+};
+
+const AREA = { field: 'area', type: 'quantitative' } as const;
+const POP = { field: 'pop', type: 'quantitative' } as const;
+
+function layersOf(spec: VegaLiteSpec): ReturnType<typeof vegaLiteToMaidr>['subplots'][0][0]['layers'] {
+  return vegaLiteToMaidr(spec).subplots[0][0].layers;
+}
+
+describe('a layered spec\'s data', () => {
+  it('reaches a layer that declares none of its own', () => {
+    const layers = layersOf({
+      data: CITIES,
+      layer: [{ mark: 'point', encoding: { x: AREA, y: POP } }],
+    });
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0].data as ScatterPoint[]).toEqual([
+      { x: 10, y: 3 },
+      { x: 20, y: 5 },
+      { x: 30, y: 2 },
+    ]);
+  });
+
+  it('reaches every layer of a multi-layer chart', () => {
+    // Encoding hoisted to the parent too, which is how the form is usually
+    // written: one `data`, one `encoding`, and the marks beneath them.
+    const layers = layersOf({
+      data: CITIES,
+      encoding: { x: AREA, y: POP },
+      layer: [{ mark: 'point' }, { mark: 'line' }],
+    });
+
+    expect(layers.map(layer => layer.type)).toEqual(['point', 'line']);
+    expect(layers[0].data as ScatterPoint[]).toHaveLength(3);
+    // A line layer's payload is one series of points, not a flat list.
+    expect((layers[1].data as LinePoint[][])[0]).toHaveLength(3);
+  });
+
+  it('lets a layer\'s own data win over the parent\'s', () => {
+    // Vega-Lite's own precedence, and the reason this is an inheritance
+    // rather than an override: a layer that names a dataset means it.
+    const layers = layersOf({
+      data: CITIES,
+      layer: [
+        {
+          data: { values: [{ area: 99, pop: 1 }] },
+          mark: 'point',
+          encoding: { x: AREA, y: POP },
+        },
+        { mark: 'point', encoding: { x: AREA, y: POP } },
+      ],
+    });
+
+    expect(layers[0].data as ScatterPoint[]).toEqual([{ x: 99, y: 1 }]);
+    expect(layers[1].data as ScatterPoint[]).toHaveLength(3);
+  });
+
+  it('reaches the layers of a concat child', () => {
+    // The other path that enumerates layer children without inheriting.
+    const spec: VegaLiteSpec = {
+      hconcat: [
+        {
+          data: CITIES,
+          layer: [{ mark: 'point', encoding: { x: AREA, y: POP } }],
+        },
+      ],
+    };
+
+    const layers = vegaLiteToMaidr(spec).subplots[0][0].layers;
+    expect(layers[0].data as ScatterPoint[]).toHaveLength(3);
+  });
+
+  it('leaves a single-view spec exactly as it was', () => {
+    // The path that already worked, asserted beside the others so a change
+    // to the inheritance cannot quietly reach it.
+    const layers = layersOf({
+      data: CITIES,
+      mark: 'point',
+      encoding: { x: AREA, y: POP },
+    });
+
+    expect(layers[0].data as ScatterPoint[]).toEqual([
+      { x: 10, y: 3 },
+      { x: 20, y: 5 },
+      { x: 30, y: 2 },
+    ]);
+  });
+
+  it('does not invent data for a layered spec that has none', () => {
+    // No parent data and no child data is still no data. The layer is
+    // emitted with an empty payload rather than anything being conjured.
+    const layers = layersOf({
+      layer: [{ mark: 'point', encoding: { x: AREA, y: POP } }],
+    });
+
+    expect(layers[0].data as ScatterPoint[]).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1126.

Found while starting #1124's recorded follow-up — the first thing that work needs is a layered spec that carries data, and it turned out none of them do.

## Measured

`vegaLiteToMaidr(spec)` on `main` at `1b4b25da`, no compiled view:

| spec | types | rows per layer |
| --- | --- | --- |
| single `point`, `data` at top | `["point"]` | `[2]` |
| **layered** `point`, `data` on parent | `["point"]` | **`[0]`** |
| **layered** `bar`, `data` on parent | `["bar"]` | **`[0]`** |
| **layered** `line`, `data` on parent | `["line"]` | **`[1]`** (one empty series) |
| **layered** `point`+`line`, encoding hoisted | `["point","line"]` | **`[0, 1]`** |
| layered `point`, `data` repeated per child | `["point"]` | `[2]` |

Only the last works, and it is the form nobody writes.

## Cause

`resolveData`'s inline fallback reads the spec it was handed, and `convertLayerSpec` gets the **child**:

```ts
if (spec.data && typeof spec.data === 'object') { … }
```

`parentEncoding` and `parentTransform` are both threaded down. `data` is not.

## Fix

A new `inheritData` gives each child the parent's `data` where it declares none — Vega-Lite's own precedence, so a layer that names a dataset keeps it. Applied to the specs rather than threaded as a tenth parameter, because `resolveData` is reached from several places (per-layer conversion, and the paired lollipop/dumbbell pass either side of it) and each would otherwise need the parent handed to it separately.

**The facet path already did exactly this** — `{ ...layerSpec, data: childSpec.data ?? spec.data }` — so this is following an idiom already in the file, not inventing one. The plain layered and concat paths had simply missed it.

## Scope, stated plainly

`bindVegaLite` always passes a compiled view, and the view path runs first, so an ordinary browser chart takes its rows from the view and never reaches this fallback. I'm not claiming every layered chart in the wild was broken. What changes:

1. **The fallback becomes a fallback again for layered specs.** When the view path misses — `rowsCarryFields` rejects every candidate, or enumeration finds only internal datasets — a single-view spec recovers from its inline data and a layered one could not.
2. **Spec-only tests of layered charts were asserting against no data.** That is why this went unnoticed: the existing layered tests check `layer.type` only and pass whether the data is right, wrong, or absent. #1124's follow-up is about the *values* a layered chart announces, and there was no way to test that.

## Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` all clean. Full suite `5410 passed` + `137 passed`, no regressions — this touches shared data resolution, so that was the real risk.

Three mutations, each applied alone, each hitting exactly its own tests:

| mutation | fails |
| --- | --- |
| revert the layered inheritance | 3 (incl. the own-data-wins case, which needs the code path to run at all) |
| revert the concat inheritance | 1 (the concat test only) |
| let the parent override a layer's own data | 1 (the precedence test only) |

A sixth test pins that a layered spec with no data anywhere still gets an empty payload rather than anything conjured.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_