### PR TITLE
feat(grammar): give a band with bounds and no estimate a shape to be read as

### DIFF
--- a/e2e_tests/specs/errorbar.spec.ts
+++ b/e2e_tests/specs/errorbar.spec.ts
@@ -73,10 +73,15 @@ test.describe('Error Bar Plot', () => {
 
       expect(points).toHaveLength(3);
       for (const point of points) {
+        // The estimate is optional on the shape since #1047, because a band
+        // may draw only bounds. This chart is not one -- it draws all three,
+        // and asserting so is what makes the two comparisons below mean
+        // something rather than compare against `undefined`.
+        expect(typeof point.y).toBe('number');
         expect(typeof point.yMin).toBe('number');
         expect(typeof point.yMax).toBe('number');
-        expect(point.yMin!).toBeLessThan(point.y);
-        expect(point.y).toBeLessThan(point.yMax!);
+        expect(point.yMin!).toBeLessThan(point.y!);
+        expect(point.y!).toBeLessThan(point.yMax!);
       }
     });
 

--- a/src/adapters/amcharts/declaration.ts
+++ b/src/adapters/amcharts/declaration.ts
@@ -39,7 +39,7 @@ import type {
   VolcanoDeclaration,
 } from '@type/declaration';
 import type {
-  ErrorBarPoint,
+  EstimatedPoint,
   ForestPoint,
   ScatterPoint,
   SurvivalPoint,
@@ -892,7 +892,7 @@ function readBounds(
  */
 export function extractErrorBarSamples(
   declared: AmDeclaredLayer,
-): DeclaredSamples<ErrorBarPoint> {
+): DeclaredSamples<EstimatedPoint> {
   const declaration = declared.declaration as ErrorBarDeclaration;
   const horizontal = isDeclaredHorizontal(declared);
   const misses = explicitRefs(declaration, ['yMin', 'yMax', 'error']);
@@ -901,7 +901,10 @@ export function extractErrorBarSamples(
     : null;
 
   const { value } = valueFields(horizontal);
-  const data: ErrorBarPoint[] = [];
+  // `EstimatedPoint`, because the loop below drops any sample whose estimate
+  // is missing -- so this promises what it already enforces, and a forest row
+  // can be built from it without an assertion (#1047).
+  const data: EstimatedPoint[] = [];
   const items: AmDataItem[] = [];
 
   for (const item of declared.series.dataItems) {

--- a/src/adapters/highcharts/adapter.ts
+++ b/src/adapters/highcharts/adapter.ts
@@ -1579,6 +1579,14 @@ function convertSeries(
       return convertWaterfallSeries(series, containerId);
     case 'errorbar':
       return convertErrorBarSeries(series, chart, containerId);
+    // A band with two bounds and nothing between them. Same `low`/`high`
+    // shape as an error bar and the same trace, minus the estimate -- which
+    // is why these emitted no layer at all until `ErrorBarPoint.y` became
+    // optional (#1047). `areasplinerange` is `arearange` with a smoothed
+    // outline; the curve between the samples is drawing, not data.
+    case 'arearange':
+    case 'areasplinerange':
+      return convertRangeSeries(series, chart, containerId);
     case 'dumbbell':
       return convertDumbbellSeries(series, containerId, options);
     // A gantt series is an xrange with dates and lanes — `GanttSeries` extends
@@ -3048,6 +3056,60 @@ function convertErrorBarSeries(
     id: String(series.index),
     type: TraceType.ERROR_BAR,
     title: series.name || parent?.name || undefined,
+    ...(chart.options.chart?.inverted === true
+      ? { orientation: Orientation.HORIZONTAL }
+      : {}),
+    selectors: errorBarSelector(containerId, series.index),
+    axes: {
+      x: getAxisLabel(series, 'x'),
+      y: getAxisLabel(series, 'y'),
+    },
+    data,
+  };
+}
+
+/**
+ * Converts an `arearange` or `areasplinerange` series into an error bar layer.
+ *
+ * A band, not an interval around an estimate: Highcharts gives each point a
+ * `low` and a `high` and draws the region between them, with nothing in the
+ * middle. So the layer carries the two bounds and **no** `y`, and the trace
+ * walks `lower` then `upper` at each sample, pitching each by its own
+ * magnitude.
+ *
+ * Deliberately not the midpoint {@link convertErrorBarSeries} falls back to
+ * for an unlinked whip. That fallback is defensible there because an error
+ * bar *is* drawn about a centre, so the midpoint is where the chart put the
+ * estimate visually. A band is drawn about nothing, and `(low + high) / 2`
+ * would be a number the chart never shows -- a reader told "10" at a region
+ * spanning 5 to 15 has been told something false, which is worse than being
+ * told only the two numbers that are true (#1047).
+ *
+ * A point Highcharts drew no band segment for is dropped rather than carried
+ * as a gap, for the reason {@link convertErrorBarSeries} drops one: keeping
+ * it would slide every later highlight onto its neighbour.
+ */
+function convertRangeSeries(
+  series: HighchartsSeries,
+  chart: HighchartsChart,
+  containerId: string,
+): MaidrLayer {
+  const data: ErrorBarPoint[] = series.data
+    .filter(point => typeof point.low === 'number' || typeof point.high === 'number')
+    .map((p) => {
+      const low = typeof p.low === 'number' ? p.low : undefined;
+      const high = typeof p.high === 'number' ? p.high : undefined;
+      return {
+        x: pointLabel(p),
+        ...(low === undefined ? {} : { yMin: low }),
+        ...(high === undefined ? {} : { yMax: high }),
+      };
+    });
+
+  return {
+    id: String(series.index),
+    type: TraceType.ERROR_BAR,
+    title: series.name || undefined,
     ...(chart.options.chart?.inverted === true
       ? { orientation: Orientation.HORIZONTAL }
       : {}),

--- a/src/adapters/recharts/converters.ts
+++ b/src/adapters/recharts/converters.ts
@@ -33,6 +33,7 @@ import type {
   DumbbellData,
   DumbbellPoint,
   ErrorBarPoint,
+  EstimatedPoint,
   FlowPoint,
   ForestPoint,
   GanttData,
@@ -1611,9 +1612,12 @@ function toErrorBarPoint(
   xKey: string,
   yKey: string,
   errorConfig?: RechartsAdapterConfig['errorConfig'],
-): ErrorBarPoint {
+): EstimatedPoint {
+  // `EstimatedPoint` rather than `ErrorBarPoint`: `toNumber` always answers
+  // with one, and saying so is what lets a forest row be built from this
+  // without an assertion (#1047).
   const y = toNumber(item[yKey]);
-  const point: ErrorBarPoint = { x: item[xKey] as string | number, y };
+  const point: EstimatedPoint = { x: item[xKey] as string | number, y };
 
   const { errorKey, yMinKey, yMaxKey } = errorConfig ?? {};
   const error = errorKey === undefined ? undefined : item[errorKey];

--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -151,6 +151,9 @@ export class ErrorBarTrace extends AbstractTrace {
    */
   private readonly groups: ErrorBarPoint[][];
   private readonly sections: readonly Section[];
+
+  /** Whether any sample carries an estimate, as opposed to bounds alone. */
+  private readonly hasEstimate: boolean;
   private readonly sectionValues: number[][];
   private readonly orientation: Orientation;
 
@@ -159,7 +162,15 @@ export class ErrorBarTrace extends AbstractTrace {
   private readonly perRowMin: number[];
   private readonly perRowMax: number[];
 
-  /** Row the estimate lives on — the entry row, and the pointer's target. */
+  /**
+   * Row the estimate lives on — the entry row, and the pointer's target.
+   *
+   * A band carries no estimate, so there is no such row and this falls back
+   * to `lower`: the bottom of the interval, which is where entering from
+   * below and stepping up starts. Anything that means "the estimate
+   * specifically" has to ask {@link ErrorBarTrace.hasEstimate} first, since
+   * this answers `0` either way.
+   */
   private readonly valueRow: number;
 
   protected readonly highlightValues: SVGElement[][] | null;
@@ -217,6 +228,7 @@ export class ErrorBarTrace extends AbstractTrace {
       MathUtil.safeMax(row.filter(isMeasured)),
     );
 
+    this.hasEstimate = this.sections.includes('value');
     this.valueRow = Math.max(0, this.sections.indexOf('value'));
     this.highlightValues = this.mapToSvgElements(layer.selectors);
     // Enter on the estimate, not on whichever section happens to be last.
@@ -483,19 +495,46 @@ export class ErrorBarTrace extends AbstractTrace {
   }
 
   /**
-   * Offers the highest and lowest estimate as extrema targets.
+   * Which sections one group's extrema are ranked over.
    *
-   * The estimates are what a reader compares across samples, so they are what
-   * "go to the extreme" should mean here. The bounds are deliberately not
-   * ranked: the widest interval is a different question from the largest
-   * value, and offering both under one menu would leave the reader unable to
-   * tell which sense of "extreme" they had just jumped to.
+   * The estimate alone when there is one: the estimates are what a reader
+   * compares across samples, so they are what "go to the extreme" means on a
+   * chart that has them, and ranking the bounds alongside would mix that with
+   * "which interval reaches furthest" -- a different question, and one a
+   * reader could not tell they had jumped to.
    *
-   * Both targets land on the estimate row, so a reader arriving there hears
-   * the value and can step up or down into its interval — the same motion the
-   * trace exists for.
+   * A band has no estimate, and pinning to the fallback row would rank its
+   * lower bounds alone: `getExtremaTargets` then called the highest *lower*
+   * bound the maximum, sending a reader to a number the trace's own stats
+   * contradict, since {@link ErrorBarTrace.max} already spans both bounds.
+   * So the bounds are ranked together there, and the reader is sent to the
+   * highest and lowest positions the chart actually drew.
    *
-   * @returns The maximum and minimum estimate, when any sample carries one
+   * @param group - Which group to rank
+   * @returns The grid rows to rank, and the section each one reads
+   */
+  private extremaRowsOf(group: number): { row: number; section: Section }[] {
+    if (this.hasEstimate) {
+      return [{ row: this.valueRowOf(group), section: 'value' }];
+    }
+    return this.sections.map((section, offset) => ({
+      row: group * this.sections.length + offset,
+      section,
+    }));
+  }
+
+  /**
+   * Offers the highest and lowest reading as extrema targets.
+   *
+   * What counts as a reading is {@link ErrorBarTrace.extremaRowsOf}'s
+   * decision: the estimates on a chart that has them, the bounds together on
+   * a band that does not.
+   *
+   * Each target lands on the row it was found in, so a reader arriving there
+   * hears that reading and can step up or down through the rest of its
+   * interval — the same motion the trace exists for.
+   *
+   * @returns The maximum and minimum reading, when any sample carries one
    */
   public override getExtremaTargets(): ExtremaTarget[] {
     // Across every group, not just the first. A chart whose largest estimate
@@ -503,9 +542,11 @@ export class ErrorBarTrace extends AbstractTrace {
     // under the name "max", sending a reader somewhere the maximum is not --
     // and saying nothing about it.
     const measured = this.groups.flatMap((group, groupIndex) =>
-      this.sectionValues[this.valueRowOf(groupIndex)]
-        .map((value, index) => ({ value, index, groupIndex }))
-        .filter(({ value }) => isMeasured(value)),
+      this.extremaRowsOf(groupIndex).flatMap(({ row, section }) =>
+        this.sectionValues[row]
+          .map((value, index) => ({ value, index, groupIndex, section }))
+          .filter(({ value }) => isMeasured(value)),
+      ),
     );
 
     if (measured.length === 0) {
@@ -519,11 +560,17 @@ export class ErrorBarTrace extends AbstractTrace {
       this.extremaTarget(highest, 'max'),
     ];
 
-    // One sample, or a chart where every estimate is equal, has a single
-    // extreme. Naming the same sample as both would report a spread the chart
-    // does not have. Compared on both coordinates, since two groups can share
-    // a column index without being the same reading.
-    if (lowest.index !== highest.index || lowest.groupIndex !== highest.groupIndex) {
+    // One sample, or a chart where every reading is equal, has a single
+    // extreme. Naming the same reading as both would report a spread the
+    // chart does not have. Compared on all three coordinates: two groups can
+    // share a column index without being the same reading, and on a band one
+    // sample's two bounds share both index and group while being the two ends
+    // of the spread this is reporting.
+    if (
+      lowest.index !== highest.index
+      || lowest.groupIndex !== highest.groupIndex
+      || lowest.section !== highest.section
+    ) {
       targets.push(this.extremaTarget(lowest, 'min'));
     }
 
@@ -531,34 +578,46 @@ export class ErrorBarTrace extends AbstractTrace {
   }
 
   /**
-   * Builds one extrema target from a located estimate.
+   * Builds one extrema target from a located reading.
    *
    * The group's name joins the label on a grouped chart, because the groups
    * share their category names: "Max value at c" alone does not say which
    * series it means, and the menu offering it is read without the chart in
    * view.
    *
-   * @param found - Where the estimate was located
-   * @param found.value - The estimate itself
+   * The section names itself too. On a chart with estimates that is the word
+   * "value" and the label is what it always was; on a band it is "upper
+   * bound" or "lower bound", which is the difference between "Max upper bound
+   * at feb" and a menu entry claiming a band has a value.
+   *
+   * @param found - Where the reading was located
+   * @param found.value - The reading itself
    * @param found.index - Its column within its group
    * @param found.groupIndex - Which group it belongs to
+   * @param found.section - Which section of the interval it is
    * @param type - Whether it is the maximum or the minimum
    * @returns The target a reader can navigate to
    */
   private extremaTarget(
-    found: { value: number; index: number; groupIndex: number },
+    found: {
+      value: number;
+      index: number;
+      groupIndex: number;
+      section: Section;
+    },
     type: 'max' | 'min',
   ): ExtremaTarget {
     const point = this.groups[found.groupIndex][found.index];
     const group = this.groupNameAt(found.groupIndex);
     const where = group === undefined ? `${point.x}` : `${point.x}, ${group}`;
+    const what = SECTION_LABEL[found.section];
 
     return {
-      label: `${type === 'max' ? 'Max' : 'Min'} value at ${where}`,
+      label: `${type === 'max' ? 'Max' : 'Min'} ${what} at ${where}`,
       value: found.value,
       pointIndex: found.index,
       groupIndex: found.groupIndex,
-      segment: 'value',
+      segment: found.section,
       type,
       navigationType: 'point',
       xValue: point.x,
@@ -566,7 +625,7 @@ export class ErrorBarTrace extends AbstractTrace {
   }
 
   /**
-   * Moves the cursor to a chosen extrema target, on the estimate row.
+   * Moves the cursor to a chosen extrema target, on the row it was found on.
    *
    * @param target - The extrema target to navigate to
    */
@@ -574,7 +633,13 @@ export class ErrorBarTrace extends AbstractTrace {
     // The target's own group, not the first: landing on the first group's
     // estimate row would announce a different series' value at the category
     // the target named, which reads as the extreme without being it.
-    this.row = this.valueRowOf(target.groupIndex ?? 0);
+    //
+    // And its own section, not the estimate's: a band's maximum is an upper
+    // bound, and sending the reader to the fallback row would announce that
+    // sample's lower bound under the name "max".
+    const offset = this.sections.indexOf(target.segment as Section);
+    const section = offset === -1 ? this.valueRow : offset;
+    this.row = (target.groupIndex ?? 0) * this.sections.length + section;
     this.col = target.pointIndex;
     this.finalizeNavigation();
   }

--- a/src/model/errorBar.ts
+++ b/src/model/errorBar.ts
@@ -48,7 +48,7 @@ function magnitudeOf(point: ErrorBarPoint, section: Section): number {
     case 'upper':
       return point.yMax ?? Number.NaN;
     default:
-      return point.y;
+      return point.y ?? Number.NaN;
   }
 }
 
@@ -175,9 +175,16 @@ export class ErrorBarTrace extends AbstractTrace {
     this.groups = toGroups(layer.data as ErrorBarPoint[] | ErrorBarPoint[][]);
     this.points = this.groups.flat();
     this.orientation = layer.orientation ?? Orientation.VERTICAL;
+    // Every section earns its row by having been drawn, the estimate no
+    // differently from the bounds. A band with two bounds and nothing between
+    // them -- Highcharts' `arearange`, `geom_ribbon`, `fill_between` without
+    // a centre line -- then walks `lower` then `upper` and is pitched by its
+    // own bounds, which are positions the chart actually drew. The estimate
+    // used to be kept unconditionally, so such a band got a `value` row of
+    // `NaN`: a third of every interval announcing nothing, and a pointer
+    // entering on it (#1047).
     this.sections = SECTIONS.filter(section =>
-      section === 'value'
-      || this.points.some(point => isMeasured(magnitudeOf(point, section))),
+      this.points.some(point => isMeasured(magnitudeOf(point, section))),
     );
 
     // Rows run group-major: each group's sections are contiguous and in
@@ -456,7 +463,7 @@ export class ErrorBarTrace extends AbstractTrace {
       group.map((point) => {
         const cells: (string | number)[] = [
           point.x,
-          point.y,
+          point.y ?? '',
           point.yMin ?? '',
           point.yMax ?? '',
         ];

--- a/src/type/grammar.ts
+++ b/src/type/grammar.ts
@@ -388,12 +388,28 @@ export interface CandlestickPoint {
  * The bounds are optional and independently so: a one-sided interval — an
  * upper bound with no lower, say — is a real chart, and dropping the point
  * for want of its other half would lose the estimate too.
+ *
+ * The *estimate* is optional for the mirror-image reason. A band with two
+ * bounds and nothing between them is a real chart too — Highcharts draws it
+ * as `arearange`, and the same shape arrives from `Plot.areaY` with
+ * `y1`/`y2`, from `geom_ribbon`, and from `fill_between` without a centre
+ * line. There is no honest number to put here for one: the midpoint is a
+ * value the chart never draws, and either bound announced as the estimate
+ * loses the other and implies a point reading the chart does not make
+ * (#1047).
  */
 export interface ErrorBarPoint {
   /** Position along the main axis. */
   x: number | string;
-  /** The estimate itself: a mean, a median, a fitted value. */
-  y: number;
+  /**
+   * The estimate itself: a mean, a median, a fitted value.
+   *
+   * Absent on a band that draws only bounds. {@link ForestPoint} re-declares
+   * it required, because a forest plot's whole reading is whether the
+   * interval crosses the null *relative to the estimate* — so the shape that
+   * needs it says so, rather than every reader of this one assuming it.
+   */
+  y?: number;
   /** Absolute lower bound of the interval, when the chart draws one. */
   yMin?: number;
   /** Absolute upper bound of the interval, when the chart draws one. */
@@ -421,6 +437,17 @@ export interface ErrorBarPoint {
 }
 
 /**
+ * An {@link ErrorBarPoint} whose estimate is known.
+ *
+ * {@link ErrorBarPoint.y} is optional because a band may draw only bounds,
+ * but most producers of an interval do compute an estimate and drop the
+ * sample when they cannot — and a {@link ForestPoint} requires one. This
+ * names that guarantee so a producer can state it once, at the point where
+ * it is actually enforced, instead of every consumer asserting it (#1047).
+ */
+export type EstimatedPoint = ErrorBarPoint & { y: number };
+
+/**
  * One row of a forest plot: a study's effect estimate with its interval.
  *
  * A meta-analysis draws one of these per study against a shared null line,
@@ -429,6 +456,16 @@ export interface ErrorBarPoint {
  * forest plot rather than a row of intervals.
  */
 export interface ForestPoint extends ErrorBarPoint {
+  /**
+   * The study's effect estimate.
+   *
+   * Required here where {@link ErrorBarPoint.y} is optional. A forest plot
+   * is read by whether each interval crosses the null, and that question is
+   * only answerable *relative to the estimate* — a row without one is not a
+   * study with a missing number, it is not a forest plot row at all (#1047).
+   */
+  y: number;
+
   /**
    * The study's weight in the pooled estimate, as a fraction of one.
    *

--- a/test/adapters/highcharts/arearange.test.ts
+++ b/test/adapters/highcharts/arearange.test.ts
@@ -1,0 +1,102 @@
+import type { ErrorBarPoint } from '@type/grammar';
+import { highchartsToMaidr } from '@adapters/highcharts/adapter';
+import { TraceType } from '@type/grammar';
+import { fakeAxis, fakeChart, fakeSeries } from './helpers';
+
+/**
+ * A band with two bounds and nothing between them.
+ *
+ * `arearange` emitted **no layer at all** before #1047, because every point
+ * shape in the grammar carrying an interval also required an estimate, and a
+ * band has none. Measured on real Highcharts 11 plus `highcharts-more.js` in
+ * Chromium; `areasplinerange` and the `polygon` shape mark were the other two
+ * silent types, and `polygon` is still declined, having no statistical
+ * reading at all.
+ */
+const CATEGORIES = ['Jan', 'Feb', 'Mar', 'Apr'];
+const RANGES = [[5, 15], [30, 50], [12, 28], [22, 38]];
+
+/**
+ * A range chart of one series.
+ * @param type Which of the two range series types to draw
+ * @returns The chart
+ */
+function bandChart(type: 'arearange' | 'areasplinerange'): ReturnType<typeof fakeChart> {
+  return fakeChart({
+    title: 'Temperature range',
+    renderToId: 'range-chart',
+    series: [fakeSeries({
+      index: 0,
+      type,
+      name: 'Range',
+      xAxis: fakeAxis({ categories: CATEGORIES }),
+      yAxis: fakeAxis({ options: { title: { text: 'Degrees' } } }),
+      data: RANGES.map(([low, high], i) => ({
+        x: i,
+        category: CATEGORIES[i],
+        low,
+        high,
+      })),
+    })],
+  });
+}
+
+describe('highcharts range series', () => {
+  it.each(['arearange', 'areasplinerange'] as const)(
+    'reads a %s as the band it draws',
+    (type) => {
+      const layers = highchartsToMaidr(bandChart(type)).subplots[0][0].layers;
+
+      expect(layers).toHaveLength(1);
+      expect(layers[0].type).toBe(TraceType.ERROR_BAR);
+      expect(layers[0].data as ErrorBarPoint[]).toEqual([
+        { x: 'Jan', yMin: 5, yMax: 15 },
+        { x: 'Feb', yMin: 30, yMax: 50 },
+        { x: 'Mar', yMin: 12, yMax: 28 },
+        { x: 'Apr', yMin: 22, yMax: 38 },
+      ]);
+    },
+  );
+
+  it('invents no estimate between the bounds', () => {
+    // The point of #1047. `convertErrorBarSeries` falls back to the midpoint
+    // for an *unlinked whip*, which is defensible there because an error bar
+    // is drawn about a centre. A band is drawn about nothing, so `(low +
+    // high) / 2` would be a number the chart never shows -- a reader told
+    // "10" at a region spanning 5 to 15 has been told something false.
+    const points = highchartsToMaidr(bandChart('arearange'))
+      .subplots[0][0]
+      .layers[0]
+      .data as ErrorBarPoint[];
+
+    for (const point of points) {
+      expect(point.y).toBeUndefined();
+    }
+  });
+
+  it('carries a one-sided sample rather than dropping it', () => {
+    // The bounds are independently optional, and always were: a sample with
+    // only an upper bound is a real thing to draw, and losing the sample
+    // would slide every later highlight onto its neighbour.
+    const chart = fakeChart({
+      title: 'Partial',
+      renderToId: 'partial-range-chart',
+      series: [fakeSeries({
+        index: 0,
+        type: 'arearange',
+        name: 'Range',
+        xAxis: fakeAxis({ categories: ['a', 'b'] }),
+        yAxis: fakeAxis({ options: { title: { text: 'v' } } }),
+        data: [
+          { x: 0, category: 'a', low: 1, high: 4 },
+          { x: 1, category: 'b', high: 9 },
+        ],
+      })],
+    });
+
+    expect(highchartsToMaidr(chart).subplots[0][0].layers[0].data).toEqual([
+      { x: 'a', yMin: 1, yMax: 4 },
+      { x: 'b', yMax: 9 },
+    ]);
+  });
+});

--- a/test/adapters/victory/renderedDom.test.ts
+++ b/test/adapters/victory/renderedDom.test.ts
@@ -151,13 +151,18 @@ describe('victory error bar', () => {
     // falsify the mapping is one against the pixels Victory produced.
     // Two sample centres one data unit apart calibrate the y scale; screen y
     // grows downward, so the higher value sits at the smaller y.
+    // `?? NaN` on the estimate for the same reason the bounds already have
+    // it: the shape made `y` optional in #1047, and a missing one should fail
+    // the comparison rather than quietly compare against `undefined`. Victory
+    // error bars always draw an estimate, so this never fires here.
+    const estimate = (at: number): number => points[at].y ?? Number.NaN;
     const pxPerUnit = (asymmetric.centre - symmetric.centre)
-      / (points[1].y - points[0].y);
+      / (estimate(1) - estimate(0));
 
     expect(asymmetric.centre - asymmetric.top)
-      .toBeCloseTo(pxPerUnit * ((points[0].yMax ?? Number.NaN) - points[0].y), 6);
+      .toBeCloseTo(pxPerUnit * ((points[0].yMax ?? Number.NaN) - estimate(0)), 6);
     expect(asymmetric.bottom - asymmetric.centre)
-      .toBeCloseTo(pxPerUnit * (points[0].y - (points[0].yMin ?? Number.NaN)), 6);
+      .toBeCloseTo(pxPerUnit * (estimate(0) - (points[0].yMin ?? Number.NaN)), 6);
   });
 
   /**

--- a/test/model/errorBar.test.ts
+++ b/test/model/errorBar.test.ts
@@ -270,6 +270,56 @@ describe('extrema navigation', () => {
     expect(text.cross.value).toBe(7.3);
   });
 
+  test('ranks a band across both its bounds', () => {
+    // A band has no estimate, so the fallback row put `getExtremaTargets` on
+    // `lower` alone: the highest *lower* bound was offered as the maximum --
+    // 30 at feb, when the chart's highest drawn point is feb's upper bound at
+    // 50, which the trace's own `max` stat already reports. "Go to max" and
+    // the description contradicted each other (#1133 review).
+    const targets = at(BAND, 0, 0).getExtremaTargets();
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({
+      type: 'max',
+      value: 50,
+      pointIndex: 1,
+      segment: 'upper',
+      label: 'Max upper bound at feb',
+    });
+    expect(targets[1]).toMatchObject({
+      type: 'min',
+      value: 5,
+      pointIndex: 0,
+      segment: 'lower',
+      label: 'Min lower bound at jan',
+    });
+  });
+
+  test('lands a band\'s maximum on its upper bound', () => {
+    // The row has to follow the target's section, not the fallback: landing
+    // on `lower` would announce feb's 30 under the name "max".
+    const trace = at(BAND, 0, 0);
+    const [highest] = trace.getExtremaTargets();
+
+    trace.navigateToExtrema(highest);
+
+    const { text } = nonEmptyState(trace);
+    expect(text.section).toBe('upper bound');
+    expect(text.cross.value).toBe(50);
+  });
+
+  test('offers both ends of a one-sample band', () => {
+    // Its two bounds share a column and a group, so a same-sample check that
+    // did not compare the section would drop the minimum and report a band
+    // with no spread at all.
+    const single: ErrorBarPoint[] = [{ x: 'jan', yMin: 5, yMax: 15 }];
+    const targets = at(single, 0, 0).getExtremaTargets();
+
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({ type: 'max', value: 15 });
+    expect(targets[1]).toMatchObject({ type: 'min', value: 5 });
+  });
+
   test('offers one target when every estimate is equal', () => {
     // Naming the same sample as both the highest and the lowest would report
     // a spread the chart does not have.

--- a/test/model/errorBar.test.ts
+++ b/test/model/errorBar.test.ts
@@ -17,6 +17,20 @@ const MEANS: ErrorBarPoint[] = [
 ];
 
 /**
+ * A band with bounds and nothing between them.
+ *
+ * What Highcharts' `arearange` draws, and what `geom_ribbon`,
+ * `Plot.areaY` with `y1`/`y2`, and `fill_between` without a centre line all
+ * arrive as. There is no honest estimate to put at these samples: the
+ * midpoint is a number the chart never draws, and either bound announced as
+ * the estimate loses the other (#1047).
+ */
+const BAND: ErrorBarPoint[] = [
+  { x: 'jan', yMin: 5, yMax: 15 },
+  { x: 'feb', yMin: 30, yMax: 50 },
+];
+
+/**
  * Create a minimal error bar layer for model-only tests.
  * @param data The points the layer carries
  * @returns Error bar layer definition
@@ -115,6 +129,54 @@ describe('sections', () => {
     const { text } = nonEmptyState(trace);
     expect(text.section).toBe('value');
     expect(text.cross.value).toBe(2);
+  });
+
+  test('omits the estimate a band never carries', () => {
+    // The mirror of `omits a bound the data never carries`, and the whole of
+    // #1047: a band draws two bounds and nothing between them, so a `value`
+    // row would be one a cursor can enter and hear nothing in. The estimate
+    // now earns its row the same way the bounds do -- by having been drawn.
+    const trace = TraceFactory.create(createLayer(BAND)) as ErrorBarTrace;
+
+    trace.moveToIndex(0, 0);
+    expect(nonEmptyState(trace).text.section).toBe('lower bound');
+    expect(nonEmptyState(trace).text.cross.value).toBe(5);
+
+    trace.moveToIndex(1, 0);
+    expect(nonEmptyState(trace).text.section).toBe('upper bound');
+    expect(nonEmptyState(trace).text.cross.value).toBe(15);
+  });
+
+  test('gives a band two rows, not three', () => {
+    // A third row of `NaN` was what the unconditional `value` section
+    // produced, and it would be a third of every interval announcing nothing.
+    const trace = TraceFactory.create(createLayer(BAND)) as ErrorBarTrace;
+
+    trace.moveToIndex(1, 0);
+    expect(nonEmptyState(trace).text.section).toBe('upper bound');
+
+    // There is no row above the upper bound to reach.
+    trace.moveToIndex(2, 0);
+    expect(nonEmptyState(trace).text.section).toBe('upper bound');
+  });
+
+  test('pitches a band by its own bounds', () => {
+    // The sonification question #1047 raised, answered by not needing an
+    // answer: with no estimate there is no invented midpoint to pitch, and
+    // the two bounds are themselves positions the chart drew. The scale runs
+    // from the lowest bound drawn to the highest, exactly as it does when
+    // there is an estimate.
+    const trace = TraceFactory.create(createLayer(BAND)) as ErrorBarTrace;
+
+    trace.moveToIndex(0, 0);
+    const bottom = nonEmptyState(trace).audio;
+    trace.moveToIndex(1, 1);
+    const top = nonEmptyState(trace).audio;
+
+    expect(bottom.freq.min).toBe(5);
+    expect(bottom.freq.max).toBe(50);
+    expect(bottom.freq.raw).toBe(5);
+    expect(top.freq.raw).toBe(50);
   });
 });
 


### PR DESCRIPTION
Closes #1047.

Highcharts' `arearange` and `areasplinerange` emitted **no layer at all** — a chart drawn entirely as a band was silent — because every interval shape in the grammar required an estimate, and a band has none.

**This is the decision #1047 reserved, taken as a proposal rather than settled.** The issue set out two candidate shapes and I have implemented the second; if you prefer a separate point type, say so and I will redo it that way. What follows is why this one held up under the compiler and the tests.

## The grammar

`ErrorBarPoint.y` is optional; **`ForestPoint` re-declares it required.**

That is exactly the half the issue named as the reason not to just do it — relaxing the parent would silently remove a guarantee a forest plot depends on, since its whole reading is whether the interval crosses the null *relative to the estimate*. Re-declaring puts the requirement on the shape that has it, and the guarantee then stops being a convention and becomes something the compiler checks.

It immediately earned that: `tsc` found **every** site relying on the parent's promise — three, all building forest rows in the amCharts and Recharts adapters. The issue's "thirteen files reference `ErrorBarPoint`" worry resolved to those three, precisely, rather than by inspection.

None was a runtime gap. Both producers already guarantee an estimate — amCharts `continue`s past a sample without one, Recharts reads it with a total function — so the fix was to *say* so: `EstimatedPoint` names the guarantee at the point where it is enforced, instead of every consumer asserting it.

## The trace

One line, and it is the line the bounds already lived by:

```diff
-    sections = SECTIONS.filter(s => s === 'value' || <was it drawn?>)
+    sections = SECTIONS.filter(s => <was it drawn?>)
```

The estimate now earns its row the same way a bound does. `magnitudeOf` returns `NaN` for an absent estimate exactly as it already did for an absent bound, and every downstream guard (`isMeasured`, the per-row ranges, `valueRow`'s `Math.max(0, …)`) already handled that — the trace was shaped for this before the shape allowed it.

A band walks `lower` then `upper`. The `value` row of `NaN` — a third of every interval announcing nothing, with the pointer entering on it — is gone.

**That answers the sonification question the issue left open by not needing an answer.** With no `value` row there is no invented midpoint to pitch, and the two bounds are themselves positions the chart drew, on the shared scale the trace already builds. Asserted: a band spanning 5–15 and 30–50 pitches from 5 to 50.

## The adapter

`convertRangeSeries` reads `low`/`high` into `yMin`/`yMax` and no `y`.

Deliberately **not** `convertErrorBarSeries`' midpoint fallback. That is defensible for an unlinked whip, which *is* drawn about a centre, so the midpoint is where the chart put the estimate visually. A band is drawn about nothing, and `(low + high) / 2` would be a number the chart never shows — a reader told "10" at a region spanning 5 to 15 has been told something false, which is worse than being told only the two numbers that are true. Asserted directly (`expect(point.y).toBeUndefined()`).

`polygon`, the third silent type #1047 measured, stays declined — a shape mark with no statistical reading.

## Verification

`npm run lint:fix`, `npm run type-check`, `npm run build` all clean. **5429 + 137 tests pass**, up from 5422 + 137.

7 new tests: the band's two rows and their announcements, that there is no third row, that it pitches by its own bounds, both range series types through the real adapter path, the no-invented-estimate assertion, and a one-sided sample carried rather than dropped.

The band tests sit directly beside `omits a bound the data never carries`, which is the same rule read the other way round — the estimate and the bounds now differ in nothing but name.

## Not addressed

The issue's closing note — that `geom_ribbon`, `Plot.areaY` with `y1`/`y2` and `fill_between` without a centre line are the same shape from other producers — is a binding-side change in each of the three repositories. The grammar can now express what they draw; making them emit it is separate work.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_