### PR TITLE
fix(model): say when an axis never moves in four more range stats

### DIFF
--- a/src/model/candlestickDelta.ts
+++ b/src/model/candlestickDelta.ts
@@ -10,6 +10,7 @@ import type {
   TraceState,
 } from '@type/state';
 import type { CompareModeInfo, Dimension, NearestPoint, RotorFilterUnit } from './abstract';
+import { MathUtil } from '@util/math';
 import { AbstractTrace } from './abstract';
 import { MovableGrid } from './movable';
 
@@ -508,7 +509,7 @@ export class CandlestickDeltaTrace extends AbstractTrace {
       { label: 'Points above line', value: aboveCount },
       { label: 'Points below line', value: belowCount },
       { label: 'Points on line', value: onLineCount },
-      { label: 'Delta range', value: `${minDelta} to ${maxDelta}` },
+      { label: 'Delta range', value: MathUtil.spanned(minDelta, maxDelta) },
     ];
 
     const headers = [

--- a/src/model/gauge.ts
+++ b/src/model/gauge.ts
@@ -2,6 +2,7 @@ import type { GaugeBand, GaugePoint, MaidrLayer } from '@type/grammar';
 import type { Movable } from '@type/movable';
 import type { AudioState, BrailleState, DescriptionState, TextState } from '@type/state';
 import type { Dimension, NearestPoint } from './abstract';
+import { MathUtil } from '@util/math';
 import { Svg } from '@util/svg';
 import { AbstractTrace } from './abstract';
 import { MovableGrid } from './movable';
@@ -163,7 +164,7 @@ export class GaugeTrace extends AbstractTrace {
       // way a histogram announces a bin's span instead of a single x. Setting
       // it here would drop the measure's name from every announcement and
       // render the dial's ends through the category axis's formatter.
-      z: { label: 'Range', value: `${this.min} to ${this.max}` },
+      z: { label: 'Range', value: MathUtil.spanned(this.min, this.max) },
       mainAxis: 'x',
       crossAxis: 'y',
     };
@@ -185,7 +186,7 @@ export class GaugeTrace extends AbstractTrace {
   public get description(): DescriptionState {
     const stats: DescriptionState['stats'] = [
       { label: 'Value', value: this.value },
-      { label: 'Range', value: `${this.min} to ${this.max}` },
+      { label: 'Range', value: MathUtil.spanned(this.min, this.max) },
     ];
 
     if (this.point.target !== undefined) {

--- a/src/model/histogram.ts
+++ b/src/model/histogram.ts
@@ -1,6 +1,7 @@
 import type { HistogramPoint, MaidrLayer } from '@type/grammar';
 import type { DescriptionState, TextState } from '@type/state';
 import { Orientation } from '@type/grammar';
+import { MathUtil } from '@util/math';
 import { AbstractBarPlot } from './bar';
 
 export class Histogram extends AbstractBarPlot<HistogramPoint> {
@@ -25,7 +26,7 @@ export class Histogram extends AbstractBarPlot<HistogramPoint> {
     const stats: DescriptionState['stats'] = [
       { label: 'Number of bins', value: points.length },
       ...this.rangeStats(),
-      { label: 'Bin range', value: `${binRangeMin} to ${binRangeMax}` },
+      { label: 'Bin range', value: MathUtil.spanned(binRangeMin, binRangeMax) },
     ];
 
     const headers = isVertical

--- a/src/model/parallel.ts
+++ b/src/model/parallel.ts
@@ -173,7 +173,7 @@ export class ParallelTrace extends LineTrace {
       for (const [column, name] of axisNames.entries()) {
         stats.push({
           label: name,
-          value: `${this.axisMin[column]} to ${this.axisMax[column]}`,
+          value: MathUtil.spanned(this.axisMin[column], this.axisMax[column]),
         });
       }
     }

--- a/src/model/scatter.ts
+++ b/src/model/scatter.ts
@@ -153,37 +153,6 @@ interface FlatPoint {
   yIndexInColumn: number;
 }
 
-/**
- * How an axis's extent reads: a span, or the one value it never leaves.
- *
- * `0 to 0` is true and says nothing. It is what a rug plot's cross axis
- * prints, because both bindings read a rug as a point trace with a constant
- * on that axis -- the tick's own length is a fraction of the panel rather
- * than data, so there is nothing else to put there (#1132,
- * xability/py-maidr#250, xability/r-maidr#222).
- *
- * That constant is also why pitch carries nothing on such a chart: every
- * sample sonifies at the bottom of the range, because the range has no
- * height. Saying so here is the smallest thing that removes the surprise --
- * a reader who has been told the axis does not move knows the identical
- * tones are the chart rather than a fault -- and it needs no new
- * announcement convention, because it is a stat that already existed and was
- * merely uninformative.
- *
- * What it deliberately does not do is change what pitch *means* mid-chart.
- * Mapping it to the varying axis instead would hand a reader who has learnt
- * "pitch is y" a chart where pitch is x, unannounced, which is the kind of
- * silent mode change #855 and #947 were both about. That option, and a trace
- * type of its own, are still open on #1132.
- *
- * @param min - The axis minimum
- * @param max - The axis maximum
- * @returns `constant <value>` when the axis never moves, `<min> to <max>` otherwise
- */
-function spanned(min: number, max: number): string {
-  return min === max ? `constant ${min}` : `${min} to ${max}`;
-}
-
 export class ScatterTrace extends AbstractTrace implements GridNavigable, PointNavigable, PointCloudHighlightable {
   private mode: NavMode;
   protected readonly movable: MovablePlane;
@@ -1023,8 +992,8 @@ export class ScatterTrace extends AbstractTrace implements GridNavigable, PointN
       { label: 'Total points', value: totalPoints },
       { label: 'Unique X values', value: this.xPoints.length },
       { label: 'Unique Y values', value: this.yPoints.length },
-      { label: 'X range', value: spanned(this.minX, this.maxX) },
-      { label: 'Y range', value: spanned(this.minY, this.maxY) },
+      { label: 'X range', value: MathUtil.spanned(this.minX, this.maxX) },
+      { label: 'Y range', value: MathUtil.spanned(this.minY, this.maxY) },
     ];
 
     const headers = [this.xAxis, this.yAxis];

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -6,6 +6,43 @@ export abstract class MathUtil {
   private constructor() { /* Prevent instantiation */ }
 
   /**
+   * How an axis's extent reads: a span, or the one value it never leaves.
+   *
+   * `5 to 5` is true and says nothing. A rug plot's cross axis prints it
+   * because both bindings read a rug as a point trace with a constant on that
+   * axis (#1132); a parallel-coordinates column that never varies prints it
+   * because the column really is constant; a one-bin histogram prints it
+   * because there is one bin. In every case the reader is told a range and
+   * handed a point.
+   *
+   * That constant is also why pitch carries nothing on such an axis: every
+   * sample sonifies at the bottom of the range, because the range has no
+   * height. Saying so is the smallest thing that removes the surprise -- a
+   * reader who has been told the axis does not move knows the identical tones
+   * are the chart rather than a fault -- and it needs no new announcement
+   * convention, because these are stats that already existed and were merely
+   * uninformative (#1136).
+   *
+   * What it deliberately does not do is change what pitch *means* mid-chart.
+   * Mapping it to a varying axis instead would hand a reader who has learnt
+   * "pitch is y" a chart where pitch is x, unannounced, which is the kind of
+   * silent mode change #855 and #947 were both about. That option, and a
+   * trace type of its own, are still open on #1132.
+   *
+   * Not for every `a to b` in a description. A choropleth's jump, a flow's
+   * source and target, and a ridgeline's narrowest and widest modes are a
+   * pair or a path rather than one axis's extent, and `constant x` would be
+   * the wrong sentence for all three.
+   *
+   * @param min - The axis minimum
+   * @param max - The axis maximum
+   * @returns `constant <value>` when the axis never moves, `<min> to <max>` otherwise
+   */
+  static spanned(min: number, max: number): string {
+    return min === max ? `constant ${min}` : `${min} to ${max}`;
+  }
+
+  /**
    * Safely finds the minimum value from an array of numbers.
    * Returns Infinity for empty arrays (mathematically correct: empty set has no minimum).
    * This prevents subtle bugs where 0 might be confused with actual data.

--- a/test/model/constantAxisStats.test.ts
+++ b/test/model/constantAxisStats.test.ts
@@ -1,0 +1,219 @@
+import type { CandlestickDeltaCandle } from '@model/candlestickDelta';
+import type {
+  CandlestickPoint,
+  GaugePoint,
+  HistogramPoint,
+  LinePoint,
+  MaidrLayer,
+} from '@type/grammar';
+import type { DescriptionState, NonEmptyTraceState } from '@type/state';
+import { describe, expect, test } from '@jest/globals';
+import { CandlestickDeltaTrace } from '@model/candlestickDelta';
+import { TraceFactory } from '@model/factory';
+import { TraceType } from '@type/grammar';
+
+/**
+ * Range stats read `constant x` where the axis never moves (#1136).
+ *
+ * `${min} to ${max}` is true and uninformative when the two are the same
+ * number: the reader is told a range and handed a point. #1134 fixed the
+ * scatter trace, where a rug plot printed `Y range: 0 to 0`; the same
+ * expression stood in five more description stats, and two of them reach the
+ * degenerate case on ordinary data rather than contrived data.
+ *
+ * `MathUtil.spanned` is the one place that decides it now, so a sixth site
+ * added tomorrow gets the answer by calling it. What these cases hold is that
+ * each trace actually routes through it -- the helper being right is not the
+ * same as the trace using it, and that gap is what the direct
+ * `${min} to ${max}` was.
+ */
+
+/**
+ * The value of one named stat in a trace's description.
+ *
+ * @param layer - The layer to build a trace from
+ * @param label - The stat to read
+ * @returns The stat's value, or undefined when the description has no such stat
+ */
+function statOf(layer: MaidrLayer, label: string): string | number | undefined {
+  const trace = TraceFactory.create(layer) as unknown as { description: DescriptionState };
+  return trace.description.stats?.find(stat => stat.label === label)?.value;
+}
+
+describe('a stat for an axis that never moves', () => {
+  test('names a parallel coordinates column that does not vary', () => {
+    // The most ordinary of the set, and the one where the reading is a
+    // finding rather than a curiosity: a constant column on a parallel plot
+    // is exactly what a reader wants to be told, because every line crosses
+    // it at the same height and the axis separates nothing.
+    const data: LinePoint[][] = [
+      [{ x: 'mpg', y: 33, z: 'A' }, { x: 'cyl', y: 4, z: 'A' }],
+      [{ x: 'mpg', y: 21, z: 'B' }, { x: 'cyl', y: 4, z: 'B' }],
+      [{ x: 'mpg', y: 15, z: 'C' }, { x: 'cyl', y: 4, z: 'C' }],
+    ];
+    const layer: MaidrLayer = {
+      id: 'parallel',
+      type: TraceType.PARALLEL,
+      title: 'Cars',
+      axes: { x: { label: 'Variable' }, y: { label: 'Value' } },
+      data,
+    };
+
+    expect(statOf(layer, 'cyl')).toBe('constant 4');
+    // The varying column on the same chart is untouched, so this is a fact
+    // about the axis rather than about the trace type.
+    expect(statOf(layer, 'mpg')).toBe('15 to 33');
+  });
+
+  test('names a histogram whose observations all fall in one bin', () => {
+    const layer = {
+      id: 'histogram',
+      type: TraceType.HISTOGRAM,
+      title: 'One bin',
+      axes: { x: { label: 'Value' }, y: { label: 'Count' } },
+      data: [
+        { x: 5, y: 12, xMin: 5, xMax: 5, yMin: 0, yMax: 12 },
+      ] as HistogramPoint[],
+    } as unknown as MaidrLayer;
+
+    expect(statOf(layer, 'Bin range')).toBe('constant 5');
+  });
+
+  test('names a flat gauge scale on every move, not only in the description', () => {
+    // A gauge carries its dial's ends in the text state's `z`, which is read
+    // out on every move -- so this is the more consequential of the trace's
+    // two `Range` readings, and the one a description-only test misses. A
+    // mutation aimed at the description stat matched this line first and
+    // survived, which is how the gap showed up.
+    const data: GaugePoint = {
+      label: 'Conversion',
+      value: 40,
+      min: 40,
+      max: 40,
+      target: 40,
+      bands: [{ to: 40, label: 'flat' }],
+    };
+    const layer: MaidrLayer = {
+      id: 'gauge',
+      type: TraceType.GAUGE,
+      title: 'Conversion rate',
+      axes: { x: { label: 'Measure' }, y: { label: 'Percent' } },
+      data,
+    };
+
+    const trace = TraceFactory.create(layer);
+    const state = trace.state as NonEmptyTraceState;
+    expect(state.text.z).toEqual({ label: 'Range', value: 'constant 40' });
+  });
+
+  test('names a gauge whose scale has no width', () => {
+    const data: GaugePoint = {
+      label: 'Conversion',
+      value: 40,
+      min: 40,
+      max: 40,
+      target: 40,
+      bands: [{ to: 40, label: 'flat' }],
+    };
+    const layer: MaidrLayer = {
+      id: 'gauge',
+      type: TraceType.GAUGE,
+      title: 'Conversion rate',
+      axes: { x: { label: 'Measure' }, y: { label: 'Percent' } },
+      data,
+    };
+
+    expect(statOf(layer, 'Range')).toBe('constant 40');
+  });
+
+  test('names a series that never left its reference line', () => {
+    // Every delta is zero, so the delta range genuinely has no width -- and
+    // unlike the candlestick's own price range, this one is reachable on
+    // ordinary data: a series tracking its moving average exactly.
+    const flat: CandlestickDeltaCandle[] = [
+      { x: 'mon', reference: 10, open: 10, high: 10, low: 10, close: 10 },
+      { x: 'tue', reference: 10, open: 10, high: 10, low: 10, close: 10 },
+    ];
+    const layer: MaidrLayer = {
+      id: 'delta',
+      type: TraceType.CANDLESTICK_DELTA,
+      title: 'Price vs MA',
+      axes: { x: { label: 'Date' }, y: { label: 'Price delta' } },
+      data: [],
+    };
+    const trace = new CandlestickDeltaTrace(layer, {
+      candles: flat,
+      referenceLabel: 'Moving Average',
+      initialField: 'close',
+    });
+
+    expect(
+      trace.description.stats?.find(s => s.label === 'Delta range')?.value,
+    ).toBe('constant 0');
+  });
+
+  test('leaves a candlestick range that really is a range alone', () => {
+    // The guard on the whole change: it fires only where the current text was
+    // uninformative, so nothing that reads correctly today reads differently.
+    //
+    // `CandlestickTrace` is deliberately NOT routed through the helper, and
+    // this case records why rather than leaving the omission to look like an
+    // oversight. `this.min`/`this.max` span the `volatility` section as well
+    // as the four prices, and volatility is a difference -- so the only chart
+    // where all five agree is one whose every price is zero. A change there
+    // could not alter any reading, and a mutation reverting it survived every
+    // test, which is the same fact from the other side.
+    //
+    // Separately, and noted on #1136: the stat is labelled `Price range`
+    // while ranging over a quantity that is not a price.
+    const moving: CandlestickPoint[] = [
+      {
+        value: 'mon',
+        open: 10,
+        high: 14,
+        low: 9,
+        close: 13,
+        trend: 'Bull',
+        volatility: 5,
+      },
+      {
+        value: 'tue',
+        open: 13,
+        high: 18,
+        low: 12,
+        close: 17,
+        trend: 'Bull',
+        volatility: 6,
+      },
+    ];
+    const layer: MaidrLayer = {
+      id: 'candles',
+      type: TraceType.CANDLESTICK,
+      title: 'A busy week',
+      axes: { x: { label: 'Day' }, y: { label: 'Price' } },
+      data: moving,
+    };
+
+    expect(statOf(layer, 'Price range')).toContain(' to ');
+  });
+
+  test('leaves a gauge scale with width alone', () => {
+    const data: GaugePoint = {
+      label: 'Conversion',
+      value: 73,
+      min: 0,
+      max: 100,
+      target: 80,
+      bands: [{ to: 100, label: 'all' }],
+    };
+    const layer: MaidrLayer = {
+      id: 'gauge',
+      type: TraceType.GAUGE,
+      title: 'Conversion rate',
+      axes: { x: { label: 'Measure' }, y: { label: 'Percent' } },
+      data,
+    };
+
+    expect(statOf(layer, 'Range')).toBe('0 to 100');
+  });
+});


### PR DESCRIPTION
Closes #1136. This is the follow-up the review on #1134 named — the same `` `${min} to ${max}` `` in the other traces — measured rather than swept.

## What was measured

Two of the six sites reach the degenerate case on **ordinary data**, not contrived data:

```
ParallelTrace   a column constant across every observation   {"label":"cyl","value":"4 to 4"}
HistogramTrace  every observation in one bin                 {"label":"Bin range","value":"5 to 5"}
```

The parallel one is the one worth having. A constant column means every line crosses that axis at the same height and the axis separates nothing — a finding, not a curiosity — and `4 to 4` is exactly the wrong way to tell someone that.

`CandlestickDeltaTrace` is the third reachable one: a series that tracks its reference exactly has every delta at zero, so its delta range genuinely has no width.

## The change

`spanned` moves out of `src/model/scatter.ts` into `MathUtil`, so one place decides it. Five call sites route through it: scatter (×2), parallel, histogram, candlestick-delta, and **both** gauge sites.

The second gauge site matters more than the first, and I only found it because a mutation survived: `GaugeTrace` carries the dial's ends in the **text state's `z`**, read out on every move, not just in the description. A mutation aimed at the description stat matched that line first, survived, and pointed at behaviour nothing covered. Both are now covered separately.

## What is deliberately left alone

**`CandlestickTrace`.** I changed it, then reverted it. Its `min`/`max` span the `volatility` section as well as the four prices, and volatility is a difference — so the only chart where all five agree is one whose every price is zero. A mutation reverting that site survived every test, which is the same fact from the other side. Changing a line that cannot alter a reading would imply coverage that does not exist. The test records this so the omission does not read as an oversight.

*(Separately, and noted on #1136: that stat is labelled `Price range` while ranging over a quantity that is not a price. Not this PR's business.)*

**Three other `${a} to ${b}` sites** — `choropleth.ts:435`, `flow.ts:492,649`, `ridgeline.ts:368` — are a pair or a path rather than one axis's extent, so `constant x` would be the wrong sentence for all three.

**`BoxenTrace`** already answers the question in its own words (`deepest === shallowest ? deepest : …`) and keeps them; `Depth range: 3` reads correctly as it is.

## Verification

Seven tests in `test/model/constantAxisStats.test.ts`, including two that assert a real range is untouched — the guard that this only fires where the text was already uninformative.

Mutation-tested, each site reverted alone against a restored baseline:

| mutation | tests failed |
|---|---|
| `spanned` never says `constant` | 5 |
| parallel bypasses the helper | 1 |
| histogram bypasses the helper | 1 |
| gauge `z` cell bypasses the helper | 1 |
| gauge description stat bypasses the helper | 1 |
| scatter Y bypasses the helper | 1 |
| candlestick-delta bypasses the helper | 1 |
| *candlestick bypasses the helper* | **0 — investigated, site reverted** |

`npm run lint:fix`, `npm run type-check` and `npm run build` clean. `npm test` → 5445 passed (391 suites) + 137 passed (10 ESM suites).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_