### PR TITLE
fix(scatter): say when an axis never moves instead of printing "0 to 0"

### DIFF
--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -153,6 +153,37 @@ interface FlatPoint {
   yIndexInColumn: number;
 }
 
+/**
+ * How an axis's extent reads: a span, or the one value it never leaves.
+ *
+ * `0 to 0` is true and says nothing. It is what a rug plot's cross axis
+ * prints, because both bindings read a rug as a point trace with a constant
+ * on that axis -- the tick's own length is a fraction of the panel rather
+ * than data, so there is nothing else to put there (#1132,
+ * xability/py-maidr#250, xability/r-maidr#222).
+ *
+ * That constant is also why pitch carries nothing on such a chart: every
+ * sample sonifies at the bottom of the range, because the range has no
+ * height. Saying so here is the smallest thing that removes the surprise --
+ * a reader who has been told the axis does not move knows the identical
+ * tones are the chart rather than a fault -- and it needs no new
+ * announcement convention, because it is a stat that already existed and was
+ * merely uninformative.
+ *
+ * What it deliberately does not do is change what pitch *means* mid-chart.
+ * Mapping it to the varying axis instead would hand a reader who has learnt
+ * "pitch is y" a chart where pitch is x, unannounced, which is the kind of
+ * silent mode change #855 and #947 were both about. That option, and a trace
+ * type of its own, are still open on #1132.
+ *
+ * @param min - The axis minimum
+ * @param max - The axis maximum
+ * @returns `constant <value>` when the axis never moves, `<min> to <max>` otherwise
+ */
+function spanned(min: number, max: number): string {
+  return min === max ? `constant ${min}` : `${min} to ${max}`;
+}
+
 export class ScatterTrace extends AbstractTrace implements GridNavigable, PointNavigable, PointCloudHighlightable {
   private mode: NavMode;
   protected readonly movable: MovablePlane;
@@ -992,8 +1023,8 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       { label: 'Total points', value: totalPoints },
       { label: 'Unique X values', value: this.xPoints.length },
       { label: 'Unique Y values', value: this.yPoints.length },
-      { label: 'X range', value: `${this.minX} to ${this.maxX}` },
-      { label: 'Y range', value: `${this.minY} to ${this.maxY}` },
+      { label: 'X range', value: spanned(this.minX, this.maxX) },
+      { label: 'Y range', value: spanned(this.minY, this.maxY) },
     ];
 
     const headers = [this.xAxis, this.yAxis];

--- a/test/model/rugDescription.test.ts
+++ b/test/model/rugDescription.test.ts
@@ -1,0 +1,89 @@
+import type { ScatterTrace } from '@model/scatter';
+import type { MaidrLayer, ScatterPoint } from '@type/grammar';
+import { describe, expect, test } from '@jest/globals';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * A rug plot, as both bindings emit one.
+ *
+ * One entry per observation, the observation on `x`, a constant `0` on the
+ * axis across the ticks. `height`/`length` is one number for the whole layer,
+ * so a tick's length is decoration and only its position is data
+ * (xability/py-maidr#250, xability/r-maidr#222).
+ */
+const RUG: ScatterPoint[] = [
+  { x: 1.5, y: 0 },
+  { x: 2.5, y: 0 },
+  { x: 3.5, y: 0 },
+  { x: 7, y: 0 },
+];
+
+/**
+ * Build a trace over the given points.
+ * @param data The points the layer carries
+ * @param crossLabel What the constant axis is called
+ * @returns The trace
+ */
+function traceOf(data: ScatterPoint[], crossLabel = 'Rug'): ScatterTrace {
+  const layer: MaidrLayer = {
+    id: 'rug-layer',
+    type: TraceType.SCATTER,
+    title: 'Observations',
+    axes: { x: { label: 'v' }, y: { label: crossLabel } },
+    data,
+  };
+  return TraceFactory.create(layer) as ScatterTrace;
+}
+
+/**
+ * Read one stat out of a trace's description.
+ * @param trace The trace to read
+ * @param label Which stat to take
+ * @returns The stat's value
+ */
+function statOf(trace: ScatterTrace, label: string): unknown {
+  return trace.description.stats?.find(stat => stat.label === label)?.value;
+}
+
+describe('an axis that never moves', () => {
+  test('says it is constant rather than printing a span of nothing', () => {
+    // #1132. A rug's pitch axis is the constant one, so every tick sonifies
+    // at the bottom of the range and a reader has no way to tell the chart
+    // from a fault. `0 to 0` was true and said nothing.
+    expect(statOf(traceOf(RUG), 'Y range')).toBe('constant 0');
+  });
+
+  test('leaves an axis that does move alone', () => {
+    // The rug's *own* axis is where its data is, and it must keep reading as
+    // a span -- this is the axis carrying everything the chart shows.
+    expect(statOf(traceOf(RUG), 'X range')).toBe('1.5 to 7');
+  });
+
+  test('applies to whichever axis is flat, not to rugs by name', () => {
+    // Nothing here knows what a rug is. A scatter that happens to be drawn
+    // along a horizontal line reads the same way, which is what makes this a
+    // fact about the axis rather than a special case.
+    const flatOnX: ScatterPoint[] = [
+      { x: 3, y: 1 },
+      { x: 3, y: 4 },
+      { x: 3, y: 9 },
+    ];
+    const trace = traceOf(flatOnX, 'height');
+
+    expect(statOf(trace, 'X range')).toBe('constant 3');
+    expect(statOf(trace, 'Y range')).toBe('1 to 9');
+  });
+
+  test('an ordinary scatter still reads as two spans', () => {
+    const ordinary: ScatterPoint[] = [
+      { x: 1, y: 3 },
+      { x: 2, y: 8 },
+      { x: 4, y: 1 },
+    ];
+    const trace = traceOf(ordinary, 'y');
+
+    expect(statOf(trace, 'X range')).toBe('1 to 4');
+    expect(statOf(trace, 'Y range')).toBe('1 to 8');
+  });
+});


### PR DESCRIPTION
Refs #1132.

**This is option 4, narrowed to the description — and it is a proposal, not a decision taken.** #1132 lists four ways to give a rug plot a sonification, and reserves the choice because each of the first three sets a new convention. This takes none of them. It fixes a stat that already existed and was merely uninformative, which is the one part of the problem that needs no convention at all. Options 1–3 remain open; if you want one of them instead, this does not stand in the way.

## What a rug reads as today

Both bindings hand the core a point trace with a constant on the cross axis — a tick's length is a fraction of the panel rather than data, so there is nothing else to put there (xability/py-maidr#250, xability/r-maidr#222). The description then prints:

```
Y range: 0 to 0
```

True, and it says nothing. That same constant is why pitch carries no information on the chart: every sample sonifies at the bottom of the range, because the range has no height. A reader hearing eight identical tones has no way to tell that from a broken chart.

## The change

Both range stats go through one helper:

```ts
function spanned(min: number, max: number): string {
  return min === max ? `constant ${min}` : `${min} to ${max}`;
}
```

`Y range: constant 0`. A reader who has been told the axis does not move knows the identical tones are the chart rather than a fault.

**What it deliberately does not do** is change what pitch *means* mid-chart. Option 2 — mapping pitch to the varying axis — would hand a reader who has learnt "pitch is y" a chart where pitch is x, unannounced. That is the kind of silent mode change #855 and #947 were both about, which is why it belongs to you rather than to this PR. The helper's docstring records that reasoning in the code, so the next person reads it before reaching for the same option.

## Scope

It is a fact about a flat axis, not about rug plots. A scatter that is flat on x reads `X range: constant 3` by the same rule, and one of the four tests asserts exactly that, so the behaviour is not a special case waiting to surprise someone.

## Verification

`test/model/rugDescription.test.ts`, four cases: a rug's Y reads `constant 0`; its X still reads `1.5 to 7`; a scatter flat on X reads symmetrically; an ordinary scatter still reads as two spans.

`npm run lint:fix`, `npm run type-check` and `npm run build` clean. `npm test` → 5436 passed (389 suites) + 137 passed (10 ESM suites).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_